### PR TITLE
Add server thinking mode flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,14 @@ mlx_vlm.generate --model mlx-community/Qwen3.5-2B-4bit \
 
 When the budget is exceeded, the model is forced to emit `\n</think>` and transition to the answer. If `--enable-thinking` is passed but the model's chat template does not support it, the budget is applied only if the model generates the start token on its own.
 
+On the server, thinking mode is disabled by default. Start the server with `--enable-thinking` to make thinking mode the default for requests that do not specify it:
+
+```sh
+mlx_vlm.server --model MODEL_NAME --enable-thinking
+```
+
+Requests can override the server default with `enable_thinking: true` or `enable_thinking: false`.
+
 ### Speculative Decoding
 
 Speed up generation by drafting several candidate tokens with a small "drafter" model and verifying them in a single target forward pass. Two drafter families are supported.
@@ -268,6 +276,9 @@ mlx_vlm.server --model <hf_repo_or_local_path> --adapter-path <adapter_path>
 
 # With trust remote code enabled (required for some models)
 mlx_vlm.server --trust-remote-code
+
+# Enable thinking mode by default for requests that do not override it
+mlx_vlm.server --model Qwen/Qwen3.5-4B --enable-thinking
 ```
 
 #### Server Options
@@ -280,6 +291,7 @@ mlx_vlm.server --trust-remote-code
 - `--host`: Host address (default: `0.0.0.0`)
 - `--port`: Port number (default: `8080`)
 - `--trust-remote-code`: Trust remote code when loading models from Hugging Face Hub
+- `--enable-thinking`: Enable thinking mode by default for requests that do not set `enable_thinking`
 - `--kv-bits`: Number of bits for KV cache quantization (e.g. `8` for uniform, `3.5` for TurboQuant)
 - `--kv-quant-scheme`: KV cache quantization backend (`uniform` or `turboquant`)
 - `--kv-group-size`: Group size for uniform KV cache quantization (default: `64`)
@@ -749,6 +761,9 @@ curl -X POST "http://localhost:8080/responses" \
 - `top_k`: Top-k sampling cutoff
 - `min_p`: Min-p sampling threshold
 - `repetition_penalty`: Penalty applied to repeated tokens
+- `enable_thinking`: Override the server thinking-mode default for a request (`true` or `false`)
+- `thinking_budget`: Maximum tokens allowed inside the thinking block
+- `thinking_start_token`: Token that opens a thinking block
 - `stream`: Enable streaming responses
 
 

--- a/README.md
+++ b/README.md
@@ -387,24 +387,212 @@ finally:
     apc.close()
 ```
 
-To compare cold, warm-memory, and warm-disk behavior with a model:
+To compare cold, warm-memory, warm-disk, and disk-eviction behavior with a
+model, use the same direct API path:
 
