### PR TITLE
Fix pixtral text-only regression from batch generation PR

### DIFF
--- a/mlx_vlm/utils.py
+++ b/mlx_vlm/utils.py
@@ -819,6 +819,9 @@ def prepare_inputs(
         tokenizer = (
             processor.tokenizer if hasattr(processor, "tokenizer") else processor
         )
+        # Ensure pad_token exists when padding text-only inputs
+        if padding and tokenizer.pad_token is None:
+            tokenizer.pad_token = tokenizer.eos_token
         inputs = tokenizer(
             prompts,
             add_special_tokens=add_special_tokens,


### PR DESCRIPTION
## Summary

Fixes `mlx-community/pixtral-12b-8bit` text-only requests that broke after PR #538 (Batch Generation).

## Problem

After commit d7d73de, pixtral models fail on text-only requests with:
```
RuntimeError: The key pad_token does not exist in the config
```

**Root cause:** `prepare_inputs()` in `mlx_vlm/utils.py:809` enables padding for batch generation without checking if `pad_token` exists in the tokenizer config.

## Solution

3-line fix in `mlx_vlm/utils.py`:
- Check if `pad_token` exists in config before using it
- Fall back to `eos_token` if missing (standard tokenizer behavior)
- Preserves batch generation functionality while supporting models without explicit pad tokens

## Testing

✅ Isolated reproduction case (minimal `mlx-community/pixtral-12b-8bit` text-only request)
✅ Integration testing with mlx-knife 2.0.4-beta.3:
   - 487 unit tests passing
   - 144/144 E2E tests passing (26 models including `mlx-community/pixtral-12b-8bit`)

## References

Fixes #643