### PR TITLE
Add Gemma 4 video support (multi-video capable)

### DIFF
--- a/mlx_vlm/generate.py
+++ b/mlx_vlm/generate.py
@@ -30,6 +30,7 @@ from .utils import (
 DEFAULT_MODEL_PATH = "mlx-community/nanoLLaVA-1.5-8bit"
 DEFAULT_IMAGE = None
 DEFAULT_AUDIO = None
+DEFAULT_VIDEO = None
 DEFAULT_PROMPT = "What are these?"
 DEFAULT_MAX_TOKENS = 2048
 DEFAULT_TEMPERATURE = 0.0
@@ -77,6 +78,19 @@ def parse_arguments():
         nargs="+",
         default=DEFAULT_AUDIO,
         help="URL or path of the audio to process.",
+    )
+    parser.add_argument(
+        "--video",
+        type=str,
+        nargs="+",
+        default=DEFAULT_VIDEO,
+        help="URL or path of the video to process.",
+    )
+    parser.add_argument(
+        "--fps",
+        type=float,
+        default=2.0,
+        help="Frames-per-second to sample from --video.",
     )
     parser.add_argument(
         "--resize-shape",
@@ -2373,6 +2387,12 @@ def main():
     )  # TODO: Support multiple audio files
 
     chat_template_kwargs = {"enable_thinking": args.enable_thinking}
