### PR TITLE
Fix Gemma 4 chunked prefill for KV-shared models and thinking 

### DIFF
--- a/mlx_vlm/models/gemma4/README.md
+++ b/mlx_vlm/models/gemma4/README.md
@@ -116,6 +116,7 @@ result = generate(
     max_tokens=500,
     temperature=1.0,
     top_p=0.95,
+    top_k=64,
 )
 print(result)
 ```
@@ -142,6 +143,7 @@ result = generate(
     max_tokens=500,
     temperature=1.0,
     top_p=0.95,
+    top_k=64,
 )
 print(result)
 ```
@@ -167,6 +169,7 @@ result = generate(
     max_tokens=500,
     temperature=1.0,
     top_p=0.95,
+    top_k=64,
 )
 print(result)
 ```
@@ -192,6 +195,7 @@ result = generate(
     max_tokens=2000,
     temperature=1.0,
     top_p=0.95,
+    top_k=64,
 )
 print(result)
 ```

--- a/mlx_vlm/models/gemma4/README.md
+++ b/mlx_vlm/models/gemma4/README.md
@@ -35,7 +35,7 @@ python -m mlx_vlm.generate \
   --model google/gemma-4-e4b-it \
   --prompt "What is the capital of France?" \
   --max-tokens 500 \
-  --temperature 0
+  --temperature 1.0 --top-p 0.95 --top-k 64
 ```
 
 ### Image understanding
@@ -46,7 +46,7 @@ python -m mlx_vlm.generate \
   --image path/to/image.jpg \
   --prompt "Describe this image." \
   --max-tokens 500 \
-  --temperature 0
+  --temperature 1.0 --top-p 0.95 --top-k 64
 ```
 
 ### Audio understanding (2B/4B only)
@@ -57,7 +57,7 @@ python -m mlx_vlm.generate \
   --audio path/to/audio.wav \
   --prompt "Transcribe this audio" \
   --max-tokens 500 \
-  --temperature 0
+  --temperature 1.0 --top-p 0.95 --top-k 64
 ```
 
 ### Thinking mode (chain-of-thought)
@@ -68,7 +68,7 @@ python -m mlx_vlm.generate \
   --prompt "I want to do a car wash that is 50 meters away, should I walk or drive?" \
   --enable-thinking \
   --max-tokens 2000 \
-  --temperature 0
+  --temperature 1.0 --top-p 0.95 --top-k 64
 ```
 
 ### Image + thinking
@@ -80,7 +80,7 @@ python -m mlx_vlm.generate \
   --prompt "Describe this image." \
   --enable-thinking \
   --max-tokens 2000 \
-  --temperature 0
+  --temperature 1.0 --top-p 0.95 --top-k 64
 ```
 
 ### Thinking with budget
@@ -92,7 +92,7 @@ python -m mlx_vlm.generate \
   --enable-thinking \
   --thinking-budget 512 \
   --max-tokens 2000 \
-  --temperature 0
+  --temperature 1.0 --top-p 0.95 --top-k 64
 ```
 
 ## Python
@@ -114,7 +114,8 @@ result = generate(
     processor=processor,
     prompt=prompt,
     max_tokens=500,
-    temperature=0.0,
+    temperature=1.0,
+    top_p=0.95,
 )
 print(result)
 ```
@@ -139,7 +140,8 @@ result = generate(
     prompt=prompt,
     image=image,
     max_tokens=500,
-    temperature=0.0,
+    temperature=1.0,
+    top_p=0.95,
 )
 print(result)
 ```
@@ -163,7 +165,8 @@ result = generate(
     prompt=prompt,
     audio=["path/to/audio.wav"],
     max_tokens=500,
-    temperature=0.0,
+    temperature=1.0,
+    top_p=0.95,
 )
 print(result)
 ```
@@ -187,7 +190,8 @@ result = generate(
     processor=processor,
     prompt=prompt,
     max_tokens=2000,
-    temperature=0.0,
+    temperature=1.0,
+    top_p=0.95,
 )
 print(result)
 ```

