### PR TITLE
Security: Remote image fetch lacks timeout and payload size limits (DoS risk)

### DIFF
--- a/computer_use/utils.py
+++ b/computer_use/utils.py
@@ -6,6 +6,12 @@ import requests
 from PIL import Image, ImageDraw
 
 
+REQUEST_TIMEOUT = (5, 10)
+MAX_IMAGE_DOWNLOAD_SIZE = 10 * 1024 * 1024
+MAX_IMAGE_PIXELS = 25_000_000
+Image.MAX_IMAGE_PIXELS = MAX_IMAGE_PIXELS
+
+
 def draw_point(
     image_input, point: tuple = None, radius: int = 8, color: str = "red"
 ) -> Image.Image:
@@ -16,15 +22,37 @@ def draw_point(
     # Load image from path/URL or use directly if it's already a PIL Image
     if isinstance(image_input, str):
         if image_input.startswith("http"):
-            response = requests.get(image_input)
-            response.raise_for_status()
-            image = Image.open(BytesIO(response.content))
+            image_bytes = BytesIO()
+            downloaded = 0
+            with requests.get(
+                image_input, timeout=REQUEST_TIMEOUT, stream=True
+            ) as response:
+                response.raise_for_status()
+                content_length = response.headers.get("Content-Length")
+                if content_length is not None:
+                    try:
+                        if int(content_length) > MAX_IMAGE_DOWNLOAD_SIZE:
+                            raise ValueError("Remote image is too large")
+                    except ValueError:
+                        pass
+                for chunk in response.iter_content(chunk_size=8192):
+                    if not chunk:
+                        continue
+                    downloaded += len(chunk)
+                    if downloaded > MAX_IMAGE_DOWNLOAD_SIZE:
+                        raise ValueError("Remote image is too large")
+                    image_bytes.write(chunk)
+            image_bytes.seek(0)
+            image = Image.open(image_bytes)
         else:
             image = Image.open(image_input)
     elif isinstance(image_input, Image.Image):
         image = image_input
     else:
         raise ValueError("image_input must be a string path/URL or a PIL Image object")
+
+    if image.width * image.height > MAX_IMAGE_PIXELS:
+        raise ValueError("Image dimensions are too large")
 
     # Only draw if a valid point is provided
     if point is not None:


### PR DESCRIPTION
## Summary

Security: Remote image fetch lacks timeout and payload size limits (DoS risk)

## Problem

**Severity**: `Medium` | **File**: `computer_use/utils.py:L19`

`requests.get(image_input)` is called without a timeout, and response content is loaded directly into memory before decoding with PIL. A malicious endpoint can hold connections open or return very large/decompression-bomb images, causing resource exhaustion.

## Solution

Use `requests.get(..., timeout=(connect_timeout, read_timeout), stream=True)`, enforce a maximum download size before reading body, and validate image dimensions/file size before decoding. Consider PIL safety settings (e.g., `Image.MAX_IMAGE_PIXELS`) to mitigate decompression bombs.

## Changes

- `computer_use/utils.py` (modified)