### PR TITLE
Fix Gemma4 chat templating for Python generate()

### DIFF
--- a/mlx_vlm/generate.py
+++ b/mlx_vlm/generate.py
@@ -1009,11 +1009,33 @@ def stream_generate(
         else []
     )
 
-    add_special_tokens = (
-        getattr(processor, "chat_template", None) is None
-        if model.config.model_type in ["gemma3", "gemma3n", "gemma4"]
-        else True
-    )
+    # Some models (e.g. Gemma 3/4) rely on a HF chat template to format turns.
+    # The CLI path applies the chat template before calling generate(), but the
+    # Python API often passes raw strings. If the tokenizer provides a chat
+    # template, apply it here to avoid pathological repetition/echoing.
+    applied_chat_template = False
+    if (
+        isinstance(prompt, str)
+        and model.config.model_type in ["gemma3", "gemma3n", "gemma4"]
+        and hasattr(tokenizer, "apply_chat_template")
+        and getattr(tokenizer, "chat_template", None) is not None
+        and not kwargs.pop("skip_chat_template", False)
+    ):
+        try:
+            prompt = apply_chat_template(
+                processor,
+                model.config,
+                prompt,
+                add_generation_prompt=True,
+                num_images=len(image) if isinstance(image, list) else (1 if image else 0),
+                num_audios=len(audio) if isinstance(audio, list) else (1 if audio else 0),
+            )
+            applied_chat_template = True
+        except Exception:
+            # Fall back to raw prompt if templating fails.
+            applied_chat_template = False
+
+    add_special_tokens = False if applied_chat_template else True
 
     resize_shape = normalize_resize_shape(kwargs.pop("resize_shape", None))
     image_token_index = getattr(model.config, "image_token_index", None)

--- a/mlx_vlm/tests/test_gemma4_chat_template.py
+++ b/mlx_vlm/tests/test_gemma4_chat_template.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+
+class DummyTokenizer:
+    chat_template = "dummy"
+
+    def apply_chat_template(self, messages, tokenize, add_generation_prompt, **kwargs):
+        # Return a sentinel string so we can assert it was used.
+        return "TEMPLATED_PROMPT"
+
+
+class DummyProcessor:
+    def __init__(self):
+        self.tokenizer = DummyTokenizer()
+
+
+class DummyConfig:
+    def __init__(self):
+        self.model_type = "gemma4"
+
+
+class DummyModel:
+    def __init__(self):
+        self.config = DummyConfig()
+
+
+def test_stream_generate_applies_chat_template_for_gemma4(monkeypatch):
+    # Import inside test to avoid import-time side effects.
+    import importlib
+
+    gen = importlib.import_module("mlx_vlm.generate")
+
+    proc = DummyProcessor()
+    model = DummyModel()
+
+    captured = {}
+
+    def fake_prepare_inputs(*args, **kwargs):
+        captured["prompts"] = kwargs.get("prompts")
+        return {"input_ids": None, "pixel_values": None, "attention_mask": None}
+
+    # Prevent actual generation and avoid dependency on MLX arrays
+    def fake_generate_step(*args, **kwargs):
+        if False:
+            yield None
+
+    monkeypatch.setattr(gen, "prepare_inputs", fake_prepare_inputs)
+    monkeypatch.setattr(gen, "generate_step", fake_generate_step)
+
+    # Call generator; it will hit prepare_inputs before trying to generate.
+    g = gen.stream_generate(model, proc, "Hello", image=None, audio=None, max_tokens=1)
+    try:
+        next(g)
+    except StopIteration:
+        pass
+    except Exception:
+        # We only care that prepare_inputs saw the templated prompt.
+        pass
+
+    assert captured.get("prompts") == "TEMPLATED_PROMPT"
+
+
+def test_stream_generate_can_skip_chat_template(monkeypatch):
+    import importlib
+
+    gen = importlib.import_module("mlx_vlm.generate")
+
+    proc = DummyProcessor()
+    model = DummyModel()
+    captured = {}
+
+    def fake_prepare_inputs(*args, **kwargs):
+        captured["prompts"] = kwargs.get("prompts")
+        return {"input_ids": None, "pixel_values": None, "attention_mask": None}
+
+    monkeypatch.setattr(gen, "prepare_inputs", fake_prepare_inputs)
+    monkeypatch.setattr(gen, "generate_step", lambda *a, **k: iter(()))
+
+    g = gen.stream_generate(
+        model,
+        proc,
+        "Hello",
+        image=None,
+        audio=None,
+        max_tokens=1,
+        skip_chat_template=True,
+    )
+    try:
+        next(g)
+    except StopIteration:
+        pass
+    except Exception:
+        pass
+
+    assert captured.get("prompts") == "Hello"
+


### PR DESCRIPTION
## Summary
- Apply the tokenizer's chat template for Gemma 3/4 when calling the Python `generate()`/`stream_generate()` APIs with a raw string prompt.
- This avoids pathological repetition/echoing for Gemma4 (e.g., repeated `Say hello.` loops) and matches the CLI behavior that already applies chat templates.
- Adds a unit test to ensure the templated prompt is passed into `prepare_inputs`, and allows opting out via `skip_chat_template=True`.

## Repro
```python
from mlx_vlm import load, generate
model, proc = load('mlx-community/gemma-4-e4b-it-4bit')
out = generate(model, proc, prompt='Say hello in one sentence.', max_tokens=40, temperature=0.7, top_p=0.9)
print(out.text)
```

Before: output tends to loop/repeat the prompt.
After: produces a normal short response.

## Test plan
- `python -m pytest mlx_vlm/tests/test_gemma4_chat_template.py -q`