### PR TITLE
Fix add_eos_token_ids early exit

### DIFF
--- a/mlx_vlm/utils.py
+++ b/mlx_vlm/utils.py
@@ -1074,7 +1074,7 @@ class StoppingCriteria:
                                If strings are provided, they will be converted to integers if possible.
         """
         if new_eos_token_ids is None:
-            pass
+            return
 
         if self.tokenizer is None:
             raise ValueError("Processor is not provided")


### PR DESCRIPTION
## Summary
- correct early return when no EOS tokens are provided

## Testing
- `python -m unittest discover -v` *(fails: No module named 'mlx')*