### PR TITLE
fix(qwen3_5_moe): handle nested model.language_model.visual.* in sanitize

### DIFF
--- a/mlx_vlm/models/qwen3_5_moe/qwen3_5_moe.py
+++ b/mlx_vlm/models/qwen3_5_moe/qwen3_5_moe.py
@@ -46,7 +46,14 @@ class Model(Qwen3_5Model):
         sanitized_weights = {}
         for key, value in weights.items():
             if "model" in key:
-                if "model.language_model" in key:
+                # Qwen3.6-35B-A3B nests the ViT under
+                # `model.language_model.visual.*`. Handle that before the
+                # generic `model.language_model` rewrite so visual weights
+                # are routed to `vision_tower` rather than being buried at
+                # `language_model.model.visual.*`.
+                if "model.language_model.visual" in key:
+                    key = key.replace("model.language_model.visual", "vision_tower")
+                elif "model.language_model" in key:
                     key = key.replace("model.language_model", "language_model.model")
                 elif "model.visual" in key:
                     key = key.replace("model.visual", "vision_tower")

--- a/mlx_vlm/tests/test_qwen3_5_moe_sanitize.py
+++ b/mlx_vlm/tests/test_qwen3_5_moe_sanitize.py
@@ -1,0 +1,88 @@
+"""Regression test for Qwen3.6-35B-A3B nested visual layout.
+
+Qwen/Qwen3.6-35B-A3B and its derivatives ship the ViT nested under
+`model.language_model.visual.*` in the HF checkpoint rather than the
+flat `model.visual.*` layout used by other Qwen VLMs. Before the fix,
+the `elif` ordering in `Model.sanitize` mis-routed those keys through
+the generic `model.language_model -> language_model.model` rewrite, so
+visual weights ended up at `language_model.model.visual.*` and were
+orphaned on load (333 tensors silently dropped).
+"""
+
+import unittest
+from types import SimpleNamespace
+
+import mlx.core as mx
+
+from mlx_vlm.models.qwen3_5_moe.qwen3_5_moe import Model
+
+
+def _fake(shape=(2, 2)):
+    """Tiny mx.array stand-in for a weight value."""
+    return mx.zeros(shape)
+
+
+def _mock_model():
+    # Model.sanitize only reads self.config.text_config for
+    # tie_word_embeddings and num_hidden_layers; construct the minimum.
+    cfg = SimpleNamespace(
+        text_config=SimpleNamespace(
+            tie_word_embeddings=False,
+            num_hidden_layers=0,  # skip the MoE expert-split loop
+        )
+    )
+    return SimpleNamespace(config=cfg)
+
+
+class TestQwen35MoESanitize(unittest.TestCase):
+    def test_nested_visual_routes_to_vision_tower(self):
+        """Keys like model.language_model.visual.* must land at vision_tower.*"""
+        weights = {
+            "model.language_model.visual.blocks.0.attn.qkv.weight": _fake(),
+            "model.language_model.visual.patch_embed.proj.weight": _fake(),
+            "model.language_model.visual.pos_embed.weight": _fake(),
+            "model.language_model.visual.merger.linear_fc1.weight": _fake(),
+        }
+        out = Model.sanitize(_mock_model(), dict(weights))
+        self.assertIn("vision_tower.blocks.0.attn.qkv.weight", out)
+        self.assertIn("vision_tower.patch_embed.proj.weight", out)
+        self.assertIn("vision_tower.pos_embed.weight", out)
+        self.assertIn("vision_tower.merger.linear_fc1.weight", out)
+        self.assertFalse(
+            any(k.startswith("language_model.model.visual") for k in out),
+            "nested visual keys must not remain after sanitize",
+        )
+
+    def test_language_keys_unchanged(self):
+        """Language-only `model.language_model.*` keys must still route to
+        `language_model.model.*` (regression guard for the generic rule)."""
+        weights = {
+            "model.language_model.layers.0.self_attn.q_proj.weight": _fake(),
+            "model.language_model.embed_tokens.weight": _fake(),
+            # 1-D norm weight to exercise the norm_keys +1.0 branch
+            "model.language_model.norm.weight": mx.zeros((8,)),
+        }
+        out = Model.sanitize(_mock_model(), dict(weights))
+        self.assertIn("language_model.model.layers.0.self_attn.q_proj.weight", out)
+        self.assertIn("language_model.model.embed_tokens.weight", out)
+        self.assertIn("language_model.model.norm.weight", out)
+
+    def test_flat_visual_still_routes_to_vision_tower(self):
+        """Pre-existing `model.visual.*` flat layout must keep working."""
+        weights = {
+            "model.visual.blocks.1.attn.qkv.weight": _fake(),
+            "model.visual.patch_embed.proj.weight": _fake(),
+        }
+        out = Model.sanitize(_mock_model(), dict(weights))
+        self.assertIn("vision_tower.blocks.1.attn.qkv.weight", out)
+        self.assertIn("vision_tower.patch_embed.proj.weight", out)
+
+    def test_lm_head_unchanged(self):
+        """lm_head rewrite path must still be reached when no `model` prefix."""
+        weights = {"lm_head.weight": _fake()}
+        out = Model.sanitize(_mock_model(), dict(weights))
+        self.assertIn("language_model.lm_head.weight", out)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

