### PR TITLE
Feature: Add native Gemma 4 video support

### DIFF
--- a/mlx_vlm/models/gemma4/config.py
+++ b/mlx_vlm/models/gemma4/config.py
@@ -129,6 +129,7 @@ class ModelConfig(BaseModelConfig):
     ignore_index: int = -100
     image_token_id: int = 258880
     audio_token_id: int = 258881
+    video_token_id: int = 258884
     boi_token_id: int = 255999
     eoi_token_id: int = 258882
     boa_token_id: int = 256000

--- a/mlx_vlm/models/gemma4/gemma4.py
+++ b/mlx_vlm/models/gemma4/gemma4.py
@@ -71,6 +71,8 @@ class Model(nn.Module):
         self,
         input_ids: Optional[mx.array] = None,
         pixel_values: Optional[mx.array] = None,
+        pixel_values_videos: Optional[mx.array] = None,
+        video_features: Optional[mx.array] = None,
         audio_features: Optional[mx.array] = None,
         audio_mask: Optional[mx.array] = None,
         input_features: Optional[mx.array] = None,
@@ -87,8 +89,9 @@ class Model(nn.Module):
         per_layer_inputs = None
         if self.language_model.model.hidden_size_per_layer_input:
             image_mask_ids = input_ids == self.config.image_token_id
+            video_mask_ids = input_ids == self.config.video_token_id
             audio_mask_ids = input_ids == self.config.audio_token_id
-            text_mask = ~(image_mask_ids | audio_mask_ids)
+            text_mask = ~(image_mask_ids | video_mask_ids | audio_mask_ids)
             per_layer_inputs_tokens = mx.where(
                 text_mask, input_ids, mx.zeros_like(input_ids)
             )
@@ -113,6 +116,34 @@ class Model(nn.Module):
 
             inputs_embeds = masked_scatter(
                 inputs_embeds, image_mask_expanded, image_features
+            )
+
+        if video_features is None:
+            cached_video = kwargs.get("cached_video_features", None)
+            if cached_video is not None:
+                video_features = cached_video
+            elif pixel_values_videos is not None:
+                video_encode_inputs = pixel_values_videos
+                video_position_ids = kwargs.get("video_position_ids")
+                output_length = kwargs.get("output_length")
+                if video_position_ids is not None or output_length is not None:
+                    video_encode_inputs = {
+                        "pixel_values_videos": pixel_values_videos,
+                        "video_position_ids": video_position_ids,
+                        "output_length": output_length,
+                    }
+                video_features = self.encode_video(video_encode_inputs)
+
+        if video_features is not None:
+            video_features = video_features.astype(inputs_embeds.dtype)
+            video_mask = input_ids == self.config.video_token_id
+            video_mask_expanded = mx.expand_dims(video_mask, -1)
+            video_mask_expanded = mx.broadcast_to(
+                video_mask_expanded, inputs_embeds.shape
+            )
+
+            inputs_embeds = masked_scatter(
+                inputs_embeds, video_mask_expanded, video_features
             )
 
         # Scatter audio features
@@ -150,6 +181,54 @@ class Model(nn.Module):
         image_features = self.vision_tower(pixel_values)
         image_features = self.embed_vision(image_features)
         return image_features
