### PR TITLE
Fix mixed-length Gemma 4 batching

### DIFF
--- a/mlx_vlm/generate.py
+++ b/mlx_vlm/generate.py
@@ -2015,6 +2015,29 @@ def _prompt_kwarg_row(v: mx.array, row_idx: int, batch_size: int) -> mx.array:
     return v[:1]
 
 
+def _split_prompt_kwargs_per_row(prompt_kwargs: dict, batch_size: int) -> List[dict]:
+    """Normalize batched prompt kwargs into one dict per batch row.
+
+    ``model.get_input_embeddings()`` commonly returns batch-sized tensors
+    (notably ``inputs_embeds``). ``BatchGenerator.insert()`` stores prompt
+    kwargs per sequence, so passing the same batched dict for every row causes
+    the prompt builder to concatenate those batched tensors ``batch_size``
+    times, effectively squaring the batch dimension.
+    """
+    if batch_size <= 1:
+        return [prompt_kwargs or {}]
+
+    rows = [{} for _ in range(batch_size)]
+    for k, v in (prompt_kwargs or {}).items():
+        if isinstance(v, mx.array) and v.ndim > 0 and v.shape[0] >= 1:
+            for i in range(batch_size):
+                rows[i][k] = _prompt_kwarg_row(v, i, batch_size)
+        else:
+            for row in rows:
+                row[k] = v
+    return rows
+
+
 def _is_sequence_aligned_prompt_kwarg(
     key: str, v: mx.array, sequence_length: int
 ) -> bool:
@@ -3853,7 +3876,7 @@ def _generate_batch(
     uids = gen.insert(
         input_ids.tolist(),
         max_tokens,
-        prompt_kwargs=[gen_kwargs] * len(input_ids),
+        prompt_kwargs=_split_prompt_kwargs_per_row(gen_kwargs, batch_size),
         logits_processors=logits_processors,
     )
     results = {uid: [] for uid in uids}

--- a/mlx_vlm/generate.py
+++ b/mlx_vlm/generate.py
@@ -1997,6 +1997,46 @@ def _right_pad_prompts(prompts, max_length=None):
     return mx.array([list(p) + [0] * (max_length - len(p)) for p in prompts])
 
 
+_SEQUENCE_ALIGNED_PROMPT_KWARGS = {
+    "attention_mask",
+    "decoder_inputs_embeds",
+    "deepstack_visual_embeds",
+    "visual_pos_masks",
+    "per_layer_inputs",
+    "full_text_row_masked_out_mask",
+    "position_ids",
+    "pos_hw",
+}
+
+
+def _prompt_kwarg_row(v: mx.array, row_idx: int, batch_size: int) -> mx.array:
+    if v.shape[0] == batch_size:
+        return v[row_idx : row_idx + 1]
+    return v[:1]
+
+
+def _is_sequence_aligned_prompt_kwarg(
+    key: str, v: mx.array, sequence_length: int
+) -> bool:
+    return (
+        key in _SEQUENCE_ALIGNED_PROMPT_KWARGS
+        and v.ndim >= 2
+        and v.shape[1] == sequence_length
+    )
+
+
+def _pad_sequence_aligned_prompt_kwarg(
+    v: mx.array, target_length: int, *, left: bool
+) -> mx.array:
+    pad = target_length - v.shape[1]
+    if pad <= 0:
+        return v
+    pad_shape = (v.shape[0], pad) + tuple(v.shape[2:])
+    pad_v = mx.zeros(pad_shape, dtype=v.dtype)
+    parts = [pad_v, v] if left else [v, pad_v]
+    return mx.concatenate(parts, axis=1)
+
+
 def _extend_cache(cache_a, cache_b):
     """Extend cache_a with cache_b along the batch dimension."""
     if not cache_a:
@@ -3142,6 +3182,7 @@ class BatchGenerator:
         # in _apc_extra_hash, never forwarded to the model.
         merged_kwargs: dict = {}
         per_row_keys: dict = {}
+        batch_size = len(prompt_kwargs_list)
         for i, kw in enumerate(prompt_kwargs_list):
             if not kw:
                 continue
@@ -3152,15 +3193,14 @@ class BatchGenerator:
                 if k == "inputs_embeds" or k in self._APC_PRIVATE_KEYS:
                     continue
                 if isinstance(v, mx.array) and v.ndim > 0 and v.shape[0] >= 1:
-                    row_v = v[:1]
-                    if v.shape[0] == 1 and v.ndim >= 2 and v.shape[1] == full_len:
+                    row_v = _prompt_kwarg_row(v, i, batch_size)
+                    if _is_sequence_aligned_prompt_kwarg(k, row_v, full_len):
                         row_v = row_v[:, prefix_len:, ...]
-                        if right_pad > 0:
-                            pad_shape = (row_v.shape[0], right_pad) + tuple(
-                                row_v.shape[2:]
-                            )
-                            row_pad = mx.zeros(pad_shape, dtype=row_v.dtype)
-                            row_v = mx.concatenate([row_v, row_pad], axis=1)
+                        row_v = _pad_sequence_aligned_prompt_kwarg(
+                            row_v,
+                            max_suffix_len,
+                            left=False,
+                        )
                     per_row_keys.setdefault(k, []).append(row_v)
                 elif k not in merged_kwargs:
                     merged_kwargs[k] = v
@@ -3472,14 +3512,20 @@ class BatchGenerator:
 
             merged_kwargs: dict = {}
             per_row_keys: dict = {}
-            for kw in prompt_kwargs_list:
+            batch_size = len(prompt_kwargs_list)
+            for i, (kw, l) in enumerate(zip(prompt_kwargs_list, lengths)):
                 if not kw:
                     continue
                 for k, v in kw.items():
                     if k == "inputs_embeds" or k in self._APC_PRIVATE_KEYS:
                         continue
                     if isinstance(v, mx.array) and v.ndim > 0 and v.shape[0] >= 1:
-                        per_row_keys.setdefault(k, []).append(v[:1])
+                        row_v = _prompt_kwarg_row(v, i, batch_size)
+                        if _is_sequence_aligned_prompt_kwarg(k, row_v, l):
+                            row_v = _pad_sequence_aligned_prompt_kwarg(
+                                row_v, max_length, left=True
+                            )
+                        per_row_keys.setdefault(k, []).append(row_v)
                     elif k not in merged_kwargs:
                         merged_kwargs[k] = v
             for k, vs in per_row_keys.items():

--- a/mlx_vlm/tests/test_generate.py
+++ b/mlx_vlm/tests/test_generate.py
@@ -1240,6 +1240,78 @@ def test_batch_apc_extra_hash_uses_precomputed_image_hash():
     assert got == apc_module.tenant_scoped_hash("tenant-a", 123)
 
 
+def test_cold_batch_left_pads_sequence_aligned_prompt_kwargs():
+    class EmptyGenerationBatch:
+        def __len__(self):
+            return 0
+
+    bg = object.__new__(BatchGenerator)
+    bg._generation_batch = EmptyGenerationBatch()
+    bg._prompt_batch = None
+    bg._prompt_tokens_counter = 0
+    bg._prompt_time_counter = 0
+    bg._gen_tokens_counter = 0
+    bg._steps_counter = 0
+    bg.completion_batch_size = 4
+    bg.prefill_batch_size = 4
+    bg.prefill_step_size = 1
+    bg.kv_bits = None
+    bg.kv_group_size = 64
+    bg.kv_quant_scheme = "affine"
+    bg.apc_manager = None
+    bg.apc_mode = None
+    bg.model = SimpleNamespace()
+    bg._wire_stack = None
+    bg.compute_logprobs = False
+    bg.top_logprobs_k = 0
+    bg.sampler = lambda logprobs: mx.argmax(logprobs, axis=-1)
+    bg.tokenizer = SimpleNamespace(stopping_criteria=object())
+
+    lengths = [2, 4, 3, 1]
+    bg._unprocessed_sequences = [
+        (
+            i,
+            list(range(length)),
+            1,
+            {
+                "inputs_embeds": mx.ones((1, length, 3)) * (i + 1),
+                "per_layer_inputs": mx.ones((1, length, 2, 5)) * (i + 1),
+                "attention_mask": mx.ones((1, length), dtype=mx.int32),
+                "pixel_values": mx.ones((1, 3, 2, 2)) * (i + 1),
+                "keep_tensor": mx.array([[i + 1]], dtype=mx.int32),
+                "rope_deltas": mx.array([[i + 10]], dtype=mx.int32),
+                "_apc_tenant": "tenant",
+            },
+            [],
+        )
+        for i, length in enumerate(lengths)
+    ]
+
+    captured = {}
+
+    def fake_prompt_batch(**kwargs):
+        captured.update(kwargs)
+        return SimpleNamespace(
+            total_prompt_tokens=sum(len(ids) for ids in kwargs["input_ids"]),
+            needs_processing=lambda: True,
+            prompt_step=lambda: 0,
+        )
+
+    with patch.object(generate_module, "PromptProcessingBatch", fake_prompt_batch):
+        bg._next()
+
+    prompt_kwargs = captured["prompt_kwargs"]
+    assert captured["inputs_embeds"].shape == (4, 4, 3)
+    assert prompt_kwargs["per_layer_inputs"].shape == (4, 4, 2, 5)
+    assert prompt_kwargs["attention_mask"].shape == (4, 4)
+    assert prompt_kwargs["pixel_values"].shape == (4, 3, 2, 2)
+    assert prompt_kwargs["keep_tensor"].shape == (4, 1)
+    assert prompt_kwargs["rope_deltas"].shape == (4, 1)
+    assert "_apc_tenant" not in prompt_kwargs
+    assert prompt_kwargs["per_layer_inputs"][0, :, 0, 0].tolist() == [0, 0, 1, 1]
+    assert prompt_kwargs["per_layer_inputs"][3, :, 0, 0].tolist() == [0, 0, 0, 4]
+
+
 def test_mixed_apc_batch_strips_private_kwargs_before_prefill():
     bg = object.__new__(BatchGenerator)
     bg.apc_manager = object()

--- a/mlx_vlm/tests/test_generate.py
+++ b/mlx_vlm/tests/test_generate.py
@@ -604,6 +604,83 @@ class TestBatchGenerate:
         assert response.texts == ["Response 1", "Response 2"]
         mock_generate_batch.assert_called_once()
 
+    def test_generate_batch_splits_batched_prompt_kwargs_per_row(
+        self, mock_model, mock_processor
+    ):
+        """Regression test for Gemma 4-style batched ``inputs_embeds``."""
+
+        class _EmbeddingOutput:
+            def __init__(self, inputs_embeds, position_ids):
+                self.inputs_embeds = inputs_embeds
+                self.position_ids = position_ids
+
+            def to_dict(self):
+                return {
+                    "inputs_embeds": self.inputs_embeds,
+                    "position_ids": self.position_ids,
+                }
+
+        class _StopInsert(Exception):
+            pass
+
+        batch_size = 3
+        seq_len = 5
+        hidden_size = 7
+        input_ids = mx.array(
+            [
+                [11, 12, 13, 14, 15],
+                [21, 22, 23, 24, 25],
+                [31, 32, 33, 34, 35],
+            ],
+            dtype=mx.int32,
+        )
+        inputs_embeds = mx.arange(
+            batch_size * seq_len * hidden_size, dtype=mx.float32
+        ).reshape(batch_size, seq_len, hidden_size)
+        position_ids = mx.arange(batch_size * seq_len, dtype=mx.int32).reshape(
+            batch_size, seq_len
+        )
+        embedding_output = _EmbeddingOutput(inputs_embeds, position_ids)
+
+        def fake_insert(
+            self, prompts, max_tokens, prompt_kwargs=None, logits_processors=None
+        ):
+            assert len(prompts) == batch_size
+            assert len(prompt_kwargs) == batch_size
+            for i, kw in enumerate(prompt_kwargs):
+                assert kw["inputs_embeds"].shape == (1, seq_len, hidden_size)
+                assert kw["position_ids"].shape == (1, seq_len)
+                assert kw["inputs_embeds"].tolist() == inputs_embeds[i : i + 1].tolist()
+                assert kw["position_ids"].tolist() == position_ids[i : i + 1].tolist()
+            raise _StopInsert
+
+        with (
+            patch.object(
+                generate_module,
+                "apply_chat_template",
+                side_effect=lambda processor, config, prompt, num_images=0: prompt,
+            ),
+            patch.object(
+                generate_module,
+                "prepare_inputs",
+                return_value={
+                    "input_ids": input_ids,
+                    "attention_mask": mx.ones((batch_size, seq_len), dtype=mx.int32),
+                },
+            ),
+            patch.object(
+                mock_model, "get_input_embeddings", return_value=embedding_output
+            ),
+            patch.object(generate_module.BatchGenerator, "insert", new=fake_insert),
+        ):
+            with pytest.raises(_StopInsert):
+                generate_module._generate_batch(
+                    mock_model,
+                    mock_processor,
+                    prompts=["alpha", "beta", "gamma"],
+                    max_tokens=5,
+                )
+
     @patch.object(generate_module, "_generate_batch")
     @patch("mlx_vlm.utils.process_image")
     def test_with_images_same_shape(


### PR DESCRIPTION
## Summary

Fixes the mixed-length Gemma 4 continuous batching crash reported in #1124.

The cold prefill path already left-padded `inputs_embeds` to the prompt batch max length, but other sequence-aligned prompt kwargs such as Gemma 4 `per_layer_inputs` were concatenated without matching sequence lengths. Mixed-length B=4 requests could therefore fail with an MLX concatenate shape mismatch before generation.

This change adds scoped helpers for sequence-aligned prompt kwargs and applies the same padding rules when merging cold and APC mixed prompt batches. Non-sequence tensors such as image tensors and scalar-ish per-row metadata are left on their original axes.

## Validation

- `python -m pytest mlx_vlm/tests/test_generate.py -q` -> `59 passed`
- `python -m compileall -q mlx_vlm/generate.py mlx_vlm/tests/test_generate.py`
- Live server repro with `mlx-community/gemma-4-e4b-it-8bit`, 4 concurrent mixed-length `/v1/chat/completions`, `max_tokens=200` -> all 4 returned HTTP 200 with no server traceback

## Notes

This fixes the #1124 HTTP 500 / `[concatenate]` shape mismatch. The separate `batch_generate` B=4 Gemma 4 issue in #1083 also fixed.
