### PR TITLE
Fix UnicodeDecodeError in BPEStreamingDetokenizer.add_token()

### DIFF
--- a/mlx_vlm/tokenizer_utils.py
+++ b/mlx_vlm/tokenizer_utils.py
@@ -229,7 +229,7 @@ class BPEStreamingDetokenizer(StreamingDetokenizer):
         if self._byte_decoder[v[0]] == 32:
             current_text = bytearray(
                 self._byte_decoder[c] for c in self._unflushed
-            ).decode("utf-8")
+            ).decode("utf-8", errors="replace")
             if self.text or not self.trim_space:
                 self.text += current_text
             else:


### PR DESCRIPTION
One-line fix: add `errors="replace"` to the `.decode("utf-8")` call in `BPEStreamingDetokenizer.add_token()` (line 232 of `tokenizer_utils.py`).

The `finalize()` method already handles this with `errors="ignore"` on line 245, but the hot path in `add_token()` does not, causing a hard crash when models with ByteLevel tokenizers (e.g. GLM-OCR) emit byte sequences that are not valid UTF-8 at a token boundary.

Using `errors="replace"` rather than `errors="ignore"` so that U+FFFD markers make it visible when bytes are lost, rather than silently dropping them.

Related issue: #834 (also related to #463)