+
+    def encode_video(self, pixel_values_videos: mx.array) -> mx.array:
+        """Encode externally prepared video frames through the vision tower.
+
+        This expects video frames to already be sampled outside the library and
+        preprocessed in the same format as image inputs. Frames are encoded
+        frame-by-frame and concatenated so they can be scattered into
+        ``video_token_id`` placeholders.
+        """
+        video_position_ids = None
+        output_length = None
+        if isinstance(pixel_values_videos, tuple):
+            pixel_values_videos, video_position_ids = pixel_values_videos
+        elif isinstance(pixel_values_videos, dict):
+            video_position_ids = pixel_values_videos.get("video_position_ids")
+            output_length = pixel_values_videos.get("output_length")
+            pixel_values_videos = pixel_values_videos["pixel_values_videos"]
+
+        if not isinstance(pixel_values_videos, mx.array):
+            pixel_values_videos = mx.array(pixel_values_videos)
+        if video_position_ids is not None and not isinstance(video_position_ids, mx.array):
+            video_position_ids = mx.array(video_position_ids)
+
+        if pixel_values_videos.ndim == 4:
+            batch_size, num_frames, max_patches, patch_dim = pixel_values_videos.shape
+            pixel_values_videos = pixel_values_videos.reshape(
+                batch_size * num_frames, max_patches, patch_dim
+            )
+            if video_position_ids is not None:
+                video_position_ids = video_position_ids.reshape(
+                    batch_size * num_frames, max_patches, video_position_ids.shape[-1]
+                )
+            if output_length is None:
+                output_length = (
+                    max_patches // self.vision_tower.pooling_kernel_size**2
+                )
+        elif pixel_values_videos.ndim == 3 and output_length is None:
+            output_length = (
+                pixel_values_videos.shape[1] // self.vision_tower.pooling_kernel_size**2
+            )
+
+        video_features = self.vision_tower(
+            pixel_values_videos,
+            pixel_position_ids=video_position_ids,
+            output_length=output_length,
+        )
+        video_features = self.embed_vision(video_features)
+        return video_features
 
     def __call__(
         self,

--- a/mlx_vlm/models/gemma4/processing_gemma4.py
+++ b/mlx_vlm/models/gemma4/processing_gemma4.py
@@ -48,19 +48,6 @@ _DEFAULT_VIDEO_PROCESSOR_CONFIG = {
 }
 
 
-def _normalize_gemma4_chat_template(chat_template: Optional[str]) -> Optional[str]:
-    """Align older MLX Gemma 4 chat templates with the compact HF formatting."""
-    if not chat_template:
-        return chat_template
-
-    return (
-        chat_template.replace("\n\n<|image|>\n\n", "<|image|>")
-        .replace("\\n\\n<|image|>\\n\\n", "<|image|>")
-        .replace("\n\n<|video|>\n\n", "<|video|>")
-        .replace("\\n\\n<|video|>\\n\\n", "<|video|>")
-    )
-
-
 def _convert_to_rgb(image):
     from PIL import Image
 
@@ -278,11 +265,10 @@ class Gemma4Processor(ProcessorMixin):
         # repeated <|video|> placeholders for each sampled frame.
         if tokenizer is not None:
             video_token_id = tokenizer.convert_tokens_to_ids("<|video|>")
-            if video_token_id == tokenizer.unk_token_id:
-                tokenizer.add_special_tokens(
-                    {"additional_special_tokens": ["<|video|>"]}
+            if video_token_id is None or video_token_id == tokenizer.unk_token_id:
+                raise ValueError(
+                    "Gemma 4 tokenizer is missing the <|video|> special token."
                 )
-                video_token_id = tokenizer.convert_tokens_to_ids("<|video|>")
             self.video_token = "<|video|>"
             self.video_token_id = video_token_id
         else:
@@ -594,9 +580,6 @@ class Gemma4Processor(ProcessorMixin):
             local_files_only=is_local,
         )
         load_chat_template(tokenizer, pretrained_model_name_or_path)
-        tokenizer.chat_template = _normalize_gemma4_chat_template(
-            getattr(tokenizer, "chat_template", None)
-        )
 
         # Load processor config (contains image_processor and feature_extractor settings)
         proc_config = {}

--- a/mlx_vlm/models/gemma4/processing_gemma4.py
+++ b/mlx_vlm/models/gemma4/processing_gemma4.py
@@ -23,12 +23,42 @@ from transformers.image_utils import (
     to_numpy_array,
     valid_images,
 )
+from transformers.models.gemma4.video_processing_gemma4 import Gemma4VideoProcessor
 from transformers.processing_utils import ProcessorMixin
 from transformers.tokenization_utils_base import PreTokenizedInput, TextInput
 
 from ..base import load_chat_template, to_mlx
 
 _SUPPORTED_SOFT_TOKENS = (70, 140, 280, 560, 1120)
+_DEFAULT_VIDEO_PROCESSOR_CONFIG = {
+    "do_convert_rgb": True,
+    "do_normalize": True,
+    "do_rescale": True,
+    "do_resize": True,
+    "do_sample_frames": True,
+    "image_mean": [0.0, 0.0, 0.0],
+    "image_std": [1.0, 1.0, 1.0],
+    "max_soft_tokens": 70,
+    "num_frames": 32,
+    "patch_size": 16,
+    "pooling_kernel_size": 3,
+    "resample": PILImageResampling.BICUBIC,
+    "rescale_factor": 1 / 255,
+    "return_metadata": False,
+}
+
+
+def _normalize_gemma4_chat_template(chat_template: Optional[str]) -> Optional[str]:
+    """Align older MLX Gemma 4 chat templates with the compact HF formatting."""
+    if not chat_template:
+        return chat_template
+
+    return (
+        chat_template.replace("\n\n<|image|>\n\n", "<|image|>")
+        .replace("\\n\\n<|image|>\\n\\n", "<|image|>")
+        .replace("\n\n<|video|>\n\n", "<|video|>")
+        .replace("\\n\\n<|video|>\\n\\n", "<|video|>")
+    )
 
 
 def _convert_to_rgb(image):
@@ -211,17 +241,19 @@ class Gemma4ImageProcessor(HFBaseImageProcessor):
 
 
 class Gemma4Processor(ProcessorMixin):
-    """Combined processor for Gemma 4 (image + text + audio)."""
+    """Combined processor for Gemma 4 (image + video + text + audio)."""
 
-    attributes = ["image_processor", "tokenizer"]
+    attributes = ["image_processor", "tokenizer", "video_processor"]
     image_processor_class = "Gemma4ImageProcessor"
     tokenizer_class = "AutoTokenizer"
+    video_processor_class = "AutoVideoProcessor"
     valid_kwargs = ["chat_template", "image_seq_length", "audio_seq_length"]
 
     def __init__(
         self,
         image_processor=None,
         tokenizer=None,
+        video_processor=None,
         chat_template=None,
         image_seq_length: int = 280,
         audio_seq_length: int = 750,
@@ -241,6 +273,21 @@ class Gemma4Processor(ProcessorMixin):
         self.boi_token = getattr(tokenizer, "boi_token", "")
         self.eoi_token = getattr(tokenizer, "eoi_token", "")
         self.image_token = getattr(tokenizer, "image_token", "")
+
+        # Video token attributes. Gemma 4 uses image boundary tokens around
+        # repeated <|video|> placeholders for each sampled frame.
+        if tokenizer is not None:
+            video_token_id = tokenizer.convert_tokens_to_ids("<|video|>")
+            if video_token_id == tokenizer.unk_token_id:
+                tokenizer.add_special_tokens(
+                    {"additional_special_tokens": ["<|video|>"]}
+                )
+                video_token_id = tokenizer.convert_tokens_to_ids("<|video|>")
+            self.video_token = "<|video|>"
+            self.video_token_id = video_token_id
+        else:
+            self.video_token = "<|video|>"
+            self.video_token_id = None
 
         # Audio token attributes
         self.audio_token_id = getattr(tokenizer, "audio_token_id", None)
@@ -265,6 +312,7 @@ class Gemma4Processor(ProcessorMixin):
         super().__init__(
             image_processor=image_processor,
             tokenizer=tokenizer,
+            video_processor=video_processor,
             chat_template=chat_template,
             **kwargs,
         )
@@ -292,14 +340,18 @@ class Gemma4Processor(ProcessorMixin):
                 List[PreTokenizedInput],
             ]
         ] = None,
+        videos=None,
         audio: Optional[List] = None,
         **kwargs,
     ) -> BatchFeature:
-        if text is None and images is None and audio is None:
-            raise ValueError("Provide at least one of `text`, `images`, or `audio`.")
+        if text is None and images is None and videos is None and audio is None:
+            raise ValueError(
+                "Provide at least one of `text`, `images`, `videos`, or `audio`."
+            )
 
         # Pop return_tensors - we handle conversion ourselves via to_mlx()
         kwargs.pop("return_tensors", None)
