### PR TITLE
Fix revision argument not passed in load

### DIFF
--- a/mlx_vlm/tests/test_utils.py
+++ b/mlx_vlm/tests/test_utils.py
@@ -1,9 +1,12 @@
 import mlx.core as mx
 import mlx.nn as nn
+from pathlib import Path
+from unittest.mock import MagicMock, patch
 
 from mlx_vlm.utils import (
     StoppingCriteria,
     get_class_predicate,
+    load,
     prepare_inputs,
     quantize_model,
     sanitize_weights,
@@ -235,3 +238,26 @@ def test_stopping_criteria_reset():
     stopping_criteria.reset([5, 7])
     assert stopping_criteria.eos_token_ids == [5, 7]
     assert stopping_criteria(7) is True
+
+
+def test_load_passes_revision():
+    model_mock = MagicMock()
+    model_mock.config = MagicMock(eos_token_id=None)
+    processor_mock = MagicMock()
+
+    with patch("mlx_vlm.utils.get_model_path") as mock_get_model_path, patch(
+        "mlx_vlm.utils.load_model",
+        return_value=model_mock,
+    ) as mock_load_model, patch(
+        "mlx_vlm.utils.load_processor",
+        return_value=processor_mock,
+    ) as mock_load_processor, patch(
+        "mlx_vlm.utils.load_image_processor", return_value=None
+    ):
+        mock_get_model_path.return_value = Path("/tmp/model")
+
+        model, processor = load("repo", revision="abc")
+
+        assert model is model_mock
+        assert processor is processor_mock
+        mock_get_model_path.assert_called_with("repo", revision="abc")

--- a/mlx_vlm/utils.py
+++ b/mlx_vlm/utils.py
@@ -153,6 +153,8 @@ def load_model(model_path: Path, lazy: bool = False, **kwargs) -> nn.Module:
         lazy (bool): If False eval the model parameters to make sure they are
             loaded in memory before returning, otherwise they will be loaded
             when needed. Default: ``False``
+        revision (str, optional): A revision id which can be a branch name,
+            a tag, or a commit hash. Default: ``None``.
 
     Returns:
         nn.Module: The loaded and initialized model.
@@ -288,6 +290,7 @@ def load(
     path_or_hf_repo: str,
     adapter_path: Optional[str] = None,
     lazy: bool = False,
+    revision: Optional[str] = None,
     **kwargs,
 ) -> Tuple[nn.Module, Union[PreTrainedTokenizer, PreTrainedTokenizerFast]]:
     """
@@ -302,6 +305,8 @@ def load(
         lazy (bool): If False eval the model parameters to make sure they are
             loaded in memory before returning, otherwise they will be loaded
             when needed. Default: ``False``
+        revision (str, optional): A revision id which can be a branch name,
+            a tag, or a commit hash. Default: ``None``.
     Returns:
         Tuple[nn.Module, TokenizerWrapper]: A tuple containing the loaded model and tokenizer.
 
@@ -309,7 +314,7 @@ def load(
         FileNotFoundError: If config file or safetensors are not found.
         ValueError: If model class or args class are not found.
     """
-    model_path = get_model_path(path_or_hf_repo)
+    model_path = get_model_path(path_or_hf_repo, revision=revision)
 
     model = load_model(model_path, lazy, **kwargs)
     if adapter_path is not None:


### PR DESCRIPTION
## Summary
- pass revision to `get_model_path` in `load`
- extend load docstring and add a test for revision forwarding

## Testing
- `pytest -q` *(fails: command not found)*
- `pre-commit run --files mlx_vlm/utils.py mlx_vlm/tests/test_utils.py` *(fails: command not found)*