### PR TITLE
Add ZAYA1-VL model support

### DIFF
--- a/mlx_vlm/models/qwen2_5_vl/vision.py
+++ b/mlx_vlm/models/qwen2_5_vl/vision.py
@@ -116,9 +116,8 @@ class PatchMerger(nn.Module):
 
     def __call__(self, x: mx.array) -> mx.array:
         x = self.ln_q(x).reshape(-1, self.hidden_size)
-        x = self.mlp[0](x)
-        x = self.mlp[1](x.astype(mx.float32)).astype(x.dtype)
-        x = self.mlp[2](x)
+        for layer in self.mlp:
+            x = layer(x)
         return x
 
 
@@ -172,11 +171,7 @@ class MLP(nn.Module):
         self.down_proj = nn.Linear(hidden_dim, dim)
 
     def __call__(self, x: mx.array) -> mx.array:
-        hidden_states = (
-            nn.silu(self.gate_proj(x).astype(mx.float32))
-            * self.up_proj(x).astype(mx.float32)
-        ).astype(x.dtype)
-        return self.down_proj(hidden_states)
+        return self.down_proj(nn.silu(self.gate_proj(x)) * self.up_proj(x))
 
 
 class Qwen2VLVisionBlock(nn.Module):

--- a/mlx_vlm/models/qwen2_5_vl/vision.py
+++ b/mlx_vlm/models/qwen2_5_vl/vision.py
@@ -116,8 +116,9 @@ class PatchMerger(nn.Module):
 
     def __call__(self, x: mx.array) -> mx.array:
         x = self.ln_q(x).reshape(-1, self.hidden_size)
-        for layer in self.mlp:
-            x = layer(x)
+        x = self.mlp[0](x)
+        x = self.mlp[1](x.astype(mx.float32)).astype(x.dtype)
+        x = self.mlp[2](x)
         return x
 
 
@@ -171,7 +172,11 @@ class MLP(nn.Module):
         self.down_proj = nn.Linear(hidden_dim, dim)
 
     def __call__(self, x: mx.array) -> mx.array:
-        return self.down_proj(nn.silu(self.gate_proj(x)) * self.up_proj(x))
+        hidden_states = (
+            nn.silu(self.gate_proj(x).astype(mx.float32))
+            * self.up_proj(x).astype(mx.float32)
+        ).astype(x.dtype)
+        return self.down_proj(hidden_states)
 
 
 class Qwen2VLVisionBlock(nn.Module):

--- a/mlx_vlm/models/zaya1_vl/__init__.py
+++ b/mlx_vlm/models/zaya1_vl/__init__.py
@@ -1,0 +1,15 @@
+from .config import ModelConfig, TextConfig, VisionConfig
+from .language import LanguageModel
+from .processing_zaya1_vl import Zaya1VLProcessor
+from ..qwen2_5_vl.vision import VisionModel
+from .zaya1_vl import Model
+
+__all__ = [
+    "Model",
+    "ModelConfig",
+    "TextConfig",
+    "VisionConfig",
+    "LanguageModel",
+    "VisionModel",
+    "Zaya1VLProcessor",
+]

--- a/mlx_vlm/models/zaya1_vl/__init__.py
+++ b/mlx_vlm/models/zaya1_vl/__init__.py
@@ -1,7 +1,7 @@
-from ..qwen2_5_vl.vision import VisionModel
 from .config import ModelConfig, TextConfig, VisionConfig
 from .language import LanguageModel
 from .processing_zaya1_vl import Zaya1VLProcessor
+from .vision import VisionModel
 from .zaya1_vl import Model
 
 __all__ = [

--- a/mlx_vlm/models/zaya1_vl/__init__.py
+++ b/mlx_vlm/models/zaya1_vl/__init__.py
@@ -1,7 +1,7 @@
+from ..qwen2_5_vl.vision import VisionModel
 from .config import ModelConfig, TextConfig, VisionConfig
 from .language import LanguageModel
 from .processing_zaya1_vl import Zaya1VLProcessor
-from ..qwen2_5_vl.vision import VisionModel
 from .zaya1_vl import Model
 
 __all__ = [

--- a/mlx_vlm/models/zaya1_vl/config.py
+++ b/mlx_vlm/models/zaya1_vl/config.py
@@ -1,0 +1,131 @@
+import inspect
+from dataclasses import dataclass
+from typing import Optional
+
+from ..base import BaseModelConfig
+from ..qwen2_5_vl.config import VisionConfig as Qwen2_5VisionConfig
+
+
+@dataclass
+class VisionConfig(Qwen2_5VisionConfig):
+    @classmethod
+    def from_dict(cls, params):
+        if not params:
+            return cls()
+
+        params = dict(params)
+        if "in_chans" in params and "in_channels" not in params:
+            params["in_channels"] = params["in_chans"]
+        if "spatial_patch_size" in params and "patch_size" not in params:
+            params["patch_size"] = params["spatial_patch_size"]
+
+        return cls(
+            **{
+                k: v
+                for k, v in params.items()
+                if k in inspect.signature(cls).parameters
+            }
+        )
+
+
+@dataclass
+class TextConfig(BaseModelConfig):
+    model_type: str = "zaya1_vl"
+    cca: bool = True
+    num_query_groups: int = 2
+    use_cache: bool = True
+    attention_bias: bool = False
+    lm_head_bias: bool = False
+    vocab_size: int = 262272
+    hidden_size: int = 2048
+    ffn_hidden_size: int = 4096
+    num_hidden_layers: int = 40
+    num_experts: int = 16
+    num_attention_heads: int = 8
+    head_dim: int = 128
+    activation_func: str = "swiglu"
+    max_position_embeddings: int = 32768
+    norm_epsilon: float = 1e-5
+    pad_token_id: Optional[int] = 0
+    bos_token_id: int = 2
+    eos_token_id: int = 262143
+    tie_word_embeddings: bool = True
+    rope_theta: float = 1000000.0
+    rotary_base: Optional[float] = None
+    attention_dropout: float = 0.0
+    moe_router_topk: int = 1
+    normalization: str = "RMSNorm"
+    zaya_mlp_expansion: int = 256
+    zaya_use_mod: bool = True
+    zaya_high_prec: bool = True
+    zaya_use_eda: bool = True
+    add_bias_linear: bool = False
+    gated_linear_unit: bool = True
+    scale_residual_merge: bool = True
+    fused_add_norm: bool = False
+    residual_in_fp32: bool = False
+    sliding_window: Optional[int] = None
+    rope_scaling: Optional[dict] = None
+    rope_parameters: Optional[dict] = None
+    partial_rotary_factor: float = 0.5
+    rope_pct: Optional[float] = None
+    num_key_value_heads: int = 2
+    clamp_temp: bool = False
+    cca_time0: int = 2
+    cca_time1: int = 2
+    swa_layers: Optional[list] = None
+    swa_rotary_base: Optional[float] = None
+    vision_lora: bool = True
+    vision_lora_rank_attn: Optional[int] = 8
+    vision_lora_rank_mlp: Optional[int] = 32
+    use_lora_att: bool = False
+    lora_rank: int = 0
+    initializer_range: float = 0.02
+
+    def __post_init__(self):
+        if self.rotary_base is not None:
+            self.rope_theta = self.rotary_base
+        if self.rope_pct is not None:
+            self.partial_rotary_factor = self.rope_pct
+        if self.num_key_value_heads is None:
+            self.num_key_value_heads = self.num_query_groups
+        if self.num_query_groups != self.num_key_value_heads:
+            raise ValueError("num_query_groups must match num_key_value_heads")
+
+        rope_parameters = self.rope_parameters or self.rope_scaling or {}
+        rope_parameters = dict(rope_parameters)
+        if "type" in rope_parameters and "rope_type" not in rope_parameters:
+            rope_parameters["rope_type"] = rope_parameters.pop("type")
+        rope_parameters.setdefault("rope_type", "default")
+        rope_parameters.setdefault("rope_theta", self.rope_theta)
+        rope_parameters.setdefault("partial_rotary_factor", self.partial_rotary_factor)
+        self.rope_parameters = rope_parameters
+
+
+@dataclass
+class ModelConfig(BaseModelConfig):
+    text_config: TextConfig
+    vision_config: VisionConfig
+    model_type: str = "zaya1_vl"
+    image_token_id: int = 262147
+    vision_start_token_id: Optional[int] = 255999
+    vision_end_token_id: Optional[int] = 256000
+    projector_hidden_act: str = "gelu"
+    vocab_size: int = 262272
+    eos_token_id: int = 262143
+    pad_token_id: int = 0
+
+    @classmethod
+    def from_dict(cls, params):
+        excluded_keys = {"vision_config"}
+        params["text_config"] = dict(
+            filter(lambda item: item[0] not in excluded_keys, params.items())
+        )
+
+        return cls(
+            **{
+                k: v
+                for k, v in params.items()
+                if k in inspect.signature(cls).parameters
+            }
+        )

--- a/mlx_vlm/models/zaya1_vl/language.py
+++ b/mlx_vlm/models/zaya1_vl/language.py
@@ -4,6 +4,7 @@ from typing import Optional
 import mlx.core as mx
 import mlx.nn as nn
 from mlx_lm.models.cache import ArraysCache, CacheList, KVCache
+from mlx_lm.models.rope_utils import initialize_rope
 from mlx_lm.models.switch_layers import SwitchLinear
 
 from ..base import LanguageModelOutput, create_attention_mask, scaled_dot_product_attention
@@ -24,63 +25,10 @@ def _cache_is_empty(cache) -> bool:
     return cache is None or (hasattr(cache, "empty") and cache.empty())
 
 
-def _position_ids_from_cache(batch_size: int, length: int, cache) -> mx.array:
-    positions = mx.arange(length)
-    if cache is None or not hasattr(cache, "offset"):
-        return mx.broadcast_to(positions[None, :], (batch_size, length))
-
-    offset = cache.offset
-    if isinstance(offset, mx.array):
-        if offset.ndim == 0:
-            offset = offset.reshape(1, 1)
-        else:
-            offset = offset[:, None]
-    else:
-        offset = mx.array(offset).reshape(1, 1)
-    return offset + positions[None, :]
-
-
 def _repeat_kv(x: mx.array, repeats: int) -> mx.array:
     if repeats == 1:
         return x
     return mx.repeat(x, repeats, axis=1)
-
-
-def _rotate_half(x):
-    x1 = x[..., : x.shape[-1] // 2]
-    x2 = x[..., x.shape[-1] // 2 :]
-    return mx.concatenate([-x2, x1], axis=-1)
-
-
-class ZayaRotaryEmbedding:
-    def __init__(self, config: TextConfig):
-        self.dim = int(config.head_dim * config.rope_parameters["partial_rotary_factor"])
-        self.base = config.rope_parameters["rope_theta"]
-        self.inv_freq = 1.0 / (
-            self.base ** (mx.arange(0, self.dim, 2).astype(mx.float32) / self.dim)
-        )
-
-    def __call__(self, position_ids: mx.array):
-        freqs = position_ids.astype(mx.float32)[..., None] * self.inv_freq
-        emb = mx.concatenate([freqs, freqs], axis=-1)
-        return mx.cos(emb), mx.sin(emb)
-
-
-def apply_rotary_pos_emb(q, k, cos, sin):
-    cos = mx.expand_dims(cos, axis=1)
-    sin = mx.expand_dims(sin, axis=1)
-    rotary_dim = cos.shape[-1]
-
-    q_rot, q_pass = q[..., :rotary_dim], q[..., rotary_dim:]
-    k_rot, k_pass = k[..., :rotary_dim], k[..., rotary_dim:]
-
-    q_embed = (q_rot * cos) + (_rotate_half(q_rot) * sin)
-    k_embed = (k_rot * cos) + (_rotate_half(k_rot) * sin)
-
-    return (
-        mx.concatenate([q_embed.astype(q.dtype), q_pass], axis=-1),
-        mx.concatenate([k_embed.astype(k.dtype), k_pass], axis=-1),
-    )
 
 
 class ResidualScaling(nn.Module):
@@ -308,7 +256,13 @@ class ZayaAttention(nn.Module):
             bias=config.attention_bias,
         )
         self.qkv = CCA(config, layer_n)
-        self.rotary_emb = ZayaRotaryEmbedding(config)
+        self.rope = initialize_rope(
+            int(config.head_dim * config.rope_parameters["partial_rotary_factor"]),
+            base=config.rope_parameters["rope_theta"],
+            traditional=False,
+            scaling_config=config.rope_parameters,
+            max_position_embeddings=config.max_position_embeddings,
+        )
 
         if config.vision_lora:
             r = config.vision_lora_rank_attn
@@ -339,8 +293,9 @@ class ZayaAttention(nn.Module):
             0, 2, 1, 3
         )
 
-        cos, sin = self.rotary_emb(_position_ids_from_cache(B, L, kv_cache))
-        q, k = apply_rotary_pos_emb(q, k, cos, sin)
+        offset = kv_cache.offset if kv_cache is not None else 0
+        q = self.rope(q, offset=offset)
+        k = self.rope(k, offset=offset)
 
         if kv_cache is not None:
             k, v = kv_cache.update_and_fetch(k, v)

--- a/mlx_vlm/models/zaya1_vl/language.py
+++ b/mlx_vlm/models/zaya1_vl/language.py
@@ -300,9 +300,6 @@ class ZayaAttention(nn.Module):
         if kv_cache is not None:
             k, v = kv_cache.update_and_fetch(k, v)
 
-        k = _repeat_kv(k, self.num_key_value_groups)
-        v = _repeat_kv(v, self.num_key_value_groups)
-
         if mask is not None and isinstance(mask, mx.array):
             mask = mask[..., : k.shape[-2]]
 

--- a/mlx_vlm/models/zaya1_vl/language.py
+++ b/mlx_vlm/models/zaya1_vl/language.py
@@ -373,9 +373,7 @@ class ZayaRouter(nn.Module):
         self.down_proj = nn.Linear(
             config.hidden_size, config.zaya_mlp_expansion, bias=True
         )
-        self.rmsnorm_eda = RMSNorm(
-            config.zaya_mlp_expansion, eps=config.norm_epsilon
-        )
+        self.rmsnorm_eda = RMSNorm(config.zaya_mlp_expansion, eps=config.norm_epsilon)
         if self.use_eda:
             self.router_states_scale = mx.ones((config.zaya_mlp_expansion,))
 

--- a/mlx_vlm/models/zaya1_vl/language.py
+++ b/mlx_vlm/models/zaya1_vl/language.py
@@ -3,7 +3,7 @@ from typing import Optional
 
 import mlx.core as mx
 import mlx.nn as nn
-from mlx_lm.models.cache import ArraysCache, CacheList, KVCache
+from ..cache import ArraysCache, CacheList, KVCache
 from mlx_lm.models.rope_utils import initialize_rope
 from mlx_lm.models.switch_layers import SwitchLinear
 
@@ -27,6 +27,39 @@ def _split_cache(cache):
 
 def _cache_is_empty(cache) -> bool:
     return cache is None or (hasattr(cache, "empty") and cache.empty())
+
+
+def _causal_conv1d_stack(
+    conv_layers, x: mx.array, state, state_size: int, use_state: bool
+):
+    if use_state:
+        if (
+            state is None
+            or state.shape[0] != x.shape[0]
+            or state.shape[1] != state_size
+        ):
+            state = mx.zeros((x.shape[0], state_size, x.shape[-1]), dtype=x.dtype)
+        conv_input = mx.concatenate([state, x], axis=1)
+        state_source = conv_input
+    else:
+        conv_input = mx.pad(x, ((0, 0), (state_size, 0), (0, 0)))
+        state_source = x
+
+    y = conv_input
+    for conv in conv_layers:
+        y = conv(y)
+
+    if state_size == 0:
+        next_state = mx.zeros((x.shape[0], 0, x.shape[-1]), dtype=x.dtype)
+    else:
+        if state_source.shape[1] < state_size:
+            state_source = mx.pad(
+                state_source,
+                ((0, 0), (state_size - state_source.shape[1], 0), (0, 0)),
+            )
+        next_state = mx.contiguous(state_source[:, -state_size:, :])
+
+    return y, next_state
 
 
 class ResidualScaling(nn.Module):
@@ -121,36 +154,16 @@ class CCA(nn.Module):
 
     def _conv(self, qk_packed0: mx.array, aux_cache, kv_cache):
         x = qk_packed0.transpose(1, 0, 2)
-        use_decode_state = (
-            aux_cache is not None
-            and not _cache_is_empty(kv_cache)
-            and aux_cache[0] is not None
-            and x.shape[1] == 1
+        state = aux_cache[0] if aux_cache is not None else None
+        y, state = _causal_conv1d_stack(
+            self.conv_qk,
+            x,
+            state,
+            self.total_padding,
+            use_state=aux_cache is not None and not _cache_is_empty(kv_cache),
         )
-
-        if use_decode_state:
-            cached = aux_cache[0]
-            if cached.shape[0] != x.shape[0]:
-                cached = mx.zeros(
-                    (x.shape[0], self.cca_time0, x.shape[-1]), dtype=x.dtype
-                )
-            conv_input = mx.concatenate([cached, x], axis=1)
-        else:
-            conv_input = mx.pad(x, ((0, 0), (self.total_padding, 0), (0, 0)))
-
-        y = conv_input
-        for conv in self.conv_qk:
-            y = conv(y)
-
         if aux_cache is not None:
-            tail_source = conv_input if use_decode_state else x
-            if tail_source.shape[1] < self.cca_time0:
-                tail_source = mx.pad(
-                    tail_source,
-                    ((0, 0), (self.cca_time0 - tail_source.shape[1], 0), (0, 0)),
-                )
-            aux_cache[0] = tail_source[:, -self.cca_time0 :, :]
-
+            aux_cache[0] = state
         return y.transpose(1, 0, 2)
 
     def __call__(
@@ -213,9 +226,8 @@ class CCA(nn.Module):
             aux_cache is not None
             and not _cache_is_empty(kv_cache)
             and aux_cache[1] is not None
-            and hs.shape[0] == 1
         ):
-            hs_d = aux_cache[1][None, ...]
+            hs_d = mx.concatenate([aux_cache[1][None, ...], hs[:-1]], axis=0)
         if aux_cache is not None:
             aux_cache[1] = hs[-1]
 

--- a/mlx_vlm/models/zaya1_vl/language.py
+++ b/mlx_vlm/models/zaya1_vl/language.py
@@ -91,19 +91,6 @@ class ResidualScaling(nn.Module):
         return residual, hidden_states
 
 
-class RMSNorm(nn.Module):
-    def __init__(self, dims: int, eps: float = 1e-6):
-        super().__init__()
-        self.weight = mx.ones((dims,))
-        self.eps = eps
-
-    def __call__(self, x: mx.array) -> mx.array:
-        dtype = x.dtype
-        x = x.astype(mx.float32)
-        x = x * mx.rsqrt(mx.mean(x * x, axis=-1, keepdims=True) + self.eps)
-        return self.weight * x.astype(dtype)
-
-
 class CCA(nn.Module):
     def __init__(self, config: TextConfig, layer_number: int):
         super().__init__()
@@ -373,7 +360,9 @@ class ZayaRouter(nn.Module):
         self.down_proj = nn.Linear(
             config.hidden_size, config.zaya_mlp_expansion, bias=True
         )
-        self.rmsnorm_eda = RMSNorm(config.zaya_mlp_expansion, eps=config.norm_epsilon)
+        self.rmsnorm_eda = nn.RMSNorm(
+            config.zaya_mlp_expansion, eps=config.norm_epsilon
+        )
         if self.use_eda:
             self.router_states_scale = mx.ones((config.zaya_mlp_expansion,))
 
@@ -526,7 +515,7 @@ class ZayaDecoderATTLayer(nn.Module):
         super().__init__()
         self.config = config
         self.self_attn = ZayaAttention(config, layer_n)
-        self.input_norm = RMSNorm(config.hidden_size, eps=config.norm_epsilon)
+        self.input_norm = nn.RMSNorm(config.hidden_size, eps=config.norm_epsilon)
         if config.scale_residual_merge:
             self.res_scale = ResidualScaling(config, 2 * layer_n)
 
@@ -552,7 +541,7 @@ class ZayaDecoderMLPLayer(nn.Module):
         super().__init__()
         self.config = config
         self.zaya_block = ZayaBlock(config, layer_n)
-        self.input_norm = RMSNorm(config.hidden_size, eps=config.norm_epsilon)
+        self.input_norm = nn.RMSNorm(config.hidden_size, eps=config.norm_epsilon)
         if config.scale_residual_merge:
             self.res_scale = ResidualScaling(config, 2 * layer_n + 1)
 
@@ -616,7 +605,7 @@ class ZayaModel(nn.Module):
         ]
         if config.scale_residual_merge:
             self.res_scale = ResidualScaling(config, config.num_hidden_layers)
-        self.final_norm = RMSNorm(config.hidden_size, eps=config.norm_epsilon)
+        self.final_norm = nn.RMSNorm(config.hidden_size, eps=config.norm_epsilon)
 
     def __call__(
         self,

--- a/mlx_vlm/models/zaya1_vl/language.py
+++ b/mlx_vlm/models/zaya1_vl/language.py
@@ -7,7 +7,11 @@ from mlx_lm.models.cache import ArraysCache, CacheList, KVCache
 from mlx_lm.models.rope_utils import initialize_rope
 from mlx_lm.models.switch_layers import SwitchLinear
 
-from ..base import LanguageModelOutput, create_attention_mask, scaled_dot_product_attention
+from ..base import (
+    LanguageModelOutput,
+    create_attention_mask,
+    scaled_dot_product_attention,
+)
 from .config import ModelConfig, TextConfig
 
 
@@ -25,12 +29,6 @@ def _cache_is_empty(cache) -> bool:
     return cache is None or (hasattr(cache, "empty") and cache.empty())
 
 
-def _repeat_kv(x: mx.array, repeats: int) -> mx.array:
-    if repeats == 1:
-        return x
-    return mx.repeat(x, repeats, axis=1)
-
-
 class ResidualScaling(nn.Module):
     def __init__(self, config: TextConfig, layer_n: int):
         super().__init__()
@@ -42,7 +40,9 @@ class ResidualScaling(nn.Module):
             self.residual_bias = mx.zeros((config.hidden_size,))
 
     def __call__(self, residual: Optional[mx.array], hidden_states: mx.array):
-        hidden_states = (hidden_states + self.hidden_states_bias) * self.hidden_states_scale
+        hidden_states = (
+            hidden_states + self.hidden_states_bias
+        ) * self.hidden_states_scale
         if self.not_first_layer and residual is not None:
             residual = (residual + self.residual_bias) * self.residual_scale
         return residual, hidden_states
@@ -163,7 +163,9 @@ class CCA(nn.Module):
         kv_cache, aux_cache = _split_cache(cache)
 
         if cca_mask is not None and hidden_states.shape[1] > 1:
-            hidden_states = hidden_states * cca_mask[..., None].astype(hidden_states.dtype)
+            hidden_states = hidden_states * cca_mask[..., None].astype(
+                hidden_states.dtype
+            )
 
         hs = hidden_states.transpose(1, 0, 2)
         if hs.shape[0] > 1:
@@ -228,16 +230,16 @@ class CCA(nn.Module):
         query_norm = mx.sqrt(mx.sum(query * query, axis=-1, keepdims=True) + 1e-6)
         key_norm = mx.sqrt(mx.sum(key * key, axis=-1, keepdims=True) + 1e-6)
         query = query * (self.sqrt_head_dim / query_norm)
-        key = (
-            key
-            * (self.sqrt_head_dim / key_norm)
-            * self.temp[None, None, :, None]
-        )
+        key = key * (self.sqrt_head_dim / key_norm) * self.temp[None, None, :, None]
 
         query = query.reshape(*query.shape[:2], self.num_q_heads * self.head_dim)
         key = key.reshape(*key.shape[:2], self.num_kv_heads * self.head_dim)
         value = value.reshape(*value.shape[:2], self.num_kv_heads * self.head_dim)
-        return query.transpose(1, 0, 2), key.transpose(1, 0, 2), value.transpose(1, 0, 2)
+        return (
+            query.transpose(1, 0, 2),
+            key.transpose(1, 0, 2),
+            value.transpose(1, 0, 2),
+        )
 
 
 class ZayaAttention(nn.Module):
@@ -303,13 +305,17 @@ class ZayaAttention(nn.Module):
         if mask is not None and isinstance(mask, mx.array):
             mask = mask[..., : k.shape[-2]]
 
-        out = scaled_dot_product_attention(q, k, v, cache=None, scale=self.scale, mask=mask)
+        out = scaled_dot_product_attention(
+            q, k, v, cache=None, scale=self.scale, mask=mask
+        )
         out = out.transpose(0, 2, 1, 3).reshape(B, L, -1)
 
         projected = self.o_proj(out)
         if self.config.vision_lora and image_mask is not None:
             addon = self.lora_linear_o[1](self.lora_linear_o[0](out))
-            projected = projected + addon * image_mask[..., None].astype(projected.dtype)
+            projected = projected + addon * image_mask[..., None].astype(
+                projected.dtype
+            )
         return projected
 
 
@@ -324,7 +330,9 @@ class ZayaRouter(nn.Module):
         self.layer_number = layer_number
         self.use_eda = config.zaya_use_eda and layer_number != 0
 
-        self.down_proj = nn.Linear(config.hidden_size, config.zaya_mlp_expansion, bias=True)
+        self.down_proj = nn.Linear(
+            config.hidden_size, config.zaya_mlp_expansion, bias=True
+        )
         self.rmsnorm_eda = nn.RMSNorm(config.zaya_mlp_expansion, eps=1e-6)
         if self.use_eda:
             self.router_states_scale = mx.ones((config.zaya_mlp_expansion,))
@@ -340,7 +348,9 @@ class ZayaRouter(nn.Module):
         if self.use_mod:
             self.balancing_biases[-1] = -1.0
 
-    def __call__(self, hidden_states: mx.array, router_states: Optional[mx.array] = None):
+    def __call__(
+        self, hidden_states: mx.array, router_states: Optional[mx.array] = None
+    ):
         hs = self.down_proj(hidden_states)
         if self.use_eda and router_states is not None:
             hs = hs + router_states * self.router_states_scale
@@ -349,7 +359,9 @@ class ZayaRouter(nn.Module):
         for layer in self.router_mlp:
             hs = layer(hs)
 
-        expert_prob = mx.softmax(hs.astype(mx.float32), axis=-1).astype(hidden_states.dtype)
+        expert_prob = mx.softmax(hs.astype(mx.float32), axis=-1).astype(
+            hidden_states.dtype
+        )
         biased = expert_prob.astype(mx.float32) + self.balancing_biases
         if self.topk == 1:
             expert_choice = mx.expand_dims(mx.argmax(biased, axis=-1), axis=-1)
@@ -360,20 +372,6 @@ class ZayaRouter(nn.Module):
             ]
             route_prob = mx.take_along_axis(expert_prob, expert_choice, axis=-1)
         return route_prob, expert_choice, next_router_states
-
-
-def _switch_linear(linear: SwitchLinear, x: mx.array, indices: mx.array) -> mx.array:
-    if x.ndim == indices.ndim:
-        x = mx.expand_dims(x, (-2, -3))
-    elif x.ndim == indices.ndim + 1:
-        if x.shape[:-1] == indices.shape:
-            x = mx.expand_dims(x, -2)
-        else:
-            x = mx.expand_dims(x, (-2, -3))
-    else:
-        x = mx.expand_dims(x, -2)
-    y = linear(x, indices, sorted_indices=False)
-    return y.squeeze(-2)
 
 
 class ZayaSwitchMLP(nn.Module):
@@ -389,10 +387,16 @@ class ZayaSwitchMLP(nn.Module):
             else config.ffn_hidden_size
         )
         self.linear_fc1 = SwitchLinear(
-            config.hidden_size, self.ffn_hidden_size, config.num_experts, bias=config.add_bias_linear
+            config.hidden_size,
+            self.ffn_hidden_size,
+            config.num_experts,
+            bias=config.add_bias_linear,
         )
         self.linear_fc2 = SwitchLinear(
-            self.ffn_hidden_size_out, config.hidden_size, config.num_experts, bias=config.add_bias_linear
+            self.ffn_hidden_size_out,
+            config.hidden_size,
+            config.num_experts,
+            bias=config.add_bias_linear,
         )
 
         if config.vision_lora:
@@ -402,7 +406,9 @@ class ZayaSwitchMLP(nn.Module):
                 SwitchLinear(r, self.ffn_hidden_size, config.num_experts, bias=False),
             ]
             self.lora_fc2 = [
-                SwitchLinear(self.ffn_hidden_size_out, r, config.num_experts, bias=False),
+                SwitchLinear(
+                    self.ffn_hidden_size_out, r, config.num_experts, bias=False
+                ),
                 SwitchLinear(r, config.hidden_size, config.num_experts, bias=False),
             ]
 
