### PR TITLE
fix: return finish_reason=tool_calls when tool calls detected

### DIFF
--- a/mlx_vlm/server.py
+++ b/mlx_vlm/server.py
@@ -1,5 +1,4 @@
 import argparse
-import asyncio
 import gc
 import json
 import os

--- a/mlx_vlm/server.py
+++ b/mlx_vlm/server.py
@@ -1,4 +1,5 @@
 import argparse
+import asyncio
 import gc
 import json
 import os
@@ -1176,10 +1177,11 @@ async def chat_completions_endpoint(request: ChatRequest):
                         tool_calls = {}
                         tool_calls["calls"] = []
 
-                    # Signal stream end
+                    # Signal stream end with correct finish_reason
+                    stream_finish = "tool_calls" if tool_calls.get("calls") else "stop"
                     choices = [
                         ChatStreamChoice(
-                            finish_reason="stop",
+                            finish_reason=stream_finish,
                             delta=ChatMessage(
                                 role="assistant",
                                 content="",
@@ -1259,9 +1261,10 @@ async def chat_completions_endpoint(request: ChatRequest):
                     tool_calls["calls"] = []
                     tool_calls["remaining_text"] = gen_result.text
 
+                finish = "tool_calls" if tool_calls.get("calls") else "stop"
                 choices = [
                     ChatChoice(
-                        finish_reason="stop",
+                        finish_reason=finish,
                         message=ChatMessage(
                             role="assistant",
                             content=tool_calls["remaining_text"],

--- a/mlx_vlm/tests/test_server.py
+++ b/mlx_vlm/tests/test_server.py
@@ -130,3 +130,97 @@ def test_chat_completions_endpoint_forwards_explicit_sampling_args(client):
     assert mock_generate.call_args.kwargs["repetition_penalty"] == 1.15
     assert mock_generate.call_args.kwargs["logit_bias"] == {12: -1.5}
     assert mock_generate.call_args.kwargs["resize_shape"] == (512, 512)
+
+
+# ---------------------------------------------------------------------------
+# finish_reason tests
+# ---------------------------------------------------------------------------
+
+
+def _mock_result(text="Hello!", **overrides):
+    defaults = dict(
+        text=text,
+        prompt_tokens=10,
+        generation_tokens=5,
+        total_tokens=15,
+        prompt_tps=100.0,
+        generation_tps=50.0,
+        peak_memory=1.0,
+    )
+    defaults.update(overrides)
+    return SimpleNamespace(**defaults)
+
+
+def _base_mocks(result=None):
+    """Return context managers for model, template, and generate mocks."""
+    if result is None:
+        result = _mock_result()
+    model = SimpleNamespace()
+    processor = SimpleNamespace(tokenizer=SimpleNamespace(chat_template=""))
+    config = SimpleNamespace(model_type="test")
+    return (
+        patch.object(server, "get_cached_model", return_value=(model, processor, config)),
+        patch.object(server, "apply_chat_template", return_value="prompt"),
+        patch.object(server, "generate", return_value=result),
+    )
+
+
+def test_chat_completions_finish_reason_stop_without_tools(client):
+    """finish_reason should be 'stop' for plain text responses."""
+    m1, m2, m3 = _base_mocks()
+    with m1, m2, m3:
+        resp = client.post(
+            "/chat/completions",
+            json={"model": "demo", "messages": [{"role": "user", "content": "hello"}]},
+        )
+    assert resp.status_code == 200
+    assert resp.json()["choices"][0]["finish_reason"] == "stop"
+
+
+def test_chat_completions_finish_reason_tool_calls(client):
+    """finish_reason should be 'tool_calls' when tool calls are detected."""
+    result = _mock_result()
+    m1, m2, m3 = _base_mocks(result)
+
+    fake_tool_calls = {
+        "calls": [{"type": "function", "id": "call_1", "function": {"name": "search", "arguments": "{}"}}],
+        "remaining_text": "",
+    }
+
+    with m1, m2, m3, \
+         patch.object(server, "_infer_tool_parser", return_value="qwen3_coder"), \
+         patch.object(server, "load_tool_module", return_value=SimpleNamespace()), \
+         patch.object(server, "process_tool_calls", return_value=fake_tool_calls):
+        resp = client.post(
+            "/chat/completions",
+            json={
+                "model": "demo",
+                "messages": [{"role": "user", "content": "search for test"}],
+                "tools": [{"type": "function", "function": {"name": "search", "parameters": {}}}],
+            },
+        )
+    assert resp.status_code == 200
+    assert resp.json()["choices"][0]["finish_reason"] == "tool_calls"
+
+
+def test_chat_completions_finish_reason_stop_with_tools_no_calls(client):
+    """finish_reason should be 'stop' when tools defined but model doesn't call any."""
+    result = _mock_result(text="I don't need tools for this.")
+    m1, m2, m3 = _base_mocks(result)
+
+    no_calls = {"calls": [], "remaining_text": "I don't need tools for this."}
+
+    with m1, m2, m3, \
+         patch.object(server, "_infer_tool_parser", return_value="qwen3_coder"), \
+         patch.object(server, "load_tool_module", return_value=SimpleNamespace()), \
+         patch.object(server, "process_tool_calls", return_value=no_calls):
+        resp = client.post(
+            "/chat/completions",
+            json={
+                "model": "demo",
+                "messages": [{"role": "user", "content": "hello"}],
+                "tools": [{"type": "function", "function": {"name": "search", "parameters": {}}}],
+            },
+        )
+    assert resp.status_code == 200
+    assert resp.json()["choices"][0]["finish_reason"] == "stop"

--- a/mlx_vlm/tests/test_server.py
+++ b/mlx_vlm/tests/test_server.py
@@ -1,3 +1,4 @@
+import json
 from types import SimpleNamespace
 from unittest.mock import patch
 
@@ -201,6 +202,51 @@ def test_chat_completions_finish_reason_tool_calls(client):
         )
     assert resp.status_code == 200
     assert resp.json()["choices"][0]["finish_reason"] == "tool_calls"
+
+
+def test_chat_completions_streaming_finish_reason_tool_calls(client):
+    """Streaming finish_reason should be 'tool_calls' when tool calls are detected."""
+    chunks = [
+        SimpleNamespace(
+            text="calling search",
+            prompt_tokens=10,
+            generation_tokens=i + 1,
+            prompt_tps=100.0,
+            generation_tps=50.0,
+            peak_memory=1.0,
+        )
+        for i in range(2)
+    ]
+
+    fake_tool_calls = {
+        "calls": [{"type": "function", "id": "call_1", "function": {"name": "search", "arguments": "{}"}}],
+        "remaining_text": "",
+    }
+
+    model = SimpleNamespace()
+    processor = SimpleNamespace(tokenizer=SimpleNamespace(chat_template=""))
+    config = SimpleNamespace(model_type="test")
+
+    with patch.object(server, "get_cached_model", return_value=(model, processor, config)), \
+         patch.object(server, "apply_chat_template", return_value="prompt"), \
+         patch.object(server, "stream_generate", return_value=iter(chunks)), \
+         patch.object(server, "_infer_tool_parser", return_value="qwen3_coder"), \
+         patch.object(server, "load_tool_module", return_value=SimpleNamespace()), \
+         patch.object(server, "process_tool_calls", return_value=fake_tool_calls):
+        resp = client.post(
+            "/chat/completions",
+            json={
+                "model": "demo",
+                "messages": [{"role": "user", "content": "search for test"}],
+                "tools": [{"type": "function", "function": {"name": "search", "parameters": {}}}],
+                "stream": True,
+            },
+        )
+    assert resp.status_code == 200
+    # Parse SSE events to find the final chunk with finish_reason
+    events = [line for line in resp.text.strip().split("\n") if line.startswith("data: ") and line != "data: [DONE]"]
+    last_event = json.loads(events[-1].removeprefix("data: "))
+    assert last_event["choices"][0]["finish_reason"] == "tool_calls"
 
 
 def test_chat_completions_finish_reason_stop_with_tools_no_calls(client):


### PR DESCRIPTION
## Summary

Per the [OpenAI Chat Completions spec](https://platform.openai.com/docs/api-reference/chat/object), `finish_reason` should be `"tool_calls"` when the model emits tool calls, not `"stop"`. Strict OpenAI-compatible clients (including agent frameworks like LangChain, CrewAI, and others) use `finish_reason == "tool_calls"` as the branch condition for entering the tool-execution loop.

Currently both streaming and non-streaming paths hardcode `"stop"`. This PR fixes both:

- **Non-streaming** (`ChatChoice`): `finish_reason = "tool_calls" if tool_calls.get("calls") else "stop"`
- **Streaming** (`ChatStreamChoice`): Final chunk uses `"tool_calls"` finish_reason when tools detected

### Tests

4 tests covering all combinations:

- `test_chat_completions_finish_reason_stop_no_tools` — plain text, no tools defined
- `test_chat_completions_finish_reason_tool_calls` — non-streaming with tool calls
- `test_chat_completions_finish_reason_stop_tools_no_calls` — tools defined but model doesn't call any
- `test_chat_completions_streaming_finish_reason_tool_calls` — streaming with tool calls

```
python -m pytest mlx_vlm/tests/test_server.py -k "finish_reason" -v
```

### Related

This overlaps with #964 by @michaelstingl which addresses the non-streaming path. This PR additionally covers the streaming path and includes 4 tests (streaming + non-streaming, with and without tool calls).