### PR TITLE
Fix Gemma 4 E2B/E4B per_layer_inputs crash in batched prefill

### DIFF
--- a/mlx_vlm/generate.py
+++ b/mlx_vlm/generate.py
@@ -2497,7 +2497,19 @@ class PromptProcessingBatch:
             else []
         )
         self._inputs_embeds = inputs_embeds
-        self._prompt_kwargs = prompt_kwargs
+        self._prompt_kwargs = prompt_kwargs or {}
+        self._prompt_length_aware_keys: List[str] = []
+        if self._prompt_kwargs and self._inputs_embeds is not None:
+            prompt_batch = self._inputs_embeds.shape[0]
+            prompt_len = self._inputs_embeds.shape[1]
+            for k, v in self._prompt_kwargs.items():
+                if (
+                    isinstance(v, mx.array)
+                    and v.ndim >= 2
+                    and v.shape[0] == prompt_batch
+                    and v.shape[1] == prompt_len
+                ):
+                    self._prompt_length_aware_keys.append(k)
 
         # APC metadata used for post-prefill block harvest (per-row).
         self._apc_meta = apc_meta or []
@@ -2626,6 +2638,14 @@ class PromptProcessingBatch:
             )
             meta["checkpoint_done"] = True
 
+    def _prompt_kwargs_for_step(self, n: Optional[int] = None) -> dict:
+        if n is None or not self._prompt_length_aware_keys:
+            return self._prompt_kwargs
+        out = dict(self._prompt_kwargs)
+        for k in self._prompt_length_aware_keys:
+            out[k] = out[k][:, :n, ...]
+        return out
+
     def prompt_step(self) -> int:
         """Process one chunk of the prompt. Returns tokens processed."""
         if not self.needs_processing():
@@ -2638,18 +2658,21 @@ class PromptProcessingBatch:
             n = min(n, checkpoint_col - self._processed_prompt_columns)
         if n <= 0:
             return 0
+        prompt_kwargs = self._prompt_kwargs_for_step(n)
         self.model(
             self._input_ids[:, :n],
             cache=self.prompt_cache,
             inputs_embeds=self._inputs_embeds[:, :n],
             n_to_process=n,
-            **self._prompt_kwargs,
+            **prompt_kwargs,
         )
         mx.eval([c.state for c in self.prompt_cache])
         self._processed_prompt_columns += n
         self._store_apc_exact_checkpoints()
         self._inputs_embeds = self._inputs_embeds[:, n:]
         self._input_ids = self._input_ids[:, n:]
+        for k in self._prompt_length_aware_keys:
+            self._prompt_kwargs[k] = self._prompt_kwargs[k][:, n:, ...]
         mx.clear_cache()
         return n
 
@@ -3119,14 +3142,26 @@ class BatchGenerator:
         # in _apc_extra_hash, never forwarded to the model.
         merged_kwargs: dict = {}
         per_row_keys: dict = {}
-        for kw in prompt_kwargs_list:
+        for i, kw in enumerate(prompt_kwargs_list):
             if not kw:
                 continue
+            full_len = len(full_ids[i])
+            prefix_len = prefix_lens[i]
+            right_pad = right_pad_per_row[i]
             for k, v in kw.items():
                 if k == "inputs_embeds" or k in self._APC_PRIVATE_KEYS:
                     continue
                 if isinstance(v, mx.array) and v.ndim > 0 and v.shape[0] >= 1:
-                    per_row_keys.setdefault(k, []).append(v[:1])
+                    row_v = v[:1]
+                    if v.shape[0] == 1 and v.ndim >= 2 and v.shape[1] == full_len:
+                        row_v = row_v[:, prefix_len:, ...]
+                        if right_pad > 0:
+                            pad_shape = (row_v.shape[0], right_pad) + tuple(
+                                row_v.shape[2:]
+                            )
+                            row_pad = mx.zeros(pad_shape, dtype=row_v.dtype)
+                            row_v = mx.concatenate([row_v, row_pad], axis=1)
+                    per_row_keys.setdefault(k, []).append(row_v)
                 elif k not in merged_kwargs:
                     merged_kwargs[k] = v
         for k, vs in per_row_keys.items():


### PR DESCRIPTION
## Summary

Fixes a crash on Gemma 4 E2B/E4B (`hidden_size_per_layer_input > 0`) when the
server batches multiple text-only requests of different prompt lengths. The
mixed warm/cold APC prefill path was concatenating each row's `per_layer_inputs`
(shape `[1, L_i, num_layers, h_per_layer]`) along the batch axis without first
aligning `L_i`, raising:

```
[concatenate] All the input array dimensions must match exactly except for the
concatenation axis. However, the provided shapes are (1,24,42,256), (1,26,42,256),
(1,28,42,256), and the concatenation axis is 0.
```

`inputs_embeds` was already handled — sliced to suffix per-row and right-padded
to `max_suffix_len` before the batch concat. This change applies the same
treatment to any per-row tensor whose `shape[1]` equals that row's full input
length, and extends `PromptProcessingBatch`'s chunked prefill to slice those
length-aware kwargs alongside `inputs_embeds`.

## Test plan

Repro: send 4 concurrent text-only requests with prompts of different
tokenized lengths (e.g. 21/25/25/23 tokens) to an E4B server.

- Pre-fix: `B=4` returns `500 Internal Server Error` (`concatenate` shape mismatch above).
- Post-fix: `B=4` returns 4 coherent responses; aggregate ~54 tok/s on E4B.

Verified locally:
- `B=1`: 25.62 tok/s (unchanged from pre-fix)
- `B=2`: 27.63 tok/s (unchanged)
- `B=4`: **54.36 tok/s** (was: crashed)

## Notes

- Single-file change, +39 / -4 in `mlx_vlm/generate.py`.
- Length-agnostic per-row tensors (scalars, per-layer broadcast constants) keep
  the existing concat path; only tensors with `shape[1] == row prompt length`
  go through the slice + right-pad logic.
- Doesn't touch any model code or the drafter — purely a server-side
  batched-prefill fix in `BatchGenerator`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)