### PR TITLE
Fix per-sequence MRoPE alignment in mixed VL+text batches

### DIFF
--- a/mlx_vlm/generate.py
+++ b/mlx_vlm/generate.py
@@ -1605,6 +1605,7 @@ class GenerationBatch:
 
     def extend(self, other: "GenerationBatch"):
         """Extend this batch with another generation batch."""
+        self_was_empty = len(self.uids) == 0
         self.uids.extend(other.uids)
         self.prompt_cache = _extend_cache(self.prompt_cache, other.prompt_cache)
         self.max_tokens.extend(other.max_tokens)
@@ -1649,9 +1650,14 @@ class GenerationBatch:
                 self._next_top_idx = None
                 self._next_top_lp = None
 
-        if self._rope_deltas is None:
+        if self_was_empty:
             self._rope_deltas = other._rope_deltas
-        elif other._rope_deltas is not None:
+        elif (self._rope_deltas is None) != (other._rope_deltas is None):
+            raise RuntimeError(
+                "extend() mixes MRoPE and non-MRoPE batches; both sides must "
+                "carry rope_deltas or neither side may."
+            )
+        elif self._rope_deltas is not None:
             self._rope_deltas = mx.concatenate([self._rope_deltas, other._rope_deltas])
 
     def filter(self, keep: List[int]):
@@ -1895,13 +1901,8 @@ class PromptProcessingBatch:
             gen_batch._next_top_lp = top_lp
 
         language_model = getattr(self.model, "language_model", self.model)
-        rope_deltas = getattr(language_model, "_rope_deltas", None)
+        rope_deltas = self._capture_rope_deltas(language_model, len(gen_batch.uids))
         if rope_deltas is not None:
-            # Normalize to shape (B, 1) so extend/filter stay consistent.
-            if rope_deltas.ndim == 0:
-                rope_deltas = rope_deltas.reshape(1, 1)
-            elif rope_deltas.ndim == 1:
-                rope_deltas = rope_deltas[:, None]
             gen_batch._rope_deltas = rope_deltas
 
         self.uids = []
@@ -1913,6 +1914,26 @@ class PromptProcessingBatch:
     @property
     def total_prompt_tokens(self):
         return self._total_prompt_tokens
+
+    @staticmethod
+    def _capture_rope_deltas(language_model, B: int):
+        if not hasattr(language_model, "_rope_deltas"):
+            return None
+        rope_deltas = language_model._rope_deltas
+        if rope_deltas is None:
+            return mx.zeros((B, 1), dtype=mx.int32)
+        if rope_deltas.ndim == 0:
+            rope_deltas = rope_deltas.reshape(1, 1)
+        elif rope_deltas.ndim == 1:
+            rope_deltas = rope_deltas[:, None]
+        # Falcon OCR emits a singleton meant to broadcast across rows.
+        if rope_deltas.shape[0] == 1 and B > 1:
+            rope_deltas = mx.broadcast_to(rope_deltas, (B, 1))
+        if rope_deltas.shape[0] != B:
+            raise RuntimeError(
+                f"_rope_deltas shape {rope_deltas.shape} does not match prefill batch size {B}"
+            )
+        return rope_deltas
 
 
 class BatchGenerator:

--- a/mlx_vlm/models/glm4v/language.py
+++ b/mlx_vlm/models/glm4v/language.py
@@ -471,7 +471,7 @@ class LanguageModel(nn.Module):
                 mrope_position_deltas.append(
                     llm_positions.max() + 1 - len(total_input_ids[i])
                 )
-            mrope_position_deltas = mx.array(mrope_position_deltas)[0]
+            mrope_position_deltas = mx.array(mrope_position_deltas).reshape(-1, 1)
             return position_ids, mrope_position_deltas
         else:
             if attention_mask is not None:
@@ -479,11 +479,10 @@ class LanguageModel(nn.Module):
                 position_ids = mx.where(
                     attention_mask == 0, mx.ones_like(position_ids), position_ids
                 )
