### PR TITLE
Open tokenizer.json within context manager

### DIFF
--- a/mlx_vlm/tokenizer_utils.py
+++ b/mlx_vlm/tokenizer_utils.py
@@ -314,7 +314,8 @@ def load_tokenizer(model_path, return_tokenizer=True, tokenizer_config_extra={})
 
     tokenizer_file = model_path / "tokenizer.json"
     if tokenizer_file.exists():
-        tokenizer_content = json.load(tokenizer_file.open())
+        with open(tokenizer_file, "r") as f:
+            tokenizer_content = json.load(f)
         if "decoder" in tokenizer_content:
             if _is_spm_decoder(tokenizer_content["decoder"]):
                 detokenizer_class = SPMStreamingDetokenizer

--- a/mlx_vlm/tokenizer_utils.py
+++ b/mlx_vlm/tokenizer_utils.py
@@ -315,7 +315,14 @@ def load_tokenizer(model_path, return_tokenizer=True, tokenizer_config_extra={})
     tokenizer_file = model_path / "tokenizer.json"
     if tokenizer_file.exists():
         with open(tokenizer_file, "r") as f:
-            tokenizer_content = json.load(f)
+            try:
+                tokenizer_content = json.load(f)
+            except JSONDecodeError as e:
+                raise JSONDecodeError(
+                    "Failed to parse tokenizer.json", 
+                    e.doc, 
+                    e.pos
+                )
         if "decoder" in tokenizer_content:
             if _is_spm_decoder(tokenizer_content["decoder"]):
                 detokenizer_class = SPMStreamingDetokenizer

--- a/mlx_vlm/tokenizer_utils.py
+++ b/mlx_vlm/tokenizer_utils.py
@@ -1,5 +1,6 @@
 import json
 from functools import partial
+from json import JSONDecodeError
 
 from transformers import AutoTokenizer
 
@@ -318,11 +319,7 @@ def load_tokenizer(model_path, return_tokenizer=True, tokenizer_config_extra={})
             try:
                 tokenizer_content = json.load(f)
             except JSONDecodeError as e:
-                raise JSONDecodeError(
-                    "Failed to parse tokenizer.json", 
-                    e.doc, 
-                    e.pos
-                )
+                raise JSONDecodeError("Failed to parse tokenizer.json", e.doc, e.pos)
         if "decoder" in tokenizer_content:
             if _is_spm_decoder(tokenizer_content["decoder"]):
                 detokenizer_class = SPMStreamingDetokenizer


### PR DESCRIPTION
Seeing this warning:
```
ResourceWarning: unclosed file <_io.TextIOWrapper name='/Users/neil/.cache/lm-studio/models/mlx-community/pixtral-12b-4bit/tokenizer.json' mode='r' encoding='UTF-8'>
  tokenizer_content = json.load(tokenizer_file.open())
```

This PR fixes this warning by closing the tokenizer file after reading it.