### PR TITLE
fix(generate): auto-apply chat template for vision/audio prompts

### DIFF
--- a/mlx_vlm/generate.py
+++ b/mlx_vlm/generate.py
@@ -627,6 +627,36 @@ def stream_generate(
     image_token_index = getattr(model.config, "image_token_index", None)
     vision_cache = kwargs.pop("vision_cache", None)
 
+    # Apply chat template if the prompt is raw text (not already templated).
+    # The CLI path (main()) and callers like chat_ui.py/server.py apply
+    # apply_chat_template() before calling stream_generate(). The direct
+    # API path (generate()/stream_generate()) receives raw text from users.
+    # Without the template, models like Gemma 4 don't get image tokens in
+    # the input_ids and produce empty output.
+    if (image is not None or audio is not None) and not kwargs.pop(
+        "_skip_template", False
+    ):
+        # Detect if prompt is already templated by checking for any special
+        # tokens from the tokenizer (covers all model formats).
+        special_tokens = set(
+            getattr(tokenizer, "all_special_tokens", [])
+        )
+        has_template = any(tok in prompt for tok in special_tokens if len(tok) > 1)
+        if not has_template:
+            num_images = (
+                len(image) if isinstance(image, list) else (1 if image else 0)
+            )
+            num_audios = (
+                len(audio) if isinstance(audio, list) else (1 if audio else 0)
+            )
+            prompt = apply_chat_template(
+                processor,
+                model.config,
+                prompt,
+                num_images=num_images,
+                num_audios=num_audios,
+            )
+
     if kwargs.get("input_ids", None) is not None:
         input_ids = kwargs.pop("input_ids")
         pixel_values = kwargs.pop("pixel_values", None)


### PR DESCRIPTION
## Summary

`generate()` and `stream_generate()` return empty output for Gemma 4 vision models when called with raw text prompts and images via the Python API.

**Root cause**: The CLI path (`main()` in generate.py) calls `apply_chat_template()` before `stream_generate()`, but the Python API path does not. Without the template, the processor tokenizes raw text without inserting image tokens (`258880`), so the model never sees the image.

```python
# Before (empty output):
generate(model, processor, "What do you see?", image=["photo.jpg"])
# → GenerationResult(text="")

# After (works):
generate(model, processor, "What do you see?", image=["photo.jpg"])
# → GenerationResult(text="This image shows a traffic camera recording...")
```

## Fix

Detect raw prompts by checking if they contain any special tokens from `tokenizer.all_special_tokens`. If none found, auto-apply `apply_chat_template()`. Pre-templated prompts (from CLI, `chat_ui.py`, `server.py`) are detected and left unchanged.

## Test results

- Raw prompt + image → produces real text (was empty before)
- Pre-templated prompt + image → no double-templating, same output
- Tested on Gemma 4 E2B-it 8bit with real security camera frames

## Changes

1 file, +30 lines. `mlx_vlm/generate.py` only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)