### PR TITLE
Add support for TokenizersBackend

### DIFF
--- a/mlx_vlm/tokenizer_utils.py
+++ b/mlx_vlm/tokenizer_utils.py
@@ -314,6 +314,27 @@ def _is_bpe_decoder(decoder):
     return _match(_target_description, decoder)
 
 
+def _has_bytelevel_pretokenizer(pre_tokenizer):
+    """Check if the pre-tokenizer uses ByteLevel encoding.
+
+    This is important because of the TokenizersBackend in HuggingFace v5 or higher,
+    """
+    if not isinstance(pre_tokenizer, dict):
+        return False
+
+    # Direct ByteLevel pre-tokenizer
+    if pre_tokenizer.get("type") == "ByteLevel":
+        return True
+
+    # Sequence of pre-tokenizers - check if any is ByteLevel
+    if pre_tokenizer.get("type") == "Sequence":
+        for pt in pre_tokenizer.get("pretokenizers", []):
+            if isinstance(pt, dict) and pt.get("type") == "ByteLevel":
+                return True
+
+    return False
+
+
 def load_tokenizer(model_path, return_tokenizer=True, tokenizer_config_extra={}):
     """Load a huggingface tokenizer and try to infer the type of streaming
     detokenizer to use.
@@ -330,7 +351,11 @@ def load_tokenizer(model_path, return_tokenizer=True, tokenizer_config_extra={})
                 tokenizer_content = json.load(f)
             except JSONDecodeError as e:
                 raise JSONDecodeError("Failed to parse tokenizer.json", e.doc, e.pos)
-        if "decoder" in tokenizer_content:
+
+        pre_tokenizer = tokenizer_content.get("pre_tokenizer")
+        if _has_bytelevel_pretokenizer(pre_tokenizer):
+            detokenizer_class = BPEStreamingDetokenizer
+        elif "decoder" in tokenizer_content:
             if _is_spm_decoder(tokenizer_content["decoder"]):
                 detokenizer_class = SPMStreamingDetokenizer
             elif _is_spm_decoder_no_space(tokenizer_content["decoder"]):


### PR DESCRIPTION
This patch is to support the new TokenizersBackend, which doesn’t need a properly configured json and it's affecting Ministral3 and Devstral.

I haven’t tested all models so there is a risk my patch might break another model. Please let me know if notice any issues.

Before:
```basg
mlx_vlm.generate --model mlx-community/Ministral-3-3B-Instruct-2512-4bit --prompt "Convert the document to markdown." --image "/Users/prince_canuma/Downloads/chart.png" --temperature 0.7 
==========
Here'sĠtheĠdocumentĠconvertedĠintoĠaĠmarkdown-likeĠrepresentationĠwithĠtheĠstructureĠpreserved.ĠSinceĠthisĠisĠaĠscreenshotĠofĠaĠfinancialĠchartĠandĠarticleĠsnippet,ĠitĠwon'tĠbeĠaĠdirectĠtranslationĠbutĠformattedĠtoĠrepresentĠitĠclearly:ĊĊ```markdownĊ#ĠAlphaĠAmex:ĠAĠBetterĠBenchmarkĊĊ---ĊĊ###Ġ**LiveĠStockĠMarketĠChart**Ċ![AlphaĠAmexĠChart](image_of_alpha_amex_chart)Ċ*(Note:ĠPlaceholderĠforĠtheĠactualĠimageĠrepresentationĠofĠstockĠprices)*ĊĊ---ĊĊ###Ġ**ImageĠandĠHeading:**Ċ---Ċ**AlphaĠAMEX**ĠâĢĵĠ*TheĠFirstĠBenchmarkĠBuiltĠonĠtheĠStockĠExchange*Ċ*EachĠmonth,ĠinvestorsĠareĠgivenĠE10,000Ġ(aboutĠ$13,800)ĠforĠfree,ĠenablingĠreal-timeĠintelligenceĠonĠstockĠpricesĠandĠpriceĠdata.*ĊĊ---ĊĊ###Ġ**Description:**ĊOurĠgoalĠwithĠAlphaĠAmexĠisĠtoĠmakeĠbenchmarksĠmoreĠdynamic,Ġtransparent,ĠandĠeasierĠtoĠunderstand.ĠWeĠaimĠtoĠprovideĠreal-timeĠdataĠandĠinsights,ĠhelpingĠinvestorsĠmakeĠinformedĠdecisions.Ċ**Remarks:**Ċ>ĠToĠdoĠaĠbetterĠjobĠwithĠfinance,ĠweĠneedĠtoĠenableĠbetterĠfinancialĠliteracyĠamongĠinvestors,ĠandĠthatâĢĻsĠwhatĠAlphaĠAmexĠcouldĠhelpĠusĠachieve.ĊĊ---ĊĊ###Ġ**TheĠContents:**Ċ-Ġ*ClaudeĠA.ĠE.ĠSorrento*Ċ
==========
Prompt: 2590 tokens, 525.766 tokens-per-sec
Generation: 256 tokens, 95.711 tokens-per-sec
Peak memory: 7.302 GB
```

After:

```
mlx_vlm.generate --model mlx-community/Ministral-3-3B-Instruct-2512-4bit --prompt "Convert the document to markdown." --image "/Users/prince_canuma/Downloads/chart.png" --temperature 0.7 --resize-shape 500
==========
Here's the document converted into Markdown format based on the visible elements from the image:

```markdown
# Alpha Arena

**Live | Leaderboard | Blog | Models**

**Join the Platform Waitlist** | **About NOF1**

---

### Current Prices and Market Stats
| Cryptocurrency | Price  |
|----------------|--------|
| BTC (₿ BTC)    | $113,856.50       |
| ETH (🔹 ETH)    | $4,084.05          |
| SOL (▲ SOL)     | $199.00            |
| BNB (🟡 BNB)     | $1,127.25          |
| DOGE (🐶 DOGE)   | $0.1986            |
| XRP (❌ XRP)     | $2.62             |

**Highest**: DeepSeek Chat V3.1 @ $21,108.69 (+111.09%)
**Lowest**: GPT 5 @ $3,521.39 (-64.7
==========
Prompt: 2590 tokens, 525.766 tokens-per-sec
Generation: 256 tokens, 95.711 tokens-per-sec
Peak memory: 7.302 GB
```