### PR TITLE
feat: Resume Lora fine-tuning from saved adapter file

### DIFF
--- a/mlx_vlm/lora.py
+++ b/mlx_vlm/lora.py
@@ -70,12 +70,18 @@ def main(args):
 
     logger.info(f"\033[32mSetting up LoRA\033[0m")
     list_of_modules = find_all_linear_names(model.language_model)
+
+    resume_adapter_file = args.resume_adapter_file
+    if resume_adapter_file:
+        logger.info(f"\033[32mResuming from adapter file {resume_adapter_file}\033[0m")
+
     model = get_peft_model(
         model,
         list_of_modules,
         rank=args.lora_rank,
         alpha=args.lora_alpha,
         dropout=args.lora_dropout,
+        resume_adapter_file=args.resume_adapter_file,
     )
 
     logger.info(f"\033[32mSetting up optimizer\033[0m")
@@ -171,6 +177,12 @@ if __name__ == "__main__":
         type=str,
         default="adapters",
         help="Path to save the trained adapter",
+    )
+    parser.add_argument(
+        "--resume-adapter-file",
+        type=str,
+        default="",
+        help="Load path to resume training from the given fine-tuned weights.",
     )
 
     args = parser.parse_args()

--- a/mlx_vlm/lora.py
+++ b/mlx_vlm/lora.py
@@ -81,7 +81,7 @@ def main(args):
         rank=args.lora_rank,
         alpha=args.lora_alpha,
         dropout=args.lora_dropout,
-        resume_adapter_file=args.resume_adapter_file,
+        resume_adapter_file=resume_adapter_file,
     )
 
     logger.info(f"\033[32mSetting up optimizer\033[0m")

--- a/mlx_vlm/tests/test_trainer_utils.py
+++ b/mlx_vlm/tests/test_trainer_utils.py
@@ -40,6 +40,23 @@ class TestTrainerUtils(unittest.TestCase):
 
         self.assertTrue(mock_freeze.called)
         self.assertTrue(mock_print.called)
+        model.load_weights.assert_not_called()
+        self.assertTrue(hasattr(model.config, "lora"))
+
+    @patch("mlx_vlm.trainer.utils.freeze_model")
+    @patch("mlx_vlm.trainer.utils.print_trainable_parameters")
+    def test_get_peft_model_with_resume_adapter_file(self, mock_print, mock_freeze):
+        model = MagicMock()
+        model.language_model.named_modules.return_value = [
+            ("layer1", nn.Linear(256, 512)),
+            ("layer2", nn.QuantizedLinear(256, 512, 8)),
+        ]
+
+        result = get_peft_model(model, ["layer1", "layer2"], 10, 0.1, 0.1, False, False, "resume_adapter_file")
+
+        self.assertFalse(mock_freeze.called)
+        self.assertFalse(mock_print.called)
+        model.load_weights.assert_called()
         self.assertTrue(hasattr(model.config, "lora"))
 
     def test_find_all_linear_names(self):

--- a/mlx_vlm/trainer/utils.py
+++ b/mlx_vlm/trainer/utils.py
@@ -33,7 +33,14 @@ def set_module_by_name(model, name, new_module):
 
 
 def get_peft_model(
-    model, linear_layers, rank=10, alpha=0.1, dropout=0.1, freeze=True, verbose=True
+    model,
+    linear_layers,
+    rank=10,
+    alpha=0.1,
+    dropout=0.1,
+    freeze=True,
+    verbose=True,
+    resume_adapter_file="",
 ):
     if freeze:
         freeze_model(model)
@@ -43,6 +50,9 @@ def get_peft_model(
             if name.split(".")[-1] in linear_layers:
                 lora_layer = LoRaLayer(module, rank, alpha, dropout)
                 set_module_by_name(model.language_model, name, lora_layer)
+
+    if resume_adapter_file:
+        model.load_weights(resume_adapter_file, strict=False)
 
     model.config.lora = {}
     model.config.lora["rank"] = rank

--- a/mlx_vlm/trainer/utils.py
+++ b/mlx_vlm/trainer/utils.py
@@ -156,6 +156,8 @@ def apply_lora_layers(model: nn.Module, adapter_path: str) -> nn.Module:
         config = json.load(f)
         if "rank" not in config:
             raise ValueError("The adapter does not have lora params in the config")
+        if "resume_adapter_file" not in config:
+            config["resume_adapter_file"] = ""
 
     # TODO: add lora params to the config and load them here
     list_of_modules = find_all_linear_names(model.language_model.model)


### PR DESCRIPTION
Adds the ability to resume Lora training from previously saved weights by passing:

--resume-adapter-file <path_to_adapters.safetensors>

It's the same syntax as used in mlx-lm. 

- Updated trainer.utils and added a simple unit test.
- Black is happy with the formatting; it forced me to change **get_peft_model()** to have one argument on each line.