### PR TITLE
fix: slice per_layer_inputs during chunked prefill for Gemma4 e2b/e4b

### DIFF
--- a/mlx_vlm/generate.py
+++ b/mlx_vlm/generate.py
@@ -513,7 +513,10 @@ def generate_step(
                         **chunk_kwargs,
                     )
                     quantize_cache_fn(prompt_cache)
-                    mx.eval([c.state for c in prompt_cache])
+                    # Skip caches whose keys are not yet populated (e.g. KV-shared
+                    # layers in Gemma4 e2b/e4b that never call update_and_fetch).
+                    mx.eval([c.state for c in prompt_cache
+                             if getattr(c, "keys", None) is not None])
                     inputs_embeds = inputs_embeds[:, n_to_process:]
                     input_ids = input_ids[:, n_to_process:]
                     if kwargs.get("per_layer_inputs") is not None:


### PR DESCRIPTION
## Problem

Gemma4 Efficient models (`gemma-4-e2b-it` and `gemma-4-e4b-it`) fail with a broadcast shape error when the input context exceeds 2048 tokens:

```
[broadcast_shapes] Shapes (1,2048,42,256) and (1,32548,42,256) cannot be broadcast.
```

## Root Cause

These models compute per-layer token embeddings (`per_layer_inputs`) for every input token inside `get_input_embeddings()`. The result is added to `kwargs` and forwarded to `language_model()` calls.

During **chunked prefill** (`prefill_step_size=2048` by default), `inputs_embeds` and `input_ids` are correctly sliced to the chunk size, but `per_layer_inputs` in `kwargs` remained at full sequence length. This caused a shape mismatch inside `project_per_layer_inputs()`:

```
per_layer_projection : (1, 2048,  42, 256)  ← from h (chunk)
per_layer_inputs     : (1, 32548, 42, 256)  ← from kwargs (full context)
→ broadcast error
```

## Fix

Slice `per_layer_inputs` to match each chunk at the start of the loop, and advance its offset alongside `inputs_embeds` and `input_ids`.

## Testing

Verified with `mlx-community/gemma-4-e4b-it-4bit` (42 layers, 35 sliding + 7 full attention) on a 32K+ token conversation — previously crashed, now completes successfully.