### PR TITLE
Fix LoRA scaling: divide alpha by rank (#845)

### DIFF
--- a/mlx_vlm/tests/test_trainer_utils.py
+++ b/mlx_vlm/tests/test_trainer_utils.py
@@ -1,8 +1,10 @@
 import unittest
 from unittest.mock import MagicMock, patch
 
+import mlx.core as mx
 import mlx.nn as nn
 
+from mlx_vlm.trainer.lora import LoRaLayer
 from mlx_vlm.trainer.utils import (
     find_all_linear_names,
     get_module_by_name,
@@ -53,6 +55,46 @@ class TestTrainerUtils(unittest.TestCase):
 
         result = find_all_linear_names(model)
         self.assertEqual(set(result), {"layer1", "layer2"})
+
+    def test_lora_layer_uses_alpha_over_rank_scaling(self):
+        """LoRaLayer must apply the standard alpha/rank scaling factor.
+
+        Regression test for issue #845: previously the layer multiplied
+        the LoRA update by raw `alpha`, making the effective scaling
+        rank-times too large for the documented defaults.
+        """
+        rank = 8
+        alpha = 16
+        linear = nn.Linear(64, 64)
+        lora = LoRaLayer(linear, rank=rank, alpha=alpha, dropout=0.0)
+
+        self.assertEqual(lora.rank, rank)
+        self.assertEqual(lora.alpha, alpha)
+        self.assertAlmostEqual(lora.scaling, alpha / rank)
+
+    def test_lora_layer_forward_matches_alpha_over_rank(self):
+        """LoRaLayer.__call__ output should equal base + (alpha/rank) * (x A B).
+
+        Verifies the actual forward pass uses the corrected scaling, not
+        just the stored attribute. Sets B to a non-zero value so the
+        update is observable (zero-init B is the standard PEFT default).
+        """
+        rank = 4
+        alpha = 8
+        linear = nn.Linear(8, 8, bias=False)
+        lora = LoRaLayer(linear, rank=rank, alpha=alpha, dropout=0.0)
+
+        # Override B with deterministic non-zero values so update != 0.
+        lora.B = mx.ones((rank, 8))
+        x = mx.ones((1, 8))
+
+        expected_base = linear(x)
+        expected_update = (alpha / rank) * ((x @ lora.A) @ lora.B)
+        expected = expected_base + expected_update.astype(x.dtype)
+
+        actual = lora(x)
+        mx.eval(actual, expected)
+        self.assertTrue(mx.allclose(actual, expected, atol=1e-5).item())
 
 
 if __name__ == "__main__":

--- a/mlx_vlm/trainer/lora.py
+++ b/mlx_vlm/trainer/lora.py
@@ -31,19 +31,29 @@ class LoRaLayer(nn.Module):
             shape=(input_dims, rank),
         )
         self.B = mx.zeros((rank, output_dims))
+        self.rank = rank
         self.alpha = alpha
+        # Standard LoRA scaling factor (Hu et al. 2021): alpha / rank.
+        # Computed once at construction so __call__ and
+        # replace_lora_with_linear apply consistent scaling. Previously
+        # this layer multiplied the update by raw `alpha`, which made
+        # the effective scaling rank-times too large for the documented
+        # defaults (e.g. r=8 alpha=16 gave an effective scaling of 16
+        # instead of 2). See issue #845.
+        self.scaling = alpha / rank
 
     def __call__(self, x):
         y = self.original_layer(x)
         lora_update = (self.dropout(x) @ self.A) @ self.B
-        return y + (self.alpha * lora_update).astype(x.dtype)
+        return y + (self.scaling * lora_update).astype(x.dtype)
 
 
 def replace_lora_with_linear(model):
     for i, layer in enumerate(model.layers):
         if isinstance(layer, LoRaLayer):
-            # Compute the final merged weight
-            lora_update = layer.alpha * (layer.A @ layer.B)
+            # Compute the final merged weight using the same alpha/rank
+            # scaling that LoRaLayer.__call__ applies during training.
+            lora_update = layer.scaling * (layer.A @ layer.B)
             updated_weight = layer.original_layer.weight + lora_update
             use_bias = layer.original_layer.bias is not None
 


### PR DESCRIPTION
## What

Apply the standard LoRA scaling factor `alpha / rank` (Hu et al. 2021) in `LoRaLayer.__call__` and `replace_lora_with_linear`. Previously the layer multiplied the LoRA update by raw `alpha`, making the effective scaling rank-times too large for the documented defaults — for example `r=8`, `alpha=16` gave an effective scaling of 16 instead of the intended 2.

This matches every other PEFT implementation, including HuggingFace `peft` and the original Microsoft LoRA reference.

Closes #845.

## Changes

- `LoRaLayer.__init__` now stores `self.rank` and `self.scaling = alpha / rank`.
- `LoRaLayer.__call__` multiplies the update by `self.scaling`.
- `replace_lora_with_linear` uses `layer.scaling` so merged weights match what the trained adapter applies during inference.
- Two regression tests in `mlx_vlm/tests/test_trainer_utils.py`:
  - `test_lora_layer_uses_alpha_over_rank_scaling` — checks the stored attribute.
  - `test_lora_layer_forward_matches_alpha_over_rank` — checks the actual forward-pass output against the expected `base + (alpha/rank) * (x A B)` formula with a non-zero `B`.

## Backwards compatibility

⚠️ This is a **behavioural change**. Adapters trained against the previous (broken) scaling will behave 8× weaker after this fix when `r=8`, `alpha=16`. Users who want the old effective scaling can multiply their alpha by rank — e.g. set `--lora-alpha 128` to recover the old `r=8, alpha=16` behaviour. The recommended action is to retrain with the documented defaults now that they actually mean what the docs say.

If maintainers prefer to gate this behind a flag for one release I am happy to do that — let me know.

## Tests

```bash
python -m pytest mlx_vlm/tests/test_trainer_utils.py -v
```

```
test_find_all_linear_names PASSED
test_get_module_by_name PASSED
test_get_peft_model PASSED
test_lora_layer_forward_matches_alpha_over_rank PASSED
test_lora_layer_uses_alpha_over_rank_scaling PASSED
test_set_module_by_name PASSED
======================== 6 passed in 4.97s =========================
```