### PR TITLE
fix: ensure 2D inputs in generate_step._step()

### DIFF
--- a/mlx_vlm/generate.py
+++ b/mlx_vlm/generate.py
@@ -316,6 +316,12 @@ def generate_step(
         nonlocal tokens, kwargs
 
         with mx.stream(generation_stream):
+            # Ensure inputs are 2D [batch, seq] (matches mlx-lm convention)
+            if y.ndim == 1:
+                y = y[None]
+            if inputs_embeds is not None and inputs_embeds.ndim == 2:
+                inputs_embeds = inputs_embeds[None]
+
             if "decoder_input_ids" in kwargs:
                 outputs = model.language_model(
                     cache=prompt_cache,


### PR DESCRIPTION
## Summary

Adds batch dimension normalization in `generate_step._step()`, matching [mlx-lm's convention](https://github.com/ml-explore/mlx-lm/blob/main/mlx_lm/generate.py#L397).

`prepare_inputs()` produces 1D `input_ids` `(seq,)` for single-prompt tokenization. All language models expect 2D `(batch, seq)` — Qwen3.5's `get_rope_index()` crashes with `ValueError: not enough values to unpack (expected 2, got 1)`.

This is a **one-file, 6-line fix** in `generate.py`. No model code changes needed.

Fixes #769

## Changes

```python
# generate.py _step() — before calling model.language_model()
if y.ndim == 1:
    y = y[None]
if inputs_embeds is not None and inputs_embeds.ndim == 2:
    inputs_embeds = inputs_embeds[None]
```

## Test

Tested on clean main with all deps (torch 2.10.0, torchvision 0.25.0, transformers 5.2.0):
- Qwen3.5-35B-A3B-mlx-4bit: **84 tok/s**, 20.5GB peak memory
- Qwen3.5-35B-A3B-mlx-8bit: **39 tok/s**, 40GB peak memory