### PR TITLE
fix: remove dataset.select(range(iters)) that crashes when epochs > 1

### DIFF
--- a/mlx_vlm/lora.py
+++ b/mlx_vlm/lora.py
@@ -208,7 +208,10 @@ def main(args):
     else:
         iters = args.iters
 
-    dataset = dataset.select(range(iters))
+    if iters <= 0:
+        raise ValueError(
+            "Computed iterations is 0. Increase dataset size, lower batch_size, or set --iters."
+        )
 
     # Transform dataset to messages format (support custom prompt template)
     dataset = transform_dataset_to_messages(


### PR DESCRIPTION
  ## Problem

  Using `--epochs > 1` with any dataset crashes with `IndexError` before training starts.

  IndexError: Index 283 out of range for dataset of size 71.

  `dataset.select(range(iters))` confuses training **steps** with dataset **sample count**.
  For example, with 71 samples, `batch_size=1`, and `epochs=4`:
  - `iters = (71 // 1) * 4 = 284`
  - `dataset.select(range(284))` on a 71-row dataset → crash

  ## Fix

  Remove `dataset.select(range(iters))` and add a guard for `iters <= 0`.

  This select call is unnecessary because:
  1. `iterate_batches()` in `trainer.py` already uses `while True:` to cycle through the
  dataset
  2. The training loop limits steps via `zip(range(1, args.iters + 1), iterate_batches(...))`

  ## Regression test

  - Dataset: 71 samples, `batch_size=1`, `epochs=4` → should train 284 steps without crashing