+        return_metadata = kwargs.pop("return_metadata", False)
 
         if isinstance(text, str):
             text = [text]
@@ -335,6 +387,66 @@ class Gemma4Processor(ProcessorMixin):
                     prompt.replace(self.image_token, self.full_image_sequence)
                     for prompt in text
                 ]
+
+        # ── Process videos ──────────────────────────────────────────────
+        video_inputs = {}
+        if videos is not None:
+            if text is None:
+                text = [self.video_token] * len(videos)
+
+            video_kwargs = {}
+            for key in (
+                "video_metadata",
+                "do_sample_frames",
+                "fps",
+                "num_frames",
+                "max_soft_tokens",
+                "return_metadata",
+                "device",
+                "input_data_format",
+            ):
+                if key in kwargs:
+                    video_kwargs[key] = kwargs.pop(key)
+            video_kwargs["return_metadata"] = True
+
+            video_processor = self.video_processor or Gemma4VideoProcessor(
+                **_DEFAULT_VIDEO_PROCESSOR_CONFIG
+            )
+            video_inputs = video_processor(videos=videos, **video_kwargs)
+            num_video_tokens = video_inputs.pop("num_soft_tokens_per_video")
+            video_metadata = video_inputs.get("video_metadata")
+
+            if video_metadata is None:
+                raise ValueError(
+                    "Gemma 4 video processing requires video metadata to build timestamped prompts."
+                )
+
+            video_replacements = []
+            for metadata, n_tokens in zip(video_metadata, num_video_tokens):
+                metadata_fps = 24 if metadata.fps is None else metadata.fps
+                metadata.fps = metadata_fps
+                timestamp_str = [
+                    f"{int(seconds // 60):02d}:{int(seconds % 60):02d}"
+                    for seconds in metadata.timestamps
+                ]
+                video_replacements.append(
+                    " ".join(
+                        [
+                            f"{t} {self.boi_token}{self.video_token * n_tokens}{self.eoi_token}"
+                            for t in timestamp_str
+                        ]
+                    )
+                )
+
+            replacements_iter = iter(video_replacements)
+            video_pattern = re.escape(self.video_token)
+            text = [
+                re.sub(video_pattern, lambda _: next(replacements_iter), prompt)
+                for prompt in text
+            ]
+
+            if not return_metadata:
+                video_inputs.pop("video_metadata", None)
 
         # ── Process audio ───────────────────────────────────────────────
         audio_inputs = {}
@@ -400,11 +512,13 @@ class Gemma4Processor(ProcessorMixin):
                 mm_token_type_ids[array_ids == self.image_token_id] = 1
             if self.audio_token_id is not None:
                 mm_token_type_ids[array_ids == self.audio_token_id] = 2
+            if self.video_token_id is not None:
+                mm_token_type_ids[array_ids == self.video_token_id] = 3
             text_inputs["token_type_ids"] = mm_token_type_ids.tolist()
 
         # Merge all inputs and convert to MLX arrays
         return BatchFeature(
-            data=to_mlx({**text_inputs, **image_inputs, **audio_inputs})
+            data=to_mlx({**text_inputs, **image_inputs, **video_inputs, **audio_inputs})
         )
 
     def save_pretrained(self, save_directory, **kwargs):
@@ -445,7 +559,20 @@ class Gemma4Processor(ProcessorMixin):
     def model_input_names(self):
         tokenizer_input_names = self.tokenizer.model_input_names + ["token_type_ids"]
         image_processor_input_names = self.image_processor.model_input_names
-        all_names = list(tokenizer_input_names + image_processor_input_names)
+        video_processor_input_names = (
+            self.video_processor.model_input_names if self.video_processor else []
+        )
+        feature_extractor_input_names = (
+            self.feature_extractor.model_input_names
+            if self.feature_extractor is not None
+            else []
+        )
+        all_names = list(
+            tokenizer_input_names
+            + image_processor_input_names
+            + video_processor_input_names
+            + feature_extractor_input_names
+        )
         return list(dict.fromkeys(all_names))
 
     @classmethod
@@ -467,6 +594,9 @@ class Gemma4Processor(ProcessorMixin):
             local_files_only=is_local,
         )
         load_chat_template(tokenizer, pretrained_model_name_or_path)
+        tokenizer.chat_template = _normalize_gemma4_chat_template(
+            getattr(tokenizer, "chat_template", None)
+        )
 
         # Load processor config (contains image_processor and feature_extractor settings)
         proc_config = {}
@@ -546,7 +676,22 @@ class Gemma4Processor(ProcessorMixin):
             fe_config = proc_config["feature_extractor"]
             fe_config.pop("feature_extractor_type", None)
 
+        vp_config = {}
+        if "video_processor" in proc_config and isinstance(
+            proc_config["video_processor"], dict
+        ):
+            vp_config = proc_config["video_processor"]
+            vp_config.pop("video_processor_type", None)
+
         image_processor = Gemma4ImageProcessor(**ip_config)
+
+        video_processor = None
+        video_processor_kwargs = dict(_DEFAULT_VIDEO_PROCESSOR_CONFIG)
+        video_processor_kwargs.update(vp_config)
+        try:
+            video_processor = Gemma4VideoProcessor(**video_processor_kwargs)
+        except Exception:
+            video_processor = None
 
         # Load audio feature extractor.
         # The standard HF checkpoint does not include a "feature_extractor" key
@@ -572,6 +717,7 @@ class Gemma4Processor(ProcessorMixin):
         return cls(
             image_processor=image_processor,
             tokenizer=tokenizer,
+            video_processor=video_processor,
             image_seq_length=image_seq_length,
             audio_seq_length=audio_seq_length,
             audio_ms_per_token=audio_ms_per_token,

--- a/mlx_vlm/models/gemma4/vision.py
+++ b/mlx_vlm/models/gemma4/vision.py
@@ -316,6 +316,9 @@ class VisionPatchEmbedder(nn.Module):
         patches = pixel_values.reshape(B, C, pH, p, pW, p)
         patches = patches.transpose(0, 2, 4, 3, 5, 1)  # [B, pH, pW, p, p, C]
         patches = patches.reshape(B, pH * pW, C * p * p)
+        return patches
+
+    def _project_patches(self, patches: mx.array) -> mx.array:
         patches = 2 * (patches - 0.5)
         return self.input_proj(patches.astype(self.input_proj.weight.dtype))
 
@@ -325,7 +328,15 @@ class VisionPatchEmbedder(nn.Module):
         patch_positions: mx.array,
         padding_positions: mx.array,
     ) -> mx.array:
