### PR TITLE
Initialize qwen3_5_moe.LanguageModel with _position_ids

### DIFF
--- a/mlx_vlm/models/qwen3_5_moe/language.py
+++ b/mlx_vlm/models/qwen3_5_moe/language.py
@@ -104,6 +104,7 @@ class LanguageModel(Qwen3_5LanguageModel):
         self.model_type = args.model_type
         self.model = Qwen3_5MoeModel(args)
         self._rope_deltas = None
+        self._position_ids = None
 
         if not args.tie_word_embeddings:
             self.lm_head = nn.Linear(args.hidden_size, args.vocab_size, bias=False)


### PR DESCRIPTION
I was hitting an error (pasted below) when using mlx-engine's [demo.py](https://github.com/lmstudio-ai/mlx-engine/blob/main/demo.py) with a text only prompt. This PR fixes that issue by initializing `qwen3_5_moe.LanguageModel` with `_position_ids` set to None. This aligns with the `Qwen3_5LanguageModel` init.

Error:
```
$ python3 demo.py --model ~/.lmstudio/models/lmstudio-community/Qwen3.5-397B-A17B-MLX-4bit/ --prompt "hello"
Loading model...
You are using a model of type qwen3_5_moe to instantiate a model of type . This is not supported for all configurations of models and can yield errors.
[vision_model_kit][INFO]: Setting eos token ids: [248044, 248046]
You are using a model of type qwen3_5_moe to instantiate a model of type . This is not supported for all configurations of models and can yield errors.
Model load complete ✓
You are using a model of type qwen3_5_moe to instantiate a model of type . This is not supported for all configurations of models and can yield errors.         [generate][WARNING]: request_id missing for sequential generation; cancellation by id is disabled
[prompt_progress_reporter][INFO]: begin: is_draft=False, cached_tokens=0, total_prompt_tokens=22, prefill_tokens_processed=0                                    Traceback (most recent call last):
  File "/mlx-engine/demo.py", line 265, in <module>
    for generation_result in generator:
  File "/mlx-engine/mlx_engine/generate.py", line 529, in _sequential_generation
    generation_result = next(stream)
  File "/mlx-lm/mlx_lm/generate.py", line 705, in stream_generate
    for n, (token, logprobs, from_draft) in enumerate(token_generator):
  File "/mlx-lm/mlx_lm/generate.py", line 694, in <genexpr>
    token_generator = (
  File "/mlx-lm/mlx_lm/generate.py", line 429, in generate_step
    _model_call(
  File "/mlx-lm/mlx_lm/generate.py", line 390, in _model_call
    return model(input_tokens, cache=prompt_cache)
  File "/mlx-engine/mlx_engine/vision_model_kit/vision_model_wrapper.py", line 151, in __call__
    outputs = self.language_model(
  File "/mlx-vlm/mlx_vlm/models/qwen3_5/language.py", line 608, in __call__
    if self._position_ids is not None:
  File "/mlx-engine/.venv/lib/python3.10/site-packages/mlx/nn/layers/base.py", line 103, in __getattr__
    super(Module, self).__getattribute__(key)
AttributeError: 'LanguageModel' object has no attribute '_position_ids'
```