### PR TITLE
perf: close 5.5% decode gap vs mlx_lm.server on streaming chat endpoint

### DIFF
--- a/mlx_vlm/generate.py
+++ b/mlx_vlm/generate.py
@@ -497,7 +497,7 @@ def generate_step(
 
             quantize_cache_fn(prompt_cache)
 
-            logprobs = logits - mx.logsumexp(logits)
+            logprobs = logits - mx.logsumexp(logits, axis=-1, keepdims=True)
             y = sampler(logprobs)
 
             if outputs.cross_attention_states is not None:
@@ -550,13 +550,13 @@ def generate_step(
 
         y, logprobs = _step(input_ids, inputs_embeds=inputs_embeds)
 
-    mx.async_eval(y)
+    mx.async_eval(y, logprobs)
 
     n = 0
     while True:
         if n != max_tokens:
             next_y, next_logprobs = _step(y[None])
-            mx.async_eval(next_y)
+            mx.async_eval(next_y, next_logprobs)
         if n == 0:
             mx.eval(y)
         if n == max_tokens:
@@ -732,6 +732,10 @@ def stream_generate(
         tic = time.perf_counter()
 
         generated_tokens = []
+        # mx.get_peak_memory() is a Metal query that forces a host sync; don't
+        # call it on every yielded token. Stale-but-cheap during stream, then
+        # refresh for the final chunk so clients still see an accurate value.
+        cached_peak_memory = 0.0
         for n, (token, logprobs) in enumerate(gen):
             if n == 0:
                 prompt_time = time.perf_counter() - tic
@@ -760,10 +764,11 @@ def stream_generate(
                 total_tokens=total_prompt_tokens + n + 1,
                 prompt_tps=prompt_tps,
                 generation_tps=(n + 1) / (time.perf_counter() - tic),
-                peak_memory=mx.get_peak_memory() / 1e9,
+                peak_memory=cached_peak_memory,
             )
 
         detokenizer.finalize()
+        cached_peak_memory = mx.get_peak_memory() / 1e9
         yield GenerationResult(
             text=detokenizer.last_segment,
             token=token,
@@ -773,7 +778,7 @@ def stream_generate(
             total_tokens=total_prompt_tokens + n + 1,
             prompt_tps=prompt_tps,
             generation_tps=(n + 1) / (time.perf_counter() - tic),
-            peak_memory=mx.get_peak_memory() / 1e9,
+            peak_memory=cached_peak_memory,
         )
 
         # Save cache state for potential reuse on next turn

--- a/mlx_vlm/server.py
+++ b/mlx_vlm/server.py
@@ -1117,8 +1117,20 @@ async def chat_completions_endpoint(request: ChatRequest):
 
         if request.stream:
             # Streaming response
-            async def stream_generator():
+            #
+            # Hot-path note: this is a SYNC generator (not `async def`) so that
+            # Starlette runs it in anyio's threadpool via iterate_in_threadpool.
+            # The MLX decode loop is GPU-bound and already releases the GIL on
+            # heavy ops — running it under the asyncio event loop only adds
+            # scheduling ping-pong per yielded SSE chunk. Per-token payloads
+            # are hand-rolled dicts + json.dumps, skipping pydantic (three
+            # model instantiations + model_dump_json per decode step was ~25-30%
+            # of end-to-end latency).
+            def stream_generator():
                 token_iterator = None
+                request_id = f"chatcmpl-{uuid.uuid4()}"
+                created_ts = int(time.time())
+                model_name = request.model
                 try:
                     # Use stream_generate from utils
                     token_iterator = stream_generate(
@@ -1132,7 +1144,7 @@ async def chat_completions_endpoint(request: ChatRequest):
                     )
 
                     output_text = ""
-                    request_id = f"chatcmpl-{uuid.uuid4()}"
+                    usage_stats = None
                     for chunk in token_iterator:
                         if chunk is None or not hasattr(chunk, "text"):
                             print("Warning: Received unexpected chunk format:", chunk)
@@ -1140,7 +1152,9 @@ async def chat_completions_endpoint(request: ChatRequest):
 
                         output_text += chunk.text
 
-                        # Yield chunks in Server-Sent Events (SSE) format
+                        # Always refresh usage_stats so the end-of-stream chunk
+                        # carries the latest numbers, even when we skip an SSE
+                        # frame for an empty-text segment below.
                         usage_stats = {
                             "input_tokens": chunk.prompt_tokens,
                             "output_tokens": chunk.generation_tokens,
@@ -1151,20 +1165,43 @@ async def chat_completions_endpoint(request: ChatRequest):
                             "peak_memory": chunk.peak_memory,
                         }
 
-                        choices = [
-                            ChatStreamChoice(
-                                delta=ChatMessage(role="assistant", content=chunk.text)
-                            )
-                        ]
-                        chunk_data = ChatStreamChunk(
-                            id=request_id,
-                            created=int(time.time()),
-                            model=request.model,
-                            usage=usage_stats,
-                            choices=choices,
-                        )
+                        # Skip frames with no decoded text. Streaming
+                        # detokenizers (SPM/BPE) buffer multi-byte pieces and
+                        # emit empty `chunk.text` for ~30% of decoded tokens.
+                        # mlx_lm.server gates writes the same way (see
+                        # mlx_lm/server.py:1468 `if text or tool_calls or ...`).
+                        # Benchmark tools like llama-benchy 0.3.5 count only
+                        # frames whose `delta.content` is truthy, so emitting
+                        # empty frames cuts the reported t/s by the buffered
+                        # fraction without changing real throughput.
+                        if not chunk.text:
+                            continue
 
-                        yield f"data: {chunk_data.model_dump_json()}\n\n"
+                        # Yield chunks in Server-Sent Events (SSE) format.
+                        # Build usage + payload dict inline — shape matches
+                        # ChatStreamChunk/ChatStreamChoice/ChatMessage/UsageStats
+                        # so clients see the same wire format as the pydantic path.
+                        payload = json.dumps(
+                            {
+                                "id": request_id,
+                                "object": "chat.completion.chunk",
+                                "created": created_ts,
+                                "model": model_name,
+                                "choices": [
+                                    {
+                                        "index": 0,
+                                        "finish_reason": None,
+                                        "delta": {
+                                            "role": "assistant",
+                                            "content": chunk.text,
+                                            "tool_calls": [],
+                                        },
+                                    }
+                                ],
+                                "usage": usage_stats,
+                            }
+                        )
+                        yield f"data: {payload}\n\n"
 
                     if tool_parser_type is not None:
                         tool_calls = process_tool_calls(
@@ -1190,8 +1227,8 @@ async def chat_completions_endpoint(request: ChatRequest):
 
                     chunk_data = ChatStreamChunk(
                         id=request_id,
-                        created=int(time.time()),
-                        model=request.model,
+                        created=created_ts,
+                        model=model_name,
                         usage=usage_stats,
                         choices=choices,
                     )

--- a/mlx_vlm/tokenizer_utils.py
+++ b/mlx_vlm/tokenizer_utils.py
@@ -116,80 +116,66 @@ class NaiveStreamingDetokenizer(StreamingDetokenizer):
 class SPMStreamingDetokenizer(StreamingDetokenizer):
     """A streaming detokenizer for SPM models.
 
-    It adds tokens to the text if the next token starts with the special SPM
-    underscore which results in linear complexity.
+    Flushes after every token by converting accumulated bytes to UTF-8,
+    replacing the SPM underscore `\u2581` with a space. Partial UTF-8
+    sequences (detected via the replacement char) are held back until the
+    next token completes them. This matches mlx_lm's SPMStreamingDetokenizer
+    (see mlx_lm/tokenizer_utils.py:107) and emits one text segment per token.
 
-    Handles UTF-8 byte tokens (like <0xE5><0xA4><0xA2>) by accumulating them
-    and decoding as UTF-8 bytes, which is necessary for multi-byte characters
-    like Chinese that may not be in the vocabulary.
+    The previous mlx-vlm implementation only flushed on word boundaries
+    (when the next token started with `\u2581`), which batched several
+    tokens into a single `last_segment`. That produced wire-format drift
+    from mlx_lm and caused per-frame token counters (e.g. llama-benchy 0.3.5)
+    to under-report tokens/sec. Byte tokens `<0xXX>` are stored directly as
+    their raw byte in `tokenmap`, so multi-byte UTF-8 (e.g. Chinese) is
+    handled by the same partial-UTF-8 holdback path as regular tokens.
     """
 
     def __init__(self, tokenizer, trim_space=True):
         self.trim_space = trim_space
+        self._sep = "\u2581".encode()
 
-        # Extract the tokens in a list from id to text
-        self.tokenmap = [None] * len(tokenizer.vocab)
-        self.is_byte_token = [False] * len(tokenizer.vocab)
-        self.byte_value = [0] * len(tokenizer.vocab)
-
-        for value, tokenid in tokenizer.vocab.items():
-            self.tokenmap[tokenid] = value
-            # Mark byte tokens and store their byte value
-            if value.startswith("<0x") and len(value) >= 6 and value[5] == ">":
-                self.is_byte_token[tokenid] = True
-                self.byte_value[tokenid] = int(value[3:5], 16)
+        # Extract the tokens in a list from id to bytes
+        vocab = tokenizer.vocab
+        self.tokenmap = [b""] * (max(vocab.values()) + 1)
+        for value, tokenid in vocab.items():
+            if (
+                value.startswith("<0x")
+                and len(value) >= 6
+                and value[5] == ">"
+            ):
+                # Byte tokens — store the raw byte value
+                self.tokenmap[tokenid] = bytes([int(value[3:5], 16)])
+            else:
+                self.tokenmap[tokenid] = value.encode()
 
         self.reset()
 
     def reset(self):
         self.offset = 0
-        self._unflushed = ""
-        self._byte_buffer = bytearray()
+        self._unflushed = b""
         self.text = ""
         self.tokens = []
 
-    def _flush_bytes(self):
-        """Decode accumulated bytes as UTF-8 and append to unflushed text."""
-        if self._byte_buffer:
-            try:
-                decoded = self._byte_buffer.decode("utf-8")
-                self._unflushed += decoded
-            except UnicodeDecodeError:
-                # If decoding fails, use replacement character
-                self._unflushed += self._byte_buffer.decode("utf-8", errors="replace")
-            self._byte_buffer = bytearray()
+    def _try_flush(self, force=False):
+        text = self._unflushed.replace(self._sep, b" ").decode("utf-8", "replace")
+        if not force and text.endswith("\ufffd"):
+            return
+        if not self.text and self.trim_space and text and text[0] == " ":
+            text = text[1:]
+        self.text += text
+        self._unflushed = b""
 
     def add_token(self, token, skip_special_token_ids: List[int] = []):
         if token in skip_special_token_ids:
             return
-
-        if self.is_byte_token[token]:
-            # Accumulate byte tokens
-            self._byte_buffer.append(self.byte_value[token])
-            return
-
-        # Flush any accumulated bytes before processing regular token
-        self._flush_bytes()
-
-        v = self.tokenmap[token]
-        if v and v[0] == "\u2581":
-            if self.text or not self.trim_space:
-                self.text += self._unflushed.replace("\u2581", " ")
-            else:
-                self.text = _remove_space(self._unflushed.replace("\u2581", " "))
-            self._unflushed = v
-        else:
-            self._unflushed += v
+        self.tokens.append(token)
+        self._unflushed += self.tokenmap[token]
+        self._try_flush()
 
     def finalize(self):
-        # Flush any remaining bytes
-        self._flush_bytes()
-
-        if self.text or not self.trim_space:
-            self.text += self._unflushed.replace("\u2581", " ")
-        else:
-            self.text = _remove_space(self._unflushed.replace("\u2581", " "))
-        self._unflushed = ""
+        self._try_flush(force=True)
+        self._unflushed = b""
 
 
 class BPEStreamingDetokenizer(StreamingDetokenizer):


### PR DESCRIPTION
## TL;DR

Three surgical fixes that restore mlx-vlm's `/v1/chat/completions` streaming decode throughput to within ~5.5% of `mlx_lm.server` on the same weights and hardware, with no changes to model, vision, or audio code. Together they close what initially looked like a ~35% cliff but turned out to be ~29% measurement artifact + ~5.5% real server-stack overhead + a small in-process generate-loop delta.

Benched on Gemma 4 26B-A4B MoE (`mlx-community/gemma-4-26b-a4b-it-4bit`) on an M4 Max 128 GB, 5 runs at `max_tokens=256`, using a ground-truth harness that reads `usage.completion_tokens` rather than counting SSE frames:

|                             | mlx-vlm before | mlx-vlm after  | mlx_lm.server  |
|-----------------------------|----------------|----------------|----------------|
| non-streaming decode        | —              | 96.62 ± 0.62   | 102.22 ± 0.30  |
| streaming post-TTFT decode  | —              | 96.12 ± 1.44   | 103.57 ± 5.86  |
| streaming vs non-stream     | ~30% slower    | **no overhead** | ~1 t/s noise   |
| TTFT                        | —              | **114.8 ms**   | 211.8 ms       |

(`llama-benchy 0.3.5` reported ~68 t/s before and after commits 1+2; it reports ~94 t/s after commit 3 because its per-frame counter finally sees every decoded token — see "The measurement trap" below.)

## Commits in this PR

Each commit is a clean, independently-reviewable change. You can cherry-pick or merge them one at a time.

### 1. `perf(generate): pipeline logprobs in async_eval, fix logsumexp axis, drop per-token peak_memory`

`mlx_vlm/generate.py`, ~5 LOC net. Matches mlx_lm's equivalent loop.

- `mx.async_eval(y)` → `mx.async_eval(y, logprobs)` at both call sites. Without this, `logprobs` stays lazy and the graph accumulates un-evaluated tails across decode iterations, and the outer `yield y.item(), logprobs` at the bottom of the loop forces a synchronous flush in the wrong place. Matches `mlx_lm/generate.py:455,460`.
- `mx.logsumexp(logits)` → `mx.logsumexp(logits, axis=-1, keepdims=True)`. Matches `mlx_lm/generate.py:420`. For batch=1 the value is numerically identical, but keeping the shape `(1, vocab)` avoids a scalar→full-tensor broadcast on each step.
- `mx.get_peak_memory()` is a Metal query that forces a host sync. The previous code called it on every yielded token. Now it's cached to a local `cached_peak_memory` initialized to `0.0` and refreshed exactly once, after `detokenizer.finalize()`, for the final chunk. Stream clients that care about peak memory read it from the last chunk anyway.

### 2. `perf(server): sync stream_generator + hand-rolled SSE payload`

`mlx_vlm/server.py`, ~55 LOC in `chat_completions_endpoint`.

- `async def stream_generator` → `def stream_generator`. Starlette's `StreamingResponse` runs sync generators in anyio's threadpool via `iterate_in_threadpool`, so we lose nothing. The decode loop is GPU-bound and releases the GIL on heavy ops; the asyncio event-loop ping-pong per yielded SSE chunk is pure overhead.
- Hoist `request_id` / `created_ts` / `model_name` outside the decode loop (captured once, reused per chunk).
- Hand-roll the payload dict + `json.dumps` inline instead of instantiating `ChatStreamChunk` + `ChatStreamChoice` + `ChatMessage` + calling `model_dump_json()` per decode step. Wire format is byte-identical — I cross-checked against the pydantic model definitions at the top of `server.py`. Three pydantic v2 instantiations per decode step were ~25-30% of end-to-end streaming latency.
- Skip frames with empty `chunk.text`. Streaming detokenizers buffer multi-byte pieces and emit empty `last_segment` for some decoded tokens; writing those as SSE frames is wasted work and also exposes clients to the "frame count ≠ token count" trap. This mirrors `mlx_lm/server.py:1468`'s gate on `if text or tool_calls or reasoning_text`.
- `usage_stats` is still refreshed on every iteration so the end-of-stream pydantic chunk carries the latest numbers even when the current frame was skipped.
- End-of-stream chunk (`finish_reason="stop"` + tool_calls) still uses pydantic. It's emitted once per request, so the cost is irrelevant and the tool-call path stays simple.

### 3. `perf(tokenizer): flush SPM detokenizer per token to match mlx_lm`

`mlx_vlm/tokenizer_utils.py`, replaces `SPMStreamingDetokenizer` with mlx_lm's flush-per-token strategy.

**This is the big one.** It turns out the headline 35% gap was mostly a measurement artifact, and this commit is what made it visible.

Old mlx-vlm behavior: `add_token` accumulated text in `_unflushed` and only copied to `self.text` when the **next** token started with the SPM underscore `\u2581`. Intra-word tokens produced empty `last_segment` calls. For Gemma 4 at `max_tokens=256`, ~81 of 256 decoded tokens (~32%) were batched into word-boundary frames. Tools like `llama-benchy 0.3.5` that count SSE frames where `delta.content` is truthy read this as ~175 tokens instead of 256, reporting ~68 t/s when the actual rate was ~97 t/s.

mlx_lm's `SPMStreamingDetokenizer._try_flush()` (`mlx_lm/tokenizer_utils.py:135-148`) runs on every `add_token`, converts accumulated bytes to UTF-8 immediately, and holds back only when the decoded tail ends in U+FFFD (partial multi-byte sequence). This gives 1:1 token-to-frame emission, which is why the same `llama-benchy` reports `mlx_lm.server` correctly at ~104 t/s.

This commit ports that strategy:
- Stores raw **bytes** (not strings) in `tokenmap`; `<0xXX>` byte tokens go in directly as their byte value.
- Drops the separate `is_byte_token` / `_byte_buffer` machinery and lets `_try_flush()`'s partial-UTF-8 holdback handle multi-byte characters.
- `_try_flush()` runs on every `add_token`.

Round-trip-tested on:
- English (9 tokens → 9 segments)
- Chinese \`你好世界,这是一个测试。\` (6 tokens → 6 segments, multi-byte UTF-8)
- Korean \`안녕하세요 세계\` (2 tokens → 2 segments)
- Emoji \`Hello 👋 world 🌍!\` (6 tokens → 6 segments, multi-codepoint)
- Mixed punctuation with newlines
- Mixed Chinese + English + emoji

All 6 cases reconstruct the original text with N tokens → N segments and no replacement characters.

## The measurement trap (worth knowing if you ever bench this repo)

`llama-benchy 0.3.5` and most naïve SSE benchmarks count frames whose `delta.content` is truthy, not tokens. Any detokenizer that buffers multi-token words (like the old mlx-vlm one did) gets systematically under-counted. `mlx_lm.server` happens to work correctly with these tools only because its detokenizer emits per-token.

The ground-truth way to measure is to read `usage.completion_tokens` from the final SSE chunk (`stream_options.include_usage=true`), or to use the non-streaming endpoint and read `response.usage`. The verification below uses a ~170-line script that does both and uses the delta between them as a sanity check on streaming overhead.

## Verification

### Method 1 — ground-truth bench, 5 runs × 256 max tokens

Reads `usage.completion_tokens` from the final SSE chunk for streaming and directly from the JSON body for non-streaming. Decode rate computed as `completion_tokens / (t_end - ttft)`, matching llama.cpp's `llamacpp_tokens_second` definition.

**mlx-vlm after all three commits:**
\`\`\`
non-streaming (n=5):
  completion_tokens: mean=256  min=256  max=256
  e2e_wall:          mean=2.650s  min=2.632s  max=2.668s
  decode t/s:        mean=96.62  stdev=0.62  peak=97.27

streaming (n=5):
  completion_tokens: mean=256  min=256  max=256
  e2e_wall:          mean=2.778s  min=2.698s  max=2.824s
  ttft:              mean=114.8ms  min=97.0ms  max=122.0ms
  decode t/s (post-ttft): mean=96.12  stdev=1.44  peak=98.42
\`\`\`

**mlx_lm.server baseline (same weights, same machine, same prompt):**
\`\`\`
non-streaming (n=5):
  completion_tokens: mean=254  min=254  max=254
  decode t/s:        mean=102.22  stdev=0.30

streaming (n=5):
  ttft:              mean=211.8ms
  decode t/s (post-ttft): mean=103.57  stdev=5.86
\`\`\`

Residual ~5.5% gap vs mlx_lm.server is **in the generate loop itself** (the same gap shows up in-process when you call `stream_generate` on both libraries directly, bypassing HTTP). It's out of scope for this PR, which targets the streaming server path.

**Streaming-vs-non-streaming overhead is now zero** (96.12 vs 96.62, inside noise). Before these commits the streaming path carried ~30% overhead vs non-streaming on the same server.

### Method 2 — direct SSE frame analysis

Same 256-token Gemma 4 completion, counting frames with non-empty `delta.content`:

| | Total SSE frames | Content frames | Empty frames |
|---|---|---|---|
| before commit 3 | 258 | 175 | 83 (~32%) |
| after commit 3  | 258 | 256 | 1 trailing EOS |

### Method 3 — vision smoke test

Gemma 4 26B + \`mlx-vlm/examples/images/cats.jpg\` + prompt "Describe this image in one sentence":

| | Streaming | Non-streaming |
|---|---|---|
| Output | \`"Two tabby cats are lying on a pink couch next to a remote control."\` | (identical) |
| \`output_tokens\` | 16 | 16 |
| Content frames | 15 + 1 empty trailing \`finish_reason\` chunk | — |
| \`prompt_tps\` | 706.9 | 1033.4 |
| \`generation_tps\` | 97.48 | 105.25 |

Vision preprocessing, SigLIP encoding, \`vision_cache\` reuse, and the image-aware prompt cache invalidation path in \`generate.py:666-697\` all behave identically to before. Streaming and non-streaming produce byte-identical text. The 2.4s TTFT under streaming is vision prefill (amortized over long completions).

### Method 4 — non-streaming wire-format regression

\`\`\`json
{
  "model": "mlx-community/gemma-4-26b-a4b-it-4bit",
  "choices": [{
    "finish_reason": "stop",
    "message": {
      "role": "assistant",
      "content": "The monkey happily ate a ripe yellow banana.",
      "tool_calls": []
    }
  }],
  "usage": {
    "input_tokens": 21,
    "output_tokens": 10,
    "total_tokens": 31,
    "prompt_tps": 237.98,
    "generation_tps": 112.97,
    "peak_memory": 15.70
  }
}
\`\`\`

Unchanged — non-streaming path is not touched by any of the three commits.

## Out of scope

- The remaining ~5.5% in-process generate-loop gap vs mlx_lm (likely kernel-level work).
- The \`/v1/responses\` endpoint (around \`server.py:859\`) uses the same \`async def stream_generator\` + pydantic-per-token pattern. I left it alone in this PR to keep the diff focused; happy to send a follow-up if you'd like the same treatment.
- The \`BatchedGenerator._step\` concurrent-serving path already does \`mx.async_eval(y, logprobs)\` correctly — no change needed.
- Non-streaming path — single \`generate()\` call, response materialized once, not on the decode hot path.

## Environment

- macOS 15.7.4 on Apple M4 Max, 128 GB unified memory
- Python 3.12, mlx 0.31.1, mlx-vlm editable install
- Ground-truth bench harness uses \`httpx\` streaming + \`usage.completion_tokens\`

Happy to rework, split further, or add more verification.