### PR TITLE
fix: Restore Compatibility with models other than Qwen2-VL

### DIFF
--- a/mlx_vlm/utils.py
+++ b/mlx_vlm/utils.py
@@ -708,6 +708,7 @@ def prepare_inputs(image_processor, processor, image, prompt, image_token_index)
     from transformers.image_utils import load_image
 
     mask = None
+    image_grid_thw = None
     if isinstance(image, str):
         image = load_image(image)
 
@@ -932,9 +933,9 @@ def generate(
         image_processor, processor, image, prompt, image_token_index
     )
 
-    kwargs = {
-        "image_grid_thw": image_grid_thw,
-    }
+    kwargs = {}
+    if image_grid_thw is not None:
+        kwargs["image_grid_thw"] = image_grid_thw
 
     tic = time.perf_counter()
     detokenizer = processor.detokenizer


### PR DESCRIPTION
https://github.com/Blaizzy/mlx-vlm/pull/59 added `image_grid_thw` temporal height and width image feature shape input to support Qwen2-VL, however this broke inference using other models:
```
UnboundLocalError: cannot access local variable 'image_grid_thw' where it is not associated with a value
```

The changes assign a value of `None` to the variable, as well as conditionally guard its assignment in the `kwargs` dictionary.

inference with `Qwen/Qwen2-VL-2B-Instruct` as well as `qnguyen3/nanoLLaVA` (and others) is again functional:
![Screenshot 2024-09-28 at 10 28 44 PM](https://github.com/user-attachments/assets/f210538c-2ab0-481d-988a-1aa199ec4a2e)