@@ -416,10 +422,17 @@ class ZayaSwitchMLP(nn.Module):
         skip_mask = expert_choice == self.num_experts
         expert_indices = mx.minimum(expert_choice, self.num_experts - 1)
 
-        x = _switch_linear(self.linear_fc1, hidden_states, expert_indices)
+        routed_hidden_states = hidden_states[..., None, None, :]
+        x = self.linear_fc1(
+            routed_hidden_states, expert_indices, sorted_indices=False
+        ).squeeze(-2)
         if self.config.vision_lora and image_mask is not None:
-            addon = _switch_linear(self.lora_fc1[0], hidden_states, expert_indices)
-            addon = _switch_linear(self.lora_fc1[1], addon, expert_indices)
+            addon = self.lora_fc1[0](
+                routed_hidden_states, expert_indices, sorted_indices=False
+            ).squeeze(-2)
+            addon = self.lora_fc1[1](
+                addon[..., None, :], expert_indices, sorted_indices=False
+            ).squeeze(-2)
             x = x + addon * image_mask[..., None, None].astype(x.dtype)
 
         if self.config.gated_linear_unit:
@@ -430,10 +443,16 @@ class ZayaSwitchMLP(nn.Module):
         else:
             x = nn.silu(x)
 
-        y = _switch_linear(self.linear_fc2, x, expert_indices)
+        y = self.linear_fc2(
+            x[..., None, :], expert_indices, sorted_indices=False
+        ).squeeze(-2)
         if self.config.vision_lora and image_mask is not None:
-            addon = _switch_linear(self.lora_fc2[0], x, expert_indices)
-            addon = _switch_linear(self.lora_fc2[1], addon, expert_indices)
+            addon = self.lora_fc2[0](
+                x[..., None, :], expert_indices, sorted_indices=False
+            ).squeeze(-2)
+            addon = self.lora_fc2[1](
+                addon[..., None, :], expert_indices, sorted_indices=False
+            ).squeeze(-2)
             y = y + addon * image_mask[..., None, None].astype(y.dtype)
 
         if self.config.zaya_use_mod:
@@ -553,8 +572,7 @@ class ZayaModel(nn.Module):
         self.config = config
         self.embed_tokens = nn.Embedding(config.vocab_size, config.hidden_size)
         self.layers = [
-            ZayaDecoderBlock(config, layer_n=i)
-            for i in range(config.num_hidden_layers)
+            ZayaDecoderBlock(config, layer_n=i) for i in range(config.num_hidden_layers)
         ]
         if config.scale_residual_merge:
             self.res_scale = ResidualScaling(config, config.num_hidden_layers)
@@ -603,7 +621,9 @@ class LanguageModel(nn.Module):
         self.model_type = args.model_type
         self.model = ZayaModel(args)
         if not args.tie_word_embeddings:
-            self.lm_head = nn.Linear(args.hidden_size, args.vocab_size, bias=args.lm_head_bias)
+            self.lm_head = nn.Linear(
+                args.hidden_size, args.vocab_size, bias=args.lm_head_bias
+            )
 
     def __call__(
         self,
@@ -640,7 +660,9 @@ class LanguageModel(nn.Module):
                     if key in sanitized_weights:
                         stacked.append(sanitized_weights.pop(key))
                 if stacked:
-                    sanitized_weights[f"{prefix}.{name}.weight"] = mx.stack(stacked, axis=0)
+                    sanitized_weights[f"{prefix}.{name}.weight"] = mx.stack(
+                        stacked, axis=0
+                    )
 
             if self.args.vision_lora:
                 for lora_name in ("lora_fc1", "lora_fc2"):

--- a/mlx_vlm/models/zaya1_vl/language.py
+++ b/mlx_vlm/models/zaya1_vl/language.py
@@ -91,6 +91,19 @@ class ResidualScaling(nn.Module):
         return residual, hidden_states
 
 
+class RMSNorm(nn.Module):
+    def __init__(self, dims: int, eps: float = 1e-6):
+        super().__init__()
+        self.weight = mx.ones((dims,))
+        self.eps = eps
+
+    def __call__(self, x: mx.array) -> mx.array:
+        dtype = x.dtype
+        x = x.astype(mx.float32)
+        x = x * mx.rsqrt(mx.mean(x * x, axis=-1, keepdims=True) + self.eps)
+        return (x * self.weight.astype(mx.float32)).astype(dtype)
+
+
 class CCA(nn.Module):
     def __init__(self, config: TextConfig, layer_number: int):
         super().__init__()
@@ -355,7 +368,7 @@ class ZayaRouter(nn.Module):
         self.down_proj = nn.Linear(
             config.hidden_size, config.zaya_mlp_expansion, bias=True
         )
-        self.rmsnorm_eda = nn.RMSNorm(config.zaya_mlp_expansion, eps=1e-6)
+        self.rmsnorm_eda = RMSNorm(config.zaya_mlp_expansion, eps=1e-6)
         if self.use_eda:
             self.router_states_scale = mx.ones((config.zaya_mlp_expansion,))
 
@@ -508,7 +521,7 @@ class ZayaDecoderATTLayer(nn.Module):
         super().__init__()
         self.config = config
         self.self_attn = ZayaAttention(config, layer_n)
-        self.input_norm = nn.RMSNorm(config.hidden_size, eps=config.norm_epsilon)
+        self.input_norm = RMSNorm(config.hidden_size, eps=config.norm_epsilon)
         if config.scale_residual_merge:
             self.res_scale = ResidualScaling(config, 2 * layer_n)
 
@@ -534,7 +547,7 @@ class ZayaDecoderMLPLayer(nn.Module):
         super().__init__()
         self.config = config
         self.zaya_block = ZayaBlock(config, layer_n)
-        self.input_norm = nn.RMSNorm(config.hidden_size, eps=config.norm_epsilon)
+        self.input_norm = RMSNorm(config.hidden_size, eps=config.norm_epsilon)
         if config.scale_residual_merge:
             self.res_scale = ResidualScaling(config, 2 * layer_n + 1)
 
@@ -598,7 +611,7 @@ class ZayaModel(nn.Module):
         ]
         if config.scale_residual_merge:
             self.res_scale = ResidualScaling(config, config.num_hidden_layers)
-        self.final_norm = nn.RMSNorm(config.hidden_size, eps=config.norm_epsilon)
+        self.final_norm = RMSNorm(config.hidden_size, eps=config.norm_epsilon)
 
     def __call__(
         self,
@@ -660,6 +673,18 @@ class LanguageModel(nn.Module):
         cache=None,
         **kwargs,
     ):
+        if image_mask is None:
+            image_mask = kwargs.pop("visual_pos_masks", None)
+        else:
+            kwargs.pop("visual_pos_masks", None)
+
+        if image_mask is not None and image_mask.shape[1] != input_ids.shape[1]:
+            first_kv_cache, _ = _split_cache(cache[0]) if cache else (None, None)
+            start = 0
+            if first_kv_cache is not None and hasattr(first_kv_cache, "offset"):
+                start = int(first_kv_cache.offset)
+            image_mask = image_mask[:, start : start + input_ids.shape[1]]
+
         out = self.model(input_ids, inputs_embeds, mask, image_mask, cache)
         if self.args.tie_word_embeddings:
             logits = self.model.embed_tokens.as_linear(out)

--- a/mlx_vlm/models/zaya1_vl/language.py
+++ b/mlx_vlm/models/zaya1_vl/language.py
@@ -29,6 +29,16 @@ def _cache_is_empty(cache) -> bool:
     return cache is None or (hasattr(cache, "empty") and cache.empty())
 
 
+def _cache_position_mask(hidden_states: mx.array, cache) -> Optional[mx.array]:
+    left_padding = getattr(cache, "left_padding", None)
+    if left_padding is None:
+        return None
+
+    size = cache.size() if hasattr(cache, "size") else 0
+    positions = mx.arange(hidden_states.shape[1]) + size
+    return positions[None, :] >= left_padding[:, None]
+
+
 def _causal_conv1d_stack(
     conv_layers, x: mx.array, state, state_size: int, use_state: bool
 ):
@@ -604,7 +614,11 @@ class ZayaModel(nn.Module):
 
         first_kv_cache, _ = _split_cache(cache[0]) if cache else (None, None)
         attn_mask = create_attention_mask(h, first_kv_cache)
-        cca_mask = mask
+        padding_mask = _cache_position_mask(h, first_kv_cache)
+        if mask is not None and getattr(mask, "ndim", 0) == 2:
+            cca_mask = mask if padding_mask is None else mask & padding_mask
+        else:
+            cca_mask = padding_mask
 
         residual = None
         prev_router_hidden_states = None

