### PR TITLE
Remove hardcoded pytorch install error message

### DIFF
--- a/mlx_vlm/utils.py
+++ b/mlx_vlm/utils.py
@@ -836,7 +836,7 @@ def process_inputs_with_fallback(processor, images, prompts, return_tensors="mlx
             inputs = process_inputs(processor, images, prompts, return_tensors="pt")
         except Exception as e:
             raise ValueError(
-                f"Failed to process inputs with error: {e}."
+                f"Failed to process inputs with error: {e}. Please install PyTorch and try again."
             )
     return inputs
 

--- a/mlx_vlm/utils.py
+++ b/mlx_vlm/utils.py
@@ -836,7 +836,7 @@ def process_inputs_with_fallback(processor, images, prompts, return_tensors="mlx
             inputs = process_inputs(processor, images, prompts, return_tensors="pt")
         except Exception as e:
             raise ValueError(
-                f"Failed to process inputs with error: {e}. Please install PyTorch and try again."
+                f"Failed to process inputs with error: {e}."
             )
     return inputs
 

--- a/mlx_vlm/utils.py
+++ b/mlx_vlm/utils.py
@@ -835,9 +835,7 @@ def process_inputs_with_fallback(processor, images, prompts, return_tensors="mlx
             )
             inputs = process_inputs(processor, images, prompts, return_tensors="pt")
         except Exception as e:
-            raise ValueError(
-                f"Failed to process inputs with error: {e}. Please install PyTorch and try again."
-            )
+            raise ValueError(f"Failed to process inputs with error: {e}")
     return inputs
 
 


### PR DESCRIPTION
This message is often misleading, as it shows even for completely unrelated `huggingface/transformers` processing errors.

For example, if you send a prompt without image markers, such as `"hi"`, into `generate()` alongside any number of images, for models like Gemma 3, Llama 4, InternVL, aya vision, you get an error message containing `Please install PyTorch and try again`:

```
ValueError: Failed to process inputs with error: Prompt contained 0 image tokens but received 1 images. Please install PyTorch and try again.
```

Even if you have PyTorch already installed - and the error has nothing to do with PyTorch installation.

Furthermore, if you don't have PyTorch installed, the error message already contains `PyTorch is not installed`:
```
ValueError: Failed to process inputs with error: Unable to convert output to PyTorch tensors format, PyTorch is not installed. Please install PyTorch and try again.
```

Removing this hardcoded PyTorch install message helps improve clarity of debugging if `process_inputs` fails.

Env details:
```
matt@Matts-MacBook-Pro [10:22:34] [~/Workspace/forks/mlx-vlm] [remove-pytorch-install-message]
-> % pip list | grep -E "transformers|mlx"
mlx                0.25.2
mlx-lm             0.24.1
transformers       4.51.3
```