### PR TITLE
Fix Gemma 4 embedding scaling

### DIFF
--- a/mlx_vlm/models/gemma4/language.py
+++ b/mlx_vlm/models/gemma4/language.py
@@ -405,9 +405,7 @@ class Gemma4TextModel(nn.Module):
                 config.vocab_size_per_layer_input,
                 config.num_hidden_layers * config.hidden_size_per_layer_input,
             )
-            self.embed_tokens_per_layer_scale = (
-                config.hidden_size_per_layer_input**0.5
-            )
+            self.embed_tokens_per_layer_scale = config.hidden_size_per_layer_input**0.5
             self.per_layer_input_scale = 2.0**-0.5
             self.per_layer_model_projection = ScaledLinear(
                 config.hidden_size,


### PR DESCRIPTION
## Summary
- Replace custom `ScaledEmbedding` class with standard `nn.Embedding` and apply `hidden_size**0.5` scaling separately
- Same fix applied to `embed_tokens_per_layer` for per-layer input embeddings
- Aligns with mlx_lm conventions and fixes weight loading issues with the custom subclass