--- a/mlx_vlm/models/gemma4/gemma4.py
+++ b/mlx_vlm/models/gemma4/gemma4.py
@@ -221,5 +221,9 @@ class Model(nn.Module):
         return sanitized
 
     @property
+    def quant_predicate(self):
+        return self.language_model.quant_predicate
+
+    @property
     def layers(self):
         return self.language_model.model.layers

--- a/mlx_vlm/models/gemma4/language.py
+++ b/mlx_vlm/models/gemma4/language.py
@@ -602,7 +602,9 @@ class LanguageModel(nn.Module):
         def predicate(path, m):
             if not hasattr(m, "to_quantized"):
                 return False
-            if path.endswith("router.proj"):
+            if "router" in path:
+                return {"group_size": 64, "bits": 8}
+            if path.endswith(("mlp.gate_proj", "mlp.up_proj", "mlp.down_proj")):
                 return {"group_size": 64, "bits": 8}
             return True
 

--- a/mlx_vlm/models/gemma4/language.py
+++ b/mlx_vlm/models/gemma4/language.py
@@ -597,6 +597,17 @@ class LanguageModel(nn.Module):
     def n_kv_heads(self):
         return self.config.num_key_value_heads
 
+    @property
+    def quant_predicate(self):
+        def predicate(path, m):
+            if not hasattr(m, "to_quantized"):
+                return False
+            if path.endswith("router.proj"):
+                return {"group_size": 64, "bits": 8}
+            return True
+
+        return predicate
+
     def make_cache(self):
         caches = []
         for layer_type in self.config.layer_types[

--- a/mlx_vlm/models/gemma4/language.py
+++ b/mlx_vlm/models/gemma4/language.py
@@ -188,41 +188,26 @@ class Attention(nn.Module):
             config, "num_kv_shared_layers", 0
         )
         self.is_kv_shared_layer = layer_idx >= first_kv_shared_layer_idx > 0
-        if self.is_kv_shared_layer:
-            prev_layers = config.layer_types[:first_kv_shared_layer_idx]
-            self.kv_shared_layer_index = (
-                len(prev_layers)
-                - 1
-                - prev_layers[::-1].index(config.layer_types[layer_idx])
-            )
-        else:
-            self.kv_shared_layer_index = None
-
-        if not self.is_kv_shared_layer:
-            prev_layers = config.layer_types[:first_kv_shared_layer_idx]
-            self.store_full_length_kv = layer_idx == len(prev_layers) - 1 - prev_layers[
-                ::-1
-            ].index(config.layer_types[layer_idx])
-        else:
-            self.store_full_length_kv = False
 
     def __call__(
         self,
         x: mx.array,
         mask: Optional[mx.array] = None,
         cache: Optional[Any] = None,
-        shared_kv: Optional[tuple] = None,
     ) -> mx.array:
         B, L, _ = x.shape
 
         queries = self.q_proj(x).reshape(B, L, self.n_heads, self.head_dim)
         queries = self.q_norm(queries)
 
-        if self.is_kv_shared_layer and shared_kv is not None:
-            keys, values = shared_kv
-            offset = cache.offset if cache is not None else 0
+        offset = 0
+        if self.is_kv_shared_layer and cache is not None:
+            state = cache.state
+            keys, values = state[0], state[1]
+            offset = cache.offset
         else:
-            offset = cache.offset if cache is not None else 0
+            if cache is not None:
+                offset = cache.offset
 
             keys = self.k_proj(x).reshape(B, L, self.n_kv_heads, self.head_dim)
 
@@ -241,9 +226,6 @@ class Attention(nn.Module):
 
             if cache is not None:
                 keys, values = cache.update_and_fetch(keys, values)
