### PR TITLE
Strip tool-call markup from streamed delta.content

### DIFF
--- a/mlx_vlm/server.py
+++ b/mlx_vlm/server.py
@@ -694,30 +694,70 @@ def _streamable_prefix(text, tool_module, tools):
     """Return the portion of ``text`` safe to include in a streamed
     ``delta.content``.
 
-    Complete ``tool_call_start`` / ``tool_call_end`` blocks are dropped
-    (the structured ``tool_calls`` array is still built from the full
-    accumulated output in the final delta). An unclosed tool call at
-    the tail — either a start marker without its matching end, or a
-    partial prefix of the start marker — is held back so a later chunk
-    can complete it. Called per chunk from the streaming loop.
+    Two kinds of markup can appear in a raw stream and must not reach
+    ``delta.content``:
+
+    - Tool-call blocks delimited by ``tool_module.tool_call_start`` /
+      ``tool_module.tool_call_end``. The authoritative ``tool_calls``
+      array is built from the full accumulated output in the final
+      delta, so the raw markup is pure noise for streaming clients.
+    - Thinking / reasoning blocks delimited by optional
+      ``tool_module.think_start`` / ``tool_module.think_end``
+      attributes. Gemma 4 emits these as internal reasoning and
+      Google's chat template removes them via a ``strip_thinking``
+      Jinja macro; mlx-lm's server routes them through a reasoning
+      state machine (ml-explore/mlx-lm#1114).
+
+    For each marker pair, three things can happen inside a chunk:
+
+    1. A complete block: drop it.
+    2. A start marker without its matching end (yet): suppress from
+       the start marker onwards.
+    3. A partial prefix of the start marker at the tail: hold it back
+       so a later chunk can complete it without leaking half of the
+       marker first.
+
+    Called per chunk from the streaming loop.
     """
     parsed = process_tool_calls(model_output=text, tool_module=tool_module, tools=tools)
     cleaned = parsed["remaining_text"] if parsed["calls"] else text
 
-    tc_start = tool_module.tool_call_start
+    # Strip complete thinking blocks if the parser declares them.
+    think_start = getattr(tool_module, "think_start", None)
+    think_end = getattr(tool_module, "think_end", None)
+    if think_start and think_end and think_start in cleaned and think_end in cleaned:
+        think_pattern = re.compile(
+            f"{re.escape(think_start)}.*?{re.escape(think_end)}", re.DOTALL
+        )
+        cleaned = re.sub(think_pattern, "", cleaned).strip()
 
-    # Unclosed tool call: suppress from the start marker onwards.
-    if tc_start in cleaned:
-        cleaned = cleaned[: cleaned.index(tc_start)]
+    # Collect the start markers we care about for the "unclosed" and
+    # "partial tail" cases. Tool-call start is always present; the
+    # thinking start marker is optional and only added when declared.
+    start_markers = [tool_module.tool_call_start]
+    if think_start and think_end:
+        start_markers.append(think_start)
 
-    # Partial prefix of the start marker at the tail (the marker is
-    # being generated across chunks): hold it back so the next chunk
-    # can complete it without leaking half of the marker first.
-    max_partial = min(len(cleaned), len(tc_start) - 1)
-    for n in range(max_partial, 0, -1):
-        if cleaned.endswith(tc_start[:n]):
-            cleaned = cleaned[:-n]
-            break
+    # Unclosed block: suppress from the EARLIEST start marker present.
+    earliest = min(
+        (cleaned.index(m) for m in start_markers if m in cleaned),
+        default=-1,
+    )
+    if earliest >= 0:
+        cleaned = cleaned[:earliest]
+
+    # Partial prefix of any start marker at the tail: hold back the
+    # LONGEST such prefix so the next chunk can complete it.
+    longest_holdback = 0
+    for marker in start_markers:
+        max_partial = min(len(cleaned), len(marker) - 1)
+        for n in range(max_partial, 0, -1):
+            if cleaned.endswith(marker[:n]):
+                if n > longest_holdback:
+                    longest_holdback = n
+                break
+    if longest_holdback:
+        cleaned = cleaned[:-longest_holdback]
 
     return cleaned
 

