### PR TITLE
fix: Remove unnecessary unicode_escape decoding for Chinese text input

### DIFF
--- a/mlx_vlm/server.py
+++ b/mlx_vlm/server.py
@@ -800,9 +800,11 @@ async def generate_endpoint(request: GenerationRequest):
         # Prepare the prompt using the chat template logic
         chat_messages = []
         if request.system:
-            system_prompt = codecs.decode(request.system, "unicode_escape")
+            # 直接使用原始 system prompt，避免对 UTF-8 中文文本进行不必要的 unicode_escape 解码
+            system_prompt = request.system
             chat_messages.append({"role": "system", "content": system_prompt})
-        prompt = codecs.decode(request.prompt, "unicode_escape")
+        # 直接使用原始 prompt，避免对 UTF-8 中文文本进行不必要的 unicode_escape 解码
+        prompt = request.prompt
         chat_messages.append({"role": "user", "content": prompt})
 
         formatted_prompt = apply_chat_template(


### PR DESCRIPTION
This commit fixes an issue where Chinese text input was being corrupted due to unnecessary unicode_escape decoding in both CLI and server components.

Problem:
- codecs.decode(text, 'unicode_escape') was applied to user prompts
- This caused UTF-8 encoded Chinese characters to be incorrectly decoded
- Example: '讲讲人类发展史' became 'è®²è®²äººç±»åå±å²' (garbled text)
- Models received corrupted input and responded with safety fallbacks

Changes:
1. mlx_vlm/generate.py:
   - Remove unicode_escape decoding from args.prompt (line 124)
   - Add safe unicode_escape decoding for eos_tokens with fallback
   - Preserve original text for proper UTF-8 handling

2. mlx_vlm/server.py:
   - Remove unicode_escape decoding from request.prompt and request.system
   - Ensure API endpoints handle Chinese text correctly

Impact:
- Fixes Chinese text processing in CLI tool (mlx-vlm-generate)
- Fixes Chinese text processing in HTTP API server
- Maintains backward compatibility for escape sequences in eos_tokens
- No impact on English or other language processing

Resolves issue where local MLX-VLM deployments would respond with 'I'm sorry, I can't understand what you're asking...' for Chinese input.