### PR TITLE
Fix sft_trainer crash when adapter_file is None (#908)

### DIFF
--- a/mlx_vlm/tests/test_trainer.py
+++ b/mlx_vlm/tests/test_trainer.py
@@ -141,6 +141,46 @@ class TestTrainer(unittest.TestCase):
         self.mock_optimizer.update.assert_called()
         mock_save_safetensors.assert_called()
 
+    @patch("mlx_vlm.trainer.sft_trainer.iterate_batches")
+    @patch("mlx_vlm.trainer.sft_trainer.mx.save_safetensors")
+    def test_train_handles_none_adapter_file(
+        self, mock_save_safetensors, mock_iterate_batches
+    ):
+        """Regression test for issue #908.
+
+        When `args.adapter_file` is None, the train loop previously
+        crashed at the first checkpoint or final save with
+        `TypeError: argument should be a str ... not 'NoneType'`.
+        It should now fall back to a sensible default and complete
+        the run, with the save still being invoked.
+        """
+        mock_batch = {
+            "input_ids": mx.array([[1, 2, 3], [1, 2, 3], [1, 2, 3], [1, 2, 3]]),
+            "attention_mask": mx.array([[1, 1, 1], [1, 1, 1], [1, 1, 1], [1, 1, 1]]),
+            "pixel_values": mx.array(
+                [[[0.1, 0.2]], [[0.1, 0.2]], [[0.1, 0.2]], [[0.1, 0.2]]]
+            ),
+            "labels": mx.array([[0, 1, 2], [0, 1, 2], [0, 1, 2], [0, 1, 2]]),
+        }
+        mock_iterate_batches.return_value = iter([mock_batch])
+
+        args = TrainingArgs(iters=1, batch_size=4)
+        args.adapter_file = None  # the buggy state from issue #908
+
+        train(
+            model=self.mock_model,
+            optimizer=self.mock_optimizer,
+            train_dataset=MagicMock(__len__=lambda self: 4),
+            val_dataset=None,
+            args=args,
+        )
+
+        # The defensive default should have been applied.
+        self.assertIsNotNone(args.adapter_file)
+        self.assertTrue(args.adapter_file.endswith("adapters.safetensors"))
+        # And the save should still have run without crashing.
+        mock_save_safetensors.assert_called()
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/mlx_vlm/trainer/orpo_trainer.py
+++ b/mlx_vlm/trainer/orpo_trainer.py
@@ -306,6 +306,15 @@ def train_orpo(
     """
     Main training function for vision-language models.
     """
+    # Defensive default — see issue #908. Same fix as sft_trainer.train.
+    if getattr(args, "adapter_file", None) is None:
+        args.adapter_file = "adapters.safetensors"
+        if mx.distributed.init().rank() == 0:
+            print(
+                f"{Colors.WARNING}[warning] args.adapter_file was None — "
+                f"defaulting to '{args.adapter_file}'.{Colors.ENDC}"
+            )
+
     # Set memory limit if using Metal
     if mx.metal.is_available():
         mx.set_wired_limit(mx.metal.device_info()["max_recommended_working_set_size"])

--- a/mlx_vlm/trainer/sft_trainer.py
+++ b/mlx_vlm/trainer/sft_trainer.py
@@ -304,6 +304,21 @@ def train(
     """
     Main training function for vision-language models.
     """
+    # Defensive default — checkpoint and final saves crash with a
+    # `TypeError: argument should be a str ... not 'NoneType'` if
+    # `args.adapter_file` is None. This can happen when callers
+    # construct TrainingArgs (or a SimpleNamespace) without setting
+    # `adapter_file` explicitly. Falling back to the dataclass default
+    # keeps training useful while making the situation visible.
+    # See issue #908.
+    if getattr(args, "adapter_file", None) is None:
+        args.adapter_file = "adapters.safetensors"
+        if mx.distributed.init().rank() == 0:
+            print(
+                f"{Colors.WARNING}[warning] args.adapter_file was None — "
+                f"defaulting to '{args.adapter_file}'.{Colors.ENDC}"
+            )
+
     # Set memory limit if using Metal
     if mx.metal.is_available():
         device_info = mx.device_info()


### PR DESCRIPTION
## What

`sft_trainer.train` (and the analogous `orpo_trainer.train_orpo`) crash on the first checkpoint or final save if `args.adapter_file` is `None`:

```
File "mlx_vlm/trainer/sft_trainer.py", line 471, in train
    save_adapter(model, args.adapter_file)
File "mlx_vlm/trainer/utils.py", line 235, in save_adapter
    path = Path(adapter_file)
TypeError: argument should be a str or an os.PathLike object
where __fspath__ returns a str, not 'NoneType'
```

This happens when callers construct `TrainingArgs` (or pass a `SimpleNamespace`) without explicitly setting `adapter_file`. The dataclass default is `"adapters.safetensors"`, but if a caller overrides that to `None` — or if the field is shadowed during serialisation — the train loop runs to the first save, then crashes and loses the work.

Closes #908.

## Fix

Defend at the top of `train` / `train_orpo`. If `args.adapter_file` is `None`, set it to the dataclass default (`adapters.safetensors`) and emit a warning on rank 0 so the substitution is visible. Covers all three call sites (steps_per_save checkpoint, indexed checkpoint filename, final save) with one guard per trainer.

## Changes

- `mlx_vlm/trainer/sft_trainer.py`: defensive guard at top of `train()`.
- `mlx_vlm/trainer/orpo_trainer.py`: same guard at top of `train_orpo()` (the same bug exists in the ORPO trainer).
- `mlx_vlm/tests/test_trainer.py`: regression test `test_train_handles_none_adapter_file` that constructs `TrainingArgs(...)`, sets `adapter_file = None`, runs a single-iteration training loop, and asserts both that the default is applied and that `save_safetensors` is still invoked.

## Tests

```bash
python -m pytest mlx_vlm/tests/test_trainer.py -v
```

```
test_dataset_getitem PASSED
test_dataset_initialization PASSED
test_train_handles_none_adapter_file PASSED
test_train_smoke PASSED
test_trainer_initialization PASSED
======================== 5 passed in 3.84s =========================
```