### PR TITLE
Tool calling in server

### DIFF
--- a/mlx_vlm/server.py
+++ b/mlx_vlm/server.py
@@ -657,9 +657,7 @@ async def responses_endpoint(request: Request):
                 for message in openai_request.input:
                     if isinstance(message, ChatMessage):
                         if message.content is None:
-                            chat_messages.append(
-                                {"role": message.role, "content": ""}
-                            )
+                            chat_messages.append({"role": message.role, "content": ""})
                         elif isinstance(message.content, str):
                             chat_messages.append(
                                 {"role": message.role, "content": message.content}
@@ -982,9 +980,7 @@ async def chat_completions_endpoint(request: ChatRequest):
         processed_messages = []
         for message in request.messages:
             if message.content is None:
-                processed_messages.append(
-                    {"role": message.role, "content": ""}
-                )
+                processed_messages.append({"role": message.role, "content": ""})
             elif isinstance(message.content, str):
                 processed_messages.append(
                     {"role": message.role, "content": message.content}


### PR DESCRIPTION
Various models support tool calling, but the server doesn't implement it.
mlx_lm also supports tool calling.

This PR adds tool calling to the server's "chat/completions" endpoint with various tool parsers implemented and imported from mlx_lm.

This WiP initial version works _(I'm using osaurus.ai for testing)_, and any input, improvements or changes are welcome. I'm not happy with it yet, because this implementation leaves the model output in the assistant's turn, but I have no solution for it in the streaming case, because stream_generate returns multiple tokens at a time.

Fixes: #772