### PR TITLE
[gemma3n] Correctly scale text embeddings for quantized gemma3n conversions

### DIFF
--- a/mlx_vlm/models/gemma3n/language.py
+++ b/mlx_vlm/models/gemma3n/language.py
@@ -728,7 +728,7 @@ class Gemma3Model(nn.Module):
         )
         tokens = mx.where(per_layer_inputs_mask, input_ids, mx.zeros_like(input_ids))
         result = self.embed_tokens_per_layer(tokens)
-        result = (result * mx.array(self._embed_tokens_scale, mx.float32)).astype(
+        result = (result * mx.array(self._embed_tokens_per_layer_scale, mx.float32)).astype(
             result.dtype
         )
         result = result.reshape(

--- a/mlx_vlm/models/gemma3n/language.py
+++ b/mlx_vlm/models/gemma3n/language.py
@@ -728,9 +728,9 @@ class Gemma3Model(nn.Module):
         )
         tokens = mx.where(per_layer_inputs_mask, input_ids, mx.zeros_like(input_ids))
         result = self.embed_tokens_per_layer(tokens)
-        result = (result * mx.array(self._embed_tokens_per_layer_scale, mx.float32)).astype(
-            result.dtype
-        )
+        result = (
+            result * mx.array(self._embed_tokens_per_layer_scale, mx.float32)
+        ).astype(result.dtype)
         result = result.reshape(
             *input_ids.shape,
             self.config.num_hidden_layers,


### PR DESCRIPTION
When quantizing the `Gemma3nTextScaledWordEmbedding` module, it follows this code path:
- https://github.com/ml-explore/mlx/blob/2c11d10/python/mlx/nn/layers/embedding.py#L42
- https://github.com/ml-explore/mlx/blob/2c11d10/python/mlx/nn/layers/quantized.py#L138

Which ends up overwriting the `Gemma3nTextScaledWordEmbedding` instance with `QuantizedEmbedding`. This means that `Gemma3nTextScaledWordEmbedding.__call__` never gets called when the model is quantized.

Fix this issue by moving the scaling outside of `Gemma3nTextScaledWordEmbedding` and deleting `Gemma3nTextScaledWordEmbedding`.

@awni : I would be curious to hear your thoughts on how to enable the use case of inheriting from `nn.Embeddings` while correctly quantizing the underlying weights in the base class.