### PR TITLE
Fix multi images understand for Qwen2 and Qwen2.5 VL

### DIFF
--- a/mlx_vlm/models/qwen2_5_vl/qwen2_5_vl.py
+++ b/mlx_vlm/models/qwen2_5_vl/qwen2_5_vl.py
@@ -74,8 +74,8 @@ class Model(nn.Module):
             pixel_values, image_grid_thw, output_hidden_states=False
         )
 
-        if hidden_states.ndim == 2:
-            hidden_states = hidden_states[None, :, :]
+        # hidden_states is already in the correct shape (num_features, hidden_dim)
+        # Don't add extra batch dimension
 
         # Insert special image tokens in the input_ids
         final_inputs_embeds = self.merge_input_ids_with_image_features(
@@ -84,23 +84,111 @@ class Model(nn.Module):
             hidden_states,
             inputs_embeds,
             input_ids,
+            image_grid_thw,
         )
         return final_inputs_embeds
 
     @staticmethod
     def merge_input_ids_with_image_features(
-        image_token_id, video_token_id, image_features, inputs_embeds, input_ids
+        image_token_id, video_token_id, image_features, inputs_embeds, input_ids, grid_thw=None
     ):
-        image_token_id = image_token_id
-        video_token_id = video_token_id
-        # Positions of <image> tokens in input_ids, assuming batch size is 1
+        """Merge image features into input embeddings at image token positions.
+        
+        Args:
+            image_token_id: The token ID for image placeholders
+            video_token_id: The token ID for video placeholders (fallback)
+            image_features: Vision features from the vision tower [num_features, hidden_dim]
+            inputs_embeds: Input embeddings [batch_size, seq_len, hidden_dim]
+            input_ids: Input token IDs [batch_size, seq_len]
+            grid_thw: Grid dimensions for each image (optional, not used in simple case)
+        
+        Returns:
+            Updated input embeddings with image features inserted
+        """
+        # Find positions of image tokens
         image_positions = input_ids == image_token_id
         if mx.sum(image_positions) == 0:
             image_positions = input_ids == video_token_id
