### PR TITLE
server: populate cached_tokens and tps in usage envelope

### DIFF
--- a/mlx_vlm/generate.py
+++ b/mlx_vlm/generate.py
@@ -2262,6 +2262,9 @@ class PromptProgress:
     prompt_tokens: int
     prompt_tps: float = 0.0
     prompt_time: float = 0.0
+    # Number of leading prompt tokens served from a prefix cache (APC).
+    # Reported back as ``usage.prompt_tokens_details.cached_tokens``.
+    cached_tokens: int = 0
 
 
 class GenerationBatch:
@@ -2829,15 +2832,28 @@ class PromptProcessingBatch:
     def prompt_progress(self) -> List[PromptProgress]:
         if self._prompt_time_s <= 0:
             return []
+        cached_tokens_per_row: List[int] = []
+        for idx in range(len(self._prompt_uids)):
+            meta = (
+                self._apc_meta[idx]
+                if self._apc_meta and idx < len(self._apc_meta)
+                else None
+            )
+            cached_tokens_per_row.append(
+                int(meta.get("prefix_len", 0)) if meta else 0
+            )
         return [
             PromptProgress(
                 uid=uid,
                 prompt_tokens=prompt_tokens,
                 prompt_tps=prompt_tokens / self._prompt_time_s,
                 prompt_time=self._prompt_time_s,
+                cached_tokens=cached,
             )
-            for uid, prompt_tokens in zip(
-                self._prompt_uids, self._prompt_tokens_per_row
+            for uid, prompt_tokens, cached in zip(
+                self._prompt_uids,
+                self._prompt_tokens_per_row,
+                cached_tokens_per_row,
             )
         ]
 

--- a/mlx_vlm/server.py
+++ b/mlx_vlm/server.py
@@ -498,6 +498,12 @@ class StreamingToken:
     finish_reason: Optional[str]
     peak_memory: float = 0.0
     prompt_tps: Optional[float] = None
+    generation_tps: Optional[float] = None
+    # Number of leading prompt tokens served from a prefix cache (APC).
+    # Surfaced via PromptProgress on the first prompt response and copied
+    # onto every subsequent StreamingToken for the same request so the
+    # final usage envelope can report it.
+    cached_tokens: int = 0
     top_logprobs: Optional[List[Tuple[int, float]]] = None
 
 
@@ -1139,6 +1145,12 @@ class ResponseGenerator:
         for prompt_response in prompt_responses:
             if prompt_response.uid in active:
                 active[prompt_response.uid]["prompt_tps"] = prompt_response.prompt_tps
+                # APC-driven prefix hits surface through PromptProgress;
+                # stash so each StreamingToken can report it back to the
+                # client in the final usage envelope.
+                active[prompt_response.uid]["cached_tokens"] = int(
+                    getattr(prompt_response, "cached_tokens", 0) or 0
+                )
         if not responses:
             return
 
@@ -1165,6 +1177,7 @@ class ResponseGenerator:
                     finish_reason=r.finish_reason,
                     peak_memory=mx.get_peak_memory() / 1e9 if r.finish_reason else 0,
                     prompt_tps=info.get("prompt_tps"),
+                    cached_tokens=int(info.get("cached_tokens", 0) or 0),
                     top_logprobs=getattr(r, "top_logprobs", None),
                 )
             )
@@ -1756,12 +1769,22 @@ class OpenAIRequest(FlexibleBaseModel):
     )
 
 
+class InputTokensDetails(BaseModel):
+    """Breakdown of input tokens. ``cached_tokens`` mirrors OpenAI's
+    /responses usage payload — the count of leading prompt tokens served
+    from a prefix cache (APC).
+    """
+
+    cached_tokens: int = 0
+
+
 class OpenAIUsage(BaseModel):
     """Token usage details including input tokens, output tokens, breakdown, and total tokens used."""
 
     input_tokens: int
     output_tokens: int
     total_tokens: int