-
-        if self.store_full_length_kv:
-            self._last_kv = (keys, values)
 
         queries = queries.transpose(0, 2, 1, 3)
         queries = self.rope(queries, offset=offset)
@@ -321,12 +303,11 @@ class DecoderLayer(nn.Module):
         mask: Optional[mx.array] = None,
         cache: Optional[Any] = None,
         per_layer_input: Optional[mx.array] = None,
-        shared_kv: Optional[tuple] = None,
     ) -> mx.array:
         residual = x
 
         h = self.input_layernorm(x)
-        h = self.self_attn(h, mask, cache, shared_kv=shared_kv)
+        h = self.self_attn(h, mask, cache)
         h = self.post_attention_layernorm(h)
         h = residual + h
 
@@ -399,6 +380,37 @@ class Gemma4TextModel(nn.Module):
         ]
         self.norm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
 
+        # KV sharing: only non-shared layers own a cache
+        self.first_kv_shared_layer_idx = config.num_hidden_layers - getattr(
+            config, "num_kv_shared_layers", 0
+        )
+        concrete_layers = config.layer_types[: self.first_kv_shared_layer_idx]
+        self.layer_idx_to_cache_idx = list(range(self.first_kv_shared_layer_idx))
+        if self.first_kv_shared_layer_idx < config.num_hidden_layers:
+            shared_full_idx = (
+                len(concrete_layers)
+                - 1
+                - concrete_layers[::-1].index("full_attention")
+            )
+            shared_sliding_idx = (
+                len(concrete_layers)
+                - 1
+                - concrete_layers[::-1].index("sliding_attention")
+            )
+            for i in range(self.first_kv_shared_layer_idx, config.num_hidden_layers):
+                if config.layer_types[i] == "full_attention":
+                    self.layer_idx_to_cache_idx.append(shared_full_idx)
+                else:
+                    self.layer_idx_to_cache_idx.append(shared_sliding_idx)
+
+        # First cache indices by attention type (for mask creation)
+        self.first_full_cache_idx = next(
+            (i for i, t in enumerate(concrete_layers) if t == "full_attention"), 0
+        )
+        self.first_sliding_cache_idx = next(
+            (i for i, t in enumerate(concrete_layers) if t == "sliding_attention"), 0
+        )
+
         # Per-layer input embeddings (2B/4B models)
         self.hidden_size_per_layer_input = config.hidden_size_per_layer_input
         if self.hidden_size_per_layer_input:
@@ -456,6 +468,7 @@ class Gemma4TextModel(nn.Module):
         mask: Optional[mx.array] = None,
         cache=None,
         per_layer_inputs: Optional[mx.array] = None,
+        **kwargs,
     ):
         if inputs_embeds is None:
             h = self.embed_tokens(inputs)
@@ -467,45 +480,47 @@ class Gemma4TextModel(nn.Module):
         if self.hidden_size_per_layer_input:
             if inputs is not None and per_layer_inputs is None:
                 per_layer_inputs = self.get_per_layer_inputs(inputs)
+            elif per_layer_inputs is not None:
+                # Slice per_layer_inputs to match current chunk (chunked prefill)
+                target_len = h.shape[1]
+                if per_layer_inputs.shape[1] != target_len:
+                    cache_offset = next(
+                        (
+                            int(c.offset)
+                            for c in (cache or [])
+                            if c is not None and hasattr(c, "offset")
+                        ),
+                        0,
+                    )
+                    max_start = max(per_layer_inputs.shape[1] - target_len, 0)
+                    start = min(cache_offset, max_start)
+                    per_layer_inputs = per_layer_inputs[
+                        :, start : start + target_len
+                    ]
             if per_layer_inputs is not None or inputs is not None:
                 per_layer_inputs = self.project_per_layer_inputs(h, per_layer_inputs)
 
         if cache is None:
