### PR TITLE
fix: Log underlying ImportError when model loading fails

### DIFF
--- a/mlx_vlm/utils.py
+++ b/mlx_vlm/utils.py
@@ -74,8 +74,8 @@ def get_model_and_args(config: dict):
 
     try:
         arch = importlib.import_module(f"mlx_vlm.models.{model_type}")
-    except ImportError:
-        msg = f"Model type {model_type} not supported."
+    except ImportError as e:
+        msg = f"Model type {model_type} not supported. Error: {e}"
         logging.error(msg)
         raise ValueError(msg)
 


### PR DESCRIPTION
When a model fails to import due to missing dependencies, the current code swallows the ImportError and raises a generic 'Model type not supported' message. This makes debugging difficult.

This change captures and includes the underlying ImportError in the error message, making it much easier to diagnose missing dependencies (e.g., missing \`SwitchGLU\` from \`mlx-lm\` for \`deepseekocr_2\`).

Also adds \`get_class_predicate\` as a module-level factory function to support existing tests.