### PR TITLE
[Qwen3.5 MoE] Fix quant predicate

### DIFF
--- a/mlx_vlm/models/qwen3_5/language.py
+++ b/mlx_vlm/models/qwen3_5/language.py
@@ -667,7 +667,8 @@ class LanguageModel(nn.Module):
 
     @property
     def quant_predicate(self):
-        if self.config.num_experts <= 0:
+
+        if getattr(self.args, "num_experts", 0) <= 0:
             return None
 
         def predicate(path, _):


### PR DESCRIPTION
Closes #778 
### Before

```bash
uv run mlx_vlm.generate --model Qwen3.5-35B-A3B-mxfp4 --prompt "What is the capital of France?" --max-tokens 100
==========
Files: [] 

Prompt: <|im_start|>user
What is the capital of France?<|im_end|>
<|im_start|>assistant
<think>

<|im_start|>

<|im_start|>

<|im_start|>


==========
Prompt: 17 tokens, 54.525 tokens-per-sec
Generation: 7 tokens, 99.244 tokens-per-sec
Peak memory: 19.388 GB
```

### After

```bash
uv run mlx_vlm.generate --model Qwen3.5-35B-A3B-mxfp4 --prompt "What is the capital of France?" --max-tokens 100
==========
Files: [] 

Prompt: <|im_start|>user
What is the capital of France?<|im_end|>
<|im_start|>assistant
<think>

Thinking Process:

1.  **Identify the core question:** The user is asking "What is the capital of France?"
2.  **Retrieve knowledge:** Access knowledge about geography and countries.
3.  **Verify the fact:** The capital of France is Paris.
4.  **Formulate the answer:** State the answer clearly and concisely.
5.  **Final Output:** "The capital of France is Paris." or simply "Paris."

Decision:
==========
Prompt: 17 tokens, 75.553 tokens-per-sec
Generation: 100 tokens, 83.705 tokens-per-sec
Peak memory: 19.399 GB
```