### PR TITLE
Fix TurboQuant crash with PromptCacheState prefix reuse

### DIFF
--- a/mlx_vlm/generate.py
+++ b/mlx_vlm/generate.py
@@ -688,12 +688,19 @@ def stream_generate(
             # Trim cache to prefix_len in case it includes generated tokens
             for c in kv_cache:
                 if hasattr(c, "keys") and c.keys is not None:
-                    cached_len = c.keys.shape[2]
-                    if cached_len > prefix_len:
-                        c.keys = c.keys[:, :, :prefix_len, :]
-                        c.values = c.values[:, :, :prefix_len, :]
-                        if hasattr(c, "offset"):
-                            c.offset = prefix_len
+                    # TurboQuant caches store quantized states (NamedTuples)
+                    # instead of raw tensors, so use trim() instead of slicing
+                    if hasattr(c, "trim") and not hasattr(c.keys, "shape"):
+                        excess = c.offset - prefix_len
+                        if excess > 0:
+                            c.trim(excess)
+                    elif hasattr(c.keys, "shape"):
+                        cached_len = c.keys.shape[2]
+                        if cached_len > prefix_len:
+                            c.keys = c.keys[:, :, :prefix_len, :]
+                            c.values = c.values[:, :, :prefix_len, :]
+                            if hasattr(c, "offset"):
+                                c.offset = prefix_len
             kwargs["prompt_cache"] = kv_cache
 
     if thinking_budget is not None:

--- a/mlx_vlm/tests/test_turboquant.py
+++ b/mlx_vlm/tests/test_turboquant.py
@@ -385,3 +385,24 @@ def test_turboquant_prefill_attention_matches_dequantized_attention():
     diff = mx.max(mx.abs(reference - quantized)).item()
     assert quantized.shape == reference.shape
     assert diff < 1e-4
+
+
+def test_turboquant_cache_trim_for_prefix_reuse():
+    keys = mx.random.normal((1, 2, 16, 32))
+    values = mx.random.normal((1, 2, 16, 32))
+
+    fp_cache = KVCache()
+    fp_cache.update_and_fetch(keys, values)
+    turbo_cache = TurboQuantKVCache.from_cache(fp_cache, bits=3.5)
+
+    assert turbo_cache.offset == 16
+
+    # Simulate prefix reuse: trim to keep first 12 tokens
+    turbo_cache.trim(4)
+    assert turbo_cache.offset == 12
+
+    # Cache should still accept new tokens after trim
+    new_keys = mx.random.normal((1, 2, 1, 32))
+    new_values = mx.random.normal((1, 2, 1, 32))
+    turbo_cache.update_and_fetch(new_keys, new_values)
+    assert turbo_cache.offset == 13


### PR DESCRIPTION
`stream_generate` crashes with `AttributeError: 'TurboQuantMSEState' object has no attribute 'shape'` when using TurboQuant (`kv_bits=3.5`) together with `prompt_cache_state` for multi-turn prefix reuse.

The cache trimming code assumes `.keys` is a raw tensor and does `c.keys.shape[2]` / `c.keys[:, :, :n, :]`. TurboQuant caches store quantized NamedTuples instead. Fix: use `c.trim()` which `TurboQuantKVCache` already provides.

Repro: call `stream_generate` twice with `prompt_cache_state=PromptCacheState()` and `kv_bits=3.5, kv_quant_scheme="turboquant"`. Second call crashes at line 691.