### PR TITLE
feat: allow `PIL.Image.Image` as input

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ config = load_config(model_path)
 
 # Prepare input
 image = ["http://images.cocodataset.org/val2017/000000039769.jpg"]
+# image = [Image.open("...")] can also be used with PIL.Image.Image objects
 prompt = "Describe this image."
 
 # Apply chat template

--- a/mlx_vlm/utils.py
+++ b/mlx_vlm/utils.py
@@ -338,7 +338,6 @@ def load_image_processor(model_path: Union[str, Path], **kwargs) -> BaseImagePro
 def load_processor(
     model_path, add_detokenizer=True, **kwargs
 ) -> Union[PreTrainedTokenizer, PreTrainedTokenizerFast]:
-
     processor = AutoProcessor.from_pretrained(model_path, **kwargs)
     if add_detokenizer:
         detokenizer_class = load_tokenizer(model_path, return_tokenizer=False)
@@ -753,7 +752,10 @@ def resize_image(img, max_size):
 
 
 def process_image(img, resize_shape, image_processor):
-    if isinstance(img, str):
+    # load image if not already loaded
+    if isinstance(img, Image.Image):
+        img = img
+    elif isinstance(img, str):
         img = load_image(img)
     if resize_shape is not None and not isinstance(image_processor, BaseImageProcessor):
         img = resize_image(img, resize_shape)
@@ -795,7 +797,6 @@ def process_inputs_with_fallback(processor, images, prompts, return_tensors="mlx
 
 
 def prepare_inputs(processor, images, prompts, image_token_index, resize_shape=None):
-
     if not isinstance(images, list):
         images = [images]
 
@@ -953,7 +954,6 @@ def generate_step(
                 **kwargs,
             )
         else:
-
             outputs = model.language_model(
                 y[None],
                 cache=cache,


### PR DESCRIPTION
simple patch to allow passing PIL Images as input to the model. I tested this locally by a modified version of the script in the README.

```python
from PIL import Image

from mlx_vlm import load, generate
from mlx_vlm.prompt_utils import apply_chat_template
from mlx_vlm.utils import load_config

# Load the model
model_path = "mlx-community/Qwen2-VL-2B-Instruct-4bit"
model, processor = load(model_path)
config = load_config(model_path)

# Prepare input
image = [Image.open("snoopy.png")]
prompt = "Describe this image."

# Apply chat template
formatted_prompt = apply_chat_template(
    processor, config, prompt, num_images=len(image)
)

# Generate output
output = generate(model, processor, formatted_prompt, image, verbose=False)
print(output)
```