-            cache = [None] * len(self.layers)
-
-        global_cache_idx = None
-        sliding_cache_idx = None
-        for i, layer in enumerate(self.layers):
-            if layer.layer_type == "full_attention" and global_cache_idx is None:
-                global_cache_idx = i
-            elif layer.layer_type == "sliding_attention" and sliding_cache_idx is None:
-                sliding_cache_idx = i
+            cache = [None] * self.first_kv_shared_layer_idx
 
         if mask is None:
             global_mask = create_attention_mask(
-                h, cache[global_cache_idx] if global_cache_idx is not None else None
+                h,
+                cache[self.first_full_cache_idx]
+                if self.first_full_cache_idx < len(cache)
+                else None,
             )
             sliding_window_mask = create_attention_mask(
                 h,
-                cache[sliding_cache_idx] if sliding_cache_idx is not None else None,
+                cache[self.first_sliding_cache_idx]
+                if self.first_sliding_cache_idx < len(cache)
+                else None,
                 window_size=self.window_size,
             )
 
-        shared_kv_store = {}
-
-        for i, (layer, c) in enumerate(zip(self.layers, cache)):
+        for i, layer in enumerate(self.layers):
+            c = cache[self.layer_idx_to_cache_idx[i]]
             is_global = layer.layer_type == "full_attention"
-
-            layer_shared_kv = None
-            if (
-                layer.self_attn.is_kv_shared_layer
-                and layer.self_attn.kv_shared_layer_index is not None
-            ):
-                ref_idx = layer.self_attn.kv_shared_layer_index
-                if ref_idx in shared_kv_store:
-                    layer_shared_kv, ref_offset = shared_kv_store[ref_idx]
-                    if c is not None:
-                        c.offset = ref_offset
 
             local_mask = mask
             if mask is None and is_global:
@@ -517,18 +532,12 @@ class Gemma4TextModel(nn.Module):
             if per_layer_inputs is not None:
                 per_layer_input = per_layer_inputs[:, :, i, :]
 
-            pre_offset = c.offset if c is not None else 0
-
             h = layer(
                 h,
                 local_mask,
                 c,
                 per_layer_input=per_layer_input,
-                shared_kv=layer_shared_kv,
             )
-
-            if layer.self_attn.store_full_length_kv:
-                shared_kv_store[i] = (layer.self_attn._last_kv, pre_offset)
 
         return self.norm(h)
 
@@ -556,6 +565,7 @@ class LanguageModel(nn.Module):
             mask=mask,
             cache=cache,
             per_layer_inputs=per_layer_inputs,
+            **kwargs,
         )
         out = self.model.embed_tokens.as_linear(out)
         if self.final_logit_softcapping is not None:
@@ -589,8 +599,9 @@ class LanguageModel(nn.Module):
 
     def make_cache(self):
         caches = []
-        for i in range(self.config.num_hidden_layers):
-            layer_type = self.config.layer_types[i]
+        for layer_type in self.config.layer_types[
+            : self.model.first_kv_shared_layer_idx
+        ]:
             if layer_type == "full_attention":
                 caches.append(KVCache())
             else:

--- a/mlx_vlm/models/gemma4/language.py
+++ b/mlx_vlm/models/gemma4/language.py
@@ -12,6 +12,7 @@ from ..base import (
 )
 from ..cache import KVCache, RotatingKVCache
 from .config import TextConfig
+from .rope_utils import initialize_rope
 
 
 class RMSNormNoScale(nn.Module):
@@ -173,13 +174,13 @@ class Attention(nn.Module):
         layer_key = "sliding_attention" if self.is_sliding else "full_attention"
         rope_params = config.rope_parameters.get(layer_key, {})
         rope_theta = rope_params.get("rope_theta", 10000.0)
-        partial_rotary_factor = rope_params.get("partial_rotary_factor", 1.0)
-        rope_dims = int(self.head_dim * partial_rotary_factor)
 
