### PR TITLE
fix: preserve tool_calls and tool_call_id through message processing

### DIFF
--- a/mlx_vlm/prompt_utils.py
+++ b/mlx_vlm/prompt_utils.py
@@ -710,6 +710,12 @@ def apply_chat_template(
                         **kwargs,
                     )
                 )
+            elif isinstance(p, dict) and (
+                p.get("tool_calls") or p.get("role") == "tool"
+            ):
+                # Tool-calling messages: pass through as-is so the tokenizer's
+                # Jinja chat template sees tool_calls and tool_call_id intact.
+                messages.append(p)
             elif (role_content := _get_role_content(p)) is not None:
                 role, content = role_content
                 # Handle multimodal content: extract only text, skip image/audio URLs

--- a/mlx_vlm/server.py
+++ b/mlx_vlm/server.py
@@ -1068,11 +1068,9 @@ async def chat_completions_endpoint(request: ChatRequest):
         processed_messages = []
         for message in request.messages:
             if message.content is None:
-                processed_messages.append({"role": message.role, "content": ""})
+                msg = {"role": message.role, "content": ""}
             elif isinstance(message.content, str):
-                processed_messages.append(
-                    {"role": message.role, "content": message.content}
-                )
+                msg = {"role": message.role, "content": message.content}
             elif isinstance(message.content, list):
                 text_content = ""
                 for item in message.content:
@@ -1087,9 +1085,22 @@ async def chat_completions_endpoint(request: ChatRequest):
                                 audio.append(item["input_audio"]["data"])
                         if item["type"] in ("text", "input_text"):
                             text_content = item.get("text", "")
-                processed_messages.append(
-                    {"role": message.role, "content": text_content}
-                )
+                msg = {"role": message.role, "content": text_content}
+            else:
+                msg = {"role": message.role, "content": ""}
+
+            # Preserve tool-calling metadata so the tokenizer's Jinja chat
+            # template can correctly format multi-turn tool call / result turns.
+            if getattr(message, "tool_calls", None):
+                msg["tool_calls"] = [
+                    tc if isinstance(tc, dict) else tc.model_dump()
+                    for tc in message.tool_calls
+                ]
+            tool_call_id = getattr(message, "tool_call_id", None)
+            if tool_call_id:
+                msg["tool_call_id"] = tool_call_id
+
+            processed_messages.append(msg)
 
         tools = None
         if hasattr(request, "tools"):

--- a/mlx_vlm/server.py
+++ b/mlx_vlm/server.py
@@ -1092,10 +1092,28 @@ async def chat_completions_endpoint(request: ChatRequest):
             # Preserve tool-calling metadata so the tokenizer's Jinja chat
             # template can correctly format multi-turn tool call / result turns.
             if getattr(message, "tool_calls", None):
-                msg["tool_calls"] = [
-                    tc if isinstance(tc, dict) else tc.model_dump()
-                    for tc in message.tool_calls
-                ]
+                tool_calls_out = []
+                for tc in message.tool_calls:
+                    tc_dict = tc if isinstance(tc, dict) else tc.model_dump()
+                    # arguments is stored as a JSON string in the OpenAI wire
+                    # format, but Gemma 4's Jinja template expects a native
+                    # object. Passing a string causes the model to re-emit it
+                    # verbatim with <|"|> escapes around JSON fragments,
+                    # producing double-encoded arguments on the next turn.
+                    func = tc_dict.get("function", {})
+                    if isinstance(func.get("arguments"), str):
+                        try:
+                            tc_dict = {
+                                **tc_dict,
+                                "function": {
+                                    **func,
+                                    "arguments": json.loads(func["arguments"]),
+                                },
+                            }
+                        except (json.JSONDecodeError, TypeError):
+                            pass
+                    tool_calls_out.append(tc_dict)
+                msg["tool_calls"] = tool_calls_out
             tool_call_id = getattr(message, "tool_call_id", None)
             if tool_call_id:
                 msg["tool_call_id"] = tool_call_id


### PR DESCRIPTION
Multi-turn tool calling loops because two independent passes strip tool metadata before the tokenizer's Jinja chat template runs, and a third bug causes double-encoded arguments on subsequent tool calls.

---

**Bug 1 — `server.py` `chat_completions_endpoint` (~line 1068)**

The message loop rebuilds each message as a plain `{role, content}` dict. For an assistant message with `content: null, tool_calls: [...]` this produces `{"role": "assistant", "content": ""}` — `tool_calls` is gone. For a `role: tool` message, `tool_call_id` is similarly dropped.

**Bug 2 — `prompt_utils.py` `apply_chat_template` (~line 713)**

All dict messages are routed through `_get_role_content` → `get_message_json`, neither of which carry `tool_calls` or `tool_call_id`. Even if Bug 1 were fixed in isolation, this pass would strip the fields again.

**Bug 3 — `server.py`: `arguments` passed as JSON string instead of dict**

The OpenAI wire format stores `function.arguments` as a JSON string. Gemma 4's Jinja chat template expects a native object. When passed a string, the template embeds it verbatim in the model context, so on the next turn the model mirrors it back using `<|"|>` escapes around the JSON fragments rather than around individual string values. The parser then decodes those fragments literally, producing double-encoded arguments — e.g. `JSON.parse` gives `{ '{"date"': '"2026-04-14"}' }` instead of `{ date: '2026-04-14' }`.

---

**Fixes**

- `server.py` (Bug 1): accumulate into a local `msg` dict, then conditionally attach `tool_calls` and `tool_call_id` before appending. Also adds a previously-missing `else` branch for unrecognised content types.
- `prompt_utils.py` (Bug 2): insert a pass-through branch before the `_get_role_content` branch — any dict with `tool_calls` or `role == "tool"` is appended as-is.
- `server.py` (Bug 3): parse `arguments` from JSON string back to dict during `tool_calls` serialisation. Falls back to the original string if `json.loads` fails.

All changes are non-breaking (no-tool conversations are unaffected).

**Validation**

Tested against `mlx-community/gemma-4-26b-a4b-it-4bit` with a multi-turn agentic workflow requiring three sequential tool calls (`get_time_entries` → `get_holidays` → `get_bookings`). Before: model looped on the first tool call. After: all three tool calls resolved correctly with results accumulated in history.