### PR TITLE
Fix broken wheel builds caused by ambiguous package spec

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,8 +33,9 @@ Issues = "https://github.com/Blaizzy/mlx-vlm/issues"
 "mlx_vlm.convert" = "mlx_vlm.convert:main"
 "mlx_vlm.generate" = "mlx_vlm.generate:main"
 
-[tool.setuptools]
-packages = ["mlx_vlm"]
+[tool.setuptools.packages.find]
+include = ["mlx_vlm*"]
+exclude = ["mlx_vlm.tests*"]
 
 [tool.setuptools.dynamic]
 version = {attr = "mlx_vlm.version.__version__"}


### PR DESCRIPTION
Current main does not consistently build the mlx-vlm wheel correctly with a variety of builders. `uv build --wheel` works occasionally but `pip wheel` is certainly broken.

Bug repro from current main (5a0fcefd):
```bash
$ git reset --hard @
$ git clean -fdx .

$ python -Im pip wheel --no-deps --only-binary=:all: .
$ wheel unpack mlx_vlm-0.3.1-py3-none-any.whl
$ ls mlx_vlm-0.3.1/mlx_vlm
__init__.py               convert.py                prompt_utils.py           tokenizer_utils.py
__main__.py               deprecation.py            sample_utils.py           utils.py
chat.py                   generate.py               server.py                 version.py
chat_ui.py                lora.py                   smolvlm_video_generate.py video_generate.py

```

see that the `models` dir isn't included in the build. 

Here is some warning text output from setuptools saying that the build is ambiguous:
```bash
    This leads to an ambiguous overall configuration. If you want to distribute this
    package, please make sure that 'mlx_vlm.models' is explicitly added
    to the `packages` configuration field
```
<details>

<summary>Click here to see full warning</summary>

```bash
!!

        ********************************************************************************
        ############################
        # Package would be ignored #
        ############################
        Python recognizes 'mlx_vlm.models' as an importable package[^1],
        but it is absent from setuptools' `packages` configuration.

        This leads to an ambiguous overall configuration. If you want to distribute this
        package, please make sure that 'mlx_vlm.models' is explicitly added
        to the `packages` configuration field.

        Alternatively, you can also rely on setuptools' discovery methods
        (for example by using `find_namespace_packages(...)`/`find_namespace:`
        instead of `find_packages(...)`/`find:`).

        You can read more about "package discovery" on setuptools documentation page:

        - https://setuptools.pypa.io/en/latest/userguide/package_discovery.html

        If you don't want 'mlx_vlm.models' to be distributed and are
        already explicitly excluding 'mlx_vlm.models' via
        `find_namespace_packages(...)/find_namespace` or `find_packages(...)/find`,
        you can try to use `exclude_package_data`, or `include-package-data=False` in
        combination with a more fine grained `package-data` configuration.

        You can read more about "package data files" on setuptools documentation page:

        - https://setuptools.pypa.io/en/latest/userguide/datafiles.html


        [^1]: For Python, any directory (with suitable naming) can be imported,
              even if it does not contain any `.py` files.
              On the other hand, currently there is no concept of package data
              directory, all directories are treated like packages.
        ********************************************************************************

!!
```

</details>

After this fix:
```bash
$ ls mlx_vlm-0.3.1/mlx_vlm
__init__.py               convert.py                models                    smolvlm_video_generate.py version.py
__main__.py               deprecation.py            prompt_utils.py           tokenizer_utils.py        video_generate.py
chat.py                   generate.py               sample_utils.py           trainer
chat_ui.py                lora.py                   server.py                 utils.py
```

The fix was chosen based on the documentation in the [setuptools docs](https://setuptools.pypa.io/en/latest/userguide/pyproject_config.html#setuptools-specific-configuration).