--- a/mlx_vlm/models/zaya1_vl/language.py
+++ b/mlx_vlm/models/zaya1_vl/language.py
@@ -3,7 +3,6 @@ from typing import Optional
 
 import mlx.core as mx
 import mlx.nn as nn
-from ..cache import ArraysCache, CacheList, KVCache
 from mlx_lm.models.rope_utils import initialize_rope
 from mlx_lm.models.switch_layers import SwitchLinear
 
@@ -12,6 +11,7 @@ from ..base import (
     create_attention_mask,
     scaled_dot_product_attention,
 )
+from ..cache import ArraysCache, CacheList, KVCache
 from .config import ModelConfig, TextConfig
 
 

--- a/mlx_vlm/models/zaya1_vl/language.py
+++ b/mlx_vlm/models/zaya1_vl/language.py
@@ -101,7 +101,7 @@ class RMSNorm(nn.Module):
         dtype = x.dtype
         x = x.astype(mx.float32)
         x = x * mx.rsqrt(mx.mean(x * x, axis=-1, keepdims=True) + self.eps)
-        return (x * self.weight.astype(mx.float32)).astype(dtype)
+        return self.weight * x.astype(dtype)
 
 
 class CCA(nn.Module):
@@ -262,8 +262,13 @@ class CCA(nn.Module):
             *hs.shape[:2], self.num_kv_heads, self.head_dim
         )
 
-        query_norm = mx.sqrt(mx.sum(query * query, axis=-1, keepdims=True) + 1e-6)
-        key_norm = mx.sqrt(mx.sum(key * key, axis=-1, keepdims=True) + 1e-6)
+        norm_eps = mx.finfo(query.dtype).eps
+        query_norm = mx.maximum(
+            mx.sqrt(mx.sum(query * query, axis=-1, keepdims=True)), norm_eps
+        )
+        key_norm = mx.maximum(
+            mx.sqrt(mx.sum(key * key, axis=-1, keepdims=True)), norm_eps
+        )
         query = query * (self.sqrt_head_dim / query_norm)
         key = key * (self.sqrt_head_dim / key_norm) * self.temp[None, None, :, None]
 
@@ -368,7 +373,9 @@ class ZayaRouter(nn.Module):
         self.down_proj = nn.Linear(
             config.hidden_size, config.zaya_mlp_expansion, bias=True
         )
-        self.rmsnorm_eda = RMSNorm(config.zaya_mlp_expansion, eps=1e-6)
+        self.rmsnorm_eda = RMSNorm(
+            config.zaya_mlp_expansion, eps=config.norm_epsilon
+        )
         if self.use_eda:
             self.router_states_scale = mx.ones((config.zaya_mlp_expansion,))
 

