### PR TITLE
Add server metrics and improve streamed response handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -820,6 +820,7 @@ Structured outputs are not currently supported with speculative decoding.
 - `/chat/completions` and `/v1/chat/completions` - OpenAI-compatible chat-style interaction endpoint with support for images, audio, and text
 - `/responses` and `/v1/responses` - OpenAI-compatible responses endpoint
 - `/health` - Check server status
+- `/metrics` and `/v1/metrics` - Inspect rolling request metrics, throughput, and runtime counters
 - `/unload` - Unload current model from memory
 
 #### Usage Examples

--- a/mlx_vlm/generate.py
+++ b/mlx_vlm/generate.py
@@ -2876,9 +2876,8 @@ class PromptProcessingBatch:
 
         logprobs = logits - mx.logsumexp(logits, axis=-1, keepdims=True)
         first_tokens = sampler(logprobs)
-        # Materialize the first sampled token so prompt timing ends when the
-        # first token is actually ready, matching the CLI prompt TPS semantics.
-        mx.eval(first_tokens)
+
+        mx.async_eval(first_tokens)
 
         # Roll any right-padding into left-padding so the cache decoded by
         # GenerationBatch sees a canonical layout.

--- a/mlx_vlm/generate.py
+++ b/mlx_vlm/generate.py
@@ -2254,6 +2254,16 @@ class BatchResponse:
     image_sizes: Optional[List[Tuple[int, int]]] = None
 
 
+@dataclass
+class PromptProgress:
+    """Per-request prompt processing metrics for continuous batching."""
+
+    uid: int
+    prompt_tokens: int
+    prompt_tps: float = 0.0
+    prompt_time: float = 0.0
+
+
 class GenerationBatch:
     """
     Batched token generator with double-buffered pipelining.
@@ -2591,6 +2601,7 @@ class PromptProcessingBatch:
     ):
         self.model = model
         self.uids = uids
+        self._prompt_uids = list(uids)
         self.max_tokens = max_tokens
         self.prefill_step_size = prefill_step_size
 
@@ -2643,6 +2654,15 @@ class PromptProcessingBatch:
         self._apc_manager = apc_manager
         self._apc_mode = apc_mode
         self._apc_harvest_enabled = True
+        self._prompt_time_s = 0.0
+        self._prompt_tokens_per_row: List[int] = []
+        for idx, suffix_len in enumerate(lengths):
+            full_input_ids = None
+            if idx < len(self._apc_meta) and self._apc_meta[idx] is not None:
+                full_input_ids = self._apc_meta[idx].get("full_input_ids")
+            self._prompt_tokens_per_row.append(
+                len(full_input_ids) if full_input_ids is not None else suffix_len
+            )
 
         if warm_cache is not None:
             self.prompt_cache = warm_cache
@@ -2803,6 +2823,24 @@ class PromptProcessingBatch:
         mx.clear_cache()
         return n
 
+    def record_prompt_time(self, elapsed_s: float) -> None:
+        self._prompt_time_s += max(0.0, float(elapsed_s))
+
+    def prompt_progress(self) -> List[PromptProgress]:
+        if self._prompt_time_s <= 0:
+            return []
+        return [
+            PromptProgress(
+                uid=uid,
+                prompt_tokens=prompt_tokens,
+                prompt_tps=prompt_tokens / self._prompt_time_s,
+                prompt_time=self._prompt_time_s,
+            )
+            for uid, prompt_tokens in zip(
+                self._prompt_uids, self._prompt_tokens_per_row
+            )
+        ]
+
     def generate(
         self, sampler, stop_criteria, compute_logprobs=True, top_logprobs_k=0
     ) -> GenerationBatch:
@@ -2838,6 +2876,9 @@ class PromptProcessingBatch:
 
         logprobs = logits - mx.logsumexp(logits, axis=-1, keepdims=True)
         first_tokens = sampler(logprobs)
+        # Materialize the first sampled token so prompt timing ends when the
+        # first token is actually ready, matching the CLI prompt TPS semantics.
+        mx.eval(first_tokens)
 
         # Roll any right-padding into left-padding so the cache decoded by
         # GenerationBatch sees a canonical layout.
@@ -3008,7 +3049,7 @@ class BatchGenerator:
     Continuous batching with separate prompt processing and generation phases.
 
     next() returns (prompt_responses, generation_responses) where:
-    - prompt_responses is currently always [] (reserved for progress tracking)
+    - prompt_responses contains completed prompt-batch timing stats
     - generation_responses is a list of GenerationBatch.Response objects
     """
 
@@ -3493,6 +3534,19 @@ class BatchGenerator:
         stats.peak_memory = mx.get_peak_memory() / 1e9
         return stats
 
+    @staticmethod
+    def _record_prompt_batch_time(prompt_batch, elapsed_s: float) -> None:
+        recorder = getattr(prompt_batch, "record_prompt_time", None)
+        if callable(recorder):
+            recorder(elapsed_s)
+
+    @staticmethod
+    def _prompt_batch_progress(prompt_batch) -> List[PromptProgress]:
+        progress = getattr(prompt_batch, "prompt_progress", None)
+        if callable(progress):
+            return progress()
+        return []
+
     def _next(self, **kwargs):
         generation_responses = []
         prompt_responses = []
@@ -3512,7 +3566,9 @@ class BatchGenerator:
             if self._prompt_batch.needs_processing():
                 tic = time.perf_counter()
                 n = self._prompt_batch.prompt_step()
-                self._prompt_time_counter += time.perf_counter() - tic
+                elapsed = time.perf_counter() - tic
+                self._prompt_time_counter += elapsed
+                self._record_prompt_batch_time(self._prompt_batch, elapsed)
                 self._prompt_tokens_counter += n
                 return prompt_responses, generation_responses
 
@@ -3523,7 +3579,10 @@ class BatchGenerator:
                 compute_logprobs=self.compute_logprobs,
                 top_logprobs_k=self.top_logprobs_k,
             )
-            self._prompt_time_counter += time.perf_counter() - tic
+            elapsed = time.perf_counter() - tic
+            self._prompt_time_counter += elapsed
+            self._record_prompt_batch_time(self._prompt_batch, elapsed)
+            prompt_responses = self._prompt_batch_progress(self._prompt_batch)
             self._generation_batch.extend(gen_batch)
             self._prompt_batch = None
             mx.clear_cache()
@@ -3552,7 +3611,9 @@ class BatchGenerator:
                 if self._prompt_batch.needs_processing():
                     tic = time.perf_counter()
                     nstep = self._prompt_batch.prompt_step()
-                    self._prompt_time_counter += time.perf_counter() - tic
+                    elapsed = time.perf_counter() - tic
+                    self._prompt_time_counter += elapsed
+                    self._record_prompt_batch_time(self._prompt_batch, elapsed)
                 else:
                     tic = time.perf_counter()
                     gen_batch = self._prompt_batch.generate(
@@ -3561,7 +3622,10 @@ class BatchGenerator:
                         compute_logprobs=self.compute_logprobs,
                         top_logprobs_k=self.top_logprobs_k,
                     )
-                    self._prompt_time_counter += time.perf_counter() - tic
+                    elapsed = time.perf_counter() - tic
+                    self._prompt_time_counter += elapsed
+                    self._record_prompt_batch_time(self._prompt_batch, elapsed)
+                    prompt_responses = self._prompt_batch_progress(self._prompt_batch)
                     self._generation_batch.extend(gen_batch)
                     self._prompt_batch = None
                     mx.clear_cache()
