### PR TITLE
Fix top_p_sampling crash on 3D logits in speculative decoding

### DIFF
--- a/mlx_vlm/sample_utils.py
+++ b/mlx_vlm/sample_utils.py
@@ -6,11 +6,14 @@ def top_p_sampling(logits: mx.array, top_p: float, temperature: float) -> mx.arr
     Apply top-p (nucleus) sampling to logits.
 
     Args:
-        logits: The logits from the model's output. Shape [vocab] or [B, vocab].
+        logits: The logits from the model's output. Shape [..., vocab];
+            commonly [vocab], [B, vocab], or [B, T, vocab] (e.g. MTP
+            speculative verify output).
         top_p: The cumulative probability threshold for top-p filtering.
         temperature: Temperature parameter for softmax distribution reshaping.
     Returns:
-        token selected based on the top-p criterion. Shape [] or [B].
+        token selected based on the top-p criterion. Shape matches logits
+        with the trailing vocab axis removed (e.g. [], [B], or [B, T]).
     """
     unbatched = logits.ndim == 1
     if unbatched:
@@ -38,7 +41,7 @@ def top_p_sampling(logits: mx.array, top_p: float, temperature: float) -> mx.arr
     )
 
     sampled_pos = mx.random.categorical(mx.log(top_probs))
-    token = mx.take_along_axis(sorted_indices, sampled_pos[:, None], axis=-1).squeeze(
+    token = mx.take_along_axis(sorted_indices, sampled_pos[..., None], axis=-1).squeeze(
         -1
     )
     return token.squeeze(0) if unbatched else token

--- a/mlx_vlm/tests/test_sample_utils.py
+++ b/mlx_vlm/tests/test_sample_utils.py
@@ -41,6 +41,41 @@ class TestTopPSampling(unittest.TestCase):
         self.assertEqual(tokens[0].item(), 0)
         self.assertEqual(tokens[1].item(), 1)
 
+    def test_three_dim_input_shape(self):
+        """3D [B, T, V] logits (e.g. MTP speculative verify output) should
+        return a [B, T] array.
+
+        Regression test: top_p_sampling previously hard-coded
+        ``sampled_pos[:, None]`` which only works for 2D inputs. With 3D
+        logits, take_along_axis produced a [B, T, T] tensor and the trailing
+        ``.squeeze(-1)`` raised ``Cannot squeeze axis -1 with size T which is
+        not equal to 1``. Reproduced by speculative generation in server.py.
+        """
+        B, T, V = 2, 4, 100
+        for top_p in [0.9, 1.0]:
+            with self.subTest(top_p=top_p):
+                tokens = top_p_sampling(
+                    mx.zeros([B, T, V]), top_p=top_p, temperature=1.0
+                )
+                self.assertEqual(tokens.shape, (B, T))
+
+    def test_three_dim_per_position_sampling(self):
+        """Each (batch, time) position must sample from its own row."""
+        V = 8
+        # Peaked logits make the outcome deterministic regardless of seed.
+        row_a = [100.0] + [-100.0] * (V - 1)  # token 0
+        row_b = [-100.0] + [100.0] + [-100.0] * (V - 2)  # token 1
+        row_c = [-100.0] * (V - 1) + [100.0]  # token V-1
+        row_d = [-100.0, -100.0] + [100.0] + [-100.0] * (V - 3)  # token 2
+        logits = mx.array([[row_a, row_b, row_c, row_d]])  # [1, 4, V]
+        tokens = top_p_sampling(logits, top_p=0.9, temperature=1.0)
+        mx.eval(tokens)
+        self.assertEqual(tokens.shape, (1, 4))
+        self.assertEqual(tokens[0, 0].item(), 0)
+        self.assertEqual(tokens[0, 1].item(), 1)
+        self.assertEqual(tokens[0, 2].item(), V - 1)
+        self.assertEqual(tokens[0, 3].item(), 2)
+
     def test_bfloat16_input(self):
         """bfloat16 path should return correct shapes for both input ranks."""
         token = top_p_sampling(


### PR DESCRIPTION
## Summary

  Speculative generation crashes with `ValueError: [squeeze] Cannot squeeze axis -1 with size N which is
  not equal to 1` whenever `top_p` sampling is enabled (i.e. `top_p ∈ (0, 1)` and `temperature > 0`).

  ```
  File "/.../mlx_vlm/server.py", line 804, in _run_speculative
      for tok_list, _ in rounds_iter:
  File "/.../mlx_vlm/generate.py", line 725, in _mtp_rounds_batch
      target_tokens = sampler(verify_out.logits)
  File "/.../mlx_vlm/server.py", line 456, in sampler
      return top_p_sampling(logprobs, args.top_p, args.temperature)
  File "/.../mlx_vlm/sample_utils.py", line 41, in top_p_sampling
      token = mx.take_along_axis(sorted_indices, sampled_pos[:, None], axis=-1).squeeze(-1)
  ValueError: [squeeze] Cannot squeeze axis -1 with size 4 which is not equal to 1.
  ```

  ## Root cause

  `top_p_sampling` was written assuming logits are 1D `[V]` or 2D `[B, V]` and used `sampled_pos[:, None]`
   to add a trailing axis for `take_along_axis`. In MTP speculative decoding (`mlx_vlm/generate.py:725`),
  the verify step runs the LM over the initial token concatenated with `bs - 1` draft tokens, so
  `verify_out.logits` is 3D `[B_active, bs, V]`.

  With 3D input:
  - `sampled_pos` ends up as `[B, bs]`,
  - `sampled_pos[:, None]` becomes `[B, 1, bs]`,
  - `take_along_axis(sorted_indices=[B, bs, V], indices=[B, 1, bs], axis=-1)` broadcasts to `[B, bs, bs]`,
  - `.squeeze(-1)` rejects the size-`bs` last axis.

  The `size 4` in the error matches the speculative block size (`bs=4`), confirming the path.

  The greedy / pure-categorical path in `Server._make_sampler` doesn't hit this because it skips
  `top_p_sampling` entirely.

  ## Fix

  One-line change: use `sampled_pos[..., None]` instead of `sampled_pos[:, None]` so the function works
  for any leading rank (`[V]`, `[B, V]`, `[B, T, V]`, …). Updated the docstring to reflect the broader
  contract.

  ## Tests

  Added two regression tests in `mlx_vlm/tests/test_sample_utils.py`:

  - `test_three_dim_input_shape` — directly reproduces the original `ValueError` for `[B, T, V]` logits at
   `top_p ∈ {0.9, 1.0}`. Fails on `main`, passes with the fix.
  - `test_three_dim_per_position_sampling` — verifies each `(batch, time)` slot samples from its own row
  by feeding peaked logits and asserting per-position outcomes (analogous to the existing 2D
  `test_per_row_sampling`).

  All 6 tests in `test_sample_utils.py` pass.

  ## Reproducer

  ```bash
  cd /path/to/llm_context_benchmarks
  uv run benchmark -- mlx-vlm-server google/gemma-4-26B-A4B-it --contexts 0.5
  ```

  (any speculative-decoding path with `temperature > 0` and `0 < top_p < 1` triggers it).

  ## Test plan
  - [x] `pytest mlx_vlm/tests/test_sample_utils.py` — 6 passed
  - [x] End-to-end: re-run the benchmark above and confirm no `[squeeze]` error