### PR TITLE
Use mx.fast.scaled_dot_product_attention in pixtral vision

### DIFF
--- a/mlx_vlm/models/pixtral/vision.py
+++ b/mlx_vlm/models/pixtral/vision.py
@@ -120,13 +120,11 @@ class Attention(nn.Module):
         cos, sin = position_embeddings
         queries, keys = apply_rotary_pos_emb(queries, keys, cos, sin, unsqueeze_dim=0)
 
-        attn_weights = mx.matmul(queries, keys.transpose(0, 1, 3, 2)) * self.scale
-
-        if mask is not None:
-            attn_weights = attn_weights + mask
-
-        attn_weights = mx.softmax(attn_weights, axis=-1)
-        output = mx.matmul(attn_weights, values)
+        output = mx.fast.scaled_dot_product_attention(
+            queries, keys, values,
+            scale=self.scale,
+            mask=mask
+        )
 
         output = output.transpose(0, 2, 1, 3).reshape(B, L, -1)
 


### PR DESCRIPTION
**Vision encoder benchmark on 768x1024 image (3072 patches)**
Original: 735ms
Scaled DP Attention: 607ms
~17% speed up for vision encoding

Just forwarding a change I made locally when I discovered I could use mlx-vlm to do OCR extraction with https://huggingface.co/lightonai/LightOnOCR-2-1B which I have been a big fan of. Noticed that the pixtral vision encoder inside was not updated to the way many of the other vision encoders use fast attention is all. Extraction is also as easy as doing something like this instead:

```python
from mlx_vlm import load, generate
from mlx_vlm.prompt_utils import apply_chat_template

model, processor = load("lightonai/LightOnOCR-2-1B", fix_mistral_regex=True)

url = "https://huggingface.co/datasets/hf-internal-testing/fixtures_ocr/resolve/main/SROIE-receipt.jpeg"

prompt = apply_chat_template(processor, config=model.config, prompt="", num_images=1)

output = generate(model, processor, prompt, image=[url], max_tokens=1024, verbose=False)

print(output.text)
```

Got down to ~25 minutes to run a large PDF conversion from the ~2 hours it was taking with the PyTorch MPS backend version listed on their model card.