@@ -3603,7 +3667,9 @@ class BatchGenerator:
             if self._prompt_batch.needs_processing():
                 tic = time.perf_counter()
                 n = self._prompt_batch.prompt_step()
-                self._prompt_time_counter += time.perf_counter() - tic
+                elapsed = time.perf_counter() - tic
+                self._prompt_time_counter += elapsed
+                self._record_prompt_batch_time(self._prompt_batch, elapsed)
             else:
                 tic = time.perf_counter()
                 gen_batch = self._prompt_batch.generate(
@@ -3612,7 +3678,10 @@ class BatchGenerator:
                     compute_logprobs=self.compute_logprobs,
                     top_logprobs_k=self.top_logprobs_k,
                 )
-                self._prompt_time_counter += time.perf_counter() - tic
+                elapsed = time.perf_counter() - tic
+                self._prompt_time_counter += elapsed
+                self._record_prompt_batch_time(self._prompt_batch, elapsed)
+                prompt_responses = self._prompt_batch_progress(self._prompt_batch)
                 self._generation_batch.extend(gen_batch)
                 self._prompt_batch = None
                 mx.clear_cache()

--- a/mlx_vlm/server.py
+++ b/mlx_vlm/server.py
@@ -343,7 +343,6 @@ def _build_metrics_envelope(
     tool_calls: bool = False,
 ) -> dict:
     token_times = token_times or []
-    prompt_eval_time_s = _prompt_eval_time_from_tps(prompt_tokens, prompt_tps)
     ttft_s = (
         max(0.0, token_times[0] - request_started_s)
         if token_times
@@ -357,6 +356,7 @@ def _build_metrics_envelope(
         decode_tok_s = generation_tps
     elif decode_elapsed_s is not None and decode_elapsed_s > 0 and generated_tokens > 0:
         decode_tok_s = generated_tokens / decode_elapsed_s
+    prompt_eval_time_s = _prompt_eval_time_from_tps(prompt_tokens, prompt_tps)
     request_tok_s = (
         completion_tokens / request_elapsed_s if request_elapsed_s > 0 else 0.0
     )
@@ -499,6 +499,7 @@ class StreamingToken:
     logprobs: float
     finish_reason: Optional[str]
     peak_memory: float = 0.0
+    prompt_tps: Optional[float] = None
     top_logprobs: Optional[List[Tuple[int, float]]] = None
 
 
@@ -871,6 +872,7 @@ class ResponseGenerator:
                         "rqueue": rqueue,
                         "detokenizer": make_streaming_detokenizer(self.processor),
                         "gen_kwargs": gen_kwargs if has_embeds else None,
+                        "prompt_tps": None,
                     }
 
                 if not active or batch_gen is None:
@@ -944,6 +946,8 @@ class ResponseGenerator:
                 token_lists = {}
                 stream_infos = {}
                 max_tokens_map = {}
+                prompt_tokens_map = {}
+                prompt_tps_map = {}
                 all_input_ids = []
                 prompt_kwargs_list = []
 
@@ -962,6 +966,7 @@ class ResponseGenerator:
                         "detokenizer": make_streaming_detokenizer(self.processor)
                     }
                     max_tokens_map[uid] = args.max_tokens
+                    prompt_tokens_map[uid] = prompt_tokens
                     all_input_ids.append(input_ids.squeeze(0).tolist())
                     prompt_kwargs_list.append(gen_kwargs)
                     rqueue.put(GenerationContext(uid=uid, prompt_tokens=prompt_tokens))
@@ -984,12 +989,21 @@ class ResponseGenerator:
                 lm_call_kwargs = {**prefill_kwargs, **prompt_kwargs}
                 lm_call_kwargs["inputs_embeds"] = inputs_embeds_mx
 
+                prompt_started = time.perf_counter()
                 with mx.stream(generation_stream):
                     out = lm(input_mx, cache=prompt_cache, **lm_call_kwargs)
                 hidden = _speculative_hidden_state(draft_kind, out)
                 shared_kv_states = out.shared_kv_states if is_mtp else None
                 first_bonus = sampler(out.logits[:, -1:]).squeeze(-1)
                 mx.eval(first_bonus, hidden, out.logits)
+                prompt_elapsed = time.perf_counter() - prompt_started
+                for uid in uids:
+                    prompt_tokens = prompt_tokens_map[uid]
+                    prompt_tps_map[uid] = (
+                        prompt_tokens / prompt_elapsed
+                        if prompt_tokens > 0 and prompt_elapsed > 0
+                        else None
+                    )
 
                 finished_uids = set()
 
@@ -1009,6 +1023,7 @@ class ResponseGenerator:
                             logprobs=0.0,
                             finish_reason=finish,
                             peak_memory=mx.get_peak_memory() / 1e9,
+                            prompt_tps=prompt_tps_map.get(uid),
                         )
                     )
                     if finish is not None:
@@ -1080,6 +1095,7 @@ class ResponseGenerator:
                                 logprobs=0.0,
                                 finish_reason=finish,
                                 peak_memory=mx.get_peak_memory() / 1e9,
+                                prompt_tps=prompt_tps_map.get(uid),
                             )
                         )
 
@@ -1109,6 +1125,7 @@ class ResponseGenerator:
                                 logprobs=0.0,
                                 finish_reason="length",
                                 peak_memory=mx.get_peak_memory() / 1e9,
+                                prompt_tps=prompt_tps_map.get(uid),
                             )
                         )
                         rqueues[uid].put(None)
@@ -1120,7 +1137,12 @@ class ResponseGenerator:
     def _step(self, batch_gen, active, gen_kwargs=None):
         """One batch generation step: prefill + decode."""
         kwargs = gen_kwargs or {}
-        _, responses = batch_gen.next(**kwargs)
+        prompt_responses, responses = batch_gen.next(**kwargs)
+        for prompt_response in prompt_responses:
+            if prompt_response.uid in active:
+                active[prompt_response.uid]["prompt_tps"] = (
+                    prompt_response.prompt_tps
+                )
         if not responses:
             return
 
@@ -1146,6 +1168,7 @@ class ResponseGenerator:
                     logprobs=lp,
                     finish_reason=r.finish_reason,
                     peak_memory=mx.get_peak_memory() / 1e9 if r.finish_reason else 0,
+                    prompt_tps=info.get("prompt_tps"),
                     top_logprobs=getattr(r, "top_logprobs", None),
                 )
             )
@@ -2305,6 +2328,7 @@ async def responses_endpoint(request: Request):
                                 peak_memory,
                                 float(getattr(token, "peak_memory", 0.0) or 0.0),
                             )
+                            prompt_tps = getattr(token, "prompt_tps", prompt_tps)
                             usage_stats = {
                                 "input_tokens": ctx.prompt_tokens,
                                 "output_tokens": output_tokens,
@@ -2490,12 +2514,14 @@ async def responses_endpoint(request: Request):
                         text = ""
                         ot = 0
                         tt: List[float] = []
+                        ptps = None
                         pm = 0.0
                         fr = None
                         for tok in ti:
                             text += tok.text
                             ot += 1
                             tt.append(time.perf_counter())
+                            ptps = getattr(tok, "prompt_tps", ptps)
                             pm = max(
                                 pm, float(getattr(tok, "peak_memory", 0.0) or 0.0)
                             )
@@ -2506,13 +2532,14 @@ async def responses_endpoint(request: Request):
                             ti.close()
                         except Exception:
                             pass
-                        return ctx_.prompt_tokens, text, ot, tt, pm, fr
+                        return ctx_.prompt_tokens, text, ot, tt, ptps, pm, fr
 
                     (
                         prompt_tokens,
                         full_text,
                         output_tokens,
                         token_times,
+                        prompt_tps,
                         peak_memory,
                         finish_reason,
                     ) = await asyncio.to_thread(_blocking_resp)
@@ -2819,6 +2846,7 @@ async def chat_completions_endpoint(request: ChatRequest, http_request: Request)
                                 peak_memory,
                                 float(getattr(token, "peak_memory", 0.0) or 0.0),
                             )
