### PR TITLE
fix(qwen3_5): restore thinking prefix, forward kwargs, ensure 2D inpu…

### DIFF
--- a/mlx_vlm/prompt_utils.py
+++ b/mlx_vlm/prompt_utils.py
@@ -621,7 +621,10 @@ def apply_chat_template(
         return_messages: Whether to return messages list instead of template
         num_images: Number of images in the input
         num_audios: Number of audio files in the input
-        **kwargs: Additional arguments for message formatting
+        **kwargs: Additional arguments for message formatting and chat template.
+            For Qwen3.5 / Qwen3 thinking models, pass enable_thinking=False to get
+            direct answers without a thinking block (e.g. enable_thinking=False or
+            chat_template_kwargs={"enable_thinking": False}).
 
     Returns:
         Formatted messages or chat template
@@ -707,4 +710,4 @@ def apply_chat_template(
     if model_type in ["paligemma", "molmo", "florence2"]:
         return messages[-1]
 
-    return get_chat_template(processor, messages, add_generation_prompt)
+    return get_chat_template(processor, messages, add_generation_prompt, **kwargs)

--- a/mlx_vlm/utils.py
+++ b/mlx_vlm/utils.py
@@ -932,6 +932,10 @@ def prepare_inputs(
         )
         input_ids = mx.array(inputs.input_ids)
         mask = mx.array(inputs.attention_mask)
+        # Ensure 2D (batch, seq) so downstream models (e.g. Qwen3.5) get consistent shape
+        if input_ids.ndim == 1:
+            input_ids = input_ids[None, :]
+            mask = mask[None, :]
         return {
             "input_ids": input_ids,
             "attention_mask": mask,
@@ -1140,6 +1144,12 @@ def prepare_inputs(
             ]
         else:
             model_inputs["input_features"] = normalize_audio_features(f)
+
+    # Ensure input_ids is 2D (batch, seq) for models that expect it (e.g. Qwen3.5)
+    if "input_ids" in model_inputs and model_inputs["input_ids"].ndim == 1:
+        model_inputs["input_ids"] = model_inputs["input_ids"][None, :]
+        if model_inputs.get("attention_mask") is not None:
+            model_inputs["attention_mask"] = model_inputs["attention_mask"][None, :]
 
     return model_inputs
 


### PR DESCRIPTION
…t_ids

- Restore <think> prefix stripped during prompt tokenization in stream_generate
- Forward **kwargs in apply_chat_template so enable_thinking takes effect
- Pass --processor-kwargs through to apply_chat_template in main/chat mode
- Ensure input_ids is 2D (batch, seq) in prepare_inputs for Qwen3.5