### PR TITLE
[codex] Enforce server context budget

### DIFF
--- a/mlx_vlm/server.py
+++ b/mlx_vlm/server.py
@@ -65,6 +65,10 @@ METRICS_HISTORY_LIMIT = 100
 METRICS_RECENT_LIMIT = 32
 
 
+class PromptTooLongError(ValueError):
+    """Raised when a request exceeds the configured server context budget."""
+
+
 def _get_speculative_rounds_batch(draft_kind: str):
     if draft_kind == "mtp":
         return _mtp_rounds_batch
@@ -153,6 +157,11 @@ def get_max_kv_size(model: str):
         print(f"Model {model} uses QuantizedKVCache, can't set max KV size.")
         return None
     return max_kv_tokens
+
+
+def get_configured_context_limit():
+    max_kv_tokens = int(os.environ.get("MAX_KV_SIZE", 0))
+    return max_kv_tokens or None
 
 
 def get_quantized_kv_start():
@@ -395,6 +404,13 @@ def _build_metrics_envelope(
 def _server_runtime_snapshot() -> dict:
     config = model_cache.get("config")
     text_config = getattr(config, "text_config", None)
+    native_context_size = getattr(text_config, "max_position_embeddings", None)
+    configured_context_limit = get_configured_context_limit()
+    effective_context_limit = (
+        min(native_context_size, configured_context_limit)
+        if native_context_size is not None and configured_context_limit is not None
+        else configured_context_limit or native_context_size
+    )
     queue_depth = 0
     if response_generator is not None and hasattr(response_generator, "requests"):
         try:
@@ -404,7 +420,9 @@ def _server_runtime_snapshot() -> dict:
     return {
         "loaded_model": model_cache.get("model_path", None),
         "loaded_adapter": model_cache.get("adapter_path", None),
-        "loaded_context_size": getattr(text_config, "max_position_embeddings", None),
+        "loaded_context_size": native_context_size,
+        "configured_context_limit": configured_context_limit,
+        "effective_context_limit": effective_context_limit,
         "loaded_tool_parser": (
             _infer_tool_parser_from_processor(model_cache.get("processor"))
             if model_cache.get("processor")
@@ -634,6 +652,15 @@ class ResponseGenerator:
             if hasattr(raw_inputs["input_ids"], "size")
             else len(raw_inputs["input_ids"])
         )
+        context_limit = get_configured_context_limit()
+        requested_tokens = prompt_tokens + max(0, int(args.max_tokens or 0))
+        if context_limit is not None and requested_tokens > context_limit:
+            raise PromptTooLongError(
+                "Request needs "
+                f"{requested_tokens} context tokens "
+                f"({prompt_tokens} prompt + {args.max_tokens} max generation), "
+                f"but MAX_KV_SIZE is {context_limit}."
+            )
 
         self.requests.put((rqueue, raw_inputs, prompt_tokens, args, images))
 
@@ -2632,6 +2659,16 @@ async def responses_endpoint(request: Request):
 
                 return response
 
+            except PromptTooLongError as e:
+                server_metrics.record_failure(
+                    endpoint="/responses",
+                    model=openai_request.model,
+                    stream=False,
+                    error=str(e),
+                )
+                mx.clear_cache()
+                gc.collect()
+                raise HTTPException(status_code=400, detail=str(e))
             except Exception as e:
                 server_metrics.record_failure(
                     endpoint="/responses",
@@ -3308,6 +3345,16 @@ async def chat_completions_endpoint(request: ChatRequest, http_request: Request)
 
                 return result
 
+            except PromptTooLongError as e:
+                server_metrics.record_failure(
+                    endpoint="/chat/completions",
+                    model=request.model,
+                    stream=False,
+                    error=str(e),
+                )
+                mx.clear_cache()
+                gc.collect()
+                raise HTTPException(status_code=400, detail=str(e))
             except Exception as e:
                 server_metrics.record_failure(
                     endpoint="/chat/completions",
@@ -3388,6 +3435,8 @@ async def health_check():
         "loaded_model": runtime["loaded_model"],
         "loaded_adapter": runtime["loaded_adapter"],
         "loaded_context_size": runtime["loaded_context_size"],
+        "configured_context_limit": runtime["configured_context_limit"],
+        "effective_context_limit": runtime["effective_context_limit"],
         "loaded_tool_parser": runtime["loaded_tool_parser"],
         "continuous_batching_enabled": runtime["continuous_batching_enabled"],
         "apc_enabled": runtime["apc"]["enabled"],

--- a/mlx_vlm/tests/test_server.py
+++ b/mlx_vlm/tests/test_server.py
@@ -539,9 +539,7 @@ class TestResponseGenerator:
         gen._cpu_preprocess = lambda prompt, images, audio: {"input_ids": [1, 2, 3]}
         return gen
 
-    def test_generate_rejects_requests_over_configured_context_limit(
-        self, monkeypatch
-    ):
+    def test_generate_rejects_requests_over_configured_context_limit(self, monkeypatch):
         gen = server.ResponseGenerator.__new__(server.ResponseGenerator)
         gen.wait_until_ready = lambda: None
         gen.draft_model = None
@@ -557,9 +555,7 @@ class TestResponseGenerator:
 
         assert gen.requests.empty()
 
-    def test_server_runtime_snapshot_reports_effective_context_limit(
-        self, monkeypatch
-    ):
+    def test_server_runtime_snapshot_reports_effective_context_limit(self, monkeypatch):
         monkeypatch.setenv("MAX_KV_SIZE", "8")
         monkeypatch.setattr(
             server,

--- a/mlx_vlm/tests/test_server.py
+++ b/mlx_vlm/tests/test_server.py
@@ -539,6 +539,46 @@ class TestResponseGenerator:
         gen._cpu_preprocess = lambda prompt, images, audio: {"input_ids": [1, 2, 3]}
         return gen
 
+    def test_generate_rejects_requests_over_configured_context_limit(
+        self, monkeypatch
+    ):
+        gen = server.ResponseGenerator.__new__(server.ResponseGenerator)
+        gen.wait_until_ready = lambda: None
+        gen.draft_model = None
+        gen._cpu_preprocess = lambda prompt, images, audio: {
+            "input_ids": mx.array([[1, 2, 3, 4, 5]], dtype=mx.int32)
+        }
+        gen.requests = Queue()
+
+        monkeypatch.setenv("MAX_KV_SIZE", "8")
+
+        with pytest.raises(server.PromptTooLongError, match="MAX_KV_SIZE is 8"):
+            gen.generate("prompt", args=server.GenerationArguments(max_tokens=4))
+
+        assert gen.requests.empty()
+
+    def test_server_runtime_snapshot_reports_effective_context_limit(
+        self, monkeypatch
+    ):
+        monkeypatch.setenv("MAX_KV_SIZE", "8")
+        monkeypatch.setattr(
+            server,
+            "model_cache",
+            {
+                "config": SimpleNamespace(
+                    text_config=SimpleNamespace(max_position_embeddings=16)
+                )
+            },
+        )
+        monkeypatch.setattr(server, "response_generator", None)
+        monkeypatch.setattr(server, "apc_manager", None)
+
+        runtime = server._server_runtime_snapshot()
+
+        assert runtime["loaded_context_size"] == 16
+        assert runtime["configured_context_limit"] == 8
+        assert runtime["effective_context_limit"] == 8
+
     def test_generate_arguments_defaults(self):
         args = server.GenerationArguments()
         assert args.max_tokens == server.DEFAULT_MAX_TOKENS


### PR DESCRIPTION
Fixes #1154

## Summary
- enforce configured `MAX_KV_SIZE` as a request-level context budget before server generation queues work
- expose configured and effective context limits in `/health` alongside the native model context
- add focused server tests for over-budget rejection and runtime context reporting

## Why
When KV cache quantization is enabled, `get_max_kv_size()` intentionally returns `None` because quantized caches do not use the rotating-cache `max_kv_size` path. That leaves `--max-kv-size` unable to protect server users from direct requests that exceed the intended runtime context budget. On memory-constrained Apple Silicon, those oversized requests can progress until Metal allocation or prefill failure instead of getting a clear client error.

## Validation
- `PYTHONPATH=/tmp/mlx-vlm-context-budget-pr pytest -q mlx_vlm/tests/test_server.py -k "context_limit or configured_context_limit"`
- `python -m py_compile mlx_vlm/server.py mlx_vlm/tests/test_server.py`
