### PR TITLE
fix: use use_fast=False in load_processor to support Qwen3.5 vision models

### DIFF
--- a/mlx_vlm/utils.py
+++ b/mlx_vlm/utils.py
@@ -475,7 +475,7 @@ def load_processor(
     model_path, add_detokenizer=True, eos_token_ids=None, **kwargs
 ) -> ProcessorMixin:
 
-    processor = AutoProcessor.from_pretrained(model_path, use_fast=True, **kwargs)
+    processor = AutoProcessor.from_pretrained(model_path, use_fast=False, **kwargs)
     if add_detokenizer:
         detokenizer_class = load_tokenizer(model_path, return_tokenizer=False)
 


### PR DESCRIPTION
## Problem

`load_processor` calls `AutoProcessor.from_pretrained` with `use_fast=True`. For Qwen3.5 models this loads a `BaseImageProcessorFast`, which only accepts `return_tensors="pt"`. Since `mlx_vlm` passes `return_tensors="mlx"`, any request with an image fails:

```
ValueError: Only returning PyTorch tensors is currently supported.
```

This makes the server completely unable to process images for Qwen3.5 models.

## Fix

Use `use_fast=False` so the standard image processor is loaded, which accepts all tensor formats including `"mlx"`.

## Testing

Verified with `mlx-community/Qwen3.5-35B-A3B-4bit` via `mlx_vlm.server` — images process correctly after this change.

Closes #847