-                position_ids = mx.expand_dims(position_ids[0], axis=0)
-                position_ids = mx.tile(position_ids, (3, 1, 1))
-                max_position_ids = position_ids.max(0, keepdims=False)[0].max(
-                    -1, keepdims=True
-                )[0]
+                max_position_ids = position_ids.max(axis=-1, keepdims=True)
+                position_ids = mx.broadcast_to(
+                    position_ids[None, :, :], (3, *position_ids.shape)
+                )
                 mrope_position_deltas = max_position_ids + 1 - attention_mask.shape[-1]
             else:
                 position_ids = mx.arange(input_ids.shape[1]).reshape(1, -1)

--- a/mlx_vlm/models/glm4v_moe/language.py
+++ b/mlx_vlm/models/glm4v_moe/language.py
@@ -545,7 +545,7 @@ class LanguageModel(nn.Module):
                 mrope_position_deltas.append(
                     llm_positions.max() + 1 - len(total_input_ids[i])
                 )
-            mrope_position_deltas = mx.array(mrope_position_deltas)[0]
+            mrope_position_deltas = mx.array(mrope_position_deltas).reshape(-1, 1)
             return position_ids, mrope_position_deltas
         else:
             if attention_mask is not None:
@@ -553,11 +553,10 @@ class LanguageModel(nn.Module):
                 position_ids = mx.where(
                     attention_mask == 0, mx.ones_like(position_ids), position_ids
                 )
-                position_ids = mx.expand_dims(position_ids[0], axis=0)
-                position_ids = mx.tile(position_ids, (3, 1, 1))
-                max_position_ids = position_ids.max(0, keepdims=False)[0].max(
-                    -1, keepdims=True
-                )[0]
+                max_position_ids = position_ids.max(axis=-1, keepdims=True)
+                position_ids = mx.broadcast_to(
+                    position_ids[None, :, :], (3, *position_ids.shape)
+                )
                 mrope_position_deltas = max_position_ids + 1 - attention_mask.shape[-1]
             else:
                 position_ids = mx.arange(input_ids.shape[1]).reshape(1, -1)

--- a/mlx_vlm/models/glm_ocr/language.py
+++ b/mlx_vlm/models/glm_ocr/language.py
@@ -466,7 +466,7 @@ class LanguageModel(nn.Module):
                 mrope_position_deltas.append(
                     llm_positions.max() + 1 - len(total_input_ids[i])
                 )
-            mrope_position_deltas = mx.array(mrope_position_deltas)[0]
+            mrope_position_deltas = mx.array(mrope_position_deltas).reshape(-1, 1)
             return position_ids, mrope_position_deltas
         else:
             if attention_mask is not None:
@@ -474,11 +474,10 @@ class LanguageModel(nn.Module):
                 position_ids = mx.where(
                     attention_mask == 0, mx.ones_like(position_ids), position_ids
                 )
-                position_ids = mx.expand_dims(position_ids[0], axis=0)
-                position_ids = mx.tile(position_ids, (3, 1, 1))
-                max_position_ids = position_ids.max(0, keepdims=False)[0].max(
-                    -1, keepdims=True
-                )[0]
+                max_position_ids = position_ids.max(axis=-1, keepdims=True)
+                position_ids = mx.broadcast_to(
+                    position_ids[None, :, :], (3, *position_ids.shape)
+                )
                 mrope_position_deltas = max_position_ids + 1 - attention_mask.shape[-1]
             else:
                 position_ids = mx.arange(input_ids.shape[1]).reshape(1, -1)

--- a/mlx_vlm/models/paddleocr_vl/language.py
+++ b/mlx_vlm/models/paddleocr_vl/language.py
@@ -403,7 +403,7 @@ class LanguageModel(nn.Module):
                 mrope_position_deltas.append(
                     llm_positions.max() + 1 - len(total_input_ids[i])
                 )
-            mrope_position_deltas = mx.array(mrope_position_deltas)[0]
+            mrope_position_deltas = mx.array(mrope_position_deltas).reshape(-1, 1)
             return position_ids, mrope_position_deltas
         else:
             if attention_mask is not None:
