### PR TITLE
Fix server chat completions text content array handling

### DIFF
--- a/mlx_vlm/server.py
+++ b/mlx_vlm/server.py
@@ -47,7 +47,7 @@ from .generate import (
     normalize_resize_shape,
     stream_generate,
 )
-from .prompt_utils import apply_chat_template
+from .prompt_utils import apply_chat_template, extract_text_from_content
 from .sample_utils import top_p_sampling
 from .structured import build_json_schema_logits_processor
 from .tokenizer_utils import make_streaming_detokenizer
@@ -2294,19 +2294,18 @@ async def chat_completions_endpoint(request: ChatRequest, http_request: Request)
             if isinstance(message.content, str):
                 msg["content"] = message.content
             elif isinstance(message.content, list):
-                text_content = ""
-                for item in message.content:
-                    if isinstance(item, dict):
-                        if message.role == "user":
-                            if item["type"] == "input_image":
-                                images.append(item["image_url"])
-                            elif item["type"] == "image_url":
-                                images.append(item["image_url"]["url"])
-                            elif item["type"] == "input_audio":
-                                audio.append(item["input_audio"]["data"])
-                        if item["type"] in ("text", "input_text"):
-                            text_content = item.get("text", "")
-                msg["content"] = text_content
+                if message.role == "user":
+                    for item in message.content:
+                        if not isinstance(item, dict):
+                            continue
+                        item_type = item.get("type")
+                        if item_type == "input_image":
+                            images.append(item["image_url"])
+                        elif item_type == "image_url":
+                            images.append(item["image_url"]["url"])
+                        elif item_type == "input_audio":
+                            audio.append(item["input_audio"]["data"])
+                msg["content"] = extract_text_from_content(message.content)
             else:
                 msg["content"] = message.content
 

--- a/mlx_vlm/tests/test_server.py
+++ b/mlx_vlm/tests/test_server.py
@@ -349,6 +349,54 @@ def test_chat_completions_endpoint_forwards_explicit_sampling_args(client):
     assert mock_generate.call_args.kwargs["resize_shape"] == (512, 512)
 
 
+def test_chat_completions_endpoint_flattens_text_content_parts(client):
+    model = SimpleNamespace()
+    processor = SimpleNamespace()
+    config = SimpleNamespace(model_type="qwen2_vl")
+    result = SimpleNamespace(
+        text="done",
+        prompt_tokens=8,
+        generation_tokens=4,
+        total_tokens=12,
+        prompt_tps=10.0,
+        generation_tps=5.0,
+        peak_memory=0.1,
+    )
+
+    with (
+        patch.object(
+            server, "get_cached_model", return_value=(model, processor, config)
+        ),
+        patch.object(
+            server, "apply_chat_template", return_value="prompt"
+        ) as mock_template,
+        patch.object(server, "generate", return_value=result),
+    ):
+        response = client.post(
+            "/chat/completions",
+            json={
+                "model": "demo",
+                "messages": [
+                    {
+                        "role": "user",
+                        "content": [
+                            {"type": "text", "text": "First text block."},
+                            {"type": "text", "text": "Second text block."},
+                        ],
+                    }
+                ],
+            },
+        )
+
+    assert response.status_code == 200
+    assert mock_template.call_args.args[2] == [
+        {
+            "role": "user",
+            "content": "First text block. Second text block.",
+        }
+    ]
+
+
 def test_cache_endpoints_report_disabled_stats_and_reset(client, monkeypatch):
     monkeypatch.setattr(server, "apc_manager", None)
 


### PR DESCRIPTION
This fixes `/v1/chat/completions` handling for messages where `content` is an array of text parts. Some harnesses (Claude Code in my case), frequently send user text as multiple content parts and expect the server to flatten them before applying the chat template. Previously, this endpoint kept only the last text part, so earlier parts were silently dropped.

Ex:

```json
[
    {
      "content": "You are Claude Code...",
      "role": "system"
    },
    {
      "content": [
        {
          "text": "<system-reminder>\nAs you answer the user's questions, you can use the following context:\n# claudeMd\nCodebase and user instructions are shown below. ...\n</system-reminder>\n\n",
          "type": "text"
        },
        {
          "text": "Test!",
          "type": "text"
        }
      ],
      "role": "user"
    }
  ]
```

Changes:
- Reuse the existing `extract_text_from_content(...)` helper for chat completion message arrays.
- Preserve existing user image/audio extraction behavior.
- Add a regression test covering multiple `type: "text"` parts.

One note: `mlx-lm` flattens text fragments with an empty-string join. This repo’s existing helper joins text parts with a space, so this PR keeps the local behavior rather than changing broader prompt formatting.

That said, should `mlx-vlm` standardize on the upstream `mlx-lm` empty-string join behavior? Both directions potentially introduce whitespace issues, though these are probably negligible in most cases.