### PR TITLE
fix(qwen3_5_moe): route nested model.language_model.visual.* to vision_tower (#1057)

### DIFF
--- a/mlx_vlm/models/qwen3_5_moe/qwen3_5_moe.py
+++ b/mlx_vlm/models/qwen3_5_moe/qwen3_5_moe.py
@@ -46,7 +46,18 @@ class Model(Qwen3_5Model):
         sanitized_weights = {}
         for key, value in weights.items():
             if "model" in key:
-                if "model.language_model" in key:
+                # Qwen3.6 HF checkpoints nest the ViT inside the language-model
+                # submodule as ``model.language_model.visual.*``. Match the
+                # more-specific nested-visual prefix first so those keys route
+                # to ``vision_tower.*`` rather than being captured by the
+                # broader ``model.language_model`` branch (issue #1057). The
+                # trailing dot anchors the namespace boundary so that keys
+                # like ``model.language_model.visualizer.*`` (hypothetical)
+                # fall through to the language-model branch instead of being
+                # mis-routed to ``vision_tower``.
+                if "model.language_model.visual." in key:
+                    key = key.replace("model.language_model.visual", "vision_tower")
+                elif "model.language_model" in key:
                     key = key.replace("model.language_model", "language_model.model")
                 elif "model.visual" in key:
                     key = key.replace("model.visual", "vision_tower")

--- a/mlx_vlm/tests/test_models.py
+++ b/mlx_vlm/tests/test_models.py
@@ -5764,5 +5764,111 @@ class TestSam3(unittest.TestCase):
         self.assertEqual(sin.shape, (64, 64))
 
 
+class TestQwen3_5MoeSanitize(unittest.TestCase):
+    """Regression tests for issue #1057.
+
+    Qwen3.6 HF checkpoints nest the ViT inside the language-model submodule
+    as ``model.language_model.visual.*``. The sanitize chain previously
+    matched the broader ``model.language_model`` prefix first and rewrote
+    those keys to ``language_model.model.visual.*``, where they became
+    orphans the model has no attribute for and got silently dropped (333
+    ViT tensors lost on load).
+
+    Reported and diagnosed by @a4501150.
+    """
+
+    @staticmethod
+    def _stub_model():
+        """Build a minimal stub that exposes only what ``Model.sanitize`` reads.
+
+        ``num_hidden_layers = 0`` skips the per-layer ``gate_up_proj`` rewrite
+        loop so the test can focus on the prefix-routing chain that is the
+        subject of the bug. ``tie_word_embeddings = False`` keeps the
+        ``lm_head.weight`` pop branch off.
+        """
+
+        class _StubTextConfig:
+            tie_word_embeddings = False
+            num_hidden_layers = 0
+
+        class _StubConfig:
+            text_config = _StubTextConfig()
+
+        class _StubModel:
+            config = _StubConfig()
+
+        return _StubModel()
+
+    def test_sanitize_routes_nested_visual_to_vision_tower(self):
+        """Issue #1057: nested ``model.language_model.visual.*`` -> ``vision_tower.*``."""
+        from mlx_vlm.models.qwen3_5_moe.qwen3_5_moe import Model
+
+        weights = {
+            "model.language_model.visual.blocks.0.attn.qkv.weight": mx.zeros((1,)),
+            "model.language_model.visual.patch_embed.proj.weight": mx.zeros((1,)),
+        }
+        sanitized = Model.sanitize(self._stub_model(), weights)
+
+        self.assertIn("vision_tower.blocks.0.attn.qkv.weight", sanitized)
+        self.assertIn("vision_tower.patch_embed.proj.weight", sanitized)
+        # Must NOT land under the orphan path that the buggy chain produced.
+        self.assertNotIn(
+            "language_model.model.visual.blocks.0.attn.qkv.weight", sanitized
+        )
+        self.assertNotIn(
+            "language_model.model.visual.patch_embed.proj.weight", sanitized
+        )
+
+    def test_sanitize_routes_pure_language_model_keys(self):
+        """Pure ``model.language_model.*`` (no visual) -> ``language_model.model.*``."""
+        from mlx_vlm.models.qwen3_5_moe.qwen3_5_moe import Model
+
+        weights = {
+            "model.language_model.layers.0.self_attn.q_proj.weight": mx.zeros((1,)),
+            "model.language_model.embed_tokens.weight": mx.zeros((1,)),
+        }
+        sanitized = Model.sanitize(self._stub_model(), weights)
+
+        self.assertIn(
+            "language_model.model.layers.0.self_attn.q_proj.weight", sanitized
+        )
+        self.assertIn("language_model.model.embed_tokens.weight", sanitized)
+
+    def test_sanitize_routes_flat_visual_keys(self):
+        """Legacy flat ``model.visual.*`` -> ``vision_tower.*`` still works."""
+        from mlx_vlm.models.qwen3_5_moe.qwen3_5_moe import Model
+
+        weights = {
+            "model.visual.blocks.0.attn.proj.weight": mx.zeros((1,)),
+        }
+        sanitized = Model.sanitize(self._stub_model(), weights)
+
+        self.assertIn("vision_tower.blocks.0.attn.proj.weight", sanitized)
+
+    def test_sanitize_namespace_boundary_for_nested_visual(self):
+        """Trailing-dot anchor: ``model.language_model.visualizer.*`` (hypothetical)
+        must NOT mis-route to ``vision_tower.*``. Falls through to the language-model
+        branch instead.
+        """
+        from mlx_vlm.models.qwen3_5_moe.qwen3_5_moe import Model
+
+        weights = {
+            # Hypothetical sibling whose name shares the 'visual' prefix but
+            # is NOT a vision-tower key. Without the trailing-dot anchor on
+            # the first branch, this would mis-route to ``vision_towerizer.*``.
+            "model.language_model.visualizer.blocks.0.weight": mx.zeros((1,)),
+        }
+        sanitized = Model.sanitize(self._stub_model(), weights)
+
+        self.assertNotIn(
+            "vision_towerizer.blocks.0.weight", sanitized,
+            "Namespace boundary leaked: 'visualizer' was matched by the 'visual' prefix",
+        )
+        self.assertIn(
+            "language_model.model.visualizer.blocks.0.weight", sanitized,
+            "Hypothetical visualizer key should fall through to the language-model branch",
+        )
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Fixes #1057. Qwen3.6 HF checkpoints nest the ViT inside the language-model
submodule as `model.language_model.visual.*`. The current sanitize chain
captures those keys with the broader `model.language_model` branch and
rewrites them to `language_model.model.visual.*` — orphans that
`Qwen3_5MoeForConditionalGeneration` silently drops, leaving the vision
tower uninitialized.

The fix prepends a more-specific nested-visual branch so it matches first,
anchored with a trailing dot to enforce a namespace boundary (so hypothetical
sibling keys like `model.language_model.visualizer.*` fall through to the
language-model branch instead of being mis-routed to `vision_tower`).

## Test plan

- [x] **Unit tests** in `mlx_vlm/tests/test_models.py::TestQwen3_5MoeSanitize`
      (4 cases) cover nested ViT, flat ViT, pure language-model, and
      namespace-boundary routing.

- [x] **Real-checkpoint validation** against the reporter's model
      `Youssofal/Qwen3.6-35B-A3B-Abliterated-Heretic-BF16`. Pulled the
      `model.safetensors.index.json` (1026 weight keys) and ran them
      through `Model.sanitize()`:

      ```
      Input keys
        nested visual (model.language_model.visual.*) : 333
        pure language (model.language_model.*)        : 692
        flat visual (model.visual.*)                  :   0
        other (lm_head)                               :   1

      After sanitize
        -> vision_tower.*                : 333
        -> language_model.model.*        : 612
        -> language_model.model.visual.* :   0  (no orphans)
        -> other                         :   0
      ```

      The 333 nested ViT tensors all route to `vision_tower.*` with
      zero orphans — matching the exact "333 parameters not in model"
      count from the bug report.

- [x] **Adjacent test sweep** — `pytest -k "qwen3_5 or sanitize or qwen3_vl"`
      passes 11 tests, no regressions.

## Attribution

Diagnosis and proposed fix by @a4501150 (issue #1057). Both contributions
are credited via `Reported-by` and `Co-authored-by` trailers on the
commit.

## Notes

The same `if/elif` chain pattern (no nested-visual check) exists in three
sibling Qwen modules and would have the same latent bug if/when those
models encounter Qwen3.6-style nested HF checkpoints:

- `mlx_vlm/models/qwen3_5/qwen3_5.py:126-129`
- `mlx_vlm/models/qwen3_vl/qwen3_vl.py:164-168`
- `mlx_vlm/models/qwen3_vl_moe/qwen3_vl_moe.py:161-181`

Out of scope for this PR per YAGNI — verification against actual
checkpoints would be needed to know if any of those models is affected
in practice. Happy to file follow-up issues or extend the fix in a
separate PR if helpful.
