### PR TITLE
Add n_kv_heads property used in LM Studio to glm4v_moe.LanguageModel

### DIFF
--- a/mlx_vlm/models/glm4v_moe/language.py
+++ b/mlx_vlm/models/glm4v_moe/language.py
@@ -653,3 +653,7 @@ class LanguageModel(nn.Module):
             return "e_score_correction_bias" not in k
 
         return predicate
+
+    @property
+    def n_kv_heads(self):
+        return self.args.num_key_value_heads


### PR DESCRIPTION
Fix https://github.com/lmstudio-ai/lmstudio-bug-tracker/issues/912

```python
Error in iterating prediction stream: AttributeError: 'LanguageModel' object has no attribute 'n_kv_heads'
```