+    if args.video:
+        # The MessageFormatter video path expects a single video path in
+        # `video=`; pass the first (and for now only) value.
+        video_arg = args.video[0] if isinstance(args.video, list) else args.video
+        chat_template_kwargs["video"] = video_arg
+        chat_template_kwargs["fps"] = args.fps
 
     prompt = apply_chat_template(
         processor,
@@ -2453,6 +2473,8 @@ def main():
         gen_kwargs = {
             "image": args.image,
             "audio": args.audio,
+            "video": args.video,
+            "fps": args.fps,
             "temperature": args.temperature,
             "max_tokens": args.max_tokens,
             "verbose": args.verbose,

--- a/mlx_vlm/generate.py
+++ b/mlx_vlm/generate.py
@@ -2388,10 +2388,7 @@ def main():
 
     chat_template_kwargs = {"enable_thinking": args.enable_thinking}
     if args.video:
-        # The MessageFormatter video path expects a single video path in
-        # `video=`; pass the first (and for now only) value.
-        video_arg = args.video[0] if isinstance(args.video, list) else args.video
-        chat_template_kwargs["video"] = video_arg
+        chat_template_kwargs["video"] = args.video
         chat_template_kwargs["fps"] = args.fps
 
     prompt = apply_chat_template(

--- a/mlx_vlm/generate.py
+++ b/mlx_vlm/generate.py
@@ -926,6 +926,7 @@ def stream_generate(
     prompt: str,
     image: Union[str, List[str]] = None,
     audio: Union[str, List[str]] = None,
+    video: Union[str, List[str]] = None,
     **kwargs,
 ) -> Union[str, Generator[str, None, None]]:
     """
@@ -984,6 +985,7 @@ def stream_generate(
             processor,
             images=image,
             audio=audio,
+            videos=video,
             prompts=prompt,
             image_token_index=image_token_index,
             resize_shape=resize_shape,
@@ -1141,6 +1143,7 @@ def generate(
     prompt: str,
     image: Union[str, List[str]] = None,
     audio: Union[str, List[str]] = None,
+    video: Union[str, List[str]] = None,
     verbose: bool = False,
     **kwargs,
 ) -> GenerationResult:
@@ -1168,8 +1171,8 @@ def generate(
             files.extend(image)
         if audio is not None:
             files.extend(audio)
-        if kwargs.get("video") is not None:
-            files.extend(kwargs.get("video"))
+        if video is not None:
+            files.extend(video if isinstance(video, list) else [video])
 
         print(f"Files: {files}", "\n")
 
@@ -1201,7 +1204,9 @@ def generate(
     else:
         tokenizer.stopping_criteria.reset(model.config.eos_token_id)
 
-    for response in stream_generate(model, processor, prompt, image, audio, **kwargs):
+    for response in stream_generate(
+        model, processor, prompt, image, audio, video, **kwargs
+    ):
         if verbose:
             print(response.text, end="", flush=True)
         text += response.text

--- a/mlx_vlm/models/gemma4/config.py
+++ b/mlx_vlm/models/gemma4/config.py
@@ -129,6 +129,7 @@ class ModelConfig(BaseModelConfig):
     ignore_index: int = -100
     image_token_id: int = 258880
     audio_token_id: int = 258881
+    video_token_id: Optional[int] = None
     boi_token_id: int = 255999
     eoi_token_id: int = 258882
     boa_token_id: int = 256000
@@ -136,6 +137,7 @@ class ModelConfig(BaseModelConfig):
     hidden_size: int = 1536
     pad_token_id: int = 0
     vision_soft_tokens_per_image: int = 280
+    vision_soft_tokens_per_video_frame: int = 70
     audio_soft_tokens_per_image: int = 750
     audio_ms_per_token: int = 40
     eos_token_id: Optional[List[int]] = None

--- a/mlx_vlm/models/gemma4/gemma4.py
+++ b/mlx_vlm/models/gemma4/gemma4.py
@@ -71,6 +71,7 @@ class Model(nn.Module):
         self,
         input_ids: Optional[mx.array] = None,
         pixel_values: Optional[mx.array] = None,
+        pixel_values_videos: Optional[mx.array] = None,
         audio_features: Optional[mx.array] = None,
         audio_mask: Optional[mx.array] = None,
         input_features: Optional[mx.array] = None,
@@ -84,11 +85,16 @@ class Model(nn.Module):
         inputs_embeds = self.language_model.model.embed_tokens(input_ids)
         inputs_embeds = inputs_embeds * self.language_model.model.embed_scale
 
+        video_token_id = getattr(self.config, "video_token_id", None)
+
         per_layer_inputs = None
         if self.language_model.model.hidden_size_per_layer_input:
             image_mask_ids = input_ids == self.config.image_token_id
             audio_mask_ids = input_ids == self.config.audio_token_id
-            text_mask = ~(image_mask_ids | audio_mask_ids)
+            mm_mask = image_mask_ids | audio_mask_ids
+            if video_token_id is not None:
+                mm_mask = mm_mask | (input_ids == video_token_id)
+            text_mask = ~mm_mask
             per_layer_inputs_tokens = mx.where(
                 text_mask, input_ids, mx.zeros_like(input_ids)
             )
@@ -96,51 +102,59 @@ class Model(nn.Module):
                 per_layer_inputs_tokens
             )
 
-        if pixel_values is not None:
-            vision_cache = kwargs.get("vision_cache", None)
-            cached = kwargs.get("cached_image_features", None)
+        def _scatter(source, token_id, encode, cached_kw=None, key_kw=None):
+            if source is None or token_id is None:
+                return inputs_embeds
+            vision_cache = kwargs.get("vision_cache", None) if key_kw else None
+            cache_key = kwargs.get(key_kw) if key_kw else None
+            cached = kwargs.get(cached_kw, None) if cached_kw else None
             if cached is None and vision_cache is not None:
-                cached = vision_cache.get(kwargs.get("_image_key"))
+                cached = vision_cache.get(cache_key)
             if cached is not None:
-                image_features = cached.astype(inputs_embeds.dtype)
+                features = cached.astype(inputs_embeds.dtype)
             else:
-                image_features = self.vision_tower(pixel_values)
-                image_features = self.embed_vision(image_features)
-                image_features = image_features.astype(inputs_embeds.dtype)
-                if vision_cache is not None and kwargs.get("_image_key") is not None:
-                    mx.eval(image_features)
-                    vision_cache.put(kwargs["_image_key"], image_features)
+                features = encode(source).astype(inputs_embeds.dtype)
+                if vision_cache is not None and cache_key is not None:
+                    mx.eval(features)
+                    vision_cache.put(cache_key, features)
 
-            image_mask = input_ids == self.config.image_token_id
-            image_mask_expanded = mx.expand_dims(image_mask, -1)
-            image_mask_expanded = mx.broadcast_to(
-                image_mask_expanded, inputs_embeds.shape
+            mask_expanded = mx.broadcast_to(
+                mx.expand_dims(input_ids == token_id, -1), inputs_embeds.shape
             )
+            return masked_scatter(inputs_embeds, mask_expanded, features)
 
-            inputs_embeds = masked_scatter(
-                inputs_embeds, image_mask_expanded, image_features
-            )
+        def _encode_vision(pixels):
+            return self.embed_vision(self.vision_tower(pixels))
 
-        # Scatter audio features
-        if (
-            audio_features is not None
-            and self.audio_tower is not None
-            and self.embed_audio is not None
-        ):
-            if audio_mask is None:
-                audio_mask = mx.zeros(audio_features.shape[:2], dtype=mx.bool_)
-            audio_encodings, _ = self.audio_tower(audio_features, audio_mask)
-            audio_encodings = self.embed_audio(audio_encodings)
-            audio_encodings = audio_encodings.astype(inputs_embeds.dtype)
+        inputs_embeds = _scatter(
+            pixel_values,
+            self.config.image_token_id,
+            _encode_vision,
+            "cached_image_features",
+            "_image_key",
+        )
+        inputs_embeds = _scatter(
+            pixel_values_videos,
+            video_token_id,
+            _encode_vision,
+            "cached_video_features",
+            "_video_key",
+        )
 
-            audio_token_mask = input_ids == self.config.audio_token_id
-            audio_mask_expanded = mx.expand_dims(audio_token_mask, -1)
-            audio_mask_expanded = mx.broadcast_to(
-                audio_mask_expanded, inputs_embeds.shape
-            )
+        if self.audio_tower is not None and self.embed_audio is not None:
+            def _encode_audio(feat):
+                mask = (
+                    audio_mask
+                    if audio_mask is not None
+                    else mx.zeros(feat.shape[:2], dtype=mx.bool_)
+                )
+                enc, _ = self.audio_tower(feat, mask)
+                return self.embed_audio(enc)
 
-            inputs_embeds = masked_scatter(
-                inputs_embeds, audio_mask_expanded, audio_encodings
+            inputs_embeds = _scatter(
+                audio_features,
+                self.config.audio_token_id,
+                _encode_audio,
             )
 
         return InputEmbeddingsFeatures(

--- a/mlx_vlm/models/gemma4/gemma4.py
+++ b/mlx_vlm/models/gemma4/gemma4.py
@@ -142,6 +142,7 @@ class Model(nn.Module):
         )
 
         if self.audio_tower is not None and self.embed_audio is not None:
+
             def _encode_audio(feat):
                 mask = (
                     audio_mask

--- a/mlx_vlm/models/gemma4/processing_gemma4.py
+++ b/mlx_vlm/models/gemma4/processing_gemma4.py
@@ -259,9 +259,7 @@ class Gemma4VideoProcessor:
         idx = np.linspace(0, T - 1, num=num_frames).round().astype(np.int64)
         return video[idx]
 
-    def _resize_frames(
-        self, video: np.ndarray, max_patches: int
-    ) -> np.ndarray:
+    def _resize_frames(self, video: np.ndarray, max_patches: int) -> np.ndarray:
         from PIL import Image
 
         T, C, H, W = video.shape
@@ -544,9 +542,7 @@ class Gemma4Processor(ProcessorMixin):
                 replacements_iter = iter(replacements)
                 video_pattern = re.escape(self.video_token)
                 text = [
-                    re.sub(
-                        video_pattern, lambda _: next(replacements_iter), prompt
-                    )
+                    re.sub(video_pattern, lambda _: next(replacements_iter), prompt)
                     for prompt in text
                 ]
 
@@ -630,9 +626,7 @@ class Gemma4Processor(ProcessorMixin):
             )
 
         # Merge all inputs and convert to MLX arrays
-        merged = to_mlx(
-            {**text_inputs, **image_inputs, **audio_inputs, **video_inputs}
-        )
+        merged = to_mlx({**text_inputs, **image_inputs, **audio_inputs, **video_inputs})
         merged.update(video_meta)
         return BatchFeature(data=merged)
 

--- a/mlx_vlm/models/gemma4/processing_gemma4.py
+++ b/mlx_vlm/models/gemma4/processing_gemma4.py
@@ -210,8 +210,166 @@ class Gemma4ImageProcessor(HFBaseImageProcessor):
         return self.preprocess(images, **kwargs)
 
 
+class Gemma4VideoProcessor:
+    """Video processor for Gemma 4.
+
+    Samples frames, applies the same aspect-ratio preserving resize as images
+    (with a smaller per-frame token budget), rescales to [0, 1], and returns
+    channel-first pixel tensors stacked across frames. The existing
+    ``vision_tower`` internally patchifies each frame, so we output regular
+    (N_frames, C, H, W) tensors rather than pre-patched ones.
+    """
+
+    model_input_names = ["pixel_values_videos"]
+
+    def __init__(
+        self,
+        patch_size: int = 16,
+        max_soft_tokens: int = 70,
+        pooling_kernel_size: int = 3,
+        num_frames: int = 32,
+        do_rescale: bool = True,
+        rescale_factor: float = 1 / 255,
+        do_normalize: bool = False,
+        image_mean: Optional[list] = None,
+        image_std: Optional[list] = None,
+        default_fps: float = 2.0,
+    ):
+        if max_soft_tokens not in _SUPPORTED_SOFT_TOKENS:
+            raise ValueError(
+                f"`max_soft_tokens` must be one of {_SUPPORTED_SOFT_TOKENS}, "
+                f"got {max_soft_tokens}."
+            )
+        self.patch_size = patch_size
+        self.max_soft_tokens = max_soft_tokens
+        self.pooling_kernel_size = pooling_kernel_size
+        self.num_frames = num_frames
+        self.do_rescale = do_rescale
+        self.rescale_factor = rescale_factor
+        self.do_normalize = do_normalize
+        self.image_mean = image_mean or [0.0, 0.0, 0.0]
+        self.image_std = image_std or [1.0, 1.0, 1.0]
+        self.default_fps = default_fps
+
+    def _sample_frames(self, video: np.ndarray, num_frames: int) -> np.ndarray:
+        """Uniformly sample ``num_frames`` frames from ``video`` (T, C, H, W)."""
+        T = video.shape[0]
+        if T <= num_frames:
+            return video
+        idx = np.linspace(0, T - 1, num=num_frames).round().astype(np.int64)
+        return video[idx]
+
+    def _resize_frames(
+        self, video: np.ndarray, max_patches: int
+    ) -> np.ndarray:
+        from PIL import Image
+
+        T, C, H, W = video.shape
+        target_px = max_patches * (self.patch_size**2)
+        factor = math.sqrt(target_px / (H * W))
+        side_mult = self.pooling_kernel_size * self.patch_size
+        target_h = int(math.floor(factor * H / side_mult)) * side_mult
+        target_w = int(math.floor(factor * W / side_mult)) * side_mult
+        max_side = (max_patches // self.pooling_kernel_size**2) * side_mult
+        if target_h == 0:
+            target_h = side_mult
+            target_w = min(int(math.floor(W / H)) * side_mult, max_side)
+        if target_w == 0:
+            target_w = side_mult
+            target_h = min(int(math.floor(H / W)) * side_mult, max_side)
+
+        if target_h == H and target_w == W:
+            return video
+
+        resized = np.empty((T, C, target_h, target_w), dtype=video.dtype)
+        for i, frame in enumerate(video):
+            arr = np.transpose(frame, (1, 2, 0))
+            if arr.dtype in (np.float32, np.float64):
+                arr = (arr * 255).clip(0, 255).astype(np.uint8)
+            pil = Image.fromarray(arr)
+            pil = pil.resize((target_w, target_h), resample=Image.BICUBIC)
+            resized[i] = np.transpose(np.array(pil), (2, 0, 1))
+        return resized
+
+    def __call__(self, videos, fps=None):
+        """Process a list of videos.
+
+        Args:
+            videos: list of numpy arrays, each shape (T, C, H, W) uint8 or float.
+            fps: optional list of sampling fps per video used to compute
+                per-frame timestamps. If None, uses ``default_fps`` for all.
+
+        Returns:
+            dict with:
+              - pixel_values_videos: np.ndarray (N_total_frames, C, H, W)
+                where all frames share the same H/W (one video at a time
+                preserves sizes; cross-video sizes may differ so we return a
+                list in that case)
+              - num_frames_per_video: list[int]
+              - num_soft_tokens_per_frame: list[int] (one per video)
+              - frame_timestamps: list[list[float]] seconds per frame
+        """
+        if not isinstance(videos, list):
+            videos = [videos]
+
+        max_patches = self.max_soft_tokens * self.pooling_kernel_size**2
+
+        if fps is None:
+            fps = [self.default_fps] * len(videos)
+        elif not isinstance(fps, list):
+            fps = [fps] * len(videos)
+
+        processed = []
+        num_frames_per_video = []
+        num_soft_tokens_per_frame = []
+        frame_timestamps = []
+
+        for i, video in enumerate(videos):
+            if not isinstance(video, np.ndarray):
+                video = np.asarray(video)
+            if video.ndim != 4:
+                raise ValueError(
+                    f"Expected video as (T, C, H, W), got shape {video.shape}."
+                )
+
+            video = self._sample_frames(video, self.num_frames)
+            video = self._resize_frames(video, max_patches)
+
+            video_f = video.astype(np.float32)
+            if self.do_rescale and video.dtype == np.uint8:
+                video_f = video_f * self.rescale_factor
+
+            if self.do_normalize:
+                mean = np.array(self.image_mean, dtype=np.float32)[:, None, None]
+                std = np.array(self.image_std, dtype=np.float32)[:, None, None]
+                video_f = (video_f - mean) / std
+
+            T, _, H, W = video_f.shape
+            num_patches = (H // self.patch_size) * (W // self.patch_size)
+            tokens_per_frame = num_patches // (self.pooling_kernel_size**2)
+
+            processed.append(video_f)
+            num_frames_per_video.append(T)
+            num_soft_tokens_per_frame.append(int(tokens_per_frame))
+            sr = fps[i] if fps[i] and fps[i] > 0 else self.default_fps
+            frame_timestamps.append([float(j) / float(sr) for j in range(T)])
+
+        shapes = {v.shape[1:] for v in processed}
+        if len(shapes) == 1:
+            pixel_values_videos = np.concatenate(processed, axis=0)
+        else:
+            pixel_values_videos = processed
+
+        return {
+            "pixel_values_videos": pixel_values_videos,
+            "num_frames_per_video": num_frames_per_video,
+            "num_soft_tokens_per_frame": num_soft_tokens_per_frame,
+            "frame_timestamps": frame_timestamps,
+        }
+
+
 class Gemma4Processor(ProcessorMixin):
-    """Combined processor for Gemma 4 (image + text + audio)."""
+    """Combined processor for Gemma 4 (image + text + audio + video)."""
 
     attributes = ["image_processor", "tokenizer"]
     image_processor_class = "Gemma4ImageProcessor"
@@ -228,9 +386,12 @@ class Gemma4Processor(ProcessorMixin):
         **kwargs,
     ):
         feature_extractor = kwargs.pop("feature_extractor", None)
+        video_processor = kwargs.pop("video_processor", None)
 
         if image_processor is None:
             image_processor = Gemma4ImageProcessor()
+        if video_processor is None:
+            video_processor = Gemma4VideoProcessor()
 
         self.image_seq_length = image_seq_length
         self.audio_seq_length = audio_seq_length
@@ -247,6 +408,18 @@ class Gemma4Processor(ProcessorMixin):
         self.audio_token = getattr(tokenizer, "audio_token", "")
         self.boa_token = getattr(tokenizer, "boa_token", "")
         self.eoa_token = getattr(tokenizer, "eoa_token", "")
+
+        self.video_token = getattr(tokenizer, "video_token", "<|video|>")
+        if tokenizer is not None:
+            existing = tokenizer.convert_tokens_to_ids(self.video_token)
+            unk_id = getattr(tokenizer, "unk_token_id", None)
+            if existing is None or existing == unk_id:
+                tokenizer.add_special_tokens(
+                    {"additional_special_tokens": [self.video_token]}
+                )
+            self.video_token_id = tokenizer.convert_tokens_to_ids(self.video_token)
+        else:
+            self.video_token_id = None
 
         # Precompute fallback full sequences
         image_tokens_expanded = self.image_token * image_seq_length
@@ -270,6 +443,7 @@ class Gemma4Processor(ProcessorMixin):
         )
 
         self.feature_extractor = feature_extractor
+        self.video_processor = video_processor
 
     def _compute_audio_num_tokens(self, audio_waveform, sampling_rate: int) -> int:
         """Compute number of audio soft tokens from waveform duration.
@@ -293,10 +467,16 @@ class Gemma4Processor(ProcessorMixin):
             ]
         ] = None,
         audio: Optional[List] = None,
+        videos: Optional[List] = None,
+        fps: Optional[Union[float, List[float]]] = None,
         **kwargs,
     ) -> BatchFeature:
