### PR TITLE
fix(qwen3_5_moe): handle per-expert weight format in sanitize()

### DIFF
--- a/mlx_vlm/models/qwen3_5_moe/qwen3_5_moe.py
+++ b/mlx_vlm/models/qwen3_5_moe/qwen3_5_moe.py
@@ -25,15 +25,30 @@ class Model(Qwen3_5Model):
 
         for l in range(self.config.text_config.num_hidden_layers):
             prefix = f"model.language_model.layers.{l}.mlp"
-            # process gate_up_proj [num_experts, 2 * intermediate_size, hidden_size]
-            gate_up_weight = weights.pop(f"{prefix}.experts.gate_up_proj")
-            gate_weight, up_weights = mx.split(gate_up_weight, 2, axis=-2)
-            weights[f"{prefix}.switch_mlp.gate_proj.weight"] = gate_weight
-            weights[f"{prefix}.switch_mlp.up_proj.weight"] = up_weights
-            # down_proj
-            weights[f"{prefix}.switch_mlp.down_proj.weight"] = weights.pop(
-                f"{prefix}.experts.down_proj"
-            )
+            combined_key = f"{prefix}.experts.gate_up_proj"
+            if combined_key in weights:
+                # pre-stacked format: gate_up_proj [num_experts, 2 * intermediate_size, hidden_size]
+                gate_up_weight = weights.pop(combined_key)
+                gate_weight, up_weights = mx.split(gate_up_weight, 2, axis=-2)
+                weights[f"{prefix}.switch_mlp.gate_proj.weight"] = gate_weight
+                weights[f"{prefix}.switch_mlp.up_proj.weight"] = up_weights
+                weights[f"{prefix}.switch_mlp.down_proj.weight"] = weights.pop(
+                    f"{prefix}.experts.down_proj"
+                )
+            else:
+                # per-expert format: experts.{n}.gate_proj.weight, experts.{n}.up_proj.weight, etc.
+                # used by models such as llmfan46/Qwen3.5-35B-A3B-heretic-v2
+                n = 0
+                gate_list, up_list, down_list = [], [], []
+                while f"{prefix}.experts.{n}.gate_proj.weight" in weights:
+                    gate_list.append(weights.pop(f"{prefix}.experts.{n}.gate_proj.weight"))
+                    up_list.append(weights.pop(f"{prefix}.experts.{n}.up_proj.weight"))
+                    down_list.append(weights.pop(f"{prefix}.experts.{n}.down_proj.weight"))
+                    n += 1
+                if gate_list:
+                    weights[f"{prefix}.switch_mlp.gate_proj.weight"] = mx.stack(gate_list)
+                    weights[f"{prefix}.switch_mlp.up_proj.weight"] = mx.stack(up_list)
+                    weights[f"{prefix}.switch_mlp.down_proj.weight"] = mx.stack(down_list)
 
         norm_keys = (
             ".input_layernorm.weight",


### PR DESCRIPTION
## Problem

When converting certain Qwen3.5-MoE VLM checkpoints, the conversion fails with:

```
KeyError: 'model.language_model.layers.0.mlp.experts.gate_up_proj'
```

`sanitize()` assumes expert weights are pre-stacked in the format:
- `experts.gate_up_proj` — shape `[num_experts, 2 * intermediate_size, hidden_size]`
- `experts.down_proj` — shape `[num_experts, intermediate_size, hidden_size]`

However, some Qwen3.5-MoE checkpoints store weights individually per expert:
- `experts.{n}.gate_proj.weight`
- `experts.{n}.up_proj.weight`
- `experts.{n}.down_proj.weight`

## Fix

Detect which format is present and handle both cases. For the per-expert format, use `mx.stack()` to assemble the individual tensors into the shape expected by `SwitchGLU`.
