### PR TITLE
Fix TPS in API response

### DIFF
--- a/mlx_vlm/generate.py
+++ b/mlx_vlm/generate.py
@@ -2004,6 +2004,7 @@ class BatchGenerator:
         self._prompt_tokens_counter = 0
         self._prompt_time_counter = 0
         self._gen_tokens_counter = 0
+        self._gen_time_counter = 0.0
         self._steps_counter = 0
 
         self._wire_stack = contextlib.ExitStack()
@@ -2109,6 +2110,12 @@ class BatchGenerator:
             else 0
         )
         stats.generation_tokens = self._gen_tokens_counter
+        stats.generation_time = self._gen_time_counter
+        stats.generation_tps = (
+            self._gen_tokens_counter / self._gen_time_counter
+            if self._gen_time_counter > 0
+            else 0
+        )
         stats.peak_memory = mx.get_peak_memory() / 1e9
         return stats
 
@@ -2118,7 +2125,9 @@ class BatchGenerator:
 
         # Decode-first: always emit a generation step before touching prefill.
         if len(self._generation_batch) > 0:
+            tic = time.perf_counter()
             generation_responses = self._generation_batch.next()
+            self._gen_time_counter += time.perf_counter() - tic
             self._gen_tokens_counter += len(generation_responses)
             self._steps_counter += 1
             if self._steps_counter % 512 == 0:

--- a/mlx_vlm/server.py
+++ b/mlx_vlm/server.py
@@ -174,6 +174,8 @@ class StreamingToken:
     finish_reason: Optional[str]
     peak_memory: float = 0.0
     top_logprobs: Optional[List[Tuple[int, float]]] = None
+    prompt_tps: float = 0.0
+    generation_tps: float = 0.0
 
 
 class ResponseGenerator:
@@ -730,6 +732,14 @@ class ResponseGenerator:
 
             lp = r.token_logprob
 
+            tps_kwargs = {}
+            if r.finish_reason:
+                s = batch_gen.stats()
+                tps_kwargs = {
+                    "prompt_tps": s.prompt_tps,
+                    "generation_tps": s.generation_tps,
+                }
+
             rqueue.put(
                 StreamingToken(
                     text=text,
@@ -738,6 +748,7 @@ class ResponseGenerator:
                     finish_reason=r.finish_reason,
                     peak_memory=mx.get_peak_memory() / 1e9 if r.finish_reason else 0,
                     top_logprobs=getattr(r, "top_logprobs", None),
+                    **tps_kwargs,
                 )
             )
 
@@ -1797,6 +1808,10 @@ async def responses_endpoint(request: Request):
                             usage_stats = {
                                 "input_tokens": ctx.prompt_tokens,
                                 "output_tokens": output_tokens,
+                                "total_tokens": ctx.prompt_tokens + output_tokens,
+                                "prompt_tps": token.prompt_tps,
+                                "generation_tps": token.generation_tps,
+                                "peak_memory": token.peak_memory,
                             }
 
                             yield f"event: response.output_text.delta\ndata: {ResponseOutputTextDeltaEvent(type='response.output_text.delta', item_id=message_id, output_index=0, content_index=0, delta=delta).model_dump_json()}\n\n"
@@ -1828,6 +1843,10 @@ async def responses_endpoint(request: Request):
                             usage_stats = {
                                 "input_tokens": chunk.prompt_tokens,
                                 "output_tokens": chunk.generation_tokens,
+                                "total_tokens": chunk.prompt_tokens
+                                + chunk.generation_tokens,
+                                "prompt_tps": chunk.prompt_tps,
+                                "generation_tps": chunk.generation_tps,
                             }
 
                             yield f"event: response.output_text.delta\ndata: {ResponseOutputTextDeltaEvent(type='response.output_text.delta', item_id=message_id, output_index=0, content_index=0, delta=delta).model_dump_json()}\n\n"
@@ -1865,6 +1884,10 @@ async def responses_endpoint(request: Request):
                                 "output_tokens": usage_stats["output_tokens"],
                                 "total_tokens": usage_stats["input_tokens"]
                                 + usage_stats["output_tokens"],
+                                "prompt_tps": usage_stats.get("prompt_tps", 0.0),
+                                "generation_tps": usage_stats.get(
+                                    "generation_tps", 0.0
+                                ),
                             },
                         }
                     )
@@ -1902,6 +1925,8 @@ async def responses_endpoint(request: Request):
                 full_text = ""
                 prompt_tokens = 0
                 output_tokens = 0
+                prompt_tps = 0.0
+                generation_tps = 0.0
 
                 if response_generator is not None:
                     ctx, token_iter = response_generator.generate(
@@ -1933,6 +1958,8 @@ async def responses_endpoint(request: Request):
                     full_text = result.text
                     prompt_tokens = result.prompt_tokens
                     output_tokens = result.generation_tokens
+                    prompt_tps = result.prompt_tps
+                    generation_tps = result.generation_tps
 
                 mx.clear_cache()
                 gc.collect()
@@ -1966,6 +1993,8 @@ async def responses_endpoint(request: Request):
                         "input_tokens": prompt_tokens,
                         "output_tokens": output_tokens,
                         "total_tokens": prompt_tokens + output_tokens,
+                        "prompt_tps": prompt_tps,
+                        "generation_tps": generation_tps,
                     },
                 )
 
