### PR TITLE
Use local rotating-cache offsets for Gemma assistant MTP masks

### DIFF
--- a/mlx_vlm/speculative/drafters/gemma4_assistant/masks.py
+++ b/mlx_vlm/speculative/drafters/gemma4_assistant/masks.py
@@ -129,14 +129,19 @@ def make_drafter_masks(
     masks = {}
     for layer_type, kv in shared_kv_states.items():
         kv_len = _kv_len(kv)
-        kv_valid_len = query_offset
+        local_valid_len = _local_window_offset(query_offset, kv_len)
         if layer_type == "sliding_attention":
             masks[layer_type] = bidirectional_swa_mask(
-                query_len, query_offset, kv_len, sliding_window, kv_valid_len, dtype
+                query_len,
+                local_valid_len,
+                kv_len,
+                sliding_window,
+                local_valid_len,
+                dtype,
             )
         else:
             masks[layer_type] = bidirectional_full_mask(
-                query_len, kv_len, kv_valid_len, dtype
+                query_len, kv_len, local_valid_len, dtype
             )
     return masks
 
@@ -144,6 +149,16 @@ def make_drafter_masks(
 def _kv_len(kv: Tuple[mx.array, mx.array]) -> int:
     K, _ = kv
     return int(K.shape[-2])
+
+
+def _local_window_offset(
+    query_offset: Union[int, mx.array],
+    kv_len: int,
+) -> Union[int, mx.array]:
+    """Map absolute decode positions onto the local rotating-cache window."""
+    if isinstance(query_offset, int):
+        return min(query_offset, kv_len)
+    return mx.minimum(query_offset, kv_len)
 
 
 def _normalize_shared_kv_tensor(

--- a/mlx_vlm/tests/test_gemma4_assistant_masks_static.py
+++ b/mlx_vlm/tests/test_gemma4_assistant_masks_static.py
@@ -1,0 +1,61 @@
+"""Static Gemma assistant drafter mask tests that do not import MLX."""
+
+from __future__ import annotations
+
+import importlib.machinery
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+
+class _FakeArray:
+    def __init__(self, values):
+        self.values = list(values)
+
+
+def _fake_minimum(values: _FakeArray, limit: int) -> _FakeArray:
+    return _FakeArray([min(value, limit) for value in values.values])
+
+
+def _load_masks_module(monkeypatch):
+    fake_mx = types.SimpleNamespace(
+        Dtype=object,
+        array=_FakeArray,
+        float32=object(),
+        minimum=_fake_minimum,
+    )
+    fake_mlx = types.ModuleType("mlx")
+    fake_mlx.core = fake_mx
+    fake_cache = types.ModuleType("mlx_lm.models.cache")
+    fake_cache.dynamic_roll = lambda tensor, *_args, **_kwargs: tensor
+    monkeypatch.setitem(sys.modules, "mlx", fake_mlx)
+    monkeypatch.setitem(sys.modules, "mlx.core", fake_mx)
+    monkeypatch.setitem(sys.modules, "mlx_lm", types.ModuleType("mlx_lm"))
+    monkeypatch.setitem(sys.modules, "mlx_lm.models", types.ModuleType("mlx_lm.models"))
+    monkeypatch.setitem(sys.modules, "mlx_lm.models.cache", fake_cache)
+
+    path = (
+        Path(__file__).resolve().parents[1]
+        / "speculative/drafters/gemma4_assistant/masks.py"
+    )
+    loader = importlib.machinery.SourceFileLoader("gemma4_masks_under_test", str(path))
+    spec = importlib.util.spec_from_loader("gemma4_masks_under_test", loader)
+    assert spec is not None
+    module = importlib.util.module_from_spec(spec)
+    loader.exec_module(module)
+    return module
+
+
+def test_local_window_offset_clamps_absolute_decode_position(monkeypatch):
+    module = _load_masks_module(monkeypatch)
+
+    assert module._local_window_offset(128, 8) == 8
+
+
+def test_local_window_offset_clamps_batched_decode_positions(monkeypatch):
+    module = _load_masks_module(monkeypatch)
+
+    result = module._local_window_offset(_FakeArray([5, 128]), 8)
+
+    assert result.values == [5, 8]

--- a/mlx_vlm/tests/test_speculative.py
+++ b/mlx_vlm/tests/test_speculative.py
@@ -158,6 +158,21 @@ def test_mtp_drafter_masks_support_batched_offsets():
     assert full[1][0][0][7] == 0.0
 
 
+def test_mtp_drafter_sliding_mask_uses_local_rotating_cache_offset():
+    kv = (mx.zeros((1, 1, 8, 4)), mx.zeros((1, 1, 8, 4)))
+
+    masks = make_drafter_masks(
+        {"sliding_attention": kv},
+        query_len=1,
+        query_offset=128,
+        sliding_window=4,
+    )
+
+    mask = masks["sliding_attention"].tolist()[0][0][0]
+    assert mask[:5] == [-float("inf")] * 5
+    assert mask[5:] == [0.0, 0.0, 0.0]
+
+
 def test_normalize_batched_shared_kv_states_repacks_left_padded_rows():
     keys = mx.array(
         [


### PR DESCRIPTION
# Use local rotating-cache offsets for Gemma assistant MTP masks

Related issue: #1138

## Summary

Updates Gemma assistant MTP mask construction so sliding-window layers compare
queries against the local rotating-cache window shared by the target model.
Absolute decode positions are clamped into the local cache coordinate system
before `bidirectional_swa_mask` is built.

## Local repro

Local Runtime evidence before this fix:

- `/opt/ai-runtime/run/non-live-jobs-ab/20260507T020113Z-gemma4_31b_mtp_assistant_no_think`
- `/opt/ai-runtime/run/non-live-jobs-ab/20260507T015456Z-gemma4_26b_a4b_mtp_assistant_no_think`

Observed behavior:

- long-prompt assistant-MTP requests could produce repetitive or corrupt output
  patterns
- shorter bounded probes could still engage MTP and accept drafts
- the failure pattern was tied to long-prompt sliding-window mask behavior, not
  basic drafter loading

## Exact upstream code path compared

Base commit: `aec6998d329b7c02e1e51c57cf085c9437e8d97f`

Compared path/function:

- `mlx_vlm/speculative/drafters/gemma4_assistant/masks.py::make_drafter_masks`

The previous implementation used absolute `query_offset` as the sliding-window
mask offset while the shared target K/V state is local to the rotating cache.

## What changed

- Added `_local_window_offset`.
- Used the local offset for sliding-window drafter masks.
- Used `kv_len` as the valid K/V length for shared K/V masks.
- Added focused tests for long-prompt local-window behavior.

## Validation

- `git diff --check`
- `python -m py_compile mlx_vlm/speculative/drafters/gemma4_assistant/masks.py mlx_vlm/tests/test_gemma4_assistant_masks_static.py mlx_vlm/tests/test_speculative.py`
- direct focused execution of:
  - `test_local_window_offset_clamps_absolute_decode_position`
  - `test_local_window_offset_clamps_batched_decode_positions`

I did not bypass the local Runtime safety gate to run the full pytest command
while a live LaunchAgent was loaded.

## What this does not claim

- This does not enable assistant-MTP by default.
- This is not a Jobs workload-quality claim.
- This does not claim every Gemma assistant-MTP issue is caused by masks.