-        self.rope = nn.RoPE(
-            rope_dims,
+        self.rope = initialize_rope(
+            dims=self.head_dim,
             traditional=config.rope_traditional,
             base=rope_theta,
+            scaling_config=rope_params,
+            max_position_embeddings=config.max_position_embeddings,
         )
 
         # KV sharing (2B/4B models)

--- a/mlx_vlm/models/gemma4/language.py
+++ b/mlx_vlm/models/gemma4/language.py
@@ -388,9 +388,7 @@ class Gemma4TextModel(nn.Module):
         self.layer_idx_to_cache_idx = list(range(self.first_kv_shared_layer_idx))
         if self.first_kv_shared_layer_idx < config.num_hidden_layers:
             shared_full_idx = (
-                len(concrete_layers)
-                - 1
-                - concrete_layers[::-1].index("full_attention")
+                len(concrete_layers) - 1 - concrete_layers[::-1].index("full_attention")
             )
             shared_sliding_idx = (
                 len(concrete_layers)
@@ -494,9 +492,7 @@ class Gemma4TextModel(nn.Module):
                     )
                     max_start = max(per_layer_inputs.shape[1] - target_len, 0)
                     start = min(cache_offset, max_start)
-                    per_layer_inputs = per_layer_inputs[
-                        :, start : start + target_len
-                    ]
+                    per_layer_inputs = per_layer_inputs[:, start : start + target_len]
             if per_layer_inputs is not None or inputs is not None:
                 per_layer_inputs = self.project_per_layer_inputs(h, per_layer_inputs)
 
@@ -506,15 +502,19 @@ class Gemma4TextModel(nn.Module):
         if mask is None:
             global_mask = create_attention_mask(
                 h,
-                cache[self.first_full_cache_idx]
-                if self.first_full_cache_idx < len(cache)
-                else None,
+                (
+                    cache[self.first_full_cache_idx]
+                    if self.first_full_cache_idx < len(cache)
+                    else None
+                ),
             )
             sliding_window_mask = create_attention_mask(
                 h,
-                cache[self.first_sliding_cache_idx]
-                if self.first_sliding_cache_idx < len(cache)
-                else None,
+                (
+                    cache[self.first_sliding_cache_idx]
+                    if self.first_sliding_cache_idx < len(cache)
+                    else None
+                ),
                 window_size=self.window_size,
             )
 

--- a/mlx_vlm/models/gemma4/processing_gemma4.py
+++ b/mlx_vlm/models/gemma4/processing_gemma4.py
@@ -407,6 +407,10 @@ class Gemma4Processor(ProcessorMixin):
             data=to_mlx({**text_inputs, **image_inputs, **audio_inputs})
         )
 
+    def apply_chat_template(self, messages, **kwargs):
+        kwargs.setdefault("enable_thinking", False)
+        return self.tokenizer.apply_chat_template(messages, **kwargs)
+
     def batch_decode(self, *args, **kwargs):
         return self.tokenizer.batch_decode(*args, **kwargs)
 

