### PR TITLE
Fix: fixes mlx-vlm.generate --chat when prompted with no imgages

### DIFF
--- a/mlx_vlm/generate.py
+++ b/mlx_vlm/generate.py
@@ -1254,9 +1254,7 @@ def main():
             chat.append({"role": "system", "content": args.system})
         while user := input("User:"):
             chat.append({"role": "user", "content": user})
-            prompt = apply_chat_template(
-                processor, config, chat, num_images=len(args.image)
-            )
+            prompt = apply_chat_template(processor, config, chat, num_images=num_images)
             response = ""
             print("Assistant:", end="")
             for chunk in stream_generate(


### PR DESCRIPTION
Chat errors out with "TypeError: object of type 'NoneType' has no len()", this fixes the error.