### PR TITLE
Support OpenAI stop sequences in server

### DIFF
--- a/mlx_vlm/server.py
+++ b/mlx_vlm/server.py
@@ -121,6 +121,7 @@ class GenerationArguments:
     enable_thinking: bool = True
     thinking_budget: Optional[int] = None
     thinking_start_token: Optional[str] = None
+    stop: Optional[List[str]] = None
 
     def to_generate_kwargs(self) -> dict:
         """Convert to kwargs dict for generate()/stream_generate()."""
@@ -170,6 +171,56 @@ class StreamingToken:
     finish_reason: Optional[str]
     peak_memory: float = 0.0
     top_logprobs: Optional[List[Tuple[int, float]]] = None
+
+
+class StopMatcher:
+    """Incrementally trims OpenAI stop strings from decoded token text."""
+
+    def __init__(self, stop: Optional[List[str]] = None):
+        self.stop = stop or []
+        self.buffer = ""
+        self.max_stop_len = max((len(s) for s in self.stop), default=0)
+        self.stopped = False
+
+    def append(self, text: str) -> Tuple[str, bool]:
+        if self.stopped or not text:
+            return "", self.stopped
+        if not self.stop:
+            return text, False
+
+        self.buffer += text
+        stop_at = None
+        for stop in self.stop:
+            idx = self.buffer.find(stop)
+            if idx != -1 and (stop_at is None or idx < stop_at):
+                stop_at = idx
+
+        if stop_at is not None:
+            out = self.buffer[:stop_at]
+            self.buffer = ""
+            self.stopped = True
+            return out, True
+
+        keep = max(self.max_stop_len - 1, 0)
+        if keep == 0:
+            out = self.buffer
+            self.buffer = ""
+            return out, False
+        if len(self.buffer) <= keep:
+            return "", False
+        out = self.buffer[:-keep]
+        self.buffer = self.buffer[-keep:]
+        return out, False
+
+    def feed(self, text: str) -> Tuple[str, bool]:
+        return self.append(text)
+
+    def flush(self) -> str:
+        if self.stopped:
+            return ""
+        out = self.buffer
+        self.buffer = ""
+        return out
 
 
 class ResponseGenerator:
@@ -302,9 +353,10 @@ class ResponseGenerator:
             # closes immediately after seeing finish_reason isn't treated
             # as a client abort.
             ended = False
+            queue_timeout = float(os.environ.get("TOKEN_QUEUE_TIMEOUT", "600"))
             try:
                 while True:
-                    item = rqueue.get(timeout=60.0)
+                    item = rqueue.get(timeout=queue_timeout)
                     if item is None:
                         ended = True
                         break
@@ -491,6 +543,7 @@ class ResponseGenerator:
                         "rqueue": rqueue,
                         "tokens": [],
                         "prev_text": "",
+                        "stop_filter": StopMatcher(args.stop),
                         "gen_kwargs": gen_kwargs if has_embeds else None,
                     }
 
@@ -556,6 +609,8 @@ class ResponseGenerator:
                 uids = []
                 rqueues = {}
                 token_lists = {}
+                prev_texts = {}
+                stop_matchers = {}
                 max_tokens_map = {}
                 all_input_ids = []
 
@@ -565,6 +620,8 @@ class ResponseGenerator:
                     uids.append(uid)
                     rqueues[uid] = rqueue
                     token_lists[uid] = []
+                    prev_texts[uid] = ""
+                    stop_matchers[uid] = StopMatcher(args.stop)
                     max_tokens_map[uid] = args.max_tokens
                     all_input_ids.append(input_ids.squeeze(0).tolist())
                     rqueue.put(GenerationContext(uid=uid, prompt_tokens=prompt_tokens))
@@ -588,26 +645,31 @@ class ResponseGenerator:
                 hidden = mx.concatenate(out.hidden_states, axis=-1)
                 first_bonus = sampler(out.logits[:, -1:]).squeeze(-1)
                 mx.eval(first_bonus, hidden, out.logits)
+                finished_uids = set()
 
                 # Send first bonus tokens to clients
                 fb_list = first_bonus.tolist()
                 for j, uid in enumerate(uids):
                     tok = int(fb_list[j])
                     token_lists[uid].append(tok)
-                    text = self.tokenizer.decode([tok])
+                    raw_text = self.tokenizer.decode([tok])
+                    prev_texts[uid] = raw_text
+                    text, server_stop = stop_matchers[uid].append(raw_text)
                     rqueues[uid].put(
                         StreamingToken(
                             text=text,
                             token=tok,
                             logprobs=0.0,
-                            finish_reason=None,
+                            finish_reason="stop" if server_stop else None,
                             peak_memory=mx.get_peak_memory() / 1e9,
                         )
                     )
+                    if server_stop:
+                        rqueues[uid].put(None)
+                        finished_uids.add(uid)
 
                 # --- Phase 3: speculative decode rounds ---
                 max_tok = max(max_tokens_map[u] for u in uids)
-                finished_uids = set()
 
                 def stop_check(seq_idx, token_id):
                     uid = uids[seq_idx]
@@ -641,20 +703,25 @@ class ResponseGenerator:
                         token_lists[uid].append(tok)
                         tokens = token_lists[uid]
 
-                        if len(tokens) >= 2:
-                            prev = self.tokenizer.decode(tokens[:-1])
-                            curr = self.tokenizer.decode(tokens)
-                            text = curr[len(prev) :]
-                        else:
-                            text = self.tokenizer.decode(tokens)
+                        curr = self.tokenizer.decode(tokens)
+                        raw_text = curr[len(prev_texts[uid]) :]
+                        prev_texts[uid] = curr
 
                         is_stop = tok in self.stop_tokens
                         is_max = len(tokens) >= max_tokens_map[uid]
                         finish = "stop" if is_stop else "length" if is_max else None
