### PR TITLE
Add Youtu-VL

### DIFF
--- a/mlx_vlm/models/youtu_vl/__init__.py
+++ b/mlx_vlm/models/youtu_vl/__init__.py
@@ -1,0 +1,4 @@
+from .config import ModelConfig, TextConfig, VisionConfig
+from .language import LanguageModel
+from .vision import VisionModel
+from .youtu_vl import Model

--- a/mlx_vlm/models/youtu_vl/config.py
+++ b/mlx_vlm/models/youtu_vl/config.py
@@ -1,6 +1,6 @@
 import inspect
 from dataclasses import dataclass, field
-from typing import Dict, List, Optional, Union
+from typing import Dict, List, Optional
 
 from ..base import BaseModelConfig
 
@@ -21,9 +21,7 @@ class VisionConfig(BaseModelConfig):
     attention_dropout: float = 0.0
     spatial_merge_size: int = 2
     window_size: int = 256
-    fullatt_block_indexes: list = field(
-        default_factory=lambda: [7, 15, 23, 26]
-    )
+    fullatt_block_indexes: list = field(default_factory=lambda: [7, 15, 23, 26])
 
 
 @dataclass

--- a/mlx_vlm/models/youtu_vl/config.py
+++ b/mlx_vlm/models/youtu_vl/config.py
@@ -1,0 +1,110 @@
+import inspect
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional, Union
+
+from ..base import BaseModelConfig
+
+
+@dataclass
+class VisionConfig(BaseModelConfig):
+    model_type: str = "siglip2_vision_model"
+    hidden_size: int = 1152
+    out_hidden_size: int = 2560
+    intermediate_size: int = 4304
+    num_hidden_layers: int = 27
+    num_attention_heads: int = 16
+    num_channels: int = 3
+    num_patches: int = 4096
+    patch_size: int = 16
+    hidden_act: str = "gelu_pytorch_tanh"
+    layer_norm_eps: float = 1e-6
+    attention_dropout: float = 0.0
+    spatial_merge_size: int = 2
+    window_size: int = 256
+    fullatt_block_indexes: list = field(
+        default_factory=lambda: [7, 15, 23, 26]
+    )
+
+
+@dataclass
+class TextConfig(BaseModelConfig):
+    model_type: str = "youtu_vl"
+    hidden_size: int = 2560
+    intermediate_size: int = 9728
+    num_hidden_layers: int = 40
+    num_attention_heads: int = 32
+    num_key_value_heads: int = 32
+    vocab_size: int = 283386
+    rms_norm_eps: float = 1e-6
+    max_position_embeddings: int = 32768
+
+    # MLA params
+    kv_lora_rank: int = 512
+    q_lora_rank: int = 1536
+    qk_rope_head_dim: int = 64
+    v_head_dim: int = 128
+    qk_nope_head_dim: int = 128
+
+    # RoPE params
+    rope_theta: float = 500000.0
+    rope_interleave: bool = True
+    rope_traditional: bool = True
+    rope_scaling: Optional[Dict] = None
+
+    # MoE params (optional, for future larger models)
+    n_shared_experts: Optional[int] = None
+    n_routed_experts: Optional[int] = None
+    moe_intermediate_size: Optional[int] = None
+    num_experts_per_tok: int = 1
+    n_group: int = 1
+    topk_group: int = 1
+    routed_scaling_factor: float = 1.0
+    norm_topk_prob: bool = True
+    moe_layer_freq: int = 1
+    first_k_dense_replace: int = 0
+    topk_method: str = "noaux_tc"
+    scoring_func: str = "sigmoid"
+
+    # Other
+    tie_word_embeddings: bool = True
+    attention_bias: bool = False
+    mlp_bias: bool = False
+
+    def __post_init__(self):
+        if self.rope_interleave:
+            self.rope_traditional = True
+
+
+@dataclass
+class ModelConfig(BaseModelConfig):
+    text_config: TextConfig = None
+    vision_config: VisionConfig = None
+    model_type: str = "youtu_vl"
+    image_token_id: int = 128264
+    video_token_id: int = 128265
+    vision_start_token_id: int = 128262
+    vision_end_token_id: int = 128263
+    vocab_size: int = 283386
+    eos_token_id: Optional[List[int]] = None
+
+    @classmethod
+    def from_dict(cls, params):
+        # Copy text config parameters from root level (excluding vision-specific keys)
+        excluded_keys = {"vision_config"}
+        params["text_config"] = dict(
+            filter(lambda x: x[0] not in excluded_keys, params.items())
+        )
+
+        return cls(
+            **{
+                k: v
+                for k, v in params.items()
+                if k in inspect.signature(cls).parameters
+            }
+        )
+
+    def __post_init__(self):
+        if isinstance(self.vision_config, dict):
+            self.vision_config = VisionConfig.from_dict(self.vision_config)
+        if isinstance(self.text_config, dict):
+            self.text_config = TextConfig.from_dict(self.text_config)

--- a/mlx_vlm/models/youtu_vl/language.py
+++ b/mlx_vlm/models/youtu_vl/language.py
@@ -1,13 +1,13 @@
 import math
-from dataclasses import dataclass
 from typing import Any, Optional
 
 import mlx.core as mx
 import mlx.nn as nn
-
 from mlx_lm.models.activations import swiglu
-from mlx_lm.models.switch_layers import SwitchGLU
+from mlx_lm.models.mla import MultiLinear
 from mlx_lm.models.rope_utils import initialize_rope
