### PR TITLE
Add prefill-step-size optional command line argument for server.

### DIFF
--- a/mlx_vlm/generate.py
+++ b/mlx_vlm/generate.py
@@ -34,6 +34,7 @@ DEFAULT_TEMPERATURE = 0.5
 DEFAULT_TOP_P = 1.0
 DEFAULT_SEED = 0
 DEFAULT_QUANTIZED_KV_START = 5000
+DEFAULT_PREFILL_STEP_SIZE = 2048
 
 
 def parse_arguments():
@@ -169,7 +170,7 @@ def parse_arguments():
     parser.add_argument(
         "--prefill-step-size",
         type=int,
-        default=None,
+        default=DEFAULT_PREFILL_STEP_SIZE,
         help="Number of tokens to process per prefill step. "
         "Lower values reduce peak memory usage but may be slower. "
         "Try 512 or 256 if you hit GPU memory errors during prefill.",
@@ -276,7 +277,7 @@ def generate_step(
     quantized_kv_start: int = 0,
     sampler: Optional[Callable[[mx.array], mx.array]] = None,
     logits_processors: Optional[List[Callable[[mx.array, mx.array], mx.array]]] = None,
-    prefill_step_size: Optional[int] = 2048,
+    prefill_step_size: Optional[int] = DEFAULT_PREFILL_STEP_SIZE,
     **kwargs,
 ) -> Generator[Tuple[mx.array, mx.array], None, None]:
     """

--- a/mlx_vlm/server.py
+++ b/mlx_vlm/server.py
@@ -24,6 +24,7 @@ from typing_extensions import Required, TypeAlias, TypedDict
 from .generate import (
     DEFAULT_MAX_TOKENS,
     DEFAULT_MODEL_PATH,
+    DEFAULT_PREFILL_STEP_SIZE,
     DEFAULT_QUANTIZED_KV_START,
     DEFAULT_SEED,
     DEFAULT_TEMPERATURE,
@@ -41,6 +42,10 @@ ALLOWED_TEMPLATE_KWARGS = {
     "thinking_start_token",
     "thinking_end_token",
 }
+
+
+def get_prefill_step_size():
+    return int(os.environ.get("PREFILL_STEP_SIZE", DEFAULT_PREFILL_STEP_SIZE))
 
 
 def get_quantized_kv_bits(model: str):
@@ -791,6 +796,7 @@ async def responses_endpoint(request: Request):
                         temperature=openai_request.temperature,
                         max_tokens=openai_request.max_output_tokens,
                         top_p=openai_request.top_p,
+                        prefill_step_size=get_prefill_step_size(),
                         kv_bits=get_quantized_kv_bits(openai_request.model),
                         kv_group_size=get_kv_group_size(),
                         max_kv_size=get_max_kv_size(openai_request.model),
@@ -882,6 +888,7 @@ async def responses_endpoint(request: Request):
                     temperature=openai_request.temperature,
                     max_tokens=openai_request.max_output_tokens,
                     top_p=openai_request.top_p,
+                    prefill_step_size=get_prefill_step_size(),
                     kv_bits=get_quantized_kv_bits(openai_request.model),
                     kv_group_size=get_kv_group_size(),
                     max_kv_size=get_max_kv_size(openai_request.model),
@@ -1051,6 +1058,7 @@ async def chat_completions_endpoint(request: ChatRequest):
                         temperature=request.temperature,
                         max_tokens=request.max_tokens,
                         top_p=request.top_p,
+                        prefill_step_size=get_prefill_step_size(),
                         kv_bits=get_quantized_kv_bits(request.model),
                         kv_group_size=get_kv_group_size(),
                         max_kv_size=get_max_kv_size(request.model),
@@ -1163,6 +1171,7 @@ async def chat_completions_endpoint(request: ChatRequest):
                     temperature=request.temperature,
                     max_tokens=request.max_tokens,
                     top_p=request.top_p,
+                    prefill_step_size=get_prefill_step_size(),
                     kv_bits=get_quantized_kv_bits(request.model),
                     kv_group_size=get_kv_group_size(),
                     max_kv_size=get_max_kv_size(request.model),
@@ -1320,6 +1329,14 @@ def main():
         help="Trust remote code when loading models from Hugging Face Hub.",
     )
     parser.add_argument(
+        "--prefill-step-size",
+        type=int,
+        default=DEFAULT_PREFILL_STEP_SIZE,
+        help="Number of tokens to process per prefill step. "
+        "Lower values reduce peak memory usage but may be slower. "
+        "Try 512 or 256 if you hit GPU memory errors during prefill.",
+    )
+    parser.add_argument(
         "--kv-bits",
         type=int,
         default=0,
@@ -1346,6 +1363,7 @@ def main():
     args = parser.parse_args()
     if args.trust_remote_code:
         os.environ["MLX_TRUST_REMOTE_CODE"] = "true"
+    os.environ["PREFILL_STEP_SIZE"] = str(args.prefill_step_size)
     os.environ["KV_BITS"] = str(args.kv_bits)
     os.environ["KV_GROUP_SIZE"] = str(args.kv_group_size)
     os.environ["MAX_KV_SIZE"] = str(args.max_kv_size)


### PR DESCRIPTION
Adding --prefix-step-size optional command line argument to server.py too, with a global default.
Reducing it from the default 2048 will reduce memory spikes while the prompt is loading with minimal speed degradation.
On systems with tight unified memory, this may prevent out-of-memory situations.