### PR TITLE
Set finish_reason to "tool_calls" when the model emits tool calls

### DIFF
--- a/mlx_vlm/server.py
+++ b/mlx_vlm/server.py
@@ -1179,7 +1179,9 @@ async def chat_completions_endpoint(request: ChatRequest):
                     # Signal stream end
                     choices = [
                         ChatStreamChoice(
-                            finish_reason="stop",
+                            finish_reason=(
+                                "tool_calls" if tool_calls["calls"] else "stop"
+                            ),
                             delta=ChatMessage(
                                 role="assistant",
                                 content="",
@@ -1261,7 +1263,7 @@ async def chat_completions_endpoint(request: ChatRequest):
 
                 choices = [
                     ChatChoice(
-                        finish_reason="stop",
+                        finish_reason=("tool_calls" if tool_calls["calls"] else "stop"),
                         message=ChatMessage(
                             role="assistant",
                             content=tool_calls["remaining_text"],

--- a/mlx_vlm/tests/test_server.py
+++ b/mlx_vlm/tests/test_server.py
@@ -88,6 +88,113 @@ def test_responses_endpoint_forwards_new_sampling_args(client):
     assert mock_generate.call_args.kwargs["thinking_start_token"] == "<think>"
 
 
+def test_chat_completions_finish_reason_is_tool_calls_when_tools_emitted(client):
+    model = SimpleNamespace()
+    tokenizer = SimpleNamespace(chat_template="dummy")
+    processor = SimpleNamespace(tokenizer=tokenizer)
+    config = SimpleNamespace(model_type="gemma4")
+    result = SimpleNamespace(
+        text="ignored — process_tool_calls is mocked",
+        prompt_tokens=8,
+        generation_tokens=4,
+        total_tokens=12,
+        prompt_tps=10.0,
+        generation_tps=5.0,
+        peak_memory=0.1,
+    )
+    fake_tool_module = SimpleNamespace(
+        tool_call_start="<|tool_call>",
+        tool_call_end="<tool_call|>",
+    )
+    fake_tool_calls = {
+        "calls": [
+            {
+                "type": "function",
+                "id": "abc123",
+                "function": {
+                    "name": "get_weather",
+                    "arguments": '{"city": "Tokyo"}',
+                },
+            }
+        ],
+        "remaining_text": "",
+    }
+
+    with (
+        patch.object(
+            server, "get_cached_model", return_value=(model, processor, config)
+        ),
+        patch.object(server, "apply_chat_template", return_value="prompt"),
+        patch.object(server, "generate", return_value=result),
+        patch.object(server, "_infer_tool_parser", return_value="gemma4"),
+        patch.object(server, "load_tool_module", return_value=fake_tool_module),
+        patch.object(server, "process_tool_calls", return_value=fake_tool_calls),
+    ):
+        response = client.post(
+            "/chat/completions",
+            json={
+                "model": "demo",
+                "messages": [{"role": "user", "content": "What's the weather?"}],
+                "tools": [
+                    {
+                        "type": "function",
+                        "function": {
+                            "name": "get_weather",
+                            "parameters": {
+                                "type": "object",
+                                "properties": {"city": {"type": "string"}},
+                                "required": ["city"],
+                            },
+                        },
+                    }
+                ],
+            },
+        )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["choices"][0]["finish_reason"] == "tool_calls"
+    assert len(body["choices"][0]["message"]["tool_calls"]) == 1
+    assert (
+        body["choices"][0]["message"]["tool_calls"][0]["function"]["name"]
+        == "get_weather"
+    )
+
+
+def test_chat_completions_finish_reason_stays_stop_when_no_tool_calls(client):
+    model = SimpleNamespace()
+    processor = SimpleNamespace()
+    config = SimpleNamespace(model_type="qwen2_vl")
+    result = SimpleNamespace(
+        text="Just a normal answer.",
+        prompt_tokens=8,
+        generation_tokens=4,
+        total_tokens=12,
+        prompt_tps=10.0,
+        generation_tps=5.0,
+        peak_memory=0.1,
+    )
+
+    with (
+        patch.object(
+            server, "get_cached_model", return_value=(model, processor, config)
+        ),
+        patch.object(server, "apply_chat_template", return_value="prompt"),
+        patch.object(server, "generate", return_value=result),
+    ):
+        response = client.post(
+            "/chat/completions",
+            json={
+                "model": "demo",
+                "messages": [{"role": "user", "content": "Hi"}],
+            },
+        )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["choices"][0]["finish_reason"] == "stop"
+
+
 def test_chat_completions_endpoint_forwards_explicit_sampling_args(client):
     model = SimpleNamespace()
     processor = SimpleNamespace()


### PR DESCRIPTION
Returns `finish_reason: "tool_calls"` from the chat completions endpoint when the model emits tool calls, instead of always returning `"stop"`. Per the OpenAI Chat Completions spec, the `finish_reason` enum is "`tool_calls` if the model called a tool" ([openai-openapi `CreateChatCompletionResponse.choices[].finish_reason`](https://github.com/openai/openai-openapi/blob/498c71ddf6f1c45b983f972ccabca795da211a3e/openapi.yaml#L19676-L19696)).

Both `server.py:1182` (streaming, `ChatStreamChoice`) and `server.py:1264` (non-streaming, `ChatChoice`) hardcoded `"stop"`. The variable `tool_calls["calls"]` is already in scope at both spots, so the fix is a local conditional.

The bug is visible in [#773](https://github.com/Blaizzy/mlx-vlm/pull/773) (the PR that added tool calling) — the test response posted in the discussion shows `"finish_reason":"stop"` alongside a populated `tool_calls` array. The mapping was outside the scope of that PR.

Strict OpenAI-spec clients use `finish_reason == "tool_calls"` as the branch condition for entering the tool-execution loop and currently treat tool-emitting responses as plain stops.

## Tests

Two tests added to `mlx_vlm/tests/test_server.py` following the existing pattern (`FastAPI TestClient` + `patch.object` on `get_cached_model` / `apply_chat_template` / `generate`, plus `_infer_tool_parser` / `load_tool_module` / `process_tool_calls` for the tool path):

- `test_chat_completions_finish_reason_is_tool_calls_when_tools_emitted` — covers the non-streaming positive case. Verified to fail without the fix.
- `test_chat_completions_finish_reason_stays_stop_when_no_tool_calls` — regression guard for the unchanged path.

```
$ python -m pytest mlx_vlm/tests/test_server.py
======================== 11 passed, 2 warnings in 0.80s ========================
```

The streaming path (line 1182) is structurally identical to the non-streaming path for the `finish_reason` branch and not separately covered. Happy to add a streaming test if you'd like — it would need an SSE-parsing helper that doesn't exist yet in `test_server.py`. Let me know your preference.

<sub>🤖 drafted with Claude Code, reviewed before submitting.</sub>
