### PR TITLE
perf(generate): increase default prefill_step_size from 2048 to 32768

### DIFF
--- a/mlx_vlm/generate.py
+++ b/mlx_vlm/generate.py
@@ -45,7 +45,7 @@ DEFAULT_PREFILL_BATCH_SIZE = 8
 DEFAULT_THINKING_START_TOKEN = "<think>"
 DEFAULT_THINKING_END_TOKEN = "</think>"
 DEFAULT_QUANTIZED_KV_START = 5000
-DEFAULT_PREFILL_STEP_SIZE = 2048
+DEFAULT_PREFILL_STEP_SIZE = 32768
 
 
 def parse_arguments():
@@ -191,8 +191,8 @@ def parse_arguments():
         type=int,
         default=DEFAULT_PREFILL_STEP_SIZE,
         help="Number of tokens to process per prefill step. "
-        "Lower values reduce peak memory usage but may be slower. "
-        "Try 512 or 256 if you hit GPU memory errors during prefill.",
+        "Defaults to 32768 so most prompts prefill in a single pass. "
+        "Lower to 2048 or 512 if you hit GPU memory errors during prefill.",
     )
     parser.add_argument(
         "--enable-thinking",

--- a/mlx_vlm/server.py
+++ b/mlx_vlm/server.py
@@ -1398,8 +1398,8 @@ def main():
         type=int,
         default=DEFAULT_PREFILL_STEP_SIZE,
         help="Number of tokens to process per prefill step. "
-        "Lower values reduce peak memory usage but may be slower. "
-        "Try 512 or 256 if you hit GPU memory errors during prefill.",
+        "Defaults to 32768 so most prompts prefill in a single pass. "
+        "Lower to 2048 or 512 if you hit GPU memory errors during prefill.",
     )
     parser.add_argument(
         "--kv-bits",


### PR DESCRIPTION
## Summary

- Increases `DEFAULT_PREFILL_STEP_SIZE` from 2048 to 32768
- Most prompts now prefill in a single pass with no GPU sync overhead
- Users on memory-constrained devices can still lower it with `--prefill-step-size 2048`

## Problem

The default chunked prefill size of 2048 tokens creates excessive GPU sync barriers (`mx.eval` + `mx.clear_cache` per chunk) during prompt processing. For a 10K token prompt, this means ~5 sync cycles that stall the GPU pipeline between chunks. This is the root cause of the slowdown reported in #945.

mlx-lm does not use chunked prefill at all, which is why vMLX shows dramatically higher prefill throughput on the same hardware.

## Why 32768 instead of disabling entirely

Codex (GPT-5.4) adversarial review found that setting the default to `None` (no chunking) would cause OOM on 16GB Macs with multi-image VLM prompts. Several VLM families expand image tokens aggressively:
- Qwen2/2.5/3-VL: `image_grid_thw.prod() // merge_size**2` tokens per image
- Hunyuan-VL: up to ~4,162 tokens for max-sized images
- PaddleOCR-VL: up to ~3,600 tokens at max resolution

32768 is large enough that virtually all prompts (including multi-image) process in a single chunk, while still providing OOM protection for extreme edge cases.

## Test plan

- [x] Codex adversarial review for user impact
- [x] Server env var path (`PREFILL_STEP_SIZE`) handles int default correctly
- [x] `no_chunked_prefill` model flag still works (sets to None, skipping chunks entirely)
- [ ] Benchmark prefill throughput on long prompts (community testing welcome)

Fixes #945

🤖 Generated with [Claude Code](https://claude.com/claude-code)