+                            prompt_tps = getattr(token, "prompt_tps", prompt_tps)
 
                             # Detect thinking boundaries
                             delta_reasoning = None
@@ -3105,6 +3133,7 @@ async def chat_completions_endpoint(request: ChatRequest, http_request: Request)
                         pt = gt = 0
                         pm = 0.0
                         tt: List[float] = []
+                        ptps = None
                         fr = None
                         ctx, token_iter = response_generator.generate(
                             prompt=formatted_prompt,
@@ -3117,6 +3146,7 @@ async def chat_completions_endpoint(request: ChatRequest, http_request: Request)
                             text += token.text
                             gt += 1
                             tt.append(time.perf_counter())
+                            ptps = getattr(token, "prompt_tps", ptps)
                             pm = token.peak_memory
                             if request.logprobs and token.finish_reason != "stop":
                                 collected_logprobs.append(
@@ -3129,12 +3159,13 @@ async def chat_completions_endpoint(request: ChatRequest, http_request: Request)
                             token_iter.close()
                         except Exception:
                             pass
-                        return text, pt, gt, pm, tt, fr
+                        return text, pt, gt, ptps, pm, tt, fr
 
                     (
                         full_text,
                         prompt_tokens,
                         output_tokens,
+                        prompt_tps,
                         peak_memory,
                         token_times,
                         finish_reason,
@@ -3178,6 +3209,8 @@ async def chat_completions_endpoint(request: ChatRequest, http_request: Request)
                     prompt_tokens=prompt_tokens,
                     completion_tokens=completion_tokens,
                     total_tokens=prompt_tokens + completion_tokens,
+                    prompt_tps=float(prompt_tps or 0.0),
+                    generation_tps=float(generation_tps or 0.0),
                     peak_memory=peak_memory,
                 )
 

--- a/mlx_vlm/server.py
+++ b/mlx_vlm/server.py
@@ -1186,7 +1186,8 @@ def suppress_tool_call_content(
     if not in_tool_call:
         if tc_start in full_output:
             return True, None
-        if any(full_output.endswith(tc_start[:j]) for j in range(1, len(tc_start))):
+
+        if any(full_output.endswith(tc_start[:j]) for j in range(2, len(tc_start))):
             return False, None
     else:
         return True, None

--- a/mlx_vlm/server.py
+++ b/mlx_vlm/server.py
@@ -273,7 +273,9 @@ class ServerMetricsStore:
                 if self._decode_time_total_s > 0
                 else 0.0
             )
-            last_error = dict(self._last_error) if self._last_error is not None else None
+            last_error = (
+                dict(self._last_error) if self._last_error is not None else None
+            )
             last_request_at = self._last_request_at
             return {
                 "latest": latest,
@@ -343,11 +345,7 @@ def _build_metrics_envelope(
     tool_calls: bool = False,
 ) -> dict:
     token_times = token_times or []
-    ttft_s = (
-        max(0.0, token_times[0] - request_started_s)
-        if token_times
-        else None
-    )
+    ttft_s = max(0.0, token_times[0] - request_started_s) if token_times else None
     decode_elapsed_s = _decode_elapsed_from_metrics(
         token_times, generated_tokens, generation_tps
     )
@@ -1140,9 +1138,7 @@ class ResponseGenerator:
         prompt_responses, responses = batch_gen.next(**kwargs)
         for prompt_response in prompt_responses:
             if prompt_response.uid in active:
-                active[prompt_response.uid]["prompt_tps"] = (
-                    prompt_response.prompt_tps
-                )
+                active[prompt_response.uid]["prompt_tps"] = prompt_response.prompt_tps
         if not responses:
             return
 
@@ -2522,9 +2518,7 @@ async def responses_endpoint(request: Request):
                             ot += 1
                             tt.append(time.perf_counter())
                             ptps = getattr(tok, "prompt_tps", ptps)
-                            pm = max(
-                                pm, float(getattr(tok, "peak_memory", 0.0) or 0.0)
-                            )
+                            pm = max(pm, float(getattr(tok, "peak_memory", 0.0) or 0.0))
                             if tok.finish_reason:
                                 fr = tok.finish_reason
                                 break
@@ -3039,9 +3033,8 @@ async def chat_completions_endpoint(request: ChatRequest, http_request: Request)
                         prompt_tps=prompt_tps,
                         generation_tps=generation_tps,
                         peak_memory_gb=peak_memory or None,
-                        finish_reason=finish_reason or (
-                            "stop" if output_tokens > 0 else None
-                        ),
+                        finish_reason=finish_reason
+                        or ("stop" if output_tokens > 0 else None),
                         image_count=len(images),
                         audio_count=len(audio),
                         structured_output=bool(gen_args.logits_processors),
@@ -3168,9 +3161,7 @@ async def chat_completions_endpoint(request: ChatRequest, http_request: Request)
                         peak_memory,
                         token_times,
                         finish_reason,
-                    ) = (
-                        await asyncio.to_thread(_blocking_generate)
-                    )
+                    ) = await asyncio.to_thread(_blocking_generate)
                 else:
                     gen_result = generate(
                         model=model,
@@ -3187,9 +3178,7 @@ async def chat_completions_endpoint(request: ChatRequest, http_request: Request)
                     full_text = gen_result.text
                     prompt_tokens = gen_result.prompt_tokens
                     output_tokens = gen_result.generation_tokens
-                    peak_memory = float(
-                        getattr(gen_result, "peak_memory", 0.0) or 0.0
-                    )
+                    peak_memory = float(getattr(gen_result, "peak_memory", 0.0) or 0.0)
                     prompt_tps = getattr(gen_result, "prompt_tps", None)
                     generation_tps = getattr(gen_result, "generation_tps", None)
                     finish_reason = "stop"

--- a/mlx_vlm/server.py
+++ b/mlx_vlm/server.py
@@ -8,6 +8,7 @@ import re
 import time
 import traceback
 import uuid
+from collections import deque
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from datetime import datetime
@@ -60,6 +61,8 @@ DEFAULT_SERVER_HOST = "0.0.0.0"
 DEFAULT_SERVER_PORT = 8080
 DEFAULT_TOKEN_QUEUE_TIMEOUT = 600.0
 DEFAULT_ENABLE_THINKING = False
+METRICS_HISTORY_LIMIT = 100
+METRICS_RECENT_LIMIT = 32
 
 
 def _get_speculative_rounds_batch(draft_kind: str):
@@ -164,6 +167,259 @@ def get_top_logprobs_k():
     """
     k = int(os.environ.get("TOP_LOGPROBS_K", 0))
     return max(0, min(k, 20))
+
+
+def _token_window_rate(token_times: List[float], window: int) -> Optional[float]:
+    if len(token_times) < 2:
+        return None
+    subset = token_times[-window:]
+    if len(subset) < 2:
+        return None
+    elapsed = subset[-1] - subset[0]
+    if elapsed <= 0:
+        return None
+    return (len(subset) - 1) / elapsed
+
+
+def _token_window_rate_first(token_times: List[float], window: int) -> Optional[float]:
+    if len(token_times) < 2:
+        return None
+    subset = token_times[:window]
+    if len(subset) < 2:
+        return None
+    elapsed = subset[-1] - subset[0]
+    if elapsed <= 0:
+        return None
+    return (len(subset) - 1) / elapsed
+
+
+class ServerMetricsStore:
+    """Rolling request metrics and lifetime counters for the server."""
+
+    def __init__(self, history_limit: int = METRICS_HISTORY_LIMIT):
+        self.history_limit = history_limit
+        self.reset()
+
+    def reset(self):
+        self.started_at = time.time()
+        self._lock = Lock()
+        self._latest: Optional[dict] = None
+        self._recent = deque(maxlen=self.history_limit)
+        self._requests_started = 0
+        self._requests_completed = 0
+        self._requests_failed = 0
+        self._streaming_requests = 0
+        self._in_flight = 0
+        self._prompt_tokens_total = 0
+        self._completion_tokens_total = 0
+        self._generated_tokens_total = 0
+        self._request_time_total_s = 0.0
+        self._decode_time_total_s = 0.0
+        self._last_request_at: Optional[float] = None
+        self._last_error: Optional[dict] = None
+
+    def begin_request(self, *, endpoint: str, model: str, stream: bool):
+        del endpoint, model
+        with self._lock:
+            self._requests_started += 1
+            self._in_flight += 1
+            if stream:
+                self._streaming_requests += 1
+
+    def record_success(self, envelope: dict):
+        payload = dict(envelope)
+        with self._lock:
+            self._requests_completed += 1
+            self._in_flight = max(0, self._in_flight - 1)
+            self._latest = payload
+            self._recent.append(payload)
+            self._last_request_at = payload.get("timestamp_unix")
+            self._prompt_tokens_total += int(payload.get("prompt_tokens") or 0)
+            self._completion_tokens_total += int(payload.get("completion_tokens") or 0)
+            self._generated_tokens_total += int(payload.get("generated_tokens") or 0)
+            self._request_time_total_s += float(payload.get("request_elapsed_s") or 0.0)
+            self._decode_time_total_s += float(payload.get("decode_elapsed_s") or 0.0)
+
+    def record_failure(self, *, endpoint: str, model: str, stream: bool, error: str):
+        with self._lock:
+            self._requests_failed += 1
+            self._in_flight = max(0, self._in_flight - 1)
+            self._last_request_at = time.time()
+            self._last_error = {
+                "timestamp_unix": self._last_request_at,
+                "endpoint": endpoint,
+                "model": model,
+                "stream": bool(stream),
+                "error": error,
+            }
+
+    def snapshot(self) -> dict:
+        with self._lock:
+            latest = dict(self._latest) if self._latest is not None else None
+            recent = [dict(item) for item in list(self._recent)[-METRICS_RECENT_LIMIT:]]
+            requests_completed = self._requests_completed
+            avg_request_time = (
+                self._request_time_total_s / requests_completed
+                if requests_completed > 0
+                else 0.0
+            )
+            avg_request_tok_s = (
+                self._completion_tokens_total / self._request_time_total_s
+                if self._request_time_total_s > 0
+                else 0.0
+            )
+            avg_decode_tok_s = (
+                self._generated_tokens_total / self._decode_time_total_s
+                if self._decode_time_total_s > 0
+                else 0.0
+            )
+            last_error = dict(self._last_error) if self._last_error is not None else None
+            last_request_at = self._last_request_at
+            return {
+                "latest": latest,
+                "recent": recent,
+                "summary": {
+                    "uptime_s": max(0.0, time.time() - self.started_at),
+                    "requests_started": self._requests_started,
+                    "requests_completed": requests_completed,
+                    "requests_failed": self._requests_failed,
+                    "streaming_requests": self._streaming_requests,
+                    "in_flight": self._in_flight,
+                    "prompt_tokens_total": self._prompt_tokens_total,
+                    "completion_tokens_total": self._completion_tokens_total,
+                    "generated_tokens_total": self._generated_tokens_total,
+                    "avg_request_time_s": avg_request_time,
+                    "avg_request_tok_s": avg_request_tok_s,
+                    "avg_decode_tok_s": avg_decode_tok_s,
+                    "last_request_at": last_request_at,
+                    "last_error": last_error,
+                },
+            }
+
+
+def _prompt_eval_time_from_tps(
+    prompt_tokens: int, prompt_tps: Optional[float]
+) -> Optional[float]:
+    if prompt_tokens <= 0 or prompt_tps is None or prompt_tps <= 0:
+        return None
+    return prompt_tokens / prompt_tps
+
+
+def _decode_elapsed_from_metrics(
+    token_times: List[float],
+    generated_tokens: int,
+    generation_tps: Optional[float],
+) -> Optional[float]:
+    if len(token_times) >= 2:
+        elapsed = token_times[-1] - token_times[0]
+        if elapsed > 0:
+            return elapsed
+    if generated_tokens > 0 and generation_tps is not None and generation_tps > 0:
+        return generated_tokens / generation_tps
+    return None
+
+
+def _build_metrics_envelope(
+    *,
+    endpoint: str,
+    model: str,
+    stream: bool,
+    backend: str,
+    prompt_tokens: int,
+    completion_tokens: int,
+    generated_tokens: int,
+    request_elapsed_s: float,
+    request_started_s: float,
+    token_times: Optional[List[float]] = None,
+    prompt_tps: Optional[float] = None,
+    generation_tps: Optional[float] = None,
+    peak_memory_gb: Optional[float] = None,
+    finish_reason: Optional[str] = None,
+    image_count: int = 0,
+    audio_count: int = 0,
+    structured_output: bool = False,
+    thinking_enabled: bool = False,
+    tool_parser: Optional[str] = None,
+    tool_calls: bool = False,
+) -> dict:
+    token_times = token_times or []
+    prompt_eval_time_s = _prompt_eval_time_from_tps(prompt_tokens, prompt_tps)
+    ttft_s = (
+        max(0.0, token_times[0] - request_started_s)
+        if token_times
+        else None
+    )
+    decode_elapsed_s = _decode_elapsed_from_metrics(
+        token_times, generated_tokens, generation_tps
+    )
+    decode_tok_s = None
+    if generation_tps is not None and generation_tps > 0:
+        decode_tok_s = generation_tps
+    elif decode_elapsed_s is not None and decode_elapsed_s > 0 and generated_tokens > 0:
+        decode_tok_s = generated_tokens / decode_elapsed_s
+    request_tok_s = (
+        completion_tokens / request_elapsed_s if request_elapsed_s > 0 else 0.0
+    )
+    return {
+        "timestamp_unix": time.time(),
+        "endpoint": endpoint,
+        "model": model,
+        "stream": bool(stream),
+        "backend": backend,
+        "prompt_tokens": int(prompt_tokens),
+        "completion_tokens": int(completion_tokens),
+        "generated_tokens": int(generated_tokens),
+        "reasoning_tokens": max(0, int(generated_tokens) - int(completion_tokens)),
+        "total_tokens": int(prompt_tokens) + int(completion_tokens),
+        "prompt_eval_time_s": prompt_eval_time_s,
+        "prefill_tok_s": prompt_tps,
+        "ttft_s": ttft_s,
+        "decode_elapsed_s": decode_elapsed_s,
+        "request_elapsed_s": request_elapsed_s,
+        "request_tok_s": request_tok_s,
+        "decode_tok_s": decode_tok_s,
+        "sliding_decode_tok_s_first_32": _token_window_rate_first(token_times, 32),
+        "sliding_decode_tok_s_first_64": _token_window_rate_first(token_times, 64),
+        "sliding_decode_tok_s_last_32": _token_window_rate(token_times, 32),
+        "sliding_decode_tok_s_last_64": _token_window_rate(token_times, 64),
+        "peak_memory_gb": peak_memory_gb,
+        "finish_reason": finish_reason,
+        "image_count": int(image_count),
+        "audio_count": int(audio_count),
+        "structured_output": bool(structured_output),
+        "thinking_enabled": bool(thinking_enabled),
+        "tool_parser": tool_parser,
+        "tool_calls": bool(tool_calls),
+        "apc_enabled": apc_manager is not None,
+    }
+
+
+def _server_runtime_snapshot() -> dict:
+    config = model_cache.get("config")
+    text_config = getattr(config, "text_config", None)
+    queue_depth = 0
+    if response_generator is not None and hasattr(response_generator, "requests"):
+        try:
+            queue_depth = response_generator.requests.qsize()
+        except Exception:
+            queue_depth = 0
+    return {
+        "loaded_model": model_cache.get("model_path", None),
+        "loaded_adapter": model_cache.get("adapter_path", None),
+        "loaded_context_size": getattr(text_config, "max_position_embeddings", None),
+        "loaded_tool_parser": (
+            _infer_tool_parser_from_processor(model_cache.get("processor"))
+            if model_cache.get("processor")
+            else None
+        ),
+        "continuous_batching_enabled": response_generator is not None,
+        "request_queue_depth": queue_depth,
+        "apc": (
+            {"enabled": False}
+            if apc_manager is None
+            else {"enabled": True, **apc_manager.stats_snapshot()}
+        ),
+    }
 
 
 # =============================================================================
@@ -1169,6 +1425,7 @@ apc_manager: Optional[_apc.APCManager] = None
 
 # Loading/unloading utilities
 model_cache = {}
+server_metrics = ServerMetricsStore()
 
 
 @asynccontextmanager
@@ -1954,9 +2211,21 @@ async def responses_endpoint(request: Request):
 
         if openai_request.stream:
             # Streaming response
+            server_metrics.begin_request(
+                endpoint="/responses",
+                model=openai_request.model,
+                stream=True,
+            )
+
             async def stream_generator():
                 token_iterator = None
                 token_iter = None  # For ResponseGenerator cleanup
+                metrics_finalized = False
+                token_times: List[float] = []
+                prompt_tps = None
+                generation_tps = None
+                peak_memory = 0.0
+                finish_reason = None
                 try:
                     # Create base response object (to match the openai pipeline)
                     base_response = OpenAIResponse(
@@ -2030,6 +2299,11 @@ async def responses_endpoint(request: Request):
                             output_tokens += 1
                             delta = token.text
                             full_text += delta
+                            token_times.append(time.perf_counter())
+                            peak_memory = max(
+                                peak_memory,
+                                float(getattr(token, "peak_memory", 0.0) or 0.0),
+                            )
                             usage_stats = {
                                 "input_tokens": ctx.prompt_tokens,
                                 "output_tokens": output_tokens,
@@ -2039,6 +2313,7 @@ async def responses_endpoint(request: Request):
                             await asyncio.sleep(0.01)
 
                             if token.finish_reason:
+                                finish_reason = token.finish_reason
                                 break
                     else:
                         # Fallback to stream_generate
@@ -2063,6 +2338,15 @@ async def responses_endpoint(request: Request):
 
                             delta = chunk.text
                             full_text += delta
+                            token_times.append(time.perf_counter())
+                            prompt_tps = getattr(chunk, "prompt_tps", prompt_tps)
+                            generation_tps = getattr(
+                                chunk, "generation_tps", generation_tps
+                            )
+                            peak_memory = max(
+                                peak_memory,
+                                float(getattr(chunk, "peak_memory", 0.0) or 0.0),
+                            )
                             usage_stats = {
                                 "input_tokens": chunk.prompt_tokens,
                                 "output_tokens": chunk.generation_tokens,
@@ -2094,6 +2378,34 @@ async def responses_endpoint(request: Request):
                     yield f"event: response.output_item.done\ndata: {ResponseOutputItemDoneEvent(type='response.output_item.done', output_index=0, item=final_message_item).model_dump_json()}\n\n"
 
                     # Send response.completed event (to match the openai pipeline)
+                    finish_reason = finish_reason or (
+                        "stop" if usage_stats["output_tokens"] > 0 else None
+                    )
+                    envelope = _build_metrics_envelope(
+                        endpoint="/responses",
+                        model=openai_request.model,
+                        stream=True,
+                        backend=(
+                            "continuous_batching"
+                            if response_generator is not None
+                            else "generate"
+                        ),
+                        prompt_tokens=usage_stats["input_tokens"],
+                        completion_tokens=usage_stats["output_tokens"],
+                        generated_tokens=usage_stats["output_tokens"],
+                        request_elapsed_s=time.perf_counter() - request_start,
+                        request_started_s=request_start,
+                        token_times=token_times,
+                        prompt_tps=prompt_tps,
+                        generation_tps=generation_tps,
+                        peak_memory_gb=peak_memory or None,
+                        finish_reason=finish_reason,
+                        image_count=len(images),
+                        structured_output=bool(gen_args.logits_processors),
+                        thinking_enabled=bool(gen_args.enable_thinking),
+                    )
+                    server_metrics.record_success(envelope)
+                    metrics_finalized = True
                     completed_response = base_response.model_copy(
                         update={
                             "status": "completed",
@@ -2109,6 +2421,14 @@ async def responses_endpoint(request: Request):
                     yield f"event: response.completed\ndata: {ResponseCompletedEvent(type='response.completed', response=completed_response).model_dump_json()}\n\n"
 
                 except Exception as e:
+                    if not metrics_finalized:
+                        server_metrics.record_failure(
+                            endpoint="/responses",
+                            model=openai_request.model,
+                            stream=True,
+                            error=str(e),
+                        )
+                        metrics_finalized = True
                     print(f"Error during stream generation: {e}")
                     traceback.print_exc()
                     error_data = json.dumps({"error": str(e)})
@@ -2120,6 +2440,13 @@ async def responses_endpoint(request: Request):
                             token_iter.close()
                         except Exception:
                             pass
+                    if not metrics_finalized:
+                        server_metrics.record_failure(
+                            endpoint="/responses",
+                            model=openai_request.model,
+                            stream=True,
+                            error="stream_closed_before_completion",
+                        )
                     mx.clear_cache()
                     gc.collect()
                     print("Stream finished, cleared cache.")
@@ -2136,10 +2463,20 @@ async def responses_endpoint(request: Request):
 
         else:
             # Non-streaming response
+            server_metrics.begin_request(
+                endpoint="/responses",
+                model=openai_request.model,
+                stream=False,
+            )
             try:
                 full_text = ""
                 prompt_tokens = 0
                 output_tokens = 0
+                token_times: List[float] = []
+                prompt_tps = None
+                generation_tps = None
+                peak_memory = 0.0
+                finish_reason = None
 
                 if response_generator is not None:
 
@@ -2151,20 +2488,33 @@ async def responses_endpoint(request: Request):
                         )
                         text = ""
                         ot = 0
+                        tt: List[float] = []
+                        pm = 0.0
+                        fr = None
                         for tok in ti:
                             text += tok.text
                             ot += 1
+                            tt.append(time.perf_counter())
+                            pm = max(
+                                pm, float(getattr(tok, "peak_memory", 0.0) or 0.0)
+                            )
                             if tok.finish_reason:
+                                fr = tok.finish_reason
                                 break
                         try:
                             ti.close()
                         except Exception:
                             pass
-                        return ctx_.prompt_tokens, text, ot
+                        return ctx_.prompt_tokens, text, ot, tt, pm, fr
 
-                    prompt_tokens, full_text, output_tokens = await asyncio.to_thread(
-                        _blocking_resp
-                    )
+                    (
+                        prompt_tokens,
+                        full_text,
+                        output_tokens,
+                        token_times,
+                        peak_memory,
+                        finish_reason,
+                    ) = await asyncio.to_thread(_blocking_resp)
                 else:
                     result = generate(
                         model=model,
@@ -2180,6 +2530,10 @@ async def responses_endpoint(request: Request):
                     full_text = result.text
                     prompt_tokens = result.prompt_tokens
                     output_tokens = result.generation_tokens
+                    prompt_tps = getattr(result, "prompt_tps", None)
+                    generation_tps = getattr(result, "generation_tps", None)
+                    peak_memory = float(getattr(result, "peak_memory", 0.0) or 0.0)
+                    finish_reason = "stop"
 
                 mx.clear_cache()
                 gc.collect()
@@ -2231,9 +2585,40 @@ async def responses_endpoint(request: Request):
                         resp_text[:200] + ("..." if len(resp_text) > 200 else ""),
                     )
 
+                envelope = _build_metrics_envelope(
+                    endpoint="/responses",
+                    model=openai_request.model,
+                    stream=False,
+                    backend=(
+                        "continuous_batching"
+                        if response_generator is not None
+                        else "generate"
+                    ),
+                    prompt_tokens=prompt_tokens,
+                    completion_tokens=output_tokens,
+                    generated_tokens=output_tokens,
+                    request_elapsed_s=elapsed,
+                    request_started_s=request_start,
+                    token_times=token_times,
+                    prompt_tps=prompt_tps,
+                    generation_tps=generation_tps,
+                    peak_memory_gb=peak_memory or None,
+                    finish_reason=finish_reason,
+                    image_count=len(images),
+                    structured_output=bool(gen_args.logits_processors),
+                    thinking_enabled=bool(gen_args.enable_thinking),
+                )
+                server_metrics.record_success(envelope)
+
                 return response
 
             except Exception as e:
+                server_metrics.record_failure(
+                    endpoint="/responses",
+                    model=openai_request.model,
+                    stream=False,
+                    error=str(e),
+                )
                 print(f"Error during generation: {e}")
                 traceback.print_exc()
                 mx.clear_cache()
@@ -2370,11 +2755,29 @@ async def chat_completions_endpoint(request: ChatRequest, http_request: Request)
 
         if request.stream:
             # Streaming response using ResponseGenerator for continuous batching
+            server_metrics.begin_request(
+                endpoint="/chat/completions",
+                model=request.model,
+                stream=True,
+            )
+
             async def stream_generator():
                 global response_generator
                 token_iterator = None
                 token_iter = None  # For ResponseGenerator cleanup
+                metrics_finalized = False
+                token_times: List[float] = []
+                prompt_tps = None
+                generation_tps = None
+                peak_memory = 0.0
+                finish_reason = None
                 try:
+                    output_tokens = 0
+                    full_output = ""
+                    output_text = ""
+                    stream_prompt_tokens = 0
+                    tool_calls_made = False
+
                     # Use ResponseGenerator if available, otherwise fall back to stream_generate
                     if response_generator is not None:
                         # generate() does blocking Queue.get — run off event loop
@@ -2410,6 +2813,11 @@ async def chat_completions_endpoint(request: ChatRequest, http_request: Request)
                             output_tokens += 1
                             accumulated += token.text
                             full_output += token.text
+                            token_times.append(time.perf_counter())
+                            peak_memory = max(
+                                peak_memory,
+                                float(getattr(token, "peak_memory", 0.0) or 0.0),
+                            )
 
                             # Detect thinking boundaries
                             delta_reasoning = None
@@ -2492,12 +2900,15 @@ async def chat_completions_endpoint(request: ChatRequest, http_request: Request)
                                 yield f"data: {chunk_data.model_dump_json()}\n\n"
 
                             if token.finish_reason:
+                                finish_reason = token.finish_reason
                                 break
 
                         # Parse tool calls from full output and emit final chunk
                         if tool_module is not None:
                             tc = process_tool_calls(full_output, tool_module, tools)
                             if tc["calls"]:
+                                tool_calls_made = True
+                                finish_reason = "tool_calls"
                                 choices = [
                                     ChatStreamChoice(
                                         finish_reason="tool_calls",
@@ -2539,6 +2950,17 @@ async def chat_completions_endpoint(request: ChatRequest, http_request: Request)
                                 continue
 
                             output_text += chunk.text
+                            stream_prompt_tokens = chunk.prompt_tokens
+                            token_times.append(time.perf_counter())
+                            output_tokens = chunk.generation_tokens
+                            prompt_tps = getattr(chunk, "prompt_tps", prompt_tps)
+                            generation_tps = getattr(
+                                chunk, "generation_tps", generation_tps
+                            )
+                            peak_memory = max(
+                                peak_memory,
+                                float(getattr(chunk, "peak_memory", 0.0) or 0.0),
+                            )
 
                             choices = [
                                 ChatStreamChoice(
@@ -2563,6 +2985,45 @@ async def chat_completions_endpoint(request: ChatRequest, http_request: Request)
                             yield f"data: {chunk_data.model_dump_json()}\n\n"
                             await asyncio.sleep(0.01)
 
+                    metrics_text = full_output or output_text
+                    completion_tokens = max(
+                        0, output_tokens - _count_thinking_tag_tokens(metrics_text)
+                    )
+                    envelope = _build_metrics_envelope(
+                        endpoint="/chat/completions",
+                        model=request.model,
+                        stream=True,
+                        backend=(
+                            "continuous_batching"
+                            if response_generator is not None
+                            else "generate"
+                        ),
+                        prompt_tokens=(
+                            ctx.prompt_tokens
+                            if response_generator is not None
+                            else stream_prompt_tokens
+                        ),
+                        completion_tokens=completion_tokens,
+                        generated_tokens=output_tokens,
+                        request_elapsed_s=time.perf_counter() - request_start,
+                        request_started_s=request_start,
+                        token_times=token_times,
+                        prompt_tps=prompt_tps,
+                        generation_tps=generation_tps,
+                        peak_memory_gb=peak_memory or None,
+                        finish_reason=finish_reason or (
+                            "stop" if output_tokens > 0 else None
+                        ),
+                        image_count=len(images),
+                        audio_count=len(audio),
+                        structured_output=bool(gen_args.logits_processors),
+                        thinking_enabled=bool(gen_args.enable_thinking),
+                        tool_parser=tool_parser_type,
+                        tool_calls=tool_calls_made,
+                    )
+                    server_metrics.record_success(envelope)
+                    metrics_finalized = True
+
                     # Signal stream end
                     yield "data: [DONE]\n\n"
 
@@ -2574,6 +3035,14 @@ async def chat_completions_endpoint(request: ChatRequest, http_request: Request)
                     )
 
                 except Exception as e:
+                    if not metrics_finalized:
+                        server_metrics.record_failure(
+                            endpoint="/chat/completions",
+                            model=request.model,
+                            stream=True,
+                            error=str(e),
+                        )
+                        metrics_finalized = True
                     print(f"Error during stream generation: {e}")
                     traceback.print_exc()
                     error_data = json.dumps({"error": str(e)})
@@ -2586,6 +3055,13 @@ async def chat_completions_endpoint(request: ChatRequest, http_request: Request)
                             token_iter.close()
                         except Exception:
                             pass
+                    if not metrics_finalized:
+                        server_metrics.record_failure(
+                            endpoint="/chat/completions",
+                            model=request.model,
+                            stream=True,
+                            error="stream_closed_before_completion",
+                        )
                     mx.clear_cache()
                     gc.collect()
                     print("Stream finished, cleared cache.")
@@ -2602,11 +3078,20 @@ async def chat_completions_endpoint(request: ChatRequest, http_request: Request)
 
         else:
             # Non-streaming response
+            server_metrics.begin_request(
+                endpoint="/chat/completions",
+                model=request.model,
+                stream=False,
+            )
             try:
                 full_text = ""
                 prompt_tokens = 0
                 output_tokens = 0
                 peak_memory = 0.0
+                token_times: List[float] = []
+                prompt_tps = None
+                generation_tps = None
+                finish_reason = None
 
                 collected_logprobs: List[
                     Tuple[int, float, Optional[List[Tuple[int, float]]]]
@@ -2618,6 +3103,8 @@ async def chat_completions_endpoint(request: ChatRequest, http_request: Request)
                         text = ""
                         pt = gt = 0
                         pm = 0.0
+                        tt: List[float] = []
+                        fr = None
                         ctx, token_iter = response_generator.generate(
                             prompt=formatted_prompt,
                             images=images if images else None,
@@ -2628,20 +3115,29 @@ async def chat_completions_endpoint(request: ChatRequest, http_request: Request)
                         for token in token_iter:
                             text += token.text
                             gt += 1
+                            tt.append(time.perf_counter())
                             pm = token.peak_memory
                             if request.logprobs and token.finish_reason != "stop":
                                 collected_logprobs.append(
                                     (token.token, token.logprobs, token.top_logprobs)
                                 )
                             if token.finish_reason:
+                                fr = token.finish_reason
                                 break
                         try:
                             token_iter.close()
                         except Exception:
                             pass
-                        return text, pt, gt, pm
+                        return text, pt, gt, pm, tt, fr
 
-                    full_text, prompt_tokens, output_tokens, peak_memory = (
+                    (
+                        full_text,
+                        prompt_tokens,
+                        output_tokens,
+                        peak_memory,
+                        token_times,
+                        finish_reason,
+                    ) = (
                         await asyncio.to_thread(_blocking_generate)
                     )
                 else:
@@ -2660,7 +3156,12 @@ async def chat_completions_endpoint(request: ChatRequest, http_request: Request)
                     full_text = gen_result.text
                     prompt_tokens = gen_result.prompt_tokens
                     output_tokens = gen_result.generation_tokens
-                    peak_memory = gen_result.peak_memory
+                    peak_memory = float(
+                        getattr(gen_result, "peak_memory", 0.0) or 0.0
+                    )
+                    prompt_tps = getattr(gen_result, "prompt_tps", None)
+                    generation_tps = getattr(gen_result, "generation_tps", None)
+                    finish_reason = "stop"
 
                 mx.clear_cache()
                 gc.collect()
@@ -2755,9 +3256,45 @@ async def chat_completions_endpoint(request: ChatRequest, http_request: Request)
                         resp_text[:200] + ("..." if len(resp_text) > 200 else ""),
                     )
 
+                envelope = _build_metrics_envelope(
+                    endpoint="/chat/completions",
+                    model=request.model,
+                    stream=False,
+                    backend=(
+                        "continuous_batching"
+                        if response_generator is not None
+                        else "generate"
+                    ),
+                    prompt_tokens=prompt_tokens,
+                    completion_tokens=completion_tokens,
+                    generated_tokens=output_tokens,
+                    request_elapsed_s=elapsed,
+                    request_started_s=request_start,
+                    token_times=token_times,
+                    prompt_tps=prompt_tps,
+                    generation_tps=generation_tps,
+                    peak_memory_gb=peak_memory or None,
+                    finish_reason=(
+                        "tool_calls" if parsed_tool_calls else finish_reason or "stop"
+                    ),
+                    image_count=len(images),
+                    audio_count=len(audio),
+                    structured_output=bool(gen_args.logits_processors),
+                    thinking_enabled=bool(gen_args.enable_thinking),
+                    tool_parser=tool_parser_type,
+                    tool_calls=bool(parsed_tool_calls),
+                )
+                server_metrics.record_success(envelope)
+
                 return result
 
             except Exception as e:
+                server_metrics.record_failure(
+                    endpoint="/chat/completions",
+                    model=request.model,
+                    stream=False,
+                    error=str(e),
+                )
                 print(f"Error during generation: {e}")
                 traceback.print_exc()
                 mx.clear_cache()
@@ -2825,22 +3362,24 @@ async def health_check():
     """
     Check if the server is healthy and what model is loaded.
     """
-    config = model_cache.get("config")
-    text_config = getattr(config, "text_config", None)
-
+    runtime = _server_runtime_snapshot()
     return {
         "status": "healthy",
-        "loaded_model": model_cache.get("model_path", None),
-        "loaded_adapter": model_cache.get("adapter_path", None),
-        "loaded_context_size": getattr(text_config, "max_position_embeddings", None),
-        "loaded_tool_parser": (
-            _infer_tool_parser_from_processor(model_cache.get("processor"))
-            if model_cache.get("processor")
-            else None
-        ),
-        "continuous_batching_enabled": response_generator is not None,
-        "apc_enabled": apc_manager is not None,
+        "loaded_model": runtime["loaded_model"],
+        "loaded_adapter": runtime["loaded_adapter"],
+        "loaded_context_size": runtime["loaded_context_size"],
+        "loaded_tool_parser": runtime["loaded_tool_parser"],
+        "continuous_batching_enabled": runtime["continuous_batching_enabled"],
+        "apc_enabled": runtime["apc"]["enabled"],
     }
+
+
+@app.get("/metrics")
+@app.get("/v1/metrics", include_in_schema=False)
+async def metrics_endpoint():
+    payload = server_metrics.snapshot()
+    payload["server"] = _server_runtime_snapshot()
+    return payload
 
 
 @app.get("/v1/cache/stats")

--- a/mlx_vlm/tests/test_generate.py
+++ b/mlx_vlm/tests/test_generate.py
@@ -503,6 +503,34 @@ class TestBatchGenerator:
         assert stats.prompt_tps == 200.0  # 100 / 0.5
         assert stats.prompt_tokens == 100
 
+    def test_next_reports_prompt_progress_for_completed_prefill(
+        self, mock_model, mock_processor, monkeypatch
+    ):
+        gen = BatchGenerator(
+            model=mock_model.language_model,
+            processor=mock_processor,
+            prefill_batch_size=1,
+            completion_batch_size=1,
+            prefill_step_size=None,
+        )
+        prompt = [1, 2, 3]
+        inputs_embeds = mx.random.normal((1, len(prompt), 8))
+        uids = gen.insert(
+            [prompt],
+            prompt_kwargs=[{"inputs_embeds": inputs_embeds}],
+        )
+        ticks = iter([10.0, 10.2])
+        monkeypatch.setattr(generate_module.time, "perf_counter", lambda: next(ticks))
+
+        prompt_responses, generation_responses = gen.next()
+
+        assert generation_responses == []
+        assert len(prompt_responses) == 1
+        assert prompt_responses[0].uid == uids[0]
+        assert prompt_responses[0].prompt_tokens == len(prompt)
+        assert prompt_responses[0].prompt_tps == pytest.approx(15.0)
+        assert prompt_responses[0].prompt_time == pytest.approx(0.2)
+
     def test_response_dataclass(self):
         response = GenerationBatch.Response(
             uid=0, token=42, token_logprob=-0.5, finish_reason="stop"

--- a/mlx_vlm/tests/test_server.py
+++ b/mlx_vlm/tests/test_server.py
@@ -375,7 +375,6 @@ def test_cache_endpoints_report_disabled_stats_and_reset(client, monkeypatch):
     assert response.json() == {"enabled": True, "status": "cleared"}
     manager.clear.assert_called_once_with()
 
-
 def test_metrics_endpoint_reports_empty_state(client, monkeypatch):
     monkeypatch.setattr(server, "server_metrics", server.ServerMetricsStore())
     monkeypatch.setattr(server, "apc_manager", None)
@@ -652,6 +651,46 @@ class TestResponseGenerator:
 
         assert streamed_text == "hi😀"
         assert "\ufffd" not in streamed_text
+
+    def test_step_attaches_prompt_tps_from_prompt_progress(self):
+        class SimpleTokenizer:
+            vocab = {"hi": 0}
+
+            def decode(self, tokens):
+                return "hi" if tokens else ""
+
+        class PromptProgressBatch:
+            def next(self, **kwargs):
+                return (
+                    [SimpleNamespace(uid=1, prompt_tps=184.431)],
+                    [
+                        SimpleNamespace(
+                            uid=1,
+                            token=0,
+                            token_logprob=0.0,
+                            finish_reason="stop",
+                        )
+                    ],
+                )
+
+        processor = SimpleNamespace(
+            detokenizer=SPMStreamingDetokenizer(SimpleTokenizer(), trim_space=False)
+        )
+        gen = server.ResponseGenerator.__new__(server.ResponseGenerator)
+        rqueue = Queue()
+        active = {
+            1: {
+                "rqueue": rqueue,
+                "detokenizer": server.make_streaming_detokenizer(processor),
+                "prompt_tps": None,
+            }
+        }
+
+        gen._step(PromptProgressBatch(), active)
+
+        item = rqueue.get()
+        assert item.prompt_tps == pytest.approx(184.431)
+        assert rqueue.get() is None
 
     def test_generate_arguments_to_generate_kwargs(self):
         processor = lambda tokens, logits: logits

--- a/mlx_vlm/tests/test_server.py
+++ b/mlx_vlm/tests/test_server.py
@@ -999,6 +999,13 @@ class TestSuppressToolCallContent:
         assert in_tc is False
         assert content is None
 
+    def test_literal_less_than_is_not_suppressed(self):
+        in_tc, content = server.suppress_tool_call_content(
+            "if n <", False, "<tool_call>", "<"
+        )
+        assert in_tc is False
+        assert content == "<"
+
 
 class TestProcessToolCalls:
     """Tests for tool call parsing from model output."""

--- a/mlx_vlm/tests/test_server.py
+++ b/mlx_vlm/tests/test_server.py
@@ -423,6 +423,7 @@ def test_cache_endpoints_report_disabled_stats_and_reset(client, monkeypatch):
     assert response.json() == {"enabled": True, "status": "cleared"}
     manager.clear.assert_called_once_with()
 
+
 def test_metrics_endpoint_reports_empty_state(client, monkeypatch):
     monkeypatch.setattr(server, "server_metrics", server.ServerMetricsStore())
     monkeypatch.setattr(server, "apc_manager", None)

--- a/mlx_vlm/tests/test_server.py
+++ b/mlx_vlm/tests/test_server.py
@@ -376,6 +376,107 @@ def test_cache_endpoints_report_disabled_stats_and_reset(client, monkeypatch):
     manager.clear.assert_called_once_with()
 
 
+def test_metrics_endpoint_reports_empty_state(client, monkeypatch):
+    monkeypatch.setattr(server, "server_metrics", server.ServerMetricsStore())
+    monkeypatch.setattr(server, "apc_manager", None)
+    monkeypatch.setattr(server, "response_generator", None)
+    monkeypatch.setattr(server, "model_cache", {})
+
+    response = client.get("/metrics")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["latest"] is None
+    assert payload["recent"] == []
+    assert payload["summary"]["requests_started"] == 0
+    assert payload["summary"]["requests_completed"] == 0
+    assert payload["summary"]["requests_failed"] == 0
+    assert payload["server"]["loaded_model"] is None
+    assert payload["server"]["apc"] == {"enabled": False}
+
+
+def test_metrics_endpoint_records_chat_completion_metrics(client, monkeypatch):
+    monkeypatch.setattr(server, "server_metrics", server.ServerMetricsStore())
+    monkeypatch.setattr(server, "apc_manager", None)
+    monkeypatch.setattr(server, "response_generator", None)
+
+    config = SimpleNamespace(
+        text_config=SimpleNamespace(max_position_embeddings=4096),
+    )
+    processor = SimpleNamespace()
+    model = SimpleNamespace()
+    monkeypatch.setattr(
+        server,
+        "model_cache",
+        {
+            "model_path": "demo-model",
+            "adapter_path": None,
+            "config": config,
+            "processor": processor,
+        },
+    )
+    monkeypatch.setattr(
+        server,
+        "get_cached_model",
+        MagicMock(return_value=(model, processor, config)),
+    )
+    monkeypatch.setattr(server, "apply_chat_template", MagicMock(return_value="prompt"))
+    monkeypatch.setattr(
+        server,
+        "generate",
+        MagicMock(
+            return_value=SimpleNamespace(
+                text="Hello there",
+                prompt_tokens=12,
+                generation_tokens=5,
+                prompt_tps=120.0,
+                generation_tps=50.0,
+                peak_memory=1.25,
+            )
+        ),
+    )
+
+    response = client.post(
+        "/chat/completions",
+        json={
+            "model": "demo-model",
+            "messages": [{"role": "user", "content": "Hello"}],
+            "max_tokens": 8,
+        },
+    )
+
+    assert response.status_code == 200
+
+    metrics = client.get("/metrics")
+    assert metrics.status_code == 200
+    payload = metrics.json()
+
+    latest = payload["latest"]
+    assert latest["endpoint"] == "/chat/completions"
+    assert latest["model"] == "demo-model"
+    assert latest["stream"] is False
+    assert latest["backend"] == "generate"
+    assert latest["prompt_tokens"] == 12
+    assert latest["completion_tokens"] == 5
+    assert latest["generated_tokens"] == 5
+    assert latest["prefill_tok_s"] == 120.0
+    assert latest["decode_tok_s"] == 50.0
+    assert latest["peak_memory_gb"] == 1.25
+    assert latest["image_count"] == 0
+    assert latest["audio_count"] == 0
+    assert latest["apc_enabled"] is False
+
+    assert len(payload["recent"]) == 1
+    assert payload["summary"]["requests_started"] == 1
+    assert payload["summary"]["requests_completed"] == 1
+    assert payload["summary"]["requests_failed"] == 0
+    assert payload["summary"]["prompt_tokens_total"] == 12
+    assert payload["summary"]["completion_tokens_total"] == 5
+    assert payload["summary"]["generated_tokens_total"] == 5
+    assert payload["server"]["loaded_model"] == "demo-model"
+    assert payload["server"]["loaded_context_size"] == 4096
+
+
 # ── Continuous batching / ResponseGenerator tests ─────────────────────
 
 


### PR DESCRIPTION
## Summary
- add a metrics endpoint for server performance and request statistics
- track prompt processing progress and prompt TPS in batch generation responses
- fix streamed Qwen output dropping less-than signs
- extend server and generation tests to cover the new metrics and reporting paths

## Testing
- pytest mlx_vlm/tests/test_server.py mlx_vlm/tests/test_generate.py