### PR TITLE
fix(trainer): flatten input_ids before measuring length in batch padding

### DIFF
--- a/mlx_vlm/trainer/orpo_trainer.py
+++ b/mlx_vlm/trainer/orpo_trainer.py
@@ -139,7 +139,8 @@ def _pad_and_collate(items, prefix, max_seq_length):
     mask_key = f"{prefix}_attention_mask"
     pv_key = f"{prefix}_pixel_values"
 
-    lengths = [min(len(x[id_key]), max_seq_length) for x in items]
+    input_arrays = [np.asarray(x[id_key]).reshape(-1) for x in items]
+    lengths = [min(arr.shape[0], max_seq_length) for arr in input_arrays]
     max_len = min(max(lengths), max_seq_length)
     pad_to = 32
     padded_len = 1 + pad_to * ((max_len + pad_to - 1) // pad_to)
@@ -149,7 +150,7 @@ def _pad_and_collate(items, prefix, max_seq_length):
     attention_mask_batch = np.zeros((len(items), padded_len), dtype=np.int32)
 
     for i, item in enumerate(items):
-        arr = np.array(item[id_key]).reshape(-1)
+        arr = input_arrays[i]
         L = min(len(arr), padded_len)
         input_ids_batch[i, :L] = arr[:L]
 

--- a/mlx_vlm/trainer/sft_trainer.py
+++ b/mlx_vlm/trainer/sft_trainer.py
@@ -178,7 +178,8 @@ def iterate_batches(dataset, batch_size, max_seq_length, train=False):
         )
         for b in order:
             items = [dataset[idx] for idx in batch_indices[b]]
-            lengths = [min(len(x["input_ids"]), max_seq_length) for x in items]
+            input_arrays = [np.asarray(x["input_ids"]).reshape(-1) for x in items]
+            lengths = [min(arr.shape[0], max_seq_length) for arr in input_arrays]
 
             max_len = min(max(lengths), max_seq_length)
             pad_to = 32
@@ -189,7 +190,7 @@ def iterate_batches(dataset, batch_size, max_seq_length, train=False):
             attention_mask_batch = np.zeros((len(items), padded_len), dtype=np.int32)
 
             for i, item in enumerate(items):
-                arr = np.array(item["input_ids"]).reshape(-1)
+                arr = input_arrays[i]
                 L = min(len(arr), padded_len)
                 input_ids_batch[i, :L] = arr[:L]
 


### PR DESCRIPTION
## Summary

- When datasets return `input_ids` as 2D arrays of shape `(1, seq_len)`, `len()` returns `1` (the batch dimension) instead of `seq_len`
- This caused `padded_len` to compute as 33 regardless of actual sequence length, **silently truncating 78% of training sequences**
- The model trained on incomplete labels without any warning
- Fix: precompute flattened arrays before measuring lengths, reuse them in the fill loop (avoids double conversion)
- Applied to both SFT (`iterate_batches`) and ORPO (`_pad_and_collate`) trainers

## Root cause

```python
# Before (line 181 in sft_trainer.py):
lengths = [min(len(x["input_ids"]), max_seq_length) for x in items]
# len() on mx.array of shape (1, 37) returns 1, not 37

# After:
input_arrays = [np.asarray(x["input_ids"]).reshape(-1) for x in items]
lengths = [min(arr.shape[0], max_seq_length) for arr in input_arrays]
```

This matches what line 192 already does: `arr = np.array(item["input_ids"]).reshape(-1)`.

## Test plan

- [x] Verified 78% truncation rate before fix, 0% after
- [x] All existing unit tests pass
- [x] Codex (GPT-5.4) reviewed and confirmed fix is correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)