### PR TITLE
Fix Qwen3 VL vision config deserialization (patch_size ignored)

### DIFF
--- a/mlx_vlm/models/qwen3_5/config.py
+++ b/mlx_vlm/models/qwen3_5/config.py
@@ -143,6 +143,23 @@ class ModelConfig(BaseModelConfig):
 
     @classmethod
     def from_dict(cls, params):
+        params = dict(params)
+        if isinstance(params.get("vision_config"), dict):
+            params["vision_config"] = VisionConfig(
+                **{
+                    k: v
+                    for k, v in params["vision_config"].items()
+                    if k in inspect.signature(VisionConfig).parameters
+                }
+            )
+        if isinstance(params.get("text_config"), dict):
+            params["text_config"] = TextConfig(
+                **{
+                    k: v
+                    for k, v in params["text_config"].items()
+                    if k in inspect.signature(TextConfig).parameters
+                }
+            )
         return cls(
             **{
                 k: v

--- a/mlx_vlm/models/qwen3_5/config.py
+++ b/mlx_vlm/models/qwen3_5/config.py
@@ -1,9 +1,9 @@
-import inspect
 from dataclasses import dataclass, field
 from typing import Dict, List, Optional, Union
 
 from ..base import BaseModelConfig
 from ..qwen3_vl.config import VisionConfig as Qwen3VLVisionConfig
+from ..qwen3_vl.config import _config_kwargs, _maybe_deserialize_config
 
 QWEN_CHAT_EOS_TOKEN_ID = 248046
 
@@ -144,26 +144,10 @@ class ModelConfig(BaseModelConfig):
     @classmethod
     def from_dict(cls, params):
         params = dict(params)
-        if isinstance(params.get("vision_config"), dict):
-            params["vision_config"] = VisionConfig(
-                **{
-                    k: v
-                    for k, v in params["vision_config"].items()
-                    if k in inspect.signature(VisionConfig).parameters
-                }
-            )
-        if isinstance(params.get("text_config"), dict):
-            params["text_config"] = TextConfig(
-                **{
-                    k: v
-                    for k, v in params["text_config"].items()
-                    if k in inspect.signature(TextConfig).parameters
-                }
-            )
-        return cls(
-            **{
-                k: v
-                for k, v in params.items()
-                if k in inspect.signature(cls).parameters
-            }
+        params["vision_config"] = _maybe_deserialize_config(
+            VisionConfig, params.get("vision_config")
         )
+        params["text_config"] = _maybe_deserialize_config(
+            TextConfig, params.get("text_config"), require_all_fields=True
+        )
+        return cls(**_config_kwargs(cls, params))

--- a/mlx_vlm/models/qwen3_5_moe/config.py
+++ b/mlx_vlm/models/qwen3_5_moe/config.py
@@ -110,7 +110,28 @@ class ModelConfig(BaseModelConfig):
 
     @classmethod
     def from_dict(cls, params):
-
+        # Deserialize nested configs before constructing ModelConfig.
+        # Without this, vision_config and text_config remain raw dicts
+        # and their dataclass defaults (e.g. patch_size=14) take precedence
+        # over the values in config.json (e.g. patch_size=16), causing
+        # reshape failures in the vision encoder.
+        params = dict(params)
+        if isinstance(params.get("vision_config"), dict):
+            params["vision_config"] = VisionConfig(
+                **{
+                    k: v
+                    for k, v in params["vision_config"].items()
+                    if k in inspect.signature(VisionConfig).parameters
+                }
+            )
+        if isinstance(params.get("text_config"), dict):
+            params["text_config"] = TextConfig(
+                **{
+                    k: v
+                    for k, v in params["text_config"].items()
+                    if k in inspect.signature(TextConfig).parameters
+                }
+            )
         return cls(
             **{
                 k: v

--- a/mlx_vlm/models/qwen3_5_moe/config.py
+++ b/mlx_vlm/models/qwen3_5_moe/config.py
@@ -1,10 +1,10 @@
-import inspect
 from dataclasses import dataclass, field
 from typing import Dict, List, Optional, Union
 
 from ..base import BaseModelConfig
 from ..qwen3_5.config import resolve_qwen_eos_token_id, sanitize_quantization_config
 from ..qwen3_vl.config import VisionConfig as Qwen3VLVisionConfig
+from ..qwen3_vl.config import _config_kwargs, _maybe_deserialize_config
 
 
 @dataclass
@@ -116,26 +116,10 @@ class ModelConfig(BaseModelConfig):
         # over the values in config.json (e.g. patch_size=16), causing
         # reshape failures in the vision encoder.
         params = dict(params)
-        if isinstance(params.get("vision_config"), dict):
-            params["vision_config"] = VisionConfig(
-                **{
-                    k: v
-                    for k, v in params["vision_config"].items()
-                    if k in inspect.signature(VisionConfig).parameters
-                }
-            )
-        if isinstance(params.get("text_config"), dict):
-            params["text_config"] = TextConfig(
-                **{
-                    k: v
-                    for k, v in params["text_config"].items()
-                    if k in inspect.signature(TextConfig).parameters
-                }
-            )
-        return cls(
-            **{
-                k: v
-                for k, v in params.items()
-                if k in inspect.signature(cls).parameters
-            }
+        params["vision_config"] = _maybe_deserialize_config(
+            VisionConfig, params.get("vision_config")
         )
+        params["text_config"] = _maybe_deserialize_config(
+            TextConfig, params.get("text_config"), require_all_fields=True
+        )
+        return cls(**_config_kwargs(cls, params))

--- a/mlx_vlm/models/qwen3_vl/config.py
+++ b/mlx_vlm/models/qwen3_vl/config.py
@@ -5,6 +5,28 @@ from typing import Dict, List, Optional, Union
 from ..base import BaseModelConfig
 
 
+def _config_kwargs(config_cls, params):
+    return {
+        k: v for k, v in params.items() if k in inspect.signature(config_cls).parameters
+    }
+
+
+def _has_required_config_fields(config_cls, params):
+    return all(
+        name in params
+        for name, param in inspect.signature(config_cls).parameters.items()
+        if param.default is inspect.Parameter.empty
+    )
+
+
+def _maybe_deserialize_config(config_cls, params, *, require_all_fields=False):
+    if not isinstance(params, dict):
+        return params
+    if require_all_fields and not _has_required_config_fields(config_cls, params):
+        return params
+    return config_cls(**_config_kwargs(config_cls, params))
+
+
 @dataclass
 class VisionConfig(BaseModelConfig):
     model_type: str = "qwen3_vl"
@@ -94,26 +116,10 @@ class ModelConfig(BaseModelConfig):
     @classmethod
     def from_dict(cls, params):
         params = dict(params)
-        if isinstance(params.get("vision_config"), dict):
-            params["vision_config"] = VisionConfig(
-                **{
-                    k: v
-                    for k, v in params["vision_config"].items()
-                    if k in inspect.signature(VisionConfig).parameters
-                }
-            )
-        if isinstance(params.get("text_config"), dict):
-            params["text_config"] = TextConfig(
-                **{
-                    k: v
-                    for k, v in params["text_config"].items()
-                    if k in inspect.signature(TextConfig).parameters
-                }
-            )
-        return cls(
-            **{
-                k: v
-                for k, v in params.items()
-                if k in inspect.signature(cls).parameters
-            }
+        params["vision_config"] = _maybe_deserialize_config(
+            VisionConfig, params.get("vision_config")
         )
+        params["text_config"] = _maybe_deserialize_config(
+            TextConfig, params.get("text_config"), require_all_fields=True
+        )
+        return cls(**_config_kwargs(cls, params))

--- a/mlx_vlm/models/qwen3_vl/config.py
+++ b/mlx_vlm/models/qwen3_vl/config.py
@@ -93,7 +93,23 @@ class ModelConfig(BaseModelConfig):
 
     @classmethod
     def from_dict(cls, params):
-
+        params = dict(params)
+        if isinstance(params.get("vision_config"), dict):
+            params["vision_config"] = VisionConfig(
+                **{
+                    k: v
+                    for k, v in params["vision_config"].items()
+                    if k in inspect.signature(VisionConfig).parameters
+                }
+            )
+        if isinstance(params.get("text_config"), dict):
+            params["text_config"] = TextConfig(
+                **{
+                    k: v
+                    for k, v in params["text_config"].items()
+                    if k in inspect.signature(TextConfig).parameters
+                }
+            )
         return cls(
             **{
                 k: v

--- a/mlx_vlm/models/qwen3_vl_moe/config.py
+++ b/mlx_vlm/models/qwen3_vl_moe/config.py
@@ -1,8 +1,8 @@
-import inspect
 from dataclasses import dataclass, field
 from typing import Dict, List, Optional, Union
 
 from ..base import BaseModelConfig
+from ..qwen3_vl.config import _config_kwargs, _maybe_deserialize_config
 
 
 @dataclass
@@ -98,11 +98,11 @@ class ModelConfig(BaseModelConfig):
 
     @classmethod
     def from_dict(cls, params):
-
-        return cls(
-            **{
-                k: v
-                for k, v in params.items()
-                if k in inspect.signature(cls).parameters
-            }
+        params = dict(params)
+        params["vision_config"] = _maybe_deserialize_config(
+            VisionConfig, params.get("vision_config")
         )
+        params["text_config"] = _maybe_deserialize_config(
+            TextConfig, params.get("text_config"), require_all_fields=True
+        )
+        return cls(**_config_kwargs(cls, params))

--- a/mlx_vlm/tests/test_models.py
+++ b/mlx_vlm/tests/test_models.py
@@ -1406,6 +1406,22 @@ class TestModels(unittest.TestCase):
             deepstack_visual_indexes=[],
         )
 
+        config_from_dict = qwen3_vl_moe.ModelConfig.from_dict(
+            {
+                "model_type": "qwen3_vl_moe",
+                "text_config": vars(text_config).copy(),
+                "vision_config": {**vars(vision_config), "patch_size": 16},
+                "image_token_id": 151655,
+                "video_token_id": 151656,
+                "vocab_size": 10_000,
+            }
+        )
+        self.assertIsInstance(config_from_dict.text_config, qwen3_vl_moe.TextConfig)
+        self.assertIsInstance(config_from_dict.vision_config, qwen3_vl_moe.VisionConfig)
+        self.assertEqual(config_from_dict.vision_config.patch_size, 16)
+        model_from_dict = qwen3_vl_moe.Model(config_from_dict)
+        self.assertEqual(model_from_dict.vision_tower.patch_embed.patch_size, 16)
+
         config = qwen3_vl_moe.ModelConfig(
             text_config=text_config,
             vision_config=vision_config,

--- a/mlx_vlm/tests/test_models.py
+++ b/mlx_vlm/tests/test_models.py
@@ -1271,12 +1271,13 @@ class TestModels(unittest.TestCase):
                     {
                         "model_type": model_module.__name__.rsplit(".", 1)[-1],
                         "text_config": {},
-                        "vision_config": {},
+                        "vision_config": {"patch_size": 16},
                         "quantization": quantization,
                         "quantization_config": quantization,
                     }
                 )
 
+                self.assertEqual(config.vision_config.patch_size, 16)
                 self.assertIn(
                     "language_model.model.layers.0.linear_attn.in_proj_qkv",
                     config.quantization,
@@ -1351,9 +1352,10 @@ class TestModels(unittest.TestCase):
                     {
                         "model_type": model_module.__name__.rsplit(".", 1)[-1],
                         "text_config": {"eos_token_id": 248044},
-                        "vision_config": {},
+                        "vision_config": {"patch_size": 16},
                     }
                 )
+                self.assertEqual(config_from_dict.vision_config.patch_size, 16)
                 self.assertEqual(config_from_dict.eos_token_id, [248044, 248046])
 
                 explicit = model_module.ModelConfig(


### PR DESCRIPTION
## Summary

- `ModelConfig.from_dict()` in the Qwen3 VL-family config modules did not deserialize nested `vision_config` dicts into their dataclass types before constructing `ModelConfig`
- This caused `VisionConfig` defaults to silently override values from `config.json` on direct `ModelConfig.from_dict()` construction paths
- Critical for `patch_size`: `Qwen3VLVisionConfig` defaults `patch_size=14`, but Qwen3.6-VL models use `patch_size=16` (confirmed from actual weight shapes: `(1152, 2, 16, 16, 3)`)
- Result: the vision encoder can crash on image inputs with a reshape error when the processor prepares 16x16 patch input but the model config still uses 14x14 patches

## Root cause

The image processor can correctly use `patch_size=16` to compute pixel values while direct model config construction can leave `vision_config` as a raw dict or fall back to the dataclass default. In the failing path, `PatchEmbed` receives `patch_size=14`, so its reshape expects 14x14 patches while receiving 16x16-sized input.

## Fix

Explicitly deserialize nested `vision_config` dicts in `from_dict()` before passing them to the `ModelConfig` constructor. Full `text_config` dicts are also deserialized while partial text-config dicts remain supported for existing callers/tests. Applied to `qwen3_vl`, `qwen3_vl_moe`, `qwen3_5`, and `qwen3_5_moe`.

## Test plan

- [x] Verified `ModelConfig.from_dict(config)` now produces `vision_config.patch_size=16` for Qwen3.6-35B-A3B configs
- [x] Added regression coverage for `vision_config.patch_size=16` on `qwen3_5`, `qwen3_5_moe`, and `qwen3_vl_moe` nested config deserialization
- [x] Preserved existing partial `text_config` behavior for qwen3.5 configs
- [x] End-to-end image inference with `stream_generate` on Qwen3.6-35B-A3B-JANGTQ — previously crashed, now works
- [x] Tested with multiple image sizes (864x558 PNG, 840x560 JPEG, 448x448 PNG)

Generated with Claude Code and reviewed/patched with Codex.