### PR TITLE
server: added 'server' header in responses

### DIFF
--- a/mlx_vlm/server.py
+++ b/mlx_vlm/server.py
@@ -2492,6 +2492,13 @@ def models_endpoint():
 # MLX_VLM API endpoints
 
 
+@app.middleware("http")
+async def add_server_header(request: Request, call_next):
+    response = await call_next(request)
+    response.headers["Server"] = f"mlx_vlm/{__version__}"
+    return response
+
+
 @app.get("/health")
 async def health_check():
     """


### PR DESCRIPTION
Added a “Server” response header in the mlx_vlm.server cli to help identifying the running server.

This helps #1072 in detecting the server type from url only.