-
-        image_indices = np.where(image_positions)[1].tolist()
-        inputs_embeds[:, image_indices, :] = image_features
-        return inputs_embeds
+        
+        # Get all positions where we need to insert image features
+        batch_size, seq_len = input_ids.shape
+        
+        # For batch size 1 (common case), we can do direct assignment
+        if batch_size == 1:
+            # Create a mask for image positions
+            image_mask = image_positions[0]  # Shape: [seq_len]
+            
+            # Count image positions
+            num_positions = mx.sum(image_mask).item()
+            num_features = image_features.shape[0]
+            
+            if num_positions != num_features:
+                raise ValueError(
+                    f"Number of image token positions ({num_positions}) does not match "
+                    f"number of image features ({num_features})"
+                )
+            
+            # Expand masks for broadcasting
+            image_mask_expanded = mx.expand_dims(image_mask, axis=-1)  # [seq_len, 1]
+            
+            # Create indices for gathering features
+            # We need to map each image position to its corresponding feature
+            cumsum = mx.cumsum(image_mask.astype(mx.int32))
+            feature_indices = mx.where(image_mask, cumsum - 1, 0)
+            
+            # Gather the appropriate features for each position
+            # For non-image positions, we'll gather feature 0 but mask it out
+            gathered_features = image_features[feature_indices]  # [seq_len, hidden_dim]
+            
+            # Combine original embeddings with image features using the mask
+            output_embeds = mx.where(
+                image_mask_expanded,
+                gathered_features,
+                inputs_embeds[0]
+            )
+            
+            # Add batch dimension back
+            output_embeds = mx.expand_dims(output_embeds, axis=0)
+            
+            return output_embeds
+        else:
+            # For batch size > 1, process each batch separately
+            batch_outputs = []
+            feature_start_idx = 0
+            
+            for batch_idx in range(batch_size):
+                # Get mask for this batch
+                image_mask = image_positions[batch_idx]
+                num_positions = mx.sum(image_mask).item()
+                
+                if num_positions > 0:
+                    # Extract features for this batch
+                    batch_features = image_features[feature_start_idx:feature_start_idx + num_positions]
+                    
+                    # Create indices for gathering
+                    cumsum = mx.cumsum(image_mask.astype(mx.int32))
+                    feature_indices = mx.where(image_mask, cumsum - 1, 0)
+                    
+                    # Gather features
+                    gathered_features = batch_features[feature_indices]
+                    
+                    # Combine with original embeddings
+                    image_mask_expanded = mx.expand_dims(image_mask, axis=-1)
+                    batch_output = mx.where(
+                        image_mask_expanded,
+                        gathered_features,
+                        inputs_embeds[batch_idx]
+                    )
+                    
+                    feature_start_idx += num_positions
+                else:
+                    # No image tokens in this batch item
+                    batch_output = inputs_embeds[batch_idx]
+                
+                batch_outputs.append(batch_output)
+            
+            # Stack all batch outputs
+            return mx.stack(batch_outputs, axis=0)
 
     def __call__(
         self,

--- a/mlx_vlm/models/qwen2_5_vl/qwen2_5_vl.py
+++ b/mlx_vlm/models/qwen2_5_vl/qwen2_5_vl.py
@@ -113,83 +113,53 @@ class Model(nn.Module):
         if mx.sum(image_positions) == 0:
             image_positions = input_ids == video_token_id
 
-        # Get all positions where we need to insert image features
+        # Get dimensions
         batch_size, seq_len = input_ids.shape
 
-        # For batch size 1 (common case), we can do direct assignment
-        if batch_size == 1:
-            # Create a mask for image positions
-            image_mask = image_positions[0]  # Shape: [seq_len]
+        # Process each batch item
+        batch_outputs = []
+        feature_start_idx = 0
 
-            # Count image positions
+        for batch_idx in range(batch_size):
+            # Get mask for this batch
+            image_mask = image_positions[batch_idx]
             num_positions = mx.sum(image_mask).item()
-            num_features = image_features.shape[0]
 
-            if num_positions != num_features:
-                raise ValueError(
-                    f"Number of image token positions ({num_positions}) does not match "
-                    f"number of image features ({num_features})"
-                )
+            if num_positions > 0:
+                # Extract features for this batch
+                batch_features = image_features[
+                    feature_start_idx : feature_start_idx + num_positions
+                ]
 
-            # Expand masks for broadcasting
-            image_mask_expanded = mx.expand_dims(image_mask, axis=-1)  # [seq_len, 1]
-
-            # Create indices for gathering features
-            # We need to map each image position to its corresponding feature
-            cumsum = mx.cumsum(image_mask.astype(mx.int32))
-            feature_indices = mx.where(image_mask, cumsum - 1, 0)
-
-            # Gather the appropriate features for each position
-            # For non-image positions, we'll gather feature 0 but mask it out
-            gathered_features = image_features[feature_indices]  # [seq_len, hidden_dim]
-
-            # Combine original embeddings with image features using the mask
-            output_embeds = mx.where(
-                image_mask_expanded, gathered_features, inputs_embeds[0]
-            )
-
-            # Add batch dimension back
-            output_embeds = mx.expand_dims(output_embeds, axis=0)
-
-            return output_embeds
-        else:
-            # For batch size > 1, process each batch separately
-            batch_outputs = []
-            feature_start_idx = 0
-
-            for batch_idx in range(batch_size):
-                # Get mask for this batch
-                image_mask = image_positions[batch_idx]
-                num_positions = mx.sum(image_mask).item()
-
-                if num_positions > 0:
-                    # Extract features for this batch
-                    batch_features = image_features[
-                        feature_start_idx : feature_start_idx + num_positions
-                    ]
-
-                    # Create indices for gathering
-                    cumsum = mx.cumsum(image_mask.astype(mx.int32))
-                    feature_indices = mx.where(image_mask, cumsum - 1, 0)
-
-                    # Gather features
-                    gathered_features = batch_features[feature_indices]
-
-                    # Combine with original embeddings
-                    image_mask_expanded = mx.expand_dims(image_mask, axis=-1)
-                    batch_output = mx.where(
-                        image_mask_expanded, gathered_features, inputs_embeds[batch_idx]
+                # Validate we have the right number of features
+                if batch_features.shape[0] != num_positions:
+                    raise ValueError(
+                        f"Number of image token positions ({num_positions}) does not match "
+                        f"number of image features ({batch_features.shape[0]}) for batch {batch_idx}"
                     )
 
-                    feature_start_idx += num_positions
-                else:
-                    # No image tokens in this batch item
-                    batch_output = inputs_embeds[batch_idx]
+                # Create indices for gathering
+                cumsum = mx.cumsum(image_mask.astype(mx.int32))
+                feature_indices = mx.where(image_mask, cumsum - 1, 0)
 
-                batch_outputs.append(batch_output)
+                # Gather features
+                gathered_features = batch_features[feature_indices]
 
-            # Stack all batch outputs
-            return mx.stack(batch_outputs, axis=0)
+                # Combine with original embeddings
+                image_mask_expanded = mx.expand_dims(image_mask, axis=-1)
+                batch_output = mx.where(
+                    image_mask_expanded, gathered_features, inputs_embeds[batch_idx]
+                )
+
+                feature_start_idx += num_positions
+            else:
+                # No image tokens in this batch item
+                batch_output = inputs_embeds[batch_idx]
+
+            batch_outputs.append(batch_output)
+
+        # Stack all batch outputs
+        return mx.stack(batch_outputs, axis=0)
 
     def __call__(
         self,

--- a/mlx_vlm/models/qwen2_5_vl/qwen2_5_vl.py
+++ b/mlx_vlm/models/qwen2_5_vl/qwen2_5_vl.py
@@ -84,7 +84,6 @@ class Model(nn.Module):
             hidden_states,
             inputs_embeds,
             input_ids,
-            image_grid_thw,
         )
         return final_inputs_embeds
 
@@ -95,7 +94,6 @@ class Model(nn.Module):
         image_features,
         inputs_embeds,
         input_ids,
-        grid_thw=None,
     ):
         """Merge image features into input embeddings at image token positions.
 

--- a/mlx_vlm/models/qwen2_vl/qwen2_vl.py
+++ b/mlx_vlm/models/qwen2_vl/qwen2_vl.py
@@ -56,12 +56,12 @@ class Model(nn.Module):
         self, image_features, inputs_embeds, input_ids
     ):
         """Merge image features into input embeddings at image token positions.
-        
+
         Args:
             image_features: Vision features from the vision tower [num_features, hidden_dim]
             inputs_embeds: Input embeddings [batch_size, seq_len, hidden_dim]
             input_ids: Input token IDs [batch_size, seq_len]
-        
+
         Returns:
             Updated input embeddings with image features inserted
         """
@@ -72,84 +72,82 @@ class Model(nn.Module):
         image_positions = input_ids == image_token_index
         if mx.sum(image_positions) == 0:
             image_positions = input_ids == video_token_index
-        
+
         # Get all positions where we need to insert image features
         batch_size, seq_len = input_ids.shape
-        
+
         # For batch size 1 (common case), we can do direct assignment
         if batch_size == 1:
             # Create a mask for image positions
             image_mask = image_positions[0]  # Shape: [seq_len]
-            
+
             # Count image positions
             num_positions = mx.sum(image_mask).item()
             num_features = image_features.shape[0]
-            
+
             if num_positions != num_features:
                 raise ValueError(
                     f"Number of image token positions ({num_positions}) does not match "
                     f"number of image features ({num_features})"
                 )
-            
+
             # Expand masks for broadcasting
             image_mask_expanded = mx.expand_dims(image_mask, axis=-1)  # [seq_len, 1]
-            
+
             # Create indices for gathering features
             # We need to map each image position to its corresponding feature
             cumsum = mx.cumsum(image_mask.astype(mx.int32))
             feature_indices = mx.where(image_mask, cumsum - 1, 0)
-            
+
             # Gather the appropriate features for each position
             # For non-image positions, we'll gather feature 0 but mask it out
             gathered_features = image_features[feature_indices]  # [seq_len, hidden_dim]
-            
+
             # Combine original embeddings with image features using the mask
             output_embeds = mx.where(
-                image_mask_expanded,
-                gathered_features,
-                inputs_embeds[0]
+                image_mask_expanded, gathered_features, inputs_embeds[0]
             )
-            
+
             # Add batch dimension back
             output_embeds = mx.expand_dims(output_embeds, axis=0)
-            
+
             return output_embeds
         else:
             # For batch size > 1, process each batch separately
             batch_outputs = []
             feature_start_idx = 0
-            
+
             for batch_idx in range(batch_size):
                 # Get mask for this batch
                 image_mask = image_positions[batch_idx]
                 num_positions = mx.sum(image_mask).item()
-                
+
                 if num_positions > 0:
                     # Extract features for this batch
-                    batch_features = image_features[feature_start_idx:feature_start_idx + num_positions]
-                    
+                    batch_features = image_features[
+                        feature_start_idx : feature_start_idx + num_positions
+                    ]
+
                     # Create indices for gathering
                     cumsum = mx.cumsum(image_mask.astype(mx.int32))
                     feature_indices = mx.where(image_mask, cumsum - 1, 0)
-                    
+
                     # Gather features
                     gathered_features = batch_features[feature_indices]
-                    
+
                     # Combine with original embeddings
                     image_mask_expanded = mx.expand_dims(image_mask, axis=-1)
                     batch_output = mx.where(
-                        image_mask_expanded,
-                        gathered_features,
-                        inputs_embeds[batch_idx]
+                        image_mask_expanded, gathered_features, inputs_embeds[batch_idx]
                     )
-                    
+
                     feature_start_idx += num_positions
                 else:
                     # No image tokens in this batch item
                     batch_output = inputs_embeds[batch_idx]
-                
+
                 batch_outputs.append(batch_output)
-            
+
             # Stack all batch outputs
             return mx.stack(batch_outputs, axis=0)
 

--- a/mlx_vlm/models/qwen2_vl/qwen2_vl.py
+++ b/mlx_vlm/models/qwen2_vl/qwen2_vl.py
@@ -43,8 +43,8 @@ class Model(nn.Module):
             pixel_values, grid_thw, output_hidden_states=False
         )
 
-        if hidden_states.ndim == 2:
-            hidden_states = hidden_states[None, :, :]
+        # hidden_states is already in the correct shape (num_features, hidden_dim)
+        # Don't add extra batch dimension
 
         # Insert special image tokens in the input_ids
         final_inputs_embeds = self._merge_input_ids_with_image_features(
@@ -55,19 +55,103 @@ class Model(nn.Module):
     def _merge_input_ids_with_image_features(
         self, image_features, inputs_embeds, input_ids
     ):
+        """Merge image features into input embeddings at image token positions.
+        
+        Args:
+            image_features: Vision features from the vision tower [num_features, hidden_dim]
+            inputs_embeds: Input embeddings [batch_size, seq_len, hidden_dim]
+            input_ids: Input token IDs [batch_size, seq_len]
+        
+        Returns:
+            Updated input embeddings with image features inserted
+        """
         image_token_index = self.config.image_token_index
         video_token_index = self.config.video_token_index
 
-        # Positions of <image> tokens in input_ids, assuming batch size is 1
+        # Positions of <image> tokens in input_ids
         image_positions = input_ids == image_token_index
         if mx.sum(image_positions) == 0:
             image_positions = input_ids == video_token_index
-
-        image_indices = np.where(image_positions)[1].tolist()
-
-        inputs_embeds[:, image_indices, :] = image_features
-
-        return inputs_embeds
+        
+        # Get all positions where we need to insert image features
+        batch_size, seq_len = input_ids.shape
+        
+        # For batch size 1 (common case), we can do direct assignment
+        if batch_size == 1:
+            # Create a mask for image positions
+            image_mask = image_positions[0]  # Shape: [seq_len]
+            
+            # Count image positions
+            num_positions = mx.sum(image_mask).item()
+            num_features = image_features.shape[0]
+            
+            if num_positions != num_features:
+                raise ValueError(
+                    f"Number of image token positions ({num_positions}) does not match "
+                    f"number of image features ({num_features})"
+                )
+            
+            # Expand masks for broadcasting
+            image_mask_expanded = mx.expand_dims(image_mask, axis=-1)  # [seq_len, 1]
+            
+            # Create indices for gathering features
+            # We need to map each image position to its corresponding feature
+            cumsum = mx.cumsum(image_mask.astype(mx.int32))
+            feature_indices = mx.where(image_mask, cumsum - 1, 0)
+            
+            # Gather the appropriate features for each position
+            # For non-image positions, we'll gather feature 0 but mask it out
+            gathered_features = image_features[feature_indices]  # [seq_len, hidden_dim]
+            
+            # Combine original embeddings with image features using the mask
+            output_embeds = mx.where(
+                image_mask_expanded,
+                gathered_features,
+                inputs_embeds[0]
+            )
+            
+            # Add batch dimension back
+            output_embeds = mx.expand_dims(output_embeds, axis=0)
+            
+            return output_embeds
+        else:
+            # For batch size > 1, process each batch separately
+            batch_outputs = []
+            feature_start_idx = 0
+            
+            for batch_idx in range(batch_size):
+                # Get mask for this batch
+                image_mask = image_positions[batch_idx]
+                num_positions = mx.sum(image_mask).item()
+                
+                if num_positions > 0:
+                    # Extract features for this batch
+                    batch_features = image_features[feature_start_idx:feature_start_idx + num_positions]
+                    
+                    # Create indices for gathering
+                    cumsum = mx.cumsum(image_mask.astype(mx.int32))
+                    feature_indices = mx.where(image_mask, cumsum - 1, 0)
+                    
+                    # Gather features
+                    gathered_features = batch_features[feature_indices]
+                    
+                    # Combine with original embeddings
+                    image_mask_expanded = mx.expand_dims(image_mask, axis=-1)
+                    batch_output = mx.where(
+                        image_mask_expanded,
+                        gathered_features,
+                        inputs_embeds[batch_idx]
+                    )
+                    
+                    feature_start_idx += num_positions
+                else:
+                    # No image tokens in this batch item
+                    batch_output = inputs_embeds[batch_idx]
+                
+                batch_outputs.append(batch_output)
+            
+            # Stack all batch outputs
+            return mx.stack(batch_outputs, axis=0)
 
     def __call__(
         self,

--- a/mlx_vlm/models/qwen2_vl/qwen2_vl.py
+++ b/mlx_vlm/models/qwen2_vl/qwen2_vl.py
@@ -73,83 +73,53 @@ class Model(nn.Module):
         if mx.sum(image_positions) == 0:
             image_positions = input_ids == video_token_index
 
-        # Get all positions where we need to insert image features
+        # Get dimensions
         batch_size, seq_len = input_ids.shape
 
-        # For batch size 1 (common case), we can do direct assignment
-        if batch_size == 1:
-            # Create a mask for image positions
-            image_mask = image_positions[0]  # Shape: [seq_len]
+        # Process each batch item
+        batch_outputs = []
+        feature_start_idx = 0
 
-            # Count image positions
+        for batch_idx in range(batch_size):
+            # Get mask for this batch
+            image_mask = image_positions[batch_idx]
             num_positions = mx.sum(image_mask).item()
-            num_features = image_features.shape[0]
 
-            if num_positions != num_features:
-                raise ValueError(
-                    f"Number of image token positions ({num_positions}) does not match "
-                    f"number of image features ({num_features})"
-                )
+            if num_positions > 0:
+                # Extract features for this batch
+                batch_features = image_features[
+                    feature_start_idx : feature_start_idx + num_positions
+                ]
 
-            # Expand masks for broadcasting
-            image_mask_expanded = mx.expand_dims(image_mask, axis=-1)  # [seq_len, 1]
-
-            # Create indices for gathering features
-            # We need to map each image position to its corresponding feature
-            cumsum = mx.cumsum(image_mask.astype(mx.int32))
-            feature_indices = mx.where(image_mask, cumsum - 1, 0)
-
-            # Gather the appropriate features for each position
-            # For non-image positions, we'll gather feature 0 but mask it out
-            gathered_features = image_features[feature_indices]  # [seq_len, hidden_dim]
-
-            # Combine original embeddings with image features using the mask
-            output_embeds = mx.where(
-                image_mask_expanded, gathered_features, inputs_embeds[0]
-            )
-
-            # Add batch dimension back
-            output_embeds = mx.expand_dims(output_embeds, axis=0)
-
-            return output_embeds
-        else:
-            # For batch size > 1, process each batch separately
-            batch_outputs = []
-            feature_start_idx = 0
-
-            for batch_idx in range(batch_size):
-                # Get mask for this batch
-                image_mask = image_positions[batch_idx]
-                num_positions = mx.sum(image_mask).item()
-
-                if num_positions > 0:
-                    # Extract features for this batch
-                    batch_features = image_features[
-                        feature_start_idx : feature_start_idx + num_positions
-                    ]
-
-                    # Create indices for gathering
-                    cumsum = mx.cumsum(image_mask.astype(mx.int32))
-                    feature_indices = mx.where(image_mask, cumsum - 1, 0)
-
-                    # Gather features
-                    gathered_features = batch_features[feature_indices]
-
-                    # Combine with original embeddings
-                    image_mask_expanded = mx.expand_dims(image_mask, axis=-1)
-                    batch_output = mx.where(
-                        image_mask_expanded, gathered_features, inputs_embeds[batch_idx]
+                # Validate we have the right number of features
+                if batch_features.shape[0] != num_positions:
+                    raise ValueError(
+                        f"Number of image token positions ({num_positions}) does not match "
+                        f"number of image features ({batch_features.shape[0]}) for batch {batch_idx}"
                     )
 
-                    feature_start_idx += num_positions
-                else:
-                    # No image tokens in this batch item
-                    batch_output = inputs_embeds[batch_idx]
+                # Create indices for gathering
+                cumsum = mx.cumsum(image_mask.astype(mx.int32))
+                feature_indices = mx.where(image_mask, cumsum - 1, 0)
 
-                batch_outputs.append(batch_output)
+                # Gather features
+                gathered_features = batch_features[feature_indices]
 
-            # Stack all batch outputs
-            return mx.stack(batch_outputs, axis=0)
+                # Combine with original embeddings
+                image_mask_expanded = mx.expand_dims(image_mask, axis=-1)
+                batch_output = mx.where(
+                    image_mask_expanded, gathered_features, inputs_embeds[batch_idx]
+                )
+
+                feature_start_idx += num_positions
+            else:
+                # No image tokens in this batch item
+                batch_output = inputs_embeds[batch_idx]
+
+            batch_outputs.append(batch_output)
+
+        # Stack all batch outputs
+        return mx.stack(batch_outputs, axis=0)
 
     def __call__(
         self,


### PR DESCRIPTION
Hello @Blaizzy, I have figured out the issue with Qwen-VL models having a hard time understanding multiple images or images in multi-turn. It turns out that the way we replace the vision tokens with embeddings was not correct. The following implementation have fixed these issue. This also fixes for images being passed during multi-turn conversation.

This is the script used to test:
```python
from mlx_vlm import load, apply_chat_template, generate
from mlx_vlm.utils import load_image
from mlx_vlm.utils import process_image

# Load model and processor
qwen_vl_model, qwen_vl_processor = load("mlx-community/Qwen2.5-VL-7B-Instruct-4bit")
qwen_vl_config = qwen_vl_model.config

images = [
    "./mlx-vlm/examples/images/cats.jpg",
    "./mlx-vlm/examples/images/desktop_setup.png",
]

message = [
    {
        "role": "user",
        "content": [
            {"type": "image", "image": images[0]},
            {"type": "image", "image": images[1]},
            {"type": "text", "text": "Describe these images separately."},
        ],
    },
]

prompt = qwen_vl_processor.apply_chat_template(message, tokenize=False, add_generation_prompt=True)

qwen_vl_output = generate(
    qwen_vl_model,
    qwen_vl_processor,
    prompt,
    images,
    max_tokens=1000,
    temperature=0.2,
    verbose=True
)

print(qwen_vl_output)
```


The output before (model tries to blend concepts from multiple images):
```
==========
Files: ['./mlx-vlm/examples/images/cats.jpg', './mlx-vlm/examples/images/desktop_setup.png'] 

Prompt: <|im_start|>system
You are a helpful assistant.<|im_end|>
<|im_start|>user
<|vision_start|><|image_pad|><|vision_end|><|vision_start|><|image_pad|><|vision_end|>Describe these images separately.<|im_end|>
<|im_start|>assistant

The first image depicts a cozy home office setup with a pink blanket covering a desk and chair. Two cats are lounging on the blanket, one near the computer monitor and the other near a remote control. The desk has a keyboard, mouse, and a few other items. There is also a framed picture on the wall with the text "Don't Grow Up, It's a Trap." The overall scene is playful and relaxed.

The second image is a similar setup, but with a different arrangement of items. The desk is also covered with a pink blanket, and the cats are again lounging on it. The desk has a keyboard, mouse, and a few other items. The background includes a framed picture with the text "Don't Grow Up, It's a Trap" and a small plant on the desk. The overall scene is also playful and relaxed, with a focus on the cats enjoying the cozy environment.
==========
```

Now:
```
==========
Files: ['./mlx-vlm/examples/images/cats.jpg', './mlx-vlm/examples/images/desktop_setup.png'] 

Prompt: <|im_start|>system
You are a helpful assistant.<|im_end|>
<|im_start|>user
<|vision_start|><|image_pad|><|vision_end|><|vision_start|><|image_pad|><|vision_end|>Describe these images separately.<|im_end|>
<|im_start|>assistant

**Image 1:**
The image shows two cats lying on a bright pink couch. The cat on the left appears to be a tabby with a striped pattern, while the cat on the right has a tabby coat with a mix of brown and black stripes. Both cats are relaxed, with their eyes closed, suggesting they are sleeping or resting. Between them, there is a white remote control resting on the couch. The setting appears cozy and calm, with the vibrant pink couch adding a pop of color to the scene.

**Image 2:**
The second image depicts a minimalist home office or workspace. The desk is made of wood and has a clean, modern look. On the desk, there is a sleek black computer monitor, a white keyboard, and a black mouse. To the left of the monitor, there are two black speakers and a white mug. To the right of the desk, there is a framed piece of art with the text "DON'T GROW UP IT'S A TRAP" on a white background with black dots. The desk also has a small potted plant and a stack of books or magazines on the left side. The overall aesthetic of the room is simple, organized, and functional, with a focus on a clean and uncluttered design.
==========
```

Please let me know if there are any additional changes has to be made. Otherwise I am excited to see this PR get merged :)