### PR TITLE
Fix streaming thinking mode and tool-call content truncation

### DIFF
--- a/mlx_vlm/server.py
+++ b/mlx_vlm/server.py
@@ -2810,10 +2810,44 @@ async def chat_completions_endpoint(request: ChatRequest, http_request: Request)
 
                         output_tokens = 0
                         request_id = f"chatcmpl-{uuid.uuid4()}"
-                        # Track thinking state for reasoning/content split
-                        in_thinking = False
+                        # Track thinking state for reasoning/content split.
+                        # Start in thinking mode if enable_thinking is set, since the
+                        # <think> tag is injected as a prompt prefix — generation begins
+                        # already inside the think block, so in_thinking must be True.
+                        in_thinking = gen_args.enable_thinking
                         accumulated = ""
                         full_output = ""  # raw output for tool call parsing
+                        # Resolve the </think> special-token ID once. Detecting the
+                        # boundary by token ID (not string) prevents the model writing
+                        # about </think> mid-thinking from prematurely exiting thinking
+                        # mode (e.g. in code examples or explanations).
+                        _think_end_id = None
+                        try:
+                            _rtok = response_generator.tokenizer
+                            if hasattr(_rtok, "think_end_id"):
+                                _think_end_id = _rtok.think_end_id
+                            elif hasattr(_rtok, "convert_tokens_to_ids"):
+                                _unk = getattr(_rtok, "unk_token_id", None)
+                                _id = _rtok.convert_tokens_to_ids("</think>")
+                                if _id != _unk:
+                                    _think_end_id = _id
+                        except Exception:
+                            pass
+                        # Once the thinking block has closed we never re-enter it.
+                        _thinking_done = not in_thinking
+                        # Multi-token lookahead window for </think> boundary detection.
+                        # The BPE incremental decoder suppresses the </think> special
+                        # token (text='') but releases preceding-context bytes on the
+                        # *next* regular token. That next token's .text therefore
+                        # contains the </think> string followed by the first content
+                        # text. We accumulate tokens until we see \n in the combined
+                        # text: Qwen3 always emits \n\n before the response, so \n
+                        # confirms a real boundary. A </think> written inside a code
+                        # example has no following \n and is treated as spurious.
+                        _THINK_PENDING_MAX = 5   # cap on non-empty tokens before deciding
+                        _THINK_PENDING_CAP = 25  # hard cap including all-empty tokens
+                        _think_end_pending = 0   # 0 = not pending, >0 = window size
+                        _pending_buffer = []
                         # Track tool-call state to suppress markup from content
                         in_tool_call = False
                         tc_start = tool_module.tool_call_start if tool_module else None
@@ -2843,7 +2877,44 @@ async def chat_completions_endpoint(request: ChatRequest, http_request: Request)
                             delta_reasoning = None
                             delta_content = None
 
