### PR TITLE
gemma4 mtp: demote to AR on drafter mismatch + propagate speculative errors

### DIFF
--- a/mlx_vlm/server.py
+++ b/mlx_vlm/server.py
@@ -91,6 +91,26 @@ def _get_draft_block_size_from_env():
     return int(draft_block_size_str) if draft_block_size_str else None
 
 
+def _broadcast_exception_to_active(
+    rqueues: dict, finished_uids: set, exc: BaseException
+) -> None:
+    """Push (exc, None) onto each unfinished per-request queue.
+
+    The streaming iterator at ``ResponseGenerator.token_iterator`` checks
+    ``isinstance(item, Exception)`` and re-raises, which surfaces the error
+    to the client as an HTTP/SSE error instead of an indefinite hang.
+    Mirrors the non-speculative generation thread's recovery pattern.
+    """
+    for uid, rqueue in list(rqueues.items()):
+        if uid in finished_uids:
+            continue
+        try:
+            rqueue.put(exc)
+            rqueue.put(None)
+        except Exception:
+            pass
+
+
 def get_prefill_step_size():
     return int(os.environ.get("PREFILL_STEP_SIZE", DEFAULT_PREFILL_STEP_SIZE))
 
@@ -659,9 +679,15 @@ class ResponseGenerator:
         draft_block_size = _get_draft_block_size_from_env()
 
         while not self._stop:
+            # Per-iteration state — initialized outside the try so the
+            # except handler can broadcast errors back to any client whose
+            # request was already pulled off the request queue.
+            pending: list = []
+            uids: list = []
+            rqueues: dict = {}
+            finished_uids: set = set()
             try:
                 # --- Phase 1: collect pending requests ---
-                pending = []
                 timeout = 0.1
                 try:
                     item = self.requests.get(timeout=timeout)
@@ -683,8 +709,8 @@ class ResponseGenerator:
                     continue
 
                 # --- Phase 2: prefill new batch ---
-                uids = []
-                rqueues = {}
+                # uids, rqueues, finished_uids are pre-initialized above the
+                # try so error broadcast can see partial state.
                 token_lists = {}
                 stream_infos = {}
                 max_tokens_map = {}
@@ -735,7 +761,7 @@ class ResponseGenerator:
                 first_bonus = sampler(out.logits[:, -1:]).squeeze(-1)
                 mx.eval(first_bonus, hidden, out.logits)
 
-                finished_uids = set()
+                # finished_uids pre-initialized at top of loop iteration.
 
                 # Send first bonus tokens to clients
                 fb_list = first_bonus.tolist()
@@ -858,8 +884,21 @@ class ResponseGenerator:
                         rqueues[uid].put(None)
 
             except Exception as e:
-                print(f"Error in speculative generation thread: {e}")
-                traceback.print_exc()
+                logger.exception("Error in speculative generation thread")
+                # Surface the error to every client whose request reached
+                # this iteration. ``rqueues`` covers requests already
+                # admitted to the batch; ``pending`` covers items pulled
+                # off the request queue but not yet registered (the
+                # exception fired between request collection and prefill).
+                for rqueue, *_ in pending:
+                    uid = id(rqueue)
+                    if uid not in rqueues:
+                        rqueues[uid] = rqueue
+                _broadcast_exception_to_active(rqueues, finished_uids, e)
+                # Reset GPU state for the next iteration, mirroring the
+                # non-speculative recovery path.
+                mx.clear_cache()
+                gc.collect()
 
     def _step(self, batch_gen, active, gen_kwargs=None):
         """One batch generation step: prefill + decode."""

--- a/mlx_vlm/server.py
+++ b/mlx_vlm/server.py
@@ -91,6 +91,23 @@ def _get_draft_block_size_from_env():
     return int(draft_block_size_str) if draft_block_size_str else None
 
 
+def _probe_drafter_compat(drafter, target_model) -> Optional[BaseException]:
+    """Return None if the loaded drafter binds cleanly to the target.
+
+    ``drafter.bind(target_model)`` is the source-of-truth compat check
+    (e.g. Gemma 4 MTP raises ``ValueError`` on hidden-size mismatch).
+    bind() is idempotent and re-called per-request, so probing here is
+    side-effect-safe. Returns the exception so the caller can decide how
+    to react (server startup demotes to AR; future per-request path
+    surfaces it to the client).
+    """
+    try:
+        drafter.bind(target_model)
+    except ValueError as exc:
+        return exc
+    return None
+
+
 def _broadcast_exception_to_active(
     rqueues: dict, finished_uids: set, exc: BaseException
 ) -> None:
