### PR TITLE
Remove sleep duration with zero delay

### DIFF
--- a/mlx_vlm/server.py
+++ b/mlx_vlm/server.py
@@ -1,5 +1,4 @@
 import argparse
-import asyncio
 import gc
 import importlib
 import json
@@ -1099,7 +1098,6 @@ async def chat_completions_endpoint(request: ChatRequest):
                         )
 
                         yield f"data: {chunk_data.model_dump_json()}\n\n"
-                        await asyncio.sleep(0)
 
                     if tool_parser_type is not None:
                         tool_calls = process_tool_calls(


### PR DESCRIPTION


# Summary

Remove per-token `asyncio.sleep(0.01)` delay from both `/responses` and `/chat/completions` streaming endpoints.

The 10ms sleep per token was adding significant artificial latency — at 50 t/s, that's ~500ms/sec of idle time, roughly halving streaming throughput vs non-streaming.

`/chat/completions` now uses `asyncio.sleep(0)` (yields to event loop without delay); `/responses` removes the sleep entirely.

Fixes #798 


## After fix: 

- **Non-streaming:** 43.4 t/s generation
- **Streaming:** 44.5 t/s generation (previously was roughly half due to the sleep overhead)
