### PR TITLE
Improve text-only decode performance

### DIFF
--- a/mlx_vlm/models/ernie4_5_moe_vl/ernie4_5_moe_vl.py
+++ b/mlx_vlm/models/ernie4_5_moe_vl/ernie4_5_moe_vl.py
@@ -169,6 +169,7 @@ class Model(nn.Module):
         grid_thw = image_grid_thw if image_grid_thw is not None else video_grid_thw
 
         if pixel_values is None:
+            self.language_model._rope_deltas = None
             return InputEmbeddingsFeatures(
                 inputs_embeds=self.language_model.model.embed_tokens(input_ids)
             )

--- a/mlx_vlm/models/ernie4_5_moe_vl/language.py
+++ b/mlx_vlm/models/ernie4_5_moe_vl/language.py
@@ -4,6 +4,7 @@ from typing import Optional
 
 import mlx.core as mx
 import mlx.nn as nn
+from mlx_lm.models.rope_utils import initialize_rope
 from mlx_lm.models.switch_layers import SwitchGLU
 
 from ..base import (
@@ -200,6 +201,14 @@ class Attention(nn.Module):
             base=args.rope_theta,
             mrope_section=self.mrope_section,
         )
+        self.rope = initialize_rope(
+            head_dim,
+            base=args.rope_theta,
+            traditional=True,
+            scaling_config=getattr(args, "rope_scaling", None)
+            or getattr(args, "rope_parameters", None),
+            max_position_embeddings=args.max_position_embeddings,
+        )
 
     def __call__(
         self,
@@ -223,11 +232,20 @@ class Attention(nn.Module):
             0, 2, 1, 3
         )
 
-        # Handle position IDs
         if position_ids is None:
-            offset = cache.offset if cache is not None else 0
-            position_ids = mx.arange(offset, offset + L)
-            position_ids = mx.expand_dims(position_ids, axis=0)
+            if cache is not None:
+                queries = self.rope(queries, offset=cache.offset)
+                keys = self.rope(keys, offset=cache.offset)
+                keys, values = cache.update_and_fetch(keys, values)
+            else:
+                queries = self.rope(queries)
+                keys = self.rope(keys)
+
+            output = scaled_dot_product_attention(
+                queries, keys, values, cache, scale=self.scale, mask=mask
+            )
+            output = output.transpose(0, 2, 1, 3).reshape(B, L, -1)
+            return self.o_proj(output)
 
         cos, sin = self.rotary_emb(values, position_ids)
         queries, keys = apply_rotary_pos_emb(queries, keys, cos, sin)
@@ -636,7 +654,21 @@ class LanguageModel(nn.Module):
                 # for per-row position_ids + delta arithmetic.
                 cache_offsets = c0.offset
 