@@ -411,11 +411,10 @@ class LanguageModel(nn.Module):
                 position_ids = mx.where(
                     attention_mask == 0, mx.ones_like(position_ids), position_ids
                 )
-                position_ids = mx.expand_dims(position_ids[0], axis=0)
-                position_ids = mx.tile(position_ids, (3, 1, 1))
-                max_position_ids = position_ids.max(0, keepdims=False)[0].max(
-                    -1, keepdims=True
-                )[0]
+                max_position_ids = position_ids.max(axis=-1, keepdims=True)
+                position_ids = mx.broadcast_to(
+                    position_ids[None, :, :], (3, *position_ids.shape)
+                )
                 mrope_position_deltas = max_position_ids + 1 - attention_mask.shape[-1]
             else:
                 position_ids = mx.arange(input_ids.shape[1]).reshape(1, -1)

--- a/mlx_vlm/models/qwen2_5_vl/language.py
+++ b/mlx_vlm/models/qwen2_5_vl/language.py
@@ -418,7 +418,7 @@ class LanguageModel(nn.Module):
                 mrope_position_deltas.append(
                     llm_positions.max() + 1 - len(total_input_ids[i])
                 )
-            mrope_position_deltas = mx.array(mrope_position_deltas)[0]
+            mrope_position_deltas = mx.array(mrope_position_deltas).reshape(-1, 1)
             return position_ids, mrope_position_deltas
         else:
             if attention_mask is not None:
@@ -426,11 +426,10 @@ class LanguageModel(nn.Module):
                 position_ids = mx.where(
                     attention_mask == 0, mx.ones_like(position_ids), position_ids
                 )
-                position_ids = mx.expand_dims(position_ids[0], axis=0)
-                position_ids = mx.tile(position_ids, (3, 1, 1))
-                max_position_ids = position_ids.max(0, keepdims=False)[0].max(
-                    -1, keepdims=True
-                )[0]
+                max_position_ids = position_ids.max(axis=-1, keepdims=True)
+                position_ids = mx.broadcast_to(
+                    position_ids[None, :, :], (3, *position_ids.shape)
+                )
                 mrope_position_deltas = max_position_ids + 1 - attention_mask.shape[-1]
             else:
                 position_ids = mx.arange(input_ids.shape[1]).reshape(1, -1)

--- a/mlx_vlm/models/qwen2_vl/language.py
+++ b/mlx_vlm/models/qwen2_vl/language.py
@@ -417,7 +417,7 @@ class LanguageModel(nn.Module):
                 mrope_position_deltas.append(
                     llm_positions.max() + 1 - len(total_input_ids[i])
                 )
-            mrope_position_deltas = mx.array(mrope_position_deltas)[0]
+            mrope_position_deltas = mx.array(mrope_position_deltas).reshape(-1, 1)
             return position_ids, mrope_position_deltas
         else:
             if attention_mask is not None:
@@ -425,11 +425,10 @@ class LanguageModel(nn.Module):
                 position_ids = mx.where(
                     attention_mask == 0, mx.ones_like(position_ids), position_ids
                 )
-                position_ids = mx.expand_dims(position_ids[0], axis=0)
-                position_ids = mx.tile(position_ids, (3, 1, 1))
-                max_position_ids = position_ids.max(0, keepdims=False)[0].max(
-                    -1, keepdims=True
-                )[0]
+                max_position_ids = position_ids.max(axis=-1, keepdims=True)
+                position_ids = mx.broadcast_to(
+                    position_ids[None, :, :], (3, *position_ids.shape)
+                )
                 mrope_position_deltas = max_position_ids + 1 - attention_mask.shape[-1]
             else:
                 position_ids = mx.arange(input_ids.shape[1]).reshape(1, -1)

--- a/mlx_vlm/models/qwen3_5/language.py
+++ b/mlx_vlm/models/qwen3_5/language.py
@@ -698,7 +698,7 @@ class LanguageModel(nn.Module):
                 mrope_position_deltas.append(
                     llm_positions.max() + 1 - len(total_input_ids[i])
                 )