--- a/mlx_vlm/models/zaya1_vl/language.py
+++ b/mlx_vlm/models/zaya1_vl/language.py
@@ -1,0 +1,715 @@
+import math
+from typing import Optional
+
+import mlx.core as mx
+import mlx.nn as nn
+from mlx_lm.models.cache import ArraysCache, CacheList, KVCache
+from mlx_lm.models.switch_layers import SwitchLinear
+
+from ..base import LanguageModelOutput, create_attention_mask, scaled_dot_product_attention
+from .config import ModelConfig, TextConfig
+
+
+def _split_cache(cache):
+    if cache is None:
+        return None, None
+    if isinstance(cache, CacheList):
+        return cache[0], cache[1]
+    if isinstance(cache, (tuple, list)) and len(cache) == 2:
+        return cache[0], cache[1]
+    return cache, None
+
+
+def _cache_is_empty(cache) -> bool:
+    return cache is None or (hasattr(cache, "empty") and cache.empty())
+
+
+def _position_ids_from_cache(batch_size: int, length: int, cache) -> mx.array:
+    positions = mx.arange(length)
+    if cache is None or not hasattr(cache, "offset"):
+        return mx.broadcast_to(positions[None, :], (batch_size, length))
+
+    offset = cache.offset
+    if isinstance(offset, mx.array):
+        if offset.ndim == 0:
+            offset = offset.reshape(1, 1)
+        else:
+            offset = offset[:, None]
+    else:
+        offset = mx.array(offset).reshape(1, 1)
+    return offset + positions[None, :]
+
+
+def _repeat_kv(x: mx.array, repeats: int) -> mx.array:
+    if repeats == 1:
+        return x
+    return mx.repeat(x, repeats, axis=1)
+
+
+def _rotate_half(x):
+    x1 = x[..., : x.shape[-1] // 2]
+    x2 = x[..., x.shape[-1] // 2 :]
+    return mx.concatenate([-x2, x1], axis=-1)
+
+
+class ZayaRotaryEmbedding:
+    def __init__(self, config: TextConfig):
+        self.dim = int(config.head_dim * config.rope_parameters["partial_rotary_factor"])
+        self.base = config.rope_parameters["rope_theta"]
+        self.inv_freq = 1.0 / (
+            self.base ** (mx.arange(0, self.dim, 2).astype(mx.float32) / self.dim)
+        )
+
+    def __call__(self, position_ids: mx.array):
+        freqs = position_ids.astype(mx.float32)[..., None] * self.inv_freq
+        emb = mx.concatenate([freqs, freqs], axis=-1)
+        return mx.cos(emb), mx.sin(emb)
+
+
+def apply_rotary_pos_emb(q, k, cos, sin):
+    cos = mx.expand_dims(cos, axis=1)
+    sin = mx.expand_dims(sin, axis=1)
+    rotary_dim = cos.shape[-1]
+
+    q_rot, q_pass = q[..., :rotary_dim], q[..., rotary_dim:]
+    k_rot, k_pass = k[..., :rotary_dim], k[..., rotary_dim:]
+
+    q_embed = (q_rot * cos) + (_rotate_half(q_rot) * sin)
+    k_embed = (k_rot * cos) + (_rotate_half(k_rot) * sin)
+
+    return (
+        mx.concatenate([q_embed.astype(q.dtype), q_pass], axis=-1),
+        mx.concatenate([k_embed.astype(k.dtype), k_pass], axis=-1),
+    )
+
+
+class ResidualScaling(nn.Module):
+    def __init__(self, config: TextConfig, layer_n: int):
+        super().__init__()
+        self.not_first_layer = layer_n != 0
+        self.hidden_states_scale = mx.ones((config.hidden_size,))
+        self.hidden_states_bias = mx.zeros((config.hidden_size,))
+        if self.not_first_layer:
+            self.residual_scale = mx.ones((config.hidden_size,))
+            self.residual_bias = mx.zeros((config.hidden_size,))
+
+    def __call__(self, residual: Optional[mx.array], hidden_states: mx.array):
+        hidden_states = (hidden_states + self.hidden_states_bias) * self.hidden_states_scale
+        if self.not_first_layer and residual is not None:
+            residual = (residual + self.residual_bias) * self.residual_scale
+        return residual, hidden_states
+
+
+class CCA(nn.Module):
+    def __init__(self, config: TextConfig, layer_number: int):
+        super().__init__()
+        self.config = config
+        self.layer_number = layer_number
+        self.hidden_size = config.hidden_size
+        self.cca_time0 = config.cca_time0
+        self.cca_time1 = config.cca_time1
+        self.total_padding = self.cca_time0 + self.cca_time1 - 2
+
+        self.num_kv_heads = config.num_key_value_heads
+        self.num_q_heads = config.num_attention_heads
+        self.head_dim = config.head_dim
+        self.latent_k_dim = self.num_kv_heads * self.head_dim
+        self.latent_q_dim = self.num_q_heads * self.head_dim
+        self.gqa_groups = self.num_q_heads // self.num_kv_heads
+        self.sqrt_head_dim = math.sqrt(self.head_dim)
+
+        self.linear_q = nn.Linear(
+            self.hidden_size, self.latent_q_dim, bias=config.attention_bias
+        )
+        self.linear_k = nn.Linear(
+            self.hidden_size, self.latent_k_dim, bias=config.attention_bias
+        )
+        self.val_proj1 = nn.Linear(
+            self.hidden_size, self.latent_k_dim // 2, bias=config.attention_bias
+        )
+        self.val_proj2 = nn.Linear(
+            self.hidden_size, self.latent_k_dim // 2, bias=config.attention_bias
+        )
+
+        if config.vision_lora:
+            r = config.vision_lora_rank_attn
+            self.lora_linear_q = [
+                nn.Linear(self.hidden_size, r, bias=False),
+                nn.Linear(r, self.latent_q_dim, bias=False),
+            ]
+            self.lora_linear_k = [
+                nn.Linear(self.hidden_size, r, bias=False),
+                nn.Linear(r, self.latent_k_dim, bias=False),
+            ]
+            self.lora_val_proj1 = [
+                nn.Linear(self.hidden_size, r, bias=False),
+                nn.Linear(r, self.latent_k_dim // 2, bias=False),
+            ]
+            self.lora_val_proj2 = [
+                nn.Linear(self.hidden_size, r, bias=False),
+                nn.Linear(r, self.latent_k_dim // 2, bias=False),
+            ]
+
+        in_out_ch = self.latent_k_dim + self.latent_q_dim
+        self.conv_qk = [
+            nn.Conv1d(
+                in_out_ch,
+                in_out_ch,
+                kernel_size=self.cca_time0,
+                groups=in_out_ch,
+            ),
+            nn.Conv1d(
+                in_out_ch,
+                in_out_ch,
+                kernel_size=self.cca_time1,
+                groups=self.num_kv_heads + self.num_q_heads,
+            ),
+        ]
+        self.temp = mx.zeros((self.num_kv_heads,))
+
+    @staticmethod
+    def _apply_lora(layers, x):
+        return layers[1](layers[0](x))
+
+    def _conv(self, qk_packed0: mx.array, aux_cache, kv_cache):
+        x = qk_packed0.transpose(1, 0, 2)
+        use_decode_state = (
+            aux_cache is not None
+            and not _cache_is_empty(kv_cache)
+            and aux_cache[0] is not None
+            and x.shape[1] == 1
+        )
+
+        if use_decode_state:
+            cached = aux_cache[0]
+            if cached.shape[0] != x.shape[0]:
+                cached = mx.zeros(
+                    (x.shape[0], self.cca_time0, x.shape[-1]), dtype=x.dtype
+                )
+            conv_input = mx.concatenate([cached, x], axis=1)
+        else:
+            conv_input = mx.pad(x, ((0, 0), (self.total_padding, 0), (0, 0)))
+
+        y = conv_input
+        for conv in self.conv_qk:
+            y = conv(y)
+
+        if aux_cache is not None:
+            tail_source = conv_input if use_decode_state else x
+            if tail_source.shape[1] < self.cca_time0:
+                tail_source = mx.pad(
+                    tail_source,
+                    ((0, 0), (self.cca_time0 - tail_source.shape[1], 0), (0, 0)),
+                )
+            aux_cache[0] = tail_source[:, -self.cca_time0 :, :]
+
+        return y.transpose(1, 0, 2)
+
+    def __call__(
+        self,
+        hidden_states: mx.array,
+        cache=None,
+        cca_mask: Optional[mx.array] = None,
+        image_mask: Optional[mx.array] = None,
+    ):
+        kv_cache, aux_cache = _split_cache(cache)
+
+        if cca_mask is not None and hidden_states.shape[1] > 1:
+            hidden_states = hidden_states * cca_mask[..., None].astype(hidden_states.dtype)
+
+        hs = hidden_states.transpose(1, 0, 2)
+        if hs.shape[0] > 1:
+            hs_d = mx.concatenate([mx.zeros_like(hs[:1]), hs[:-1]], axis=0)
+        else:
+            hs_d = mx.zeros_like(hs)
+
+        q = self.linear_q(hs)
+        k = self.linear_k(hs)
+        lora_mask = None
+        if self.config.vision_lora and image_mask is not None:
+            lora_mask = image_mask.transpose(1, 0)[..., None].astype(q.dtype)
+            q = q + self._apply_lora(self.lora_linear_q, hs) * lora_mask
+            k = k + self._apply_lora(self.lora_linear_k, hs) * lora_mask
+
+        query_pre = q.reshape(*q.shape[:2], self.num_q_heads, self.head_dim)
+        key_pre = k.reshape(*k.shape[:2], self.num_kv_heads, self.head_dim)
+        key_pre = mx.repeat(key_pre, self.gqa_groups, axis=2)
+        qk_mean_q = (query_pre + key_pre) / 2
+        qk_mean_k = qk_mean_q.reshape(
+            *qk_mean_q.shape[:2], self.num_kv_heads, self.gqa_groups, self.head_dim
+        ).mean(axis=3)
+
+        qk_packed0 = mx.concatenate([q, k], axis=-1)
+        qk_packed3 = self._conv(qk_packed0, aux_cache, kv_cache)
+
+        query = (
+            qk_packed3[..., : self.latent_q_dim].reshape(
+                *qk_packed3.shape[:2], self.num_q_heads, self.head_dim
+            )
+            + qk_mean_q
+        )
+        key = (
+            qk_packed3[..., self.latent_q_dim :].reshape(
+                *qk_packed3.shape[:2], self.num_kv_heads, self.head_dim
+            )
+            + qk_mean_k
+        )
+
+        v1 = self.val_proj1(hs)
+        if self.config.vision_lora and image_mask is not None:
+            v1 = v1 + self._apply_lora(self.lora_val_proj1, hs) * lora_mask
+
+        if (
+            aux_cache is not None
+            and not _cache_is_empty(kv_cache)
+            and aux_cache[1] is not None
+            and hs.shape[0] == 1
+        ):
+            hs_d = aux_cache[1][None, ...]
+        if aux_cache is not None:
+            aux_cache[1] = hs[-1]
+
+        v2 = self.val_proj2(hs_d)
+        if self.config.vision_lora and image_mask is not None:
+            v2 = v2 + self._apply_lora(self.lora_val_proj2, hs_d) * lora_mask
+
+        value = mx.concatenate([v1, v2], axis=-1).reshape(
+            *hs.shape[:2], self.num_kv_heads, self.head_dim
+        )
+
+        query_norm = mx.sqrt(mx.sum(query * query, axis=-1, keepdims=True) + 1e-6)
+        key_norm = mx.sqrt(mx.sum(key * key, axis=-1, keepdims=True) + 1e-6)
+        query = query * (self.sqrt_head_dim / query_norm)
+        key = (
+            key
+            * (self.sqrt_head_dim / key_norm)
+            * self.temp[None, None, :, None]
+        )
+
+        query = query.reshape(*query.shape[:2], self.num_q_heads * self.head_dim)
+        key = key.reshape(*key.shape[:2], self.num_kv_heads * self.head_dim)
+        value = value.reshape(*value.shape[:2], self.num_kv_heads * self.head_dim)
+        return query.transpose(1, 0, 2), key.transpose(1, 0, 2), value.transpose(1, 0, 2)
+
+
+class ZayaAttention(nn.Module):
+    def __init__(self, config: TextConfig, layer_n: int):
+        super().__init__()
+        self.config = config
+        self.layer_n = layer_n
+        self.num_attention_heads = config.num_attention_heads
+        self.num_key_value_heads = config.num_key_value_heads
+        self.num_key_value_groups = self.num_attention_heads // self.num_key_value_heads
+        self.head_dim = config.head_dim
+        self.scale = self.head_dim**-0.5
+        self.o_proj = nn.Linear(
+            self.num_attention_heads * self.head_dim,
+            config.hidden_size,
+            bias=config.attention_bias,
+        )
+        self.qkv = CCA(config, layer_n)
+        self.rotary_emb = ZayaRotaryEmbedding(config)
+
+        if config.vision_lora:
+            r = config.vision_lora_rank_attn
+            self.lora_linear_o = [
+                nn.Linear(self.num_attention_heads * self.head_dim, r, bias=False),
+                nn.Linear(r, config.hidden_size, bias=False),
+            ]
+
+    def __call__(
+        self,
+        hidden_states: mx.array,
+        mask: Optional[mx.array] = None,
+        cca_mask: Optional[mx.array] = None,
+        image_mask: Optional[mx.array] = None,
+        cache=None,
+    ):
+        B, L, _ = hidden_states.shape
+        kv_cache, _ = _split_cache(cache)
+        q, k, v = self.qkv(hidden_states, cache, cca_mask, image_mask)
+
+        q = q.reshape(B, L, self.num_attention_heads, self.head_dim).transpose(
+            0, 2, 1, 3
+        )
+        k = k.reshape(B, L, self.num_key_value_heads, self.head_dim).transpose(
+            0, 2, 1, 3
+        )
+        v = v.reshape(B, L, self.num_key_value_heads, self.head_dim).transpose(
+            0, 2, 1, 3
+        )
+
+        cos, sin = self.rotary_emb(_position_ids_from_cache(B, L, kv_cache))
+        q, k = apply_rotary_pos_emb(q, k, cos, sin)
+
+        if kv_cache is not None:
+            k, v = kv_cache.update_and_fetch(k, v)
+
+        k = _repeat_kv(k, self.num_key_value_groups)
+        v = _repeat_kv(v, self.num_key_value_groups)
+
+        if mask is not None and isinstance(mask, mx.array):
+            mask = mask[..., : k.shape[-2]]
+
+        out = scaled_dot_product_attention(q, k, v, cache=None, scale=self.scale, mask=mask)
+        out = out.transpose(0, 2, 1, 3).reshape(B, L, -1)
+
+        projected = self.o_proj(out)
+        if self.config.vision_lora and image_mask is not None:
+            addon = self.lora_linear_o[1](self.lora_linear_o[0](out))
+            projected = projected + addon * image_mask[..., None].astype(projected.dtype)
+        return projected
+
+
+class ZayaRouter(nn.Module):
+    def __init__(self, config: TextConfig, layer_number: int):
+        super().__init__()
+        self.config = config
+        self.use_mod = config.zaya_use_mod
+        self.num_local_experts = config.num_experts
+        self.num_experts = config.num_experts + (1 if self.use_mod else 0)
+        self.topk = config.moe_router_topk
+        self.layer_number = layer_number
+        self.use_eda = config.zaya_use_eda and layer_number != 0
+
+        self.down_proj = nn.Linear(config.hidden_size, config.zaya_mlp_expansion, bias=True)
+        self.rmsnorm_eda = nn.RMSNorm(config.zaya_mlp_expansion, eps=1e-6)
+        if self.use_eda:
+            self.router_states_scale = mx.ones((config.zaya_mlp_expansion,))
+
+        self.router_mlp = [
+            nn.Linear(config.zaya_mlp_expansion, config.zaya_mlp_expansion, bias=True),
+            nn.GELU(),
+            nn.Linear(config.zaya_mlp_expansion, config.zaya_mlp_expansion, bias=True),
+            nn.GELU(),
+            nn.Linear(config.zaya_mlp_expansion, self.num_experts, bias=False),
+        ]
+        self.balancing_biases = mx.zeros((self.num_experts,), dtype=mx.float32)
+        if self.use_mod:
+            self.balancing_biases[-1] = -1.0
+
+    def __call__(self, hidden_states: mx.array, router_states: Optional[mx.array] = None):
+        hs = self.down_proj(hidden_states)
+        if self.use_eda and router_states is not None:
+            hs = hs + router_states * self.router_states_scale
+        next_router_states = hs
+        hs = self.rmsnorm_eda(hs)
+        for layer in self.router_mlp:
+            hs = layer(hs)
+
+        expert_prob = mx.softmax(hs.astype(mx.float32), axis=-1).astype(hidden_states.dtype)
+        biased = expert_prob.astype(mx.float32) + self.balancing_biases
+        if self.topk == 1:
+            expert_choice = mx.expand_dims(mx.argmax(biased, axis=-1), axis=-1)
+            route_prob = mx.take_along_axis(expert_prob, expert_choice, axis=-1)
+        else:
+            expert_choice = mx.argpartition(biased, kth=-self.topk, axis=-1)[
+                ..., -self.topk :
+            ]
+            route_prob = mx.take_along_axis(expert_prob, expert_choice, axis=-1)
+        return route_prob, expert_choice, next_router_states
+
+
+def _switch_linear(linear: SwitchLinear, x: mx.array, indices: mx.array) -> mx.array:
+    if x.ndim == indices.ndim:
+        x = mx.expand_dims(x, (-2, -3))
+    elif x.ndim == indices.ndim + 1:
+        if x.shape[:-1] == indices.shape:
+            x = mx.expand_dims(x, -2)
+        else:
+            x = mx.expand_dims(x, (-2, -3))
+    else:
+        x = mx.expand_dims(x, -2)
+    y = linear(x, indices, sorted_indices=False)
+    return y.squeeze(-2)
+
+
+class ZayaSwitchMLP(nn.Module):
+    def __init__(self, config: TextConfig):
+        super().__init__()
+        self.config = config
+        self.num_experts = config.num_experts
+        self.hidden_size = config.hidden_size
+        self.ffn_hidden_size = config.ffn_hidden_size
+        self.ffn_hidden_size_out = (
+            config.ffn_hidden_size // 2
+            if config.gated_linear_unit
+            else config.ffn_hidden_size
+        )
+        self.linear_fc1 = SwitchLinear(
+            config.hidden_size, self.ffn_hidden_size, config.num_experts, bias=config.add_bias_linear
+        )
+        self.linear_fc2 = SwitchLinear(
+            self.ffn_hidden_size_out, config.hidden_size, config.num_experts, bias=config.add_bias_linear
+        )
+
+        if config.vision_lora:
+            r = config.vision_lora_rank_mlp
+            self.lora_fc1 = [
+                SwitchLinear(config.hidden_size, r, config.num_experts, bias=False),
+                SwitchLinear(r, self.ffn_hidden_size, config.num_experts, bias=False),
+            ]
+            self.lora_fc2 = [
+                SwitchLinear(self.ffn_hidden_size_out, r, config.num_experts, bias=False),
+                SwitchLinear(r, config.hidden_size, config.num_experts, bias=False),
+            ]
+
+    def __call__(
+        self,
+        hidden_states: mx.array,
+        expert_choice: mx.array,
+        route_prob: mx.array,
+        image_mask: Optional[mx.array] = None,
+    ):
+        skip_mask = expert_choice == self.num_experts
+        expert_indices = mx.minimum(expert_choice, self.num_experts - 1)
+
+        x = _switch_linear(self.linear_fc1, hidden_states, expert_indices)
+        if self.config.vision_lora and image_mask is not None:
+            addon = _switch_linear(self.lora_fc1[0], hidden_states, expert_indices)
+            addon = _switch_linear(self.lora_fc1[1], addon, expert_indices)
+            x = x + addon * image_mask[..., None, None].astype(x.dtype)
+
+        if self.config.gated_linear_unit:
+            x1, x2 = mx.split(x, 2, axis=-1)
+            x = nn.silu(x1) * x2
+        elif self.config.activation_func == "gelu":
+            x = nn.gelu(x)
+        else:
+            x = nn.silu(x)
+
+        y = _switch_linear(self.linear_fc2, x, expert_indices)
+        if self.config.vision_lora and image_mask is not None:
+            addon = _switch_linear(self.lora_fc2[0], x, expert_indices)
+            addon = _switch_linear(self.lora_fc2[1], addon, expert_indices)
+            y = y + addon * image_mask[..., None, None].astype(y.dtype)
+
+        if self.config.zaya_use_mod:
+            y = mx.where(skip_mask[..., None], hidden_states[..., None, :], y)
+
+        y = y * route_prob[..., None]
+        return y.sum(axis=-2)
+
+
+class ZayaBlock(nn.Module):
+    def __init__(self, config: TextConfig, layer_n: int):
+        super().__init__()
+        self.router = ZayaRouter(config, layer_n)
+        self.experts = ZayaSwitchMLP(config)
+
+    def __call__(
+        self,
+        hidden_states: mx.array,
+        prev_router_hidden_states: Optional[mx.array] = None,
+        image_mask: Optional[mx.array] = None,
+    ):
+        route_prob, expert_choice, prev_router_hidden_states = self.router(
+            hidden_states, prev_router_hidden_states
+        )
+        output = self.experts(hidden_states, expert_choice, route_prob, image_mask)
+        return output, prev_router_hidden_states
+
+
+class ZayaDecoderATTLayer(nn.Module):
+    def __init__(self, config: TextConfig, layer_n: int):
+        super().__init__()
+        self.config = config
+        self.self_attn = ZayaAttention(config, layer_n)
+        self.input_norm = nn.RMSNorm(config.hidden_size, eps=config.norm_epsilon)
+        if config.scale_residual_merge:
+            self.res_scale = ResidualScaling(config, 2 * layer_n)
+
+    def __call__(
+        self,
+        hidden_states: mx.array,
+        residual: Optional[mx.array],
+        mask: Optional[mx.array] = None,
+        image_mask: Optional[mx.array] = None,
+        cache=None,
+        cca_mask: Optional[mx.array] = None,
+    ):
+        if self.config.scale_residual_merge:
+            residual, hidden_states = self.res_scale(residual, hidden_states)
+        residual = hidden_states if residual is None else hidden_states + residual
+        hidden_states = self.input_norm(residual)
+        hidden_states = self.self_attn(hidden_states, mask, cca_mask, image_mask, cache)
+        return hidden_states, residual
+
+
+class ZayaDecoderMLPLayer(nn.Module):
+    def __init__(self, config: TextConfig, layer_n: int):
+        super().__init__()
+        self.config = config
+        self.zaya_block = ZayaBlock(config, layer_n)
+        self.input_norm = nn.RMSNorm(config.hidden_size, eps=config.norm_epsilon)
+        if config.scale_residual_merge:
+            self.res_scale = ResidualScaling(config, 2 * layer_n + 1)
+
+    def __call__(
+        self,
+        hidden_states: mx.array,
+        residual: Optional[mx.array],
+        image_mask: Optional[mx.array] = None,
+        prev_router_hidden_states: Optional[mx.array] = None,
+    ):
+        if self.config.scale_residual_merge:
+            residual, hidden_states = self.res_scale(residual, hidden_states)
+        residual = hidden_states if residual is None else hidden_states + residual
+        hidden_states = self.input_norm(residual)
+        hidden_states, prev_router_hidden_states = self.zaya_block(
+            hidden_states, prev_router_hidden_states, image_mask
+        )
+        return hidden_states, residual, prev_router_hidden_states
+
+
+class ZayaDecoderBlock(nn.Module):
+    def __init__(self, config: TextConfig, layer_n: int):
+        super().__init__()
+        self.attn = ZayaDecoderATTLayer(config, layer_n)
+        self.mlp = ZayaDecoderMLPLayer(config, layer_n)
+
+    def __call__(
+        self,
+        hidden_states: mx.array,
+        residual: Optional[mx.array],
+        mask: Optional[mx.array] = None,
+        image_mask: Optional[mx.array] = None,
+        cache=None,
+        prev_router_hidden_states: Optional[mx.array] = None,
+        cca_mask: Optional[mx.array] = None,
+    ):
+        hidden_states, residual = self.attn(
+            hidden_states,
+            residual,
+            mask=mask,
+            image_mask=image_mask,
+            cache=cache,
+            cca_mask=cca_mask,
+        )
+        hidden_states, residual, prev_router_hidden_states = self.mlp(
+            hidden_states,
+            residual,
+            image_mask=image_mask,
+            prev_router_hidden_states=prev_router_hidden_states,
+        )
+        return hidden_states, residual, prev_router_hidden_states
+
+
+class ZayaModel(nn.Module):
+    def __init__(self, config: TextConfig):
+        super().__init__()
+        self.config = config
+        self.embed_tokens = nn.Embedding(config.vocab_size, config.hidden_size)
+        self.layers = [
+            ZayaDecoderBlock(config, layer_n=i)
+            for i in range(config.num_hidden_layers)
+        ]
+        if config.scale_residual_merge:
+            self.res_scale = ResidualScaling(config, config.num_hidden_layers)
+        self.final_norm = nn.RMSNorm(config.hidden_size, eps=config.norm_epsilon)
+
+    def __call__(
+        self,
+        input_ids: mx.array,
+        inputs_embeds: Optional[mx.array] = None,
+        mask: Optional[mx.array] = None,
+        image_mask: Optional[mx.array] = None,
+        cache=None,
+    ):
+        h = self.embed_tokens(input_ids) if inputs_embeds is None else inputs_embeds
+        if cache is None:
+            cache = [None] * len(self.layers)
+
+        first_kv_cache, _ = _split_cache(cache[0]) if cache else (None, None)
+        attn_mask = create_attention_mask(h, first_kv_cache)
+        cca_mask = mask
+
+        residual = None
+        prev_router_hidden_states = None
+        for layer, layer_cache in zip(self.layers, cache):
+            h, residual, prev_router_hidden_states = layer(
+                h,
+                residual,
+                mask=attn_mask,
+                image_mask=image_mask,
+                cache=layer_cache,
+                prev_router_hidden_states=prev_router_hidden_states,
+                cca_mask=cca_mask,
+            )
+
+        if self.config.scale_residual_merge:
+            residual, h = self.res_scale(residual, h)
+        residual = h if residual is None else h + residual
+        return self.final_norm(residual)
+
+
+class LanguageModel(nn.Module):
+    def __init__(self, args: TextConfig, config: ModelConfig = None):
+        super().__init__()
+        self.args = args
+        self.config = config
+        self.model_type = args.model_type
+        self.model = ZayaModel(args)
+        if not args.tie_word_embeddings:
+            self.lm_head = nn.Linear(args.hidden_size, args.vocab_size, bias=args.lm_head_bias)
+
+    def __call__(
+        self,
+        input_ids: mx.array,
+        inputs_embeds: Optional[mx.array] = None,
+        mask: Optional[mx.array] = None,
+        image_mask: Optional[mx.array] = None,
+        cache=None,
+        **kwargs,
+    ):
+        out = self.model(input_ids, inputs_embeds, mask, image_mask, cache)
+        if self.args.tie_word_embeddings:
+            logits = self.model.embed_tokens.as_linear(out)
+        else:
+            logits = self.lm_head(out)
+        return LanguageModelOutput(logits)
+
+    @property
+    def layers(self):
+        return self.model.layers
+
+    def make_cache(self):
+        return [CacheList(KVCache(), ArraysCache(2)) for _ in self.layers]
+
+    def sanitize(self, weights):
+        sanitized_weights = dict(weights)
+
+        for layer_idx in range(self.args.num_hidden_layers):
+            prefix = f"language_model.model.layers.{layer_idx}.mlp.zaya_block.experts"
+            for name in ("linear_fc1", "linear_fc2"):
+                stacked = []
+                for expert_idx in range(self.args.num_experts):
+                    key = f"{prefix}.local_experts.{expert_idx}.{name}.weight"
+                    if key in sanitized_weights:
+                        stacked.append(sanitized_weights.pop(key))
+                if stacked:
+                    sanitized_weights[f"{prefix}.{name}.weight"] = mx.stack(stacked, axis=0)
+
+            if self.args.vision_lora:
+                for lora_name in ("lora_fc1", "lora_fc2"):
+                    for sub_idx in (0, 1):
+                        stacked = []
+                        for expert_idx in range(self.args.num_experts):
+                            key = (
+                                f"{prefix}.local_experts.{expert_idx}."
+                                f"{lora_name}.{sub_idx}.weight"
+                            )
+                            if key in sanitized_weights:
+                                stacked.append(sanitized_weights.pop(key))
+                        if stacked:
+                            sanitized_weights[
+                                f"{prefix}.{lora_name}.{sub_idx}.weight"
+                            ] = mx.stack(stacked, axis=0)
+
+        result = {}
+        for name, param in sanitized_weights.items():
+            if "conv_qk" in name and name.endswith("weight") and param.ndim == 3:
+                if param.shape[1] != 2 and param.shape[2] == 2:
+                    param = param.transpose(0, 2, 1)
+            result[name] = param
+        return result

--- a/mlx_vlm/models/zaya1_vl/processing_zaya1_vl.py
+++ b/mlx_vlm/models/zaya1_vl/processing_zaya1_vl.py
@@ -23,9 +23,13 @@ class Zaya1VLProcessor(ProcessorMixin):
     def check_argument_for_proper_class(self, argument_name, argument):
         return type(argument)
 
-    def __init__(self, image_processor=None, tokenizer=None, chat_template=None, **kwargs):
+    def __init__(
+        self, image_processor=None, tokenizer=None, chat_template=None, **kwargs
+    ):
         self.image_token = (
-            "<image>" if not hasattr(tokenizer, "image_token") else tokenizer.image_token
+            "<image>"
+            if not hasattr(tokenizer, "image_token")
+            else tokenizer.image_token
         )
         self.image_token_id = (
             tokenizer.image_token_id

--- a/mlx_vlm/models/zaya1_vl/processing_zaya1_vl.py
+++ b/mlx_vlm/models/zaya1_vl/processing_zaya1_vl.py
@@ -1,0 +1,133 @@
+from typing import List, Optional, Union
+
+import numpy as np
+from transformers.feature_extraction_utils import BatchFeature
+from transformers.image_utils import ImageInput
+from transformers.processing_utils import ProcessorMixin
+from transformers.tokenization_utils_base import PreTokenizedInput, TextInput
+
+from ..base import load_chat_template, to_mlx
+from ..qwen3_vl.processing_qwen3_vl import (
+    Qwen3VLImageProcessor,
+    _load_qwen_vl_json,
+    _qwen_vl_image_kwargs,
+)
+
+
+class Zaya1VLProcessor(ProcessorMixin):
+    attributes = ["image_processor", "tokenizer"]
+    valid_kwargs = ["chat_template"]
+    image_processor_class = "AutoImageProcessor"
+    tokenizer_class = "AutoTokenizer"
+
+    def check_argument_for_proper_class(self, argument_name, argument):
+        return type(argument)
+
+    def __init__(self, image_processor=None, tokenizer=None, chat_template=None, **kwargs):
+        self.image_token = (
+            "<image>" if not hasattr(tokenizer, "image_token") else tokenizer.image_token
+        )
+        self.image_token_id = (
+            tokenizer.image_token_id
+            if getattr(tokenizer, "image_token_id", None)
+            else tokenizer.convert_tokens_to_ids(self.image_token)
+        )
+        super().__init__(image_processor, tokenizer, chat_template=chat_template)
+
+    def __call__(
+        self,
+        images: Optional[ImageInput] = None,
+        text: Optional[
+            Union[
+                TextInput,
+                PreTokenizedInput,
+                List[TextInput],
+                List[PreTokenizedInput],
+            ]
+        ] = None,
+        **kwargs,
+    ) -> BatchFeature:
+        image_inputs = {}
+        image_grid_thw = None
+        if images is not None:
+            image_inputs = self.image_processor(images=images)
+            image_grid_thw = image_inputs["image_grid_thw"]
+
+        if not isinstance(text, list):
+            text = [text]
+        text = text.copy()
+
+        if image_grid_thw is not None:
+            merge_length = self.image_processor.merge_size**2
+            index = 0
+            for i in range(len(text)):
+                while self.image_token in text[i]:
+                    num_image_tokens = image_grid_thw[index].prod() // merge_length
+                    text[i] = text[i].replace(
+                        self.image_token,
+                        "<|placeholder|>" * int(num_image_tokens),
+                        1,
+                    )
+                    index += 1
+                text[i] = text[i].replace("<|placeholder|>", self.image_token)
+
+        kwargs.pop("return_tensors", None)
+        return_mm_token_type_ids = kwargs.pop("return_mm_token_type_ids", None)
+        text_inputs = self.tokenizer(text, **kwargs)
+
+        if return_mm_token_type_ids:
+            array_ids = np.array(text_inputs["input_ids"])
+            mm_token_type_ids = np.zeros_like(array_ids)
+            mm_token_type_ids[array_ids == self.image_token_id] = 1
+            text_inputs["mm_token_type_ids"] = mm_token_type_ids.tolist()
+
+        return BatchFeature(data=to_mlx({**text_inputs, **image_inputs}))
+
+    def batch_decode(self, *args, **kwargs):
+        return self.tokenizer.batch_decode(*args, **kwargs)
+
+    def decode(self, *args, **kwargs):
+        return self.tokenizer.decode(*args, **kwargs)
+
+    @property
+    def model_input_names(self):
+        tokenizer_input_names = self.tokenizer.model_input_names
+        image_processor_input_names = self.image_processor.model_input_names
+        return list(dict.fromkeys(tokenizer_input_names + image_processor_input_names))
+
+    @classmethod
+    def from_pretrained(cls, pretrained_model_name_or_path, **kwargs):
+        from transformers import AutoTokenizer
+
+        kwargs.pop("use_fast", None)
+        tokenizer = AutoTokenizer.from_pretrained(
+            pretrained_model_name_or_path, **kwargs
+        )
+        load_chat_template(tokenizer, pretrained_model_name_or_path)
+
+        image_processor = Qwen3VLImageProcessor(
+            **_qwen_vl_image_kwargs(
+                pretrained_model_name_or_path,
+                default_patch_size=14,
+            )
+        )
+        proc_cfg = (
+            _load_qwen_vl_json(pretrained_model_name_or_path, "processor_config.json")
+            or {}
+        )
+        chat_template = proc_cfg.get(
+            "chat_template", getattr(tokenizer, "chat_template", None)
+        )
+        return cls(
+            image_processor=image_processor,
+            tokenizer=tokenizer,
+            chat_template=chat_template,
+        )
+
+
+__all__ = ["Zaya1VLProcessor"]
+
+
+from ..base import install_auto_processor_patch
+
+install_auto_processor_patch("zaya1_vl", Zaya1VLProcessor)

--- a/mlx_vlm/models/zaya1_vl/vision.py
+++ b/mlx_vlm/models/zaya1_vl/vision.py
@@ -17,6 +17,11 @@ def swiglu(gate: mx.array, x: mx.array) -> mx.array:
     return (nn.silu(gate.astype(mx.float32)) * x.astype(mx.float32)).astype(gate.dtype)
 
 
+@partial(mx.compile, shapeless=True)
+def gelu(x: mx.array) -> mx.array:
+    return nn.gelu(x.astype(mx.float32)).astype(x.dtype)
+
+
 class PatchMerger(nn.Module):
     def __init__(self, dim: int, context_dim: int, spatial_merge_size: int = 2) -> None:
         super().__init__()
@@ -30,10 +35,7 @@ class PatchMerger(nn.Module):
 
     def __call__(self, x: mx.array) -> mx.array:
         x = self.ln_q(x).reshape(-1, self.hidden_size)
-        x = self.mlp[0](x)
-        x = self.mlp[1](x.astype(mx.float32)).astype(x.dtype)
-        x = self.mlp[2](x)
-        return x
+        return self.mlp[2](gelu(self.mlp[0](x)))
 
 
 class MLP(nn.Module):

--- a/mlx_vlm/models/zaya1_vl/vision.py
+++ b/mlx_vlm/models/zaya1_vl/vision.py
@@ -1,3 +1,5 @@
+from functools import partial
+
 import mlx.core as mx
 import mlx.nn as nn
 
@@ -8,6 +10,11 @@ from ..qwen2_5_vl.vision import (
     VisionRotaryEmbedding,
 )
 from .config import VisionConfig
+
+
+@partial(mx.compile, shapeless=True)
+def swiglu(gate: mx.array, x: mx.array) -> mx.array:
+    return (nn.silu(gate.astype(mx.float32)) * x.astype(mx.float32)).astype(gate.dtype)
 
 
 class PatchMerger(nn.Module):
@@ -37,11 +44,9 @@ class MLP(nn.Module):
         self.down_proj = nn.Linear(hidden_dim, dim)
 
     def __call__(self, x: mx.array) -> mx.array:
-        hidden_states = (
-            nn.silu(self.gate_proj(x).astype(mx.float32))
-            * self.up_proj(x).astype(mx.float32)
-        ).astype(x.dtype)
-        return self.down_proj(hidden_states)
+        return self.down_proj(
+            swiglu(self.gate_proj(x), self.up_proj(x))
+        )
 
 
 class Zaya1VLVisionBlock(nn.Module):

--- a/mlx_vlm/models/zaya1_vl/vision.py
+++ b/mlx_vlm/models/zaya1_vl/vision.py
@@ -1,0 +1,94 @@
+import mlx.core as mx
+import mlx.nn as nn
+
+from ..qwen2_5_vl.vision import (
+    Attention,
+    PatchEmbed,
+    VisionModel as Qwen2_5VisionModel,
+    VisionRotaryEmbedding,
+)
+from .config import VisionConfig
+
+
+class PatchMerger(nn.Module):
+    def __init__(self, dim: int, context_dim: int, spatial_merge_size: int = 2) -> None:
+        super().__init__()
+        self.hidden_size = context_dim * (spatial_merge_size**2)
+        self.ln_q = nn.RMSNorm(context_dim, eps=1e-6)
+        self.mlp = [
+            nn.Linear(self.hidden_size, self.hidden_size),
+            nn.GELU(),
+            nn.Linear(self.hidden_size, dim),
+        ]
+
+    def __call__(self, x: mx.array) -> mx.array:
+        x = self.ln_q(x).reshape(-1, self.hidden_size)
+        x = self.mlp[0](x)
+        x = self.mlp[1](x.astype(mx.float32)).astype(x.dtype)
+        x = self.mlp[2](x)
+        return x
+
+
+class MLP(nn.Module):
+    def __init__(self, dim, hidden_dim):
+        super().__init__()
+        self.gate_proj = nn.Linear(dim, hidden_dim)
+        self.up_proj = nn.Linear(dim, hidden_dim)
+        self.down_proj = nn.Linear(hidden_dim, dim)
+
+    def __call__(self, x: mx.array) -> mx.array:
+        hidden_states = (
+            nn.silu(self.gate_proj(x).astype(mx.float32))
+            * self.up_proj(x).astype(mx.float32)
+        ).astype(x.dtype)
+        return self.down_proj(hidden_states)
+
+
+class Zaya1VLVisionBlock(nn.Module):
+    def __init__(self, config: VisionConfig) -> None:
+        super().__init__()
+        self.norm1 = nn.RMSNorm(config.hidden_size, eps=1e-6)
+        self.norm2 = nn.RMSNorm(config.hidden_size, eps=1e-6)
+
+        self.attn = Attention(dim=config.hidden_size, num_heads=config.num_heads)
+        self.mlp = MLP(dim=config.hidden_size, hidden_dim=config.intermediate_size)
+
+    def __call__(self, hidden_states, cu_seqlens, rotary_pos_emb) -> mx.array:
+        hidden_states = hidden_states + self.attn(
+            self.norm1(hidden_states),
+            cu_seqlens=cu_seqlens,
+            rotary_pos_emb=rotary_pos_emb,
+        )
+        hidden_states = hidden_states + self.mlp(self.norm2(hidden_states))
+        return hidden_states
+
+
+class VisionModel(Qwen2_5VisionModel):
+    def __init__(self, config: VisionConfig) -> None:
+        nn.Module.__init__(self)
+        self.config = config
+        self.model_type = config.model_type
+        if self.model_type != "qwen2_5_vl":
+            raise ValueError(f"Unsupported model type: {self.model_type}")
+        self.spatial_merge_size = config.spatial_merge_size
+
+        self.patch_embed = PatchEmbed(
+            patch_size=config.patch_size,
+            temporal_patch_size=config.temporal_patch_size,
+            in_channels=config.in_channels,
+            hidden_size=config.hidden_size,
+        )
+
+        self.window_size = config.window_size
+        self.patch_size = config.patch_size
+        self.spatial_merge_unit = self.spatial_merge_size * self.spatial_merge_size
+        self.fullatt_block_indexes = config.fullatt_block_indexes
+        head_dim = config.hidden_size // config.num_heads
+        self.rotary_pos_emb = VisionRotaryEmbedding(head_dim // 2)
+
+        self.blocks = [Zaya1VLVisionBlock(config) for _ in range(config.depth)]
+        self.merger = PatchMerger(
+            dim=config.out_hidden_size,
+            context_dim=config.hidden_size,
+            spatial_merge_size=config.spatial_merge_size,
+        )

--- a/mlx_vlm/models/zaya1_vl/vision.py
+++ b/mlx_vlm/models/zaya1_vl/vision.py
@@ -3,12 +3,9 @@ from functools import partial
 import mlx.core as mx
 import mlx.nn as nn
 
-from ..qwen2_5_vl.vision import (
-    Attention,
-    PatchEmbed,
-    VisionModel as Qwen2_5VisionModel,
-    VisionRotaryEmbedding,
-)
+from ..qwen2_5_vl.vision import Attention, PatchEmbed
+from ..qwen2_5_vl.vision import VisionModel as Qwen2_5VisionModel
+from ..qwen2_5_vl.vision import VisionRotaryEmbedding
 from .config import VisionConfig
 
 
@@ -46,9 +43,7 @@ class MLP(nn.Module):
         self.down_proj = nn.Linear(hidden_dim, dim)
 
     def __call__(self, x: mx.array) -> mx.array:
-        return self.down_proj(
-            swiglu(self.gate_proj(x), self.up_proj(x))
-        )
+        return self.down_proj(swiglu(self.gate_proj(x), self.up_proj(x)))
 
 
 class Zaya1VLVisionBlock(nn.Module):

--- a/mlx_vlm/models/zaya1_vl/zaya1_vl.py
+++ b/mlx_vlm/models/zaya1_vl/zaya1_vl.py
@@ -30,7 +30,9 @@ class Model(nn.Module):
         if pixel_values is not None:
             image_grid_thw = kwargs.get("image_grid_thw", None)
             if image_grid_thw is None:
-                raise ValueError("image_grid_thw is required when pixel_values are provided")
+                raise ValueError(
+                    "image_grid_thw is required when pixel_values are provided"
+                )
 
             cached = kwargs.get("cached_image_features", None)
             if cached is not None:

--- a/mlx_vlm/models/zaya1_vl/zaya1_vl.py
+++ b/mlx_vlm/models/zaya1_vl/zaya1_vl.py
@@ -1,0 +1,137 @@
+from typing import Optional
+
+import mlx.core as mx
+import mlx.nn as nn
+
+from ..base import InputEmbeddingsFeatures
+from ..qwen2_5_vl.vision import VisionModel
+from . import processing_zaya1_vl  # noqa: F401
+from .config import ModelConfig
+from .language import LanguageModel
+
+
+class Model(nn.Module):
+    def __init__(self, config: ModelConfig):
+        super().__init__()
+        self.config = config
+        self.model_type = config.model_type
+        self.vision_tower = VisionModel(config.vision_config)
+        self.language_model = LanguageModel(config.text_config, config)
+
+    def get_input_embeddings(
+        self,
+        input_ids: Optional[mx.array] = None,
+        pixel_values: Optional[mx.array] = None,
+        **kwargs,
+    ):
+        inputs_embeds = self.language_model.model.embed_tokens(input_ids)
+        image_mask = None
+
+        if pixel_values is not None:
+            image_grid_thw = kwargs.get("image_grid_thw", None)
+            if image_grid_thw is None:
+                raise ValueError("image_grid_thw is required when pixel_values are provided")
+
+            cached = kwargs.get("cached_image_features", None)
+            if cached is not None:
+                image_features = cached
+            else:
+                dtype = self.vision_tower.patch_embed.proj.weight.dtype
+                image_features = self.vision_tower(
+                    pixel_values.astype(dtype),
+                    image_grid_thw,
+                    output_hidden_states=False,
+                )
+
+            inputs_embeds, image_mask = self.merge_input_ids_with_image_features(
+                image_features,
+                inputs_embeds,
+                input_ids,
+                self.config.image_token_id,
+            )
+
+        return InputEmbeddingsFeatures(
+            inputs_embeds=inputs_embeds,
+            visual_pos_masks=image_mask,
+        )
+
+    @staticmethod
+    def merge_input_ids_with_image_features(
+        image_features,
+        inputs_embeds,
+        input_ids,
+        image_token_id,
+    ):
+        image_positions = input_ids == image_token_id
+        batch_outputs = []
+        feature_start_idx = 0
+
+        for batch_idx in range(input_ids.shape[0]):
+            image_mask = image_positions[batch_idx]
+            num_positions = mx.sum(image_mask).item()
+
+            if num_positions > 0:
+                batch_features = image_features[
+                    feature_start_idx : feature_start_idx + num_positions
+                ]
+                if batch_features.shape[0] != num_positions:
+                    raise ValueError(
+                        "Image features and image tokens do not match: "
+                        f"tokens: {num_positions}, features {batch_features.shape[0]}"
+                    )
+
+                cumsum = mx.cumsum(image_mask.astype(mx.int32))
+                feature_indices = mx.where(image_mask, cumsum - 1, 0)
+                gathered_features = batch_features[feature_indices]
+                batch_output = mx.where(
+                    image_mask[..., None], gathered_features, inputs_embeds[batch_idx]
+                )
+                feature_start_idx += num_positions
+            else:
+                batch_output = inputs_embeds[batch_idx]
+
+            batch_outputs.append(batch_output)
+
+        return mx.stack(batch_outputs, axis=0), image_positions
+
+    @property
+    def layers(self):
+        return self.language_model.model.layers
+
+    def make_cache(self):
+        return self.language_model.make_cache()
+
+    def __call__(
+        self,
+        input_ids: mx.array,
+        pixel_values: Optional[mx.array] = None,
+        mask: Optional[mx.array] = None,
+        cache=None,
+        **kwargs,
+    ):
+        input_embeddings_features = self.get_input_embeddings(
+            input_ids,
+            pixel_values,
+            **kwargs,
+        )
+
+        return self.language_model(
+            input_ids,
+            input_embeddings_features.inputs_embeds,
+            mask=mask,
+            image_mask=input_embeddings_features.visual_pos_masks,
+            cache=cache,
+            **kwargs,
+        )
+
+    def sanitize(self, weights):
+        sanitized = {}
+        for key, value in weights.items():
+            if key == "lm_head.weight" and self.config.text_config.tie_word_embeddings:
+                continue
+            if key.startswith("model."):
+                key = key.replace("model.", "language_model.model.", 1)
+            elif key.startswith("lm_head."):
+                key = key.replace("lm_head.", "language_model.lm_head.", 1)
+            sanitized[key] = value
+        return sanitized

--- a/mlx_vlm/models/zaya1_vl/zaya1_vl.py
+++ b/mlx_vlm/models/zaya1_vl/zaya1_vl.py
@@ -4,10 +4,10 @@ import mlx.core as mx
 import mlx.nn as nn
 
 from ..base import InputEmbeddingsFeatures
-from ..qwen2_5_vl.vision import VisionModel
 from . import processing_zaya1_vl  # noqa: F401
 from .config import ModelConfig
 from .language import LanguageModel
+from .vision import VisionModel
 
 
 class Model(nn.Module):

--- a/mlx_vlm/prompt_utils.py
+++ b/mlx_vlm/prompt_utils.py
@@ -37,6 +37,7 @@ MODEL_CONFIG = {
     "paddleocr_vl": MessageFormat.LIST_WITH_IMAGE_FIRST,
     "qwen2_vl": MessageFormat.LIST_WITH_IMAGE,
     "qwen2_5_vl": MessageFormat.LIST_WITH_IMAGE_FIRST,
+    "zaya1_vl": MessageFormat.LIST_WITH_IMAGE_FIRST,
     "qwen3_vl": MessageFormat.LIST_WITH_IMAGE_FIRST,
     "qwen3_vl_moe": MessageFormat.LIST_WITH_IMAGE_FIRST,
     "qwen3_5": MessageFormat.LIST_WITH_IMAGE_FIRST,

--- a/mlx_vlm/tests/test_models.py
+++ b/mlx_vlm/tests/test_models.py
@@ -3685,7 +3685,6 @@ class TestModels(unittest.TestCase):
         from mlx_vlm.models import zaya1_vl
         from mlx_vlm.models.zaya1_vl.language import CCA, RMSNorm, ZayaRouter
 
-
         text_config = zaya1_vl.TextConfig(
             model_type="zaya1_vl",
             hidden_size=8,
@@ -3745,11 +3744,12 @@ class TestModels(unittest.TestCase):
         H = text_config.hidden_size
         norm = RMSNorm(H, eps=text_config.norm_epsilon)
         norm.weight = mx.concatenate(
-            [mx.array([1.5, -0.25], dtype=mx.float32), mx.ones((H - 2,), dtype=mx.float32)]
+            [
+                mx.array([1.5, -0.25], dtype=mx.float32),
+                mx.ones((H - 2,), dtype=mx.float32),
+            ]
         )
-        x = mx.pad(
-            mx.array([[1.0, 2.0]], dtype=mx.float16), ((0, 0), (0, H - 2))
-        )
+        x = mx.pad(mx.array([[1.0, 2.0]], dtype=mx.float16), ((0, 0), (0, H - 2)))
         out = norm(x)
 
         x32 = x.astype(mx.float32)
@@ -3763,7 +3763,6 @@ class TestModels(unittest.TestCase):
 
         router = ZayaRouter(text_config, layer_number=1)
         self.assertEqual(router.rmsnorm_eda.eps, text_config.norm_epsilon)
-
 
         cca = CCA(text_config, layer_number=0)
         for linear in (cca.linear_q, cca.linear_k, cca.val_proj1, cca.val_proj2):

--- a/mlx_vlm/tests/test_models.py
+++ b/mlx_vlm/tests/test_models.py
@@ -3701,7 +3701,7 @@ class TestModels(unittest.TestCase):
 
     def test_zaya1_vl(self):
         from mlx_vlm.models import zaya1_vl
-        from mlx_vlm.models.zaya1_vl.language import CCA, RMSNorm, ZayaRouter
+        from mlx_vlm.models.zaya1_vl.language import CCA, ZayaRouter
 
         text_config = zaya1_vl.TextConfig(
             model_type="zaya1_vl",
@@ -3741,6 +3741,11 @@ class TestModels(unittest.TestCase):
             vocab_size=32,
         )
         model = zaya1_vl.Model(config)
+        layer = model.language_model.model.layers[0]
+        self.assertIsInstance(model.language_model.model.final_norm, nn.RMSNorm)
+        self.assertIsInstance(layer.attn.input_norm, nn.RMSNorm)
+        self.assertIsInstance(layer.mlp.input_norm, nn.RMSNorm)
+        self.assertIsInstance(layer.mlp.zaya_block.router.rmsnorm_eda, nn.RMSNorm)
 
         self.language_test_runner(
             model.language_model,
@@ -3758,28 +3763,8 @@ class TestModels(unittest.TestCase):
             grid_thw=mx.array([[1, 2, 2]], dtype=mx.int64),
         )
 
-        # Numerical test (dims follow text_config)
-        H = text_config.hidden_size
-        norm = RMSNorm(H, eps=text_config.norm_epsilon)
-        norm.weight = mx.concatenate(
-            [
-                mx.array([1.5, -0.25], dtype=mx.float32),
-                mx.ones((H - 2,), dtype=mx.float32),
-            ]
-        )
-        x = mx.pad(mx.array([[1.0, 2.0]], dtype=mx.float16), ((0, 0), (0, H - 2)))
-        out = norm(x)
-
-        x32 = x.astype(mx.float32)
-        expected = x32 * mx.rsqrt(
-            mx.mean(x32 * x32, axis=-1, keepdims=True) + text_config.norm_epsilon
-        )
-        expected = norm.weight * expected.astype(x.dtype)
-        mx.eval(out, expected)
-        self.assertEqual(out.dtype, expected.dtype)
-        self.assertTrue(mx.allclose(out, expected).item())
-
         router = ZayaRouter(text_config, layer_number=1)
+        self.assertIsInstance(router.rmsnorm_eda, nn.RMSNorm)
         self.assertEqual(router.rmsnorm_eda.eps, text_config.norm_epsilon)
 
         cca = CCA(text_config, layer_number=0)

--- a/mlx_vlm/tests/test_models.py
+++ b/mlx_vlm/tests/test_models.py
@@ -3681,6 +3681,108 @@ class TestModels(unittest.TestCase):
             sanitized[f"{prefix}.unembed_out.weight"].shape, (H, v_head, kv_rank)
         )
 
+    def test_zaya1_vl(self):
+        from mlx_vlm.models import zaya1_vl
+        from mlx_vlm.models.zaya1_vl.language import CCA, RMSNorm, ZayaRouter
+
+
+        text_config = zaya1_vl.TextConfig(
+            model_type="zaya1_vl",
+            hidden_size=8,
+            ffn_hidden_size=16,
+            num_hidden_layers=1,
+            num_experts=2,
+            num_attention_heads=2,
+            num_key_value_heads=1,
+            num_query_groups=1,
+            head_dim=4,
+            zaya_mlp_expansion=4,
+            vocab_size=32,
+            vision_lora=False,
+        )
+        vision_config = zaya1_vl.VisionConfig(
+            model_type="qwen2_5_vl",
+            depth=1,
+            hidden_size=8,
+            intermediate_size=16,
+            out_hidden_size=8,
+            num_heads=2,
+            image_size=4,
+            patch_size=2,
+            in_channels=3,
+            spatial_patch_size=2,
+            spatial_merge_size=2,
+            temporal_patch_size=1,
+            window_size=4,
+            fullatt_block_indexes=[0],
+        )
+        config = zaya1_vl.ModelConfig(
+            text_config=text_config,
+            vision_config=vision_config,
+            model_type="zaya1_vl",
+            image_token_id=31,
+            vocab_size=32,
+        )
+        model = zaya1_vl.Model(config)
+
+        self.language_test_runner(
+            model.language_model,
+            config.text_config.model_type,
+            config.text_config.vocab_size,
+            config.text_config.num_hidden_layers,
+        )
+        self.vision_test_runner(
+            model.vision_tower,
+            config.vision_config.model_type,
+            config.vision_config.out_hidden_size,
+            config.vision_config.in_channels,
+            (4, 12),
+            vision_feature_layer=-1,
+            grid_thw=mx.array([[1, 2, 2]], dtype=mx.int64),
+        )
+
+        # Numerical test (dims follow text_config)
+        H = text_config.hidden_size
+        norm = RMSNorm(H, eps=text_config.norm_epsilon)
+        norm.weight = mx.concatenate(
+            [mx.array([1.5, -0.25], dtype=mx.float32), mx.ones((H - 2,), dtype=mx.float32)]
+        )
+        x = mx.pad(
+            mx.array([[1.0, 2.0]], dtype=mx.float16), ((0, 0), (0, H - 2))
+        )
+        out = norm(x)
+
+        x32 = x.astype(mx.float32)
+        expected = x32 * mx.rsqrt(
+            mx.mean(x32 * x32, axis=-1, keepdims=True) + text_config.norm_epsilon
+        )
+        expected = norm.weight * expected.astype(x.dtype)
+        mx.eval(out, expected)
+        self.assertEqual(out.dtype, expected.dtype)
+        self.assertTrue(mx.allclose(out, expected).item())
+
+        router = ZayaRouter(text_config, layer_number=1)
+        self.assertEqual(router.rmsnorm_eda.eps, text_config.norm_epsilon)
+
+
+        cca = CCA(text_config, layer_number=0)
+        for linear in (cca.linear_q, cca.linear_k, cca.val_proj1, cca.val_proj2):
+            linear.weight = mx.zeros_like(linear.weight)
+        cca.linear_q.weight[0, 0] = 1e-4
+        cca.linear_k.weight[0, 0] = 1e-4
+        for conv in cca.conv_qk:
+            conv.weight = mx.zeros_like(conv.weight)
+            conv.bias = mx.zeros_like(conv.bias)
+
+        x_cca = mx.zeros((1, 1, text_config.hidden_size), dtype=mx.float32)
+        x_cca[0, 0, 0] = 1.0
+        query, _, _ = cca(x_cca)
+        expected_query = mx.zeros((1, 1, text_config.hidden_size), dtype=mx.float32)
+        for h in range(text_config.num_attention_heads):
+            expected_query[0, 0, h * text_config.head_dim] = 2.0
+        mx.eval(query, expected_query)
+        self.assertTrue(mx.allclose(query, expected_query, rtol=1e-5).item())
+
 
 class TestGetInputEmbeddings(unittest.TestCase):
     """Test that all models with get_input_embeddings return InputEmbeddingsFeatures."""

--- a/uv.lock
+++ b/uv.lock
@@ -926,6 +926,29 @@ wheels = [
 ]
 
 [[package]]
+name = "llguidance"
+version = "1.7.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/74/2a/e889d6fdddda852171cf537486513d59fd8d9c38104323c1851a73675f1f/llguidance-1.7.5.tar.gz", hash = "sha256:afaa8f979708cd546c762f06a4fe4748e5ef7f06ed45875dabe7db8f07b73645", size = 1156674, upload-time = "2026-04-29T19:11:09.915Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8f/fa/1b13a1d77998df4feca2e4c47e46d298050f60d6436e0e99fbd952b5e9fd/llguidance-1.7.5-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:ea659e51f57b28af93a742f748f65be92264bdcf6bdab413b08d7a539e33550a", size = 3214888, upload-time = "2026-04-29T19:10:44.519Z" },
+    { url = "https://files.pythonhosted.org/packages/04/10/43190ae55cad6d36d0dba599966b58f78acffca2f7aac63b05f67684dcbe/llguidance-1.7.5-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:9e7b181638f7b473d32e0ce6a1cac25a470f06de65e70e2c6fb2fde283047762", size = 3129767, upload-time = "2026-04-29T19:10:46.366Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/df/c8003f68c322e0476db341dac58d53bceec15a95d137f3a187637bf424a6/llguidance-1.7.5-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:289bce21879105ff26e30a6b37444de01ea09d05efc795ca4ed958097f14844c", size = 3471274, upload-time = "2026-04-29T19:10:48.161Z" },
+    { url = "https://files.pythonhosted.org/packages/05/6e/f460180fb70b28c9f9d46f66fdf70e85d24d16e80ef7f5918064553245a0/llguidance-1.7.5-cp314-cp314t-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:15ebd8b87754fb904c3029d0d7a1b1a726054d92a072c4b1e16ed6d447008ca0", size = 3761960, upload-time = "2026-04-29T19:10:49.945Z" },
+    { url = "https://files.pythonhosted.org/packages/68/de/56a42638f9c17c39c701a21c577271df962df7a7b8c9903760a0af4455eb/llguidance-1.7.5-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b950423c5e6c9c9bc35af5f86739c8a71b719a1dfa6c82bf6e3c11badeb838df", size = 3489162, upload-time = "2026-04-29T19:10:51.719Z" },
+    { url = "https://files.pythonhosted.org/packages/25/5f/4aa0494c11ff4da598a0096e498bb9670c823dd548c0debb60f3730bb1a3/llguidance-1.7.5-cp314-cp314t-win32.whl", hash = "sha256:726dc941a900c982913f21032afce66cdd35f354031cf5e5ff444155142b39f3", size = 2600613, upload-time = "2026-04-29T19:10:53.659Z" },
+    { url = "https://files.pythonhosted.org/packages/63/a3/e196571aa72f578a2a106ec29883cf11344480d7b4d2513acb348b30e4f6/llguidance-1.7.5-cp314-cp314t-win_amd64.whl", hash = "sha256:b3da6ceaa03739ff3418e7a97d456f47f6242aab328abf8ea5a0abf17cb49ffc", size = 2873031, upload-time = "2026-04-29T19:10:55.233Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/e7/5c019dcd5c0312bd7b2ddaa3563c630a87bc51bfa692aed60999d5ac2bc7/llguidance-1.7.5-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:dd805b8b0302edfa18c9b2b4b9ecf7f7b23f5bea42a44a91e7706238ffd21cef", size = 3225139, upload-time = "2026-04-29T19:10:56.95Z" },
+    { url = "https://files.pythonhosted.org/packages/32/93/ecbe86d090afe4de7ab74ddc93b03a6cef8b01c62e06fa87e462e2dc4ffc/llguidance-1.7.5-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:421ff50f59fbe21bc3cba509e02366312a0de050088d2754711d1f1edb5dfe2b", size = 3136321, upload-time = "2026-04-29T19:10:58.49Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/dc/97cff2071bd9f0659db30655cfeb10bceaed91f7dee3ecbe2c813bd43642/llguidance-1.7.5-cp39-abi3-manylinux_2_31_aarch64.whl", hash = "sha256:c1dfda8d8c47da5be5e47b30084eadb2ef331ab08dc6e3a114429511ab13ae05", size = 2901942, upload-time = "2026-04-29T19:10:59.958Z" },
+    { url = "https://files.pythonhosted.org/packages/27/c4/2b9b9d0de824a71627373b0ccdbcf61bd56133b52c3f5b988a803f55d2c0/llguidance-1.7.5-cp39-abi3-manylinux_2_31_x86_64.whl", hash = "sha256:1d02dbc64dc1afc2d2cb7e5e868886527f8c6f088062e87d81bbad6212e22500", size = 3073011, upload-time = "2026-04-29T19:11:01.949Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/c6/7cc11c2e68245cbabaf1a69a9e52a55f1216beebaeee5a8455b1d85d6d84/llguidance-1.7.5-cp39-abi3-manylinux_2_34_i686.whl", hash = "sha256:3e243bc1acf47d5200e78a082a61f4866a2a3faf59b1b2ed5748e42ecaf32397", size = 3317403, upload-time = "2026-04-29T19:11:03.607Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/78/9130ce2d49e33637de372c22620b00ae6b816c4636a3a0dee0d2390a649d/llguidance-1.7.5-cp39-abi3-manylinux_2_39_riscv64.whl", hash = "sha256:f1f9fb791a8def3de4feec9c40b5d4bd63b9f06e5315586a209d567467443293", size = 3604816, upload-time = "2026-04-29T19:11:05.244Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/98/067b0cac8143f00e72dfe81d463059fe4e3615182121df3be977443ea744/llguidance-1.7.5-cp39-abi3-win32.whl", hash = "sha256:01da2d40298c3487c188a0b3c5fba982afcccf8ed0ec523b05b6210ffa745036", size = 2612422, upload-time = "2026-04-29T19:11:06.932Z" },
+    { url = "https://files.pythonhosted.org/packages/96/10/81469d27185bec13720ff1eff4b07c3d157d5633d0b2522ffb11ae09e81b/llguidance-1.7.5-cp39-abi3-win_amd64.whl", hash = "sha256:502e55c4521dde4be352b34e508dc665ddea3ae1f73c55c869f2d8b63475e4e5", size = 2883265, upload-time = "2026-04-29T19:11:08.414Z" },
+]
+
+[[package]]
 name = "markdown-it-py"
 version = "4.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1107,6 +1130,28 @@ wheels = [
 ]
 
 [[package]]
+name = "mlx-audio"
+version = "0.4.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "huggingface-hub" },
+    { name = "miniaudio" },
+    { name = "mlx" },
+    { name = "mlx-lm" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.4.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "sounddevice" },
+    { name = "tqdm" },
+    { name = "transformers" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/95/db/a9f95e3794eca373d681220c8b9f8f84451a0d14959f85cc341ca592394c/mlx_audio-0.4.3.tar.gz", hash = "sha256:8e87badf56a0f73bf91e3797b1195c01440a181cf0b64a2a08dc1bda4b037f54", size = 1144947, upload-time = "2026-04-28T20:18:12.09Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/25/0a89073ed7b7cdf34299042bd03d867c12c0c8b43f597be61bea7f146793/mlx_audio-0.4.3-py3-none-any.whl", hash = "sha256:6b87bf42d79d9ceb6b9310a77656b9b76429c2d6ddd89f634b2786c58a2e4721", size = 1373582, upload-time = "2026-04-28T20:18:10.512Z" },
+]
+
+[[package]]
 name = "mlx-cpu"
 version = "0.30.4"
 source = { registry = "https://pypi.org/simple" }
@@ -1164,8 +1209,10 @@ source = { editable = "." }
 dependencies = [
     { name = "datasets" },
     { name = "fastapi" },
+    { name = "llguidance" },
     { name = "miniaudio" },
     { name = "mlx" },
+    { name = "mlx-audio" },
     { name = "mlx-lm" },
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "numpy", version = "2.4.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
@@ -1193,8 +1240,10 @@ requires-dist = [
     { name = "datasets", specifier = ">=2.19.1" },
     { name = "fastapi", specifier = ">=0.95.1" },
     { name = "gradio", marker = "extra == 'ui'", specifier = ">=5.19.0" },
+    { name = "llguidance", specifier = ">=1.7.0" },
     { name = "miniaudio", specifier = ">=1.59" },
     { name = "mlx", specifier = ">=0.31.2" },
+    { name = "mlx-audio", specifier = ">=0.4.3" },
     { name = "mlx-cpu", marker = "extra == 'cpu'" },
     { name = "mlx-cuda", marker = "extra == 'cuda'" },
     { name = "mlx-lm", specifier = ">=0.31.3" },
@@ -2542,6 +2591,150 @@ wheels = [
 ]
 
 [[package]]
+name = "scipy"
+version = "1.15.3"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.11'",
+]
+dependencies = [
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0f/37/6964b830433e654ec7485e45a00fc9a27cf868d622838f6b6d9c5ec0d532/scipy-1.15.3.tar.gz", hash = "sha256:eae3cf522bc7df64b42cad3925c876e1b0b6c35c1337c93e12c0f366f55b0eaf", size = 59419214, upload-time = "2025-05-08T16:13:05.955Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/2f/4966032c5f8cc7e6a60f1b2e0ad686293b9474b65246b0c642e3ef3badd0/scipy-1.15.3-cp310-cp310-macosx_10_13_x86_64.whl", hash = "sha256:a345928c86d535060c9c2b25e71e87c39ab2f22fc96e9636bd74d1dbf9de448c", size = 38702770, upload-time = "2025-05-08T16:04:20.849Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/6e/0c3bf90fae0e910c274db43304ebe25a6b391327f3f10b5dcc638c090795/scipy-1.15.3-cp310-cp310-macosx_12_0_arm64.whl", hash = "sha256:ad3432cb0f9ed87477a8d97f03b763fd1d57709f1bbde3c9369b1dff5503b253", size = 30094511, upload-time = "2025-05-08T16:04:27.103Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/b1/4deb37252311c1acff7f101f6453f0440794f51b6eacb1aad4459a134081/scipy-1.15.3-cp310-cp310-macosx_14_0_arm64.whl", hash = "sha256:aef683a9ae6eb00728a542b796f52a5477b78252edede72b8327a886ab63293f", size = 22368151, upload-time = "2025-05-08T16:04:31.731Z" },
+    { url = "https://files.pythonhosted.org/packages/38/7d/f457626e3cd3c29b3a49ca115a304cebb8cc6f31b04678f03b216899d3c6/scipy-1.15.3-cp310-cp310-macosx_14_0_x86_64.whl", hash = "sha256:1c832e1bd78dea67d5c16f786681b28dd695a8cb1fb90af2e27580d3d0967e92", size = 25121732, upload-time = "2025-05-08T16:04:36.596Z" },
+    { url = "https://files.pythonhosted.org/packages/db/0a/92b1de4a7adc7a15dcf5bddc6e191f6f29ee663b30511ce20467ef9b82e4/scipy-1.15.3-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:263961f658ce2165bbd7b99fa5135195c3a12d9bef045345016b8b50c315cb82", size = 35547617, upload-time = "2025-05-08T16:04:43.546Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/6d/41991e503e51fc1134502694c5fa7a1671501a17ffa12716a4a9151af3df/scipy-1.15.3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9e2abc762b0811e09a0d3258abee2d98e0c703eee49464ce0069590846f31d40", size = 37662964, upload-time = "2025-05-08T16:04:49.431Z" },
+    { url = "https://files.pythonhosted.org/packages/25/e1/3df8f83cb15f3500478c889be8fb18700813b95e9e087328230b98d547ff/scipy-1.15.3-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:ed7284b21a7a0c8f1b6e5977ac05396c0d008b89e05498c8b7e8f4a1423bba0e", size = 37238749, upload-time = "2025-05-08T16:04:55.215Z" },
+    { url = "https://files.pythonhosted.org/packages/93/3e/b3257cf446f2a3533ed7809757039016b74cd6f38271de91682aa844cfc5/scipy-1.15.3-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:5380741e53df2c566f4d234b100a484b420af85deb39ea35a1cc1be84ff53a5c", size = 40022383, upload-time = "2025-05-08T16:05:01.914Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/84/55bc4881973d3f79b479a5a2e2df61c8c9a04fcb986a213ac9c02cfb659b/scipy-1.15.3-cp310-cp310-win_amd64.whl", hash = "sha256:9d61e97b186a57350f6d6fd72640f9e99d5a4a2b8fbf4b9ee9a841eab327dc13", size = 41259201, upload-time = "2025-05-08T16:05:08.166Z" },
+    { url = "https://files.pythonhosted.org/packages/96/ab/5cc9f80f28f6a7dff646c5756e559823614a42b1939d86dd0ed550470210/scipy-1.15.3-cp311-cp311-macosx_10_13_x86_64.whl", hash = "sha256:993439ce220d25e3696d1b23b233dd010169b62f6456488567e830654ee37a6b", size = 38714255, upload-time = "2025-05-08T16:05:14.596Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/4a/66ba30abe5ad1a3ad15bfb0b59d22174012e8056ff448cb1644deccbfed2/scipy-1.15.3-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:34716e281f181a02341ddeaad584205bd2fd3c242063bd3423d61ac259ca7eba", size = 30111035, upload-time = "2025-05-08T16:05:20.152Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/fa/a7e5b95afd80d24313307f03624acc65801846fa75599034f8ceb9e2cbf6/scipy-1.15.3-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:3b0334816afb8b91dab859281b1b9786934392aa3d527cd847e41bb6f45bee65", size = 22384499, upload-time = "2025-05-08T16:05:24.494Z" },
+    { url = "https://files.pythonhosted.org/packages/17/99/f3aaddccf3588bb4aea70ba35328c204cadd89517a1612ecfda5b2dd9d7a/scipy-1.15.3-cp311-cp311-macosx_14_0_x86_64.whl", hash = "sha256:6db907c7368e3092e24919b5e31c76998b0ce1684d51a90943cb0ed1b4ffd6c1", size = 25152602, upload-time = "2025-05-08T16:05:29.313Z" },
+    { url = "https://files.pythonhosted.org/packages/56/c5/1032cdb565f146109212153339f9cb8b993701e9fe56b1c97699eee12586/scipy-1.15.3-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:721d6b4ef5dc82ca8968c25b111e307083d7ca9091bc38163fb89243e85e3889", size = 35503415, upload-time = "2025-05-08T16:05:34.699Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/37/89f19c8c05505d0601ed5650156e50eb881ae3918786c8fd7262b4ee66d3/scipy-1.15.3-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:39cb9c62e471b1bb3750066ecc3a3f3052b37751c7c3dfd0fd7e48900ed52982", size = 37652622, upload-time = "2025-05-08T16:05:40.762Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/31/be59513aa9695519b18e1851bb9e487de66f2d31f835201f1b42f5d4d475/scipy-1.15.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:795c46999bae845966368a3c013e0e00947932d68e235702b5c3f6ea799aa8c9", size = 37244796, upload-time = "2025-05-08T16:05:48.119Z" },
+    { url = "https://files.pythonhosted.org/packages/10/c0/4f5f3eeccc235632aab79b27a74a9130c6c35df358129f7ac8b29f562ac7/scipy-1.15.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:18aaacb735ab38b38db42cb01f6b92a2d0d4b6aabefeb07f02849e47f8fb3594", size = 40047684, upload-time = "2025-05-08T16:05:54.22Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/a7/0ddaf514ce8a8714f6ed243a2b391b41dbb65251affe21ee3077ec45ea9a/scipy-1.15.3-cp311-cp311-win_amd64.whl", hash = "sha256:ae48a786a28412d744c62fd7816a4118ef97e5be0bee968ce8f0a2fba7acf3bb", size = 41246504, upload-time = "2025-05-08T16:06:00.437Z" },
+    { url = "https://files.pythonhosted.org/packages/37/4b/683aa044c4162e10ed7a7ea30527f2cbd92e6999c10a8ed8edb253836e9c/scipy-1.15.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:6ac6310fdbfb7aa6612408bd2f07295bcbd3fda00d2d702178434751fe48e019", size = 38766735, upload-time = "2025-05-08T16:06:06.471Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/7e/f30be3d03de07f25dc0ec926d1681fed5c732d759ac8f51079708c79e680/scipy-1.15.3-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:185cd3d6d05ca4b44a8f1595af87f9c372bb6acf9c808e99aa3e9aa03bd98cf6", size = 30173284, upload-time = "2025-05-08T16:06:11.686Z" },
+    { url = "https://files.pythonhosted.org/packages/07/9c/0ddb0d0abdabe0d181c1793db51f02cd59e4901da6f9f7848e1f96759f0d/scipy-1.15.3-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:05dc6abcd105e1a29f95eada46d4a3f251743cfd7d3ae8ddb4088047f24ea477", size = 22446958, upload-time = "2025-05-08T16:06:15.97Z" },
+    { url = "https://files.pythonhosted.org/packages/af/43/0bce905a965f36c58ff80d8bea33f1f9351b05fad4beaad4eae34699b7a1/scipy-1.15.3-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:06efcba926324df1696931a57a176c80848ccd67ce6ad020c810736bfd58eb1c", size = 25242454, upload-time = "2025-05-08T16:06:20.394Z" },
+    { url = "https://files.pythonhosted.org/packages/56/30/a6f08f84ee5b7b28b4c597aca4cbe545535c39fe911845a96414700b64ba/scipy-1.15.3-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c05045d8b9bfd807ee1b9f38761993297b10b245f012b11b13b91ba8945f7e45", size = 35210199, upload-time = "2025-05-08T16:06:26.159Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/1f/03f52c282437a168ee2c7c14a1a0d0781a9a4a8962d84ac05c06b4c5b555/scipy-1.15.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:271e3713e645149ea5ea3e97b57fdab61ce61333f97cfae392c28ba786f9bb49", size = 37309455, upload-time = "2025-05-08T16:06:32.778Z" },
+    { url = "https://files.pythonhosted.org/packages/89/b1/fbb53137f42c4bf630b1ffdfc2151a62d1d1b903b249f030d2b1c0280af8/scipy-1.15.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:6cfd56fc1a8e53f6e89ba3a7a7251f7396412d655bca2aa5611c8ec9a6784a1e", size = 36885140, upload-time = "2025-05-08T16:06:39.249Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/2e/025e39e339f5090df1ff266d021892694dbb7e63568edcfe43f892fa381d/scipy-1.15.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:0ff17c0bb1cb32952c09217d8d1eed9b53d1463e5f1dd6052c7857f83127d539", size = 39710549, upload-time = "2025-05-08T16:06:45.729Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/eb/3bf6ea8ab7f1503dca3a10df2e4b9c3f6b3316df07f6c0ded94b281c7101/scipy-1.15.3-cp312-cp312-win_amd64.whl", hash = "sha256:52092bc0472cfd17df49ff17e70624345efece4e1a12b23783a1ac59a1b728ed", size = 40966184, upload-time = "2025-05-08T16:06:52.623Z" },
+    { url = "https://files.pythonhosted.org/packages/73/18/ec27848c9baae6e0d6573eda6e01a602e5649ee72c27c3a8aad673ebecfd/scipy-1.15.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:2c620736bcc334782e24d173c0fdbb7590a0a436d2fdf39310a8902505008759", size = 38728256, upload-time = "2025-05-08T16:06:58.696Z" },
+    { url = "https://files.pythonhosted.org/packages/74/cd/1aef2184948728b4b6e21267d53b3339762c285a46a274ebb7863c9e4742/scipy-1.15.3-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:7e11270a000969409d37ed399585ee530b9ef6aa99d50c019de4cb01e8e54e62", size = 30109540, upload-time = "2025-05-08T16:07:04.209Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/d8/59e452c0a255ec352bd0a833537a3bc1bfb679944c4938ab375b0a6b3a3e/scipy-1.15.3-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:8c9ed3ba2c8a2ce098163a9bdb26f891746d02136995df25227a20e71c396ebb", size = 22383115, upload-time = "2025-05-08T16:07:08.998Z" },
+    { url = "https://files.pythonhosted.org/packages/08/f5/456f56bbbfccf696263b47095291040655e3cbaf05d063bdc7c7517f32ac/scipy-1.15.3-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:0bdd905264c0c9cfa74a4772cdb2070171790381a5c4d312c973382fc6eaf730", size = 25163884, upload-time = "2025-05-08T16:07:14.091Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/66/a9618b6a435a0f0c0b8a6d0a2efb32d4ec5a85f023c2b79d39512040355b/scipy-1.15.3-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:79167bba085c31f38603e11a267d862957cbb3ce018d8b38f79ac043bc92d825", size = 35174018, upload-time = "2025-05-08T16:07:19.427Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/09/c5b6734a50ad4882432b6bb7c02baf757f5b2f256041da5df242e2d7e6b6/scipy-1.15.3-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c9deabd6d547aee2c9a81dee6cc96c6d7e9a9b1953f74850c179f91fdc729cb7", size = 37269716, upload-time = "2025-05-08T16:07:25.712Z" },
+    { url = "https://files.pythonhosted.org/packages/77/0a/eac00ff741f23bcabd352731ed9b8995a0a60ef57f5fd788d611d43d69a1/scipy-1.15.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:dde4fc32993071ac0c7dd2d82569e544f0bdaff66269cb475e0f369adad13f11", size = 36872342, upload-time = "2025-05-08T16:07:31.468Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/54/4379be86dd74b6ad81551689107360d9a3e18f24d20767a2d5b9253a3f0a/scipy-1.15.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:f77f853d584e72e874d87357ad70f44b437331507d1c311457bed8ed2b956126", size = 39670869, upload-time = "2025-05-08T16:07:38.002Z" },
+    { url = "https://files.pythonhosted.org/packages/87/2e/892ad2862ba54f084ffe8cc4a22667eaf9c2bcec6d2bff1d15713c6c0703/scipy-1.15.3-cp313-cp313-win_amd64.whl", hash = "sha256:b90ab29d0c37ec9bf55424c064312930ca5f4bde15ee8619ee44e69319aab163", size = 40988851, upload-time = "2025-05-08T16:08:33.671Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/e9/7a879c137f7e55b30d75d90ce3eb468197646bc7b443ac036ae3fe109055/scipy-1.15.3-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:3ac07623267feb3ae308487c260ac684b32ea35fd81e12845039952f558047b8", size = 38863011, upload-time = "2025-05-08T16:07:44.039Z" },
+    { url = "https://files.pythonhosted.org/packages/51/d1/226a806bbd69f62ce5ef5f3ffadc35286e9fbc802f606a07eb83bf2359de/scipy-1.15.3-cp313-cp313t-macosx_12_0_arm64.whl", hash = "sha256:6487aa99c2a3d509a5227d9a5e889ff05830a06b2ce08ec30df6d79db5fcd5c5", size = 30266407, upload-time = "2025-05-08T16:07:49.891Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/9b/f32d1d6093ab9eeabbd839b0f7619c62e46cc4b7b6dbf05b6e615bbd4400/scipy-1.15.3-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:50f9e62461c95d933d5c5ef4a1f2ebf9a2b4e83b0db374cb3f1de104d935922e", size = 22540030, upload-time = "2025-05-08T16:07:54.121Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/29/c278f699b095c1a884f29fda126340fcc201461ee8bfea5c8bdb1c7c958b/scipy-1.15.3-cp313-cp313t-macosx_14_0_x86_64.whl", hash = "sha256:14ed70039d182f411ffc74789a16df3835e05dc469b898233a245cdfd7f162cb", size = 25218709, upload-time = "2025-05-08T16:07:58.506Z" },
+    { url = "https://files.pythonhosted.org/packages/24/18/9e5374b617aba742a990581373cd6b68a2945d65cc588482749ef2e64467/scipy-1.15.3-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0a769105537aa07a69468a0eefcd121be52006db61cdd8cac8a0e68980bbb723", size = 34809045, upload-time = "2025-05-08T16:08:03.929Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/fe/9c4361e7ba2927074360856db6135ef4904d505e9b3afbbcb073c4008328/scipy-1.15.3-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9db984639887e3dffb3928d118145ffe40eff2fa40cb241a306ec57c219ebbbb", size = 36703062, upload-time = "2025-05-08T16:08:09.558Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/8e/038ccfe29d272b30086b25a4960f757f97122cb2ec42e62b460d02fe98e9/scipy-1.15.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:40e54d5c7e7ebf1aa596c374c49fa3135f04648a0caabcb66c52884b943f02b4", size = 36393132, upload-time = "2025-05-08T16:08:15.34Z" },
+    { url = "https://files.pythonhosted.org/packages/10/7e/5c12285452970be5bdbe8352c619250b97ebf7917d7a9a9e96b8a8140f17/scipy-1.15.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:5e721fed53187e71d0ccf382b6bf977644c533e506c4d33c3fb24de89f5c3ed5", size = 38979503, upload-time = "2025-05-08T16:08:21.513Z" },
+    { url = "https://files.pythonhosted.org/packages/81/06/0a5e5349474e1cbc5757975b21bd4fad0e72ebf138c5592f191646154e06/scipy-1.15.3-cp313-cp313t-win_amd64.whl", hash = "sha256:76ad1fb5f8752eabf0fa02e4cc0336b4e8f021e2d5f061ed37d6d264db35e3ca", size = 40308097, upload-time = "2025-05-08T16:08:27.627Z" },
+]
+
+[[package]]
+name = "scipy"
+version = "1.17.1"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.14' and sys_platform == 'win32'",
+    "python_full_version >= '3.14' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.13.*' and sys_platform == 'win32'",
+    "python_full_version == '3.13.*' and sys_platform == 'emscripten'",
+    "python_full_version == '3.13.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32'",
+    "python_full_version == '3.12.*' and sys_platform == 'emscripten'",
+    "python_full_version == '3.12.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.11.*' and sys_platform == 'win32'",
+    "python_full_version == '3.11.*' and sys_platform == 'emscripten'",
+    "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+]
+dependencies = [
+    { name = "numpy", version = "2.4.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7a/97/5a3609c4f8d58b039179648e62dd220f89864f56f7357f5d4f45c29eb2cc/scipy-1.17.1.tar.gz", hash = "sha256:95d8e012d8cb8816c226aef832200b1d45109ed4464303e997c5b13122b297c0", size = 30573822, upload-time = "2026-02-23T00:26:24.851Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/75/b4ce781849931fef6fd529afa6b63711d5a733065722d0c3e2724af9e40a/scipy-1.17.1-cp311-cp311-macosx_10_14_x86_64.whl", hash = "sha256:1f95b894f13729334fb990162e911c9e5dc1ab390c58aa6cbecb389c5b5e28ec", size = 31613675, upload-time = "2026-02-23T00:16:00.13Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/58/bccc2861b305abdd1b8663d6130c0b3d7cc22e8d86663edbc8401bfd40d4/scipy-1.17.1-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:e18f12c6b0bc5a592ed23d3f7b891f68fd7f8241d69b7883769eb5d5dfb52696", size = 28162057, upload-time = "2026-02-23T00:16:09.456Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/ee/18146b7757ed4976276b9c9819108adbc73c5aad636e5353e20746b73069/scipy-1.17.1-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:a3472cfbca0a54177d0faa68f697d8ba4c80bbdc19908c3465556d9f7efce9ee", size = 20334032, upload-time = "2026-02-23T00:16:17.358Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/e6/cef1cf3557f0c54954198554a10016b6a03b2ec9e22a4e1df734936bd99c/scipy-1.17.1-cp311-cp311-macosx_14_0_x86_64.whl", hash = "sha256:766e0dc5a616d026a3a1cffa379af959671729083882f50307e18175797b3dfd", size = 22709533, upload-time = "2026-02-23T00:16:25.791Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/60/8804678875fc59362b0fb759ab3ecce1f09c10a735680318ac30da8cd76b/scipy-1.17.1-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:744b2bf3640d907b79f3fd7874efe432d1cf171ee721243e350f55234b4cec4c", size = 33062057, upload-time = "2026-02-23T00:16:36.931Z" },
+    { url = "https://files.pythonhosted.org/packages/09/7d/af933f0f6e0767995b4e2d705a0665e454d1c19402aa7e895de3951ebb04/scipy-1.17.1-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:43af8d1f3bea642559019edfe64e9b11192a8978efbd1539d7bc2aaa23d92de4", size = 35349300, upload-time = "2026-02-23T00:16:49.108Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/3d/7ccbbdcbb54c8fdc20d3b6930137c782a163fa626f0aef920349873421ba/scipy-1.17.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:cd96a1898c0a47be4520327e01f874acfd61fb48a9420f8aa9f6483412ffa444", size = 35127333, upload-time = "2026-02-23T00:17:01.293Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/19/f926cb11c42b15ba08e3a71e376d816ac08614f769b4f47e06c3580c836a/scipy-1.17.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:4eb6c25dd62ee8d5edf68a8e1c171dd71c292fdae95d8aeb3dd7d7de4c364082", size = 37741314, upload-time = "2026-02-23T00:17:12.576Z" },
+    { url = "https://files.pythonhosted.org/packages/95/da/0d1df507cf574b3f224ccc3d45244c9a1d732c81dcb26b1e8a766ae271a8/scipy-1.17.1-cp311-cp311-win_amd64.whl", hash = "sha256:d30e57c72013c2a4fe441c2fcb8e77b14e152ad48b5464858e07e2ad9fbfceff", size = 36607512, upload-time = "2026-02-23T00:17:23.424Z" },
+    { url = "https://files.pythonhosted.org/packages/68/7f/bdd79ceaad24b671543ffe0ef61ed8e659440eb683b66f033454dcee90eb/scipy-1.17.1-cp311-cp311-win_arm64.whl", hash = "sha256:9ecb4efb1cd6e8c4afea0daa91a87fbddbce1b99d2895d151596716c0b2e859d", size = 24599248, upload-time = "2026-02-23T00:17:34.561Z" },
+    { url = "https://files.pythonhosted.org/packages/35/48/b992b488d6f299dbe3f11a20b24d3dda3d46f1a635ede1c46b5b17a7b163/scipy-1.17.1-cp312-cp312-macosx_10_14_x86_64.whl", hash = "sha256:35c3a56d2ef83efc372eaec584314bd0ef2e2f0d2adb21c55e6ad5b344c0dcb8", size = 31610954, upload-time = "2026-02-23T00:17:49.855Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/02/cf107b01494c19dc100f1d0b7ac3cc08666e96ba2d64db7626066cee895e/scipy-1.17.1-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:fcb310ddb270a06114bb64bbe53c94926b943f5b7f0842194d585c65eb4edd76", size = 28172662, upload-time = "2026-02-23T00:18:01.64Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/a9/599c28631bad314d219cf9ffd40e985b24d603fc8a2f4ccc5ae8419a535b/scipy-1.17.1-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:cc90d2e9c7e5c7f1a482c9875007c095c3194b1cfedca3c2f3291cdc2bc7c086", size = 20344366, upload-time = "2026-02-23T00:18:12.015Z" },
+    { url = "https://files.pythonhosted.org/packages/35/f5/906eda513271c8deb5af284e5ef0206d17a96239af79f9fa0aebfe0e36b4/scipy-1.17.1-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:c80be5ede8f3f8eded4eff73cc99a25c388ce98e555b17d31da05287015ffa5b", size = 22704017, upload-time = "2026-02-23T00:18:21.502Z" },
+    { url = "https://files.pythonhosted.org/packages/da/34/16f10e3042d2f1d6b66e0428308ab52224b6a23049cb2f5c1756f713815f/scipy-1.17.1-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e19ebea31758fac5893a2ac360fedd00116cbb7628e650842a6691ba7ca28a21", size = 32927842, upload-time = "2026-02-23T00:18:35.367Z" },
+    { url = "https://files.pythonhosted.org/packages/01/8e/1e35281b8ab6d5d72ebe9911edcdffa3f36b04ed9d51dec6dd140396e220/scipy-1.17.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:02ae3b274fde71c5e92ac4d54bc06c42d80e399fec704383dcd99b301df37458", size = 35235890, upload-time = "2026-02-23T00:18:49.188Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/5c/9d7f4c88bea6e0d5a4f1bc0506a53a00e9fcb198de372bfe4d3652cef482/scipy-1.17.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8a604bae87c6195d8b1045eddece0514d041604b14f2727bbc2b3020172045eb", size = 35003557, upload-time = "2026-02-23T00:18:54.74Z" },
+    { url = "https://files.pythonhosted.org/packages/65/94/7698add8f276dbab7a9de9fb6b0e02fc13ee61d51c7c3f85ac28b65e1239/scipy-1.17.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:f590cd684941912d10becc07325a3eeb77886fe981415660d9265c4c418d0bea", size = 37625856, upload-time = "2026-02-23T00:19:00.307Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/84/dc08d77fbf3d87d3ee27f6a0c6dcce1de5829a64f2eae85a0ecc1f0daa73/scipy-1.17.1-cp312-cp312-win_amd64.whl", hash = "sha256:41b71f4a3a4cab9d366cd9065b288efc4d4f3c0b37a91a8e0947fb5bd7f31d87", size = 36549682, upload-time = "2026-02-23T00:19:07.67Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/98/fe9ae9ffb3b54b62559f52dedaebe204b408db8109a8c66fdd04869e6424/scipy-1.17.1-cp312-cp312-win_arm64.whl", hash = "sha256:f4115102802df98b2b0db3cce5cb9b92572633a1197c77b7553e5203f284a5b3", size = 24547340, upload-time = "2026-02-23T00:19:12.024Z" },
+    { url = "https://files.pythonhosted.org/packages/76/27/07ee1b57b65e92645f219b37148a7e7928b82e2b5dbeccecb4dff7c64f0b/scipy-1.17.1-cp313-cp313-macosx_10_14_x86_64.whl", hash = "sha256:5e3c5c011904115f88a39308379c17f91546f77c1667cea98739fe0fccea804c", size = 31590199, upload-time = "2026-02-23T00:19:17.192Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/ae/db19f8ab842e9b724bf5dbb7db29302a91f1e55bc4d04b1025d6d605a2c5/scipy-1.17.1-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:6fac755ca3d2c3edcb22f479fceaa241704111414831ddd3bc6056e18516892f", size = 28154001, upload-time = "2026-02-23T00:19:22.241Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/58/3ce96251560107b381cbd6e8413c483bbb1228a6b919fa8652b0d4090e7f/scipy-1.17.1-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:7ff200bf9d24f2e4d5dc6ee8c3ac64d739d3a89e2326ba68aaf6c4a2b838fd7d", size = 20325719, upload-time = "2026-02-23T00:19:26.329Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/83/15087d945e0e4d48ce2377498abf5ad171ae013232ae31d06f336e64c999/scipy-1.17.1-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:4b400bdc6f79fa02a4d86640310dde87a21fba0c979efff5248908c6f15fad1b", size = 22683595, upload-time = "2026-02-23T00:19:30.304Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/e0/e58fbde4a1a594c8be8114eb4aac1a55bcd6587047efc18a61eb1f5c0d30/scipy-1.17.1-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2b64ca7d4aee0102a97f3ba22124052b4bd2152522355073580bf4845e2550b6", size = 32896429, upload-time = "2026-02-23T00:19:35.536Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/5f/f17563f28ff03c7b6799c50d01d5d856a1d55f2676f537ca8d28c7f627cd/scipy-1.17.1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:581b2264fc0aa555f3f435a5944da7504ea3a065d7029ad60e7c3d1ae09c5464", size = 35203952, upload-time = "2026-02-23T00:19:42.259Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/a5/9afd17de24f657fdfe4df9a3f1ea049b39aef7c06000c13db1530d81ccca/scipy-1.17.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:beeda3d4ae615106d7094f7e7cef6218392e4465cc95d25f900bebabfded0950", size = 34979063, upload-time = "2026-02-23T00:19:47.547Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/13/88b1d2384b424bf7c924f2038c1c409f8d88bb2a8d49d097861dd64a57b2/scipy-1.17.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6609bc224e9568f65064cfa72edc0f24ee6655b47575954ec6339534b2798369", size = 37598449, upload-time = "2026-02-23T00:19:53.238Z" },
+    { url = "https://files.pythonhosted.org/packages/35/e5/d6d0e51fc888f692a35134336866341c08655d92614f492c6860dc45bb2c/scipy-1.17.1-cp313-cp313-win_amd64.whl", hash = "sha256:37425bc9175607b0268f493d79a292c39f9d001a357bebb6b88fdfaff13f6448", size = 36510943, upload-time = "2026-02-23T00:20:50.89Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/fd/3be73c564e2a01e690e19cc618811540ba5354c67c8680dce3281123fb79/scipy-1.17.1-cp313-cp313-win_arm64.whl", hash = "sha256:5cf36e801231b6a2059bf354720274b7558746f3b1a4efb43fcf557ccd484a87", size = 24545621, upload-time = "2026-02-23T00:20:55.871Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/6b/17787db8b8114933a66f9dcc479a8272e4b4da75fe03b0c282f7b0ade8cd/scipy-1.17.1-cp313-cp313t-macosx_10_14_x86_64.whl", hash = "sha256:d59c30000a16d8edc7e64152e30220bfbd724c9bbb08368c054e24c651314f0a", size = 31936708, upload-time = "2026-02-23T00:19:58.694Z" },
+    { url = "https://files.pythonhosted.org/packages/38/2e/524405c2b6392765ab1e2b722a41d5da33dc5c7b7278184a8ad29b6cb206/scipy-1.17.1-cp313-cp313t-macosx_12_0_arm64.whl", hash = "sha256:010f4333c96c9bb1a4516269e33cb5917b08ef2166d5556ca2fd9f082a9e6ea0", size = 28570135, upload-time = "2026-02-23T00:20:03.934Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/c3/5bd7199f4ea8556c0c8e39f04ccb014ac37d1468e6cfa6a95c6b3562b76e/scipy-1.17.1-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:2ceb2d3e01c5f1d83c4189737a42d9cb2fc38a6eeed225e7515eef71ad301dce", size = 20741977, upload-time = "2026-02-23T00:20:07.935Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/b8/8ccd9b766ad14c78386599708eb745f6b44f08400a5fd0ade7cf89b6fc93/scipy-1.17.1-cp313-cp313t-macosx_14_0_x86_64.whl", hash = "sha256:844e165636711ef41f80b4103ed234181646b98a53c8f05da12ca5ca289134f6", size = 23029601, upload-time = "2026-02-23T00:20:12.161Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/a0/3cb6f4d2fb3e17428ad2880333cac878909ad1a89f678527b5328b93c1d4/scipy-1.17.1-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:158dd96d2207e21c966063e1635b1063cd7787b627b6f07305315dd73d9c679e", size = 33019667, upload-time = "2026-02-23T00:20:17.208Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/c3/2d834a5ac7bf3a0c806ad1508efc02dda3c8c61472a56132d7894c312dea/scipy-1.17.1-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:74cbb80d93260fe2ffa334efa24cb8f2f0f622a9b9febf8b483c0b865bfb3475", size = 35264159, upload-time = "2026-02-23T00:20:23.087Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/77/d3ed4becfdbd217c52062fafe35a72388d1bd82c2d0ba5ca19d6fcc93e11/scipy-1.17.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:dbc12c9f3d185f5c737d801da555fb74b3dcfa1a50b66a1a93e09190f41fab50", size = 35102771, upload-time = "2026-02-23T00:20:28.636Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/12/d19da97efde68ca1ee5538bb261d5d2c062f0c055575128f11a2730e3ac1/scipy-1.17.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:94055a11dfebe37c656e70317e1996dc197e1a15bbcc351bcdd4610e128fe1ca", size = 37665910, upload-time = "2026-02-23T00:20:34.743Z" },
+    { url = "https://files.pythonhosted.org/packages/06/1c/1172a88d507a4baaf72c5a09bb6c018fe2ae0ab622e5830b703a46cc9e44/scipy-1.17.1-cp313-cp313t-win_amd64.whl", hash = "sha256:e30bdeaa5deed6bc27b4cc490823cd0347d7dae09119b8803ae576ea0ce52e4c", size = 36562980, upload-time = "2026-02-23T00:20:40.575Z" },
+    { url = "https://files.pythonhosted.org/packages/70/b0/eb757336e5a76dfa7911f63252e3b7d1de00935d7705cf772db5b45ec238/scipy-1.17.1-cp313-cp313t-win_arm64.whl", hash = "sha256:a720477885a9d2411f94a93d16f9d89bad0f28ca23c3f8daa521e2dcc3f44d49", size = 24856543, upload-time = "2026-02-23T00:20:45.313Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/83/333afb452af6f0fd70414dc04f898647ee1423979ce02efa75c3b0f2c28e/scipy-1.17.1-cp314-cp314-macosx_10_14_x86_64.whl", hash = "sha256:a48a72c77a310327f6a3a920092fa2b8fd03d7deaa60f093038f22d98e096717", size = 31584510, upload-time = "2026-02-23T00:21:01.015Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/a6/d05a85fd51daeb2e4ea71d102f15b34fedca8e931af02594193ae4fd25f7/scipy-1.17.1-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:45abad819184f07240d8a696117a7aacd39787af9e0b719d00285549ed19a1e9", size = 28170131, upload-time = "2026-02-23T00:21:05.888Z" },
+    { url = "https://files.pythonhosted.org/packages/db/7b/8624a203326675d7746a254083a187398090a179335b2e4a20e2ddc46e83/scipy-1.17.1-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:3fd1fcdab3ea951b610dc4cef356d416d5802991e7e32b5254828d342f7b7e0b", size = 20342032, upload-time = "2026-02-23T00:21:09.904Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/35/2c342897c00775d688d8ff3987aced3426858fd89d5a0e26e020b660b301/scipy-1.17.1-cp314-cp314-macosx_14_0_x86_64.whl", hash = "sha256:7bdf2da170b67fdf10bca777614b1c7d96ae3ca5794fd9587dce41eb2966e866", size = 22678766, upload-time = "2026-02-23T00:21:14.313Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/f2/7cdb8eb308a1a6ae1e19f945913c82c23c0c442a462a46480ce487fdc0ac/scipy-1.17.1-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:adb2642e060a6549c343603a3851ba76ef0b74cc8c079a9a58121c7ec9fe2350", size = 32957007, upload-time = "2026-02-23T00:21:19.663Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/2e/7eea398450457ecb54e18e9d10110993fa65561c4f3add5e8eccd2b9cd41/scipy-1.17.1-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:eee2cfda04c00a857206a4330f0c5e3e56535494e30ca445eb19ec624ae75118", size = 35221333, upload-time = "2026-02-23T00:21:25.278Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/77/5b8509d03b77f093a0d52e606d3c4f79e8b06d1d38c441dacb1e26cacf46/scipy-1.17.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:d2650c1fb97e184d12d8ba010493ee7b322864f7d3d00d3f9bb97d9c21de4068", size = 35042066, upload-time = "2026-02-23T00:21:31.358Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/df/18f80fb99df40b4070328d5ae5c596f2f00fffb50167e31439e932f29e7d/scipy-1.17.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:08b900519463543aa604a06bec02461558a6e1cef8fdbb8098f77a48a83c8118", size = 37612763, upload-time = "2026-02-23T00:21:37.247Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/39/f0e8ea762a764a9dc52aa7dabcfad51a354819de1f0d4652b6a1122424d6/scipy-1.17.1-cp314-cp314-win_amd64.whl", hash = "sha256:3877ac408e14da24a6196de0ddcace62092bfc12a83823e92e49e40747e52c19", size = 37290984, upload-time = "2026-02-23T00:22:35.023Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/56/fe201e3b0f93d1a8bcf75d3379affd228a63d7e2d80ab45467a74b494947/scipy-1.17.1-cp314-cp314-win_arm64.whl", hash = "sha256:f8885db0bc2bffa59d5c1b72fad7a6a92d3e80e7257f967dd81abb553a90d293", size = 25192877, upload-time = "2026-02-23T00:22:39.798Z" },
+    { url = "https://files.pythonhosted.org/packages/96/ad/f8c414e121f82e02d76f310f16db9899c4fcde36710329502a6b2a3c0392/scipy-1.17.1-cp314-cp314t-macosx_10_14_x86_64.whl", hash = "sha256:1cc682cea2ae55524432f3cdff9e9a3be743d52a7443d0cba9017c23c87ae2f6", size = 31949750, upload-time = "2026-02-23T00:21:42.289Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/b0/c741e8865d61b67c81e255f4f0a832846c064e426636cd7de84e74d209be/scipy-1.17.1-cp314-cp314t-macosx_12_0_arm64.whl", hash = "sha256:2040ad4d1795a0ae89bfc7e8429677f365d45aa9fd5e4587cf1ea737f927b4a1", size = 28585858, upload-time = "2026-02-23T00:21:47.706Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/1b/3985219c6177866628fa7c2595bfd23f193ceebbe472c98a08824b9466ff/scipy-1.17.1-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:131f5aaea57602008f9822e2115029b55d4b5f7c070287699fe45c661d051e39", size = 20757723, upload-time = "2026-02-23T00:21:52.039Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/19/2a04aa25050d656d6f7b9e7b685cc83d6957fb101665bfd9369ca6534563/scipy-1.17.1-cp314-cp314t-macosx_14_0_x86_64.whl", hash = "sha256:9cdc1a2fcfd5c52cfb3045feb399f7b3ce822abdde3a193a6b9a60b3cb5854ca", size = 23043098, upload-time = "2026-02-23T00:21:56.185Z" },
+    { url = "https://files.pythonhosted.org/packages/86/f1/3383beb9b5d0dbddd030335bf8a8b32d4317185efe495374f134d8be6cce/scipy-1.17.1-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6e3dcd57ab780c741fde8dc68619de988b966db759a3c3152e8e9142c26295ad", size = 33030397, upload-time = "2026-02-23T00:22:01.404Z" },
+    { url = "https://files.pythonhosted.org/packages/41/68/8f21e8a65a5a03f25a79165ec9d2b28c00e66dc80546cf5eb803aeeff35b/scipy-1.17.1-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a9956e4d4f4a301ebf6cde39850333a6b6110799d470dbbb1e25326ac447f52a", size = 35281163, upload-time = "2026-02-23T00:22:07.024Z" },
+    { url = "https://files.pythonhosted.org/packages/84/8d/c8a5e19479554007a5632ed7529e665c315ae7492b4f946b0deb39870e39/scipy-1.17.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:a4328d245944d09fd639771de275701ccadf5f781ba0ff092ad141e017eccda4", size = 35116291, upload-time = "2026-02-23T00:22:12.585Z" },
+    { url = "https://files.pythonhosted.org/packages/52/52/e57eceff0e342a1f50e274264ed47497b59e6a4e3118808ee58ddda7b74a/scipy-1.17.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:a77cbd07b940d326d39a1d1b37817e2ee4d79cb30e7338f3d0cddffae70fcaa2", size = 37682317, upload-time = "2026-02-23T00:22:18.513Z" },
+    { url = "https://files.pythonhosted.org/packages/11/2f/b29eafe4a3fbc3d6de9662b36e028d5f039e72d345e05c250e121a230dd4/scipy-1.17.1-cp314-cp314t-win_amd64.whl", hash = "sha256:eb092099205ef62cd1782b006658db09e2fed75bffcae7cc0d44052d8aa0f484", size = 37345327, upload-time = "2026-02-23T00:22:24.442Z" },
+    { url = "https://files.pythonhosted.org/packages/07/39/338d9219c4e87f3e708f18857ecd24d22a0c3094752393319553096b98af/scipy-1.17.1-cp314-cp314t-win_arm64.whl", hash = "sha256:200e1050faffacc162be6a486a984a0497866ec54149a01270adc8a59b7c7d21", size = 25489165, upload-time = "2026-02-23T00:22:29.563Z" },
+]
+
+[[package]]
 name = "semantic-version"
 version = "2.10.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2630,6 +2823,22 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
+name = "sounddevice"
+version = "0.5.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2a/f9/2592608737553638fca98e21e54bfec40bf577bb98a61b2770c912aab25e/sounddevice-0.5.5.tar.gz", hash = "sha256:22487b65198cb5bf2208755105b524f78ad173e5ab6b445bdab1c989f6698df3", size = 143191, upload-time = "2026-01-23T18:36:43.529Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/0a/478e441fd049002cf308520c0d62dd8333e7c6cc8d997f0dda07b9fbcc46/sounddevice-0.5.5-py3-none-any.whl", hash = "sha256:30ff99f6c107f49d25ad16a45cacd8d91c25a1bcdd3e81a206b921a3a6405b1f", size = 32807, upload-time = "2026-01-23T18:36:35.649Z" },
+    { url = "https://files.pythonhosted.org/packages/56/f9/c037c35f6d0b6bc3bc7bfb314f1d6f1f9a341328ef47cd63fc4f850a7b27/sounddevice-0.5.5-py3-none-macosx_10_6_x86_64.macosx_10_6_universal2.whl", hash = "sha256:05eb9fd6c54c38d67741441c19164c0dae8ce80453af2d8c4ad2e7823d15b722", size = 108557, upload-time = "2026-01-23T18:36:37.41Z" },
+    { url = "https://files.pythonhosted.org/packages/88/a1/d19dd9889cd4bce2e233c4fac007cd8daaf5b9fe6e6a5d432cf17be0b807/sounddevice-0.5.5-py3-none-win32.whl", hash = "sha256:1234cc9b4c9df97b6cbe748146ae0ec64dd7d6e44739e8e42eaa5b595313a103", size = 317765, upload-time = "2026-01-23T18:36:39.047Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/0e/002ed7c4c1c2ab69031f78989d3b789fee3a7fba9e586eb2b81688bf4961/sounddevice-0.5.5-py3-none-win_amd64.whl", hash = "sha256:cfc6b2c49fb7f555591c78cb8ecf48d6a637fd5b6e1db5fec6ed9365d64b3519", size = 365324, upload-time = "2026-01-23T18:36:40.496Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/39/a61d4b83a7746b70d23d9173be688c0c6bfc7173772344b7442c2c155497/sounddevice-0.5.5-py3-none-win_arm64.whl", hash = "sha256:3861901ddd8230d2e0e8ae62ac320cdd4c688d81df89da036dcb812f757bb3e6", size = 317115, upload-time = "2026-01-23T18:36:42.235Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Adds support for `Zyphra/ZAYA1-VL-8B` in mlx-vlm, including the ZAYA language stack, multimodal wrapper, processor, prompt formatting, and weight sanitization for the upstream Transformers checkpoint layout.

Key pieces:
- Adds `mlx_vlm.models.zaya1_vl` with config, language model, processor, and multimodal model wrapper.
- Reuses the Qwen2.5-VL vision tower path for image embeddings.
- Implements ZAYA CCA attention, routed expert MLPs, residual scaling, vision LoRA paths, cache handling, and checkpoint key conversion.
- Uses the mlx-lm RoPE helper for rotary embeddings.
- Handles ZAYA CCA auxiliary state for cached and batched prefill, including left-padded continuous batching.

## Metrics

`Zyphra/ZAYA1-VL-8B` bf16 on M3 Max 96GB:

- Prompt: 406 tokens, 495.073 tokens/sec
- Generation: 186 tokens, 55.607 tokens/sec
- Peak memory: 20.200 GB

## Validation

- Real ZAYA text forward on local `Zyphra/ZAYA1-VL-8B` weights: argmax 107.
- Cached prefill/decode forward: decode argmax 107, decode vs full max abs 0.375.
- Text parity smoke against Zyphra Transformers reference: ref argmax 107, MLX argmax 107, max abs 0.5, mean abs 0.042481184.
- Batched left-padded prefill comparison: rows that previously selected EOS/point tokens now match single-request argmaxes.
- Server validation with `max_tokens=1200` through `/v1/chat/completions`:
  - single text-only and single image+text requests completed coherently
  - concurrent text-only: 4/4 completed coherently
  - concurrent mixed text and image+text: 4/4 completed coherently
  - no leaked box/point/image control tokens
  - no high-repetition responses
  - concurrent text aggregate throughput: ~100.4 completion tok/sec
  - concurrent mixed aggregate throughput: ~72.5 completion tok/sec