### PR TITLE
[llava_next] Fix config inheritance

### DIFF
--- a/mlx_vlm/models/llava_next/config.py
+++ b/mlx_vlm/models/llava_next/config.py
@@ -6,7 +6,7 @@ from ..base import BaseModelConfig
 
 
 @dataclass
-class TextConfig:
+class TextConfig(BaseModelConfig):
     model_type: str
     hidden_size: int = 4096
     num_hidden_layers: int = 32
@@ -34,7 +34,7 @@ class TextConfig:
 
 
 @dataclass
-class VisionConfig:
+class VisionConfig(BaseModelConfig):
     model_type: str
     num_hidden_layers: int = 24
     hidden_size: int = 1024


### PR DESCRIPTION
Fix bug which causes this issue when loading llava_next models:
```
        for config_name in modules:
            config_attr = f"{config_name}_config"
            if hasattr(model_config, config_attr):
                config_class = getattr(model_class, f"{config_name.title()}Config")
                setattr(
>                   model_config, config_attr, config_class.from_dict(config[config_attr])
                                               ^^^^^^^^^^^^^^^^^^^^^^
                )
E               AttributeError: type object 'TextConfig' has no attribute 'from_dict'
```

This bug is introduced from #437

The fix in this PR matches aligns the pattern of llava_next with all of the other config classes:
<img width="413" height="759" alt="Screenshot 2025-07-31 at 4 45 55 PM" src="https://github.com/user-attachments/assets/41d2c62c-186b-458c-8b06-0d4b8c0c2198" />
