### PR TITLE
Fix qwen3_vl_moe kwargs forwarding

### DIFF
--- a/mlx_vlm/models/qwen3_vl_moe/qwen3_vl_moe.py
+++ b/mlx_vlm/models/qwen3_vl_moe/qwen3_vl_moe.py
@@ -124,7 +124,7 @@ class Model(nn.Module):
         cache=None,
         **kwargs,
     ):
-        inputs_embeds = self.get_input_embeddings(input_ids, pixel_values, kwargs)
+        inputs_embeds = self.get_input_embeddings(input_ids, pixel_values, **kwargs)
 
         kwargs = {
             "pixel_values": pixel_values,


### PR DESCRIPTION
Fix kwargs forwarding in qwen3_vl_moe get_input_embeddings call after `qwen3_vl_moe` changes in https://github.com/Blaizzy/mlx-vlm/commit/d7d73de14d600c5fcb12d37e46ecbdcd458c3c6b

Before:
```
python -m mlx_vlm.generate --model /Users/matt/.cache/lm-studio/models/lmstudio-community/Qwen3-VL-30B-A3B-Instruct-MLX-4bit --max-tokens 100 --temperature 0.0 --image /Users/matt/Workspace/llmster/electron/vendor/amphibian-apps/apps/mlx-engine/demo-data/toucan.jpeg
<frozen runpy>:128: RuntimeWarning: 'mlx_vlm.generate' found in sys.modules after import of package 'mlx_vlm', but prior to execution of 'mlx_vlm.generate'; this may result in unpredictable behaviour
Calling `python -m mlx_vlm.generate ...` directly is deprecated. Use `mlx_vlm generate` or `python -m mlx_vlm generate` instead.
==========
Files: ['/Users/matt/Workspace/llmster/electron/vendor/amphibian-apps/apps/mlx-engine/demo-data/toucan.jpeg'] 

Prompt: <|im_start|>user
<|vision_start|><|image_pad|><|vision_end|>What are these?<|im_end|>
<|im_start|>assistant

Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/Users/matt/Workspace/mlx-vlm/mlx_vlm/generate.py", line 1304, in <module>
    main()
  File "/Users/matt/Workspace/mlx-vlm/mlx_vlm/generate.py", line 1279, in main
    result = generate(
             ^^^^^^^^^
  File "/Users/matt/Workspace/mlx-vlm/mlx_vlm/generate.py", line 547, in generate
    for response in stream_generate(model, processor, prompt, image, audio, **kwargs):
  File "/Users/matt/Workspace/mlx-vlm/mlx_vlm/generate.py", line 437, in stream_generate
    for n, (token, logprobs) in enumerate(
  File "/Users/matt/Workspace/mlx-vlm/mlx_vlm/generate.py", line 327, in generate_step
    outputs = model(input_ids, pixel_values, cache=prompt_cache, mask=mask, **kwargs)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/matt/Workspace/mlx-vlm/mlx_vlm/models/qwen3_vl_moe/qwen3_vl_moe.py", line 127, in __call__
    inputs_embeds = self.get_input_embeddings(input_ids, pixel_values, kwargs)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: Model.get_input_embeddings() takes from 1 to 3 positional arguments but 4 were given
```

After:
```
python -m mlx_vlm.generate --model /Users/matt/.cache/lm-studio/models/lmstudio-community/Qwen3-VL-30B-A3B-Instruct-MLX-4bit --max-tokens 100 --temperature 0.0 --image /Users/matt/Workspace/llmster/electron/vendor/amphibian-apps/apps/mlx-engine/demo-data/toucan.jpeg
<frozen runpy>:128: RuntimeWarning: 'mlx_vlm.generate' found in sys.modules after import of package 'mlx_vlm', but prior to execution of 'mlx_vlm.generate'; this may result in unpredictable behaviour
Calling `python -m mlx_vlm.generate ...` directly is deprecated. Use `mlx_vlm generate` or `python -m mlx_vlm generate` instead.
==========
Files: ['/Users/matt/Workspace/llmster/electron/vendor/amphibian-apps/apps/mlx-engine/demo-data/toucan.jpeg'] 

Prompt: <|im_start|>user
<|vision_start|><|image_pad|><|vision_end|>What are these?<|im_end|>
<|im_start|>assistant

These are toucans. They are a type of bird known for their large, colorful bills. The image shows a toucan perched on a branch, showcasing its vibrant plumage and distinctive beak.
==========
Prompt: 80 tokens, 22.959 tokens-per-sec
Generation: 43 tokens, 54.053 tokens-per-sec
Peak memory: 18.557 GB
```