### PR TITLE
hunyuan_vl / gemma3n: drop dead assignments in cache-offset extraction

### DIFF
--- a/mlx_vlm/models/gemma3n/language.py
+++ b/mlx_vlm/models/gemma3n/language.py
@@ -480,9 +480,7 @@ class Gemma3Model(nn.Module):
             if target_len != h.shape[1]:
                 target_len = h.shape[1]
 
-            # Prefer ``cache._idx`` (Python int) to avoid a per-step GPU sync;
-            # only fall back to reading ``cache.offset`` (which may require an
-            # ``.item()`` sync for ``BatchKVCache``) when no cache exposes it.
+
             c0 = next(
                 (c for c in (cache or []) if c is not None and hasattr(c, "_idx")),
                 None,

--- a/mlx_vlm/models/gemma3n/language.py
+++ b/mlx_vlm/models/gemma3n/language.py
@@ -480,29 +480,32 @@ class Gemma3Model(nn.Module):
             if target_len != h.shape[1]:
                 target_len = h.shape[1]
 
-            raw_offset = next(
-                (
-                    c.offset
-                    for c in (cache or [])
-                    if c is not None and hasattr(c, "offset")
-                ),
-                0,
-            )
-            # Prefer ``cache._idx`` (Python int) to avoid a per-step GPU sync.
+            # Prefer ``cache._idx`` (Python int) to avoid a per-step GPU sync;
+            # only fall back to reading ``cache.offset`` (which may require an
+            # ``.item()`` sync for ``BatchKVCache``) when no cache exposes it.
             c0 = next(
                 (c for c in (cache or []) if c is not None and hasattr(c, "_idx")),
                 None,
             )
             if c0 is not None:
                 cache_offset = int(c0._idx)
-            elif isinstance(raw_offset, mx.array):
-                cache_offset = (
-                    int(raw_offset.max().item())
-                    if raw_offset.size > 1
-                    else int(raw_offset.item())
-                )
             else:
-                cache_offset = int(raw_offset)
+                raw_offset = next(
+                    (
+                        c.offset
+                        for c in (cache or [])
+                        if c is not None and hasattr(c, "offset")
+                    ),
+                    0,
+                )
+                if isinstance(raw_offset, mx.array):
+                    cache_offset = (
+                        int(raw_offset.max().item())
+                        if raw_offset.size > 1
+                        else int(raw_offset.item())
+                    )
+                else:
+                    cache_offset = int(raw_offset)
             max_start = max(per_layer_inputs.shape[1] - target_len, 0)
             start = min(cache_offset, max_start)
             per_layer_inputs = per_layer_inputs[:, start : start + target_len]

--- a/mlx_vlm/models/gemma3n/language.py
+++ b/mlx_vlm/models/gemma3n/language.py
@@ -480,7 +480,6 @@ class Gemma3Model(nn.Module):
             if target_len != h.shape[1]:
                 target_len = h.shape[1]
 
-
             c0 = next(
                 (c for c in (cache or []) if c is not None and hasattr(c, "_idx")),
                 None,

--- a/mlx_vlm/models/hunyuan_vl/language.py
+++ b/mlx_vlm/models/hunyuan_vl/language.py
@@ -199,26 +199,23 @@ class Attention(nn.Module):
         )
 
         kv_seq_len = L
-        offset = 0
+        offset_scalar = 0
         if cache is not None:
             # Prefer cache._idx (Python int) to avoid a per-step GPU sync.
             if hasattr(cache, "_idx"):
                 offset_scalar = int(cache._idx)
-                offset = cache.offset
             else:
-                offset = cache.offset
+                off = cache.offset
                 offset_scalar = (
-                    int(offset)
-                    if isinstance(offset, int)
+                    int(off)
+                    if isinstance(off, int)
                     else (
-                        int(offset.max().item())
-                        if offset.ndim > 0
-                        else int(offset.item())
+                        int(off.max().item())
+                        if off.ndim > 0
+                        else int(off.item())
                     )
                 )
             kv_seq_len += offset_scalar
-        else:
-            offset_scalar = 0
 
         cos, sin = self.rotary_emb(values, seq_len=kv_seq_len)
 

--- a/mlx_vlm/models/hunyuan_vl/language.py
+++ b/mlx_vlm/models/hunyuan_vl/language.py
@@ -209,11 +209,7 @@ class Attention(nn.Module):
                 offset_scalar = (
                     int(off)
                     if isinstance(off, int)
-                    else (
-                        int(off.max().item())
-                        if off.ndim > 0
-                        else int(off.item())
-                    )
+                    else (int(off.max().item()) if off.ndim > 0 else int(off.item()))
                 )
             kv_seq_len += offset_scalar
 


### PR DESCRIPTION
## Summary

Small follow-up to #1055 — two post-merge clean-ups spotted while re-reading the changes:

- **`hunyuan_vl/language.py`**: both branches of the ``_idx`` check assigned ``offset = cache.offset``, but only ``offset_scalar`` is read downstream (for the `xdrope_section` prefill-vs-decode branch). Dropped the dead assignment, and hoisted the ``offset_scalar = 0`` default above the ``if cache is not None`` so the no-cache ``else`` disappears.
- **`gemma3n/language.py`**: ``raw_offset`` was computed via a generator expression before the ``_idx`` fast path ran, even though the fast path doesn't use it. Moved the lookup into the fallback branch so the fast path does zero extra work.

No functional change; same outputs on the same inputs.

## Test plan

- [x] `from mlx_vlm.models.hunyuan_vl import language` / `from mlx_vlm.models.gemma3n import language` — imports clean.
- [x] Re-run the decode smoke-test on ``mlx-community/gemma-3n-E2B-it-8bit`` + ``tencent/HunyuanOCR`` (CLI + server single + server concurrent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)