-            mrope_position_deltas = mx.array(mrope_position_deltas)[0]
+            mrope_position_deltas = mx.array(mrope_position_deltas).reshape(-1, 1)
             return position_ids, mrope_position_deltas
         else:
             if attention_mask is not None:
@@ -706,11 +706,10 @@ class LanguageModel(nn.Module):
                 position_ids = mx.where(
                     attention_mask == 0, mx.ones_like(position_ids), position_ids
                 )
-                position_ids = mx.expand_dims(position_ids[0], axis=0)
-                position_ids = mx.tile(position_ids, (3, 1, 1))
-                max_position_ids = position_ids.max(0, keepdims=False)[0].max(
-                    -1, keepdims=True
-                )[0]
+                max_position_ids = position_ids.max(axis=-1, keepdims=True)
+                position_ids = mx.broadcast_to(
+                    position_ids[None, :, :], (3, *position_ids.shape)
+                )
                 mrope_position_deltas = max_position_ids + 1 - attention_mask.shape[-1]
             else:
                 position_ids = mx.arange(input_ids.shape[1]).reshape(1, -1)

--- a/mlx_vlm/models/qwen3_omni_moe/language.py
+++ b/mlx_vlm/models/qwen3_omni_moe/language.py
@@ -475,7 +475,7 @@ class LanguageModel(nn.Module):
                 mrope_position_deltas.append(
                     llm_positions.max() + 1 - len(total_input_ids[i])
                 )
-            mrope_position_deltas = mx.array(mrope_position_deltas)[0]
+            mrope_position_deltas = mx.array(mrope_position_deltas).reshape(-1, 1)
             return position_ids, mrope_position_deltas
         else:
             if attention_mask is not None:
@@ -483,11 +483,10 @@ class LanguageModel(nn.Module):
                 position_ids = mx.where(
                     attention_mask == 0, mx.ones_like(position_ids), position_ids
                 )
-                position_ids = mx.expand_dims(position_ids[0], axis=0)
-                position_ids = mx.tile(position_ids, (3, 1, 1))
-                max_position_ids = position_ids.max(0, keepdims=False)[0].max(
-                    -1, keepdims=True
-                )[0]
+                max_position_ids = position_ids.max(axis=-1, keepdims=True)
+                position_ids = mx.broadcast_to(
+                    position_ids[None, :, :], (3, *position_ids.shape)
+                )
                 mrope_position_deltas = max_position_ids + 1 - attention_mask.shape[-1]
             else:
                 position_ids = mx.arange(input_ids.shape[1]).reshape(1, -1)

--- a/mlx_vlm/models/qwen3_vl/language.py
+++ b/mlx_vlm/models/qwen3_vl/language.py
@@ -473,7 +473,7 @@ class LanguageModel(nn.Module):
                 mrope_position_deltas.append(
                     llm_positions.max() + 1 - len(total_input_ids[i])
                 )
-            mrope_position_deltas = mx.array(mrope_position_deltas)[0]
+            mrope_position_deltas = mx.array(mrope_position_deltas).reshape(-1, 1)
             return position_ids, mrope_position_deltas
         else:
             if attention_mask is not None:
@@ -481,11 +481,10 @@ class LanguageModel(nn.Module):
                 position_ids = mx.where(
                     attention_mask == 0, mx.ones_like(position_ids), position_ids
                 )
-                position_ids = mx.expand_dims(position_ids[0], axis=0)
-                position_ids = mx.tile(position_ids, (3, 1, 1))
-                max_position_ids = position_ids.max(0, keepdims=False)[0].max(
-                    -1, keepdims=True
-                )[0]
+                max_position_ids = position_ids.max(axis=-1, keepdims=True)
+                position_ids = mx.broadcast_to(
+                    position_ids[None, :, :], (3, *position_ids.shape)
+                )
                 mrope_position_deltas = max_position_ids + 1 - attention_mask.shape[-1]
             else:
                 position_ids = mx.arange(input_ids.shape[1]).reshape(1, -1)

