### PR TITLE
Improve Gemma 4 MTP server batching

### DIFF
--- a/mlx_vlm/generate.py
+++ b/mlx_vlm/generate.py
@@ -663,13 +663,13 @@ def _mtp_rounds_batch(
     # Per-row state. ``positions`` is the absolute position id of each
     # row's pending bonus (= row's logical KV length). All rows start at
     # ``L_prefill`` and advance by ``accepted_i + 1`` per round.
-    _off0 = prompt_cache[0].offset
-    L_prefill = (
-        int(mx.array(_off0).max().item())
-        if isinstance(_off0, mx.array) and _off0.size > 1
-        else int(_off0)
-    )
-    positions = [L_prefill] * B
+    offset0 = prompt_cache[0].offset
+    if isinstance(offset0, mx.array):
+        L_prefill = int(offset0.max().item())
+        positions = [int(x) for x in offset0.tolist()]
+    else:
+        L_prefill = int(offset0)
+        positions = [L_prefill] * B
     draft_model.set_shared_kv(
         shared_kv_states, kv_offset=L_prefill, position=mx.array(positions)
     )
@@ -826,12 +826,8 @@ def _mtp_rounds_batch(
 
         # Re-bind drafter with new shared_kv and per-row positions.
         positions_active = [positions[active_idx[j]] for j in range(len(active_idx))]
-        _off_now = prompt_cache[0].offset
-        new_kv_offset = (
-            int(mx.array(_off_now).max().item())
-            if isinstance(_off_now, mx.array) and _off_now.size > 1
-            else int(_off_now)
-        )
+        offset0 = prompt_cache[0].offset
+        new_kv_offset = int(offset0.max().item()) if isinstance(offset0, mx.array) else int(offset0)
         draft_model.set_shared_kv(
             next_shared_kv,
             kv_offset=new_kv_offset,

--- a/mlx_vlm/server.py
+++ b/mlx_vlm/server.py
@@ -87,6 +87,11 @@ def _get_draft_block_size_from_env():
     return int(draft_block_size_str) if draft_block_size_str else None
 
 
+def _get_spec_batch_wait_from_env() -> float:
+    wait_ms = os.environ.get("MLX_VLM_SPEC_BATCH_WAIT_MS")
+    return max(0.0, float(wait_ms) / 1000.0) if wait_ms else 0.0
+
+
 def get_prefill_step_size():
     return int(os.environ.get("PREFILL_STEP_SIZE", DEFAULT_PREFILL_STEP_SIZE))
 
@@ -600,6 +605,7 @@ class ResponseGenerator:
         eos_set = set(self.stop_tokens) if is_mtp else None
         sampler = _make_sampler(temp=0)
         draft_block_size = _get_draft_block_size_from_env()
+        spec_batch_wait = _get_spec_batch_wait_from_env()
 
         while not self._stop:
             try:
@@ -614,6 +620,8 @@ class ResponseGenerator:
                         pending.append(item)
                 except QueueEmpty:
                     pass
+                if pending and spec_batch_wait > 0:
+                    time.sleep(spec_batch_wait)
                 while True:
                     try:
                         item = self.requests.get_nowait()
@@ -645,10 +653,11 @@ class ResponseGenerator:
 
                 B = len(uids)
                 max_len = max(len(ids) for ids in all_input_ids)
-                padded = [[0] * (max_len - len(ids)) + ids for ids in all_input_ids]
+                left_padding = [max_len - len(ids) for ids in all_input_ids]
+                padded = [[0] * left_padding[i] + ids for i, ids in enumerate(all_input_ids)]
                 input_mx = mx.array(padded, dtype=mx.int32)
 
-                prompt_cache = _make_cache(lm, [0] * B)
+                prompt_cache = _make_cache(lm, left_padding)
                 lm._position_ids = None
                 lm._rope_deltas = None
 

--- a/mlx_vlm/speculative/drafters/gemma4_assistant/gemma4_assistant.py
+++ b/mlx_vlm/speculative/drafters/gemma4_assistant/gemma4_assistant.py
@@ -147,17 +147,21 @@ class Gemma4AssistantDraftModel(nn.Module):
         h = self.pre_projection(inputs_embeds)
 
         query_len = h.shape[1]
-        query_offset_scalar = int(position_ids[0, 0].item())
+        query_offset = (
+            int(position_ids[0, 0].item())
+            if position_ids.shape[0] == 1
+            else position_ids[:, 0]
+        )
         masks = make_drafter_masks(
             shared_kv_states,
             query_len=query_len,
-            query_offset=query_offset_scalar,
+            query_offset=query_offset,
             sliding_window=text_cfg.sliding_window,
             dtype=h.dtype,
         )
 
         if position_ids.shape[0] == 1:
-            offset = mx.array(query_offset_scalar)
+            offset = mx.array(query_offset)
         else:
             offset = position_ids[:, 0]
 

--- a/mlx_vlm/speculative/drafters/gemma4_assistant/masks.py
+++ b/mlx_vlm/speculative/drafters/gemma4_assistant/masks.py
@@ -8,7 +8,7 @@ SDPA handles it) or a small additive bias for SWA layers when the KV is
 longer than the sliding window.
 """
 
-from typing import Optional, Tuple
+from typing import Optional, Tuple, Union
 
 import mlx.core as mx
 
@@ -16,19 +16,38 @@ import mlx.core as mx
 def bidirectional_full_mask(
     query_len: int,
     kv_len: int,
+    kv_valid_len: Optional[Union[int, mx.array]] = None,
     dtype: mx.Dtype = mx.float32,
 ) -> Optional[mx.array]:
-    """No-op for unbatched, no-padding case — SDPA treats ``None`` as fully
-    attending."""
-    del query_len, kv_len, dtype
+    """Full-attention mask.
+
+    In the unbatched, no-padding case this is a no-op. In batched MTP, rows
+    can have different prompt lengths while the K/V tensor is padded to a
+    common length, so each row must mask keys beyond its own valid prefix.
+    """
+    del query_len
+    if kv_valid_len is None or isinstance(kv_valid_len, int):
+        if kv_valid_len is None or kv_valid_len >= kv_len:
+            return None
+        k_idx = mx.arange(kv_len)
+        inside = k_idx < kv_valid_len
+        bias = mx.where(
+            inside, mx.array(0.0, dtype=dtype), mx.array(-mx.inf, dtype=dtype)
+        )
+        return bias[None, None, None, :]
+    k_idx = mx.arange(kv_len)[None, :]
+    inside = k_idx < kv_valid_len[:, None]
+    bias = mx.where(inside, mx.array(0.0, dtype=dtype), mx.array(-mx.inf, dtype=dtype))
+    return bias[:, None, None, :]
     return None
 
 
 def bidirectional_swa_mask(
     query_len: int,
-    query_offset: int,
+    query_offset: Union[int, mx.array],
     kv_len: int,
     window: int,
+    kv_valid_len: Optional[Union[int, mx.array]] = None,
     dtype: mx.Dtype = mx.float32,
 ) -> Optional[mx.array]:
     """Bidirectional sliding-window mask.
@@ -38,22 +57,39 @@ def bidirectional_swa_mask(
     Returns ``None`` when no masking is needed (the entire KV fits in the
     bidirectional window of every query).
     """
-    if kv_len <= window and query_offset + query_len <= kv_len + window:
+    if isinstance(query_offset, int) and (
+        kv_valid_len is None or isinstance(kv_valid_len, int)
+    ) and kv_len <= window and query_offset + query_len <= kv_len + window:
         return None
 
-    q_idx = mx.arange(query_offset, query_offset + query_len)[:, None]
-    k_idx = mx.arange(kv_len)[None, :]
-    dist = q_idx - k_idx
+    if isinstance(query_offset, int):
+        q_idx = mx.arange(query_offset, query_offset + query_len)[:, None]
+        k_idx = mx.arange(kv_len)[None, :]
+        dist = q_idx - k_idx
+        inside = (dist > -window) & (dist < window)
+        if kv_valid_len is not None:
+            inside = inside & (k_idx < int(kv_valid_len))
+        bias = mx.where(
+            inside, mx.array(0.0, dtype=dtype), mx.array(-mx.inf, dtype=dtype)
+        )
+        return bias[None, None, :, :]
+
+    q_idx = query_offset[:, None] + mx.arange(query_len)[None, :]
+    k_idx = mx.arange(kv_len)[None, None, :]
+    dist = q_idx[:, :, None] - k_idx
     inside = (dist > -window) & (dist < window)
+    if kv_valid_len is not None:
+        valid = kv_valid_len if isinstance(kv_valid_len, mx.array) else mx.array(kv_valid_len)
+        inside = inside & (k_idx < valid[:, None, None])
     # SDPA expects an additive mask broadcastable to (B, H, L, S).
     bias = mx.where(inside, mx.array(0.0, dtype=dtype), mx.array(-mx.inf, dtype=dtype))
-    return bias[None, None, :, :]
+    return bias[:, None, :, :]
 
 
 def make_drafter_masks(
     shared_kv_states: dict,
     query_len: int,
-    query_offset: int,
+    query_offset: Union[int, mx.array],
     sliding_window: int,
     dtype: mx.Dtype = mx.float32,
 ) -> dict:
@@ -61,12 +97,15 @@ def make_drafter_masks(
     masks = {}
     for layer_type, kv in shared_kv_states.items():
         kv_len = _kv_len(kv)
+        kv_valid_len = query_offset
         if layer_type == "sliding_attention":
             masks[layer_type] = bidirectional_swa_mask(
-                query_len, query_offset, kv_len, sliding_window, dtype
+                query_len, query_offset, kv_len, sliding_window, kv_valid_len, dtype
             )
         else:
-            masks[layer_type] = bidirectional_full_mask(query_len, kv_len, dtype)
+            masks[layer_type] = bidirectional_full_mask(
+                query_len, kv_len, kv_valid_len, dtype
+            )
     return masks
 
 

--- a/mlx_vlm/tests/test_gemma4_assistant_masks.py
+++ b/mlx_vlm/tests/test_gemma4_assistant_masks.py
@@ -1,0 +1,20 @@
+import mlx.core as mx
+
+from mlx_vlm.speculative.drafters.gemma4_assistant.masks import make_drafter_masks
+
+
+def test_mtp_drafter_masks_support_batched_offsets():
+    kv = (mx.zeros((2, 1, 8, 4)), mx.zeros((2, 1, 8, 4)))
+
+    masks = make_drafter_masks(
+        {"sliding_attention": kv, "full_attention": kv},
+        query_len=1,
+        query_offset=mx.array([5, 8]),
+        sliding_window=4,
+    )
+
+    assert masks["sliding_attention"].shape == (2, 1, 1, 8)
+    assert masks["full_attention"].shape == (2, 1, 1, 8)
+    full = masks["full_attention"].tolist()
+    assert full[0][0][0][5] == -float("inf")
+    assert full[1][0][0][7] == 0.0

--- a/mlx_vlm/tests/test_server.py
+++ b/mlx_vlm/tests/test_server.py
@@ -88,6 +88,14 @@ def test_speculative_server_reads_draft_block_size_env(monkeypatch):
     assert server._get_draft_block_size_from_env() == 3
 
 
+def test_speculative_server_reads_batch_wait_env(monkeypatch):
+    monkeypatch.delenv("MLX_VLM_SPEC_BATCH_WAIT_MS", raising=False)
+    assert server._get_spec_batch_wait_from_env() == 0.0
+
+    monkeypatch.setenv("MLX_VLM_SPEC_BATCH_WAIT_MS", "750")
+    assert server._get_spec_batch_wait_from_env() == 0.75
+
+
 def test_responses_endpoint_forwards_new_sampling_args(client):
     model = SimpleNamespace()
     processor = SimpleNamespace()


### PR DESCRIPTION
## Summary

Follow-up to #1115, per @Blaizzy's request on #1116.

This PR targets `pc/fix-gemma-4-mtp-server` and keeps the diff limited to the remaining batching/correctness improvements from the local Gemma 4 31B MTP validation work.

## Changes

- Handle vector-valued `BatchKVCache.offset` in `_mtp_rounds_batch` by preserving per-row positions instead of collapsing every row to the max offset.
- Add `MLX_VLM_SPEC_BATCH_WAIT_MS` so speculative serving can briefly coalesce simultaneous requests into real MTP batches.
- Pass correct left-padding metadata to the speculative server prefill cache for mixed-length request batches.
- Make Gemma 4 assistant masks respect per-row offsets/valid lengths for batched rows.
- Add tests for the coalescing env var and batched assistant masks.

## Local validation

Target/runtime used locally:

- Hardware: Apple M4 Max, 64 GB RAM
- Target: `/Users/jkooker/.lmstudio/models/lmstudio-community/gemma-4-31B-it-MLX-6bit`
- Assistant: `mlx-community/gemma-4-31B-it-assistant-bf16`
- Endpoint: patched `mlx_vlm.server`, `/v1/chat/completions`
- Sampling: temperature 0, thinking disabled
- Coalescing: `MLX_VLM_SPEC_BATCH_WAIT_MS=1000`

Same-prompt/equal-length batch throughput after these changes:

| draft_block_size | user batch | aggregate tok/s | assistant accept/round |
| --- | ---: | ---: | ---: |
| 4 | 4 | 41.59 | 1.87 |
| 4 | 8 | 65.64 | 1.87 |
| 7 | 4 | 33.18 | 2.88 |
| 7 | 8 | 39.94 | 2.88 |

Mixed-length batches are now position/mask-correct, but acceptance is lower. For maximum throughput, production servers may want to batch by similar prompt length/template.

## Tests

```bash
/opt/miniconda3/bin/python -m pytest \
  mlx_vlm/tests/test_server.py \
  mlx_vlm/tests/test_gemma4_assistant_masks.py \
  mlx_vlm/tests/test_generate.py::test_generate_cli_smoke -q
```

Result: `50 passed`.
