### PR TITLE
fix(gemma4): guard against empty processed list for text-only requests

### DIFF
--- a/mlx_vlm/models/gemma4/processing_gemma4.py
+++ b/mlx_vlm/models/gemma4/processing_gemma4.py
@@ -197,6 +197,10 @@ class Gemma4ImageProcessor(HFBaseImageProcessor):
             num_patches = (h // patch_size) * (w // patch_size)
             num_soft_tokens_per_image.append(num_patches // (pooling_kernel_size**2))
 
+        # No images were provided (e.g. text-only request); return empty
+        if not processed:
+            return {}, []
+
         # Different-shaped images can't be stacked; return as a list
         shapes = {img.shape for img in processed}
         if len(shapes) > 1:


### PR DESCRIPTION
## Problem

When the Gemma4 model receives a **text-only request** (no images), the image preprocessing loop in `Gemma4ImageProcessor.preprocess()` never appends anything to `processed`, leaving it as an empty list.

Execution then falls through to:

```python
shapes = {img.shape for img in processed}  # empty set — fine so far
data = {"pixel_values": np.stack(processed)}  # ValueError: need at least one array to stack
```

This crashes any text-only inference call against the Gemma4 endpoint.

## Fix

Add an early return before the `np.stack` block:

```python
if not processed:
    return {}, []
```

This matches the function's return type `(dict, list)` and lets the caller proceed with no pixel values, which is the correct behaviour for text-only input.

## Reproduction

Run the mlx-vlm HTTP server with `mlx-community/gemma-4-e4b-it-4bit` and send a chat completion request with no image in the message — the server will crash without this fix.

## Testing

- Confirmed fix on `mlx-vlm==0.4.3` with `mlx-community/gemma-4-e4b-it-4bit` (4-bit quantised).
- Text-only requests now complete successfully; image requests are unaffected.