### PR TITLE
Ignore MTP sidecar when loading base VLM weights

### DIFF
--- a/mlx_vlm/tests/test_utils.py
+++ b/mlx_vlm/tests/test_utils.py
@@ -370,11 +370,11 @@ def test_load_passes_revision():
         patch(
             "mlx_vlm.utils.load_model",
             return_value=model_mock,
-        ) as mock_load_model,
+        ),
         patch(
             "mlx_vlm.utils.load_processor",
             return_value=processor_mock,
-        ) as mock_load_processor,
+        ),
         patch("mlx_vlm.utils.load_image_processor", return_value=None),
     ):
         mock_get_model_path.return_value = Path("/tmp/model")
@@ -429,6 +429,60 @@ def test_load_model_routes_text_models_through_existing_loader():
         model = load_model(Path("/tmp/model"), lazy=True, strict=False)
 
     assert getattr(model, "_is_text_model", False) is True
+
+
+def test_load_model_ignores_model_mtp_sidecar_for_base_weights():
+    safe_open = MagicMock()
+    safe_open.__enter__.return_value.metadata.return_value = {"format": "mlx"}
+
+    class FakeConfig:
+        @classmethod
+        def from_dict(cls, config):
+            del config
+            return cls()
+
+    class FakeModel(nn.Module):
+        def __init__(self, config):
+            super().__init__()
+            del config
+            self.model = nn.Linear(2, 2, bias=False)
+            self.loaded_names = []
+
+        def load_weights(self, weights, *args, **kwargs):
+            del args, kwargs
+            self.loaded_names = [name for name, _ in weights]
+
+    class FakeModelModule:
+        ModelConfig = FakeConfig
+        Model = FakeModel
+
+    weight_files = [
+        "/tmp/model/model-mtp.safetensors",
+        "/tmp/model/model-00002-of-00002.safetensors",
+        "/tmp/model/model-00001-of-00002.safetensors",
+    ]
+
+    def fake_load(path):
+        name = Path(path).name
+        if name == "model-mtp.safetensors":
+            return {"language_model.mtp.fc.weight": mx.ones((2, 2))}
+        return {f"{name}.weight": mx.zeros((2, 2))}
+
+    with (
+        patch("mlx_vlm.utils.load_config", return_value={"model_type": "fake"}),
+        patch("mlx_vlm.utils.glob.glob", return_value=weight_files),
+        patch("mlx_vlm.utils.mx.load", side_effect=fake_load) as mx_load,
+        patch("mlx_vlm.utils.safetensors.safe_open", return_value=safe_open),
+        patch("mlx_vlm.utils.get_model_and_args", return_value=(FakeModelModule, None)),
+    ):
+        model = load_model(Path("/tmp/model"), lazy=True)
+
+    loaded_paths = [Path(call.args[0]).name for call in mx_load.call_args_list]
+    assert loaded_paths == [
+        "model-00001-of-00002.safetensors",
+        "model-00002-of-00002.safetensors",
+    ]
+    assert "language_model.mtp.fc.weight" not in model.loaded_names
 
 
 def test_load_delegates_adapter_loading_to_trainer_entrypoint():

--- a/mlx_vlm/utils.py
+++ b/mlx_vlm/utils.py
@@ -216,11 +216,12 @@ def load_model(model_path: Path, lazy: bool = False, **kwargs) -> nn.Module:
     config = load_config(model_path, **kwargs)
 
     # Find all .safetensors files in the model_path, excluding consolidated model weights
-    weight_files = [
+    weight_files = sorted(
         wf
         for wf in glob.glob(str(model_path / "*.safetensors"))
-        if not wf.endswith("consolidated.safetensors")
-    ]
+        if Path(wf).name != "model-mtp.safetensors"
+        and not wf.endswith("consolidated.safetensors")
+    )
 
     if not weight_files:
         logging.error(f"No safetensors found in {model_path}")


### PR DESCRIPTION
## Summary

Exclude `model-mtp.safetensors` from the base VLM weight files loaded by `load_model`.

## Local Repro

Using a converted Qwen 3.6 VLM artifact that includes a base shard set plus `model-mtp.safetensors`, `mlx_vlm.utils.load_model()` currently glob-loads every `*.safetensors` file except consolidated weights. For MLX-format weights, the loader bypasses `sanitize()` and passes the sidecar assistant weights into the base model.

Observed local failure:

```text
ValueError: Received 35 parameters not in model: language_model.mtp.*
```

The target model artifact path in the local repro was:

```text
/Users/David/ai-models/mlx_models/Qwen3.6-35B-A3B-VLM-MTP-8bit
```

## Code Path Compared

Compared upstream `Blaizzy/mlx-vlm` main at `180e21c`:

```text
mlx_vlm/utils.py::load_model
```

The existing filter skips `consolidated.safetensors` but does not skip the known MTP sidecar filename.

## Change

Filter `model-mtp.safetensors` out of the base weight-file list before calling `mx.load`, while preserving deterministic shard order.

## Tests

Added a focused loader regression test proving:

- base shards are loaded in sorted order
- `model-mtp.safetensors` is not passed to `mx.load`
- `language_model.mtp.*` weights are not loaded into the base model

Local verification:

```text
UV_PYTHON=/opt/homebrew/bin/python3.12 uv run --with pytest python -m pytest -q mlx_vlm/tests/test_utils.py::test_load_model_ignores_model_mtp_sidecar_for_base_weights mlx_vlm/tests/test_utils.py::test_load_model_routes_text_models_through_existing_loader
2 passed

UV_PYTHON=/opt/homebrew/bin/python3.12 uv run --with ruff ruff check mlx_vlm/utils.py mlx_vlm/tests/test_utils.py
All checks passed

UV_PYTHON=/opt/homebrew/bin/python3.12 uv run --with pre-commit pre-commit run --files mlx_vlm/utils.py mlx_vlm/tests/test_utils.py
black/isort/autoflake passed

git diff --check
passed
```

## Not Claimed

This PR does not add MTP support to `mlx-vlm`, does not change model conversion, and does not alter target-model quantization. It only prevents the base VLM loader from treating the known MTP sidecar as a base weight shard.
