### PR TITLE
Fix: Skip index.json in file copy to prevent overwrite

### DIFF
--- a/mlx_vlm/convert.py
+++ b/mlx_vlm/convert.py
@@ -172,6 +172,9 @@ def convert(
     for pattern in ["*.py", "*.json"]:
         files = glob.glob(str(model_path / pattern))
         for file in files:
+            # Skip the index file - save_weights() already generated the correct one
+            if Path(file).name == "model.safetensors.index.json":
+                continue
             shutil.copy(file, mlx_path)
 
     processor.save_pretrained(mlx_path)


### PR DESCRIPTION
## Summary

Fixes #624 - The `model.safetensors.index.json` file generated by `save_weights()` was being overwritten by the subsequent `*.json` glob copy, causing converted models to have an incorrect index that references the source model's shard count instead of the converted model's.

## Changes

Skip `model.safetensors.index.json` in the file copy loop (lines 172-178). The correct index is already generated by `save_weights()`.

## Impact

- **Affected versions:** mlx-vlm >= 0.1.1 (regression from PR #249, commit 182df25)
- **Symptoms:** Validation tools flag models as "unhealthy" due to index/shard mismatch
- **Runtime:** Models still work (mlx-lm ignores index, scans by pattern)

## Testing

Verified with local conversion:

```
python -m mlx_vlm.convert --hf-path mistralai/Mistral-Small-3.1-24B-Instruct-2503 \
    --mlx-path ~/test-mistral-4bit -q --q-bits 4
```

Before fix: Index referenced 10 files, actual model had 3 files
After fix: Index correctly references 3 files
