### PR TITLE
Strip tool-call markup from streamed delta.content

### DIFF
--- a/mlx_vlm/server.py
+++ b/mlx_vlm/server.py
@@ -1810,6 +1810,14 @@ async def chat_completions_endpoint(request: ChatRequest):
                         in_thinking = False
                         accumulated = ""
                         full_output = ""  # raw output for tool call parsing
+                        # Track tool-call state to suppress markup from content
+                        in_tool_call = False
+                        tc_start = (
+                            tool_module.tool_call_start if tool_module else None
+                        )
+                        tc_end = (
+                            tool_module.tool_call_end if tool_module else None
+                        )
 
                         def _next_token():
                             try:
@@ -1850,6 +1858,21 @@ async def chat_completions_endpoint(request: ChatRequest):
                                 pass  # Partial tag, don't emit yet
                             else:
                                 delta_content = token.text
+
+                            # Suppress tool-call markup from content
+                            if tc_start and not in_tool_call:
+                                if tc_start in full_output:
+                                    in_tool_call = True
+                                    delta_content = None
+                                elif full_output.endswith(
+                                    tc_start[:len(tc_start) - 1]
+                                ) or any(
+                                    full_output.endswith(tc_start[:j])
+                                    for j in range(1, len(tc_start))
+                                ):
+                                    delta_content = None
+                            elif in_tool_call:
+                                delta_content = None
 
                             chunk_logprobs = None
                             if request.logprobs and token.finish_reason != "stop":

--- a/mlx_vlm/server.py
+++ b/mlx_vlm/server.py
@@ -493,6 +493,30 @@ class ResponseGenerator:
             self._step(batch_gen, active)
 
 
+def suppress_tool_call_content(
+    full_output: str,
+    in_tool_call: bool,
+    tc_start: Optional[str],
+    delta_content: Optional[str],
+) -> Tuple[bool, Optional[str]]:
+    """Suppress tool-call markup from streamed delta.content.
+
+    Returns updated (in_tool_call, delta_content).
+    """
+    if not tc_start:
+        return in_tool_call, delta_content
+    if not in_tool_call:
+        if tc_start in full_output:
+            return True, None
+        if any(
+            full_output.endswith(tc_start[:j]) for j in range(1, len(tc_start))
+        ):
+            return False, None
+    else:
+        return True, None
+    return in_tool_call, delta_content
+
+
 def process_tool_calls(model_output: str, tool_module, tools):
     """Parse tool calls from model output using the appropriate tool parser."""
     called_tools = []
@@ -1860,19 +1884,9 @@ async def chat_completions_endpoint(request: ChatRequest):
                                 delta_content = token.text
 
                             # Suppress tool-call markup from content
-                            if tc_start and not in_tool_call:
-                                if tc_start in full_output:
-                                    in_tool_call = True
-                                    delta_content = None
-                                elif full_output.endswith(
-                                    tc_start[:len(tc_start) - 1]
-                                ) or any(
-                                    full_output.endswith(tc_start[:j])
-                                    for j in range(1, len(tc_start))
-                                ):
-                                    delta_content = None
-                            elif in_tool_call:
-                                delta_content = None
+                            in_tool_call, delta_content = suppress_tool_call_content(
+                                full_output, in_tool_call, tc_start, delta_content
+                            )
 
                             chunk_logprobs = None
                             if request.logprobs and token.finish_reason != "stop":

--- a/mlx_vlm/server.py
+++ b/mlx_vlm/server.py
@@ -1889,30 +1889,39 @@ async def chat_completions_endpoint(request: ChatRequest):
                                     ]
                                 )
 
