### PR TITLE
Fix max kv size enforcement

### DIFF
--- a/mlx_vlm/server.py
+++ b/mlx_vlm/server.py
@@ -65,6 +65,10 @@ METRICS_HISTORY_LIMIT = 100
 METRICS_RECENT_LIMIT = 32
 
 
+class PromptTooLongError(ValueError):
+    """Raised when a request exceeds the configured server context budget."""
+
+
 def _get_speculative_rounds_batch(draft_kind: str):
     if draft_kind == "mtp":
         return _mtp_rounds_batch
@@ -153,6 +157,11 @@ def get_max_kv_size(model: str):
         print(f"Model {model} uses QuantizedKVCache, can't set max KV size.")
         return None
     return max_kv_tokens
+
+
+def get_configured_context_limit():
+    max_kv_tokens = int(os.environ.get("MAX_KV_SIZE", 0))
+    return max_kv_tokens or None
 
 
 def get_quantized_kv_start():
@@ -395,6 +404,13 @@ def _build_metrics_envelope(
 def _server_runtime_snapshot() -> dict:
     config = model_cache.get("config")
     text_config = getattr(config, "text_config", None)
+    native_context_size = getattr(text_config, "max_position_embeddings", None)
+    configured_context_limit = get_configured_context_limit()
+    effective_context_limit = (
+        min(native_context_size, configured_context_limit)
+        if native_context_size is not None and configured_context_limit is not None
+        else configured_context_limit or native_context_size
+    )
     queue_depth = 0
     if response_generator is not None and hasattr(response_generator, "requests"):
         try:
@@ -404,7 +420,9 @@ def _server_runtime_snapshot() -> dict:
     return {
         "loaded_model": model_cache.get("model_path", None),
         "loaded_adapter": model_cache.get("adapter_path", None),
-        "loaded_context_size": getattr(text_config, "max_position_embeddings", None),
+        "loaded_context_size": native_context_size,
+        "configured_context_limit": configured_context_limit,
+        "effective_context_limit": effective_context_limit,
         "loaded_tool_parser": (
             _infer_tool_parser_from_processor(model_cache.get("processor"))
             if model_cache.get("processor")
@@ -634,6 +652,15 @@ class ResponseGenerator:
             if hasattr(raw_inputs["input_ids"], "size")
             else len(raw_inputs["input_ids"])
         )
+        context_limit = get_configured_context_limit()
+        requested_tokens = prompt_tokens + max(0, int(args.max_tokens or 0))
+        if context_limit is not None and requested_tokens > context_limit:
+            raise PromptTooLongError(
+                "Request needs "
+                f"{requested_tokens} context tokens "
+                f"({prompt_tokens} prompt + {args.max_tokens} max generation), "
+                f"but MAX_KV_SIZE is {context_limit}."
+            )
 
         self.requests.put((rqueue, raw_inputs, prompt_tokens, args, images))
 
@@ -2632,6 +2659,16 @@ async def responses_endpoint(request: Request):
 
                 return response
 
+            except PromptTooLongError as e:
+                server_metrics.record_failure(
+                    endpoint="/responses",
+                    model=openai_request.model,
+                    stream=False,
+                    error=str(e),
+                )
+                mx.clear_cache()
+                gc.collect()
+                raise HTTPException(status_code=400, detail=str(e))
             except Exception as e:
                 server_metrics.record_failure(
                     endpoint="/responses",
@@ -3308,6 +3345,16 @@ async def chat_completions_endpoint(request: ChatRequest, http_request: Request)
 
                 return result
 
+            except PromptTooLongError as e:
+                server_metrics.record_failure(
+                    endpoint="/chat/completions",
+                    model=request.model,
+                    stream=False,
+                    error=str(e),
+                )
+                mx.clear_cache()
+                gc.collect()
+                raise HTTPException(status_code=400, detail=str(e))
             except Exception as e:
                 server_metrics.record_failure(
                     endpoint="/chat/completions",
@@ -3388,6 +3435,8 @@ async def health_check():
         "loaded_model": runtime["loaded_model"],
         "loaded_adapter": runtime["loaded_adapter"],
         "loaded_context_size": runtime["loaded_context_size"],
+        "configured_context_limit": runtime["configured_context_limit"],
+        "effective_context_limit": runtime["effective_context_limit"],
         "loaded_tool_parser": runtime["loaded_tool_parser"],
         "continuous_batching_enabled": runtime["continuous_batching_enabled"],
         "apc_enabled": runtime["apc"]["enabled"],

--- a/mlx_vlm/server.py
+++ b/mlx_vlm/server.py
@@ -164,6 +164,23 @@ def get_configured_context_limit():
     return max_kv_tokens or None
 
 
+def _count_prompt_tokens(raw_inputs: dict) -> int:
+    input_ids = raw_inputs["input_ids"]
+    return input_ids.size if hasattr(input_ids, "size") else len(input_ids)
+
+
+def _check_configured_context_budget(prompt_tokens: int, max_tokens: int):
+    context_limit = get_configured_context_limit()
+    requested_tokens = prompt_tokens + max(0, int(max_tokens or 0))
+    if context_limit is not None and requested_tokens > context_limit:
+        raise PromptTooLongError(
+            "Request needs "
+            f"{requested_tokens} context tokens "
+            f"({prompt_tokens} prompt + {max_tokens} max generation), "
+            f"but MAX_KV_SIZE is {context_limit}."
+        )
+
+
 def get_quantized_kv_start():
     return int(os.environ.get("QUANTIZED_KV_START", DEFAULT_QUANTIZED_KV_START))
 
@@ -647,20 +664,8 @@ class ResponseGenerator:
         # CPU preprocessing (tokenize, load images) on caller thread.
         # GPU work (vision encoder) deferred to GPU thread.
         raw_inputs = self._cpu_preprocess(prompt, images, audio)
-        prompt_tokens = (
-            raw_inputs["input_ids"].size
-            if hasattr(raw_inputs["input_ids"], "size")
-            else len(raw_inputs["input_ids"])
-        )
-        context_limit = get_configured_context_limit()
-        requested_tokens = prompt_tokens + max(0, int(args.max_tokens or 0))
-        if context_limit is not None and requested_tokens > context_limit:
-            raise PromptTooLongError(
-                "Request needs "
-                f"{requested_tokens} context tokens "
-                f"({prompt_tokens} prompt + {args.max_tokens} max generation), "
-                f"but MAX_KV_SIZE is {context_limit}."
-            )
+        prompt_tokens = _count_prompt_tokens(raw_inputs)
+        _check_configured_context_budget(prompt_tokens, args.max_tokens)
 
         self.requests.put((rqueue, raw_inputs, prompt_tokens, args, images))
 
@@ -1214,6 +1219,23 @@ class ResponseGenerator:
         while batch_gen.has_pending_prompts:
             self._step(batch_gen, active)
 
+    def validate_context_budget(
+        self,
+        prompt: str,
+        images: Optional[List] = None,
+        audio: Optional[List] = None,
+        args: Optional[GenerationArguments] = None,
+    ):
+        """Validate request size before opening a streaming response."""
+        if get_configured_context_limit() is None:
+            return
+        self.wait_until_ready()
+        args = args or GenerationArguments(max_tokens=get_server_max_tokens())
+        raw_inputs = self._cpu_preprocess(prompt, images, audio)
+        _check_configured_context_budget(
+            _count_prompt_tokens(raw_inputs), args.max_tokens
+        )
+
 
 def suppress_tool_call_content(
     full_output: str,
@@ -1338,6 +1360,38 @@ def _read_tenant_id(http_request) -> Optional[str]:
         return None
     h = http_request.headers
     return h.get("x-apc-tenant") or h.get("x-tenant-id") or None
+
+
+async def _preflight_stream_context_budget(
+    *,
+    endpoint: str,
+    model: str,
+    prompt: str,
+    images: Optional[List] = None,
+    audio: Optional[List] = None,
+    args: GenerationArguments,
+):
+    """Reject over-budget streaming requests before the HTTP stream starts."""
+    if response_generator is None:
+        return
+    try:
+        await asyncio.to_thread(
+            response_generator.validate_context_budget,
+            prompt,
+            images,
+            audio,
+            args,
+        )
+    except PromptTooLongError as e:
+        server_metrics.record_failure(
+            endpoint=endpoint,
+            model=model,
+            stream=True,
+            error=str(e),
+        )
+        mx.clear_cache()
+        gc.collect()
+        raise HTTPException(status_code=400, detail=str(e))
 
 
 def _as_plain_dict(value):
@@ -2261,6 +2315,14 @@ async def responses_endpoint(request: Request):
                 model=openai_request.model,
                 stream=True,
             )
+            await _preflight_stream_context_budget(
+                endpoint="/responses",
+                model=openai_request.model,
+                prompt=formatted_prompt,
+                images=images if images else None,
+                audio=None,
+                args=gen_args,
+            )
 
             async def stream_generator():
                 token_iterator = None
@@ -2815,6 +2877,14 @@ async def chat_completions_endpoint(request: ChatRequest, http_request: Request)
                 endpoint="/chat/completions",
                 model=request.model,
                 stream=True,
+            )
+            await _preflight_stream_context_budget(
+                endpoint="/chat/completions",
+                model=request.model,
+                prompt=formatted_prompt,
+                images=images if images else None,
+                audio=audio if audio else None,
+                args=gen_args,
             )
 
             async def stream_generator():

--- a/mlx_vlm/tests/test_server.py
+++ b/mlx_vlm/tests/test_server.py
@@ -306,6 +306,112 @@ def test_responses_endpoint_forwards_new_sampling_args(client):
     assert mock_generate.call_args.kwargs["thinking_start_token"] == "<think>"
 
 
+@pytest.mark.parametrize(
+    ("path", "payload"),
+    [
+        (
+            "/v1/chat/completions",
+            {
+                "model": "demo",
+                "messages": [{"role": "user", "content": "Hello"}],
+                "max_tokens": 4,
+                "stream": True,
+            },
+        ),
+        (
+            "/v1/responses",
+            {
+                "model": "demo",
+                "input": "Hello",
+                "max_output_tokens": 4,
+                "stream": True,
+            },
+        ),
+    ],
+)
+def test_v1_stream_endpoints_reject_over_context_before_sse(
+    client, monkeypatch, path, payload
+):
+    class OverBudgetResponseGenerator:
+        generate_called = False
+
+        def validate_context_budget(self, prompt, images=None, audio=None, args=None):
+            raise server.PromptTooLongError(
+                "Request needs 9 context tokens "
+                "(5 prompt + 4 max generation), but MAX_KV_SIZE is 8."
+            )
+
+        def generate(self, *args, **kwargs):
+            self.generate_called = True
+            raise AssertionError("streaming should not start")
+
+    response_generator = OverBudgetResponseGenerator()
+    model = SimpleNamespace()
+    processor = SimpleNamespace()
+    config = SimpleNamespace(model_type="qwen2_vl")
+
+    monkeypatch.setattr(server, "server_metrics", server.ServerMetricsStore())
+    monkeypatch.setattr(server, "response_generator", response_generator)
+    monkeypatch.setattr(
+        server, "get_cached_model", MagicMock(return_value=(model, processor, config))
+    )
+    monkeypatch.setattr(server, "apply_chat_template", MagicMock(return_value="prompt"))
+
+    response = client.post(path, json=payload)
+
+    assert response.status_code == 400
+    assert "MAX_KV_SIZE is 8" in response.json()["detail"]
+    assert response_generator.generate_called is False
+
+
+@pytest.mark.parametrize(
+    ("path", "payload"),
+    [
+        (
+            "/v1/chat/completions",
+            {
+                "model": "demo",
+                "messages": [{"role": "user", "content": "Hello"}],
+                "max_tokens": 4,
+            },
+        ),
+        (
+            "/v1/responses",
+            {
+                "model": "demo",
+                "input": "Hello",
+                "max_output_tokens": 4,
+            },
+        ),
+    ],
+)
+def test_v1_non_stream_endpoints_reject_over_context(
+    client, monkeypatch, path, payload
+):
+    class OverBudgetResponseGenerator:
+        def generate(self, *args, **kwargs):
+            raise server.PromptTooLongError(
+                "Request needs 9 context tokens "
+                "(5 prompt + 4 max generation), but MAX_KV_SIZE is 8."
+            )
+
+    model = SimpleNamespace()
+    processor = SimpleNamespace()
+    config = SimpleNamespace(model_type="qwen2_vl")
+
+    monkeypatch.setattr(server, "server_metrics", server.ServerMetricsStore())
+    monkeypatch.setattr(server, "response_generator", OverBudgetResponseGenerator())
+    monkeypatch.setattr(
+        server, "get_cached_model", MagicMock(return_value=(model, processor, config))
+    )
+    monkeypatch.setattr(server, "apply_chat_template", MagicMock(return_value="prompt"))
+
+    response = client.post(path, json=payload)
+
+    assert response.status_code == 400
+    assert "MAX_KV_SIZE is 8" in response.json()["detail"]
+
+
 def test_chat_completions_endpoint_forwards_explicit_sampling_args(client):
     model = SimpleNamespace()
     processor = SimpleNamespace()

--- a/mlx_vlm/tests/test_server.py
+++ b/mlx_vlm/tests/test_server.py
@@ -539,9 +539,7 @@ class TestResponseGenerator:
         gen._cpu_preprocess = lambda prompt, images, audio: {"input_ids": [1, 2, 3]}
         return gen
 
-    def test_generate_rejects_requests_over_configured_context_limit(
-        self, monkeypatch
-    ):
+    def test_generate_rejects_requests_over_configured_context_limit(self, monkeypatch):
         gen = server.ResponseGenerator.__new__(server.ResponseGenerator)
         gen.wait_until_ready = lambda: None
         gen.draft_model = None
@@ -557,9 +555,7 @@ class TestResponseGenerator:
 
         assert gen.requests.empty()
 
-    def test_server_runtime_snapshot_reports_effective_context_limit(
-        self, monkeypatch
-    ):
+    def test_server_runtime_snapshot_reports_effective_context_limit(self, monkeypatch):
         monkeypatch.setenv("MAX_KV_SIZE", "8")
         monkeypatch.setattr(
             server,

--- a/mlx_vlm/tests/test_server.py
+++ b/mlx_vlm/tests/test_server.py
@@ -539,6 +539,46 @@ class TestResponseGenerator:
         gen._cpu_preprocess = lambda prompt, images, audio: {"input_ids": [1, 2, 3]}
         return gen
 
+    def test_generate_rejects_requests_over_configured_context_limit(
+        self, monkeypatch
+    ):
+        gen = server.ResponseGenerator.__new__(server.ResponseGenerator)
+        gen.wait_until_ready = lambda: None
+        gen.draft_model = None
+        gen._cpu_preprocess = lambda prompt, images, audio: {
+            "input_ids": mx.array([[1, 2, 3, 4, 5]], dtype=mx.int32)
+        }
+        gen.requests = Queue()
+
+        monkeypatch.setenv("MAX_KV_SIZE", "8")
+
+        with pytest.raises(server.PromptTooLongError, match="MAX_KV_SIZE is 8"):
+            gen.generate("prompt", args=server.GenerationArguments(max_tokens=4))
+
+        assert gen.requests.empty()
+
+    def test_server_runtime_snapshot_reports_effective_context_limit(
+        self, monkeypatch
+    ):
+        monkeypatch.setenv("MAX_KV_SIZE", "8")
+        monkeypatch.setattr(
+            server,
+            "model_cache",
+            {
+                "config": SimpleNamespace(
+                    text_config=SimpleNamespace(max_position_embeddings=16)
+                )
+            },
+        )
+        monkeypatch.setattr(server, "response_generator", None)
+        monkeypatch.setattr(server, "apc_manager", None)
+
+        runtime = server._server_runtime_snapshot()
+
+        assert runtime["loaded_context_size"] == 16
+        assert runtime["configured_context_limit"] == 8
+        assert runtime["effective_context_limit"] == 8
+
     def test_generate_arguments_defaults(self):
         args = server.GenerationArguments()
         assert args.max_tokens == server.DEFAULT_MAX_TOKENS


### PR DESCRIPTION
Based on https://github.com/Blaizzy/mlx-vlm/pull/1153, but expanded to cover both streaming an non-streaming responses so we consistently serve an HTTP 400 in all cases.

Resolves https://github.com/Blaizzy/mlx-vlm/issues/1154