### PR TITLE
Fix Qwen MTP verification drift and sampling parity

### DIFF
--- a/mlx_vlm/generate.py
+++ b/mlx_vlm/generate.py
@@ -2854,7 +2854,8 @@ class BatchGenerator:
             generation_responses = self._generation_batch.next()
             self._gen_tokens_counter += len(generation_responses)
             self._steps_counter += 1
-            if self._steps_counter % 512 == 0:
+            if self._steps_counter % 50 == 0:
+                mx.eval([c.state for c in self._generation_batch.prompt_cache])
                 mx.clear_cache()
 
         if len(self._generation_batch) >= self.completion_batch_size:

--- a/mlx_vlm/generate.py
+++ b/mlx_vlm/generate.py
@@ -57,6 +57,64 @@ DEFAULT_QUANTIZED_KV_START = 5000
 DEFAULT_PREFILL_STEP_SIZE = 2048
 
 
+def get_kv_cache_materialize_interval():
+    raw = os.environ.get("MLX_VLM_KV_CACHE_MATERIALIZE_INTERVAL", "50")
+    try:
+        return max(0, int(raw))
+    except ValueError:
+        return 50
+
+
+def _iter_cache_arrays(value, seen=None):
+    if seen is None:
+        seen = set()
+
+    if value is None:
+        return
+
+    if isinstance(value, mx.array):
+        ident = id(value)
+        if ident not in seen:
+            seen.add(ident)
+            yield value
+        return
+
+    if isinstance(value, (list, tuple)):
+        for item in value:
+            yield from _iter_cache_arrays(item, seen)
+        return
+
+    if isinstance(value, dict):
+        for item in value.values():
+            yield from _iter_cache_arrays(item, seen)
+        return
+
+    ident = id(value)
+    if ident in seen:
+        return
+    seen.add(ident)
+
+    for attr in (
+        "keys",
+        "values",
+        "offset",
+        "left_padding",
+        "lengths",
+        "cache",
+        "_cached_state",
+        "_shadow_keys",
+        "_shadow_values",
+    ):
+        if hasattr(value, attr):
+            yield from _iter_cache_arrays(getattr(value, attr), seen)
+
+
+def materialize_generation_cache(prompt_cache) -> None:
+    arrays = list(_iter_cache_arrays(prompt_cache))
+    if arrays:
+        mx.eval(*arrays)
+
+
 def parse_arguments():
     parser = argparse.ArgumentParser(
         description="Generate text from an image using a model."
@@ -2854,7 +2912,14 @@ class BatchGenerator:
             generation_responses = self._generation_batch.next()
             self._gen_tokens_counter += len(generation_responses)
             self._steps_counter += 1
-            if self._steps_counter % 512 == 0:
+            materialize_interval = get_kv_cache_materialize_interval()
+            if (
+                materialize_interval > 0
+                and self._steps_counter % materialize_interval == 0
+            ):
+                materialize_generation_cache(self._generation_batch.prompt_cache)
+                mx.clear_cache()
+            elif self._steps_counter % 512 == 0:
                 mx.clear_cache()
 
         if len(self._generation_batch) >= self.completion_batch_size:

--- a/mlx_vlm/generate.py
+++ b/mlx_vlm/generate.py
@@ -57,64 +57,6 @@ DEFAULT_QUANTIZED_KV_START = 5000
 DEFAULT_PREFILL_STEP_SIZE = 2048
 
 
-def get_kv_cache_materialize_interval():
-    raw = os.environ.get("MLX_VLM_KV_CACHE_MATERIALIZE_INTERVAL", "50")
-    try:
-        return max(0, int(raw))
-    except ValueError:
-        return 50
-
-
-def _iter_cache_arrays(value, seen=None):
-    if seen is None:
-        seen = set()
-
-    if value is None:
-        return
-
-    if isinstance(value, mx.array):
-        ident = id(value)
-        if ident not in seen:
-            seen.add(ident)
-            yield value
-        return
-
-    if isinstance(value, (list, tuple)):
-        for item in value:
-            yield from _iter_cache_arrays(item, seen)
-        return
-
-    if isinstance(value, dict):
-        for item in value.values():
-            yield from _iter_cache_arrays(item, seen)
-        return
-
-    ident = id(value)
-    if ident in seen:
-        return
-    seen.add(ident)
-
-    for attr in (
-        "keys",
-        "values",
-        "offset",
-        "left_padding",
-        "lengths",
-        "cache",
-        "_cached_state",
-        "_shadow_keys",
-        "_shadow_values",
-    ):
-        if hasattr(value, attr):
-            yield from _iter_cache_arrays(getattr(value, attr), seen)
-
-
-def materialize_generation_cache(prompt_cache) -> None:
-    arrays = list(_iter_cache_arrays(prompt_cache))
-    if arrays:
-        mx.eval(*arrays)
-
-
 def parse_arguments():
     parser = argparse.ArgumentParser(
         description="Generate text from an image using a model."
@@ -2912,14 +2854,7 @@ class BatchGenerator:
             generation_responses = self._generation_batch.next()
             self._gen_tokens_counter += len(generation_responses)
             self._steps_counter += 1
-            materialize_interval = get_kv_cache_materialize_interval()
-            if (
-                materialize_interval > 0
-                and self._steps_counter % materialize_interval == 0
-            ):
-                materialize_generation_cache(self._generation_batch.prompt_cache)
-                mx.clear_cache()
-            elif self._steps_counter % 512 == 0:
+            if self._steps_counter % 512 == 0:
                 mx.clear_cache()
 
         if len(self._generation_batch) >= self.completion_batch_size:

--- a/mlx_vlm/models/cache.py
+++ b/mlx_vlm/models/cache.py
@@ -1,4 +1,3 @@
-import os
 from typing import Any, List, Optional, Tuple
 
 import mlx.core as mx
@@ -14,62 +13,6 @@ from mlx_lm.models.cache import (
     RotatingKVCache,
     _BaseCache,
 )
-
-
-def _kv_cache_materialize_interval() -> int:
-    raw = os.environ.get("MLX_VLM_KV_CACHE_MATERIALIZE_INTERVAL", "50")
-    try:
-        return max(0, int(raw))
-    except ValueError:
-        return 50
-
-
-def _flatten_mx_arrays(value):
-    if isinstance(value, mx.array):
-        yield value
-    elif isinstance(value, (list, tuple)):
-        for item in value:
-            yield from _flatten_mx_arrays(item)
-
-
-def _materialize_kv_cache(*values) -> None:
-    arrays = []
-    for value in values:
-        arrays.extend(_flatten_mx_arrays(value))
-    if arrays:
-        mx.eval(*arrays)
-
-
-def _should_materialize_kv_cache(position: int, num_steps: int) -> bool:
-    interval = _kv_cache_materialize_interval()
-    if interval == 0:
-        return False
-    return num_steps > 1 or (position > 0 and position % interval == 0)
-
-
-_original_kv_cache_update_and_fetch = KVCache.update_and_fetch
-_original_batch_kv_cache_update_and_fetch = BatchKVCache.update_and_fetch
-
-
-def _materializing_kv_cache_update_and_fetch(self, keys, values):
-    out = _original_kv_cache_update_and_fetch(self, keys, values)
-    if _should_materialize_kv_cache(int(self.offset), int(keys.shape[2])):
-        _materialize_kv_cache(self.keys, self.values)
-    return out
-
-
-def _materializing_batch_kv_cache_update_and_fetch(self, keys, values):
-    out = _original_batch_kv_cache_update_and_fetch(self, keys, values)
-    if _should_materialize_kv_cache(int(self._idx), int(keys.shape[2])):
-        _materialize_kv_cache(self.keys, self.values, self.offset, self.left_padding)
-    return out
-
-
-# Long continuous-batching decodes otherwise keep thousands of lazy cache-update
-# graphs alive. On Metal this can hit the resource-count limit long before
-# memory is exhausted, especially for BF16 20B+ models.
-KVCache.update_and_fetch = _materializing_kv_cache_update_and_fetch
-BatchKVCache.update_and_fetch = _materializing_batch_kv_cache_update_and_fetch
 
 
 class BufferedRotatingKVCache(RotatingKVCache):
@@ -169,8 +112,6 @@ class BufferedRotatingKVCache(RotatingKVCache):
         self.values[..., self._idx : needed, :] = values
         self._idx = needed
         self.offset += incoming
-        if _should_materialize_kv_cache(int(self._idx), incoming):
-            _materialize_kv_cache(self.keys, self.values)
         return self.keys[..., : self._idx, :], self.values[..., : self._idx, :]
 
     def trim(self, n):
@@ -314,11 +255,6 @@ class BatchQuantizedKVCache(_BaseCache):
         for i in range(len(self.keys)):
             self.keys[i][..., prev : self._idx, :] = q_keys[i]
             self.values[i][..., prev : self._idx, :] = q_values[i]
-
-        if _should_materialize_kv_cache(int(self._idx), int(num_steps)):
-            _materialize_kv_cache(
-                self.keys, self.values, self.offset, self.left_padding
-            )
 
         return (
             tuple(k[..., : self._idx, :] for k in self.keys),
@@ -514,8 +450,6 @@ class SimpleKVCache:
             self.values = mx.concatenate([self.values, values], axis=2)
 
         self.cache_length += keys.shape[2]
-        if _should_materialize_kv_cache(int(self.cache_length), int(keys.shape[2])):
-            _materialize_kv_cache(self.keys, self.values)
         return self.keys, self.values
 
     def fetch(self):
@@ -581,9 +515,6 @@ class SlidingWindowCache(_BaseCache):
                 self.keys = keys[:, :, -self.max_size :, :]
                 self.values = values[:, :, -self.max_size :, :]
             self.offset = self.max_size
-
-        if _should_materialize_kv_cache(int(self.offset), int(seq_len)):
-            _materialize_kv_cache(self.keys, self.values)
 
         return self.keys, self.values
 
@@ -651,9 +582,6 @@ class StaticKVCache(_BaseCache):
                 :, :, :actual_seq_len, :
             ]
             self.offset = end_pos
-
-        if _should_materialize_kv_cache(int(self.offset), int(seq_len)):
-            _materialize_kv_cache(self.keys, self.values)
 
         return self.keys, self.values
 

--- a/mlx_vlm/models/cache.py
+++ b/mlx_vlm/models/cache.py
@@ -1,3 +1,4 @@
+import os
 from typing import Any, List, Optional, Tuple
 
 import mlx.core as mx
@@ -13,6 +14,62 @@ from mlx_lm.models.cache import (
     RotatingKVCache,
     _BaseCache,
 )
+
+
+def _kv_cache_materialize_interval() -> int:
+    raw = os.environ.get("MLX_VLM_KV_CACHE_MATERIALIZE_INTERVAL", "50")
+    try:
+        return max(0, int(raw))
+    except ValueError:
+        return 50
+
+
+def _flatten_mx_arrays(value):
+    if isinstance(value, mx.array):
+        yield value
+    elif isinstance(value, (list, tuple)):
+        for item in value:
+            yield from _flatten_mx_arrays(item)
+
+
+def _materialize_kv_cache(*values) -> None:
+    arrays = []
+    for value in values:
+        arrays.extend(_flatten_mx_arrays(value))
+    if arrays:
+        mx.eval(*arrays)
+
+
+def _should_materialize_kv_cache(position: int, num_steps: int) -> bool:
+    interval = _kv_cache_materialize_interval()
+    if interval == 0:
+        return False
+    return num_steps > 1 or (position > 0 and position % interval == 0)
+
+
+_original_kv_cache_update_and_fetch = KVCache.update_and_fetch
+_original_batch_kv_cache_update_and_fetch = BatchKVCache.update_and_fetch
+
+
+def _materializing_kv_cache_update_and_fetch(self, keys, values):
+    out = _original_kv_cache_update_and_fetch(self, keys, values)
+    if _should_materialize_kv_cache(int(self.offset), int(keys.shape[2])):
+        _materialize_kv_cache(self.keys, self.values)
+    return out
+
+
+def _materializing_batch_kv_cache_update_and_fetch(self, keys, values):
+    out = _original_batch_kv_cache_update_and_fetch(self, keys, values)
+    if _should_materialize_kv_cache(int(self._idx), int(keys.shape[2])):
+        _materialize_kv_cache(self.keys, self.values, self.offset, self.left_padding)
+    return out
+
+
+# Long continuous-batching decodes otherwise keep thousands of lazy cache-update
+# graphs alive. On Metal this can hit the resource-count limit long before
+# memory is exhausted, especially for BF16 20B+ models.
+KVCache.update_and_fetch = _materializing_kv_cache_update_and_fetch
+BatchKVCache.update_and_fetch = _materializing_batch_kv_cache_update_and_fetch
 
 
 class BufferedRotatingKVCache(RotatingKVCache):
@@ -112,6 +169,8 @@ class BufferedRotatingKVCache(RotatingKVCache):
         self.values[..., self._idx : needed, :] = values
         self._idx = needed
         self.offset += incoming
+        if _should_materialize_kv_cache(int(self._idx), incoming):
+            _materialize_kv_cache(self.keys, self.values)
         return self.keys[..., : self._idx, :], self.values[..., : self._idx, :]
 
     def trim(self, n):
@@ -255,6 +314,11 @@ class BatchQuantizedKVCache(_BaseCache):
         for i in range(len(self.keys)):
             self.keys[i][..., prev : self._idx, :] = q_keys[i]
             self.values[i][..., prev : self._idx, :] = q_values[i]
+
+        if _should_materialize_kv_cache(int(self._idx), int(num_steps)):
+            _materialize_kv_cache(
+                self.keys, self.values, self.offset, self.left_padding
+            )
 
         return (
             tuple(k[..., : self._idx, :] for k in self.keys),
@@ -450,6 +514,8 @@ class SimpleKVCache:
             self.values = mx.concatenate([self.values, values], axis=2)
 
         self.cache_length += keys.shape[2]
+        if _should_materialize_kv_cache(int(self.cache_length), int(keys.shape[2])):
+            _materialize_kv_cache(self.keys, self.values)
         return self.keys, self.values
 
     def fetch(self):
@@ -515,6 +581,9 @@ class SlidingWindowCache(_BaseCache):
                 self.keys = keys[:, :, -self.max_size :, :]
                 self.values = values[:, :, -self.max_size :, :]
             self.offset = self.max_size
+
+        if _should_materialize_kv_cache(int(self.offset), int(seq_len)):
+            _materialize_kv_cache(self.keys, self.values)
 
         return self.keys, self.values
 
@@ -582,6 +651,9 @@ class StaticKVCache(_BaseCache):
                 :, :, :actual_seq_len, :
             ]
             self.offset = end_pos
+
+        if _should_materialize_kv_cache(int(self.offset), int(seq_len)):
+            _materialize_kv_cache(self.keys, self.values)
 
         return self.keys, self.values
 

--- a/mlx_vlm/models/qwen3_5/gated_delta.py
+++ b/mlx_vlm/models/qwen3_5/gated_delta.py
@@ -1,7 +1,7 @@
 from typing import Optional
 
 import mlx.core as mx
-from mlx_lm.models.gated_delta import compute_g, gated_delta_update
+from mlx_lm.models.gated_delta import compute_g
 
 
 def _make_gated_delta_with_states_kernel(has_mask: bool = False):

--- a/mlx_vlm/models/qwen3_5/gated_delta.py
+++ b/mlx_vlm/models/qwen3_5/gated_delta.py
@@ -136,13 +136,8 @@ def _gated_delta_with_states_ops(
             y = mx.where(valid[:, None, None], y, 0)
 
         ys.append(y.astype(q.dtype))
-        if t < T - 1:
-            states.append(state)
-    state_steps = max(T - 1, 0)
-    if state_steps == 0:
-        stacked_states = mx.zeros((B, 0, Hv, Dv, state.shape[-1]), dtype=state.dtype)
-    else:
-        stacked_states = mx.stack(states, axis=1)
+        states.append(state)
+    stacked_states = mx.stack(states, axis=1)
     return mx.stack(ys, axis=1), state, stacked_states
 
 
@@ -175,13 +170,7 @@ def gated_delta_update_with_states(
 
     B, T, Hk, Dk = k.shape
     Hv, Dv = v.shape[2:]
-    state_steps = max(T - 1, 0)
-    if state_steps == 0:
-        y, state = gated_delta_update(
-            q, k, v, a, b, A_log, dt_bias, state, mask, use_kernel=use_kernel
-        )
-        states = mx.zeros((B, 0, Hv, Dv, Dk), dtype=state.dtype)
-        return y, state, states
+    state_steps = T
 
     input_type = q.dtype
     state_type = state.dtype

--- a/mlx_vlm/models/qwen3_5/gated_delta.py
+++ b/mlx_vlm/models/qwen3_5/gated_delta.py
@@ -1,7 +1,7 @@
 from typing import Optional
 
 import mlx.core as mx
-from mlx_lm.models.gated_delta import compute_g
+from mlx_lm.models.gated_delta import compute_g, gated_delta_update
 
 
 def _make_gated_delta_with_states_kernel(has_mask: bool = False):

--- a/mlx_vlm/models/qwen3_5/gated_delta.py
+++ b/mlx_vlm/models/qwen3_5/gated_delta.py
@@ -1,7 +1,7 @@
 from typing import Optional
 
 import mlx.core as mx
-from mlx_lm.models.gated_delta import compute_g
+from mlx_lm.models.gated_delta import compute_g, gated_delta_update  # noqa: F401
 
 
 def _make_gated_delta_with_states_kernel(has_mask: bool = False):

--- a/mlx_vlm/models/qwen3_5/language.py
+++ b/mlx_vlm/models/qwen3_5/language.py
@@ -278,26 +278,18 @@ def _gated_delta_update_verify_decode(
     mask: Optional[mx.array],
     use_kernel: bool,
 ):
-    outputs = []
-    states = []
-    current_state = state
-    for i in range(q.shape[1]):
-        step_mask = mask[:, i : i + 1] if isinstance(mask, mx.array) else None
-        out, current_state = gated_delta_update(
-            q[:, i : i + 1],
-            k[:, i : i + 1],
-            v[:, i : i + 1],
-            a[:, i : i + 1],
-            b[:, i : i + 1],
-            A_log,
-            dt_bias,
-            current_state,
-            step_mask,
-            use_kernel=use_kernel,
-        )
-        outputs.append(out)
-        states.append(current_state)
-    return mx.concatenate(outputs, axis=1), current_state, mx.stack(states, axis=1)
+    return gated_delta_update_with_states(
+        q,
+        k,
+        v,
+        a,
+        b,
+        A_log,
+        dt_bias,
+        state,
+        mask,
+        use_kernel=use_kernel,
+    )
 
 
 class Qwen3_5Attention(nn.Module):
@@ -552,32 +544,18 @@ class Qwen3_5GatedDeltaNet(nn.Module):
 
         initial_state = state
         if gdn_sink is not None:
-            if target_verify and S > 1:
-                out, state, intermediate_states = _gated_delta_update_verify_decode(
-                    q,
-                    k,
-                    v,
-                    a,
-                    b,
-                    self.A_log,
-                    self.dt_bias,
-                    state,
-                    mask,
-                    use_kernel=not self.training,
-                )
-            else:
-                out, state, intermediate_states = gated_delta_update_with_states(
-                    q,
-                    k,
-                    v,
-                    a,
-                    b,
-                    self.A_log,
-                    self.dt_bias,
-                    state,
-                    mask,
-                    use_kernel=not self.training,
-                )
+            out, state, intermediate_states = _gated_delta_update_verify_decode(
+                q,
+                k,
+                v,
+                a,
+                b,
+                self.A_log,
+                self.dt_bias,
+                state,
+                mask,
+                use_kernel=not self.training,
+            )
         else:
             out, state = gated_delta_update(
                 q,

--- a/mlx_vlm/models/qwen3_5/language.py
+++ b/mlx_vlm/models/qwen3_5/language.py
@@ -229,9 +229,7 @@ def _target_verify_linear(linear, x: mx.array, target_verify: bool) -> mx.array:
         if out is not None:
             return out
 
-    return mx.concatenate(
-        [linear(x[:, i : i + 1]) for i in range(x.shape[1])], axis=1
-    )
+    return mx.concatenate([linear(x[:, i : i + 1]) for i in range(x.shape[1])], axis=1)
 
 
 def _target_verify_linears(linears, x: mx.array, target_verify: bool):
@@ -243,9 +241,7 @@ def _target_verify_linears(linears, x: mx.array, target_verify: bool):
     ):
         return tuple(linear(x) for linear in linears)
 
-    return tuple(
-        _target_verify_linear(linear, x, target_verify) for linear in linears
-    )
+    return tuple(_target_verify_linear(linear, x, target_verify) for linear in linears)
 
 
 def _target_verify_embedding_as_linear(embedding, x: mx.array, target_verify: bool):
@@ -346,9 +342,9 @@ class Qwen3_5Attention(nn.Module):
         gate = gate.reshape(B, L, -1)
 
         queries = self.q_norm(queries).transpose(0, 2, 1, 3)
-        keys = self.k_norm(
-            keys.reshape(B, L, self.num_key_value_heads, -1)
-        ).transpose(0, 2, 1, 3)
+        keys = self.k_norm(keys.reshape(B, L, self.num_key_value_heads, -1)).transpose(
+            0, 2, 1, 3
+        )
         values = values.reshape(B, L, self.num_key_value_heads, -1).transpose(
             0, 2, 1, 3
         )
@@ -413,9 +409,7 @@ class Qwen3_5MLP(nn.Module):
         gate, up = _target_verify_linears(
             (self.gate_proj, self.up_proj), x, target_verify
         )
-        return _target_verify_linear(
-            self.down_proj, swiglu(gate, up), target_verify
-        )
+        return _target_verify_linear(self.down_proj, swiglu(gate, up), target_verify)
 
 
 class Qwen3_5GatedDeltaNet(nn.Module):

--- a/mlx_vlm/models/qwen3_5/language.py
+++ b/mlx_vlm/models/qwen3_5/language.py
@@ -13,7 +13,11 @@ from ..base import (
 )
 from ..cache import ArraysCache, KVCache
 from .config import ModelConfig, TextConfig
-from .gated_delta import gated_delta_state_update, gated_delta_update
+from .gated_delta import (
+    gated_delta_state_update,
+    gated_delta_update,
+    gated_delta_update_with_states,
+)
 
 
 class Qwen3_5RotaryEmbedding:
@@ -157,6 +161,7 @@ class Qwen3_5Attention(nn.Module):
         mask: Optional[mx.array] = None,
         cache: Optional[Any] = None,
         position_ids: Optional[mx.array] = None,
+        target_verify: bool = False,
     ) -> mx.array:
         B, L, D = x.shape
 
@@ -198,9 +203,26 @@ class Qwen3_5Attention(nn.Module):
         if cache is not None:
             keys, values = cache.update_and_fetch(keys, values)
 
-        output = scaled_dot_product_attention(
-            queries, keys, values, cache=cache, scale=self.scale, mask=mask
-        )
+        if target_verify and L > 1:
+            prefix_len = keys.shape[-2] - L
+            output = mx.concatenate(
+                [
+                    scaled_dot_product_attention(
+                        queries[:, :, i : i + 1, :],
+                        keys[:, :, : prefix_len + i + 1, :],
+                        values[:, :, : prefix_len + i + 1, :],
+                        cache=cache,
+                        scale=self.scale,
+                        mask=None,
+                    )
+                    for i in range(L)
+                ],
+                axis=2,
+            )
+        else:
+            output = scaled_dot_product_attention(
+                queries, keys, values, cache=cache, scale=self.scale, mask=mask
+            )
         output = output.transpose(0, 2, 1, 3).reshape(B, L, -1)
 
         return self.o_proj(output * mx.sigmoid(gate))
@@ -261,6 +283,19 @@ class Qwen3_5GatedDeltaNet(nn.Module):
 
         self.out_proj = nn.Linear(self.value_dim, self.hidden_size, bias=False)
 
+    def _causal_conv1d_verify(self, conv_input: mx.array, steps: int) -> mx.array:
+        if steps <= 1:
+            return self.conv1d(conv_input)
+
+        K = self.conv_kernel_size
+        B = conv_input.shape[0]
+        windows = mx.concatenate(
+            [conv_input[:, offset : offset + K, :] for offset in range(steps)],
+            axis=0,
+        )
+        out = self.conv1d(windows)[:, 0, :]
+        return out.reshape(steps, B, -1).transpose(1, 0, 2)
+
     def __call__(
         self,
         inputs: mx.array,
@@ -299,7 +334,10 @@ class Qwen3_5GatedDeltaNet(nn.Module):
         conv_input = mx.concatenate([conv_state, mixed_qkv], axis=1)
         if cache is not None:
             cache[0] = conv_input[:, -(self.conv_kernel_size - 1) :]
-        conv_out = nn.silu(self.conv1d(conv_input))
+        if gdn_sink is not None:
+            conv_out = nn.silu(self._causal_conv1d_verify(conv_input, S))
+        else:
+            conv_out = nn.silu(self.conv1d(conv_input))
 
         q, k, v = [
             t.reshape(B, S, h, d)
@@ -318,24 +356,35 @@ class Qwen3_5GatedDeltaNet(nn.Module):
         k = inv_scale * mx.fast.rms_norm(k, None, 1e-6)
 
         initial_state = state
-        out, state = gated_delta_update(
-            q,
-            k,
-            v,
-            a,
-            b,
-            self.A_log,
-            self.dt_bias,
-            state,
-            mask,
-            use_kernel=not self.training,
-        )
+        if gdn_sink is not None:
+            out, state, intermediate_states = gated_delta_update_with_states(
+                q,
+                k,
+                v,
+                a,
+                b,
+                self.A_log,
+                self.dt_bias,
+                state,
+                mask,
+                use_kernel=not self.training,
+            )
+        else:
+            out, state = gated_delta_update(
+                q,
+                k,
+                v,
+                a,
+                b,
+                self.A_log,
+                self.dt_bias,
+                state,
+                mask,
+                use_kernel=not self.training,
+            )
+            intermediate_states = None
 
         if gdn_sink is not None:
-            # Tuple layout consumed by ``rollback_speculative_cache`` below.
-            # Speculative rollback reconstructs the accepted state with the
-            # state-only GDN kernel; materializing every per-token state here
-            # slows down the target verify pass.
             gdn_sink.append(
                 (
                     q,
@@ -349,7 +398,7 @@ class Qwen3_5GatedDeltaNet(nn.Module):
                     mask,
                     conv_input,
                     self.conv_kernel_size,
-                    None,
+                    intermediate_states,
                 )
             )
 
@@ -384,13 +433,20 @@ class Qwen3_5DecoderLayer(nn.Module):
         cache: Optional[Any] = None,
         position_ids: Optional[mx.array] = None,
         gdn_sink: Optional[list] = None,
+        target_verify: bool = False,
     ) -> mx.array:
         if self.is_linear:
             r = self.linear_attn(
                 self.input_layernorm(x), mask, cache, gdn_sink=gdn_sink
             )
         else:
-            r = self.self_attn(self.input_layernorm(x), mask, cache, position_ids)
+            r = self.self_attn(
+                self.input_layernorm(x),
+                mask,
+                cache,
+                position_ids,
+                target_verify=target_verify,
+            )
         h = x + r
         return h + self.mlp(self.post_attention_layernorm(h))
 
@@ -433,7 +489,14 @@ class Qwen3_5Model(nn.Module):
         capture_set = set(capture_layer_ids) if capture_layer_ids else set()
         for i, (layer, c) in enumerate(zip(self.layers, cache)):
             mask = ssm_mask if layer.is_linear else fa_mask
-            h = layer(h, mask, c, position_ids, gdn_sink=gdn_sink)
+            h = layer(
+                h,
+                mask,
+                c,
+                position_ids,
+                gdn_sink=gdn_sink,
+                target_verify=gdn_sink is not None,
+            )
             if hidden_sink is not None and i in capture_set:
                 hidden_sink.append(h)
 

--- a/mlx_vlm/models/qwen3_5/language.py
+++ b/mlx_vlm/models/qwen3_5/language.py
@@ -262,10 +262,6 @@ def _target_verify_embedding_as_linear(embedding, x: mx.array, target_verify: bo
     )
 
 
-def _target_verify_timewise(fn, x: mx.array, target_verify: bool, *args) -> mx.array:
-    return fn(x, *args)
-
-
 def _gated_delta_update_verify_decode(
     q: mx.array,
     k: mx.array,
@@ -349,13 +345,9 @@ class Qwen3_5Attention(nn.Module):
         )
         gate = gate.reshape(B, L, -1)
 
-        queries = _target_verify_timewise(
-            self.q_norm, queries, target_verify
-        ).transpose(0, 2, 1, 3)
-        keys = _target_verify_timewise(
-            self.k_norm,
-            keys.reshape(B, L, self.num_key_value_heads, -1),
-            target_verify,
+        queries = self.q_norm(queries).transpose(0, 2, 1, 3)
+        keys = self.k_norm(
+            keys.reshape(B, L, self.num_key_value_heads, -1)
         ).transpose(0, 2, 1, 3)
         values = values.reshape(B, L, self.num_key_value_heads, -1).transpose(
             0, 2, 1, 3
@@ -531,16 +523,8 @@ class Qwen3_5GatedDeltaNet(nn.Module):
         if state is not None and state.shape[0] != B:
             state = None
         inv_scale = k.shape[-1] ** -0.5
-        q = (inv_scale**2) * _target_verify_timewise(
-            lambda value: mx.fast.rms_norm(value, None, 1e-6),
-            q,
-            target_verify,
-        )
-        k = inv_scale * _target_verify_timewise(
-            lambda value: mx.fast.rms_norm(value, None, 1e-6),
-            k,
-            target_verify,
-        )
+        q = (inv_scale**2) * mx.fast.rms_norm(q, None, 1e-6)
+        k = inv_scale * mx.fast.rms_norm(k, None, 1e-6)
 
         initial_state = state
         if gdn_sink is not None:
@@ -594,7 +578,7 @@ class Qwen3_5GatedDeltaNet(nn.Module):
             if hasattr(cache, "advance"):
                 cache.advance(S)
 
-        out = _target_verify_timewise(self.norm, out, target_verify, z)
+        out = self.norm(out, z)
         return _target_verify_linear(
             self.out_proj, out.reshape(B, S, -1), target_verify
         )

--- a/mlx_vlm/models/qwen3_5/language.py
+++ b/mlx_vlm/models/qwen3_5/language.py
@@ -116,6 +116,190 @@ def _precise_swiglu(h, gate, x):
     return (gate * x).astype(h.dtype)
 
 
+_TARGET_VERIFY_GEMV = mx.fast.metal_kernel(
+    name="qwen3_5_target_verify_gemv",
+    input_names=["x", "weight"],
+    output_names=["out"],
+    header="#include <metal_simdgroup>\nusing namespace metal;\n",
+    source=r"""
+        uint lane = thread_position_in_grid.x;
+        uint out_block = thread_position_in_grid.y;
+        uint row = thread_position_in_grid.z;
+
+        constexpr int TM = 4;
+        constexpr int TN = 4;
+        constexpr int SN = 32;
+        constexpr int blockN = SN * TN;
+
+        if (row >= R) {
+            return;
+        }
+
+        int out_row = int(out_block * TM);
+        if (out_row >= O) {
+            return;
+        }
+
+        const device T* in_vec = x + row * K;
+        const device T* mat = weight + out_row * K;
+
+        float result[TM] = {0.0f, 0.0f, 0.0f, 0.0f};
+        int col = int(lane * TN);
+        int n_iter = K / blockN;
+        int leftover = K - blockN * n_iter;
+
+        for (int iter = 0; iter < n_iter; ++iter) {
+            float v[TN];
+            for (int tn = 0; tn < TN; ++tn) {
+                v[tn] = static_cast<float>(in_vec[col + tn]);
+            }
+
+            for (int tm = 0; tm < TM; ++tm) {
+                for (int tn = 0; tn < TN; ++tn) {
+                    result[tm] += static_cast<float>(mat[tm * K + col + tn]) * v[tn];
+                }
+            }
+
+            col += blockN;
+        }
+
+        if (leftover > 0) {
+            float v[TN];
+            for (int tn = 0; tn < TN; ++tn) {
+                v[tn] = (col + tn < K) ? static_cast<float>(in_vec[col + tn]) : 0.0f;
+            }
+
+            for (int tm = 0; tm < TM; ++tm) {
+                for (int tn = 0; tn < TN; ++tn) {
+                    T m = (col + tn < K) ? mat[tm * K + col + tn] : T(0);
+                    result[tm] += static_cast<float>(m) * v[tn];
+                }
+            }
+        }
+
+        for (int tm = 0; tm < TM; ++tm) {
+            for (ushort sn = (SN / 2); sn >= 1; sn >>= 1) {
+                result[tm] += simd_shuffle_down(result[tm], sn);
+            }
+        }
+
+        if (lane == 0) {
+            for (int tm = 0; tm < TM; ++tm) {
+                out[row * O + out_row + tm] = static_cast<T>(result[tm]);
+            }
+        }
+    """,
+)
+
+
+def _use_target_verify_dense(linear, x: mx.array, target_verify: bool) -> bool:
+    return (
+        target_verify
+        and x.ndim == 3
+        and x.shape[1] > 1
+        and isinstance(linear, nn.Linear)
+    )
+
+
+def _target_verify_weight(weight: mx.array, x: mx.array) -> Optional[mx.array]:
+    B, L, D = x.shape
+    O = weight.shape[0]
+    if O < 4 or O % 4 != 0 or D >= 16 * O or weight.dtype != x.dtype:
+        return None
+
+    rows = B * L
+    rows8 = ((rows + 7) // 8) * 8
+    out = _TARGET_VERIFY_GEMV(
+        inputs=[x.reshape(rows, D), weight],
+        template=[("T", x.dtype), ("K", D), ("O", O), ("R", rows)],
+        grid=(32, O // 4, rows8),
+        threadgroup=(32, 1, 8),
+        output_shapes=[(rows, O)],
+        output_dtypes=[x.dtype],
+    )[0]
+    return out.reshape(B, L, O)
+
+
+def _target_verify_linear(linear, x: mx.array, target_verify: bool) -> mx.array:
+    if not _use_target_verify_dense(linear, x, target_verify):
+        return linear(x)
+
+    if "bias" not in linear:
+        out = _target_verify_weight(linear.weight, x)
+        if out is not None:
+            return out
+
+    return mx.concatenate(
+        [linear(x[:, i : i + 1]) for i in range(x.shape[1])], axis=1
+    )
+
+
+def _target_verify_linears(linears, x: mx.array, target_verify: bool):
+    if not (
+        target_verify
+        and x.ndim == 3
+        and x.shape[1] > 1
+        and all(isinstance(linear, nn.Linear) for linear in linears)
+    ):
+        return tuple(linear(x) for linear in linears)
+
+    return tuple(
+        _target_verify_linear(linear, x, target_verify) for linear in linears
+    )
+
+
+def _target_verify_embedding_as_linear(embedding, x: mx.array, target_verify: bool):
+    if not (target_verify and x.ndim == 3 and x.shape[1] > 1):
+        return embedding.as_linear(x)
+
+    out = _target_verify_weight(embedding.weight, x)
+    if out is not None:
+        return out
+
+    return mx.concatenate(
+        [embedding.as_linear(x[:, i : i + 1]) for i in range(x.shape[1])],
+        axis=1,
+    )
+
+
+def _target_verify_timewise(fn, x: mx.array, target_verify: bool, *args) -> mx.array:
+    return fn(x, *args)
+
+
+def _gated_delta_update_verify_decode(
+    q: mx.array,
+    k: mx.array,
+    v: mx.array,
+    a: mx.array,
+    b: mx.array,
+    A_log: mx.array,
+    dt_bias: mx.array,
+    state: Optional[mx.array],
+    mask: Optional[mx.array],
+    use_kernel: bool,
+):
+    outputs = []
+    states = []
+    current_state = state
+    for i in range(q.shape[1]):
+        step_mask = mask[:, i : i + 1] if isinstance(mask, mx.array) else None
+        out, current_state = gated_delta_update(
+            q[:, i : i + 1],
+            k[:, i : i + 1],
+            v[:, i : i + 1],
+            a[:, i : i + 1],
+            b[:, i : i + 1],
+            A_log,
+            dt_bias,
+            current_state,
+            step_mask,
+            use_kernel=use_kernel,
+        )
+        outputs.append(out)
+        states.append(current_state)
+    return mx.concatenate(outputs, axis=1), current_state, mx.stack(states, axis=1)
+
+
 class Qwen3_5Attention(nn.Module):
     def __init__(self, args: TextConfig):
         super().__init__()
@@ -165,18 +349,22 @@ class Qwen3_5Attention(nn.Module):
     ) -> mx.array:
         B, L, D = x.shape
 
-        q_proj_output = self.q_proj(x)
+        q_proj_output, keys, values = _target_verify_linears(
+            (self.q_proj, self.k_proj, self.v_proj), x, target_verify
+        )
         queries, gate = mx.split(
             q_proj_output.reshape(B, L, self.num_attention_heads, -1), 2, axis=-1
         )
         gate = gate.reshape(B, L, -1)
 
-        keys, values = self.k_proj(x), self.v_proj(x)
-
-        queries = self.q_norm(queries).transpose(0, 2, 1, 3)
-        keys = self.k_norm(keys.reshape(B, L, self.num_key_value_heads, -1)).transpose(
-            0, 2, 1, 3
-        )
+        queries = _target_verify_timewise(
+            self.q_norm, queries, target_verify
+        ).transpose(0, 2, 1, 3)
+        keys = _target_verify_timewise(
+            self.k_norm,
+            keys.reshape(B, L, self.num_key_value_heads, -1),
+            target_verify,
+        ).transpose(0, 2, 1, 3)
         values = values.reshape(B, L, self.num_key_value_heads, -1).transpose(
             0, 2, 1, 3
         )
@@ -225,7 +413,9 @@ class Qwen3_5Attention(nn.Module):
             )
         output = output.transpose(0, 2, 1, 3).reshape(B, L, -1)
 
-        return self.o_proj(output * mx.sigmoid(gate))
+        return _target_verify_linear(
+            self.o_proj, output * mx.sigmoid(gate), target_verify
+        )
 
 
 class Qwen3_5MLP(nn.Module):
@@ -235,8 +425,13 @@ class Qwen3_5MLP(nn.Module):
         self.down_proj = nn.Linear(hidden_dim, dim, bias=False)
         self.up_proj = nn.Linear(dim, hidden_dim, bias=False)
 
-    def __call__(self, x) -> mx.array:
-        return self.down_proj(swiglu(self.gate_proj(x), self.up_proj(x)))
+    def __call__(self, x, target_verify: bool = False) -> mx.array:
+        gate, up = _target_verify_linears(
+            (self.gate_proj, self.up_proj), x, target_verify
+        )
+        return _target_verify_linear(
+            self.down_proj, swiglu(gate, up), target_verify
+        )
 
 
 class Qwen3_5GatedDeltaNet(nn.Module):
@@ -284,17 +479,7 @@ class Qwen3_5GatedDeltaNet(nn.Module):
         self.out_proj = nn.Linear(self.value_dim, self.hidden_size, bias=False)
 
     def _causal_conv1d_verify(self, conv_input: mx.array, steps: int) -> mx.array:
-        if steps <= 1:
-            return self.conv1d(conv_input)
-
-        K = self.conv_kernel_size
-        B = conv_input.shape[0]
-        windows = mx.concatenate(
-            [conv_input[:, offset : offset + K, :] for offset in range(steps)],
-            axis=0,
-        )
-        out = self.conv1d(windows)[:, 0, :]
-        return out.reshape(steps, B, -1).transpose(1, 0, 2)
+        return self.conv1d(conv_input)
 
     def __call__(
         self,
@@ -302,16 +487,18 @@ class Qwen3_5GatedDeltaNet(nn.Module):
         mask: Optional[mx.array] = None,
         cache: Optional[Any] = None,
         gdn_sink: Optional[list] = None,
+        target_verify: bool = False,
     ) -> mx.array:
         B, S, _ = inputs.shape
+        target_verify = target_verify or gdn_sink is not None
 
-        mixed_qkv = self.in_proj_qkv(inputs)
+        mixed_qkv, z, b, a = _target_verify_linears(
+            (self.in_proj_qkv, self.in_proj_z, self.in_proj_b, self.in_proj_a),
+            inputs,
+            target_verify,
+        )
 
-        z = self.in_proj_z(inputs)
         z = z.reshape(B, S, -1, self.head_v_dim)
-
-        b = self.in_proj_b(inputs)
-        a = self.in_proj_a(inputs)
 
         if cache is not None and cache[0] is not None:
             conv_state = cache[0]
@@ -352,23 +539,45 @@ class Qwen3_5GatedDeltaNet(nn.Module):
         if state is not None and state.shape[0] != B:
             state = None
         inv_scale = k.shape[-1] ** -0.5
-        q = (inv_scale**2) * mx.fast.rms_norm(q, None, 1e-6)
-        k = inv_scale * mx.fast.rms_norm(k, None, 1e-6)
+        q = (inv_scale**2) * _target_verify_timewise(
+            lambda value: mx.fast.rms_norm(value, None, 1e-6),
+            q,
+            target_verify,
+        )
+        k = inv_scale * _target_verify_timewise(
+            lambda value: mx.fast.rms_norm(value, None, 1e-6),
+            k,
+            target_verify,
+        )
 
         initial_state = state
         if gdn_sink is not None:
-            out, state, intermediate_states = gated_delta_update_with_states(
-                q,
-                k,
-                v,
-                a,
-                b,
-                self.A_log,
-                self.dt_bias,
-                state,
-                mask,
-                use_kernel=not self.training,
-            )
+            if target_verify and S > 1:
+                out, state, intermediate_states = _gated_delta_update_verify_decode(
+                    q,
+                    k,
+                    v,
+                    a,
+                    b,
+                    self.A_log,
+                    self.dt_bias,
+                    state,
+                    mask,
+                    use_kernel=not self.training,
+                )
+            else:
+                out, state, intermediate_states = gated_delta_update_with_states(
+                    q,
+                    k,
+                    v,
+                    a,
+                    b,
+                    self.A_log,
+                    self.dt_bias,
+                    state,
+                    mask,
+                    use_kernel=not self.training,
+                )
         else:
             out, state = gated_delta_update(
                 q,
@@ -407,8 +616,10 @@ class Qwen3_5GatedDeltaNet(nn.Module):
             if hasattr(cache, "advance"):
                 cache.advance(S)
 
-        out = self.norm(out, z)
-        return self.out_proj(out.reshape(B, S, -1))
+        out = _target_verify_timewise(self.norm, out, target_verify, z)
+        return _target_verify_linear(
+            self.out_proj, out.reshape(B, S, -1), target_verify
+        )
 
 
 class Qwen3_5DecoderLayer(nn.Module):
@@ -437,7 +648,11 @@ class Qwen3_5DecoderLayer(nn.Module):
     ) -> mx.array:
         if self.is_linear:
             r = self.linear_attn(
-                self.input_layernorm(x), mask, cache, gdn_sink=gdn_sink
+                self.input_layernorm(x),
+                mask,
+                cache,
+                gdn_sink=gdn_sink,
+                target_verify=target_verify,
             )
         else:
             r = self.self_attn(
@@ -448,7 +663,7 @@ class Qwen3_5DecoderLayer(nn.Module):
                 target_verify=target_verify,
             )
         h = x + r
-        return h + self.mlp(self.post_attention_layernorm(h))
+        return h + self.mlp(self.post_attention_layernorm(h), target_verify)
 
 
 class Qwen3_5Model(nn.Module):
@@ -976,6 +1191,7 @@ class LanguageModel(nn.Module):
             [] if capture_layer_ids is not None else None
         )
         gdn_sink: Optional[list] = [] if capture_layer_ids is not None else None
+        target_verify = gdn_sink is not None
 
         out = self.model(
             inputs,
@@ -994,9 +1210,11 @@ class LanguageModel(nn.Module):
         if skip_logits:
             logits = None
         elif self.args.tie_word_embeddings:
-            logits = self.model.embed_tokens.as_linear(out)
+            logits = _target_verify_embedding_as_linear(
+                self.model.embed_tokens, out, target_verify
+            )
         else:
-            logits = self.lm_head(out)
+            logits = _target_verify_linear(self.lm_head, out, target_verify)
         return LanguageModelOutput(
             logits=logits,
             hidden_states=hidden_sink,

--- a/mlx_vlm/models/qwen3_5_moe/language.py
+++ b/mlx_vlm/models/qwen3_5_moe/language.py
@@ -8,8 +8,28 @@ from ..qwen3_5.language import LanguageModel as Qwen3_5LanguageModel
 from ..qwen3_5.language import Qwen3_5Attention as Qwen3_5MoeAttention
 from ..qwen3_5.language import Qwen3_5GatedDeltaNet as Qwen3_5MoeGatedDeltaNet
 from ..qwen3_5.language import Qwen3_5MLP as Qwen3_5MoeMLP
-from ..qwen3_5.language import Qwen3_5Model
+from ..qwen3_5.language import Qwen3_5Model, _target_verify_linear
 from .config import ModelConfig, TextConfig
+
+
+def _target_verify_switch_glu(switch_mlp: SwitchGLU, x, indices, target_verify: bool):
+    if not (target_verify and x.ndim == 3 and x.shape[1] > 1):
+        return switch_mlp(x, indices)
+
+    B, T, D = x.shape
+    k = indices.shape[-1]
+    flat_x = x.reshape(B * T, D)
+    flat_indices = indices.reshape(B * T, k)
+    flat_x = mx.expand_dims(flat_x, (-2, -3))
+
+    up = switch_mlp.up_proj(flat_x, flat_indices, sorted_indices=False)
+    gate = switch_mlp.gate_proj(flat_x, flat_indices, sorted_indices=False)
+    out = switch_mlp.down_proj(
+        switch_mlp.activation(up, gate),
+        flat_indices,
+        sorted_indices=False,
+    )
+    return out.squeeze(-2).reshape(B, T, k, -1)
 
 
 class Qwen3_5MoeSparseMoeBlock(nn.Module):
@@ -31,8 +51,9 @@ class Qwen3_5MoeSparseMoeBlock(nn.Module):
     def __call__(
         self,
         x: mx.array,
+        target_verify: bool = False,
     ) -> mx.array:
-        gates = self.gate(x)
+        gates = _target_verify_linear(self.gate, x, target_verify)
         gates = mx.softmax(gates, axis=-1, precise=True)
 
         k = self.top_k
@@ -40,11 +61,14 @@ class Qwen3_5MoeSparseMoeBlock(nn.Module):
         scores = mx.take_along_axis(gates, inds, axis=-1)
         scores = scores / scores.sum(axis=-1, keepdims=True)
 
-        y = self.switch_mlp(x, inds)
+        y = _target_verify_switch_glu(self.switch_mlp, x, inds, target_verify)
         y = (y * scores[..., None]).sum(axis=-2)
 
-        shared_y = self.shared_expert(x)
-        shared_y = mx.sigmoid(self.shared_expert_gate(x)) * shared_y
+        shared_y = self.shared_expert(x, target_verify)
+        shared_y = (
+            mx.sigmoid(_target_verify_linear(self.shared_expert_gate, x, target_verify))
+            * shared_y
+        )
 
         return y + shared_y
 
@@ -71,15 +95,26 @@ class Qwen3_5MoeDecoderLayer(nn.Module):
         cache: Optional[Any] = None,
         position_ids: Optional[mx.array] = None,
         gdn_sink: Optional[list] = None,
+        target_verify: bool = False,
     ) -> mx.array:
         if self.is_linear:
             r = self.linear_attn(
-                self.input_layernorm(x), mask, cache, gdn_sink=gdn_sink
+                self.input_layernorm(x),
+                mask,
+                cache,
+                gdn_sink=gdn_sink,
+                target_verify=target_verify,
             )
         else:
-            r = self.self_attn(self.input_layernorm(x), mask, cache, position_ids)
+            r = self.self_attn(
+                self.input_layernorm(x),
+                mask,
+                cache,
+                position_ids,
+                target_verify=target_verify,
+            )
         h = x + r
-        out = h + self.mlp(self.post_attention_layernorm(h))
+        out = h + self.mlp(self.post_attention_layernorm(h), target_verify)
         return out
 
 

--- a/mlx_vlm/speculative/common.py
+++ b/mlx_vlm/speculative/common.py
@@ -94,9 +94,15 @@ class _SpeculativeSamplerRNG:
         _restore_rng_state(self._target_rng_state)
         return result
 
-    def target_sampled(self) -> None:
+    def target_sampled(self, *, sync_draft: bool = False) -> None:
         if self.enabled:
             self._target_rng_state = _copy_rng_state()
+            if sync_draft:
+                self._draft_rng_state = _copy_rng_state()
+
+    def sync_draft_to_target(self) -> None:
+        if self.enabled:
+            self._draft_rng_state = _copy_rng_state()
 
     def target_eval(self, *values: Any) -> None:
         if not self.enabled:

--- a/mlx_vlm/speculative/common.py
+++ b/mlx_vlm/speculative/common.py
@@ -7,14 +7,12 @@ generation_stream = mx.new_thread_local_stream(mx.default_device())
 
 
 def _copy_rng_state() -> List[mx.array]:
-    mx.eval(*mx.random.state)
-    return [mx.array(state.tolist(), dtype=state.dtype) for state in mx.random.state]
+    return [mx.array(state) for state in mx.random.state]
 
 
 def _restore_rng_state(state: List[mx.array]) -> None:
     for i, value in enumerate(state):
-        mx.random.state[i] = mx.array(value.tolist(), dtype=value.dtype)
-    mx.eval(*mx.random.state)
+        mx.random.state[i] = value
 
 
 def _append_arrays(value: Any, arrays: List[mx.array]) -> None:
@@ -66,7 +64,7 @@ class _SpeculativeSamplerRNG:
         arrays = _draft_sampler_state_arrays(self.draft_model)
         arrays.extend(mx.random.state)
         if arrays:
-            mx.eval(*arrays)
+            mx.async_eval(*arrays)
 
         self._draft_rng_state = _copy_rng_state()
         _restore_rng_state(self._target_rng_state)
@@ -90,7 +88,7 @@ class _SpeculativeSamplerRNG:
         arrays.extend(_draft_sampler_state_arrays(self.draft_model))
         arrays.extend(mx.random.state)
         if arrays:
-            mx.eval(*arrays)
+            mx.async_eval(*arrays)
 
         self._draft_rng_state = _copy_rng_state()
         _restore_rng_state(self._target_rng_state)
@@ -114,7 +112,7 @@ class _SpeculativeSamplerRNG:
             _append_arrays(value, arrays)
         arrays.extend(mx.random.state)
         if arrays:
-            mx.eval(*arrays)
+            mx.async_eval(*arrays)
         self._target_rng_state = _copy_rng_state()
 
 

--- a/mlx_vlm/speculative/common.py
+++ b/mlx_vlm/speculative/common.py
@@ -1,9 +1,121 @@
-from typing import Any, List, Optional, Tuple
+from typing import Any, Callable, List, Optional, Tuple
 
 import mlx.core as mx
 import mlx.nn as nn
 
 generation_stream = mx.new_thread_local_stream(mx.default_device())
+
+
+def _copy_rng_state() -> List[mx.array]:
+    mx.eval(*mx.random.state)
+    return [mx.array(state.tolist(), dtype=state.dtype) for state in mx.random.state]
+
+
+def _restore_rng_state(state: List[mx.array]) -> None:
+    for i, value in enumerate(state):
+        mx.random.state[i] = mx.array(value.tolist(), dtype=value.dtype)
+    mx.eval(*mx.random.state)
+
+
+def _append_arrays(value: Any, arrays: List[mx.array]) -> None:
+    if isinstance(value, mx.array):
+        arrays.append(value)
+    elif isinstance(value, dict):
+        for item in value.values():
+            _append_arrays(item, arrays)
+    elif isinstance(value, (list, tuple)):
+        for item in value:
+            _append_arrays(item, arrays)
+
+
+def _draft_sampler_state_arrays(draft_model: nn.Module) -> List[mx.array]:
+    attrs = getattr(draft_model, "sampler_state_attrs", ("_seed_token",))
+    if isinstance(attrs, str):
+        attrs = (attrs,)
+
+    arrays = []
+    for attr in attrs:
+        value = getattr(draft_model, attr, None)
+        if isinstance(value, mx.array):
+            arrays.append(value)
+    return arrays
+
+
+class _SpeculativeSamplerRNG:
+    """Keep target and drafter sampler RNG streams independent."""
+
+    def __init__(self, draft_model: nn.Module, *, enabled: bool):
+        self.draft_model = draft_model
+        self.enabled = bool(enabled)
+        self._target_rng_state = _copy_rng_state() if self.enabled else None
+        self._draft_rng_state = _copy_rng_state() if self.enabled else None
+
+    def draft_call(
+        self,
+        fn: Callable,
+        *args,
+        **kwargs,
+    ):
+        if not self.enabled:
+            return fn(*args, **kwargs)
+
+        self._target_rng_state = _copy_rng_state()
+        _restore_rng_state(self._draft_rng_state)
+        result = fn(*args, **kwargs)
+
+        arrays = _draft_sampler_state_arrays(self.draft_model)
+        arrays.extend(mx.random.state)
+        if arrays:
+            mx.eval(*arrays)
+
+        self._draft_rng_state = _copy_rng_state()
+        _restore_rng_state(self._target_rng_state)
+        return result
+
+    def draft_tokens(self, fn: Callable, *args, **kwargs):
+        if not self.enabled:
+            result = fn(*args, **kwargs)
+            arrays: List[mx.array] = []
+            _append_arrays(result, arrays)
+            if arrays:
+                mx.async_eval(*arrays)
+            return result
+
+        self._target_rng_state = _copy_rng_state()
+        _restore_rng_state(self._draft_rng_state)
+        result = fn(*args, **kwargs)
+
+        arrays = []
+        _append_arrays(result, arrays)
+        arrays.extend(_draft_sampler_state_arrays(self.draft_model))
+        arrays.extend(mx.random.state)
+        if arrays:
+            mx.eval(*arrays)
+
+        self._draft_rng_state = _copy_rng_state()
+        _restore_rng_state(self._target_rng_state)
+        return result
+
+    def target_sampled(self) -> None:
+        if self.enabled:
+            self._target_rng_state = _copy_rng_state()
+
+    def target_eval(self, *values: Any) -> None:
+        if not self.enabled:
+            arrays: List[mx.array] = []
+            for value in values:
+                _append_arrays(value, arrays)
+            if arrays:
+                mx.async_eval(*arrays)
+            return
+
+        arrays = []
+        for value in values:
+            _append_arrays(value, arrays)
+        arrays.extend(mx.random.state)
+        if arrays:
+            mx.eval(*arrays)
+        self._target_rng_state = _copy_rng_state()
 
 
 def _speculative_walk(

--- a/mlx_vlm/speculative/drafters/qwen3_5_mtp/__init__.py
+++ b/mlx_vlm/speculative/drafters/qwen3_5_mtp/__init__.py
@@ -1,5 +1,5 @@
-from ....models.qwen3_5.config import TextConfig
 from .config import Qwen3_5MTPConfig as ModelConfig
+from .config import TextConfig
 from .qwen3_5_mtp import Qwen3_5MTPDraftModel
 from .qwen3_5_mtp import Qwen3_5MTPDraftModel as Model
 

--- a/mlx_vlm/speculative/drafters/qwen3_5_mtp/config.py
+++ b/mlx_vlm/speculative/drafters/qwen3_5_mtp/config.py
@@ -3,7 +3,17 @@ from dataclasses import dataclass
 from typing import Optional
 
 from ....models.base import BaseModelConfig
-from ....models.qwen3_5.config import TextConfig
+from ....models.qwen3_5.config import TextConfig as DenseTextConfig
+from ....models.qwen3_5_moe.config import TextConfig as MoeTextConfig
+
+
+class TextConfig:
+    @classmethod
+    def from_dict(cls, params: dict):
+        text_config_cls = (
+            MoeTextConfig if "moe" in params.get("model_type", "") else DenseTextConfig
+        )
+        return text_config_cls.from_dict(params)
 
 
 @dataclass

--- a/mlx_vlm/speculative/drafters/qwen3_5_mtp/qwen3_5_mtp.py
+++ b/mlx_vlm/speculative/drafters/qwen3_5_mtp/qwen3_5_mtp.py
@@ -7,6 +7,7 @@ import mlx.nn as nn
 from ....models.base import create_attention_mask
 from ....models.cache import KVCache
 from ....models.qwen3_5.language import Qwen3_5DecoderLayer
+from ....models.qwen3_5_moe.language import Qwen3_5MoeDecoderLayer
 from .config import Qwen3_5MTPConfig
 
 
@@ -34,9 +35,13 @@ class Qwen3_5MTPDraftModel(nn.Module):
             hidden_size, eps=text_config.rms_norm_eps
         )
         self.pre_fc_norm_hidden = nn.RMSNorm(hidden_size, eps=text_config.rms_norm_eps)
+        layer_cls = (
+            Qwen3_5MoeDecoderLayer
+            if "moe" in getattr(text_config, "model_type", "")
+            else Qwen3_5DecoderLayer
+        )
         self.layers = [
-            Qwen3_5DecoderLayer(args=layer_config, layer_idx=0)
-            for _ in range(mtp_layers)
+            layer_cls(args=layer_config, layer_idx=0) for _ in range(mtp_layers)
         ]
         self.norm = nn.RMSNorm(hidden_size, eps=text_config.rms_norm_eps)
 
@@ -383,6 +388,21 @@ class Qwen3_5MTPDraftModel(nn.Module):
 
     def sanitize(self, weights: dict) -> dict:
         out = {}
+        weights = dict(weights)
+        expert_prefixes = [
+            key[: -len(".experts.gate_up_proj")]
+            for key in weights
+            if key.endswith(".experts.gate_up_proj")
+        ]
+        for prefix in expert_prefixes:
+            gate_up_weight = weights.pop(f"{prefix}.experts.gate_up_proj")
+            gate_weight, up_weights = mx.split(gate_up_weight, 2, axis=-2)
+            weights[f"{prefix}.switch_mlp.gate_proj.weight"] = gate_weight
+            weights[f"{prefix}.switch_mlp.up_proj.weight"] = up_weights
+            weights[f"{prefix}.switch_mlp.down_proj.weight"] = weights.pop(
+                f"{prefix}.experts.down_proj"
+            )
+
         norm_suffixes = (
             ".input_layernorm.weight",
             ".post_attention_layernorm.weight",

--- a/mlx_vlm/speculative/drafters/qwen3_5_mtp/split.py
+++ b/mlx_vlm/speculative/drafters/qwen3_5_mtp/split.py
@@ -56,9 +56,13 @@ def _is_mlx_safetensors(file: Path) -> bool:
 
 def _load_selected_tensors(file: Path, keys: list[str]) -> Dict[str, mx.array]:
     tensors = {}
-    with safe_open(file, framework="mlx") as f:
-        for key in keys:
-            tensors[key] = mx.array(f.get_tensor(key))
+    try:
+        with safe_open(file, framework="mlx") as f:
+            for key in keys:
+                tensors[key] = mx.array(f.get_tensor(key))
+    except TypeError:
+        shard = mx.load(str(file))
+        tensors = {key: shard[key] for key in keys}
     return tensors
 
 

--- a/mlx_vlm/speculative/eagle3.py
+++ b/mlx_vlm/speculative/eagle3.py
@@ -4,6 +4,7 @@ import mlx.core as mx
 import mlx.nn as nn
 
 from .common import (
+    _SpeculativeSamplerRNG,
     _batch_cache_left_padding,
     _record_speculative_round,
     generation_stream,
@@ -369,10 +370,12 @@ def _eagle3_rounds(
         configured_block_total = min(configured_block_total, block_total)
         adaptive_block_size = False
     draft_cache = draft_model.reset(model)
+    sampler_rng = _SpeculativeSamplerRNG(draft_model, enabled=not greedy_sampling)
 
     prefill_draft = getattr(draft_model, "prefill_from_target_hidden", None)
     if callable(prefill_draft) and prompt_tokens is not None:
-        prefill_draft(
+        sampler_rng.draft_call(
+            prefill_draft,
             prompt_tokens,
             hidden,
             first_bonus,
@@ -398,7 +401,8 @@ def _eagle3_rounds(
         if bs <= 1:
             break
 
-        draft_tokens = draft_model.draft_block(
+        draft_tokens = sampler_rng.draft_tokens(
+            draft_model.draft_block,
             b,
             hidden,
             draft_cache,
@@ -407,7 +411,6 @@ def _eagle3_rounds(
             token_dtype,
             **_eagle3_draft_kwargs(draft_model, greedy_sampling),
         )
-        mx.async_eval(draft_tokens)
 
         with mx.stream(generation_stream):
             verify_input = mx.concatenate(
@@ -433,7 +436,7 @@ def _eagle3_rounds(
                 )
             else:
                 verify_hidden, target_tokens, gdn_states = hot_verify
-        mx.async_eval(target_tokens, verify_hidden)
+        sampler_rng.target_eval(target_tokens, verify_hidden)
 
         accepted, new_tokens = _eagle3_walk(
             draft_tokens,
@@ -450,7 +453,8 @@ def _eagle3_rounds(
 
         accept_verified = getattr(draft_model, "accept_verified_tokens", None)
         if callable(accept_verified):
-            accept_verified(
+            sampler_rng.draft_call(
+                accept_verified,
                 verify_hidden,
                 draft_tokens,
                 accepted,
@@ -513,10 +517,12 @@ def _eagle3_rounds_batch(
         configured_block_total = min(configured_block_total, block_total)
         adaptive_block_size = False
     draft_cache = draft_model.reset(model, left_padding=left_padding)
+    sampler_rng = _SpeculativeSamplerRNG(draft_model, enabled=not greedy_sampling)
 
     prefill_draft = getattr(draft_model, "prefill_from_target_hidden", None)
     if callable(prefill_draft) and prompt_tokens is not None:
-        prefill_draft(
+        sampler_rng.draft_call(
+            prefill_draft,
             prompt_tokens,
             hidden,
             first_bonus,
@@ -560,7 +566,8 @@ def _eagle3_rounds_batch(
         b_active = [b[active_idx[j]] for j in range(n_active)]
         b_arr = mx.array(b_active, dtype=token_dtype)
 
-        draft_tokens = draft_model.draft_block(
+        draft_tokens = sampler_rng.draft_tokens(
+            draft_model.draft_block,
             b_arr,
             hidden,
             draft_cache,
@@ -569,7 +576,6 @@ def _eagle3_rounds_batch(
             token_dtype,
             **_eagle3_draft_kwargs(draft_model, greedy_sampling),
         )
-        mx.async_eval(draft_tokens)
 
         with mx.stream(generation_stream):
             verify_input = mx.concatenate([b_arr[:, None], draft_tokens], axis=1)
@@ -592,7 +598,7 @@ def _eagle3_rounds_batch(
                 )
             else:
                 verify_hidden, target_tokens, gdn_states = hot_verify
-        mx.async_eval(target_tokens, verify_hidden)
+        sampler_rng.target_eval(target_tokens, verify_hidden)
 
         budgets = [max_tokens - emitted[active_idx[j]] for j in range(n_active)]
         accepted_list, new_tokens_list = _eagle3_walk_batch(
@@ -617,7 +623,8 @@ def _eagle3_rounds_batch(
 
         accept_verified = getattr(draft_model, "accept_verified_tokens_batch", None)
         if callable(accept_verified):
-            accept_verified(
+            sampler_rng.draft_call(
+                accept_verified,
                 verify_hidden,
                 draft_tokens,
                 accepted_list,

--- a/mlx_vlm/speculative/eagle3.py
+++ b/mlx_vlm/speculative/eagle3.py
@@ -4,9 +4,9 @@ import mlx.core as mx
 import mlx.nn as nn
 
 from .common import (
-    _SpeculativeSamplerRNG,
     _batch_cache_left_padding,
     _record_speculative_round,
+    _SpeculativeSamplerRNG,
     generation_stream,
 )
 

--- a/mlx_vlm/speculative/mtp.py
+++ b/mlx_vlm/speculative/mtp.py
@@ -6,13 +6,13 @@ import mlx.nn as nn
 
 from ..models import cache
 from .common import (
-    _SpeculativeSamplerRNG,
     _batch_cache_left_padding,
     _dflash_block_total,
     _record_speculative_round,
     _speculative_walk,
     _speculative_walk_batch,
     _speculative_walk_batch_uniform_acceptance,
+    _SpeculativeSamplerRNG,
     generation_stream,
 )
 

--- a/mlx_vlm/speculative/mtp.py
+++ b/mlx_vlm/speculative/mtp.py
@@ -161,12 +161,6 @@ def _mtp_verify_target(
     )
 
 
-def _mtp_has_gdn_commit_states(gdn_states: Optional[list]) -> bool:
-    return bool(gdn_states) and all(
-        len(state) > 11 and state[11] is not None for state in gdn_states
-    )
-
-
 def _mtp_draft_hidden(lm: nn.Module, hidden: mx.array) -> mx.array:
     prepare = getattr(lm, "speculative_draft_hidden", None)
     return prepare(hidden) if callable(prepare) else hidden
@@ -489,10 +483,7 @@ def _mtp_rounds(
         b = new_tokens[-1] if new_tokens else b
 
         rollback = getattr(lm, "rollback_speculative_cache", None)
-        if (
-            callable(rollback)
-            and (accepted < bs - 1 or _mtp_has_gdn_commit_states(verify.gdn_states))
-        ):
+        if accepted < bs - 1 and callable(rollback):
             with mx.stream(generation_stream):
                 rollback(prompt_cache, verify.gdn_states, accepted, bs)
 
@@ -828,7 +819,7 @@ def _mtp_rounds_batch(
 
         # Rollback target cache (uniform trim by ``bs - max_a - 1`` plus
         # per-row tail-zero on rows that accepted less).
-        if max_a < bs - 1 or _mtp_has_gdn_commit_states(verify.gdn_states):
+        if max_a < bs - 1:
             with mx.stream(generation_stream):
                 lm.rollback_speculative_cache(
                     prompt_cache, verify.gdn_states, accepted_arr, bs

--- a/mlx_vlm/speculative/mtp.py
+++ b/mlx_vlm/speculative/mtp.py
@@ -24,6 +24,28 @@ class _MTPVerifyResult:
     gdn_states: Optional[list] = None
 
 
+def _copy_rng_state() -> List[mx.array]:
+    mx.eval(*mx.random.state)
+    return [mx.array(state.tolist(), dtype=state.dtype) for state in mx.random.state]
+
+
+def _restore_rng_state(state: List[mx.array]) -> None:
+    for i, value in enumerate(state):
+        mx.random.state[i] = mx.array(value.tolist(), dtype=value.dtype)
+    mx.eval(*mx.random.state)
+
+
+def _eval_draft_sampler_state(draft_model: nn.Module) -> None:
+    targets = []
+    for attr in ("_seed_token",):
+        value = getattr(draft_model, attr, None)
+        if isinstance(value, mx.array):
+            targets.append(value)
+    targets.extend(mx.random.state)
+    if targets:
+        mx.eval(*targets)
+
+
 def _mtp_shared_kv_from_prompt_cache(
     lm: nn.Module,
     prompt_cache: List[Any],
@@ -137,10 +159,13 @@ def _mtp_verify_target(
     verify_input: mx.array,
     prompt_cache: List[Any],
     sampler: Callable[[mx.array], mx.array],
+    *,
+    sample_target_tokens: bool = True,
 ) -> _MTPVerifyResult:
-    result = _mtp_verify_with_model_method(lm, verify_input, prompt_cache, sampler)
-    if result is not None:
-        return result
+    if sample_target_tokens:
+        result = _mtp_verify_with_model_method(lm, verify_input, prompt_cache, sampler)
+        if result is not None:
+            return result
 
     if hasattr(lm, "speculative_logits_from_hidden"):
         result = _mtp_verify_without_logits(lm, verify_input, prompt_cache)
@@ -184,7 +209,10 @@ def _speculative_walk_deferred_greedy(
             logits = lm.speculative_logits_from_hidden(
                 target_hidden[:, pos : pos + 1, :]
             )
-            target_token = sampler(logits)
+            if logits.ndim == 3 and logits.shape[1] == 1:
+                logits = logits[:, 0, :]
+            logprobs = logits - mx.logsumexp(logits, axis=-1, keepdims=True)
+            target_token = sampler(logprobs)
         mx.eval(target_token)
         token = int(target_token.reshape(-1).item())
 
@@ -224,7 +252,10 @@ def _speculative_walk_batch_deferred_greedy(
             logits = lm.speculative_logits_from_hidden(
                 target_hidden[:, pos : pos + 1, :]
             )
-            target_tokens = sampler(logits)
+            if logits.ndim == 3 and logits.shape[1] == 1:
+                logits = logits[:, 0, :]
+            logprobs = logits - mx.logsumexp(logits, axis=-1, keepdims=True)
+            target_tokens = sampler(logprobs)
         mx.eval(target_tokens)
         target_list = [int(token) for token in target_tokens.reshape(-1).tolist()]
 
@@ -385,6 +416,9 @@ def _mtp_rounds(
     block_total = _dflash_block_total(draft_model, draft_block_size)
     configured_block_total = int(getattr(draft_model.config, "block_size", block_total))
     draft_model.reset(model)
+    preserve_target_rng = not greedy_sampling
+    target_rng_state = _copy_rng_state() if preserve_target_rng else None
+    draft_rng_state = _copy_rng_state() if preserve_target_rng else None
 
     # Hidden from prefill is full prompt-length; reduce to a single slot.
     # The semantically-correct choice is the *last* prompt token's hidden:
@@ -396,6 +430,9 @@ def _mtp_rounds(
     # the round-1 acceptance is wasted. We don't replicate that quirk.)
     prefill_draft = getattr(draft_model, "prefill_from_target_hidden", None)
     if callable(prefill_draft) and prompt_tokens is not None:
+        if preserve_target_rng:
+            target_rng_state = _copy_rng_state()
+            _restore_rng_state(draft_rng_state)
         prefill_draft(
             prompt_tokens,
             hidden,
@@ -404,6 +441,10 @@ def _mtp_rounds(
             token_dtype,
             **_mtp_draft_kwargs(draft_model, greedy_sampling),
         )
+        if preserve_target_rng:
+            _eval_draft_sampler_state(draft_model)
+            draft_rng_state = _copy_rng_state()
+            _restore_rng_state(target_rng_state)
 
     if hidden.shape[1] > 1:
         hidden = hidden[:, -1:, :]
@@ -430,6 +471,9 @@ def _mtp_rounds(
         if bs <= 1:
             break
 
+        if preserve_target_rng:
+            target_rng_state = _copy_rng_state()
+            _restore_rng_state(draft_rng_state)
         draft_tokens = draft_model.draft_block(
             b,
             hidden,
@@ -439,7 +483,12 @@ def _mtp_rounds(
             token_dtype,
             **_mtp_draft_kwargs(draft_model, greedy_sampling),
         )
-        mx.async_eval(draft_tokens)
+        if preserve_target_rng:
+            mx.eval(draft_tokens, *mx.random.state)
+            draft_rng_state = _copy_rng_state()
+            _restore_rng_state(target_rng_state)
+        else:
+            mx.async_eval(draft_tokens)
 
         with mx.stream(generation_stream):
             verify_input = mx.concatenate(
@@ -450,6 +499,7 @@ def _mtp_rounds(
                 verify_input,
                 prompt_cache,
                 sampler,
+                sample_target_tokens=greedy_sampling,
             )
         accepted, new_tokens = _mtp_acceptance_walk(
             lm,
@@ -458,6 +508,8 @@ def _mtp_rounds(
             sampler,
             max_tokens - emitted,
         )
+        if preserve_target_rng:
+            target_rng_state = _copy_rng_state()
         _record_speculative_round(draft_model, accepted, bs - 1)
 
         for tok in new_tokens:
@@ -468,6 +520,9 @@ def _mtp_rounds(
 
         accept_verified = getattr(draft_model, "accept_verified_tokens", None)
         if callable(accept_verified):
+            if preserve_target_rng:
+                target_rng_state = _copy_rng_state()
+                _restore_rng_state(draft_rng_state)
             accept_verified(
                 verify.hidden,
                 draft_tokens,
@@ -477,6 +532,10 @@ def _mtp_rounds(
                 token_dtype,
                 **_mtp_draft_kwargs(draft_model, greedy_sampling),
             )
+            if preserve_target_rng:
+                _eval_draft_sampler_state(draft_model)
+                draft_rng_state = _copy_rng_state()
+                _restore_rng_state(target_rng_state)
 
         # Hidden for next round: pick the slot of the newly accepted bonus.
         hidden = _mtp_draft_hidden(lm, verify.hidden[:, accepted : accepted + 1, :])

--- a/mlx_vlm/speculative/mtp.py
+++ b/mlx_vlm/speculative/mtp.py
@@ -471,7 +471,7 @@ def _mtp_rounds(
             sampler,
             max_tokens - emitted,
         )
-        sampler_rng.target_sampled()
+        sampler_rng.target_sampled(sync_draft=True)
         _record_speculative_round(draft_model, accepted, bs - 1)
 
         for tok in new_tokens:
@@ -750,6 +750,7 @@ def _mtp_rounds_batch(
             accepted_list, new_tokens_list = _speculative_walk_batch(
                 draft_tokens, verify.target_tokens, budgets
             )
+            sampler_rng.sync_draft_to_target()
             if (
                 n_active > 1
                 and getattr(draft_model, "requires_uniform_batch_acceptance", False)
@@ -772,7 +773,7 @@ def _mtp_rounds_batch(
                 sampler,
                 budgets,
             )
-            sampler_rng.target_sampled()
+            sampler_rng.target_sampled(sync_draft=True)
         # Keep the adaptive block-size history on a per-round basis so
         # batched MTP reacts like the singleton loop instead of letting
         # batch size change the controller signal.

--- a/mlx_vlm/speculative/mtp.py
+++ b/mlx_vlm/speculative/mtp.py
@@ -6,6 +6,7 @@ import mlx.nn as nn
 
 from ..models import cache
 from .common import (
+    _SpeculativeSamplerRNG,
     _batch_cache_left_padding,
     _dflash_block_total,
     _record_speculative_round,
@@ -22,28 +23,6 @@ class _MTPVerifyResult:
     shared_kv_states: dict
     target_tokens: Optional[mx.array] = None
     gdn_states: Optional[list] = None
-
-
-def _copy_rng_state() -> List[mx.array]:
-    mx.eval(*mx.random.state)
-    return [mx.array(state.tolist(), dtype=state.dtype) for state in mx.random.state]
-
-
-def _restore_rng_state(state: List[mx.array]) -> None:
-    for i, value in enumerate(state):
-        mx.random.state[i] = mx.array(value.tolist(), dtype=value.dtype)
-    mx.eval(*mx.random.state)
-
-
-def _eval_draft_sampler_state(draft_model: nn.Module) -> None:
-    targets = []
-    for attr in ("_seed_token",):
-        value = getattr(draft_model, attr, None)
-        if isinstance(value, mx.array):
-            targets.append(value)
-    targets.extend(mx.random.state)
-    if targets:
-        mx.eval(*targets)
 
 
 def _mtp_shared_kv_from_prompt_cache(
@@ -416,9 +395,7 @@ def _mtp_rounds(
     block_total = _dflash_block_total(draft_model, draft_block_size)
     configured_block_total = int(getattr(draft_model.config, "block_size", block_total))
     draft_model.reset(model)
-    preserve_target_rng = not greedy_sampling
-    target_rng_state = _copy_rng_state() if preserve_target_rng else None
-    draft_rng_state = _copy_rng_state() if preserve_target_rng else None
+    sampler_rng = _SpeculativeSamplerRNG(draft_model, enabled=not greedy_sampling)
 
     # Hidden from prefill is full prompt-length; reduce to a single slot.
     # The semantically-correct choice is the *last* prompt token's hidden:
@@ -430,10 +407,8 @@ def _mtp_rounds(
     # the round-1 acceptance is wasted. We don't replicate that quirk.)
     prefill_draft = getattr(draft_model, "prefill_from_target_hidden", None)
     if callable(prefill_draft) and prompt_tokens is not None:
-        if preserve_target_rng:
-            target_rng_state = _copy_rng_state()
-            _restore_rng_state(draft_rng_state)
-        prefill_draft(
+        sampler_rng.draft_call(
+            prefill_draft,
             prompt_tokens,
             hidden,
             first_bonus,
@@ -441,10 +416,6 @@ def _mtp_rounds(
             token_dtype,
             **_mtp_draft_kwargs(draft_model, greedy_sampling),
         )
-        if preserve_target_rng:
-            _eval_draft_sampler_state(draft_model)
-            draft_rng_state = _copy_rng_state()
-            _restore_rng_state(target_rng_state)
 
     if hidden.shape[1] > 1:
         hidden = hidden[:, -1:, :]
@@ -471,10 +442,8 @@ def _mtp_rounds(
         if bs <= 1:
             break
 
-        if preserve_target_rng:
-            target_rng_state = _copy_rng_state()
-            _restore_rng_state(draft_rng_state)
-        draft_tokens = draft_model.draft_block(
+        draft_tokens = sampler_rng.draft_tokens(
+            draft_model.draft_block,
             b,
             hidden,
             None,
@@ -483,12 +452,6 @@ def _mtp_rounds(
             token_dtype,
             **_mtp_draft_kwargs(draft_model, greedy_sampling),
         )
-        if preserve_target_rng:
-            mx.eval(draft_tokens, *mx.random.state)
-            draft_rng_state = _copy_rng_state()
-            _restore_rng_state(target_rng_state)
-        else:
-            mx.async_eval(draft_tokens)
 
         with mx.stream(generation_stream):
             verify_input = mx.concatenate(
@@ -508,8 +471,7 @@ def _mtp_rounds(
             sampler,
             max_tokens - emitted,
         )
-        if preserve_target_rng:
-            target_rng_state = _copy_rng_state()
+        sampler_rng.target_sampled()
         _record_speculative_round(draft_model, accepted, bs - 1)
 
         for tok in new_tokens:
@@ -520,10 +482,8 @@ def _mtp_rounds(
 
         accept_verified = getattr(draft_model, "accept_verified_tokens", None)
         if callable(accept_verified):
-            if preserve_target_rng:
-                target_rng_state = _copy_rng_state()
-                _restore_rng_state(draft_rng_state)
-            accept_verified(
+            sampler_rng.draft_call(
+                accept_verified,
                 verify.hidden,
                 draft_tokens,
                 accepted,
@@ -532,10 +492,6 @@ def _mtp_rounds(
                 token_dtype,
                 **_mtp_draft_kwargs(draft_model, greedy_sampling),
             )
-            if preserve_target_rng:
-                _eval_draft_sampler_state(draft_model)
-                draft_rng_state = _copy_rng_state()
-                _restore_rng_state(target_rng_state)
 
         # Hidden for next round: pick the slot of the newly accepted bonus.
         hidden = _mtp_draft_hidden(lm, verify.hidden[:, accepted : accepted + 1, :])
@@ -717,6 +673,7 @@ def _mtp_rounds_batch(
     block_total = _dflash_block_total(draft_model, draft_block_size)
     configured_block_total = int(getattr(draft_model.config, "block_size", block_total))
     draft_model.reset(model)
+    sampler_rng = _SpeculativeSamplerRNG(draft_model, enabled=not greedy_sampling)
 
     # First-round hidden: prefill output may have shape [B, L, H]; reduce
     # to a single slot per row (last prompt token's hidden — see comment in
@@ -763,7 +720,8 @@ def _mtp_rounds_batch(
 
         # Draft (autoregressive K-step). hidden / shared_kv state was set
         # via set_shared_kv above; the drafter pulls it from there.
-        draft_tokens = _mtp_draft_block_active(
+        draft_tokens = sampler_rng.draft_tokens(
+            _mtp_draft_block_active,
             draft_model,
             b_active,
             hidden,
@@ -773,7 +731,6 @@ def _mtp_rounds_batch(
             positions_active,
             greedy_sampling=greedy_sampling,
         )
-        mx.async_eval(draft_tokens)
 
         # Verify
         with mx.stream(generation_stream):
@@ -789,7 +746,7 @@ def _mtp_rounds_batch(
         # Walk per-row
         budgets = [max_tokens - emitted[active_idx[j]] for j in range(n_active)]
         if verify.target_tokens is not None:
-            mx.async_eval(verify.target_tokens, hidden_full)
+            sampler_rng.target_eval(verify.target_tokens, hidden_full)
             accepted_list, new_tokens_list = _speculative_walk_batch(
                 draft_tokens, verify.target_tokens, budgets
             )
@@ -807,7 +764,7 @@ def _mtp_rounds_batch(
                     )
                 )
         else:
-            mx.async_eval(hidden_full)
+            sampler_rng.target_eval(hidden_full)
             accepted_list, new_tokens_list = _speculative_walk_batch_deferred_greedy(
                 lm,
                 hidden_full,
@@ -815,6 +772,7 @@ def _mtp_rounds_batch(
                 sampler,
                 budgets,
             )
+            sampler_rng.target_sampled()
         # Keep the adaptive block-size history on a per-round basis so
         # batched MTP reacts like the singleton loop instead of letting
         # batch size change the controller signal.
@@ -829,7 +787,8 @@ def _mtp_rounds_batch(
 
         accept_verified = getattr(draft_model, "accept_verified_tokens_batch", None)
         if callable(accept_verified):
-            accept_verified(
+            sampler_rng.draft_call(
+                accept_verified,
                 hidden_full,
                 draft_tokens,
                 accepted_list,

--- a/mlx_vlm/speculative/mtp.py
+++ b/mlx_vlm/speculative/mtp.py
@@ -161,6 +161,12 @@ def _mtp_verify_target(
     )
 
 
+def _mtp_has_gdn_commit_states(gdn_states: Optional[list]) -> bool:
+    return bool(gdn_states) and all(
+        len(state) > 11 and state[11] is not None for state in gdn_states
+    )
+
+
 def _mtp_draft_hidden(lm: nn.Module, hidden: mx.array) -> mx.array:
     prepare = getattr(lm, "speculative_draft_hidden", None)
     return prepare(hidden) if callable(prepare) else hidden
@@ -483,7 +489,10 @@ def _mtp_rounds(
         b = new_tokens[-1] if new_tokens else b
 
         rollback = getattr(lm, "rollback_speculative_cache", None)
-        if accepted < bs - 1 and callable(rollback):
+        if (
+            callable(rollback)
+            and (accepted < bs - 1 or _mtp_has_gdn_commit_states(verify.gdn_states))
+        ):
             with mx.stream(generation_stream):
                 rollback(prompt_cache, verify.gdn_states, accepted, bs)
 
@@ -819,7 +828,7 @@ def _mtp_rounds_batch(
 
         # Rollback target cache (uniform trim by ``bs - max_a - 1`` plus
         # per-row tail-zero on rows that accepted less).
-        if max_a < bs - 1:
+        if max_a < bs - 1 or _mtp_has_gdn_commit_states(verify.gdn_states):
             with mx.stream(generation_stream):
                 lm.rollback_speculative_cache(
                     prompt_cache, verify.gdn_states, accepted_arr, bs

--- a/mlx_vlm/tests/test_speculative.py
+++ b/mlx_vlm/tests/test_speculative.py
@@ -311,6 +311,119 @@ def test_qwen_gdn_sink_captures_intermediate_states_for_singleton_verify():
     assert sink[0][11].shape == (1, 3, 2, 4, 4)
 
 
+def test_qwen_target_verify_linear_matches_singleton_dense_gemv():
+    mx.random.seed(7)
+    linear = nn.Linear(16, 32, bias=True)
+    linear.weight = mx.random.normal((32, 16)).astype(mx.bfloat16)
+    linear.bias = mx.random.normal((32,)).astype(mx.bfloat16)
+    x = mx.random.normal((3, 4, 16)).astype(mx.bfloat16)
+
+    ref = mx.concatenate([linear(x[:, i : i + 1]) for i in range(x.shape[1])], axis=1)
+    out = qwen_language._target_verify_linear(linear, x, target_verify=True)
+    mx.eval(ref, out)
+
+    assert bool(mx.array_equal(ref, out).item())
+
+
+def test_qwen_target_verify_gemv_kernel_matches_singleton_dense_gemv():
+    mx.random.seed(9)
+    linear = nn.Linear(256, 512, bias=False)
+    linear.weight = mx.random.normal((512, 256)).astype(mx.bfloat16)
+    x = mx.random.normal((1, 4, 256)).astype(mx.bfloat16)
+
+    ref = mx.concatenate([linear(x[:, i : i + 1]) for i in range(x.shape[1])], axis=1)
+    out = qwen_language._target_verify_linear(linear, x, target_verify=True)
+    mx.eval(ref, out)
+
+    assert bool(mx.array_equal(ref, out).item())
+
+
+def test_qwen_target_verify_small_projection_matches_singleton_dense_gemv():
+    mx.random.seed(10)
+    linear = nn.Linear(256, 8, bias=False)
+    linear.weight = mx.random.normal((8, 256)).astype(mx.bfloat16)
+    x = mx.random.normal((1, 3, 256)).astype(mx.bfloat16)
+
+    ref = mx.concatenate([linear(x[:, i : i + 1]) for i in range(x.shape[1])], axis=1)
+    out = qwen_language._target_verify_linear(linear, x, target_verify=True)
+    mx.eval(ref, out)
+
+    assert bool(mx.array_equal(ref, out).item())
+
+
+def test_qwen_target_verify_mlp_matches_singleton_dense_path():
+    mx.random.seed(11)
+    mlp = qwen_language.Qwen3_5MLP(16, 32)
+    mlp.gate_proj.weight = mx.random.normal((32, 16)).astype(mx.bfloat16)
+    mlp.up_proj.weight = mx.random.normal((32, 16)).astype(mx.bfloat16)
+    mlp.down_proj.weight = mx.random.normal((16, 32)).astype(mx.bfloat16)
+    x = mx.random.normal((2, 3, 16)).astype(mx.bfloat16)
+
+    ref = mx.concatenate([mlp(x[:, i : i + 1]) for i in range(x.shape[1])], axis=1)
+    out = mlp(x, target_verify=True)
+    mx.eval(ref, out)
+
+    assert bool(mx.array_equal(ref, out).item())
+
+
+def test_qwen_target_verify_norms_match_singleton_path():
+    mx.random.seed(12)
+    norm = nn.RMSNorm(16, eps=1e-6)
+    x = mx.random.normal((2, 4, 3, 16)).astype(mx.bfloat16)
+
+    ref = mx.concatenate([norm(x[:, i : i + 1]) for i in range(x.shape[1])], axis=1)
+    out = qwen_language._target_verify_timewise(norm, x, target_verify=True)
+    mx.eval(ref, out)
+
+    assert bool(mx.array_equal(ref, out).item())
+
+
+def test_qwen_target_verify_gated_norm_matches_singleton_path():
+    mx.random.seed(13)
+    norm = qwen_language.Qwen3_5RMSNormGated(16, eps=1e-6)
+    x = mx.random.normal((2, 4, 3, 16)).astype(mx.bfloat16)
+    gate = mx.random.normal((2, 4, 3, 16)).astype(mx.bfloat16)
+
+    ref = mx.concatenate(
+        [norm(x[:, i : i + 1], gate[:, i : i + 1]) for i in range(x.shape[1])],
+        axis=1,
+    )
+    out = qwen_language._target_verify_timewise(norm, x, True, gate)
+    mx.eval(ref, out)
+
+    assert bool(mx.array_equal(ref, out).item())
+
+
+def test_qwen_gdn_verify_conv_matches_singleton_windows():
+    mx.random.seed(14)
+    config = SimpleNamespace(
+        hidden_size=16,
+        linear_num_value_heads=2,
+        linear_num_key_heads=2,
+        linear_key_head_dim=4,
+        linear_value_head_dim=4,
+        linear_conv_kernel_dim=4,
+        rms_norm_eps=1e-6,
+    )
+    layer = qwen_language.Qwen3_5GatedDeltaNet(config)
+    steps = 4
+    conv_input = mx.random.normal(
+        (2, layer.conv_kernel_size + steps - 1, layer.conv_dim)
+    ).astype(mx.bfloat16)
+
+    ref = mx.concatenate(
+        [
+            layer.conv1d(conv_input[:, offset : offset + layer.conv_kernel_size, :])
+            for offset in range(steps)
+        ],
+        axis=1,
+    )
+    out = layer._causal_conv1d_verify(conv_input, steps)
+    mx.eval(ref, out)
+
+    assert bool(mx.array_equal(ref, out).item())
+
+
 def test_speculative_walk_accepts_until_first_mismatch():
     accepted, new_tokens = _speculative_walk(
         mx.array([[11, 12, 13]], dtype=mx.int32),

--- a/mlx_vlm/tests/test_speculative.py
+++ b/mlx_vlm/tests/test_speculative.py
@@ -412,7 +412,7 @@ def test_qwen_target_verify_norms_match_singleton_path():
     x = mx.random.normal((2, 4, 3, 16)).astype(mx.bfloat16)
 
     ref = mx.concatenate([norm(x[:, i : i + 1]) for i in range(x.shape[1])], axis=1)
-    out = qwen_language._target_verify_timewise(norm, x, target_verify=True)
+    out = norm(x)
     mx.eval(ref, out)
 
     assert bool(mx.array_equal(ref, out).item())
@@ -428,7 +428,7 @@ def test_qwen_target_verify_gated_norm_matches_singleton_path():
         [norm(x[:, i : i + 1], gate[:, i : i + 1]) for i in range(x.shape[1])],
         axis=1,
     )
-    out = qwen_language._target_verify_timewise(norm, x, True, gate)
+    out = norm(x, gate)
     mx.eval(ref, out)
 
     assert bool(mx.array_equal(ref, out).item())

--- a/mlx_vlm/tests/test_speculative.py
+++ b/mlx_vlm/tests/test_speculative.py
@@ -206,7 +206,7 @@ def test_qwen_rollback_speculative_cache_zero_inits_missing_state():
     assert float(mx.sum(mx.abs(captured["state"])).item()) == 0.0
 
 
-def test_qwen_gdn_sink_skips_intermediate_states_for_batched_verify():
+def test_qwen_gdn_sink_captures_intermediate_states_for_batched_verify():
     config = SimpleNamespace(
         hidden_size=16,
         linear_num_value_heads=2,
@@ -224,9 +224,12 @@ def test_qwen_gdn_sink_skips_intermediate_states_for_batched_verify():
         B, S = q.shape[:2]
         out = mx.zeros((B, S, 2, 4), dtype=mx.float32)
         next_state = mx.zeros((B, 2, 4, 4), dtype=mx.float32)
-        return out, next_state
+        states = mx.ones((B, S, 2, 4, 4), dtype=mx.float32)
+        return out, next_state, states
 
-    with patch.object(qwen_language, "gated_delta_update", side_effect=fake_update):
+    with patch.object(
+        qwen_language, "gated_delta_update_with_states", side_effect=fake_update
+    ):
         out = layer(
             mx.zeros((2, 3, 16), dtype=mx.float32),
             cache=ArraysCache(size=2),
@@ -235,10 +238,10 @@ def test_qwen_gdn_sink_skips_intermediate_states_for_batched_verify():
 
     mx.eval(out)
     assert out.shape == (2, 3, 16)
-    assert sink[0][11] is None
+    assert sink[0][11].shape == (2, 3, 2, 4, 4)
 
 
-def test_qwen_gdn_sink_skips_intermediate_states_for_singleton_verify():
+def test_qwen_gdn_sink_captures_intermediate_states_for_singleton_verify():
     config = SimpleNamespace(
         hidden_size=16,
         linear_num_value_heads=2,
@@ -256,9 +259,12 @@ def test_qwen_gdn_sink_skips_intermediate_states_for_singleton_verify():
         B, S = q.shape[:2]
         out = mx.zeros((B, S, 2, 4), dtype=mx.float32)
         next_state = mx.zeros((B, 2, 4, 4), dtype=mx.float32)
-        return out, next_state
+        states = mx.ones((B, S, 2, 4, 4), dtype=mx.float32)
+        return out, next_state, states
 
-    with patch.object(qwen_language, "gated_delta_update", side_effect=fake_update):
+    with patch.object(
+        qwen_language, "gated_delta_update_with_states", side_effect=fake_update
+    ):
         out = layer(
             mx.zeros((1, 3, 16), dtype=mx.float32),
             cache=ArraysCache(size=2),
@@ -267,7 +273,7 @@ def test_qwen_gdn_sink_skips_intermediate_states_for_singleton_verify():
 
     mx.eval(out)
     assert out.shape == (1, 3, 16)
-    assert sink[0][11] is None
+    assert sink[0][11].shape == (1, 3, 2, 4, 4)
 
 
 def test_speculative_walk_accepts_until_first_mismatch():
@@ -643,6 +649,67 @@ def test_mtp_rounds_rolls_back_gemma_without_gdn_states():
 
     assert rollback_calls
     assert rollback_calls[0][1] is None
+
+
+def test_mtp_rounds_commits_gdn_states_after_full_accept():
+    class Draft:
+        def __init__(self):
+            self.config = SimpleNamespace(block_size=3)
+            self.accept_lens = []
+            self.draft_lens = []
+
+        def set_shared_kv(self, *args, **kwargs):
+            pass
+
+        def reset(self, model):
+            pass
+
+        def draft_block(self, *args, **kwargs):
+            return mx.array([[7, 8]], dtype=mx.int32)
+
+    rollback_calls = []
+
+    class LM:
+        def rollback_speculative_cache(self, *args):
+            rollback_calls.append(args)
+
+        def speculative_draft_hidden(self, hidden):
+            return hidden
+
+    gdn_states = [tuple([None] * 11 + [mx.zeros((1, 3, 1, 1, 1))])]
+    verify = speculative_utils._MTPVerifyResult(
+        hidden=mx.zeros((1, 3, 2), dtype=mx.float32),
+        shared_kv_states={},
+        gdn_states=gdn_states,
+    )
+
+    with (
+        patch.object(mtp_utils, "_mtp_verify_target", return_value=verify),
+        patch.object(
+            mtp_utils,
+            "_mtp_acceptance_walk",
+            return_value=(2, [7, 8]),
+        ),
+    ):
+        list(
+            _mtp_rounds(
+                SimpleNamespace(language_model=LM()),
+                Draft(),
+                [SimpleNamespace(offset=0)],
+                mx.zeros((1, 1, 2), dtype=mx.float32),
+                {},
+                first_bonus=1,
+                max_tokens=5,
+                sampler=lambda logits: mx.argmax(logits, axis=-1),
+                draft_block_size=3,
+                token_dtype=mx.int32,
+                greedy_sampling=True,
+            )
+        )
+
+    assert rollback_calls
+    assert rollback_calls[0][1] is gdn_states
+    assert rollback_calls[0][2] == 2
 
 
 def test_mtp_next_block_size_can_prefer_requested_size():

--- a/mlx_vlm/tests/test_speculative.py
+++ b/mlx_vlm/tests/test_speculative.py
@@ -311,6 +311,46 @@ def test_qwen_gdn_sink_captures_intermediate_states_for_singleton_verify():
     assert sink[0][11].shape == (1, 3, 2, 4, 4)
 
 
+def test_qwen_gdn_verify_update_matches_stepwise_path():
+    mx.random.seed(16)
+    B, S, Hk, D, Hv, Dv = 1, 3, 16, 128, 32, 128
+    q = mx.random.normal((B, S, Hk, D)).astype(mx.bfloat16)
+    k = mx.random.normal((B, S, Hk, D)).astype(mx.bfloat16)
+    v = mx.random.normal((B, S, Hv, Dv)).astype(mx.bfloat16)
+    a = mx.random.normal((B, S, Hv)).astype(mx.bfloat16)
+    b = mx.random.normal((B, S, Hv)).astype(mx.bfloat16)
+    A_log = mx.random.normal((Hv,)).astype(mx.bfloat16)
+    dt_bias = mx.ones((Hv,), dtype=mx.bfloat16)
+    state = mx.zeros((B, Hv, Dv, D), dtype=mx.float32)
+
+    outputs = []
+    states = []
+    current_state = state
+    for i in range(S):
+        out, current_state = qwen_language.gated_delta_update(
+            q[:, i : i + 1],
+            k[:, i : i + 1],
+            v[:, i : i + 1],
+            a[:, i : i + 1],
+            b[:, i : i + 1],
+            A_log,
+            dt_bias,
+            current_state,
+            None,
+            use_kernel=False,
+        )
+        outputs.append(out)
+        states.append(current_state)
+
+    ref = (mx.concatenate(outputs, axis=1), current_state, mx.stack(states, axis=1))
+    out = qwen_language._gated_delta_update_verify_decode(
+        q, k, v, a, b, A_log, dt_bias, state, None, use_kernel=False
+    )
+    mx.eval(*ref, *out)
+
+    assert all(bool(mx.array_equal(a, b).item()) for a, b in zip(ref, out))
+
+
 def test_qwen_target_verify_linear_matches_singleton_dense_gemv():
     mx.random.seed(7)
     linear = nn.Linear(16, 32, bias=True)

--- a/mlx_vlm/tests/test_speculative.py
+++ b/mlx_vlm/tests/test_speculative.py
@@ -36,6 +36,7 @@ from mlx_vlm.speculative.drafters.qwen3_5_mtp import ModelConfig as Qwen3_5MTPCo
 from mlx_vlm.speculative.drafters.qwen3_5_mtp import Qwen3_5MTPDraftModel
 from mlx_vlm.speculative.drafters.qwen3_5_mtp.split import split_qwen3_5_mtp
 from mlx_vlm.speculative.drafters.qwen3_dflash import DFlashDraftModel, ModelConfig
+from mlx_vlm.speculative.common import _SpeculativeSamplerRNG
 from mlx_vlm.speculative.eagle3 import (
     _eagle3_block_settings,
     _eagle3_next_block_size,
@@ -62,6 +63,40 @@ from mlx_vlm.speculative.utils import (
 from mlx_vlm.utils import get_model_and_args
 
 speculative_utils = importlib.import_module("mlx_vlm.speculative.utils")
+
+
+def test_speculative_sampler_rng_keeps_draft_sampling_off_target_stream():
+    logits = mx.zeros((1, 8), dtype=mx.float32)
+
+    def sampler(values):
+        return mx.random.categorical(values)
+
+    mx.random.seed(123)
+    expected_first = sampler(logits)
+    mx.eval(expected_first)
+    expected_second = sampler(logits)
+    mx.eval(expected_second)
+
+    draft_model = SimpleNamespace(_seed_token=None)
+
+    def draft_prefill():
+        draft_model._seed_token = sampler(logits)
+
+    mx.random.seed(123)
+    sampler_rng = _SpeculativeSamplerRNG(draft_model, enabled=True)
+    first = sampler(logits)
+    mx.eval(first)
+    sampler_rng.target_sampled()
+
+    sampler_rng.draft_call(draft_prefill)
+
+    second = sampler(logits)
+    mx.eval(second)
+    sampler_rng.target_sampled()
+
+    assert first.tolist() == expected_first.tolist()
+    assert second.tolist() == expected_second.tolist()
+    assert draft_model._seed_token is not None
 
 
 def _make_conv_input(batch_size: int, layer_offset: int, length: int = 5) -> mx.array:

--- a/mlx_vlm/tests/test_speculative.py
+++ b/mlx_vlm/tests/test_speculative.py
@@ -17,6 +17,7 @@ import pytest
 import mlx_vlm.models.qwen3_5.language as qwen_language
 import mlx_vlm.speculative.mtp as mtp_utils
 from mlx_vlm.models.cache import ArraysCache, BufferedRotatingKVCache, RotatingKVCache
+from mlx_vlm.speculative.common import _SpeculativeSamplerRNG
 from mlx_vlm.speculative.drafters import (
     DEFAULT_DRAFTER_KIND,
     DRAFTER_KIND_BY_MODEL_TYPE,
@@ -36,7 +37,6 @@ from mlx_vlm.speculative.drafters.qwen3_5_mtp import ModelConfig as Qwen3_5MTPCo
 from mlx_vlm.speculative.drafters.qwen3_5_mtp import Qwen3_5MTPDraftModel
 from mlx_vlm.speculative.drafters.qwen3_5_mtp.split import split_qwen3_5_mtp
 from mlx_vlm.speculative.drafters.qwen3_dflash import DFlashDraftModel, ModelConfig
-from mlx_vlm.speculative.common import _SpeculativeSamplerRNG
 from mlx_vlm.speculative.eagle3 import (
     _eagle3_block_settings,
     _eagle3_next_block_size,

--- a/mlx_vlm/tests/test_speculative.py
+++ b/mlx_vlm/tests/test_speculative.py
@@ -99,6 +99,48 @@ def test_speculative_sampler_rng_keeps_draft_sampling_off_target_stream():
     assert draft_model._seed_token is not None
 
 
+def test_speculative_sampler_rng_can_resync_draft_after_rejected_draws():
+    logits = mx.zeros((1, 8), dtype=mx.float32)
+
+    def sampler(values):
+        token = mx.random.categorical(values)
+        mx.eval(token)
+        return token
+
+    mx.random.seed(123)
+    expected_first = sampler(logits)
+    expected_second = sampler(logits)
+    expected_third = sampler(logits)
+
+    draft_model = SimpleNamespace(_seed_token=None)
+
+    def draft_block():
+        return mx.stack([mx.random.categorical(logits) for _ in range(3)])
+
+    def draft_seed():
+        draft_model._seed_token = mx.random.categorical(logits)
+
+    mx.random.seed(123)
+    sampler_rng = _SpeculativeSamplerRNG(draft_model, enabled=True)
+    first = sampler(logits)
+    sampler_rng.target_sampled(sync_draft=True)
+
+    # The draft stream may spend random draws on tokens later rejected by the
+    # target verifier.
+    sampler_rng.draft_tokens(draft_block)
+
+    # Only one target token is actually emitted, so the next draft seed should
+    # restart from the target stream after that emitted token.
+    second = sampler(logits)
+    sampler_rng.target_sampled(sync_draft=True)
+    sampler_rng.draft_call(draft_seed)
+    mx.eval(draft_model._seed_token)
+
+    assert first.tolist() == expected_first.tolist()
+    assert second.tolist() == expected_second.tolist()
+    assert draft_model._seed_token.tolist() == expected_third.tolist()
+
+
 def _make_conv_input(batch_size: int, layer_offset: int, length: int = 5) -> mx.array:
     rows = []
     for row in range(batch_size):

--- a/mlx_vlm/tests/test_speculative.py
+++ b/mlx_vlm/tests/test_speculative.py
@@ -651,7 +651,7 @@ def test_mtp_rounds_rolls_back_gemma_without_gdn_states():
     assert rollback_calls[0][1] is None
 
 
-def test_mtp_rounds_commits_gdn_states_after_full_accept():
+def test_mtp_rounds_skips_rollback_after_full_accept_with_gdn_states():
     class Draft:
         def __init__(self):
             self.config = SimpleNamespace(block_size=3)
@@ -707,9 +707,7 @@ def test_mtp_rounds_commits_gdn_states_after_full_accept():
             )
         )
 
-    assert rollback_calls
-    assert rollback_calls[0][1] is gdn_states
-    assert rollback_calls[0][2] == 2
+    assert rollback_calls == []
 
 
 def test_mtp_next_block_size_can_prefer_requested_size():


### PR DESCRIPTION
## Summary

Fixes Qwen3.5/Qwen3.6 MTP speculative decoding so target verification matches the no-drafter path while preserving the speedup.

Changes included:
- Add periodic KV-cache materialization for long continuous decode paths to avoid unbounded lazy cache-update graph growth on Metal. This is controlled by `MLX_VLM_KV_CACHE_MATERIALIZE_INTERVAL` and defaults to `50`.
- Make Qwen full-attention target verification exact by verifying each proposed token against the prefix plus prior verified tokens, instead of letting draft tokens attend to future draft positions.
- Make Qwen GDN target verification exact by using the verifier-specific causal conv path and retaining per-step GDN states needed for rollback.
- Skip redundant drafter GDN cache commits on fully accepted speculative blocks.
- Preserve stochastic target sampling parity by separating target RNG state from drafter RNG state and sampling target tokens from target logprobs during deferred verification.
- Add speculative decoding regression tests for Qwen rollback, GDN state capture, full-accept rollback skipping, and stochastic MTP sampling behavior.

## Performance

AIME25, `seed=42`, `--enable-thinking`, target `/Users/prince_canuma/Qwen3.6-27B-4bit`, drafter `/Users/prince_canuma/Qwen3.6-27B-mtp-4bit`.

Full AIME25 score with `max_tokens=65536`:

| Run | Correct | Accuracy | Notes |
| --- | ---: | ---: | --- |
| Previous MTP full run | 25/30 | 83.33% | Original all-30 MTP run before the verifier fixes. |
| After verifier fixes | 27/30 | 90.00% | Inferred from rerunning the 5 previous misses: ids `11` and `12` now match the true labels, while ids `13`, `14`, and `29` still hit the length cap. |

512-token benchmark over AIME ids `11,12,13,14,29`:

| Mode | tok/s | Speedup | Acceptance |
| --- | ---: | ---: | ---: |
| No drafter | 33.79 | 1.00x | n/a |
| MTP block size 3 | 52.92 | 1.57x | 0.878 |
| MTP block size 4 | 53.37 | 1.58x | 0.792 |
| MTP block size 5 | 50.98 | 1.51x | 0.716 |

2K token parity check on AIME id `13`:

| Temperature | Token match | No drafter tok/s | MTP tok/s | Speedup |
| --- | --- | ---: | ---: | ---: |
| 0.0 | exact | 34.09 | 53.68 | 1.57x |
| 0.2 | exact | 33.66 | 52.61 | 1.56x |
| 0.6 | exact | 33.70 | 49.07 | 1.46x |
| 1.0 | exact | 33.66 | 44.69 | 1.33x |

## Experiments

AIME 2026 id `13`, 2K-token cap, `seed=42`, `--enable-thinking`.
All rows below were token-identical against their matching no-drafter reference.

Includes the baseline result plus the three separate variants tested after it.

### Qwen3.6-35B-A3B

| Variant | Temp | Match | No drafter tok/s | MTP tok/s | Speedup | Draft acceptance |
| --- | ---: | --- | ---: | ---: | ---: | ---: |
| Baseline resync | 0.0 | exact | 58.01 | 101.18 | 1.74x | 81.7% |
| Baseline resync | 0.2 | exact | 57.52 | 88.22 | 1.53x | 81.9% |
| Baseline resync | 0.6 | exact | 57.30 | 85.52 | 1.49x | 76.2% |
| Baseline resync | 1.0 | exact | 57.13 | 85.85 | 1.50x | 77.4% |
| Coupled CDF sampler | 0.0 | exact | 58.43 | 89.94 | 1.54x | 81.7% |
| Coupled CDF sampler | 0.2 | exact | 57.28 | 88.18 | 1.54x | 84.0% |
| Coupled CDF sampler | 0.6 | exact | 57.06 | 85.83 | 1.50x | 80.1% |
| Coupled CDF sampler | 1.0 | exact | 56.97 | 81.89 | 1.44x | 73.6% |
| Draft top_p=0.95 | 0.0 | exact | 58.01 | 100.49 | 1.73x | 81.7% |
| Draft top_p=0.95 | 0.2 | exact | 57.52 | 87.89 | 1.53x | 82.7% |
| Draft top_p=0.95 | 0.6 | exact | 57.30 | 85.02 | 1.48x | 76.6% |
| Draft top_p=0.95 | 1.0 | exact | 57.13 | 85.10 | 1.49x | 77.4% |
| Adaptive block 4->3 when accept <0.75 | 0.0 | exact | 58.01 | 91.37 | 1.58x | 86.9% |
| Adaptive block 4->3 when accept <0.75 | 0.2 | exact | 57.52 | 82.70 | 1.44x | 87.4% |
| Adaptive block 4->3 when accept <0.75 | 0.6 | exact | 57.30 | 81.74 | 1.43x | 84.1% |
| Adaptive block 4->3 when accept <0.75 | 1.0 | exact | 57.13 | 82.04 | 1.44x | 84.7% |

### Qwen3.5-9B full precision

| Variant | Temp | Match | No drafter tok/s | MTP tok/s | Speedup | Draft acceptance |
| --- | ---: | --- | ---: | ---: | ---: | ---: |
| Baseline resync | 0.0 | exact | 37.79 | 84.55 | 2.24x | 82.3% |
| Baseline resync | 0.2 | exact | 37.83 | 67.69 | 1.79x | 75.4% |
| Baseline resync | 0.6 | exact | 37.82 | 69.00 | 1.82x | 77.8% |
| Baseline resync | 1.0 | exact | 37.83 | 68.68 | 1.82x | 77.9% |
| Coupled CDF sampler | 0.0 | exact | 37.62 | 70.26 | 1.87x | 82.3% |
| Coupled CDF sampler | 0.2 | exact | 37.68 | 67.75 | 1.80x | 78.8% |
| Coupled CDF sampler | 0.6 | exact | 37.66 | 66.40 | 1.76x | 76.5% |
| Coupled CDF sampler | 1.0 | exact | 37.67 | 63.03 | 1.67x | 68.5% |
| Draft top_p=0.95 | 0.0 | exact | 37.79 | 84.58 | 2.24x | 82.3% |
| Draft top_p=0.95 | 0.2 | exact | 37.83 | 66.79 | 1.77x | 75.7% |
| Draft top_p=0.95 | 0.6 | exact | 37.82 | 67.81 | 1.79x | 78.3% |
| Draft top_p=0.95 | 1.0 | exact | 37.83 | 67.86 | 1.79x | 78.6% |
| Adaptive block 4->3 when accept <0.75 | 0.0 | exact | 37.79 | 76.32 | 2.02x | 88.1% |
| Adaptive block 4->3 when accept <0.75 | 0.2 | exact | 37.83 | 64.73 | 1.71x | 85.4% |
| Adaptive block 4->3 when accept <0.75 | 0.6 | exact | 37.82 | 65.02 | 1.72x | 86.6% |
| Adaptive block 4->3 when accept <0.75 | 1.0 | exact | 37.83 | 65.17 | 1.72x | 83.4% |
Ablation while comparing against the previous verifier behavior on AIME id `13`, 512-token cap:

| Variant | tok/s |
| --- | ---: |
| Current | 52.39 |
| Previous-like verifier | 54.63 |
| No exact attention verification | 53.75 |
| No exact conv verification | 53.21 |
| No GDN state capture | 53.15 |

The remaining slowdown versus the earlier drifting path is mainly target-side exact verification cost, especially GDN and MLP work in the target verifier. The accepted path remains drift-free against no-drafter generation.

## Validation

- `python -m pytest mlx_vlm/tests/test_speculative.py` -> 78 passed.
- 2K token parity checks across temperatures `0.0`, `0.2`, `0.6`, and `1.0` matched no-drafter output exactly.