### PR TITLE
Add Nemotron 3 Nano Omni model

### DIFF
--- a/mlx_vlm/generate.py
+++ b/mlx_vlm/generate.py
@@ -2398,6 +2398,10 @@ def main():
     args = parse_arguments()
     if isinstance(args.image, str):
         args.image = [args.image]
+    if isinstance(args.audio, str):
+        args.audio = [args.audio]
+    if isinstance(args.video, str):
+        args.video = [args.video]
 
     model, processor = load(
         args.model,
@@ -2418,9 +2422,7 @@ def main():
     prompt = args.prompt
 
     num_images = len(args.image) if args.image is not None else 0
-    num_audios = (
-        1 if args.audio is not None else 0
-    )  # TODO: Support multiple audio files
+    num_audios = len(args.audio) if args.audio is not None else 0
 
     chat_template_kwargs = {"enable_thinking": args.enable_thinking}
     if args.video:
@@ -2473,7 +2475,12 @@ def main():
         while user := input("User:"):
             chat.append({"role": "user", "content": user})
             prompt = apply_chat_template(
-                processor, config, chat, num_images=num_images, **chat_template_kwargs
+                processor,
+                config,
+                chat,
+                num_images=num_images,
+                num_audios=num_audios,
+                **chat_template_kwargs,
             )
             response = ""
             print("Assistant:", end="")

--- a/mlx_vlm/models/nemotron_h_nano_omni/__init__.py
+++ b/mlx_vlm/models/nemotron_h_nano_omni/__init__.py
@@ -1,0 +1,14 @@
+from .config import ModelConfig, SoundConfig, TextConfig, VisionConfig
+from .language import LanguageModel
+from .nemotron_h_nano_omni import Model
+from .vision import VisionModel
+
+__all__ = [
+    "LanguageModel",
+    "Model",
+    "ModelConfig",
+    "SoundConfig",
+    "TextConfig",
+    "VisionConfig",
+    "VisionModel",
+]

--- a/mlx_vlm/models/nemotron_h_nano_omni/audio.py
+++ b/mlx_vlm/models/nemotron_h_nano_omni/audio.py
@@ -1,0 +1,561 @@
+import math
+from typing import Sequence
+
+import mlx.core as mx
+import mlx.nn as nn
+import numpy as np
+
+from .config import SoundConfig
+
+
+class SquaredReLU(nn.Module):
+    def __call__(self, x):
+        return nn.relu(x) ** 2
+
+
+class SoundProjection(nn.Module):
+    def __init__(self, config: SoundConfig, llm_hidden_size: int):
+        super().__init__()
+        self.norm = nn.RMSNorm(config.hidden_size, eps=1e-5)
+        self.linear1 = nn.Linear(
+            config.hidden_size,
+            config.projection_hidden_size,
+            bias=config.projection_bias,
+        )
+        self.activation = SquaredReLU()
+        self.linear2 = nn.Linear(
+            config.projection_hidden_size,
+            llm_hidden_size,
+            bias=config.projection_bias,
+        )
+
+    def __call__(self, hidden_states):
+        hidden_states = self.norm(hidden_states)
+        hidden_states = self.linear1(hidden_states)
+        hidden_states = self.activation(hidden_states)
+        return self.linear2(hidden_states)
+
+
+class ParakeetEncoderRelPositionalEncoding(nn.Module):
+    def __init__(self, config: SoundConfig):
+        super().__init__()
+        self.hidden_size = config.hidden_size
+        self.max_position_embeddings = config.max_position_embeddings
+
+    def __call__(self, hidden_states):
+        seq_length = hidden_states.shape[1]
+        if seq_length > self.max_position_embeddings:
+            raise ValueError(
+                f"Sequence length {seq_length} exceeds "
+                f"max_position_embeddings={self.max_position_embeddings}."
+            )
+
+        positions = mx.arange(seq_length - 1, -seq_length, -1, dtype=mx.float32)
+        inv_freq = 1.0 / (
+            10000.0
+            ** (mx.arange(0, self.hidden_size, 2, dtype=mx.float32) / self.hidden_size)
+        )
+        freqs = positions[:, None] * inv_freq[None, :]
+        pos_embed = mx.stack([mx.sin(freqs), mx.cos(freqs)], axis=-1).reshape(
+            2 * seq_length - 1, self.hidden_size
+        )
+        pos_embed = mx.broadcast_to(
+            pos_embed[None, :, :],
+            (hidden_states.shape[0], pos_embed.shape[0], pos_embed.shape[1]),
+        )
+        return pos_embed.astype(hidden_states.dtype)
+
+
+class ParakeetEncoderFeedForward(nn.Module):
+    def __init__(self, config: SoundConfig):
+        super().__init__()
+        self.linear1 = nn.Linear(
+            config.hidden_size,
+            config.intermediate_size,
+            bias=config.attention_bias,
+        )
+        self.activation = nn.SiLU()
+        self.linear2 = nn.Linear(
+            config.intermediate_size,
+            config.hidden_size,
+            bias=config.attention_bias,
+        )
+
+    def __call__(self, hidden_states):
+        return self.linear2(self.activation(self.linear1(hidden_states)))
+
+
+class ParakeetEncoderConvolutionModule(nn.Module):
+    def __init__(self, config: SoundConfig):
+        super().__init__()
+        channels = config.hidden_size
+        kernel_size = config.conv_kernel_size
+        self.pointwise_conv1 = nn.Conv1d(
+            channels,
+            2 * channels,
+            kernel_size=1,
+            stride=1,
+            padding=0,
+            bias=config.convolution_bias,
+        )
+        self.depthwise_conv = nn.Conv1d(
+            channels,
+            channels,
+            kernel_size=kernel_size,
+            stride=1,
+            padding=(kernel_size - 1) // 2,
+            groups=channels,
+            bias=config.convolution_bias,
+        )
+        self.norm = nn.BatchNorm(channels)
+        self.activation = nn.SiLU()
+        self.pointwise_conv2 = nn.Conv1d(
+            channels,
+            channels,
+            kernel_size=1,
+            stride=1,
+            padding=0,
+            bias=config.convolution_bias,
+        )
+
+    def __call__(self, hidden_states, attention_mask=None):
+        hidden_states = self.pointwise_conv1(hidden_states)
+        hidden_states = nn.glu(hidden_states, axis=-1)
+
+        if attention_mask is not None:
+            all_masked_rows = mx.all(mx.logical_not(attention_mask), axis=2)
+            all_masked_rows = mx.squeeze(all_masked_rows, axis=1)
+            hidden_states = mx.where(all_masked_rows[..., None], 0.0, hidden_states)
+
+        hidden_states = self.depthwise_conv(hidden_states)
+        hidden_states = self.norm(hidden_states)
+        hidden_states = self.activation(hidden_states)
+        return self.pointwise_conv2(hidden_states)
+
+
+class ParakeetEncoderAttention(nn.Module):
+    def __init__(self, config: SoundConfig, layer_idx: int):
+        super().__init__()
+        self.config = config
+        self.layer_idx = layer_idx
+        self.head_dim = config.hidden_size // config.num_attention_heads
+        self.scaling = self.head_dim**-0.5
+
+        self.q_proj = nn.Linear(
+            config.hidden_size,
+            config.num_attention_heads * self.head_dim,
+            bias=config.attention_bias,
+        )
+        self.k_proj = nn.Linear(
+            config.hidden_size,
+            config.num_attention_heads * self.head_dim,
+            bias=config.attention_bias,
+        )
+        self.v_proj = nn.Linear(
+            config.hidden_size,
+            config.num_attention_heads * self.head_dim,
+            bias=config.attention_bias,
+        )
+        self.o_proj = nn.Linear(
+            config.num_attention_heads * self.head_dim,
+            config.hidden_size,
+            bias=config.attention_bias,
+        )
+        self.relative_k_proj = nn.Linear(
+            config.hidden_size,
+            config.num_attention_heads * self.head_dim,
+            bias=False,
+        )
+        self.bias_u = mx.zeros((config.num_attention_heads, self.head_dim))
+        self.bias_v = mx.zeros((config.num_attention_heads, self.head_dim))
+
+    def _rel_shift(self, attention_scores):
+        batch_size, num_heads, query_length, position_length = attention_scores.shape
+        attention_scores = mx.pad(attention_scores, [(0, 0), (0, 0), (0, 0), (1, 0)])
+        attention_scores = attention_scores.reshape(
+            batch_size, num_heads, position_length + 1, query_length
+        )
+        attention_scores = attention_scores[:, :, 1:, :]
+        return attention_scores.reshape(
+            batch_size, num_heads, query_length, position_length
+        )
+
+    def __call__(self, hidden_states, position_embeddings, attention_mask=None):
+        batch_size, seq_length, _ = hidden_states.shape
+        hidden_shape = (
+            batch_size,
+            seq_length,
+            self.config.num_attention_heads,
+            self.head_dim,
+        )
+
+        query_states = (
+            self.q_proj(hidden_states).reshape(hidden_shape).transpose(0, 2, 1, 3)
+        )
+        key_states = (
+            self.k_proj(hidden_states).reshape(hidden_shape).transpose(0, 2, 1, 3)
+        )
+        value_states = (
+            self.v_proj(hidden_states).reshape(hidden_shape).transpose(0, 2, 1, 3)
+        )
+
+        query_states_with_bias_u = query_states + self.bias_u[None, :, None, :]
+        query_states_with_bias_v = query_states + self.bias_v[None, :, None, :]
+
+        relative_key_states = self.relative_k_proj(position_embeddings).reshape(
+            batch_size, -1, self.config.num_attention_heads, self.head_dim
+        )
+
+        matrix_bd = mx.matmul(
+            query_states_with_bias_v,
+            relative_key_states.transpose(0, 2, 3, 1),
+        )
+        matrix_bd = self._rel_shift(matrix_bd)[..., :seq_length] * self.scaling
+
+        if attention_mask is not None:
+            matrix_bd = mx.where(
+                attention_mask,
+                matrix_bd,
+                mx.array(mx.finfo(matrix_bd.dtype).min, dtype=matrix_bd.dtype),
+            )
+
+        attn_output = mx.fast.scaled_dot_product_attention(
+            query_states_with_bias_u,
+            key_states,
+            value_states,
+            scale=self.scaling,
+            mask=matrix_bd,
+        )
+        if attention_mask is not None:
+            valid_queries = mx.any(attention_mask, axis=-1)
+            attn_output = attn_output * valid_queries[..., None].astype(
+                attn_output.dtype
+            )
+        attn_output = attn_output.transpose(0, 2, 1, 3).reshape(
+            batch_size, seq_length, -1
+        )
+        return self.o_proj(attn_output)
+
+
+class ParakeetEncoderSubsamplingConv2D(nn.Module):
+    def __init__(self, config: SoundConfig):
+        super().__init__()
+        self.kernel_size = config.subsampling_conv_kernel_size
+        self.stride = config.subsampling_conv_stride
+        self.channels = config.subsampling_conv_channels
+        self.padding = (self.kernel_size - 1) // 2
+        self.num_layers = int(math.log2(config.subsampling_factor))
+
+        self.layers = [
+            nn.Conv2d(
+                1,
+                self.channels,
+                kernel_size=self.kernel_size,
+                stride=self.stride,
+                padding=self.padding,
+            ),
+            nn.ReLU(),
+        ]
+        for _ in range(self.num_layers - 1):
+            self.layers.extend(
+                [
+                    nn.Conv2d(
+                        self.channels,
+                        self.channels,
+                        kernel_size=self.kernel_size,
+                        stride=self.stride,
+                        padding=self.padding,
+                        groups=self.channels,
+                    ),
+                    nn.Conv2d(self.channels, self.channels, kernel_size=1),
+                    nn.ReLU(),
+                ]
+            )
+
+        out_length = config.num_mel_bins // (self.stride**self.num_layers)
+        self.linear = nn.Linear(
+            config.subsampling_conv_channels * out_length,
+            config.hidden_size,
+            bias=True,
+        )
+
+    def _get_output_length(self, input_lengths, conv_layer):
+        if getattr(conv_layer, "stride", (1, 1)) == (1, 1):
+            return input_lengths
+
+        padding = conv_layer.padding[0]
+        kernel_size = conv_layer.weight.shape[1]
+        stride = conv_layer.stride[0]
+        lengths = mx.floor(
+            (input_lengths.astype(mx.float32) + 2 * padding - kernel_size) / stride
+            + 1.0
+        )
+        return lengths.astype(mx.int32)
+
+    def __call__(self, input_features, attention_mask=None):
+        hidden_states = input_features[..., None]
+        current_lengths = (
+            mx.sum(attention_mask, axis=-1).astype(mx.int32)
+            if attention_mask is not None
+            else None
+        )
+
+        for layer in self.layers:
+            hidden_states = layer(hidden_states)
+            if isinstance(layer, nn.Conv2d) and attention_mask is not None:
+                current_lengths = self._get_output_length(current_lengths, layer)
+                current_seq_length = hidden_states.shape[1]
+                channel_mask = (
+                    mx.arange(current_seq_length)[None, :] < current_lengths[:, None]
+                )
+                hidden_states = hidden_states * channel_mask[:, :, None, None].astype(
+                    hidden_states.dtype
+                )
+
+        hidden_states = hidden_states.transpose(0, 1, 3, 2).reshape(
+            hidden_states.shape[0], hidden_states.shape[1], -1
+        )
+        return self.linear(hidden_states)
+
+
+class ParakeetEncoderBlock(nn.Module):
+    def __init__(self, config: SoundConfig, layer_idx: int):
+        super().__init__()
+        self.feed_forward1 = ParakeetEncoderFeedForward(config)
+        self.self_attn = ParakeetEncoderAttention(config, layer_idx)
+        self.conv = ParakeetEncoderConvolutionModule(config)
+        self.feed_forward2 = ParakeetEncoderFeedForward(config)
+        self.norm_feed_forward1 = nn.LayerNorm(config.hidden_size)
+        self.norm_self_att = nn.LayerNorm(config.hidden_size)
+        self.norm_conv = nn.LayerNorm(config.hidden_size)
+        self.norm_feed_forward2 = nn.LayerNorm(config.hidden_size)
+        self.norm_out = nn.LayerNorm(config.hidden_size)
+
+    def __call__(self, hidden_states, attention_mask=None, position_embeddings=None):
+        residual = hidden_states
+        hidden_states = self.feed_forward1(self.norm_feed_forward1(hidden_states))
+        hidden_states = residual + 0.5 * hidden_states
+
+        normalized_hidden_states = self.norm_self_att(hidden_states)
+        hidden_states = hidden_states + self.self_attn(
+            normalized_hidden_states,
+            attention_mask=attention_mask,
+            position_embeddings=position_embeddings,
+        )
+
+        hidden_states = hidden_states + self.conv(
+            self.norm_conv(hidden_states), attention_mask=attention_mask
+        )
+        hidden_states = hidden_states + 0.5 * self.feed_forward2(
+            self.norm_feed_forward2(hidden_states)
+        )
+        return self.norm_out(hidden_states)
+
+
+class ParakeetEncoder(nn.Module):
+    def __init__(self, config: SoundConfig):
+        super().__init__()
+        self.config = config
+        self.input_scale = math.sqrt(config.hidden_size) if config.scale_input else 1.0
+        self.subsampling = ParakeetEncoderSubsamplingConv2D(config)
+        self.encode_positions = ParakeetEncoderRelPositionalEncoding(config)
+        self.layers = [
+            ParakeetEncoderBlock(config, layer_idx)
+            for layer_idx in range(config.num_hidden_layers)
+        ]
+
+    def _get_subsampling_output_length(self, input_lengths):
+        kernel_size = self.config.subsampling_conv_kernel_size
+        stride = self.config.subsampling_conv_stride
+        num_layers = int(math.log2(self.config.subsampling_factor))
+        add_pad = ((kernel_size - 1) // 2) * 2 - kernel_size
+        lengths = input_lengths
+        for _ in range(num_layers):
+            lengths = mx.floor((lengths.astype(mx.float32) + add_pad) / stride + 1.0)
+        return lengths.astype(mx.int32)
+
+    def _get_output_attention_mask(self, attention_mask, target_length=None):
+        output_lengths = self._get_subsampling_output_length(
+            mx.sum(attention_mask, axis=-1)
+        )
+        max_length = (
+            target_length if target_length is not None else mx.max(output_lengths)
+        )
+        max_length = (
+            int(max_length.item()) if isinstance(max_length, mx.array) else max_length
+        )
+        return mx.arange(max_length)[None, :] < output_lengths[:, None]
+
+    def __call__(self, input_features, attention_mask=None):
+        hidden_states = self.subsampling(input_features, attention_mask)
+        hidden_states = hidden_states * self.input_scale
+        position_embeddings = self.encode_positions(hidden_states)
+
+        output_mask = None
+        if attention_mask is not None:
+            output_mask = self._get_output_attention_mask(
+                attention_mask, target_length=hidden_states.shape[1]
+            )
+            attention_mask = (
+                output_mask[:, None, :, None] & output_mask[:, None, None, :]
+            )
+
+        for layer in self.layers:
+            hidden_states = layer(
+                hidden_states,
+                attention_mask=attention_mask,
+                position_embeddings=position_embeddings,
+            )
+
+        return hidden_states, output_mask
+
+
+class SoundEncoder(nn.Module):
+    def __init__(self, config: SoundConfig):
+        super().__init__()
+        self.config = config
+        self.encoder = ParakeetEncoder(config)
+
+    def __call__(self, input_features, attention_mask=None):
+        hidden_states, _ = self.encoder(input_features, attention_mask)
+        return hidden_states
+
+    @property
+    def hidden_size(self) -> int:
+        return self.config.hidden_size
+
+
+class SoundFeatureExtractor:
+    def __init__(self, config: SoundConfig):
+        self.config = config
+        self.sampling_rate = config.sampling_rate
+
+        try:
+            from mlx_audio.dsp import hanning, mel_filters, stft
+        except ImportError as exc:
+            raise ImportError(
+                "Nemotron Omni audio preprocessing requires mlx-audio. "
+                "Install mlx-audio or make it importable on PYTHONPATH."
+            ) from exc
+
+        self._hanning = hanning
+        self._mel_filters = mel_filters
+        self._stft = stft
+
+    def _to_waveform(self, audio):
+        if isinstance(audio, mx.array):
+            waveform = audio
+        elif isinstance(audio, np.ndarray):
+            waveform = mx.array(audio)
+        elif isinstance(audio, (list, tuple)):
+            waveform = mx.array(np.asarray(audio, dtype=np.float32))
+        elif isinstance(audio, str):
+            from mlx_audio.stt.utils import load_audio
+
+            waveform = load_audio(audio, self.sampling_rate, dtype=mx.float32)
+        else:
+            raise ValueError(f"Unsupported audio input type: {type(audio)}")
+
+        if waveform.ndim > 1:
+            waveform = mx.mean(waveform, axis=-1)
+        return waveform.astype(mx.float32)
+
+    def _log_mel_spectrogram(self, waveform):
+        original_dtype = waveform.dtype
+        if self.config.preemphasis is not None:
+            waveform = mx.concatenate(
+                [
+                    waveform[:1],
+                    waveform[1:] - self.config.preemphasis * waveform[:-1],
+                ],
+                axis=0,
+            )
+
+        window = self._hanning(self.config.win_length, periodic=False)
+        if window.shape[0] < self.config.n_fft:
+            left = (self.config.n_fft - window.shape[0]) // 2
+            right = self.config.n_fft - window.shape[0] - left
+            window = mx.concatenate(
+                [
+                    mx.zeros((left,), dtype=window.dtype),
+                    window,
+                    mx.zeros((right,), dtype=window.dtype),
+                ]
+            )
+
+        spec = self._stft(
+            waveform,
+            self.config.n_fft,
+            self.config.hop_length,
+            self.config.n_fft,
+            window,
+            pad_mode="constant",
+        )
+        spec = mx.square(mx.abs(spec)).astype(original_dtype)
+        filters = self._mel_filters(
+            self.config.sampling_rate,
+            self.config.n_fft,
+            self.config.num_mel_bins,
+            norm="slaney",
+            mel_scale="slaney",
+        )
+        mel = filters.astype(spec.dtype) @ spec.T
+        mel = mx.log(mel + mx.array(2**-24, dtype=mel.dtype)).T
+        return mel
+
+    def __call__(self, audio: Sequence):
+        if not isinstance(audio, (list, tuple)):
+            audio = [audio]
+
+        features = []
+        full_lengths = []
+        valid_lengths = []
+        for clip in audio:
+            waveform = self._to_waveform(clip)
+            mel = self._log_mel_spectrogram(waveform)
+            valid_length = waveform.shape[0] // self.config.hop_length
+            valid_length = min(valid_length, mel.shape[0])
+            mask = mx.arange(mel.shape[0]) < valid_length
+            mask_f = mask[:, None].astype(mel.dtype)
+            denom = max(valid_length, 1)
+            mean = mx.sum(mel * mask_f, axis=0) / denom
+            variance_denom = max(valid_length - 1, 1)
+            variance = mx.sum(((mel - mean) ** 2) * mask_f, axis=0) / variance_denom
+            mel = ((mel - mean) / (mx.sqrt(variance) + 1e-5)) * mask_f
+            features.append(mel)
+            full_lengths.append(mel.shape[0])
+            valid_lengths.append(valid_length)
+
+        max_length = max(full_lengths)
+        padded = []
+        masks = []
+        for mel, full_length, valid_length in zip(
+            features, full_lengths, valid_lengths
+        ):
+            pad = max_length - full_length
+            if pad:
+                mel = mx.pad(mel, [(0, pad), (0, 0)])
+            padded.append(mel)
+            masks.append(mx.arange(max_length) < valid_length)
+
+        return (
+            mx.stack(padded, axis=0),
+            mx.stack(masks, axis=0).astype(mx.int32),
+            mx.array(full_lengths, dtype=mx.int32),
+        )
+
+
+def sanitize_audio_weights(weights):
+    sanitized = {}
+    for key, value in weights.items():
+        if key.startswith("sound_encoder.encoder.feature_extractor."):
+            continue
+        if key.endswith(".num_batches_tracked"):
+            continue
+        if key.startswith("sound_encoder.encoder."):
+            if key.endswith(".weight") and value.ndim == 3:
+                value = value.transpose(0, 2, 1)
+            elif key.endswith(".weight") and value.ndim == 4:
+                value = value.transpose(0, 2, 3, 1)
+        sanitized[key] = value
+    return sanitized

--- a/mlx_vlm/models/nemotron_h_nano_omni/config.py
+++ b/mlx_vlm/models/nemotron_h_nano_omni/config.py
@@ -1,0 +1,143 @@
+from dataclasses import asdict, dataclass, is_dataclass
+from typing import Any, Dict, Optional
+
+from mlx_lm.models.nemotron_h import ModelArgs as TextConfig
+
+from ..base import BaseModelConfig
+
+
+@dataclass
+class VisionConfig(BaseModelConfig):
+    model_type: str = "radio"
+    args: Optional[dict] = None
+    version: str = "radio_v2.5-h"
+    hidden_size: int = 1280
+    num_hidden_layers: int = 32
+    num_attention_heads: int = 16
+    intermediate_size: int = 5120
+    image_size: int = 224
+    patch_size: int = 16
+    max_resolution: int = 2048
+    preferred_resolution: Any = None
+    adaptor_names: Any = None
+    adaptor_configs: Optional[Dict[str, Dict[str, int]]] = None
+    vitdet_window_size: Optional[int] = None
+    feature_normalizer_config: Optional[dict] = None
+    inter_feature_normalizer_config: Optional[dict] = None
+    min_num_patches: Optional[int] = None
+    max_num_patches: Optional[int] = None
+    dynamic_image_min_num_patches: int = 1024
+    dynamic_image_max_num_patches: int = 13312
+    video_target_num_patches: int = 1024
+    video_temporal_patch_size: int = 2
+    separate_video_embedder: bool = True
+    force_image_size: Optional[int] = None
+
+    def __post_init__(self):
+        if self.min_num_patches is not None:
+            self.dynamic_image_min_num_patches = self.min_num_patches
+        if self.max_num_patches is not None:
+            self.dynamic_image_max_num_patches = self.max_num_patches
+
+
+@dataclass
+class SoundConfig(BaseModelConfig):
+    model_type: str = "parakeet"
+    hidden_size: int = 1024
+    num_attention_heads: int = 8
+    num_hidden_layers: int = 24
+    intermediate_size: int = 4096
+    hidden_act: str = "silu"
+    attention_bias: bool = False
+    convolution_bias: bool = False
+    conv_kernel_size: int = 9
+    subsampling_factor: int = 8
+    subsampling_conv_channels: int = 256
+    num_mel_bins: int = 128
+    feat_in: Optional[int] = None
+    subsampling_conv_kernel_size: int = 3
+    subsampling_conv_stride: int = 2
+    dropout: float = 0.0
+    dropout_positions: float = 0.0
+    layerdrop: float = 0.0
+    activation_dropout: float = 0.0
+    attention_dropout: float = 0.0
+    max_position_embeddings: int = 5000
+    scale_input: bool = False
+    initializer_range: float = 0.02
+    projection_hidden_size: int = 4096
+    projection_bias: bool = False
+    sampling_rate: int = 16000
+    hop_length: int = 160
+    n_fft: int = 512
+    win_length: int = 400
+    preemphasis: float = 0.97
+
+    def __post_init__(self):
+        if self.feat_in is None:
+            self.feat_in = self.num_mel_bins
+        self.num_key_value_heads = self.num_attention_heads
+
+
+@dataclass
+class ModelConfig(BaseModelConfig):
+    text_config: TextConfig
+    vision_config: VisionConfig
+    sound_config: Optional[SoundConfig] = None
+    model_type: str = "nemotron_h_nano_omni"
+    force_image_size: Optional[int] = None
+    downsample_ratio: float = 0.5
+    template: Optional[str] = None
+    ps_version: str = "v1"
+    image_tag_type: str = "internvl"
+    projector_hidden_size: int = 4096
+    vit_hidden_size: int = 1280
+    attn_implementation: Optional[str] = None
+    video_pruning_rate: float = 0.0
+    video_temporal_patch_size: int = 2
+    img_context_token_id: Optional[int] = None
+    video_context_token_id: Optional[int] = None
+    sound_context_token_id: Optional[int] = None
+    eos_token_id: Any = None
+    image_token_index: Optional[int] = None
+
+    @classmethod
+    def from_dict(cls, params):
+        params = dict(params or {})
+        text_config = TextConfig.from_dict(
+            params.pop("text_config", params.pop("llm_config", {}))
+        )
+        vision_config = VisionConfig.from_dict(params.pop("vision_config", {}))
+
+        raw_sound_config = params.pop("sound_config", None)
+        sound_config = (
+            SoundConfig.from_dict(raw_sound_config)
+            if raw_sound_config is not None
+            else None
+        )
+
+        allowed = cls.__dataclass_fields__
+        kwargs = {k: v for k, v in params.items() if k in allowed}
+        config = cls(
+            text_config=text_config,
+            vision_config=vision_config,
+            sound_config=sound_config,
+            **kwargs,
+        )
+        if config.image_token_index is None:
+            config.image_token_index = config.img_context_token_id
+        return config
+
+    def to_dict(self):
+        def convert(value):
+            if is_dataclass(value):
+                return asdict(value)
+            if hasattr(value, "__dict__"):
+                return {
+                    k: convert(v)
+                    for k, v in value.__dict__.items()
+                    if not k.startswith("_") and v is not None
+                }
+            return value
+
+        return {k: convert(v) for k, v in self.__dict__.items() if v is not None}

--- a/mlx_vlm/models/nemotron_h_nano_omni/language.py
+++ b/mlx_vlm/models/nemotron_h_nano_omni/language.py
@@ -1,0 +1,113 @@
+from typing import Any, Optional
+
+import mlx.core as mx
+import mlx.nn as nn
+from mlx_lm.models.base import create_attention_mask, create_ssm_mask
+from mlx_lm.models.cache import ArraysCache, KVCache
+from mlx_lm.models.nemotron_h import Model as NemotronHForCausalLM
+from mlx_lm.models.nemotron_h import ModelArgs, NemotronHModel
+
+from ..base import LanguageModelOutput
+
+
+class LanguageModel(nn.Module):
+    def __init__(self, args: ModelArgs):
+        super().__init__()
+        self.args = args
+        self.config = args
+        self.model_type = args.model_type
+        self.backbone = NemotronHModel(args)
+        self.lm_head = nn.Linear(args.hidden_size, args.vocab_size, bias=False)
+
+    @property
+    def layers(self):
+        return self.backbone.layers
+
+    def make_cache(self):
+        caches = []
+        for layer in self.layers:
+            if layer.block_type == "M":
+                caches.append(ArraysCache(size=2))
+            elif layer.block_type == "*":
+                caches.append(KVCache())
+        return caches
+
+    def get_input_embeddings(self, input_ids: mx.array) -> mx.array:
+        return self.backbone.embeddings(input_ids)
+
+    def __call__(
+        self,
+        inputs: Optional[mx.array] = None,
+        *,
+        inputs_embeds: Optional[mx.array] = None,
+        cache: Optional[Any] = None,
+        output_hidden_states: bool = False,
+        **kwargs,
+    ):
+        if inputs_embeds is None:
+            if inputs is None:
+                raise ValueError("Either inputs or inputs_embeds must be provided.")
+            hidden_states = self.backbone.embeddings(inputs)
+        else:
+            hidden_states = inputs_embeds
+
+        if cache is None:
+            cache = [None] * len(self.layers)
+
+        attn_cache = (
+            cache[self.backbone.fa_idx] if self.backbone.fa_idx < len(cache) else None
+        )
+        ssm_cache = (
+            cache[self.backbone.ssm_idx] if self.backbone.ssm_idx < len(cache) else None
+        )
+        attn_mask = create_attention_mask(hidden_states, attn_cache)
+        ssm_mask = create_ssm_mask(hidden_states, ssm_cache)
+
+        all_hidden_states = [] if output_hidden_states else None
+        cache_counter = 0
+        for layer in self.layers:
+            if output_hidden_states:
+                all_hidden_states.append(hidden_states)
+
+            if layer.block_type in ("M", "*"):
+                layer_cache = cache[cache_counter]
+                cache_counter += 1
+            else:
+                layer_cache = None
+
+            mask = attn_mask if layer.block_type == "*" else ssm_mask
+            hidden_states = layer(hidden_states, mask=mask, cache=layer_cache)
+
+        hidden_states = self.backbone.norm_f(hidden_states)
+        if output_hidden_states:
+            all_hidden_states.append(hidden_states)
+
+        return LanguageModelOutput(
+            logits=self.lm_head(hidden_states),
+            hidden_states=all_hidden_states,
+        )
+
+    def sanitize(self, weights):
+        language_weights = {}
+        passthrough = {}
+        prefix = "language_model."
+        for key, value in weights.items():
+            if key.startswith(prefix):
+                language_weights[key[len(prefix) :]] = value
+            else:
+                passthrough[key] = value
+
+        if language_weights:
+            language_weights = NemotronHForCausalLM.sanitize(self, language_weights)
+            passthrough.update(
+                {f"{prefix}{key}": value for key, value in language_weights.items()}
+            )
+
+        return passthrough
+
+    @property
+    def cast_predicate(self):
+        def predicate(key):
+            return "e_score_correction_bias" not in key and "A_log" not in key
+
+        return predicate

--- a/mlx_vlm/models/nemotron_h_nano_omni/nemotron_h_nano_omni.py
+++ b/mlx_vlm/models/nemotron_h_nano_omni/nemotron_h_nano_omni.py
@@ -1,0 +1,320 @@
+from typing import Optional
+
+import mlx.core as mx
+import mlx.nn as nn
+import numpy as np
+
+from ..base import InputEmbeddingsFeatures, LanguageModelOutput
+from .audio import (
+    SoundEncoder,
+    SoundFeatureExtractor,
+    SoundProjection,
+    SquaredReLU,
+    sanitize_audio_weights,
+)
+from .config import ModelConfig
+from .language import LanguageModel
+from .vision import VisionModel
+
+
+class VisionProjection(nn.Module):
+    def __init__(self, config: ModelConfig):
+        super().__init__()
+        scale = int(1 / config.downsample_ratio)
+        in_features = config.vit_hidden_size * (scale**2)
+        self.layers = [
+            nn.RMSNorm(in_features, eps=1e-5),
+            nn.Linear(in_features, config.projector_hidden_size, bias=False),
+            SquaredReLU(),
+            nn.Linear(
+                config.projector_hidden_size,
+                config.text_config.hidden_size,
+                bias=False,
+            ),
+        ]
+
+    def __call__(self, x):
+        for layer in self.layers:
+            x = layer(x)
+        return x
+
+
+def masked_scatter(
+    final_embedding: mx.array,
+    mask: mx.array,
+    source: mx.array,
+):
+    final_shape = final_embedding.shape
+    final_flat = mx.flatten(final_embedding)
+    source_flat = mx.flatten(source)
+    mask_flat = mx.flatten(mask)
+    positions = mx.array(np.where(mask_flat)[0], mx.uint32)
+    final_flat[positions] = source_flat
+    return final_flat.reshape(final_shape)
+
+
+class Model(nn.Module):
+    def __init__(self, config: ModelConfig):
+        super().__init__()
+        self.config = config
+        self.model_type = config.model_type
+        self.language_model = LanguageModel(config.text_config)
+        self.vision_model = VisionModel(config.vision_config)
+        self.mlp1 = VisionProjection(config)
+
+        self.img_context_token_id = config.img_context_token_id
+        self.video_context_token_id = config.video_context_token_id
+        self.sound_context_token_id = config.sound_context_token_id
+        self.video_temporal_patch_dim = config.video_temporal_patch_size
+        self.video_pruning_rate = config.video_pruning_rate
+
+        self.sound_encoder = None
+        self.sound_projection = None
+        self.sound_feature_extractor = None
+        if config.sound_config is not None:
+            self.sound_encoder = SoundEncoder(config.sound_config)
+            self.sound_projection = SoundProjection(
+                config.sound_config, config.text_config.hidden_size
+            )
+            self.sound_feature_extractor = SoundFeatureExtractor(config.sound_config)
+
+    @property
+    def layers(self):
+        return self.language_model.layers
+
+    def _merge_features(self, inputs_embeds, input_ids, token_id, features, name):
+        if token_id is None:
+            raise ValueError(f"{name} context token id is not configured.")
+
+        features = features.reshape(-1, inputs_embeds.shape[-1]).astype(
+            inputs_embeds.dtype
+        )
+        token_mask = input_ids == token_id
+        n_tokens = int(mx.sum(token_mask).item())
+        if n_tokens != features.shape[0]:
+            raise ValueError(
+                f"{name} token count ({n_tokens}) does not match feature count "
+                f"({features.shape[0]})."
+            )
+
+        token_mask = mx.broadcast_to(token_mask[..., None], inputs_embeds.shape)
+        return masked_scatter(inputs_embeds, token_mask, features)
+
+    def _extract_sound_features(
+        self,
+        sound_clips=None,
+        input_features=None,
+        feature_attention_mask=None,
+        feature_lengths=None,
+    ):
+        if sound_clips is None and input_features is None:
+            return None
+
+        if self.sound_encoder is None or self.sound_projection is None:
+            raise RuntimeError("Sound encoder is not initialized for this model.")
+
+        if sound_clips is not None:
+            (
+                input_features,
+                feature_attention_mask,
+                feature_lengths,
+            ) = self.sound_feature_extractor(sound_clips)
+        if not isinstance(input_features, mx.array):
+            input_features = mx.array(input_features)
+        input_features = input_features.astype(self.language_model.lm_head.weight.dtype)
+
+        if feature_attention_mask is not None and not isinstance(
+            feature_attention_mask, mx.array
+        ):
+            feature_attention_mask = mx.array(feature_attention_mask)
+
+        sound_embeds = self.sound_encoder(input_features, feature_attention_mask)
+        sound_embeds = self.sound_projection(sound_embeds)
+
+        if feature_lengths is None and feature_attention_mask is not None:
+            feature_lengths = mx.sum(feature_attention_mask, axis=-1).astype(mx.int32)
+
+        if feature_lengths is None:
+            return sound_embeds
+
+        if not isinstance(feature_lengths, mx.array):
+            feature_lengths = mx.array(feature_lengths, dtype=mx.int32)
+
+        output_lengths = self.sound_encoder.encoder._get_subsampling_output_length(
+            feature_lengths
+        )
+        pieces = [
+            sound_embeds[i, : int(length)]
+            for i, length in enumerate(output_lengths.tolist())
+        ]
+        return mx.concatenate(pieces, axis=0) if pieces else None
+
+    def pixel_shuffle(self, x, scale_factor=0.5):
+        batch, width, height, channels = x.shape
+        x = x.reshape(
+            batch,
+            width,
+            int(height * scale_factor),
+            int(channels / scale_factor),
+        )
+        x = x.transpose(0, 2, 1, 3)
+        x = x.reshape(
+            batch,
+            int(height * scale_factor),
+            int(width * scale_factor),
+            int(channels / (scale_factor * scale_factor)),
+        )
+        if self.config.ps_version != "v1":
+            x = x.transpose(0, 2, 1, 3)
+        return x
+
+    def _ensure_4d_pixels(self, pixel_values):
+        if not isinstance(pixel_values, mx.array):
+            pixel_values = mx.array(pixel_values)
+        if pixel_values.ndim == 3:
+            pixel_values = pixel_values[None, ...]
+        return pixel_values
+
+    def _extract_feature_single(self, pixel_values):
+        pixel_values = self._ensure_4d_pixels(pixel_values)
+        vit_embeds = self.vision_model(pixel_values).features
+        patch_size = self.vision_model.radio_model.model.patch_generator.patch_size
+        _, _, height, width = pixel_values.shape
+        patch_h = height // patch_size
+        patch_w = width // patch_size
+        vit_embeds = vit_embeds.reshape(vit_embeds.shape[0], patch_h, patch_w, -1)
+        vit_embeds = self.pixel_shuffle(
+            vit_embeds, scale_factor=self.config.downsample_ratio
+        )
+        vit_embeds = vit_embeds.reshape(vit_embeds.shape[0], -1, vit_embeds.shape[-1])
+        return self.mlp1(vit_embeds)
+
+    def extract_feature(self, pixel_values):
+        if isinstance(pixel_values, (list, tuple)):
+            return mx.concatenate(
+                [self._extract_feature_single(pv) for pv in pixel_values], axis=0
+            )
+        return self._extract_feature_single(pixel_values)
+
+    def extract_video_feature(self, pixel_values_videos):
+        if isinstance(pixel_values_videos, (list, tuple)):
+            pixel_values_videos = mx.concatenate(
+                [self._ensure_4d_pixels(pv) for pv in pixel_values_videos], axis=0
+            )
+        else:
+            pixel_values_videos = self._ensure_4d_pixels(pixel_values_videos)
+
+        temporal = self.video_temporal_patch_dim
+        num_frames, channels, height, width = pixel_values_videos.shape
+        if num_frames % temporal != 0:
+            pad = temporal - (num_frames % temporal)
+            padding = mx.broadcast_to(
+                pixel_values_videos[-1:],
+                (pad, channels, height, width),
+            )
+            pixel_values_videos = mx.concatenate([pixel_values_videos, padding], axis=0)
+            num_frames = pixel_values_videos.shape[0]
+
+        num_groups = num_frames // temporal
+        x = pixel_values_videos.reshape(num_groups, temporal * channels, height, width)
+        vit_embeds = self.vision_model(x, use_video_embedder=True).features
+
+        patch_size = self.vision_model.radio_model.model.patch_generator.patch_size
+        patch_h = height // patch_size
+        patch_w = width // patch_size
+        vit_embeds = vit_embeds.reshape(vit_embeds.shape[0], patch_h, patch_w, -1)
+        vit_embeds = self.pixel_shuffle(
+            vit_embeds, scale_factor=self.config.downsample_ratio
+        )
+        vit_embeds = vit_embeds.reshape(vit_embeds.shape[0], -1, vit_embeds.shape[-1])
+        return self.mlp1(vit_embeds)
+
+    def get_input_embeddings(
+        self,
+        input_ids: Optional[mx.array] = None,
+        pixel_values: Optional[mx.array] = None,
+        mask: Optional[mx.array] = None,
+        **kwargs,
+    ):
+        inputs_embeds = self.language_model.get_input_embeddings(input_ids)
+
+        if pixel_values is not None:
+            image_features = self.extract_feature(pixel_values)
+            inputs_embeds = self._merge_features(
+                inputs_embeds,
+                input_ids,
+                self.img_context_token_id,
+                image_features,
+                "Image",
+            )
+
+        pixel_values_videos = kwargs.get("pixel_values_videos", None)
+        if pixel_values_videos is not None:
+            if self.video_pruning_rate > 0:
+                raise NotImplementedError(
+                    "Efficient video sampling is not implemented for Nemotron Omni yet."
+                )
+            video_features = self.extract_video_feature(pixel_values_videos)
+            inputs_embeds = self._merge_features(
+                inputs_embeds,
+                input_ids,
+                self.img_context_token_id,
+                video_features,
+                "Video",
+            )
+
+        feature_attention_mask = kwargs.get("feature_attention_mask", None)
+        if feature_attention_mask is None:
+            feature_attention_mask = kwargs.get("sound_attention_mask", None)
+
+        feature_lengths = kwargs.get("audio_feature_lengths", None)
+        if feature_lengths is None:
+            feature_lengths = kwargs.get("sound_feature_lengths", None)
+
+        sound_features = self._extract_sound_features(
+            sound_clips=kwargs.get("sound_clips", None),
+            input_features=kwargs.get("input_features", None),
+            feature_attention_mask=feature_attention_mask,
+            feature_lengths=feature_lengths,
+        )
+        if sound_features is not None:
+            inputs_embeds = self._merge_features(
+                inputs_embeds,
+                input_ids,
+                self.sound_context_token_id,
+                sound_features,
+                "Sound",
+            )
+
+        return InputEmbeddingsFeatures(inputs_embeds=inputs_embeds)
+
+    def __call__(
+        self,
+        input_ids: mx.array,
+        pixel_values: Optional[mx.array] = None,
+        mask: Optional[mx.array] = None,
+        cache=None,
+        **kwargs,
+    ):
+        embedding_output = self.get_input_embeddings(
+            input_ids, pixel_values, mask=mask, **kwargs
+        )
+        return self.language_model(
+            input_ids,
+            inputs_embeds=embedding_output.inputs_embeds,
+            cache=cache,
+            **kwargs,
+        )
+
+    def sanitize(self, weights):
+        sanitized = {}
+        for key, value in sanitize_audio_weights(weights).items():
+            if key.startswith("mlp1."):
+                key = key.replace("mlp1.0.", "mlp1.layers.0.")
+                key = key.replace("mlp1.1.", "mlp1.layers.1.")
+                key = key.replace("mlp1.3.", "mlp1.layers.3.")
+            sanitized[key] = value
+        return sanitized
+
+
+__all__ = ["Model", "VisionModel", "LanguageModel", "LanguageModelOutput"]

--- a/mlx_vlm/models/nemotron_h_nano_omni/vision.py
+++ b/mlx_vlm/models/nemotron_h_nano_omni/vision.py
@@ -1,0 +1,245 @@
+from dataclasses import dataclass
+
+import mlx.core as mx
+import mlx.nn as nn
+
+from ..interpolate import resize_bilinear
+from .config import VisionConfig
+
+
+@dataclass
+class RadioOutput:
+    summary: mx.array
+    features: mx.array
+
+
+class InputConditioner(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.norm_mean = mx.zeros((3, 1, 1))
+        self.norm_std = mx.ones((3, 1, 1))
+
+    def __call__(self, x):
+        return (x - self.norm_mean) / self.norm_std
+
+
+class ClsToken(nn.Module):
+    def __init__(self, embed_dim: int, num_tokens: int, register_multiple: int | None):
+        super().__init__()
+        self.num_tokens = num_tokens
+        self.num_registers = 0
+        if register_multiple:
+            self.num_registers = register_multiple - (num_tokens % register_multiple)
+        self.token = mx.zeros((self.num_tokens + self.num_registers, embed_dim))
+
+    @property
+    def num_patches(self):
+        return self.num_tokens + self.num_registers
+
+    def __call__(self, x):
+        token = mx.broadcast_to(
+            self.token[None, :, :],
+            (x.shape[0], self.token.shape[0], self.token.shape[1]),
+        ).astype(x.dtype)
+        return mx.concatenate([token, x], axis=1)
+
+
+class ViTPatchGenerator(nn.Module):
+    def __init__(self, config: VisionConfig):
+        super().__init__()
+        args = config.args or {}
+        embed_dim = config.hidden_size
+        input_dims = (config.image_size, config.image_size)
+        max_input_dims = int(args.get("cpe_max_size") or config.max_resolution)
+        patch_size = config.patch_size
+
+        self.patch_size = patch_size
+        self.embed_dim = embed_dim
+        self.num_rows = max_input_dims // patch_size
+        self.num_cols = max_input_dims // patch_size
+        self.input_dims = tuple(d // patch_size for d in input_dims)
+        self.num_patches = self.num_rows * self.num_cols
+        self.cpe_mode = (self.num_rows, self.num_cols) != self.input_dims
+
+        teachers = args.get("teachers", [])
+        if args.get("cls_token_per_teacher", True) and teachers:
+            num_cls_tokens = len({teacher["name"] for teacher in teachers})
+        else:
+            num_cls_tokens = 1
+        self.cls_token = ClsToken(
+            embed_dim,
+            num_tokens=num_cls_tokens,
+            register_multiple=args.get("register_multiple", None),
+        )
+        self.embedder = nn.Linear(3 * patch_size * patch_size, embed_dim, bias=False)
+        self.video_embedder = nn.Linear(
+            config.video_temporal_patch_size * 3 * patch_size * patch_size,
+            embed_dim,
+            bias=False,
+        )
+        self.pos_embed = mx.zeros((1, self.num_patches, embed_dim))
+
+    @property
+    def num_cls_tokens(self):
+        return self.cls_token.num_tokens
+
+    @property
+    def num_registers(self):
+        return self.cls_token.num_registers
+
+    @property
+    def num_skip(self):
+        return self.num_cls_tokens + self.num_registers
+
+    def _im_to_patches(self, x):
+        batch, channels, height, width = x.shape
+        patch = self.patch_size
+        patch_h = height // patch
+        patch_w = width // patch
+        x = x.reshape(batch, channels, patch_h, patch, patch_w, patch)
+        x = x.transpose(0, 2, 4, 1, 3, 5)
+        return x.reshape(batch, patch_h * patch_w, channels * patch * patch)
+
+    def _get_pos_embeddings(self, batch_size, input_dims):
+        if (self.num_rows, self.num_cols) == input_dims:
+            pos_embed = self.pos_embed
+        else:
+            pos_embed = self.pos_embed.reshape(
+                1, self.num_rows, self.num_cols, self.embed_dim
+            )[0]
+
+            def window_select(pe):
+                if input_dims[0] < pe.shape[0]:
+                    pe = pe[: input_dims[0], :, :]
+                if input_dims[1] < pe.shape[1]:
+                    pe = pe[:, : input_dims[1], :]
+                return pe
+
+            if self.cpe_mode:
+                max_dim = max(input_dims)
+                pos_embed = resize_bilinear(
+                    pos_embed,
+                    (max_dim, max_dim),
+                    align_corners=False,
+                    antialias=False,
+                )
+                pos_embed = window_select(pos_embed)
+            else:
+                pos_embed = window_select(pos_embed)
+
+            if pos_embed.shape[:2] != input_dims:
+                pos_embed = resize_bilinear(
+                    pos_embed,
+                    input_dims,
+                    align_corners=False,
+                    antialias=False,
+                )
+            pos_embed = pos_embed.reshape(1, input_dims[0] * input_dims[1], -1)
+
+        return mx.broadcast_to(
+            pos_embed, (batch_size, pos_embed.shape[1], pos_embed.shape[2])
+        )
+
+    def __call__(self, x, use_video_embedder=False):
+        patches = self._im_to_patches(x)
+        patches = (
+            self.video_embedder(patches)
+            if use_video_embedder
+            else self.embedder(patches)
+        )
+        input_dims = (x.shape[-2] // self.patch_size, x.shape[-1] // self.patch_size)
+        patches = patches + self._get_pos_embeddings(x.shape[0], input_dims).astype(
+            patches.dtype
+        )
+        return self.cls_token(patches)
+
+
+class Attention(nn.Module):
+    def __init__(self, dim: int, num_heads: int):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = dim // num_heads
+        self.scale = self.head_dim**-0.5
+        self.qkv = nn.Linear(dim, dim * 3, bias=True)
+        self.proj = nn.Linear(dim, dim, bias=True)
+
+    def __call__(self, x):
+        batch, length, dim = x.shape
+        qkv = self.qkv(x).reshape(batch, length, 3, self.num_heads, self.head_dim)
+        qkv = qkv.transpose(2, 0, 3, 1, 4)
+        queries, keys, values = qkv[0], qkv[1], qkv[2]
+        out = mx.fast.scaled_dot_product_attention(
+            queries, keys, values, scale=self.scale
+        )
+        out = out.transpose(0, 2, 1, 3).reshape(batch, length, dim)
+        return self.proj(out)
+
+
+class MLP(nn.Module):
+    def __init__(self, dim: int, hidden_dim: int):
+        super().__init__()
+        self.fc1 = nn.Linear(dim, hidden_dim, bias=True)
+        self.fc2 = nn.Linear(hidden_dim, dim, bias=True)
+
+    def __call__(self, x):
+        return self.fc2(nn.gelu(self.fc1(x)))
+
+
+class Block(nn.Module):
+    def __init__(self, dim: int, num_heads: int, mlp_hidden_dim: int):
+        super().__init__()
+        self.norm1 = nn.LayerNorm(dim, eps=1e-6)
+        self.attn = Attention(dim, num_heads)
+        self.norm2 = nn.LayerNorm(dim, eps=1e-6)
+        self.mlp = MLP(dim, mlp_hidden_dim)
+
+    def __call__(self, x):
+        x = x + self.attn(self.norm1(x))
+        x = x + self.mlp(self.norm2(x))
+        return x
+
+
+class RadioBackbone(nn.Module):
+    def __init__(self, config: VisionConfig):
+        super().__init__()
+        self.embed_dim = config.hidden_size
+        self.patch_generator = ViTPatchGenerator(config)
+        self.blocks = [
+            Block(
+                self.embed_dim,
+                num_heads=config.num_attention_heads,
+                mlp_hidden_dim=config.intermediate_size,
+            )
+            for _ in range(config.num_hidden_layers)
+        ]
+
+    def forward_features(self, x, use_video_embedder=False):
+        x = self.patch_generator(x, use_video_embedder=use_video_embedder)
+        for block in self.blocks:
+            x = block(x)
+        return x
+
+
+class RadioModel(nn.Module):
+    def __init__(self, config: VisionConfig):
+        super().__init__()
+        self.input_conditioner = InputConditioner()
+        self.model = RadioBackbone(config)
+        self.patch_size = config.patch_size
+
+    def __call__(self, x, use_video_embedder=False):
+        y = self.model.forward_features(x, use_video_embedder=use_video_embedder)
+        patch_generator = self.model.patch_generator
+        all_summary = y[:, : patch_generator.num_cls_tokens]
+        all_features = y[:, patch_generator.num_skip :]
+        return RadioOutput(all_summary.reshape(all_summary.shape[0], -1), all_features)
+
+
+class VisionModel(nn.Module):
+    def __init__(self, config: VisionConfig):
+        super().__init__()
+        self.config = config
+        self.radio_model = RadioModel(config)
+
+    def __call__(self, pixel_values, use_video_embedder=False):
+        return self.radio_model(pixel_values, use_video_embedder=use_video_embedder)

--- a/mlx_vlm/prompt_utils.py
+++ b/mlx_vlm/prompt_utils.py
@@ -50,6 +50,8 @@ MODEL_CONFIG = {
     "dots_ocr": MessageFormat.LIST_WITH_IMAGE_FIRST,
     "ernie4_5_moe_vl": MessageFormat.LIST_WITH_IMAGE_URL_FIRST,
     "internvl_chat": MessageFormat.LIST_WITH_IMAGE_TYPE,
+    "nemotron_h_nano_omni": MessageFormat.LIST_WITH_IMAGE_TYPE,
+    "nemotronh_nano_omni_reasoning_v3": MessageFormat.LIST_WITH_IMAGE_TYPE,
     "kimi_vl": MessageFormat.LIST_WITH_IMAGE,
     "kimi_k25": MessageFormat.LIST_WITH_IMAGE,
     "gemma3": MessageFormat.START_IMAGE_TOKEN,

--- a/mlx_vlm/tests/test_audio_utils.py
+++ b/mlx_vlm/tests/test_audio_utils.py
@@ -1,0 +1,32 @@
+import numpy as np
+
+from mlx_vlm.utils import load_audio
+
+
+def test_load_audio_uses_mlx_audio_io_and_returns_mono_float32(monkeypatch):
+    from mlx_audio import audio_io
+
+    calls = []
+
+    def fake_read(file, dtype="float64"):
+        calls.append((file, dtype))
+        return (
+            np.array(
+                [
+                    [0.0, 1.0],
+                    [0.5, -0.5],
+                    [1.0, 0.0],
+                ],
+                dtype=np.float32,
+            ),
+            16000,
+        )
+
+    monkeypatch.setattr(audio_io, "read", fake_read)
+
+    audio = load_audio("sample.wav", sr=16000)
+
+    assert calls == [("sample.wav", "float32")]
+    assert audio.dtype == np.float32
+    assert audio.shape == (3,)
+    np.testing.assert_allclose(audio, np.array([0.5, 0.0, 0.5], dtype=np.float32))

--- a/mlx_vlm/tests/test_nemotron_h_nano_omni.py
+++ b/mlx_vlm/tests/test_nemotron_h_nano_omni.py
@@ -1,0 +1,209 @@
+import mlx.core as mx
+import numpy as np
+import pytest
+
+from mlx_vlm.models.nemotron_h_nano_omni.audio import (
+    SoundEncoder,
+    SoundFeatureExtractor,
+    SoundProjection,
+    sanitize_audio_weights,
+)
+from mlx_vlm.models.nemotron_h_nano_omni.config import (
+    ModelConfig,
+    SoundConfig,
+    TextConfig,
+    VisionConfig,
+)
+from mlx_vlm.models.nemotron_h_nano_omni.nemotron_h_nano_omni import Model
+
+
+def tiny_text_config(hidden_size=24):
+    return TextConfig(
+        model_type="nemotron_h",
+        vocab_size=128,
+        hidden_size=hidden_size,
+        intermediate_size=32,
+        num_hidden_layers=1,
+        max_position_embeddings=128,
+        num_attention_heads=4,
+        num_key_value_heads=4,
+        attention_bias=False,
+        mamba_num_heads=1,
+        mamba_head_dim=8,
+        mamba_proj_bias=False,
+        ssm_state_size=8,
+        conv_kernel=3,
+        n_groups=1,
+        mlp_bias=False,
+        layer_norm_epsilon=1e-5,
+        use_bias=False,
+        use_conv_bias=False,
+        hybrid_override_pattern=["*"],
+    )
+
+
+def tiny_vision_config():
+    return VisionConfig(
+        hidden_size=16,
+        num_hidden_layers=1,
+        num_attention_heads=4,
+        intermediate_size=32,
+        image_size=32,
+        patch_size=16,
+        max_resolution=32,
+        args={"teachers": [{"name": "test"}]},
+    )
+
+
+def tiny_sound_config(hidden_size=16):
+    return SoundConfig(
+        hidden_size=hidden_size,
+        num_attention_heads=4,
+        num_hidden_layers=1,
+        intermediate_size=32,
+        conv_kernel_size=3,
+        subsampling_factor=8,
+        subsampling_conv_channels=4,
+        num_mel_bins=16,
+        projection_hidden_size=32,
+    )
+
+
+def test_sound_feature_extractor_shapes_and_masks():
+    pytest.importorskip("mlx_audio")
+    config = SoundConfig()
+    extractor = SoundFeatureExtractor(config)
+    waveform = np.linspace(-0.5, 0.5, 1600, dtype=np.float32)
+
+    features, mask, lengths = extractor([waveform])
+
+    assert features.shape == (1, 11, config.num_mel_bins)
+    assert mask.shape == (1, 11)
+    assert lengths.tolist() == [11]
+    assert mask.sum(axis=1).tolist() == [10]
+    assert np.isfinite(np.array(features)).all()
+
+
+def test_sound_encoder_and_projection_tiny_smoke():
+    config = tiny_sound_config()
+    encoder = SoundEncoder(config)
+    projection = SoundProjection(config, llm_hidden_size=24)
+    encoder.eval()
+    projection.eval()
+
+    features = mx.random.normal((1, 17, config.num_mel_bins))
+    mask = mx.ones((1, 17), dtype=mx.int32)
+    mask[:, -1] = 0
+
+    encoded = encoder(features, mask)
+    projected = projection(encoded)
+
+    assert encoded.shape == (1, 3, config.hidden_size)
+    assert projected.shape == (1, 3, 24)
+    assert np.isfinite(np.array(encoded)).all()
+    assert np.isfinite(np.array(projected)).all()
+
+
+def test_model_merges_sound_features_into_input_embeddings():
+    model = Model(
+        ModelConfig(
+            text_config=tiny_text_config(),
+            vision_config=tiny_vision_config(),
+            sound_config=tiny_sound_config(),
+            projector_hidden_size=32,
+            vit_hidden_size=16,
+            img_context_token_id=98,
+            sound_context_token_id=99,
+        )
+    )
+    model.eval()
+
+    input_ids = mx.array([[1, 99, 99, 99, 2]])
+    input_features = mx.random.normal((1, 17, 16))
+    feature_attention_mask = mx.ones((1, 17), dtype=mx.int32)
+    base_embeddings = model.language_model.get_input_embeddings(input_ids)
+
+    output = model.get_input_embeddings(
+        input_ids,
+        input_features=input_features,
+        feature_attention_mask=feature_attention_mask,
+    )
+
+    assert output.inputs_embeds.shape == base_embeddings.shape
+    assert np.allclose(
+        np.array(output.inputs_embeds[:, [0, 4], :]),
+        np.array(base_embeddings[:, [0, 4], :]),
+    )
+    assert not np.allclose(
+        np.array(output.inputs_embeds[:, 1:4, :]),
+        np.array(base_embeddings[:, 1:4, :]),
+    )
+
+
+def test_model_rejects_sound_token_feature_count_mismatch():
+    model = Model(
+        ModelConfig(
+            text_config=tiny_text_config(),
+            vision_config=tiny_vision_config(),
+            sound_config=tiny_sound_config(),
+            projector_hidden_size=32,
+            vit_hidden_size=16,
+            img_context_token_id=98,
+            sound_context_token_id=99,
+        )
+    )
+    model.eval()
+
+    with pytest.raises(ValueError, match="Sound token count"):
+        model.get_input_embeddings(
+            mx.array([[1, 99, 99, 2]]),
+            input_features=mx.random.normal((1, 17, 16)),
+            feature_attention_mask=mx.ones((1, 17), dtype=mx.int32),
+        )
+
+
+def test_sanitize_audio_and_projection_weights():
+    weights = {
+        "sound_encoder.encoder.feature_extractor.window": mx.ones((2,)),
+        "sound_encoder.encoder.layers.0.conv.norm.num_batches_tracked": mx.array(0),
+        "sound_encoder.encoder.layers.0.conv.pointwise_conv1.weight": mx.zeros(
+            (8, 4, 3)
+        ),
+        "sound_encoder.encoder.subsampling.layers.0.weight": mx.zeros((4, 1, 3, 3)),
+        "mlp1.0.weight": mx.ones((4,)),
+        "mlp1.1.weight": mx.ones((4, 4)),
+        "mlp1.3.weight": mx.ones((4, 4)),
+    }
+
+    audio_sanitized = sanitize_audio_weights(weights)
+    assert "sound_encoder.encoder.feature_extractor.window" not in audio_sanitized
+    assert (
+        "sound_encoder.encoder.layers.0.conv.norm.num_batches_tracked"
+        not in audio_sanitized
+    )
+    assert audio_sanitized[
+        "sound_encoder.encoder.layers.0.conv.pointwise_conv1.weight"
+    ].shape == (8, 3, 4)
+    assert audio_sanitized[
+        "sound_encoder.encoder.subsampling.layers.0.weight"
+    ].shape == (
+        4,
+        3,
+        3,
+        1,
+    )
+
+    model = Model(
+        ModelConfig(
+            text_config=tiny_text_config(),
+            vision_config=tiny_vision_config(),
+            sound_config=None,
+            projector_hidden_size=4,
+            vit_hidden_size=1,
+            img_context_token_id=98,
+        )
+    )
+    model_sanitized = model.sanitize(weights)
+    assert "mlp1.layers.0.weight" in model_sanitized
+    assert "mlp1.layers.1.weight" in model_sanitized
+    assert "mlp1.layers.3.weight" in model_sanitized

--- a/mlx_vlm/tests/test_prompt_utils.py
+++ b/mlx_vlm/tests/test_prompt_utils.py
@@ -141,6 +141,38 @@ class TestApplyChatTemplateIntegration:
     Uses return_messages=True to inspect intermediate messages without mocking.
     """
 
+    def test_nemotron_omni_formats_image_and_audio_messages(self):
+        """Nemotron Omni should use typed multimodal content for HF templates."""
+        from mlx_vlm.prompt_utils import apply_chat_template
+
+        for model_type in (
+            "nemotron_h_nano_omni",
+            "nemotronh_nano_omni_reasoning_v3",
+        ):
+            result = apply_chat_template(
+                None,
+                {"model_type": model_type},
+                "Describe the inputs.",
+                return_messages=True,
+                num_images=1,
+                num_audios=1,
+            )
+
+            assert result == [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "image"},
+                        {
+                            "type": "text",
+                            "text": "Describe the inputs.",
+                            "content": "Describe the inputs.",
+                        },
+                        {"type": "audio"},
+                    ],
+                }
+            ]
+
     def test_multimodal_message_does_not_include_base64_in_prompt(self):
         """Critical regression test: base64 should NOT appear in formatted messages.
 

--- a/mlx_vlm/utils.py
+++ b/mlx_vlm/utils.py
@@ -42,6 +42,7 @@ MODEL_REMAPPING = {
     "granite4_vision": "granite4_vision",
     "rf-detr": "rfdetr",
     "falcon-perception": "falcon_perception",
+    "nemotronh_nano_omni_reasoning_v3": "nemotron_h_nano_omni",
 }
 
 MAX_FILE_SIZE_GB = 5
@@ -269,7 +270,7 @@ python -m mlx_vlm.convert --hf-path <local_dir> --mlx-path <mlx_dir>
                     model_class.AudioModel, weights, model_config.audio_config
                 )
 
-    if not "quantization" in config:
+    if "quantization" not in config:
         quantization_config = config.get("quantization_config", None)
         if quantization_config is None:
             text_config = config.get("text_config", {})
@@ -846,55 +847,6 @@ def process_image(img, resize_shape, image_processor):
     return img
 
 
-def _resample_fft(signal: np.ndarray, n_target: int) -> np.ndarray:
-    """FFT-based resampling for a 1D signal (matches scipy.signal.resample)."""
-    n_orig = len(signal)
-    if n_orig == n_target:
-        return signal
-
-    X = np.fft.rfft(signal)
-    m = min(n_target, n_orig)
-    m2 = m // 2 + 1
-
-    # Truncate to relevant frequency bins
-    X = X[:m2].copy()
-
-    # Account for unpaired Nyquist bin (matches scipy exactly)
-    if m % 2 == 0 and n_target != n_orig:
-        X[m // 2] *= 2.0 if n_target < n_orig else 0.5
-
-    s_fac = n_orig / n_target
-    resampled = np.fft.irfft(X / s_fac, n=n_target)
-    return resampled.astype(signal.dtype)
-
-
-def resample_audio(audio: np.ndarray, orig_sr: int, target_sr: int) -> np.ndarray:
-    """Resample audio using FFT (matches scipy.signal.resample)."""
-    if orig_sr == target_sr:
-        return audio
-
-    ratio = target_sr / orig_sr
-
-    if audio.ndim == 1:
-        new_length = int(len(audio) * ratio)
-        resampled = _resample_fft(audio, new_length)
-
-    elif audio.ndim == 2:
-        if audio.shape[0] < audio.shape[1]:
-            audio = audio.T
-
-        n_samples, n_channels = audio.shape
-        new_length = int(n_samples * ratio)
-
-        resampled = np.zeros((new_length, n_channels), dtype=audio.dtype)
-        for i in range(n_channels):
-            resampled[:, i] = _resample_fft(audio[:, i], new_length)
-    else:
-        raise ValueError(f"Audio array has unsupported shape: {audio.shape}")
-
-    return resampled
-
-
 def read_audio(file) -> tuple:
     """Read an audio file using miniaudio (or ffmpeg for m4a/aac/ogg/opus).
 
@@ -1049,24 +1001,30 @@ def load_audio(
     Helper function to load audio from either a URL, file path, or numpy array.
     """
     if isinstance(file, np.ndarray):
-        return file
+        audio = file.astype(np.float32, copy=False)
+        return audio.mean(axis=1) if audio.ndim > 1 else audio
+
+    from mlx_audio.audio_io import read as read_audio
+    from mlx_audio.utils import resample_audio
+
     if isinstance(file, Path):
         file = str(file)
     if isinstance(file, str) and file.startswith(("http://", "https://")):
         try:
             response = requests.get(file, stream=True, timeout=timeout)
             response.raise_for_status()
-            audio, sample_rate = read_audio(BytesIO(response.content))
+            audio, sample_rate = read_audio(BytesIO(response.content), dtype="float32")
         except Exception as e:
             raise ValueError(
                 f"Failed to load audio from URL: {file} with error {e}"
             ) from e
     else:
-        audio, sample_rate = read_audio(file)
+        audio, sample_rate = read_audio(file, dtype="float32")
 
     if sample_rate != sr:
         audio = resample_audio(audio, sample_rate, sr)
-    return np.array(audio).mean(axis=1)
+    audio = np.asarray(audio, dtype=np.float32)
+    return audio.mean(axis=1) if audio.ndim > 1 else audio
 
 
 def normalize_audio_features(features: mx.array) -> mx.array:

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ tqdm>=4.66.2
 Pillow>=10.3.0
 requests>=2.31.0
 mlx-lm>=0.31.3
+mlx-audio>=0.4.3
 opencv-python>=4.12.0.88
 fastapi>=0.95.1
 uvicorn


### PR DESCRIPTION
A new 10B/A3B omni model from Nvidia, supporting text, images, audio, and video.

[Announcement](https://x.com/piotrzelasko/status/2049162049599455725)
[Model Card](https://huggingface.co/nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-BF16)

Audio example:

```sh
% python -m mlx_vlm generate \
  --model nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-BF16 \
  --audio <audio_path> \
  --prompt "Describe the speaker and the qualities of their voice in the audio." \
  --max-tokens 128 \
  --temperature 0 \
  --trust-remote-code \
  --prefill-step-size 128 \
  --verbose

The speaker is a female with a normal pitch and volume, speaking in a clear and articulate manner.
```

Image example:

```sh
% python -m mlx_vlm generate \
  --model nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-BF16 \
  --image examples/images/cats.jpg \
  --prompt "What's in this picture?" \
  --max-tokens 128 \
  --temperature 0 \
  --trust-remote-code \
  --prefill-step-size 128 \
  --verbose
  
Two cats sleeping on a pink couch
```

Note this PR relies on a new version of `mlx-audio` being tagged, so it will need to be merged once that's available.