### PR TITLE
External access to LFM2-VL merge-input-IDs method

### DIFF
--- a/mlx_vlm/models/lfm2_vl/lfm2_vl.py
+++ b/mlx_vlm/models/lfm2_vl/lfm2_vl.py
@@ -134,6 +134,7 @@ class Model(nn.Module):
         spatial_shapes: Optional[mx.array] = None,
         pixel_attention_mask: Optional[mx.array] = None,
     ):
+
         inputs_embeds = self.language_model.model.embed_tokens(input_ids)
 
         if pixel_values is None:


### PR DESCRIPTION
For https://github.com/lmstudio-ai/mlx-engine/pull/209 and other integrations of LFM2-VL, we'd like `merge_input_ids_with_image_features` to be a public static method. Additionally: does not change behavior within mlx-vlm, and improves readability as to the true inputs to the function