--- a/mlx_vlm/models/qwen3_vl_moe/language.py
+++ b/mlx_vlm/models/qwen3_vl_moe/language.py
@@ -523,7 +523,7 @@ class LanguageModel(nn.Module):
                 mrope_position_deltas.append(
                     llm_positions.max() + 1 - len(total_input_ids[i])
                 )
-            mrope_position_deltas = mx.array(mrope_position_deltas)[0]
+            mrope_position_deltas = mx.array(mrope_position_deltas).reshape(-1, 1)
             return position_ids, mrope_position_deltas
         else:
             if attention_mask is not None:
@@ -531,11 +531,10 @@ class LanguageModel(nn.Module):
                 position_ids = mx.where(
                     attention_mask == 0, mx.ones_like(position_ids), position_ids
                 )
-                position_ids = mx.expand_dims(position_ids[0], axis=0)
-                position_ids = mx.tile(position_ids, (3, 1, 1))
-                max_position_ids = position_ids.max(0, keepdims=False)[0].max(
-                    -1, keepdims=True
-                )[0]
+                max_position_ids = position_ids.max(axis=-1, keepdims=True)
+                position_ids = mx.broadcast_to(
+                    position_ids[None, :, :], (3, *position_ids.shape)
+                )
                 mrope_position_deltas = max_position_ids + 1 - attention_mask.shape[-1]
             else:
                 position_ids = mx.arange(input_ids.shape[1]).reshape(1, -1)

--- a/mlx_vlm/tests/test_generate.py
+++ b/mlx_vlm/tests/test_generate.py
@@ -313,6 +313,62 @@ class TestGenerationBatch:
         assert batch._num_tokens == [5, 15]
         assert len(batch) == 2
 
+    @staticmethod
+    def _mrope_batch(uids, deltas):
+        sampler = lambda x: mx.argmax(x, axis=-1)
+        batch = GenerationBatch.empty(MagicMock(), sampler, lambda tok: False)
+        batch.uids = list(uids)
+        batch.max_tokens = [10] * len(uids)
+        batch._num_tokens = [0] * len(uids)
+        batch._rope_deltas = mx.array(deltas, dtype=mx.int32)
+        return batch
+
+    def test_extend_concatenates_and_filters_per_row_rope_deltas(self):
+        a = self._mrope_batch([0, 1], [[5], [7]])
+        b = self._mrope_batch([2], [[0]])
+        a.extend(b)
+        assert a._rope_deltas.tolist() == [[5], [7], [0]]
+        a.filter([0, 2])
+        assert a.uids == [0, 2]
+        assert a._rope_deltas.tolist() == [[5], [0]]
+
+    def test_extend_rejects_mixed_mrope_state(self):
+        a = self._mrope_batch([0], [[3]])
+        b = self._mrope_batch([1], [[0]])
+        b._rope_deltas = None
+        with pytest.raises(RuntimeError, match="MRoPE"):
+            a.extend(b)
+
+    def test_extend_into_empty_accumulator_absorbs_mrope_state(self):
+        empty = GenerationBatch.empty(
+            MagicMock(), lambda x: mx.argmax(x, axis=-1), lambda tok: False
+        )
+        empty.extend(self._mrope_batch([0, 1], [[5], [7]]))
+        assert empty._rope_deltas.tolist() == [[5], [7]]
+
+    @staticmethod
+    def _capture(value, B):
+        from mlx_vlm.generate import PromptProcessingBatch
+
+        return PromptProcessingBatch._capture_rope_deltas(
+            SimpleNamespace(_rope_deltas=value), B
+        )
+
+    def test_capture_rope_deltas(self):
+        from mlx_vlm.generate import PromptProcessingBatch
+
+        assert PromptProcessingBatch._capture_rope_deltas(SimpleNamespace(), 3) is None
+        assert self._capture(None, 3).tolist() == [[0], [0], [0]]
+        assert self._capture(mx.array([[5], [7], [9]], dtype=mx.int32), 3).tolist() == [
+            [5],
+            [7],
+            [9],
+        ]
+        # Falcon OCR singleton: (1, 1) broadcasts to (B, 1).
+        assert self._capture(mx.array([[5]], dtype=mx.int32), 4).tolist() == [[5]] * 4
+        with pytest.raises(RuntimeError, match="does not match"):
+            self._capture(mx.array([[5], [7]], dtype=mx.int32), 3)
+
 
 # ============================================================================
 # Tests for Helper Functions

