### PR TITLE
gemma3n: added lm_head weight check to sanitize

### DIFF
--- a/mlx_vlm/models/gemma3n/gemma3n.py
+++ b/mlx_vlm/models/gemma3n/gemma3n.py
@@ -293,11 +293,16 @@ class Model(nn.Module):
     def sanitize(self, weights):
         sanitized_weights = {}
         for k, v in weights.items():
-            # if "vision_tower" not in k and "embed_vision" not in k:
             if k.startswith("model."):
                 sanitized_weights[".".join(k.split(".")[1:])] = v
             else:
                 sanitized_weights[k] = v
+
+        # The language model has tied embeddings, so the lm_head is not needed.
+        # Pop the unused weight if it exists.
+        if "language_model.lm_head.weight" in sanitized_weights:
+            sanitized_weights.pop("language_model.lm_head.weight")
+
         return sanitized_weights
 
     @property


### PR DESCRIPTION
Fix: Prevent ValueError on gemma3n model loading due to using tied embeddings and not needing lm_head.

Confirmed this fixes the errors I experienced and same error mentioned here: [https://github.com/Blaizzy/mlx-vlm/pull/391#issuecomment-3036566329](url)

Issue encountered: Loading a gemma3n model fails with a ValueError because the weights file contains a language_model.lm_head.weight parameter that is not defined in the mlx-vlm model architecture

Why: gemma3nuses tied embeddings, which means the language model head shares weights with the token embedding layer and does not have its own separate lm_head layer

What/how: sanitizes the weights by removing the unused key before loading, resolving the error and allowing the gemma3n model to load and run successfully