### PR TITLE
Fix Qwen3.5 quantization config keys

### DIFF
--- a/mlx_vlm/models/qwen3_5/config.py
+++ b/mlx_vlm/models/qwen3_5/config.py
@@ -6,6 +6,18 @@ from ..base import BaseModelConfig
 from ..qwen3_vl.config import VisionConfig as Qwen3VLVisionConfig
 
 
+def sanitize_quantization_config(quantization):
+    if not isinstance(quantization, dict):
+        return quantization
+
+    from .qwen3_5 import sanitize_key
+
+    sanitized = {}
+    for key, value in quantization.items():
+        sanitized[sanitize_key(key)] = value
+    return sanitized
+
+
 @dataclass
 class VisionConfig(Qwen3VLVisionConfig):
     model_type: str = "qwen3_5"
@@ -83,12 +95,22 @@ class ModelConfig(BaseModelConfig):
     vision_end_token_id: int = 248046
     vocab_size: int = 248320
     eos_token_id: Optional[List[int]] = None
+    quantization: Optional[Dict] = None
+    quantization_config: Optional[Dict] = None
 
     def __post_init__(self):
         if self.image_token_index is None:
             self.image_token_index = self.image_token_id
         if self.video_token_index is None:
             self.video_token_index = self.video_token_id
+        quantization = self.quantization
+        self.quantization = sanitize_quantization_config(quantization)
+        if self.quantization_config == quantization:
+            self.quantization_config = self.quantization
+        else:
+            self.quantization_config = sanitize_quantization_config(
+                self.quantization_config
+            )
 
     @classmethod
     def from_dict(cls, params):

--- a/mlx_vlm/models/qwen3_5/qwen3_5.py
+++ b/mlx_vlm/models/qwen3_5/qwen3_5.py
@@ -12,6 +12,17 @@ from .language import LanguageModel
 from .vision import VisionModel
 
 
+def sanitize_key(key):
+    if "model" in key:
+        if "model.language_model" in key:
+            key = key.replace("model.language_model", "language_model.model")
+        elif "model.visual" in key:
+            key = key.replace("model.visual", "vision_tower")
+    elif "lm_head" in key:
+        key = key.replace("lm_head", "language_model.lm_head")
+    return key
+
+
 class Model(Qwen3VLModel):
 
     def __init__(self, config: ModelConfig):
@@ -122,13 +133,7 @@ class Model(Qwen3VLModel):
 
         sanitized_weights = {}
         for key, value in weights.items():
-            if "model" in key:
-                if "model.language_model" in key:
-                    key = key.replace("model.language_model", "language_model.model")
-                elif "model.visual" in key:
-                    key = key.replace("model.visual", "vision_tower")
-            elif "lm_head" in key:
-                key = key.replace("lm_head", "language_model.lm_head")
+            key = sanitize_key(key)
 
             if "conv1d.weight" in key and value.shape[-1] != 1:
                 value = value.moveaxis(2, 1)

--- a/mlx_vlm/models/qwen3_5_moe/config.py
+++ b/mlx_vlm/models/qwen3_5_moe/config.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass, field
 from typing import Dict, List, Optional, Union
 
 from ..base import BaseModelConfig
+from ..qwen3_5.config import sanitize_quantization_config
 from ..qwen3_vl.config import VisionConfig as Qwen3VLVisionConfig
 
 
@@ -86,12 +87,22 @@ class ModelConfig(BaseModelConfig):
     vision_end_token_id: int = 248046
     vocab_size: int = 248320
     eos_token_id: Optional[List[int]] = None
+    quantization: Optional[Dict] = None
+    quantization_config: Optional[Dict] = None
 
     def __post_init__(self):
         if self.image_token_index is None:
             self.image_token_index = self.image_token_id
         if self.video_token_index is None:
             self.video_token_index = self.video_token_id
+        quantization = self.quantization
+        self.quantization = sanitize_quantization_config(quantization)
+        if self.quantization_config == quantization:
+            self.quantization_config = self.quantization
+        else:
+            self.quantization_config = sanitize_quantization_config(
+                self.quantization_config
+            )
 
     @classmethod
     def from_dict(cls, params):

--- a/mlx_vlm/models/qwen3_5_moe/qwen3_5_moe.py
+++ b/mlx_vlm/models/qwen3_5_moe/qwen3_5_moe.py
@@ -2,6 +2,7 @@ import mlx.core as mx
 import mlx.nn as nn
 
 from ..qwen3_5 import Model as Qwen3_5Model
+from ..qwen3_5.qwen3_5 import sanitize_key
 from .config import ModelConfig
 from .language import LanguageModel
 from .vision import VisionModel
@@ -45,13 +46,7 @@ class Model(Qwen3_5Model):
 
         sanitized_weights = {}
         for key, value in weights.items():