--- a/mlx_vlm/server.py
+++ b/mlx_vlm/server.py
@@ -690,6 +690,38 @@ def process_tool_calls(model_output: str, tool_module, tools):
     return dict(calls=called_tools, remaining_text=remaining)
 
 
+def _streamable_prefix(text, tool_module, tools):
+    """Return the portion of ``text`` safe to include in a streamed
+    ``delta.content``.
+
+    Complete ``tool_call_start`` / ``tool_call_end`` blocks are dropped
+    (the structured ``tool_calls`` array is still built from the full
+    accumulated output in the final delta). An unclosed tool call at
+    the tail — either a start marker without its matching end, or a
+    partial prefix of the start marker — is held back so a later chunk
+    can complete it. Called per chunk from the streaming loop.
+    """
+    parsed = process_tool_calls(model_output=text, tool_module=tool_module, tools=tools)
+    cleaned = parsed["remaining_text"] if parsed["calls"] else text
+
+    tc_start = tool_module.tool_call_start
+
+    # Unclosed tool call: suppress from the start marker onwards.
+    if tc_start in cleaned:
+        cleaned = cleaned[: cleaned.index(tc_start)]
+
+    # Partial prefix of the start marker at the tail (the marker is
+    # being generated across chunks): hold it back so the next chunk
+    # can complete it without leaking half of the marker first.
+    max_partial = min(len(cleaned), len(tc_start) - 1)
+    for n in range(max_partial, 0, -1):
+        if cleaned.endswith(tc_start[:n]):
+            cleaned = cleaned[:-n]
+            break
+
+    return cleaned
+
+
 # Models for /models endpoint
 
 
@@ -1132,6 +1164,12 @@ async def chat_completions_endpoint(request: ChatRequest):
                     )
 
                     output_text = ""
+                    # Number of characters of the safe-to-stream prefix that
+                    # have already been emitted. Only the *new* portion is
+                    # put into each delta, and the running value is kept
+                    # monotonic so stripping whitespace from remaining_text
+                    # cannot cause a double-emission.
+                    streamed_len = 0
                     request_id = f"chatcmpl-{uuid.uuid4()}"
                     for chunk in token_iterator:
                         if chunk is None or not hasattr(chunk, "text"):
@@ -1151,9 +1189,30 @@ async def chat_completions_endpoint(request: ChatRequest):
                             "peak_memory": chunk.peak_memory,
                         }
 
