### PR TITLE
fix: Qwen3.5 generation crash and processor loading failures

### DIFF
--- a/mlx_vlm/generate.py
+++ b/mlx_vlm/generate.py
@@ -316,6 +316,12 @@ def generate_step(
         nonlocal tokens, kwargs
 
         with mx.stream(generation_stream):
+            # Ensure inputs are 2D [batch, seq] (matches mlx-lm convention)
+            if y.ndim == 1:
+                y = y[None]
+            if inputs_embeds is not None and inputs_embeds.ndim == 2:
+                inputs_embeds = inputs_embeds[None]
+
             if "decoder_input_ids" in kwargs:
                 outputs = model.language_model(
                     cache=prompt_cache,

--- a/mlx_vlm/utils.py
+++ b/mlx_vlm/utils.py
@@ -475,7 +475,12 @@ def load_processor(
     model_path, add_detokenizer=True, eos_token_ids=None, **kwargs
 ) -> ProcessorMixin:
 
-    processor = AutoProcessor.from_pretrained(model_path, use_fast=True, **kwargs)
+    try:
+        processor = AutoProcessor.from_pretrained(model_path, use_fast=True, **kwargs)
+    except ImportError:
+        processor = AutoProcessor.from_pretrained(
+            model_path, use_fast=True, video_processor=None, **kwargs
+        )
     if add_detokenizer:
         detokenizer_class = load_tokenizer(model_path, return_tokenizer=False)
 


### PR DESCRIPTION
## Summary

Fixes three issues blocking Qwen3.5 (`qwen3_5_moe`) usage, plus an optional disk-space optimization for conversion.

- **Fix 1D input_ids crash in `generate_step._step()`** — `prepare_inputs` produces 1D `(seq,)` for single prompts, but all models expect 2D `(batch, seq)`. Added batch dim check matching [mlx-lm's convention](https://github.com/ml-explore/mlx-lm/blob/main/mlx_lm/generate.py#L397). This is not Qwen3.5-specific — any model receiving single-prompt input could hit it.
- **Catch `ImportError` in `load_processor()`** — `AutoProcessor` fails when torchvision isn't installed (tries to instantiate `Qwen3VLVideoProcessor`). Falls back to `video_processor=None`. Related to #715.
- **Handle `AttributeError` in `processor.save_pretrained()` during conversion** — crashes when video_processor is None. Config files are already copied via `shutil.copy` above, so safe to skip with a warning.
- **Add opt-in `MLX_VLM_FREE_CACHE` env var** — deletes HF cache mid-conversion to reclaim disk space for disk-constrained environments (e.g., converting 70GB+ models on machines with limited SSD).

### Note on the 2D fix approach

Closed PR #762 also addressed the 1D→2D issue but placed the fix in `prepare_inputs` (utils.py). This PR instead fixes it in `generate_step._step()`, which matches [mlx-lm's approach](https://github.com/ml-explore/mlx-lm/blob/main/mlx_lm/generate.py#L397) — mlx-lm wraps `input_tokens[None]` inside `_step` rather than normalizing at the caller. This keeps `_step` defensive regardless of how inputs arrive.

Fixes #767

## Test plan

- [x] Tested text-only generation with Qwen3.5-35B-A3B-mlx-4bit (20.4GB, 84 tok/s)
- [x] Tested text-only generation with Qwen3.5-35B-A3B-mlx-8bit (39.9GB, 39 tok/s)
- [x] Verified `processor.save_pretrained()` fallback during conversion
- [x] Verified `MLX_VLM_FREE_CACHE` frees cache and conversion completes
- [x] Confirmed no changes needed in model-level code (`qwen3_5/language.py` untouched)