### PR TITLE
Attempt to fix Qwen VL generation

### DIFF
--- a/mlx_vlm/generate.py
+++ b/mlx_vlm/generate.py
@@ -1106,13 +1106,6 @@ class BatchGenerator:
         left_padding = [max_length - l for l in lengths]
         inputs = _left_pad_prompts(inputs, max_length=max_length)
 
-        # Reset cached position state from previous prefills
-        # (e.g. Qwen3.5 caches _position_ids / _rope_deltas on the model)
-        if hasattr(self.model, "_position_ids"):
-            self.model._position_ids = None
-        if hasattr(self.model, "_rope_deltas"):
-            self.model._rope_deltas = None
-
         if self.prompt_cache is not None:
             prompt_cache = self.prompt_cache
         else:

--- a/mlx_vlm/models/qwen2_vl/language.py
+++ b/mlx_vlm/models/qwen2_vl/language.py
@@ -481,9 +481,7 @@ class LanguageModel(nn.Module):
                 or self._rope_deltas is None
                 or cache is None
             ):
-                # Only reuse _position_ids for chunked prefill (cache_offset > 0)
-                # For new prompts (cache_offset == 0), always recalculate
-                if self._position_ids is not None and cache_offset > 0:
+                if self._position_ids is not None:
                     seq_length = inputs.shape[1]
                     position_ids = self._position_ids[
                         :, :, cache_offset : cache_offset + seq_length

--- a/mlx_vlm/models/qwen3_vl/language.py
+++ b/mlx_vlm/models/qwen3_vl/language.py
@@ -544,9 +544,7 @@ class LanguageModel(nn.Module):
                 or cache is None
             )
             if recalc_condition:
-                # Only reuse _position_ids for chunked prefill (cache_offset > 0)
-                # For new prompts (cache_offset == 0), always recalculate
-                if self._position_ids is not None and cache_offset > 0:
+                if self._position_ids is not None:
                     seq_length = inputs.shape[1]
                     position_ids = self._position_ids[
                         :, :, cache_offset : cache_offset + seq_length

--- a/mlx_vlm/models/qwen3_vl_moe/language.py
+++ b/mlx_vlm/models/qwen3_vl_moe/language.py
@@ -578,9 +578,7 @@ class LanguageModel(nn.Module):
                 or self._rope_deltas is None
                 or cache is None
             ):
-                # Only reuse _position_ids for chunked prefill (cache_offset > 0)
-                # For new prompts (cache_offset == 0), always recalculate
-                if self._position_ids is not None and cache_offset > 0:
+                if self._position_ids is not None:
                     seq_length = inputs.shape[1]
                     position_ids = self._position_ids[
                         :, :, cache_offset : cache_offset + seq_length


### PR DESCRIPTION
Chunked prefill for this family appears to have broken after CB was introduced.

Reproducer:

```bash
mlx_vlm.generate --model mlx-community/Qwen3-VL-30B-A3B-Instruct-bf16 --prompt "Describe this image" --image https://huggingface.co/datasets/huggingface/documentation-images/resolve/0052a70beed5bf71b92610a43a52df6d286cd5f3/diffusers/rabbit.jpg
```

This fails before this patch and works after.

`get_input_embeddings` already resets the cache positions, so Claude claims it's not necessary to do it again in `_process_prompts`.

I tested generation (example above) and CB against the server and both work.

**Note** it does not fail for all images, just when chunked prefill is engaged.