### PR TITLE
Strip tool-call markup from streamed delta.content

### DIFF
--- a/mlx_vlm/server.py
+++ b/mlx_vlm/server.py
@@ -1607,10 +1607,26 @@ async def chat_completions_endpoint(request: ChatRequest):
 
                         output_tokens = 0
                         request_id = f"chatcmpl-{uuid.uuid4()}"
-                        # Track thinking state for reasoning/content split
+                        # Track thinking / tool-call state for content routing
                         in_thinking = False
+                        in_tool = False
                         accumulated = ""
                         full_output = ""  # raw output for tool call parsing
+
+                        # Marker strings for the active tool parser (if any).
+                        # Tokens emitted while in_tool is True are absorbed
+                        # into full_output for process_tool_calls() to parse,
+                        # and never streamed as delta.content.
+                        tc_start = (
+                            tool_module.tool_call_start
+                            if tool_module is not None
+                            else None
+                        )
+                        tc_end = (
+                            tool_module.tool_call_end
+                            if tool_module is not None
+                            else None
+                        )
 
                         def _next_token():
                             try:
@@ -1626,13 +1642,17 @@ async def chat_completions_endpoint(request: ChatRequest):
                             accumulated += token.text
                             full_output += token.text
 
-                            # Detect thinking boundaries
+                            # Detect thinking / tool-call boundaries
                             delta_reasoning = None
                             delta_content = None
 
