### PR TITLE
fix pixtral image prompt order for doc VQA

### DIFF
--- a/mlx_vlm/prompt_utils.py
+++ b/mlx_vlm/prompt_utils.py
@@ -25,7 +25,9 @@ def get_message_json(
         if role == "user" and not skip_image_token:
             if isinstance(message["content"], list):
                 if model_name == "pixtral":
-                    message["content"] = [{"type": "image"}] * num_images + message["content"]
+                    message["content"] = [{"type": "image"}] * num_images + message[
+                        "content"
+                    ]
                 else:
                     message["content"].extend([{"type": "image"}] * num_images)
             else:

--- a/mlx_vlm/prompt_utils.py
+++ b/mlx_vlm/prompt_utils.py
@@ -24,7 +24,10 @@ def get_message_json(
             return message
         if role == "user" and not skip_image_token:
             if isinstance(message["content"], list):
-                message["content"].extend([{"type": "image"}] * num_images)
+                if model_name == "pixtral":
+                    message["content"] = [{"type": "image"}] * num_images + message["content"]
+                else:
+                    message["content"].extend([{"type": "image"}] * num_images)
             else:
                 if model_name == "phi3_v":
                     message["content"] = f"{token_format}{message['content']}"


### PR DESCRIPTION
Puts image references at the beginning of the prompt to Pixtral to make prompting more natural - without using "following" which the API user is likely not aware of. Fixes #98.