### PR TITLE
Add Gemma 4 MTP speculative-decoding drafter

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,9 @@ MLX-VLM is a package for inference and fine-tuning of Vision Language Models (VL
 - [Usage](#usage)
   - [Command Line Interface (CLI)](#command-line-interface-cli)
     - [Thinking Budget](#thinking-budget)
-  - [Speculative Decoding (DFlash)](#speculative-decoding-dflash)
+  - [Speculative Decoding](#speculative-decoding)
+    - [DFlash (Qwen3.5)](#dflash-qwen35)
+    - [Gemma 4 MTP](#gemma-4-mtp)
   - [Chat UI with Gradio](#chat-ui-with-gradio)
   - [Python Script](#python-script)
   - [Server (FastAPI)](#server-fastapi)
@@ -95,9 +97,21 @@ mlx_vlm.generate --model mlx-community/Qwen3.5-2B-4bit \
 
 When the budget is exceeded, the model is forced to emit `\n</think>` and transition to the answer. If `--enable-thinking` is passed but the model's chat template does not support it, the budget is applied only if the model generates the start token on its own.
 
-### Speculative Decoding (DFlash)
+### Speculative Decoding
 
-Speed up generation 2–3× using a lightweight block-diffusion drafter that predicts multiple tokens per round, verified in parallel by the target model.
+Speed up generation by drafting several candidate tokens with a small "drafter" model and verifying them in a single target forward pass. Two drafter families are supported.
+
+| Flag | Description |
+|------|-------------|
+| `--draft-model` | HuggingFace repo or local path for the drafter |
+| `--draft-kind` | Drafter family — `dflash` (default) or `mtp` (Gemma 4) |
+| `--draft-block-size` | Override the drafter's configured block size |
+
+See [docs/usage.md](docs/usage.md) for Python API examples including batch generation.
+
+#### DFlash (Qwen3.5)
+
+A lightweight block-diffusion drafter that predicts multiple tokens per round, typically 2–3× faster.
 
 ```sh
 # Text generation with speculative decoding
@@ -118,13 +132,28 @@ mlx_vlm.server --model Qwen/Qwen3.5-4B \
   --draft-model z-lab/Qwen3.5-4B-DFlash
 ```
 
-| Flag | Description |
-|------|-------------|
-| `--draft-model` | HuggingFace repo or local path for the drafter |
-| `--draft-kind` | Drafter family (default: `dflash`) |
-| `--draft-block-size` | Override the drafter's configured block size |
+#### Gemma 4 MTP
 
-See [docs/usage.md](docs/usage.md) for Python API examples including batch generation.
+[Multi-Token Prediction](https://ai.google.dev/gemma/docs/mtp/mtp): Google's 4-layer "assistant" drafter that shares K/V with the target and drafts multiple tokens autoregressively from a constant position. Pass `--draft-kind mtp` to dispatch the MTP round-loop.
+
+```sh
+mlx_vlm.generate --model google/gemma-4-31B-it \
+  --draft-model google/gemma-4-31B-it-assistant \
+  --draft-kind mtp --draft-block-size 4 \
+  --prompt "Explain speculative decoding in 3 sentences." \
+  --max-tokens 256 --temperature 0
+```
+
+Supported pairings (target ↔ drafter):
+
+| Target                          | Drafter                                  |
+|---------------------------------|------------------------------------------|
+| `google/gemma-4-E2B-it`         | `google/gemma-4-E2B-it-assistant`        |
+| `google/gemma-4-E4B-it`         | `google/gemma-4-E4B-it-assistant`        |
+| `google/gemma-4-26B-A4B-it`     | `google/gemma-4-26B-A4B-it-assistant`    |
+| `google/gemma-4-31B-it`         | `google/gemma-4-31B-it-assistant`        |
+
+Measured speedups (greedy, byte-identical output): up to **3.94×** on 26B-A4B and **2.29×** on 31B at B=4. See [`mlx_vlm/speculative/drafters/gemma4_assistant/README.md`](mlx_vlm/speculative/drafters/gemma4_assistant/README.md) for full sweeps and architecture notes.
 
 ### Chat UI with Gradio
 
@@ -239,8 +268,8 @@ mlx_vlm.server --trust-remote-code
 
 - `--model`: Preload a model at server startup, accepts a Hugging Face repo ID or local path (optional, loads lazily on first request if omitted)
 - `--adapter-path`: Path for adapter weights to use with the preloaded model
-- `--draft-model`: Speculative drafter path or HF id (e.g. `z-lab/Qwen3.5-4B-DFlash`) — enables DFlash speculative decoding for ~2× higher throughput
-- `--draft-kind`: Drafter family (default: `dflash`)
+- `--draft-model`: Speculative drafter path or HF id (e.g. `z-lab/Qwen3.5-4B-DFlash`, `google/gemma-4-31B-it-assistant`) — enables speculative decoding for ~2× or higher throughput
+- `--draft-kind`: Drafter family — `dflash` (default) or `mtp` (Gemma 4)
 - `--draft-block-size`: Override the drafter's configured block size
 - `--host`: Host address (default: `0.0.0.0`)
 - `--port`: Port number (default: `8080`)

--- a/README.md
+++ b/README.md
@@ -137,8 +137,8 @@ mlx_vlm.server --model Qwen/Qwen3.5-4B \
 [Multi-Token Prediction](https://ai.google.dev/gemma/docs/mtp/mtp): Google's 4-layer "assistant" drafter that shares K/V with the target and drafts multiple tokens autoregressively from a constant position. Pass `--draft-kind mtp` to dispatch the MTP round-loop.
 
 ```sh
-mlx_vlm.generate --model google/gemma-4-31B-it \
-  --draft-model google/gemma-4-31B-it-assistant \
+mlx_vlm.generate --model mlx-community/gemma-4-31B-it-bf16 \
+  --draft-model mlx-community/gemma-4-31B-it-assistant-bf16 \
   --draft-kind mtp --draft-block-size 4 \
   --prompt "Explain speculative decoding in 3 sentences." \
   --max-tokens 256 --temperature 0
@@ -148,10 +148,10 @@ Supported pairings (target ↔ drafter):
 
 | Target                          | Drafter                                  |
 |---------------------------------|------------------------------------------|
-| `google/gemma-4-E2B-it`         | `google/gemma-4-E2B-it-assistant`        |
-| `google/gemma-4-E4B-it`         | `google/gemma-4-E4B-it-assistant`        |
-| `google/gemma-4-26B-A4B-it`     | `google/gemma-4-26B-A4B-it-assistant`    |
-| `google/gemma-4-31B-it`         | `google/gemma-4-31B-it-assistant`        |
+| `mlx-community/gemma-4-E2B-it-bf16`         | `mlx-community/gemma-4-E2B-it-assistant-bf16`        |
+| `mlx-community/gemma-4-E4B-it-bf16`         | `mlx-community/gemma-4-E4B-it-assistant-bf16`        |
+| `mlx-community/gemma-4-26B-A4B-it-bf16`     | `mlx-community/gemma-4-26B-A4B-it-assistant-bf16`    |
+| `mlx-community/gemma-4-31B-it-bf16`         | `mlx-community/gemma-4-31B-it-assistant-bf16`        |
 
 Measured speedups (greedy, byte-identical output): up to **3.94×** on 26B-A4B and **2.29×** on 31B at B=4. See [`mlx_vlm/speculative/drafters/gemma4_assistant/README.md`](mlx_vlm/speculative/drafters/gemma4_assistant/README.md) for full sweeps and architecture notes.
 

--- a/mlx_vlm/generate.py
+++ b/mlx_vlm/generate.py
@@ -491,9 +491,14 @@ def _mtp_rounds(
     )
     draft_model.reset(model)
 
-    # Hidden from prefill is full prompt-length; we only need the last slot.
+    # Hidden from prefill is full prompt-length; reduce to a single slot.
+    # Mirrors HF SinglePositionMultiTokenCandidateGenerator's
+    # ``last_hidden_state[:, n_last_matches:n_last_matches+1]`` with
+    # n_last_matches=0 on the first round (= position 0 of the prefill
+    # output). Subsequent rounds slice into the verify forward's hidden
+    # at index ``accepted`` further below.
     if hidden.shape[1] > 1:
-        hidden = hidden[:, -1:, :]
+        hidden = hidden[:, 0:1, :]
 
     kv_offset = int(prompt_cache[0].offset)
     draft_model.set_shared_kv(shared_kv_states, kv_offset)

--- a/mlx_vlm/generate.py
+++ b/mlx_vlm/generate.py
@@ -549,9 +549,7 @@ def _mtp_rounds(
 
         if accepted < bs - 1:
             with mx.stream(generation_stream):
-                lm.rollback_speculative_cache(
-                    prompt_cache, None, accepted, bs
-                )
+                lm.rollback_speculative_cache(prompt_cache, None, accepted, bs)
 
         # Slice shared_kv_states to the post-rollback length and rebind.
         rejected = bs - (accepted + 1)
@@ -560,8 +558,8 @@ def _mtp_rounds(
             K, V = kv
             valid = K.shape[-2] - rejected
             if valid <= 0 or valid >= K.shape[-2]:
-                next_shared_kv[k] = (K, V) if valid >= K.shape[-2] else (
-                    K[..., :1, :], V[..., :1, :]
+                next_shared_kv[k] = (
+                    (K, V) if valid >= K.shape[-2] else (K[..., :1, :], V[..., :1, :])
                 )
             else:
                 next_shared_kv[k] = (K[..., :valid, :], V[..., :valid, :])
@@ -715,9 +713,7 @@ def _mtp_rounds_batch(
         # per-row tail-zero on rows that accepted less).
         if max_a < bs - 1:
             with mx.stream(generation_stream):
-                lm.rollback_speculative_cache(
-                    prompt_cache, None, accepted_arr, bs
-                )
+                lm.rollback_speculative_cache(prompt_cache, None, accepted_arr, bs)
 
         # Slice + tail-zero ``verify_out.shared_kv_states`` to match the
         # post-rollback target cache. After this, all rows share the same
@@ -1299,8 +1295,7 @@ def generate_step(
 
         if draft_kind != "dflash":
             raise ValueError(
-                f"Unknown draft_kind {draft_kind!r}. Supported: "
-                "['dflash', 'mtp']"
+                f"Unknown draft_kind {draft_kind!r}. Supported: " "['dflash', 'mtp']"
             )
         hidden = mx.concatenate(last_outputs.hidden_states, axis=-1)
         if B == 1:

--- a/mlx_vlm/generate.py
+++ b/mlx_vlm/generate.py
@@ -219,7 +219,8 @@ def parse_arguments():
         "--draft-kind",
         type=str,
         default="dflash",
-        help="Drafter family. Currently only 'dflash' is supported.",
+        help="Drafter family. Supported: 'dflash' (Qwen3.5 DFlash), "
+        "'mtp' (Gemma 4 Multi-Token Prediction / Assistant model).",
     )
     parser.add_argument(
         "--draft-block-size",
@@ -452,6 +453,116 @@ def _speculative_walk_batch(
         accepted_list.append(acc)
         new_tokens_list.append(new)
     return accepted_list, new_tokens_list
+
+
+def _mtp_rounds(
+    model: nn.Module,
+    draft_model: nn.Module,
+    prompt_cache: List[Any],
+    hidden: mx.array,
+    shared_kv_states: dict,
+    *,
+    first_bonus: int,
+    max_tokens: int,
+    sampler: Callable[[mx.array], mx.array],
+    draft_block_size: Optional[int] = None,
+    token_dtype: mx.Dtype = mx.int32,
+) -> Generator[Tuple[int, None], None, None]:
+    """Gemma 4 MTP (Single-Position Multi-Token) speculative-decoding round loop.
+
+    Mirrors ``_dflash_rounds`` but with three differences:
+    (1) the drafter consumes the target's last-layer hidden + last-layer
+    shared K/V per layer-type rather than concatenated multi-layer hiddens;
+    (2) ``draft_block`` is autoregressive (K small forwards) rather than a
+    single masked forward; (3) ``rollback_speculative_cache`` ignores
+    ``gdn_states`` (Gemma 4 has no SSM/GDN state).
+    """
+    lm = model.language_model if hasattr(model, "language_model") else model
+    if not hasattr(lm, "rollback_speculative_cache"):
+        raise RuntimeError(
+            f"{type(lm).__name__} does not implement rollback_speculative_cache. "
+            "MTP speculative decoding currently only supports gemma4."
+        )
+
+    block_total = (
+        draft_block_size
+        if draft_block_size is not None
+        else int(draft_model.config.block_size)
+    )
+    draft_model.reset(model)
+
+    # Hidden from prefill is full prompt-length; we only need the last slot.
+    if hidden.shape[1] > 1:
+        hidden = hidden[:, -1:, :]
+
+    kv_offset = int(prompt_cache[0].offset)
+    draft_model.set_shared_kv(shared_kv_states, kv_offset)
+
+    b = first_bonus
+    emitted = 1  # caller already yielded the first bonus
+
+    while emitted < max_tokens:
+        bs = min(block_total, max_tokens - emitted + 1)
+        if bs <= 1:
+            break
+
+        draft_tokens = draft_model.draft_block(
+            b, hidden, None, bs, sampler, token_dtype
+        )
+        mx.async_eval(draft_tokens)
+
+        with mx.stream(generation_stream):
+            verify_input = mx.concatenate(
+                [mx.array([[b]], dtype=token_dtype), draft_tokens], axis=1
+            )
+            verify_out = lm(
+                verify_input,
+                cache=prompt_cache,
+                return_hidden=True,
+                return_shared_kv=True,
+            )
+            hidden_full = verify_out.hidden_states[-1]  # [B, bs, backbone]
+            target_tokens = sampler(verify_out.logits)
+        mx.async_eval(target_tokens, hidden_full)
+
+        accepted, new_tokens = _speculative_walk(
+            draft_tokens, target_tokens, max_tokens - emitted
+        )
+        draft_model.accept_lens.append(accepted)
+
+        for tok in new_tokens:
+            yield tok, None
+            emitted += 1
+            if emitted >= max_tokens:
+                return
+
+        # Hidden for next round: pick the slot of the newly accepted bonus.
+        hidden = hidden_full[:, accepted : accepted + 1, :]
+        b = new_tokens[-1] if new_tokens else b
+
+        if accepted < bs - 1:
+            with mx.stream(generation_stream):
+                lm.rollback_speculative_cache(
+                    prompt_cache, None, accepted, bs
+                )
+
+        # Slice shared_kv_states to the post-rollback length and rebind.
+        rejected = bs - (accepted + 1)
+        next_shared_kv = {}
+        for k, kv in verify_out.shared_kv_states.items():
+            K, V = kv
+            valid = K.shape[-2] - rejected
+            if valid <= 0 or valid >= K.shape[-2]:
+                next_shared_kv[k] = (K, V) if valid >= K.shape[-2] else (
+                    K[..., :1, :], V[..., :1, :]
+                )
+            else:
+                next_shared_kv[k] = (K[..., :valid, :], V[..., :valid, :])
+        kv_offset = int(prompt_cache[0].offset)
+        draft_model.set_shared_kv(next_shared_kv, kv_offset)
+
+        if emitted % 256 == 0:
+            mx.clear_cache()
 
 
 def _dflash_rounds(
@@ -812,7 +923,13 @@ def generate_step(
     # Speculative decoding setup
     last_outputs = None
     if draft_model is not None:
-        kwargs["capture_layer_ids"] = list(draft_model.config.target_layer_ids)
+        if draft_kind == "mtp":
+            # MTP drafter consumes target's last-layer hidden + shared K/V
+            # (per layer-type) rather than per-layer hidden captures.
+            kwargs["return_hidden"] = True
+            kwargs["return_shared_kv"] = True
+        else:
+            kwargs["capture_layer_ids"] = list(draft_model.config.target_layer_ids)
         prefill_step_size = None
         # Reset stale mRoPE state from any previous generation.
         lm = model.language_model if hasattr(model, "language_model") else model
@@ -906,12 +1023,36 @@ def generate_step(
 
     # Speculative decoding
     if draft_model is not None:
-        hidden = mx.concatenate(last_outputs.hidden_states, axis=-1)
         B = input_ids.shape[0]
+        if draft_kind == "mtp":
+            if B != 1:
+                raise NotImplementedError(
+                    "MTP speculative decoding currently only supports batch=1."
+                )
+            shared_kv_states = last_outputs.shared_kv_states
+            hidden = last_outputs.hidden_states[-1]
+            mx.eval(y)
+            yield y.item(), logprobs
+            yield from _mtp_rounds(
+                model,
+                draft_model,
+                prompt_cache,
+                hidden,
+                shared_kv_states,
+                first_bonus=y.item(),
+                max_tokens=max_tokens,
+                sampler=sampler,
+                draft_block_size=draft_block_size,
+                token_dtype=input_ids.dtype,
+            )
+            return
+
         if draft_kind != "dflash":
             raise ValueError(
-                f"Unknown draft_kind {draft_kind!r}. Supported: ['dflash']"
+                f"Unknown draft_kind {draft_kind!r}. Supported: "
+                "['dflash', 'mtp']"
             )
+        hidden = mx.concatenate(last_outputs.hidden_states, axis=-1)
         if B == 1:
             mx.eval(y)
             yield y.item(), logprobs

--- a/mlx_vlm/generate.py
+++ b/mlx_vlm/generate.py
@@ -492,13 +492,15 @@ def _mtp_rounds(
     draft_model.reset(model)
 
     # Hidden from prefill is full prompt-length; reduce to a single slot.
-    # Mirrors HF SinglePositionMultiTokenCandidateGenerator's
-    # ``last_hidden_state[:, n_last_matches:n_last_matches+1]`` with
-    # n_last_matches=0 on the first round (= position 0 of the prefill
-    # output). Subsequent rounds slice into the verify forward's hidden
-    # at index ``accepted`` further below.
+    # The semantically-correct choice is the *last* prompt token's hidden:
+    # the just-sampled bonus is the next-token prediction from that position,
+    # so its embedding paired with that hidden is what the drafter expects.
+    # (HF's literal ``[:, n_last_matches:n_last_matches+1]`` with ``n_matches=0``
+    # on the first round picks position 0, which is BOS — they get away with
+    # it because subsequent rounds slice into the per-call verify hidden, but
+    # the round-1 acceptance is wasted. We don't replicate that quirk.)
     if hidden.shape[1] > 1:
-        hidden = hidden[:, 0:1, :]
+        hidden = hidden[:, -1:, :]
 
     kv_offset = int(prompt_cache[0].offset)
     draft_model.set_shared_kv(shared_kv_states, kv_offset)

--- a/mlx_vlm/generate.py
+++ b/mlx_vlm/generate.py
@@ -572,6 +572,225 @@ def _mtp_rounds(
             mx.clear_cache()
 
 
+def _mtp_rounds_batch(
+    model: nn.Module,
+    draft_model: nn.Module,
+    prompt_cache: List[Any],
+    hidden: mx.array,
+    shared_kv_states: dict,
+    *,
+    first_bonus: mx.array,
+    max_tokens: int,
+    sampler: Callable[[mx.array], mx.array],
+    draft_block_size: Optional[int] = None,
+    token_dtype: mx.Dtype = mx.int32,
+    stop_check: Optional[Callable[[int, int], bool]] = None,
+    eos_token_ids: Optional[set] = None,
+) -> Generator[Tuple[List[Optional[int]], None], None, None]:
+    """Batched Gemma 4 MTP round loop (B > 1).
+
+    Mirrors ``_dflash_rounds_batch``: per-row state tracked by original
+    index, continuous-batching filter on row finish. Differences vs DFlash
+    batched: drafter consumes ``shared_kv_states`` (per-layer-type K/V
+    snapshot) instead of multi-layer hidden capture, ``draft_block`` is
+    autoregressive, and the per-round ``shared_kv`` slicing mirrors
+    ``rollback_speculative_cache``'s tail-zero pattern so each row's KV
+    has the correct row-specific valid length.
+    """
+    lm = model.language_model if hasattr(model, "language_model") else model
+    if not hasattr(lm, "rollback_speculative_cache"):
+        raise RuntimeError(
+            f"{type(lm).__name__} does not implement rollback_speculative_cache."
+        )
+
+    B = first_bonus.shape[0]
+    block_total = (
+        draft_block_size
+        if draft_block_size is not None
+        else int(draft_model.config.block_size)
+    )
+    draft_model.reset(model)
+
+    # First-round hidden: prefill output may have shape [B, L, H]; reduce
+    # to a single slot per row (last prompt token's hidden — see comment in
+    # ``_mtp_rounds`` for rationale).
+    if hidden.shape[1] > 1:
+        hidden = hidden[:, -1:, :]
+
+    # Per-row state. ``positions`` is the absolute position id of each
+    # row's pending bonus (= row's logical KV length). All rows start at
+    # ``L_prefill`` and advance by ``accepted_i + 1`` per round.
+    L_prefill = int(prompt_cache[0].offset)
+    positions = [L_prefill] * B
+    draft_model.set_shared_kv(
+        shared_kv_states, kv_offset=L_prefill, position=mx.array(positions)
+    )
+
+    b = first_bonus.tolist()
+    emitted = [1] * B
+    finished = [False] * B
+    active_idx = list(range(B))
+
+    while len(active_idx) > 0:
+        remaining = [
+            max(1, max_tokens - emitted[active_idx[j]] + 1)
+            for j in range(len(active_idx))
+        ]
+        bs = min(block_total, min(remaining))
+        if bs <= 1:
+            break
+
+        n_active = len(active_idx)
+        b_active = [b[active_idx[j]] for j in range(n_active)]
+        b_arr = mx.array(b_active, dtype=token_dtype)
+
+        # Draft (autoregressive K-step). hidden / shared_kv state was set
+        # via set_shared_kv above; the drafter pulls it from there.
+        draft_tokens = draft_model.draft_block(
+            b_arr, hidden, None, bs, sampler, token_dtype
+        )
+        mx.async_eval(draft_tokens)
+
+        # Verify
+        with mx.stream(generation_stream):
+            verify_input = mx.concatenate([b_arr[:, None], draft_tokens], axis=1)
+            verify_out = lm(
+                verify_input,
+                cache=prompt_cache,
+                return_hidden=True,
+                return_shared_kv=True,
+            )
+            hidden_full = verify_out.hidden_states[-1]  # [B_active, bs, H]
+            target_tokens = sampler(verify_out.logits)
+        mx.async_eval(target_tokens, hidden_full)
+
+        # Walk per-row
+        budgets = [max_tokens - emitted[active_idx[j]] for j in range(n_active)]
+        accepted_list, new_tokens_list = _speculative_walk_batch(
+            draft_tokens, target_tokens, budgets
+        )
+        for a in accepted_list:
+            draft_model.accept_lens.append(a)
+
+        max_a = max(accepted_list)
+        accepted_arr = mx.array(accepted_list)
+
+        # Per-row hidden: each row picks its own accepted slot from
+        # hidden_full. Build [B_active, 1, H] with row-i's hidden at
+        # position accepted_list[i].
+        if max_a < bs - 1 or any(a < max_a for a in accepted_list):
+            row_idx = mx.arange(n_active)
+            col_idx = mx.array(accepted_list)
+            # gather: hidden_full[row_idx, col_idx, :] -> [B_active, H]
+            hidden = hidden_full[row_idx, col_idx, :][:, None, :]
+        else:
+            hidden = hidden_full[:, -1:, :]
+
+        # Emit (map active slots back to original indices)
+        max_new = max(len(nt) for nt in new_tokens_list) if new_tokens_list else 0
+        for pos in range(max_new):
+            tokens_out: List[Optional[int]] = [None] * B
+            for j in range(n_active):
+                orig = active_idx[j]
+                if pos < len(new_tokens_list[j]) and not finished[orig]:
+                    tok = new_tokens_list[j][pos]
+                    tokens_out[orig] = tok
+                    emitted[orig] += 1
+                    if emitted[orig] >= max_tokens:
+                        finished[orig] = True
+                    if eos_token_ids is not None and tok in eos_token_ids:
+                        finished[orig] = True
+                    if stop_check is not None and stop_check(orig, tok):
+                        finished[orig] = True
+            yield tokens_out, None
+
+        # Update bonus tokens and per-row positions
+        for j in range(n_active):
+            orig = active_idx[j]
+            if new_tokens_list[j]:
+                b[orig] = new_tokens_list[j][-1]
+            positions[orig] = positions[orig] + accepted_list[j] + 1
+
+        # Rollback target cache (uniform trim by ``bs - max_a - 1`` plus
+        # per-row tail-zero on rows that accepted less).
+        if max_a < bs - 1:
+            with mx.stream(generation_stream):
+                lm.rollback_speculative_cache(
+                    prompt_cache, None, accepted_arr, bs
+                )
+
+        # Slice + tail-zero ``verify_out.shared_kv_states`` to match the
+        # post-rollback target cache. After this, all rows share the same
+        # tensor length but rows that accepted less have zeros in the tail
+        # positions [L_prefill_round + accepted_i + 1, L_prefill_round + max_a + 1).
+        rejected_global = bs - (max_a + 1)
+        next_shared_kv = {}
+        for k, kv in verify_out.shared_kv_states.items():
+            K, V = kv
+            valid = K.shape[-2] - rejected_global
+            if valid >= K.shape[-2]:
+                K_next, V_next = K, V
+            elif valid <= 0:
+                K_next = K[..., :1, :]
+                V_next = V[..., :1, :]
+            else:
+                K_next = K[..., :valid, :]
+                V_next = V[..., :valid, :]
+            # Per-row tail-zero on rows that accepted less than max_a.
+            if any(a < max_a for a in accepted_list):
+                # K_next/V_next shape: [B_active, H, valid, D]
+                # For row i, zero positions [valid - max_a + accepted_i, valid).
+                # (verify_start = valid - (max_a + 1), and tail begins at
+                # verify_start + accepted_i + 1 = valid - max_a + accepted_i.)
+                K_arr = mx.array(K_next)  # ensure materialized for slicing
+                V_arr = mx.array(V_next)
+                K_arr = mx.array(K_arr)
+                V_arr = mx.array(V_arr)
+                mask_rows = mx.arange(K_next.shape[-2])  # [valid]
+                # Build per-row mask: True where position should be kept.
+                # Shape [B_active, valid]. Row i keeps positions [0, valid - max_a + accepted_i).
+                keep_lens = mx.array(
+                    [valid - max_a + a for a in accepted_list], dtype=mx.int32
+                )  # [B_active]
+                keep_mask = mask_rows[None, :] < keep_lens[:, None]  # [B_active, valid]
+                keep_f = keep_mask.astype(K_next.dtype)[:, None, :, None]  # broadcast
+                K_next = K_next * keep_f
+                V_next = V_next * keep_f
+            next_shared_kv[k] = (K_next, V_next)
+
+        # Continuous batching: filter finished sequences. Only safe when
+        # the caches expose a .filter() method (e.g. BatchKVCache); the
+        # plain KVCache / RotatingKVCache do not, so we keep all rows
+        # in the batch and just stop emitting for finished rows. End the
+        # round-loop when every row has finished.
+        cache_filterable = all(hasattr(c, "filter") for c in prompt_cache)
+        if all(finished[active_idx[j]] for j in range(n_active)):
+            break
+        if cache_filterable:
+            keep_slots = [j for j in range(n_active) if not finished[active_idx[j]]]
+            if len(keep_slots) < n_active:
+                keep_mx = mx.array(keep_slots, dtype=mx.int32)
+                for c in prompt_cache:
+                    c.filter(keep_mx)
+                hidden = hidden[keep_mx]
+                for k in next_shared_kv:
+                    K_next, V_next = next_shared_kv[k]
+                    next_shared_kv[k] = (K_next[keep_mx], V_next[keep_mx])
+                active_idx = [active_idx[j] for j in keep_slots]
+
+        # Re-bind drafter with new shared_kv and per-row positions.
+        positions_active = [positions[active_idx[j]] for j in range(len(active_idx))]
+        new_kv_offset = int(prompt_cache[0].offset)
+        draft_model.set_shared_kv(
+            next_shared_kv,
+            kv_offset=new_kv_offset,
+            position=mx.array(positions_active),
+        )
+
+        if sum(emitted) % 256 == 0:
+            mx.clear_cache()
+
+
 def _dflash_rounds(
     model: nn.Module,
     draft_model: nn.Module,
@@ -983,7 +1202,7 @@ def generate_step(
             else:
                 kwargs = {}
 
-            return y, logprobs.squeeze(0)
+            return y, logprobs.squeeze(0) if logprobs.shape[0] == 1 else logprobs
 
     with mx.stream(generation_stream):
         # Get input embeddings (handles both multimodal and text-only)
@@ -1032,26 +1251,50 @@ def generate_step(
     if draft_model is not None:
         B = input_ids.shape[0]
         if draft_kind == "mtp":
-            if B != 1:
-                raise NotImplementedError(
-                    "MTP speculative decoding currently only supports batch=1."
-                )
             shared_kv_states = last_outputs.shared_kv_states
             hidden = last_outputs.hidden_states[-1]
-            mx.eval(y)
-            yield y.item(), logprobs
-            yield from _mtp_rounds(
-                model,
-                draft_model,
-                prompt_cache,
-                hidden,
-                shared_kv_states,
-                first_bonus=y.item(),
-                max_tokens=max_tokens,
-                sampler=sampler,
-                draft_block_size=draft_block_size,
-                token_dtype=input_ids.dtype,
-            )
+            if B == 1:
+                mx.eval(y)
+                yield y.item(), logprobs
+                yield from _mtp_rounds(
+                    model,
+                    draft_model,
+                    prompt_cache,
+                    hidden,
+                    shared_kv_states,
+                    first_bonus=y.item(),
+                    max_tokens=max_tokens,
+                    sampler=sampler,
+                    draft_block_size=draft_block_size,
+                    token_dtype=input_ids.dtype,
+                )
+            else:
+                mx.eval(y)
+                # ``y`` is shape (B,) from sampler — no squeeze needed.
+                first_bonus = y if y.ndim == 1 else y.reshape(-1)
+                yield first_bonus.tolist(), logprobs
+                # Surface EOS token IDs from the model config so per-row
+                # stops are detected inside the round loop.
+                eos = getattr(model.config, "eos_token_id", None)
+                if isinstance(eos, int):
+                    eos_set = {eos}
+                elif eos is None:
+                    eos_set = None
+                else:
+                    eos_set = set(int(x) for x in eos)
+                yield from _mtp_rounds_batch(
+                    model,
+                    draft_model,
+                    prompt_cache,
+                    hidden,
+                    shared_kv_states,
+                    first_bonus=first_bonus,
+                    max_tokens=max_tokens,
+                    sampler=sampler,
+                    draft_block_size=draft_block_size,
+                    token_dtype=input_ids.dtype,
+                    eos_token_ids=eos_set,
+                )
             return
 
         if draft_kind != "dflash":

--- a/mlx_vlm/models/base.py
+++ b/mlx_vlm/models/base.py
@@ -59,6 +59,7 @@ class LanguageModelOutput:
     cross_attention_states: Optional[List[mx.array]] = None
     encoder_outputs: Optional[List[mx.array]] = None
     gdn_states: Optional[List] = None
+    shared_kv_states: Optional[Dict[str, tuple]] = None
 
 
 @dataclass

--- a/mlx_vlm/models/gemma4/gemma4.py
+++ b/mlx_vlm/models/gemma4/gemma4.py
@@ -186,11 +186,25 @@ class Model(nn.Module):
             **kwargs,
         )
 
+        # Forward speculative-decoding hooks straight through to the LM.
+        lm_kwargs = {
+            k: kwargs[k]
+            for k in (
+                "capture_layer_ids",
+                "hidden_sink",
+                "shared_kv_sink",
+                "return_hidden",
+                "return_shared_kv",
+            )
+            if k in kwargs
+        }
+
         logits = self.language_model(
             input_ids=None,
             cache=cache,
             inputs_embeds=input_embeddings_features.inputs_embeds,
             per_layer_inputs=input_embeddings_features.per_layer_inputs,
+            **lm_kwargs,
         )
         return logits
 

--- a/mlx_vlm/models/gemma4/language.py
+++ b/mlx_vlm/models/gemma4/language.py
@@ -543,10 +543,16 @@ class Gemma4TextModel(nn.Module):
                 if kvs is not None:
                     shared_kv_sink[layer.layer_type] = kvs
 
+        # Match HF's `_can_record_outputs={"hidden_states": Gemma4TextDecoderLayer}`
+        # — the recorded value is the LAST decoder layer's output, captured
+        # BEFORE the final RMSNorm. The drafter's `pre_projection` was trained
+        # against this pre-norm hidden.
         if hidden_sink is not None and not capture_set:
             hidden_sink.append(h)
 
-        return self.norm(h)
+        h = self.norm(h)
+
+        return h
 
 
 class LanguageModel(nn.Module):
@@ -610,6 +616,7 @@ class LanguageModel(nn.Module):
         simple trim + per-row tail-zero. ``gdn_states`` is accepted (and
         ignored) for API parity with qwen3_5's hook.
         """
+        del gdn_states  # API-parity placeholder; Gemma 4 has no SSM/GDN state.
         if isinstance(accepted, int):
             accepted = mx.array([accepted])
 

--- a/mlx_vlm/models/gemma4/language.py
+++ b/mlx_vlm/models/gemma4/language.py
@@ -574,7 +574,9 @@ class LanguageModel(nn.Module):
         **kwargs,
     ):
         hidden_sink: Optional[list] = (
-            [] if capture_layer_ids is not None or kwargs.pop("return_hidden", False) else None
+            []
+            if capture_layer_ids is not None or kwargs.pop("return_hidden", False)
+            else None
         )
         shared_kv_sink: Optional[dict] = (
             {} if kwargs.pop("return_shared_kv", False) else None

--- a/mlx_vlm/models/gemma4/language.py
+++ b/mlx_vlm/models/gemma4/language.py
@@ -1,5 +1,5 @@
 from functools import partial
-from typing import Any, Optional
+from typing import Any, List, Optional
 
 import mlx.core as mx
 import mlx.nn as nn
@@ -128,12 +128,18 @@ class Experts(nn.Module):
 
 
 class Attention(nn.Module):
-    def __init__(self, config: TextConfig, layer_idx: int):
+    def __init__(
+        self,
+        config: TextConfig,
+        layer_idx: int,
+        kv_shared_only: bool = False,
+    ):
         super().__init__()
         self.config = config
         self.layer_idx = layer_idx
         self.layer_type = config.layer_types[layer_idx]
         self.is_sliding = self.layer_type == "sliding_attention"
+        self.kv_shared_only = kv_shared_only
 
         self.head_dim = (
             config.global_head_dim
@@ -158,14 +164,18 @@ class Attention(nn.Module):
         self.scale = 1.0
 
         self.q_proj = nn.Linear(dim, self.n_heads * self.head_dim, bias=False)
-        self.k_proj = nn.Linear(dim, self.n_kv_heads * self.head_dim, bias=False)
-        if not self.use_k_eq_v:
-            self.v_proj = nn.Linear(dim, self.n_kv_heads * self.head_dim, bias=False)
+        if not kv_shared_only:
+            self.k_proj = nn.Linear(dim, self.n_kv_heads * self.head_dim, bias=False)
+            if not self.use_k_eq_v:
+                self.v_proj = nn.Linear(
+                    dim, self.n_kv_heads * self.head_dim, bias=False
+                )
         self.o_proj = nn.Linear(self.n_heads * self.head_dim, dim, bias=False)
 
         self.q_norm = RMSNorm(self.head_dim, eps=config.rms_norm_eps)
-        self.k_norm = RMSNorm(self.head_dim, eps=config.rms_norm_eps)
-        self.v_norm = RMSNormNoScale(self.head_dim, eps=config.rms_norm_eps)
+        if not kv_shared_only:
+            self.k_norm = RMSNorm(self.head_dim, eps=config.rms_norm_eps)
+            self.v_norm = RMSNormNoScale(self.head_dim, eps=config.rms_norm_eps)
 
         # RoPE (with partial rotation support)
         layer_key = "sliding_attention" if self.is_sliding else "full_attention"
@@ -234,12 +244,17 @@ class Attention(nn.Module):
 
 
 class DecoderLayer(nn.Module):
-    def __init__(self, config: TextConfig, layer_idx: int):
+    def __init__(
+        self,
+        config: TextConfig,
+        layer_idx: int,
+        kv_shared_only: bool = False,
+    ):
         super().__init__()
         self.config = config
         self.layer_idx = layer_idx
         self.layer_type = config.layer_types[layer_idx]
-        self.self_attn = Attention(config, layer_idx)
+        self.self_attn = Attention(config, layer_idx, kv_shared_only=kv_shared_only)
         self.mlp = MLP(config, layer_idx)
         self.input_layernorm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
         self.post_attention_layernorm = RMSNorm(
@@ -349,7 +364,7 @@ class DecoderLayer(nn.Module):
 
 
 class Gemma4TextModel(nn.Module):
-    def __init__(self, config: TextConfig):
+    def __init__(self, config: TextConfig, kv_shared_only: bool = False):
         super().__init__()
         self.config = config
         self.vocab_size = config.vocab_size
@@ -360,7 +375,8 @@ class Gemma4TextModel(nn.Module):
         self.embed_tokens = nn.Embedding(config.vocab_size, config.hidden_size)
         self.embed_scale = config.hidden_size**0.5
         self.layers = [
-            DecoderLayer(config, layer_idx=i) for i in range(config.num_hidden_layers)
+            DecoderLayer(config, layer_idx=i, kv_shared_only=kv_shared_only)
+            for i in range(config.num_hidden_layers)
         ]
         self.norm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
 
@@ -451,6 +467,9 @@ class Gemma4TextModel(nn.Module):
         mask: Optional[mx.array] = None,
         cache=None,
         per_layer_inputs: Optional[mx.array] = None,
+        capture_layer_ids: Optional[List[int]] = None,
+        hidden_sink: Optional[list] = None,
+        shared_kv_sink: Optional[dict] = None,
         **kwargs,
     ):
         if inputs_embeds is None:
@@ -499,6 +518,7 @@ class Gemma4TextModel(nn.Module):
         else:
             per_layer_inputs = [None] * len(self.layers)
 
+        capture_set = set(capture_layer_ids) if capture_layer_ids else set()
         intermediates = [(None, None)] * len(self.layers)
         for idx, (layer, c, m, prev_idx, pli) in enumerate(
             zip(
@@ -514,6 +534,17 @@ class Gemma4TextModel(nn.Module):
                 h, m, c, per_layer_input=pli, shared_kv=kvs, offset=offset
             )
             intermediates[idx] = (kvs, offset)
+            if hidden_sink is not None and idx in capture_set:
+                hidden_sink.append(h)
+
+        if shared_kv_sink is not None:
+            for idx, layer in enumerate(self.layers):
+                kvs, _ = intermediates[idx]
+                if kvs is not None:
+                    shared_kv_sink[layer.layer_type] = kvs
+
+        if hidden_sink is not None and not capture_set:
+            hidden_sink.append(h)
 
         return self.norm(h)
 
@@ -533,20 +564,76 @@ class LanguageModel(nn.Module):
         mask: Optional[mx.array] = None,
         cache=None,
         per_layer_inputs: Optional[mx.array] = None,
+        capture_layer_ids: Optional[List[int]] = None,
         **kwargs,
     ):
+        hidden_sink: Optional[list] = (
+            [] if capture_layer_ids is not None or kwargs.pop("return_hidden", False) else None
+        )
+        shared_kv_sink: Optional[dict] = (
+            {} if kwargs.pop("return_shared_kv", False) else None
+        )
+        # Allow callers to pass pre-allocated sinks directly.
+        hidden_sink = kwargs.pop("hidden_sink", hidden_sink)
+        shared_kv_sink = kwargs.pop("shared_kv_sink", shared_kv_sink)
+
         out = self.model(
             inputs,
             inputs_embeds=inputs_embeds,
             mask=mask,
             cache=cache,
             per_layer_inputs=per_layer_inputs,
+            capture_layer_ids=capture_layer_ids,
+            hidden_sink=hidden_sink,
+            shared_kv_sink=shared_kv_sink,
             **kwargs,
         )
         out = self.model.embed_tokens.as_linear(out)
         if self.final_logit_softcapping is not None:
             out = logit_softcap(self.final_logit_softcapping, out)
-        return LanguageModelOutput(logits=out)
+        return LanguageModelOutput(
+            logits=out,
+            hidden_states=hidden_sink,
+            shared_kv_states=shared_kv_sink,
+        )
+
+    def rollback_speculative_cache(
+        self,
+        caches: List[Any],
+        gdn_states: Any,
+        accepted: Any,
+        block_size: int,
+    ) -> int:
+        """Rewind target KV caches after a speculative-decoding round.
+
+        Gemma 4 has only KV/RotatingKV caches (no SSM/GDN), so this is a
+        simple trim + per-row tail-zero. ``gdn_states`` is accepted (and
+        ignored) for API parity with qwen3_5's hook.
+        """
+        if isinstance(accepted, int):
+            accepted = mx.array([accepted])
+
+        max_a = int(accepted.max().item())
+        n = max_a + 1
+        trim = block_size - n
+        is_batch = accepted.size > 1
+        valid_ends = accepted + 1
+
+        for c in caches:
+            if c is None or not c.is_trimmable():
+                continue
+            if trim > 0:
+                c.trim(trim)
+            if is_batch and hasattr(c, "_idx") and c.keys is not None and max_a > 0:
+                kv_len = c._idx
+                ve = valid_ends.tolist()
+                verify_start = kv_len - n
+                for bi in range(accepted.shape[0]):
+                    start = verify_start + int(ve[bi])
+                    if start < kv_len:
+                        c.keys[bi, :, start:kv_len, :] = 0
+                        c.values[bi, :, start:kv_len, :] = 0
+        return max_a
 
     def sanitize(self, weights):
         sanitized = {}

--- a/mlx_vlm/speculative/drafters/__init__.py
+++ b/mlx_vlm/speculative/drafters/__init__.py
@@ -1,12 +1,16 @@
 from .qwen3_dflash import DFlashDraftModel
 
+KNOWN_DRAFTER_KINDS = {"dflash", "mtp"}
+
 
 def load_drafter(path_or_repo: str, kind: str = "dflash", **kwargs):
-    if kind != "dflash":
-        raise ValueError(f"Unknown drafter kind {kind!r}. Known: ['dflash']")
+    if kind not in KNOWN_DRAFTER_KINDS:
+        raise ValueError(
+            f"Unknown drafter kind {kind!r}. Known: {sorted(KNOWN_DRAFTER_KINDS)}"
+        )
     from ...utils import get_model_path, load_model
 
     return load_model(get_model_path(path_or_repo), **kwargs)
 
 
-__all__ = ["DFlashDraftModel", "load_drafter"]
+__all__ = ["DFlashDraftModel", "KNOWN_DRAFTER_KINDS", "load_drafter"]

--- a/mlx_vlm/speculative/drafters/gemma4_assistant/README.md
+++ b/mlx_vlm/speculative/drafters/gemma4_assistant/README.md
@@ -112,27 +112,6 @@ target forward time dominates. On the small E4B target, target forward is
 already cheap and at high batch sizes the drafter's per-step overhead
 exceeds the speedup it buys.
 
-Reproduce with `scripts/mtp_batch_sweep.py`:
-
-```bash
-uv run python scripts/mtp_batch_sweep.py \
-    --model mlx-community/gemma-4-26B-A4B-it-bf16 \
-    --drafter mlx-community/gemma-4-26B-A4B-it-assistant-bf16 \
-    --batch-sizes 4 8 --block-sizes 2 3 --max-tokens 64
-```
-
-## Smoke test
-
-```bash
-uv run python -m mlx_vlm.speculative.drafters.gemma4_assistant.parity_check \
-    --drafter mlx-community/gemma-4-E4B-it-assistant-bf16
-```
-
-Expects `forward OK: logits shape=(1, 1, 262144) ...` and
-`draft_block OK: tokens shape=(1, 3) ...`. For drafters with the centroid
-LM head the parity check exercises `MaskedEmbedder` end-to-end (most
-positions land at the sparse `min - 1` floor).
-
 ## Caveats
 
 - **Sampling.** Greedy (temp 0) is verified byte-identical. Stochastic

--- a/mlx_vlm/speculative/drafters/gemma4_assistant/README.md
+++ b/mlx_vlm/speculative/drafters/gemma4_assistant/README.md
@@ -1,0 +1,151 @@
+# Gemma 4 Assistant Drafter (MTP)
+
+MLX port of Google's Gemma 4 **Multi-Token Prediction (MTP)** drafter for
+speculative decoding. Reference:
+[ai.google.dev/gemma/docs/mtp](https://ai.google.dev/gemma/docs/mtp/mtp).
+
+## What it is
+
+A small, 4-layer "assistant" model trained to draft several candidate tokens
+per round; the full Gemma 4 target verifies them in a single forward pass.
+Accepted tokens advance, rejected ones (and everything after) are discarded.
+Quality matches the target at temperature 0 (byte-identical greedy output).
+
+The drafter is tightly coupled to the target's internals:
+
+- **KV-cache sharing** — every drafter layer is `is_kv_shared_layer=True` and
+  reads K/V from the target's last full-attention and last sliding-attention
+  layers. The drafter has **no KV cache of its own**; its only recurrent
+  state is the target's last hidden, projected through `post_projection`.
+- **Cross-attention from constant position** — the drafter's queries are
+  RoPE-rotated at the bonus token's absolute position and held constant
+  across all draft steps within a block.
+- **Hidden+token concatenation** — drafter input each step is
+  `concat([target_embed(last_token), last_hidden_state], dim=-1)` of shape
+  `[B, 1, 2 * backbone_hidden_size]`, projected to drafter hidden size by
+  `pre_projection`.
+
+## Supported pairings
+
+| Target                                | Drafter                                              | LM head                |
+| ------------------------------------- | ---------------------------------------------------- | ---------------------- |
+| `google/gemma-4-E2B-it`               | `google/gemma-4-E2B-it-assistant`                  | centroid (sparse)      |
+| `google/gemma-4-E4B-it`               | `google/gemma-4-E4B-it-assistant`                  | centroid (sparse)      |
+| `google/gemma-4-26B-A4B-it`           | `google/gemma-4-26B-A4B-it-assistant`              | tied dense             |
+| `google/gemma-4-31B-it`               | `google/gemma-4-31B-it-assistant`                  | tied dense             |
+
+For E2B / E4B drafters, `use_ordered_embeddings=True` and the LM head is a
+**centroid-routed sparse softmax** (`MaskedEmbedder`): the drafter scores
+2048 token clusters, materialises the top-K (default 32) clusters' tokens
+(~4096 of 262144), and scatters those logits back into a full-vocab tensor —
+non-selected positions filled with `min(selected) - 1` so they lose any
+argmax / sampling competition.
+
+## Files
+
+- `config.py` — `Gemma4AssistantConfig` (HF-compatible, flattened).
+- `gemma4_assistant.py` — `Gemma4AssistantDraftModel` (forward, `bind`,
+  `set_shared_kv`, `draft_block`, `sanitize`).
+- `masked_embedder.py` — centroid-routed sparse LM head for E2B / E4B.
+- `masks.py` — bidirectional full / SWA masks for the drafter forward.
+- `parity_check.py` — fake-target smoke test.
+
+## Usage
+
+The drafter is auto-discovered by HF `model_type == "gemma4_assistant"`;
+just pass `--draft-model` and `--draft-kind mtp` to `mlx_vlm.generate`:
+
+```bash
+uv run python -m mlx_vlm.generate \
+    --model google/gemma-4-31B-it \
+    --draft-model google/gemma-4-31B-it-assistant \
+    --draft-kind mtp \
+    --draft-block-size 4 \
+    --prompt "Explain speculative decoding in 3 sentences." \
+    --max-tokens 256 --temp 0
+```
+
+`--draft-block-size` is the number of speculatively drafted tokens per
+round (Google calls this `num_assistant_tokens`). The first token of the
+block is the most recently accepted bonus, so the drafter actually
+generates `block_size - 1` candidates each round.
+
+Programmatic use:
+
+```python
+from mlx_vlm.utils import load
+from mlx_vlm.speculative.drafters import load_drafter
+from mlx_vlm.generate import generate_step
+
+model, processor = load("google/gemma-4-31B-it")
+drafter = load_drafter("google/gemma-4-31B-it-assistant", kind="mtp")
+
+for tok, _ in generate_step(
+    input_ids, model, None, None,
+    max_tokens=256,
+    draft_model=drafter,
+    draft_kind="mtp",
+    draft_block_size=4,
+):
+    ...
+```
+
+## Performance
+
+Measured on Apple Silicon (M3 Max, 96GB RAM), 17-token prompt, max 64–96 tokens, greedy
+(`temp=0`), output byte-identical to the no-drafter baseline.
+
+Best `block_size` per (target, batch):
+
+| Target  | B  | best bs | tot tok/s | speedup vs no-drafter |
+|---------|----|---------|-----------|-----------------------|
+| 26B-A4B | 4  | 3       | 85.5      | **3.94×**             |
+| 26B-A4B | 8  | 3       | 165.1     | **1.55×**             |
+| 31B     | 4  | 3       | 17.1      | **2.29×**             |
+| 31B     | 8  | 2       | 21.4      | **1.41×**             |
+| E4B     | 4  | 4       | 62.1      | **1.56×**             |
+| E4B     | 8  | 2       | 115.9     | 1.07×                 |
+| E4B     | 16 | —       | —         | drafter slower (≤1.0×)|
+
+The drafter is most attractive on large/slow targets (26B-A4B, 31B) where
+target forward time dominates. On the small E4B target, target forward is
+already cheap and at high batch sizes the drafter's per-step overhead
+exceeds the speedup it buys.
+
+Reproduce with `scripts/mtp_batch_sweep.py`:
+
+```bash
+uv run python scripts/mtp_batch_sweep.py \
+    --model google/gemma-4-26B-A4B-it \
+    --drafter google/gemma-4-26B-A4B-it-assistant \
+    --batch-sizes 4 8 --block-sizes 2 3 --max-tokens 64
+```
+
+## Smoke test
+
+```bash
+uv run python -m mlx_vlm.speculative.drafters.gemma4_assistant.parity_check \
+    --drafter google/gemma-4-E4B-it-assistant
+```
+
+Expects `forward OK: logits shape=(1, 1, 262144) ...` and
+`draft_block OK: tokens shape=(1, 3) ...`. For drafters with the centroid
+LM head the parity check exercises `MaskedEmbedder` end-to-end (most
+positions land at the sparse `min - 1` floor).
+
+## Caveats
+
+- **Sampling.** Greedy (temp 0) is verified byte-identical. Stochastic
+  sampling works but acceptance rates drop because drafter and target
+  draws diverge.
+- **Multimodal prompts.** Image / audio prefill runs through the target
+  unchanged; speculative decoding only kicks in on the text-decode tail,
+  so multimodal works but the drafter only ever sees text tokens.
+- **Sliding-window masks.** The bidirectional SWA mask in `masks.py`
+  short-circuits to `None` when `kv_len <= sliding_window`, which is the
+  only regime `RotatingKVCache` ever produces. Long-prompt mask paths are
+  effectively dead code today.
+- **Batched generation.** Continuous-batching support is in
+  `_mtp_rounds_batch` (`mlx_vlm/generate.py`). For targets whose KV caches
+  don't implement `.filter()`, finished rows are kept in the batch and
+  simply stop emitting; throughput doesn't shrink with retired rows.

--- a/mlx_vlm/speculative/drafters/gemma4_assistant/README.md
+++ b/mlx_vlm/speculative/drafters/gemma4_assistant/README.md
@@ -29,10 +29,10 @@ The drafter is tightly coupled to the target's internals:
 
 | Target                                | Drafter                                              | LM head                |
 | ------------------------------------- | ---------------------------------------------------- | ---------------------- |
-| `google/gemma-4-E2B-it`               | `google/gemma-4-E2B-it-assistant`                  | centroid (sparse)      |
-| `google/gemma-4-E4B-it`               | `google/gemma-4-E4B-it-assistant`                  | centroid (sparse)      |
-| `google/gemma-4-26B-A4B-it`           | `google/gemma-4-26B-A4B-it-assistant`              | tied dense             |
-| `google/gemma-4-31B-it`               | `google/gemma-4-31B-it-assistant`                  | tied dense             |
+| `mlx-community/gemma-4-E2B-it-bf16`               | `mlx-community/gemma-4-E2B-it-assistant-bf16`                  | centroid (sparse)      |
+| `mlx-community/gemma-4-E4B-it-bf16`               | `mlx-community/gemma-4-E4B-it-assistant-bf16`                  | centroid (sparse)      |
+| `mlx-community/gemma-4-26B-A4B-it-bf16`           | `mlx-community/gemma-4-26B-A4B-it-assistant-bf16`              | tied dense             |
+| `mlx-community/gemma-4-31B-it-bf16`               | `mlx-community/gemma-4-31B-it-assistant-bf16  `                  | tied dense             |
 
 For E2B / E4B drafters, `use_ordered_embeddings=True` and the LM head is a
 **centroid-routed sparse softmax** (`MaskedEmbedder`): the drafter scores
@@ -57,8 +57,8 @@ just pass `--draft-model` and `--draft-kind mtp` to `mlx_vlm.generate`:
 
 ```bash
 uv run python -m mlx_vlm.generate \
-    --model google/gemma-4-31B-it \
-    --draft-model google/gemma-4-31B-it-assistant \
+    --model mlx-community/gemma-4-31B-it-bf16 \
+    --draft-model mlx-community/gemma-4-31B-it-assistant-bf16 \
     --draft-kind mtp \
     --draft-block-size 4 \
     --prompt "Explain speculative decoding in 3 sentences." \
@@ -66,7 +66,7 @@ uv run python -m mlx_vlm.generate \
 ```
 
 `--draft-block-size` is the number of speculatively drafted tokens per
-round (Google calls this `num_assistant_tokens`). The first token of the
+round (google calls this `num_assistant_tokens`). The first token of the
 block is the most recently accepted bonus, so the drafter actually
 generates `block_size - 1` candidates each round.
 
@@ -77,8 +77,8 @@ from mlx_vlm.utils import load
 from mlx_vlm.speculative.drafters import load_drafter
 from mlx_vlm.generate import generate_step
 
-model, processor = load("google/gemma-4-31B-it")
-drafter = load_drafter("google/gemma-4-31B-it-assistant", kind="mtp")
+model, processor = load("mlx-community/gemma-4-31B-it-bf16")
+drafter = load_drafter("mlx-community/gemma-4-31B-it-assistant-bf16", kind="mtp")
 
 for tok, _ in generate_step(
     input_ids, model, None, None,
@@ -116,8 +116,8 @@ Reproduce with `scripts/mtp_batch_sweep.py`:
 
 ```bash
 uv run python scripts/mtp_batch_sweep.py \
-    --model google/gemma-4-26B-A4B-it \
-    --drafter google/gemma-4-26B-A4B-it-assistant \
+    --model mlx-community/gemma-4-26B-A4B-it-bf16 \
+    --drafter mlx-community/gemma-4-26B-A4B-it-assistant-bf16 \
     --batch-sizes 4 8 --block-sizes 2 3 --max-tokens 64
 ```
 
@@ -125,7 +125,7 @@ uv run python scripts/mtp_batch_sweep.py \
 
 ```bash
 uv run python -m mlx_vlm.speculative.drafters.gemma4_assistant.parity_check \
-    --drafter google/gemma-4-E4B-it-assistant
+    --drafter mlx-community/gemma-4-E4B-it-assistant-bf16
 ```
 
 Expects `forward OK: logits shape=(1, 1, 262144) ...` and

--- a/mlx_vlm/speculative/drafters/gemma4_assistant/__init__.py
+++ b/mlx_vlm/speculative/drafters/gemma4_assistant/__init__.py
@@ -1,0 +1,11 @@
+from ....models.gemma4.config import TextConfig
+from .config import Gemma4AssistantConfig as ModelConfig
+from .gemma4_assistant import Gemma4AssistantDraftModel
+from .gemma4_assistant import Gemma4AssistantDraftModel as Model
+
+__all__ = [
+    "Model",
+    "ModelConfig",
+    "TextConfig",
+    "Gemma4AssistantDraftModel",
+]

--- a/mlx_vlm/speculative/drafters/gemma4_assistant/config.py
+++ b/mlx_vlm/speculative/drafters/gemma4_assistant/config.py
@@ -1,0 +1,47 @@
+import inspect
+from dataclasses import dataclass, field
+from typing import List, Optional
+
+from ....models.base import BaseModelConfig
+from ....models.gemma4.config import TextConfig
+
+
+@dataclass
+class Gemma4AssistantConfig(BaseModelConfig):
+    """Drafter config for Gemma 4 Multi-Token Prediction (assistant) models.
+
+    Mirrors the HF ``Gemma4AssistantConfig`` shape (top-level + nested
+    ``text_config``). Defaults match ``gg-hf-am/gemma-4-26B-A4B-it-assistant``.
+    """
+
+    model_type: str = "gemma4_assistant"
+    backbone_hidden_size: int = 1536
+    use_ordered_embeddings: bool = False
+    num_centroids: int = 2048
+    centroid_intermediate_top_k: int = 32
+    tie_word_embeddings: bool = True
+    block_size: int = 4
+    # Unused by MTP (drafter consumes shared K/V, not per-layer hidden
+    # captures) but kept for API parity with DFlash so the round-loop's
+    # references to ``draft_model.config.target_layer_ids`` don't crash.
+    target_layer_ids: List[int] = field(default_factory=list)
+    text_config: Optional[TextConfig] = None
+
+    def __post_init__(self):
+        if isinstance(self.text_config, dict):
+            self.text_config = TextConfig.from_dict(self.text_config)
+        if self.text_config is not None:
+            # HF Gemma4AssistantConfig.__post_init__: when num_kv_shared_layers
+            # is unset/0 the assistant shares K/V across all layers.
+            if not self.text_config.num_kv_shared_layers:
+                self.text_config.num_kv_shared_layers = (
+                    self.text_config.num_hidden_layers
+                )
+
+    @classmethod
+    def from_dict(cls, params: dict) -> "Gemma4AssistantConfig":
+        flat = dict(params)
+        sig = inspect.signature(cls).parameters
+        return cls(**{k: v for k, v in flat.items() if k in sig})
+
+    from_hf_dict = from_dict

--- a/mlx_vlm/speculative/drafters/gemma4_assistant/gemma4_assistant.py
+++ b/mlx_vlm/speculative/drafters/gemma4_assistant/gemma4_assistant.py
@@ -68,6 +68,7 @@ class Gemma4AssistantDraftModel(nn.Module):
         # Bound at runtime via bind().
         self._lm_head_fn = None
         self._input_embed = None  # target's embed_tokens (backbone_hidden_size)
+        self._input_embed_scale: float = 1.0
         # Threaded by reset() / round-loop before each draft_block.
         self._shared_kv: Optional[dict] = None
         self._kv_offset: int = 0
@@ -116,6 +117,16 @@ class Gemma4AssistantDraftModel(nn.Module):
             inner = target_model.language_model.model
         if inner is not None:
             self._input_embed = inner.embed_tokens
+            # HF's target uses ``Gemma4TextScaledWordEmbedding`` which
+            # multiplies the lookup by ``sqrt(hidden_size)`` *inside* the
+            # module. In MLX-VLM the same scale is applied externally
+            # (``language.py: h = self.embed_tokens(inputs) * self.embed_scale``),
+            # so the bare ``embed_tokens`` here returns *unscaled* vectors.
+            # The drafter's ``pre_projection`` was trained against scaled
+            # target embeddings, so we replicate the scale at call time.
+            self._input_embed_scale = float(
+                getattr(inner, "embed_scale", 1.0)
+            )
 
         # Stash the target's layer_types so the round-loop knows which keys
         # the drafter expects in shared_kv_states.
@@ -148,15 +159,16 @@ class Gemma4AssistantDraftModel(nn.Module):
         """Threaded by the round-loop before each ``draft_block`` call.
 
         ``kv_offset`` is the length of the target's KV cache (= number of
-        tokens already in the cache). ``position`` is the absolute
-        position id used for RoPE on the drafter's queries — defaults to
-        ``kv_offset - 1`` (the position of the last seen token), matching
-        the HF SinglePositionMultiToken behavior of holding position_ids
-        constant across draft steps.
+        target-side tokens already written to KV; the just-sampled bonus
+        is *not* yet in the cache). ``position`` is the absolute position
+        id used for RoPE on the drafter's queries; HF
+        ``SinglePositionMultiTokenCandidateGenerator`` locks it to
+        ``input_ids.shape[1] - 1`` which equals the bonus's position —
+        i.e. ``kv_offset`` (one past the last cached token).
         """
         self._shared_kv = shared_kv_states
         self._kv_offset = int(kv_offset)
-        self._position = int(position) if position is not None else int(kv_offset) - 1
+        self._position = int(position) if position is not None else int(kv_offset)
 
     # ------------------------------------------------------------------
     # forward
@@ -252,7 +264,7 @@ class Gemma4AssistantDraftModel(nn.Module):
         tokens: List[mx.array] = []
 
         for _ in range(block_size - 1):
-            tok_embed = self._input_embed(tok)
+            tok_embed = self._input_embed(tok) * self._input_embed_scale
             inputs_embeds = mx.concatenate([tok_embed, h_prev], axis=-1)
             h_prev, logits = self(inputs_embeds, shared_kv, position_ids)
             tok = sampler(logits)  # [B, 1]

--- a/mlx_vlm/speculative/drafters/gemma4_assistant/gemma4_assistant.py
+++ b/mlx_vlm/speculative/drafters/gemma4_assistant/gemma4_assistant.py
@@ -12,15 +12,6 @@ from .masks import make_drafter_masks
 
 
 class _DraftInner(nn.Module):
-    """Minimal Gemma-4 text model holding the drafter's per-layer modules.
-
-    Mirrors ``mlx_vlm.models.gemma4.language.Gemma4TextModel`` weight-key
-    shape (``embed_tokens``, ``layers.{i}.*``, ``norm``) so the HF drafter
-    checkpoint loads as-is. Skips the target's KV-sharing/per-layer-input
-    bookkeeping — the drafter has its own forward in
-    ``Gemma4AssistantDraftModel.__call__`` and consumes ``shared_kv_states``
-    coming from the target rather than computing or sharing K/V internally.
-    """
 
     def __init__(self, text_config: TextConfig):
         super().__init__()
@@ -36,18 +27,7 @@ class _DraftInner(nn.Module):
 
 
 class Gemma4AssistantDraftModel(nn.Module):
-    """Gemma 4 Multi-Token Prediction drafter.
 
-    Surface mirrors ``DFlashDraftModel``: ``bind`` / ``make_cache`` /
-    ``reset`` / ``draft_block`` / ``__call__`` / ``sanitize`` / ``accept_lens``.
-    The drafter has no KV cache of its own — its recurrent state is the
-    ``post_projection``-projected hidden carried across draft steps.
-
-    ``draft_block``'s ``cache`` argument is repurposed to thread the
-    target's ``shared_kv_states`` dict into the drafter; the round-loop
-    in ``mlx_vlm/generate.py`` sets this via ``reset(target, shared_kv)``
-    before each block.
-    """
 
     def __init__(self, config: Gemma4AssistantConfig):
         super().__init__()
@@ -68,39 +48,23 @@ class Gemma4AssistantDraftModel(nn.Module):
                 text_cfg.hidden_size, text_cfg.vocab_size, bias=False
             )
 
-        # Bound at runtime via bind().
         self._lm_head_fn = None
-        self._input_embed = None  # target's embed_tokens (backbone_hidden_size)
+        self._input_embed = None
         self._input_embed_scale: float = 1.0
-        # Threaded by reset() / round-loop before each draft_block.
         self._shared_kv: Optional[dict] = None
         self._kv_offset: int = 0
         self._position: int = 0
 
         self.accept_lens: List[int] = []
 
-        # Centroid-routed sparse LM head for E2B / E4B drafters.
         if config.use_ordered_embeddings:
             self.masked_embedding = MaskedEmbedder(config)
         else:
             self.masked_embedding = None
 
-    # ------------------------------------------------------------------
-    # binding / cache management
-    # ------------------------------------------------------------------
     def bind(self, target_model) -> "Gemma4AssistantDraftModel":
-        """Wire input embeddings (target's, backbone_hidden_size) and lm_head
-        (drafter's tied, hidden_size).
 
-        Per the HF ``SinglePositionMultiTokenCandidateGenerator`` the input
-        pathway uses the *target*'s embed table (because ``inputs_embeds``
-        feeds into ``pre_projection`` which expects ``2 *
-        backbone_hidden_size``), while the LM head uses the drafter's own
-        tied embedding.
-        """
-        # LM head — drafter's own tied embed.
         if self.masked_embedding is not None:
-            # Centroid-routed: lm_head_weight is the (tied) embed_tokens weight.
             embed_w = self.model.embed_tokens.weight
             masked = self.masked_embedding
             self._lm_head_fn = lambda h: masked(h, embed_w)
@@ -109,7 +73,6 @@ class Gemma4AssistantDraftModel(nn.Module):
         else:
             self._lm_head_fn = self.lm_head
 
-        # Input embeddings — target's. Walk the standard wrappers.
         inner = None
         if hasattr(target_model, "embed_tokens"):
             inner = target_model
@@ -125,17 +88,8 @@ class Gemma4AssistantDraftModel(nn.Module):
             inner = target_model.language_model.model
         if inner is not None:
             self._input_embed = inner.embed_tokens
-            # HF's target uses ``Gemma4TextScaledWordEmbedding`` which
-            # multiplies the lookup by ``sqrt(hidden_size)`` *inside* the
-            # module. In MLX-VLM the same scale is applied externally
-            # (``language.py: h = self.embed_tokens(inputs) * self.embed_scale``),
-            # so the bare ``embed_tokens`` here returns *unscaled* vectors.
-            # The drafter's ``pre_projection`` was trained against scaled
-            # target embeddings, so we replicate the scale at call time.
             self._input_embed_scale = float(getattr(inner, "embed_scale", 1.0))
 
-        # Stash the target's layer_types so the round-loop knows which keys
-        # the drafter expects in shared_kv_states.
         try:
             tcfg = getattr(target_model, "language_model", target_model)
             tcfg = getattr(tcfg, "config", None)
@@ -162,22 +116,7 @@ class Gemma4AssistantDraftModel(nn.Module):
         kv_offset,
         position=None,
     ) -> None:
-        """Threaded by the round-loop before each ``draft_block`` call.
-
-        ``kv_offset`` is the length of the target's KV cache (= number of
-        target-side tokens already written to KV; the just-sampled bonus
-        is *not* yet in the cache). ``position`` is the absolute position
-        id used for RoPE on the drafter's queries; HF
-        ``SinglePositionMultiTokenCandidateGenerator`` locks it to
-        ``input_ids.shape[1] - 1`` which equals the bonus's position —
-        i.e. ``kv_offset`` (one past the last cached token).
-
-        Both ``kv_offset`` and ``position`` may be int (B=1) or array-like
-        of length B (per-row, for batched MTP). All rows share the same
-        ``shared_kv_states`` tensors; per-row variation in valid length is
-        expressed via tail-zeroing in those tensors and per-row ``position``
-        for RoPE.
-        """
+        
         self._shared_kv = shared_kv_states
         if isinstance(kv_offset, int):
             self._kv_offset = kv_offset
@@ -196,9 +135,6 @@ class Gemma4AssistantDraftModel(nn.Module):
         else:
             self._position = mx.array(position)
 
-    # ------------------------------------------------------------------
-    # forward
-    # ------------------------------------------------------------------
     def __call__(
         self,
         inputs_embeds: mx.array,
@@ -206,16 +142,12 @@ class Gemma4AssistantDraftModel(nn.Module):
         position_ids: mx.array,
         cache: Any = None,
     ) -> Tuple[mx.array, mx.array]:
-        del cache  # drafter has no own KV cache
+        del cache
         text_cfg = self.config.text_config
 
         h = self.pre_projection(inputs_embeds)
 
         query_len = h.shape[1]
-        # ``position_ids`` is [B, 1]. For B=1 we forward an int for the
-        # mask helper (which only branches on whether kv_len > sliding_window).
-        # For B>1 the mask helper still returns None for short prompts so this
-        # is fine; the per-row offset matters only for RoPE below.
         query_offset_scalar = int(position_ids[0, 0].item())
         masks = make_drafter_masks(
             shared_kv_states,
@@ -225,9 +157,6 @@ class Gemma4AssistantDraftModel(nn.Module):
             dtype=h.dtype,
         )
 
-        # Per-row RoPE offset for the drafter's queries. For B=1 this is a
-        # scalar; for B>1 it's an array of shape [B] so each row's Q is
-        # rotated at its own absolute position.
         if position_ids.shape[0] == 1:
             offset = mx.array(query_offset_scalar)
         else:
@@ -254,9 +183,7 @@ class Gemma4AssistantDraftModel(nn.Module):
         )
         return last_hidden, logits
 
-    # ------------------------------------------------------------------
-    # block drafting
-    # ------------------------------------------------------------------
+
     def draft_block(
         self,
         last_bonus,
@@ -292,8 +219,6 @@ class Gemma4AssistantDraftModel(nn.Module):
         if isinstance(self._position, int):
             position_ids = mx.array([[self._position]])
         else:
-            # Per-row positions for batched MTP. ``self._position`` is a
-            # 1-D mx.array of length B.
             position_ids = self._position[:, None]
 
         if isinstance(last_bonus, int):
@@ -301,30 +226,25 @@ class Gemma4AssistantDraftModel(nn.Module):
         else:
             tok = last_bonus[:, None].astype(token_dtype)
 
-        h_prev = hidden  # [B, 1, backbone_hidden_size]
+        h_prev = hidden
         tokens: List[mx.array] = []
 
         for _ in range(block_size - 1):
             tok_embed = self._input_embed(tok) * self._input_embed_scale
             inputs_embeds = mx.concatenate([tok_embed, h_prev], axis=-1)
             h_prev, logits = self(inputs_embeds, shared_kv, position_ids)
-            tok = sampler(logits)  # [B, 1]
+            tok = sampler(logits)
             tokens.append(tok)
 
         return mx.concatenate(tokens, axis=1)
 
-    # ------------------------------------------------------------------
-    # weight loading
-    # ------------------------------------------------------------------
+
     def sanitize(self, weights: dict) -> dict:
         out = {}
         for k, v in weights.items():
-            # ``token_ordering`` ships as int64 in the checkpoint; cast to
-            # int32 because mlx ``take`` expects int32/uint32 indices.
             if k == "masked_embedding.token_ordering":
                 v = v.astype(mx.int32)
-            # Drop any (rare) tied lm_head copy when we'll bind to the
-            # embedding's as_linear at runtime.
+
             if k == "lm_head.weight" and self.config.tie_word_embeddings:
                 continue
             out[k] = v

--- a/mlx_vlm/speculative/drafters/gemma4_assistant/gemma4_assistant.py
+++ b/mlx_vlm/speculative/drafters/gemma4_assistant/gemma4_assistant.py
@@ -7,6 +7,7 @@ from mlx.nn import RMSNorm
 from ....models.gemma4.config import TextConfig
 from ....models.gemma4.language import DecoderLayer
 from .config import Gemma4AssistantConfig
+from .masked_embedder import MaskedEmbedder
 from .masks import make_drafter_masks
 
 
@@ -76,11 +77,11 @@ class Gemma4AssistantDraftModel(nn.Module):
 
         self.accept_lens: List[int] = []
 
+        # Centroid-routed sparse LM head for E2B / E4B drafters.
         if config.use_ordered_embeddings:
-            raise NotImplementedError(
-                "Gemma4Assistant `use_ordered_embeddings=True` (centroid LM "
-                "head) is not yet ported to mlx-vlm."
-            )
+            self.masked_embedding = MaskedEmbedder(config)
+        else:
+            self.masked_embedding = None
 
     # ------------------------------------------------------------------
     # binding / cache management
@@ -96,7 +97,12 @@ class Gemma4AssistantDraftModel(nn.Module):
         tied embedding.
         """
         # LM head — drafter's own tied embed.
-        if self.config.tie_word_embeddings:
+        if self.masked_embedding is not None:
+            # Centroid-routed: lm_head_weight is the (tied) embed_tokens weight.
+            embed_w = self.model.embed_tokens.weight
+            masked = self.masked_embedding
+            self._lm_head_fn = lambda h: masked(h, embed_w)
+        elif self.config.tie_word_embeddings:
             self._lm_head_fn = self.model.embed_tokens.as_linear
         else:
             self._lm_head_fn = self.lm_head
@@ -307,6 +313,10 @@ class Gemma4AssistantDraftModel(nn.Module):
     def sanitize(self, weights: dict) -> dict:
         out = {}
         for k, v in weights.items():
+            # ``token_ordering`` ships as int64 in the checkpoint; cast to
+            # int32 because mlx ``take`` expects int32/uint32 indices.
+            if k == "masked_embedding.token_ordering":
+                v = v.astype(mx.int32)
             # Drop any (rare) tied lm_head copy when we'll bind to the
             # embedding's as_linear at runtime.
             if k == "lm_head.weight" and self.config.tie_word_embeddings:

--- a/mlx_vlm/speculative/drafters/gemma4_assistant/gemma4_assistant.py
+++ b/mlx_vlm/speculative/drafters/gemma4_assistant/gemma4_assistant.py
@@ -28,7 +28,6 @@ class _DraftInner(nn.Module):
 
 class Gemma4AssistantDraftModel(nn.Module):
 
-
     def __init__(self, config: Gemma4AssistantConfig):
         super().__init__()
         self.config = config
@@ -116,7 +115,7 @@ class Gemma4AssistantDraftModel(nn.Module):
         kv_offset,
         position=None,
     ) -> None:
-        
+
         self._shared_kv = shared_kv_states
         if isinstance(kv_offset, int):
             self._kv_offset = kv_offset
@@ -183,7 +182,6 @@ class Gemma4AssistantDraftModel(nn.Module):
         )
         return last_hidden, logits
 
-
     def draft_block(
         self,
         last_bonus,
@@ -237,7 +235,6 @@ class Gemma4AssistantDraftModel(nn.Module):
             tokens.append(tok)
 
         return mx.concatenate(tokens, axis=1)
-
 
     def sanitize(self, weights: dict) -> dict:
         out = {}

--- a/mlx_vlm/speculative/drafters/gemma4_assistant/gemma4_assistant.py
+++ b/mlx_vlm/speculative/drafters/gemma4_assistant/gemma4_assistant.py
@@ -153,8 +153,8 @@ class Gemma4AssistantDraftModel(nn.Module):
     def set_shared_kv(
         self,
         shared_kv_states: dict,
-        kv_offset: int,
-        position: Optional[int] = None,
+        kv_offset,
+        position=None,
     ) -> None:
         """Threaded by the round-loop before each ``draft_block`` call.
 
@@ -165,10 +165,26 @@ class Gemma4AssistantDraftModel(nn.Module):
         ``SinglePositionMultiTokenCandidateGenerator`` locks it to
         ``input_ids.shape[1] - 1`` which equals the bonus's position —
         i.e. ``kv_offset`` (one past the last cached token).
+
+        Both ``kv_offset`` and ``position`` may be int (B=1) or array-like
+        of length B (per-row, for batched MTP). All rows share the same
+        ``shared_kv_states`` tensors; per-row variation in valid length is
+        expressed via tail-zeroing in those tensors and per-row ``position``
+        for RoPE.
         """
         self._shared_kv = shared_kv_states
-        self._kv_offset = int(kv_offset)
-        self._position = int(position) if position is not None else int(kv_offset)
+        if isinstance(kv_offset, int):
+            self._kv_offset = kv_offset
+        else:
+            self._kv_offset = int(mx.array(kv_offset).max().item()) if not isinstance(kv_offset, mx.array) else int(kv_offset.max().item())
+        if position is None:
+            position = kv_offset
+        if isinstance(position, int):
+            self._position = position
+        elif isinstance(position, mx.array):
+            self._position = position
+        else:
+            self._position = mx.array(position)
 
     # ------------------------------------------------------------------
     # forward
@@ -186,18 +202,26 @@ class Gemma4AssistantDraftModel(nn.Module):
         h = self.pre_projection(inputs_embeds)
 
         query_len = h.shape[1]
-        query_offset = int(position_ids[0, 0].item())
+        # ``position_ids`` is [B, 1]. For B=1 we forward an int for the
+        # mask helper (which only branches on whether kv_len > sliding_window).
+        # For B>1 the mask helper still returns None for short prompts so this
+        # is fine; the per-row offset matters only for RoPE below.
+        query_offset_scalar = int(position_ids[0, 0].item())
         masks = make_drafter_masks(
             shared_kv_states,
             query_len=query_len,
-            query_offset=query_offset,
+            query_offset=query_offset_scalar,
             sliding_window=text_cfg.sliding_window,
             dtype=h.dtype,
         )
 
-        # Drafter queries always live one slot past the end of the KV; the
-        # absolute position is what RoPE needs.
-        offset = mx.array(query_offset)
+        # Per-row RoPE offset for the drafter's queries. For B=1 this is a
+        # scalar; for B>1 it's an array of shape [B] so each row's Q is
+        # rotated at its own absolute position.
+        if position_ids.shape[0] == 1:
+            offset = mx.array(query_offset_scalar)
+        else:
+            offset = position_ids[:, 0]
 
         for layer in self.model.layers:
             kv = shared_kv_states[layer.layer_type]
@@ -253,7 +277,12 @@ class Gemma4AssistantDraftModel(nn.Module):
                 "so the drafter can use the target's input embeddings."
             )
         shared_kv = self._shared_kv
-        position_ids = mx.array([[self._position]])
+        if isinstance(self._position, int):
+            position_ids = mx.array([[self._position]])
+        else:
+            # Per-row positions for batched MTP. ``self._position`` is a
+            # 1-D mx.array of length B.
+            position_ids = self._position[:, None]
 
         if isinstance(last_bonus, int):
             tok = mx.array([[last_bonus]], dtype=token_dtype)

--- a/mlx_vlm/speculative/drafters/gemma4_assistant/gemma4_assistant.py
+++ b/mlx_vlm/speculative/drafters/gemma4_assistant/gemma4_assistant.py
@@ -25,7 +25,9 @@ class _DraftInner(nn.Module):
     def __init__(self, text_config: TextConfig):
         super().__init__()
         self.config = text_config
-        self.embed_tokens = nn.Embedding(text_config.vocab_size, text_config.hidden_size)
+        self.embed_tokens = nn.Embedding(
+            text_config.vocab_size, text_config.hidden_size
+        )
         self.layers = [
             DecoderLayer(text_config, layer_idx=i, kv_shared_only=True)
             for i in range(text_config.num_hidden_layers)
@@ -130,9 +132,7 @@ class Gemma4AssistantDraftModel(nn.Module):
             # so the bare ``embed_tokens`` here returns *unscaled* vectors.
             # The drafter's ``pre_projection`` was trained against scaled
             # target embeddings, so we replicate the scale at call time.
-            self._input_embed_scale = float(
-                getattr(inner, "embed_scale", 1.0)
-            )
+            self._input_embed_scale = float(getattr(inner, "embed_scale", 1.0))
 
         # Stash the target's layer_types so the round-loop knows which keys
         # the drafter expects in shared_kv_states.
@@ -182,7 +182,11 @@ class Gemma4AssistantDraftModel(nn.Module):
         if isinstance(kv_offset, int):
             self._kv_offset = kv_offset
         else:
-            self._kv_offset = int(mx.array(kv_offset).max().item()) if not isinstance(kv_offset, mx.array) else int(kv_offset.max().item())
+            self._kv_offset = (
+                int(mx.array(kv_offset).max().item())
+                if not isinstance(kv_offset, mx.array)
+                else int(kv_offset.max().item())
+            )
         if position is None:
             position = kv_offset
         if isinstance(position, int):
@@ -243,8 +247,10 @@ class Gemma4AssistantDraftModel(nn.Module):
 
         h = self.model.norm(h)
         last_hidden = self.post_projection(h)
-        logits = self._lm_head_fn(h) if self._lm_head_fn is not None else (
-            self.model.embed_tokens.as_linear(h)
+        logits = (
+            self._lm_head_fn(h)
+            if self._lm_head_fn is not None
+            else (self.model.embed_tokens.as_linear(h))
         )
         return last_hidden, logits
 

--- a/mlx_vlm/speculative/drafters/gemma4_assistant/gemma4_assistant.py
+++ b/mlx_vlm/speculative/drafters/gemma4_assistant/gemma4_assistant.py
@@ -1,0 +1,274 @@
+from typing import Any, List, Optional, Tuple
+
+import mlx.core as mx
+import mlx.nn as nn
+from mlx.nn import RMSNorm
+
+from ....models.gemma4.config import TextConfig
+from ....models.gemma4.language import DecoderLayer
+from .config import Gemma4AssistantConfig
+from .masks import make_drafter_masks
+
+
+class _DraftInner(nn.Module):
+    """Minimal Gemma-4 text model holding the drafter's per-layer modules.
+
+    Mirrors ``mlx_vlm.models.gemma4.language.Gemma4TextModel`` weight-key
+    shape (``embed_tokens``, ``layers.{i}.*``, ``norm``) so the HF drafter
+    checkpoint loads as-is. Skips the target's KV-sharing/per-layer-input
+    bookkeeping — the drafter has its own forward in
+    ``Gemma4AssistantDraftModel.__call__`` and consumes ``shared_kv_states``
+    coming from the target rather than computing or sharing K/V internally.
+    """
+
+    def __init__(self, text_config: TextConfig):
+        super().__init__()
+        self.config = text_config
+        self.embed_tokens = nn.Embedding(text_config.vocab_size, text_config.hidden_size)
+        self.layers = [
+            DecoderLayer(text_config, layer_idx=i, kv_shared_only=True)
+            for i in range(text_config.num_hidden_layers)
+        ]
+        self.norm = RMSNorm(text_config.hidden_size, eps=text_config.rms_norm_eps)
+
+
+class Gemma4AssistantDraftModel(nn.Module):
+    """Gemma 4 Multi-Token Prediction drafter.
+
+    Surface mirrors ``DFlashDraftModel``: ``bind`` / ``make_cache`` /
+    ``reset`` / ``draft_block`` / ``__call__`` / ``sanitize`` / ``accept_lens``.
+    The drafter has no KV cache of its own — its recurrent state is the
+    ``post_projection``-projected hidden carried across draft steps.
+
+    ``draft_block``'s ``cache`` argument is repurposed to thread the
+    target's ``shared_kv_states`` dict into the drafter; the round-loop
+    in ``mlx_vlm/generate.py`` sets this via ``reset(target, shared_kv)``
+    before each block.
+    """
+
+    def __init__(self, config: Gemma4AssistantConfig):
+        super().__init__()
+        self.config = config
+        text_cfg = config.text_config
+        if text_cfg is None:
+            raise ValueError("Gemma4AssistantConfig.text_config must be set")
+
+        self.model = _DraftInner(text_cfg)
+        self.pre_projection = nn.Linear(
+            2 * config.backbone_hidden_size, text_cfg.hidden_size, bias=False
+        )
+        self.post_projection = nn.Linear(
+            text_cfg.hidden_size, config.backbone_hidden_size, bias=False
+        )
+        if not config.tie_word_embeddings:
+            self.lm_head = nn.Linear(
+                text_cfg.hidden_size, text_cfg.vocab_size, bias=False
+            )
+
+        # Bound at runtime via bind().
+        self._lm_head_fn = None
+        self._input_embed = None  # target's embed_tokens (backbone_hidden_size)
+        # Threaded by reset() / round-loop before each draft_block.
+        self._shared_kv: Optional[dict] = None
+        self._kv_offset: int = 0
+        self._position: int = 0
+
+        self.accept_lens: List[int] = []
+
+        if config.use_ordered_embeddings:
+            raise NotImplementedError(
+                "Gemma4Assistant `use_ordered_embeddings=True` (centroid LM "
+                "head) is not yet ported to mlx-vlm."
+            )
+
+    # ------------------------------------------------------------------
+    # binding / cache management
+    # ------------------------------------------------------------------
+    def bind(self, target_model) -> "Gemma4AssistantDraftModel":
+        """Wire input embeddings (target's, backbone_hidden_size) and lm_head
+        (drafter's tied, hidden_size).
+
+        Per the HF ``SinglePositionMultiTokenCandidateGenerator`` the input
+        pathway uses the *target*'s embed table (because ``inputs_embeds``
+        feeds into ``pre_projection`` which expects ``2 *
+        backbone_hidden_size``), while the LM head uses the drafter's own
+        tied embedding.
+        """
+        # LM head — drafter's own tied embed.
+        if self.config.tie_word_embeddings:
+            self._lm_head_fn = self.model.embed_tokens.as_linear
+        else:
+            self._lm_head_fn = self.lm_head
+
+        # Input embeddings — target's. Walk the standard wrappers.
+        inner = None
+        if hasattr(target_model, "embed_tokens"):
+            inner = target_model
+        elif hasattr(target_model, "model") and hasattr(
+            target_model.model, "embed_tokens"
+        ):
+            inner = target_model.model
+        elif (
+            hasattr(target_model, "language_model")
+            and hasattr(target_model.language_model, "model")
+            and hasattr(target_model.language_model.model, "embed_tokens")
+        ):
+            inner = target_model.language_model.model
+        if inner is not None:
+            self._input_embed = inner.embed_tokens
+
+        # Stash the target's layer_types so the round-loop knows which keys
+        # the drafter expects in shared_kv_states.
+        try:
+            tcfg = getattr(target_model, "language_model", target_model)
+            tcfg = getattr(tcfg, "config", None)
+            if tcfg is not None:
+                self.config.target_layer_types = list(tcfg.layer_types)
+        except Exception:
+            pass
+        return self
+
+    def make_cache(self) -> List:
+        """Drafter has no cache of its own."""
+        return []
+
+    def reset(self, target_model) -> List:
+        self.bind(target_model)
+        self.accept_lens = []
+        self._shared_kv = None
+        self._kv_offset = 0
+        return self.make_cache()
+
+    def set_shared_kv(
+        self,
+        shared_kv_states: dict,
+        kv_offset: int,
+        position: Optional[int] = None,
+    ) -> None:
+        """Threaded by the round-loop before each ``draft_block`` call.
+
+        ``kv_offset`` is the length of the target's KV cache (= number of
+        tokens already in the cache). ``position`` is the absolute
+        position id used for RoPE on the drafter's queries — defaults to
+        ``kv_offset - 1`` (the position of the last seen token), matching
+        the HF SinglePositionMultiToken behavior of holding position_ids
+        constant across draft steps.
+        """
+        self._shared_kv = shared_kv_states
+        self._kv_offset = int(kv_offset)
+        self._position = int(position) if position is not None else int(kv_offset) - 1
+
+    # ------------------------------------------------------------------
+    # forward
+    # ------------------------------------------------------------------
+    def __call__(
+        self,
+        inputs_embeds: mx.array,
+        shared_kv_states: dict,
+        position_ids: mx.array,
+        cache: Any = None,
+    ) -> Tuple[mx.array, mx.array]:
+        del cache  # drafter has no own KV cache
+        text_cfg = self.config.text_config
+
+        h = self.pre_projection(inputs_embeds)
+
+        query_len = h.shape[1]
+        query_offset = int(position_ids[0, 0].item())
+        masks = make_drafter_masks(
+            shared_kv_states,
+            query_len=query_len,
+            query_offset=query_offset,
+            sliding_window=text_cfg.sliding_window,
+            dtype=h.dtype,
+        )
+
+        # Drafter queries always live one slot past the end of the KV; the
+        # absolute position is what RoPE needs.
+        offset = mx.array(query_offset)
+
+        for layer in self.model.layers:
+            kv = shared_kv_states[layer.layer_type]
+            mask = masks[layer.layer_type]
+            h, _, _ = layer(
+                h,
+                mask=mask,
+                cache=None,
+                per_layer_input=None,
+                shared_kv=kv,
+                offset=offset,
+            )
+
+        h = self.model.norm(h)
+        last_hidden = self.post_projection(h)
+        logits = self._lm_head_fn(h) if self._lm_head_fn is not None else (
+            self.model.embed_tokens.as_linear(h)
+        )
+        return last_hidden, logits
+
+    # ------------------------------------------------------------------
+    # block drafting
+    # ------------------------------------------------------------------
+    def draft_block(
+        self,
+        last_bonus,
+        hidden: mx.array,
+        cache,
+        block_size: int,
+        sampler,
+        token_dtype: mx.Dtype = mx.int32,
+    ) -> mx.array:
+        """Autoregressive K-step drafting.
+
+        Returns an ``[B, block_size - 1]`` token tensor — drop-in
+        compatible with ``_speculative_walk(_batch)`` in ``generate.py``.
+        ``cache`` is unused (drafter has no own cache); ``shared_kv`` is
+        threaded via ``set_shared_kv`` before this call.
+
+        Mirrors HF ``SinglePositionMultiTokenCandidateGenerator``: input
+        is ``[target_embed(last_token), last_hidden_state]`` (in that
+        order), ``position_ids`` is held constant across all draft steps.
+        """
+        del cache
+        if self._shared_kv is None:
+            raise RuntimeError(
+                "set_shared_kv() must be called before draft_block(). "
+                "The round-loop in generate.py is responsible for this."
+            )
+        if self._input_embed is None:
+            raise RuntimeError(
+                "bind(target_model) must be called before draft_block() "
+                "so the drafter can use the target's input embeddings."
+            )
+        shared_kv = self._shared_kv
+        position_ids = mx.array([[self._position]])
+
+        if isinstance(last_bonus, int):
+            tok = mx.array([[last_bonus]], dtype=token_dtype)
+        else:
+            tok = last_bonus[:, None].astype(token_dtype)
+
+        h_prev = hidden  # [B, 1, backbone_hidden_size]
+        tokens: List[mx.array] = []
+
+        for _ in range(block_size - 1):
+            tok_embed = self._input_embed(tok)
+            inputs_embeds = mx.concatenate([tok_embed, h_prev], axis=-1)
+            h_prev, logits = self(inputs_embeds, shared_kv, position_ids)
+            tok = sampler(logits)  # [B, 1]
+            tokens.append(tok)
+
+        return mx.concatenate(tokens, axis=1)
+
+    # ------------------------------------------------------------------
+    # weight loading
+    # ------------------------------------------------------------------
+    def sanitize(self, weights: dict) -> dict:
+        out = {}
+        for k, v in weights.items():
+            # Drop any (rare) tied lm_head copy when we'll bind to the
+            # embedding's as_linear at runtime.
+            if k == "lm_head.weight" and self.config.tie_word_embeddings:
+                continue
+            out[k] = v
+        return out

--- a/mlx_vlm/speculative/drafters/gemma4_assistant/masked_embedder.py
+++ b/mlx_vlm/speculative/drafters/gemma4_assistant/masked_embedder.py
@@ -1,0 +1,87 @@
+"""Centroid-routed sparse LM head for Gemma 4 E2B / E4B drafters.
+
+Mirrors HF's ``Gemma4AssistantMaskedEmbedder``
+(``transformers/models/gemma4_assistant/modeling_gemma4_assistant.py:43``).
+
+Idea: rather than computing ``hidden @ embed.T`` over the full 262144-vocab
+(expensive for a tiny drafter with ``hidden_size=256``), the drafter learns a
+``centroids`` Linear that scores 2048 token clusters, and a ``token_ordering``
+buffer that maps each cluster to a contiguous block of canonical token IDs.
+At inference, the top-K clusters' tokens (typ. 32×128 = 4096 of 262144) are
+materialized and scored densely; the rest of the vocab is filled with a
+sentinel ``min - 1`` so it loses any argmax / sampling competition.
+"""
+
+from typing import Any
+
+import mlx.core as mx
+import mlx.nn as nn
+
+
+class MaskedEmbedder(nn.Module):
+    """Centroid-routed sparse softmax for the assistant drafter's LM head."""
+
+    def __init__(self, config: Any):
+        super().__init__()
+        text_cfg = config.text_config
+        self.hidden_size = text_cfg.hidden_size
+        self.vocab_size = text_cfg.vocab_size
+        self.num_centroids = config.num_centroids
+        self.top_k = config.centroid_intermediate_top_k
+        self.vocab_size_per_centroid = self.vocab_size // self.num_centroids
+
+        self.centroids = nn.Linear(self.hidden_size, self.num_centroids, bias=False)
+        # ``token_ordering[c * vocab_size_per_centroid : (c+1) * vocab_size_per_centroid]``
+        # holds the canonical token IDs assigned to centroid ``c``.
+        # Loaded from checkpoint as int64; cast to int32 for indexing.
+        self.token_ordering = mx.zeros((self.vocab_size,), dtype=mx.int32)
+
+    def __call__(self, hidden_states: mx.array, lm_head_weight: mx.array) -> mx.array:
+        """Compute sparse logits over the full vocab.
+
+        ``hidden_states``: ``[B, L, hidden_size]``.
+        ``lm_head_weight``: ``[vocab_size, hidden_size]`` (tied to the drafter's
+        ``embed_tokens.weight``).
+        Returns: ``[B, L, vocab_size]`` with non-selected positions masked
+        to ``min(selected_logits) - 1``.
+        """
+        B, L = hidden_states.shape[:2]
+
+        # Cluster scores → top-K cluster indices.
+        centroid_logits = self.centroids(hidden_states)  # [B, L, num_centroids]
+        topk_idx = mx.argpartition(
+            centroid_logits, kth=-self.top_k, axis=-1
+        )[..., -self.top_k :]  # [B, L, top_k]
+
+        # Reshape token_ordering to [num_centroids, vocab_size_per_centroid].
+        ordering = self.token_ordering.reshape(
+            self.num_centroids, self.vocab_size_per_centroid
+        )
+
+        # For each selected cluster, fetch its canonical token IDs.
+        # selected_canonical: [B, L, top_k, vocab_size_per_centroid]
+        selected_canonical = ordering[topk_idx]
+
+        # Gather embeddings: lm_head_weight[selected_canonical] → [B, L, top_k * vsc, hidden]
+        flat_idx = selected_canonical.reshape(-1)
+        selected_emb = lm_head_weight[flat_idx].reshape(
+            B, L, self.top_k * self.vocab_size_per_centroid, self.hidden_size
+        )
+
+        # selected_logits = (h @ E.T)
+        selected_logits = mx.matmul(
+            hidden_states[..., None, :],  # [B, L, 1, hidden]
+            selected_emb.swapaxes(-1, -2),  # [B, L, hidden, top_k*vsc]
+        ).squeeze(-2)  # [B, L, top_k*vsc]
+
+        mask_value = float(selected_logits.min().item()) - 1.0
+
+        # Scatter selected_logits into a full-vocab tensor at canonical positions.
+        scatter_idx = selected_canonical.reshape(B, L, -1)  # [B, L, top_k*vsc]
+        out = mx.full(
+            (B, L, self.vocab_size),
+            vals=mask_value,
+            dtype=hidden_states.dtype,
+        )
+        # mlx.put_along_axis writes ``src`` at ``index`` along ``axis``.
+        return mx.put_along_axis(out, scatter_idx, selected_logits, axis=-1)

--- a/mlx_vlm/speculative/drafters/gemma4_assistant/masked_embedder.py
+++ b/mlx_vlm/speculative/drafters/gemma4_assistant/masked_embedder.py
@@ -49,9 +49,9 @@ class MaskedEmbedder(nn.Module):
 
         # Cluster scores → top-K cluster indices.
         centroid_logits = self.centroids(hidden_states)  # [B, L, num_centroids]
-        topk_idx = mx.argpartition(
-            centroid_logits, kth=-self.top_k, axis=-1
-        )[..., -self.top_k :]  # [B, L, top_k]
+        topk_idx = mx.argpartition(centroid_logits, kth=-self.top_k, axis=-1)[
+            ..., -self.top_k :
+        ]  # [B, L, top_k]
 
         # Reshape token_ordering to [num_centroids, vocab_size_per_centroid].
         ordering = self.token_ordering.reshape(
@@ -72,7 +72,9 @@ class MaskedEmbedder(nn.Module):
         selected_logits = mx.matmul(
             hidden_states[..., None, :],  # [B, L, 1, hidden]
             selected_emb.swapaxes(-1, -2),  # [B, L, hidden, top_k*vsc]
-        ).squeeze(-2)  # [B, L, top_k*vsc]
+        ).squeeze(
+            -2
+        )  # [B, L, top_k*vsc]
 
         mask_value = float(selected_logits.min().item()) - 1.0
 

--- a/mlx_vlm/speculative/drafters/gemma4_assistant/masks.py
+++ b/mlx_vlm/speculative/drafters/gemma4_assistant/masks.py
@@ -1,0 +1,75 @@
+"""Bidirectional attention-mask helpers for the Gemma 4 MTP drafter.
+
+The drafter attends from L query positions (placed just past the end of the
+target's KV cache) over the target's last-layer K/V — bidirectionally for
+both full-attention and sliding-window layers. For the unbatched MVP
+(B=1, no padding), the masks degenerate to either ``None`` (full attention,
+SDPA handles it) or a small additive bias for SWA layers when the KV is
+longer than the sliding window.
+"""
+
+from typing import Optional, Tuple
+
+import mlx.core as mx
+
+
+def bidirectional_full_mask(
+    query_len: int,
+    kv_len: int,
+    dtype: mx.Dtype = mx.float32,
+) -> Optional[mx.array]:
+    """No-op for unbatched, no-padding case — SDPA treats ``None`` as fully
+    attending."""
+    del query_len, kv_len, dtype
+    return None
+
+
+def bidirectional_swa_mask(
+    query_len: int,
+    query_offset: int,
+    kv_len: int,
+    window: int,
+    dtype: mx.Dtype = mx.float32,
+) -> Optional[mx.array]:
+    """Bidirectional sliding-window mask.
+
+    For each query position ``q ∈ [query_offset, query_offset + query_len)``,
+    allow attention to KV positions ``k ∈ (q - window, q + window)``.
+    Returns ``None`` when no masking is needed (the entire KV fits in the
+    bidirectional window of every query).
+    """
+    if kv_len <= window and query_offset + query_len <= kv_len + window:
+        return None
+
+    q_idx = mx.arange(query_offset, query_offset + query_len)[:, None]
+    k_idx = mx.arange(kv_len)[None, :]
+    dist = q_idx - k_idx
+    inside = (dist > -window) & (dist < window)
+    # SDPA expects an additive mask broadcastable to (B, H, L, S).
+    bias = mx.where(inside, mx.array(0.0, dtype=dtype), mx.array(-mx.inf, dtype=dtype))
+    return bias[None, None, :, :]
+
+
+def make_drafter_masks(
+    shared_kv_states: dict,
+    query_len: int,
+    query_offset: int,
+    sliding_window: int,
+    dtype: mx.Dtype = mx.float32,
+) -> dict:
+    """Build masks per layer-type for the drafter forward."""
+    masks = {}
+    for layer_type, kv in shared_kv_states.items():
+        kv_len = _kv_len(kv)
+        if layer_type == "sliding_attention":
+            masks[layer_type] = bidirectional_swa_mask(
+                query_len, query_offset, kv_len, sliding_window, dtype
+            )
+        else:
+            masks[layer_type] = bidirectional_full_mask(query_len, kv_len, dtype)
+    return masks
+
+
+def _kv_len(kv: Tuple[mx.array, mx.array]) -> int:
+    K, _ = kv
+    return int(K.shape[-2])

--- a/mlx_vlm/speculative/drafters/gemma4_assistant/parity_check.py
+++ b/mlx_vlm/speculative/drafters/gemma4_assistant/parity_check.py
@@ -24,8 +24,15 @@ def main():
     cfg = model.config
     text_cfg = cfg.text_config
 
-    # No real target — fake the bind() outputs.
-    model._lm_head_fn = model.model.embed_tokens.as_linear
+    # No real target — fake the bind() outputs. Route lm_head through the
+    # centroid head when present (E2B / E4B) so this exercises the same path
+    # real generation uses; otherwise fall back to the tied embed.
+    if model.masked_embedding is not None:
+        embed_w = model.model.embed_tokens.weight
+        masked = model.masked_embedding
+        model._lm_head_fn = lambda h: masked(h, embed_w)
+    else:
+        model._lm_head_fn = model.model.embed_tokens.as_linear
     model._input_embed = _FakeTargetEmbed(
         text_cfg.vocab_size, cfg.backbone_hidden_size
     )
@@ -41,12 +48,9 @@ def main():
 
     kv_len = 32
     # Provide one dict per layer-type. Use the global head dim for full
-    # attention layers when present.
-    full_head = (
-        text_cfg.global_head_dim
-        if text_cfg.attention_k_eq_v and text_cfg.global_head_dim
-        else text_cfg.head_dim
-    )
+    # attention layers when present (the model code gates on layer_type ==
+    # "full_attention" + global_head_dim, regardless of ``attention_k_eq_v``).
+    full_head = text_cfg.global_head_dim or text_cfg.head_dim
 
     def _kv(seq_len: int, head_dim: int):
         return (

--- a/mlx_vlm/speculative/drafters/gemma4_assistant/parity_check.py
+++ b/mlx_vlm/speculative/drafters/gemma4_assistant/parity_check.py
@@ -33,9 +33,7 @@ def main():
         model._lm_head_fn = lambda h: masked(h, embed_w)
     else:
         model._lm_head_fn = model.model.embed_tokens.as_linear
-    model._input_embed = _FakeTargetEmbed(
-        text_cfg.vocab_size, cfg.backbone_hidden_size
-    )
+    model._input_embed = _FakeTargetEmbed(text_cfg.vocab_size, cfg.backbone_hidden_size)
 
     B = 1
     block = cfg.block_size
@@ -60,7 +58,9 @@ def main():
 
     shared_kv = {
         "full_attention": _kv(kv_len, full_head),
-        "sliding_attention": _kv(min(kv_len, text_cfg.sliding_window), text_cfg.head_dim),
+        "sliding_attention": _kv(
+            min(kv_len, text_cfg.sliding_window), text_cfg.head_dim
+        ),
     }
     model.set_shared_kv(shared_kv, kv_offset=kv_len)
 

--- a/mlx_vlm/speculative/drafters/gemma4_assistant/parity_check.py
+++ b/mlx_vlm/speculative/drafters/gemma4_assistant/parity_check.py
@@ -1,0 +1,92 @@
+import argparse
+
+import mlx.core as mx
+import mlx.nn as nn
+
+from ...drafters import load_drafter
+
+
+class _FakeTargetEmbed(nn.Module):
+    def __init__(self, vocab_size: int, backbone_hidden_size: int):
+        super().__init__()
+        self.weight = mx.random.normal((vocab_size, backbone_hidden_size)) * 0.02
+
+    def __call__(self, ids: mx.array) -> mx.array:
+        return self.weight[ids]
+
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument("--drafter", default="gg-hf-am/gemma-4-26B-A4B-it-assistant")
+    args = p.parse_args()
+
+    model = load_drafter(args.drafter, kind="mtp")
+    cfg = model.config
+    text_cfg = cfg.text_config
+
+    # No real target — fake the bind() outputs.
+    model._lm_head_fn = model.model.embed_tokens.as_linear
+    model._input_embed = _FakeTargetEmbed(
+        text_cfg.vocab_size, cfg.backbone_hidden_size
+    )
+
+    B = 1
+    block = cfg.block_size
+    backbone = cfg.backbone_hidden_size
+    h_dim = text_cfg.hidden_size
+    n_kv_heads = (
+        text_cfg.num_global_key_value_heads
+        if text_cfg.attention_k_eq_v and text_cfg.num_global_key_value_heads
+        else text_cfg.num_key_value_heads
+    )
+
+    kv_len = 32
+    # Provide one dict per layer-type. Use the global head dim for full
+    # attention layers when present.
+    full_head = (
+        text_cfg.global_head_dim
+        if text_cfg.attention_k_eq_v and text_cfg.global_head_dim
+        else text_cfg.head_dim
+    )
+
+    def _kv(seq_len: int, head_dim: int):
+        return (
+            mx.random.normal((B, n_kv_heads, seq_len, head_dim)) * 0.02,
+            mx.random.normal((B, n_kv_heads, seq_len, head_dim)) * 0.02,
+        )
+
+    shared_kv = {
+        "full_attention": _kv(kv_len, full_head),
+        "sliding_attention": _kv(min(kv_len, text_cfg.sliding_window), text_cfg.head_dim),
+    }
+    model.set_shared_kv(shared_kv, kv_offset=kv_len)
+
+    # Single forward smoke
+    inputs_embeds = mx.random.normal((B, 1, 2 * backbone)) * 0.02
+    position_ids = mx.array([[kv_len]])
+    h, logits = model(inputs_embeds, shared_kv, position_ids)
+    mx.eval(h, logits)
+    print(
+        f"forward OK: logits shape={tuple(logits.shape)} "
+        f"hidden shape={tuple(h.shape)} "
+        f"mean={float(logits.mean()):.5f} std={float(logits.std()):.5f}"
+    )
+
+    # Multi-step draft_block smoke
+    def _greedy(x):
+        return mx.argmax(x[:, -1:, :], axis=-1).astype(mx.int32)
+
+    drafted = model.draft_block(
+        last_bonus=42,
+        hidden=mx.random.normal((B, 1, backbone)) * 0.02,
+        cache=None,
+        block_size=block,
+        sampler=_greedy,
+        token_dtype=mx.int32,
+    )
+    mx.eval(drafted)
+    print(f"draft_block OK: tokens shape={tuple(drafted.shape)} dtype={drafted.dtype}")
+
+
+if __name__ == "__main__":
+    main()

--- a/mlx_vlm/speculative/drafters/gemma4_assistant/parity_check.py
+++ b/mlx_vlm/speculative/drafters/gemma4_assistant/parity_check.py
@@ -33,7 +33,6 @@ def main():
     B = 1
     block = cfg.block_size
     backbone = cfg.backbone_hidden_size
-    h_dim = text_cfg.hidden_size
     n_kv_heads = (
         text_cfg.num_global_key_value_heads
         if text_cfg.attention_k_eq_v and text_cfg.num_global_key_value_heads

--- a/uv.lock
+++ b/uv.lock
@@ -926,29 +926,6 @@ wheels = [
 ]
 
 [[package]]
-name = "llguidance"
-version = "1.7.3"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f0/1b/d23007f94b74a8465a8a12602579aca5f9cf4bf868dab5fd5b2d61a233ee/llguidance-1.7.3.tar.gz", hash = "sha256:b97ba454c723d70d3b036dea7ef7f2de376d0bd81ab3d99502cc1efe373b03ec", size = 1153440, upload-time = "2026-04-20T21:15:08.781Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/2c/f1/818e93b059bf00219cfcaa1157b176492e03a5f488cfe159566f7e6e5fde/llguidance-1.7.3-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:e2eeeeb54bb033bc070c828eba6a0644644756a6e4ce4898d5cd79caf2462390", size = 3240288, upload-time = "2026-04-20T21:14:42.984Z" },
-    { url = "https://files.pythonhosted.org/packages/6b/c9/896f56f36673b230d32af473d957dfd8e979d66879ebf2eaf699257f572f/llguidance-1.7.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:fe42358c2fb476b69789c555743e0d12fb354d6ddf8bbd2c669c710ee4e2cbb2", size = 3144890, upload-time = "2026-04-20T21:14:44.868Z" },
-    { url = "https://files.pythonhosted.org/packages/6c/ea/ddc889167111d00a91cb4f9b6cbc9e451786439a13c5522b01be479ae01c/llguidance-1.7.3-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:fc74a9390418d9a2ed7811f243eb1417842aa23a850233914311a51bbcea29ee", size = 3470103, upload-time = "2026-04-20T21:14:46.624Z" },
-    { url = "https://files.pythonhosted.org/packages/d4/f3/79db5a135f5d587d0f589004e2352f77f127cc92db352dba3904685ad88b/llguidance-1.7.3-cp314-cp314t-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7c578a077a7b87c9ef57717dc9fa61513cbb3ebb30c5b58acd0c18b2fb627187", size = 3760709, upload-time = "2026-04-20T21:14:48.191Z" },
-    { url = "https://files.pythonhosted.org/packages/0d/42/9542dae2efcbd83940bd9dbe7b65ad09342608d509535835c005b32d0a0a/llguidance-1.7.3-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1cbf32aa6cfbf0fefde5b8ea98903b1c29f4ac8216c082c740f7592618fff7f8", size = 3490209, upload-time = "2026-04-20T21:14:50.138Z" },
-    { url = "https://files.pythonhosted.org/packages/db/3a/fd453c7df03633f35c0e6ef4b9679df28ea6cd9983e4480710b710d2f834/llguidance-1.7.3-cp314-cp314t-win32.whl", hash = "sha256:d3ae30aa74ebb9727ad2649fbcdabf55c6dd4c7dd424094539f8508d780f70e8", size = 2600881, upload-time = "2026-04-20T21:14:51.636Z" },
-    { url = "https://files.pythonhosted.org/packages/bd/7d/82ca82290f80a89de9fb6d64f9208917e13aa0a114619ffea0647c1cdbe6/llguidance-1.7.3-cp314-cp314t-win_amd64.whl", hash = "sha256:418f34ff6e1ec96cab89b13dcc15b1a696eb36aba90fe49e3fa06b593ddedb28", size = 2867893, upload-time = "2026-04-20T21:14:53.493Z" },
-    { url = "https://files.pythonhosted.org/packages/29/19/31349c112f1dd62e2e1613dd5fee10419fd67ca3497332b802fc98a9b4f6/llguidance-1.7.3-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:d441049d75286f60d55b28a73483ad02ffb742ef9b33ac8efa98b29c698897ec", size = 3248781, upload-time = "2026-04-20T21:14:55.023Z" },
-    { url = "https://files.pythonhosted.org/packages/a7/d6/e8a6b4a17a0ddcd19dd522bc0e479939d3775456ba15116fc8cf51a3b1b0/llguidance-1.7.3-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:76aced208b63d732f15cc848765023c9e91e492f80ed3458b407f023a07761ff", size = 3149797, upload-time = "2026-04-20T21:14:56.9Z" },
-    { url = "https://files.pythonhosted.org/packages/31/c5/dc9156786739a267978b0b5e593b1d61e92db97f76b00794f625def8a176/llguidance-1.7.3-cp39-abi3-manylinux_2_31_aarch64.whl", hash = "sha256:1a35f8296159d7cecc488e702f698658da4b6a0eeca421f1f1bf1349d00bb0c7", size = 2891142, upload-time = "2026-04-20T21:14:58.747Z" },
-    { url = "https://files.pythonhosted.org/packages/4f/c5/4564d131a02caefcf4876c26c33d05a35fddf53980b4c86fce31fdb27088/llguidance-1.7.3-cp39-abi3-manylinux_2_31_x86_64.whl", hash = "sha256:50dd687a5d944c898dfe66af7af86c7591a0425fe84c4862b8f5549582106732", size = 3083627, upload-time = "2026-04-20T21:15:00.592Z" },
-    { url = "https://files.pythonhosted.org/packages/4b/05/201350217c781d6ad131af4fbb5644a551de1b9012a734bccc44300495f9/llguidance-1.7.3-cp39-abi3-manylinux_2_34_i686.whl", hash = "sha256:87b2019ff00b463558f6731b82246095bab202c45291a6038933bc75efbc674a", size = 3341351, upload-time = "2026-04-20T21:15:02.243Z" },
-    { url = "https://files.pythonhosted.org/packages/97/50/f89f4ba15ead1e472ace2b919adf28e9fb88334f6c5796e46ee1937def7c/llguidance-1.7.3-cp39-abi3-manylinux_2_39_riscv64.whl", hash = "sha256:0ca0ba2985a09a74c6572d72d0f1885c90f01276b079f32ab0fbe41818dfc955", size = 3611737, upload-time = "2026-04-20T21:15:04.264Z" },
-    { url = "https://files.pythonhosted.org/packages/59/b2/bd822432b8be03cc610790708ba6516a02dd4d1090f3dad95c74d8cdc77b/llguidance-1.7.3-cp39-abi3-win32.whl", hash = "sha256:ff5c6e16727fb1d72609600b8ec94023a57a13799583b9ca77f8de56c4425df9", size = 2613685, upload-time = "2026-04-20T21:15:05.738Z" },
-    { url = "https://files.pythonhosted.org/packages/3e/97/2a488c3e696e3fb22e0bc5e07248736626f7ad92c0caf9d88dbc7866c6bd/llguidance-1.7.3-cp39-abi3-win_amd64.whl", hash = "sha256:c2f3d5f369fb74dc7ecdc4f686b15ec5522c6b81a903024078f9a6ab9b2dc1f4", size = 2873297, upload-time = "2026-04-20T21:15:07.451Z" },
-]
-
-[[package]]
 name = "markdown-it-py"
 version = "4.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1096,37 +1073,37 @@ wheels = [
 
 [[package]]
 name = "mlx"
-version = "0.31.1"
+version = "0.31.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "mlx-metal", marker = "sys_platform == 'darwin'" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9b/f9/f1663dafd45af02467f4f41777c13ec34b9104b2b0450d870c3f906285cd/mlx-0.31.1-cp310-cp310-macosx_14_0_arm64.whl", hash = "sha256:bc46c911cc060d2eaf21b9e24a1712dc56763b660b53631b9057a32ab1c0271a", size = 574137, upload-time = "2026-03-12T02:15:54.996Z" },
-    { url = "https://files.pythonhosted.org/packages/c6/26/1fd632f537a5160a21475a70aaef252090c62f9629f45ad20f5acfe810f3/mlx-0.31.1-cp310-cp310-macosx_15_0_arm64.whl", hash = "sha256:fa132def5b3d959362077521c80f1fc80f64c45060d2940dc1d66a1aa19ce5f6", size = 574140, upload-time = "2026-03-12T02:15:56.709Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/c9/e790fa8ddc1b27fea7ba749699883f31c65e166b18e4598beab4574e4686/mlx-0.31.1-cp310-cp310-macosx_26_0_arm64.whl", hash = "sha256:877ff2f98debd035b922825a0d7e7e1be0959fc5ca1d24cb5020a23e510ff16d", size = 574124, upload-time = "2026-03-12T02:15:58.323Z" },
-    { url = "https://files.pythonhosted.org/packages/b4/da/f7375fc2be05d026640c5ced085a9e71066a33100638e5762347dae5d680/mlx-0.31.1-cp310-cp310-manylinux_2_35_aarch64.whl", hash = "sha256:931c9316ec47b45ec0e737519f4f4c90eb69cbbdaaecadd6dd2ccdf1a85d4e61", size = 641428, upload-time = "2026-03-12T02:15:59.743Z" },
-    { url = "https://files.pythonhosted.org/packages/1c/3f/ab060661d966d435e41212d4f6d6e9d1202da8b9043b1c18c343ab7d1b08/mlx-0.31.1-cp310-cp310-manylinux_2_35_x86_64.whl", hash = "sha256:dec00ce7b094d6bc2876996291fd76c9e28326bc1a9853440903f2a06946ce1f", size = 674521, upload-time = "2026-03-12T02:16:01.057Z" },
-    { url = "https://files.pythonhosted.org/packages/75/32/25dc2eae1d6f867224ef2bca2c644e3e913fe8067991f8394c090b720e3e/mlx-0.31.1-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:8863835fb36c7c4f65008b1426ddb9ff7931a13c975e0ef58a40002ae8048922", size = 574311, upload-time = "2026-03-12T02:16:02.651Z" },
-    { url = "https://files.pythonhosted.org/packages/9b/bf/c5aa1d1154f5a216139c8162cd3e6568b7eb427390d655f7f5ae3a1a61e7/mlx-0.31.1-cp311-cp311-macosx_15_0_arm64.whl", hash = "sha256:0de504c1f1fe73b32fc3cf457b8eac30d1f7ce22440ef075c1970f96712e6fff", size = 574312, upload-time = "2026-03-12T02:16:04.231Z" },
-    { url = "https://files.pythonhosted.org/packages/3a/88/ef57747552c9e9da0c28465d9266c05a0009b698d90fb0bc63eb81840b8d/mlx-0.31.1-cp311-cp311-macosx_26_0_arm64.whl", hash = "sha256:10715b895e1f3e984c2c54257b7db956ff8af1fa93255412794a3724fe2dd3b1", size = 574385, upload-time = "2026-03-12T02:16:05.528Z" },
-    { url = "https://files.pythonhosted.org/packages/ac/51/dbea4bbe7a2e4cd05226965b34198d49459cfaef8b9b37b72f006a9811ab/mlx-0.31.1-cp311-cp311-manylinux_2_35_aarch64.whl", hash = "sha256:d065625ab3101adcd7f5824297243fe40a0615099a06f5597ab67284483aa2f8", size = 641347, upload-time = "2026-03-12T02:16:07.013Z" },
-    { url = "https://files.pythonhosted.org/packages/c5/86/3db98e8805637fb56f078311d622e9500f5c9088f6d79a6e304ec8235b47/mlx-0.31.1-cp311-cp311-manylinux_2_35_x86_64.whl", hash = "sha256:b2cf8502d9d64dc6851034fcd4a656cbb26be20c36f190f2971f4ac0caed89cb", size = 674769, upload-time = "2026-03-12T02:16:08.51Z" },
-    { url = "https://files.pythonhosted.org/packages/38/29/71fe1f68756f515856e6930973c23245810d4aa3cd22fddd719d86a709dc/mlx-0.31.1-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:8a63b31a398c9519f2bb0c81cf3865d9baca4ff573ffc31ead465d18286184e8", size = 574308, upload-time = "2026-03-12T02:16:10.256Z" },
-    { url = "https://files.pythonhosted.org/packages/21/be/70654a2cee0d71fd10bd237a50a79d06ae51679a194db6a3b16c0c84e6a5/mlx-0.31.1-cp312-cp312-macosx_15_0_arm64.whl", hash = "sha256:a7a9347df4dcc41f0d16ff70b65650820af4879f686534b233b16826a22afa00", size = 574309, upload-time = "2026-03-12T02:16:11.577Z" },
-    { url = "https://files.pythonhosted.org/packages/ad/69/c7bc7b04f76b0cbd678f328011d1634bd0bcfc2da45aba06e084cb031127/mlx-0.31.1-cp312-cp312-macosx_26_0_arm64.whl", hash = "sha256:6cdb797ea31787d1ce9e5be77991c4bd5cbf129ab15f7253b78e09737f535fce", size = 574289, upload-time = "2026-03-12T02:16:13.146Z" },
-    { url = "https://files.pythonhosted.org/packages/55/f7/dcc129228faab4d406041d91413c5999250ab79da6fe5417ac84f1616ff1/mlx-0.31.1-cp312-cp312-manylinux_2_35_aarch64.whl", hash = "sha256:1ed1991c8e39f841d5756c0c543beb819763a2f80fba3f4b150bc6cad4d973de", size = 626439, upload-time = "2026-03-12T02:16:14.741Z" },
-    { url = "https://files.pythonhosted.org/packages/90/1d/8b32e46ea98ab5c1c15cf1b37ac97af651977f84e72e1800412a700c51d9/mlx-0.31.1-cp312-cp312-manylinux_2_35_x86_64.whl", hash = "sha256:195c5cb27328380287c0ffe9ef48f860ab75ec5d3dfce153d475dc2c99369708", size = 668679, upload-time = "2026-03-12T02:16:16.012Z" },
-    { url = "https://files.pythonhosted.org/packages/44/45/04465da443634b23fb11670bbd2f7538b1ed43ffc5e0de44a95b3c29e9c1/mlx-0.31.1-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:9a6d3410fc951bd28508fed9c1ab5d9903f6f6bb101c3a5d63d4191d49a384a1", size = 574268, upload-time = "2026-03-12T02:16:17.27Z" },
-    { url = "https://files.pythonhosted.org/packages/85/7b/84956960356ff36e8c1bbed68fac96709e98e6a1adbc8e3d0ff71022d84e/mlx-0.31.1-cp313-cp313-macosx_15_0_arm64.whl", hash = "sha256:20bd7ba19882603ac22711092d0e799f1ff7b5183c2c641d417dab4d2423d99e", size = 574265, upload-time = "2026-03-12T02:16:18.479Z" },
-    { url = "https://files.pythonhosted.org/packages/86/01/d6f0ef5b8c0b390af08246d1301e9717dfb076b3920012b53105a888ed8c/mlx-0.31.1-cp313-cp313-macosx_26_0_arm64.whl", hash = "sha256:4c4565d6f4f8ce295613ee342d313ee5ab0b0eab9a6272954450f8343f7876bc", size = 574172, upload-time = "2026-03-12T02:16:19.898Z" },
-    { url = "https://files.pythonhosted.org/packages/df/05/eb29e9eb0cff9c7dfd872e26663e6e9512629730740e1db629086c80ac5a/mlx-0.31.1-cp313-cp313-manylinux_2_35_aarch64.whl", hash = "sha256:9dc564a8b38b9aec279a1c7d34551068b1cc1f8e43b5ac044b56b2a9a4205195", size = 626558, upload-time = "2026-03-12T02:16:21.652Z" },
-    { url = "https://files.pythonhosted.org/packages/25/45/ecb746fbb6acb75d03760e41cc7bd21c2e2b544528b3033f7d70402334ac/mlx-0.31.1-cp313-cp313-manylinux_2_35_x86_64.whl", hash = "sha256:78f51ab929278366006ee7793dbb5c942b121542c793c33eb9b894a2ce8e27e1", size = 668625, upload-time = "2026-03-12T02:16:23.103Z" },
-    { url = "https://files.pythonhosted.org/packages/99/65/208f511acd5fb1ed0b08f047bd6229583845cc6f4b5aa6547a3219332dbb/mlx-0.31.1-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:bba9d471ba20e050676292b1089a355c8042d3fc9462e4c1738a9735d7d40cfa", size = 576300, upload-time = "2026-03-12T02:16:24.545Z" },
-    { url = "https://files.pythonhosted.org/packages/98/58/2d925cb3fa3cd28d279ed6f44508ab7fbbf7359b17359914aa3652a7d734/mlx-0.31.1-cp314-cp314-macosx_15_0_arm64.whl", hash = "sha256:d90b0529b22553eb1353b113b7233aa391ca55e24b1ba69024c732fcc21c5c49", size = 576303, upload-time = "2026-03-12T02:16:26.283Z" },
-    { url = "https://files.pythonhosted.org/packages/e1/17/abec0bd0f9347dae13e60b33325cb199312798842901953495e19f3bb3c8/mlx-0.31.1-cp314-cp314-macosx_26_0_arm64.whl", hash = "sha256:69bc88b41ddd61b44cd6a4d417790f9971ba3fdf58d824934cea95a95b9b4031", size = 576275, upload-time = "2026-03-12T02:16:27.57Z" },
-    { url = "https://files.pythonhosted.org/packages/a2/91/85c73f7cc3a661416d05315623458c719eda7de958b05f4e10ba40c52d07/mlx-0.31.1-cp314-cp314-manylinux_2_35_aarch64.whl", hash = "sha256:b973506fd49ba39df6dc4ff655b77bd35ea193cee878e71d6ee3d1a951d2b3a6", size = 628701, upload-time = "2026-03-12T02:16:28.949Z" },
-    { url = "https://files.pythonhosted.org/packages/7d/e9/d87638e00a44dcf346fe838caaf1e2dae96a88d5779edbd66ce27d4bbdcc/mlx-0.31.1-cp314-cp314-manylinux_2_35_x86_64.whl", hash = "sha256:3987282a1e63252bdd7c636138812c67316c3f7c7a7acad08e76c8843648a056", size = 668959, upload-time = "2026-03-12T02:16:30.41Z" },
+    { url = "https://files.pythonhosted.org/packages/29/7c/c16d52494a1ba6d90443f31fa26bc810bf878d532dfa9a7a13f49ef9542d/mlx-0.31.2-cp310-cp310-macosx_14_0_arm64.whl", hash = "sha256:b29cf940f34205f09bb552ac60465ae833c4ae640b52777c6d725ddbad8461ca", size = 586942, upload-time = "2026-04-22T03:14:21.97Z" },
+    { url = "https://files.pythonhosted.org/packages/74/da/1c7f3dc39b7bda65b0cafbaf1e58a35eea118622c6f4506c9a4294c9806e/mlx-0.31.2-cp310-cp310-macosx_15_0_arm64.whl", hash = "sha256:ebdc47b87b4b0216ceab3b5961716804bba3107c16454b65ae51d0e0c059f298", size = 586942, upload-time = "2026-04-22T03:14:23.527Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/e9/a8559389706d39f613620a8b6b42ed03cf3155a516b0762d355c5116fdab/mlx-0.31.2-cp310-cp310-macosx_26_0_arm64.whl", hash = "sha256:2a64db61b2840f28bae08354e6f999698e30381af201cc12354290673c96213b", size = 586804, upload-time = "2026-04-22T03:14:24.882Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/4a/274ebee3783a37560cddc8e781ec3eefadd17f3f85a7dcd5df6f07d200d6/mlx-0.31.2-cp310-cp310-manylinux_2_35_aarch64.whl", hash = "sha256:e3e2818157371501de097887f371784227f9dd9c91e177f986db7b25319c55d7", size = 653252, upload-time = "2026-04-22T03:14:26.275Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/c7/79283370001660102f5c5c772b649f69da02113609d927af35e747508320/mlx-0.31.2-cp310-cp310-manylinux_2_35_x86_64.whl", hash = "sha256:c71dff00cc1b363d542f111d9e8b7b59dadb65b29d027f798b71ea34da75b665", size = 692109, upload-time = "2026-04-22T03:14:28.05Z" },
+    { url = "https://files.pythonhosted.org/packages/94/89/1e77ec3ff380e8fb9e7258047374d31452a0f9828a0e370f127b07dd8288/mlx-0.31.2-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:4a3f181b367d404e44a6bd68ef5eb573930809ac60cacd51d0c851c629b1b651", size = 586911, upload-time = "2026-04-22T03:14:29.675Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/41/c1907f05f8a3fc54025fb78ad68d3c4a4b931664d03c0a24f7f431cc4087/mlx-0.31.2-cp311-cp311-macosx_15_0_arm64.whl", hash = "sha256:70297cbef7479429f69c966bfed10da20a6f0c2aa997eec2b4f6ba1a07caf2ef", size = 586915, upload-time = "2026-04-22T03:14:31.403Z" },
+    { url = "https://files.pythonhosted.org/packages/97/b0/61ac2c14773c786fecbda28067b0207a0c654cb4d10c548808c51284d700/mlx-0.31.2-cp311-cp311-macosx_26_0_arm64.whl", hash = "sha256:c0ff158b7ac93a4b5659adbc70053498b30a5964fc45f78596398e056a96c36a", size = 587030, upload-time = "2026-04-22T03:14:32.961Z" },
+    { url = "https://files.pythonhosted.org/packages/de/53/e12feb7078ee472983555fcb1da4749a2bbbc8fc5b29b78c205b96d37d1e/mlx-0.31.2-cp311-cp311-manylinux_2_35_aarch64.whl", hash = "sha256:cd5d42b0b2bee7efe1b0680a7e302943dd33b92c879cffa0358ffdb5a4a8d27b", size = 652994, upload-time = "2026-04-22T03:14:34.691Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/40/f92c8cdc9595bf24c7e483a3156bfe0cc99a5cf5545d8dba8e7fe000c10b/mlx-0.31.2-cp311-cp311-manylinux_2_35_x86_64.whl", hash = "sha256:b368f7ede4238cc44076e4843820338c453c21ee50bd3ee26d4b182c179fd8e1", size = 692086, upload-time = "2026-04-22T03:14:36.45Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/47/5f33906cb03d6a378a697cd2d2641a26b37dea17ee3d9124d7e39e8eca01/mlx-0.31.2-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:e5067aaf2be1f3d7bba5be52348775804f111173c1ed04639618fd713b1a530f", size = 584863, upload-time = "2026-04-22T03:14:38.211Z" },
+    { url = "https://files.pythonhosted.org/packages/08/e7/a851a451b1327af9fb4df3991b9ae87d066b6f6630e854af55c288b0995a/mlx-0.31.2-cp312-cp312-macosx_15_0_arm64.whl", hash = "sha256:edb9797db7d852477ca1c99708058654ee860d4148fe5765f0d55528e2b1aa22", size = 584860, upload-time = "2026-04-22T03:14:39.746Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/15/0d1dc0597644e5e7b011ca954ba0c47e13cd880a3b909b0c3f1b4d8bf8f1/mlx-0.31.2-cp312-cp312-macosx_26_0_arm64.whl", hash = "sha256:51ca102db641b01e7cb083ce8ecb580e281530a141a7ca12544bb370641630ae", size = 584887, upload-time = "2026-04-22T03:14:41.585Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/c3/00664239a98e8bd614733c4182cd402d2bacad2d7f79eca66562ac406870/mlx-0.31.2-cp312-cp312-manylinux_2_35_aarch64.whl", hash = "sha256:117c7583cae0ca107cd53c591cc34f8e75f97a505aa47088844b7dc0fc69dc67", size = 627863, upload-time = "2026-04-22T03:14:43.326Z" },
+    { url = "https://files.pythonhosted.org/packages/53/7b/af6cd73a79772af6f19eab2cb4c48eda23a9294d1650a4c1269a9996e532/mlx-0.31.2-cp312-cp312-manylinux_2_35_x86_64.whl", hash = "sha256:99572133181481640a8bf8d449daf083816d0af3ee050c8adfc5bf45ceca91c6", size = 685090, upload-time = "2026-04-22T03:14:45.058Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/3f/888f8664d4f8e23a1363a5f50024be5216e199ab7ad0ba20988c7ed6d729/mlx-0.31.2-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:1b3fb0dda955b0d552ce57bdd6f42b3309ab21b067e40587d6848443d307e91f", size = 584796, upload-time = "2026-04-22T03:14:47.215Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/14/e9cd18b51f9e1dbcb060eec0fafc2d2428c8e1eacd9b0a02d7c5ce75b661/mlx-0.31.2-cp313-cp313-macosx_15_0_arm64.whl", hash = "sha256:34b0171cd9eb5c43fdd82091f6135d6ccc5a065363a4a3e68fac64fb4e53d37c", size = 584790, upload-time = "2026-04-22T03:14:48.519Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/20/c6c5fb998c7834d094b2bfb9f003b5246cb270f0266da055c55546c34999/mlx-0.31.2-cp313-cp313-macosx_26_0_arm64.whl", hash = "sha256:c05981684279a8935d58b0dde3ea5b02d210c3bad3319aa0e9934ec2df165752", size = 584795, upload-time = "2026-04-22T03:14:49.904Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/19/aca251d4c5f3532ce9c2c1e95ad76740d9c6c298f406f62d992f465b9be0/mlx-0.31.2-cp313-cp313-manylinux_2_35_aarch64.whl", hash = "sha256:cd1f4189e5f1bc68735f44eb63ce98ae09d66ac75d7ab5b15a41afae7e9f0513", size = 627843, upload-time = "2026-04-22T03:14:51.351Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/2b/b89364883b98f21c2fe29e52d4ac8bc2fa2fe0d79293b36ec421efc1854a/mlx-0.31.2-cp313-cp313-manylinux_2_35_x86_64.whl", hash = "sha256:53c8d57ffa9ce77f8355663be05014c0dd37280e57f19126fb0a24389a30684b", size = 685064, upload-time = "2026-04-22T03:14:52.75Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/f5/e63f6a9316ded2d14a8ebc7a9ca25734c784e8c54d064a78b4dceeacec0e/mlx-0.31.2-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:a13c9ce23c3deef6aa5a09315e7953e1a5dc311e851fa16fc74c81fb2509c0b9", size = 588417, upload-time = "2026-04-22T03:14:54.094Z" },
+    { url = "https://files.pythonhosted.org/packages/31/50/9d0c03ea3134cd85c132df7b0e4b75e6344bd8b4881a0b9c465cfa27f724/mlx-0.31.2-cp314-cp314-macosx_15_0_arm64.whl", hash = "sha256:b0764bf11fc3a71dee988e19275eef67775cab63112d8bb7ef173ca8b2a1247c", size = 588421, upload-time = "2026-04-22T03:14:55.898Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/5b/d364cc793bcb504621313acb55627cf0d5403ab2e0a594aa081cdbe4591f/mlx-0.31.2-cp314-cp314-macosx_26_0_arm64.whl", hash = "sha256:59ccbd0f0044d4f97f11ebcbf0c480bc9e962935fd96275f120954afea65be8a", size = 588384, upload-time = "2026-04-22T03:14:57.439Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/a4/e822202dd2e4e7d08671f2ecf7b6500af74f5bad5ceb27086b1aa6902f3a/mlx-0.31.2-cp314-cp314-manylinux_2_35_aarch64.whl", hash = "sha256:e81798c610f95a09c642c89214ba5c23b72ce18ce4728184aceabe7eddca33d7", size = 630473, upload-time = "2026-04-22T03:14:58.985Z" },
+    { url = "https://files.pythonhosted.org/packages/40/6f/da48d2d7a76e644d35438ef6f33c68755fdd382e2c546fd1804ccba01d04/mlx-0.31.2-cp314-cp314-manylinux_2_35_x86_64.whl", hash = "sha256:69fbc94bf53607a75af9eb3e22c354738a6fe4e25aa4e2b20934b009a4bba1f3", size = 685459, upload-time = "2026-04-22T03:15:00.45Z" },
 ]
 
 [[package]]
@@ -1154,7 +1131,7 @@ wheels = [
 
 [[package]]
 name = "mlx-lm"
-version = "0.31.1"
+version = "0.31.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jinja2" },
@@ -1166,19 +1143,19 @@ dependencies = [
     { name = "sentencepiece" },
     { name = "transformers" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9e/f9/3f5597c62bd5733ebb3c9f96c33f2065db16353d743b8548bb05a01b7dd3/mlx_lm-0.31.1.tar.gz", hash = "sha256:1b2362ea301427004e5dda43b9241d751d4cb80eba641f6b85b29fc493affac5", size = 285473, upload-time = "2026-03-11T02:02:57.466Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/84/94/9a38d6b0c6fcca995b9136c94eb7da1e9c5165652edf228b96b29960fa7a/mlx_lm-0.31.3.tar.gz", hash = "sha256:61eb0e3ba09444f77f874aff295401d7ccd20b39495cbbce0c782a15474ce733", size = 304318, upload-time = "2026-04-22T07:37:27.922Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3b/8e/2e40713fc673d7268e32222752919075c0024b02635af56531d9ee8317b5/mlx_lm-0.31.1-py3-none-any.whl", hash = "sha256:bfc3e08e919b87bebb6fe2dbea980ece8ae8ee7132b31421aa0923c4286ecfa0", size = 393971, upload-time = "2026-03-11T02:02:54.973Z" },
+    { url = "https://files.pythonhosted.org/packages/90/02/9a67b8e4f87e3e2e5cd7b1ad79304b93c09a0db6af34bee75e6551c06c60/mlx_lm-0.31.3-py3-none-any.whl", hash = "sha256:758cfddf1180053b7613db76fad3d246a331a2a905808e1164a275621fc983b8", size = 408890, upload-time = "2026-04-22T07:37:25.965Z" },
 ]
 
 [[package]]
 name = "mlx-metal"
-version = "0.31.1"
+version = "0.31.2"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/39/66/2313497fdbc7fbadf8e026c09366e3f049f9114e65ca4edc23cdb8699186/mlx_metal-0.31.1-py3-none-macosx_14_0_arm64.whl", hash = "sha256:70741174131dbf7fdd479cb730e06e08c358eac3bf7905d9e884e7960cfdd5b8", size = 38624074, upload-time = "2026-03-12T02:15:48.036Z" },
-    { url = "https://files.pythonhosted.org/packages/c7/34/4c3c6890ce6095b2ab2ba2f5f15c9a7ba17208d47f8cacb572885a2dc0eb/mlx_metal-0.31.1-py3-none-macosx_15_0_arm64.whl", hash = "sha256:6c56bd8cd27743e635f5a90a22535af7c31bd22b4b126d46b6da2da52d72e413", size = 38618950, upload-time = "2026-03-12T02:15:51.908Z" },
-    { url = "https://files.pythonhosted.org/packages/51/bc/987cb99e3aafb296aa11ce5133838a10eae8447edd53168d0804d4fb3a14/mlx_metal-0.31.1-py3-none-macosx_26_0_arm64.whl", hash = "sha256:e7324b7c56b519ae67c025d3ced07e5d35bc3a9f19d4c45fe4927f385148c59e", size = 49256543, upload-time = "2026-03-12T02:15:54.851Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/69/fe3b783ebe999f3118234e1e940feb622518bfb1dea6ac5d13b1d36a8449/mlx_metal-0.31.2-py3-none-macosx_14_0_arm64.whl", hash = "sha256:b25385bcee18fc194092255b8b53b9a3d8489eb650e59160f1b57aadd07aa2dc", size = 40055588, upload-time = "2026-04-22T03:14:14.43Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/5d/4c690d5b93c30ba002656c37363159d978705bf8eb801b8481840fb942c2/mlx_metal-0.31.2-py3-none-macosx_15_0_arm64.whl", hash = "sha256:e9d4e5fce6ca10a87a0e388597f99519ad594d09e674708b5312bd8bd4f5997d", size = 40053220, upload-time = "2026-04-22T03:14:18.048Z" },
+    { url = "https://files.pythonhosted.org/packages/99/82/11fd62a8d7a3e96e5c43220b17de0151e3f10101f8bb3b865f5bd9cdd074/mlx_metal-0.31.2-py3-none-macosx_26_0_arm64.whl", hash = "sha256:84ffb60ee503f03eb684f5fb168d5cff31e2a16b7f27c1731eaf7662bd6e9b46", size = 55792151, upload-time = "2026-04-22T03:14:22.059Z" },
 ]
 
 [[package]]
@@ -1187,7 +1164,6 @@ source = { editable = "." }
 dependencies = [
     { name = "datasets" },
     { name = "fastapi" },
-    { name = "llguidance" },
     { name = "miniaudio" },
     { name = "mlx" },
     { name = "mlx-lm" },
@@ -1217,12 +1193,11 @@ requires-dist = [
     { name = "datasets", specifier = ">=2.19.1" },
     { name = "fastapi", specifier = ">=0.95.1" },
     { name = "gradio", marker = "extra == 'ui'", specifier = ">=5.19.0" },
-    { name = "llguidance", specifier = ">=1.7.0" },
     { name = "miniaudio", specifier = ">=1.59" },
-    { name = "mlx", specifier = ">=0.31.1" },
+    { name = "mlx", specifier = ">=0.31.2" },
     { name = "mlx-cpu", marker = "extra == 'cpu'" },
     { name = "mlx-cuda", marker = "extra == 'cuda'" },
-    { name = "mlx-lm", specifier = ">=0.31.1" },
+    { name = "mlx-lm", specifier = ">=0.31.3" },
     { name = "numpy" },
     { name = "opencv-python", specifier = ">=4.12.0.88" },
     { name = "pillow", specifier = ">=10.3.0" },


### PR DESCRIPTION
## Summary
- Port Google's **Gemma 4 Multi-Token Prediction (MTP)** drafter to mlx-vlm. New package at `mlx_vlm/speculative/drafters/gemma4_assistant/` mirrors the DFlash surface (`bind` / `make_cache` / `reset` / `draft_block` / `__call__` / `sanitize`) so existing CLI flags, batched generation, and \`accept_lens\` tracking apply unchanged. Dispatch via \`--draft-kind mtp\`.
- Target-side hooks added to \`gemma4\`: \`shared_kv_sink\`, \`hidden_sink\`, \`capture_layer_ids\` plumbing, and \`rollback_speculative_cache\` (no SSM/GDN — Gemma 4 has only KV / RotatingKV caches).
- Round-loops \`_mtp_rounds\` and \`_mtp_rounds_batch\` in \`generate.py\`, mirrored from \`_dflash_rounds_*\`. Continuous-batching, per-row positions, EOS-pair detection (\`[1, 106]\`), and post-verify shared-KV slicing all wired.
- Centroid-routed sparse LM head (\`MaskedEmbedder\`) for E2B / E4B drafters with \`use_ordered_embeddings=True\`. Bypassed for 26B-A4B / 31B (tied dense head).
- Bidirectional full / SWA mask helpers in \`masks.py\`.
- Drafter package README + main README \"Speculative Decoding\" section reorganised into DFlash and Gemma 4 MTP subsections.

## Supported pairings

| Target                          | Drafter                                  | LM head           |
|---------------------------------|------------------------------------------|-------------------|
| \`google/gemma-4-E2B-it\`         | \`google/gemma-4-E2B-it-assistant\`        | centroid (sparse) |
| \`google/gemma-4-E4B-it\`         | \`google/gemma-4-E4B-it-assistant\`        | centroid (sparse) |
| \`google/gemma-4-26B-A4B-it\`     | \`google/gemma-4-26B-A4B-it-assistant\`    | tied dense        |
| \`google/gemma-4-31B-it\`         | \`google/gemma-4-31B-it-assistant\`        | tied dense        |

## Measured performance (Apple Silicon, greedy, byte-identical output)

| Target  | B  | best bs | tot tok/s | speedup |
|---------|----|---------|-----------|---------|
| 26B-A4B | 4  | 3       | 85.5      | **3.94×** |
| 26B-A4B | 8  | 3       | 165.1     | **1.55×** |
| 31B     | 4  | 3       | 17.1      | **2.29×** |
| 31B     | 8  | 2       | 21.4      | **1.41×** |
| E4B     | 4  | 4       | 62.1      | **1.56×** |
| E4B     | 8  | 2       | 115.9     | 1.07×     |

Reference: https://ai.google.dev/gemma/docs/mtp/mtp.

## Test plan
- [x] \`uv run python -m mlx_vlm.speculative.drafters.gemma4_assistant.parity_check --drafter <repo>\` passes for E4B (centroid head), 26B-A4B and 31B (tied dense)
- [x] End-to-end greedy generation byte-identical to no-drafter baseline on each of E4B, 26B-A4B, 31B
- [x] Batched MTP sweep (\`scripts/mtp_batch_sweep.py\`) across B ∈ {4, 8, 16}, block ∈ {2, 3, 4} on each target
- [x] \`--draft-kind dflash\` (Qwen3.5-4B-DFlash) still works (round-loop dispatch unchanged for DFlash)
- [x] Reviewer: run end-to-end on a multimodal prompt (image / audio prefill should pass through; speculative kicks in only on text decode)
