### PR TITLE
Fix LFM2-VL model

### DIFF
--- a/mlx_vlm/models/lfm2_vl/lfm2_vl.py
+++ b/mlx_vlm/models/lfm2_vl/lfm2_vl.py
@@ -15,10 +15,8 @@ class Lfm2VlMultiModalProjector(nn.Module):
     def __init__(self, config: ModelConfig):
         super().__init__()
         in_channels = config.vision_config.hidden_size * (config.downsample_factor**2)
-        if config.projector_use_layernorm:
-            self.layer_norm = nn.LayerNorm(in_channels)
-        else:
-            self.layer_norm = nn.Identity()
+        self.projector_use_layernorm = config.projector_use_layernorm
+        self.layer_norm = nn.LayerNorm(in_channels)
         self.linear_1 = nn.Linear(
             in_channels,
             config.projector_hidden_size,
@@ -32,7 +30,9 @@ class Lfm2VlMultiModalProjector(nn.Module):
         )
 
     def __call__(self, x):
-        x = self.linear_1(self.layer_norm(x))
+        if self.projector_use_layernorm:
+            x = self.layer_norm(x)
+        x = self.linear_1(x)
         x = self.linear_2(nn.gelu(x))
         return x
 

--- a/mlx_vlm/tests/test_models.py
+++ b/mlx_vlm/tests/test_models.py
@@ -1844,6 +1844,53 @@ class TestModels(unittest.TestCase):
         # TODO: Add vision test runner for lfm2_vl
         # Rewrite inputs to be defined by the test classes
 
+    def test_lfm2_vl_initializes_projector_layernorm_even_when_disabled(self):
+        from mlx_vlm.models import lfm2_vl
+
+        text_config = lfm2_vl.TextConfig(layer_types=["full_attention"])
+        vision_config = lfm2_vl.VisionConfig()
+        config = lfm2_vl.ModelConfig(
+            text_config=text_config,
+            vision_config=vision_config,
+            projector_use_layernorm=False,
+        )
+        model = lfm2_vl.Model(config)
+
+        self.assertIsInstance(model.multi_modal_projector.layer_norm, nn.LayerNorm)
+        self.assertIn("weight", model.multi_modal_projector.layer_norm.parameters())
+        self.assertIn("bias", model.multi_modal_projector.layer_norm.parameters())
+
+    def test_lfm2_vl_projector_skips_disabled_layernorm_branch(self):
+        from mlx_vlm.models import lfm2_vl
+        from mlx_vlm.models.lfm2_vl.lfm2_vl import Lfm2VlMultiModalProjector
+
+        class ExplodingLayerNorm(nn.Module):
+            def __call__(self, x):
+                raise AssertionError("layernorm branch should be disabled")
+
+        text_config = lfm2_vl.TextConfig(
+            hidden_size=4,
+            num_hidden_layers=1,
+            num_attention_heads=1,
+            num_key_value_heads=1,
+            intermediate_size=8,
+            layer_types=["full_attention"],
+        )
+        vision_config = lfm2_vl.VisionConfig(hidden_size=2)
+        config = lfm2_vl.ModelConfig(
+            text_config=text_config,
+            vision_config=vision_config,
+            downsample_factor=1,
+            projector_hidden_size=3,
+            projector_use_layernorm=False,
+        )
+        projector = Lfm2VlMultiModalProjector(config)
+        projector.layer_norm = ExplodingLayerNorm()
+
+        output = projector(mx.zeros((1, 1, 1, 2)))
+
+        self.assertEqual(output.shape, (1, 1, 1, 4))
+
     def test_mllama(self):
         from mlx_vlm.models import mllama
 

--- a/mlx_vlm/tests/test_tokenizer_utils.py
+++ b/mlx_vlm/tests/test_tokenizer_utils.py
@@ -14,6 +14,7 @@ from mlx_vlm.tokenizer_utils import (
     _is_spm_decoder_no_space,
     _match,
     _remove_space,
+    make_streaming_detokenizer,
 )
 
 # ============================================================================
@@ -239,6 +240,32 @@ class TestNaiveStreamingDetokenizer:
         detokenizer.finalize()
 
         assert "world" not in detokenizer.text
+
+    def test_copy_returns_reset_instance(self):
+        from copy import copy
+
+        tokenizer = MockTokenizer()
+        detokenizer = NaiveStreamingDetokenizer(tokenizer)
+        detokenizer.add_token(0)
+
+        copied = copy(detokenizer)
+        copied.add_token(1)
+        copied.finalize()
+
+        assert copied.text == "world"
+
+    def test_make_streaming_detokenizer_copies_naive_detokenizer(self):
+        tokenizer = MockTokenizer()
+        processor = type("Processor", (), {})()
+        processor.detokenizer = NaiveStreamingDetokenizer(tokenizer)
+        processor.detokenizer.add_token(0)
+
+        copied = make_streaming_detokenizer(processor)
+        copied.add_token(1)
+        copied.finalize()
+
+        assert copied.text == "world"
+        assert processor.detokenizer.text == "hello"
 
 
 # ============================================================================

--- a/mlx_vlm/tokenizer_utils.py
+++ b/mlx_vlm/tokenizer_utils.py
@@ -81,6 +81,9 @@ class NaiveStreamingDetokenizer(StreamingDetokenizer):
         self._tokenizer.decode([0])
         self.reset()
 
+    def __copy__(self):
+        return type(self)(self._tokenizer)
+
     def reset(self):
         self.offset = 0
         self._tokens = []


### PR DESCRIPTION
This resolves the first two issues reported in https://github.com/Blaizzy/mlx-vlm/issues/1156

1) The weights for the` LiquidAI/LFM2-VL-*` models include the layernorm weights even when the config specifies the project doesn't use it, so just load them at skip it at eval time instead. (Note the config has format = mlx so there's no sanitize_weights() hook.)
2) Implement a safe copy for NaiveStreamingDetokenizer, which also affected the quantized models, e.g. `mlx-community/LFM2-VL-1.6B-8bit`