-                            if not in_thinking and (
-                                "<|channel>thought" in accumulated
-                                or "<think>" in accumulated
+                            if (
+                                not in_thinking
+                                and not in_tool
+                                and (
+                                    "<|channel>thought" in accumulated
+                                    or "<think>" in accumulated
+                                )
                             ):
                                 in_thinking = True
                                 accumulated = ""
@@ -1643,10 +1663,30 @@ async def chat_completions_endpoint(request: ChatRequest):
                                 in_thinking = False
                                 accumulated = ""
                                 # Don't emit closing tag tokens
+                            elif (
+                                not in_thinking
+                                and not in_tool
+                                and tc_start
+                                and tc_start in accumulated
+                            ):
+                                in_tool = True
+                                accumulated = ""
+                                # Don't emit tool-call opening tokens
+                            elif in_tool and tc_end and tc_end in accumulated:
+                                in_tool = False
+                                accumulated = ""
+                                # Don't emit tool-call closing tokens
                             elif in_thinking:
                                 delta_reasoning = token.text
-                            elif not in_thinking and (
-                                "<|channel>" in accumulated or "<think" in accumulated
+                            elif in_tool:
+                                pass  # Suppress: tool tokens are parsed from full_output
+                            elif (
+                                not in_thinking
+                                and not in_tool
+                                and (
+                                    "<|channel>" in accumulated
+                                    or "<think" in accumulated
+                                )
                             ):
                                 pass  # Partial tag, don't emit yet
                             else:

--- a/mlx_vlm/tests/test_server.py
+++ b/mlx_vlm/tests/test_server.py
@@ -284,6 +284,142 @@ class TestProcessToolCalls:
         assert result["remaining_text"] == "Just text."
 
 
+class TestStreamStateRouting:
+    """Tests for the streaming state machine that routes tokens between
+    ``delta.content`` / ``delta.reasoning`` / tool-call buffering.
+
+    These tests mirror the inline token-routing logic inside
+    ``stream_generator()`` in ``server.py``.  They verify the *contract*
+    that logic is supposed to uphold: thinking and tool-call markers
+    never leak into ``delta.content``.  If the streaming loop is
+    refactored, update the helper below to keep the tests in sync.
+    """
+
+    def _route_tokens(self, tokens, tc_start=None, tc_end=None):
+        """Simulate the stream_generator state machine for a token list.
+
+        Returns dict with ``content`` (joined delta.content),
+        ``reasoning`` (joined delta.reasoning), and ``full_output``
+        (raw concatenation used by process_tool_calls()).
+        """
+        in_thinking = False
+        in_tool = False
+        accumulated = ""
+        full_output = ""
+        content_parts = []
+        reasoning_parts = []
+
+        for text in tokens:
+            accumulated += text
+            full_output += text
+
+            delta_reasoning = None
+            delta_content = None
+
+            if (
+                not in_thinking
+                and not in_tool
+                and ("<|channel>thought" in accumulated or "<think>" in accumulated)
+            ):
+                in_thinking = True
+                accumulated = ""
+            elif in_thinking and (
+                "<channel|>" in accumulated or "</think>" in accumulated
+            ):
+                in_thinking = False
+                accumulated = ""
+            elif (
+                not in_thinking and not in_tool and tc_start and tc_start in accumulated
+            ):
+                in_tool = True
+                accumulated = ""
+            elif in_tool and tc_end and tc_end in accumulated:
+                in_tool = False
+                accumulated = ""
+            elif in_thinking:
+                delta_reasoning = text
+            elif in_tool:
+                pass
+            elif (
+                not in_thinking
+                and not in_tool
+                and ("<|channel>" in accumulated or "<think" in accumulated)
+            ):
+                pass
+            else:
+                delta_content = text
+
+            if delta_reasoning is not None:
+                reasoning_parts.append(delta_reasoning)
+            if delta_content is not None:
+                content_parts.append(delta_content)
+
+        return {
+            "content": "".join(content_parts),
+            "reasoning": "".join(reasoning_parts),
+            "full_output": full_output,
+        }
+
+    def test_tool_call_markers_stripped_from_content(self):
+        tokens = [
+            "Hello ",
+            "<|tool_call>",
+            'call:get_weather{location:<|"|>Nuremberg<|"|>}',
+            "<tool_call|>",
+            " done",
+        ]
+        result = self._route_tokens(
+            tokens, tc_start="<|tool_call>", tc_end="<tool_call|>"
+        )
+        # Neither start nor end marker should leak into delta.content
+        assert "<|tool_call>" not in result["content"]
+        assert "<tool_call|>" not in result["content"]
+        # Tool body is also not streamed — it is parsed from full_output
+        assert "call:get_weather" not in result["content"]
+        # Normal text before/after the tool call is preserved
+        assert result["content"] == "Hello  done"
+        # full_output retains the complete sequence for process_tool_calls()
+        assert "<|tool_call>" in result["full_output"]
+
+    def test_thinking_still_works_with_tool_parser_active(self):
+        tokens = [
+            "<|channel>thought\n",
+            "reasoning text",
+            "<channel|>",
+            "answer",
+        ]
+        result = self._route_tokens(
+            tokens, tc_start="<|tool_call>", tc_end="<tool_call|>"
+        )
+        assert result["reasoning"] == "reasoning text"
+        assert result["content"] == "answer"
+
+    def test_thinking_then_tool_call_gemma4_pattern(self):
+        # Gemma 4 commonly emits <|channel>thought ... <channel|><|tool_call>...
+        tokens = [
+            "<|channel>thought\n",
+            "reason about weather",
+            "<channel|>",
+            "<|tool_call>",
+            "call:get_weather{}",
+            "<tool_call|>",
+        ]
+        result = self._route_tokens(
+            tokens, tc_start="<|tool_call>", tc_end="<tool_call|>"
+        )
+        assert result["reasoning"] == "reason about weather"
+        # No tool markup leaks, no content emitted for this turn
+        assert result["content"] == ""
+        assert "<|tool_call>" not in result["content"]
+
+    def test_content_passes_through_without_tool_parser(self):
+        # If the model has no tool parser, the new branch is inert and
+        # existing behaviour is preserved.
+        tokens = ["Hello ", "world"]
+        result = self._route_tokens(tokens)
+        assert result["content"] == "Hello world"
+
+
 class TestCountThinkingTagTokens:
     """Tests for thinking tag token counting."""
 


### PR DESCRIPTION
## Summary

The streaming loop in `chat_completions_endpoint` already filters thinking markers (`<|channel>thought` / `<channel|>`, `<think>` / `</think>`) from `delta.content` via an inline state machine. Tool-call markers (`<|tool_call>` / `<tool_call|>` for Gemma 4, `[TOOL_CALLS]` for Mistral, etc.) follow the same contract but are not filtered today — tokens inside a tool-call block leak into `delta.content` before the final structured `tool_calls` chunk arrives, and downstream OpenAI-compatible clients render the raw markup.

This PR adds a symmetric `in_tool` branch to the existing inline state machine, driven by the active tool parser module's `tool_call_start` / `tool_call_end` strings. No new dependencies, no refactor of the surrounding code — just the missing second half of the existing pattern.

The leak mostly hurts agent frameworks (OpenCode, Hermes Agent, OpenClaw and similar) that stream to OpenAI-compatible endpoints and commit to "this is a text reply" as soon as non-empty `delta.content` arrives. See the two independent reproductions in #974 for concrete cases.

## What changes

- **`mlx_vlm/server.py`** (stream branch of `chat_completions_endpoint`)
  - New `in_tool` boolean alongside the existing `in_thinking`.
  - Reads `tc_start` / `tc_end` from `tool_module` once (both `None` when no parser is matched — the new branch is then inert).
  - Two new transitions: `normal → in_tool` when `tc_start in accumulated`, `in_tool → normal` when `tc_end in accumulated`.
  - While `in_tool`, tokens are still appended to `full_output` (so `process_tool_calls()` sees the full sequence at turn end) but are not streamed as `delta.content`.

- **`mlx_vlm/tests/test_server.py`**
  - New `TestStreamStateRouting` class with 4 tests over representative token sequences: tool-call markers stripped, thinking still works when a tool parser is active, Gemma 4 `<|channel>thought … <channel|><|tool_call> … <tool_call|>` combined pattern, and content passthrough without a parser.
  - The helper mirrors the inline loop's routing rules; a docstring note flags that the two must stay in sync.

## Scope I deliberately kept narrow

- No extraction of the state-update logic into a helper function — the diff stays surgical and symmetric to the existing thinking code.
- No partial-marker suppression. For Gemma 4 `<|tool_call>` is typically a single vocab token so the transition fires atomically. Multi-token markers that stream token-by-token could leak a few characters before the transition; that's the same trade-off the existing thinking filter makes and can be a follow-up.
- Mistral's empty `tool_call_end` means once `in_tool` is `True`, the turn stays in tool mode until EOS. That matches Mistral's convention that tool calls are terminal.

## Test plan

- [x] `python -m pytest mlx_vlm/tests/test_server.py` — 31 passed (27 existing + 4 new)
- [x] `pre-commit run --files mlx_vlm/server.py mlx_vlm/tests/test_server.py` — black + isort + autoflake clean
- [x] End-to-end verification against `mlx-community/gemma-4-26b-a4b-it-4bit` via mlx-lm's server + OpenCode (single tool call, multi-turn with `tool_response` feedback, parallel tool calls, nested arguments with `<|"|>` escape tokens) — no marker leakage, structured `tool_calls` emitted at the right boundary.

<sub>🤖 drafted with Claude Code, reviewed before submitting.</sub>