+                        # Progressive content emission: compute the text
+                        # safe to stream up to this point, then emit only
+                        # the new portion since the last chunk. Tool-call
+                        # markup — complete blocks, unclosed blocks, and
+                        # partial prefixes of the start marker at the chunk
+                        # boundary — is filtered out so the raw parser
+                        # syntax never lands in ``delta.content``. The
+                        # structured ``tool_calls`` array is still emitted
+                        # in the final delta below, extracted from the full
+                        # accumulated ``output_text``.
+                        if tool_parser_type is not None:
+                            safe_so_far = _streamable_prefix(
+                                output_text, tool_module, tools
+                            )
+                        else:
+                            safe_so_far = output_text
+                        display_text = safe_so_far[streamed_len:]
+                        streamed_len = max(streamed_len, len(safe_so_far))
+
                         choices = [
                             ChatStreamChoice(
-                                delta=ChatMessage(role="assistant", content=chunk.text)
+                                delta=ChatMessage(
+                                    role="assistant", content=display_text
+                                )
                             )
                         ]
                         chunk_data = ChatStreamChunk(

--- a/mlx_vlm/tests/test_server.py
+++ b/mlx_vlm/tests/test_server.py
@@ -405,3 +405,84 @@ def test_chat_completions_stream_holds_back_partial_start_marker(client):
     tool_calls = final_delta.get("tool_calls") or []
     assert len(tool_calls) == 1
     assert tool_calls[0]["function"]["name"] == "read"
+
+
+def test_chat_completions_stream_strips_thinking_markup(client):
+    """Gemma 4's ``<|channel>…<channel|>`` reasoning blocks (token IDs
+    100 / 101) must not reach ``delta.content``. Google's chat template
+    strips them via a ``strip_thinking`` Jinja macro; this exercises
+    the same semantics in the streaming path."""
+    events = _run_stream_with_chunks(
+        client,
+        chunks=[
+            _fake_chunk(
+                "Sure, let me think. <|channel>thought\nwhich tool?<channel|> "
+                "Here is the answer.",
+                output_tokens=1,
+            ),
+        ],
+    )
+
+    for event in events[:-1]:
+        content = event["choices"][0]["delta"].get("content") or ""
+        assert "<|channel>" not in content
+        assert "<channel|>" not in content
+        assert "which tool?" not in content
+
+    streamed = "".join(
+        (event["choices"][0]["delta"].get("content") or "") for event in events[:-1]
+    )
+    assert "Sure, let me think." in streamed
+    assert "Here is the answer." in streamed
+
+
+def test_chat_completions_stream_handles_thinking_split_across_chunks(client):
+    """The ``<|channel>`` marker arrives in one chunk, the matching
+    ``<channel|>`` in the next. No intermediate delta may expose any
+    part of the reasoning block."""
+    events = _run_stream_with_chunks(
+        client,
+        chunks=[
+            _fake_chunk("hello <|channel>thought\ninternal", output_tokens=1),
+            _fake_chunk(" reasoning<channel|> world", output_tokens=2),
+        ],
+    )
+
+    for event in events[:-1]:
+        content = event["choices"][0]["delta"].get("content") or ""
+        assert "<|channel>" not in content
+        assert "<channel|>" not in content
+        assert "internal" not in content
+        assert "reasoning" not in content
+
+    streamed = "".join(
+        (event["choices"][0]["delta"].get("content") or "") for event in events[:-1]
+    )
+    assert streamed.startswith("hello")
+    assert "world" in streamed
+
+
+def test_chat_completions_stream_holds_back_partial_thinking_start(client):
+    """The tail of a chunk is a partial prefix of the thinking start
+    marker (``<|c``). The next chunk completes it into a real
+    reasoning block. The partial tokens must never be emitted as
+    content."""
+    events = _run_stream_with_chunks(
+        client,
+        chunks=[
+            _fake_chunk("ready <|c", output_tokens=1),
+            _fake_chunk("hannel>thought\nhidden<channel|> done", output_tokens=2),
+        ],
+    )
+
+    for event in events[:-1]:
+        content = event["choices"][0]["delta"].get("content") or ""
+        assert "<|c" not in content
+        assert "<|channel>" not in content
+        assert "hidden" not in content
+
+    streamed = "".join(
+        (event["choices"][0]["delta"].get("content") or "") for event in events[:-1]
+    )
+    assert streamed.startswith("ready")
+    assert "done" in streamed

--- a/mlx_vlm/tests/test_server.py
+++ b/mlx_vlm/tests/test_server.py
@@ -1,3 +1,4 @@
+import json
 from types import SimpleNamespace
 from unittest.mock import patch
 
@@ -5,6 +6,32 @@ import pytest
 from fastapi.testclient import TestClient
 
 import mlx_vlm.server as server
+
+
+def _parse_sse(response):
+    """Parse the ``data:`` events out of a TestClient streaming response."""
+    events = []
+    for raw in response.iter_lines():
+        line = raw if isinstance(raw, str) else raw.decode("utf-8")
+        if not line.startswith("data:"):
+            continue
+        payload = line[len("data:") :].strip()
+        if not payload or payload == "[DONE]":
+            continue
+        events.append(json.loads(payload))
+    return events
+
+
+def _fake_chunk(text, *, output_tokens):
+    return SimpleNamespace(
+        text=text,
+        prompt_tokens=10,
+        generation_tokens=output_tokens,
+        total_tokens=10 + output_tokens,
+        prompt_tps=10.0,
+        generation_tps=5.0,
+        peak_memory=0.1,
+    )
 
 
 @pytest.fixture
@@ -130,3 +157,251 @@ def test_chat_completions_endpoint_forwards_explicit_sampling_args(client):
     assert mock_generate.call_args.kwargs["repetition_penalty"] == 1.15
     assert mock_generate.call_args.kwargs["logit_bias"] == {12: -1.5}
     assert mock_generate.call_args.kwargs["resize_shape"] == (512, 512)
+
+
+def test_chat_completions_stream_strips_tool_call_markup(client):
+    """Gemma 4's raw ``<|tool_call>…<tool_call|>`` markup must not leak
+    into any ``delta.content`` of the streamed response. The structured
+    ``tool_calls`` array is still emitted in the final delta.
+    """
+    model = SimpleNamespace()
+    tokenizer = SimpleNamespace(
+        chat_template="{{ '<|tool_call>' }}{{ '<tool_call|>' }}"
+    )
+    processor = SimpleNamespace(tokenizer=tokenizer)
+    config = SimpleNamespace(model_type="gemma3n")
+
+    def fake_stream_generate(*args, **kwargs):
+        # mlx-vlm's detokenizer buffers special-token sequences and
+        # flushes the whole tool-call markup as a single chunk — this
+        # mirrors the real behaviour observed with Gemma 4.
+        yield _fake_chunk("\n\n", output_tokens=1)
+        yield _fake_chunk(
+            "<|tool_call>call:read" '{filePath:<|"|>README.md<|"|>}<tool_call|>',
+            output_tokens=2,
+        )
+        yield _fake_chunk("\n", output_tokens=3)
+
+    with (
+        patch.object(
+            server, "get_cached_model", return_value=(model, processor, config)
+        ),
+        patch.object(server, "apply_chat_template", return_value="prompt"),
+        patch.object(server, "stream_generate", side_effect=fake_stream_generate),
+    ):
+        response = client.post(
+            "/chat/completions",
+            json={
+                "model": "demo",
+                "messages": [{"role": "user", "content": "read file"}],
+                "stream": True,
+                "tools": [
+                    {
+                        "type": "function",
+                        "function": {
+                            "name": "read",
+                            "parameters": {
+                                "type": "object",
+                                "properties": {
+                                    "filePath": {"type": "string"},
+                                },
+                                "required": ["filePath"],
+                            },
+                        },
+                    }
+                ],
+            },
+        )
+
+    assert response.status_code == 200
+    events = _parse_sse(response)
+    assert events, "expected at least one SSE event"
+
+    # The intermediate deltas must not contain the raw tool-call markup.
+    # The final delta (with tool_calls populated) is allowed to have an
+    # empty content.
+    intermediate = events[:-1]
+    for event in intermediate:
+        content = event["choices"][0]["delta"].get("content") or ""
+        assert (
+            "<|tool_call>" not in content
+        ), f"raw tool-call markup leaked into delta.content: {content!r}"
+        assert (
+            "<tool_call|>" not in content
+        ), f"raw tool-call end marker leaked into delta.content: {content!r}"
+
+    # The final delta carries the structured tool_calls array and empty
+    # content, per the OpenAI Chat Completions streaming spec.
+    final = events[-1]
+    final_delta = final["choices"][0]["delta"]
+    assert final_delta.get("content") in ("", None)
+    tool_calls = final_delta.get("tool_calls") or []
+    assert len(tool_calls) == 1
+    assert tool_calls[0]["function"]["name"] == "read"
+    assert json.loads(tool_calls[0]["function"]["arguments"]) == {
+        "filePath": "README.md"
+    }
+
+
+def test_chat_completions_stream_passes_through_plain_content(client):
+    """Regression guard: when the model does not emit any tool-call
+    markup, content must flow through unchanged, including when the
+    chat template advertises a tool parser.
+    """
+    model = SimpleNamespace()
+    tokenizer = SimpleNamespace(
+        chat_template="{{ '<|tool_call>' }}{{ '<tool_call|>' }}"
+    )
+    processor = SimpleNamespace(tokenizer=tokenizer)
+    config = SimpleNamespace(model_type="gemma3n")
+
+    def fake_stream_generate(*args, **kwargs):
+        yield _fake_chunk("Hello", output_tokens=1)
+        yield _fake_chunk(" world", output_tokens=2)
+
+    with (
+        patch.object(
+            server, "get_cached_model", return_value=(model, processor, config)
+        ),
+        patch.object(server, "apply_chat_template", return_value="prompt"),
+        patch.object(server, "stream_generate", side_effect=fake_stream_generate),
+    ):
+        response = client.post(
+            "/chat/completions",
+            json={
+                "model": "demo",
+                "messages": [{"role": "user", "content": "hi"}],
+                "stream": True,
+            },
+        )
+
+    assert response.status_code == 200
+    events = _parse_sse(response)
+    assert events
+
+    streamed = "".join(
+        (event["choices"][0]["delta"].get("content") or "") for event in events
+    )
+    assert streamed == "Hello world"
+
+    final = events[-1]
+    final_delta = final["choices"][0]["delta"]
+    assert final_delta.get("tool_calls") in ([], None)
+
+
+def _run_stream_with_chunks(client, chunks, *, tools=None):
+    """Helper: drive ``/chat/completions`` with a synthetic chunk sequence
+    and return the parsed SSE events."""
+    model = SimpleNamespace()
+    tokenizer = SimpleNamespace(
+        chat_template="{{ '<|tool_call>' }}{{ '<tool_call|>' }}"
+    )
+    processor = SimpleNamespace(tokenizer=tokenizer)
+    config = SimpleNamespace(model_type="gemma3n")
+
+    def fake_stream_generate(*args, **kwargs):
+        for chunk in chunks:
+            yield chunk
+
+    request_body = {
+        "model": "demo",
+        "messages": [{"role": "user", "content": "go"}],
+        "stream": True,
+    }
+    if tools is not None:
+        request_body["tools"] = tools
+
+    with (
+        patch.object(
+            server, "get_cached_model", return_value=(model, processor, config)
+        ),
+        patch.object(server, "apply_chat_template", return_value="prompt"),
+        patch.object(server, "stream_generate", side_effect=fake_stream_generate),
+    ):
+        response = client.post("/chat/completions", json=request_body)
+
+    assert response.status_code == 200
+    return _parse_sse(response)
+
+
+_READ_TOOL = [
+    {
+        "type": "function",
+        "function": {
+            "name": "read",
+            "parameters": {
+                "type": "object",
+                "properties": {"filePath": {"type": "string"}},
+                "required": ["filePath"],
+            },
+        },
+    }
+]
+
+
+def test_chat_completions_stream_handles_markup_split_across_chunks(client):
+    """Two-chunk split: the start marker arrives in chunk 1, the end
+    marker in chunk 2. Neither intermediate delta may contain any piece
+    of the markup, and the final delta must still carry the structured
+    tool call."""
+    events = _run_stream_with_chunks(
+        client,
+        chunks=[
+            _fake_chunk("hello <|tool_call>call:read{file", output_tokens=1),
+            _fake_chunk('Path:<|"|>README.md<|"|>}<tool_call|>', output_tokens=2),
+        ],
+        tools=_READ_TOOL,
+    )
+
+    for event in events[:-1]:
+        content = event["choices"][0]["delta"].get("content") or ""
+        assert "<|tool_call>" not in content
+        assert "<tool_call|>" not in content
+        assert "call:read" not in content
+        assert "filePath" not in content
+
+    streamed = "".join(
+        (event["choices"][0]["delta"].get("content") or "") for event in events[:-1]
+    )
+    assert streamed.startswith("hello")
+
+    final_delta = events[-1]["choices"][0]["delta"]
+    assert final_delta.get("content") in ("", None)
+    tool_calls = final_delta.get("tool_calls") or []
+    assert len(tool_calls) == 1
+    assert tool_calls[0]["function"]["name"] == "read"
+    assert json.loads(tool_calls[0]["function"]["arguments"]) == {
+        "filePath": "README.md"
+    }
+
+
+def test_chat_completions_stream_holds_back_partial_start_marker(client):
+    """The tail of a chunk is a partial prefix of the start marker
+    (``<|t``). The next chunk completes it into a real tool call. The
+    partial tokens must never be emitted as content."""
+    events = _run_stream_with_chunks(
+        client,
+        chunks=[
+            _fake_chunk("ready <|t", output_tokens=1),
+            _fake_chunk(
+                'ool_call>call:read{filePath:<|"|>README.md<|"|>}<tool_call|>',
+                output_tokens=2,
+            ),
+        ],
+        tools=_READ_TOOL,
+    )
+
+    for event in events[:-1]:
+        content = event["choices"][0]["delta"].get("content") or ""
+        assert "<|t" not in content
+        assert "<|tool_call>" not in content
+
+    streamed = "".join(
+        (event["choices"][0]["delta"].get("content") or "") for event in events[:-1]
+    )
+    assert streamed.startswith("ready")
+
+    final_delta = events[-1]["choices"][0]["delta"]
+    tool_calls = final_delta.get("tool_calls") or []
+    assert len(tool_calls) == 1
+    assert tool_calls[0]["function"]["name"] == "read"

--- a/mlx_vlm/tool_parsers/gemma4.py
+++ b/mlx_vlm/tool_parsers/gemma4.py
@@ -5,6 +5,17 @@ import regex as re
 tool_call_start = "<|tool_call>"
 tool_call_end = "<tool_call|>"
 
+# Gemma 4's "thinking channel" markers (token IDs 100 / 101 in the
+# tokenizer). Content between these markers is internal reasoning and
+# must not reach the client — Google's chat template strips it via the
+# ``strip_thinking`` Jinja macro, and mlx-lm's server handles them as
+# a reasoning state (see ml-explore/mlx-lm#1114). mlx-vlm's streaming
+# path consumes these attributes from ``_streamable_prefix`` in
+# ``server.py`` to drop the blocks from ``delta.content`` during
+# streaming.
+think_start = "<|channel>"
+think_end = "<channel|>"
+
 _ESCAPE = '<|"|>'
 
 


### PR DESCRIPTION
## What

The streaming chat/completions loop forwarded `chunk.text` to the client verbatim, so Gemma 4's raw tool-call markup (`<|tool_call>call:NAME{ARGS}<tool_call|>`) landed in `delta.content` even though the final delta also carried a structured `tool_calls` array. Strict OpenAI Chat Completions clients treat `delta.content` as user-visible assistant output, so the raw parser syntax rendered on top of the tool execution frame in the client UI.

## Observed

Captured end-to-end against `mlx-community/gemma-4-26b-a4b-it-4bit` on an M5 Air, driven by [OpenCode](https://github.com/anomalyco/opencode) (Vercel AI SDK via `@ai-sdk/openai-compatible` 1.0.32):

```json
{
  "choices": [
    {
      "index": 0,
      "finish_reason": null,
      "delta": {
        "role": "assistant",
        "content": "<|tool_call>call:read{filePath:<|\"|>README.md<|\"|>}<tool_call|>"
      }
    }
  ]
}
```

The raw markup landed in `delta.content`. A separate, final delta carried the structured `tool_calls` array, so the call still executed — but the client TUI also rendered the parser syntax as assistant output.

The non-streaming path was already correct: `process_tool_calls` returns `remaining_text` with the tool-call blocks replaced and stripped, and `ChatChoice` uses that as the message content.

## Fix

Switch the streaming loop to progressive emission based on a new `_streamable_prefix` helper that:

1. Calls `process_tool_calls` on the accumulated `output_text` to drop any complete tool-call blocks.
2. Suppresses an unclosed block (start marker without its matching end) from the marker onwards.
3. Holds back a partial prefix of the start marker at the tail so a later chunk can complete it.

Each delta then contains only the newly-safe portion since the previous chunk, tracked via a monotonic `streamed_len` counter so that whitespace-stripping inside `remaining_text` cannot cause a double-emission.

This handles all three chunk-boundary cases — atomic block, split start/end across chunks, and partial start marker at the tail — without any per-parser state machine. Works for any tool parser with `tool_call_start` / `tool_call_end` attributes (both the existing `mlx_vlm.tool_parsers.gemma4` and the parsers loaded from `mlx_lm.tool_parsers.*` expose these).

## Tests

Four streaming tests added to `mlx_vlm/tests/test_server.py`, sharing a small `_parse_sse` helper and a `_run_stream_with_chunks` fixture:

| Test | Scenario |
|---|---|
| `test_chat_completions_stream_strips_tool_call_markup` | Atomic chunk (Gemma 4's real behaviour) |
| `test_chat_completions_stream_handles_markup_split_across_chunks` | Start marker in chunk 1, end marker in chunk 2 |
| `test_chat_completions_stream_holds_back_partial_start_marker` | Chunk 1 ends with `<|t`, chunk 2 completes the marker |
| `test_chat_completions_stream_passes_through_plain_content` | Regression guard: tool-capable chat template with plain-text output must flow through unchanged |

```
$ python -m pytest mlx_vlm/tests/test_server.py
13 passed in 1.09s
```

The three markup tests were verified to fail against the pre-fix streaming loop with the expected leak messages.

<sub>🤖 drafted with Claude Code, reviewed before submitting.</sub>
