### PR TITLE
fastvlm: support untied lm_head for the 7B variant

### DIFF
--- a/mlx_vlm/models/fastvlm/fastvlm.py
+++ b/mlx_vlm/models/fastvlm/fastvlm.py
@@ -212,11 +212,11 @@ class Model(nn.Module):
                     )
                     key = key.replace("patch_embed", "patch_embed.blocks")
                 return key
-            if "lm_head" in key:
-                return key
             if "mm_projector" in key:
                 return key.replace("model.", "")
             if "language_model" not in key:
+                # Includes lm_head.weight on untied checkpoints (e.g. 7B);
+                # LanguageModel.sanitize handles dropping it for tied configs.
                 return "language_model." + key
             return key
 

--- a/mlx_vlm/models/fastvlm/language.py
+++ b/mlx_vlm/models/fastvlm/language.py
@@ -27,12 +27,16 @@ class LanguageModel(nn.Module):
         **kwargs,
     ):
         out = self.model(inputs, cache=cache, input_embeddings=inputs_embeds)
-        out = self.model.embed_tokens.as_linear(out)
+        if self.config.tie_word_embeddings:
+            out = self.model.embed_tokens.as_linear(out)
+        else:
+            out = self.lm_head(out)
         return LanguageModelOutput(out)
 
     def sanitize(self, weights):
         if self.config.tie_word_embeddings:
-            weights.pop("lm_head.weight", None)
+            # Model.sanitize prepends "language_model." to top-level lm_head.weight.
+            weights.pop("language_model.lm_head.weight", None)
         return {
             k: v for k, v in weights.items() if "self_attn.rotary_emb.inv_freq" not in k
         }


### PR DESCRIPTION
## Problem

`apple/FastVLM-7B` is the only FastVLM size with `tie_word_embeddings: false` — it ships a separate `lm_head.weight` rather than tying the output projection to the input embedding. The user-visible symptom on a working load is `UnicodeDecodeError: 'utf-8' codec can't decode byte 0x?? in position N: unexpected end of data` mid-stream — the tied-embedding logits produce token IDs whose byte sequences are not valid UTF-8.

Two bugs:

1. **`Model.sanitize` in `mlx_vlm/models/fastvlm/fastvlm.py:215-216`** short-circuits on any `lm_head` key and skips the `language_model.` prefix, so the unprefixed key never reaches `LanguageModel`. Dropping the short-circuit means the key arrives prefixed at `LanguageModel.sanitize`, so the pop key must change from `lm_head.weight` to `language_model.lm_head.weight`.

2. **`LanguageModel.__call__` in `mlx_vlm/models/fastvlm/language.py:30`** always projects via `self.model.embed_tokens.as_linear(out)` regardless of the tie flag. #1098 added `self.lm_head` instantiation for untied configs (line 17-18) but left the forward path untouched — so the untied weight is never read and outputs are wrong.

## Fix

- Drop the `lm_head` short-circuit in `Model.sanitize` so the prefix is added.
- Gate the forward-pass projection on `tie_word_embeddings`, mirroring the qwen2_vl / qwen2_5_vl pattern.
- `LanguageModel.sanitize` now pops the prefixed key (`language_model.lm_head.weight`), matching what reaches it after `Model.sanitize` runs.

4 added lines, 2 modified, across two files.

### How the sanitize chain wires up

mlx-vlm's load pipeline at `mlx_vlm/utils.py:267-270` explicitly invokes `LanguageModel.sanitize` via the `sanitize_weights` helper *after* `Model.sanitize` runs — it instantiates a fresh `LanguageModel(text_config)` and calls `.sanitize(weights)` on the post-`Model.sanitize` key-space. So MLX's `nn.Module.load_weights` does not need to recurse into nested sanitize methods; the loader's helper does the wiring. That is what lets `LanguageModel.sanitize` see the prefixed `language_model.lm_head.weight` key produced by the earlier `Model.sanitize` step.

## Verification

Empirically verified against all three FastVLM bf16 variants using the fix branch via `PYTHONPATH=<branch-path> python -m mlx_vlm.generate`:

| variant | `tie_word_embeddings` | generation | tokens/s |
|---|---|---|---|
| FastVLM-0.5B-bf16 | True (tied) | `Hello! How can I help you today` | 348 |
| FastVLM-1.5B-bf16 | True (tied) | `Hello! How can I help you today` | 123 |
| FastVLM-7B-bf16 | False (untied) | `Hello! How can I help you today` | 34 |

- Untied 7B: previously raised mid-stream `UnicodeDecodeError: 'utf-8' codec can't decode byte 0x??` from garbage logits, or failed at load.
- Tied 0.5B / 1.5B: behavior identical to pre-fix — the `tie_word_embeddings: True` branch in `LanguageModel.__call__` runs the same `self.model.embed_tokens.as_linear(out)` projection that ran before, and `LanguageModel.sanitize` pops the (now-prefixed) `language_model.lm_head.weight` key when one is present in the checkpoint (none is for the bf16 tied uploads).