--- a/mlx_vlm/tests/test_models.py
+++ b/mlx_vlm/tests/test_models.py
@@ -5036,6 +5036,76 @@ class TestChunkedPrefillRoPE(unittest.TestCase):
             (1, chunked_input_ids.shape[1], text_config.vocab_size),
         )
 
+    def test_glm4v_get_rope_index_per_row_deltas(self):
+        from mlx_vlm.models import glm4v
+
+        text_config = glm4v.TextConfig(
+            model_type="glm4v_text",
+            hidden_size=16,
+            num_hidden_layers=1,
+            intermediate_size=32,
+            num_attention_heads=2,
+            num_key_value_heads=2,
+            vocab_size=64,
+            max_position_embeddings=256,
+        )
+        vision_config = glm4v.VisionConfig(
+            model_type="glm4v_vision",
+            depth=1,
+            hidden_size=16,
+            intermediate_size=32,
+            num_heads=2,
+            patch_size=14,
+            out_hidden_size=16,
+            spatial_merge_size=2,
+            temporal_patch_size=2,
+            image_size=28,
+        )
+        lm = glm4v.LanguageModel(
+            text_config,
+            glm4v.ModelConfig(
+                text_config=text_config,
+                vision_config=vision_config,
+                model_type="glm4v",
+                vocab_size=64,
+                image_token_id=61,
+                image_token_index=61,
+                video_token_id=62,
+                video_token_index=62,
+                vision_start_token_id=60,
+                vision_end_token_id=59,
+                pad_token_id=0,
+            ),
+        )
+
+        input_ids = mx.array(
+            [
+                [10, 60, 61, 61, 61, 61, 11, 12],
+                [10, 11, 12, 13, 14, 15, 16, 17],
+            ],
+            dtype=mx.int32,
+        )
+        _, rope_deltas = lm.get_rope_index(
+            input_ids, mx.array([[1, 4, 4]], dtype=mx.int32)
+        )
+        self.assertEqual(rope_deltas.shape, (2, 1))
+        self.assertEqual(rope_deltas[1, 0].item(), 0)
+        self.assertNotEqual(rope_deltas[0, 0].item(), rope_deltas[1, 0].item())
+
+        input_ids = mx.array(
+            [[0, 0, 10, 11, 12, 13], [10, 11, 12, 13, 14, 15]], dtype=mx.int32
+        )
+        attention_mask = mx.array(
+            [[0, 0, 1, 1, 1, 1], [1, 1, 1, 1, 1, 1]], dtype=mx.int32
+        )
+        position_ids, rope_deltas = lm.get_rope_index(
+            input_ids, image_grid_thw=None, attention_mask=attention_mask
+        )
+        self.assertEqual(rope_deltas.shape, (2, 1))
+        self.assertEqual(position_ids.shape, (3, 2, 6))
+        self.assertEqual(rope_deltas[0, 0].item(), -2)
+        self.assertEqual(rope_deltas[1, 0].item(), 0)
+
     def test_glm4v_moe_chunked_prefill_rope(self):
         """Test GLM4V-MoE chunked prefill RoPE position ID generation."""
         from mlx_vlm.models import glm4v_moe


### PR DESCRIPTION
GenerationBatch currently carries per-sequence rope_deltas for Qwen-style MRoPE models. In mixed batches where some sequences came from image prompts and some are text-only, make sure rope_deltas are always aligned one row per active sequence. A text-only sequence must not accidentally inherit another sequence's image MRoPE delta. When merging batches, if one side has rope_deltas and the other does not, synthesize zero-delta rows for the text-only side.