### PR TITLE
Make UI and audio dependencies optional

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,3 +40,7 @@ exclude = ["mlx_vlm.tests*"]
 [tool.setuptools.dynamic]
 version = {attr = "mlx_vlm.version.__version__"}
 dependencies = {file = ["requirements.txt"]}
+
+[project.optional-dependencies]
+ui = ["gradio>=5.19.0"]
+audio = ["mlx-audio"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,6 @@ mlx>=0.26.0
 datasets>=2.19.1
 tqdm>=4.66.2
 transformers>=4.53.0
-gradio>=5.19.0
 Pillow>=10.3.0
 requests>=2.31.0
 opencv-python==4.10.0.84
@@ -11,4 +10,3 @@ fastapi>=0.95.1
 soundfile>=0.13.1
 scipy>=1.15.3
 numpy
-mlx-audio


### PR DESCRIPTION
This PR makes UI (gradio) and audio (mlx-audio) dependencies optional to reduce the installation footprint for users who don't need these features.

### Changes
- ✅ Removed `gradio>=5.19.0` from `requirements.txt`
- ✅ Removed `mlx-audio` from `requirements.txt`
- ✅ Added optional dependencies in `pyproject.toml`:
  - `ui = ["gradio>=5.19.0"]`
  - `audio = ["mlx-audio"]`

### Installation Options
After this change, users can install mlx-vlm with different dependency sets:

- **Base installation**: `pip install mlx-vlm`
- **With UI support**: `pip install mlx-vlm[ui]`
- **With audio support**: `pip install mlx-vlm[audio]`
- **With both**: `pip install mlx-vlm[ui,audio]`

### Benefits
- Reduces installation size for users who don't need UI or audio features
- Provides flexibility in choosing required dependencies
- Follows Python packaging best practices for optional dependencies
- Maintains backward compatibility for existing functionality