+    input_tokens_details: InputTokensDetails = InputTokensDetails()
 
 
 class OpenAIErrorObject(BaseModel):
@@ -2312,6 +2335,7 @@ async def responses_endpoint(request: Request):
                             except StopIteration:
                                 return None
 
+                        cached_tokens = 0
                         while True:
                             token = await asyncio.to_thread(_next_token_resp_stream)
                             if token is None:
@@ -2325,9 +2349,16 @@ async def responses_endpoint(request: Request):
                                 float(getattr(token, "peak_memory", 0.0) or 0.0),
                             )
                             prompt_tps = getattr(token, "prompt_tps", prompt_tps)
+                            generation_tps = (
+                                getattr(token, "generation_tps", None) or generation_tps
+                            )
+                            tok_cached = int(getattr(token, "cached_tokens", 0) or 0)
+                            if tok_cached:
+                                cached_tokens = tok_cached
                             usage_stats = {
                                 "input_tokens": ctx.prompt_tokens,
                                 "output_tokens": output_tokens,
+                                "cached_tokens": cached_tokens,
                             }
 
                             yield f"event: response.output_text.delta\ndata: {ResponseOutputTextDeltaEvent(type='response.output_text.delta', item_id=message_id, output_index=0, content_index=0, delta=delta).model_dump_json()}\n\n"
@@ -2436,6 +2467,11 @@ async def responses_endpoint(request: Request):
                                 "output_tokens": usage_stats["output_tokens"],
                                 "total_tokens": usage_stats["input_tokens"]
                                 + usage_stats["output_tokens"],
+                                "input_tokens_details": {
+                                    "cached_tokens": usage_stats.get(
+                                        "cached_tokens", 0
+                                    ),
+                                },
                             },
                         }
                     )
@@ -2827,6 +2863,7 @@ async def chat_completions_endpoint(request: ChatRequest, http_request: Request)
                             except StopIteration:
                                 return None
 
+                        cached_tokens = 0
                         while True:
                             token = await asyncio.to_thread(_next_token)
                             if token is None:
@@ -2840,6 +2877,12 @@ async def chat_completions_endpoint(request: ChatRequest, http_request: Request)
                                 float(getattr(token, "peak_memory", 0.0) or 0.0),
                             )
                             prompt_tps = getattr(token, "prompt_tps", prompt_tps)
+                            generation_tps = (
+                                getattr(token, "generation_tps", None) or generation_tps
+                            )
+                            tok_cached = int(getattr(token, "cached_tokens", 0) or 0)
+                            if tok_cached:
+                                cached_tokens = tok_cached
 
                             # Detect thinking boundaries
                             delta_reasoning = None
@@ -2910,12 +2953,18 @@ async def chat_completions_endpoint(request: ChatRequest, http_request: Request)
                                     id=request_id,
                                     created=int(time.time()),
                                     model=request.model,
-                                    usage={
-                                        "prompt_tokens": ctx.prompt_tokens,
-                                        "completion_tokens": output_tokens,
-                                        "total_tokens": ctx.prompt_tokens
+                                    usage=UsageStats(
+                                        prompt_tokens=ctx.prompt_tokens,
+                                        completion_tokens=output_tokens,
+                                        total_tokens=ctx.prompt_tokens
                                         + output_tokens,
-                                    },
+                                        prompt_tokens_details=PromptTokensDetails(
+                                            cached_tokens=cached_tokens,
+                                        ),
+                                        prompt_tps=float(prompt_tps or 0.0),
+                                        generation_tps=float(generation_tps or 0.0),
+                                        peak_memory=peak_memory,
+                                    ),
                                     choices=choices,
                                 )
 
@@ -2995,12 +3044,15 @@ async def chat_completions_endpoint(request: ChatRequest, http_request: Request)
                                 id=request_id,
                                 created=int(time.time()),
                                 model=request.model,
