### PR TITLE
fix(server): remove duplicate “server” response header

### DIFF
--- a/mlx_vlm/server.py
+++ b/mlx_vlm/server.py
@@ -3059,6 +3059,7 @@ def main():
         port=args.port,
         workers=1,
         reload=args.reload,
+        server_header=False,
     )
 
 


### PR DESCRIPTION
My PR #1082 added server http response header indicating it’s a mlx-vlm server, but apparently the uvicorn server adds duplicate server headers now :(
This PR disables the “server: uvicorn” builtin header leaving the “server: mlx_vlm/$v” header.

Before:
<img width="600" height="90" alt="image" src="https://github.com/user-attachments/assets/94c863a7-0607-4aef-b46d-0ee23098fbe0" />

After:
<img width="563" height="89" alt="image" src="https://github.com/user-attachments/assets/f804a7af-467f-48c3-9508-10f49ce8daf4" />