+from mlx_lm.models.switch_layers import SwitchGLU
+
 from ..base import (
     LanguageModelOutput,
     create_attention_mask,
@@ -33,7 +33,6 @@ class YoutuAttention(nn.Module):
 
         self.scale = self.q_head_dim**-0.5
 
-        # Handle mscale for rope_scaling
         if config.rope_scaling is not None:
             mscale_all_dim = config.rope_scaling.get("mscale_all_dim", 0)
             if mscale_all_dim:
@@ -42,7 +41,6 @@ class YoutuAttention(nn.Module):
                     s = 0.1 * mscale_all_dim * math.log(scaling_factor) + 1.0
                     self.scale = self.scale * s * s
 
-        # Q projection (LoRA-style)
         if self.q_lora_rank is None:
             self.q_proj = nn.Linear(
                 self.hidden_size, self.num_heads * self.q_head_dim, bias=False
@@ -51,27 +49,22 @@ class YoutuAttention(nn.Module):
             self.q_a_proj = nn.Linear(
                 self.hidden_size, self.q_lora_rank, bias=config.attention_bias
             )
-            self.q_a_layernorm = nn.RMSNorm(
-                self.q_lora_rank, eps=config.rms_norm_eps
-            )
+            self.q_a_layernorm = nn.RMSNorm(self.q_lora_rank, eps=config.rms_norm_eps)
             self.q_b_proj = nn.Linear(
                 self.q_lora_rank, self.num_heads * self.q_head_dim, bias=False
             )
 
-        # KV projection (MQA with LoRA)
         self.kv_a_proj_with_mqa = nn.Linear(
             self.hidden_size,
             self.kv_lora_rank + self.qk_rope_head_dim,
             bias=config.attention_bias,
         )
-        self.kv_a_layernorm = nn.RMSNorm(
-            self.kv_lora_rank, eps=config.rms_norm_eps
+        self.kv_a_layernorm = nn.RMSNorm(self.kv_lora_rank, eps=config.rms_norm_eps)
+        self.embed_q = MultiLinear(
+            self.qk_nope_head_dim, self.kv_lora_rank, self.num_heads
         )
-        self.kv_b_proj = nn.Linear(
-            self.kv_lora_rank,
-            self.num_heads
-            * (self.q_head_dim - self.qk_rope_head_dim + self.v_head_dim),
-            bias=False,
+        self.unembed_out = MultiLinear(
+            self.kv_lora_rank, self.v_head_dim, self.num_heads
         )
 
         self.o_proj = nn.Linear(
@@ -96,7 +89,6 @@ class YoutuAttention(nn.Module):
     ) -> mx.array:
         B, L, _ = x.shape
 
-        # Q projection
         if self.q_lora_rank is None:
             q = self.q_proj(x)
         else:
@@ -105,36 +97,41 @@ class YoutuAttention(nn.Module):
         q = q.reshape(B, L, self.num_heads, self.q_head_dim).transpose(0, 2, 1, 3)
         q_nope, q_pe = mx.split(q, [self.qk_nope_head_dim], axis=-1)
 
-        # KV projection
         compressed_kv = self.kv_a_proj_with_mqa(x)
-        compressed_kv, k_pe = mx.split(
-            compressed_kv, [self.kv_lora_rank], axis=-1
-        )
+        compressed_kv, k_pe = mx.split(compressed_kv, [self.kv_lora_rank], axis=-1)
         k_pe = k_pe.reshape(B, L, 1, self.qk_rope_head_dim).transpose(0, 2, 1, 3)
-        kv = self.kv_b_proj(self.kv_a_layernorm(compressed_kv))
-        kv = kv.reshape(B, L, self.num_heads, -1).transpose(0, 2, 1, 3)
+        kv_latent = self.kv_a_layernorm(compressed_kv)
 
-        k_nope, values = mx.split(kv, [self.qk_nope_head_dim], axis=-1)
+        offset = cache.offset if cache is not None else 0
+        q_pe = self.rope(q_pe, offset)
+        k_pe = self.rope(k_pe, offset)
 
-        # Apply RoPE
+        kv_latent = mx.expand_dims(kv_latent, axis=1)
+
         if cache is not None:
-            q_pe = self.rope(q_pe, cache.offset)
-            k_pe = self.rope(k_pe, cache.offset)
-            k_pe = mx.repeat(k_pe, self.num_heads, axis=1)
-            keys, values = cache.update_and_fetch(
-                mx.concatenate([k_nope, k_pe], axis=-1), values
-            )
-        else:
-            q_pe = self.rope(q_pe)
-            k_pe = self.rope(k_pe)
-            k_pe = mx.repeat(k_pe, self.num_heads, axis=1)
-            keys = mx.concatenate([k_nope, k_pe], axis=-1)
+            kv_latent, k_pe = cache.update_and_fetch(kv_latent, k_pe)
 
-        queries = mx.concatenate([q_nope, q_pe], axis=-1)
+        pe_scores = (q_pe * self.scale) @ k_pe.swapaxes(-1, -2)
+        if mask is not None:
+            pe_scores = mx.where(
+                mask,
+                pe_scores,
+                mx.array(mx.finfo(pe_scores.dtype).min, pe_scores.dtype),
+            )
+
+        if L == 1:
+            q_nope = self.embed_q(q_nope)
+            k = v = kv_latent
+        else:
+            k = self.embed_q(kv_latent, transpose=False)
+            v = self.unembed_out(kv_latent)
 
         output = scaled_dot_product_attention(
-            queries, keys, values, cache=cache, scale=self.scale, mask=mask
+            q_nope, k, v, cache=cache, scale=self.scale, mask=pe_scores
         )
+        if L == 1:
+            output = self.unembed_out(output)
+
         output = output.transpose(0, 2, 1, 3).reshape(B, L, -1)
         return self.o_proj(output)
 
@@ -266,9 +263,7 @@ class YoutuDecoderLayer(nn.Module):
         else:
             self.mlp = YoutuMLP(config)
 
-        self.input_layernorm = nn.RMSNorm(
-            config.hidden_size, eps=config.rms_norm_eps
-        )
+        self.input_layernorm = nn.RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
         self.post_attention_layernorm = nn.RMSNorm(
             config.hidden_size, eps=config.rms_norm_eps
         )
@@ -315,7 +310,7 @@ class YoutuModel(nn.Module):
             cache = [None] * len(self.layers)
 
         if mask is None:
-            mask = create_attention_mask(h, cache[0])
+            mask = create_attention_mask(h, cache[0], return_array=True)
 
         for layer, c in zip(self.layers, cache):
             h = layer(h, mask, c)
@@ -332,9 +327,7 @@ class LanguageModel(nn.Module):
         self.model = YoutuModel(config)
 
         if not config.tie_word_embeddings:
-            self.lm_head = nn.Linear(
-                config.hidden_size, config.vocab_size, bias=False
-            )
+            self.lm_head = nn.Linear(config.hidden_size, config.vocab_size, bias=False)
 
     def __call__(
         self,
@@ -344,9 +337,7 @@ class LanguageModel(nn.Module):
         cache=None,
         **kwargs,
     ):
-        out = self.model(
-            inputs, cache=cache, inputs_embeds=inputs_embeds, mask=mask
-        )
+        out = self.model(inputs, cache=cache, inputs_embeds=inputs_embeds, mask=mask)
         if self.config.tie_word_embeddings:
             out = self.model.embed_tokens.as_linear(out)
         else:
@@ -359,9 +350,7 @@ class LanguageModel(nn.Module):
 
     @property
     def head_dim(self):
-        return (
-            self.config.qk_nope_head_dim + self.config.qk_rope_head_dim
-        )
+        return self.config.qk_nope_head_dim + self.config.qk_rope_head_dim
 
     @property
     def n_kv_heads(self):

--- a/mlx_vlm/models/youtu_vl/language.py
+++ b/mlx_vlm/models/youtu_vl/language.py
@@ -1,0 +1,368 @@
+import math
+from dataclasses import dataclass
+from typing import Any, Optional
+
+import mlx.core as mx
+import mlx.nn as nn
+
+from mlx_lm.models.activations import swiglu
+from mlx_lm.models.switch_layers import SwitchGLU
+from mlx_lm.models.rope_utils import initialize_rope
+from ..base import (
+    LanguageModelOutput,
+    create_attention_mask,
+    scaled_dot_product_attention,
+)
+from .config import ModelConfig, TextConfig
+
+
+class YoutuAttention(nn.Module):
+    """Multi-Latent Attention (MLA) from DeepSeek-V2/V3 architecture."""
+
+    def __init__(self, config: TextConfig):
+        super().__init__()
+        self.config = config
+        self.hidden_size = config.hidden_size
+        self.num_heads = config.num_attention_heads
+        self.q_lora_rank = config.q_lora_rank
+        self.qk_rope_head_dim = config.qk_rope_head_dim
+        self.kv_lora_rank = config.kv_lora_rank
+        self.v_head_dim = config.v_head_dim
+        self.qk_nope_head_dim = config.qk_nope_head_dim
+        self.q_head_dim = config.qk_nope_head_dim + config.qk_rope_head_dim
+
+        self.scale = self.q_head_dim**-0.5
+
+        # Handle mscale for rope_scaling
+        if config.rope_scaling is not None:
+            mscale_all_dim = config.rope_scaling.get("mscale_all_dim", 0)
+            if mscale_all_dim:
+                scaling_factor = config.rope_scaling.get("factor", 1.0)
+                if scaling_factor > 1:
+                    s = 0.1 * mscale_all_dim * math.log(scaling_factor) + 1.0
+                    self.scale = self.scale * s * s
+
+        # Q projection (LoRA-style)
+        if self.q_lora_rank is None:
+            self.q_proj = nn.Linear(
+                self.hidden_size, self.num_heads * self.q_head_dim, bias=False
+            )
+        else:
+            self.q_a_proj = nn.Linear(
+                self.hidden_size, self.q_lora_rank, bias=config.attention_bias
+            )
+            self.q_a_layernorm = nn.RMSNorm(
+                self.q_lora_rank, eps=config.rms_norm_eps
+            )
+            self.q_b_proj = nn.Linear(
+                self.q_lora_rank, self.num_heads * self.q_head_dim, bias=False
+            )
+
+        # KV projection (MQA with LoRA)
+        self.kv_a_proj_with_mqa = nn.Linear(
+            self.hidden_size,
+            self.kv_lora_rank + self.qk_rope_head_dim,
+            bias=config.attention_bias,
+        )
+        self.kv_a_layernorm = nn.RMSNorm(
+            self.kv_lora_rank, eps=config.rms_norm_eps
+        )
+        self.kv_b_proj = nn.Linear(
+            self.kv_lora_rank,
+            self.num_heads
+            * (self.q_head_dim - self.qk_rope_head_dim + self.v_head_dim),
+            bias=False,
+        )
+
+        self.o_proj = nn.Linear(
+            self.num_heads * self.v_head_dim,
+            self.hidden_size,
+            bias=config.attention_bias,
+        )
+
+        self.rope = initialize_rope(
+            self.qk_rope_head_dim,
+            base=config.rope_theta,
+            traditional=config.rope_traditional,
+            scaling_config=config.rope_scaling,
+            max_position_embeddings=config.max_position_embeddings,
+        )
+
+    def __call__(
+        self,
+        x: mx.array,
+        mask: Optional[mx.array] = None,
+        cache: Optional[Any] = None,
+    ) -> mx.array:
+        B, L, _ = x.shape
+
+        # Q projection
+        if self.q_lora_rank is None:
+            q = self.q_proj(x)
+        else:
+            q = self.q_b_proj(self.q_a_layernorm(self.q_a_proj(x)))
+
+        q = q.reshape(B, L, self.num_heads, self.q_head_dim).transpose(0, 2, 1, 3)
+        q_nope, q_pe = mx.split(q, [self.qk_nope_head_dim], axis=-1)
+
+        # KV projection
+        compressed_kv = self.kv_a_proj_with_mqa(x)
+        compressed_kv, k_pe = mx.split(
+            compressed_kv, [self.kv_lora_rank], axis=-1
+        )
+        k_pe = k_pe.reshape(B, L, 1, self.qk_rope_head_dim).transpose(0, 2, 1, 3)
+        kv = self.kv_b_proj(self.kv_a_layernorm(compressed_kv))
+        kv = kv.reshape(B, L, self.num_heads, -1).transpose(0, 2, 1, 3)
+
+        k_nope, values = mx.split(kv, [self.qk_nope_head_dim], axis=-1)
+
+        # Apply RoPE
+        if cache is not None:
+            q_pe = self.rope(q_pe, cache.offset)
+            k_pe = self.rope(k_pe, cache.offset)
+            k_pe = mx.repeat(k_pe, self.num_heads, axis=1)
+            keys, values = cache.update_and_fetch(
+                mx.concatenate([k_nope, k_pe], axis=-1), values
+            )
+        else:
+            q_pe = self.rope(q_pe)
+            k_pe = self.rope(k_pe)
+            k_pe = mx.repeat(k_pe, self.num_heads, axis=1)
+            keys = mx.concatenate([k_nope, k_pe], axis=-1)
+
+        queries = mx.concatenate([q_nope, q_pe], axis=-1)
+
+        output = scaled_dot_product_attention(
+            queries, keys, values, cache=cache, scale=self.scale, mask=mask
+        )
+        output = output.transpose(0, 2, 1, 3).reshape(B, L, -1)
+        return self.o_proj(output)
+
+
+class YoutuMLP(nn.Module):
+    def __init__(self, config: TextConfig, hidden_size=None, intermediate_size=None):
+        super().__init__()
+        self.hidden_size = config.hidden_size if hidden_size is None else hidden_size
+        self.intermediate_size = (
+            config.intermediate_size if intermediate_size is None else intermediate_size
+        )
+        self.gate_proj = nn.Linear(
+            self.hidden_size, self.intermediate_size, bias=config.mlp_bias
+        )
+        self.up_proj = nn.Linear(
+            self.hidden_size, self.intermediate_size, bias=config.mlp_bias
+        )
+        self.down_proj = nn.Linear(
+            self.intermediate_size, self.hidden_size, bias=config.mlp_bias
+        )
+
+    def __call__(self, x) -> mx.array:
+        return self.down_proj(swiglu(self.gate_proj(x), self.up_proj(x)))
+
+
+@mx.compile
+def group_expert_select(
+    gates,
+    e_score_correction_bias,
+    top_k,
+    n_group,
+    topk_group,
+    routed_scaling_factor,
+    norm_topk_prob,
+):
+    scores = mx.sigmoid(gates.astype(mx.float32))
+    orig_scores = scores
+    scores = scores + e_score_correction_bias
+    if n_group > 1:
+        scores = mx.unflatten(scores, axis=-1, shape=(n_group, -1))
+        group_scores = mx.topk(scores, 2, axis=-1).sum(axis=-1, keepdims=True)
+        k = n_group - topk_group
+        group_idx = mx.argpartition(group_scores, kth=k - 1, axis=-2)[..., :k, :]
+        scores = mx.put_along_axis(
+            scores, mx.stop_gradient(group_idx), mx.array(0.0), axis=-2
+        )
+        scores = mx.flatten(scores, -2, -1)
+
+    k = top_k
+    inds = mx.argpartition(-scores, kth=k - 1, axis=-1)[..., :k]
+    scores = mx.take_along_axis(orig_scores, inds, axis=-1)
+    if top_k > 1 and norm_topk_prob:
+        denominator = scores.sum(axis=-1, keepdims=True)
+        scores = scores / denominator
+    scores = scores * routed_scaling_factor
+
+    return inds, scores
+
+
+class MoEGate(nn.Module):
+    def __init__(self, config: TextConfig):
+        super().__init__()
+        self.config = config
+        self.top_k = config.num_experts_per_tok
+        self.norm_topk_prob = config.norm_topk_prob
+        self.n_routed_experts = config.n_routed_experts
+        self.routed_scaling_factor = config.routed_scaling_factor
+        self.n_group = config.n_group
+        self.topk_group = config.topk_group
+        self.weight = mx.zeros((self.n_routed_experts, config.hidden_size))
+        self.e_score_correction_bias = mx.zeros((self.n_routed_experts,))
+
+    def __call__(self, x):
+        return group_expert_select(
+            x @ self.weight.T,
+            self.e_score_correction_bias,
+            self.top_k,
+            self.n_group,
+            self.topk_group,
+            self.routed_scaling_factor,
+            self.norm_topk_prob,
+        )
+
+
+class YoutuMoE(nn.Module):
+    def __init__(self, config: TextConfig):
+        super().__init__()
+        self.config = config
+        self.num_experts_per_tok = config.num_experts_per_tok
+
+        if SwitchGLU is not None:
+            self.switch_mlp = SwitchGLU(
+                config.hidden_size,
+                config.moe_intermediate_size,
+                config.n_routed_experts,
+            )
+        else:
+            raise ImportError("SwitchGLU not available. Cannot use MoE.")
+
+        self.gate = MoEGate(config)
+        if config.n_shared_experts is not None:
+            intermediate_size = config.moe_intermediate_size * config.n_shared_experts
+            self.shared_experts = YoutuMLP(
+                config=config, intermediate_size=intermediate_size
+            )
+
+    def __call__(self, x):
+        inds, scores = self.gate(x)
+        y = self.switch_mlp(x, inds)
+        y = (y * scores[..., None]).sum(axis=-2).astype(y.dtype)
+        if self.config.n_shared_experts is not None:
+            y = y + self.shared_experts(x)
+        return y
+
+
+class YoutuDecoderLayer(nn.Module):
+    def __init__(self, config: TextConfig, layer_idx: int):
+        super().__init__()
+        self.hidden_size = config.hidden_size
+        self.self_attn = YoutuAttention(config)
+
+        # Use MoE if configured
+        if (
+            config.n_routed_experts is not None
+            and layer_idx >= config.first_k_dense_replace
+            and layer_idx % config.moe_layer_freq == 0
+        ):
+            self.mlp = YoutuMoE(config)
+        else:
+            self.mlp = YoutuMLP(config)
+
+        self.input_layernorm = nn.RMSNorm(
+            config.hidden_size, eps=config.rms_norm_eps
+        )
+        self.post_attention_layernorm = nn.RMSNorm(
+            config.hidden_size, eps=config.rms_norm_eps
+        )
+
+    def __call__(
+        self,
+        x: mx.array,
+        mask: Optional[mx.array] = None,
+        cache: Optional[Any] = None,
+    ) -> mx.array:
+        r = self.self_attn(self.input_layernorm(x), mask, cache)
+        h = x + r
+        r = self.mlp(self.post_attention_layernorm(h))
+        out = h + r
+        return out
+
+
+class YoutuModel(nn.Module):
+    def __init__(self, config: TextConfig):
+        super().__init__()
+        self.config = config
+        self.vocab_size = config.vocab_size
+        self.num_hidden_layers = config.num_hidden_layers
+        self.embed_tokens = nn.Embedding(config.vocab_size, config.hidden_size)
+        self.layers = [
+            YoutuDecoderLayer(config=config, layer_idx=i)
+            for i in range(config.num_hidden_layers)
+        ]
+        self.norm = nn.RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+
+    def __call__(
+        self,
+        inputs: mx.array,
+        inputs_embeds: Optional[mx.array] = None,
+        mask: Optional[mx.array] = None,
+        cache=None,
+    ):
+        if inputs_embeds is None:
+            h = self.embed_tokens(inputs)
+        else:
+            h = inputs_embeds
+
+        if cache is None:
+            cache = [None] * len(self.layers)
+
+        if mask is None:
+            mask = create_attention_mask(h, cache[0])
+
+        for layer, c in zip(self.layers, cache):
+            h = layer(h, mask, c)
+
+        return self.norm(h)
+
+
+class LanguageModel(nn.Module):
+    def __init__(self, config: TextConfig, model_config: ModelConfig = None):
+        super().__init__()
+        self.config = config
+        self.model_config = model_config
+        self.model_type = config.model_type
+        self.model = YoutuModel(config)
+
+        if not config.tie_word_embeddings:
+            self.lm_head = nn.Linear(
+                config.hidden_size, config.vocab_size, bias=False
+            )
+
+    def __call__(
+        self,
+        inputs: mx.array,
+        inputs_embeds: Optional[mx.array] = None,
+        mask: Optional[mx.array] = None,
+        cache=None,
+        **kwargs,
+    ):
+        out = self.model(
+            inputs, cache=cache, inputs_embeds=inputs_embeds, mask=mask
+        )
+        if self.config.tie_word_embeddings:
+            out = self.model.embed_tokens.as_linear(out)
+        else:
+            out = self.lm_head(out)
+        return LanguageModelOutput(logits=out)
+
+    @property
+    def layers(self):
+        return self.model.layers
+
+    @property
+    def head_dim(self):
+        return (
+            self.config.qk_nope_head_dim + self.config.qk_rope_head_dim
+        )
+
+    @property
+    def n_kv_heads(self):
+        return self.config.num_key_value_heads

--- a/mlx_vlm/models/youtu_vl/vision.py
+++ b/mlx_vlm/models/youtu_vl/vision.py
@@ -1,4 +1,3 @@
-from typing import Optional
 
 import mlx.core as mx
 import mlx.nn as nn
@@ -37,8 +36,7 @@ class VisionRoPE(nn.Module):
         if isinstance(seqlen, mx.array):
             seqlen = seqlen.item()
         inv_freq = 1.0 / (
-            self.theta
-            ** (mx.arange(0, self.dim, 2, dtype=mx.float32) / self.dim)
+            self.theta ** (mx.arange(0, self.dim, 2, dtype=mx.float32) / self.dim)
         )
         seq = mx.arange(seqlen, dtype=mx.float32)
         freqs = mx.outer(seq, inv_freq)
@@ -178,8 +176,7 @@ class Siglip2Encoder(nn.Module):
         super().__init__()
         self.config = config
         self.layers = [
-            Siglip2EncoderLayer(config)
-            for _ in range(config.num_hidden_layers)
+            Siglip2EncoderLayer(config) for _ in range(config.num_hidden_layers)
         ]
         self.spatial_merge_size = config.spatial_merge_size
         self.spatial_merge_unit = self.spatial_merge_size * self.spatial_merge_size
@@ -246,8 +243,12 @@ class Siglip2Encoder(nn.Module):
                 grid_t, llm_grid_h, llm_grid_w
             )
 
-            pad_h = (vit_merger_window_size - llm_grid_h % vit_merger_window_size) % vit_merger_window_size
-            pad_w = (vit_merger_window_size - llm_grid_w % vit_merger_window_size) % vit_merger_window_size
+            pad_h = (
+                vit_merger_window_size - llm_grid_h % vit_merger_window_size
+            ) % vit_merger_window_size
+            pad_w = (
+                vit_merger_window_size - llm_grid_w % vit_merger_window_size
+            ) % vit_merger_window_size
             num_windows_h = (llm_grid_h + pad_h) // vit_merger_window_size
             num_windows_w = (llm_grid_w + pad_w) // vit_merger_window_size
 
@@ -413,4 +414,3 @@ class VisionModel(nn.Module):
         hidden_states = self.post_layernorm(hidden_states)
         hidden_states = self.merger(hidden_states)
         return hidden_states
-

--- a/mlx_vlm/models/youtu_vl/vision.py
+++ b/mlx_vlm/models/youtu_vl/vision.py
@@ -1,4 +1,3 @@
-
 import mlx.core as mx
 import mlx.nn as nn
 import numpy as np

--- a/mlx_vlm/models/youtu_vl/vision.py
+++ b/mlx_vlm/models/youtu_vl/vision.py
@@ -393,6 +393,7 @@ class VisionModel(nn.Module):
     def __init__(self, config: VisionConfig) -> None:
         super().__init__()
         self.config = config
+        self.model_type = config.model_type
         self.embeddings = Siglip2VisionEmbeddings(config)
         self.encoder = Siglip2Encoder(config)
         self.post_layernorm = nn.LayerNorm(

--- a/mlx_vlm/models/youtu_vl/vision.py
+++ b/mlx_vlm/models/youtu_vl/vision.py
@@ -1,0 +1,416 @@
+from typing import Optional
+
+import mlx.core as mx
+import mlx.nn as nn
+import numpy as np
+
+from .config import VisionConfig
+
+
+def rotate_half(x):
+    """Rotates half the hidden dims of the input."""
+    x1 = x[..., : x.shape[-1] // 2]
+    x2 = x[..., x.shape[-1] // 2 :]
+    return mx.concatenate([-x2, x1], axis=-1)
+
+
+def apply_rotary_pos_emb_vision(q, k, cos, sin):
+    """Apply rotary position embeddings to vision q, k tensors.
+    cos, sin: (seq_len, head_dim) with unsqueeze(-2) -> (seq_len, 1, head_dim)
+    q, k: (seq_len, num_heads, head_dim)
+    """
+    orig_dtype = q.dtype
+    cos = mx.expand_dims(cos, axis=-2)
+    sin = mx.expand_dims(sin, axis=-2)
+    q_embed = (q * cos) + (rotate_half(q) * sin)
+    k_embed = (k * cos) + (rotate_half(k) * sin)
+    return q_embed.astype(orig_dtype), k_embed.astype(orig_dtype)
+
+
+class VisionRoPE(nn.Module):
+    def __init__(self, dim: int, theta: float = 10000.0) -> None:
+        super().__init__()
+        self.dim = dim
+        self.theta = theta
+
+    def __call__(self, seqlen) -> mx.array:
+        if isinstance(seqlen, mx.array):
+            seqlen = seqlen.item()
+        inv_freq = 1.0 / (
+            self.theta
+            ** (mx.arange(0, self.dim, 2, dtype=mx.float32) / self.dim)
+        )
+        seq = mx.arange(seqlen, dtype=mx.float32)
+        freqs = mx.outer(seq, inv_freq)
+        return freqs
+
+
+class Siglip2VisionEmbeddings(nn.Module):
+    """Patch embedding without positional embedding (RoPE is used in encoder)."""
+
+    def __init__(self, config: VisionConfig):
+        super().__init__()
+        self.config = config
+        self.embed_dim = config.hidden_size
+        self.patch_size = config.patch_size
+        self.in_features = config.num_channels * self.patch_size * self.patch_size
+        self.patch_embedding = nn.Linear(self.in_features, self.embed_dim)
+
+    def __call__(self, pixel_values: mx.array) -> mx.array:
+        # pixel_values: (batch, num_patches, patch_dim)
+        # Flatten to (total_patches, embed_dim)
+        patch_embeds = self.patch_embedding(pixel_values)
+        patch_embeds = patch_embeds.reshape(-1, self.embed_dim)
+        return patch_embeds
+
+
+class Siglip2Attention(nn.Module):
+    """Vision attention with RoPE and windowed attention via cu_seqlens."""
+
+    def __init__(self, config: VisionConfig) -> None:
+        super().__init__()
+        dim = config.hidden_size
+        self.num_heads = config.num_attention_heads
+        self.head_dim = dim // self.num_heads
+        self.scale = self.head_dim**-0.5
+
+        self.q_proj = nn.Linear(dim, dim)
+        self.k_proj = nn.Linear(dim, dim)
+        self.v_proj = nn.Linear(dim, dim)
+        self.out_proj = nn.Linear(dim, dim)
+
+    def __call__(
+        self,
+        hidden_states: mx.array,
+        cu_seqlens: mx.array,
+        position_embeddings=None,
+    ) -> mx.array:
+        seq_length = hidden_states.shape[0]
+
+        q = self.q_proj(hidden_states).reshape(seq_length, self.num_heads, -1)
+        k = self.k_proj(hidden_states).reshape(seq_length, self.num_heads, -1)
+        v = self.v_proj(hidden_states).reshape(seq_length, self.num_heads, -1)
+
+        # Apply rotary position embeddings
+        if position_embeddings is not None:
+            cos, sin = position_embeddings
+            q, k = apply_rotary_pos_emb_vision(q, k, cos, sin)
+
+        # Windowed attention: split by cu_seqlens and attend within each window
+        # Transpose to (num_heads, seq_len, head_dim) for attention
+        q = q.transpose(1, 0, 2)  # (num_heads, seq_len, head_dim)
+        k = k.transpose(1, 0, 2)
+        v = v.transpose(1, 0, 2)
+
+        cu_seqlens_list = cu_seqlens.tolist()
+        if isinstance(cu_seqlens_list[0], list):
+            cu_seqlens_list = [int(x) for x in cu_seqlens_list]
+
+        # Split by windows and attend
+        attn_outputs = []
+        for i in range(len(cu_seqlens_list) - 1):
+            start = int(cu_seqlens_list[i])
+            end = int(cu_seqlens_list[i + 1])
+            q_win = q[:, start:end, :]
+            k_win = k[:, start:end, :]
+            v_win = v[:, start:end, :]
+            out = mx.fast.scaled_dot_product_attention(
+                mx.expand_dims(q_win, 0),
+                mx.expand_dims(k_win, 0),
+                mx.expand_dims(v_win, 0),
+                scale=self.scale,
+                mask=None,
+            )
+            attn_outputs.append(out[0])
+
+        output = mx.concatenate(attn_outputs, axis=1)  # (num_heads, seq_len, head_dim)
+        output = output.transpose(1, 0, 2)  # (seq_len, num_heads, head_dim)
+        output = output.reshape(seq_length, -1)
+        return self.out_proj(output)
+
+
+class Siglip2MLP(nn.Module):
+    def __init__(self, config: VisionConfig):
+        super().__init__()
+        self.fc1 = nn.Linear(config.hidden_size, config.intermediate_size)
+        self.fc2 = nn.Linear(config.intermediate_size, config.hidden_size)
+
+    def __call__(self, x: mx.array) -> mx.array:
+        x = self.fc1(x)
+        x = nn.gelu_approx(x)  # gelu_pytorch_tanh
+        x = self.fc2(x)
+        return x
+
+
+class Siglip2EncoderLayer(nn.Module):
+    def __init__(self, config: VisionConfig):
+        super().__init__()
+        self.layer_norm1 = nn.LayerNorm(config.hidden_size, eps=config.layer_norm_eps)
+        self.self_attn = Siglip2Attention(config)
+        self.layer_norm2 = nn.LayerNorm(config.hidden_size, eps=config.layer_norm_eps)
+        self.mlp = Siglip2MLP(config)
+
+    def __call__(
+        self,
+        hidden_states: mx.array,
+        cu_seqlens: mx.array,
+        position_embeddings=None,
+    ) -> mx.array:
+        residual = hidden_states
+        hidden_states = self.layer_norm1(hidden_states)
+        hidden_states = self.self_attn(
+            hidden_states,
+            cu_seqlens=cu_seqlens,
+            position_embeddings=position_embeddings,
+        )
+        hidden_states = residual + hidden_states
+
+        residual = hidden_states
+        hidden_states = self.layer_norm2(hidden_states)
+        hidden_states = self.mlp(hidden_states)
+        hidden_states = residual + hidden_states
+
+        return hidden_states
+
+
+class Siglip2Encoder(nn.Module):
+    def __init__(self, config: VisionConfig):
+        super().__init__()
+        self.config = config
+        self.layers = [
+            Siglip2EncoderLayer(config)
+            for _ in range(config.num_hidden_layers)
+        ]
+        self.spatial_merge_size = config.spatial_merge_size
+        self.spatial_merge_unit = self.spatial_merge_size * self.spatial_merge_size
+        self.patch_size = config.patch_size
+        self.window_size = config.window_size
+        self.fullatt_block_indexes = config.fullatt_block_indexes
+
+        head_dim = config.hidden_size // config.num_attention_heads
+        self.rotary_pos_emb = VisionRoPE(head_dim // 2)
+
+    def rot_pos_emb(self, spatial_shapes):
+        """Compute rotary position embeddings for vision tokens."""
+        pos_ids = []
+
+        for h, w in spatial_shapes.tolist():
+            h, w = int(h), int(w)
+            hpos_ids = mx.expand_dims(mx.arange(h), 1)
+            hpos_ids = mx.repeat(hpos_ids, w, axis=1)
+            hpos_ids = hpos_ids.reshape(
+                h // self.spatial_merge_size,
+                self.spatial_merge_size,
+                w // self.spatial_merge_size,
+                self.spatial_merge_size,
+            )
+            hpos_ids = mx.transpose(hpos_ids, (0, 2, 1, 3))
+            hpos_ids = hpos_ids.flatten()
+
+            wpos_ids = mx.expand_dims(mx.arange(w), 0)
+            wpos_ids = mx.repeat(wpos_ids, h, axis=0)
+            wpos_ids = wpos_ids.reshape(
+                h // self.spatial_merge_size,
+                self.spatial_merge_size,
+                w // self.spatial_merge_size,
+                self.spatial_merge_size,
+            )
+            wpos_ids = mx.transpose(wpos_ids, (0, 2, 1, 3))
+            wpos_ids = wpos_ids.flatten()
+
+            stacked_pos_ids = mx.stack([hpos_ids, wpos_ids], axis=-1)
+            pos_ids.append(stacked_pos_ids)  # t=1, no repeat needed
+
+        pos_ids = mx.concatenate(pos_ids, axis=0)
+        max_grid_size = mx.max(spatial_shapes)
+        rotary_pos_emb_full = self.rotary_pos_emb(max_grid_size)
+        rotary_pos_emb = rotary_pos_emb_full[pos_ids]
+        return rotary_pos_emb.reshape(pos_ids.shape[0], -1)
+
+    def get_window_index(self, spatial_shapes):
+        """Compute window indices for windowed attention."""
+        window_index = []
+        cu_window_seqlens = [0]
+        window_index_id = 0
+        vit_merger_window_size = (
+            self.window_size // self.spatial_merge_size // self.patch_size
+        )
+
+        for grid_h, grid_w in spatial_shapes.tolist():
+            grid_h, grid_w = int(grid_h), int(grid_w)
+            grid_t = 1
+            llm_grid_h = grid_h // self.spatial_merge_size
+            llm_grid_w = grid_w // self.spatial_merge_size
+
+            index = mx.arange(grid_t * llm_grid_h * llm_grid_w).reshape(
+                grid_t, llm_grid_h, llm_grid_w
+            )
+
+            pad_h = (vit_merger_window_size - llm_grid_h % vit_merger_window_size) % vit_merger_window_size
+            pad_w = (vit_merger_window_size - llm_grid_w % vit_merger_window_size) % vit_merger_window_size
+            num_windows_h = (llm_grid_h + pad_h) // vit_merger_window_size
+            num_windows_w = (llm_grid_w + pad_w) // vit_merger_window_size
+
+            index_padded = mx.pad(
+                index,
+                ((0, 0), (0, pad_h), (0, pad_w)),
+                mode="constant",
+                constant_values=-100,
+            )
+
+            index_padded = index_padded.reshape(
+                grid_t,
+                num_windows_h,
+                vit_merger_window_size,
+                num_windows_w,
+                vit_merger_window_size,
+            )
+            index_padded = mx.transpose(index_padded, (0, 1, 3, 2, 4)).reshape(
+                grid_t,
+                num_windows_h * num_windows_w,
+                vit_merger_window_size,
+                vit_merger_window_size,
+            )
+
+            seqlens = mx.sum(index_padded != -100, axis=(2, 3)).reshape(-1)
+            index_padded = index_padded.reshape(-1)
+            # Get indices where value is not -100
+            valid_mask = np.where(np.array(index_padded) != -100)[0].tolist()
+            index_new = index_padded[valid_mask]
+
+            window_index.append(index_new + window_index_id)
+            cu_seqlens_tmp = (
+                mx.cumsum(seqlens, axis=0) * self.spatial_merge_unit
+                + cu_window_seqlens[-1]
+            )
+            cu_window_seqlens.extend(cu_seqlens_tmp.tolist())
+            window_index_id += int(grid_t * llm_grid_h * llm_grid_w)
+
+        window_index = mx.concatenate(window_index, axis=0)
+        cu_window_seqlens = mx.array(cu_window_seqlens, dtype=mx.int32)
+
+        return window_index, cu_window_seqlens
+
+    def __call__(
+        self,
+        inputs_embeds: mx.array,
+        spatial_shapes: mx.array,
+    ) -> mx.array:
+        hidden_states = inputs_embeds
+        rotary_pos_emb = self.rot_pos_emb(spatial_shapes)
+        window_index, cu_window_seqlens = self.get_window_index(spatial_shapes)
+
+        # Deduplicate cu_window_seqlens
+        seen = set()
+        idx = []
+        for i, x in enumerate(cu_window_seqlens.tolist()):
+            x_int = int(x)
+            if x_int not in seen:
+                seen.add(x_int)
+                idx.append(i)
+        idx = mx.array(idx, dtype=mx.int32)
+        cu_window_seqlens = cu_window_seqlens[idx]
+
+        seq_len = hidden_states.shape[0]
+
+        # Reorder by window index
+        hidden_states = hidden_states.reshape(
+            seq_len // self.spatial_merge_unit, self.spatial_merge_unit, -1
+        )
+        hidden_states = hidden_states[window_index, :, :]
+        hidden_states = hidden_states.reshape(seq_len, -1)
+
+        rotary_pos_emb = rotary_pos_emb.reshape(
+            seq_len // self.spatial_merge_unit, self.spatial_merge_unit, -1
+        )
+        rotary_pos_emb = rotary_pos_emb[window_index, :, :]
+        rotary_pos_emb = rotary_pos_emb.reshape(seq_len, -1)
+
+        # Precompute position embeddings (cos, sin) from rotary freqs
+        emb = mx.concatenate([rotary_pos_emb, rotary_pos_emb], axis=-1)
+        position_embeddings = (mx.cos(emb), mx.sin(emb))
+
+        # Compute full cu_seqlens for full attention layers
+        cu_seqlens = (
+            (spatial_shapes[:, 0] * spatial_shapes[:, 1])
+            .cumsum(axis=0)
+            .astype(mx.int32)
+        )
+        cu_seqlens = mx.pad(cu_seqlens, (1, 0), mode="constant", constant_values=0)
+
+        for layer_num, layer in enumerate(self.layers):
+            if layer_num in self.fullatt_block_indexes:
+                cu_seqlens_now = cu_seqlens
+            else:
+                cu_seqlens_now = cu_window_seqlens
+
+            hidden_states = layer(
+                hidden_states,
+                cu_seqlens=cu_seqlens_now,
+                position_embeddings=position_embeddings,
+            )
+
+        # Reverse window reordering
+        hidden_states = hidden_states.reshape(
+            seq_len // self.spatial_merge_unit, self.spatial_merge_unit, -1
+        )
+        reverse_indices = mx.argsort(window_index, axis=0)
+        hidden_states = hidden_states[reverse_indices, :, :]
+        hidden_states = hidden_states.reshape(seq_len, -1)
+
+        return hidden_states
+
+
+class VLPatchMerger(nn.Module):
+    """Merge vision patches to match language model hidden size."""
+
+    def __init__(
+        self,
+        dim: int,
+        context_dim: int,
+        spatial_merge_size: int = 2,
+    ) -> None:
+        super().__init__()
+        self.hidden_size = context_dim * (spatial_merge_size**2)
+        self.ln_q = nn.RMSNorm(context_dim, eps=1e-6)
+        self.mlp = [
+            nn.Linear(self.hidden_size, self.hidden_size),
+            nn.GELU(),
+            nn.Linear(self.hidden_size, dim),
+        ]
+
+    def __call__(self, x: mx.array) -> mx.array:
+        x = self.ln_q(x).reshape(-1, self.hidden_size)
+        for layer in self.mlp:
+            x = layer(x)
+        return x
+
+
+class VisionModel(nn.Module):
+    """Top-level Siglip2 vision model for YoutuVL."""
+
+    def __init__(self, config: VisionConfig) -> None:
+        super().__init__()
+        self.config = config
+        self.embeddings = Siglip2VisionEmbeddings(config)
+        self.encoder = Siglip2Encoder(config)
+        self.post_layernorm = nn.LayerNorm(
+            config.hidden_size, eps=config.layer_norm_eps
+        )
+        self.merger = VLPatchMerger(
+            dim=config.out_hidden_size,
+            context_dim=config.hidden_size,
+            spatial_merge_size=config.spatial_merge_size,
+        )
+
+    def __call__(
+        self,
+        pixel_values: mx.array,
+        spatial_shapes: mx.array,
+    ) -> mx.array:
+        hidden_states = self.embeddings(pixel_values)
+        hidden_states = self.encoder(hidden_states, spatial_shapes)
+        hidden_states = self.post_layernorm(hidden_states)
+        hidden_states = self.merger(hidden_states)
+        return hidden_states
+

--- a/mlx_vlm/models/youtu_vl/youtu_vl.py
+++ b/mlx_vlm/models/youtu_vl/youtu_vl.py
@@ -1,0 +1,163 @@
+from typing import Optional
+
+import mlx.core as mx
+import mlx.nn as nn
+
+from ..base import InputEmbeddingsFeatures
+from .config import ModelConfig
+from .language import LanguageModel
+from .vision import VisionModel
+
+
+class Model(nn.Module):
+    def __init__(self, config: ModelConfig):
+        super().__init__()
+        self.config = config
+        self.vision_tower = VisionModel(config.vision_config)
+        self.language_model = LanguageModel(config.text_config, config)
+
+    def get_input_embeddings(
+        self,
+        input_ids: Optional[mx.array] = None,
+        pixel_values: Optional[mx.array] = None,
+        **kwargs,
+    ):
+        spatial_shapes = kwargs.get("spatial_shapes", None)
+
+        if pixel_values is None:
+            return InputEmbeddingsFeatures(
+                inputs_embeds=self.language_model.model.embed_tokens(input_ids)
+            )
+
+        dtype = self.vision_tower.embeddings.patch_embedding.weight.dtype
+        pixel_values = pixel_values.astype(dtype)
+
+        # Get text embeddings
+        inputs_embeds = self.language_model.model.embed_tokens(input_ids)
+
+        # Get vision features
+        hidden_states = self.vision_tower(pixel_values, spatial_shapes)
+
+        # Merge vision features into text embeddings at image token positions
+        final_inputs_embeds = self.merge_input_ids_with_image_features(
+            self.config.image_token_id,
+            self.config.video_token_id,
+            hidden_states,
+            inputs_embeds,
+            input_ids,
+        )
+
+        return InputEmbeddingsFeatures(inputs_embeds=final_inputs_embeds)
+
+    @staticmethod
+    def merge_input_ids_with_image_features(
+        image_token_id,
+        video_token_id,
+        image_features,
+        inputs_embeds,
+        input_ids,
+    ):
+        """Merge image features into input embeddings at image token positions."""
+        # Find positions of image tokens
+        image_positions = input_ids == image_token_id
+        if mx.sum(image_positions) == 0:
+            image_positions = input_ids == video_token_id
+
+        batch_size, seq_len = input_ids.shape
+
+        batch_outputs = []
+        feature_start_idx = 0
+
+        for batch_idx in range(batch_size):
+            image_mask = image_positions[batch_idx]
+            num_positions = mx.sum(image_mask).item()
+
+            if num_positions > 0:
+                batch_features = image_features[
+                    feature_start_idx : feature_start_idx + num_positions
+                ]
+
+                if batch_features.shape[0] != num_positions:
+                    raise ValueError(
+                        f"Number of image token positions ({num_positions}) does not match "
+                        f"number of image features ({batch_features.shape[0]}) for batch {batch_idx}"
+                    )
+
+                cumsum = mx.cumsum(image_mask.astype(mx.int32))
+                feature_indices = mx.where(image_mask, cumsum - 1, 0)
+                gathered_features = batch_features[feature_indices]
+
+                image_mask_expanded = mx.expand_dims(image_mask, axis=-1)
+                batch_output = mx.where(
+                    image_mask_expanded, gathered_features, inputs_embeds[batch_idx]
+                )
+
+                feature_start_idx += num_positions
+            else:
+                batch_output = inputs_embeds[batch_idx]
+
+            batch_outputs.append(batch_output)
+
+        return mx.stack(batch_outputs, axis=0)
+
+    @property
+    def layers(self):
+        return self.language_model.model.layers
+
+    def __call__(
+        self,
+        input_ids: mx.array,
+        pixel_values: Optional[mx.array] = None,
+        mask: Optional[mx.array] = None,
+        cache=None,
+        **kwargs,
+    ):
+        input_embeddings_features = self.get_input_embeddings(
+            input_ids, pixel_values, **kwargs
+        )
+
+        logits = self.language_model(
+            input_ids,
+            input_embeddings_features.inputs_embeds,
+            mask=mask,
+            cache=cache,
+        )
+
+        return logits
+
+    def sanitize(self, weights):
+        def transform_key(key):
+            # Map HF weight keys to our model structure
+            # siglip2.vision_model.xxx -> vision_tower.xxx
+            if key.startswith("siglip2.vision_model."):
+                key = key.replace("siglip2.vision_model.", "vision_tower.")
+            elif key.startswith("siglip2."):
+                key = key.replace("siglip2.", "vision_tower.")
+
+            # merger.xxx stays as merger.xxx but needs to go under vision_tower
+            if key.startswith("merger."):
+                key = "vision_tower." + key
+
+            # model.xxx -> language_model.model.xxx
+            if key.startswith("model."):
+                key = key.replace("model.", "language_model.model.", 1)
+
+            # lm_head.xxx -> language_model.lm_head.xxx
+            if key.startswith("lm_head."):
+                key = key.replace("lm_head.", "language_model.lm_head.")
+
+            return key
+
+        sanitized = {}
+        for k, v in weights.items():
+            new_key = transform_key(k)
+            # Skip position_ids and position_embedding (RoPE used instead)
+            if "position_ids" in new_key or "position_embedding" in new_key:
+                continue
+            sanitized[new_key] = v
+
+        # Handle tie_word_embeddings
+        if self.config.text_config.tie_word_embeddings:
+            sanitized.pop("language_model.lm_head.weight", None)
+
+        return sanitized

--- a/mlx_vlm/models/youtu_vl/youtu_vl.py
+++ b/mlx_vlm/models/youtu_vl/youtu_vl.py
@@ -160,4 +160,22 @@ class Model(nn.Module):
         if self.config.text_config.tie_word_embeddings:
             sanitized.pop("language_model.lm_head.weight", None)
 
+        # Split kv_b_proj into per-head embed_q (k) and unembed_out (v)
+        tcfg = self.config.text_config
+        num_heads = tcfg.num_attention_heads
+        qk_nope = tcfg.qk_nope_head_dim
+        v_head = tcfg.v_head_dim
+        head_dim = qk_nope + v_head
+        for layer_idx in range(tcfg.num_hidden_layers):
+            prefix = f"language_model.model.layers.{layer_idx}.self_attn"
+            kv_b_key = f"{prefix}.kv_b_proj.weight"
+            if kv_b_key not in sanitized:
+                continue
+            w = sanitized.pop(kv_b_key)
+            w = w.reshape(num_heads, head_dim, -1)
+            wk = mx.contiguous(w[:, :qk_nope, :].swapaxes(-1, -2))
+            wv = mx.contiguous(w[:, qk_nope:, :])
+            sanitized[f"{prefix}.embed_q.weight"] = wk
+            sanitized[f"{prefix}.unembed_out.weight"] = wv
+
         return sanitized

--- a/mlx_vlm/prompt_utils.py
+++ b/mlx_vlm/prompt_utils.py
@@ -74,6 +74,7 @@ MODEL_CONFIG = {
     "deepseekocr": MessageFormat.IMAGE_TOKEN_NEWLINE,
     "phi4-siglip": MessageFormat.IMAGE_TOKEN_NEWLINE,
     "hunyuan_vl": MessageFormat.LIST_WITH_IMAGE_FIRST,
+    "youtu_vl": MessageFormat.LIST_WITH_IMAGE_FIRST,
     # Prompt-only models
     "florence2": MessageFormat.PROMPT_ONLY,
     "molmo": MessageFormat.PROMPT_ONLY,

--- a/mlx_vlm/tests/test_models.py
+++ b/mlx_vlm/tests/test_models.py
@@ -3291,7 +3291,7 @@ class TestModels(unittest.TestCase):
         # Vision tower takes packed patches + spatial_shapes:
         #   pixel_values: (num_patches, patch_size**2 * channels)
         #   spatial_shapes: (batch, 2) — (h_patches, w_patches)
-        patch_dim = vision_config.patch_size ** 2 * vision_config.num_channels
+        patch_dim = vision_config.patch_size**2 * vision_config.num_channels
         h_p, w_p = 4, 4
         num_patches = h_p * w_p
         self.vision_test_runner(
@@ -3303,7 +3303,6 @@ class TestModels(unittest.TestCase):
             vision_feature_layer=-1,
             spatial_shapes=mx.array([[h_p, w_p]], dtype=mx.int32),
         )
-
 
         # sanitize splits kv_b_proj per-head into embed_q (k) + unembed_out (v)
         H, nope, v_head = 4, 32, 32
@@ -3320,8 +3319,12 @@ class TestModels(unittest.TestCase):
         prefix = "language_model.model.layers.0.self_attn"
         self.assertNotIn(f"{prefix}.kv_b_proj.weight", sanitized)
         self.assertNotIn("language_model.lm_head.weight", sanitized)
-        self.assertEqual(sanitized[f"{prefix}.embed_q.weight"].shape, (H, kv_rank, nope))
-        self.assertEqual(sanitized[f"{prefix}.unembed_out.weight"].shape, (H, v_head, kv_rank))
+        self.assertEqual(
+            sanitized[f"{prefix}.embed_q.weight"].shape, (H, kv_rank, nope)
+        )
+        self.assertEqual(
+            sanitized[f"{prefix}.unembed_out.weight"].shape, (H, v_head, kv_rank)
+        )
 
 
 class TestGetInputEmbeddings(unittest.TestCase):

--- a/mlx_vlm/tests/test_models.py
+++ b/mlx_vlm/tests/test_models.py
@@ -70,7 +70,13 @@ class TestModels(unittest.TestCase):
                 )
 
             batch_size = kwargs.pop("batch_size", 1)
-            if model_type in ["qwen2_5_vl", "glm4v_moe", "glm4v", "hunyuan_vl"]:
+            if model_type in [
+                "qwen2_5_vl",
+                "glm4v_moe",
+                "glm4v",
+                "hunyuan_vl",
+                "siglip2_vision_model",
+            ]:
                 input_tensor = mx.random.uniform(shape=(image_size[0], image_size[1]))
             else:
                 shape = (
@@ -3229,6 +3235,93 @@ class TestModels(unittest.TestCase):
             config.text_config.vocab_size,
             config.text_config.num_hidden_layers,
         )
+
+    def test_youtu_vl(self):
+        from mlx_vlm.models import youtu_vl
+
+        text_config = youtu_vl.TextConfig(
+            model_type="youtu_vl",
+            hidden_size=256,
+            intermediate_size=512,
+            num_hidden_layers=2,
+            num_attention_heads=4,
+            num_key_value_heads=4,
+            vocab_size=1024,
+            q_lora_rank=128,
+            kv_lora_rank=64,
+            qk_rope_head_dim=16,
+            v_head_dim=32,
+            qk_nope_head_dim=32,
+            rope_theta=500000.0,
+            rope_interleave=True,
+            max_position_embeddings=2048,
+            tie_word_embeddings=True,
+        )
+        vision_config = youtu_vl.VisionConfig(
+            model_type="siglip2_vision_model",
+            hidden_size=128,
+            out_hidden_size=256,
+            intermediate_size=256,
+            num_hidden_layers=2,
+            num_attention_heads=4,
+            num_channels=3,
+            patch_size=16,
+            spatial_merge_size=2,
+            window_size=64,
+            fullatt_block_indexes=[1],
+        )
+        config = youtu_vl.ModelConfig(
+            model_type="youtu_vl",
+            text_config=text_config,
+            vision_config=vision_config,
+            image_token_id=100,
+            video_token_id=101,
+            vocab_size=1024,
+        )
+        model = youtu_vl.Model(config)
+
+        # Language model: MLA with absorb — fp32/fp16 forward + cached decode check
+        self.language_test_runner(
+            model.language_model,
+            config.text_config.model_type,
+            config.text_config.vocab_size,
+            config.text_config.num_hidden_layers,
+        )
+
+        # Vision tower takes packed patches + spatial_shapes:
+        #   pixel_values: (num_patches, patch_size**2 * channels)
+        #   spatial_shapes: (batch, 2) — (h_patches, w_patches)
+        patch_dim = vision_config.patch_size ** 2 * vision_config.num_channels
+        h_p, w_p = 4, 4
+        num_patches = h_p * w_p
+        self.vision_test_runner(
+            model.vision_tower,
+            config.vision_config.model_type,
+            config.vision_config.out_hidden_size,
+            config.vision_config.num_channels,
+            (num_patches, patch_dim),
+            vision_feature_layer=-1,
+            spatial_shapes=mx.array([[h_p, w_p]], dtype=mx.int32),
+        )
+
+
+        # sanitize splits kv_b_proj per-head into embed_q (k) + unembed_out (v)
+        H, nope, v_head = 4, 32, 32
+        kv_rank = text_config.kv_lora_rank
+        w = mx.arange(H * (nope + v_head) * kv_rank, dtype=mx.float32).reshape(
+            H * (nope + v_head), kv_rank
+        )
+        sanitized = model.sanitize(
+            {
+                "model.layers.0.self_attn.kv_b_proj.weight": w,
+                "lm_head.weight": mx.zeros((1, 1)),  # tied; must be dropped
+            }
+        )
+        prefix = "language_model.model.layers.0.self_attn"
+        self.assertNotIn(f"{prefix}.kv_b_proj.weight", sanitized)
+        self.assertNotIn("language_model.lm_head.weight", sanitized)
+        self.assertEqual(sanitized[f"{prefix}.embed_q.weight"].shape, (H, kv_rank, nope))
+        self.assertEqual(sanitized[f"{prefix}.unembed_out.weight"].shape, (H, v_head, kv_rank))
 
 
 class TestGetInputEmbeddings(unittest.TestCase):


### PR DESCRIPTION
HF: https://huggingface.co/tencent/Youtu-VL-4B-Instruct
<img width="504" height="542" alt="截屏2026-04-13 11 09 21" src="https://github.com/user-attachments/assets/665dd1ff-84f7-4780-b5d8-00997d11da0d" />

```
# molly @ MOLLYJI-MB1 in ~/workspace/mlx-vlm on git:main x .venv [11:03:33] 
$ mlx_vlm.convert \        
    --hf-path /Users/molly/workspace-youtulm-ncnn/Youtu-VL-4B-Instruct \
    --mlx-path /Users/molly/workspace/Youtu-VL-4B-Instruct-4bit-test \
    -q --q-bits 4 --trust-remote-code
[INFO] Loading
[INFO] Using dtype: bfloat16
[INFO] Quantizing
[INFO] Quantized model with 5.460 bits per weight.
```

```
# molly @ MOLLYJI-MB1 in ~/workspace/mlx-vlm on git:main x .venv [11:11:41] 
$ mlx_vlm.generate --model ../Youtu-VL-4B-Instruct-4bit-test --max-tokens 512 --prompt "Please describe this image shortly" --trust-remote-code --image /Users/molly/workspace/Youtu-VL-4B-Instruct-6bit-mlx/assets/youtu-vl-logo.png
==========
Files: ['/Users/molly/workspace/Youtu-VL-4B-Instruct-6bit-mlx/assets/youtu-vl-logo.png'] 

Prompt: <|begin_of_text|>system
You are a helpful assistant.<|end_of_text|>
<|begin_of_text|>user
<|vision_start|><|image_pad|><|vision_end|>Please describe this image shortly<|end_of_text|>
<|begin_of_text|>assistant

This image is a promotional banner for a project called “Youtu-VL.”

It features:

- A cute cartoon penguin on the left, wearing headphones and a colorful scarf, suggesting a fun or accessible AI tool.
- The main title “Youtu-VL” in large, gray, sans-serif font centered on a black background.
- The tagline below: “Unleashing Visual Potential via Unified Vision-Language Supervision,” indicating the project’s focus on combining visual and language understanding.
- A colorful abstract logo on the right, composed of three interconnected shapes in blue, pink, and teal — likely representing the Youtu Lab’s branding.

The overall design is clean, modern, and tech-oriented, aimed at conveying innovation and accessibility in vision-language AI.
==========
Prompt: 348 tokens, 131.744 tokens-per-sec
Generation: 165 tokens, 42.101 tokens-per-sec
Peak memory: 4.887 GB
```