+                        if is_stop:
+                            text = stop_matchers[uid].flush()
+                        else:
+                            text, server_stop = stop_matchers[uid].append(raw_text)
+                            if server_stop:
+                                finish = "stop"
+                            elif finish is not None:
+                                text += stop_matchers[uid].flush()
 
                         rqueues[uid].put(
                             StreamingToken(
-                                text="" if is_stop else text,
+                                text=text,
                                 token=tok,
                                 logprobs=0.0,
                                 finish_reason=finish,
@@ -680,7 +747,7 @@ class ResponseGenerator:
                     if uid not in finished_uids:
                         rqueues[uid].put(
                             StreamingToken(
-                                text="",
+                                text=stop_matchers[uid].flush(),
                                 token=0,
                                 logprobs=0.0,
                                 finish_reason="length",
@@ -711,13 +778,24 @@ class ResponseGenerator:
             if hasattr(tok, "item"):
                 tok = tok.item()
 
+            finish_reason = r.finish_reason
+            stop_filter = info.get("stop_filter")
+
             if r.finish_reason == "stop":
-                text = ""
+                text = stop_filter.flush() if stop_filter is not None else ""
             else:
                 info["tokens"].append(tok)
                 curr = self.tokenizer.decode(info["tokens"])
-                text = curr[len(info["prev_text"]) :]
+                raw_text = curr[len(info["prev_text"]) :]
                 info["prev_text"] = curr
+                if stop_filter is not None:
+                    text, server_stop = stop_filter.append(raw_text)
+                    if server_stop:
+                        finish_reason = "stop"
+                    elif finish_reason is not None:
+                        text += stop_filter.flush()
+                else:
+                    text = raw_text
 
             lp = r.token_logprob
 
@@ -726,13 +804,15 @@ class ResponseGenerator:
                     text=text,
                     token=tok,
                     logprobs=lp,
-                    finish_reason=r.finish_reason,
-                    peak_memory=mx.get_peak_memory() / 1e9 if r.finish_reason else 0,
+                    finish_reason=finish_reason,
+                    peak_memory=mx.get_peak_memory() / 1e9 if finish_reason else 0,
                     top_logprobs=getattr(r, "top_logprobs", None),
                 )
             )
 
-            if r.finish_reason is not None:
+            if finish_reason is not None:
+                if r.finish_reason is None:
+                    batch_gen.remove(r.uid)
                 rqueue.put(None)
                 del active[r.uid]
 
@@ -831,7 +911,36 @@ def _build_gen_args(request) -> GenerationArguments:
         enable_thinking=getattr(request, "enable_thinking", True),
         thinking_budget=getattr(request, "thinking_budget", None),
         thinking_start_token=getattr(request, "thinking_start_token", None),
+        stop=_normalize_stop(getattr(request, "stop", None)),
     )
+
+
+def _normalize_stop(stop: Optional[Union[str, List[str]]]) -> Optional[List[str]]:
+    """Normalize OpenAI-compatible stop into a list of up to 4 strings."""
+    if stop is None:
+        return None
+    if isinstance(stop, str):
+        stop_sequences = [stop]
+    elif isinstance(stop, list):
+        stop_sequences = stop
+    else:
+        raise HTTPException(
+            status_code=400, detail="stop must be a string or a list of strings."
+        )
+
+    if len(stop_sequences) == 0:
+        raise HTTPException(
+            status_code=400, detail="stop must contain at least 1 string."
+        )
+    if len(stop_sequences) > 4:
+        raise HTTPException(
+            status_code=400, detail="stop must contain at most 4 strings."
+        )
+    if not all(isinstance(item, str) for item in stop_sequences):
+        raise HTTPException(status_code=400, detail="stop entries must be strings.")
+    if any(item == "" for item in stop_sequences):
+        raise HTTPException(status_code=400, detail="stop entries must be non-empty.")
+    return stop_sequences
 
 
 def _count_thinking_tag_tokens(text: str) -> int:
@@ -1196,6 +1305,9 @@ class OpenAIRequest(FlexibleBaseModel):
     thinking_start_token: Optional[str] = Field(
         None, description="Thinking start token."
     )
+    stop: Optional[Union[str, List[str]]] = Field(
+        None, description="Up to 4 stop sequences where generation should stop."
+    )
     stream: bool = Field(
         False, description="Whether to stream the response chunk by chunk."
     )
@@ -1382,6 +1494,9 @@ class VLMRequest(FlexibleBaseModel):
     thinking_budget: Optional[int] = Field(None, description="Max thinking tokens.")
     thinking_start_token: Optional[str] = Field(
         None, description="Thinking start token."
+    )
+    stop: Optional[Union[str, List[str]]] = Field(
+        None, description="Up to 4 stop sequences where generation should stop."
     )
     logprobs: Optional[bool] = Field(
         None,
@@ -1637,6 +1752,7 @@ async def responses_endpoint(request: Request):
             raise HTTPException(status_code=400, detail="Missing input.")
 
         gen_args = _build_gen_args(openai_request)
+        stop_sequences = gen_args.stop or []
 
         formatted_prompt = apply_chat_template(
             processor,
@@ -1709,6 +1825,7 @@ async def responses_endpoint(request: Request):
 
                     # Stream text deltas using ResponseGenerator (continuous batching)
                     full_text = ""
+                    stop_filter = StopMatcher(stop_sequences)
                     usage_stats = {"input_tokens": 0, "output_tokens": 0}
 
                     if response_generator is not None:
@@ -1721,17 +1838,23 @@ async def responses_endpoint(request: Request):
                         output_tokens = 0
                         for token in token_iter:
                             output_tokens += 1
-                            delta = token.text
+                            delta, stopped = stop_filter.feed(token.text)
                             full_text += delta
                             usage_stats = {
                                 "input_tokens": ctx.prompt_tokens,
                                 "output_tokens": output_tokens,
                             }
 
-                            yield f"event: response.output_text.delta\ndata: {ResponseOutputTextDeltaEvent(type='response.output_text.delta', item_id=message_id, output_index=0, content_index=0, delta=delta).model_dump_json()}\n\n"
-                            await asyncio.sleep(0.01)
+                            if delta:
+                                yield f"event: response.output_text.delta\ndata: {ResponseOutputTextDeltaEvent(type='response.output_text.delta', item_id=message_id, output_index=0, content_index=0, delta=delta).model_dump_json()}\n\n"
+                                await asyncio.sleep(0.01)
 
-                            if token.finish_reason:
+                            if stopped or token.finish_reason:
+                                if not stopped:
+                                    tail = stop_filter.flush()
+                                    if tail:
+                                        full_text += tail
+                                        yield f"event: response.output_text.delta\ndata: {ResponseOutputTextDeltaEvent(type='response.output_text.delta', item_id=message_id, output_index=0, content_index=0, delta=tail).model_dump_json()}\n\n"
                                 break
                     else:
                         # Fallback to stream_generate
@@ -1751,15 +1874,24 @@ async def responses_endpoint(request: Request):
                             if chunk is None or not hasattr(chunk, "text"):
                                 continue
 
-                            delta = chunk.text
+                            delta, stopped = stop_filter.feed(chunk.text)
                             full_text += delta
                             usage_stats = {
                                 "input_tokens": chunk.prompt_tokens,
                                 "output_tokens": chunk.generation_tokens,
                             }
 
-                            yield f"event: response.output_text.delta\ndata: {ResponseOutputTextDeltaEvent(type='response.output_text.delta', item_id=message_id, output_index=0, content_index=0, delta=delta).model_dump_json()}\n\n"
-                            await asyncio.sleep(0.01)
+                            if delta:
+                                yield f"event: response.output_text.delta\ndata: {ResponseOutputTextDeltaEvent(type='response.output_text.delta', item_id=message_id, output_index=0, content_index=0, delta=delta).model_dump_json()}\n\n"
+                                await asyncio.sleep(0.01)
+
+                            if stopped:
+                                break
+                        else:
+                            tail = stop_filter.flush()
+                            if tail:
+                                full_text += tail
+                                yield f"event: response.output_text.delta\ndata: {ResponseOutputTextDeltaEvent(type='response.output_text.delta', item_id=message_id, output_index=0, content_index=0, delta=tail).model_dump_json()}\n\n"
 
                     # Split thinking from content for final events
                     _, clean_text = _split_thinking(full_text)
@@ -1788,6 +1920,7 @@ async def responses_endpoint(request: Request):
                         update={
                             "status": "completed",
                             "output": [final_message_item],
+                            "output_text": clean_text,
                             "usage": {
                                 "input_tokens": usage_stats["input_tokens"],
                                 "output_tokens": usage_stats["output_tokens"],
@@ -1830,6 +1963,7 @@ async def responses_endpoint(request: Request):
                 full_text = ""
                 prompt_tokens = 0
                 output_tokens = 0
+                stop_filter = StopMatcher(stop_sequences)
 
                 if response_generator is not None:
                     ctx, token_iter = response_generator.generate(
@@ -1839,28 +1973,53 @@ async def responses_endpoint(request: Request):
                     )
                     prompt_tokens = ctx.prompt_tokens
                     for token in token_iter:
-                        full_text += token.text
+                        text, stopped = stop_filter.feed(token.text)
+                        full_text += text
                         output_tokens += 1
-                        if token.finish_reason:
+                        if stopped or token.finish_reason:
+                            if not stopped:
+                                full_text += stop_filter.flush()
                             break
                     try:
                         token_iter.close()
                     except Exception:
                         pass
                 else:
-                    result = generate(
-                        model=model,
-                        processor=processor,
-                        prompt=formatted_prompt,
-                        image=images,
-                        verbose=logger.isEnabledFor(logging.DEBUG),
-                        vision_cache=model_cache.get("vision_cache"),
-                        **gen_args.to_generate_kwargs(),
-                        **kwargs,
-                    )
-                    full_text = result.text
-                    prompt_tokens = result.prompt_tokens
-                    output_tokens = result.generation_tokens
+                    if stop_sequences:
+                        token_iterator = stream_generate(
+                            model=model,
+                            processor=processor,
+                            prompt=formatted_prompt,
+                            image=images,
+                            vision_cache=model_cache.get("vision_cache"),
+                            **gen_args.to_generate_kwargs(),
+                            **kwargs,
+                        )
+                        for chunk in token_iterator:
+                            if chunk is None or not hasattr(chunk, "text"):
+                                continue
+                            text, stopped = stop_filter.feed(chunk.text)
+                            full_text += text
+                            prompt_tokens = chunk.prompt_tokens
+                            output_tokens = chunk.generation_tokens
+                            if stopped:
+                                break
+                        else:
+                            full_text += stop_filter.flush()
+                    else:
+                        result = generate(
+                            model=model,
+                            processor=processor,
+                            prompt=formatted_prompt,
+                            image=images,
+                            verbose=logger.isEnabledFor(logging.DEBUG),
+                            vision_cache=model_cache.get("vision_cache"),
+                            **gen_args.to_generate_kwargs(),
+                            **kwargs,
+                        )
+                        full_text = result.text
+                        prompt_tokens = result.prompt_tokens
+                        output_tokens = result.generation_tokens
 
                 mx.clear_cache()
                 gc.collect()
@@ -2029,6 +2188,7 @@ async def chat_completions_endpoint(request: ChatRequest):
                 tool_module = load_tool_module(tool_parser_type)
 
         gen_args = _build_gen_args(request)
+        stop_sequences = gen_args.stop or []
 
         formatted_prompt = apply_chat_template(
             processor,
@@ -2059,6 +2219,7 @@ async def chat_completions_endpoint(request: ChatRequest):
                 token_iter = None  # For ResponseGenerator cleanup
                 try:
                     # Use ResponseGenerator if available, otherwise fall back to stream_generate
+                    output_tokens = 0
                     if response_generator is not None:
                         # generate() does blocking Queue.get — run off event loop
                         ctx, token_iter = await asyncio.to_thread(
@@ -2068,13 +2229,12 @@ async def chat_completions_endpoint(request: ChatRequest):
                             audio if audio else None,
                             gen_args,
                         )
-
-                        output_tokens = 0
                         request_id = f"chatcmpl-{uuid.uuid4()}"
                         # Track thinking state for reasoning/content split
                         in_thinking = False
                         accumulated = ""
                         full_output = ""  # raw output for tool call parsing
+                        stop_filter = StopMatcher(stop_sequences)
                         # Track tool-call state to suppress markup from content
                         in_tool_call = False
                         tc_start = tool_module.tool_call_start if tool_module else None
@@ -2091,8 +2251,12 @@ async def chat_completions_endpoint(request: ChatRequest):
                             if token is None:
                                 break
                             output_tokens += 1
-                            accumulated += token.text
-                            full_output += token.text
+                            token_text, stopped = stop_filter.feed(token.text)
+                            finish_reason = "stop" if stopped else token.finish_reason
+                            if finish_reason and not stopped:
+                                token_text += stop_filter.flush()
+                            accumulated += token_text
+                            full_output += token_text
 
                             # Detect thinking boundaries
                             delta_reasoning = None
@@ -2112,13 +2276,13 @@ async def chat_completions_endpoint(request: ChatRequest):
                                 accumulated = ""
                                 # Don't emit closing tag tokens
                             elif in_thinking:
-                                delta_reasoning = token.text
+                                delta_reasoning = token_text or None
                             elif not in_thinking and (
                                 "<|channel>" in accumulated or "<think" in accumulated
                             ):
                                 pass  # Partial tag, don't emit yet
                             else:
-                                delta_content = token.text
+                                delta_content = token_text or None
 
                             # Suppress tool-call markup from content
                             in_tool_call, delta_content = suppress_tool_call_content(
@@ -2126,7 +2290,7 @@ async def chat_completions_endpoint(request: ChatRequest):
                             )
 
                             chunk_logprobs = None
-                            if request.logprobs and token.finish_reason != "stop":
+                            if request.logprobs and token_text and finish_reason != "stop":
                                 req_top_k = int(request.top_logprobs or 0)
                                 chunk_logprobs = ChatLogprobs(
                                     content=[
@@ -2144,13 +2308,13 @@ async def chat_completions_endpoint(request: ChatRequest):
                             has_payload = (
                                 delta_content is not None
                                 or delta_reasoning is not None
-                                or token.finish_reason is not None
+                                or finish_reason is not None
                                 or chunk_logprobs is not None
                             )
                             if has_payload:
                                 choices = [
                                     ChatStreamChoice(
-                                        finish_reason=token.finish_reason,
+                                        finish_reason=finish_reason,
                                         delta=ChatMessage(
                                             role="assistant",
                                             content=delta_content,
@@ -2174,7 +2338,7 @@ async def chat_completions_endpoint(request: ChatRequest):
 
                                 yield f"data: {chunk_data.model_dump_json()}\n\n"
 
-                            if token.finish_reason:
+                            if finish_reason:
                                 break
 
                         # Parse tool calls from full output and emit final chunk
@@ -2213,35 +2377,70 @@ async def chat_completions_endpoint(request: ChatRequest):
                         )
 
                         request_id = f"chatcmpl-{uuid.uuid4()}"
-                        output_text = ""
+                        stop_filter = StopMatcher(stop_sequences)
                         for chunk in token_iterator:
                             if chunk is None or not hasattr(chunk, "text"):
                                 continue
 
-                            output_text += chunk.text
+                            delta, stopped = stop_filter.feed(chunk.text)
 
+                            if delta or stopped:
+                                choices = [
+                                    ChatStreamChoice(
+                                        finish_reason="stop" if stopped else None,
+                                        delta=ChatMessage(
+                                            role="assistant", content=delta or None
+                                        ),
+                                    )
+                                ]
+                                chunk_data = ChatStreamChunk(
+                                    id=request_id,
+                                    created=int(time.time()),
+                                    model=request.model,
+                                    usage={
+                                        "prompt_tokens": chunk.prompt_tokens,
+                                        "completion_tokens": chunk.generation_tokens,
+                                        "total_tokens": chunk.prompt_tokens
+                                        + chunk.generation_tokens,
+                                    },
+                                    choices=choices,
+                                )
+
+                                yield f"data: {chunk_data.model_dump_json()}\n\n"
+                                await asyncio.sleep(0.01)
+
+                            if stopped:
+                                break
+                        else:
+                            tail = stop_filter.flush()
+                            if tail:
+                                choices = [
+                                    ChatStreamChoice(
+                                        delta=ChatMessage(
+                                            role="assistant", content=tail
+                                        )
+                                    )
+                                ]
+                                chunk_data = ChatStreamChunk(
+                                    id=request_id,
+                                    created=int(time.time()),
+                                    model=request.model,
+                                    choices=choices,
+                                )
+                                yield f"data: {chunk_data.model_dump_json()}\n\n"
                             choices = [
                                 ChatStreamChoice(
-                                    delta=ChatMessage(
-                                        role="assistant", content=chunk.text
-                                    )
+                                    finish_reason="length",
+                                    delta=ChatMessage(role="assistant"),
                                 )
                             ]
                             chunk_data = ChatStreamChunk(
                                 id=request_id,
                                 created=int(time.time()),
                                 model=request.model,
-                                usage={
-                                    "prompt_tokens": chunk.prompt_tokens,
-                                    "completion_tokens": chunk.generation_tokens,
-                                    "total_tokens": chunk.prompt_tokens
-                                    + chunk.generation_tokens,
-                                },
                                 choices=choices,
                             )
-
                             yield f"data: {chunk_data.model_dump_json()}\n\n"
-                            await asyncio.sleep(0.01)
 
                     # Signal stream end
                     yield "data: [DONE]\n\n"
@@ -2287,6 +2486,8 @@ async def chat_completions_endpoint(request: ChatRequest):
                 prompt_tokens = 0
                 output_tokens = 0
                 peak_memory = 0.0
+                finish_reason = "stop"
+                stop_filter = StopMatcher(stop_sequences)
 
                 collected_logprobs: List[
                     Tuple[int, float, Optional[List[Tuple[int, float]]]]
@@ -2298,6 +2499,7 @@ async def chat_completions_endpoint(request: ChatRequest):
                         text = ""
                         pt = gt = 0
                         pm = 0.0
+                        local_finish_reason = "stop"
                         ctx, token_iter = response_generator.generate(
                             prompt=formatted_prompt,
                             images=images if images else None,
@@ -2306,40 +2508,83 @@ async def chat_completions_endpoint(request: ChatRequest):
                         )
                         pt = ctx.prompt_tokens
                         for token in token_iter:
-                            text += token.text
+                            token_text, stopped = stop_filter.feed(token.text)
+                            token_finish_reason = (
+                                "stop" if stopped else token.finish_reason
+                            )
+                            if token_finish_reason and not stopped:
+                                token_text += stop_filter.flush()
+                            text += token_text
                             gt += 1
                             pm = token.peak_memory
-                            if request.logprobs and token.finish_reason != "stop":
+                            if (
+                                request.logprobs
+                                and token_text
+                                and token_finish_reason != "stop"
+                            ):
                                 collected_logprobs.append(
                                     (token.token, token.logprobs, token.top_logprobs)
                                 )
-                            if token.finish_reason:
+                            if token_finish_reason:
+                                local_finish_reason = token_finish_reason
                                 break
                         try:
                             token_iter.close()
                         except Exception:
                             pass
-                        return text, pt, gt, pm
+                        return text, pt, gt, pm, local_finish_reason
 
-                    full_text, prompt_tokens, output_tokens, peak_memory = (
+                    (
+                        full_text,
+                        prompt_tokens,
+                        output_tokens,
+                        peak_memory,
+                        finish_reason,
+                    ) = (
                         await asyncio.to_thread(_blocking_generate)
                     )
                 else:
-                    gen_result = generate(
-                        model=model,
-                        processor=processor,
-                        prompt=formatted_prompt,
-                        image=images,
-                        audio=audio,
-                        verbose=logger.isEnabledFor(logging.DEBUG),
-                        vision_cache=model_cache.get("vision_cache"),
-                        **gen_args.to_generate_kwargs(),
-                        **kwargs,
-                    )
-                    full_text = gen_result.text
-                    prompt_tokens = gen_result.prompt_tokens
-                    output_tokens = gen_result.generation_tokens
-                    peak_memory = gen_result.peak_memory
+                    if stop_sequences:
+                        token_iterator = stream_generate(
+                            model=model,
+                            processor=processor,
+                            prompt=formatted_prompt,
+                            image=images,
+                            audio=audio,
+                            vision_cache=model_cache.get("vision_cache"),
+                            **gen_args.to_generate_kwargs(),
+                            **kwargs,
+                        )
+                        for chunk in token_iterator:
+                            if chunk is None or not hasattr(chunk, "text"):
+                                continue
+                            text, stopped = stop_filter.feed(chunk.text)
+                            full_text += text
+                            prompt_tokens = chunk.prompt_tokens
+                            output_tokens = chunk.generation_tokens
+                            peak_memory = chunk.peak_memory
+                            if stopped:
+                                finish_reason = "stop"
+                                break
+                        else:
+                            full_text += stop_filter.flush()
+                            finish_reason = "length"
+                    else:
+                        gen_result = generate(
+                            model=model,
+                            processor=processor,
+                            prompt=formatted_prompt,
+                            image=images,
+                            audio=audio,
+                            verbose=logger.isEnabledFor(logging.DEBUG),
+                            vision_cache=model_cache.get("vision_cache"),
+                            **gen_args.to_generate_kwargs(),
+                            **kwargs,
+                        )
+                        full_text = gen_result.text
+                        prompt_tokens = gen_result.prompt_tokens
+                        output_tokens = gen_result.generation_tokens
+                        peak_memory = gen_result.peak_memory
 
                 mx.clear_cache()
                 gc.collect()
@@ -2400,7 +2645,9 @@ async def chat_completions_endpoint(request: ChatRequest):
 
                 choices = [
                     ChatChoice(
-                        finish_reason="tool_calls" if parsed_tool_calls else "stop",
+                        finish_reason=(
+                            "tool_calls" if parsed_tool_calls else finish_reason
+                        ),
                         message=ChatMessage(
                             role="assistant",
                             content=content if content else None,

--- a/mlx_vlm/tests/test_server.py
+++ b/mlx_vlm/tests/test_server.py
@@ -1,3 +1,4 @@
+import json
 from types import SimpleNamespace
 from unittest.mock import patch
 
@@ -11,6 +12,20 @@ import mlx_vlm.server as server
 def client():
     with TestClient(server.app) as test_client:
         yield test_client
+
+
+def sse_json_events(response_text):
+    events = []
+    for block in response_text.split("\n\n"):
+        for line in block.splitlines():
+            if not line.startswith("data: "):
+                continue
+            data = line.removeprefix("data: ")
+            if data == "[DONE]":
+                events.append(data)
+            else:
+                events.append(json.loads(data))
+    return events
 
 
 @pytest.mark.parametrize("value", [224, "22", [1.0], [1.5], [True], [1, 2, 3]])
@@ -190,11 +205,13 @@ class TestResponseGenerator:
             enable_thinking=False,
             thinking_budget=None,
             thinking_start_token=None,
+            stop=["END"],
         )
         args = server._build_gen_args(req)
         assert args.max_tokens == 128
         assert args.top_k == 32
         assert args.logit_bias == {5: -1.0}  # string keys converted to int
+        assert args.stop == ["END"]
 
     def test_build_gen_args_from_chat_request(self):
         req = SimpleNamespace(
@@ -209,10 +226,407 @@ class TestResponseGenerator:
             enable_thinking=True,
             thinking_budget=None,
             thinking_start_token=None,
+            stop="END",
         )
         args = server._build_gen_args(req)
         assert args.max_tokens == 256
         assert args.enable_thinking is True
+        assert args.stop == ["END"]
+
+    def test_normalize_stop_rejects_more_than_four_values(self):
+        with pytest.raises(server.HTTPException):
+            server._normalize_stop(["a", "b", "c", "d", "e"])
+
+    @pytest.mark.parametrize(
+        ("raw", "expected"),
+        [
+            (None, None),
+            ("END", ["END"]),
+            (["END"], ["END"]),
+            (["a", "b", "c", "d"], ["a", "b", "c", "d"]),
+        ],
+    )
+    def test_normalize_stop_accepts_openai_shapes(self, raw, expected):
+        assert server._normalize_stop(raw) == expected
+
+    @pytest.mark.parametrize("raw", ["", [], ["END", ""], ["END", 1], {"stop": "END"}])
+    def test_normalize_stop_rejects_invalid_values(self, raw):
+        with pytest.raises(server.HTTPException):
+            server._normalize_stop(raw)
+
+
+class TestStopMatcher:
+    """Tests for decoded text stop matching."""
+
+    def test_trims_stop_sequence_across_chunks(self):
+        matcher = server.StopMatcher(["END"])
+
+        text, stopped = matcher.feed("hello E")
+        assert text == "hello"
+        assert stopped is False
+
+        text, stopped = matcher.feed("ND tail")
+        assert text == " "
+        assert stopped is True
+        assert matcher.flush() == ""
+
+    def test_flushes_held_suffix_without_stop(self):
+        matcher = server.StopMatcher(["END"])
+
+        text, stopped = matcher.feed("hello E")
+        assert text == "hello"
+        assert stopped is False
+        assert matcher.flush() == " E"
+
+    def test_single_character_stop_does_not_buffer_unmatched_text(self):
+        matcher = server.StopMatcher(["x"])
+
+        text, stopped = matcher.feed("abc")
+        assert text == "abc"
+        assert stopped is False
+
+    def test_trims_stop_sequence_in_single_chunk(self):
+        matcher = server.StopMatcher(["END"])
+
+        text, stopped = matcher.feed("hello END tail")
+
+        assert text == "hello "
+        assert stopped is True
+        assert matcher.flush() == ""
+
+    def test_stop_at_beginning_emits_no_text(self):
+        matcher = server.StopMatcher(["END"])
+
+        text, stopped = matcher.feed("END tail")
+
+        assert text == ""
+        assert stopped is True
+
+    def test_uses_earliest_matching_stop_sequence(self):
+        matcher = server.StopMatcher(["world", "END"])
+
+        text, stopped = matcher.feed("hello world END")
+
+        assert text == "hello "
+        assert stopped is True
+
+    def test_does_not_emit_text_after_stop(self):
+        matcher = server.StopMatcher(["END"])
+
+        assert matcher.feed("hello END") == ("hello ", True)
+        assert matcher.feed("tail") == ("", True)
+
+    def test_partial_prefix_is_released_when_it_cannot_match(self):
+        matcher = server.StopMatcher(["END"])
+
+        assert matcher.feed("hello E") == ("hello", False)
+        assert matcher.feed("x") == (" ", False)
+        assert matcher.flush() == "Ex"
+
+
+def test_chat_completions_fallback_applies_stop_sequence(client):
+    model = SimpleNamespace()
+    processor = SimpleNamespace()
+    config = SimpleNamespace(model_type="qwen2_vl")
+    chunks = [
+        SimpleNamespace(
+            text="hello E",
+            prompt_tokens=8,
+            generation_tokens=1,
+            peak_memory=0.1,
+        ),
+        SimpleNamespace(
+            text="ND tail",
+            prompt_tokens=8,
+            generation_tokens=2,
+            peak_memory=0.1,
+        ),
+    ]
+
+    with (
+        patch.object(server, "response_generator", None),
+        patch.object(
+            server, "get_cached_model", return_value=(model, processor, config)
+        ),
+        patch.object(server, "apply_chat_template", return_value="prompt"),
+        patch.object(server, "stream_generate", return_value=iter(chunks)),
+    ):
+        response = client.post(
+            "/chat/completions",
+            json={
+                "model": "demo",
+                "messages": [{"role": "user", "content": "Hello"}],
+                "stop": "END",
+            },
+        )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["choices"][0]["message"]["content"] == "hello "
+    assert body["choices"][0]["finish_reason"] == "stop"
+
+
+def test_chat_completions_fallback_applies_earliest_stop_sequence(client):
+    model = SimpleNamespace()
+    processor = SimpleNamespace()
+    config = SimpleNamespace(model_type="qwen2_vl")
+    chunks = [
+        SimpleNamespace(
+            text="hello world END tail",
+            prompt_tokens=8,
+            generation_tokens=1,
+            peak_memory=0.1,
+        ),
+    ]
+
+    with (
+        patch.object(server, "response_generator", None),
+        patch.object(
+            server, "get_cached_model", return_value=(model, processor, config)
+        ),
+        patch.object(server, "apply_chat_template", return_value="prompt"),
+        patch.object(server, "stream_generate", return_value=iter(chunks)),
+    ):
+        response = client.post(
+            "/chat/completions",
+            json={
+                "model": "demo",
+                "messages": [{"role": "user", "content": "Hello"}],
+                "stop": ["END", "world"],
+            },
+        )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["choices"][0]["message"]["content"] == "hello "
+    assert body["choices"][0]["finish_reason"] == "stop"
+
+
+def test_chat_completions_fallback_reports_length_when_stop_does_not_match(client):
+    model = SimpleNamespace()
+    processor = SimpleNamespace()
+    config = SimpleNamespace(model_type="qwen2_vl")
+    chunks = [
+        SimpleNamespace(
+            text="hello",
+            prompt_tokens=8,
+            generation_tokens=1,
+            peak_memory=0.1,
+        ),
+        SimpleNamespace(
+            text=" world",
+            prompt_tokens=8,
+            generation_tokens=2,
+            peak_memory=0.1,
+        ),
+    ]
+
+    with (
+        patch.object(server, "response_generator", None),
+        patch.object(
+            server, "get_cached_model", return_value=(model, processor, config)
+        ),
+        patch.object(server, "apply_chat_template", return_value="prompt"),
+        patch.object(server, "stream_generate", return_value=iter(chunks)),
+    ):
+        response = client.post(
+            "/chat/completions",
+            json={
+                "model": "demo",
+                "messages": [{"role": "user", "content": "Hello"}],
+                "stop": "END",
+            },
+        )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["choices"][0]["message"]["content"] == "hello world"
+    assert body["choices"][0]["finish_reason"] == "length"
+
+
+def test_chat_completions_streaming_fallback_applies_stop_sequence(client):
+    model = SimpleNamespace()
+    processor = SimpleNamespace()
+    config = SimpleNamespace(model_type="qwen2_vl")
+    chunks = [
+        SimpleNamespace(
+            text="hello E",
+            prompt_tokens=8,
+            generation_tokens=1,
+            peak_memory=0.1,
+        ),
+        SimpleNamespace(
+            text="ND tail",
+            prompt_tokens=8,
+            generation_tokens=2,
+            peak_memory=0.1,
+        ),
+    ]
+
+    with (
+        patch.object(server, "response_generator", None),
+        patch.object(
+            server, "get_cached_model", return_value=(model, processor, config)
+        ),
+        patch.object(server, "apply_chat_template", return_value="prompt"),
+        patch.object(server, "stream_generate", return_value=iter(chunks)),
+    ):
+        with client.stream(
+            "POST",
+            "/chat/completions",
+            json={
+                "model": "demo",
+                "messages": [{"role": "user", "content": "Hello"}],
+                "stream": True,
+                "stop": "END",
+            },
+        ) as response:
+            body = response.read().decode()
+
+    assert response.status_code == 200
+    events = sse_json_events(body)
+    chunks = [event for event in events if event != "[DONE]"]
+    assert [chunk["choices"][0]["delta"]["content"] for chunk in chunks] == [
+        "hello",
+        " ",
+    ]
+    assert chunks[-1]["choices"][0]["finish_reason"] == "stop"
+    assert events[-1] == "[DONE]"
+
+
+def test_chat_completions_streaming_fallback_reports_length_without_stop_match(client):
+    model = SimpleNamespace()
+    processor = SimpleNamespace()
+    config = SimpleNamespace(model_type="qwen2_vl")
+    chunks = [
+        SimpleNamespace(
+            text="hello",
+            prompt_tokens=8,
+            generation_tokens=1,
+            peak_memory=0.1,
+        ),
+        SimpleNamespace(
+            text=" world",
+            prompt_tokens=8,
+            generation_tokens=2,
+            peak_memory=0.1,
+        ),
+    ]
+
+    with (
+        patch.object(server, "response_generator", None),
+        patch.object(
+            server, "get_cached_model", return_value=(model, processor, config)
+        ),
+        patch.object(server, "apply_chat_template", return_value="prompt"),
+        patch.object(server, "stream_generate", return_value=iter(chunks)),
+    ):
+        with client.stream(
+            "POST",
+            "/chat/completions",
+            json={
+                "model": "demo",
+                "messages": [{"role": "user", "content": "Hello"}],
+                "stream": True,
+                "stop": "END",
+            },
+        ) as response:
+            body = response.read().decode()
+
+    assert response.status_code == 200
+    events = sse_json_events(body)
+    chunks = [event for event in events if event != "[DONE]"]
+    assert (
+        "".join(
+            chunk["choices"][0]["delta"].get("content") or "" for chunk in chunks
+        )
+        == "hello world"
+    )
+    assert chunks[-1]["choices"][0]["finish_reason"] == "length"
+    assert events[-1] == "[DONE]"
+
+
+def test_responses_fallback_applies_stop_sequence(client):
+    model = SimpleNamespace()
+    processor = SimpleNamespace()
+    config = SimpleNamespace(model_type="qwen2_vl")
+    chunks = [
+        SimpleNamespace(text="answer<", prompt_tokens=5, generation_tokens=1),
+        SimpleNamespace(text="stop>extra", prompt_tokens=5, generation_tokens=2),
+    ]
+
+    with (
+        patch.object(server, "response_generator", None),
+        patch.object(
+            server, "get_cached_model", return_value=(model, processor, config)
+        ),
+        patch.object(server, "apply_chat_template", return_value="prompt"),
+        patch.object(server, "stream_generate", return_value=iter(chunks)),
+    ):
+        response = client.post(
+            "/responses",
+            json={
+                "model": "demo",
+                "input": "Hello",
+                "stop": "<stop>",
+            },
+        )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["output_text"] == "answer"
+
+
+def test_responses_streaming_fallback_applies_stop_sequence(client):
+    model = SimpleNamespace()
+    processor = SimpleNamespace()
+    config = SimpleNamespace(model_type="qwen2_vl")
+    chunks = [
+        SimpleNamespace(text="answer<", prompt_tokens=5, generation_tokens=1),
+        SimpleNamespace(text="stop>extra", prompt_tokens=5, generation_tokens=2),
+    ]
+
+    with (
+        patch.object(server, "response_generator", None),
+        patch.object(
+            server, "get_cached_model", return_value=(model, processor, config)
+        ),
+        patch.object(server, "apply_chat_template", return_value="prompt"),
+        patch.object(server, "stream_generate", return_value=iter(chunks)),
+    ):
+        with client.stream(
+            "POST",
+            "/responses",
+            json={
+                "model": "demo",
+                "input": "Hello",
+                "stream": True,
+                "stop": "<stop>",
+            },
+        ) as response:
+            body = response.read().decode()
+
+    assert response.status_code == 200
+    events = sse_json_events(body)
+    deltas = [
+        event["delta"]
+        for event in events
+        if isinstance(event, dict) and event.get("type") == "response.output_text.delta"
+    ]
+    done = next(
+        event
+        for event in events
+        if isinstance(event, dict) and event.get("type") == "response.output_text.done"
+    )
+    completed = next(
+        event
+        for event in events
+        if isinstance(event, dict) and event.get("type") == "response.completed"
+    )
+
+    assert "".join(deltas) == "answer"
+    assert done["text"] == "answer"
+    assert completed["response"]["output_text"] == "answer"
 
 
 class TestSplitThinking:


### PR DESCRIPTION
## Summary

Fixes Blaizzy/mlx-vlm#1044.

This adds OpenAI-compatible `stop` handling to the MLX-VLM server for `/chat/completions`, plus matching mlx-vlm compatibility support for `/responses` so both server endpoints honor the same caller intent.

The implementation normalizes `stop` as either a string or a list of one to four non-empty strings, then incrementally filters decoded text so stop sequences are trimmed even when they span token/chunk boundaries. It is wired through continuous batching, speculative decoding, and non-batching fallback paths. When a server-side stop sequence is matched, generation is cancelled/removed from the active batch and the response reports `finish_reason: "stop"`. When a requested stop sequence is not emitted before generation exhausts, chat completions report `finish_reason: "length"`.

I also fixed a related Responses streaming consistency issue discovered while testing: `response.completed.response.output_text` now matches the final trimmed `response.output_text.done` text.

## OpenAI spec validation

Validated against the current official OpenAI documented OpenAPI spec at `https://app.stainless.com/api/spec/documented/openai/openapi.documented.yml`.

- Chat Completions defines `stop` via `StopConfiguration`: nullable string or array with `minItems: 1` and `maxItems: 4`; returned text must not contain the stop sequence.
- Chat completion `finish_reason` includes `stop` for a natural stop or provided stop sequence, and `length` when the token limit is reached.
- Streaming chat examples finish with a final chunk whose `delta` is empty and whose `finish_reason` is `stop`.
- The current OpenAI `CreateResponse` schema does not define a top-level `stop` parameter, so `/responses` handling here is intentionally treated as mlx-vlm compatibility behavior rather than a claim that OpenAI Responses currently accepts top-level `stop`.

## Validation

Automated tests:

```bash
uv run --with pytest python -m pytest mlx_vlm/tests/test_server.py
# 59 passed, 3 warnings
```

Additional checks:

```bash
python3 -m compileall -q mlx_vlm/server.py mlx_vlm/tests/test_server.py
git diff --check
```

Live worktree integration validation against `mlx-community/Qwen3.6-35B-A3B-nvfp4` on the local MLX-VLM server:

- Chat non-streaming string stop: passed
- Chat streaming string stop: passed
- Responses non-streaming string stop: passed
- Responses streaming string stop: passed
- Chat newline stop: passed
- Responses newline stop: passed
- No matching stop reaches `length`: passed
- List stop chooses earliest emitted stop: passed
- Rejects more than four stop strings: passed
- Rejects empty stop string: passed

Integration sweep result: `10 passed, 0 failed`.

Broader repo note: `pytest -q` still fails during collection on an unrelated existing mismatch in `mlx_vlm/tests/test_utils.py`, which imports `get_class_predicate` from `mlx_vlm.utils` although that symbol is not present.
