### PR TITLE
When converting models, default dtype to config.json's torch_dtype

### DIFF
--- a/mlx_vlm/convert.py
+++ b/mlx_vlm/convert.py
@@ -31,7 +31,7 @@ def configure_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument(
         "--dtype",
-        help="Type to save the parameter. Defaults to config.json's `torch_dtype` or bfloat16",
+        help="Type to save the parameter. Defaults to config.json's `torch_dtype` or the current model weights dtype",
         type=str,
         choices=MODEL_CONVERSION_DTYPES,
         default=None,

--- a/mlx_vlm/convert.py
+++ b/mlx_vlm/convert.py
@@ -2,7 +2,7 @@
 
 import argparse
 
-from .utils import convert
+from .utils import MODEL_CONVERSION_DTYPES, convert
 
 
 def configure_parser() -> argparse.ArgumentParser:

--- a/mlx_vlm/convert.py
+++ b/mlx_vlm/convert.py
@@ -31,10 +31,10 @@ def configure_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument(
         "--dtype",
-        help="Type to save the parameters, ignored if -q is given.",
+        help="Type to save the parameter. Defaults to config.json's `torch_dtype` or bfloat16",
         type=str,
-        choices=["float16", "bfloat16", "float32"],
-        default="float16",
+        choices=MODEL_CONVERSION_DTYPES,
+        default=None,
     )
     parser.add_argument(
         "--upload-repo",

--- a/mlx_vlm/utils.py
+++ b/mlx_vlm/utils.py
@@ -37,6 +37,8 @@ MODEL_REMAPPING = {"llava-qwen2": "llava_bunny", "bunny-llama": "llava_bunny"}
 
 MAX_FILE_SIZE_GB = 5
 
+MODEL_CONVERSION_DTYPES = ["float16", "bfloat16", "float32"]
+
 
 # A stream on the default device just for generation
 generation_stream = mx.new_stream(mx.default_device())
@@ -730,7 +732,7 @@ def convert(
     quantize: bool = False,
     q_group_size: int = 64,
     q_bits: int = 4,
-    dtype: str = "float16",
+    dtype: Optional[str] = None,
     upload_repo: str = None,
     revision: Optional[str] = None,
     dequantize: bool = False,
@@ -743,8 +745,14 @@ def convert(
         model_path, lazy=True, trust_remote_code=trust_remote_code
     )
 
-    weights = dict(tree_flatten(model.parameters()))
+    if dtype is None:
+        dtype = config.get("torch_dtype", None)
+    if dtype not in MODEL_CONVERSION_DTYPES:
+        dtype = "bfloat16"
+    print("[INFO] Using dtype:", dtype)
     dtype = getattr(mx, dtype)
+
+    weights = dict(tree_flatten(model.parameters()))
     weights = {k: v.astype(dtype) for k, v in weights.items()}
 
     if quantize and dequantize:

--- a/mlx_vlm/utils.py
+++ b/mlx_vlm/utils.py
@@ -747,13 +747,11 @@ def convert(
 
     if dtype is None:
         dtype = config.get("torch_dtype", None)
-    if dtype not in MODEL_CONVERSION_DTYPES:
-        dtype = "bfloat16"
-    print("[INFO] Using dtype:", dtype)
-    dtype = getattr(mx, dtype)
-
     weights = dict(tree_flatten(model.parameters()))
-    weights = {k: v.astype(dtype) for k, v in weights.items()}
+    if dtype in MODEL_CONVERSION_DTYPES:
+        print("[INFO] Using dtype:", dtype)
+        dtype = getattr(mx, dtype) 
+        weights = {k: v.astype(dtype) for k, v in weights.items()}
 
     if quantize and dequantize:
         raise ValueError("Choose either quantize or dequantize, not both.")

--- a/mlx_vlm/utils.py
+++ b/mlx_vlm/utils.py
@@ -750,7 +750,7 @@ def convert(
     weights = dict(tree_flatten(model.parameters()))
     if dtype in MODEL_CONVERSION_DTYPES:
         print("[INFO] Using dtype:", dtype)
-        dtype = getattr(mx, dtype) 
+        dtype = getattr(mx, dtype)
         weights = {k: v.astype(dtype) for k, v in weights.items()}
 
     if quantize and dequantize:


### PR DESCRIPTION
Check the `torch_dtype` in the hf-model before starting conversion. We need this because precision is lost when casting from `bfloat16` to `float16`
- Remove the `ignored if -q is given` from the help text, since it's not true and it does indeed affect the quantization quality
- Check if the `torch_dtype` top-level field in the hf-model's config.json matches one of our three dtypes. If it does, and the user has not specified a dtype, use `torch_dtype`
- If `torch_dtype` isn't found, or if the value isn't one we expect, we default to `bfloat16`. More and more models need `bfloat16` to work well, so this is a better default moving forward