### PR TITLE
Resolve no images crash for qwen3_vl and qwen3_vl_moe generate call

### DIFF
--- a/mlx_vlm/models/qwen3_vl/language.py
+++ b/mlx_vlm/models/qwen3_vl/language.py
@@ -503,7 +503,7 @@ class LanguageModel(nn.Module):
     ):
         # Slicing visual_pos_masks when prefilling
         n_to_process = kwargs.get("n_to_process", None)
-        if n_to_process is not None:
+        if n_to_process is not None and visual_pos_masks is not None:
             visual_pos_masks = visual_pos_masks[:, n_to_process:]
 
         position_ids = kwargs.pop("position_ids", None)

--- a/mlx_vlm/models/qwen3_vl_moe/language.py
+++ b/mlx_vlm/models/qwen3_vl_moe/language.py
@@ -544,7 +544,7 @@ class LanguageModel(nn.Module):
     ):
         # Slicing visual_pos_masks when prefilling
         n_to_process = kwargs.get("n_to_process", None)
-        if n_to_process is not None:
+        if n_to_process is not None and visual_pos_masks is not None:
             visual_pos_masks = visual_pos_masks[:, n_to_process:]
 
         position_ids = kwargs.pop("position_ids", None)


### PR DESCRIPTION
The code blindly slices visual_pos_masks during chunked prefill without checking if it's None.
The image parameter in the generate call is optional and with no images, visual_pos_masks is never set, but chunked prefill still passes n_to_process as a kwarg.