-            if "model" in key:
-                if "model.language_model" in key:
-                    key = key.replace("model.language_model", "language_model.model")
-                elif "model.visual" in key:
-                    key = key.replace("model.visual", "vision_tower")
-            elif "lm_head" in key:
-                key = key.replace("lm_head", "language_model.lm_head")
+            key = sanitize_key(key)
 
             if "conv1d.weight" in key and value.shape[-1] != 1:
                 value = value.moveaxis(2, 1)

--- a/mlx_vlm/tests/test_models.py
+++ b/mlx_vlm/tests/test_models.py
@@ -1244,6 +1244,50 @@ class TestModels(unittest.TestCase):
             model.language_model, config.text_config.hidden_size
         )
 
+    def test_qwen3_5_model_config(self):
+        from mlx_vlm.models import qwen3_5, qwen3_5_moe
+
+        quantization = {
+            "group_size": 128,
+            "bits": 4,
+            "model.language_model.layers.0.linear_attn.in_proj_qkv": {
+                "group_size": 128,
+                "bits": 6,
+            },
+            "model.visual.blocks.0.attn.qkv": False,
+            "lm_head": False,
+        }
+
+        for model_module in (qwen3_5, qwen3_5_moe):
+            with self.subTest(model_type=model_module.__name__):
+                config = model_module.ModelConfig.from_dict(
+                    {
+                        "model_type": model_module.__name__.rsplit(".", 1)[-1],
+                        "text_config": {},
+                        "vision_config": {},
+                        "quantization": quantization,
+                        "quantization_config": quantization,
+                    }
+                )
+
+                self.assertIn(
+                    "language_model.model.layers.0.linear_attn.in_proj_qkv",
+                    config.quantization,
+                )
+                self.assertEqual(
+                    config.quantization[
+                        "language_model.model.layers.0.linear_attn.in_proj_qkv"
+                    ],
+                    {"group_size": 128, "bits": 6},
+                )
+                self.assertNotIn(
+                    "model.language_model.layers.0.linear_attn.in_proj_qkv",
+                    config.quantization,
+                )
+                self.assertIn("vision_tower.blocks.0.attn.qkv", config.quantization)
+                self.assertIn("language_model.lm_head", config.quantization)
+                self.assertIs(config.quantization, config.quantization_config)
+
     def test_qwen3_vl_moe(self):
         from mlx_vlm.models import qwen3_vl_moe
 

--- a/mlx_vlm/utils.py
+++ b/mlx_vlm/utils.py
@@ -240,6 +240,8 @@ python -m mlx_vlm.convert --hf-path <local_dir> --mlx-path <mlx_dir>
     config.setdefault("vision_config", {})
     config.setdefault("audio_config", {})
 
+    has_quantization = "quantization" in config
+
     # Initialize model config and update it with module configs
     model_config = model_class.ModelConfig.from_dict(config)
     modules = ["text", "vision", "perceiver", "projector", "audio"]
@@ -272,7 +274,7 @@ python -m mlx_vlm.convert --hf-path <local_dir> --mlx-path <mlx_dir>
                     model_class.AudioModel, weights, model_config.audio_config
                 )
 
-    if "quantization" not in config:
+    if not has_quantization:
         quantization_config = config.get("quantization_config", None)
         if quantization_config is None:
             text_config = config.get("text_config", {})
@@ -296,6 +298,12 @@ python -m mlx_vlm.convert --hf-path <local_dir> --mlx-path <mlx_dir>
             if quantization is not None:
                 config["quantization"] = quantization
                 config["quantization_config"] = quantization
+
+    if has_quantization:
+        for quantization_key in ("quantization", "quantization_config"):
+            quantization_value = getattr(model_config, quantization_key, None)
+            if quantization_value is not None:
+                config[quantization_key] = quantization_value
 
     if (quantization := config.get("quantization", None)) is not None:
         # Handle legacy models which may or may not have vision quantized


### PR DESCRIPTION
## Summary
- Sanitize Qwen3.5 quantization config keys during model config initialization so per-module overrides match MLX module paths.
- Reuse the Qwen3.5 weight key sanitizer for Qwen3.5-MoE instead of duplicating the path mapping.
- Feed sanitized quantization config back into `load_model()` before building the quantization predicate.

References #1078.

## Validation
- `pytest mlx_vlm/tests/test_models.py::TestModels::test_qwen3_5_model_config -q`
- `python -m py_compile mlx_vlm/models/qwen3_5/config.py mlx_vlm/models/qwen3_5/qwen3_5.py mlx_vlm/models/qwen3_5_moe/config.py mlx_vlm/models/qwen3_5_moe/qwen3_5_moe.py mlx_vlm/utils.py mlx_vlm/tests/test_models.py`
- Lazy-load check for `Intel/Qwen3.6-27B-4.5b-mlx-AutoRound` confirmed `linear_attn.in_proj_qkv` loads as `QuantizedLinear 6 128 affine`.
- `uv run mlx_vlm.generate --model Intel/Qwen3.6-27B-4.5b-mlx-AutoRound --image /Users/prince_canuma/Documents/mlx-vlm/examples/images/cats.jpg --prompt "Descriibe this image" --max-tokens 16`