### PR TITLE
fix(trainer): pass images to prepare_inputs for Gemma, Qwen, and SmolVLM

### DIFF
--- a/mlx_vlm/trainer/datasets.py
+++ b/mlx_vlm/trainer/datasets.py
@@ -98,15 +98,9 @@ class VisionDataset:
                 "Config must contain 'image_token_index' or 'image_token_id'"
             )
 
-        use_embedded_images = (
-            model_type.startswith("gemma")
-            or model_type.startswith("qwen")
-            or model_type == "smolvlm"
-        )
-
         inputs = prepare_inputs(
             processor=self.processor,
-            images=None if use_embedded_images else (images if images else None),
+            images=images if images else None,
             audio=audio if audio else None,
             prompts=prompts,
             image_token_index=image_token_index,
@@ -167,15 +161,6 @@ class PreferenceVisionDataset:
                 "Config must contain 'image_token_index' or 'image_token_id'"
             )
 
-        use_embedded_images = (
-            model_type.startswith("gemma")
-            or model_type.startswith("qwen")
-            or model_type == "smolvlm"
-        )
-        images_for_inputs = (
-            None if use_embedded_images else (images if images else None)
-        )
-
         result = {}
         for key in ("chosen", "rejected"):
             sequence = item[key]
@@ -186,7 +171,7 @@ class PreferenceVisionDataset:
             )
             inputs = prepare_inputs(
                 processor=self.processor,
-                images=images_for_inputs,
+                images=images if images else None,
                 audio=None,
                 prompts=[prompt],
                 image_token_index=image_token_index,

--- a/mlx_vlm/trainer/datasets.py
+++ b/mlx_vlm/trainer/datasets.py
@@ -98,14 +98,23 @@ class VisionDataset:
                 "Config must contain 'image_token_index' or 'image_token_id'"
             )
 
-        inputs = prepare_inputs(
-            processor=self.processor,
-            images=images if images else None,
-            audio=audio if audio else None,
-            prompts=prompts,
-            image_token_index=image_token_index,
-            resize_shape=self.image_resize_shape,
-        )
+        try:
+            inputs = prepare_inputs(
+                processor=self.processor,
+                images=images if images else None,
+                audio=audio if audio else None,
+                prompts=prompts,
+                image_token_index=image_token_index,
+                resize_shape=self.image_resize_shape,
+            )
+        except (ValueError, IndexError) as e:
+            raise ValueError(
+                f"Failed to process images for model_type={model_type!r}. "
+                f"This model's processor may require image placeholder tokens "
+                f"(e.g. <image>) in the prompt template. "
+                f"See https://github.com/Blaizzy/mlx-vlm/issues/824 "
+                f"Original error: {e}"
+            ) from e
 
         return {
             "pixel_values": inputs.get("pixel_values"),
@@ -169,14 +178,23 @@ class PreferenceVisionDataset:
                 if isinstance(sequence, str)
                 else get_prompt(model_type, self.processor, sequence)
             )
-            inputs = prepare_inputs(
-                processor=self.processor,
-                images=images if images else None,
-                audio=None,
-                prompts=[prompt],
-                image_token_index=image_token_index,
-                resize_shape=self.image_resize_shape,
-            )
+            try:
+                inputs = prepare_inputs(
+                    processor=self.processor,
+                    images=images if images else None,
+                    audio=None,
+                    prompts=[prompt],
+                    image_token_index=image_token_index,
+                    resize_shape=self.image_resize_shape,
+                )
+            except (ValueError, IndexError) as e:
+                raise ValueError(
+                    f"Failed to process images for model_type={model_type!r}. "
+                    f"This model's processor may require image placeholder tokens "
+                    f"(e.g. <image>) in the prompt template. "
+                    f"See https://github.com/Blaizzy/mlx-vlm/issues/824 "
+                    f"Original error: {e}"
+                ) from e
             result[f"{key}_input_ids"] = inputs["input_ids"]
             result[f"{key}_attention_mask"] = inputs.get(
                 "attention_mask", mx.ones_like(inputs["input_ids"])


### PR DESCRIPTION
## Summary

- `VisionDataset.process()` discards images for Gemma, Qwen, and SmolVLM models by passing `images=None` to `prepare_inputs()`
- The model trains on text-only with `<|image|>` placeholder tokens but **no actual image features**
- Fix: remove the `use_embedded_images` conditional, always pass images

## The bug

```python
# Before (datasets.py line 101-109):
use_embedded_images = (
    model_type.startswith("gemma")
    or model_type.startswith("qwen")
    or model_type == "smolvlm"
)
inputs = prepare_inputs(
    processor=self.processor,
    images=None if use_embedded_images else (images if images else None),  # <-- discards images
    ...
)
```

When `images=None`, `prepare_inputs` returns only `input_ids` + `attention_mask` with no `pixel_values`. The vision tower is never called during training.

## Impact

| Metric | Without images (bug) | With images (fix) |
|--------|---------------------|-------------------|
| Tokens/sample (Gemma4) | 37 | 304 (266 image + 38 text) |
| pixel_values | None | (1, 3, 672, 912) |
| Loss (20 iters) | 5.3 → 1.7 | 0.62 → 0.23 |

Same bug exists in `PreferenceVisionDataset` (ORPO trainer). Fixed in both.

## Verified on

- Gemma4 E2B (gemma4): pixel_values present, 266 image tokens, training loss drops correctly
- Gemma3 4B (gemma3): pixel_values present, 256 image tokens, dataset loads correctly
- All 8 existing unit tests pass

## Note on Qwen and SmolVLM

Qwen2.5-VL and SmolVLM processors fail after this fix because their prompt templates don't insert `<image>` placeholder tokens that the processors expect. This is a **pre-existing** bug in the message formatting pipeline (see #824, #826), not caused by this change. Previously these models "worked" by silently training without images. Now they properly fail, making the real issue visible.

Relates to #824 (Bug 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)