-                            choices = [
-                                ChatStreamChoice(
-                                    finish_reason=token.finish_reason,
-                                    delta=ChatMessage(
-                                        role="assistant",
-                                        content=delta_content,
-                                        reasoning=delta_reasoning,
-                                    ),
-                                    logprobs=chunk_logprobs,
-                                )
-                            ]
-                            chunk_data = ChatStreamChunk(
-                                id=request_id,
-                                created=int(time.time()),
-                                model=request.model,
-                                usage={
-                                    "prompt_tokens": ctx.prompt_tokens,
-                                    "completion_tokens": output_tokens,
-                                    "total_tokens": ctx.prompt_tokens + output_tokens,
-                                },
-                                choices=choices,
+                            # Skip empty deltas (e.g. suppressed tool-call tokens)
+                            has_payload = (
+                                delta_content is not None
+                                or delta_reasoning is not None
+                                or token.finish_reason is not None
+                                or chunk_logprobs is not None
                             )
+                            if has_payload:
+                                choices = [
+                                    ChatStreamChoice(
+                                        finish_reason=token.finish_reason,
+                                        delta=ChatMessage(
+                                            role="assistant",
+                                            content=delta_content,
+                                            reasoning=delta_reasoning,
+                                        ),
+                                        logprobs=chunk_logprobs,
+                                    )
+                                ]
+                                chunk_data = ChatStreamChunk(
+                                    id=request_id,
+                                    created=int(time.time()),
+                                    model=request.model,
+                                    usage={
+                                        "prompt_tokens": ctx.prompt_tokens,
+                                        "completion_tokens": output_tokens,
+                                        "total_tokens": ctx.prompt_tokens
+                                        + output_tokens,
+                                    },
+                                    choices=choices,
+                                )
 
-                            yield f"data: {chunk_data.model_dump_json()}\n\n"
+                                yield f"data: {chunk_data.model_dump_json()}\n\n"
 
                             if token.finish_reason:
                                 break

--- a/mlx_vlm/server.py
+++ b/mlx_vlm/server.py
@@ -508,9 +508,7 @@ def suppress_tool_call_content(
     if not in_tool_call:
         if tc_start in full_output:
             return True, None
-        if any(
-            full_output.endswith(tc_start[:j]) for j in range(1, len(tc_start))
-        ):
+        if any(full_output.endswith(tc_start[:j]) for j in range(1, len(tc_start))):
             return False, None
     else:
         return True, None
@@ -1836,12 +1834,8 @@ async def chat_completions_endpoint(request: ChatRequest):
                         full_output = ""  # raw output for tool call parsing
                         # Track tool-call state to suppress markup from content
                         in_tool_call = False
-                        tc_start = (
-                            tool_module.tool_call_start if tool_module else None
-                        )
-                        tc_end = (
-                            tool_module.tool_call_end if tool_module else None
-                        )
+                        tc_start = tool_module.tool_call_start if tool_module else None
+                        tc_end = tool_module.tool_call_end if tool_module else None
 
                         def _next_token():
                             try:

--- a/mlx_vlm/tests/test_server.py
+++ b/mlx_vlm/tests/test_server.py
@@ -311,14 +311,14 @@ class TestSuppressToolCallContent:
         assert in_tc is True
         assert content is None
 
-    def test_gemma4_marker(self):
+    def test_pipe_delimited_marker(self):
         in_tc, content = server.suppress_tool_call_content(
             "text<|tool_call>call:get_weather", False, "<|tool_call>", "weather"
         )
         assert in_tc is True
         assert content is None
 
-    def test_gemma4_partial_marker(self):
+    def test_pipe_delimited_partial_marker(self):
         in_tc, content = server.suppress_tool_call_content(
             "text<|tool", False, "<|tool_call>", "<|tool"
         )

--- a/mlx_vlm/tests/test_server.py
+++ b/mlx_vlm/tests/test_server.py
@@ -273,6 +273,59 @@ class TestChatMessageSchema:
         assert msg.reasoning == "thought"
 
 
+class TestSuppressToolCallContent:
+    """Tests for tool-call markup suppression in streaming."""
+
+    def test_no_tool_module(self):
+        in_tc, content = server.suppress_tool_call_content(
+            "Hello world", False, None, "world"
+        )
+        assert in_tc is False
+        assert content == "world"
+
+    def test_normal_text_before_tool_call(self):
+        in_tc, content = server.suppress_tool_call_content(
+            "I will call", False, "<tool_call>", "call"
+        )
+        assert in_tc is False
+        assert content == "call"
+
+    def test_suppresses_on_start_marker(self):
+        in_tc, content = server.suppress_tool_call_content(
+            "text<tool_call>", False, "<tool_call>", ">"
+        )
+        assert in_tc is True
+        assert content is None
+
+    def test_suppresses_partial_marker(self):
+        in_tc, content = server.suppress_tool_call_content(
+            "text<tool", False, "<tool_call>", "<tool"
+        )
+        assert in_tc is False
+        assert content is None
+
+    def test_stays_suppressed_after_entering(self):
+        in_tc, content = server.suppress_tool_call_content(
+            "text<tool_call>get_weather", True, "<tool_call>", "weather"
+        )
+        assert in_tc is True
+        assert content is None
+
+    def test_gemma4_marker(self):
+        in_tc, content = server.suppress_tool_call_content(
+            "text<|tool_call>call:get_weather", False, "<|tool_call>", "weather"
+        )
+        assert in_tc is True
+        assert content is None
+
+    def test_gemma4_partial_marker(self):
+        in_tc, content = server.suppress_tool_call_content(
+            "text<|tool", False, "<|tool_call>", "<|tool"
+        )
+        assert in_tc is False
+        assert content is None
+
+
 class TestProcessToolCalls:
     """Tests for tool call parsing from model output."""
 


### PR DESCRIPTION
## Summary
- Detect `tool_call_start` marker during streaming and suppress tool-call markup tokens from `delta.content`
- Skip emitting empty stream chunks when tool-call tokens are suppressed (no more `content: null, reasoning: null` noise)
- The existing final-chunk logic already emits parsed `tool_calls` with `finish_reason: "tool_calls"`

## Tested with
- **Qwen3.5-4B** (`<tool_call>...</tool_call>` via `qwen3_coder` parser)
- **Gemma4-26B-A4B** (`<|tool_call>...<tool_call|>` via `gemma4` parser)
- Normal requests without tools are unaffected

## Test plan
- [x] Streaming with tools: verify no raw markup in `delta.content`
- [x] Streaming with tools: verify final chunk has `tool_calls` + `finish_reason: "tool_calls"`
- [x] Streaming without tools: verify normal behavior unchanged
- [x] Non-streaming with tools: verify `content: null` + `tool_calls` parsed
- [x] Non-streaming without tools: verify normal behavior unchanged
