### PR TITLE
Nemotron H Nano Omni: rename SoundConfig and add processor

### DIFF
--- a/mlx_vlm/models/nemotron_h_nano_omni/__init__.py
+++ b/mlx_vlm/models/nemotron_h_nano_omni/__init__.py
@@ -1,4 +1,5 @@
 from .config import AudioConfig, ModelConfig, TextConfig, VisionConfig
+from .image_processing_nemotron_h_nano_omni import NemotronHNanoOmniImageProcessor
 from .language import LanguageModel
 from .nemotron_h_nano_omni import Model
 from .processing_nemotron_h_nano_omni import NemotronHNanoOmniProcessor
@@ -9,6 +10,7 @@ __all__ = [
     "LanguageModel",
     "Model",
     "ModelConfig",
+    "NemotronHNanoOmniImageProcessor",
     "NemotronHNanoOmniProcessor",
     "TextConfig",
     "VisionConfig",

--- a/mlx_vlm/models/nemotron_h_nano_omni/__init__.py
+++ b/mlx_vlm/models/nemotron_h_nano_omni/__init__.py
@@ -1,13 +1,13 @@
-from .config import ModelConfig, SoundConfig, TextConfig, VisionConfig
+from .config import AudioConfig, ModelConfig, TextConfig, VisionConfig
 from .language import LanguageModel
 from .nemotron_h_nano_omni import Model
 from .vision import VisionModel
 
 __all__ = [
+    "AudioConfig",
     "LanguageModel",
     "Model",
     "ModelConfig",
-    "SoundConfig",
     "TextConfig",
     "VisionConfig",
     "VisionModel",

--- a/mlx_vlm/models/nemotron_h_nano_omni/__init__.py
+++ b/mlx_vlm/models/nemotron_h_nano_omni/__init__.py
@@ -1,6 +1,7 @@
 from .config import AudioConfig, ModelConfig, TextConfig, VisionConfig
 from .language import LanguageModel
 from .nemotron_h_nano_omni import Model
+from .processing_nemotron_h_nano_omni import NemotronHNanoOmniProcessor
 from .vision import VisionModel
 
 __all__ = [
@@ -8,6 +9,7 @@ __all__ = [
     "LanguageModel",
     "Model",
     "ModelConfig",
+    "NemotronHNanoOmniProcessor",
     "TextConfig",
     "VisionConfig",
     "VisionModel",

--- a/mlx_vlm/models/nemotron_h_nano_omni/audio.py
+++ b/mlx_vlm/models/nemotron_h_nano_omni/audio.py
@@ -5,7 +5,7 @@ import mlx.core as mx
 import mlx.nn as nn
 import numpy as np
 
-from .config import SoundConfig
+from .config import AudioConfig
 
 
 class SquaredReLU(nn.Module):
@@ -14,7 +14,7 @@ class SquaredReLU(nn.Module):
 
 
 class SoundProjection(nn.Module):
-    def __init__(self, config: SoundConfig, llm_hidden_size: int):
+    def __init__(self, config: AudioConfig, llm_hidden_size: int):
         super().__init__()
         self.norm = nn.RMSNorm(config.hidden_size, eps=1e-5)
         self.linear1 = nn.Linear(
@@ -37,7 +37,7 @@ class SoundProjection(nn.Module):
 
 
 class ParakeetEncoderRelPositionalEncoding(nn.Module):
-    def __init__(self, config: SoundConfig):
+    def __init__(self, config: AudioConfig):
         super().__init__()
         self.hidden_size = config.hidden_size
         self.max_position_embeddings = config.max_position_embeddings
@@ -67,7 +67,7 @@ class ParakeetEncoderRelPositionalEncoding(nn.Module):
 
 
 class ParakeetEncoderFeedForward(nn.Module):
-    def __init__(self, config: SoundConfig):
+    def __init__(self, config: AudioConfig):
         super().__init__()
         self.linear1 = nn.Linear(
             config.hidden_size,
@@ -86,7 +86,7 @@ class ParakeetEncoderFeedForward(nn.Module):
 
 
 class ParakeetEncoderConvolutionModule(nn.Module):
-    def __init__(self, config: SoundConfig):
+    def __init__(self, config: AudioConfig):
         super().__init__()
         channels = config.hidden_size
         kernel_size = config.conv_kernel_size
@@ -134,7 +134,7 @@ class ParakeetEncoderConvolutionModule(nn.Module):
 
 
 class ParakeetEncoderAttention(nn.Module):
-    def __init__(self, config: SoundConfig, layer_idx: int):
+    def __init__(self, config: AudioConfig, layer_idx: int):
         super().__init__()
         self.config = config
         self.layer_idx = layer_idx
@@ -238,7 +238,7 @@ class ParakeetEncoderAttention(nn.Module):
 
 
 class ParakeetEncoderSubsamplingConv2D(nn.Module):
-    def __init__(self, config: SoundConfig):
+    def __init__(self, config: AudioConfig):
         super().__init__()
         self.kernel_size = config.subsampling_conv_kernel_size
         self.stride = config.subsampling_conv_stride
@@ -319,7 +319,7 @@ class ParakeetEncoderSubsamplingConv2D(nn.Module):
 
 
 class ParakeetEncoderBlock(nn.Module):
-    def __init__(self, config: SoundConfig, layer_idx: int):
+    def __init__(self, config: AudioConfig, layer_idx: int):
         super().__init__()
         self.feed_forward1 = ParakeetEncoderFeedForward(config)
         self.self_attn = ParakeetEncoderAttention(config, layer_idx)
@@ -353,7 +353,7 @@ class ParakeetEncoderBlock(nn.Module):
 
 
 class ParakeetEncoder(nn.Module):
-    def __init__(self, config: SoundConfig):
+    def __init__(self, config: AudioConfig):
         super().__init__()
         self.config = config
         self.input_scale = math.sqrt(config.hidden_size) if config.scale_input else 1.0
@@ -411,7 +411,7 @@ class ParakeetEncoder(nn.Module):
 
 
 class SoundEncoder(nn.Module):
-    def __init__(self, config: SoundConfig):
+    def __init__(self, config: AudioConfig):
         super().__init__()
         self.config = config
         self.encoder = ParakeetEncoder(config)
@@ -426,7 +426,7 @@ class SoundEncoder(nn.Module):
 
 
 class SoundFeatureExtractor:
-    def __init__(self, config: SoundConfig):
+    def __init__(self, config: AudioConfig):
         self.config = config
         self.sampling_rate = config.sampling_rate
 

--- a/mlx_vlm/models/nemotron_h_nano_omni/config.py
+++ b/mlx_vlm/models/nemotron_h_nano_omni/config.py
@@ -41,7 +41,7 @@ class VisionConfig(BaseModelConfig):
 
 
 @dataclass
-class SoundConfig(BaseModelConfig):
+class AudioConfig(BaseModelConfig):
     model_type: str = "parakeet"
     hidden_size: int = 1024
     num_attention_heads: int = 8
@@ -83,7 +83,7 @@ class SoundConfig(BaseModelConfig):
 class ModelConfig(BaseModelConfig):
     text_config: TextConfig
     vision_config: VisionConfig
-    sound_config: Optional[SoundConfig] = None
+    sound_config: Optional[AudioConfig] = None
     model_type: str = "nemotron_h_nano_omni"
     force_image_size: Optional[int] = None
     downsample_ratio: float = 0.5
@@ -111,7 +111,7 @@ class ModelConfig(BaseModelConfig):
 
         raw_sound_config = params.pop("sound_config", None)
         sound_config = (
-            SoundConfig.from_dict(raw_sound_config)
+            AudioConfig.from_dict(raw_sound_config)
             if raw_sound_config is not None
             else None
         )

--- a/mlx_vlm/models/nemotron_h_nano_omni/image_processing_nemotron_h_nano_omni.py
+++ b/mlx_vlm/models/nemotron_h_nano_omni/image_processing_nemotron_h_nano_omni.py
@@ -73,7 +73,9 @@ class NemotronHNanoOmniImageProcessor(BaseImageProcessorFast):
         target_sizes = []
         if is_video:
             for img in images:
-                target_w_patches, target_h_patches = self._compute_target_patches_video(img)
+                target_w_patches, target_h_patches = self._compute_target_patches_video(
+                    img
+                )
                 target_sizes.append((target_w_patches, target_h_patches))
         else:
             num_tokens_available = self.max_model_len - 4

--- a/mlx_vlm/models/nemotron_h_nano_omni/image_processing_nemotron_h_nano_omni.py
+++ b/mlx_vlm/models/nemotron_h_nano_omni/image_processing_nemotron_h_nano_omni.py
@@ -1,0 +1,206 @@
+"""
+Image processor for Nemotron-3 Nano Omni.
+
+Port of NVIDIA's reference implementation:
+https://huggingface.co/nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-BF16/blob/main/image_processing.py
+"""
+
+import math
+from typing import Optional, Union
+
+import numpy as np
+import torch
+from PIL import Image
+from transformers.image_processing_base import BatchFeature
+from transformers.image_processing_utils_fast import BaseImageProcessorFast
+from transformers.image_utils import (
+    ImageInput,
+    ImageType,
+    get_image_type,
+    make_list_of_images,
+)
+from transformers.utils import TensorType
+
+
+class NemotronHNanoOmniImageProcessor(BaseImageProcessorFast):
+    """Dynamic-resolution image processor matching NVIDIA's reference and vLLM's tiler."""
+
+    model_input_names = ["pixel_values"]
+    _is_video_mode: bool = False
+
+    def __init__(
+        self,
+        norm_mean=None,
+        norm_std=None,
+        patch_size=16,
+        downsample_ratio=0.5,
+        min_num_patches=1024,
+        max_num_patches=13312,
+        max_model_len=16384,
+        video_target_num_patches=1024,
+        video_maintain_aspect_ratio=True,
+        **kwargs,
+    ):
+        super().__init__(**kwargs)
+        self.norm_mean = norm_mean
+        self.norm_std = norm_std
+        self.patch_size = patch_size
+        self.downsample_ratio = downsample_ratio
+        self._downsample_factor = int(round(1.0 / downsample_ratio))
+        self.min_num_patches = min_num_patches
+        self.max_num_patches = max_num_patches
+        self.max_model_len = max_model_len
+        self.video_target_num_patches = video_target_num_patches
+        self.video_maintain_aspect_ratio = video_maintain_aspect_ratio
+
+    def _process_image(self, image: ImageInput, **kwargs):
+        if get_image_type(image) == ImageType.PIL:
+            if image.mode != "RGB":
+                image = image.convert("RGB")
+        return image
+
+    process_image = _process_image
+
+    def _preprocess(
+        self,
+        images,
+        return_tensors: Optional[Union[str, TensorType]] = None,
+        **kwargs,
+    ) -> BatchFeature:
+        is_video = self._is_video_mode
+        images = make_list_of_images(images)
+
+        target_sizes = []
+        if is_video:
+            for img in images:
+                target_w_patches, target_h_patches = self._compute_target_patches_video(img)
+                target_sizes.append((target_w_patches, target_h_patches))
+        else:
+            num_tokens_available = self.max_model_len - 4
+            budget = num_tokens_available * (self._downsample_factor**2)
+            budget = max(budget, self.min_num_patches * len(images))
+            max_budget = (
+                self.max_num_patches
+                if (self.max_num_patches and self.max_num_patches > 0)
+                else float("inf")
+            )
+            per_image_budget = [
+                max(min(budget, max_budget), self.min_num_patches) for _ in images
+            ]
+            for img, tokens_for_media in zip(images, per_image_budget):
+                target_w_patches, target_h_patches = self._compute_target_patches(
+                    img, tokens_for_media
+                )
+                target_sizes.append((target_w_patches, target_h_patches))
+
+        norm_mean = torch.tensor(self.norm_mean).view(1, 3, 1, 1)
+        norm_std = torch.tensor(self.norm_std).view(1, 3, 1, 1)
+
+        pixel_values_list = []
+        num_tokens_per_image = []
+        imgs_sizes = []
+        for img, (wp, hp) in zip(images, target_sizes):
+            target_w = wp * self.patch_size
+            target_h = hp * self.patch_size
+            arr = np.asarray(img, dtype=np.uint8)
+            t = (
+                torch.from_numpy(arr)
+                .permute(2, 0, 1)
+                .unsqueeze(0)
+                .to(dtype=torch.float32)
+            )
+            if t.shape[-2] != target_h or t.shape[-1] != target_w:
+                t = torch.nn.functional.interpolate(
+                    t,
+                    size=(target_h, target_w),
+                    mode="bicubic",
+                    align_corners=False,
+                    antialias=True,
+                )
+            t = (t / 255.0 - norm_mean) / norm_std
+            pixel_values_list.append(t.squeeze(0))
+            num_tokens_per_image.append((wp * hp) // (self._downsample_factor**2))
+            imgs_sizes.append((target_h, target_w))
+
+        all_same_shape = all(
+            t.shape == pixel_values_list[0].shape for t in pixel_values_list
+        )
+        if all_same_shape:
+            pixel_values = torch.stack(pixel_values_list, dim=0)
+        else:
+            pixel_values = pixel_values_list
+
+        return BatchFeature(
+            data={
+                "pixel_values": pixel_values,
+                "num_patches": [1] * len(images),
+                "num_tokens": num_tokens_per_image,
+                "imgs_sizes": imgs_sizes,
+            },
+            tensor_type=(return_tensors if all_same_shape else None),
+        )
+
+    def _compute_target_patches(self, img: Image.Image, tokens_available: int):
+        orig_w, orig_h = img.width, img.height
+        closest_patch_h = round(orig_h / self.patch_size + 0.5)
+        closest_patch_w = round(orig_w / self.patch_size + 0.5)
+        patches = closest_patch_h * closest_patch_w
+
+        factor = min(math.sqrt(tokens_available / patches), 1.0)
+        target_h = math.floor(factor * closest_patch_h)
+        target_w = math.floor(factor * closest_patch_w)
+
+        if (
+            tokens_available > self.min_num_patches
+            and target_h * target_w < self.min_num_patches
+        ):
+            up = math.sqrt(self.min_num_patches / (target_h * target_w))
+            target_h = math.ceil(up * target_h)
+            target_w = math.ceil(up * target_w)
+
+        divisor = self._downsample_factor
+        rem_h = target_h % divisor
+        if rem_h:
+            inc_h = divisor - rem_h
+            if (target_h + inc_h) * target_w <= tokens_available:
+                target_h += inc_h
+            else:
+                target_h = max(divisor, target_h - rem_h)
+        rem_w = target_w % divisor
+        if rem_w:
+            inc_w = divisor - rem_w
+            if target_h * (target_w + inc_w) <= tokens_available:
+                target_w += inc_w
+            else:
+                target_w = max(divisor, target_w - rem_w)
+
+        return target_w, target_h
+
+    def _compute_target_patches_video(self, img: Image.Image):
+        orig_w, orig_h = img.width, img.height
+        target = self.video_target_num_patches
+        divisor = self._downsample_factor
+        if self.video_maintain_aspect_ratio:
+            aspect_wh = orig_w / max(orig_h, 1)
+            ph = max(round(math.sqrt(target / aspect_wh)), 1)
+            pw = max(round(math.sqrt(target * aspect_wh)), 1)
+            if divisor > 1:
+                rem_h = ph % divisor
+                rem_w = pw % divisor
+                ph_up = ph + (divisor - rem_h if rem_h else 0)
+                ph_down = ph - rem_h
+                pw_up = pw + (divisor - rem_w if rem_w else 0)
+                pw_down = pw - rem_w
+                if ph_up * pw_up <= target:
+                    ph, pw = ph_up, pw_up
+                else:
+                    ph = max(divisor, ph_down)
+                    pw = max(divisor, pw_down)
+        else:
+            side = int(math.sqrt(target))
+            side = max(divisor, (side // divisor) * divisor)
+            ph = pw = side
+        return pw, ph
+
+
+__all__ = ["NemotronHNanoOmniImageProcessor"]

--- a/mlx_vlm/models/nemotron_h_nano_omni/image_processing_nemotron_h_nano_omni.py
+++ b/mlx_vlm/models/nemotron_h_nano_omni/image_processing_nemotron_h_nano_omni.py
@@ -9,7 +9,6 @@ import math
 from typing import Optional, Union
 
 import numpy as np
-import torch
 from PIL import Image
 from transformers.image_processing_base import BatchFeature
 from transformers.image_processing_utils_fast import BaseImageProcessorFast
@@ -95,8 +94,8 @@ class NemotronHNanoOmniImageProcessor(BaseImageProcessorFast):
                 )
                 target_sizes.append((target_w_patches, target_h_patches))
 
-        norm_mean = torch.tensor(self.norm_mean).view(1, 3, 1, 1)
-        norm_std = torch.tensor(self.norm_std).view(1, 3, 1, 1)
+        norm_mean = np.asarray(self.norm_mean, dtype=np.float32).reshape(3, 1, 1)
+        norm_std = np.asarray(self.norm_std, dtype=np.float32).reshape(3, 1, 1)
 
         pixel_values_list = []
         num_tokens_per_image = []
@@ -104,23 +103,18 @@ class NemotronHNanoOmniImageProcessor(BaseImageProcessorFast):
         for img, (wp, hp) in zip(images, target_sizes):
             target_w = wp * self.patch_size
             target_h = hp * self.patch_size
-            arr = np.asarray(img, dtype=np.uint8)
-            t = (
-                torch.from_numpy(arr)
-                .permute(2, 0, 1)
-                .unsqueeze(0)
-                .to(dtype=torch.float32)
-            )
-            if t.shape[-2] != target_h or t.shape[-1] != target_w:
-                t = torch.nn.functional.interpolate(
-                    t,
-                    size=(target_h, target_w),
-                    mode="bicubic",
-                    align_corners=False,
-                    antialias=True,
+            if img.size != (target_w, target_h):
+                # PIL's BICUBIC isn't antialiased like torch's, but with reducing_gap
+                # it pre-filters during downsample — close to the reference for
+                # typical token-bounded sizes.
+                img = img.resize(
+                    (target_w, target_h),
+                    resample=Image.Resampling.BICUBIC,
+                    reducing_gap=3.0,
                 )
-            t = (t / 255.0 - norm_mean) / norm_std
-            pixel_values_list.append(t.squeeze(0))
+            arr = np.asarray(img, dtype=np.float32).transpose(2, 0, 1)  # (3, H, W)
+            arr = (arr / 255.0 - norm_mean) / norm_std
+            pixel_values_list.append(arr)
             num_tokens_per_image.append((wp * hp) // (self._downsample_factor**2))
             imgs_sizes.append((target_h, target_w))
 
@@ -128,7 +122,7 @@ class NemotronHNanoOmniImageProcessor(BaseImageProcessorFast):
             t.shape == pixel_values_list[0].shape for t in pixel_values_list
         )
         if all_same_shape:
-            pixel_values = torch.stack(pixel_values_list, dim=0)
+            pixel_values = np.stack(pixel_values_list, axis=0)
         else:
             pixel_values = pixel_values_list
 

--- a/mlx_vlm/models/nemotron_h_nano_omni/nemotron_h_nano_omni.py
+++ b/mlx_vlm/models/nemotron_h_nano_omni/nemotron_h_nano_omni.py
@@ -121,7 +121,11 @@ class Model(nn.Module):
             ) = self.sound_feature_extractor(sound_clips)
         if not isinstance(input_features, mx.array):
             input_features = mx.array(input_features)
-        input_features = input_features.astype(self.language_model.lm_head.weight.dtype)
+        lm_head = self.language_model.lm_head
+        compute_dtype = (
+            lm_head.scales.dtype if hasattr(lm_head, "scales") else lm_head.weight.dtype
+        )
+        input_features = input_features.astype(compute_dtype)
 
         if feature_attention_mask is not None and not isinstance(
             feature_attention_mask, mx.array

--- a/mlx_vlm/models/nemotron_h_nano_omni/processing_nemotron_h_nano_omni.py
+++ b/mlx_vlm/models/nemotron_h_nano_omni/processing_nemotron_h_nano_omni.py
@@ -1,0 +1,375 @@
+"""
+Processor class for Nemotron-3 Nano Omni.
+
+Adapted from NVIDIA's reference implementation:
+https://huggingface.co/nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-BF16/blob/main/processing.py
+"""
+
+import math
+from typing import List, Optional, Union
+
+import numpy as np
+from transformers.feature_extraction_utils import BatchFeature
+from transformers.image_utils import ImageInput
+from transformers.processing_utils import ProcessorMixin
+from transformers.tokenization_utils_base import PreTokenizedInput, TextInput
+
+from ..base import install_auto_processor_patch, load_chat_template, to_mlx
+
+AudioInput = Union[str, np.ndarray, List[str], List[np.ndarray]]
+
+
+class NemotronHNanoOmniProcessor(ProcessorMixin):
+    attributes = ["image_processor", "tokenizer"]
+    image_processor_class = "AutoImageProcessor"
+    video_processor_class = "AutoVideoProcessor"
+    tokenizer_class = "AutoTokenizer"
+
+    def __init__(
+        self,
+        image_processor=None,
+        tokenizer=None,
+        chat_template=None,
+        audio_sampling_rate: int = 16000,
+        audio_subsampling_factor: int = 8,
+        audio_hop_length: int = 160,
+        audio_subsampling_conv_kernel_size: int = 3,
+        audio_subsampling_conv_stride: int = 2,
+        video_temporal_patch_dim: int = 2,
+        **kwargs,
+    ):
+        self.video_temporal_patch_dim = video_temporal_patch_dim
+
+        self.image_token = (
+            tokenizer.image_token if hasattr(tokenizer, "image_token") else "<image>"
+        )
+        self.video_token = (
+            tokenizer.video_token if hasattr(tokenizer, "video_token") else "<video>"
+        )
+        self.audio_token = (
+            tokenizer.audio_token
+            if hasattr(tokenizer, "audio_token")
+            else "<so_embedding>"
+        )
+        self.audio_start_token = "<so_start>"
+        self.audio_end_token = "<so_end>"
+        self.image_start_token = (
+            tokenizer.image_start_token
+            if hasattr(tokenizer, "image_start_token")
+            else "<img>"
+        )
+        self.image_end_token = (
+            tokenizer.image_end_token
+            if hasattr(tokenizer, "image_end_token")
+            else "</img>"
+        )
+        self.image_token_id = (
+            tokenizer.image_token_id
+            if getattr(tokenizer, "image_token_id", None)
+            else tokenizer.convert_tokens_to_ids(self.image_token)
+        )
+        self.video_token_id = (
+            tokenizer.video_token_id
+            if getattr(tokenizer, "video_token_id", None)
+            else tokenizer.convert_tokens_to_ids(self.video_token)
+        )
+        self.audio_token_id = (
+            tokenizer.audio_token_id
+            if getattr(tokenizer, "audio_token_id", None)
+            else tokenizer.convert_tokens_to_ids(self.audio_token)
+        )
+
+        self.audio_sampling_rate = audio_sampling_rate
+        self.audio_subsampling_factor = audio_subsampling_factor
+        self.audio_hop_length = audio_hop_length
+        self.audio_subsampling_conv_kernel_size = audio_subsampling_conv_kernel_size
+        self.audio_subsampling_conv_stride = audio_subsampling_conv_stride
+
+        super().__init__(image_processor, tokenizer, chat_template=chat_template)
+
+    @classmethod
+    def from_pretrained(cls, pretrained_model_name_or_path, **kwargs):
+        import json
+        from pathlib import Path
+
+        from transformers import AutoImageProcessor, AutoTokenizer
+
+        kwargs.pop("use_fast", None)
+        kwargs.setdefault("trust_remote_code", True)
+
+        tokenizer = AutoTokenizer.from_pretrained(
+            pretrained_model_name_or_path, **kwargs
+        )
+        load_chat_template(tokenizer, pretrained_model_name_or_path)
+
+        try:
+            image_processor = AutoImageProcessor.from_pretrained(
+                pretrained_model_name_or_path, use_fast=False, **kwargs
+            )
+        except ValueError:
+            image_processor = AutoImageProcessor.from_pretrained(
+                pretrained_model_name_or_path, **kwargs
+            )
+
+        proc_kwargs = {}
+        proc_cfg_path = Path(pretrained_model_name_or_path) / "processor_config.json"
+        if proc_cfg_path.exists():
+            with open(proc_cfg_path) as f:
+                proc_cfg = json.load(f)
+            for k in (
+                "audio_sampling_rate",
+                "audio_subsampling_factor",
+                "audio_hop_length",
+                "audio_subsampling_conv_kernel_size",
+                "audio_subsampling_conv_stride",
+                "video_temporal_patch_dim",
+            ):
+                if k in proc_cfg:
+                    proc_kwargs[k] = proc_cfg[k]
+
+        return cls(
+            image_processor=image_processor,
+            tokenizer=tokenizer,
+            **proc_kwargs,
+        )
+
+    def __call__(
+        self,
+        images: Optional[ImageInput] = None,
+        text: Optional[
+            Union[
+                TextInput,
+                PreTokenizedInput,
+                List[TextInput],
+                List[PreTokenizedInput],
+            ]
+        ] = None,
+        videos=None,
+        audio: Optional[AudioInput] = None,
+        **kwargs,
+    ) -> BatchFeature:
+        if text is None and images is None and videos is None and audio is None:
+            raise ValueError(
+                "Provide at least one of `text`, `images`, `videos`, or `audio`."
+            )
+
+        images_kwargs = kwargs.pop("images_kwargs", {}) or {}
+        videos_kwargs = kwargs.pop("videos_kwargs", {}) or {}
+        audio_kwargs = kwargs.pop("audio_kwargs", {}) or {}
+        text_kwargs = kwargs.pop("text_kwargs", {}) or {}
+        # Allow flat kwargs (mlx-vlm convention) — fall through to text tokenization.
+        text_kwargs = {**kwargs, **text_kwargs}
+
+        image_inputs, videos_inputs, audio_inputs = {}, {}, {}
+
+        if images is not None:
+            image_inputs = self.image_processor(images=images, **images_kwargs)
+            image_num_tokens = image_inputs["num_tokens"]
+
+        if videos is not None:
+            self.image_processor._is_video_mode = True
+            try:
+                videos_inputs = self.image_processor(images=videos, **images_kwargs)
+            finally:
+                self.image_processor._is_video_mode = False
+            video_num_patches = [sum(videos_inputs["num_patches"])]
+            videos_inputs["pixel_values_videos"] = videos_inputs["pixel_values"]
+            del videos_inputs["pixel_values"]
+
+        audio_num_tokens = []
+        if audio is not None:
+            audio_clips, audio_num_tokens = self._process_audio(audio, audio_kwargs)
+            audio_inputs["sound_clips"] = audio_clips
+
+        if text is None:
+            text = []
+        if isinstance(text, str):
+            text = [text]
+        text = list(text)
+
+        if images is not None:
+            index = 0
+            for i in range(len(text)):
+                while self.image_token in text[i]:
+                    n_tokens = image_num_tokens[index]
+                    text[i] = text[i].replace(
+                        self.image_token,
+                        self.image_start_token
+                        + "<|placeholder|>" * n_tokens
+                        + self.image_end_token,
+                        1,
+                    )
+                    index += 1
+                text[i] = text[i].replace("<|placeholder|>", self.image_token)
+
+        if videos is not None:
+            assert len(text) == 1, "Video is not supported for batch size > 1"
+            video_metadata = videos_kwargs.get("video_metadata", None)
+            i = 0
+            index = 0
+            if self.video_token in text[i]:
+                tokens_per_tubelet = videos_inputs["num_tokens"][0]
+                each_group = (
+                    self.image_start_token
+                    + "<|placeholder|>" * tokens_per_tubelet
+                    + self.image_end_token
+                )
+                T = self.video_temporal_patch_dim
+                n_frames = video_num_patches[index]
+                n_groups = (n_frames + T - 1) // T
+
+                source_fps = (
+                    video_metadata.fps
+                    if (video_metadata is not None and getattr(video_metadata, "fps", None))
+                    else None
+                )
+                frames_indices = (
+                    getattr(video_metadata, "frames_indices", None)
+                    if video_metadata is not None
+                    else None
+                )
+                frame_duration_ms = (
+                    int(1000.0 / source_fps) if source_fps is not None else None
+                )
+
+                frame_labels = []
+                for g in range(n_groups):
+                    parts = []
+                    for j in range(T):
+                        fi = g * T + j
+                        if fi >= n_frames:
+                            break
+                        prefix = "Frame" if j == 0 else "frame"
+                        if (
+                            source_fps is not None
+                            and frames_indices is not None
+                            and fi < len(frames_indices)
+                        ):
+                            ts = int(frames_indices[fi]) * frame_duration_ms / 1000.0
+                            parts.append(f"{prefix} {fi+1} sampled at {ts:.2f} seconds")
+                        elif source_fps is not None:
+                            ts = fi / source_fps
+                            parts.append(f"{prefix} {fi+1} sampled at {ts:.2f} seconds")
+                        else:
+                            parts.append(f"{prefix} {fi+1}")
+                    frame_labels.append(" and ".join(parts) + ": ")
+
+                video_prompt = ""
+                for g, label in enumerate(frame_labels):
+                    if g > 0:
+                        video_prompt += "\n"
+                    video_prompt += label + each_group
+
+                text[i] = text[i].replace(self.video_token, video_prompt, 1)
+            text[i] = text[i].replace("<|placeholder|>", self.image_token)
+
+        if audio is not None:
+            index = 0
+            for i in range(len(text)):
+                while self.audio_token in text[i]:
+                    num_tokens = (
+                        audio_num_tokens[index] if index < len(audio_num_tokens) else 1
+                    )
+                    text[i] = text[i].replace(
+                        self.audio_token,
+                        self.audio_start_token
+                        + "<|audio_placeholder|>" * num_tokens
+                        + self.audio_end_token,
+                        1,
+                    )
+                    index += 1
+                text[i] = text[i].replace("<|audio_placeholder|>", self.audio_token)
+
+        text_kwargs.pop("return_tensors", None)
+        text_inputs = self.tokenizer(text, **text_kwargs)
+
+        result = BatchFeature(
+            data=to_mlx({**text_inputs, **image_inputs, **videos_inputs})
+        )
+
+        if audio_inputs:
+            result["sound_clips"] = audio_inputs["sound_clips"]
+
+        return result
+
+    def _process_audio(self, audio: AudioInput, audio_kwargs: dict):
+        sampling_rate = audio_kwargs.get("sampling_rate", self.audio_sampling_rate)
+
+        if not isinstance(audio, list):
+            audio = [audio]
+
+        audio_clips = []
+        num_tokens = []
+        for audio_item in audio:
+            if isinstance(audio_item, str):
+                waveform = self._load_audio(audio_item, sampling_rate)
+            elif isinstance(audio_item, np.ndarray):
+                waveform = audio_item.squeeze() if audio_item.ndim > 1 else audio_item
+            elif hasattr(audio_item, "numpy"):
+                waveform = np.asarray(audio_item).squeeze()
+            else:
+                raise ValueError(f"Unsupported audio type: {type(audio_item)}")
+
+            audio_clips.append(waveform)
+            n_tokens = self._estimate_audio_num_embeddings(len(waveform))
+            num_tokens.append(max(1, n_tokens))
+
+        return audio_clips, num_tokens
+
+    def _estimate_audio_num_embeddings(self, audio_length_samples: int) -> int:
+        n_frames = 1 + audio_length_samples // self.audio_hop_length
+        kernel_size = self.audio_subsampling_conv_kernel_size
+        stride = self.audio_subsampling_conv_stride
+        num_layers = int(math.log2(self.audio_subsampling_factor))
+        all_paddings = (kernel_size - 1) // 2 * 2
+        add_pad = all_paddings - kernel_size
+        L = n_frames
+        for _ in range(num_layers):
+            L = (L + add_pad) // stride + 1
+        return L
+
+    def _load_audio(self, audio_path: str, target_sr: int) -> np.ndarray:
+        from mlx_audio.audio_io import read as read_audio
+        from mlx_audio.utils import resample_audio
+
+        waveform, sr = read_audio(audio_path, dtype="float32")
+        if waveform.ndim > 1:
+            waveform = waveform.mean(axis=1)
+        if sr != target_sr:
+            waveform = resample_audio(waveform, sr, target_sr)
+        return waveform.astype(np.float32)
+
+    def batch_decode(self, *args, **kwargs):
+        return self.tokenizer.batch_decode(*args, **kwargs)
+
+    def decode(self, *args, **kwargs):
+        return self.tokenizer.decode(*args, **kwargs)
+
+    def post_process_image_text_to_text(
+        self,
+        generated_outputs,
+        skip_special_tokens=True,
+        clean_up_tokenization_spaces=False,
+        **kwargs,
+    ):
+        return self.tokenizer.batch_decode(
+            generated_outputs,
+            skip_special_tokens=skip_special_tokens,
+            clean_up_tokenization_spaces=clean_up_tokenization_spaces,
+            **kwargs,
+        )
+
+    @property
+    def model_input_names(self):
+        tokenizer_input_names = self.tokenizer.model_input_names
+        image_processor_input_names = self.image_processor.model_input_names
+        return list(dict.fromkeys(tokenizer_input_names + image_processor_input_names))
+
+
+__all__ = ["NemotronHNanoOmniProcessor"]
+
+
+install_auto_processor_patch(
+    ["nemotronh_nano_omni_reasoning_v3", "nemotron_h_nano_omni"],
+    NemotronHNanoOmniProcessor,
+)

--- a/mlx_vlm/models/nemotron_h_nano_omni/processing_nemotron_h_nano_omni.py
+++ b/mlx_vlm/models/nemotron_h_nano_omni/processing_nemotron_h_nano_omni.py
@@ -220,7 +220,10 @@ class NemotronHNanoOmniProcessor(ProcessorMixin):
 
                 source_fps = (
                     video_metadata.fps
-                    if (video_metadata is not None and getattr(video_metadata, "fps", None))
+                    if (
+                        video_metadata is not None
+                        and getattr(video_metadata, "fps", None)
+                    )
                     else None
                 )
                 frames_indices = (

--- a/mlx_vlm/models/nemotron_h_nano_omni/processing_nemotron_h_nano_omni.py
+++ b/mlx_vlm/models/nemotron_h_nano_omni/processing_nemotron_h_nano_omni.py
@@ -25,6 +25,9 @@ class NemotronHNanoOmniProcessor(ProcessorMixin):
     video_processor_class = "AutoVideoProcessor"
     tokenizer_class = "AutoTokenizer"
 
+    def check_argument_for_proper_class(self, argument_name, argument):
+        return type(argument)
+
     def __init__(
         self,
         image_processor=None,
@@ -92,30 +95,57 @@ class NemotronHNanoOmniProcessor(ProcessorMixin):
         import json
         from pathlib import Path
 
-        from transformers import AutoImageProcessor, AutoTokenizer
+        from huggingface_hub import hf_hub_download
+        from transformers import AutoTokenizer
+
+        from .image_processing_nemotron_h_nano_omni import (
+            NemotronHNanoOmniImageProcessor,
+        )
 
         kwargs.pop("use_fast", None)
-        kwargs.setdefault("trust_remote_code", True)
 
         tokenizer = AutoTokenizer.from_pretrained(
             pretrained_model_name_or_path, **kwargs
         )
         load_chat_template(tokenizer, pretrained_model_name_or_path)
 
-        try:
-            image_processor = AutoImageProcessor.from_pretrained(
-                pretrained_model_name_or_path, use_fast=False, **kwargs
-            )
-        except ValueError:
-            image_processor = AutoImageProcessor.from_pretrained(
-                pretrained_model_name_or_path, **kwargs
-            )
+        def _read_json(name: str):
+            local = Path(pretrained_model_name_or_path) / name
+            if local.exists():
+                with open(local) as f:
+                    return json.load(f)
+            try:
+                path = hf_hub_download(str(pretrained_model_name_or_path), name)
+                with open(path) as f:
+                    return json.load(f)
+            except Exception:
+                return {}
 
-        proc_kwargs = {}
-        proc_cfg_path = Path(pretrained_model_name_or_path) / "processor_config.json"
-        if proc_cfg_path.exists():
-            with open(proc_cfg_path) as f:
-                proc_cfg = json.load(f)
+        proc_cfg = _read_json("processor_config.json")
+        pre_cfg = _read_json("preprocessor_config.json")
+
+        # Image-processor kwargs come from preprocessor_config.json (or the nested
+        # `image_processor` block in processor_config.json on older exports).
+        ip_cfg = pre_cfg or proc_cfg.get("image_processor", {})
+        ip_kwargs = {
+            k: ip_cfg[k]
+            for k in (
+                "norm_mean",
+                "norm_std",
+                "patch_size",
+                "downsample_ratio",
+                "min_num_patches",
+                "max_num_patches",
+                "max_model_len",
+                "video_target_num_patches",
+                "video_maintain_aspect_ratio",
+            )
+            if k in ip_cfg
+        }
+        image_processor = NemotronHNanoOmniImageProcessor(**ip_kwargs)
+
+        proc_kwargs = {
+            k: proc_cfg[k]
             for k in (
                 "audio_sampling_rate",
                 "audio_subsampling_factor",
@@ -123,9 +153,9 @@ class NemotronHNanoOmniProcessor(ProcessorMixin):
                 "audio_subsampling_conv_kernel_size",
                 "audio_subsampling_conv_stride",
                 "video_temporal_patch_dim",
-            ):
-                if k in proc_cfg:
-                    proc_kwargs[k] = proc_cfg[k]
+            )
+            if k in proc_cfg
+        }
 
         return cls(
             image_processor=image_processor,

--- a/mlx_vlm/tests/test_nemotron_h_nano_omni.py
+++ b/mlx_vlm/tests/test_nemotron_h_nano_omni.py
@@ -9,8 +9,8 @@ from mlx_vlm.models.nemotron_h_nano_omni.audio import (
     sanitize_audio_weights,
 )
 from mlx_vlm.models.nemotron_h_nano_omni.config import (
+    AudioConfig,
     ModelConfig,
-    SoundConfig,
     TextConfig,
     VisionConfig,
 )
@@ -56,7 +56,7 @@ def tiny_vision_config():
 
 
 def tiny_sound_config(hidden_size=16):
-    return SoundConfig(
+    return AudioConfig(
         hidden_size=hidden_size,
         num_attention_heads=4,
         num_hidden_layers=1,
@@ -71,7 +71,7 @@ def tiny_sound_config(hidden_size=16):
 
 def test_sound_feature_extractor_shapes_and_masks():
     pytest.importorskip("mlx_audio")
-    config = SoundConfig()
+    config = AudioConfig()
     extractor = SoundFeatureExtractor(config)
     waveform = np.linspace(-0.5, 0.5, 1600, dtype=np.float32)
 


### PR DESCRIPTION
## Summary
- Renamed `SoundConfig` → `AudioConfig` across the `nemotron_h_nano_omni` package, `__init__` exports, audio module type hints, and tests. The `sound_config` field name on `ModelConfig` is kept to match the upstream HF config key.
- Added `NemotronHNanoOmniProcessor` (`processing_nemotron_h_nano_omni.py`), ported from NVIDIA's reference processor at `nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-BF16`. Adapted to mlx-vlm conventions: drop torch, use flat `images_kwargs`/`videos_kwargs`/`audio_kwargs`/`text_kwargs`, return mlx tensors via `to_mlx`, and keep `sound_clips` as a list of raw waveforms so the model's `SoundFeatureExtractor` can consume them at runtime.
- `from_pretrained` loads `AutoTokenizer` + `AutoImageProcessor` (with `trust_remote_code=True`) and applies `load_chat_template`; optional overrides come from `processor_config.json`.
- Audio file loading goes directly through `mlx_audio` — no librosa/soundfile fallback.
- Registered with `install_auto_processor_patch` for both the upstream model_type (`nemotronh_nano_omni_reasoning_v3`) and the canonical mlx-vlm name.