### PR TITLE
Fix qwen3_vl

### DIFF
--- a/mlx_vlm/models/qwen3_vl/vision.py
+++ b/mlx_vlm/models/qwen3_vl/vision.py
@@ -168,7 +168,7 @@ class MLP(nn.Module):
         super().__init__()
         self.linear_fc1 = nn.Linear(dim, hidden_dim, bias=True)
         self.linear_fc2 = nn.Linear(hidden_dim, dim, bias=True)
-        self.act_fn = nn.GELU()
+        self.act_fn = nn.GELU(approx="tanh")
 
     def __call__(self, x: mx.array) -> mx.array:
         return self.linear_fc2(self.act_fn(self.linear_fc1(x)))

--- a/mlx_vlm/models/qwen3_vl_moe/language.py
+++ b/mlx_vlm/models/qwen3_vl_moe/language.py
@@ -26,7 +26,6 @@ class Qwen3VLMoERotaryEmbedding:
             self.base ** (mx.arange(0, self.dim, 2).astype(mx.float32) / self.dim)
         )
         self.inv_freq = inv_freq
-        self.attention_scaling = 1.0  # type: default
 
         self.mrope_section = rope_scaling.get("mrope_section", [24, 20, 20])
 
@@ -69,8 +68,8 @@ class Qwen3VLMoERotaryEmbedding:
         freqs = mx.swapaxes(freqs, 2, 3)
         freqs = self.apply_interleaved_mrope(freqs, self.mrope_section)
         emb = mx.concatenate([freqs, freqs], axis=-1)
-        cos = mx.cos(emb) * self.attention_scaling
-        sin = mx.sin(emb) * self.attention_scaling
+        cos = mx.cos(emb)
+        sin = mx.sin(emb)
 
         return cos.astype(x.dtype), sin.astype(x.dtype)
 

--- a/mlx_vlm/models/qwen3_vl_moe/vision.py
+++ b/mlx_vlm/models/qwen3_vl_moe/vision.py
@@ -111,7 +111,7 @@ class PatchMerger(nn.Module):
             self.hidden_size if use_postshuffle_norm else config.hidden_size, eps=1e-6
         )
         self.linear_fc1 = nn.Linear(self.hidden_size, self.hidden_size)
-        self.act_fn = nn.GELU()
+        self.act_fn = nn.GELU(approx="tanh")
         self.linear_fc2 = nn.Linear(self.hidden_size, config.out_hidden_size)
 
     def __call__(self, x: mx.array) -> mx.array:


### PR DESCRIPTION
Closes #597. The diffs pre / post fix for the below test:

Pre: `array(0.0621961, dtype=float32)`
Post: `array(0.000521279, dtype=float32)`

```python
import torch
model = Qwen3VLForConditionalGeneration.from_pretrained("Qwen/Qwen3-VL-2B-Instruct", dtype=torch.float32)

model_path = "Qwen/Qwen3-VL-2B-Instruct"
processor = AutoProcessor.from_pretrained(model_path)

messages = [
    {
        "role": "user",
        "content": [
            {
                "type": "image",
                "image": "download.jpg",
            },
            {"type": "text", "text": "Describe this image."},
        ],
    }
]

inputs = processor.apply_chat_template(
    messages,
    tokenize=True,
    add_generation_prompt=True,
    return_dict=True,
    return_tensors="pt"
)

pt_logits = model(**inputs).logits.detach().numpy()

import mlx.core as mx
from mlx_vlm import load, generate
from mlx_vlm.prompt_utils import apply_chat_template
from mlx_vlm.prompt_utils import apply_chat_template
from mlx_vlm.utils import load_config

model, processor = load(model_path)
model.set_dtype(mx.float32)
config = load_config(model_path)
mx_logits = model(
    mx.array(inputs["input_ids"].numpy()),
    mx.array(inputs["pixel_values"].numpy()),
    image_grid_thw=mx.array(inputs["image_grid_thw"].numpy())
).logits

print((mx_logits - pt_logits).abs().max() / mx_logits.abs().max())
```