### PR TITLE
Add Gemma 4 DFlash + adaptive block sizing

### DIFF
--- a/mlx_vlm/models/qwen3_5/language.py
+++ b/mlx_vlm/models/qwen3_5/language.py
@@ -16,7 +16,6 @@ from .config import ModelConfig, TextConfig
 from .gated_delta import (
     gated_delta_state_update,
     gated_delta_update,
-    gated_delta_update_with_states,
 )
 
 
@@ -322,40 +321,24 @@ class Qwen3_5GatedDeltaNet(nn.Module):
         k = inv_scale * mx.fast.rms_norm(k, None, 1e-6)
 
         initial_state = state
-        intermediate_states = None
-        capture_intermediate_states = gdn_sink is not None and B == 1
-        if capture_intermediate_states:
-            out, state, intermediate_states = gated_delta_update_with_states(
-                q,
-                k,
-                v,
-                a,
-                b,
-                self.A_log,
-                self.dt_bias,
-                state,
-                mask,
-                use_kernel=not self.training,
-            )
-        else:
-            out, state = gated_delta_update(
-                q,
-                k,
-                v,
-                a,
-                b,
-                self.A_log,
-                self.dt_bias,
-                state,
-                mask,
-                use_kernel=not self.training,
-            )
+        out, state = gated_delta_update(
+            q,
+            k,
+            v,
+            a,
+            b,
+            self.A_log,
+            self.dt_bias,
+            state,
+            mask,
+            use_kernel=not self.training,
+        )
 
         if gdn_sink is not None:
             # Tuple layout consumed by ``rollback_speculative_cache`` below.
-            # Batched MTP uses the replay rollback path because materializing
-            # per-token intermediate GDN states is both expensive and has
-            # different batch semantics from the normal decode path.
+            # Speculative rollback reconstructs the accepted state with the
+            # state-only GDN kernel; materializing every per-token state here
+            # slows down the target verify pass.
             gdn_sink.append(
                 (
                     q,
@@ -369,7 +352,7 @@ class Qwen3_5GatedDeltaNet(nn.Module):
                     mask,
                     conv_input,
                     self.conv_kernel_size,
-                    intermediate_states,
+                    None,
                 )
             )
 

--- a/mlx_vlm/models/qwen3_5/language.py
+++ b/mlx_vlm/models/qwen3_5/language.py
@@ -13,10 +13,7 @@ from ..base import (
 )
 from ..cache import ArraysCache, KVCache
 from .config import ModelConfig, TextConfig
-from .gated_delta import (
-    gated_delta_state_update,
-    gated_delta_update,
-)
+from .gated_delta import gated_delta_state_update, gated_delta_update
 
 
 class Qwen3_5RotaryEmbedding:

--- a/mlx_vlm/speculative/drafters/gemma4_dflash/__init__.py
+++ b/mlx_vlm/speculative/drafters/gemma4_dflash/__init__.py
@@ -1,0 +1,33 @@
+from ..qwen3_dflash.config import DFlashConfig
+from ..qwen3_dflash.dflash import DFlashDraftModel, DFlashKVCache
+
+
+class Gemma4DFlashConfig(DFlashConfig):
+    @classmethod
+    def from_dict(cls, params: dict) -> "Gemma4DFlashConfig":
+        config = super().from_dict(params)
+        if config.num_target_layers == 30:
+            # The 26B-A4B DFlash checkpoint publishes one-based target layer ids
+            # for the MLX Gemma4 capture path.
+            config.target_layer_ids = [
+                max(0, layer_id - 1) for layer_id in config.target_layer_ids
+            ]
+        return config
+
+    from_hf_dict = from_dict
+
+
+class Gemma4DFlashDraftModel(DFlashDraftModel):
+    pass
+
+
+Model = Gemma4DFlashDraftModel
+ModelConfig = Gemma4DFlashConfig
+
+__all__ = [
+    "Gemma4DFlashConfig",
+    "Gemma4DFlashDraftModel",
+    "DFlashKVCache",
+    "Model",
+    "ModelConfig",
+]

--- a/mlx_vlm/speculative/drafters/gemma4_dflash/__init__.py
+++ b/mlx_vlm/speculative/drafters/gemma4_dflash/__init__.py
@@ -5,14 +5,11 @@ from ..qwen3_dflash.dflash import DFlashDraftModel, DFlashKVCache
 class Gemma4DFlashConfig(DFlashConfig):
     @classmethod
     def from_dict(cls, params: dict) -> "Gemma4DFlashConfig":
-        config = super().from_dict(params)
-        if config.num_target_layers == 30:
-            # The 26B-A4B DFlash checkpoint publishes one-based target layer ids
-            # for the MLX Gemma4 capture path.
-            config.target_layer_ids = [
-                max(0, layer_id - 1) for layer_id in config.target_layer_ids
-            ]
-        return config
+        flat = dict(params)
+        dflash_cfg = dict(flat.get("dflash_config", None) or {})
+        dflash_cfg.setdefault("mask_token_id", 4)
+        flat["dflash_config"] = dflash_cfg
+        return super().from_dict(flat)
 
     from_hf_dict = from_dict
 

--- a/mlx_vlm/speculative/drafters/qwen3_dflash/config.py
+++ b/mlx_vlm/speculative/drafters/qwen3_dflash/config.py
@@ -27,7 +27,7 @@ class DFlashConfig(BaseModelConfig):
     layer_types: List[str] = field(default_factory=list)
     sliding_window: Optional[int] = None
     final_logit_softcapping: Optional[float] = None