-                                usage={
-                                    "prompt_tokens": chunk.prompt_tokens,
-                                    "completion_tokens": chunk.generation_tokens,
-                                    "total_tokens": chunk.prompt_tokens
+                                usage=UsageStats(
+                                    prompt_tokens=chunk.prompt_tokens,
+                                    completion_tokens=chunk.generation_tokens,
+                                    total_tokens=chunk.prompt_tokens
                                     + chunk.generation_tokens,
-                                },
+                                    prompt_tps=float(prompt_tps or 0.0),
+                                    generation_tps=float(generation_tps or 0.0),
+                                    peak_memory=peak_memory,
+                                ),
                                 choices=choices,
                             )
 
@@ -3112,6 +3164,7 @@ async def chat_completions_endpoint(request: ChatRequest, http_request: Request)
                 token_times: List[float] = []
                 prompt_tps = None
                 generation_tps = None
+                cached_tokens = 0
                 finish_reason = None
 
                 collected_logprobs: List[
@@ -3126,6 +3179,8 @@ async def chat_completions_endpoint(request: ChatRequest, http_request: Request)
                         pm = 0.0
                         tt: List[float] = []
                         ptps = None
+                        gtps = None
+                        cached = 0
                         fr = None
                         ctx, token_iter = response_generator.generate(
                             prompt=formatted_prompt,
@@ -3139,6 +3194,10 @@ async def chat_completions_endpoint(request: ChatRequest, http_request: Request)
                             gt += 1
                             tt.append(time.perf_counter())
                             ptps = getattr(token, "prompt_tps", ptps)
+                            gtps = getattr(token, "generation_tps", gtps) or gtps
+                            tok_cached = int(getattr(token, "cached_tokens", 0) or 0)
+                            if tok_cached:
+                                cached = tok_cached
                             pm = token.peak_memory
                             if request.logprobs and token.finish_reason != "stop":
                                 collected_logprobs.append(
@@ -3151,15 +3210,17 @@ async def chat_completions_endpoint(request: ChatRequest, http_request: Request)
                             token_iter.close()
                         except Exception:
                             pass
-                        return text, pt, gt, ptps, pm, tt, fr
+                        return text, pt, gt, ptps, gtps, pm, tt, cached, fr
 
                     (
                         full_text,
                         prompt_tokens,
                         output_tokens,
                         prompt_tps,
+                        generation_tps,
                         peak_memory,
                         token_times,
+                        cached_tokens,
                         finish_reason,
                     ) = await asyncio.to_thread(_blocking_generate)
                 else:
@@ -3197,6 +3258,9 @@ async def chat_completions_endpoint(request: ChatRequest, http_request: Request)
                     prompt_tokens=prompt_tokens,
                     completion_tokens=completion_tokens,
                     total_tokens=prompt_tokens + completion_tokens,
+                    prompt_tokens_details=PromptTokensDetails(
+                        cached_tokens=cached_tokens,
+                    ),
                     prompt_tps=float(prompt_tps or 0.0),
                     generation_tps=float(generation_tps or 0.0),
                     peak_memory=peak_memory,

--- a/mlx_vlm/server.py
+++ b/mlx_vlm/server.py
@@ -498,7 +498,6 @@ class StreamingToken:
     finish_reason: Optional[str]
     peak_memory: float = 0.0
     prompt_tps: Optional[float] = None
-    generation_tps: Optional[float] = None
     # Number of leading prompt tokens served from a prefix cache (APC).
     # Surfaced via PromptProgress on the first prompt response and copied
     # onto every subsequent StreamingToken for the same request so the
@@ -2349,9 +2348,6 @@ async def responses_endpoint(request: Request):
                                 float(getattr(token, "peak_memory", 0.0) or 0.0),
                             )
                             prompt_tps = getattr(token, "prompt_tps", prompt_tps)
-                            generation_tps = (
-                                getattr(token, "generation_tps", None) or generation_tps
-                            )
                             tok_cached = int(getattr(token, "cached_tokens", 0) or 0)
                             if tok_cached:
                                 cached_tokens = tok_cached
@@ -2877,9 +2873,6 @@ async def chat_completions_endpoint(request: ChatRequest, http_request: Request)
                                 float(getattr(token, "peak_memory", 0.0) or 0.0),
                             )
                             prompt_tps = getattr(token, "prompt_tps", prompt_tps)
-                            generation_tps = (
-                                getattr(token, "generation_tps", None) or generation_tps
-                            )
                             tok_cached = int(getattr(token, "cached_tokens", 0) or 0)
                             if tok_cached:
                                 cached_tokens = tok_cached
@@ -3179,7 +3172,6 @@ async def chat_completions_endpoint(request: ChatRequest, http_request: Request)
                         pm = 0.0
                         tt: List[float] = []
                         ptps = None
-                        gtps = None
                         cached = 0
                         fr = None
                         ctx, token_iter = response_generator.generate(
@@ -3194,7 +3186,6 @@ async def chat_completions_endpoint(request: ChatRequest, http_request: Request)
                             gt += 1
                             tt.append(time.perf_counter())
                             ptps = getattr(token, "prompt_tps", ptps)
-                            gtps = getattr(token, "generation_tps", gtps) or gtps
                             tok_cached = int(getattr(token, "cached_tokens", 0) or 0)
                             if tok_cached:
                                 cached = tok_cached
@@ -3210,14 +3201,13 @@ async def chat_completions_endpoint(request: ChatRequest, http_request: Request)
                             token_iter.close()
                         except Exception:
                             pass
-                        return text, pt, gt, ptps, gtps, pm, tt, cached, fr
+                        return text, pt, gt, ptps, pm, tt, cached, fr
 
                     (
                         full_text,
                         prompt_tokens,
                         output_tokens,
                         prompt_tps,
-                        generation_tps,
                         peak_memory,
                         token_times,
                         cached_tokens,

--- a/mlx_vlm/tests/test_usage_envelope.py
+++ b/mlx_vlm/tests/test_usage_envelope.py
@@ -1,19 +1,19 @@
 """Tests for the streaming/non-streaming usage envelope fixes.
 
-Covers two intertwined fixes:
+Covers two related fixes:
 
   * Streaming /chat/completions chunks were being constructed with a
-    plain ``dict`` for ``usage`` that dropped ``prompt_tps``,
-    ``generation_tps``, ``peak_memory``, and ``prompt_tokens_details``.
-    They now use ``UsageStats``.
-  * Non-streaming ``_blocking_generate`` previously dropped
-    ``generation_tps`` (only ``prompt_tps`` was returned), so the
-    final ``UsageStats.generation_tps`` was always 0. The tuple is now
-    extended.
+    plain ``dict`` for ``usage``. Pydantic coerced it into ``UsageStats``
+    with ``prompt_tps``, ``peak_memory``, and ``prompt_tokens_details``
+    silently filled from defaults — clients always saw 0. Pass a full
+    ``UsageStats`` so chunks report real rates.
   * ``cached_tokens`` is plumbed from APC's per-row ``prefix_len``
     through ``PromptProgress`` → ``StreamingToken`` →
     ``UsageStats.prompt_tokens_details.cached_tokens``, mirroring
     OpenAI's ``input_tokens_details.cached_tokens``.
+
+``generation_tps`` is intentionally untouched — its source is not yet
+wired in continuous batching (#1113 is the open PR for that).
 
 These tests run without a real model — they exercise the data-class
 plumbing only.
@@ -49,19 +49,17 @@ def test_prompt_progress_carries_cached_tokens():
     assert PromptProgress(uid=1, prompt_tokens=10).cached_tokens == 0
 
 
-def test_streaming_token_carries_tps_and_cached_tokens():
+def test_streaming_token_carries_prompt_tps_and_cached_tokens():
     tok = StreamingToken(
         text="x",
         token=42,
         logprobs=0.0,
         finish_reason=None,
         prompt_tps=120.0,
-        generation_tps=33.5,
         cached_tokens=128,
     )
     assert tok.cached_tokens == 128
     assert tok.prompt_tps == 120.0
-    assert tok.generation_tps == 33.5
 
 
 def test_streaming_token_defaults_preserve_old_callers():
@@ -69,7 +67,7 @@ def test_streaming_token_defaults_preserve_old_callers():
         text="x", token=1, logprobs=0.0, finish_reason=None,
     )
     assert tok.cached_tokens == 0
-    assert tok.generation_tps is None
+    assert tok.prompt_tps is None
 
 
 def test_generation_context_unchanged():

--- a/mlx_vlm/tests/test_usage_envelope.py
+++ b/mlx_vlm/tests/test_usage_envelope.py
@@ -1,0 +1,133 @@
+"""Tests for the streaming/non-streaming usage envelope fixes.
+
+Covers two intertwined fixes:
+
+  * Streaming /chat/completions chunks were being constructed with a
+    plain ``dict`` for ``usage`` that dropped ``prompt_tps``,
+    ``generation_tps``, ``peak_memory``, and ``prompt_tokens_details``.
+    They now use ``UsageStats``.
+  * Non-streaming ``_blocking_generate`` previously dropped
+    ``generation_tps`` (only ``prompt_tps`` was returned), so the
+    final ``UsageStats.generation_tps`` was always 0. The tuple is now
+    extended.
+  * ``cached_tokens`` is plumbed from APC's per-row ``prefix_len``
+    through ``PromptProgress`` → ``StreamingToken`` →
+    ``UsageStats.prompt_tokens_details.cached_tokens``, mirroring
+    OpenAI's ``input_tokens_details.cached_tokens``.
+
+These tests run without a real model — they exercise the data-class
+plumbing only.
+"""
+
+from __future__ import annotations
+
+from mlx_vlm.generate import PromptProgress
+from mlx_vlm.server import (
+    GenerationContext,
+    InputTokensDetails,
+    OpenAIUsage,
+    PromptTokensDetails,
+    StreamingToken,
+    UsageStats,
+)
+
+
+def test_prompt_progress_carries_cached_tokens():
+    """``PromptProcessingBatch.prompt_progress()`` builds these from
+    ``apc_meta[i]['prefix_len']`` so the server can attribute APC hits
+    per request.
+    """
+    p = PromptProgress(
+        uid=7,
+        prompt_tokens=128,
+        prompt_tps=42.0,
+        prompt_time=3.0,
+        cached_tokens=96,
+    )
+    assert p.cached_tokens == 96
+    # Default still 0 so old call sites continue to work.
+    assert PromptProgress(uid=1, prompt_tokens=10).cached_tokens == 0
+
+
+def test_streaming_token_carries_tps_and_cached_tokens():
+    tok = StreamingToken(
+        text="x",
+        token=42,
+        logprobs=0.0,
+        finish_reason=None,
+        prompt_tps=120.0,
+        generation_tps=33.5,
+        cached_tokens=128,
+    )
+    assert tok.cached_tokens == 128
+    assert tok.prompt_tps == 120.0
+    assert tok.generation_tps == 33.5
+
+
+def test_streaming_token_defaults_preserve_old_callers():
+    tok = StreamingToken(
+        text="x", token=1, logprobs=0.0, finish_reason=None,
+    )
+    assert tok.cached_tokens == 0
+    assert tok.generation_tps is None
+
+
+def test_generation_context_unchanged():
+    """``GenerationContext`` deliberately stays minimal — cached_tokens
+    only becomes known after admission, so it rides on
+    ``StreamingToken``/``UsageStats`` instead.
+    """
+    ctx = GenerationContext(uid=1, prompt_tokens=100)
+    assert ctx.uid == 1
+    assert ctx.prompt_tokens == 100
+
+
+def test_usage_stats_serialises_full_envelope():
+    """The streaming chat fix means a chunk's ``usage`` field now
+    serialises every UsageStats field, including ``cached_tokens``.
+    """
+    usage = UsageStats(
+        prompt_tokens=200,
+        completion_tokens=50,
+        total_tokens=250,
+        prompt_tokens_details=PromptTokensDetails(cached_tokens=128),
+        prompt_tps=120.0,
+        generation_tps=33.5,
+        peak_memory=4.2,
+    )
+    payload = usage.model_dump()
+    assert payload["prompt_tokens_details"]["cached_tokens"] == 128
+    assert payload["prompt_tps"] == 120.0
+    assert payload["generation_tps"] == 33.5
+    assert payload["peak_memory"] == 4.2
+
+
+def test_usage_stats_defaults_when_no_cache_hit():
+    """Without an APC hit, ``cached_tokens`` defaults to 0 so the
+    field is always present in the envelope.
+    """
+    usage = UsageStats(prompt_tokens=10, completion_tokens=5, total_tokens=15)
+    payload = usage.model_dump()
+    assert payload["prompt_tokens_details"]["cached_tokens"] == 0
+    assert payload["prompt_tps"] == 0.0
+    assert payload["generation_tps"] == 0.0
+
+
+def test_openai_usage_input_tokens_details():
+    """OpenAI's /responses spec puts cached_tokens under
+    ``input_tokens_details.cached_tokens``. We mirror that field name.
+    """
+    usage = OpenAIUsage(
+        input_tokens=100,
+        output_tokens=10,
+        total_tokens=110,
+        input_tokens_details=InputTokensDetails(cached_tokens=80),
+    )
+    assert usage.input_tokens_details.cached_tokens == 80
+    payload = usage.model_dump()
+    assert payload["input_tokens_details"]["cached_tokens"] == 80
+
+
+def test_openai_usage_default_input_tokens_details():
+    usage = OpenAIUsage(input_tokens=100, output_tokens=10, total_tokens=110)
+    assert usage.input_tokens_details.cached_tokens == 0


### PR DESCRIPTION
Two `usage` fields were broken or missing. Fixing the parts that have an obvious source.

- `cached_tokens`: 9719c63 added `UsageStats.prompt_tokens_details.cached_tokens` to match OpenAI's response shape but never populated it. APC already records prefix hits per row in `apc_meta[i]["prefix_len"]`. Surface that on `PromptProgress`, carry through `StreamingToken`, write it onto the final `UsageStats` / `OpenAIUsage.input_tokens_details`.

- Streaming chat chunks were building `usage` from a partial dict (`prompt_tokens` / `completion_tokens` / `total_tokens` only). Pydantic coerced it into `UsageStats` with `prompt_tps`, `peak_memory`, and `prompt_tokens_details` filled from defaults — clients saw the fields but they were always 0. Pass a full `UsageStats` so chunks report the real values that 23ea54d already wired at the server level.

`generation_tps` is intentionally not addressed here: see #1113. The continuous-batching path doesn't have a per-uid generation timing source (only batch-aggregate via `batch_gen.stats()`, which the maintainer correctly flagged as inaccurate), and the proper fix is best landed alongside that PR's per-request approach. Calling it out so this PR isn't claiming a fix it doesn't deliver.

## Test plan

- 8 unit tests in `mlx_vlm/tests/test_usage_envelope.py` for the dataclass plumbing and envelope serialisation.
- Existing suite green (`test_models.py` / `test_smoke.py` excluded they need a real model / extra deps and are unrelated).
- Wants a real-model smoke before merge:
  - `/chat/completions` stream + non-stream with `APC_ENABLED=1` and a repeated prefix → `cached_tokens` non-zero on the second hit.
  - `/responses` stream + non-stream → `input_tokens_details.cached_tokens` populated.
  - Streaming chat chunks → `prompt_tps` and `peak_memory` non-zero (previously always 0 due to dict coercion).