### PR TITLE
Pass kwargs through to snapshot_download in get_model_path

### DIFF
--- a/mlx_vlm/utils.py
+++ b/mlx_vlm/utils.py
@@ -83,7 +83,7 @@ def get_model_and_args(config: dict):
 
 
 def get_model_path(
-    path_or_hf_repo: str, revision: Optional[str] = None, force_download: bool = False
+    path_or_hf_repo: str, revision: Optional[str] = None, **kwargs
 ) -> Path:
     """
     Ensures the model is available locally. If the path does not exist locally,
@@ -111,7 +111,7 @@ def get_model_path(
                     "*.txt",
                     "*.jinja",
                 ],
-                force_download=force_download,
+                **kwargs,
             )
         )
     return model_path
@@ -309,10 +309,7 @@ def load(
         FileNotFoundError: If config file or safetensors are not found.
         ValueError: If model class or args class are not found.
     """
-    force_download = kwargs.get("force_download", False)
-    model_path = get_model_path(
-        path_or_hf_repo, force_download=force_download, revision=revision
-    )
+    model_path = get_model_path(path_or_hf_repo, revision=revision, **kwargs)
     model = load_model(model_path, lazy, **kwargs)
     if adapter_path is not None:
         model = apply_lora_layers(model, adapter_path)
@@ -345,7 +342,7 @@ def load_config(model_path: Union[str, Path], **kwargs) -> dict:
         FileNotFoundError: If config.json is not found at the path
     """
     if isinstance(model_path, str):
-        model_path = get_model_path(model_path)
+        model_path = get_model_path(model_path, **kwargs)
 
     try:
         with open(model_path / "config.json", encoding="utf-8") as f:
@@ -371,7 +368,7 @@ def load_config(model_path: Union[str, Path], **kwargs) -> dict:
 
 def load_image_processor(model_path: Union[str, Path], **kwargs) -> BaseImageProcessor:
     if isinstance(model_path, str):
-        model_path = get_model_path(model_path)
+        model_path = get_model_path(model_path, **kwargs)
 
     if not kwargs:
         config = load_config(model_path, trust_remote_code=True)


### PR DESCRIPTION
Allow passing additional arguments like local_files_only, cache_dir, token, etc. to snapshot_download via kwargs. This enables users to control download behavior when using load() and related functions.