### PR TITLE
Fix broken stream generate for SmolVLM and others

### DIFF
--- a/mlx_vlm/utils.py
+++ b/mlx_vlm/utils.py
@@ -1095,7 +1095,10 @@ def stream_generate(
         tokenizer = processor.tokenizer
 
     resize_shape = kwargs.pop("resize_shape", None)
-    image_token_index = model.config.image_token_index
+    if hasattr(model.config, "image_token_index"):
+        image_token_index = model.config.image_token_index
+    else:
+        image_token_index = None
 
     # Prepare inputs
     inputs = prepare_inputs(


### PR DESCRIPTION
This breaks stream generation if the model doesn't have image_token_index