### PR TITLE
Fix Gemma 4 MTP per-row K/V corruption in batched speculative decoding

### DIFF
--- a/mlx_vlm/generate.py
+++ b/mlx_vlm/generate.py
@@ -854,10 +854,7 @@ def _mtp_rounds_batch(
                     K_next, V_next = next_shared_kv[k]
                     next_shared_kv[k] = (K_next[keep_mx], V_next[keep_mx])
                 if snap_left_padding is not None:
-                    if isinstance(snap_left_padding, mx.array):
-                        snap_left_padding = snap_left_padding[keep_mx]
-                    else:
-                        snap_left_padding = [snap_left_padding[s] for s in keep_slots]
+                    snap_left_padding = snap_left_padding[keep_mx]
                 active_idx = [active_idx[j] for j in keep_slots]
 
         # Re-bind drafter with new shared_kv and per-row positions.

--- a/mlx_vlm/generate.py
+++ b/mlx_vlm/generate.py
@@ -772,9 +772,21 @@ def _mtp_rounds_batch(
                 b[orig] = new_tokens_list[j][-1]
             positions[orig] = positions[orig] + accepted_list[j] + 1
 
-        # Rollback target cache (uniform trim by ``bs - max_a - 1`` plus
-        # per-row tail-zero on rows that accepted less).
-        if max_a < bs - 1:
+        # Rollback target cache. Two cases:
+        #   (a) max_a < bs - 1: at least one row accepted fewer than the
+        #       full draft block, so the uniform tail of the cache must be
+        #       trimmed.
+        #   (b) per-row variance (some a_i < max_a): rows accepted
+        #       different counts, so each under-accepting row must be
+        #       cyclically shifted to move its garbage K/V slots out of
+        #       the live region (handled in ``rollback_speculative_cache``
+        #       via per-row ``dynamic_roll`` + per-row ``offset`` /
+        #       ``left_padding`` adjustment).
+        # Snapshot left_padding BEFORE rollback so the drafter's
+        # ``set_shared_kv`` normalizes the (pre-rollback) verify snapshot
+        # with the matching layout.
+        pre_rollback_left_padding = _batch_cache_left_padding(prompt_cache)
+        if max_a < bs - 1 or any(a < max_a for a in accepted_list):
             with mx.stream(generation_stream):
                 lm.rollback_speculative_cache(prompt_cache, None, accepted_arr, bs)
 
@@ -816,6 +828,13 @@ def _mtp_rounds_batch(
                 V_next = V_next * keep_f
             next_shared_kv[k] = (K_next, V_next)
 
+        # ``snap_left_padding`` is the left_padding to use when normalizing
+        # ``next_shared_kv`` inside ``set_shared_kv``. It must match the
+        # layout of the (pre-rollback) verify snapshot, not the
+        # post-rollback target cache (rollback bumps left_padding for
+        # under-accepting rows, which would over-roll the snapshot).
+        snap_left_padding = pre_rollback_left_padding
+
         # Continuous batching: filter finished sequences. Only safe when
         # the caches expose a .filter() method (e.g. BatchKVCache); the
         # plain KVCache / RotatingKVCache do not, so we keep all rows
@@ -834,6 +853,11 @@ def _mtp_rounds_batch(
                 for k in next_shared_kv:
                     K_next, V_next = next_shared_kv[k]
                     next_shared_kv[k] = (K_next[keep_mx], V_next[keep_mx])
+                if snap_left_padding is not None:
+                    if isinstance(snap_left_padding, mx.array):
+                        snap_left_padding = snap_left_padding[keep_mx]
+                    else:
+                        snap_left_padding = [snap_left_padding[s] for s in keep_slots]
                 active_idx = [active_idx[j] for j in keep_slots]
 
         # Re-bind drafter with new shared_kv and per-row positions.
@@ -846,7 +870,7 @@ def _mtp_rounds_batch(
             next_shared_kv,
             kv_offset=new_kv_offset,
             position=mx.array(positions_active),
-            left_padding=_batch_cache_left_padding(prompt_cache),
+            left_padding=snap_left_padding,
         )
 
         if sum(emitted) % 256 == 0:

--- a/mlx_vlm/models/gemma4/language.py
+++ b/mlx_vlm/models/gemma4/language.py
@@ -4,6 +4,7 @@ from typing import Any, List, Optional
 import mlx.core as mx
 import mlx.nn as nn
 from mlx.nn import RMSNorm
+from mlx_lm.models.cache import dynamic_roll
 
 from ..base import (
     LanguageModelOutput,
@@ -621,8 +622,6 @@ class LanguageModel(nn.Module):
         advance. ``gdn_states`` is accepted (and ignored) for API parity
         with qwen3_5's hook.
         """
-        from mlx_lm.models.cache import dynamic_roll
-
         del gdn_states  # API-parity placeholder; Gemma 4 has no SSM/GDN state.
         if isinstance(accepted, int):
             accepted = mx.array([accepted])
@@ -648,16 +647,24 @@ class LanguageModel(nn.Module):
                 and hasattr(c, "left_padding")
             ):
                 # After trim, the cache offset has advanced uniformly to
-                # old_offset + max_a + 1, but rows that accepted less than
-                # max_a have garbage K/V from rejected drafts in their tail
-                # at slots [old_idx + a + 1, old_idx + max_a + 1). Cyclic-
-                # shift each row forward by (max_a - a) so the garbage moves
-                # into the left-padding region; bump left_padding[i] and
-                # drop offset[i] by the same amount, landing offset[i] at
-                # old_offset[i] + a + 1. Done directly (not via prepare /
-                # finalize) because BatchRotatingKVCache.prepare derives
-                # ``_lengths = mx.array(lengths) + self.offset`` and a single
-                # post-update prepare/finalize would resolve to a no-op.
+                # old_offset + max_a + 1, but rows that accepted fewer
+                # than max_a have garbage K/V from rejected drafts in
+                # their tail at slots [old_idx + a + 1, old_idx + max_a
+                # + 1). Right-cyclic-shift each row by (max_a - a) over
+                # the buffer. Depending on cache shape, the rejected K/V
+                # either lands past _idx in unused storage
+                # (BatchKVCache: step-padded, overwritten on the next
+                # update) or wraps modulo shape[2] into the head slots
+                # (BatchRotatingKVCache pre-rotation). Either way,
+                # bumping left_padding[i] by the same shift masks the
+                # new head slots from attention, and dropping offset[i]
+                # leaves the per-row logical length at
+                # old_offset[i] + a + 1. Done directly (not via
+                # prepare / finalize) because
+                # BatchRotatingKVCache.prepare derives
+                # ``_lengths = mx.array(lengths) + self.offset`` and a
+                # single post-update prepare/finalize would resolve to a
+                # no-op.
                 if hasattr(c, "_temporal_order"):
                     c._temporal_order()
                 row_padding = mx.array([max_a - a for a in accepted_list])

--- a/mlx_vlm/models/gemma4/language.py
+++ b/mlx_vlm/models/gemma4/language.py
@@ -615,9 +615,14 @@ class LanguageModel(nn.Module):
         """Rewind target KV caches after a speculative-decoding round.
 
         Gemma 4 has only KV/RotatingKV caches (no SSM/GDN), so this is a
-        simple trim + per-row tail-zero. ``gdn_states`` is accepted (and
-        ignored) for API parity with qwen3_5's hook.
+        uniform trim plus, in the batched per-row-variance case, a per-row
+        cyclic shift so each row's accepted content stays right-justified to
+        ``_idx`` and per-row ``offset`` correctly reflects ``accepted+1``
+        advance. ``gdn_states`` is accepted (and ignored) for API parity
+        with qwen3_5's hook.
         """
+        from mlx_lm.models.cache import dynamic_roll
+
         del gdn_states  # API-parity placeholder; Gemma 4 has no SSM/GDN state.
         if isinstance(accepted, int):
             accepted = mx.array([accepted])
@@ -625,8 +630,9 @@ class LanguageModel(nn.Module):
         max_a = int(accepted.max().item())
         n = max_a + 1
         trim = block_size - n
+        accepted_list = [int(a) for a in accepted.tolist()]
         is_batch = accepted.size > 1
-        valid_ends = accepted + 1
+        per_row_variance = is_batch and any(a < max_a for a in accepted_list)
 
         for c in caches:
             if c is None:
@@ -634,15 +640,31 @@ class LanguageModel(nn.Module):
 
             if trim > 0 and hasattr(c, "trim"):
                 c.trim(trim)
-            if is_batch and hasattr(c, "_idx") and c.keys is not None and max_a > 0:
-                kv_len = c._idx
-                ve = valid_ends.tolist()
-                verify_start = kv_len - n
-                for bi in range(accepted.shape[0]):
-                    start = verify_start + int(ve[bi])
-                    if start < kv_len:
-                        c.keys[bi, :, start:kv_len, :] = 0
-                        c.values[bi, :, start:kv_len, :] = 0
+
+            if (
+                per_row_variance
+                and hasattr(c, "keys")
+                and c.keys is not None
+                and hasattr(c, "left_padding")
+            ):
+                # After trim, the cache offset has advanced uniformly to
+                # old_offset + max_a + 1, but rows that accepted less than
+                # max_a have garbage K/V from rejected drafts in their tail
+                # at slots [old_idx + a + 1, old_idx + max_a + 1). Cyclic-
+                # shift each row forward by (max_a - a) so the garbage moves
+                # into the left-padding region; bump left_padding[i] and
+                # drop offset[i] by the same amount, landing offset[i] at
+                # old_offset[i] + a + 1. Done directly (not via prepare /
+                # finalize) because BatchRotatingKVCache.prepare derives
+                # ``_lengths = mx.array(lengths) + self.offset`` and a single
+                # post-update prepare/finalize would resolve to a no-op.
+                if hasattr(c, "_temporal_order"):
+                    c._temporal_order()
+                row_padding = mx.array([max_a - a for a in accepted_list])
+                c.keys = dynamic_roll(c.keys, row_padding[:, None], axis=2)
+                c.values = dynamic_roll(c.values, row_padding[:, None], axis=2)
+                c.offset = c.offset - row_padding
+                c.left_padding = c.left_padding + row_padding
         return max_a
 
     def sanitize(self, weights):

--- a/mlx_vlm/tests/test_speculative.py
+++ b/mlx_vlm/tests/test_speculative.py
@@ -12,7 +12,9 @@ from unittest.mock import patch
 import mlx.core as mx
 import pytest
 
+import mlx_vlm.models.gemma4.language as gemma4_language
 import mlx_vlm.models.qwen3_5.language as qwen_language
+from mlx_lm.models.cache import BatchKVCache
 from mlx_vlm.models.cache import ArraysCache
 from mlx_vlm.speculative.drafters import (
     DEFAULT_DRAFTER_KIND,
@@ -139,6 +141,76 @@ def test_qwen_rollback_speculative_cache_zero_inits_missing_state():
 
     assert captured["state"].shape == (2, 3, 5, 4)
     assert float(mx.sum(mx.abs(captured["state"])).item()) == 0.0
+
+
+def _populate_batch_kv_cache(B: int, H: int, D: int, prefill_len: int, verify_len: int):
+    """Build a BatchKVCache prefilled with deterministic K/V sentinels.
+
+    Prefill positions hold value ``p`` for position ``p`` in [0, prefill_len);
+    verify positions hold value ``100 + p`` for position ``p`` in
+    [0, verify_len). Returns the cache plus the reference K array.
+    """
+    cache = BatchKVCache(left_padding=[0] * B)
+    prefill_K = mx.zeros((B, H, prefill_len, D), dtype=mx.float32)
+    for p in range(prefill_len):
+        prefill_K[:, :, p, :] = float(p)
+    cache.update_and_fetch(prefill_K, prefill_K)
+    verify_K = mx.zeros((B, H, verify_len, D), dtype=mx.float32)
+    for p in range(verify_len):
+        verify_K[:, :, p, :] = 100.0 + float(p)
+    cache.update_and_fetch(verify_K, verify_K)
+    return cache
+
+
+def test_gemma4_rollback_per_row_variance_rolls_kv_and_adjusts_offsets():
+    # bs (= draft_block_size) = 4, accepts = [3, 0, 1] gives max_a = 3
+    # so the uniform trim is zero and only the per-row dynamic_roll path
+    # exercises. Each under-accepting row must move its garbage K/V
+    # (rejected drafts) into the left-padding region while keeping its
+    # accepted prefix right-justified to ``_idx``.
+    bs, B, H, D = 4, 3, 2, 4
+    cache = _populate_batch_kv_cache(B, H, D, prefill_len=5, verify_len=bs)
+    accepted = mx.array([3, 0, 1], dtype=mx.int32)
+
+    lm = gemma4_language.LanguageModel.__new__(gemma4_language.LanguageModel)
+    max_a = gemma4_language.LanguageModel.rollback_speculative_cache(
+        lm, [cache], None, accepted, block_size=bs
+    )
+    assert max_a == 3
+
+    # offset[i] = old_offset - (max_a - a_i); left_padding[i] += (max_a - a_i)
+    assert cache.offset.tolist() == [9, 6, 7]
+    assert cache.left_padding.tolist() == [0, 3, 2]
+    # No uniform trim, so _idx is unchanged.
+    assert cache._idx == 9
+
+    K = cache.keys[:, 0, : cache._idx, 0].tolist()
+    # Row 0 (a=3, full accept): unchanged. 5 prefill + 4 verify.
+    assert K[0] == [0.0, 1.0, 2.0, 3.0, 4.0, 100.0, 101.0, 102.0, 103.0]
+    # Row 1 (a=0): rolled right by 3. Slots 0..2 are garbage from rejected
+    # drafts now sitting in the left-padding region; live slice [3, 9)
+    # holds the 5 prefill tokens plus the first verify token (a+1=1 kept).
+    assert K[1][3:9] == [0.0, 1.0, 2.0, 3.0, 4.0, 100.0]
+    # Row 2 (a=1): rolled right by 2. Live slice [2, 9) holds 5 prefill +
+    # first 2 verify tokens (a+1=2 kept).
+    assert K[2][2:9] == [0.0, 1.0, 2.0, 3.0, 4.0, 100.0, 101.0]
+
+
+def test_gemma4_rollback_uniform_no_variance_only_trims():
+    # All rows accept the same count: trim is uniform, no per-row roll.
+    bs, B, H, D = 4, 3, 1, 2
+    cache = _populate_batch_kv_cache(B, H, D, prefill_len=5, verify_len=bs)
+    accepted = mx.array([1, 1, 1], dtype=mx.int32)
+
+    lm = gemma4_language.LanguageModel.__new__(gemma4_language.LanguageModel)
+    max_a = gemma4_language.LanguageModel.rollback_speculative_cache(
+        lm, [cache], None, accepted, block_size=bs
+    )
+    assert max_a == 1
+    # block_size - (max_a + 1) = 2 trimmed uniformly.
+    assert cache._idx == 7
+    assert cache.offset.tolist() == [7, 7, 7]
+    assert cache.left_padding.tolist() == [0, 0, 0]
 
 
 def test_mtp_drafter_masks_support_batched_offsets():

--- a/mlx_vlm/tests/test_speculative.py
+++ b/mlx_vlm/tests/test_speculative.py
@@ -11,10 +11,10 @@ from unittest.mock import patch
 
 import mlx.core as mx
 import pytest
+from mlx_lm.models.cache import BatchKVCache
 
 import mlx_vlm.models.gemma4.language as gemma4_language
 import mlx_vlm.models.qwen3_5.language as qwen_language
-from mlx_lm.models.cache import BatchKVCache
 from mlx_vlm.models.cache import ArraysCache
 from mlx_vlm.speculative.drafters import (
     DEFAULT_DRAFTER_KIND,

--- a/mlx_vlm/tests/test_speculative.py
+++ b/mlx_vlm/tests/test_speculative.py
@@ -11,7 +11,7 @@ from unittest.mock import patch
 
 import mlx.core as mx
 import pytest
-from mlx_lm.models.cache import BatchKVCache
+from mlx_lm.models.cache import BatchKVCache, BatchRotatingKVCache
 
 import mlx_vlm.models.gemma4.language as gemma4_language
 import mlx_vlm.models.qwen3_5.language as qwen_language
@@ -187,12 +187,79 @@ def test_gemma4_rollback_per_row_variance_rolls_kv_and_adjusts_offsets():
     K = cache.keys[:, 0, : cache._idx, 0].tolist()
     # Row 0 (a=3, full accept): unchanged. 5 prefill + 4 verify.
     assert K[0] == [0.0, 1.0, 2.0, 3.0, 4.0, 100.0, 101.0, 102.0, 103.0]
-    # Row 1 (a=0): rolled right by 3. Slots 0..2 are garbage from rejected
-    # drafts now sitting in the left-padding region; live slice [3, 9)
-    # holds the 5 prefill tokens plus the first verify token (a+1=1 kept).
+    # BatchKVCache buffer is step-padded (256 slots), so the right-
+    # cyclic shift rotates zeros from the unused tail into the
+    # left-padding head; rejected drafts roll past _idx and are
+    # overwritten on the next update.
+    # Row 1 (a=0): rolled right by 3. Live slice [3, 9) holds the 5
+    # prefill tokens plus the first verify token (a+1=1 kept). Head
+    # slots [0, 3) hold zeros (masked by left_padding=3).
+    assert K[1][:3] == [0.0, 0.0, 0.0]
     assert K[1][3:9] == [0.0, 1.0, 2.0, 3.0, 4.0, 100.0]
     # Row 2 (a=1): rolled right by 2. Live slice [2, 9) holds 5 prefill +
     # first 2 verify tokens (a+1=2 kept).
+    assert K[2][:2] == [0.0, 0.0]
+    assert K[2][2:9] == [0.0, 1.0, 2.0, 3.0, 4.0, 100.0, 101.0]
+
+
+def _populate_batch_rotating_kv_cache(
+    B: int, H: int, D: int, max_size: int, prefill_len: int, verify_len: int
+):
+    """Build a BatchRotatingKVCache prefilled with deterministic K/V sentinels.
+
+    Same sentinel scheme as ``_populate_batch_kv_cache`` (prefill positions
+    hold ``p``; verify positions hold ``100 + p``). ``max_size`` must be
+    large enough to hold prefill + verify without rotating.
+    """
+    cache = BatchRotatingKVCache(max_size=max_size, left_padding=[0] * B)
+    prefill_K = mx.zeros((B, H, prefill_len, D), dtype=mx.float32)
+    for p in range(prefill_len):
+        prefill_K[:, :, p, :] = float(p)
+    cache.update_and_fetch(prefill_K, prefill_K)
+    verify_K = mx.zeros((B, H, verify_len, D), dtype=mx.float32)
+    for p in range(verify_len):
+        verify_K[:, :, p, :] = 100.0 + float(p)
+    cache.update_and_fetch(verify_K, verify_K)
+    return cache
+
+
+def test_gemma4_rollback_per_row_variance_on_rotating_cache():
+    # Same scenario as the BatchKVCache variant, but on
+    # BatchRotatingKVCache. Half of Gemma 4's layers use this cache type
+    # (sliding-attention), so the rollback's per-row dynamic_roll path
+    # must behave correctly here too. With max_size > prefill+verify,
+    # the buffer is shape[2] == _idx == 9 (no step-padding tail), so
+    # the right-cyclic shift wraps rejected K/V modulo shape[2] into
+    # the head slots — which the bumped left_padding then masks out.
+    bs, B, H, D = 4, 3, 2, 4
+    cache = _populate_batch_rotating_kv_cache(
+        B, H, D, max_size=16, prefill_len=5, verify_len=bs
+    )
+    accepted = mx.array([3, 0, 1], dtype=mx.int32)
+
+    lm = gemma4_language.LanguageModel.__new__(gemma4_language.LanguageModel)
+    max_a = gemma4_language.LanguageModel.rollback_speculative_cache(
+        lm, [cache], None, accepted, block_size=bs
+    )
+    assert max_a == 3
+
+    assert cache.offset.tolist() == [9, 6, 7]
+    assert cache.left_padding.tolist() == [0, 3, 2]
+    assert cache._idx == 9
+    assert cache.rotated is False  # _temporal_order leaves rotated=False
+
+    K = cache.keys[:, 0, : cache._idx, 0].tolist()
+    # Row 0 (a=3, full accept): unchanged.
+    assert K[0] == [0.0, 1.0, 2.0, 3.0, 4.0, 100.0, 101.0, 102.0, 103.0]
+    # Row 1 (a=0): rolled right by 3. Buffer is sized exactly to _idx,
+    # so the rejected verify tokens [101, 102, 103] wrap into the head
+    # slots [0, 3) (masked by left_padding=3). Live slice [3, 9) holds
+    # the 5 prefill tokens plus the first verify token (a+1=1 kept).
+    assert K[1][:3] == [101.0, 102.0, 103.0]
+    assert K[1][3:9] == [0.0, 1.0, 2.0, 3.0, 4.0, 100.0]
+    # Row 2 (a=1): rolled right by 2. Head [0, 2) holds the rejected
+    # tail [102, 103]; live slice [2, 9) holds 5 prefill + 2 verify.
+    assert K[2][:2] == [102.0, 103.0]
     assert K[2][2:9] == [0.0, 1.0, 2.0, 3.0, 4.0, 100.0, 101.0]
 
 


### PR DESCRIPTION
Fixes #1144.

## Summary

In batched MTP speculative decoding for Gemma 4 (`_mtp_rounds_batch` with `B≥2`, mixed-length prompts), the target's `BatchKVCache.update_and_fetch` advances `offset` uniformly across all rows by the full draft block size. When rows accept different numbers of draft tokens, under-accepting rows are left with `(max_a − a_i)` slots of garbage K/V (rejected drafts) in their tail, and the next verify forward consumes those wrong slots. Acceptance collapses (~1.50 → ~0.47) and outputs corrupt with short-range token loops, exactly matching #1144.

## Root cause

`_mtp_rounds_batch` (in `mlx_vlm/generate.py`) calls `lm.rollback_speculative_cache` after each verify round to rewind the target cache. The pre-fix gemma4 hook only blanked the per-row tail K/V, but did **not** adjust per-row `offset` / `left_padding`, so:

- the cache's `_idx` and uniform `offset += block_size` left a per-row mismatch — under-accepting rows still saw their next forward as if they had advanced by the full block;
- the next attention pass ran with wrong RoPE positions (`+ block_size` instead of `+ a_i + 1`);
- the drafter's `set_shared_kv` snapshot, normalized by `dynamic_roll(-left_padding)`, had no per-row alignment information to undo the mismatch.

The result is the symptom report in #1144: at `B=3`, mean accepted/round drops to ~0.30 with the same drafter that gets ~1.5 at `B=1`, and outputs degenerate to "the sun's the sun shines down…"-style loops.

This is _not_ a sliding-mask issue (#1138/#1139 already addressed those); the corruption is in the post-verify cache layout, not the prefill snapshot.

## Fix

**`mlx_vlm/models/gemma4/language.py::rollback_speculative_cache`** — replace tail-zero with a per-row cyclic shift:

After the uniform `c.trim(bs − max_a − 1)`, when any row accepted fewer than `max_a` (per-row variance):

1. If `BatchRotatingKVCache`, call `c._temporal_order()` first so the buffer is unrolled.
2. `dynamic_roll(c.keys, row_padding[:, None], axis=2)` and same for `c.values`, where `row_padding[i] = max_a − a_i`.
3. `c.offset = c.offset − row_padding`
4. `c.left_padding = c.left_padding + row_padding`

Depending on the cache shape, the rejected K/V either lands past `_idx` in unused storage (`BatchKVCache`, step-padded — overwritten on the next update) or wraps modulo `shape[2]` into the head slots (`BatchRotatingKVCache` pre-rotation). Either way, bumping `left_padding[i]` by the same shift masks the new head slots from attention, and dropping `offset[i]` leaves the per-row logical length at `old_offset[i] + a + 1`.

We do this directly rather than via `c.prepare(lengths=…, right_padding=…)` + `c.finalize()` because `BatchRotatingKVCache.prepare` derives `_lengths = mx.array(lengths) + self.offset`, then `finalize` does `roll = max(0, self.offset − self._lengths)` which is `0` for non-negative `lengths_user`. The `prepare`/`finalize` API is designed for prefill-with-right-padding (called _before_ forward, completed _after_ offset advances), not for after-the-fact rollback. A single post-update `prepare`/`finalize` is a no-op for sliding-attention layers, which is half the Gemma 4 layers.

**`mlx_vlm/generate.py::_mtp_rounds_batch`** — three companion edits:

1. Snapshot `pre_rollback_left_padding = _batch_cache_left_padding(prompt_cache)` **before** calling `rollback_speculative_cache`. The drafter's `set_shared_kv(...)` normalizes the verify snapshot via `dynamic_roll(-left_padding)`, and the snapshot was captured pre-rollback, so it must be normalized with the pre-rollback `left_padding`. Using post-rollback `left_padding` would over-roll the snapshot for under-accepting rows.
2. Initialize `snap_left_padding = pre_rollback_left_padding` after the next-shared-kv block; in the continuous-batching `c.filter(keep_mx)` step, also filter `snap_left_padding`.
3. Widen the rollback gate from `if max_a < bs − 1:` to `if max_a < bs − 1 or any(a < max_a for a in accepted_list):` so per-row variance with `max_a == bs − 1` (e.g. accepts `[3, 1, 2, 3]` at `bs=4`) still triggers per-row alignment instead of being skipped.

## Tests

Three new unit tests in `mlx_vlm/tests/test_speculative.py`:

- `test_gemma4_rollback_per_row_variance_rolls_kv_and_adjusts_offsets` — `BatchKVCache`, `bs=4`, accepts `[3, 0, 1]` (no uniform trim, only the per-row path). Asserts `offset == [9, 6, 7]`, `left_padding == [0, 3, 2]`, and that each row's live K-slice contains its prefill prefix plus exactly `a_i + 1` verify tokens, with zeros from the step-padded buffer tail rotated into the (masked) left-padding head.
- `test_gemma4_rollback_per_row_variance_on_rotating_cache` — same scenario on `BatchRotatingKVCache` (used for sliding-attention layers, half of Gemma 4). Asserts the rejected K/V wraps modulo `shape[2]` into the head slots and is correctly masked.
- `test_gemma4_rollback_uniform_no_variance_only_trims` — `bs=4`, accepts `[1, 1, 1]`. Asserts that with no per-row variance the rollback degenerates to a uniform trim and leaves `left_padding` untouched.

```
PYTHONPATH=. pytest mlx_vlm/tests/test_speculative.py -q
# 19 passed
```

Adjacent suites also pass:

```
PYTHONPATH=. pytest mlx_vlm/tests/test_speculative.py mlx_vlm/tests/test_server.py \
                     mlx_vlm/tests/test_gemma4_assistant_masks_static.py \
                     mlx_vlm/tests/test_generate.py -q
# 148 passed
```

`pre-commit run --all-files` clean (black, isort, autoflake).

## Validation against #1144's repro

Same 4-prompt concurrent client, `gemma-4-26b-a4b-it-bf16` ↔ `gemma-4-26B-A4B-it-assistant-bf16`, `--draft-kind mtp --draft-block-size 4` on M5 Max:

| | mean accepted/round | output |
|---|---|---|
| pre-fix `B=3` (#1144) | ~0.30 | corrupt (short-range loops) |
| this PR `B=3` | ~1.40 | coherent, grammatical |
| this PR `B=1` (reference) | ~1.51 | coherent |

That's ~92% of the B=1 acceptance rate at B=3, vs the pre-fix collapse to ~20%. The remaining gap to perfect bit-exactness with B=1 is **not** a logic bug: batched matmul has a different floating-point summation order than per-row matmul, so close logits can flip on argmax. Outputs diverge sentence-by-sentence rather than degenerate.

## Test plan

- [x] `pytest mlx_vlm/tests/test_speculative.py` — 19 passed, including 3 new gemma4 rollback tests
- [x] `pytest mlx_vlm/tests/test_server.py mlx_vlm/tests/test_generate.py mlx_vlm/tests/test_gemma4_assistant_masks_static.py` — 129 passed
- [x] `pre-commit run --all-files` — clean
- [x] End-to-end #1144 repro shows acceptance and output recovery