### PR TITLE
Fix Nemotron processor metadata loading

### DIFF
--- a/mlx_vlm/models/nemotron_h_nano_omni/processing_nemotron_h_nano_omni.py
+++ b/mlx_vlm/models/nemotron_h_nano_omni/processing_nemotron_h_nano_omni.py
@@ -103,6 +103,17 @@ class NemotronHNanoOmniProcessor(ProcessorMixin):
         )
 
         kwargs.pop("use_fast", None)
+        hub_kwargs = {
+            key: kwargs[key]
+            for key in (
+                "revision",
+                "cache_dir",
+                "force_download",
+                "local_files_only",
+                "token",
+            )
+            if key in kwargs
+        }
 
         tokenizer = AutoTokenizer.from_pretrained(
             pretrained_model_name_or_path, **kwargs
@@ -115,7 +126,9 @@ class NemotronHNanoOmniProcessor(ProcessorMixin):
                 with open(local) as f:
                     return json.load(f)
             try:
-                path = hf_hub_download(str(pretrained_model_name_or_path), name)
+                path = hf_hub_download(
+                    str(pretrained_model_name_or_path), name, **hub_kwargs
+                )
                 with open(path) as f:
                     return json.load(f)
             except Exception:

--- a/mlx_vlm/tests/test_processors.py
+++ b/mlx_vlm/tests/test_processors.py
@@ -1315,6 +1315,66 @@ class TestMolmoPointProcessor(unittest.TestCase):
         self.assertIn("image_num_crops", result)
 
 
+class TestNemotronHNanoOmniProcessor(unittest.TestCase):
+    def test_native_processor_handles_stripped_auto_map(self):
+        import importlib
+        import json
+        import tempfile
+        from pathlib import Path
+
+        from mlx_vlm.utils import load_processor, prepare_inputs
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            model_dir = Path(tmpdir)
+            (model_dir / "config.json").write_text(
+                json.dumps({"model_type": "NemotronH_Nano_Omni_Reasoning_V3"})
+            )
+            (model_dir / "processor_config.json").write_text(
+                json.dumps(
+                    {"processor_class": "NemotronH_Nano_Omni_Reasoning_V3Processor"}
+                )
+            )
+            (model_dir / "preprocessor_config.json").write_text(
+                json.dumps(
+                    {
+                        "image_processor_type": (
+                            "NemotronH_Nano_Omni_Reasoning_V3ImageProcessor"
+                        ),
+                        "patch_size": 16,
+                        "downsample_ratio": 0.5,
+                        "norm_mean": [0.48145466, 0.4578275, 0.40821073],
+                        "norm_std": [0.26862954, 0.26130258, 0.27577711],
+                        "min_num_patches": 64,
+                        "max_num_patches": 64,
+                        "max_model_len": 128,
+                    }
+                )
+            )
+
+            importlib.import_module("mlx_vlm.models.nemotron_h_nano_omni")
+
+            with patch(
+                "transformers.AutoTokenizer.from_pretrained",
+                return_value=_mock_tokenizer(image_token_id=18),
+            ):
+                processor = load_processor(tmpdir, add_detokenizer=False)
+
+            result = prepare_inputs(
+                processor,
+                images=[_make_image()],
+                prompts="<image>\nDescribe this image.",
+                image_token_index=processor.image_token_id,
+            )
+
+        self.assertEqual(
+            processor.__class__.__name__,
+            "NemotronHNanoOmniProcessor",
+        )
+        self.assertIn("pixel_values", result)
+        self.assertIn("num_tokens", result)
+        self.assertGreater(int(result["num_tokens"][0].item()), 0)
+
+
 # ── AutoProcessor patch tests ─────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

- preserve revision/cache-related Hub kwargs when the Nemotron processor reads `processor_config.json` and `preprocessor_config.json`
- add a regression test covering Nemotron processor loading for a stripped-`auto_map` model directory after the native model module has been imported

## Context

`mlx-community/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-nvfp4` at `3f65bc48...` no longer ships remote processor code or processor `auto_map`. The native Nemotron processor path should handle that stripped metadata once the native model module has been loaded by the normal model-loading flow.

Fixes #1090

## Validation

- `python -m pytest mlx_vlm/tests/test_processors.py::TestNemotronHNanoOmniProcessor::test_native_processor_handles_stripped_auto_map mlx_vlm/tests/test_processors.py::TestPatchChainsForUnknownModelType::test_falls_through`
- `python -m pytest mlx_vlm/tests/test_processors.py`
- direct `mlx-community/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-nvfp4` processor check after importing `mlx_vlm.models.nemotron_h_nano_omni`: returned `NemotronHNanoOmniProcessor`, included `pixel_values`, and produced `input_ids` shape `(1, 282)` with `pixel_values` shape `(1, 3, 480, 576)`
- `pre-commit run --all-files`
