### PR TITLE
Fix Gemma 4 MTP server dispatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,11 @@ mlx_vlm.generate --model mlx-community/gemma-4-31B-it-bf16 \
   --draft-kind mtp --draft-block-size 4 \
   --prompt "Explain speculative decoding in 3 sentences." \
   --max-tokens 256 --temperature 0
+
+# Server
+mlx_vlm.server --model mlx-community/gemma-4-31B-it-bf16 \
+  --draft-model mlx-community/gemma-4-31B-it-assistant-bf16 \
+  --draft-kind mtp --draft-block-size 4
 ```
 
 Supported pairings (target ↔ drafter):
@@ -155,6 +160,11 @@ Supported pairings (target ↔ drafter):
 | `mlx-community/gemma-4-31B-it-bf16`         | `mlx-community/gemma-4-31B-it-assistant-bf16`        |
 
 Measured speedups (greedy, byte-identical output): up to **3.94×** on 26B-A4B and **2.29×** on 31B at B=4. See [`mlx_vlm/speculative/drafters/gemma4_assistant/README.md`](mlx_vlm/speculative/drafters/gemma4_assistant/README.md) for full sweeps and architecture notes.
+
+For memory-constrained 31B deployments, `mlx_vlm.convert` also provides
+Gemma-safe mixed quantization predicates (`mixed_4_6_gemma31_safe` and
+`mixed_4_8_gemma31_safe`) that keep embeddings / per-layer embedding paths and
+selected `v_proj` / `down_proj` tensors at higher precision.
 
 ### Chat UI with Gradio
 

--- a/mlx_vlm/convert.py
+++ b/mlx_vlm/convert.py
@@ -27,6 +27,8 @@ QUANT_RECIPES = [
     "mixed_3_8",
     "mixed_4_6",
     "mixed_4_8",
+    "mixed_4_6_gemma31_safe",
+    "mixed_4_8_gemma31_safe",
 ]
 
 
@@ -43,12 +45,16 @@ def mixed_quant_predicate_builder(
         "mixed_3_8": (3, 8),
         "mixed_4_6": (4, 6),
         "mixed_4_8": (4, 8),
+        "mixed_4_6_gemma31_safe": (4, 6),
+        "mixed_4_8_gemma31_safe": (4, 8),
     }
 
     if recipe not in recipe_config:
         raise ValueError(f"Invalid quant recipe {recipe}")
 
     low_bits, high_bits = recipe_config[recipe]
+    gemma31_safe = recipe.endswith("_gemma31_safe")
+    model_quant_predicate = getattr(model, "quant_predicate", None)
 
     down_keys = [k for k, _ in model.named_modules() if "down_proj" in k]
     if len(down_keys) == 0:
@@ -71,10 +77,31 @@ def mixed_quant_predicate_builder(
 
         if skip_multimodal_module(path):
             return False
+        model_decision = (
+            model_quant_predicate(path, module)
+            if model_quant_predicate is not None
+            else None
+        )
+        if model_decision is False:
+            return False
         if not hasattr(module, "to_quantized"):
             return False
         if module.weight.shape[1] % group_size != 0:
             return False
+
+        if gemma31_safe:
+            if "router" in path:
+                return {"group_size": group_size, "bits": 8}
+            if any(
+                s in path
+                for s in [
+                    "embed_tokens_per_layer",
+                    "per_layer_input",
+                    "per_layer_model_projection",
+                    "per_layer_projection",
+                ]
+            ):
+                return {"group_size": group_size, "bits": high_bits}
 
         path_parts = path.split(".")
         index = 0

--- a/mlx_vlm/server.py
+++ b/mlx_vlm/server.py
@@ -40,6 +40,7 @@ from .generate import (
     DEFAULT_TOP_P,
     BatchGenerator,
     _dflash_rounds_batch,
+    _mtp_rounds_batch,
     _make_cache,
     generate,
     normalize_resize_shape,
@@ -55,6 +56,35 @@ from .vision_cache import VisionFeatureCache
 
 DEFAULT_SERVER_HOST = "0.0.0.0"
 DEFAULT_SERVER_PORT = 8080
+
+
+def _get_speculative_rounds_batch(draft_kind: str):
+    if draft_kind == "mtp":
+        return _mtp_rounds_batch
+    if draft_kind == "dflash":
+        return _dflash_rounds_batch
+    raise ValueError(f"Unknown draft_kind {draft_kind!r}. Supported: ['dflash', 'mtp']")
+
+
+def _speculative_prefill_kwargs(draft_kind: str, drafter) -> dict:
+    if draft_kind == "mtp":
+        return {"return_hidden": True, "return_shared_kv": True}
+    if draft_kind == "dflash":
+        return {"capture_layer_ids": list(drafter.config.target_layer_ids)}
+    raise ValueError(f"Unknown draft_kind {draft_kind!r}. Supported: ['dflash', 'mtp']")
+
+
+def _speculative_hidden_state(draft_kind: str, outputs):
+    if draft_kind == "mtp":
+        return outputs.hidden_states[-1]
+    if draft_kind == "dflash":
+        return mx.concatenate(outputs.hidden_states, axis=-1)
+    raise ValueError(f"Unknown draft_kind {draft_kind!r}. Supported: ['dflash', 'mtp']")
+
+
+def _get_draft_block_size_from_env():
+    draft_block_size_str = os.environ.get("MLX_VLM_DRAFT_BLOCK_SIZE")
+    return int(draft_block_size_str) if draft_block_size_str else None
 
 
 def get_prefill_step_size():
@@ -548,15 +578,15 @@ class ResponseGenerator:
                 gc.collect()
 
     def _run_speculative(self):
-        """GPU thread loop with DFlash speculative decoding.
+        """GPU thread loop with speculative decoding.
 
         Collects incoming requests, prefills them as a batch with
-        ``capture_layer_ids``, then runs ``_dflash_rounds_batch`` for
+        the drafter-specific target hooks, then runs the matching round loop for
         decode. Between speculative rounds the loop checks for new
         requests — new arrivals trigger a batch rebuild (re-prefill
         for the new sequences, extend target caches, cold-restart
-        drafter). Finished sequences are filtered out automatically
-        by ``_dflash_rounds_batch``'s ``stop_check`` callback.
+        drafter). Finished sequences are filtered out automatically by the
+        speculative round loop's ``stop_check`` callback.
         """
         from mlx_lm.sample_utils import make_sampler as _make_sampler
 
@@ -564,10 +594,11 @@ class ResponseGenerator:
 
         lm = self.model.language_model
         drafter = self.draft_model
-        target_layer_ids = list(drafter.config.target_layer_ids)
+        draft_kind = os.environ.get("MLX_VLM_DRAFT_KIND", "dflash")
+        rounds_batch = _get_speculative_rounds_batch(draft_kind)
+        prefill_kwargs = _speculative_prefill_kwargs(draft_kind, drafter)
         sampler = _make_sampler(temp=0)
-        draft_block_size_str = os.environ.get("MLX_VLM_DRAFT_BLOCK_SIZE")
-        draft_block_size = int(draft_block_size_str) if draft_block_size_str else None
+        draft_block_size = _get_draft_block_size_from_env()
 
         while not self._stop:
             try:
@@ -624,9 +655,9 @@ class ResponseGenerator:
                     out = lm(
                         input_mx,
                         cache=prompt_cache,
-                        capture_layer_ids=target_layer_ids,
+                        **prefill_kwargs,
                     )
-                hidden = mx.concatenate(out.hidden_states, axis=-1)
+                hidden = _speculative_hidden_state(draft_kind, out)
                 first_bonus = sampler(out.logits[:, -1:]).squeeze(-1)
                 mx.eval(first_bonus, hidden, out.logits)
 
@@ -660,18 +691,42 @@ class ResponseGenerator:
                         return True
                     return False
 
-                for tok_list, _ in _dflash_rounds_batch(
-                    self.model,
-                    drafter,
-                    prompt_cache,
-                    hidden,
-                    first_bonus=first_bonus,
-                    max_tokens=max_tok,
-                    sampler=sampler,
-                    draft_block_size=draft_block_size,
-                    token_dtype=mx.int32,
-                    stop_check=stop_check,
-                ):
+                eos = getattr(self.config, "eos_token_id", None)
+                if isinstance(eos, int):
+                    eos_set = {eos}
+                elif eos is None:
+                    eos_set = None
+                else:
+                    eos_set = set(int(x) for x in eos)
+
+                rounds_kwargs = {
+                    "first_bonus": first_bonus,
+                    "max_tokens": max_tok,
+                    "sampler": sampler,
+                    "draft_block_size": draft_block_size,
+                    "token_dtype": mx.int32,
+                    "stop_check": stop_check,
+                }
+                if draft_kind == "mtp":
+                    rounds = rounds_batch(
+                        self.model,
+                        drafter,
+                        prompt_cache,
+                        hidden,
+                        out.shared_kv_states,
+                        eos_token_ids=eos_set,
+                        **rounds_kwargs,
+                    )
+                else:
+                    rounds = rounds_batch(
+                        self.model,
+                        drafter,
+                        prompt_cache,
+                        hidden,
+                        **rounds_kwargs,
+                    )
+
+                for tok_list, _ in rounds:
                     for j, tok in enumerate(tok_list):
                         if tok is None:
                             continue
@@ -712,7 +767,7 @@ class ResponseGenerator:
                 if al:
                     mean_a = sum(al) / len(al)
                     print(
-                        f"[DFlash] batch={B} tokens={sum(len(token_lists[u]) for u in uids)} "
+                        f"[{draft_kind.upper()}] batch={B} tokens={sum(len(token_lists[u]) for u in uids)} "
                         f"accept={mean_a:.2f} rounds={len(al)}"
                     )
 
@@ -2797,13 +2852,17 @@ def main():
         "--draft-model",
         type=str,
         default=None,
-        help="Speculative drafter path or HF id (e.g. z-lab/Qwen3.5-4B-DFlash).",
+        help=(
+            "Speculative drafter path or HF id (e.g. z-lab/Qwen3.5-4B-DFlash "
+            "or mlx-community/gemma-4-31B-it-assistant-bf16)."
+        ),
     )
     parser.add_argument(
         "--draft-kind",
         type=str,
         default="dflash",
-        help="Drafter family (default: dflash).",
+        choices=["dflash", "mtp"],
+        help="Drafter family: dflash or mtp for Gemma 4 assistant models (default: dflash).",
     )
     parser.add_argument(
         "--draft-block-size",

--- a/mlx_vlm/tests/test_convert_quant_predicates.py
+++ b/mlx_vlm/tests/test_convert_quant_predicates.py
@@ -1,0 +1,59 @@
+from types import SimpleNamespace
+
+from mlx_vlm.convert import QUANT_RECIPES, mixed_quant_predicate_builder
+
+
+class _FakeLinear:
+    weight = SimpleNamespace(shape=(128, 128))
+
+    def to_quantized(self):
+        return self
+
+
+class _FakeModel:
+    layers = [object() for _ in range(16)]
+
+    def named_modules(self):
+        return [("model.layers.0.mlp.down_proj", _FakeLinear())]
+
+    def quant_predicate(self, path, module):
+        if "blocked" in path:
+            return False
+        return True
+
+
+def test_gemma31_safe_mixed_recipes_are_available():
+    assert "mixed_4_6_gemma31_safe" in QUANT_RECIPES
+    assert "mixed_4_8_gemma31_safe" in QUANT_RECIPES
+
+
+def test_gemma31_safe_recipe_keeps_sensitive_paths_higher_precision():
+    predicate = mixed_quant_predicate_builder("mixed_4_6_gemma31_safe", _FakeModel())
+
+    assert predicate("model.embed_tokens", _FakeLinear()) == {
+        "group_size": 64,
+        "bits": 6,
+    }
+    assert predicate("model.embed_tokens_per_layer", _FakeLinear()) == {
+        "group_size": 64,
+        "bits": 6,
+    }
+    assert predicate("model.layers.0.self_attn.v_proj", _FakeLinear()) == {
+        "group_size": 64,
+        "bits": 6,
+    }
+
+
+def test_gemma31_safe_recipe_uses_four_bits_for_regular_paths():
+    predicate = mixed_quant_predicate_builder("mixed_4_6_gemma31_safe", _FakeModel())
+
+    assert predicate("model.layers.2.self_attn.q_proj", _FakeLinear()) == {
+        "group_size": 64,
+        "bits": 4,
+    }
+
+
+def test_gemma31_safe_recipe_respects_model_quantization_blocks():
+    predicate = mixed_quant_predicate_builder("mixed_4_6_gemma31_safe", _FakeModel())
+
+    assert predicate("model.blocked.linear", _FakeLinear()) is False

--- a/mlx_vlm/tests/test_server.py
+++ b/mlx_vlm/tests/test_server.py
@@ -40,6 +40,34 @@ def test_chat_request_schema_allows_one_or_two_resize_shape_values():
     assert lengths == {(1, 1), (2, 2)}
 
 
+def test_speculative_server_dispatches_mtp_batch_loop():
+    assert server._get_speculative_rounds_batch("mtp") is server._mtp_rounds_batch
+
+
+def test_speculative_server_keeps_dflash_default_batch_loop():
+    assert server._get_speculative_rounds_batch("dflash") is server._dflash_rounds_batch
+
+
+def test_speculative_server_prefill_kwargs_are_drafter_specific():
+    drafter = SimpleNamespace(config=SimpleNamespace(target_layer_ids=[1, 2, 3]))
+
+    assert server._speculative_prefill_kwargs("mtp", drafter) == {
+        "return_hidden": True,
+        "return_shared_kv": True,
+    }
+    assert server._speculative_prefill_kwargs("dflash", drafter) == {
+        "capture_layer_ids": [1, 2, 3],
+    }
+
+
+def test_speculative_server_reads_draft_block_size_env(monkeypatch):
+    monkeypatch.delenv("MLX_VLM_DRAFT_BLOCK_SIZE", raising=False)
+    assert server._get_draft_block_size_from_env() is None
+
+    monkeypatch.setenv("MLX_VLM_DRAFT_BLOCK_SIZE", "3")
+    assert server._get_draft_block_size_from_env() == 3
+
+
 def test_responses_endpoint_forwards_new_sampling_args(client):
     model = SimpleNamespace()
     processor = SimpleNamespace()


### PR DESCRIPTION
## Summary

Fixes Gemma 4 MTP speculative decoding in `mlx_vlm.server`.

`mlx_vlm.generate` already dispatches `draft_kind="mtp"` to the Gemma 4 MTP round loops, but the server speculative worker still always imported/called `_dflash_rounds_batch`. That meant `mlx_vlm.server --draft-kind mtp` could load a Gemma 4 assistant drafter but route the decode loop through the wrong speculative implementation.

This PR:

- dispatches server speculative decoding to `_mtp_rounds_batch` when `--draft-kind mtp` is selected;
- keeps DFlash as the default path and leaves DFlash routing unchanged;
- uses Gemma MTP-specific prefill hooks (`return_hidden=True`, `return_shared_kv=True`);
- passes shared KV state and EOS IDs into the MTP batch loop;
- labels acceptance logs as `[MTP]` or `[DFLASH]`;
- adds small dispatch tests;
- adds Gemma 31B-safe mixed quantization predicates for memory-constrained local 31B deployments.

## Validation

Unit/static checks:

- `python -m py_compile mlx_vlm/server.py mlx_vlm/convert.py`
- `python -m pytest mlx_vlm/tests/test_server.py mlx_vlm/tests/test_convert_quant_predicates.py mlx_vlm/tests/test_generate.py::test_generate_cli_smoke -q`
- Result: `47 passed`

Local Apple Silicon smoke with Gemma 4 31B target + official 31B assistant:

- target: `/Users/jkooker/.lmstudio/models/lmstudio-community/gemma-4-31B-it-MLX-6bit`
- drafter: `mlx-community/gemma-4-31B-it-assistant-bf16`
- `generate` no-MTP: `13.34 tok/s` for 32 generated tokens
- `generate` MTP: `22.03 tok/s`, acceptance `1.385` tokens/round
- patched `server` MTP request completed with HTTP 200 and logged: `[MTP] batch=1 tokens=32 accept=1.46 rounds=13`

## Notes

The Gemma-safe quant predicates are intended as a fallback for memory-constrained 31B deployments. They follow the existing mixed quantization style while keeping embeddings/per-layer embedding paths and selected `v_proj` / `down_proj` tensors at higher precision.