@@ -364,7 +381,30 @@ class ResponseGenerator:
                     f"using {resolved_kind!r} instead of {draft_kind!r}."
                 )
             draft_kind = resolved_kind
-            print("Drafter ready — speculative decoding enabled.")
+
+            # Probe drafter ↔ target compatibility before announcing
+            # speculative decoding. On mismatch, demote to AR so the
+            # server keeps serving requests instead of crashing the
+            # generation thread on the first request.
+            compat_err = _probe_drafter_compat(draft_model, model)
+            if compat_err is not None:
+                logger.warning(
+                    "Loaded drafter %s is incompatible with target %s; "
+                    "speculative decoding disabled, falling back to "
+                    "autoregressive generation. Reason: %s",
+                    draft_model_path,
+                    self.model_path,
+                    compat_err,
+                )
+                print(
+                    "WARNING: drafter ↔ target incompatibility — "
+                    "speculative decoding DISABLED. Server will run "
+                    "autoregressive. See log for details."
+                )
+                draft_model = None
+                draft_kind = None
+            else:
+                print("Drafter ready — speculative decoding enabled.")
 
         self.model = model
         self.processor = processor

--- a/mlx_vlm/speculative/drafters/gemma4_assistant/gemma4_assistant.py
+++ b/mlx_vlm/speculative/drafters/gemma4_assistant/gemma4_assistant.py
@@ -89,13 +89,32 @@ class Gemma4AssistantDraftModel(nn.Module):
             self._input_embed = inner.embed_tokens
             self._input_embed_scale = float(getattr(inner, "embed_scale", 1.0))
 
-        try:
-            tcfg = getattr(target_model, "language_model", target_model)
-            tcfg = getattr(tcfg, "config", None)
-            if tcfg is not None:
+        tcfg = getattr(target_model, "language_model", target_model)
+        tcfg = getattr(tcfg, "config", None)
+        if tcfg is not None:
+            try:
                 self.config.target_layer_types = list(tcfg.layer_types)
-        except Exception:
-            pass
+            except Exception:
+                pass
+
+            target_hidden = getattr(tcfg, "hidden_size", None)
+            if (
+                target_hidden is not None
+                and target_hidden != self.config.backbone_hidden_size
+            ):
+                raise ValueError(
+                    "Gemma 4 MTP drafter ↔ target hidden-size mismatch:\n"
+                    f"  drafter backbone_hidden_size = {self.config.backbone_hidden_size}\n"
+                    f"  target hidden_size           = {target_hidden}\n\n"
+                    "This drafter checkpoint was trained for a different "
+                    "target. Each Gemma 4 target has its own paired drafter:\n"
+                    "  mlx-community/gemma-4-E2B-it-bf16     ↔ mlx-community/gemma-4-E2B-it-assistant-bf16\n"
+                    "  mlx-community/gemma-4-E4B-it-bf16     ↔ mlx-community/gemma-4-E4B-it-assistant-bf16\n"
+                    "  mlx-community/gemma-4-26B-A4B-it-bf16 ↔ mlx-community/gemma-4-26B-A4B-it-assistant-bf16\n"
+                    "  mlx-community/gemma-4-31B-it-bf16     ↔ mlx-community/gemma-4-31B-it-assistant-bf16\n"
+                    "Pass --draft-model pointing to the drafter that matches "
+                    "your --model."
+                )
         return self
 
     def make_cache(self) -> List:

--- a/mlx_vlm/tests/test_speculative.py
+++ b/mlx_vlm/tests/test_speculative.py
@@ -371,6 +371,37 @@ def test_gemma4_drafter_bind_works_for_language_only_target():
     drafter.bind(target)
 
 
