### PR TITLE
Add lazy eval during conversion

### DIFF
--- a/mlx_vlm/utils.py
+++ b/mlx_vlm/utils.py
@@ -728,7 +728,7 @@ def convert(
 ):
     print("[INFO] Loading")
     model_path = get_model_path(hf_path, revision=revision)
-    model, config, processor = fetch_from_hub(model_path, lazy=False)
+    model, config, processor = fetch_from_hub(model_path, lazy=True)
 
     weights = dict(tree_flatten(model.parameters()))
     dtype = mx.float16 if quantize else getattr(mx, dtype)


### PR DESCRIPTION
This PR implements lazy evaluation during the model loading and conversion process to improve memory efficiency. By utilizing MLX's lazy evaluation feature, we defer actual memory allocation until weights are needed.

### Key changes:

- Added lazy=True parameter when fetching models from HuggingFace hub
- Memory allocation now happens on-demand rather than eagerly
- Works with both float16 (quantized) and user-specified dtype configurations

### Benefits:

- Reduced peak memory usage during model conversion
- Smoother handling of large models, particularly when converting to float16
- Maintains compatibility with existing model loading workflows


Read more here: https://ml-explore.github.io/mlx/build/html/usage/lazy_evaluation.html