-```sh
-python scripts/bench_apc_context_sweep.py \
-  --model Qwen/Qwen3-VL-4B-Instruct \
-  --contexts 8000 20000 50000 100000 \
-  --disk-cap-gb 0 \
-  --shard-max-blocks 256
-```
+```python
+import os
+import tempfile
+import time
+from pathlib import Path
 
-For a disk-eviction workload:
+from mlx_vlm import load, stream_generate
+from mlx_vlm.apc import APCManager, DiskBlockStore
+from mlx_vlm.prompt_utils import apply_chat_template
 
-```sh
-python scripts/bench_apc_disk_genstep.py \
-  --model Qwen/Qwen3-VL-4B-Instruct \
-  --test-prompt-tokens 8000 \
-  --fill-prompts 80 \
-  --disk-cap-gb 3.0
+model_id = "Qwen/Qwen3-VL-4B-Instruct"
+contexts = [8000, 20000, 50000, 100000]
+disk_cap_gb = 0  # 0 means uncapped
+shard_max_blocks = 256
+context_sweep_max_tokens = 1  # one token is enough to measure prefill reuse
+
+test_prompt_tokens = 8000
+fill_prompts = 80
+eviction_disk_cap_gb = 3.0
+
+os.environ["APC_DISK_SHARD_MAX_BLOCKS"] = str(shard_max_blocks)
+
+model, processor = load(model_id)
+tokenizer = processor.tokenizer if hasattr(processor, "tokenizer") else processor
+
+
+def disk_cap_bytes(gb: float):
+    return None if gb <= 0 else int(gb * (1 << 30))
+
+
+def make_context(target_tokens: int, seed: int = 0) -> str:
+    line = (
+        f"Document {seed}: APC benchmark content with deterministic facts, "
+        "dates, identifiers, and repeated technical notes.\n"
+    )
+    line_tokens = max(1, len(tokenizer.encode(line, add_special_tokens=False)))
+    text = line * max(1, target_tokens // line_tokens)
+    while len(tokenizer.encode(text, add_special_tokens=False)) < target_tokens:
+        text += line
+    return text
+
+
+def make_prompt(context: str, question: str) -> str:
+    return apply_chat_template(
+        processor,
+        model.config,
+        prompt=f"{context}\n\n{question}",
+        num_images=0,
+    )
+
+
+def run_once(apc: APCManager, context: str, question: str, max_tokens: int = 32):
+    prompt = make_prompt(context, question)
+    apc.reset_stats()
+
+    last = None
+    output = []
+    start = time.perf_counter()
+    for chunk in stream_generate(
+        model,
+        processor,
+        prompt,
+        max_tokens=max_tokens,
+        temperature=0.0,
+        apc_manager=apc,
+    ):
+        output.append(chunk.text)
+        last = chunk
+
+    if last is None:
+        raise RuntimeError("generation returned no chunks")
+
+    return {
+        "wall_s": time.perf_counter() - start,
+        "prompt_tokens": last.prompt_tokens,
+        "prompt_tps": last.prompt_tps,
+        "generation_tps": last.generation_tps,
+        "apc": apc.stats_snapshot(),
+        "text": "".join(output).strip(),
+    }
+
+
+def print_result(label: str, result: dict) -> None:
+    stats = result["apc"]
+    print(
+        f"{label:<12} "
+        f"prompt_tokens={result['prompt_tokens']:>7} "
+        f"prompt_tps={result['prompt_tps']:>8.1f} "
+        f"gen_tps={result['generation_tps']:>7.1f} "
+        f"matched={stats.get('matched_tokens', 0):>7} "
+        f"disk_hits={stats.get('disk_hits', 0):>5} "
+        f"disk_evictions={stats.get('disk_evictions', 0):>5}"
+    )
+
+
+def open_apc(cache_root: Path, namespace: str, disk_gb: float) -> APCManager:
+    disk = DiskBlockStore(
+        cache_root,
+        namespace=namespace,
+        max_bytes=disk_cap_bytes(disk_gb),
+    )
+    return APCManager(num_blocks=4096, block_size=16, disk=disk)
+
+
+def run_context_sweep() -> None:
+    print("cold / warm-memory / warm-disk")
+    with tempfile.TemporaryDirectory() as tmp:
+        cache_root = Path(tmp)
+        for target_tokens in contexts:
+            context = make_context(target_tokens)
+            namespace = f"{model_id}-context-{target_tokens}"
+            apc = open_apc(cache_root, namespace, disk_cap_gb)
+            try:
+                print(f"\ncontext ~= {target_tokens} text tokens")
+                print_result(
+                    "cold",
+                    run_once(
+                        apc,
+                        context,
+                        "Summarize the key decisions.",
+                        max_tokens=context_sweep_max_tokens,
+                    ),
+                )
+                print_result(
+                    "warm-memory",
+                    run_once(
+                        apc,
+                        context,
+                        "List the open engineering risks.",
+                        max_tokens=context_sweep_max_tokens,
+                    ),
+                )
+            finally:
+                # Closing waits for queued disk writes before reopening the disk tier.
+                apc.close()
+
+            apc = open_apc(cache_root, namespace, disk_cap_gb)
+            try:
+                print_result(
+                    "warm-disk",
+                    run_once(
+                        apc,
+                        context,
+                        "Extract the implementation timeline.",
+                        max_tokens=context_sweep_max_tokens,
+                    ),
+                )
+            finally:
+                apc.close()
+
+
+def run_disk_eviction_workload() -> None:
+    print("\ndisk eviction workload")
+    with tempfile.TemporaryDirectory() as tmp:
+        cache_root = Path(tmp)
+        namespace = f"{model_id}-eviction"
+        test_context = make_context(test_prompt_tokens, seed=0)
+
+        apc = open_apc(cache_root, namespace, eviction_disk_cap_gb)
+        try:
+            print_result(
+                "seed",
+                run_once(apc, test_context, "Summarize the retained test prefix."),
+            )
+        finally:
+            apc.close()
+
+        apc = open_apc(cache_root, namespace, eviction_disk_cap_gb)
+        try:
+            for i in range(fill_prompts):
+                fill_context = make_context(test_prompt_tokens, seed=i + 1)
+                run_once(
+                    apc,
+                    fill_context,
+                    f"Summarize filler document {i + 1}.",
+                    max_tokens=1,
+                )
+                if (i + 1) % 10 == 0:
+                    stats = apc.stats_snapshot()
+                    print(
+                        f"filled={i + 1:>3} "
+                        f"disk_gb={stats.get('disk_bytes', 0) / (1 << 30):.2f} "
+                        f"disk_evictions={stats.get('disk_evictions', 0)}"
+                    )
+        finally:
+            apc.close()
+
+        apc = open_apc(cache_root, namespace, eviction_disk_cap_gb)
+        try:
+            print_result(
+                "post-fill",
+                run_once(
+                    apc,
+                    test_context,
+                    "Check whether the retained test prefix still restores.",
+                ),
+            )
+        finally:
+            apc.close()
+
+
+run_context_sweep()
+run_disk_eviction_workload()
 ```
 
 #### Server

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ When the budget is exceeded, the model is forced to emit `\n</think>` and transi
 On the server, thinking mode is disabled by default. Start the server with `--enable-thinking` to make thinking mode the default for requests that do not specify it:
 
 ```sh
-mlx_vlm.server --model MODEL_NAME --enable-thinking
+mlx_vlm.server --model Qwen/Qwen3.5-4B --enable-thinking
 ```
 
 Requests can override the server default with `enable_thinking: true` or `enable_thinking: false`.

--- a/mlx_vlm/server.py
+++ b/mlx_vlm/server.py
@@ -58,6 +58,7 @@ from .vision_cache import VisionFeatureCache
 DEFAULT_SERVER_HOST = "0.0.0.0"
 DEFAULT_SERVER_PORT = 8080
 DEFAULT_TOKEN_QUEUE_TIMEOUT = 600.0
+DEFAULT_ENABLE_THINKING = False
 
 
 def _get_speculative_rounds_batch(draft_kind: str):
@@ -113,6 +114,13 @@ def get_token_queue_timeout():
     if timeout <= 0:
         return None
     return timeout
+
+
+def get_server_enable_thinking():
+    raw = os.environ.get("MLX_VLM_ENABLE_THINKING")
+    if raw is None:
+        return DEFAULT_ENABLE_THINKING
+    return raw.lower() in ("1", "true", "yes", "on")
 
 
 def get_quantized_kv_bits(model: str):
@@ -174,7 +182,7 @@ class GenerationArguments:
     seed: Optional[int] = None
     repetition_penalty: Optional[float] = None
     logit_bias: Optional[dict] = None
-    enable_thinking: bool = True
+    enable_thinking: bool = DEFAULT_ENABLE_THINKING
     thinking_budget: Optional[int] = None
     thinking_start_token: Optional[str] = None
     logits_processors: Optional[List[Callable[[mx.array, mx.array], mx.array]]] = None
@@ -965,6 +973,11 @@ def _build_gen_args(
     logit_bias = getattr(request, "logit_bias", None)
     if logit_bias is not None and isinstance(logit_bias, dict):
         logit_bias = {int(k): v for k, v in logit_bias.items()}
+    enable_thinking = _request_field_or_default(
+        request,
+        "enable_thinking",
+        get_server_enable_thinking(),
+    )
     args = GenerationArguments(
         max_tokens=max_tokens,
         temperature=getattr(request, "temperature", DEFAULT_TEMPERATURE),
@@ -973,7 +986,7 @@ def _build_gen_args(
         min_p=getattr(request, "min_p", 0.0),
         repetition_penalty=getattr(request, "repetition_penalty", None),
         logit_bias=logit_bias,
-        enable_thinking=getattr(request, "enable_thinking", True),
+        enable_thinking=enable_thinking,
         thinking_budget=getattr(request, "thinking_budget", None),
         thinking_start_token=getattr(request, "thinking_start_token", None),
         tenant_id=tenant_id,
@@ -981,6 +994,14 @@ def _build_gen_args(
     if processor is not None:
         args.logits_processors = _build_structured_logits_processors(request, processor)
     return args
+
+
+def _request_field_or_default(request, field_name: str, default):
+    fields_set = getattr(request, "model_fields_set", None)
+    if fields_set is not None and field_name not in fields_set:
+        return default
+    value = getattr(request, field_name, default)
+    return default if value is None else value
 
 
 def _read_tenant_id(http_request) -> Optional[str]:
@@ -1412,7 +1433,13 @@ class OpenAIRequest(FlexibleBaseModel):
     min_p: float = Field(0.0, description="Min-p sampling.")
     repetition_penalty: Optional[float] = Field(None, description="Repetition penalty.")
     logit_bias: Optional[Any] = Field(None, description="Logit bias dict.")
-    enable_thinking: bool = Field(True, description="Enable thinking mode.")
+    enable_thinking: Optional[bool] = Field(
+        None,
+        description=(
+            "Override server thinking mode for this request. If omitted, the "
+            "server default set by --enable-thinking is used."
+        ),
+    )
     thinking_budget: Optional[int] = Field(None, description="Max thinking tokens.")
     thinking_start_token: Optional[str] = Field(
         None, description="Thinking start token."
@@ -1606,7 +1633,13 @@ class VLMRequest(FlexibleBaseModel):
     seed: int = Field(DEFAULT_SEED, description="Seed for random generation.")
     repetition_penalty: Optional[float] = Field(None, description="Repetition penalty.")
     logit_bias: Optional[Any] = Field(None, description="Logit bias dict.")
-    enable_thinking: bool = Field(True, description="Enable thinking mode.")
+    enable_thinking: Optional[bool] = Field(
+        None,
+        description=(
+            "Override server thinking mode for this request. If omitted, the "
+            "server default set by --enable-thinking is used."
+        ),
+    )
     thinking_budget: Optional[int] = Field(None, description="Max thinking tokens.")
     thinking_start_token: Optional[str] = Field(
         None, description="Thinking start token."
@@ -2876,6 +2909,15 @@ def main():
         help="Maximum number of tokens to generate.",
     )
     parser.add_argument(
+        "--enable-thinking",
+        action="store_true",
+        default=DEFAULT_ENABLE_THINKING,
+        help=(
+            "Enable thinking mode by default for requests that do not set "
+            "enable_thinking explicitly."
+        ),
+    )
+    parser.add_argument(
         "--kv-bits",
         type=float,
         default=None,
@@ -2966,6 +3008,7 @@ def main():
     if args.prefill_step_size:
         os.environ["PREFILL_STEP_SIZE"] = str(args.prefill_step_size)
     os.environ["MLX_VLM_MAX_TOKENS"] = str(args.max_tokens)
+    os.environ["MLX_VLM_ENABLE_THINKING"] = "1" if args.enable_thinking else "0"
     if args.kv_bits is not None:
         os.environ["KV_BITS"] = str(args.kv_bits)
     os.environ["KV_GROUP_SIZE"] = str(args.kv_group_size)

--- a/mlx_vlm/tests/test_server.py
+++ b/mlx_vlm/tests/test_server.py
@@ -229,7 +229,7 @@ class TestResponseGenerator:
         args = server.GenerationArguments()
         assert args.max_tokens == server.DEFAULT_MAX_TOKENS
         assert args.temperature == server.DEFAULT_TEMPERATURE
-        assert args.enable_thinking is True
+        assert args.enable_thinking is False
         assert args.logit_bias is None
 
     def test_token_queue_timeout_defaults_to_long_prefill_window(self, monkeypatch):
@@ -462,6 +462,47 @@ class TestResponseGenerator:
         args = server._build_gen_args(req)
         assert args.max_tokens == 256
         assert args.enable_thinking is True
+
+    def test_build_gen_args_uses_server_thinking_default_when_omitted(
+        self, monkeypatch
+    ):
+        monkeypatch.setenv("MLX_VLM_ENABLE_THINKING", "1")
+        req = server.ChatRequest(
+            model="demo",
+            messages=[server.ChatMessage(role="user", content="hi")],
+        )
+
+        assert "enable_thinking" not in req.model_fields_set
+        assert server._build_gen_args(req).enable_thinking is True
+
+        monkeypatch.setenv("MLX_VLM_ENABLE_THINKING", "0")
+        req = server.ChatRequest(
+            model="demo",
+            messages=[server.ChatMessage(role="user", content="hi")],
+        )
+
+        assert server._build_gen_args(req).enable_thinking is False
+
+    def test_build_gen_args_request_thinking_overrides_server_default(
+        self, monkeypatch
+    ):
+        monkeypatch.setenv("MLX_VLM_ENABLE_THINKING", "1")
+        req = server.ChatRequest(
+            model="demo",
+            messages=[server.ChatMessage(role="user", content="hi")],
+            enable_thinking=False,
+        )
+
+        assert server._build_gen_args(req).enable_thinking is False
+
+        monkeypatch.setenv("MLX_VLM_ENABLE_THINKING", "0")
+        req = server.ChatRequest(
+            model="demo",
+            messages=[server.ChatMessage(role="user", content="hi")],
+            enable_thinking=True,
+        )
+
+        assert server._build_gen_args(req).enable_thinking is True
 
     def test_gpu_embed_hashes_pixel_values_without_image_ref(self):
         class Embed:


### PR DESCRIPTION
## Summary
- Add a server-level `--enable-thinking` flag that sets the default thinking mode for requests.
- Allow explicit request `enable_thinking` values to override the server default.
- Document the new server option and update server request parameter docs.

Fixes https://github.com/Blaizzy/mlx-vlm/issues/1128

## Validation
- `pytest -q mlx_vlm/tests/test_server.py`
- `pre-commit run --all-files`
- `python -m mlx_vlm.server --help | rg -n -- "--enable-thinking|thinking"`
- `git diff --check`