### PR TITLE
Pixtral: make merge_input_ids function public static

### DIFF
--- a/mlx_vlm/models/pixtral/pixtral.py
+++ b/mlx_vlm/models/pixtral/pixtral.py
@@ -99,15 +99,15 @@ class Model(nn.Module):
         image_features = self.multi_modal_projector(selected_image_feature)
 
         # Insert special image tokens in the input_ids
-        final_inputs_embeds = self._merge_input_ids_with_image_features(
-            image_features, inputs_embeds, input_ids
+        final_inputs_embeds = self.merge_input_ids_with_image_features(
+            self.config.image_token_index, image_features, inputs_embeds, input_ids
         )
         return final_inputs_embeds
 
-    def _merge_input_ids_with_image_features(
-        self, image_features, inputs_embeds, input_ids
+    @staticmethod
+    def merge_input_ids_with_image_features(
+        image_token_index, image_features, inputs_embeds, input_ids
     ):
-        image_token_index = self.config.image_token_index
         num_images, num_image_patches, embed_dim = image_features.shape
 
         # Positions of <image> tokens in input_ids, assuming batch size is 1


### PR DESCRIPTION
Same concept as https://github.com/Blaizzy/mlx-vlm/pull/335.

Make this an importable free-function, and better clarify inputs/outputs by not having it be a potentially stateful member function.

Model works as expected:

#### Before
```
matt@Matts-MacBook-Pro [10:39:53] [~/Workspace/forks/mlx-vlm] [main]
-> % ./.venv/bin/python -m mlx_vlm.generate --model /Users/matt/.cache/lm-studio/models/mlx-community/pixtral-12b-4bit --image /Users/matt/Downloads/cartoon_black_cat.jpeg --temp 0
None of PyTorch, TensorFlow >= 2.0, or Flax have been found. Models won't be available and only tokenizers, configuration and file/data utilities can be used.
None of PyTorch, TensorFlow >= 2.0, or Flax have been found. Models won't be available and only tokenizers, configuration and file/data utilities can be used.
Using a slow image processor as `use_fast` is unset and a slow processor was saved with this model. `use_fast=True` will be the default behavior in v4.52, even if the model was saved with a slow processor. This will result in minor differences in outputs. You'll still be able to use a slow processor with `use_fast=False`.
==========
Files: ['/Users/matt/Downloads/cartoon_black_cat.jpeg'] 

Prompt: <s>[INST][IMG]What are these?[/INST]
The image depicts a cute, cartoon-style illustration of a black cat. The cat has large, round, green eyes and a small, smiling mouth. It is sitting upright with its front paws resting on its body. The cat's tail is curled around its body, and it has pointed ears. The overall design is simple and charming, emphasizing the cat's adorable features.
==========
Prompt: 1567 tokens, 173.061 tokens-per-sec
Generation: 76 tokens, 12.902 tokens-per-sec
Peak memory: 9.764 GB
```

#### After
```
matt@Matts-MacBook-Pro [10:40:15] [~/Workspace/forks/mlx-vlm] [main]
-> % git checkout -
Switched to branch 'matt/pixtral-static-merge-function'
Your branch is up to date with 'mattjcly/matt/pixtral-static-merge-function'.
(.venv) 
matt@Matts-MacBook-Pro [10:40:22] [~/Workspace/forks/mlx-vlm] [matt/pixtral-static-merge-function *]
-> % ./.venv/bin/python -m mlx_vlm.generate --model /Users/matt/.cache/lm-studio/models/mlx-community/pixtral-12b-4bit --image /Users/matt/Downloads/cartoon_black_cat.jpeg --temp 0
None of PyTorch, TensorFlow >= 2.0, or Flax have been found. Models won't be available and only tokenizers, configuration and file/data utilities can be used.
None of PyTorch, TensorFlow >= 2.0, or Flax have been found. Models won't be available and only tokenizers, configuration and file/data utilities can be used.
Using a slow image processor as `use_fast` is unset and a slow processor was saved with this model. `use_fast=True` will be the default behavior in v4.52, even if the model was saved with a slow processor. This will result in minor differences in outputs. You'll still be able to use a slow processor with `use_fast=False`.
==========
Files: ['/Users/matt/Downloads/cartoon_black_cat.jpeg'] 

Prompt: <s>[INST][IMG]What are these?[/INST]
The image depicts a cute, cartoon-style illustration of a black cat. The cat has large, round, green eyes and a small, smiling mouth. It is sitting upright with its front paws resting on its body. The cat's tail is curled around its body, and it has pointed ears. The overall design is simple and charming, emphasizing the cat's adorable features.
==========
Prompt: 1567 tokens, 173.908 tokens-per-sec
Generation: 76 tokens, 12.865 tokens-per-sec
Peak memory: 9.764 GB

```

![cartoon_black_cat](https://github.com/user-attachments/assets/6c987e51-789b-42f0-bc7c-f407b1666df1)