### PR TITLE
Fix stale position IDs and gdn_sink compatibility for Qwen3.5/3.6 MoE…

### DIFF
--- a/mlx_vlm/models/qwen3_5/language.py
+++ b/mlx_vlm/models/qwen3_5/language.py
@@ -735,6 +735,7 @@ class LanguageModel(nn.Module):
                 if (
                     self._position_ids is not None
                     and self._position_ids.shape[1] == batch_size
+                    and self._position_ids.shape[-1] == seq_length
                 ):
                     position_ids = self._position_ids[
                         :, :, cache_offset : cache_offset + seq_length

--- a/mlx_vlm/models/qwen3_5_moe/language.py
+++ b/mlx_vlm/models/qwen3_5_moe/language.py
@@ -70,9 +70,12 @@ class Qwen3_5MoeDecoderLayer(nn.Module):
         mask: Optional[mx.array] = None,
         cache: Optional[Any] = None,
         position_ids: Optional[mx.array] = None,
+        gdn_sink: Optional[list] = None,
     ) -> mx.array:
         if self.is_linear:
-            r = self.linear_attn(self.input_layernorm(x), mask, cache)
+            r = self.linear_attn(
+                self.input_layernorm(x), mask, cache, gdn_sink=gdn_sink
+            )
         else:
             r = self.self_attn(self.input_layernorm(x), mask, cache, position_ids)
         h = x + r


### PR DESCRIPTION
## Summary

Two fixes for Qwen3.5/3.6 MoE models (e.g. Qwen3.6-35B-A3B):

1. **Stale position IDs** — Add `shape[-1] == seq_length` check before reusing cached `_position_ids` in `LanguageModel.__call__()`
2. **gdn_sink compatibility** — Add `gdn_sink` parameter to `Qwen3_5MoeDecoderLayer.__call__()` and propagate to linear attention layer

## Problem 1: broadcast_shapes crash with stale position IDs

The Qwen3.6-35B-A3B model (MoE architecture based on `qwen3_5_moe`) crashes with:

```
ValueError: [broadcast_shapes] Shapes (1,16,60,64) and (1,1,28,64) cannot be broadcast.
```

when the `mlx_vlm.server` processes sequential requests with different token counts. The crash occurs in `apply_multimodal_rotary_pos_emb()` during RoPE computation.

**Root cause**: `LanguageModel` caches `_position_ids` and `_rope_deltas` as instance variables that persist across independent requests since the `LanguageModel` object is reused by the server. In `LanguageModel.__call__()`, when `cache_offset == 0` (start of a new generation), the code short-circuits to reuse stale cached position_ids:

```python
if self._position_ids is not None:
    seq_length = inputs.shape[1]
    position_ids = self._position_ids[:, :, cache_offset : cache_offset + seq_length]
```

The existing check `self._position_ids.shape[1] == batch_size` (line 737) only validates the batch dimension, not the sequence dimension. When the current request has a different token count, MLX slicing silently returns a shorter array without error. This produces cos/sin tensors with the wrong sequence dimension for RoPE, causing the broadcast crash.

**Step-by-step flow**:
1. Request 1 (28 tokens): sets `self._position_ids` with shape `(3, 1, 28)`
2. Request 2 (60 tokens): enters `cache_offset==0` branch, finds `_position_ids is not None`, slices `self._position_ids[:, :, :60]` which MLX silently returns as `(3, 1, 28)` since the original array is shorter than 60
3. Wrong position IDs produce cos/sin with dimension 28 instead of 60
4. `apply_multimodal_rotary_pos_emb()` attempts broadcast between `(1,16,60,64)` and `(1,1,28,64)` — crash

**Fix**: Add a sequence length check:

```diff
                 if (
                     self._position_ids is not None
                     and self._position_ids.shape[1] == batch_size
+                    and self._position_ids.shape[-1] == seq_length
                 ):
```

When cached position IDs don't match the current input length, the code falls through to `get_rope_index()` which correctly recomputes them. This is complementary to the `_position_ids = None` reset introduced in commit `b97bc63` for the text-only path — while that reset handles the most common case, this shape check provides defense-in-depth protection regardless of whether the reset fires, covering edge cases like multimodal requests or batches with mixed lengths.

## Problem 2: gdn_sink incompatibility with MoE models

The current main branch passes a `gdn_sink` argument to decoder layers in `Qwen3_5Model.__call__()` (line 430). This parameter was introduced in commit `3947dd0` (Add DFlash speculative decoding) to capture intermediate Gated DeltaNet states for speculative decoding rollback.

`Qwen3_5DecoderLayer` was updated to accept and propagate `gdn_sink`:

```python
class Qwen3_5DecoderLayer(nn.Module):
    def __call__(self, x, mask=None, cache=None, position_ids=None, gdn_sink=None):
        if self.is_linear:
            r = self.linear_attn(self.input_layernorm(x), mask, cache, gdn_sink=gdn_sink)
```

However, `Qwen3_5MoeDecoderLayer` was **not** updated, causing:

```
TypeError: Qwen3_5MoeDecoderLayer.__call__() got an unexpected keyword argument 'gdn_sink'
```

This is **blocking**: all `qwen3_5_moe`-based models (including Qwen3.6-35B-A3B and any Qwen3.5 MoE model) are completely non-functional on the current main branch. The crash occurs on the very first request.

The `qwen3_5_moe` module imports `Qwen3_5GatedDeltaNet` directly from `qwen3_5.language` (as `Qwen3_5MoeGatedDeltaNet`), so the linear attention layer already supports `gdn_sink` internally — only the decoder layer propagation is missing.

**Fix**: Add `gdn_sink` to `Qwen3_5MoeDecoderLayer.__call__()` and propagate to the linear attention layer:

```diff
     def __call__(
         self,
         x: mx.array,
         mask: Optional[mx.array] = None,
         cache: Optional[Any] = None,
         position_ids: Optional[mx.array] = None,
+        gdn_sink: Optional[list] = None,
     ) -> mx.array:
         if self.is_linear:
-            r = self.linear_attn(self.input_layernorm(x), mask, cache)
+            r = self.linear_attn(self.input_layernorm(x), mask, cache, gdn_sink=gdn_sink)
```

The full-attention path (`self.self_attn`) does not need `gdn_sink` since the Gated DeltaNet mechanism only operates in linear (non-full-attention) layers, consistent with the non-MoE decoder implementation.

## Testing

Verified on `unsloth/Qwen3.6-35B-A3B-UD-MLX-4bit` (4-bit MLX quantization, Apple Silicon Mac with ~32GB unified memory):

**v0.4.4 with position IDs fix**:
- Single user-only request: OK
- Multi-message (system + user): OK (was crashing)
- Sequential requests with varying lengths: OK
- Short (2 tokens) followed by long (60+ tokens): OK

**Main branch with gdn_sink fix**:
- Single user-only request: OK (was crashing with TypeError)
- Multi-message (system + user): OK
- Rapid sequence of 5 requests with alternating lengths: OK
- The `_position_ids = None` reset from commit `b97bc63` correctly handles stale position state for text-only requests

Without the `gdn_sink` fix, installing from main branch crashes on the first request with `TypeError`. With the fix applied, all `qwen3_5_moe`-based models are fully functional.

## Files changed

- `mlx_vlm/models/qwen3_5/language.py` — Add `shape[-1] == seq_length` check (1 line)
- `mlx_vlm/models/qwen3_5_moe/language.py` — Add `gdn_sink` parameter and propagation (2 lines)