### PR TITLE
Clear cached torch availability checks in install_auto_processor_patch

### DIFF
--- a/mlx_vlm/models/base.py
+++ b/mlx_vlm/models/base.py
@@ -427,6 +427,22 @@ def install_auto_processor_patch(target_model_types, processor_cls):
     """
     from transformers import AutoProcessor as _HF_AutoProcessor
 
+    # Refresh transformers' @lru_cache-backed availability checks so a mid-run
+    # `pip install torch` is picked up at the next model load. Without this,
+    # a long-running process (notebook, mlx_vlm.server) that started without
+    # torch keeps the cached `is_torch_available()=False` result, and fast
+    # image processors stay bound to DummyObjects even after torch is
+    # installed. See issue #1131.
+    try:
+        from transformers.utils.import_utils import (
+            is_torch_available,
+            is_torchvision_available,
+        )
+        is_torch_available.cache_clear()
+        is_torchvision_available.cache_clear()
+    except (ImportError, AttributeError):
+        pass
+
     if isinstance(target_model_types, str):
         target_model_types = [target_model_types]
     target_model_types = {t.lower() for t in target_model_types}

--- a/mlx_vlm/models/base.py
+++ b/mlx_vlm/models/base.py
@@ -438,6 +438,7 @@ def install_auto_processor_patch(target_model_types, processor_cls):
             is_torch_available,
             is_torchvision_available,
         )
+
         is_torch_available.cache_clear()
         is_torchvision_available.cache_clear()
     except (ImportError, AttributeError):


### PR DESCRIPTION

## Problem

In long-running environments (Jupyter notebooks, an active `mlx_vlm.server`), installing `torch` after the process starts does not unblock subsequent model loads. `transformers.utils.import_utils.is_torch_available` carries an `@lru_cache` decorator and caches its initial `False` result at import time, so the process answers "torch not available" for the rest of its life. Later model loads hit `requires_backends(["torch", "torchvision"])` deep in transformers and raise `... requires the PyTorch library but it was not found in your environment.` — the failure shape in #1131.

## Fix

Call `is_torch_available.cache_clear()` and `is_torchvision_available.cache_clear()` at the top of `install_auto_processor_patch` in `mlx_vlm/models/base.py`. The patch runs on every fresh model load, so the next load after a mid-run torch install picks up the new availability before any `requires_backends` check consults the cache.

This location (rather than `utils.load`) ties invalidation to processor-dependency evaluation, where the torch-free shim already lives — no broader disruption to normal load paths.

The `try`/`except (ImportError, AttributeError)` wrapper turns the patch into a no-op if a future transformers release renames or restructures these helpers.

## Caveat

This only refreshes the availability checks. transformers' `_LazyModule` records missing backends at module construction, then binds a `DummyObject` placeholder via `setattr(self, name, value)` on first attribute access. Clearing the `lru_cache` undoes neither step. The fix therefore helps any code path that has not yet touched the relevant lazy module; paths past that point still require a full process restart.

## How to test

1. Start a Python session (or `mlx_vlm.server`) in an environment without `torch`.
2. Load a model with a `transformers` processor (e.g., Qwen2.5-VL). The load fails or falls back to a shim.
3. Install `torch` in a second terminal while the session stays live.
4. Load the model again in the original session — the load now succeeds without a restart.

## Related

- Plausible mechanism behind #1131 (closed without a code fix); see Caveat for the remaining gap.
- Builds on the torch-free patch system from #872 (LFM2-VL) and #1048 (Qwen2/2.5/3/3.5-VL).

## Scope and risk

- Files: `mlx_vlm/models/base.py` (~16 lines including comment).
- Risk: low and scoped. `cache_clear()` is `functools`'s standard invalidation hook; the next predicate call re-runs `_is_package_available()` (a `find_spec` plus version lookup). The refresh leaves untouched transformers' lazy-module bindings and other cached predicates such as `get_torch_version`, `is_torchvision_v2_available`, `is_timm_available`, and `is_torchaudio_available`.
- No public API change.