@@ -2243,6 +2272,9 @@ async def chat_completions_endpoint(request: ChatRequest):
                                         "completion_tokens": output_tokens,
                                         "total_tokens": ctx.prompt_tokens
                                         + output_tokens,
+                                        "prompt_tps": token.prompt_tps,
+                                        "generation_tps": token.generation_tps,
+                                        "peak_memory": token.peak_memory,
                                     },
                                     choices=choices,
                                 )
@@ -2312,6 +2344,8 @@ async def chat_completions_endpoint(request: ChatRequest):
                                     "completion_tokens": chunk.generation_tokens,
                                     "total_tokens": chunk.prompt_tokens
                                     + chunk.generation_tokens,
+                                    "prompt_tps": chunk.prompt_tps,
+                                    "generation_tps": chunk.generation_tps,
                                 },
                                 choices=choices,
                             )
@@ -2324,7 +2358,7 @@ async def chat_completions_endpoint(request: ChatRequest):
 
                     elapsed = time.perf_counter() - request_start
                     logger.debug(
-                        "chat/completions stream done: tokens=%d " "total_time=%.2fs",
+                        "chat/completions stream done: tokens=%d total_time=%.2fs",
                         output_tokens,
                         elapsed,
                     )
@@ -2363,6 +2397,8 @@ async def chat_completions_endpoint(request: ChatRequest):
                 prompt_tokens = 0
                 output_tokens = 0
                 peak_memory = 0.0
+                prompt_tps = 0.0
+                generation_tps = 0.0
 
                 collected_logprobs: List[
                     Tuple[int, float, Optional[List[Tuple[int, float]]]]
@@ -2373,7 +2409,7 @@ async def chat_completions_endpoint(request: ChatRequest):
                     def _blocking_generate():
                         text = ""
                         pt = gt = 0
-                        pm = 0.0
+                        pm = p_tps = g_tps = 0.0
                         ctx, token_iter = response_generator.generate(
                             prompt=formatted_prompt,
                             images=images if images else None,
@@ -2390,16 +2426,23 @@ async def chat_completions_endpoint(request: ChatRequest):
                                     (token.token, token.logprobs, token.top_logprobs)
                                 )
                             if token.finish_reason:
+                                p_tps = token.prompt_tps
+                                g_tps = token.generation_tps
                                 break
                         try:
                             token_iter.close()
                         except Exception:
                             pass
-                        return text, pt, gt, pm
+                        return text, pt, gt, pm, p_tps, g_tps
 
-                    full_text, prompt_tokens, output_tokens, peak_memory = (
-                        await asyncio.to_thread(_blocking_generate)
-                    )
+                    (
+                        full_text,
+                        prompt_tokens,
+                        output_tokens,
+                        peak_memory,
+                        prompt_tps,
+                        generation_tps,
+                    ) = await asyncio.to_thread(_blocking_generate)
                 else:
                     gen_result = generate(
                         model=model,
@@ -2416,6 +2459,8 @@ async def chat_completions_endpoint(request: ChatRequest):
                     prompt_tokens = gen_result.prompt_tokens
                     output_tokens = gen_result.generation_tokens
                     peak_memory = gen_result.peak_memory
+                    prompt_tps = gen_result.prompt_tps
+                    generation_tps = gen_result.generation_tps
 
                 mx.clear_cache()
                 gc.collect()
@@ -2432,6 +2477,8 @@ async def chat_completions_endpoint(request: ChatRequest):
                     completion_tokens=completion_tokens,
                     total_tokens=prompt_tokens + completion_tokens,
                     peak_memory=peak_memory,
+                    prompt_tps=prompt_tps,
+                    generation_tps=generation_tps,
                 )
 
                 # Parse tool calls from generated output

--- a/mlx_vlm/server.py
+++ b/mlx_vlm/server.py
@@ -503,6 +503,9 @@ class ResponseGenerator:
                         "tokens": [],
                         "prev_text": "",
                         "gen_kwargs": gen_kwargs if has_embeds else None,
+                        "prompt_tokens": prompt_tokens,
+                        "start_time": time.perf_counter(),
+                        "first_token_time": None,
                     }
 
                     if has_embeds:
@@ -568,6 +571,9 @@ class ResponseGenerator:
                 rqueues = {}
                 token_lists = {}
                 max_tokens_map = {}
+                prompt_tokens_map = {}
+                start_time_map = {}
+                first_token_time_map = {}
                 all_input_ids = []
 
                 for rqueue, raw_inputs, prompt_tokens, args, images in pending:
@@ -577,6 +583,9 @@ class ResponseGenerator:
                     rqueues[uid] = rqueue
                     token_lists[uid] = []
                     max_tokens_map[uid] = args.max_tokens