+def test_probe_drafter_compat_returns_value_error_on_mismatch():
+    """Helper surfaces the bind-time ValueError so callers can react.
+
+    Used by ``_initialize_model`` to demote to AR on mismatch instead of
+    letting the generation thread crash on the first request. The future
+    per-request drafter API will use the same probe to surface the error
+    back to the client that explicitly opted into the mismatched drafter.
+    """
+    from mlx_vlm.server import _probe_drafter_compat
+
+    drafter = _stub_gemma4_drafter(backbone_hidden_size=2816)
+    target = _stub_target(hidden_size=5376)
+
+    err = _probe_drafter_compat(drafter, target)
+
+    assert isinstance(err, ValueError)
+    assert "hidden-size mismatch" in str(err)
+    assert "2816" in str(err)
+    assert "5376" in str(err)
+
+
+def test_probe_drafter_compat_returns_none_on_match():
+    """Matched pairing must not be flagged as incompatible."""
+    from mlx_vlm.server import _probe_drafter_compat
+
+    drafter = _stub_gemma4_drafter(backbone_hidden_size=5376)
+    target = _stub_target(hidden_size=5376)
+
+    assert _probe_drafter_compat(drafter, target) is None
+
+
 def test_broadcast_exception_to_active_unblocks_streaming_clients():
     """An exception in _run_speculative must reach every active client.
 

--- a/mlx_vlm/tests/test_speculative.py
+++ b/mlx_vlm/tests/test_speculative.py
@@ -300,3 +300,72 @@ def test_kind_none_falls_back_to_default_for_missing_config(tmp_path):
     d = tmp_path / "drafter"
     d.mkdir()
     assert resolve_drafter_kind(d, None) == DEFAULT_DRAFTER_KIND
+
+
+def _stub_gemma4_drafter(backbone_hidden_size: int):
+    """Build a Gemma4AssistantDraftModel without running __init__.
+
+    bind() only needs the config and a few tied-embedding hooks, so we skip
+    the heavy decoder-layer construction. This isolates the bind-time
+    validation we want to test.
+    """
+    from mlx_vlm.speculative.drafters.gemma4_assistant.config import (
+        Gemma4AssistantConfig,
+    )
+    from mlx_vlm.speculative.drafters.gemma4_assistant.gemma4_assistant import (
+        Gemma4AssistantDraftModel,
+    )
+
+    drafter = Gemma4AssistantDraftModel.__new__(Gemma4AssistantDraftModel)
+    drafter.config = Gemma4AssistantConfig(
+        backbone_hidden_size=backbone_hidden_size,
+        tie_word_embeddings=True,
+    )
+    drafter.masked_embedding = None
+    drafter.model = SimpleNamespace(embed_tokens=SimpleNamespace(as_linear=lambda h: h))
+    drafter._lm_head_fn = None
+    drafter._input_embed = None
+    drafter._input_embed_scale = 1.0
+    return drafter
+
+
+def _stub_target(hidden_size: int, *, multimodal: bool = True):
+    """Stub a target model exposing the same surface bind() reads."""
+    lang_cfg = SimpleNamespace(hidden_size=hidden_size, layer_types=[])
+    if multimodal:
+        return SimpleNamespace(language_model=SimpleNamespace(config=lang_cfg))
+    return SimpleNamespace(config=lang_cfg)
+
+
+def test_gemma4_drafter_bind_rejects_hidden_size_mismatch():
+    """Wrong drafter for the target should fail fast with a clear message.
+
+    Repro of the production crash: 26B-A4B-it-assistant drafter
+    (backbone_hidden_size=2816) loaded against 31B-it target
+    (hidden_size=5376). Without this guard the mismatch surfaced deep in
+    pre_projection's matmul on the first draft step as
+    ``[matmul] Last dimension of first input with shape (1,1,10752) must
+    match second to last dimension of second input with shape (5632,1024)``.
+    """
+    drafter = _stub_gemma4_drafter(backbone_hidden_size=2816)
+    target = _stub_target(hidden_size=5376)
+    with pytest.raises(ValueError, match="hidden-size mismatch") as exc:
+        drafter.bind(target)
+    msg = str(exc.value)
+    assert "2816" in msg
+    assert "5376" in msg
+    assert "--draft-model" in msg
+
+
+def test_gemma4_drafter_bind_accepts_matching_hidden_size():
+    """Matching pairing (e.g. 31B-it ↔ 31B-it-assistant) must not raise."""
+    drafter = _stub_gemma4_drafter(backbone_hidden_size=5376)
+    target = _stub_target(hidden_size=5376)
+    drafter.bind(target)
+
+
+def test_gemma4_drafter_bind_works_for_language_only_target():
+    """bind() also accepts an unwrapped LanguageModel as the target."""
+    drafter = _stub_gemma4_drafter(backbone_hidden_size=5376)
+    target = _stub_target(hidden_size=5376, multimodal=False)
+    drafter.bind(target)

--- a/mlx_vlm/tests/test_speculative.py
+++ b/mlx_vlm/tests/test_speculative.py
@@ -369,3 +369,54 @@ def test_gemma4_drafter_bind_works_for_language_only_target():
     drafter = _stub_gemma4_drafter(backbone_hidden_size=5376)
     target = _stub_target(hidden_size=5376, multimodal=False)
     drafter.bind(target)
+
+
+def test_broadcast_exception_to_active_unblocks_streaming_clients():
+    """An exception in _run_speculative must reach every active client.
+
+    Repro of the production hang: when the speculative GPU thread raised
+    a ValueError, the per-request token queue was never signalled, so
+    FastAPI handlers awaited tokens forever. This helper drives the
+    behaviour the streaming iterator at server.py:417-419 relies on
+    (``isinstance(item, Exception): raise item`` followed by ``None``).
+    """
+    from queue import Queue
+
+    from mlx_vlm.server import _broadcast_exception_to_active
+
+    rqueues = {1: Queue(), 2: Queue(), 3: Queue()}
+    finished_uids = {2}  # uid 2 already completed — must not be touched
+    exc = ValueError("mtp drafter ↔ target hidden-size mismatch")
+
+    _broadcast_exception_to_active(rqueues, finished_uids, exc)
+
+    # uid 1 and uid 3 should each see (exc, None) — the iterator raises
+    # on the exception and the None sentinel guards a hang on the next
+    # .get().
+    for uid in (1, 3):
+        assert rqueues[uid].get_nowait() is exc
+        assert rqueues[uid].get_nowait() is None
+        assert rqueues[uid].empty()
+
+    assert rqueues[2].empty()
+
+
+def test_broadcast_exception_to_active_tolerates_full_queue():
+    """A queue raising on .put() must not stop other clients from being unblocked."""
+
+    from mlx_vlm.server import _broadcast_exception_to_active
+
+    class _BrokenQueue:
+        def put(self, _):
+            raise RuntimeError("queue is dead")
+
+    good = SimpleNamespace(puts=[])
+    good.put = good.puts.append
+
+    rqueues = {1: _BrokenQueue(), 2: good}
+    exc = RuntimeError("boom")
+
+    _broadcast_exception_to_active(rqueues, set(), exc)
+
+    # Broken queue did not propagate; good queue still received (exc, None).
+    assert good.puts == [exc, None]


### PR DESCRIPTION
## Summary

  Three connected improvements to Gemma 4 MTP speculative decoding in `mlx_vlm.server`:

  1. **Drafter ↔ target compat probe at startup** with graceful demotion to autoregressive (AR) generation on mismatch. Previously, an incompatible drafter
  (e.g. the `26B-A4B-it-assistant` against a `gemma-4-31B-it` target) crashed the GPU thread on the first request with a deep `pre_projection` matmul error.
   The operator now gets a clear startup warning and the server keeps serving requests via AR.
  2. **Bind-time compat check** in `Gemma4AssistantDraftModel.bind()` — the source of truth used by the startup probe. Reusable for the planned per-request
  drafter API (where a client explicitly opts into a drafter and *should* see the error rather than have it silently swapped).
  3. **Propagate `_run_speculative` exceptions to client queues** so any speculative-thread failure (the new compat error, OOM, kernel crash, …) reaches the
   client as an HTTP/SSE error instead of leaving the FastAPI handler awaiting forever.

  ## The original failures

  ```
  [matmul] Last dimension of first input with shape (1,1,10752) must match
  second to last dimension of second input with shape (5632,1024).
    ...pre_projection(inputs_embeds)
  ```

  `10752 = 2 × 5376` (31B-it target hidden), `5632 = 2 × 2816` (26B-A4B-it-assistant `backbone_hidden_size`). Drafter weights are physically wrong-shape —
  runtime resizing is impossible.

  The exception then hung the client forever. `_run_speculative` caught the error, logged it via `print()`, and silently swallowed it. The per-request token
   queue was never signalled, so the FastAPI streaming handler awaited tokens that would never arrive.

  ## Changes

  ### Commit 1 — `bind()` compat check (source of truth)

  `mlx_vlm/speculative/drafters/gemma4_assistant/gemma4_assistant.py`

  `Gemma4AssistantDraftModel.bind()` reads the target's `hidden_size` (via the same `target.language_model.config` / `target.config` path it already uses
  for `layer_types`) and raises `ValueError` with the full pairing table when it doesn't match `self.config.backbone_hidden_size`. Cheap, idempotent — used
  by the next two commits.

  ### Commit 2 — error propagation

  `mlx_vlm/server.py`

  - New `_broadcast_exception_to_active(rqueues, finished_uids, exc)` helper pushes `(exc, None)` to each unfinished per-request queue (mirrors the
  non-speculative path at `server.py:625-636`).
  - Per-iteration state in `_run_speculative` is initialized **outside** the `try` so the except handler can see partial state when the exception fires
  during phase-1 request collection.
  - The except handler folds in `pending` items whose rqueue wasn't yet registered (covers the gap between `requests.get` and `rqueues[uid] = rqueue`).
  - `print(...) + traceback.print_exc()` replaced with `logger.exception(...)`.
  - After broadcasting, GPU state is reset (`mx.clear_cache` + `gc.collect`).

  The streaming iterator at `server.py:417-419` already handles `isinstance(item, Exception): raise item` — it just never received one in the speculative
  path before this change.

  ### Commit 3 — startup probe + AR demotion

  `mlx_vlm/server.py`

  - New `_probe_drafter_compat(drafter, target_model) -> Optional[Exception]` helper — calls `drafter.bind(target_model)` and returns the `ValueError` (or
  `None` on success). Idempotent: `bind()` is re-called per-request anyway, so the probe doesn't disturb runtime state.
  - `_initialize_model` runs the probe right after `load_drafter` succeeds. On mismatch, logs a structured `logger.warning` (with the full reason) plus a
  one-line `print` for the operator watching stdout, then sets `draft_model = None` so the existing thread router (`server.py:570`) takes the AR path.

  `bind()` still raises on mismatch — the right behavior for the future per-request drafter API, where a client explicitly opts into a drafter and should
  see the error rather than have it silently swapped.

  ## Out of scope (separate follow-up PR)

  **Per-request drafter selection.** Add `draft_model` / `draft_kind` fields to `VLMRequest`, an in-memory drafter cache, and per-request routing between AR
   and speculative threads. Real architectural change; gets its own PR.

  ## Tests

  `mlx_vlm/tests/test_speculative.py` — 7 new tests, 22 total (15 existing pass unchanged):

  **Bind guard** (3): mismatch raises with both numbers + pairing table; matched pair doesn't raise; unwrapped `LanguageModel` target works.

  **Error broadcast** (2): `(exc, None)` delivered per active queue with finished uids skipped; broken queue's `.put()` exception doesn't block other
  clients.

  **Probe helper** (2): returns the `ValueError` on mismatch; returns `None` on a matched pair.

  Tests stub the drafter via `Gemma4AssistantDraftModel.__new__(...)` — fast, hermetic, no GPU.

  ## End-to-end verification (against a live Gemma 4 server)

  | Scenario | Server log | Client |
  |---|---|---|
  | Matched pair (`gemma-4-26B-A4B-it` ↔ `gemma-4-26B-A4B-it-assistant`) | `Drafter ready — speculative decoding enabled.` then `[MTP] batch=1 tokens=…
  accept=… rounds=…` | streams normally with speculative speedup |
  | Mismatched pair (`gemma-4-31B-it` ↔ `gemma-4-26B-A4B-it-assistant`) | `WARNING: drafter ↔ target incompatibility — speculative decoding DISABLED.` +
  full pairing table in log | streams normally via AR; `lbench` runs to completion |
  | Speculative-thread exception | `ValueError: [squeeze] Cannot squeeze axis -1 with size 4 …` | receives SSE error event in **0.76 s** (vs. indefinite
  hang on `main`) |

  The third row was verified before this branch was rebased onto `main` by leveraging the latent top_p `[squeeze]` bug from #1141. That bug is now fixed, so
   the same e2e isn't reproducible on the rebased branch organically — the underlying error-propagation code is unchanged and is covered by the
  broadcast-helper unit tests.

  ## Test plan

  - [x] `pytest mlx_vlm/tests/test_speculative.py` — 22 passed
  - [x] `pytest mlx_vlm/tests/test_server.py` — 58 passed
  - [x] `pre-commit run --files <changed>` — clean
  - [x] **E2E:** matched pair streams via speculative
  - [x] **E2E:** mismatched pair demotes to AR with WARNING; server keeps serving
  - [x] **E2E:** speculative-thread exception reaches the client (verified pre-rebase against the now-fixed top_p bug)