### PR TITLE
Add max_position_embeddings to TextConfig dataclasses

### DIFF
--- a/mlx_vlm/models/aya_vision/language.py
+++ b/mlx_vlm/models/aya_vision/language.py
@@ -26,6 +26,7 @@ class TextConfig:
     layer_norm_bias: bool = False
     sliding_window: int = 4096
     sliding_window_pattern: int = 4
+    max_position_embeddings: int = 4096
 
     @classmethod
     def from_dict(cls, params):

--- a/mlx_vlm/models/gemma3/language.py
+++ b/mlx_vlm/models/gemma3/language.py
@@ -29,6 +29,7 @@ class TextConfig:
     rope_scaling: Optional[Dict[str, Union[float, List[float]]]] = None
     mm_tokens_per_image: int = 256
     sliding_window_pattern: int = 6
+    max_position_embeddings: int = 4096
 
     @classmethod
     def from_dict(cls, params):

--- a/mlx_vlm/models/idefics2/language.py
+++ b/mlx_vlm/models/idefics2/language.py
@@ -21,6 +21,7 @@ class TextConfig:
     num_key_value_heads: int
     rope_theta: float = 1000000.0
     rope_traditional: bool = False
+    max_position_embeddings: int = 4096
     tie_word_embeddings: bool = False
 
     @classmethod

--- a/mlx_vlm/models/idefics3/language.py
+++ b/mlx_vlm/models/idefics3/language.py
@@ -22,6 +22,7 @@ class TextConfig:
     rope_theta: float = 1000000.0
     num_hidden_layers: int = 32
     rope_traditional: bool = False
+    max_position_embeddings: int = 4096
     tie_word_embeddings: bool = False
 
     @classmethod

--- a/mlx_vlm/models/llava/language.py
+++ b/mlx_vlm/models/llava/language.py
@@ -22,6 +22,7 @@ class TextConfig:
     rope_theta: float = 10000
     rope_traditional: bool = False
     rope_scaling: Optional[Dict[str, Union[float, str]]] = None
+    max_position_embeddings: int = 4096
     tie_word_embeddings: bool = False
 
     @classmethod

--- a/mlx_vlm/models/llava_bunny/language.py
+++ b/mlx_vlm/models/llava_bunny/language.py
@@ -23,6 +23,7 @@ class TextConfig:
     rope_theta: float = 1000000
     rope_traditional: bool = False
     rope_scaling: Optional[Dict[str, Union[float, str]]] = None
+    max_position_embeddings: int = 4096
     tie_word_embeddings: bool = True
 
     @classmethod

--- a/mlx_vlm/models/llava_next/language.py
+++ b/mlx_vlm/models/llava_next/language.py
@@ -22,6 +22,7 @@ class TextConfig:
     rope_theta: float = 1000000
     rope_traditional: bool = False
     rope_scaling: Optional[Dict[str, Union[float, str]]] = None
+    max_position_embeddings: int = 4096
 
     @classmethod
     def from_dict(cls, params):

--- a/mlx_vlm/models/multi_modality/language.py
+++ b/mlx_vlm/models/multi_modality/language.py
@@ -22,6 +22,7 @@ class TextConfig:
     rope_theta: float = 10000
     rope_traditional: bool = False
     rope_scaling: Optional[Dict[str, Union[float, str]]] = None
+    max_position_embeddings: int = 4096
 
     @classmethod
     def from_dict(cls, params):

--- a/mlx_vlm/models/paligemma/language.py
+++ b/mlx_vlm/models/paligemma/language.py
@@ -25,6 +25,7 @@ class TextConfig:
     attn_logit_softcapping: Optional[float] = None
     final_logit_softcapping: Optional[float] = None
     query_pre_attn_scalar: Optional[float] = None
+    max_position_embeddings: int = 4096
 
     @classmethod
     def from_dict(cls, params):

--- a/mlx_vlm/models/phi3_v/language.py
+++ b/mlx_vlm/models/phi3_v/language.py
@@ -4,6 +4,8 @@ from dataclasses import dataclass
 
 @dataclass
 class TextConfig:
+    max_position_embeddings: int = 4096
+
     @classmethod
     def from_dict(cls, params):
         return cls(

--- a/mlx_vlm/models/pixtral/language.py
+++ b/mlx_vlm/models/pixtral/language.py
@@ -23,6 +23,7 @@ class TextConfig:
     rope_theta: float = 1000000000.0
     rope_traditional: bool = False
     rope_scaling: Optional[Dict[str, Union[float, str]]] = None
+    max_position_embeddings: int = 4096
 
     @classmethod
     def from_dict(cls, params):


### PR DESCRIPTION
## Summary
- add `max_position_embeddings` field to all `TextConfig` dataclasses across language models

Closes https://github.com/Blaizzy/mlx-vlm/issues/353

## Testing
- `black mlx_vlm/models/phi3_v/language.py mlx_vlm/models/gemma3/language.py mlx_vlm/models/idefics2/language.py mlx_vlm/models/idefics3/language.py mlx_vlm/models/llava/language.py mlx_vlm/models/llava_bunny/language.py mlx_vlm/models/llava_next/language.py mlx_vlm/models/multi_modality/language.py mlx_vlm/models/paligemma/language.py mlx_vlm/models/phi3_v/language.py mlx_vlm/models/pixtral/language.py`
- `isort mlx_vlm/models/aya_vision/language.py mlx_vlm/models/gemma3/language.py mlx_vlm/models/idefics2/language.py mlx_vlm/models/idefics3/language.py mlx_vlm/models/llava/language.py mlx_vlm/models/llava_bunny/language.py mlx_vlm/models/llava_next/language.py mlx_vlm/models/multi_modality/language.py mlx_vlm/models/paligemma/language.py mlx_vlm/models/phi3_v/language.py mlx_vlm/models/pixtral/language.py`
