### PR TITLE
Qwen2-VL performance improvements

### DIFF
--- a/mlx_vlm/models/qwen2_vl/language.py
+++ b/mlx_vlm/models/qwen2_vl/language.py
@@ -110,7 +110,6 @@ def apply_multimodal_rotary_pos_emb(q, k, cos, sin, position_ids, mrope_section)
 
     mrope_section = np.cumsum(mrope_section * 2)[:-1].tolist()
 
-    position_ids = position_ids.tolist()
     cos = cos[position_ids]
     sin = sin[position_ids]
 
@@ -127,7 +126,7 @@ def apply_multimodal_rotary_pos_emb(q, k, cos, sin, position_ids, mrope_section)
     q_embed = (q * cos) + (rotate_half(q) * sin)
     k_embed = (k * cos) + (rotate_half(k) * sin)
 
-    return mx.array(q_embed), mx.array(k_embed)
+    return q_embed, k_embed
 
 
 class Attention(nn.Module):
@@ -182,7 +181,7 @@ class Attention(nn.Module):
             position_ids = mx.arange(0, L)
 
         position_ids = mx.expand_dims(position_ids, axis=0)
-        position_ids = np.tile(position_ids, (3, 1, 1))
+        position_ids = mx.tile(position_ids, (3, 1, 1))
 
         cos, sin = self.rotary_emb(values, kv_seq_len)
 

--- a/mlx_vlm/models/qwen2_vl/qwen2_vl.py
+++ b/mlx_vlm/models/qwen2_vl/qwen2_vl.py
@@ -80,8 +80,6 @@ class Model(nn.Module):
         image_indices = np.where(image_positions)[1].tolist()
         inputs_embeds[:, image_indices, :] = image_features
 
-        # TODO: Add video features
-
         return inputs_embeds
 
     def __call__(

--- a/mlx_vlm/models/qwen2_vl/qwen2_vl.py
+++ b/mlx_vlm/models/qwen2_vl/qwen2_vl.py
@@ -78,7 +78,7 @@ class Model(nn.Module):
         # Positions of <image> tokens in input_ids, assuming batch size is 1
         image_positions = input_ids == image_token_index
         image_indices = np.where(image_positions)[1].tolist()
-        inputs_embeds[:, image_indices, :] = image_features.astype(mx.float32)
+        inputs_embeds[:, image_indices, :] = image_features
 
         # TODO: Add video features
 


### PR DESCRIPTION
This PR improves Qwen2-VL inference speed by 20% for 8bit and 33% for 4bit on M3 Max 96GB.
And a staggering 64% for 4bit improvement on M2 Ultra 192GB.

Thanks to @awni!

<img width="350" alt="Screenshot 2024-11-14 at 12 12 05 AM" src="https://github.com/user-attachments/assets/ab58df58-564f-4380-8f31-f5d7c85dba7d">
<img width="310" alt="Screenshot 2024-11-14 at 12 18 11 AM" src="https://github.com/user-attachments/assets/7aea19d1-da4b-435e-b061-8e1eb1c83a3b">



Closes #110 