### PR TITLE
[gemma3n] Fix OCR after weight re-upload

### DIFF
--- a/mlx_vlm/models/gemma3n/vision.py
+++ b/mlx_vlm/models/gemma3n/vision.py
@@ -969,7 +969,7 @@ class VisionTower(nn.Module):
         self, x: mx.array, output_hidden_states: Optional[bool] = None
     ) -> mx.array:
         feat_idx = 0
-        x = x.transpose(0, 3, 2, 1)  # Convert from NCHW to NHWC
+        x = x.transpose(0, 2, 3, 1)  # Convert from NCHW to NHWC
         x = self.conv_stem(x)
         intermediates = []
 


### PR DESCRIPTION
## Background

The gemma-3n weights were recently re-uploaded by google:

E2B:
https://huggingface.co/google/gemma-3n-E2B/commit/4b66db00439ae21a7beb34b699dd5caa9a8e7b12
E4B:
https://huggingface.co/google/gemma-3n-E4B/commit/ae61f7e4c3c6d13372a70f612d425a3edcaab743

The weights are backwards compatible so there are no issues loading the weights, but some of the vision encoder weights are transposed in the re-upload.

## Experiment

I converted the latest upload:
`python -m mlx_vlm.convert --hf-path google/gemma-3n-E2B-it --mlx-path neil/gemma-3n-E2B-it-4bit -q --q-bits 4`

Here are the inferencing results with the latest conversion:
Command:
`python -m mlx_vlm.generate --model ./neil/gemma-3n-E2B-it-4bit --temp 0.0 --image ~/Downloads/receipt.webp --prompt 'describe this'`
Image: https://nwlc.org/wp-content/uploads/2022/01/Brandys-walmart-receipt-8.webp
Before this change:
```
Here's a breakdown of the information on the receipt:

**General Information:**

* **Store:** WISMIRL (likely a typo, possibly "WISMIRL" or a similar name)
* **Date:** 08/25/2023
* **Time:** 11:36:18
* **Total:** $0.00

**Order Details:**

* **Item 1:** 32.36
* **Item 2:** 35.35
* **Item 3:** 35.35
* **Item 4:** 35.35
* **Item 5:** 35.35
* **Item 6:** 35.35
* **Item 7:** 35.35
* **Item 8:** 35.35
* **Item 9:** 35.35
* **Item 10:** 35.35

**Payment Information:**

* **Payment Method:** Not specified (likely cash or card)
* **Card Number:** 00000000000
```

After this change: 
```
Here's a breakdown of the Walmart receipt:

**Store Information:**

* **Store:** Walmart
* **Address:** 5940 Losee Rd, North Las Vegas, NV 89081
* **Phone Number:** 702-639-1202
* **Website:** www.walmart.com

**Transaction Information:**

* **Date:** 08/12/21
* **Time:** 11:36:18
* **Total Items:** 5
* **Total Amount:** $35.36

**Payment Information:**

* **Payment Method:** US Debit
* **Card Number:** 122404037175
* **Approval ID:** A97E6F4D6D3076AE
* **Terminal #:** SC120127E

**Item Details:**

* **Item 1:** VINYL GLOVES 0193900848 - $11.72
* **Item 2:** AJAX DISHLIM 00350049863 - $
```

## Fix explanation

Put the pixel_value data back in the regular `NHWC` format, now that the weights have been fixed. This will break the OCR capability of previous uploads, so the gemma-3n models on mlx-community should be re-uploaded 