--- a/mlx_vlm/models/gemma4/rope_utils.py
+++ b/mlx_vlm/models/gemma4/rope_utils.py
@@ -1,0 +1,110 @@
+# Re-export rope utilities from mlx-lm with ProportionalRoPE support.
+
+from typing import Optional
+
+import mlx.core as mx
+import mlx.nn as nn
+
+
+class ProportionalRoPE(nn.Module):
+    """Proportional RoPE for Gemma 4 full-attention layers.
+
+    Frequencies are computed relative to the full head dimension (not just the
+    rotated portion), and rotation is applied to the first rotated_dims//2
+    elements of each half of the head — matching HF's rotate_half convention.
+    """
+
+    def __init__(
+        self,
+        dims: int,
+        traditional: bool = False,
+        base: float = 10000.0,
+        scaling_config: Optional[dict] = None,
+    ):
+        super().__init__()
+        self.dims = dims
+        self.traditional = traditional
+
+        scaling_config = scaling_config or {}
+        factor = scaling_config.get("factor", 1.0)
+        partial_rotary_factor = scaling_config.get("partial_rotary_factor", 1.0)
+
+        rope_angles = int(partial_rotary_factor * dims // 2)
+        self.rotated_dims = 2 * rope_angles
+
+        if self.rotated_dims > 0:
+            exponents = mx.arange(0, self.rotated_dims, 2, dtype=mx.float32) / dims
+            self._freqs = factor * (base**exponents)
+        else:
+            self._freqs = None
+
+    def __call__(self, x, offset=0):
+        if self.rotated_dims <= 0:
+            return x
+
+        head = x[..., : self.dims]
+        tail = x[..., self.dims :]
+        half = self.dims // 2
+
+        left = head[..., :half]
+        right = head[..., half:]
+        rotated = mx.concatenate(
+            [left[..., : self.rotated_dims // 2], right[..., : self.rotated_dims // 2]],
+            axis=-1,
+        )
+        rotated = mx.fast.rope(
+            rotated,
+            self.rotated_dims,
+            traditional=self.traditional,
+            base=None,
+            scale=1.0,
+            offset=offset,
+            freqs=self._freqs,
+        )
+
+        left = mx.concatenate(
+            [
+                rotated[..., : self.rotated_dims // 2],
+                left[..., self.rotated_dims // 2 :],
+            ],
+            axis=-1,
+        )
+        right = mx.concatenate(
+            [
+                rotated[..., self.rotated_dims // 2 :],
+                right[..., self.rotated_dims // 2 :],
+            ],
+            axis=-1,
+        )
+        head = mx.concatenate([left, right], axis=-1)
+
+        if tail.shape[-1] == 0:
+            return head
+        return mx.concatenate([head, tail], axis=-1)
+
+
+def initialize_rope(
+    dims: int,
+    base: float,
+    traditional: bool,
+    scaling_config: Optional[dict] = None,
+    max_position_embeddings: Optional[int] = None,
+):
+    """Initialize the appropriate RoPE variant based on scaling_config."""
+    if scaling_config is not None:
+        rope_type = scaling_config.get("type") or scaling_config.get(
+            "rope_type", "default"
+        )
+    else:
+        rope_type = "default"
+
+    if rope_type == "proportional":
+        return ProportionalRoPE(
+            dims=dims,
+            traditional=traditional,
+            base=base,
+            scaling_config=scaling_config,
+        )
+
+    # Default: standard RoPE
+    return nn.RoPE(dims, traditional=traditional, base=base)

--- a/mlx_vlm/server.py
+++ b/mlx_vlm/server.py
@@ -1,6 +1,5 @@
 import argparse
 import gc
-import importlib
 import json
 import os
 import re
@@ -17,7 +16,6 @@ from fastapi import FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import StreamingResponse
 from huggingface_hub import scan_cache_dir
-from .tool_parsers import _infer_tool_parser, load_tool_module
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 from typing_extensions import Required, TypeAlias, TypedDict
 
@@ -38,6 +36,7 @@ from .generate import (
     stream_generate,
 )
 from .prompt_utils import apply_chat_template
+from .tool_parsers import _infer_tool_parser, load_tool_module
 from .utils import load
 from .version import __version__
 

--- a/mlx_vlm/server.py
+++ b/mlx_vlm/server.py
@@ -17,7 +17,7 @@ from fastapi import FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import StreamingResponse
 from huggingface_hub import scan_cache_dir
-from mlx_lm.tokenizer_utils import _infer_tool_parser
+from .tool_parsers import _infer_tool_parser, load_tool_module
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 from typing_extensions import Required, TypeAlias, TypedDict
 
@@ -1098,9 +1098,7 @@ async def chat_completions_endpoint(request: ChatRequest):
         if hasattr(tokenizer, "chat_template"):
             tool_parser_type = _infer_tool_parser(tokenizer.chat_template)
             if tool_parser_type is not None:
-                tool_module = importlib.import_module(
-                    f"mlx_lm.tool_parsers.{tool_parser_type}"
-                )
+                tool_module = load_tool_module(tool_parser_type)
         template_kwargs = request.template_kwargs()
         formatted_prompt = apply_chat_template(
             processor,

--- a/mlx_vlm/tool_parsers/__init__.py
+++ b/mlx_vlm/tool_parsers/__init__.py
@@ -1,0 +1,38 @@
+"""
+Tool parser utilities for mlx-vlm.
+
+Re-exports mlx_lm's _infer_tool_parser with additional model support,
+and loads parsers from both mlx_lm.tool_parsers and mlx_vlm.tool_parsers.
+"""
+
+import importlib
+
+from mlx_lm.tokenizer_utils import _infer_tool_parser as _mlx_lm_infer_tool_parser
+
+# Additional patterns not covered by mlx_lm
+_EXTRA_PATTERNS = [
+    ("<|tool_call>", "gemma4"),
+]
+
+
+def _infer_tool_parser(chat_template):
+    """Infer tool parser type, checking mlx_lm patterns first then extras."""
+    result = _mlx_lm_infer_tool_parser(chat_template)
+    if result is not None:
+        return result
+
+    if not isinstance(chat_template, str):
+        return None
+
+    for marker, parser_type in _EXTRA_PATTERNS:
+        if marker in chat_template:
+            return parser_type
+
+    return None
+
+
+def load_tool_module(tool_parser_type):
+    """Load a tool parser module from mlx_vlm.tool_parsers or mlx_lm.tool_parsers."""
+    if importlib.util.find_spec(f"mlx_vlm.tool_parsers.{tool_parser_type}"):
+        return importlib.import_module(f"mlx_vlm.tool_parsers.{tool_parser_type}")
+    return importlib.import_module(f"mlx_lm.tool_parsers.{tool_parser_type}")

--- a/mlx_vlm/tool_parsers/gemma4.py
+++ b/mlx_vlm/tool_parsers/gemma4.py
@@ -1,0 +1,46 @@
+import json
+
+import regex as re
+
+_tool_call_regex = re.compile(r"call:(\w+)\{(.*?)\}", re.DOTALL)
+
+tool_call_start = "<|tool_call>"
+tool_call_end = "<tool_call|>"
+
+
+def parse_tool_call(text, tools=None):
+    match = _tool_call_regex.findall(text)
+    if not match:
+        raise ValueError("No function call found in tool call text.")
+    func_name = match[0][0]
+    args_str = match[0][1]
+    arguments = {}
+    escape = '<|"|>'
+    while args_str:
+        split = args_str.index(":")
+        key = args_str[:split]
+        args_str = args_str[split + 1 :]
+        # Parse an escaped string value
+        if args_str.startswith(escape):
+            args_str = args_str[len(escape) :]
+            split = args_str.index(escape)
+            arguments[key] = args_str[:split]
+            args_str = args_str[split + len(escape) :]
+            if args_str.startswith(","):
+                args_str = args_str[1:]
+            continue
+        # Parse a non-string value
+        if "," in args_str:
+            split = args_str.index(",")
+        else:
+            split = len(args_str)
+
+        value = args_str[:split]
+        args_str = args_str[split + 1 :]
+
+        try:
+            arguments[key] = json.loads(value)
+        except json.JSONDecodeError:
+            arguments[key] = value
+
+    return dict(name=func_name, arguments=arguments)


### PR DESCRIPTION
## Summary

- Fix `per_layer_inputs` broadcast shape mismatch during chunked prefill by slicing to match current chunk using cache offset
- Fix `cache.state` crash on uninitialized shared-layer caches by only creating caches for non-shared layers (matching gemma3n pattern)
- Simplify KV sharing: shared layers read from reference cache via `layer_idx_to_cache_idx` and `cache.state` instead of manual `shared_kv_store`