-        if position_ids is None and (mask is None or mask.ndim == 2):
+        needs_explicit_positions = (
+            position_ids is not None
+            or image_grid_thw is not None
+            or video_grid_thw is not None
+            or mask is not None
+            or rope_deltas_kw is not None
+            or self._rope_deltas is not None
+            or cache_offsets is not None
+        )
+
+        if (
+            position_ids is None
+            and needs_explicit_positions
+            and (mask is None or mask.ndim == 2)
+        ):
             is_prefill = (
                 cache is None
                 or cache[0] is None

--- a/mlx_vlm/models/glm4v/glm4v.py
+++ b/mlx_vlm/models/glm4v/glm4v.py
@@ -39,6 +39,7 @@ class Model(nn.Module):
 
         if pixel_values is None:
             self.language_model._position_ids = None
+            self.language_model._rope_deltas = None
             return InputEmbeddingsFeatures(
                 inputs_embeds=self.language_model.model.embed_tokens(input_ids)
             )

--- a/mlx_vlm/models/glm4v/language.py
+++ b/mlx_vlm/models/glm4v/language.py
@@ -3,6 +3,7 @@ from typing import Any, Optional
 import mlx.core as mx
 import mlx.nn as nn
 import numpy as np
+from mlx_lm.models.rope_utils import initialize_rope
 
 from ..base import (
     LanguageModelOutput,
@@ -156,6 +157,14 @@ class Glm4vAttention(nn.Module):
         self.o_proj = nn.Linear(n_heads * head_dim, dim, bias=False)
 
         self.rope_scaling = args.rope_scaling
+        rotary_dim = int(head_dim * getattr(args, "partial_rotary_factor", 1.0))
+        self.rope = initialize_rope(
+            rotary_dim,
+            base=args.rope_theta,
+            traditional=True,
+            scaling_config=self.rope_scaling,
+            max_position_embeddings=args.max_position_embeddings,
+        )
 
     def __call__(
         self,
@@ -175,8 +184,22 @@ class Glm4vAttention(nn.Module):
         keys = keys.transpose(0, 2, 1, 3)
         values = values.reshape(B, L, self.n_kv_heads, -1).transpose(0, 2, 1, 3)
 
-        cos, sin = position_embeddings
+        if position_embeddings is None:
+            if cache is not None:
+                queries = self.rope(queries, offset=cache.offset)
+                keys = self.rope(keys, offset=cache.offset)
+                keys, values = cache.update_and_fetch(keys, values)
+            else:
+                queries = self.rope(queries)
+                keys = self.rope(keys)
 
+            output = scaled_dot_product_attention(
+                queries, keys, values, cache=cache, scale=self.scale, mask=mask
+            )
+            output = output.transpose(0, 2, 1, 3).reshape(B, L, -1)
+            return self.o_proj(output)
+
+        cos, sin = position_embeddings
         queries, keys = apply_multimodal_rotary_pos_emb(
             queries, keys, cos, sin, self.rope_scaling["mrope_section"]
         )
@@ -287,12 +310,9 @@ class GLM4VModel(nn.Module):
         else:
             h = inputs_embeds.astype(self.norm.weight.dtype)
 
-        if position_ids is None:
-            position_ids = mx.arange(cache[0].offset, cache[0].offset + h.shape[-2])
-            position_ids = mx.expand_dims(position_ids, axis=0)
-            position_ids = mx.tile(position_ids, (3, 1, 1))
-
-        position_embeddings = self.rotary_emb(h, position_ids)
+        position_embeddings = (
+            self.rotary_emb(h, position_ids) if position_ids is not None else None
+        )
 
         if mask is None:
             mask = create_attention_mask(
@@ -533,7 +553,21 @@ class LanguageModel(nn.Module):
         if mask is not None and mask.shape[-1] != inputs.shape[-1]:
             rope_mask = None
 
-        if position_ids is None and (rope_mask is None or rope_mask.ndim == 2):
+        needs_explicit_positions = (
+            position_ids is not None
+            or image_grid_thw is not None
+            or video_grid_thw is not None
+            or rope_mask is not None
+            or rope_deltas_kw is not None
+            or self._rope_deltas is not None
+            or cache_offsets is not None
+        )
+
+        if (
+            position_ids is None
+            and needs_explicit_positions
+            and (rope_mask is None or rope_mask.ndim == 2)
+        ):
             # Calculate RoPE index once per generation in the pre-fill stage only
             is_prefill = (
                 cache is None

--- a/mlx_vlm/models/glm4v_moe/glm4v_moe.py
+++ b/mlx_vlm/models/glm4v_moe/glm4v_moe.py
@@ -40,6 +40,7 @@ class Model(nn.Module):
 
         if pixel_values is None:
             self.language_model._position_ids = None
+            self.language_model._rope_deltas = None
             return InputEmbeddingsFeatures(
                 inputs_embeds=self.language_model.model.embed_tokens(input_ids)
             )

--- a/mlx_vlm/models/glm4v_moe/language.py
+++ b/mlx_vlm/models/glm4v_moe/language.py
@@ -3,6 +3,7 @@ from typing import Any, Optional
 import mlx.core as mx
 import mlx.nn as nn
 import numpy as np
+from mlx_lm.models.rope_utils import initialize_rope
 from mlx_lm.models.switch_layers import SwitchGLU
 
 from ..base import (
@@ -152,6 +153,14 @@ class Glm4vMoeAttention(nn.Module):
         self.o_proj = nn.Linear(n_heads * head_dim, dim, bias=False)
 
         self.rope_parameters = args.rope_parameters or args.rope_scaling
+        rotary_dim = int(head_dim * getattr(args, "partial_rotary_factor", 1.0))
+        self.rope = initialize_rope(
+            rotary_dim,
+            base=args.rope_theta or self.rope_parameters["rope_theta"],
+            traditional=False,
+            scaling_config=self.rope_parameters,
+            max_position_embeddings=args.max_position_embeddings,
+        )
 
     def __call__(
         self,
@@ -171,8 +180,22 @@ class Glm4vMoeAttention(nn.Module):
         keys = keys.transpose(0, 2, 1, 3)
         values = values.reshape(B, L, self.n_kv_heads, -1).transpose(0, 2, 1, 3)
 
-        cos, sin = position_embeddings
+        if position_embeddings is None:
+            if cache is not None:
+                queries = self.rope(queries, offset=cache.offset)
+                keys = self.rope(keys, offset=cache.offset)
+                keys, values = cache.update_and_fetch(keys, values)
+            else:
+                queries = self.rope(queries)
+                keys = self.rope(keys)
 
+            output = scaled_dot_product_attention(
+                queries, keys, values, cache=cache, scale=self.scale, mask=mask
+            )
+            output = output.transpose(0, 2, 1, 3).reshape(B, L, -1)
+            return self.o_proj(output)
+
+        cos, sin = position_embeddings
         queries, keys = apply_multimodal_rotary_pos_emb(
             queries, keys, cos, sin, self.rope_parameters["mrope_section"]
         )
@@ -361,12 +384,9 @@ class GLM4VModel(nn.Module):
         else:
             h = inputs_embeds.astype(self.norm.weight.dtype)
 
-        if position_ids is None:
-            position_ids = mx.arange(cache[0].offset, cache[0].offset + h.shape[-2])
-            position_ids = mx.expand_dims(position_ids, axis=0)
-            position_ids = mx.tile(position_ids, (3, 1, 1))
-
-        position_embeddings = self.rotary_emb(h, position_ids)
+        position_embeddings = (
+            self.rotary_emb(h, position_ids) if position_ids is not None else None
+        )
 
         if mask is None:
             mask = create_attention_mask(
@@ -607,7 +627,21 @@ class LanguageModel(nn.Module):
         if mask is not None and mask.shape[-1] != inputs.shape[-1]:
             rope_mask = None
 
-        if position_ids is None and (rope_mask is None or rope_mask.ndim == 2):
+        needs_explicit_positions = (
+            position_ids is not None
+            or image_grid_thw is not None
+            or video_grid_thw is not None
+            or rope_mask is not None
+            or rope_deltas_kw is not None
+            or self._rope_deltas is not None
+            or cache_offsets is not None
+        )
+
+        if (
+            position_ids is None
+            and needs_explicit_positions
+            and (rope_mask is None or rope_mask.ndim == 2)
+        ):
             # Calculate RoPE index once per generation in the pre-fill stage only
             is_prefill = (
                 cache is None

--- a/mlx_vlm/models/glm_ocr/glm_ocr.py
+++ b/mlx_vlm/models/glm_ocr/glm_ocr.py
@@ -29,6 +29,7 @@ class Model(nn.Module):
 
         if pixel_values is None:
             self.language_model._position_ids = None
+            self.language_model._rope_deltas = None
             return InputEmbeddingsFeatures(
                 inputs_embeds=self.language_model.model.embed_tokens(input_ids)
             )

--- a/mlx_vlm/models/glm_ocr/language.py
+++ b/mlx_vlm/models/glm_ocr/language.py
@@ -3,6 +3,7 @@ from typing import Any, Optional
 import mlx.core as mx
 import mlx.nn as nn
 import numpy as np
+from mlx_lm.models.rope_utils import initialize_rope
 
 from ..base import (
     LanguageModelOutput,
@@ -161,6 +162,16 @@ class GlmOcrAttention(nn.Module):
         self.o_proj = nn.Linear(n_heads * self.head_dim, dim, bias=False)
 
         self.rope_parameters = args.rope_parameters
+        rotary_dim = int(
+            self.head_dim * self.rope_parameters.get("partial_rotary_factor", 1.0)
+        )
+        self.rope = initialize_rope(
+            rotary_dim,
+            base=args.rope_theta,
+            traditional=True,
+            scaling_config=self.rope_parameters,
+            max_position_embeddings=args.max_position_embeddings,
+        )
 
     def __call__(
         self,
@@ -182,8 +193,22 @@ class GlmOcrAttention(nn.Module):
         keys = keys.transpose(0, 2, 1, 3)
         values = values.reshape(B, L, self.n_kv_heads, -1).transpose(0, 2, 1, 3)
 
-        cos, sin = position_embeddings
+        if position_embeddings is None:
+            if cache is not None:
+                queries = self.rope(queries, offset=cache.offset)
+                keys = self.rope(keys, offset=cache.offset)
+                keys, values = cache.update_and_fetch(keys, values)
+            else:
+                queries = self.rope(queries)
+                keys = self.rope(keys)
 
+            output = scaled_dot_product_attention(
+                queries, keys, values, cache=cache, scale=self.scale, mask=mask
+            )
+            output = output.transpose(0, 2, 1, 3).reshape(B, L, -1)
+            return self.o_proj(output)
+
+        cos, sin = position_embeddings
         queries, keys = apply_rotary_pos_emb(queries, keys, cos, sin)
 
         if cache is not None:
@@ -290,12 +315,9 @@ class GlmOcrTextModel(nn.Module):
         else:
             h = inputs_embeds.astype(self.norm.weight.dtype)
 
-        if position_ids is None:
-            position_ids = mx.arange(cache[0].offset, cache[0].offset + h.shape[-2])
-            position_ids = mx.expand_dims(position_ids, axis=0)
-            position_ids = mx.tile(position_ids, (3, 1, 1))
-
-        position_embeddings = self.rotary_emb(h, position_ids)
+        position_embeddings = (
+            self.rotary_emb(h, position_ids) if position_ids is not None else None
+        )
 
         if mask is None:
             mask = create_attention_mask(
@@ -526,7 +548,21 @@ class LanguageModel(nn.Module):
         if mask is not None and mask.shape[-1] != inputs.shape[-1]:
             rope_mask = None
 
-        if position_ids is None and (rope_mask is None or rope_mask.ndim == 2):
+        needs_explicit_positions = (
+            position_ids is not None
+            or image_grid_thw is not None
+            or video_grid_thw is not None
+            or rope_mask is not None
+            or rope_deltas_kw is not None
+            or self._rope_deltas is not None
+            or cache_offsets is not None
+        )
+
+        if (
+            position_ids is None
+            and needs_explicit_positions
+            and (rope_mask is None or rope_mask.ndim == 2)
+        ):
             # Calculate RoPE index once per generation in the pre-fill stage only
             is_prefill = (
                 cache is None

--- a/mlx_vlm/models/paddleocr_vl/language.py
+++ b/mlx_vlm/models/paddleocr_vl/language.py
@@ -3,6 +3,7 @@ from typing import Optional
 import mlx.core as mx
 import mlx.nn as nn
 import numpy as np
+from mlx_lm.models.rope_utils import initialize_rope
 
 from ..base import (
     LanguageModelOutput,
@@ -109,6 +110,13 @@ class Attention(nn.Module):
         self.o_proj = nn.Linear(n_heads * head_dim, dim, bias=args.use_bias)
 
         self.rope_parameters = args.rope_parameters or args.rope_scaling
+        self.rope = initialize_rope(
+            head_dim,
+            base=args.rope_theta,
+            traditional=False,
+            scaling_config=self.rope_parameters,
+            max_position_embeddings=args.max_position_embeddings,
+        )
 
     def __call__(
         self,
@@ -130,8 +138,22 @@ class Attention(nn.Module):
             0, 2, 1, 3
         )
 
-        cos, sin = position_embeddings
+        if position_embeddings is None:
+            if cache is not None:
+                queries = self.rope(queries, offset=cache.offset)
+                keys = self.rope(keys, offset=cache.offset)
+                keys, values = cache.update_and_fetch(keys, values)
+            else:
+                queries = self.rope(queries)
+                keys = self.rope(keys)
 
+            output = scaled_dot_product_attention(
+                queries, keys, values, cache, scale=self.scale, mask=mask
+            )
+            output = output.transpose(0, 2, 1, 3).reshape(B, L, -1)
+            return self.o_proj(output)
+
+        cos, sin = position_embeddings
         queries, keys = apply_multimodal_rotary_pos_emb(
             queries, keys, cos, sin, self.rope_parameters["mrope_section"]
         )
@@ -218,12 +240,9 @@ class PaddleOCRModel(nn.Module):
         else:
             h = inputs_embeds
 
-        if position_ids is None:
-            position_ids = mx.arange(cache[0].offset, cache[0].offset + h.shape[-2])
-            position_ids = mx.expand_dims(position_ids, axis=0)
-            position_ids = mx.tile(position_ids, (3, 1, 1))
-
-        position_embeddings = self.rotary_emb(h, position_ids)
+        position_embeddings = (
+            self.rotary_emb(h, position_ids) if position_ids is not None else None
+        )
 
         if cache is None:
             cache = [None] * len(self.layers)
@@ -464,7 +483,21 @@ class LanguageModel(nn.Module):
         if mask is not None and mask.shape[-1] != inputs.shape[-1]:
             rope_mask = None
 
-        if position_ids is None and (rope_mask is None or rope_mask.ndim == 2):
+        needs_explicit_positions = (
+            position_ids is not None
+            or image_grid_thw is not None
+            or video_grid_thw is not None
+            or rope_mask is not None
+            or rope_deltas_kw is not None
+            or self._rope_deltas is not None
+            or cache_offsets is not None
+        )
+
+        if (
+            position_ids is None
+            and needs_explicit_positions
+            and (rope_mask is None or rope_mask.ndim == 2)
+        ):
             # Calculate RoPE index once per generation in the pre-fill stage only
             if (
                 (cache is not None and cache[0] is not None and (cache_offset == 0))
@@ -497,8 +530,13 @@ class LanguageModel(nn.Module):
                         rope_deltas = rope_deltas[:batch_size]
                     delta = (offsets + rope_deltas.squeeze(-1))[:, None]
                 else:
+                    rope_deltas = (
+                        rope_deltas_kw
+                        if rope_deltas_kw is not None
+                        else self._rope_deltas
+                    )
                     delta = mx.array(
-                        cache_offset + self._rope_deltas if cache is not None else 0
+                        cache_offset + rope_deltas if cache is not None else 0
                     )
                     if delta.ndim == 0:
                         delta = mx.expand_dims(delta, axis=0)

--- a/mlx_vlm/models/paddleocr_vl/paddleocr_vl.py
+++ b/mlx_vlm/models/paddleocr_vl/paddleocr_vl.py
@@ -32,6 +32,7 @@ class Model(nn.Module):
 
         if pixel_values is None:
             self.language_model._position_ids = None
+            self.language_model._rope_deltas = None
             return InputEmbeddingsFeatures(
                 inputs_embeds=self.language_model.model.embed_tokens(input_ids)
             )

--- a/mlx_vlm/models/qwen2_5_vl/language.py
+++ b/mlx_vlm/models/qwen2_5_vl/language.py
@@ -2,6 +2,7 @@ from typing import Optional
 
 import mlx.core as mx
 import mlx.nn as nn
+from mlx_lm.models.rope_utils import initialize_rope
 
 from ..base import (
     LanguageModelOutput,
@@ -128,6 +129,13 @@ class Attention(nn.Module):
             base=args.rope_theta,
             rope_scaling=args.rope_scaling,
         )
+        self.rope = initialize_rope(
+            head_dim,
+            base=args.rope_theta,
+            traditional=False,
+            scaling_config=args.rope_scaling,
+            max_position_embeddings=args.max_position_embeddings,
+        )
 
     def __call__(
         self,
@@ -149,20 +157,25 @@ class Attention(nn.Module):
             0, 2, 1, 3
         )
 
-        kv_seq_len = keys.shape[-2]
-
         if position_ids is None:
-            kv_seq_len += cache.offset + 1
-            position_ids = mx.arange(cache.offset, cache.offset + L)
-            position_ids = mx.expand_dims(position_ids, axis=0)
-            position_ids = mx.tile(position_ids, (3, 1, 1))
-        else:
-            kv_seq_len += cache.offset + 1 if cache is not None else 0
+            if cache is not None:
+                queries = self.rope(queries, offset=cache.offset)
+                keys = self.rope(keys, offset=cache.offset)
+                keys, values = cache.update_and_fetch(keys, values)
+            else:
+                queries = self.rope(queries)
+                keys = self.rope(keys)
 
-        cos, sin = self.rotary_emb(values, position_ids)
+            output = scaled_dot_product_attention(
+                queries, keys, values, cache, scale=self.scale, mask=mask
+            )
+            output = output.transpose(0, 2, 1, 3).reshape(B, L, -1)
+            return self.o_proj(output)
 
         if mask is not None and isinstance(mask, mx.array):
             mask = mask[..., : keys.shape[-2]]
+
+        cos, sin = self.rotary_emb(values, position_ids)
         queries, keys = apply_multimodal_rotary_pos_emb(
             queries, keys, cos, sin, unqueeze_dim=1
         )
@@ -484,7 +497,21 @@ class LanguageModel(nn.Module):
         if mask is not None and mask.shape[-1] != inputs.shape[-1]:
             rope_mask = None
 
-        if position_ids is None and (rope_mask is None or rope_mask.ndim == 2):
+        needs_explicit_positions = (
+            position_ids is not None
+            or image_grid_thw is not None
+            or video_grid_thw is not None
+            or rope_mask is not None
+            or rope_deltas_kw is not None
+            or self._rope_deltas is not None
+            or cache_offsets is not None
+        )
+
+        if (
+            position_ids is None
+            and needs_explicit_positions
+            and (rope_mask is None or rope_mask.ndim == 2)
+        ):
             # Calculate RoPE index once per generation in the pre-fill stage only
             if (
                 (cache is not None and cache[0] is not None and (cache_offset == 0))
@@ -515,8 +542,13 @@ class LanguageModel(nn.Module):
                         rope_deltas = rope_deltas[:batch_size]
                     delta = (offsets + rope_deltas.squeeze(-1))[:, None]
                 else:
+                    rope_deltas = (
+                        rope_deltas_kw
+                        if rope_deltas_kw is not None
+                        else self._rope_deltas
+                    )
                     delta = mx.array(
-                        cache_offset + self._rope_deltas if cache is not None else 0
+                        cache_offset + rope_deltas if cache is not None else 0
                     )
                     if delta.ndim == 0:
                         delta = mx.expand_dims(delta, axis=0)

--- a/mlx_vlm/models/qwen2_5_vl/qwen2_5_vl.py
+++ b/mlx_vlm/models/qwen2_5_vl/qwen2_5_vl.py
@@ -33,6 +33,7 @@ class Model(nn.Module):
 
         if pixel_values is None:
             self.language_model._position_ids = None
+            self.language_model._rope_deltas = None
             return InputEmbeddingsFeatures(
                 inputs_embeds=self.language_model.model.embed_tokens(input_ids)
             )

--- a/mlx_vlm/models/qwen2_vl/language.py
+++ b/mlx_vlm/models/qwen2_vl/language.py
@@ -2,6 +2,7 @@ from typing import Optional
 
 import mlx.core as mx
 import mlx.nn as nn
+from mlx_lm.models.rope_utils import initialize_rope
 
 from ..base import (
     LanguageModelOutput,
@@ -127,6 +128,13 @@ class Attention(nn.Module):
             base=args.rope_theta,
             rope_scaling=args.rope_scaling,
         )
+        self.rope = initialize_rope(
+            head_dim,
+            base=args.rope_theta,
+            traditional=False,
+            scaling_config=args.rope_scaling,
+            max_position_embeddings=args.max_position_embeddings,
+        )
 
     def __call__(
         self,
@@ -148,20 +156,25 @@ class Attention(nn.Module):
             0, 2, 1, 3
         )
 
-        kv_seq_len = keys.shape[-2]
-
         if position_ids is None:
-            kv_seq_len += cache.offset + 1
-            position_ids = mx.arange(cache.offset, cache.offset + L)
-            position_ids = mx.expand_dims(position_ids, axis=0)
-            position_ids = mx.tile(position_ids, (3, 1, 1))
-        else:
-            kv_seq_len += cache.offset + 1 if cache is not None else 0
+            if cache is not None:
+                queries = self.rope(queries, offset=cache.offset)
+                keys = self.rope(keys, offset=cache.offset)
+                keys, values = cache.update_and_fetch(keys, values)
+            else:
+                queries = self.rope(queries)
+                keys = self.rope(keys)
 
-        cos, sin = self.rotary_emb(values, position_ids)
+            output = scaled_dot_product_attention(
+                queries, keys, values, cache, scale=self.scale, mask=mask
+            )
+            output = output.transpose(0, 2, 1, 3).reshape(B, L, -1)
+            return self.o_proj(output)
 
         if mask is not None and isinstance(mask, mx.array):
             mask = mask[..., : keys.shape[-2]]
+
+        cos, sin = self.rotary_emb(values, position_ids)
         queries, keys = apply_multimodal_rotary_pos_emb(
             queries, keys, cos, sin, unqueeze_dim=1
         )
@@ -476,7 +489,21 @@ class LanguageModel(nn.Module):
         if mask is not None and mask.shape[-1] != inputs.shape[-1]:
             rope_mask = None
 
-        if position_ids is None and (rope_mask is None or rope_mask.ndim == 2):
+        needs_explicit_positions = (
+            position_ids is not None
+            or image_grid_thw is not None
+            or video_grid_thw is not None
+            or rope_mask is not None
+            or rope_deltas_kw is not None
+            or self._rope_deltas is not None
+            or cache_offsets is not None
+        )
+
+        if (
+            position_ids is None
+            and needs_explicit_positions
+            and (rope_mask is None or rope_mask.ndim == 2)
+        ):
             # Calculate RoPE index once per generation in the pre-fill stage only
             if (
                 (cache is not None and cache[0] is not None and (cache_offset == 0))
@@ -507,8 +534,13 @@ class LanguageModel(nn.Module):
                         rope_deltas = rope_deltas[:batch_size]
                     delta = (offsets + rope_deltas.squeeze(-1))[:, None]
                 else:
+                    rope_deltas = (
+                        rope_deltas_kw
+                        if rope_deltas_kw is not None
+                        else self._rope_deltas
+                    )
                     delta = mx.array(
-                        cache_offset + self._rope_deltas if cache is not None else 0
+                        cache_offset + rope_deltas if cache is not None else 0
                     )
                     if delta.ndim == 0:
                         delta = mx.expand_dims(delta, axis=0)

--- a/mlx_vlm/models/qwen2_vl/qwen2_vl.py
+++ b/mlx_vlm/models/qwen2_vl/qwen2_vl.py
@@ -33,6 +33,7 @@ class Model(nn.Module):
 
         if pixel_values is None:
             self.language_model._position_ids = None
+            self.language_model._rope_deltas = None
             return InputEmbeddingsFeatures(
                 inputs_embeds=self.language_model.model.embed_tokens(input_ids)
             )

--- a/mlx_vlm/models/qwen3_5/language.py
+++ b/mlx_vlm/models/qwen3_5/language.py
@@ -5,6 +5,7 @@ import mlx.core as mx
 import mlx.nn as nn
 from mlx_lm.models.activations import swiglu
 from mlx_lm.models.gated_delta import gated_delta_update
+from mlx_lm.models.rope_utils import initialize_rope
 
 from ..base import (
     LanguageModelOutput,
@@ -39,7 +40,7 @@ class Qwen3_5RotaryEmbedding:
             freqs_t[..., idx] = freqs[dim, ..., idx]
         return freqs_t
 
-    def __call__(self, x, position_ids):
+    def __call__(self, position_ids):
         if position_ids.ndim == 2:
             position_ids = mx.broadcast_to(
                 position_ids[None, ...],
@@ -149,6 +150,13 @@ class Qwen3_5Attention(nn.Module):
             base=args.rope_parameters["rope_theta"],
             mrope_section=args.rope_parameters["mrope_section"],
         )
+        self.rope = initialize_rope(
+            int(self.head_dim * args.rope_parameters["partial_rotary_factor"]),
+            base=args.rope_parameters["rope_theta"],
+            traditional=False,
+            scaling_config=args.rope_parameters,
+            max_position_embeddings=args.max_position_embeddings,
+        )
 
     def __call__(
         self,
@@ -156,6 +164,7 @@ class Qwen3_5Attention(nn.Module):
         mask: Optional[mx.array] = None,
         cache: Optional[Any] = None,
         position_ids: Optional[mx.array] = None,
+        rotary_embeds: Optional[tuple[mx.array, mx.array]] = None,
     ) -> mx.array:
         B, L, D = x.shape
 
@@ -175,17 +184,31 @@ class Qwen3_5Attention(nn.Module):
             0, 2, 1, 3
         )
 
+        if position_ids is None:
+            if cache is not None:
+                queries = self.rope(queries, offset=cache.offset)
+                keys = self.rope(keys, offset=cache.offset)
+                keys, values = cache.update_and_fetch(keys, values)
+            else:
+                queries = self.rope(queries)
+                keys = self.rope(keys)
+
+            output = scaled_dot_product_attention(
+                queries, keys, values, cache=cache, scale=self.scale, mask=mask
+            )
+            output = output.transpose(0, 2, 1, 3).reshape(B, L, -1)
+
+            return self.o_proj(output * mx.sigmoid(gate))
+
         kv_seq_len = keys.shape[-2]
 
-        if position_ids is None:
-            kv_seq_len += cache.offset + 1
-            position_ids = mx.arange(cache.offset, cache.offset + L)
-            position_ids = mx.expand_dims(position_ids, axis=0)
-            position_ids = mx.tile(position_ids, (3, 1, 1))
-        else:
-            kv_seq_len += cache.offset + 1 if cache is not None else 0
+        kv_seq_len += cache.offset + 1 if cache is not None else 0
 
-        cos, sin = self.rotary_emb(values, position_ids)
+        cos, sin = (
+            rotary_embeds
+            if rotary_embeds is not None
+            else self.rotary_emb(position_ids)
+        )
 
         if mask is not None and isinstance(mask, mx.array):
             if isinstance(kv_seq_len, mx.array):
@@ -297,7 +320,7 @@ class Qwen3_5GatedDeltaNet(nn.Module):
                 mixed_qkv = mx.where(mask[..., None], mixed_qkv, 0)
         conv_input = mx.concatenate([conv_state, mixed_qkv], axis=1)
         if cache is not None:
-            cache[0] = conv_input[:, -(self.conv_kernel_size - 1) :]
+            cache[0] = mx.contiguous(conv_input[:, -(self.conv_kernel_size - 1) :, :])
         conv_out = nn.silu(self.conv1d(conv_input))
 
         q, k, v = [
@@ -377,6 +400,7 @@ class Qwen3_5DecoderLayer(nn.Module):
         mask: Optional[mx.array] = None,
         cache: Optional[Any] = None,
         position_ids: Optional[mx.array] = None,
+        rotary_embeds: Optional[tuple[mx.array, mx.array]] = None,
         gdn_sink: Optional[list] = None,
     ) -> mx.array:
         if self.is_linear:
@@ -384,7 +408,9 @@ class Qwen3_5DecoderLayer(nn.Module):
                 self.input_layernorm(x), mask, cache, gdn_sink=gdn_sink
             )
         else:
-            r = self.self_attn(self.input_layernorm(x), mask, cache, position_ids)
+            r = self.self_attn(
+                self.input_layernorm(x), mask, cache, position_ids, rotary_embeds
+            )
         h = x + r
         return h + self.mlp(self.post_attention_layernorm(h))
 
@@ -423,11 +449,22 @@ class Qwen3_5Model(nn.Module):
 
         fa_mask = create_attention_mask(h, cache[self.fa_idx])
         ssm_mask = create_ssm_mask(h, cache[self.ssm_idx])
+        rotary_embeds = None
+        if position_ids is not None:
+            rotary_embeds = self.layers[self.fa_idx].self_attn.rotary_emb(position_ids)
 
         capture_set = set(capture_layer_ids) if capture_layer_ids else set()
         for i, (layer, c) in enumerate(zip(self.layers, cache)):
             mask = ssm_mask if layer.is_linear else fa_mask
-            h = layer(h, mask, c, position_ids, gdn_sink=gdn_sink)
+            layer_rotary_embeds = None if layer.is_linear else rotary_embeds
+            h = layer(
+                h,
+                mask,
+                c,
+                position_ids,
+                rotary_embeds=layer_rotary_embeds,
+                gdn_sink=gdn_sink,
+            )
             if hidden_sink is not None and i in capture_set:
                 hidden_sink.append(h)
 
@@ -757,7 +794,21 @@ class LanguageModel(nn.Module):
         if mask is not None and mask.shape[-1] != inputs.shape[-1]:
             rope_mask = None
 
-        if position_ids is None and (rope_mask is None or rope_mask.ndim == 2):
+        needs_explicit_positions = (
+            position_ids is not None
+            or image_grid_thw is not None
+            or video_grid_thw is not None
+            or rope_mask is not None
+            or rope_deltas_kw is not None
+            or self._rope_deltas is not None
+            or cache_offsets is not None
+        )
+
+        if (
+            position_ids is None
+            and needs_explicit_positions
+            and (rope_mask is None or rope_mask.ndim == 2)
+        ):
             batch_size, seq_length = inputs.shape
 
             if (
@@ -795,8 +846,13 @@ class LanguageModel(nn.Module):
                         rope_deltas = rope_deltas[:batch_size]
                     delta = (offsets + rope_deltas.squeeze(-1))[:, None]
                 else:
+                    rope_deltas = (
+                        rope_deltas_kw
+                        if rope_deltas_kw is not None
+                        else self._rope_deltas
+                    )
                     delta = mx.array(
-                        cache_offset + self._rope_deltas if cache is not None else 0
+                        cache_offset + rope_deltas if cache is not None else 0
                     )
                     if delta.ndim == 0:
                         delta = mx.expand_dims(delta, axis=0)

--- a/mlx_vlm/models/qwen3_5/qwen3_5.py
+++ b/mlx_vlm/models/qwen3_5/qwen3_5.py
@@ -37,6 +37,7 @@ class Model(Qwen3VLModel):
 
         if pixel_values is None:
             self.language_model._position_ids = None
+            self.language_model._rope_deltas = None
             return InputEmbeddingsFeatures(
                 inputs_embeds=self.language_model.model.embed_tokens(input_ids)
             )

--- a/mlx_vlm/models/qwen3_5_moe/language.py
+++ b/mlx_vlm/models/qwen3_5_moe/language.py
@@ -70,6 +70,7 @@ class Qwen3_5MoeDecoderLayer(nn.Module):
         mask: Optional[mx.array] = None,
         cache: Optional[Any] = None,
         position_ids: Optional[mx.array] = None,
+        rotary_embeds: Optional[tuple[mx.array, mx.array]] = None,
         gdn_sink: Optional[list] = None,
     ) -> mx.array:
         if self.is_linear:
@@ -77,7 +78,9 @@ class Qwen3_5MoeDecoderLayer(nn.Module):
                 self.input_layernorm(x), mask, cache, gdn_sink=gdn_sink
             )
         else:
-            r = self.self_attn(self.input_layernorm(x), mask, cache, position_ids)
+            r = self.self_attn(
+                self.input_layernorm(x), mask, cache, position_ids, rotary_embeds
+            )
         h = x + r
         out = h + self.mlp(self.post_attention_layernorm(h))
         return out

--- a/mlx_vlm/models/qwen3_omni_moe/language.py
+++ b/mlx_vlm/models/qwen3_omni_moe/language.py
@@ -3,6 +3,7 @@ from typing import Optional
 import mlx.core as mx
 import mlx.nn as nn
 import numpy as np
+from mlx_lm.models.rope_utils import initialize_rope
 from mlx_lm.models.switch_layers import SwitchGLU
 
 from ..base import (
@@ -117,6 +118,13 @@ class Attention(nn.Module):
             base=args.rope_theta,
             rope_scaling=self.rope_scaling,
         )
+        self.rope = initialize_rope(
+            head_dim,
+            base=args.rope_theta,
+            traditional=False,
+            scaling_config=self.rope_scaling,
+            max_position_embeddings=args.max_position_embeddings,
+        )
 
     def __call__(
         self,
@@ -139,23 +147,30 @@ class Attention(nn.Module):
             0, 2, 1, 3
         )
 
-        kv_seq_len = keys.shape[-2]
-
         if position_ids is None:
-            kv_seq_len += cache.offset + 1
-            position_ids = mx.arange(cache.offset, cache.offset + L)
-            position_ids = mx.expand_dims(position_ids, axis=0)
-            position_ids = mx.tile(position_ids, (3, 1, 1))
-        else:
-            kv_seq_len += cache.offset + 1 if cache is not None else 0
+            if cache is not None:
+                queries = self.rope(queries, offset=cache.offset)
+                keys = self.rope(keys, offset=cache.offset)
+                keys, values = cache.update_and_fetch(keys, values)
+            else:
+                queries = self.rope(queries)
+                keys = self.rope(keys)
 
-        cos, sin = self.rotary_emb(values, position_ids)
+            output = scaled_dot_product_attention(
+                queries, keys, values, cache, scale=self.scale, mask=mask
+            )
+            output = output.transpose(0, 2, 1, 3).reshape(B, L, -1)
+            return self.o_proj(output)
+
+        kv_seq_len = keys.shape[-2]
+        kv_seq_len += cache.offset + 1 if cache is not None else 0
 
         if mask is not None and isinstance(mask, mx.array):
             if isinstance(kv_seq_len, mx.array):
                 kv_seq_len = kv_seq_len.max().item()
             mask = mask[..., : int(kv_seq_len)]
 
+        cos, sin = self.rotary_emb(values, position_ids)
         queries, keys = apply_multimodal_rotary_pos_emb(queries, keys, cos, sin)
 
         if cache is not None:
@@ -532,7 +547,21 @@ class LanguageModel(nn.Module):
             ):
                 cache_offsets = c0.offset
 
-        if position_ids is None and (mask is None or mask.ndim == 2):
+        needs_explicit_positions = (
+            position_ids is not None
+            or image_grid_thw is not None
+            or video_grid_thw is not None
+            or mask is not None
+            or rope_deltas_kw is not None
+            or self._rope_deltas is not None
+            or cache_offsets is not None
+        )
+
+        if (
+            position_ids is None
+            and needs_explicit_positions
+            and (mask is None or mask.ndim == 2)
+        ):
             is_prefill = (
                 cache is None
                 or cache[0] is None

--- a/mlx_vlm/models/qwen3_omni_moe/thinker.py
+++ b/mlx_vlm/models/qwen3_omni_moe/thinker.py
@@ -143,6 +143,9 @@ class Thinker(nn.Module):
         deepstack_visual_embeds = None
         visual_embeds_multiscale = None
 
+        if pixel_values is None and pixel_values_videos is None:
+            self.language_model._rope_deltas = None
+
         if input_features is not None:
             audio_features = self.get_audio_features(
                 input_features,

--- a/mlx_vlm/models/qwen3_vl/language.py
+++ b/mlx_vlm/models/qwen3_vl/language.py
@@ -3,6 +3,7 @@ from typing import Optional
 import mlx.core as mx
 import mlx.nn as nn
 import numpy as np
+from mlx_lm.models.rope_utils import initialize_rope
 
 from ..base import (
     LanguageModelOutput,
@@ -133,6 +134,13 @@ class Attention(nn.Module):
             base=args.rope_theta,
             rope_scaling=self.rope_scaling,
         )
+        self.rope = initialize_rope(
+            head_dim,
+            base=args.rope_theta,
+            traditional=False,
+            scaling_config=self.rope_scaling,
+            max_position_embeddings=args.max_position_embeddings,
+        )
 
     def __call__(
         self,
@@ -156,23 +164,30 @@ class Attention(nn.Module):
             0, 2, 1, 3
         )
 
-        kv_seq_len = keys.shape[-2]
-
         if position_ids is None:
-            kv_seq_len += cache.offset + 1
-            position_ids = mx.arange(cache.offset, cache.offset + L)
-            position_ids = mx.expand_dims(position_ids, axis=0)
-            position_ids = mx.tile(position_ids, (3, 1, 1))
-        else:
-            kv_seq_len += cache.offset + 1 if cache is not None else 0
+            if cache is not None:
+                queries = self.rope(queries, offset=cache.offset)
+                keys = self.rope(keys, offset=cache.offset)
+                keys, values = cache.update_and_fetch(keys, values)
+            else:
+                queries = self.rope(queries)
+                keys = self.rope(keys)
 
-        cos, sin = self.rotary_emb(values, position_ids)
+            output = scaled_dot_product_attention(
+                queries, keys, values, cache, scale=self.scale, mask=mask
+            )
+            output = output.transpose(0, 2, 1, 3).reshape(B, L, -1)
+            return self.o_proj(output)
+
+        kv_seq_len = keys.shape[-2]
+        kv_seq_len += cache.offset + 1 if cache is not None else 0
 
         if mask is not None and isinstance(mask, mx.array):
             if isinstance(kv_seq_len, mx.array):
                 kv_seq_len = kv_seq_len.max().item()
             mask = mask[..., : int(kv_seq_len)]
 
+        cos, sin = self.rotary_emb(values, position_ids)
         queries, keys = apply_multimodal_rotary_pos_emb(queries, keys, cos, sin)
 
         if cache is not None:
@@ -526,19 +541,37 @@ class LanguageModel(nn.Module):
         # Use ``cache._idx`` — the Python-int token counter — instead of
         # syncing on ``cache[0].offset``. See Qwen2.5-VL for details.
         cache_offset = 0
-        cache_offset_array = None  # For per-sequence offsets in batch mode
+        cache_offsets = None
         if cache and cache[0] is not None:
             c0 = cache[0]
             cache_offset = c0._idx if hasattr(c0, "_idx") else c0.offset
-            if isinstance(c0.offset, mx.array) and c0.offset.ndim > 0:
-                cache_offset_array = c0.offset
+            if (
+                isinstance(c0.offset, mx.array)
+                and c0.offset.ndim > 0
+                and c0.offset.size > 1
+            ):
+                cache_offsets = c0.offset
 
         # Check if mask shape matches input shape (for chunked prefill compatibility)
         rope_mask = mask
         if mask is not None and mask.shape[-1] != inputs.shape[-1]:
             rope_mask = None
 
-        if position_ids is None and (rope_mask is None or rope_mask.ndim == 2):
+        needs_explicit_positions = (
+            position_ids is not None
+            or image_grid_thw is not None
+            or video_grid_thw is not None
+            or rope_mask is not None
+            or rope_deltas_kw is not None
+            or self._rope_deltas is not None
+            or cache_offsets is not None
+        )
+
+        if (
+            position_ids is None
+            and needs_explicit_positions
+            and (rope_mask is None or rope_mask.ndim == 2)
+        ):
             # Calculate RoPE index once per generation in the pre-fill stage only
             recalc_condition = (
                 (cache is not None and cache[0] is not None and (cache_offset == 0))
@@ -562,9 +595,9 @@ class LanguageModel(nn.Module):
                 batch_size, seq_length = inputs.shape
 
                 # Use per-sequence offsets if available (for batched generation)
-                if cache_offset_array is not None:
+                if cache_offsets is not None:
                     # Per-sequence cache offsets for continuous batching
-                    base_offset = cache_offset_array[:batch_size].reshape(-1, 1)
+                    base_offset = cache_offsets[:batch_size].reshape(-1, 1)
                 else:
                     base_offset = mx.array(cache_offset)
 

--- a/mlx_vlm/models/qwen3_vl/qwen3_vl.py
+++ b/mlx_vlm/models/qwen3_vl/qwen3_vl.py
@@ -57,6 +57,7 @@ class Model(nn.Module):
 
         if pixel_values is None:
             self.language_model._position_ids = None
+            self.language_model._rope_deltas = None
             return InputEmbeddingsFeatures(
                 inputs_embeds=self.language_model.model.embed_tokens(input_ids)
             )

--- a/mlx_vlm/models/qwen3_vl_moe/language.py
+++ b/mlx_vlm/models/qwen3_vl_moe/language.py
@@ -4,6 +4,7 @@ import mlx.core as mx
 import mlx.nn as nn
 import numpy as np
 from mlx.nn.layers.distributed import shard_inplace, shard_linear, sum_gradients
+from mlx_lm.models.rope_utils import initialize_rope
 from mlx_lm.models.switch_layers import SwitchGLU
 
 from ..base import (
@@ -135,6 +136,13 @@ class Attention(nn.Module):
             base=args.rope_theta,
             rope_scaling=self.rope_scaling,
         )
+        self.rope = initialize_rope(
+            head_dim,
+            base=args.rope_theta,
+            traditional=False,
+            scaling_config=self.rope_scaling,
+            max_position_embeddings=args.max_position_embeddings,
+        )
 
     def __call__(
         self,
@@ -158,23 +166,30 @@ class Attention(nn.Module):
             0, 2, 1, 3
         )
 
-        kv_seq_len = keys.shape[-2]
-
         if position_ids is None:
-            kv_seq_len += cache.offset + 1
-            position_ids = mx.arange(cache.offset, cache.offset + L)
-            position_ids = mx.expand_dims(position_ids, axis=0)
-            position_ids = mx.tile(position_ids, (3, 1, 1))
-        else:
-            kv_seq_len += cache.offset + 1 if cache is not None else 0
+            if cache is not None:
+                queries = self.rope(queries, offset=cache.offset)
+                keys = self.rope(keys, offset=cache.offset)
+                keys, values = cache.update_and_fetch(keys, values)
+            else:
+                queries = self.rope(queries)
+                keys = self.rope(keys)
 
-        cos, sin = self.rotary_emb(values, position_ids)
+            output = scaled_dot_product_attention(
+                queries, keys, values, cache, scale=self.scale, mask=mask
+            )
+            output = output.transpose(0, 2, 1, 3).reshape(B, L, -1)
+            return self.o_proj(output)
+
+        kv_seq_len = keys.shape[-2]
+        kv_seq_len += cache.offset + 1 if cache is not None else 0
 
         if mask is not None and isinstance(mask, mx.array):
             if isinstance(kv_seq_len, mx.array):
                 kv_seq_len = kv_seq_len.max().item()
             mask = mask[..., : int(kv_seq_len)]
 
+        cos, sin = self.rotary_emb(values, position_ids)
         queries, keys = apply_multimodal_rotary_pos_emb(queries, keys, cos, sin)
 
         if cache is not None:
@@ -592,7 +607,21 @@ class LanguageModel(nn.Module):
         if mask is not None and mask.shape[-1] != inputs.shape[-1]:
             rope_mask = None
 
-        if position_ids is None and (rope_mask is None or rope_mask.ndim == 2):
+        needs_explicit_positions = (
+            position_ids is not None
+            or image_grid_thw is not None
+            or video_grid_thw is not None
+            or rope_mask is not None
+            or rope_deltas_kw is not None
+            or self._rope_deltas is not None
+            or cache_offsets is not None
+        )
+
+        if (
+            position_ids is None
+            and needs_explicit_positions
+            and (rope_mask is None or rope_mask.ndim == 2)
+        ):
             # Calculate RoPE index once per generation in the pre-fill stage only
             is_prefill = (
                 cache is None

--- a/mlx_vlm/models/qwen3_vl_moe/qwen3_vl_moe.py
+++ b/mlx_vlm/models/qwen3_vl_moe/qwen3_vl_moe.py
@@ -52,6 +52,7 @@ class Model(nn.Module):
 
         if pixel_values is None:
             self.language_model._position_ids = None
+            self.language_model._rope_deltas = None
             return InputEmbeddingsFeatures(
                 inputs_embeds=self.language_model.model.embed_tokens(input_ids),
                 visual_pos_masks=None,

--- a/mlx_vlm/tests/test_models.py
+++ b/mlx_vlm/tests/test_models.py
@@ -1244,6 +1244,454 @@ class TestModels(unittest.TestCase):
             model.language_model, config.text_config.hidden_size
         )
 
+    def test_qwen3_5_text_and_multimodal_rope_paths(self):
+        from mlx_vlm.models import qwen3_5
+
+        class CallSpy:
+            def __init__(self, target):
+                self.target = target
+                self.calls = 0
+
+            def __call__(self, *args, **kwargs):
+                self.calls += 1
+                return self.target(*args, **kwargs)
+
+        text_config = qwen3_5.TextConfig(
+            model_type="qwen3_5",
+            hidden_size=32,
+            intermediate_size=64,
+            linear_num_value_heads=4,
+            linear_num_key_heads=2,
+            linear_key_head_dim=8,
+            linear_value_head_dim=8,
+            linear_conv_kernel_dim=4,
+            num_hidden_layers=2,
+            num_attention_heads=4,
+            rms_norm_eps=1e-5,
+            vocab_size=128,
+            num_key_value_heads=2,
+            max_position_embeddings=128,
+            head_dim=8,
+            rope_parameters={
+                "type": "default",
+                "mrope_section": [1, 1, 0],
+                "rope_theta": 1000,
+                "partial_rotary_factor": 0.5,
+            },
+            full_attention_interval=2,
+        )
+        vision_config = qwen3_5.VisionConfig(
+            model_type="qwen3_5",
+            depth=1,
+            hidden_size=32,
+            intermediate_size=64,
+            out_hidden_size=32,
+            num_heads=4,
+            patch_size=14,
+            in_channels=3,
+            spatial_merge_size=2,
+            temporal_patch_size=2,
+            num_position_embeddings=16,
+            fullatt_block_indexes=[],
+            deepstack_visual_indexes=[],
+        )
+        config = qwen3_5.ModelConfig(
+            text_config=text_config,
+            vision_config=vision_config,
+            model_type="qwen3_5",
+            image_token_id=120,
+            video_token_id=121,
+            image_token_index=120,
+            video_token_index=121,
+            vision_start_token_id=118,
+            vision_end_token_id=119,
+            vocab_size=text_config.vocab_size,
+        )
+        model = qwen3_5.Model(config)
+
+        attn = model.language_model.model.layers[1].self_attn
+        fast_rope = CallSpy(attn.rope)
+        explicit_rope = CallSpy(attn.rotary_emb)
+        attn.rope = fast_rope
+        attn.rotary_emb = explicit_rope
+
+        text_ids = mx.array([[10, 11, 12, 13]], dtype=mx.int32)
+        model.language_model._rope_deltas = mx.array([[3]], dtype=mx.int32)
+        text_features = model.get_input_embeddings(input_ids=text_ids)
+        self.assertIsNone(model.language_model._rope_deltas)
+        text_out = model.language_model(
+            text_ids,
+            inputs_embeds=text_features.inputs_embeds,
+            cache=model.language_model.make_cache(),
+        )
+        self.assertEqual(text_out.logits.shape, (1, 4, text_config.vocab_size))
+        self.assertEqual(fast_rope.calls, 2)
+        self.assertEqual(explicit_rope.calls, 0)
+
+        fast_rope.calls = 0
+        explicit_rope.calls = 0
+        image_ids = mx.array(
+            [[10, config.vision_start_token_id, 120, 120, 120, 120, 11, 12]],
+            dtype=mx.int32,
+        )
+        image_grid_thw = mx.array([[1, 4, 4]], dtype=mx.int32)
+        image_features = mx.random.normal((4, text_config.hidden_size))
+        multimodal_features = model.get_input_embeddings(
+            input_ids=image_ids,
+            pixel_values=mx.zeros((1,), dtype=mx.float32),
+            image_grid_thw=image_grid_thw,
+            cached_image_features=image_features,
+        )
+        self.assertIsNotNone(model.language_model._position_ids)
+        self.assertIsNotNone(model.language_model._rope_deltas)
+        multimodal_out = model.language_model(
+            image_ids,
+            inputs_embeds=multimodal_features.inputs_embeds,
+            image_grid_thw=image_grid_thw,
+            cache=model.language_model.make_cache(),
+        )
+        self.assertEqual(
+            multimodal_out.logits.shape, (1, image_ids.shape[1], text_config.vocab_size)
+        )
+        self.assertEqual(fast_rope.calls, 0)
+        self.assertEqual(explicit_rope.calls, 1)
+
+    def test_representative_text_only_fast_rope_paths(self):
+        class CallSpy:
+            def __init__(self, target):
+                self.target = target
+                self.calls = 0
+
+            def __call__(self, *args, **kwargs):
+                self.calls += 1
+                return self.target(*args, **kwargs)
+
+        def assert_text_only_path(
+            name,
+            model,
+            fast_rope,
+            explicit_rope,
+            explicit_position_ids,
+            multimodal_input_ids,
+            image_grid_thw,
+            image_features,
+        ):
+            with self.subTest(name=name):
+                language_model = model.language_model
+                input_ids = mx.array([[10, 11, 12, 13]], dtype=mx.int32)
+                language_model._rope_deltas = mx.array([[5]], dtype=mx.int32)
+                if hasattr(language_model, "_position_ids"):
+                    language_model._position_ids = mx.ones((3, 1, 4), dtype=mx.int32)
+
+                features = model.get_input_embeddings(input_ids=input_ids)
+                self.assertIsNone(language_model._rope_deltas)
+                if hasattr(language_model, "_position_ids"):
+                    self.assertIsNone(language_model._position_ids)
+
+                original_get_rope_index = language_model.get_rope_index
+
+                def fail_get_rope_index(*args, **kwargs):
+                    raise AssertionError("text-only path called get_rope_index")
+
+                language_model.get_rope_index = fail_get_rope_index
+                try:
+                    out = language_model(
+                        input_ids,
+                        inputs_embeds=features.inputs_embeds,
+                    )
+                finally:
+                    language_model.get_rope_index = original_get_rope_index
+
+                self.assertEqual(
+                    out.logits.shape,
+                    (1, input_ids.shape[1], model.config.text_config.vocab_size),
+                )
+                self.assertGreater(fast_rope.calls, 0)
+                self.assertEqual(explicit_rope.calls, 0)
+
+                fast_rope.calls = 0
+                explicit_rope.calls = 0
+                out = language_model(
+                    input_ids,
+                    inputs_embeds=features.inputs_embeds,
+                    position_ids=explicit_position_ids,
+                )
+                self.assertEqual(
+                    out.logits.shape,
+                    (1, input_ids.shape[1], model.config.text_config.vocab_size),
+                )
+                self.assertEqual(fast_rope.calls, 0)
+                self.assertGreater(explicit_rope.calls, 0)
+
+                fast_rope.calls = 0
+                explicit_rope.calls = 0
+                multimodal_features = model.get_input_embeddings(
+                    input_ids=multimodal_input_ids,
+                    pixel_values=mx.zeros((1,), dtype=mx.float32),
+                    image_grid_thw=image_grid_thw,
+                    cached_image_features=image_features,
+                )
+                if hasattr(language_model, "_position_ids"):
+                    self.assertIsNotNone(language_model._position_ids)
+                out = language_model(
+                    multimodal_input_ids,
+                    inputs_embeds=multimodal_features.inputs_embeds,
+                    image_grid_thw=image_grid_thw,
+                )
+                self.assertEqual(
+                    out.logits.shape,
+                    (
+                        1,
+                        multimodal_input_ids.shape[1],
+                        model.config.text_config.vocab_size,
+                    ),
+                )
+                self.assertEqual(fast_rope.calls, 0)
+                self.assertGreater(explicit_rope.calls, 0)
+
+        from mlx_vlm.models import ernie4_5_moe_vl, glm4v, qwen2_vl, qwen3_vl
+
+        qwen2_text_config = qwen2_vl.TextConfig(
+            model_type="qwen2_vl",
+            hidden_size=32,
+            num_hidden_layers=1,
+            intermediate_size=64,
+            num_attention_heads=4,
+            rms_norm_eps=1e-6,
+            vocab_size=128,
+            num_key_value_heads=2,
+            max_position_embeddings=128,
+            rope_theta=1000,
+            rope_scaling={"type": "mrope", "mrope_section": [1, 1, 2]},
+            tie_word_embeddings=False,
+        )
+        qwen2_vision_config = qwen2_vl.VisionConfig(
+            model_type="qwen2_vl",
+            depth=1,
+            embed_dim=32,
+            hidden_size=32,
+            image_size=28,
+            num_heads=4,
+            patch_size=14,
+            mlp_ratio=2,
+            in_channels=3,
+            spatial_merge_size=1,
+            temporal_patch_size=2,
+        )
+        qwen2_config = qwen2_vl.ModelConfig(
+            model_type="qwen2_vl",
+            text_config=qwen2_text_config,
+            vision_config=qwen2_vision_config,
+            image_token_id=120,
+            video_token_id=121,
+            vision_start_token_id=119,
+            vocab_size=qwen2_text_config.vocab_size,
+        )
+        qwen2_model = qwen2_vl.Model(qwen2_config)
+        qwen2_attn = qwen2_model.language_model.model.layers[0].self_attn
+        qwen2_fast_rope = CallSpy(qwen2_attn.rope)
+        qwen2_explicit_rope = CallSpy(qwen2_attn.rotary_emb)
+        qwen2_attn.rope = qwen2_fast_rope
+        qwen2_attn.rotary_emb = qwen2_explicit_rope
+        qwen2_position_ids = mx.broadcast_to(
+            mx.arange(4, dtype=mx.int32).reshape(1, 1, 4),
+            (3, 1, 4),
+        )
+        qwen2_image_ids = mx.array([[10, 119, 120, 120, 120, 120, 11]], dtype=mx.int32)
+        qwen2_image_grid_thw = mx.array([[1, 2, 2]], dtype=mx.int32)
+        assert_text_only_path(
+            "qwen2_vl",
+            qwen2_model,
+            qwen2_fast_rope,
+            qwen2_explicit_rope,
+            qwen2_position_ids,
+            qwen2_image_ids,
+            qwen2_image_grid_thw,
+            mx.random.normal((4, qwen2_text_config.hidden_size)),
+        )
+
+        qwen3_text_config = qwen3_vl.TextConfig(
+            model_type="qwen3_vl_text",
+            hidden_size=32,
+            num_hidden_layers=1,
+            intermediate_size=64,
+            num_attention_heads=4,
+            num_key_value_heads=2,
+            rms_norm_eps=1e-5,
+            head_dim=8,
+            vocab_size=128,
+            rope_theta=1000,
+            max_position_embeddings=128,
+            tie_word_embeddings=False,
+            rope_scaling={"type": "default", "mrope_section": [1, 1, 0]},
+        )
+        qwen3_vision_config = qwen3_vl.VisionConfig(
+            model_type="qwen3_vl",
+            depth=1,
+            hidden_size=32,
+            intermediate_size=64,
+            out_hidden_size=32,
+            num_heads=4,
+            patch_size=14,
+            in_channels=3,
+            spatial_merge_size=2,
+            temporal_patch_size=2,
+            num_position_embeddings=16,
+            deepstack_visual_indexes=[],
+        )
+        qwen3_config = qwen3_vl.ModelConfig(
+            text_config=qwen3_text_config,
+            vision_config=qwen3_vision_config,
+            model_type="qwen3_vl",
+            image_token_id=120,
+            video_token_id=121,
+            image_token_index=120,
+            video_token_index=121,
+            vision_start_token_id=119,
+            vocab_size=qwen3_text_config.vocab_size,
+        )
+        qwen3_model = qwen3_vl.Model(qwen3_config)
+        qwen3_attn = qwen3_model.language_model.model.layers[0].self_attn
+        qwen3_fast_rope = CallSpy(qwen3_attn.rope)
+        qwen3_explicit_rope = CallSpy(qwen3_attn.rotary_emb)
+        qwen3_attn.rope = qwen3_fast_rope
+        qwen3_attn.rotary_emb = qwen3_explicit_rope
+        qwen3_position_ids = mx.broadcast_to(
+            mx.arange(4, dtype=mx.int32).reshape(1, 1, 4),
+            (3, 1, 4),
+        )
+        qwen3_image_ids = mx.array([[10, 119, 120, 120, 120, 120, 11]], dtype=mx.int32)
+        qwen3_image_grid_thw = mx.array([[1, 4, 4]], dtype=mx.int32)
+        assert_text_only_path(
+            "qwen3_vl",
+            qwen3_model,
+            qwen3_fast_rope,
+            qwen3_explicit_rope,
+            qwen3_position_ids,
+            qwen3_image_ids,
+            qwen3_image_grid_thw,
+            mx.random.normal((4, qwen3_text_config.hidden_size)),
+        )
+
+        glm_text_config = glm4v.TextConfig(
+            model_type="glm4v_text",
+            vocab_size=128,
+            hidden_size=32,
+            intermediate_size=64,
+            max_position_embeddings=128,
+            num_attention_heads=4,
+            num_hidden_layers=1,
+            num_key_value_heads=2,
+            rms_norm_eps=1e-5,
+            rope_theta=1000,
+            attention_bias=False,
+            partial_rotary_factor=1.0,
+            rope_scaling={"rope_type": "default", "mrope_section": [1, 1, 2]},
+        )
+        glm_vision_config = glm4v.VisionConfig(
+            model_type="glm4v",
+            depth=1,
+            hidden_size=32,
+            intermediate_size=64,
+            out_hidden_size=32,
+            num_heads=4,
+            patch_size=14,
+            image_size=28,
+            in_channels=3,
+            spatial_merge_size=2,
+            temporal_patch_size=2,
+        )
+        glm_config = glm4v.ModelConfig(
+            text_config=glm_text_config,
+            vision_config=glm_vision_config,
+            model_type="glm4v",
+            vocab_size=glm_text_config.vocab_size,
+            image_token_id=120,
+            video_token_id=121,
+            image_token_index=120,
+            video_token_index=121,
+            vision_start_token_id=119,
+        )
+        glm_model = glm4v.Model(glm_config)
+        glm_attn = glm_model.language_model.model.layers[0].self_attn
+        glm_fast_rope = CallSpy(glm_attn.rope)
+        glm_explicit_rope = CallSpy(glm_model.language_model.model.rotary_emb)
+        glm_attn.rope = glm_fast_rope
+        glm_model.language_model.model.rotary_emb = glm_explicit_rope
+        glm_position_ids = mx.broadcast_to(
+            mx.arange(4, dtype=mx.int32).reshape(1, 1, 4),
+            (3, 1, 4),
+        )
+        glm_image_ids = mx.array([[10, 119, 120, 120, 120, 120, 11]], dtype=mx.int32)
+        glm_image_grid_thw = mx.array([[1, 4, 4]], dtype=mx.int32)
+        assert_text_only_path(
+            "glm4v",
+            glm_model,
+            glm_fast_rope,
+            glm_explicit_rope,
+            glm_position_ids,
+            glm_image_ids,
+            glm_image_grid_thw,
+            mx.random.normal((4, glm_text_config.hidden_size)),
+        )
+
+        ernie_text_config = ernie4_5_moe_vl.TextConfig(
+            model_type="ernie4_5_moe_vl",
+            hidden_size=32,
+            intermediate_size=64,
+            num_hidden_layers=1,
+            num_attention_heads=4,
+            num_key_value_heads=2,
+            vocab_size=128,
+            max_position_embeddings=128,
+            rope_theta=1000.0,
+            mrope_section=[1, 1, 2],
+            tie_word_embeddings=False,
+        )
+        ernie_vision_config = ernie4_5_moe_vl.VisionConfig(
+            embed_dim=32,
+            hidden_size=32,
+            num_heads=4,
+            patch_size=14,
+            spatial_merge_size=2,
+        )
+        ernie_config = ernie4_5_moe_vl.ModelConfig(
+            model_type="ernie4_5_moe_vl",
+            hidden_size=32,
+            pixel_hidden_size=32,
+            text_config=ernie_text_config,
+            vision_config=ernie_vision_config,
+            im_patch_id=120,
+            image_token_id=120,
+            video_token_id=121,
+            image_start_token_id=119,
+            vision_start_token_id=119,
+            vocab_size=ernie_text_config.vocab_size,
+        )
+        ernie_model = ernie4_5_moe_vl.Model(ernie_config)
+        ernie_attn = ernie_model.language_model.model.layers[0].self_attn
+        ernie_fast_rope = CallSpy(ernie_attn.rope)
+        ernie_explicit_rope = CallSpy(ernie_attn.rotary_emb)
+        ernie_attn.rope = ernie_fast_rope
+        ernie_attn.rotary_emb = ernie_explicit_rope
+        ernie_positions_1d = mx.arange(4, dtype=mx.int32).reshape(1, 4)
+        ernie_position_ids = mx.stack(
+            [ernie_positions_1d, ernie_positions_1d, ernie_positions_1d],
+            axis=-1,
+        )
+        ernie_image_ids = mx.array([[10, 119, 120, 120, 120, 120, 11]], dtype=mx.int32)
+        ernie_image_grid_thw = mx.array([[1, 4, 4]], dtype=mx.int32)
+        assert_text_only_path(
+            "ernie4_5_moe_vl",
+            ernie_model,
+            ernie_fast_rope,
+            ernie_explicit_rope,
+            ernie_position_ids,
+            ernie_image_ids,
+            ernie_image_grid_thw,
+            mx.random.normal((4, ernie_text_config.hidden_size)),
+        )
+
     def test_qwen3_vl_moe(self):
         from mlx_vlm.models import qwen3_vl_moe
 


### PR DESCRIPTION
Only use MRoPE when we have a vision encoder and otherwise use the standard RoPE fast-path, which matches `mlx-lm`. I tested a model from every model type that this touches for correctness, except for `glm4v_moe`, which was too large for my machine and was tested with synthetic weights.

This improves decode performance for e.g. `mlx-community/Qwen3.5-0.8B-bf16` from 203 tok/sec -> 233 tok/sec in the text-only case on my M5 Max for short generations.