### PR TITLE
Make sure weights are released during conversion

### DIFF
--- a/mlx_vlm/utils.py
+++ b/mlx_vlm/utils.py
@@ -14,7 +14,7 @@ import numpy as np
 import requests
 import soundfile as sf
 from huggingface_hub import snapshot_download
-from mlx.utils import tree_flatten
+from mlx.utils import tree_flatten, tree_map
 from PIL import Image, ImageOps
 from transformers import AutoProcessor, PreTrainedTokenizer, PreTrainedTokenizerFast
 
@@ -543,7 +543,6 @@ def save_weights(
         save_path = Path(save_path)
 
     weights = dict(tree_flatten(model.parameters()))
-    del model
 
     save_path.mkdir(parents=True, exist_ok=True)
 
@@ -561,8 +560,10 @@ def save_weights(
     # Write the weights and make sure no references are kept other than the
     # necessary ones
     if donate_weights:
-        weights.clear()
-        del weights
+        model.update(tree_map(lambda _: mx.array([]), model.parameters()))
+
+    weights.clear()
+    del weights
 
     for i in range(len(shards)):
         shard = shards[i]


### PR DESCRIPTION
I experienced this while I was working on #689 – weights were not actually released and we ran out of memory while converting.

This brings in line with mlx-lm: https://github.com/ml-explore/mlx-lm/blob/96699e6dadb13b82b28285bb131a0741997d19ae/mlx_lm/utils.py#L718

This allows conversion of models larger than the current amount of memory, as originally intended.