-        if text is None and images is None and audio is None:
-            raise ValueError("Provide at least one of `text`, `images`, or `audio`.")
+        if text is None and images is None and audio is None and videos is None:
+            raise ValueError(
+                "Provide at least one of `text`, `images`, `audio`, or `videos`."
+            )
+
+        fps_kwarg = fps
 
         # Pop return_tensors - we handle conversion ourselves via to_mlx()
         kwargs.pop("return_tensors", None)
@@ -335,6 +515,44 @@ class Gemma4Processor(ProcessorMixin):
                     prompt.replace(self.image_token, self.full_image_sequence)
                     for prompt in text
                 ]
+
+        video_inputs = {}
+        if videos is not None:
+            video_data = self.video_processor(videos, fps=fps_kwarg)
+            num_tokens_per_frame = video_data["num_soft_tokens_per_frame"]
+            num_frames_per_video = video_data["num_frames_per_video"]
+            frame_timestamps = video_data["frame_timestamps"]
+
+            if text is not None:
+                # Expand each <|video|> placeholder into a per-frame sequence:
+                #   "<mm:ss> {boi}{video_token * n}{eoi}"  repeated per frame,
+                # joined with a space, matching HF Gemma 4 processor behavior.
+                replacements = []
+                for n_tokens, timestamps in zip(num_tokens_per_frame, frame_timestamps):
+                    frames = []
+                    for secs in timestamps:
+                        mm = int(secs // 60)
+                        ss = int(secs % 60)
+                        ts = f"{mm:02d}:{ss:02d}"
+                        frames.append(
+                            f"{ts} {self.boi_token}"
+                            f"{self.video_token * n_tokens}"
+                            f"{self.eoi_token}"
+                        )
+                    replacements.append(" ".join(frames))
+
+                replacements_iter = iter(replacements)
+                video_pattern = re.escape(self.video_token)
+                text = [
+                    re.sub(
+                        video_pattern, lambda _: next(replacements_iter), prompt
+                    )
+                    for prompt in text
+                ]
+
+            pvv = video_data["pixel_values_videos"]
+            video_inputs["pixel_values_videos"] = pvv
+            video_inputs["num_frames_per_video"] = num_frames_per_video
 
         # ── Process audio ───────────────────────────────────────────────
         audio_inputs = {}
@@ -400,12 +618,23 @@ class Gemma4Processor(ProcessorMixin):
                 mm_token_type_ids[array_ids == self.image_token_id] = 1
             if self.audio_token_id is not None:
                 mm_token_type_ids[array_ids == self.audio_token_id] = 2
+            if self.video_token_id is not None:
+                mm_token_type_ids[array_ids == self.video_token_id] = 3
             text_inputs["token_type_ids"] = mm_token_type_ids.tolist()
 
+        # num_frames_per_video is Python-side metadata; keep it out of to_mlx
+        video_meta = {}
+        if "num_frames_per_video" in video_inputs:
+            video_meta["num_frames_per_video"] = video_inputs.pop(
+                "num_frames_per_video"
+            )
+
         # Merge all inputs and convert to MLX arrays
-        return BatchFeature(
-            data=to_mlx({**text_inputs, **image_inputs, **audio_inputs})
+        merged = to_mlx(
+            {**text_inputs, **image_inputs, **audio_inputs, **video_inputs}
         )
+        merged.update(video_meta)
+        return BatchFeature(data=merged)
 
     def save_pretrained(self, save_directory, **kwargs):
         import json

--- a/mlx_vlm/prompt_utils.py
+++ b/mlx_vlm/prompt_utils.py
@@ -224,8 +224,9 @@ class MessageFormatter:
             "qwen3_5",
             "qwen3_5_moe",
             "qwen3_omni_moe",
+            "gemma4",
         ] and kwargs.get("video"):
-            return self._format_video_message(prompt, kwargs)
+            return self._format_video_message(prompt, role, **kwargs)
 
         # Route to appropriate formatter
         formatter_map = {

--- a/mlx_vlm/prompt_utils.py
+++ b/mlx_vlm/prompt_utils.py
@@ -412,18 +412,31 @@ class MessageFormatter:
         num_audios: int = 0,
         **kwargs,
     ) -> Dict[str, Any]:
-        """Format a video message with text."""
-        return {
-            "role": role,
-            "content": [
-                MessageBuilder.video_message(
-                    kwargs["video"],
-                    kwargs.get("max_pixels", 224 * 224),
-                    kwargs.get("fps", 1),
-                ),
-                MessageBuilder.text_message(prompt),
-            ],
-        }
+        """Format a video message with text.
+
+        Accepts either a single path in ``video=`` or a list of paths; emits
+        one ``{"type": "video", ...}`` content item per video, followed by the
+        text. ``fps`` may be a scalar (applied to all) or a list of the same
+        length as the videos.
+        """
+        videos = kwargs["video"]
+        if not isinstance(videos, list):
+            videos = [videos]
+
+        max_pixels = kwargs.get("max_pixels", 224 * 224)
+        fps = kwargs.get("fps", 1)
+        fps_list = fps if isinstance(fps, list) else [fps] * len(videos)
+        if len(fps_list) != len(videos):
+            raise ValueError(
+                f"Got {len(fps_list)} fps values for {len(videos)} videos."
+            )
+
+        content = [
+            MessageBuilder.video_message(v, max_pixels, f)
+            for v, f in zip(videos, fps_list)
+        ]
+        content.append(MessageBuilder.text_message(prompt))
+        return {"role": role, "content": content}
 
 
 def get_message_json(

--- a/mlx_vlm/tests/test_generate.py
+++ b/mlx_vlm/tests/test_generate.py
@@ -1042,6 +1042,8 @@ def test_generate_cli_smoke(capsys):
         adapter_path=None,
         image=["image.png"],
         audio=None,
+        video=None,
+        fps=2.0,
         resize_shape=[224],
         prompt=["Describe this image."],
         system=None,

--- a/mlx_vlm/utils.py
+++ b/mlx_vlm/utils.py
@@ -1381,27 +1381,21 @@ def prepare_inputs(
             )
             audio = [load_audio(audio_file, sr=sr) for audio_file in audio]
 
-    # Process videos: if paths are given, load into (T, C, H, W) numpy arrays
-    # using the existing cv2-based loader from video_generate.
     video_fps = None
     if has_videos:
         if not isinstance(videos, list):
             videos = [videos]
-        needs_load = any(isinstance(v, (str, bytes)) for v in videos)
-        if needs_load:
-            loaded = []
-            sample_fps = []
-            fps_hint = kwargs.pop("fps", 2.0)
-            for v in videos:
-                if isinstance(v, (str, bytes)):
-                    arr, s_fps = load_video(str(v), fps=fps_hint)
-                    loaded.append(arr)
-                    sample_fps.append(s_fps)
-                else:
-                    loaded.append(v)
-                    sample_fps.append(fps_hint)
-            videos = loaded
-            video_fps = sample_fps
+        fps_hint = kwargs.pop("fps", 2.0)
+        loaded, video_fps = [], []
+        for v in videos:
+            arr, s_fps = (
+                load_video(str(v), fps=fps_hint)
+                if isinstance(v, (str, bytes))
+                else (v, fps_hint)
+            )
+            loaded.append(arr)
+            video_fps.append(s_fps)
+        videos = loaded
 
     model_inputs = {}
 

--- a/mlx_vlm/utils.py
+++ b/mlx_vlm/utils.py
@@ -1148,6 +1148,7 @@ def prepare_inputs(
     processor,
     images=None,
     audio=None,
+    videos=None,
     prompts=None,
     image_token_index=None,
     resize_shape=None,
@@ -1163,7 +1164,10 @@ def prepare_inputs(
         not hasattr(images, "__len__") or len(images) > 0
     )
     has_audio = audio is not None and (not hasattr(audio, "__len__") or len(audio) > 0)
-    if not has_images and not has_audio:
+    has_videos = videos is not None and (
+        not hasattr(videos, "__len__") or len(videos) > 0
+    )
+    if not has_images and not has_audio and not has_videos:
         tokenizer = (
             processor.tokenizer if hasattr(processor, "tokenizer") else processor
         )
@@ -1311,6 +1315,30 @@ def prepare_inputs(
             )
             audio = [load_audio(audio_file, sr=sr) for audio_file in audio]
 
+    # Process videos: if paths are given, load into (T, C, H, W) numpy arrays
+    # using the existing cv2-based loader from video_generate.
+    video_fps = None
+    if has_videos:
+        if not isinstance(videos, list):
+            videos = [videos]
+        needs_load = any(isinstance(v, (str, bytes)) for v in videos)
+        if needs_load:
+            from .video_generate import load_video
+
+            loaded = []
+            sample_fps = []
+            fps_hint = kwargs.pop("fps", 2.0)
+            for v in videos:
+                if isinstance(v, (str, bytes)):
+                    arr, s_fps = load_video({"video": str(v), "fps": fps_hint})
+                    loaded.append(arr)
+                    sample_fps.append(s_fps)
+                else:
+                    loaded.append(v)
+                    sample_fps.append(fps_hint)
+            videos = loaded
+            video_fps = sample_fps
+
     model_inputs = {}
 
     if hasattr(processor, "image_processor") and isinstance(
@@ -1349,12 +1377,18 @@ def prepare_inputs(
         if hasattr(processor, "tokenizer") and processor.tokenizer.pad_token is None:
             processor.tokenizer.pad_token = processor.tokenizer.eos_token
 
+        extra = {}
+        if has_videos:
+            extra["videos"] = videos
+            if video_fps is not None:
+                extra["fps"] = video_fps
         inputs = process_inputs_with_fallback(
             processor,
             images=images,
             audio=audio,
             prompts=prompts,
             add_special_tokens=add_special_tokens,
+            **extra,
             **kwargs,
         )
 

--- a/mlx_vlm/utils.py
+++ b/mlx_vlm/utils.py
@@ -3,6 +3,7 @@ import importlib
 import inspect
 import json
 import logging
+import math
 from io import BytesIO
 from pathlib import Path
 from textwrap import dedent
@@ -1073,6 +1074,71 @@ def normalize_audio_features(features: mx.array) -> mx.array:
     return (features - mx.mean(features)) / (mx.std(features) + 1e-6)
 
 
+def load_video(
+    video_path: str,
+    fps: float = 2.0,
+    nframes: Optional[int] = None,
+    min_frames: int = 4,
+    max_frames: int = 768,
+    frame_factor: int = 2,
+) -> Tuple[np.ndarray, float]:
+    """Read a video file as a (T, C, H, W) numpy array.
+
+    Uniformly samples ``nframes`` frames — either a fixed count or derived
+    from ``fps`` — and returns the sampled frames alongside the effective
+    sampling fps.
+    """
+    import cv2
+
+    if video_path.startswith("file://"):
+        video_path = video_path[7:]
+
+    cap = cv2.VideoCapture(video_path)
+    if not cap.isOpened():
+        raise ValueError(f"Cannot open video: {video_path}")
+    total_frames = int(cap.get(cv2.CAP_PROP_FRAME_COUNT))
+    video_fps = cap.get(cv2.CAP_PROP_FPS) or 1.0
+
+    def _round(n):
+        return round(n / frame_factor) * frame_factor
+
+    def _floor(n):
+        return math.floor(n / frame_factor) * frame_factor
+
+    def _ceil(n):
+        return math.ceil(n / frame_factor) * frame_factor
+
+    if nframes is not None:
+        n = _round(nframes)
+    else:
+        lo = _ceil(min_frames)
+        hi = _floor(min(max_frames, total_frames))
+        n = total_frames / video_fps * fps
+        n = min(max(n, lo), hi, total_frames)
+        n = _floor(n)
+    if not (frame_factor <= n <= total_frames):
+        cap.release()
+        raise ValueError(
+            f"nframes must be in [{frame_factor}, {total_frames}], got {n}."
+        )
+
+    indices = np.linspace(0, total_frames - 1, n).round().astype(int)
+    frames = []
+    for idx in indices:
+        cap.set(cv2.CAP_PROP_POS_FRAMES, idx)
+        ret, frame = cap.read()
+        if not ret:
+            break
+        frames.append(cv2.cvtColor(frame, cv2.COLOR_BGR2RGB))
+    cap.release()
+    if not frames:
+        raise ValueError("No frames read from the video.")
+
+    video_np = np.transpose(np.stack(frames, axis=0), (0, 3, 1, 2))
+    sample_fps = n / max(total_frames, 1e-6) * video_fps
+    return video_np, sample_fps
+
+
 def process_inputs(
     processor,
     prompts,
@@ -1323,14 +1389,12 @@ def prepare_inputs(
             videos = [videos]
         needs_load = any(isinstance(v, (str, bytes)) for v in videos)
         if needs_load:
-            from .video_generate import load_video
-
             loaded = []
             sample_fps = []
             fps_hint = kwargs.pop("fps", 2.0)
             for v in videos:
                 if isinstance(v, (str, bytes)):
-                    arr, s_fps = load_video({"video": str(v), "fps": fps_hint})
+                    arr, s_fps = load_video(str(v), fps=fps_hint)
                     loaded.append(arr)
                     sample_fps.append(s_fps)
                 else:


### PR DESCRIPTION
## Summary
- Adds native video support to Gemma 4 in `mlx-vlm` (matching the transformers token structure: per-frame patches wrapped as `{ts} <start_of_image>{video_token * n}<end_of_image>`).
- **Multi-video input supported**: pass multiple `--video` paths to the CLI and the processor emits one `<|video|>` block per file, each with its own timestamped frame expansion.
- New `Gemma4VideoProcessor` (frame sampling + AR-preserving resize) and `videos=` path in `Gemma4Processor.__call__` with timestamped `<|video|>` expansion.
- `get_input_embeddings` scatter path unified into a single `_scatter(source, token_id, encode, …)` helper covering image, video, and audio; video reuses the vision cache with a distinct `_video_key`.
- Video loader centralized — `load_video(video_path, fps=...)` now lives in `utils.py` (was in `video_generate.py`); `prepare_inputs` loads paths lazily.
- CLI: `--video` (accepts `nargs="+"`) and `--fps` flags in `mlx_vlm.generate`; `prompt_utils._format_video_message` now accepts a list of videos (scalar or per-video `fps`). Also fixes a pre-existing call-site bug in the same function.
- Config: `video_token_id` and `vision_soft_tokens_per_video_frame` added.

Fixes #1017.

## Validated
- Image / audio / image+text / audio+text outputs are **token-for-token identical** vs `main` on `google/gemma-4-E2B-it` (refactor is behavior-preserving).
- Image+audio cross-modal question answering works (audio asks *"what color are the animals in the image"* → model answers from image).
- Single-video generation runs end-to-end on `google/gemma-4-E2B-it` and `google/gemma-4-26b-a4b-it` via both the scripted `generate(...)` API and the CLI.
- **Multi-video** end-to-end on E2B-it: two clips (`car_video.mp4` + `fastmlx_local_ai_hub.mp4`) → model correctly contrasts *"parking lot with several cars"* vs *"a person working on a computer with lines of code"*.
- With matched 32-frame sampling, prompt token counts line up with HF transformers exactly (2415 tokens); generated output is semantically equivalent. ~6× faster throughput on the same hardware (49 tps vs ~8 tps).
- All existing Gemma 4 unit tests (`test_models.py::test_gemma4`, processor tests) still pass.

## Test plan
- [x] `pytest mlx_vlm/tests/test_models.py -k gemma4`
- [x] `pytest mlx_vlm/tests/test_processors.py -k Gemma`
- [x] `python -m mlx_vlm.generate --model google/gemma-4-E2B-it --video examples/videos/car_video.mp4 --fps 1 --prompt "Describe what happens in this video."`
- [x] Same on `google/gemma-4-26b-a4b-it`
- [x] Multi-video: `--video examples/videos/car_video.mp4 examples/videos/fastmlx_local_ai_hub.mp4 --prompt "Compare the two videos in one paragraph."`
- [x] Image/audio/joint scripted smoke tests