-    runtime_block_size: int | None = 14
+    runtime_block_size: int | None = None
     draft_window_size: int | None = None
 
     @classmethod

--- a/mlx_vlm/speculative/drafters/qwen3_dflash/config.py
+++ b/mlx_vlm/speculative/drafters/qwen3_dflash/config.py
@@ -1,6 +1,6 @@
 import inspect
 from dataclasses import dataclass, field
-from typing import List
+from typing import Any, List, Optional
 
 from ....models.base import BaseModelConfig
 
@@ -17,12 +17,16 @@ class DFlashConfig(BaseModelConfig):
     vocab_size: int = 248320
     max_position_embeddings: int = 262144
     rope_theta: float = 10000000.0
+    rope_scaling: Optional[dict[str, Any]] = None
     attention_bias: bool = False
     tie_word_embeddings: bool = True
     block_size: int = 16
     mask_token_id: int = 248070
     target_layer_ids: List[int] = field(default_factory=lambda: [1, 8, 15, 22, 29])
     num_target_layers: int = 32
+    layer_types: List[str] = field(default_factory=list)
+    sliding_window: Optional[int] = None
+    final_logit_softcapping: Optional[float] = None
     runtime_block_size: int | None = 14
     draft_window_size: int | None = None
 

--- a/mlx_vlm/speculative/drafters/qwen3_dflash/dflash.py
+++ b/mlx_vlm/speculative/drafters/qwen3_dflash/dflash.py
@@ -2,7 +2,6 @@ from typing import List
 
 import mlx.core as mx
 import mlx.nn as nn
-from mlx_lm.models.base import create_causal_mask
 from mlx_lm.models.cache import KVCache
 from mlx_lm.models.qwen3 import MLP as Qwen3MLP
 from mlx_lm.models.rope_utils import initialize_rope
@@ -79,18 +78,12 @@ class DFlashAttention(nn.Module):
         ctx_keys = rope(ctx_keys, offset=cache.offset)
         prop_keys = rope(prop_keys, offset=cache.offset + S)
         keys, values = cache.update_and_fetch(ctx_keys, ctx_values)
-        ctx_len = keys.shape[2]
         keys = mx.concatenate([keys, prop_keys], axis=2)
         values = mx.concatenate([values, prop_values], axis=2)
+        # DFlash denoises the whole proposed block at once, so draft-block
+        # self-attention is intentionally non-causal. Sliding layers already
+        # limit resident prefix context through the rotating cache above.
         mask = None
-        if self.is_sliding:
-            mask = (
-                "causal"
-                if ctx_len + L <= self.sliding_window
-                else create_causal_mask(
-                    L, offset=ctx_len, window_size=self.sliding_window
-                )
-            )
         o = mx.fast.scaled_dot_product_attention(
             queries, keys, values, scale=self.scale, mask=mask
         )

--- a/mlx_vlm/speculative/drafters/qwen3_dflash/dflash.py
+++ b/mlx_vlm/speculative/drafters/qwen3_dflash/dflash.py
@@ -2,21 +2,38 @@ from typing import List
 
 import mlx.core as mx
 import mlx.nn as nn
+from mlx_lm.models.base import create_causal_mask
 from mlx_lm.models.cache import KVCache
 from mlx_lm.models.qwen3 import MLP as Qwen3MLP
+from mlx_lm.models.rope_utils import initialize_rope
 
-from ....models.cache import BufferedRotatingKVCache
+from ....models.cache import BufferedRotatingKVCache, RotatingKVCache
 from .config import DFlashConfig
 
 
+def _build_rope(config: DFlashConfig):
+    return initialize_rope(
+        dims=config.head_dim,
+        base=config.rope_theta,
+        traditional=False,
+        scaling_config=config.rope_scaling,
+        max_position_embeddings=config.max_position_embeddings,
+    )
+
+
 class DFlashAttention(nn.Module):
-    def __init__(self, config: DFlashConfig):
+    def __init__(self, config: DFlashConfig, layer_idx: int):
         super().__init__()
         dim = config.hidden_size
         self.n_heads = config.num_attention_heads
         self.n_kv_heads = config.num_key_value_heads
         self.head_dim = config.head_dim
         self.scale = self.head_dim**-0.5
+        layer_types = (
+            config.layer_types or ["full_attention"] * config.num_hidden_layers
+        )
+        self.is_sliding = layer_types[layer_idx] == "sliding_attention"
+        self.sliding_window = config.sliding_window if self.is_sliding else None
         self.q_proj = nn.Linear(dim, self.n_heads * self.head_dim, bias=False)
         self.k_proj = nn.Linear(dim, self.n_kv_heads * self.head_dim, bias=False)
         self.v_proj = nn.Linear(dim, self.n_kv_heads * self.head_dim, bias=False)
@@ -27,6 +44,17 @@ class DFlashAttention(nn.Module):
     def __call__(self, x: mx.array, x_ctx: mx.array, rope, cache: KVCache):
         B, L, _ = x.shape
         S = x_ctx.shape[1]
+        if self.is_sliding:
+            if self.sliding_window is None:
+                raise ValueError(
+                    "DFlash draft config must define sliding_window for sliding layers."
+                )
+            keep_ctx = self.sliding_window - 1
+            if S > keep_ctx:
+                skip = S - keep_ctx
+                x_ctx = x_ctx[:, skip:]
+                S = x_ctx.shape[1]
+                cache.offset += skip
 
         # Project context and proposal separately so only context KV
         queries = self.q_proj(x)
