### PR TITLE
qwen3_omni_moe: fix visual_embeds_multiscale UnboundLocalError

### DIFF
--- a/mlx_vlm/models/qwen3_omni_moe/thinker.py
+++ b/mlx_vlm/models/qwen3_omni_moe/thinker.py
@@ -141,6 +141,7 @@ class Thinker(nn.Module):
         inputs_embeds = self.language_model.model.embed_tokens(input_ids)
         visual_pos_masks = None
         deepstack_visual_embeds = None
+        visual_embeds_multiscale = None
 
         if input_features is not None:
             audio_features = self.get_audio_features(


### PR DESCRIPTION
When I tried to run Qwen3-Omni on a video file, I got the following error:

`UnboundLocalError: cannot access local variable 'visual_embeds_multiscale' where it is not associated with a value`

Declaring `visual_embeds_multiscale` in the beginning of `get_input_embeddings()` seems to solve the issue.