+                    prompt_tokens_map[uid] = prompt_tokens
+                    start_time_map[uid] = time.perf_counter()
+                    first_token_time_map[uid] = None
                     all_input_ids.append(input_ids.squeeze(0).tolist())
                     rqueue.put(GenerationContext(uid=uid, prompt_tokens=prompt_tokens))
                     sampler = self._make_sampler(args) or _make_sampler(temp=0)
@@ -663,6 +672,27 @@ class ResponseGenerator:
                         is_max = len(tokens) >= max_tokens_map[uid]
                         finish = "stop" if is_stop else "length" if is_max else None
 
+                        # Track first token time for per-request TPS
+                        now = time.perf_counter()
+                        if first_token_time_map[uid] is None:
+                            first_token_time_map[uid] = now
+
+                        tps_kwargs = {}
+                        if finish:
+                            prompt_tps = 0.0
+                            generation_tps = 0.0
+                            start = start_time_map[uid]
+                            first = first_token_time_map[uid]
+                            num_gen_tokens = len(token_lists[uid])
+                            if first and first > start:
+                                prompt_tps = prompt_tokens_map[uid] / (first - start)
+                            if num_gen_tokens > 0 and now > first:
+                                generation_tps = num_gen_tokens / (now - first)
+                            tps_kwargs = {
+                                "prompt_tps": prompt_tps,
+                                "generation_tps": generation_tps,
+                            }
+
                         rqueues[uid].put(
                             StreamingToken(
                                 text="" if is_stop else text,
@@ -670,6 +700,7 @@ class ResponseGenerator:
                                 logprobs=0.0,
                                 finish_reason=finish,
                                 peak_memory=mx.get_peak_memory() / 1e9,
+                                **tps_kwargs,
                             )
                         )
 
@@ -689,6 +720,16 @@ class ResponseGenerator:
                 # Finalize any remaining
                 for uid in uids:
                     if uid not in finished_uids:
+                        now = time.perf_counter()
+                        prompt_tps = 0.0
+                        generation_tps = 0.0
+                        start = start_time_map[uid]
+                        first = first_token_time_map[uid]
+                        num_gen_tokens = len(token_lists[uid])
+                        if first and first > start:
+                            prompt_tps = prompt_tokens_map[uid] / (first - start)
+                        if num_gen_tokens > 0 and now > first:
+                            generation_tps = num_gen_tokens / (now - first)
                         rqueues[uid].put(
                             StreamingToken(
                                 text="",
@@ -696,6 +737,8 @@ class ResponseGenerator:
                                 logprobs=0.0,
                                 finish_reason="length",
                                 peak_memory=mx.get_peak_memory() / 1e9,
+                                prompt_tps=prompt_tps,
+                                generation_tps=generation_tps,
                             )
                         )
                         rqueues[uid].put(None)
@@ -732,12 +775,25 @@ class ResponseGenerator:
 
             lp = r.token_logprob
 
+            # Track first token time for per-request TPS
+            now = time.perf_counter()
+            if info["first_token_time"] is None:
+                info["first_token_time"] = now
+
             tps_kwargs = {}
             if r.finish_reason:
-                s = batch_gen.stats()
+                prompt_tps = 0.0
+                generation_tps = 0.0
+                start = info["start_time"]
+                first = info["first_token_time"]
+                num_gen_tokens = len(info["tokens"])
+                if first and first > start:
+                    prompt_tps = info["prompt_tokens"] / (first - start)
+                if num_gen_tokens > 0 and now > first:
+                    generation_tps = num_gen_tokens / (now - first)
                 tps_kwargs = {
-                    "prompt_tps": s.prompt_tps,
-                    "generation_tps": s.generation_tps,
+                    "prompt_tps": prompt_tps,
+                    "generation_tps": generation_tps,
                 }
 
             rqueue.put(


### PR DESCRIPTION
## Summary

Fix missing TPS (tokens per second) metrics in API responses. Previously prompt_tps and generation_tps were not properly calculated or returned, leaving clients unable to retrieve inference performance data.

## Changes

mlx_vlm/generate.py (BatchGenerator)

- Added _gen_time_counter member variable to independently track generation phase duration (excluding prefill)
- Wrapped generation_batch.next() with time.perf_counter() calls for precise timing
- Added generation_time and generation_tps fields to the stats() method
  - generation_tps = generation_tokens / generation_time
    
mlx_vlm/server.py

- StreamingToken dataclass: added prompt_tps and generation_tps fields
- ResponseGenerator: on finish_reason, fetches TPS from batch_gen.stats() and injects into StreamingToken
- responses endpoint and chat/completions endpoint: fully populated performance metrics:
  - Streaming responses: usage now includes prompt_tps, generation_tps, total_tokens, peak_memory
  - Non-streaming responses: same fields added
  - Blocking _blocking_generate: return value extended to include prompt_tps and generation_tps
- Minor fix: consolidated a split string literal in a logger format call
    
## Scope

- Affects 2 API endpoints (/v1/responses, /v1/chat/completions) for both streaming and non-streaming responses
- No changes to model inference logic — only affects statistics collection and reporting
- No breaking changes — clients can optionally consume the new fields