### PR TITLE
Corrected order of parameters on example

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ formatted_prompt = apply_chat_template(
 )
 
 # Generate output
-output = generate(model, processor, image, formatted_prompt, verbose=False)
+output = generate(model, processor, formatted_prompt, image, verbose=False)
 print(output)
 ```
 

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ formatted_prompt = apply_chat_template(
     processor, config, prompt, num_images=len(images)
 )
 
-output = generate(model, processor, images, formatted_prompt, verbose=False)
+output = generate(model, processor, formatted_prompt, images, verbose=False)
 print(output)
 ```
 


### PR DESCRIPTION
The example on the readme does not run because the order of parameters is incorrect resulting in:

`TypeError: TextEncodeInput must be Union[TextInputSequence, Tuple[InputSequence, InputSequence]]`

Fixing example on Readme