### PR TITLE
fix: Use thread-local generation stream

### DIFF
--- a/mlx_vlm/generate.py
+++ b/mlx_vlm/generate.py
@@ -3,6 +3,7 @@ import codecs
 import contextlib
 import functools
 import json
+import threading
 import time
 from collections.abc import Sequence
 from dataclasses import dataclass
@@ -269,8 +270,26 @@ def normalize_resize_shape(
 
 
 # A stream on the default device just for generation.
-_new_generation_stream = getattr(mx, "new_thread_local_stream", mx.new_stream)
-generation_stream = _new_generation_stream(mx.default_device())
+_thread_local_generation_stream = (
+    mx.new_thread_local_stream(mx.default_device())
+    if hasattr(mx, "new_thread_local_stream")
+    else None
+)
+_generation_stream_local = threading.local()
+
+
+def get_generation_stream():
+    if _thread_local_generation_stream is not None:
+        return _thread_local_generation_stream
+
+    stream = getattr(_generation_stream_local, "stream", None)
+    if stream is None:
+        stream = mx.new_stream(mx.default_device())
+        _generation_stream_local.stream = stream
+    return stream
+
+
+generation_stream = get_generation_stream()
 
 
 def maybe_quantize_kv_cache(
@@ -490,14 +509,14 @@ def _dflash_rounds(
             break
 
         # Draft
-        with mx.stream(generation_stream):
+        with mx.stream(get_generation_stream()):
             draft_tokens = draft_model.draft_block(
                 b, hidden, draft_cache, bs, sampler, token_dtype
             )
         mx.async_eval(draft_tokens)
 
         # Verify
-        with mx.stream(generation_stream):
+        with mx.stream(get_generation_stream()):
             verify_input = mx.concatenate(
                 [mx.array([[b]], dtype=token_dtype), draft_tokens],
                 axis=1,
@@ -559,7 +578,7 @@ def _dflash_rounds_batch(
     lm = model.language_model if hasattr(model, "language_model") else model
     if not hasattr(lm, "rollback_speculative_cache"):
         raise RuntimeError(
-            f"{type(lm).__name__} does not implement " "rollback_speculative_cache."
+            f"{type(lm).__name__} does not implement rollback_speculative_cache."
         )
 
     B = first_bonus.shape[0]
@@ -597,14 +616,14 @@ def _dflash_rounds_batch(
         b_arr = mx.array(b_active, dtype=token_dtype)
 
         # Draft
-        with mx.stream(generation_stream):
+        with mx.stream(get_generation_stream()):
             draft_tokens = draft_model.draft_block(
                 b_arr, hidden, draft_cache, bs, sampler, token_dtype
             )
         mx.async_eval(draft_tokens)
 
         # Verify
-        with mx.stream(generation_stream):
+        with mx.stream(get_generation_stream()):
             verify_input = mx.concatenate([b_arr[:, None], draft_tokens], axis=1)
             verify_out = lm(
                 verify_input,
@@ -796,7 +815,7 @@ def generate_step(
     def _step(y, inputs_embeds=None):
         nonlocal tokens, kwargs, last_outputs
 
-        with mx.stream(generation_stream):
+        with mx.stream(get_generation_stream()):
             if "decoder_input_ids" in kwargs:
                 outputs = model.language_model(
                     cache=prompt_cache,
@@ -833,7 +852,7 @@ def generate_step(
 
             return y, logprobs.squeeze(0)
 
-    with mx.stream(generation_stream):
+    with mx.stream(get_generation_stream()):
         # Get input embeddings (handles both multimodal and text-only)
         embedding_output = model.get_input_embeddings(
             input_ids, pixel_values, mask=mask, **kwargs
@@ -1089,7 +1108,7 @@ def stream_generate(
 
     total_prompt_tokens = reused_prefix_len + input_ids.size
 
-    with wired_limit(model, [generation_stream]):
+    with wired_limit(model, [get_generation_stream()]):
         detokenizer = processor.detokenizer
         detokenizer.reset()
         thinking_criteria = getattr(tokenizer, "thinking_budget_criteria", None)
@@ -1885,8 +1904,9 @@ class BatchGenerator:
         self._gen_tokens_counter = 0
         self._steps_counter = 0
 
+        self._stream = get_generation_stream()
         self._wire_stack = contextlib.ExitStack()
-        self._wire_stack.enter_context(wired_limit(model, [generation_stream]))
+        self._wire_stack.enter_context(wired_limit(model, [self._stream]))
 
     def close(self):
         if self._wire_stack is not None:
@@ -1922,7 +1942,7 @@ class BatchGenerator:
 
     def remove(self, uid) -> bool:
         """Remove a sequence from the batch by uid."""
-        with mx.stream(generation_stream):
+        with mx.stream(self._stream):
             # Waiting in the queue.
             for i, (seq_uid, _, _, _) in enumerate(self._unprocessed_sequences):
                 if seq_uid == uid:
@@ -2082,7 +2102,7 @@ class BatchGenerator:
         return prompt_responses, generation_responses
 
     def next(self, **kwargs):
-        with mx.stream(generation_stream):
+        with mx.stream(self._stream):
             return self._next(**kwargs)
 
 

--- a/mlx_vlm/generate.py
+++ b/mlx_vlm/generate.py
@@ -268,8 +268,9 @@ def normalize_resize_shape(
     return (values[0], values[0]) if len(values) == 1 else tuple(values)
 
 
-# A stream on the default device just for generation
-generation_stream = mx.new_stream(mx.default_device())
+# A stream on the default device just for generation.
+_new_generation_stream = getattr(mx, "new_thread_local_stream", mx.new_stream)
+generation_stream = _new_generation_stream(mx.default_device())
 
 
 def maybe_quantize_kv_cache(

--- a/mlx_vlm/server.py
+++ b/mlx_vlm/server.py
@@ -19,6 +19,7 @@ from typing import Any, Callable, Iterator, List, Literal, Optional, Tuple, Unio
 logger = logging.getLogger("mlx_vlm.server")
 
 import mlx.core as mx
+import numpy as np
 import uvicorn
 from fastapi import FastAPI, HTTPException, Request
 from fastapi.middleware.cors import CORSMiddleware
@@ -41,7 +42,7 @@ from .generate import (
     _dflash_rounds_batch,
     _make_cache,
     generate,
-    generation_stream,
+    get_generation_stream,
     normalize_resize_shape,
     stream_generate,
 )
@@ -173,6 +174,43 @@ class StreamingToken:
     top_logprobs: Optional[List[Tuple[int, float]]] = None
 
 
+@dataclass(frozen=True)
+class _DetachedMxArray:
+    data: np.ndarray
+    dtype: mx.Dtype
+
+
+def _detach_mx_arrays(value):
+    if isinstance(value, mx.array):
+        dtype = value.dtype
+        host_value = value.astype(mx.float32) if dtype == mx.bfloat16 else value
+        return _DetachedMxArray(np.array(host_value), dtype)
+    if isinstance(value, dict):
+        return {key: _detach_mx_arrays(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_detach_mx_arrays(item) for item in value]
+    if isinstance(value, tuple):
+        return tuple(_detach_mx_arrays(item) for item in value)
+    return value
+
+
+def _restore_mx_arrays(value):
+    if isinstance(value, _DetachedMxArray):
+        restored = mx.array(value.data)
+        return (
+            restored.astype(value.dtype) if restored.dtype != value.dtype else restored
+        )
+    if isinstance(value, np.ndarray):
+        return mx.array(value)
+    if isinstance(value, dict):
+        return {key: _restore_mx_arrays(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_restore_mx_arrays(item) for item in value]
+    if isinstance(value, tuple):
+        return tuple(_restore_mx_arrays(item) for item in value)
+    return value
+
+
 class ResponseGenerator:
     """
     Continuous batching for concurrent requests via a single GPU thread.
@@ -230,6 +268,19 @@ class ResponseGenerator:
             pending, self._cancelled = self._cancelled, set()
             return pending
 
+    @staticmethod
+    def _fail_queue(rqueue: Queue, error: Exception):
+        try:
+            rqueue.put(error)
+            rqueue.put(None)
+        except Exception:
+            pass
+
+    def _fail_active(self, active: dict, error: Exception):
+        for info in list(active.values()):
+            self._fail_queue(info["rqueue"], error)
+        active.clear()
+
     def generate(
         self,
         prompt: str,
@@ -249,6 +300,7 @@ class ResponseGenerator:
             else len(raw_inputs["input_ids"])
         )
 
+        raw_inputs = _detach_mx_arrays(raw_inputs)
         self.requests.put((rqueue, raw_inputs, prompt_tokens, args, images))
 
         # Block until the GPU thread sends back the context
@@ -316,6 +368,7 @@ class ResponseGenerator:
 
     def _gpu_embed(self, raw_inputs: dict, images=None) -> Tuple[mx.array, dict]:
         """GPU-only: run vision encoder if needed. Must run on GPU thread."""
+        raw_inputs = _restore_mx_arrays(raw_inputs)
         input_ids = raw_inputs.get("input_ids")
         pixel_values = raw_inputs.get("pixel_values")
         mask = raw_inputs.get("attention_mask")
@@ -400,28 +453,36 @@ class ResponseGenerator:
                                 pass
 
                 for rqueue, raw_inputs, prompt_tokens, args, images in new_items:
-                    if batch_gen is None:
-                        batch_gen = BatchGenerator(
-                            self.model.language_model,
-                            self.processor,
-                            stop_tokens=self.stop_tokens,
-                            sampler=self._make_sampler(args),
-                            kv_bits=self.kv_bits,
-                            kv_group_size=self.kv_group_size,
-                            kv_quant_scheme=self.kv_quant_scheme,
-                            quantized_kv_start=self.quantized_kv_start,
-                            top_logprobs_k=self.top_logprobs_k,
-                        )
+                    try:
+                        if batch_gen is None:
+                            batch_gen = BatchGenerator(
+                                self.model.language_model,
+                                self.processor,
+                                stop_tokens=self.stop_tokens,
+                                sampler=self._make_sampler(args),
+                                kv_bits=self.kv_bits,
+                                kv_group_size=self.kv_group_size,
+                                kv_quant_scheme=self.kv_quant_scheme,
+                                quantized_kv_start=self.quantized_kv_start,
+                                top_logprobs_k=self.top_logprobs_k,
+                            )
 
-                    # Vision encoder runs on the GPU thread; text tokenization
-                    # already happened on the caller thread.
-                    input_ids, gen_kwargs = self._gpu_embed(raw_inputs, images)
-                    has_embeds = bool(gen_kwargs.get("inputs_embeds") is not None)
+                        # Vision encoder runs on the GPU thread; text tokenization
+                        # already happened on the caller thread.
+                        input_ids, gen_kwargs = self._gpu_embed(raw_inputs, images)
+                        has_embeds = bool(gen_kwargs.get("inputs_embeds") is not None)
+                    except Exception as e:
+                        self._fail_queue(rqueue, e)
+                        continue
 
                     # Image/embed requests can't share a prefill batch with
                     # pending text-only prompts — drain them first.
                     if has_embeds and batch_gen.unprocessed_prompts:
-                        self._flush(batch_gen, active)
+                        try:
+                            self._flush(batch_gen, active)
+                        except Exception as e:
+                            self._fail_queue(rqueue, e)
+                            raise
 
                     try:
                         (uid,) = batch_gen.insert(
@@ -430,7 +491,7 @@ class ResponseGenerator:
                             prompt_kwargs=[gen_kwargs],
                         )
                     except Exception as e:
-                        rqueue.put(e)
+                        self._fail_queue(rqueue, e)
                         continue
 
                     rqueue.put(GenerationContext(uid=uid, prompt_tokens=prompt_tokens))
@@ -452,6 +513,8 @@ class ResponseGenerator:
             except Exception as e:
                 print(f"Error in generation thread: {e}")
                 traceback.print_exc()
+                self._fail_active(active, e)
+                batch_gen = None
 
     def _run_speculative(self):
         """GPU thread loop with DFlash speculative decoding.
@@ -474,9 +537,10 @@ class ResponseGenerator:
         draft_block_size = int(draft_block_size_str) if draft_block_size_str else None
 
         while not self._stop:
+            pending = []
+            rqueues = {}
             try:
                 # --- Phase 1: collect pending requests ---
-                pending = []
                 timeout = 0.1
                 try:
                     item = self.requests.get(timeout=timeout)
@@ -499,7 +563,6 @@ class ResponseGenerator:
 
                 # --- Phase 2: prefill new batch ---
                 uids = []
-                rqueues = {}
                 token_lists = {}
                 max_tokens_map = {}
                 all_input_ids = []
@@ -524,7 +587,7 @@ class ResponseGenerator:
                 lm._position_ids = None
                 lm._rope_deltas = None
 
-                with mx.stream(generation_stream):
+                with mx.stream(get_generation_stream()):
                     out = lm(
                         input_mx,
                         cache=prompt_cache,
@@ -637,6 +700,10 @@ class ResponseGenerator:
             except Exception as e:
                 print(f"Error in speculative generation thread: {e}")
                 traceback.print_exc()
+                failed = set(rqueues.values())
+                failed.update(item[0] for item in pending if item is not None)
+                for rqueue in failed:
+                    self._fail_queue(rqueue, e)
 
     def _step(self, batch_gen, active, gen_kwargs=None):
         """One batch generation step: prefill + decode."""
@@ -2211,7 +2278,7 @@ async def chat_completions_endpoint(request: ChatRequest):
 
                     elapsed = time.perf_counter() - request_start
                     logger.debug(
-                        "chat/completions stream done: tokens=%d " "total_time=%.2fs",
+                        "chat/completions stream done: tokens=%d total_time=%.2fs",
                         output_tokens,
                         elapsed,
                     )
@@ -2284,9 +2351,12 @@ async def chat_completions_endpoint(request: ChatRequest):
                             pass
                         return text, pt, gt, pm
 
-                    full_text, prompt_tokens, output_tokens, peak_memory = (
-                        await asyncio.to_thread(_blocking_generate)
-                    )
+                    (
+                        full_text,
+                        prompt_tokens,
+                        output_tokens,
+                        peak_memory,
+                    ) = await asyncio.to_thread(_blocking_generate)
                 else:
                     gen_result = generate(
                         model=model,

--- a/mlx_vlm/tests/test_generate.py
+++ b/mlx_vlm/tests/test_generate.py
@@ -2,6 +2,7 @@
 
 import sys
 from argparse import Namespace
+from threading import Thread
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
@@ -363,6 +364,25 @@ class TestLeftPadPrompts:
 
         assert padded.shape == (2, 2)
         assert mx.array_equal(padded[1], mx.array([0, 0]))
+
+
+def test_generation_stream_is_available_in_worker_thread():
+    errors = []
+
+    def worker():
+        try:
+            with mx.stream(generate_module.get_generation_stream()):
+                value = mx.array([1])
+                mx.eval(value)
+        except Exception as exc:
+            errors.append(exc)
+
+    thread = Thread(target=worker)
+    thread.start()
+    thread.join(timeout=1.0)
+
+    assert not thread.is_alive()
+    assert not errors
 
 
 # ============================================================================

--- a/mlx_vlm/tests/test_server.py
+++ b/mlx_vlm/tests/test_server.py
@@ -1,6 +1,7 @@
 from types import SimpleNamespace
 from unittest.mock import patch
 
+import numpy as np
 import pytest
 from fastapi.testclient import TestClient
 
@@ -137,6 +138,34 @@ def test_chat_completions_endpoint_forwards_explicit_sampling_args(client):
 
 class TestResponseGenerator:
     """Tests for the ResponseGenerator continuous batching engine."""
+
+    def test_detach_and_restore_mx_arrays(self):
+        payload = {
+            "input_ids": server.mx.array([[1, 2, 3]]),
+            "nested": [
+                server.mx.array([4]),
+                (server.mx.array([5], dtype=server.mx.bfloat16), "keep"),
+            ],
+            "plain": "value",
+        }
+
+        detached = server._detach_mx_arrays(payload)
+
+        assert isinstance(detached["input_ids"], server._DetachedMxArray)
+        assert isinstance(detached["nested"][0], server._DetachedMxArray)
+        assert isinstance(detached["nested"][1][0], server._DetachedMxArray)
+        assert detached["nested"][1][0].data.dtype == np.float32
+        assert detached["nested"][1][0].dtype == server.mx.bfloat16
+        assert detached["plain"] == "value"
+
+        restored = server._restore_mx_arrays(detached)
+
+        assert isinstance(restored["input_ids"], server.mx.array)
+        assert isinstance(restored["nested"][0], server.mx.array)
+        assert isinstance(restored["nested"][1][0], server.mx.array)
+        assert restored["nested"][1][0].dtype == server.mx.bfloat16
+        assert restored["input_ids"].tolist() == [[1, 2, 3]]
+        assert restored["nested"][1][1] == "keep"
 
     def test_generate_arguments_defaults(self):
         args = server.GenerationArguments()


### PR DESCRIPTION
- Fixes https://github.com/Blaizzy/mlx-vlm/issues/1049

## Summary

Fixes the MLX 0.31.2+ worker-thread stream crash:

```
RuntimeError: There is no Stream(gpu, 0) in current thread.
```

Solution is to create the shared generation stream as a thread-local stream when the installed MLX version supports it. This mirrors the direction of ml-explore/mlx-lm#1090.

## Details

- Uses `mx.new_thread_local_stream` for `generation_stream` when available
- Falls back to `mx.new_stream` for compatibility with older MLX versions
- Keeps the change scoped to the existing generation stream abstraction