### PR TITLE
Fix streamed detokenization for byte-fallback tokens

### DIFF
--- a/mlx_vlm/generate.py
+++ b/mlx_vlm/generate.py
@@ -22,6 +22,7 @@ from transformers import PreTrainedTokenizer
 from . import apc as _apc
 from .models import cache
 from .prompt_utils import apply_chat_template
+from .tokenizer_utils import make_streaming_detokenizer
 from .turboquant import BatchTurboQuantKVCache, TurboQuantKVCache, turboquant_enabled
 from .utils import (
     StoppingCriteria,
@@ -1706,8 +1707,7 @@ def stream_generate(
     total_prompt_tokens = reused_prefix_len + input_ids.size
 
     with wired_limit(model, [generation_stream]):
-        detokenizer = processor.detokenizer
-        detokenizer.reset()
+        detokenizer = make_streaming_detokenizer(processor)
         thinking_criteria = getattr(tokenizer, "thinking_budget_criteria", None)
         exact_checkpoint_len = None
         exact_checkpoint = None

--- a/mlx_vlm/server.py
+++ b/mlx_vlm/server.py
@@ -703,25 +703,35 @@ class ResponseGenerator:
                 first_bonus = sampler(out.logits[:, -1:]).squeeze(-1)
                 mx.eval(first_bonus, hidden, out.logits)
 
+                finished_uids = set()
+
                 # Send first bonus tokens to clients
                 fb_list = first_bonus.tolist()
                 for j, uid in enumerate(uids):
                     tok = int(fb_list[j])
                     token_lists[uid].append(tok)
-                    text = self._stream_text(stream_infos[uid], tok, None)
+                    is_stop = tok in self.stop_tokens
+                    is_max = len(token_lists[uid]) >= max_tokens_map[uid]
+                    finish = "stop" if is_stop else "length" if is_max else None
+                    text = self._stream_text(stream_infos[uid], tok, finish)
                     rqueues[uid].put(
                         StreamingToken(
                             text=text,
                             token=tok,
                             logprobs=0.0,
-                            finish_reason=None,
+                            finish_reason=finish,
                             peak_memory=mx.get_peak_memory() / 1e9,
                         )
                     )
+                    if finish is not None:
+                        rqueues[uid].put(None)
+                        finished_uids.add(uid)
+
+                if len(finished_uids) == len(uids):
+                    continue
 
                 # --- Phase 3: speculative decode rounds ---
                 max_tok = max(max_tokens_map[u] for u in uids)
-                finished_uids = set()
 
                 def stop_check(seq_idx, token_id):
                     uid = uids[seq_idx]

--- a/mlx_vlm/server.py
+++ b/mlx_vlm/server.py
@@ -49,6 +49,7 @@ from .generate import (
 from .prompt_utils import apply_chat_template
 from .sample_utils import top_p_sampling
 from .structured import build_json_schema_logits_processor
+from .tokenizer_utils import make_streaming_detokenizer
 from .tool_parsers import _infer_tool_parser_from_processor, load_tool_module
 from .utils import load, prepare_inputs
 from .version import __version__
@@ -592,8 +593,7 @@ class ResponseGenerator:
                     rqueue.put(GenerationContext(uid=uid, prompt_tokens=prompt_tokens))
                     active[uid] = {
                         "rqueue": rqueue,
-                        "tokens": [],
-                        "prev_text": "",
+                        "detokenizer": make_streaming_detokenizer(self.processor),
                         "gen_kwargs": gen_kwargs if has_embeds else None,
                     }
 
@@ -666,6 +666,7 @@ class ResponseGenerator:
                 uids = []
                 rqueues = {}
                 token_lists = {}
+                stream_infos = {}
                 max_tokens_map = {}
                 all_input_ids = []
 
@@ -675,6 +676,9 @@ class ResponseGenerator:
                     uids.append(uid)
                     rqueues[uid] = rqueue
                     token_lists[uid] = []
+                    stream_infos[uid] = {
+                        "detokenizer": make_streaming_detokenizer(self.processor)
+                    }
                     max_tokens_map[uid] = args.max_tokens
                     all_input_ids.append(input_ids.squeeze(0).tolist())
                     rqueue.put(GenerationContext(uid=uid, prompt_tokens=prompt_tokens))
@@ -704,7 +708,7 @@ class ResponseGenerator:
                 for j, uid in enumerate(uids):
                     tok = int(fb_list[j])
                     token_lists[uid].append(tok)
-                    text = self.tokenizer.decode([tok])
+                    text = self._stream_text(stream_infos[uid], tok, None)
                     rqueues[uid].put(
                         StreamingToken(
                             text=text,
@@ -766,20 +770,14 @@ class ResponseGenerator:
                         token_lists[uid].append(tok)
                         tokens = token_lists[uid]
 
-                        if len(tokens) >= 2:
-                            prev = self.tokenizer.decode(tokens[:-1])
-                            curr = self.tokenizer.decode(tokens)
-                            text = curr[len(prev) :]
-                        else:
-                            text = self.tokenizer.decode(tokens)
-
                         is_stop = tok in self.stop_tokens
                         is_max = len(tokens) >= max_tokens_map[uid]
                         finish = "stop" if is_stop else "length" if is_max else None
+                        text = self._stream_text(stream_infos[uid], tok, finish)
 
                         rqueues[uid].put(
                             StreamingToken(
-                                text="" if is_stop else text,
+                                text=text,
                                 token=tok,
                                 logprobs=0.0,
                                 finish_reason=finish,
@@ -804,9 +802,11 @@ class ResponseGenerator:
                 # Finalize any remaining
                 for uid in uids:
                     if uid not in finished_uids:
+                        stream_infos[uid]["detokenizer"].finalize()
+                        text = stream_infos[uid]["detokenizer"].last_segment
                         rqueues[uid].put(
                             StreamingToken(
-                                text="",
+                                text=text,
                                 token=0,
                                 logprobs=0.0,
                                 finish_reason="length",
@@ -837,13 +837,7 @@ class ResponseGenerator:
             if hasattr(tok, "item"):
                 tok = tok.item()
 
-            if r.finish_reason == "stop":
-                text = ""
-            else:
-                info["tokens"].append(tok)
-                curr = self.tokenizer.decode(info["tokens"])
-                text = curr[len(info["prev_text"]) :]
-                info["prev_text"] = curr
+            text = self._stream_text(info, tok, r.finish_reason)
 
             lp = r.token_logprob
 
@@ -861,6 +855,17 @@ class ResponseGenerator:
             if r.finish_reason is not None:
                 rqueue.put(None)
                 del active[r.uid]
+
+    def _stream_text(self, info: dict, token: int, finish_reason: Optional[str]) -> str:
+        """Convert one generated token into a streaming text segment."""
+        detokenizer = info["detokenizer"]
+        if finish_reason == "stop":
+            detokenizer.finalize()
+        else:
+            detokenizer.add_token(token)
+            if finish_reason is not None:
+                detokenizer.finalize()
+        return detokenizer.last_segment
 
     def _flush(self, batch_gen, active):
         """Drain all pending text-only prompts before inserting an image request."""

--- a/mlx_vlm/tests/test_server.py
+++ b/mlx_vlm/tests/test_server.py
@@ -9,6 +9,7 @@ from fastapi.testclient import TestClient
 
 import mlx_vlm.server as server
 from mlx_vlm.apc import hash_image_payload
+from mlx_vlm.tokenizer_utils import SPMStreamingDetokenizer
 
 
 @pytest.fixture
@@ -303,6 +304,89 @@ class TestResponseGenerator:
         with pytest.raises(StopIteration):
             next(token_iter)
         assert cancelled == []
+
+    def test_step_uses_streaming_detokenizer_for_utf8_byte_tokens(self):
+        class ByteFallbackTokenizer:
+            vocab = {
+                "hi": 0,
+                "<0xF0>": 1,
+                "<0x9F>": 2,
+                "<0x98>": 3,
+                "<0x80>": 4,
+            }
+
+            def decode(self, tokens):
+                text = ""
+                byte_buffer = bytearray()
+                byte_values = {1: 0xF0, 2: 0x9F, 3: 0x98, 4: 0x80}
+
+                def flush_bytes():
+                    nonlocal text, byte_buffer
+                    if byte_buffer:
+                        text += byte_buffer.decode("utf-8", errors="replace")
+                        byte_buffer = bytearray()
+
+                for token in tokens:
+                    if token == 0:
+                        flush_bytes()
+                        text += "hi"
+                    else:
+                        byte_buffer.append(byte_values[token])
+                flush_bytes()
+                return text
+
+        class SingleResponseBatch:
+            def __init__(self, response):
+                self.response = response
+
+            def next(self, **kwargs):
+                return [], [self.response]
+
+        tokenizer = ByteFallbackTokenizer()
+        processor = SimpleNamespace(
+            detokenizer=SPMStreamingDetokenizer(tokenizer, trim_space=False)
+        )
+        gen = server.ResponseGenerator.__new__(server.ResponseGenerator)
+        rqueue = Queue()
+        active = {
+            1: {
+                "rqueue": rqueue,
+                "detokenizer": server.make_streaming_detokenizer(processor),
+            }
+        }
+
+        for token in [0, 1, 2, 3, 4]:
+            gen._step(
+                SingleResponseBatch(
+                    SimpleNamespace(
+                        uid=1,
+                        token=token,
+                        token_logprob=0.0,
+                        finish_reason=None,
+                    )
+                ),
+                active,
+            )
+        gen._step(
+            SingleResponseBatch(
+                SimpleNamespace(
+                    uid=1,
+                    token=99,
+                    token_logprob=0.0,
+                    finish_reason="stop",
+                )
+            ),
+            active,
+        )
+
+        streamed_text = ""
+        while not rqueue.empty():
+            item = rqueue.get()
+            if item is not None:
+                streamed_text += item.text
+
+        assert streamed_text == "hi😀"
+        assert "\ufffd" not in streamed_text
 
     def test_generate_arguments_to_generate_kwargs(self):
         processor = lambda tokens, logits: logits

--- a/mlx_vlm/tokenizer_utils.py
+++ b/mlx_vlm/tokenizer_utils.py
@@ -1,4 +1,5 @@
 import json
+from copy import copy
 from functools import partial
 from json import JSONDecodeError
 from typing import List
@@ -295,6 +296,13 @@ class TokenizerWrapper:
             return self._detokenizer
         else:
             return getattr(self._tokenizer, attr)
+
+
+def make_streaming_detokenizer(processor):
+    """Return an isolated, reset streaming detokenizer for a processor."""
+    detokenizer = copy(processor.detokenizer)
+    detokenizer.reset()
+    return detokenizer
 
 
 def _match(a, b):


### PR DESCRIPTION
## Summary

Fix server-side streamed detokenization for byte-fallback tokenizers by giving each active `ResponseGenerator` request its own streaming detokenizer instead of reconstructing deltas with cumulative `tokenizer.decode(...)` slices.

This aligns the server batching path with `stream_generate`, flushes pending byte sequences on stop/length, and covers the speculative server path as well.

Fixes https://github.com/Blaizzy/mlx-vlm/issues/1126

## Validation

- `pre-commit run --all-files`
- `pytest -q mlx_vlm/tests/test_server.py::TestResponseGenerator`
- `pytest -q mlx_vlm/tests/test_generate.py`
- `pytest -q mlx_vlm/tests/test_server.py mlx_vlm/tests/test_tokenizer_utils.py`
- `git diff --check`

I also benchmarked the changed detokenization path with `Qwen/Qwen3.5-4B`, `mlx-community/gemma-4-26b-a4b-it-4bit`, and `mlx-community/gemma-4-e4b-it-8bit` tokenizers; the new streaming detokenizer path is faster than cumulative decode/slice while preserving final text output.