### PR TITLE
fix: Improve error logging when model import fails

### DIFF
--- a/mlx_vlm/utils.py
+++ b/mlx_vlm/utils.py
@@ -74,8 +74,8 @@ def get_model_and_args(config: dict):
 
     try:
         arch = importlib.import_module(f"mlx_vlm.models.{model_type}")
-    except ImportError:
-        msg = f"Model type {model_type} not supported."
+    except ImportError as e:
+        msg = f"Model type {model_type} not supported. Error: {e}"
         logging.error(msg)
         raise ValueError(msg)
 
@@ -478,8 +478,7 @@ def upload_to_hub(path: str, upload_repo: str, hf_path: str):
 
     card = ModelCard.load(hf_path)
     card.data.tags = ["mlx"] if card.data.tags is None else card.data.tags + ["mlx"]
-    card.text = dedent(
-        f"""
+    card.text = dedent(f"""
         # {upload_repo}
         This model was converted to MLX format from [`{hf_path}`]() using mlx-vlm version **{__version__}**.
         Refer to the [original model card](https://huggingface.co/{hf_path}) for more details on the model.
@@ -492,8 +491,7 @@ def upload_to_hub(path: str, upload_repo: str, hf_path: str):
         ```bash
         python -m mlx_vlm.generate --model {upload_repo} --max-tokens 100 --temperature 0.0 --prompt "Describe this image." --image <path_to_image>
         ```
-        """
-    )
+        """)
     card.save(os.path.join(path, "README.md"))
 
     logging.set_verbosity_info()


### PR DESCRIPTION
Currently, if a model fails to import (e.g. due to missing dependencies like \`SwitchGLU\` in older \`mlx-lm\` versions for \`deepseekocr_2\`), the exception is swallowed and a generic 'Model type ... not supported' ValueError is raised.

This change captures the underlying \`ImportError\` and includes it in both the log message and the raised ValueError. This makes debugging significantly easier for users who may have environment mismatches.