### PR TITLE
Fix streamed byte-fallback token handling in server batching

### DIFF
--- a/mlx_vlm/server.py
+++ b/mlx_vlm/server.py
@@ -51,10 +51,7 @@ from .generate import (
 from .prompt_utils import apply_chat_template, extract_text_from_content
 from .sample_utils import top_p_sampling
 from .structured import build_json_schema_logits_processor
-from .tokenizer_utils import (
-    _ServerTokenStreamer,
-    make_streaming_detokenizer,
-)
+from .tokenizer_utils import _ServerTokenStreamer, make_streaming_detokenizer
 from .tool_parsers import _infer_tool_parser_from_processor, load_tool_module
 from .utils import load, prepare_inputs
 from .version import __version__

--- a/mlx_vlm/server.py
+++ b/mlx_vlm/server.py
@@ -50,7 +50,10 @@ from .generate import (
 from .prompt_utils import apply_chat_template, extract_text_from_content
 from .sample_utils import top_p_sampling
 from .structured import build_json_schema_logits_processor
-from .tokenizer_utils import make_streaming_detokenizer
+from .tokenizer_utils import (
+    _ServerTokenStreamer,
+    make_streaming_detokenizer,
+)
 from .tool_parsers import _infer_tool_parser_from_processor, load_tool_module
 from .utils import load, prepare_inputs
 from .version import __version__
@@ -613,7 +616,10 @@ class ResponseGenerator:
                     rqueue.put(GenerationContext(uid=uid, prompt_tokens=prompt_tokens))
                     active[uid] = {
                         "rqueue": rqueue,
-                        "detokenizer": make_streaming_detokenizer(self.processor),
+                        "streamer": _ServerTokenStreamer(
+                            self.tokenizer,
+                            make_streaming_detokenizer(self.processor),
+                        ),
                         "gen_kwargs": gen_kwargs if has_embeds else None,
                     }
 
@@ -703,7 +709,10 @@ class ResponseGenerator:
                     rqueues[uid] = rqueue
                     token_lists[uid] = []
                     stream_infos[uid] = {
-                        "detokenizer": make_streaming_detokenizer(self.processor)
+                        "streamer": _ServerTokenStreamer(
+                            self.tokenizer,
+                            make_streaming_detokenizer(self.processor),
+                        )
                     }
                     max_tokens_map[uid] = args.max_tokens
                     all_input_ids.append(input_ids.squeeze(0).tolist())
@@ -844,8 +853,7 @@ class ResponseGenerator:
                 # Finalize any remaining
                 for uid in uids:
                     if uid not in finished_uids:
-                        stream_infos[uid]["detokenizer"].finalize()
-                        text = stream_infos[uid]["detokenizer"].last_segment
+                        text = stream_infos[uid]["streamer"].finalize()
                         rqueues[uid].put(
                             StreamingToken(
                                 text=text,
@@ -900,14 +908,7 @@ class ResponseGenerator:
 
     def _stream_text(self, info: dict, token: int, finish_reason: Optional[str]) -> str:
         """Convert one generated token into a streaming text segment."""
-        detokenizer = info["detokenizer"]
-        if finish_reason == "stop":
-            detokenizer.finalize()
-        else:
-            detokenizer.add_token(token)
-            if finish_reason is not None:
-                detokenizer.finalize()
-        return detokenizer.last_segment
+        return info["streamer"].advance(token, finish_reason)
 
     def _flush(self, batch_gen, active):
         """Drain all pending text-only prompts before inserting an image request."""

--- a/mlx_vlm/tests/test_server.py
+++ b/mlx_vlm/tests/test_server.py
@@ -1021,15 +1021,19 @@ class TestResponseGenerator:
                     ],
                 )
 
+        tokenizer = SimpleTokenizer()
         processor = SimpleNamespace(
-            detokenizer=SPMStreamingDetokenizer(SimpleTokenizer(), trim_space=False)
+            detokenizer=SPMStreamingDetokenizer(tokenizer, trim_space=False)
         )
         gen = server.ResponseGenerator.__new__(server.ResponseGenerator)
         rqueue = Queue()
         active = {
             1: {
                 "rqueue": rqueue,
-                "detokenizer": server.make_streaming_detokenizer(processor),
+                "streamer": _ServerTokenStreamer(
+                    tokenizer,
+                    server.make_streaming_detokenizer(processor),
+                ),
                 "prompt_tps": None,
             }
         }

--- a/mlx_vlm/tests/test_server.py
+++ b/mlx_vlm/tests/test_server.py
@@ -1,5 +1,6 @@
 import time
 from queue import Queue
+from threading import Event, Lock, Thread
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
@@ -9,7 +10,7 @@ from fastapi.testclient import TestClient
 
 import mlx_vlm.server as server
 from mlx_vlm.apc import hash_image_payload
-from mlx_vlm.tokenizer_utils import SPMStreamingDetokenizer
+from mlx_vlm.tokenizer_utils import SPMStreamingDetokenizer, _ServerTokenStreamer
 
 
 @pytest.fixture
@@ -517,35 +518,25 @@ class TestResponseGenerator:
             next(token_iter)
         assert cancelled == []
 
-    def test_step_uses_streaming_detokenizer_for_utf8_byte_tokens(self):
-        class ByteFallbackTokenizer:
+    def test_step_streams_spm_subword_tokens_immediately(self):
+        class SentencePieceTokenizer:
             vocab = {
-                "hi": 0,
-                "<0xF0>": 1,
-                "<0x9F>": 2,
-                "<0x98>": 3,
-                "<0x80>": 4,
+                "▁hello": 0,
+                "world": 1,
+                "!": 2,
             }
 
             def decode(self, tokens):
-                text = ""
-                byte_buffer = bytearray()
-                byte_values = {1: 0xF0, 2: 0x9F, 3: 0x98, 4: 0x80}
-
-                def flush_bytes():
-                    nonlocal text, byte_buffer
-                    if byte_buffer:
-                        text += byte_buffer.decode("utf-8", errors="replace")
-                        byte_buffer = bytearray()
-
+                parts = []
                 for token in tokens:
-                    if token == 0:
-                        flush_bytes()
-                        text += "hi"
-                    else:
-                        byte_buffer.append(byte_values[token])
-                flush_bytes()
-                return text
+                    parts.append(
+                        {
+                            0: " hello",
+                            1: "world",
+                            2: "!",
+                        }[token]
+                    )
+                return "".join(parts).lstrip()
 
         class SingleResponseBatch:
             def __init__(self, response):
@@ -554,20 +545,21 @@ class TestResponseGenerator:
             def next(self, **kwargs):
                 return [], [self.response]
 
-        tokenizer = ByteFallbackTokenizer()
-        processor = SimpleNamespace(
-            detokenizer=SPMStreamingDetokenizer(tokenizer, trim_space=False)
-        )
+        tokenizer = SentencePieceTokenizer()
+        processor = SimpleNamespace(detokenizer=SPMStreamingDetokenizer(tokenizer))
         gen = server.ResponseGenerator.__new__(server.ResponseGenerator)
         rqueue = Queue()
         active = {
             1: {
                 "rqueue": rqueue,
-                "detokenizer": server.make_streaming_detokenizer(processor),
+                "streamer": _ServerTokenStreamer(
+                    tokenizer,
+                    server.make_streaming_detokenizer(processor),
+                ),
             }
         }
 
-        for token in [0, 1, 2, 3, 4]:
+        for token in [0, 1, 2]:
             gen._step(
                 SingleResponseBatch(
                     SimpleNamespace(
@@ -591,14 +583,321 @@ class TestResponseGenerator:
             active,
         )
 
-        streamed_text = ""
+        segments = []
         while not rqueue.empty():
             item = rqueue.get()
             if item is not None:
-                streamed_text += item.text
+                segments.append(item.text)
 
-        assert streamed_text == "hi😀"
+        assert segments == ["hello", "world", "!", ""]
+
+    def test_server_token_streamer_flushes_incomplete_utf8_on_finalize(self):
+        class ByteFallbackTokenizer:
+            vocab = {
+                "<0xF0>": 0,
+                "<0x9F>": 1,
+            }
+
+            def decode(self, tokens):
+                byte_values = {0: 0xF0, 1: 0x9F}
+                return bytes(byte_values[token] for token in tokens).decode(
+                    "utf-8", errors="replace"
+                )
+
+        tokenizer = ByteFallbackTokenizer()
+        processor = SimpleNamespace(
+            detokenizer=SPMStreamingDetokenizer(tokenizer, trim_space=False)
+        )
+        streamer = _ServerTokenStreamer(
+            tokenizer,
+            server.make_streaming_detokenizer(processor),
+        )
+
+        assert streamer.advance(0, None) == ""
+        assert streamer.advance(1, None) == ""
+        assert streamer.finalize() == "\ufffd"
+
+    def test_step_streams_multiple_utf8_emojis_with_text_between_them(self):
+        class MixedEmojiTokenizer:
+            vocab = {
+                "hi": 0,
+                "<0xF0>": 1,
+                "<0x9F>": 2,
+                "<0x98>": 3,
+                "<0x80>": 4,
+                "▁mid": 5,
+                "<0x82>": 6,
+                "▁wow": 7,
+                "<0x8E>": 8,
+                "▁done": 9,
+            }
+
+            def decode(self, tokens):
+                text = ""
+                byte_buffer = bytearray()
+                byte_values = {
+                    1: 0xF0,
+                    2: 0x9F,
+                    3: 0x98,
+                    4: 0x80,
+                    6: 0x82,
+                    8: 0x8E,
+                }
+                regular = {0: "hi", 5: "▁mid", 7: "▁wow", 9: "▁done"}
+
+                def flush_bytes():
+                    nonlocal text, byte_buffer
+                    if byte_buffer:
+                        text += byte_buffer.decode("utf-8", errors="replace")
+                        byte_buffer = bytearray()
+
+                for token in tokens:
+                    if token in byte_values:
+                        byte_buffer.append(byte_values[token])
+                    else:
+                        flush_bytes()
+                        text += regular[token].replace("▁", " ")
+                flush_bytes()
+                return text
+
+        class SingleResponseBatch:
+            def __init__(self, response):
+                self.response = response
+
+            def next(self, **kwargs):
+                return [], [self.response]
+
+        tokenizer = MixedEmojiTokenizer()
+        processor = SimpleNamespace(
+            detokenizer=SPMStreamingDetokenizer(tokenizer, trim_space=False)
+        )
+        gen = server.ResponseGenerator.__new__(server.ResponseGenerator)
+        rqueue = Queue()
+        active = {
+            1: {
+                "rqueue": rqueue,
+                "streamer": _ServerTokenStreamer(
+                    tokenizer,
+                    server.make_streaming_detokenizer(processor),
+                ),
+            }
+        }
+
+        for token in [0, 1, 2, 3, 4, 5, 1, 2, 3, 6, 7, 1, 2, 3, 8, 9, 1, 2, 3, 4]:
+            gen._step(
+                SingleResponseBatch(
+                    SimpleNamespace(
+                        uid=1,
+                        token=token,
+                        token_logprob=0.0,
+                        finish_reason=None,
+                    )
+                ),
+                active,
+            )
+        gen._step(
+            SingleResponseBatch(
+                SimpleNamespace(
+                    uid=1,
+                    token=99,
+                    token_logprob=0.0,
+                    finish_reason="stop",
+                )
+            ),
+            active,
+        )
+
+        segments = []
+        while not rqueue.empty():
+            item = rqueue.get()
+            if item is not None:
+                segments.append(item.text)
+
+        streamed_text = "".join(segments)
+        assert segments == [
+            "hi",
+            "",
+            "",
+            "",
+            "😀",
+            " mid",
+            "",
+            "",
+            "",
+            "😂",
+            " wow",
+            "",
+            "",
+            "",
+            "😎",
+            " done",
+            "",
+            "",
+            "",
+            "😀",
+            "",
+        ]
+        assert streamed_text == "hi😀 mid😂 wow😎 done😀"
         assert "\ufffd" not in streamed_text
+
+    def test_run_batches_eight_streaming_requests(self, monkeypatch):
+        batch_state = {}
+
+        class FakeDetokenizer:
+            def __init__(self):
+                self.last_segment = ""
+
+            def reset(self):
+                self.last_segment = ""
+
+            def add_token(self, token):
+                self.last_segment = str(token)
+
+            def finalize(self):
+                pass
+
+        class FakeBatchGenerator:
+            def __init__(self, *args, **kwargs):
+                del args, kwargs
+                self._next_uid = 1
+                self._active = {}
+                self.inserted_uids = []
+                self.next_active_sizes = []
+                batch_state["instance"] = self
+
+            def insert(self, *args, **kwargs):
+                del args, kwargs
+                uid = self._next_uid
+                self._next_uid += 1
+                self._active[uid] = 0
+                self.inserted_uids.append(uid)
+                return (uid,)
+
+            def remove(self, uid):
+                return self._active.pop(uid, None) is not None
+
+            @property
+            def unprocessed_prompts(self):
+                return []
+
+            @property
+            def has_pending_prompts(self):
+                return False
+
+            def next(self, **kwargs):
+                del kwargs
+                self.next_active_sizes.append(len(self._active))
+                responses = []
+                finished = []
+                for uid in sorted(self._active):
+                    step = self._active[uid]
+                    token = uid * 10 + step
+                    finish_reason = None if step == 0 else "length"
+                    responses.append(
+                        SimpleNamespace(
+                            uid=uid,
+                            token=token,
+                            token_logprob=0.0,
+                            finish_reason=finish_reason,
+                        )
+                    )
+                    if finish_reason is None:
+                        self._active[uid] = step + 1
+                    else:
+                        finished.append(uid)
+                for uid in finished:
+                    del self._active[uid]
+                return [], responses
+
+        monkeypatch.setattr(server, "BatchGenerator", FakeBatchGenerator)
+        monkeypatch.setattr(
+            server, "make_streaming_detokenizer", lambda _: FakeDetokenizer()
+        )
+
+        gen = server.ResponseGenerator.__new__(server.ResponseGenerator)
+        gen.model_path = "demo"
+        gen.adapter_path = None
+        gen.model = None
+        gen.processor = None
+        gen.config = None
+        gen.stop_tokens = set()
+        gen.vision_cache = None
+        gen.draft_model = None
+        gen.draft_kind = None
+        gen.kv_bits = None
+        gen.kv_group_size = server.DEFAULT_KV_GROUP_SIZE
+        gen.kv_quant_scheme = server.DEFAULT_KV_QUANT_SCHEME
+        gen.quantized_kv_start = server.DEFAULT_QUANTIZED_KV_START
+        gen.top_logprobs_k = 0
+        gen.apc_manager = None
+        gen.tokenizer = SimpleNamespace()
+        gen.requests = Queue()
+        gen._stop = False
+        gen._ready = Event()
+        gen._load_error = None
+        gen._cancelled = set()
+        gen._cancel_lock = Lock()
+
+        def fake_initialize_model():
+            gen.model = SimpleNamespace(language_model=object())
+            gen.processor = SimpleNamespace()
+            gen.config = SimpleNamespace()
+            gen.stop_tokens = set()
+            gen.draft_model = None
+            gen.draft_kind = None
+            gen.tokenizer = SimpleNamespace()
+
+        gen._initialize_model = fake_initialize_model
+        gen._gpu_embed = lambda raw_inputs, images=None: (
+            mx.array([[raw_inputs["request_id"]]], dtype=mx.int32),
+            {},
+        )
+
+        request_queues = []
+        for request_id in range(8):
+            rqueue = Queue()
+            request_queues.append(rqueue)
+            gen.requests.put(
+                (
+                    rqueue,
+                    {"request_id": request_id},
+                    1,
+                    server.GenerationArguments(max_tokens=2),
+                    None,
+                )
+            )
+
+        worker = Thread(target=gen._run, daemon=True)
+        worker.start()
+
+        streamed_by_uid = {}
+        try:
+            for rqueue in request_queues:
+                ctx = rqueue.get(timeout=1)
+                assert isinstance(ctx, server.GenerationContext)
+                assert ctx.prompt_tokens == 1
+
+                items = []
+                while True:
+                    item = rqueue.get(timeout=1)
+                    if item is None:
+                        break
+                    items.append((item.text, item.finish_reason))
+                streamed_by_uid[ctx.uid] = items
+        finally:
+            gen._stop = True
+            gen.requests.put(None)
+            worker.join(timeout=2)
+
+        batch_gen = batch_state["instance"]
+        assert batch_gen.inserted_uids == list(range(1, 9))
+        assert batch_gen.next_active_sizes[:2] == [8, 8]
+        assert len(streamed_by_uid) == 8
+        for uid, items in streamed_by_uid.items():
+            assert items == [
+                (str(uid * 10), None),
+                (str(uid * 10 + 1), "length"),
+            ]
 
     def test_generate_arguments_to_generate_kwargs(self):
         processor = lambda tokens, logits: logits

--- a/mlx_vlm/tests/test_server.py
+++ b/mlx_vlm/tests/test_server.py
@@ -999,6 +999,7 @@ class TestResponseGenerator:
                 (str(uid * 10), None),
                 (str(uid * 10 + 1), "length"),
             ]
+
     def test_step_attaches_prompt_tps_from_prompt_progress(self):
         class SimpleTokenizer:
             vocab = {"hi": 0}

--- a/mlx_vlm/tokenizer_utils.py
+++ b/mlx_vlm/tokenizer_utils.py
@@ -1,8 +1,9 @@
+import codecs
 import json
 from copy import copy
 from functools import partial
 from json import JSONDecodeError
-from typing import List
+from typing import List, Optional
 
 from transformers import AutoTokenizer
 
@@ -278,6 +279,107 @@ class BPEStreamingDetokenizer(StreamingDetokenizer):
                 for b in range(start, stop):
                     char_to_bytes[chr(b)] = b
         cls._byte_decoder = char_to_bytes
+
+
+class _ServerTokenStreamer:
+    """Emit server text deltas per token while buffering incomplete UTF-8."""
+
+    def __init__(self, tokenizer, detokenizer):
+        self._tokenizer = tokenizer
+        self._detokenizer = detokenizer
+        self._decoder = None
+        self._started = False
+        self._tokenmap = None
+        self._mode = "delegate"
+        self._trim_space = False
+
+        if isinstance(detokenizer, SPMStreamingDetokenizer):
+            self._mode = "spm"
+            self._tokenmap = detokenizer.tokenmap
+            self._trim_space = detokenizer.trim_space
+            self._is_byte_token = detokenizer.is_byte_token
+            self._byte_value = detokenizer.byte_value
+            self._decoder = codecs.getincrementaldecoder("utf-8")("replace")
+        elif isinstance(detokenizer, BPEStreamingDetokenizer):
+            self._mode = "bpe"
+            self._tokenmap = detokenizer.tokenmap
+            self._trim_space = detokenizer.trim_space
+            self._byte_decoder = detokenizer._byte_decoder
+            self._decoder = codecs.getincrementaldecoder("utf-8")("replace")
+
+    def _emit_text(self, text: str) -> str:
+        if text and not self._started and self._trim_space and text[0] == " ":
+            text = text[1:]
+        if text:
+            self._started = True
+        return text
+
+    def _fallback_decode(self, token: int) -> str:
+        try:
+            return self._tokenizer.decode([token])
+        except Exception:
+            return ""
+
+    def _spm_text_for_token(self, token: int) -> str:
+        try:
+            if self._is_byte_token[token]:
+                byte_value = self._byte_value[token]
+                return self._decoder.decode(bytes((byte_value,)), final=False)
+            value = self._tokenmap[token]
+        except (IndexError, TypeError):
+            return self._fallback_decode(token)
+
+        if value is None:
+            return self._fallback_decode(token)
+        return value.replace("\u2581", " ")
+
+    def _bpe_text_for_token(self, token: int) -> str:
+        try:
+            value = self._tokenmap[token]
+        except (IndexError, TypeError):
+            return self._fallback_decode(token)
+
+        if value is None:
+            return self._fallback_decode(token)
+
+        try:
+            token_bytes = bytes(self._byte_decoder[c] for c in value)
+        except KeyError:
+            return self._fallback_decode(token)
+        return self._decoder.decode(token_bytes, final=False)
+
+    def _decode_token(self, token: int) -> str:
+        if self._mode == "spm":
+            return self._emit_text(self._spm_text_for_token(token))
+        if self._mode == "bpe":
+            return self._emit_text(self._bpe_text_for_token(token))
+        return self._fallback_advance(token, finish_reason=None)
+
+    def _fallback_advance(self, token: int, finish_reason: Optional[str]) -> str:
+        if finish_reason == "stop":
+            self._detokenizer.finalize()
+        else:
+            self._detokenizer.add_token(token)
+            if finish_reason is not None:
+                self._detokenizer.finalize()
+        return self._detokenizer.last_segment
+
+    def advance(self, token: int, finish_reason: Optional[str]) -> str:
+        if self._mode == "delegate":
+            return self._fallback_advance(token, finish_reason)
+
+        parts = []
+        if finish_reason != "stop":
+            parts.append(self._decode_token(token))
+        if finish_reason is not None:
+            parts.append(self._emit_text(self._decoder.decode(b"", final=True)))
+        return "".join(parts)
+
+    def finalize(self) -> str:
+        if self._mode == "delegate":
+            self._detokenizer.finalize()
+            return self._detokenizer.last_segment
+        return self._emit_text(self._decoder.decode(b"", final=True))
 
 
 class TokenizerWrapper:


### PR DESCRIPTION
## Summary

Fix server-side streaming so batched responses keep token-level text deltas while still buffering incomplete UTF-8 byte-fallback sequences until they form valid characters.

Addresses https://github.com/Blaizzy/mlx-vlm/pull/1129#issuecomment-4397556225

This change:
- introduces a server token streamer in `tokenizer_utils`
- updates the continuous batching and speculative server paths to use it
- preserves immediate streaming for normal SPM/BPE text tokens
- flushes trailing incomplete UTF-8 correctly at request finalization
- adds regression coverage for subword streaming, repeated emoji/text interleaving, finalize behavior, and 8-request batched streaming

## Before / After

For a streamed response like `hi😀`:

- before: `""`, `""`, `""`, `""`, `"hi😀"`
- after: `"hi"`, `""`, `""`, `""`, `"😀"`

This keeps normal text streaming immediately while still waiting for the final UTF-8 byte before emitting the emoji.

## Validation

- `pytest -q mlx_vlm/tests/test_server.py::TestResponseGenerator::test_run_batches_eight_streaming_requests mlx_vlm/tests/test_server.py::TestResponseGenerator::test_step_streams_spm_subword_tokens_immediately mlx_vlm/tests/test_server.py::TestResponseGenerator::test_server_token_streamer_flushes_incomplete_utf8_on_finalize mlx_vlm/tests/test_server.py::TestResponseGenerator::test_step_streams_multiple_utf8_emojis_with_text_between_them`
- manual validation with `Qwen/Qwen3.5-4B` on the local server using 8 concurrent streaming requests containing repeated emoji-heavy output