### PR TITLE
Fix incorrect attention mask in Qwen2-VL Vision

### DIFF
--- a/mlx_vlm/models/qwen2_vl/language.py
+++ b/mlx_vlm/models/qwen2_vl/language.py
@@ -46,7 +46,6 @@ class Qwen2RotaryEmbedding:
         return freqs_t
 
     def __call__(self, x, position_ids):
-
         # In contrast to other models, Qwen3VL has different position ids for the grids
         # So we expand the inv_freq to shape (3, ...)
         if position_ids.ndim == 2:
@@ -245,7 +244,7 @@ class Qwen2Model(nn.Module):
             cache = [None] * len(self.layers)
 
         if mask is None:
-            mask = create_attention_mask(h, cache)
+            mask = create_attention_mask(h, cache[0])
 
         for layer, c in zip(self.layers, cache):
             h = layer(h, mask, c, position_ids)
@@ -451,7 +450,6 @@ class LanguageModel(nn.Module):
         cache=None,
         **kwargs,
     ):
-
         position_ids = kwargs.pop("position_ids", None)
         pixel_values = kwargs.pop("pixel_values", None)
         image_grid_thw = kwargs.pop("image_grid_thw", None)

--- a/mlx_vlm/models/qwen2_vl/vision.py
+++ b/mlx_vlm/models/qwen2_vl/vision.py
@@ -140,12 +140,12 @@ class Attention(nn.Module):
 
         q = apply_rotary_pos_emb_vision(mx.expand_dims(q, 0), rotary_pos_emb)[0]
         k = apply_rotary_pos_emb_vision(mx.expand_dims(k, 0), rotary_pos_emb)[0]
-        attention_mask = mx.ones((1, seq_length, seq_length), dtype=x.dtype)
+        attention_mask = mx.zeros((seq_length, seq_length), dtype=mx.bool_)
 
         for i in range(1, len(cu_seqlens)):
             start = int(cu_seqlens[i - 1])
             end = int(cu_seqlens[i])
-            attention_mask[start:end, start:end] = 0
+            attention_mask[start:end, start:end] = True
 
         q = q.transpose(0, 2, 1, 3)
         k = k.transpose(0, 2, 1, 3)
@@ -193,7 +193,6 @@ class Qwen2VLVisionBlock(nn.Module):
 
 
 class VisionModel(nn.Module):
-
     def __init__(self, config: VisionConfig) -> None:
         super().__init__()
         self.config = config
@@ -259,7 +258,6 @@ class VisionModel(nn.Module):
         grid_thw: mx.array,
         output_hidden_states: Optional[bool] = None,
     ) -> mx.array:
-
         hidden_states = self.patch_embed(hidden_states)
         rotary_pos_emb = self.rot_pos_emb(grid_thw)
 


### PR DESCRIPTION
This PR addresses two issues in the Qwen2-VL implementation to enable correct behavior during batch processing.

### 1. Fix Vision Attention Mask Logic
The previous implementation of the attention mask in `vision.py` used an additive mask initialized with ones, where valid regions were set to zero. This is incorrect for additive masking, which requires adding `-inf` to masked positions.

* **Change:** Switched to a standard Boolean mask (supported by `mx.fast.scaled_dot_product_attention`) where `True` indicates valid attention and `False` indicates masked regions.
* **Impact:** This ensures correct isolation between images and prevents cross-sequence contamination in packed batches.

### 2. Fix Cache Handling in `create_attention_mask`
In `language.py` a list of cache objects was previously passed to `create_attention_mask` instead of the individual cache object. This prevented the method from invoking the `make_mask` method on the cache instance.

* **Change:** Passed individual cache objects to `create_attention_mask`.
* **Impact:** Ensures `make_mask` is correctly invoked, allowing for proper dynamic mask generation.