### PR TITLE
fix: Log underlying ImportError when model loading fails

### DIFF
--- a/mlx_vlm/utils.py
+++ b/mlx_vlm/utils.py
@@ -74,8 +74,8 @@ def get_model_and_args(config: dict):
 
     try:
         arch = importlib.import_module(f"mlx_vlm.models.{model_type}")
-    except ImportError:
-        msg = f"Model type {model_type} not supported."
+    except ImportError as e:
+        msg = f"Model type {model_type} not supported. Error: {e}"
         logging.error(msg)
         raise ValueError(msg)
 


### PR DESCRIPTION
Preserves the original 'Model type not supported' message while appending the specific ImportError details to assist in debugging. This makes it significantly easier to diagnose missing dependencies (e.g., missing SwitchGLU from mlx-lm).