@@ -51,18 +79,28 @@ class DFlashAttention(nn.Module):
         ctx_keys = rope(ctx_keys, offset=cache.offset)
         prop_keys = rope(prop_keys, offset=cache.offset + S)
         keys, values = cache.update_and_fetch(ctx_keys, ctx_values)
+        ctx_len = keys.shape[2]
         keys = mx.concatenate([keys, prop_keys], axis=2)
         values = mx.concatenate([values, prop_values], axis=2)
+        mask = None
+        if self.is_sliding:
+            mask = (
+                "causal"
+                if ctx_len + L <= self.sliding_window
+                else create_causal_mask(
+                    L, offset=ctx_len, window_size=self.sliding_window
+                )
+            )
         o = mx.fast.scaled_dot_product_attention(
-            queries, keys, values, scale=self.scale
+            queries, keys, values, scale=self.scale, mask=mask
         )
         return self.o_proj(o.transpose(0, 2, 1, 3).reshape(B, L, -1))
 
 
 class DFlashDecoderLayer(nn.Module):
-    def __init__(self, config: DFlashConfig):
+    def __init__(self, config: DFlashConfig, layer_idx: int):
         super().__init__()
-        self.self_attn = DFlashAttention(config)
+        self.self_attn = DFlashAttention(config, layer_idx)
         self.mlp = Qwen3MLP(config.hidden_size, config.intermediate_size)
         self.input_layernorm = nn.RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
         self.post_attention_layernorm = nn.RMSNorm(
@@ -78,15 +116,18 @@ class DFlashDraftModel(nn.Module):
     def __init__(self, config: DFlashConfig):
         super().__init__()
         self.config = config
+        if not self.config.layer_types:
+            self.config.layer_types = ["full_attention"] * self.config.num_hidden_layers
         concat_dim = len(config.target_layer_ids) * config.hidden_size
         self.fc = nn.Linear(concat_dim, config.hidden_size, bias=False)
         self.hidden_norm = nn.RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
         self.layers = [
-            DFlashDecoderLayer(config) for _ in range(config.num_hidden_layers)
+            DFlashDecoderLayer(config, i) for i in range(config.num_hidden_layers)
         ]
         self.norm = nn.RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
-        self.rope = nn.RoPE(config.head_dim, traditional=False, base=config.rope_theta)
+        self.rope = _build_rope(config)
         self.embed_tokens = None
+        self.embed_scale = 1.0
         self.lm_head = None
         self.accept_lens: List[int] = []
         self.draft_lens: List[int] = []
@@ -109,6 +150,9 @@ class DFlashDraftModel(nn.Module):
                 f"Cannot find embed_tokens in {type(target_model).__name__}"
             )
         self.embed_tokens = inner.embed_tokens
+        self.embed_scale = getattr(
+            self.embed_tokens, "embed_scale", getattr(inner, "embed_scale", 1.0)
+        )
         lm = getattr(target_model, "language_model", target_model)
         self.lm_head = (
             getattr(target_model, "lm_head", None)
@@ -124,7 +168,19 @@ class DFlashDraftModel(nn.Module):
                 BufferedRotatingKVCache(max_size=int(window), buffer_size=64)
                 for _ in self.layers
             ]
-        return [KVCache() for _ in self.layers]
+        caches = []
+        for layer_type in self.config.layer_types:
+            if layer_type == "sliding_attention":
+                if self.config.sliding_window is None:
+                    raise ValueError(
+                        "DFlash draft config must define sliding_window for sliding layers."
+                    )
+                caches.append(
+                    RotatingKVCache(max_size=self.config.sliding_window - 1, keep=0)
+                )
+            else:
+                caches.append(KVCache())
+        return caches
 
     def reset(self, target_model) -> List[KVCache]:
         self.bind(target_model)
@@ -154,7 +210,7 @@ class DFlashDraftModel(nn.Module):
                 [last_bonus[:, None].astype(token_dtype), masks], axis=1
             )
         draft_hidden = self._hidden(block, hidden, cache)
-        draft_logits = self.lm_head(draft_hidden[:, 1:])
+        draft_logits = self._logits(draft_hidden[:, 1:])
         return sampler(draft_logits)
 
     def _hidden(
@@ -163,11 +219,21 @@ class DFlashDraftModel(nn.Module):
         target_hidden: mx.array,
         cache: List[KVCache],
     ) -> mx.array:
-        h = self.embed_tokens(inputs)
+        h = self._embed_input_tokens(inputs)
         h_ctx = self.hidden_norm(self.fc(target_hidden))
         for layer, c in zip(self.layers, cache):
             h = layer(h, h_ctx, self.rope, c)
         return self.norm(h)
+
+    def _embed_input_tokens(self, inputs: mx.array) -> mx.array:
+        return self.embed_tokens(inputs) * self.embed_scale
+
+    def _logits(self, hidden: mx.array) -> mx.array:
+        logits = self.lm_head(hidden)
+        if self.config.final_logit_softcapping is not None:
+            softcap = self.config.final_logit_softcapping
+            logits = mx.tanh(logits / softcap) * softcap
+        return logits
 
     def __call__(
         self,
@@ -175,7 +241,7 @@ class DFlashDraftModel(nn.Module):
         target_hidden: mx.array,
         cache: List[KVCache],
     ) -> mx.array:
-        return self.lm_head(self._hidden(inputs, target_hidden, cache))
+        return self._logits(self._hidden(inputs, target_hidden, cache))
 
     def sanitize(self, weights: dict) -> dict:
         out = {}

--- a/mlx_vlm/speculative/utils.py
+++ b/mlx_vlm/speculative/utils.py
@@ -379,6 +379,57 @@ def _dflash_block_total(draft_model: nn.Module, draft_block_size: Optional[int])
     return min(configured, max(1, int(runtime)))
 
 
+def _dflash_next_block_size(
+    draft_model: nn.Module,
+    requested_block_total: int,
+    remaining_budget: int,
+) -> int:
+    """Choose the next DFlash verify block size from recent acceptance.
+
+    DFlash checkpoints advertise a trained block size, usually 16. Treat that
+    as the ceiling and back off quickly when deeper positions are mostly
+    rejected. When acceptance is strong at the current depth, grow back toward
+    the configured ceiling.
+    """
+    block_total = min(requested_block_total, remaining_budget)
+    if block_total <= 1:
+        return block_total
+    if getattr(draft_model, "prefer_requested_block_size", False):
+        return block_total
+
+    accept_lens = getattr(draft_model, "accept_lens", None) or []
+    draft_lens = getattr(draft_model, "draft_lens", None) or []
+    recent = [
+        (float(a), int(d))
+        for a, d in zip(accept_lens[-8:], draft_lens[-8:])
+        if int(d) > 0
+    ]
+    if not recent:
+        return block_total
+
+    current = min(block_total, max(2, recent[-1][1] + 1))
+    min_total = min(block_total, 4)
+    drafted = sum(d for _, d in recent)
+    accepted = sum(a for a, _ in recent)
+    accept_rate = accepted / drafted
+    mean_accept = accepted / len(recent)
+
+    if accept_rate < 0.30 or mean_accept < 2.0:
+        if current >= 8:
+            return max(min_total, min(block_total, current // 2))
+        return max(min_total, min(block_total, current - 2))
+
+    if accept_rate < 0.50:
+        return max(min_total, min(block_total, current - 2))
+
+    full_hits = sum(1 for a, d in recent if a >= d)
+    full_hit_rate = full_hits / len(recent)
+    if accept_rate >= 0.85 and full_hit_rate >= 0.75:
+        return min(block_total, current + 2)
+
+    return min(block_total, current)
+
+
 def _dflash_committed_hidden_segments(
     hidden_full: mx.array, new_tokens_list: List[List[int]]
 ) -> List[mx.array]:
@@ -1073,7 +1124,11 @@ def _dflash_rounds(
     emitted = 1  # the first bonus has already been yielded by the caller
 
     while emitted < max_tokens:
-        bs = min(block_total, max_tokens - emitted + 1)
+        bs = _dflash_next_block_size(
+            draft_model,
+            block_total,
+            max_tokens - emitted + 1,
+        )
         if bs <= 1:
             break
 
@@ -1176,7 +1231,7 @@ def _dflash_rounds_batch(
             max(1, max_tokens - emitted[active_idx[j]] + 1)
             for j in range(len(active_idx))
         ]
-        bs = min(block_total, min(remaining))
+        bs = _dflash_next_block_size(draft_model, block_total, min(remaining))
         if bs <= 1:
             break
 

--- a/mlx_vlm/speculative/utils.py
+++ b/mlx_vlm/speculative/utils.py
@@ -405,27 +405,27 @@ def _dflash_next_block_size(
         if int(d) > 0
     ]
     if not recent:
-        return block_total
+        return min(block_total, 3)
 
     current = min(block_total, max(2, recent[-1][1] + 1))
-    min_total = min(block_total, 4)
+    min_total = min(block_total, 3)
     drafted = sum(d for _, d in recent)
     accepted = sum(a for a, _ in recent)
     accept_rate = accepted / drafted
     mean_accept = accepted / len(recent)
-
-    if accept_rate < 0.30 or mean_accept < 2.0:
-        if current >= 8:
-            return max(min_total, min(block_total, current // 2))
-        return max(min_total, min(block_total, current - 2))
-
-    if accept_rate < 0.50:
-        return max(min_total, min(block_total, current - 2))
-
     full_hits = sum(1 for a, d in recent if a >= d)
     full_hit_rate = full_hits / len(recent)
-    if accept_rate >= 0.85 and full_hit_rate >= 0.75:
-        return min(block_total, current + 2)
+
+    if accept_rate < 0.75 or mean_accept < 1.5:
+        if current >= 8:
+            return max(min_total, min(block_total, current // 2))
+        return max(min_total, min(block_total, current - 1))
+
+    if current > 3 and (accept_rate < 0.85 or full_hit_rate < 0.80):
+        return max(min_total, min(block_total, current - 1))
+
+    if accept_rate >= 0.98 and full_hit_rate >= 1.0:
+        return min(block_total, current + 1)
 
     return min(block_total, current)
 

--- a/mlx_vlm/speculative/utils.py
+++ b/mlx_vlm/speculative/utils.py
@@ -405,27 +405,27 @@ def _dflash_next_block_size(
         if int(d) > 0
     ]
     if not recent:
-        return min(block_total, 3)
+        return block_total
 
     current = min(block_total, max(2, recent[-1][1] + 1))
-    min_total = min(block_total, 3)
+    min_total = min(block_total, 4)
     drafted = sum(d for _, d in recent)
     accepted = sum(a for a, _ in recent)
     accept_rate = accepted / drafted
     mean_accept = accepted / len(recent)
-    full_hits = sum(1 for a, d in recent if a >= d)
-    full_hit_rate = full_hits / len(recent)
 
-    if accept_rate < 0.75 or mean_accept < 1.5:
+    if accept_rate < 0.30 or mean_accept < 2.0:
         if current >= 8:
             return max(min_total, min(block_total, current // 2))
-        return max(min_total, min(block_total, current - 1))
+        return max(min_total, min(block_total, current - 2))
 
-    if current > 3 and (accept_rate < 0.85 or full_hit_rate < 0.80):
-        return max(min_total, min(block_total, current - 1))
+    if accept_rate < 0.50:
+        return max(min_total, min(block_total, current - 2))
 
-    if accept_rate >= 0.98 and full_hit_rate >= 1.0:
-        return min(block_total, current + 1)
+    full_hits = sum(1 for a, d in recent if a >= d)
+    full_hit_rate = full_hits / len(recent)
+    if accept_rate >= 0.85 and full_hit_rate >= 0.75:
+        return min(block_total, current + 2)
 
     return min(block_total, current)
 

--- a/mlx_vlm/tests/test_speculative.py
+++ b/mlx_vlm/tests/test_speculative.py
@@ -729,10 +729,10 @@ def test_dflash_config_defaults_to_checkpoint_block_size():
     assert speculative_utils._dflash_block_total(draft_model, None) == 16
 
 
-def test_dflash_next_block_size_starts_with_small_pilot_block():
+def test_dflash_next_block_size_starts_at_requested_ceiling():
     draft_model = SimpleNamespace(accept_lens=[], draft_lens=[])
 
-    assert _dflash_next_block_size(draft_model, 16, 20) == 3
+    assert _dflash_next_block_size(draft_model, 16, 20) == 16
 
 
 def test_dflash_next_block_size_backs_off_on_low_acceptance():
@@ -744,25 +744,13 @@ def test_dflash_next_block_size_backs_off_on_low_acceptance():
 def test_dflash_next_block_size_grows_after_full_prefix_hits():
     draft_model = SimpleNamespace(accept_lens=[3, 3, 3, 3], draft_lens=[3, 3, 3, 3])
 
-    assert _dflash_next_block_size(draft_model, 16, 20) == 5
-
-
-def test_dflash_next_block_size_requires_high_acceptance_to_grow():
-    draft_model = SimpleNamespace(accept_lens=[2, 2, 1, 2], draft_lens=[2, 2, 2, 2])
-
-    assert _dflash_next_block_size(draft_model, 16, 20) == 3
-
-
-def test_dflash_next_block_size_requires_full_recent_hits_to_grow():
-    draft_model = SimpleNamespace(accept_lens=[2, 2, 2, 1], draft_lens=[2, 2, 2, 2])
-
-    assert _dflash_next_block_size(draft_model, 16, 20) == 3
+    assert _dflash_next_block_size(draft_model, 16, 20) == 6
 
 
 def test_dflash_next_block_size_does_not_grow_on_middling_acceptance():
     draft_model = SimpleNamespace(accept_lens=[3, 2, 1, 3], draft_lens=[3, 3, 3, 3])
 
-    assert _dflash_next_block_size(draft_model, 16, 20) == 3
+    assert _dflash_next_block_size(draft_model, 16, 20) == 4
 
 
 def test_dflash_next_block_size_can_prefer_requested_size():

--- a/mlx_vlm/tests/test_speculative.py
+++ b/mlx_vlm/tests/test_speculative.py
@@ -213,14 +213,7 @@ def test_qwen_gdn_sink_skips_intermediate_states_for_batched_verify():
         next_state = mx.zeros((B, 2, 4, 4), dtype=mx.float32)
         return out, next_state
 
-    with (
-        patch.object(
-            qwen_language,
-            "gated_delta_update_with_states",
-            side_effect=AssertionError("batched verify must not capture states"),
-        ),
-        patch.object(qwen_language, "gated_delta_update", side_effect=fake_update),
-    ):
+    with patch.object(qwen_language, "gated_delta_update", side_effect=fake_update):
         out = layer(
             mx.zeros((2, 3, 16), dtype=mx.float32),
             cache=ArraysCache(size=2),
@@ -232,7 +225,7 @@ def test_qwen_gdn_sink_skips_intermediate_states_for_batched_verify():
     assert sink[0][11] is None
 
 
-def test_qwen_gdn_sink_keeps_intermediate_states_for_singleton_verify():
+def test_qwen_gdn_sink_skips_intermediate_states_for_singleton_verify():
     config = SimpleNamespace(
         hidden_size=16,
         linear_num_value_heads=2,
@@ -244,29 +237,15 @@ def test_qwen_gdn_sink_keeps_intermediate_states_for_singleton_verify():
     )
     layer = qwen_language.Qwen3_5GatedDeltaNet(config)
     sink = []
-    intermediate = mx.zeros((1, 3, 2, 4, 4), dtype=mx.float32)
 
-    def fake_update_with_states(
-        q, k, v, a, b, A_log, dt_bias, state, mask, use_kernel=True
-    ):
+    def fake_update(q, k, v, a, b, A_log, dt_bias, state, mask, use_kernel=True):
         del k, v, a, b, A_log, dt_bias, state, mask, use_kernel
         B, S = q.shape[:2]
         out = mx.zeros((B, S, 2, 4), dtype=mx.float32)
         next_state = mx.zeros((B, 2, 4, 4), dtype=mx.float32)
-        return out, next_state, intermediate
+        return out, next_state
 
-    with (
-        patch.object(
-            qwen_language,
-            "gated_delta_update",
-            side_effect=AssertionError("singleton verify should use state capture"),
-        ),
-        patch.object(
-            qwen_language,
-            "gated_delta_update_with_states",
-            side_effect=fake_update_with_states,
-        ),
-    ):
+    with patch.object(qwen_language, "gated_delta_update", side_effect=fake_update):
         out = layer(
             mx.zeros((1, 3, 16), dtype=mx.float32),
             cache=ArraysCache(size=2),
@@ -275,7 +254,7 @@ def test_qwen_gdn_sink_keeps_intermediate_states_for_singleton_verify():
 
     mx.eval(out)
     assert out.shape == (1, 3, 16)
-    assert sink[0][11] is intermediate
+    assert sink[0][11] is None
 
 
 def test_speculative_walk_accepts_until_first_mismatch():

--- a/mlx_vlm/tests/test_speculative.py
+++ b/mlx_vlm/tests/test_speculative.py
@@ -729,10 +729,10 @@ def test_dflash_config_defaults_to_checkpoint_block_size():
     assert speculative_utils._dflash_block_total(draft_model, None) == 16
 
 
-def test_dflash_next_block_size_starts_at_requested_ceiling():
+def test_dflash_next_block_size_starts_with_small_pilot_block():
     draft_model = SimpleNamespace(accept_lens=[], draft_lens=[])
 
-    assert _dflash_next_block_size(draft_model, 16, 20) == 16
+    assert _dflash_next_block_size(draft_model, 16, 20) == 3
 
 
 def test_dflash_next_block_size_backs_off_on_low_acceptance():
@@ -744,13 +744,25 @@ def test_dflash_next_block_size_backs_off_on_low_acceptance():
 def test_dflash_next_block_size_grows_after_full_prefix_hits():
     draft_model = SimpleNamespace(accept_lens=[3, 3, 3, 3], draft_lens=[3, 3, 3, 3])
 
-    assert _dflash_next_block_size(draft_model, 16, 20) == 6
+    assert _dflash_next_block_size(draft_model, 16, 20) == 5
+
+
+def test_dflash_next_block_size_requires_high_acceptance_to_grow():
+    draft_model = SimpleNamespace(accept_lens=[2, 2, 1, 2], draft_lens=[2, 2, 2, 2])
+
+    assert _dflash_next_block_size(draft_model, 16, 20) == 3
+
+
+def test_dflash_next_block_size_requires_full_recent_hits_to_grow():
+    draft_model = SimpleNamespace(accept_lens=[2, 2, 2, 1], draft_lens=[2, 2, 2, 2])
+
+    assert _dflash_next_block_size(draft_model, 16, 20) == 3
 
 
 def test_dflash_next_block_size_does_not_grow_on_middling_acceptance():
     draft_model = SimpleNamespace(accept_lens=[3, 2, 1, 3], draft_lens=[3, 3, 3, 3])
 
-    assert _dflash_next_block_size(draft_model, 16, 20) == 4
+    assert _dflash_next_block_size(draft_model, 16, 20) == 3
 
 
 def test_dflash_next_block_size_can_prefer_requested_size():

--- a/mlx_vlm/tests/test_speculative.py
+++ b/mlx_vlm/tests/test_speculative.py
@@ -27,9 +27,11 @@ from mlx_vlm.speculative.drafters.gemma4_assistant.masks import (
     make_drafter_masks,
     normalize_batched_shared_kv_states,
 )
+from mlx_vlm.speculative.drafters.gemma4_dflash import ModelConfig as Gemma4DFlashConfig
 from mlx_vlm.speculative.drafters.qwen3_5_mtp import ModelConfig as Qwen3_5MTPConfig
 from mlx_vlm.speculative.drafters.qwen3_5_mtp import Qwen3_5MTPDraftModel
 from mlx_vlm.speculative.drafters.qwen3_5_mtp.split import split_qwen3_5_mtp
+from mlx_vlm.speculative.drafters.qwen3_dflash import DFlashDraftModel, ModelConfig
 from mlx_vlm.speculative.utils import (
     _effective_mtp_block_size,
     _format_speculative_stats,
@@ -741,6 +743,97 @@ def test_dflash_committed_hidden_segments_keep_per_row_lengths():
     assert segments[0].tolist() == [[[0.0, 1.0], [2.0, 3.0]]]
     assert segments[1].shape == (1, 1, 2)
     assert segments[1].tolist() == [[[6.0, 7.0]]]
+
+
+def test_gemma4_26b_dflash_config_uses_zero_based_capture_layers():
+    config = Gemma4DFlashConfig.from_dict(
+        {
+            "hidden_size": 4,
+            "intermediate_size": 8,
+            "num_hidden_layers": 2,
+            "num_attention_heads": 1,
+            "num_key_value_heads": 1,
+            "head_dim": 4,
+            "vocab_size": 262144,
+            "num_target_layers": 30,
+            "dflash_config": {"target_layer_ids": [1, 6, 11]},
+        }
+    )
+
+    assert config.target_layer_ids == [0, 5, 10]
+
+
+def test_gemma4_31b_dflash_config_preserves_capture_layers():
+    config = Gemma4DFlashConfig.from_dict(
+        {
+            "hidden_size": 4,
+            "intermediate_size": 8,
+            "num_hidden_layers": 2,
+            "num_attention_heads": 1,
+            "num_key_value_heads": 1,
+            "head_dim": 4,
+            "vocab_size": 262144,
+            "num_target_layers": 60,
+            "dflash_config": {"target_layer_ids": [1, 12, 23]},
+        }
+    )
+
+    assert config.target_layer_ids == [1, 12, 23]
+
+
+def test_dflash_drafter_uses_bound_target_embedding_scale():
+    class Embed:
+        def __call__(self, inputs):
+            return mx.ones((*inputs.shape, 4), dtype=mx.float32)
+
+        def as_linear(self, hidden):
+            return hidden
+
+    config = ModelConfig(
+        hidden_size=4,
+        intermediate_size=8,
+        num_hidden_layers=0,
+        num_attention_heads=1,
+        num_key_value_heads=1,
+        head_dim=4,
+        vocab_size=8,
+        target_layer_ids=[0],
+    )
+    drafter = DFlashDraftModel(config)
+    target = SimpleNamespace(
+        model=SimpleNamespace(embed_tokens=Embed(), embed_scale=2.0)
+    )
+
+    drafter.bind(target)
+
+    embedded = drafter._embed_input_tokens(mx.array([[1, 2]], dtype=mx.int32))
+    assert embedded.tolist() == [[[2.0] * 4, [2.0] * 4]]
+
+
+def test_dflash_config_parses_sliding_attention_metadata():
+    config = ModelConfig.from_dict(
+        {
+            "hidden_size": 4,
+            "intermediate_size": 8,
+            "num_hidden_layers": 2,
+            "num_attention_heads": 1,
+            "num_key_value_heads": 1,
+            "head_dim": 4,
+            "vocab_size": 8,
+            "layer_types": ["sliding_attention", "full_attention"],
+            "sliding_window": 16,
+            "final_logit_softcapping": 30.0,
+            "dflash_config": {
+                "target_layer_ids": [0],
+                "mask_token_id": 4,
+            },
+        }
+    )
+
+    assert config.layer_types == ["sliding_attention", "full_attention"]
+    assert config.sliding_window == 16
+    assert config.final_logit_softcapping == 30.0
+    assert config.mask_token_id == 4
 
 
 def test_effective_mtp_block_size_respects_requested_block_size():

--- a/mlx_vlm/tests/test_speculative.py
+++ b/mlx_vlm/tests/test_speculative.py
@@ -33,6 +33,7 @@ from mlx_vlm.speculative.drafters.qwen3_5_mtp import Qwen3_5MTPDraftModel
 from mlx_vlm.speculative.drafters.qwen3_5_mtp.split import split_qwen3_5_mtp
 from mlx_vlm.speculative.drafters.qwen3_dflash import DFlashDraftModel, ModelConfig
 from mlx_vlm.speculative.utils import (
+    _dflash_next_block_size,
     _effective_mtp_block_size,
     _format_speculative_stats,
     _mtp_draft_block_active,
@@ -711,6 +712,57 @@ def test_dflash_block_total_falls_back_to_configured_block_size():
     assert speculative_utils._dflash_block_total(draft_model, None) == 16
 
 
+def test_dflash_config_defaults_to_checkpoint_block_size():
+    config = ModelConfig(
+        hidden_size=4,
+        intermediate_size=8,
+        num_hidden_layers=0,
+        num_attention_heads=1,
+        num_key_value_heads=1,
+        head_dim=4,
+        vocab_size=8,
+        target_layer_ids=[0],
+    )
+    draft_model = SimpleNamespace(config=config)
+
+    assert config.runtime_block_size is None
+    assert speculative_utils._dflash_block_total(draft_model, None) == 16
+
+
+def test_dflash_next_block_size_starts_at_requested_ceiling():
+    draft_model = SimpleNamespace(accept_lens=[], draft_lens=[])
+
+    assert _dflash_next_block_size(draft_model, 16, 20) == 16
+
+
+def test_dflash_next_block_size_backs_off_on_low_acceptance():
+    draft_model = SimpleNamespace(accept_lens=[1, 2], draft_lens=[15, 7])
+
+    assert _dflash_next_block_size(draft_model, 16, 20) == 4
+
+
+def test_dflash_next_block_size_grows_after_full_prefix_hits():
+    draft_model = SimpleNamespace(accept_lens=[3, 3, 3, 3], draft_lens=[3, 3, 3, 3])
+
+    assert _dflash_next_block_size(draft_model, 16, 20) == 6
+
+
+def test_dflash_next_block_size_does_not_grow_on_middling_acceptance():
+    draft_model = SimpleNamespace(accept_lens=[3, 2, 1, 3], draft_lens=[3, 3, 3, 3])
+
+    assert _dflash_next_block_size(draft_model, 16, 20) == 4
+
+
+def test_dflash_next_block_size_can_prefer_requested_size():
+    draft_model = SimpleNamespace(
+        accept_lens=[0] * 4,
+        draft_lens=[15] * 4,
+        prefer_requested_block_size=True,
+    )
+
+    assert _dflash_next_block_size(draft_model, 16, 8) == 8
+
+
 def test_dflash_committed_hidden_segments_keep_per_row_lengths():
     hidden = mx.arange(12, dtype=mx.float32).reshape(2, 3, 2)
 
@@ -724,7 +776,7 @@ def test_dflash_committed_hidden_segments_keep_per_row_lengths():
     assert segments[1].tolist() == [[[6.0, 7.0]]]
 
 
-def test_gemma4_26b_dflash_config_uses_zero_based_capture_layers():
+def test_gemma4_26b_dflash_config_preserves_capture_layers():
     config = Gemma4DFlashConfig.from_dict(
         {
             "hidden_size": 4,
@@ -739,7 +791,8 @@ def test_gemma4_26b_dflash_config_uses_zero_based_capture_layers():
         }
     )
 
-    assert config.target_layer_ids == [0, 5, 10]
+    assert config.target_layer_ids == [1, 6, 11]
+    assert config.runtime_block_size is None
 
 
 def test_gemma4_31b_dflash_config_preserves_capture_layers():
@@ -758,6 +811,51 @@ def test_gemma4_31b_dflash_config_preserves_capture_layers():
     )
 
     assert config.target_layer_ids == [1, 12, 23]
+    assert config.runtime_block_size is None
+
+
+def test_gemma4_dflash_config_honors_runtime_block_override():
+    config = Gemma4DFlashConfig.from_dict(
+        {
+            "hidden_size": 4,
+            "intermediate_size": 8,
+            "num_hidden_layers": 2,
+            "num_attention_heads": 1,
+            "num_key_value_heads": 1,
+            "head_dim": 4,
+            "vocab_size": 262144,
+            "num_target_layers": 30,
+            "dflash_config": {
+                "target_layer_ids": [1, 6, 11],
+                "runtime_block_size": 12,
+            },
+        }
+    )
+
+    assert config.target_layer_ids == [1, 6, 11]
+    assert config.runtime_block_size == 12
+
+
+def test_generic_dflash_config_parses_gemma4_metadata_without_runtime_cap():
+    config = ModelConfig.from_dict(
+        {
+            "hidden_size": 4,
+            "intermediate_size": 8,
+            "num_hidden_layers": 2,
+            "num_attention_heads": 1,
+            "num_key_value_heads": 1,
+            "head_dim": 4,
+            "vocab_size": 262144,
+            "num_target_layers": 30,
+            "dflash_config": {
+                "mask_token_id": 4,
+                "target_layer_ids": [1, 6, 11],
+            },
+        }
+    )
+
+    assert config.target_layer_ids == [1, 6, 11]
+    assert config.runtime_block_size is None
 
 
 def test_dflash_drafter_uses_bound_target_embedding_scale():


### PR DESCRIPTION
## Summary

- Adds Gemma 4 DFlash support on top of the generic DFlash drafter path.
- Keeps Gemma DFlash checkpoint layer ids intact and uses the Gemma mask token metadata without adding model-specific loader remaps.
- Makes DFlash block sizing adaptive: the checkpoint block size remains the ceiling, while each decode round backs off or grows based on recent acceptance.
- Aligns DFlash draft attention with block denoising by keeping draft-block self-attention non-causal.

## Metrics

Prompt: `Make a program to find pi`  
Temperature: `0`

| Target | Mode | Generated tokens | Prompt tok/s | Gen tok/s | Speedup vs plain | Speculative stats | Peak memory |
| --- | --- | ---: | ---: | ---: | ---: | --- | ---: |
| Gemma 4 26B-A4B 5-bit | plain | 512 | 105.200 | 80.797 | 1.00x | n/a | 18.841 GB |
| Gemma 4 26B-A4B 5-bit | DFlash adaptive | 512 | 115.458 | 120.372 | 1.49x | 2.44 accepted/round, 62.1% of drafted, avg draft 3.93 over 149 rounds | 19.747 GB |
| Gemma 4 31B 5-bit | plain | 256 | 43.444 | 25.076 | 1.00x | n/a | 41.811 GB |
| Gemma 4 31B 5-bit | DFlash adaptive | 690 | 63.885 | 30.629 | 1.22x | 2.71 accepted/round, 56.1% of drafted, avg draft 4.83 over 186 rounds | 26.075 GB |

## Server Validation

Gemma 4 26B-A4B 5-bit with `z-lab/gemma-4-26B-A4B-it-DFlash`, `stream=true`, `max_tokens=128`, sequential workloads.

| Workload | Requests | Aggregate tok/s | Tokens | Wall time | Coherence | Server DFlash stats |
| --- | ---: | ---: | ---: | ---: | --- | --- |
| Single text | 1 | 76.94 | 128 | 1.66s | ok | `batch=1`, `accept=1.51`, `rounds=51` |
| Batch text | 4 | 145.73 | 512 | 3.51s | ok | `batch=4`, `accept=1.92`, `rounds=175` |
| Mixed batch, 2 image + 2 text | 4 | 89.68 | 444 | 4.95s | ok | `batch=4`, `accept=1.43`, `rounds=182` |

The concurrent text and mixed workloads both logged `batch=4`, confirming the server speculative path is batching DFlash requests. Mixed batches are slower because image prefill/processing combines with lower DFlash acceptance.

## Validation

- `uv run pytest mlx_vlm/tests/test_speculative.py -q`