`Qwen/Qwen3.6-35B-A3B` and its community derivatives ship the ViT nested under `model.language_model.visual.*` in the HF checkpoint rather than the flat `model.visual.*` layout used by other Qwen VLMs.

The current `elif` ordering in `Model.sanitize` mis-routes these keys:

```python
if "model.language_model" in key:
    key = key.replace("model.language_model", "language_model.model")
elif "model.visual" in key:
    key = key.replace("model.visual", "vision_tower")
```

A key like `model.language_model.visual.blocks.0.attn.qkv.weight`:

1. Matches the **first** branch (`"model.language_model" in key`).
2. Gets rewritten to `language_model.model.visual.blocks.0.attn.qkv.weight` — still nested.
3. Never falls through to the visual branch (because of `elif`).
4. Ends up as an orphan parameter the `Qwen3_5MoeForConditionalGeneration` class has no attribute for.

Result: 333 ViT tensors silently dropped on load; image input produces garbage. Error surfaces as `Received 333 parameters not in model: language_model.model.visual.blocks.0.*`.

## Fix

Check the nested-visual prefix **before** the generic language rewrite:

```python
if "model.language_model.visual" in key:
    key = key.replace("model.language_model.visual", "vision_tower")
elif "model.language_model" in key:
    key = key.replace("model.language_model", "language_model.model")
elif "model.visual" in key:
    key = key.replace("model.visual", "vision_tower")
```

## Tests

Added `mlx_vlm/tests/test_qwen3_5_moe_sanitize.py` covering:

1. `model.language_model.visual.*` → `vision_tower.*` (the new case).
2. `model.language_model.*` (non-visual) → `language_model.model.*` (regression guard).
3. `model.visual.*` → `vision_tower.*` (pre-existing flat layout still works).
4. `lm_head.*` → `language_model.lm_head.*` (unchanged rewrite).

Run:

```bash
python -m unittest mlx_vlm.tests.test_qwen3_5_moe_sanitize -v
```

All 4 pass.

## Reproduction

Without the fix, loading the Qwen3.6-35B-A3B HF checkpoint (or any derivative that preserves its tensor layout, e.g. `Youssofal/Qwen3.6-35B-A3B-Abliterated-Heretic-BF16`) produces:

> Received 333 parameters not in model:
> language_model.model.visual.blocks.0.attn.proj.bias, …

With the fix, all 333 ViT tensors resolve and image input contributes to generation as expected.

## Test plan

- [x] `python -m unittest mlx_vlm.tests.test_qwen3_5_moe_sanitize -v` passes
- [x] Verified loading `Youssofal/Qwen3.6-35B-A3B-Abliterated-Heretic-BF16` end-to-end on Apple Silicon with the fix applied
- [x] All existing rewrite paths (flat `model.visual`, plain `model.language_model`, `lm_head`) covered by regression tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)