### PR TITLE
mistral3: skip lm_head quantization and add multi_modal_projector to skip list

### DIFF
--- a/mlx_vlm/models/mistral3/language.py
+++ b/mlx_vlm/models/mistral3/language.py
@@ -298,6 +298,8 @@ class LanguageModel(nn.Module):
             return None
 
         def predicate(path, _):
+            if "lm_head" in path:
+                return False
             if path.endswith("mlp.gate"):
                 return {"group_size": 64, "bits": 8}
             return True

--- a/mlx_vlm/models/mistral3/language.py
+++ b/mlx_vlm/models/mistral3/language.py
@@ -292,15 +292,14 @@ class LanguageModel(nn.Module):
 
     @property
     def quant_predicate(self):
-        if self.model_type != "mistral4" or not getattr(
+        is_mistral4_moe = self.model_type == "mistral4" and getattr(
             self.config, "n_routed_experts", 0
-        ):
-            return None
+        )
 
         def predicate(path, _):
             if "lm_head" in path:
                 return False
-            if path.endswith("mlp.gate"):
+            if is_mistral4_moe and path.endswith("mlp.gate"):
                 return {"group_size": 64, "bits": 8}
             return True
 

--- a/mlx_vlm/models/mistral3/mistral3.py
+++ b/mlx_vlm/models/mistral3/mistral3.py
@@ -368,6 +368,9 @@ class Model(nn.Module):
 
     def sanitize(self, weights):
         def transform_key(key):
+            if key.startswith(("model.vision_tower.", "model.multi_modal_projector.")):
+                key = key[len("model.") :]
+
             if "vision_tower" in key and "vision_model" not in key:
                 if "transformer" in key:
                     key = key.replace("vision_tower", "vision_tower.vision_model")

--- a/mlx_vlm/utils.py
+++ b/mlx_vlm/utils.py
@@ -88,17 +88,18 @@ def skip_multimodal_module(path: str) -> bool:
     Returns:
         bool: True if the module is multimodal and should skip quantization, False otherwise
     """
-    return (
-        "vision_model" in path
-        or "vision_tower" in path
-        or "vl_connector" in path
-        or "sam_model" in path
-        or "audio_model" in path
-        or "audio_tower" in path
-        or "code_predictor" in path
-        or "img_projector" in path
+    multimodal_modules = (
+        "vision_model",
+        "vision_tower",
+        "vl_connector",
+        "sam_model",
+        "audio_model",
+        "audio_tower",
+        "code_predictor",
+        "img_projector",
+        "multi_modal_projector",
     )
-
+    return any(module in path for module in multimodal_modules)
 
 def get_model_and_args(config: dict):
     """

--- a/mlx_vlm/utils.py
+++ b/mlx_vlm/utils.py
@@ -101,6 +101,7 @@ def skip_multimodal_module(path: str) -> bool:
     )
     return any(module in path for module in multimodal_modules)
 
+
 def get_model_and_args(config: dict):
     """
     Retrieve the model object based on the configuration.


### PR DESCRIPTION
## Summary
- Skip quantization for `lm_head` in the Mistral3 language model predicate.
- Add `multi_modal_projector` to the multimodal module skip list and refactor `skip_multimodal_module` to iterate a tuple of module names.

## Test plan
- [ ] Quantize a Mistral3 checkpoint and confirm `lm_head` weights are not quantized.
- [ ] Run `skip_multimodal_module` against representative paths (incl. `multi_modal_projector`) and verify behavior matches the previous list.
- [ ] Load and generate from a quantized Mistral3 model end-to-end.