### PR TITLE
Enhance load_config to include generation_config.json and extract eos…

### DIFF
--- a/mlx_vlm/utils.py
+++ b/mlx_vlm/utils.py
@@ -349,7 +349,7 @@ def load_config(model_path: Union[str, Path], **kwargs) -> dict:
     try:
         with open(model_path / "config.json", encoding="utf-8") as f:
             config = json.load(f)
-        
+
         generation_config_file = model_path / "generation_config.json"
         if generation_config_file.exists():
             generation_config = {}
@@ -363,7 +363,7 @@ def load_config(model_path: Union[str, Path], **kwargs) -> dict:
                 config["eos_token_id"] = eos_token_id
 
         return config
-        
+
     except FileNotFoundError as exc:
         raise FileNotFoundError(f"Config not found at {model_path}") from exc
 


### PR DESCRIPTION
## Prioritize `eos_token_id` from `generation_config.json` in `load_config`

### Summary
Updated `load_config` to prioritize `eos_token_id` from `generation_config.json` when available, allowing generation-specific configuration to override the base config.

### Changes
- Modified `load_config` in `mlx_vlm/utils.py` to check for `generation_config.json` after loading `config.json`
- If `generation_config.json` exists and contains `eos_token_id`, it now overrides the value from `config.json`
- Maintains backward compatibility: if `generation_config.json` doesn't exist, behavior is unchanged