-        hidden_states = self._patchify(pixel_values)
+        if pixel_values.ndim == 4:
+            patches = self._patchify(pixel_values)
+        elif pixel_values.ndim == 3:
+            patches = pixel_values
+        else:
+            raise ValueError(
+                f"Expected pixel_values with ndim 3 or 4, got shape {pixel_values.shape}"
+            )
+        hidden_states = self._project_patches(patches)
         position_embeddings = self._position_embeddings(
             patch_positions, padding_positions
         )
@@ -363,7 +374,7 @@ class VisionPooler(nn.Module):
 
         length = output_length or self.default_output_length
         if hidden_states.shape[1] == length:
-            mask = padding_positions
+            mask = ~padding_positions
         else:
             hidden_states, mask = self._avg_pool_by_positions(
                 hidden_states, patch_positions, length
@@ -438,7 +449,12 @@ class VisionModel(nn.Module):
 
         return patch_positions.astype(np.int32), padding_mask, num_patches
 
-    def __call__(self, pixel_values) -> mx.array:
+    def __call__(
+        self,
+        pixel_values,
+        pixel_position_ids: Optional[mx.array] = None,
+        output_length: Optional[int] = None,
+    ) -> mx.array:
         # Handle list of different-sized images: process each individually
         if isinstance(pixel_values, list):
             all_real = []
@@ -454,54 +470,70 @@ class VisionModel(nn.Module):
         if not isinstance(pixel_values, mx.array):
             pixel_values = mx.array(pixel_values)
 
-        B, C, H, W = pixel_values.shape
-        all_same_size = True
+        if pixel_values.ndim == 3:
+            if pixel_position_ids is None:
+                raise ValueError("pixel_position_ids are required for patchified inputs.")
+            if not isinstance(pixel_position_ids, mx.array):
+                pixel_position_ids = mx.array(pixel_position_ids)
 
-        if all_same_size:
-            num_real = (H // self.patch_size) * (W // self.patch_size)
-            num_real = min(num_real, self.max_patches)
-            positions, padding_mask, _ = self._patch_positions_single(H, W)
-            # Tile for batch
-            patch_positions = mx.array(np.tile(positions[None], (B, 1, 1)))
-            padding_positions = mx.array(np.tile(padding_mask[None], (B, 1)))
-
+            B, max_patches, _ = pixel_values.shape
+            patch_positions = pixel_position_ids
+            padding_positions = mx.all(patch_positions == -1, axis=-1)
             inputs_embeds = self.patch_embedder(
-                pixel_values,
-                patch_positions[:, :num_real],
-                padding_positions[:, :num_real],
+                pixel_values, patch_positions, padding_positions
             )
-
-            num_padding = self.max_patches - num_real
-            if num_padding > 0:
-                pad_embeds = mx.zeros(
-                    (B, num_padding, inputs_embeds.shape[-1]), dtype=inputs_embeds.dtype
-                )
-                inputs_embeds = mx.concatenate([inputs_embeds, pad_embeds], axis=1)
+            pooled_length = output_length or (max_patches // self.pooling_kernel_size**2)
         else:
-            # Per-image processing for different sizes (shouldn't happen with padding)
-            all_embeds = []
-            all_positions = []
-            all_padding = []
-            for i in range(B):
-                img = pixel_values[i : i + 1]
-                _, _, h, w = img.shape
-                pos, pad_mask, n_real = self._patch_positions_single(h, w)
-                pos_mx = mx.array(pos[None])
-                pad_mx = mx.array(pad_mask[None])
-                n_real = min(n_real, self.max_patches)
+            B, C, H, W = pixel_values.shape
+            all_same_size = True
 
-                emb = self.patch_embedder(img, pos_mx[:, :n_real], pad_mx[:, :n_real])
-                n_pad = self.max_patches - n_real
-                if n_pad > 0:
-                    pad_emb = mx.zeros((1, n_pad, emb.shape[-1]), dtype=emb.dtype)
-                    emb = mx.concatenate([emb, pad_emb], axis=1)
-                all_embeds.append(emb)
-                all_positions.append(pos_mx)
-                all_padding.append(pad_mx)
+            if all_same_size:
+                num_real = (H // self.patch_size) * (W // self.patch_size)
+                num_real = min(num_real, self.max_patches)
+                positions, padding_mask, _ = self._patch_positions_single(H, W)
+                # Tile for batch
+                patch_positions = mx.array(np.tile(positions[None], (B, 1, 1)))
+                padding_positions = mx.array(np.tile(padding_mask[None], (B, 1)))
 
-            inputs_embeds = mx.concatenate(all_embeds, axis=0)
-            patch_positions = mx.concatenate(all_positions, axis=0)
-            padding_positions = mx.concatenate(all_padding, axis=0)
+                inputs_embeds = self.patch_embedder(
+                    pixel_values,
+                    patch_positions[:, :num_real],
+                    padding_positions[:, :num_real],
+                )
+
+                num_padding = self.max_patches - num_real
+                if num_padding > 0:
+                    pad_embeds = mx.zeros(
+                        (B, num_padding, inputs_embeds.shape[-1]), dtype=inputs_embeds.dtype
+                    )
+                    inputs_embeds = mx.concatenate([inputs_embeds, pad_embeds], axis=1)
+            else:
+                # Per-image processing for different sizes (shouldn't happen with padding)
+                all_embeds = []
+                all_positions = []
+                all_padding = []
+                for i in range(B):
+                    img = pixel_values[i : i + 1]
+                    _, _, h, w = img.shape
+                    pos, pad_mask, n_real = self._patch_positions_single(h, w)
+                    pos_mx = mx.array(pos[None])
+                    pad_mx = mx.array(pad_mask[None])
+                    n_real = min(n_real, self.max_patches)
+
+                    emb = self.patch_embedder(img, pos_mx[:, :n_real], pad_mx[:, :n_real])
+                    n_pad = self.max_patches - n_real
+                    if n_pad > 0:
+                        pad_emb = mx.zeros((1, n_pad, emb.shape[-1]), dtype=emb.dtype)
+                        emb = mx.concatenate([emb, pad_emb], axis=1)
+                    all_embeds.append(emb)
+                    all_positions.append(pos_mx)
+                    all_padding.append(pad_mx)
+
+                inputs_embeds = mx.concatenate(all_embeds, axis=0)
+                patch_positions = mx.concatenate(all_positions, axis=0)
+                padding_positions = mx.concatenate(all_padding, axis=0)
+
+            pooled_length = output_length or self.default_output_length
 
         # Build bidirectional attention mask [B, 1, L, L] for SDPA
         valid_mask = ~padding_positions
@@ -515,13 +547,13 @@ class VisionModel(nn.Module):
         hidden_states = self.encoder(inputs_embeds, patch_positions, attn_mask)
 
         pooled, pool_mask = self.pooler(
-            hidden_states, patch_positions, padding_positions
+            hidden_states,
+            patch_positions,
+            padding_positions,
+            output_length=pooled_length,
         )
 
-        if pool_mask.shape[1] == self.default_output_length:
-            valid_mask = pool_mask
-        else:
-            valid_mask = ~pool_mask
+        valid_mask = pool_mask
 
         all_real = []
         for i in range(B):

--- a/mlx_vlm/tests/test_processors.py
+++ b/mlx_vlm/tests/test_processors.py
@@ -199,7 +199,20 @@ class TestPaliGemmaProcessor(_ProcessorTestBase, unittest.TestCase):
         p.image_token = "<image>"
         p.image_seq_length = 4
         p.bos_token = "<bos>"
-        p.image_processor = _mock_ip()
+        p.image_processor = type(
+            "Gemma4IP",
+            (),
+            {
+                "model_input_names": ["pixel_values"],
+                "__call__": lambda self, images=None, **kw: (
+                    {"pixel_values": np.random.randn(1, 3, 224, 224).astype(np.float32)},
+                    [4],
+                ),
+                "fetch_images": lambda self, images: (
+                    [images] if not isinstance(images, list) else images
+                ),
+            },
+        )()
         p.tokenizer = _mock_tokenizer()
         return p
 
@@ -316,6 +329,143 @@ class TestGemma3nProcessor(_ProcessorTestBase, unittest.TestCase):
 
     def _image_call_args(self):
         return {"text": ["<image> Cats"], "images": [_make_image()]}
+
+
+class TestGemma4Processor(_ProcessorTestBase, unittest.TestCase):
+    def _make_processor(self):
+        from mlx_vlm.models.gemma4.processing_gemma4 import Gemma4Processor
+
+        class Tokenizer:
+            model_input_names = ["input_ids", "attention_mask"]
+            bos_token = "<bos>"
+            eos_token = "<eos>"
+            pad_token = "<pad>"
+            pad_token_id = 0
+            image_token = "<image>"
+            image_token_id = 100
+            boi_token = "<boi>"
+            eoi_token = "<eoi>"
+            audio_token = "<audio>"
+            audio_token_id = 101
+            boa_token = "<boa>"
+            eoa_token = "<eoa>"
+            video_token = "<|video|>"
+            video_token_id = 102
+
+            def __init__(self):
+                self.seen_text = None
+
+            def __call__(self, text=None, return_token_type_ids=False, **kwargs):
+                batch = [text] if isinstance(text, str) else text
+                self.seen_text = batch
+                payload = {
+                    "input_ids": [list(range(12)) for _ in batch],
+                    "attention_mask": [[1] * 12 for _ in batch],
+                }
+                if return_token_type_ids:
+                    payload["token_type_ids"] = [[0] * 12 for _ in batch]
+                return payload
+
+            def convert_tokens_to_ids(self, token):
+                mapping = {
+                    self.image_token: self.image_token_id,
+                    self.audio_token: self.audio_token_id,
+                    self.video_token: self.video_token_id,
+                }
+                return mapping.get(token, 0)
+
+            def add_special_tokens(self, tokens):
+                return None
+
+            @property
+            def init_kwargs(self):
+                return {}
+
+            def batch_decode(self, ids, **kwargs):
+                return ["decoded"] * len(ids)
+
+            def decode(self, ids, **kwargs):
+                return "decoded"
+
+        class VideoProcessor:
+            model_input_names = ["pixel_values_videos", "video_position_ids"]
+
+            def __call__(self, videos=None, **kwargs):
+                return {
+                    "pixel_values_videos": np.random.randn(2, 18, 768).astype(np.float32),
+                    "video_position_ids": np.zeros((2, 18, 2), dtype=np.int64),
+                    "num_soft_tokens_per_video": [2],
+                    "video_metadata": [
+                        SimpleNamespace(fps=30.0, timestamps=[0.0, 1.0])
+                    ],
+                }
+
+        class FeatureExtractor:
+            model_input_names = ["input_features", "input_features_mask"]
+            sampling_rate = 16000
+
+            def __call__(self, audio_arrays, sampling_rate=None, return_attention_mask=True):
+                return {
+                    "input_features": np.zeros((1, 4, 8), dtype=np.float32),
+                    "input_features_mask": np.ones((1, 4), dtype=np.int64),
+                }
+
+        p = Gemma4Processor.__new__(Gemma4Processor)
+        p.image_seq_length = 4
+        p.audio_seq_length = 4
+        p.audio_ms_per_token = 40
+        p.image_token_id = 100
+        p.audio_token_id = 101
+        p.video_token_id = 102
+        p.boi_token = "<boi>"
+        p.eoi_token = "<eoi>"
+        p.image_token = "<image>"
+        p.video_token = "<|video|>"
+        p.boa_token = "<boa>"
+        p.eoa_token = "<eoa>"
+        p.audio_token = "<audio>"
+        p.full_image_sequence = "<boi>" + "<image>" * 4 + "<eoi>"
+        p.full_audio_sequence = "<boa>" + "<audio>" * 4 + "<eoa>"
+        p.image_processor = type(
+            "Gemma4IP",
+            (),
+            {
+                "model_input_names": ["pixel_values"],
+                "__call__": lambda self, images=None, **kw: (
+                    {"pixel_values": np.random.randn(1, 3, 224, 224).astype(np.float32)},
+                    [4],
+                ),
+                "fetch_images": lambda self, images: (
+                    [images] if not isinstance(images, list) else images
+                ),
+            },
+        )()
+        p.video_processor = VideoProcessor()
+        p.feature_extractor = FeatureExtractor()
+        p.tokenizer = Tokenizer()
+        return p
+
+    def _image_call_args(self):
+        return {"text": ["<image> Describe"], "images": [_make_image()]}
+
+    def test_video_and_audio_inputs_expand_native_prompt(self):
+        processor = self._make_processor()
+
+        result = processor(
+            text=["<|video|>\nList the domains.<audio>"],
+            videos=[np.zeros((2, 3, 224, 224), dtype=np.uint8)],
+            audio=[(np.zeros((1,), dtype=np.float32), 16000)],
+        )
+
+        self._assert_all_mx(result)
+        self.assertIn("pixel_values_videos", result)
+        self.assertIn("video_position_ids", result)
+        self.assertIn("input_features", result)
+
+        rendered = processor.tokenizer.seen_text[0]
+        self.assertIn("00:00 <boi><|video|><|video|><eoi>", rendered)
+        self.assertIn("00:01 <boi><|video|><|video|><eoi>", rendered)
+        self.assertIn("<boa><audio><eoa>", rendered)
 
 
 class TestDotsVLProcessor(unittest.TestCase):

--- a/mlx_vlm/tests/test_processors.py
+++ b/mlx_vlm/tests/test_processors.py
@@ -341,6 +341,7 @@ class TestGemma4Processor(_ProcessorTestBase, unittest.TestCase):
             eos_token = "<eos>"
             pad_token = "<pad>"
             pad_token_id = 0
+            unk_token_id = 0
             image_token = "<image>"
             image_token_id = 100
             boi_token = "<boi>"
@@ -466,6 +467,36 @@ class TestGemma4Processor(_ProcessorTestBase, unittest.TestCase):
         self.assertIn("00:00 <boi><|video|><|video|><eoi>", rendered)
         self.assertIn("00:01 <boi><|video|><|video|><eoi>", rendered)
         self.assertIn("<boa><audio><eoa>", rendered)
+
+    def test_missing_video_special_token_raises(self):
+        from mlx_vlm.models.gemma4.processing_gemma4 import (
+            Gemma4ImageProcessor,
+            Gemma4Processor,
+        )
+
+        class Tokenizer:
+            model_input_names = ["input_ids", "attention_mask"]
+            image_token = "<image>"
+            image_token_id = 100
+            audio_token = "<audio>"
+            audio_token_id = 101
+            boi_token = "<boi>"
+            eoi_token = "<eoi>"
+            boa_token = "<boa>"
+            eoa_token = "<eoa>"
+            unk_token_id = 0
+
+            def convert_tokens_to_ids(self, token):
+                if token == "<|video|>":
+                    return self.unk_token_id
+                return 1
+
+        with self.assertRaisesRegex(ValueError, "missing the <\\|video\\|> special token"):
+            Gemma4Processor(
+                image_processor=Gemma4ImageProcessor(),
+                tokenizer=Tokenizer(),
+                video_processor=None,
+            )
 
 
 class TestDotsVLProcessor(unittest.TestCase):

--- a/mlx_vlm/utils.py
+++ b/mlx_vlm/utils.py
@@ -850,7 +850,7 @@ def read_audio(file) -> tuple:
     use_ffmpeg = False
     if isinstance(file, (str, Path)):
         ext = Path(file).suffix.lstrip(".").lower()
-        if ext in ("m4a", "aac", "ogg", "opus"):
+        if ext in ("m4a", "aac", "ogg", "opus", "mp4", "m4v", "mov", "avi", "mkv", "webm"):
             use_ffmpeg = True
     elif isinstance(file, _io.BytesIO):
         pos = file.tell()

--- a/mlx_vlm/video_generate.py
+++ b/mlx_vlm/video_generate.py
@@ -17,7 +17,7 @@ import requests
 from PIL import Image
 
 from .generate import generate
-from .utils import load, load_image, process_inputs_with_fallback
+from .utils import load, load_audio, load_image, process_inputs_with_fallback
 
 # This is a beta version of the video generation script.
 # It is not fully tested and may not work as expected.
@@ -425,6 +425,29 @@ def is_video_file(video_path: List[str]) -> bool:
     return True
 
 
+def maybe_load_audio_from_videos(processor, video_paths: List[str], enabled: bool):
+    if not enabled:
+        return None
+    if not hasattr(processor, "feature_extractor") or processor.feature_extractor is None:
+        return None
+    if not getattr(processor, "audio_token", None):
+        return None
+
+    sample_rate = getattr(processor.feature_extractor, "sampling_rate", None)
+    if sample_rate is None:
+        return None
+
+    audio_inputs = []
+    for video_path in video_paths:
+        try:
+            waveform = load_audio(video_path, sr=sample_rate)
+        except Exception as exc:
+            logger.warning(f"Failed to extract audio from video {video_path}: {exc}")
+            return None
+        audio_inputs.append((waveform, sample_rate))
+    return audio_inputs
+
+
 def main():
     parser = argparse.ArgumentParser(description="Video Description CLI")
     parser.add_argument(
@@ -441,6 +464,17 @@ def main():
         "--max-frames", type=int, default=None, help="Maximum number of frames"
     )
     parser.add_argument("--fps", type=float, default=1.0, help="Frames per second")
+    parser.add_argument(
+        "--no-audio-from-video",
+        action="store_true",
+        help="Disable extracting audio from the input video for audio-capable models",
+    )
+    parser.add_argument(
+        "--video-max-soft-tokens",
+        type=int,
+        default=None,
+        help="Override Gemma 4 per-frame visual token budget when using native video processing",
+    )
     parser.add_argument(
         "--prompt", default="Describe this video.", help="Text prompt for the model"
     )
@@ -485,23 +519,18 @@ def main():
 
     kwargs = {}
     if is_video_model(model):
+        is_gemma4_native_video = (
+            getattr(model.config, "model_type", None) == "gemma4"
+            and hasattr(processor, "video_processor")
+        )
 
         # Check if video is image or video
         if is_video_file(args.video):
-            messages = [
-                {
-                    "role": "user",
-                    "content": [
-                        {
-                            "type": "video",
-                            "video": args.video[0],
-                            "max_pixels": max_pixels,
-                            "fps": args.fps,
-                        },
-                        {"type": "text", "text": args.prompt},
-                    ],
-                }
-            ]
+            content = [{"type": "video", "video": args.video[0]}]
+            content.append({"type": "text", "text": args.prompt})
+            if is_gemma4_native_video and not args.no_audio_from_video:
+                content.append({"type": "audio"})
+            messages = [{"role": "user", "content": content}]
         else:
             messages = [
                 {
@@ -522,31 +551,50 @@ def main():
         text = processor.apply_chat_template(
             messages, tokenize=False, add_generation_prompt=True
         )
-        image_inputs, video_inputs, fps = process_vision_info(messages, True)
+        if is_gemma4_native_video and is_video_file(args.video):
+            processor_kwargs = {"padding": True, "return_tensors": "pt"}
+            if args.max_frames is not None:
+                processor_kwargs["num_frames"] = args.max_frames
+            if args.video_max_soft_tokens is not None:
+                processor_kwargs["max_soft_tokens"] = args.video_max_soft_tokens
 
-        if args.max_frames is not None:
-            video_inputs = video_inputs[: args.max_frames]
-        inputs = processor(
-            text=[text],
-            images=image_inputs,
-            videos=video_inputs,
-            padding=True,
-            return_tensors="pt",
-        )
+            audio_inputs = maybe_load_audio_from_videos(
+                processor,
+                args.video,
+                enabled=not args.no_audio_from_video,
+            )
+            inputs = processor(
+                text=[text],
+                videos=args.video,
+                audio=audio_inputs,
+                **processor_kwargs,
+            )
+        else:
+            image_inputs, video_inputs, fps = process_vision_info(messages, True)
+
+            if args.max_frames is not None and video_inputs is not None:
+                video_inputs = video_inputs[: args.max_frames]
+            inputs = processor(
+                text=[text],
+                images=image_inputs,
+                videos=video_inputs,
+                padding=True,
+                return_tensors="pt",
+            )
 
         input_ids = mx.array(inputs["input_ids"])
-        pixel_values = inputs.get(
-            "pixel_values_videos", inputs.get("pixel_values", None)
-        )
-        if pixel_values is None:
-            raise ValueError("Please provide a valid video or image input.")
-        pixel_values = mx.array(pixel_values)
-
         mask = mx.array(inputs["attention_mask"])
-        if inputs.get("video_grid_thw", None) is not None:
-            kwargs["video_grid_thw"] = mx.array(inputs["video_grid_thw"])
-        if inputs.get("image_grid_thw", None) is not None:
-            kwargs["image_grid_thw"] = mx.array(inputs["image_grid_thw"])
+        pixel_values = None
+        for key, value in inputs.items():
+            if key in ["input_ids", "attention_mask", "video_metadata"]:
+                continue
+            if value is None:
+                continue
+            array_value = value if isinstance(value, mx.array) else mx.array(value)
+            if key == "pixel_values":
+                pixel_values = array_value
+            else:
+                kwargs[key] = array_value
 
     else:
         if is_video_file(args.video):
@@ -619,7 +667,8 @@ def main():
 
     kwargs["video"] = args.video
     kwargs["input_ids"] = input_ids
-    kwargs["pixel_values"] = pixel_values
+    if pixel_values is not None:
+        kwargs["pixel_values"] = pixel_values
     kwargs["mask"] = mask
     kwargs["temperature"] = args.temperature
     kwargs["max_tokens"] = args.max_tokens

--- a/mlx_vlm/video_generate.py
+++ b/mlx_vlm/video_generate.py
@@ -16,7 +16,11 @@ import numpy as np
 import requests
 from PIL import Image
 
-from .generate import generate
+from .generate import (
+    DEFAULT_THINKING_END_TOKEN,
+    DEFAULT_THINKING_START_TOKEN,
+    generate,
+)
 from .utils import load, load_audio, load_image, process_inputs_with_fallback
 
 # This is a beta version of the video generation script.
@@ -493,6 +497,29 @@ def main():
         default="mlx-community/Qwen2.5-VL-7B-Instruct-4bit",
         help="Select the model to use",
     )
+    parser.add_argument(
+        "--enable-thinking",
+        action="store_true",
+        help="Enable thinking mode in the chat template and generation.",
+    )
+    parser.add_argument(
+        "--thinking-budget",
+        type=int,
+        default=None,
+        help="Maximum number of thinking tokens before forcing the end-of-thinking token.",
+    )
+    parser.add_argument(
+        "--thinking-start-token",
+        type=str,
+        default=DEFAULT_THINKING_START_TOKEN,
+        help="Token that marks the start of a thinking block (default: %(default)s).",
+    )
+    parser.add_argument(
+        "--thinking-end-token",
+        type=str,
+        default=DEFAULT_THINKING_END_TOKEN,
+        help="Token that marks the end of a thinking block (default: %(default)s).",
+    )
     parser.add_argument("--verbose", action="store_false", help="Print verbose output")
 
     args = parser.parse_args()
@@ -549,7 +576,10 @@ def main():
             )
 
         text = processor.apply_chat_template(
-            messages, tokenize=False, add_generation_prompt=True
+            messages,
+            tokenize=False,
+            add_generation_prompt=True,
+            enable_thinking=args.enable_thinking,
         )
         if is_gemma4_native_video and is_video_file(args.video):
             processor_kwargs = {"padding": True, "return_tensors": "pt"}
@@ -626,7 +656,10 @@ def main():
             )
 
         text = processor.apply_chat_template(
-            messages, tokenize=False, add_generation_prompt=True
+            messages,
+            tokenize=False,
+            add_generation_prompt=True,
+            enable_thinking=args.enable_thinking,
         )
 
         # Configure processor for video frames
@@ -672,6 +705,12 @@ def main():
     kwargs["mask"] = mask
     kwargs["temperature"] = args.temperature
     kwargs["max_tokens"] = args.max_tokens
+    kwargs["enable_thinking"] = args.enable_thinking
+    if args.thinking_budget is not None:
+        kwargs["thinking_budget"] = args.thinking_budget
+        kwargs["thinking_end_token"] = args.thinking_end_token
+        if args.thinking_start_token is not None:
+            kwargs["thinking_start_token"] = args.thinking_start_token
 
     response = generate(
         model,

--- a/mlx_vlm/video_generate.py
+++ b/mlx_vlm/video_generate.py
@@ -569,11 +569,19 @@ def main():
                 "Use --video-max-soft-tokens to control the per-frame visual budget."
             )
 
+        audio_inputs = None
+        if is_gemma4_native_video and is_video_file(args.video):
+            audio_inputs = maybe_load_audio_from_videos(
+                processor,
+                args.video,
+                enabled=native_audio_enabled and not args.no_audio_from_video,
+            )
+
         # Check if video is image or video
         if is_video_file(args.video):
             content = [{"type": "video", "video": args.video[0]}]
             content.append({"type": "text", "text": args.prompt})
-            if native_audio_enabled and not args.no_audio_from_video:
+            if audio_inputs is not None:
                 content.append({"type": "audio"})
             messages = [{"role": "user", "content": content}]
         else:
@@ -608,11 +616,6 @@ def main():
             if args.video_max_soft_tokens is not None:
                 processor_kwargs["max_soft_tokens"] = args.video_max_soft_tokens
 
-            audio_inputs = maybe_load_audio_from_videos(
-                processor,
-                args.video,
-                enabled=native_audio_enabled and not args.no_audio_from_video,
-            )
             inputs = processor(
                 text=[text],
                 videos=args.video,

--- a/mlx_vlm/video_generate.py
+++ b/mlx_vlm/video_generate.py
@@ -452,6 +452,15 @@ def maybe_load_audio_from_videos(processor, video_paths: List[str], enabled: boo
     return audio_inputs
 
 
+def supports_native_gemma4_audio(model, processor) -> bool:
+    return (
+        getattr(model.config, "model_type", None) == "gemma4"
+        and getattr(model, "audio_tower", None) is not None
+        and getattr(processor, "feature_extractor", None) is not None
+        and bool(getattr(processor, "audio_token", None))
+    )
+
+
 def main():
     parser = argparse.ArgumentParser(description="Video Description CLI")
     parser.add_argument(
@@ -550,12 +559,21 @@ def main():
             getattr(model.config, "model_type", None) == "gemma4"
             and hasattr(processor, "video_processor")
         )
+        native_audio_enabled = supports_native_gemma4_audio(model, processor)
+
+        if is_gemma4_native_video and is_video_file(args.video) and len(args.video) != 1:
+            raise ValueError("Gemma 4 native video processing currently supports exactly one video input.")
+        if is_gemma4_native_video and isinstance(args.max_pixels, (tuple, list)):
+            raise ValueError(
+                "--max-pixels is not supported for native Gemma 4 video processing. "
+                "Use --video-max-soft-tokens to control the per-frame visual budget."
+            )
 
         # Check if video is image or video
         if is_video_file(args.video):
             content = [{"type": "video", "video": args.video[0]}]
             content.append({"type": "text", "text": args.prompt})
-            if is_gemma4_native_video and not args.no_audio_from_video:
+            if native_audio_enabled and not args.no_audio_from_video:
                 content.append({"type": "audio"})
             messages = [{"role": "user", "content": content}]
         else:
@@ -585,13 +603,15 @@ def main():
             processor_kwargs = {"padding": True, "return_tensors": "pt"}
             if args.max_frames is not None:
                 processor_kwargs["num_frames"] = args.max_frames
+            if args.fps != 1.0:
+                processor_kwargs["fps"] = args.fps
             if args.video_max_soft_tokens is not None:
                 processor_kwargs["max_soft_tokens"] = args.video_max_soft_tokens
 
             audio_inputs = maybe_load_audio_from_videos(
                 processor,
                 args.video,
-                enabled=not args.no_audio_from_video,
+                enabled=native_audio_enabled and not args.no_audio_from_video,
             )
             inputs = processor(
                 text=[text],


### PR DESCRIPTION
Hi! I tried getting Gemma 4 video mode to work and realized mlx-vlm doesn't support it yet, so this PR adds native Gemma 4 video support to `mlx-vlm`. It follows the token structure that transformers uses (video frames are patchified and passed in with video tokens).

It extends the Gemma 4 processor/model path to accept video inputs directly, adds native Gemma 4 handling in `mlx_vlm.video_generate`, and wires video+audio and thinking support through the CLI where the loaded model supports it.

- Gemma 4 video processing in `Gemma4Processor`
- Gemma 4 video token handling in the model/embed path
- Gemma 4 support in `mlx_vlm.video_generate`
- optional audio-from-video for Gemma 4 models with audio support
- thinking support in the native video CLI
- regression tests for Gemma 4 video/audio prompt expansion

## Performance on my M2 Max

MLX native ran at about 201-240 tok/s prefill and 15-22 tok/s generation; the comparable transformers run generated at about 1.05 tok/s. MLX completed at 280 video tokens/frame; transformers OOM’d at 280 on this machine.

## Example

```py
python -m mlx_vlm.video_generate \
  --model mlx-community/gemma-4-e4b-it-4bit \
  --video video.mp4 \
  --prompt "Describe this video in one sentence." \
  --video-max-soft-tokens 280 \
  --max-tokens 64 \
  --temperature 0.0
```
optionally, append `--enable-thinking`.

## Tests

- `python -m unittest mlx_vlm.tests.test_processors.TestGemma4Processor`
- `python -m unittest mlx_vlm.tests.test_models -k gemma4`