-                            if not in_thinking and (
+                            if _think_end_pending > 0:
+                                # Accumulate tokens after the </think> token to
+                                # confirm the boundary. Strategy: extend the window
+                                # while combined text is entirely empty (BPE buffering
+                                # may suppress multiple special tokens in a row). As
+                                # soon as the first non-empty text appears:
+                                #   \n present → real end (response follows)
+                                #   no \n      → spurious (model was writing about the tag)
+                                _pending_buffer.append(token)
+                                _combined = "".join(t.text for t in _pending_buffer)
+                                _has_newline = "\n" in _combined
+                                _has_content = bool(_combined)
+                                _content_at_cap = _has_content and _think_end_pending >= _THINK_PENDING_MAX
+                                _hard_cap = _think_end_pending >= _THINK_PENDING_CAP
+                                if _has_newline or token.finish_reason or _content_at_cap or _hard_cap:
+                                    if _has_newline:
+                                        in_thinking = False
+                                        _thinking_done = True
+                                        # Split on the tag string rather than the first \n
+                                        # because the BPE decoder embeds the </think> text
+                                        # inside the next token's .text value.
+                                        tail = None
+                                        for _tag in ("</think>", "<channel|>"):
+                                            if _tag in _combined:
+                                                tail = _combined.split(_tag, 1)[1].lstrip("\n")
+                                                break
+                                        if tail is None:
+                                            tail = _combined.split("\n", 1)[1].lstrip("\n")
+                                        delta_content = tail if tail else None
+                                    else:
+                                        # Spurious </think> inside thinking content.
+                                        delta_reasoning = _combined if _combined else None
+                                    _think_end_pending = 0
+                                    _pending_buffer = []
+                                else:
+                                    _think_end_pending += 1
+                                accumulated = token.text
+                            elif not in_thinking and not _thinking_done and (
                                 "<|channel>thought" in accumulated
                                 or "<think>" in accumulated
                             ):
@@ -2851,19 +2922,25 @@ async def chat_completions_endpoint(request: ChatRequest, http_request: Request)
                                 accumulated = ""
                                 # Don't emit opening tag tokens
                             elif in_thinking and (
-                                "<channel|>" in accumulated or "</think>" in accumulated
+                                (_think_end_id is not None and token.token == _think_end_id)
+                                or (_think_end_id is None and (
+                                    "<channel|>" in accumulated or "</think>" in accumulated
+                                ))
                             ):
-                                in_thinking = False
-                                accumulated = ""
-                                # Don't emit closing tag tokens
+                                # Begin the lookahead window; don't emit yet.
+                                _think_end_pending = 1
+                                _pending_buffer = []
+                                accumulated = token.text
                             elif in_thinking:
                                 delta_reasoning = token.text
-                            elif not in_thinking and (
+                                accumulated = token.text
+                            elif not in_thinking and not _thinking_done and (
                                 "<|channel>" in accumulated or "<think" in accumulated
                             ):
-                                pass  # Partial tag, don't emit yet
+                                pass  # Partial opening tag — hold off
                             else:
                                 delta_content = token.text
+                                accumulated = token.text
 
                             # Suppress tool-call markup from content
                             in_tool_call, delta_content = suppress_tool_call_content(

--- a/mlx_vlm/server.py
+++ b/mlx_vlm/server.py
@@ -1196,18 +1196,27 @@ def suppress_tool_call_content(
 ) -> Tuple[bool, Optional[str]]:
     """Suppress tool-call markup from streamed delta.content.
 
+    When tc_start first appears inside delta_content, the prefix preceding
+    it is real content and is emitted; tc_start onwards is suppressed.
+    Otherwise the entire delta — including the BPE-flushed text that comes
+    bundled with the tool-call special token — would be silently dropped.
+
     Returns updated (in_tool_call, delta_content).
     """
     if not tc_start:
         return in_tool_call, delta_content
-    if not in_tool_call:
-        if tc_start in full_output:
-            return True, None
-
-        if any(full_output.endswith(tc_start[:j]) for j in range(2, len(tc_start))):
-            return False, None
-    else:
+    if in_tool_call:
         return True, None
+    if tc_start in full_output:
+        if delta_content:
+            pre_delta = full_output[:-len(delta_content)]
+            if tc_start not in pre_delta:
+                offset = full_output.find(tc_start) - len(pre_delta)
+                if offset > 0:
+                    return True, delta_content[:offset]
+        return True, None
+    if any(full_output.endswith(tc_start[:j]) for j in range(2, len(tc_start))):
+        return False, None
     return in_tool_call, delta_content
 
 
@@ -2838,12 +2847,10 @@ async def chat_completions_endpoint(request: ChatRequest, http_request: Request)
                         # Multi-token lookahead window for </think> boundary detection.
                         # The BPE incremental decoder suppresses the </think> special
                         # token (text='') but releases preceding-context bytes on the
-                        # *next* regular token. That next token's .text therefore
-                        # contains the </think> string followed by the first content
-                        # text. We accumulate tokens until we see \n in the combined
-                        # text: Qwen3 always emits \n\n before the response, so \n
-                        # confirms a real boundary. A </think> written inside a code
-                        # example has no following \n and is treated as spurious.
+                        # *next* regular token. That token's .text therefore contains
+                        # the </think> string followed by the first content text.
+                        # We confirm a real boundary when the after-tag portion starts
+                        # with \n\n (Qwen3 always emits \n\n before the response).
                         _THINK_PENDING_MAX = 5   # cap on non-empty tokens before deciding
                         _THINK_PENDING_CAP = 25  # hard cap including all-empty tokens
                         _think_end_pending = 0   # 0 = not pending, >0 = window size
@@ -2887,25 +2894,42 @@ async def chat_completions_endpoint(request: ChatRequest, http_request: Request)
                                 #   no \n      → spurious (model was writing about the tag)
                                 _pending_buffer.append(token)
                                 _combined = "".join(t.text for t in _pending_buffer)
-                                _has_newline = "\n" in _combined
                                 _has_content = bool(_combined)
                                 _content_at_cap = _has_content and _think_end_pending >= _THINK_PENDING_MAX
                                 _hard_cap = _think_end_pending >= _THINK_PENDING_CAP
-                                if _has_newline or token.finish_reason or _content_at_cap or _hard_cap:
-                                    if _has_newline:
+                                # Qwen3 always emits \n\n after </think> before the
+                                # response. A single \n can appear inside a code line
+                                # or sentence — check for \n\n *after* the tag.
+                                _confirmed = False
+                                for _chk_tag in ("</think>", "<channel|>"):
+                                    if _chk_tag in _combined:
+                                        _confirmed = _combined.split(_chk_tag, 1)[1].startswith("\n\n")
+                                        break
+                                # When the stream ends with an empty window, the model
+                                # generated </think> as its very last token before hitting
+                                # max_tokens. Treat as a real end (no response tail).
+                                if not _confirmed and token.finish_reason and not _combined:
+                                    _confirmed = True
+                                if _confirmed or token.finish_reason or _content_at_cap or _hard_cap:
+                                    if _confirmed:
                                         in_thinking = False
                                         _thinking_done = True
-                                        # Split on the tag string rather than the first \n
-                                        # because the BPE decoder embeds the </think> text
-                                        # inside the next token's .text value.
+                                        # Split on the tag string to separate the last
+                                        # thinking text (before </think>) from the first
+                                        # content text (after </think>). The BPE decoder
+                                        # embeds both in the next token's .text value.
+                                        thinking_tail = None
                                         tail = None
                                         for _tag in ("</think>", "<channel|>"):
                                             if _tag in _combined:
-                                                tail = _combined.split(_tag, 1)[1].lstrip("\n")
+                                                _parts = _combined.split(_tag, 1)
+                                                thinking_tail = _parts[0].rstrip("\n") or None
+                                                tail = _parts[1].lstrip("\n") or None
                                                 break
-                                        if tail is None:
-                                            tail = _combined.split("\n", 1)[1].lstrip("\n")
-                                        delta_content = tail if tail else None
+                                        if tail is None and "\n" in _combined:
+                                            tail = _combined.split("\n", 1)[1].lstrip("\n") or None
+                                        delta_reasoning = thinking_tail
+                                        delta_content = tail
                                     else:
                                         # Spurious </think> inside thinking content.
                                         delta_reasoning = _combined if _combined else None
@@ -2962,10 +2986,12 @@ async def chat_completions_endpoint(request: ChatRequest, http_request: Request)
                                     ]
                                 )
 
-                            # Skip empty deltas (e.g. suppressed tool-call tokens)
+                            # Skip empty deltas. Empty strings produce SSE chunks
+                            # with no useful payload — many clients (Pi, etc.) treat
+                            # a run of empty chunks as a dead/finished stream.
                             has_payload = (
-                                delta_content is not None
-                                or delta_reasoning is not None
+                                bool(delta_content)
+                                or bool(delta_reasoning)
                                 or token.finish_reason is not None
                                 or chunk_logprobs is not None
                             )


### PR DESCRIPTION
## Summary

Fixes bugs in the streaming chat completions endpoint that caused thinking content to bleed into `content`, and text immediately before tool calls to be silently dropped.

### Bug 1 — `in_thinking` initialised to `False`

When `enable_thinking` is set, the `<think>` tag is injected as a **prompt prefix**, not a generated token. Generation begins already inside the think block, but `in_thinking` started `False` so all thinking content was emitted as regular `content`.

**Fix:** initialise `in_thinking = gen_args.enable_thinking`.

### Bug 2 — Boundary detected by string match on `accumulated`

The original check fired whenever the string `</think>` appeared anywhere in `accumulated` — including when the model writes **about** the tag mid-thinking (e.g. in a code example or explanation). This prematurely exited thinking mode and corrupted the output.

**Fix:** resolve the `</think>` special-token ID once at startup via `convert_tokens_to_ids("</think>")` and detect the boundary by **token ID** instead.

### Bug 3 — BPE decoder embeds `</think>` text in the next token

The BPE incremental decoder suppresses the `</think>` special token (`text=''`) but releases preceding-context bytes on the **next** regular token. That token's `.text` therefore contains the `</think>` string concatenated with the first content text (e.g. `'clearly.\n</think>\n\nThe answer is…'`).

**Fix:** a **multi-token lookahead window** accumulates tokens after the `</think>` token ID is seen. The boundary is confirmed only when the text after the tag starts with `\n\n` (Qwen3 always emits `\n\n` before the response — a single `\n` can appear inside prose or code and is not sufficient). On confirmation, the text before `</think>` is emitted as `delta_reasoning` (thinking tail) and the text after is emitted as `delta_content`. A `</think>` with no following `\n\n` is spurious and the accumulated text is re-emitted as `delta_reasoning`.

An IndexError guard prevents a crash when the window closes with an empty `_combined`.

### Bug 4 — Text before tool calls silently dropped

When the model produced text immediately before a `<tool_call>` marker (e.g. `"Here's my answer: <tool_call>…"`), the BPE decoder flushed both in the same token. `suppress_tool_call_content` detected `tc_start` in `full_output` and returned `None` for the entire delta, discarding the prefix text.

**Fix:** when `tc_start` first appears in `full_output`, compute how much of `delta_content` precedes the marker and emit only that prefix. Subsequent chunks (fully inside the tool call) are suppressed as before.

### Minor: suppress empty SSE chunks

`has_payload` now uses `bool()` rather than `is not None` so empty-string deltas don't produce SSE chunks that clients may interpret as a stalled stream.

## Test plan

- [ ] Basic thinking request with `stream: true` — `delta.reasoning` populated, `delta.content` has clean response with no `</think>` leakage
- [ ] Request where model discusses `</think>` tokens mid-thinking — spurious tag does not exit thinking mode; full reasoning and full response both delivered
- [ ] Request that ends in a tool call preceded by text — prefix text is preserved in `delta.content`
- [ ] Request with `enable_thinking: false` — no change to existing behaviour
- [ ] Non-thinking model (no `</think>` token in vocabulary) — falls back to string match, existing behaviour preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)