### PR TITLE
Add RT-DETRv2 detection model

### DIFF
--- a/mlx_vlm/models/rt_detr_v2/README.md
+++ b/mlx_vlm/models/rt_detr_v2/README.md
@@ -1,0 +1,90 @@
+# RT-DETRv2 for MLX
+
+MLX port of [RT-DETRv2](https://arxiv.org/abs/2407.17140), the real-time object detection transformer. Loads any HuggingFace `RTDetrV2ForObjectDetection` checkpoint (ResNet-50-vd or ResNet-101-vd backbone) on Apple Silicon.
+
+Validated against `transformers.RTDetrV2ForObjectDetection` end-to-end on both backbones: max abs error ~2e-5 on logits, sub-pixel on bboxes for real document inputs.
+
+## Use
+
+Pre-converted bf16 checkpoints are on the Hub:
+
+- [`mlx-community/docling-layout-heron-mlx-bf16`](https://huggingface.co/mlx-community/docling-layout-heron-mlx-bf16) — ResNet-50-vd backbone, 86 MB
+- [`mlx-community/docling-layout-heron-101-mlx-bf16`](https://huggingface.co/mlx-community/docling-layout-heron-101-mlx-bf16) — ResNet-101-vd backbone, 154 MB
+
+```python
+from pathlib import Path
+from PIL import Image
+from huggingface_hub import snapshot_download
+from transformers import AutoProcessor
+from mlx_vlm.utils import load_model
+from mlx_vlm.models.rt_detr_v2.generate import RTDetrV2Predictor
+import mlx_vlm.models.rt_detr_v2  # registers the processor with AutoProcessor
+
+path = Path(snapshot_download("mlx-community/docling-layout-heron-mlx-bf16"))
+model = load_model(path)
+processor = AutoProcessor.from_pretrained(path)
+predictor = RTDetrV2Predictor(model, processor, threshold=0.3)
+
+result = predictor.predict(Image.open("page.png"))
+for name, score, box in zip(result.class_names, result.scores, result.boxes):
+    print(f"{name:20s} {score:.3f} {box.tolist()}")
+```
+
+## Convert your own
+
+```bash
+python -m mlx_vlm.models.rt_detr_v2.convert \
+    --hf-path docling-project/docling-layout-heron \
+    --output ./docling-layout-heron-mlx-bf16 \
+    --dtype bfloat16
+```
+
+The output directory contains `model.safetensors`, `config.json`, and `preprocessor_config.json`. The converter runs a forward pass via `mlx_vlm.utils.load_model` before returning, so a successful run means the checkpoint loads cleanly.
+
+`--dtype` accepts `float16`, `bfloat16`, or `float32` (the canonical set in `mlx_vlm.utils.MODEL_CONVERSION_DTYPES`).
+
+`result` is a `DetectionResult` with vectorized fields:
+
+```
+result.boxes        # (N, 4) xyxy in original-image pixels
+result.scores       # (N,) confidence in [0, 1]
+result.labels       # (N,) integer class ids
+result.class_names  # list of str resolved via config.id2label
+```
+
+The processor is auto-registered with `transformers.AutoProcessor` at import time (see `install_auto_processor_patch` in `mlx_vlm/models/base.py`), so `AutoProcessor.from_pretrained` dispatches into `RTDetrV2Processor` for any directory whose `config.json` has `model_type: rt_detr_v2`.
+
+## Architecture
+
+```
+Image (HxW NHWC) -> ResNet-50/101-vd backbone (strides 8/16/32)
+                 -> EncoderInputProj (1x1 conv + BN per level)
+                 -> HybridEncoder: AIFI (deepest level) + FPN + PAN
+                 -> Encoder query selection (top-K on flat positions x labels)
+                 -> Deformable-attention decoder (6 layers, iterative bbox refinement)
+                 -> {pred_logits (B, Q, num_labels), pred_boxes (B, Q, 4)}
+```
+
+The backbone depth (`[3, 4, 6, 3]` for ResNet-50, `[3, 4, 23, 3]` for ResNet-101) is read from `backbone_config.depths` so the same module handles both variants.
+
+## File structure
+
+```
+mlx_vlm/models/rt_detr_v2/
+  config.py                  # Dataclass configs (top-level + backbone/encoder/decoder)
+  vision.py                  # ResNet-vd backbone + hybrid encoder (AIFI + FPN + PAN)
+  transformer.py             # MSDeformableAttention + decoder + anchor priors
+  rt_detr_v2.py              # Model wrapper + Model.sanitize
+  generate.py                # RTDetrV2Predictor + DetectionResult
+  processing_rt_detr_v2.py   # Image preprocessing + AutoProcessor registration
+  convert.py                 # HF -> MLX checkpoint converter
+  language.py                # Stub (framework compatibility)
+```
+
+Trainability is preserved on the MLX side: BatchNorms remain as layers (not folded into preceding convs), `denoising_class_embed` is loaded as a real parameter, and `n_points_scale` in `MSDeformableAttention` is a live buffer rather than a hard-coded constant.
+
+## References
+
+- [RT-DETRv2: Improved Baseline with Bag-of-Freebies for Real-Time Detection Transformer](https://arxiv.org/abs/2407.17140)
+- [HuggingFace `transformers` RT-DETRv2](https://huggingface.co/docs/transformers/model_doc/rt_detr_v2)
+- [Docling layout models on HF](https://huggingface.co/docling-project) (ResNet-50: `docling-layout-heron`, ResNet-101: `docling-layout-heron-101`)

--- a/mlx_vlm/models/rt_detr_v2/__init__.py
+++ b/mlx_vlm/models/rt_detr_v2/__init__.py
@@ -1,0 +1,20 @@
+"""RT-DETRv2 object detection model."""
+
+# Side-effect: ensure the processor module is imported alongside the package.
+from . import processing_rt_detr_v2  # noqa: F401
+
+# Sub-config classes used by `ModelConfig.__post_init__` and the framework aliases.
+from .config import ModelConfig, RTDetrResNetConfig, RTDetrV2TransformerConfig
+
+# Re-exports: mlx-vlm's framework loader accesses these as attributes on
+# the imported package (e.g. `arch.Model`, `arch.LanguageModel`).
+from .language import LanguageModel  # noqa: F401
+from .rt_detr_v2 import Model  # noqa: F401
+from .vision import VisionModel  # noqa: F401
+
+# Aliases for mlx-vlm framework compatibility (update_module_configs).
+TextConfig = RTDetrV2TransformerConfig
+VisionConfig = RTDetrResNetConfig
+PerceiverConfig = ModelConfig
+ProjectorConfig = ModelConfig
+AudioConfig = ModelConfig

--- a/mlx_vlm/models/rt_detr_v2/__init__.py
+++ b/mlx_vlm/models/rt_detr_v2/__init__.py
@@ -1,16 +1,15 @@
 """RT-DETRv2 object detection model."""
 
-# Side-effect: ensure the processor module is imported alongside the package.
-from . import processing_rt_detr_v2  # noqa: F401
-
-# Sub-config classes used by `ModelConfig.__post_init__` and the framework aliases.
+# Side effect: registers RTDetrV2Processor with transformers.AutoProcessor
+# via install_auto_processor_patch (see processing_rt_detr_v2.py).
+from . import processing_rt_detr_v2
 from .config import ModelConfig, RTDetrResNetConfig, RTDetrV2TransformerConfig
 
 # Re-exports: mlx-vlm's framework loader accesses these as attributes on
 # the imported package (e.g. `arch.Model`, `arch.LanguageModel`).
-from .language import LanguageModel  # noqa: F401
-from .rt_detr_v2 import Model  # noqa: F401
-from .vision import VisionModel  # noqa: F401
+from .language import LanguageModel
+from .rt_detr_v2 import Model
+from .vision import VisionModel
 
 # Aliases for mlx-vlm framework compatibility (update_module_configs).
 TextConfig = RTDetrV2TransformerConfig
@@ -18,3 +17,18 @@ VisionConfig = RTDetrResNetConfig
 PerceiverConfig = ModelConfig
 ProjectorConfig = ModelConfig
 AudioConfig = ModelConfig
+
+__all__ = [
+    "AudioConfig",
+    "LanguageModel",
+    "Model",
+    "ModelConfig",
+    "PerceiverConfig",
+    "ProjectorConfig",
+    "RTDetrResNetConfig",
+    "RTDetrV2TransformerConfig",
+    "TextConfig",
+    "VisionConfig",
+    "VisionModel",
+    "processing_rt_detr_v2",
+]

--- a/mlx_vlm/models/rt_detr_v2/config.py
+++ b/mlx_vlm/models/rt_detr_v2/config.py
@@ -1,0 +1,181 @@
+"""RT-DETRv2 configuration dataclasses.
+
+Fields mirror the HuggingFace `RTDetrV2Config` schema
+(`transformers.models.rt_detr_v2.configuration_rt_detr_v2`). `from_dict`
+flattens an HF `config.json` straight into `ModelConfig`; the sub-configs
+for backbone / hybrid encoder / decoder are constructed in
+`__post_init__`.
+"""
+
+from dataclasses import dataclass, field
+from typing import List, Optional, Union
+
+from ..base import BaseModelConfig
+
+
+@dataclass
+class RTDetrResNetConfig(BaseModelConfig):
+    """ResNet-vd backbone configuration.
+
+    The `vd` variant has a 3-stage stem (3x3 -> 3x3 -> 3x3, stride 2/1/1)
+    followed by a 3x3 stride-2 max-pool, and uses `AvgPool2x2 stride 2 +
+    1x1 conv` for downsampling shortcuts rather than a stride-2 1x1.
+    Depths default to ResNet-50 (`[3, 4, 6, 3]`); ResNet-101 is
+    `[3, 4, 23, 3]`. BatchNorms are typically frozen at inference.
+    """
+
+    model_type: str = "rt_detr_resnet"
+    depths: List[int] = field(default_factory=lambda: [3, 4, 6, 3])
+    downsample_in_bottleneck: bool = False
+    downsample_in_first_stage: bool = False
+    embedding_size: int = 64
+    hidden_act: str = "relu"
+    hidden_sizes: List[int] = field(default_factory=lambda: [256, 512, 1024, 2048])
+    layer_type: str = "bottleneck"
+    num_channels: int = 3
+    out_features: List[str] = field(
+        default_factory=lambda: ["stage2", "stage3", "stage4"]
+    )
+    out_indices: List[int] = field(default_factory=lambda: [2, 3, 4])
+    stage_names: List[str] = field(
+        default_factory=lambda: ["stem", "stage1", "stage2", "stage3", "stage4"]
+    )
+
+
+@dataclass
+class RTDetrV2HybridEncoderConfig(BaseModelConfig):
+    """Hybrid encoder (AIFI + FPN + PAN) configuration."""
+
+    model_type: str = "rt_detr_v2_hybrid_encoder"
+    encoder_hidden_dim: int = 256
+    encoder_in_channels: List[int] = field(default_factory=lambda: [512, 1024, 2048])
+    feat_strides: List[int] = field(default_factory=lambda: [8, 16, 32])
+    encoder_layers: int = 1
+    encoder_ffn_dim: int = 1024
+    encoder_attention_heads: int = 8
+    encoder_activation_function: str = "gelu"
+    encode_proj_layers: List[int] = field(default_factory=lambda: [2])
+    positional_encoding_temperature: int = 10000
+    activation_function: str = "silu"
+    normalize_before: bool = False
+    layer_norm_eps: float = 1e-5
+    hidden_expansion: float = 1.0
+    batch_norm_eps: float = 1e-5
+    eval_size: Optional[List[int]] = None
+
+
+@dataclass
+class RTDetrV2TransformerConfig(BaseModelConfig):
+    """Decoder + query-selection configuration."""
+
+    model_type: str = "rt_detr_v2_transformer"
+    d_model: int = 256
+    decoder_layers: int = 6
+    decoder_attention_heads: int = 8
+    decoder_ffn_dim: int = 1024
+    decoder_in_channels: List[int] = field(default_factory=lambda: [256, 256, 256])
+    decoder_activation_function: str = "relu"
+    decoder_method: str = "default"
+    decoder_n_levels: int = 3
+    decoder_n_points: int = 4
+    decoder_offset_scale: float = 0.5
+    num_feature_levels: int = 3
+    num_queries: int = 300
+    num_labels: int = 17
+    learn_initial_query: bool = False
+    layer_norm_eps: float = 1e-5
+    with_box_refine: bool = True
+    use_focal_loss: bool = True
+
+
+@dataclass
+class ModelConfig(BaseModelConfig):
+    """Top-level RT-DETRv2 config. HF stores backbone/encoder/decoder fields
+    flat in `config.json`; `__post_init__` rebuilds the sub-configs from
+    these flat fields."""
+
+    model_type: str = "rt_detr_v2"
+    image_size: int = 640
+    num_labels: int = 17
+    id2label: Optional[dict] = None
+    label2id: Optional[dict] = None
+    backbone_config: Optional[Union[dict, RTDetrResNetConfig]] = None
+    d_model: int = 256
+    encoder_hidden_dim: int = 256
+    encoder_in_channels: List[int] = field(default_factory=lambda: [512, 1024, 2048])
+    feat_strides: List[int] = field(default_factory=lambda: [8, 16, 32])
+    encoder_layers: int = 1
+    encoder_ffn_dim: int = 1024
+    encoder_attention_heads: int = 8
+    encoder_activation_function: str = "gelu"
+    encode_proj_layers: List[int] = field(default_factory=lambda: [2])
+    positional_encoding_temperature: int = 10000
+    activation_function: str = "silu"
+    normalize_before: bool = False
+    layer_norm_eps: float = 1e-5
+    hidden_expansion: float = 1.0
+    batch_norm_eps: float = 1e-5
+    eval_size: Optional[List[int]] = None
+    decoder_layers: int = 6
+    decoder_attention_heads: int = 8
+    decoder_ffn_dim: int = 1024
+    decoder_in_channels: List[int] = field(default_factory=lambda: [256, 256, 256])
+    decoder_activation_function: str = "relu"
+    decoder_method: str = "default"
+    decoder_n_levels: int = 3
+    decoder_n_points: int = 4
+    decoder_offset_scale: float = 0.5
+    num_feature_levels: int = 3
+    num_queries: int = 300
+    learn_initial_query: bool = False
+    with_box_refine: bool = True
+    use_focal_loss: bool = True
+    freeze_backbone_batch_norms: bool = True
+
+    def __post_init__(self):
+        if self.backbone_config is None:
+            self.backbone_config = RTDetrResNetConfig()
+        elif isinstance(self.backbone_config, dict):
+            self.backbone_config = RTDetrResNetConfig.from_dict(self.backbone_config)
+
+        self._hybrid_encoder_config = RTDetrV2HybridEncoderConfig(
+            encoder_hidden_dim=self.encoder_hidden_dim,
+            encoder_in_channels=self.encoder_in_channels,
+            feat_strides=self.feat_strides,
+            encoder_layers=self.encoder_layers,
+            encoder_ffn_dim=self.encoder_ffn_dim,
+            encoder_attention_heads=self.encoder_attention_heads,
+            encoder_activation_function=self.encoder_activation_function,
+            encode_proj_layers=self.encode_proj_layers,
+            positional_encoding_temperature=self.positional_encoding_temperature,
+            activation_function=self.activation_function,
+            normalize_before=self.normalize_before,
+            layer_norm_eps=self.layer_norm_eps,
+            hidden_expansion=self.hidden_expansion,
+            batch_norm_eps=self.batch_norm_eps,
+            eval_size=self.eval_size,
+        )
+
+        self._transformer_config = RTDetrV2TransformerConfig(
+            d_model=self.d_model,
+            decoder_layers=self.decoder_layers,
+            decoder_attention_heads=self.decoder_attention_heads,
+            decoder_ffn_dim=self.decoder_ffn_dim,
+            decoder_in_channels=self.decoder_in_channels,
+            decoder_activation_function=self.decoder_activation_function,
+            decoder_method=self.decoder_method,
+            decoder_n_levels=self.decoder_n_levels,
+            decoder_n_points=self.decoder_n_points,
+            decoder_offset_scale=self.decoder_offset_scale,
+            num_feature_levels=self.num_feature_levels,
+            num_queries=self.num_queries,
+            num_labels=self.num_labels,
+            learn_initial_query=self.learn_initial_query,
+            layer_norm_eps=self.layer_norm_eps,
+            with_box_refine=self.with_box_refine,
+            use_focal_loss=self.use_focal_loss,
+        )
+
+        # Framework compatibility: sanitize_weights accesses these.
+        self.text_config = None
+        self.vision_config = None

--- a/mlx_vlm/models/rt_detr_v2/convert.py
+++ b/mlx_vlm/models/rt_detr_v2/convert.py
@@ -92,16 +92,6 @@ def is_training_only(key: str) -> bool:
     return any(re.search(p, stripped) for p in TRAINING_ONLY_PATTERNS)
 
 
-_DTYPE_MAP = {
-    "float32": "float32",
-    "fp32": "float32",
-    "bfloat16": "bfloat16",
-    "bf16": "bfloat16",
-    "float16": "float16",
-    "fp16": "float16",
-}
-
-
 def convert(hf_path: str, output: str, dtype: str = "bfloat16") -> Path:
     """Convert a HuggingFace RT-DETRv2 checkpoint to MLX format.
 
@@ -109,7 +99,8 @@ def convert(hf_path: str, output: str, dtype: str = "bfloat16") -> Path:
         hf_path: HF repo id (e.g. "docling-project/docling-layout-heron")
             or a local directory containing model.safetensors + config.json.
         output: destination directory for the MLX checkpoint.
-        dtype: target dtype for the saved weights (default bfloat16).
+        dtype: target dtype for the saved weights. One of the names in
+            `mlx_vlm.utils.MODEL_CONVERSION_DTYPES`. Default bfloat16.
     Returns:
         Path to the written output directory.
     """
@@ -117,13 +108,17 @@ def convert(hf_path: str, output: str, dtype: str = "bfloat16") -> Path:
         import mlx.core as mx
         import safetensors.torch
         from huggingface_hub import snapshot_download
+
+        from ...utils import MODEL_CONVERSION_DTYPES
     except ImportError as e:
         print(f"Missing dependency: {e}", file=sys.stderr)
         sys.exit(2)
 
-    if dtype not in _DTYPE_MAP:
-        raise ValueError(f"Unsupported dtype {dtype!r}; pick from {list(_DTYPE_MAP)}")
-    mlx_dtype = getattr(mx, _DTYPE_MAP[dtype])
+    if dtype not in MODEL_CONVERSION_DTYPES:
+        raise ValueError(
+            f"Unsupported dtype {dtype!r}; expected one of {MODEL_CONVERSION_DTYPES}"
+        )
+    mlx_dtype = getattr(mx, dtype)
 
     src = Path(hf_path)
     if not src.exists():
@@ -138,9 +133,6 @@ def convert(hf_path: str, output: str, dtype: str = "bfloat16") -> Path:
     out = Path(output)
     out.mkdir(parents=True, exist_ok=True)
 
-    # Load + sanitize + cast.
-    import numpy as np
-
     raw = safetensors.torch.load_file(str(ckpt_file))
     print(f"Loaded {len(raw)} tensors from {ckpt_file}")
     sanitized: Dict[str, mx.array] = {}
@@ -150,16 +142,17 @@ def convert(hf_path: str, output: str, dtype: str = "bfloat16") -> Path:
             n_dropped += 1
             continue
         new_k = rename(k)
-        arr = mx.array(np.asarray(v.float()))
+        arr = mx.array(v.detach().cpu().numpy())
         if new_k.endswith(".conv.weight") and arr.ndim == 4:
             arr = arr.transpose(0, 2, 3, 1)
         sanitized[new_k] = arr.astype(mlx_dtype)
-    print(
-        f"  renamed {len(sanitized)} tensors, dropped {n_dropped}, " f"cast to {dtype}"
-    )
+    print(f"  renamed {len(sanitized)} tensors, dropped {n_dropped}, cast to {dtype}")
 
     weights_path = out / "model.safetensors"
-    mx.save_safetensors(str(weights_path), sanitized)
+    # `metadata={"format": "mlx"}` is what `mlx_vlm.utils.load_model` keys on
+    # to skip `Model.sanitize` — without it the loader would re-run the
+    # rename + NCHW->NHWC transpose pipeline against already-MLX weights.
+    mx.save_safetensors(str(weights_path), sanitized, metadata={"format": "mlx"})
     print(f"  wrote {weights_path} ({weights_path.stat().st_size / 1e6:.1f} MB)")
 
     # Copy config.json + preprocessor_config.json + any tokenizer files.
@@ -175,25 +168,27 @@ def convert(hf_path: str, output: str, dtype: str = "bfloat16") -> Path:
 
 
 def _verify(out: Path) -> None:
-    """Smoke-test the converted checkpoint via the framework loader."""
+    """Smoke-test the converted checkpoint via the framework loader.
+
+    Goes through `mlx_vlm.utils.load_model` (not raw `mx.load`) so the
+    sanitize-metadata path is exercised — a saved file without
+    `metadata['format'] = 'mlx'` would re-trigger `Model.sanitize`
+    and double-transpose conv weights, and this verify catches it.
+    """
     import mlx.core as mx
 
-    from . import Model, ModelConfig
+    from ...utils import load_model
 
     config = json.loads((out / "config.json").read_text())
-    cfg = ModelConfig.from_dict(config)
-    model = Model(cfg)
-    # `mx.load` returns either a dict or (weights, metadata); for
-    # safetensors files we always get the dict form.
-    weights = mx.load(str(out / "model.safetensors"))
-    assert isinstance(weights, dict)
-    model.load_weights(list(weights.items()))
+    model = load_model(out)
     model.eval()
 
     size = config.get("image_size") or 640
-    pixel = mx.zeros((1, size, size, 3), dtype=mx.float32)
+    # Random input rather than zeros: zeros let weight-transpose bugs hide
+    # because biases dominate.
+    pixel = mx.random.normal((1, size, size, 3), dtype=mx.float32)
     out_dict = model(pixel)
-    mx.eval(out_dict["pred_logits"])
+    mx.eval(out_dict["pred_logits"], out_dict["pred_boxes"])
     print(
         f"  verified forward: pred_logits {tuple(out_dict['pred_logits'].shape)}, "
         f"pred_boxes {tuple(out_dict['pred_boxes'].shape)}"
@@ -201,6 +196,8 @@ def _verify(out: Path) -> None:
 
 
 def main(argv: Optional[List[str]] = None) -> int:
+    from ...utils import MODEL_CONVERSION_DTYPES
+
     parser = argparse.ArgumentParser(description="Convert HF RT-DETRv2 -> MLX.")
     parser.add_argument(
         "--hf-path",
@@ -213,7 +210,7 @@ def main(argv: Optional[List[str]] = None) -> int:
     parser.add_argument(
         "--dtype",
         default="bfloat16",
-        choices=list(_DTYPE_MAP.keys()),
+        choices=MODEL_CONVERSION_DTYPES,
         help="Target dtype for saved weights (default bfloat16)",
     )
     args = parser.parse_args(argv)

--- a/mlx_vlm/models/rt_detr_v2/convert.py
+++ b/mlx_vlm/models/rt_detr_v2/convert.py
@@ -1,0 +1,225 @@
+"""Convert HuggingFace RT-DETRv2 checkpoints to MLX safetensors format.
+
+The HF `config.json` is consumed as-is; the only transformation is on
+the weights themselves (key renames + Conv2d NCHW->NHWC transpose), then
+optional quantization.
+
+Usage:
+    python -m mlx_vlm.models.rt_detr_v2.convert \\
+        --hf-path docling-project/docling-layout-heron \\
+        --output rt-detr-v2-heron-mlx \\
+        --dtype bfloat16
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import shutil
+import sys
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+# `_HF_PREFIX` is stripped from every key before the rename pipeline runs.
+_HF_PREFIX = "model."
+
+# Phase-specific renames applied in order, AFTER `_HF_PREFIX` is stripped.
+# Each entry is (regex pattern, replacement). Order matters: rules can
+# rely on earlier renames having fired.
+RENAMES: List[Tuple[str, str]] = [
+    # Backbone: HF wraps the ResNet body in `backbone.model.X`; we surface
+    # it as `vision.backbone.X`.
+    (r"^backbone\.model\.", "vision.backbone."),
+    # vd downsampling shortcut: HF Sequential[AvgPool, ShortCut] indexes
+    # the inner ShortCut at `.1.` (AvgPool sits at `.0.` with no params).
+    (r"\.shortcut\.1\.", ".shortcut.proj."),
+    # RTDetrResNetConvLayer field names: convolution -> conv, normalization -> bn.
+    (r"\.convolution\.", ".conv."),
+    (r"\.normalization\.", ".bn."),
+    # AIFI keys on disk are prefixed `encoder.encoder.` (older HF naming);
+    # HF runtime auto-remaps to `encoder.aifi.`, we do the same explicitly.
+    (r"^encoder\.encoder\.", "vision.hybrid_encoder.aifi."),
+    # encoder_input_proj is Sequential[Conv, BN]: `.{N}.0.X` -> `.{N}.conv.X`
+    # and `.{N}.1.X` -> `.{N}.bn.X`.
+    (r"^encoder_input_proj\.(\d+)\.0\.", r"vision.encoder_input_proj.\1.conv."),
+    (r"^encoder_input_proj\.(\d+)\.1\.", r"vision.encoder_input_proj.\1.bn."),
+    # Hybrid encoder body (FPN/PAN/laterals/downsamples): all live under `encoder.*`.
+    (r"^encoder\.", "vision.hybrid_encoder."),
+    # RTDetrV2ConvNormLayer field rename (encoder body uses `.norm.` rather
+    # than the backbone's `.normalization.`).
+    (r"\.norm\.", ".bn."),
+    # decoder_input_proj is also Sequential[Conv, BN].
+    (r"^decoder_input_proj\.(\d+)\.0\.", r"decoder_input_proj.\1.conv."),
+    (r"^decoder_input_proj\.(\d+)\.1\.", r"decoder_input_proj.\1.bn."),
+    # enc_output is Sequential[Linear, LayerNorm].
+    (r"^enc_output\.0\.", "enc_output.fc."),
+    (r"^enc_output\.1\.", "enc_output.ln."),
+]
+
+# Keys excluded from the MLX checkpoint. MLX `nn.BatchNorm` has no slot
+# for `num_batches_tracked`; trainers re-initialise this counter on resume.
+DROP_PATTERNS: List[str] = [
+    r"\.num_batches_tracked$",
+]
+
+# Keys kept in the MLX checkpoint but flagged as training-only — the
+# inference forward path doesn't read them, but trainers (LoRA, full
+# fine-tune) need them.
+TRAINING_ONLY_PATTERNS: List[str] = [
+    r"^denoising_class_embed",
+]
+
+
+def _strip_prefix(key: str) -> str:
+    return key[len(_HF_PREFIX) :] if key.startswith(_HF_PREFIX) else key
+
+
+def rename(key: str) -> str:
+    out = _strip_prefix(key)
+    for pat, repl in RENAMES:
+        out = re.sub(pat, repl, out)
+    return out
+
+
+def should_drop(key: str) -> bool:
+    stripped = _strip_prefix(key)
+    return any(re.search(p, stripped) for p in DROP_PATTERNS)
+
+
+def is_training_only(key: str) -> bool:
+    stripped = _strip_prefix(key)
+    return any(re.search(p, stripped) for p in TRAINING_ONLY_PATTERNS)
+
+
+_DTYPE_MAP = {
+    "float32": "float32",
+    "fp32": "float32",
+    "bfloat16": "bfloat16",
+    "bf16": "bfloat16",
+    "float16": "float16",
+    "fp16": "float16",
+}
+
+
+def convert(hf_path: str, output: str, dtype: str = "bfloat16") -> Path:
+    """Convert a HuggingFace RT-DETRv2 checkpoint to MLX format.
+
+    Args:
+        hf_path: HF repo id (e.g. "docling-project/docling-layout-heron")
+            or a local directory containing model.safetensors + config.json.
+        output: destination directory for the MLX checkpoint.
+        dtype: target dtype for the saved weights (default bfloat16).
+    Returns:
+        Path to the written output directory.
+    """
+    try:
+        import mlx.core as mx
+        import safetensors.torch
+        from huggingface_hub import snapshot_download
+    except ImportError as e:
+        print(f"Missing dependency: {e}", file=sys.stderr)
+        sys.exit(2)
+
+    if dtype not in _DTYPE_MAP:
+        raise ValueError(f"Unsupported dtype {dtype!r}; pick from {list(_DTYPE_MAP)}")
+    mlx_dtype = getattr(mx, _DTYPE_MAP[dtype])
+
+    src = Path(hf_path)
+    if not src.exists():
+        src = Path(snapshot_download(hf_path))
+    ckpt_file = src / "model.safetensors"
+    cfg_file = src / "config.json"
+    if not ckpt_file.is_file():
+        raise FileNotFoundError(f"No model.safetensors in {src}")
+    if not cfg_file.is_file():
+        raise FileNotFoundError(f"No config.json in {src}")
+
+    out = Path(output)
+    out.mkdir(parents=True, exist_ok=True)
+
+    # Load + sanitize + cast.
+    import numpy as np
+
+    raw = safetensors.torch.load_file(str(ckpt_file))
+    print(f"Loaded {len(raw)} tensors from {ckpt_file}")
+    sanitized: Dict[str, mx.array] = {}
+    n_dropped = 0
+    for k, v in raw.items():
+        if should_drop(k):
+            n_dropped += 1
+            continue
+        new_k = rename(k)
+        arr = mx.array(np.asarray(v.float()))
+        if new_k.endswith(".conv.weight") and arr.ndim == 4:
+            arr = arr.transpose(0, 2, 3, 1)
+        sanitized[new_k] = arr.astype(mlx_dtype)
+    print(
+        f"  renamed {len(sanitized)} tensors, dropped {n_dropped}, " f"cast to {dtype}"
+    )
+
+    weights_path = out / "model.safetensors"
+    mx.save_safetensors(str(weights_path), sanitized)
+    print(f"  wrote {weights_path} ({weights_path.stat().st_size / 1e6:.1f} MB)")
+
+    # Copy config.json + preprocessor_config.json + any tokenizer files.
+    for name in ("config.json", "preprocessor_config.json"):
+        src_file = src / name
+        if src_file.is_file():
+            shutil.copy2(src_file, out / name)
+            print(f"  copied {name}")
+
+    # Verification: load it back and run a forward pass.
+    _verify(out)
+    return out
+
+
+def _verify(out: Path) -> None:
+    """Smoke-test the converted checkpoint via the framework loader."""
+    import mlx.core as mx
+
+    from . import Model, ModelConfig
+
+    config = json.loads((out / "config.json").read_text())
+    cfg = ModelConfig.from_dict(config)
+    model = Model(cfg)
+    # `mx.load` returns either a dict or (weights, metadata); for
+    # safetensors files we always get the dict form.
+    weights = mx.load(str(out / "model.safetensors"))
+    assert isinstance(weights, dict)
+    model.load_weights(list(weights.items()))
+    model.eval()
+
+    size = config.get("image_size") or 640
+    pixel = mx.zeros((1, size, size, 3), dtype=mx.float32)
+    out_dict = model(pixel)
+    mx.eval(out_dict["pred_logits"])
+    print(
+        f"  verified forward: pred_logits {tuple(out_dict['pred_logits'].shape)}, "
+        f"pred_boxes {tuple(out_dict['pred_boxes'].shape)}"
+    )
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = argparse.ArgumentParser(description="Convert HF RT-DETRv2 -> MLX.")
+    parser.add_argument(
+        "--hf-path",
+        required=True,
+        help="HF repo id (e.g. docling-project/docling-layout-heron) or local dir",
+    )
+    parser.add_argument(
+        "--output", required=True, help="Output directory for the MLX checkpoint"
+    )
+    parser.add_argument(
+        "--dtype",
+        default="bfloat16",
+        choices=list(_DTYPE_MAP.keys()),
+        help="Target dtype for saved weights (default bfloat16)",
+    )
+    args = parser.parse_args(argv)
+    convert(args.hf_path, args.output, args.dtype)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/mlx_vlm/models/rt_detr_v2/generate.py
+++ b/mlx_vlm/models/rt_detr_v2/generate.py
@@ -1,0 +1,145 @@
+"""RT-DETRv2 postprocessing and predictor.
+
+`RTDetrV2Predictor.predict_batch` returns a list of detections per image.
+Each detection is a dict with keys `l, t, r, b, label, confidence`, where
+the box is in original image pixel coordinates.
+
+Label handling: the predictor reads `model.config.id2label` to map model
+class ids to human-readable strings. Override via the `labels` constructor
+arg to use a different vocabulary. Numeric labels are used as a fallback
+if `id2label` is missing.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Iterable, List, Optional, Sequence, Set, Union
+
+import numpy as np
+
+from .processing_rt_detr_v2 import ImageInput, RTDetrV2Processor
+
+
+@dataclass
+class Detection:
+    l: float
+    t: float
+    r: float
+    b: float
+    label: str
+    confidence: float
+
+
+LabelMap = Union[Sequence[str], Dict[int, str], Dict[str, str]]
+
+
+class RTDetrV2Predictor:
+    """Inference wrapper over `Model` + `RTDetrV2Processor`."""
+
+    DEFAULT_THRESHOLD: float = 0.3
+
+    def __init__(
+        self,
+        model,
+        processor: Optional[RTDetrV2Processor] = None,
+        threshold: float = DEFAULT_THRESHOLD,
+        blacklist: Optional[Set[str]] = None,
+        labels: Optional[LabelMap] = None,
+    ) -> None:
+        self.model = model
+        self.processor = processor or RTDetrV2Processor()
+        self.threshold = threshold
+        self.blacklist = blacklist or frozenset()
+        self.labels = _resolve_labels(labels, getattr(model, "config", None))
+
+    def predict(self, image: ImageInput) -> List[dict]:
+        return self.predict_batch([image])[0]
+
+    def predict_batch(self, images: Iterable[ImageInput]) -> List[List[dict]]:
+        out = self.processor(images)
+        result = self.model(out.pixel_values)
+        logits = np.asarray(result["pred_logits"])
+        boxes = np.asarray(result["pred_boxes"])
+        return [
+            self._decode_one(logits[i], boxes[i], w, h)
+            for i, (w, h) in enumerate(out.original_sizes)
+        ]
+
+    def _decode_one(
+        self,
+        logits: np.ndarray,
+        boxes: np.ndarray,
+        img_w: int,
+        img_h: int,
+    ) -> List[dict]:
+        """Top-K extraction across the flat (queries x labels) score space.
+
+        Matches `RTDetrImageProcessor.post_process_object_detection` for
+        `use_focal_loss=True` models: a single query can yield multiple
+        detections if it scores above threshold on multiple labels.
+        """
+        Q, num_labels = logits.shape
+        scores = 1.0 / (1.0 + np.exp(-logits))
+        flat = scores.reshape(-1)
+
+        k = min(Q, flat.size)
+        top_idx = np.argpartition(-flat, k - 1)[:k]
+        top_scores = flat[top_idx]
+        order = np.argsort(-top_scores)
+        top_idx, top_scores = top_idx[order], top_scores[order]
+
+        top_query = top_idx // num_labels
+        top_label = top_idx % num_labels
+
+        keep = top_scores >= self.threshold
+        if not keep.any():
+            return []
+        top_query = top_query[keep]
+        top_label = top_label[keep]
+        top_scores = top_scores[keep]
+
+        sel = boxes[top_query]
+        cx, cy = sel[:, 0] * img_w, sel[:, 1] * img_h
+        bw, bh = sel[:, 2] * img_w, sel[:, 3] * img_h
+        l = np.clip(cx - bw / 2.0, 0.0, img_w)
+        t = np.clip(cy - bh / 2.0, 0.0, img_h)
+        r = np.clip(cx + bw / 2.0, 0.0, img_w)
+        b = np.clip(cy + bh / 2.0, 0.0, img_h)
+
+        results: List[dict] = []
+        for i, lid in enumerate(top_label):
+            label = self.labels[int(lid)] if self.labels else str(int(lid))
+            if label in self.blacklist:
+                continue
+            results.append(
+                {
+                    "l": float(l[i]),
+                    "t": float(t[i]),
+                    "r": float(r[i]),
+                    "b": float(b[i]),
+                    "label": label,
+                    "confidence": float(top_scores[i]),
+                }
+            )
+        return results
+
+
+def _resolve_labels(labels: Optional[LabelMap], config) -> Optional[List[str]]:
+    """Build an ordered list of label strings.
+
+    Priority: user-supplied `labels` arg > `config.id2label` > None (numeric
+    fallback at decode time).
+    """
+    if labels is not None:
+        if isinstance(labels, dict):
+            return _sort_id_dict(labels)
+        return list(labels)
+    if config is not None and getattr(config, "id2label", None):
+        return _sort_id_dict(config.id2label)
+    return None
+
+
+def _sort_id_dict(d: Dict) -> List[str]:
+    """Order an id->label dict by integer-cast key. HF stores keys as
+    strings, but user-supplied dicts may use ints; handle both."""
+    return [d[k] for k in sorted(d, key=lambda x: int(x))]

--- a/mlx_vlm/models/rt_detr_v2/generate.py
+++ b/mlx_vlm/models/rt_detr_v2/generate.py
@@ -1,33 +1,39 @@
 """RT-DETRv2 postprocessing and predictor.
 
-`RTDetrV2Predictor.predict_batch` returns a list of detections per image.
-Each detection is a dict with keys `l, t, r, b, label, confidence`, where
-the box is in original image pixel coordinates.
+`RTDetrV2Predictor.predict_batch` returns a `DetectionResult` per image
+with vectorized fields: `boxes` (xyxy pixel coords), `scores`, `labels`
+(integer class ids), and `class_names`. Output schema matches the
+existing `mlx_vlm/models/rfdetr/generate.py:DetectionResult` so detection
+models in this repo share a result type.
 
-Label handling: the predictor reads `model.config.id2label` to map model
-class ids to human-readable strings. Override via the `labels` constructor
-arg to use a different vocabulary. Numeric labels are used as a fallback
-if `id2label` is missing.
+Label handling: the predictor reads `model.config.id2label` to map class
+ids to human-readable strings. Override via the `labels` constructor arg
+to use a different vocabulary. If neither is set, `class_names` holds
+stringified integer ids.
 """
 
 from __future__ import annotations
 
-from dataclasses import dataclass
-from typing import Dict, Iterable, List, Optional, Sequence, Set, Union
+from dataclasses import dataclass, field
+from typing import Dict, Iterable, List, Optional, Sequence, Union
 
+import mlx.core as mx
 import numpy as np
 
 from .processing_rt_detr_v2 import ImageInput, RTDetrV2Processor
 
 
 @dataclass
-class Detection:
-    l: float
-    t: float
-    r: float
-    b: float
-    label: str
-    confidence: float
+class DetectionResult:
+    """Per-image detection output.
+
+    Mirrors `mlx_vlm.models.rfdetr.generate.DetectionResult`.
+    """
+
+    boxes: np.ndarray  # (N, 4) xyxy pixel coordinates in the original image
+    scores: np.ndarray  # (N,) confidence scores in [0, 1]
+    labels: np.ndarray  # (N,) integer class ids
+    class_names: List[str] = field(default_factory=list)
 
 
 LabelMap = Union[Sequence[str], Dict[int, str], Dict[str, str]]
@@ -43,21 +49,20 @@ class RTDetrV2Predictor:
         model,
         processor: Optional[RTDetrV2Processor] = None,
         threshold: float = DEFAULT_THRESHOLD,
-        blacklist: Optional[Set[str]] = None,
         labels: Optional[LabelMap] = None,
     ) -> None:
         self.model = model
         self.processor = processor or RTDetrV2Processor()
         self.threshold = threshold
-        self.blacklist = blacklist or frozenset()
         self.labels = _resolve_labels(labels, getattr(model, "config", None))
 
-    def predict(self, image: ImageInput) -> List[dict]:
+    def predict(self, image: ImageInput) -> DetectionResult:
         return self.predict_batch([image])[0]
 
-    def predict_batch(self, images: Iterable[ImageInput]) -> List[List[dict]]:
+    def predict_batch(self, images: Iterable[ImageInput]) -> List[DetectionResult]:
         out = self.processor(images)
         result = self.model(out.pixel_values)
+        mx.eval(result["pred_logits"], result["pred_boxes"])
         logits = np.asarray(result["pred_logits"])
         boxes = np.asarray(result["pred_boxes"])
         return [
@@ -71,7 +76,7 @@ class RTDetrV2Predictor:
         boxes: np.ndarray,
         img_w: int,
         img_h: int,
-    ) -> List[dict]:
+    ) -> DetectionResult:
         """Top-K extraction across the flat (queries x labels) score space.
 
         Matches `RTDetrImageProcessor.post_process_object_detection` for
@@ -93,35 +98,37 @@ class RTDetrV2Predictor:
 
         keep = top_scores >= self.threshold
         if not keep.any():
-            return []
+            empty = np.zeros((0, 4), dtype=np.float32)
+            return DetectionResult(
+                boxes=empty,
+                scores=np.zeros((0,), dtype=np.float32),
+                labels=np.zeros((0,), dtype=np.int64),
+                class_names=[],
+            )
         top_query = top_query[keep]
-        top_label = top_label[keep]
-        top_scores = top_scores[keep]
+        top_label = top_label[keep].astype(np.int64)
+        top_scores = top_scores[keep].astype(np.float32)
 
         sel = boxes[top_query]
         cx, cy = sel[:, 0] * img_w, sel[:, 1] * img_h
         bw, bh = sel[:, 2] * img_w, sel[:, 3] * img_h
-        l = np.clip(cx - bw / 2.0, 0.0, img_w)
-        t = np.clip(cy - bh / 2.0, 0.0, img_h)
-        r = np.clip(cx + bw / 2.0, 0.0, img_w)
-        b = np.clip(cy + bh / 2.0, 0.0, img_h)
+        x1 = np.clip(cx - bw / 2.0, 0.0, img_w)
+        y1 = np.clip(cy - bh / 2.0, 0.0, img_h)
+        x2 = np.clip(cx + bw / 2.0, 0.0, img_w)
+        y2 = np.clip(cy + bh / 2.0, 0.0, img_h)
+        xyxy = np.stack([x1, y1, x2, y2], axis=-1).astype(np.float32)
 
-        results: List[dict] = []
-        for i, lid in enumerate(top_label):
-            label = self.labels[int(lid)] if self.labels else str(int(lid))
-            if label in self.blacklist:
-                continue
-            results.append(
-                {
-                    "l": float(l[i]),
-                    "t": float(t[i]),
-                    "r": float(r[i]),
-                    "b": float(b[i]),
-                    "label": label,
-                    "confidence": float(top_scores[i]),
-                }
-            )
-        return results
+        if self.labels is not None:
+            class_names = [self.labels[int(lid)] for lid in top_label]
+        else:
+            class_names = [str(int(lid)) for lid in top_label]
+
+        return DetectionResult(
+            boxes=xyxy,
+            scores=top_scores,
+            labels=top_label,
+            class_names=class_names,
+        )
 
 
 def _resolve_labels(labels: Optional[LabelMap], config) -> Optional[List[str]]:

--- a/mlx_vlm/models/rt_detr_v2/language.py
+++ b/mlx_vlm/models/rt_detr_v2/language.py
@@ -1,0 +1,20 @@
+"""Stub LanguageModel for mlx-vlm framework compatibility."""
+
+from typing import Dict
+
+import mlx.core as mx
+import mlx.nn as nn
+
+
+class LanguageModel(nn.Module):
+    """RT-DETRv2 has no language model; this stub satisfies the framework API."""
+
+    def __init__(self, config=None):
+        super().__init__()
+
+    def __call__(self, *args, **kwargs):
+        return None
+
+    @staticmethod
+    def sanitize(weights: Dict[str, mx.array]) -> Dict[str, mx.array]:
+        return weights

--- a/mlx_vlm/models/rt_detr_v2/processing_rt_detr_v2.py
+++ b/mlx_vlm/models/rt_detr_v2/processing_rt_detr_v2.py
@@ -1,0 +1,73 @@
+"""RT-DETRv2 image preprocessing.
+
+The standard RT-DETRv2 preprocessor: resize to 640x640 bilinear, rescale
+by 1/255, no mean/std normalization. The "no normalization" detail is
+unusual for ImageNet-style vision models, and silently adding mean/std
+subtraction is the most common way to get subtly-wrong outputs.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, List, Optional, Tuple, Union
+
+import mlx.core as mx
+import numpy as np
+from PIL import Image
+
+ImageInput = Union[Image.Image, np.ndarray]
+
+
+@dataclass
+class RTDetrV2ProcessorConfig:
+    image_size: int = 640
+    rescale_factor: float = 1.0 / 255.0
+    do_normalize: bool = False
+
+
+@dataclass
+class ProcessorOutput:
+    pixel_values: mx.array  # (B, image_size, image_size, 3) NHWC in [0, 1]
+    original_sizes: List[Tuple[int, int]]  # per-image (width, height) for box rescaling
+
+
+class RTDetrV2Processor:
+    """Batched preprocessor for RT-DETRv2."""
+
+    def __init__(self, config: Optional[RTDetrV2ProcessorConfig] = None) -> None:
+        self.config = config or RTDetrV2ProcessorConfig()
+
+    def __call__(
+        self,
+        images: Union[ImageInput, Iterable[ImageInput]],
+    ) -> ProcessorOutput:
+        batch = (
+            [images] if isinstance(images, (Image.Image, np.ndarray)) else list(images)
+        )
+        if not batch:
+            raise ValueError("Empty image batch")
+
+        size = self.config.image_size
+        rescale = self.config.rescale_factor
+
+        original_sizes: List[Tuple[int, int]] = []
+        arrays: List[np.ndarray] = []
+        for img in batch:
+            pil = _to_pil_rgb(img)
+            original_sizes.append(pil.size)
+            resized = pil.resize((size, size), Image.Resampling.BILINEAR)
+            arrays.append(np.asarray(resized, dtype=np.float32))
+
+        stacked = np.stack(arrays, axis=0) * rescale
+        return ProcessorOutput(
+            pixel_values=mx.array(stacked),
+            original_sizes=original_sizes,
+        )
+
+
+def _to_pil_rgb(img: ImageInput) -> Image.Image:
+    if isinstance(img, Image.Image):
+        return img.convert("RGB")
+    if isinstance(img, np.ndarray):
+        return Image.fromarray(img).convert("RGB")
+    raise TypeError(f"Unsupported image type: {type(img).__name__}")

--- a/mlx_vlm/models/rt_detr_v2/processing_rt_detr_v2.py
+++ b/mlx_vlm/models/rt_detr_v2/processing_rt_detr_v2.py
@@ -1,19 +1,30 @@
 """RT-DETRv2 image preprocessing.
 
-The standard RT-DETRv2 preprocessor: resize to 640x640 bilinear, rescale
-by 1/255, no mean/std normalization. The "no normalization" detail is
-unusual for ImageNet-style vision models, and silently adding mean/std
-subtraction is the most common way to get subtly-wrong outputs.
+The standard RT-DETRv2 preprocessor: resize to `image_size` bilinear,
+rescale by `rescale_factor` (1/255), no mean/std normalization. The
+"no normalization" detail is unusual for ImageNet-style vision models,
+and silently adding mean/std subtraction is the most common way to get
+subtly-wrong outputs.
+
+`from_pretrained` reads `preprocessor_config.json` if present so the
+runtime config tracks the saved checkpoint, and the
+`install_auto_processor_patch` call at the bottom makes
+`transformers.AutoProcessor.from_pretrained` dispatch RT-DETRv2
+directories here.
 """
 
 from __future__ import annotations
 
+import json
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Iterable, List, Optional, Tuple, Union
 
 import mlx.core as mx
 import numpy as np
 from PIL import Image
+
+from ..base import install_auto_processor_patch
 
 ImageInput = Union[Image.Image, np.ndarray]
 
@@ -23,6 +34,8 @@ class RTDetrV2ProcessorConfig:
     image_size: int = 640
     rescale_factor: float = 1.0 / 255.0
     do_normalize: bool = False
+    image_mean: Tuple[float, float, float] = (0.485, 0.456, 0.406)
+    image_std: Tuple[float, float, float] = (0.229, 0.224, 0.225)
 
 
 @dataclass
@@ -36,6 +49,46 @@ class RTDetrV2Processor:
 
     def __init__(self, config: Optional[RTDetrV2ProcessorConfig] = None) -> None:
         self.config = config or RTDetrV2ProcessorConfig()
+
+    @classmethod
+    def from_pretrained(cls, path, **kwargs) -> "RTDetrV2Processor":
+        """Build a processor from a model directory.
+
+        Reads `preprocessor_config.json` for resize/rescale/normalize fields
+        and falls back to `config.json["image_size"]` for the resize target
+        if the preprocessor file is missing. Matches the HF
+        `RTDetrImageProcessor` schema (`size: {height, width}`,
+        `rescale_factor`, `do_normalize`, `image_mean`, `image_std`).
+        """
+        model_dir = Path(path)
+        cfg = RTDetrV2ProcessorConfig()
+
+        preproc_file = model_dir / "preprocessor_config.json"
+        if preproc_file.is_file():
+            pp = json.loads(preproc_file.read_text())
+            size = pp.get("size")
+            if isinstance(size, dict):
+                # HF stores {"height": H, "width": W}; we require square inputs.
+                cfg.image_size = int(
+                    size.get("height", size.get("shortest_edge", cfg.image_size))
+                )
+            elif isinstance(size, int):
+                cfg.image_size = size
+            cfg.rescale_factor = float(pp.get("rescale_factor", cfg.rescale_factor))
+            cfg.do_normalize = bool(pp.get("do_normalize", cfg.do_normalize))
+            mean = pp.get("image_mean")
+            std = pp.get("image_std")
+            if mean is not None:
+                cfg.image_mean = tuple(float(x) for x in mean)
+            if std is not None:
+                cfg.image_std = tuple(float(x) for x in std)
+        else:
+            config_file = model_dir / "config.json"
+            if config_file.is_file():
+                model_cfg = json.loads(config_file.read_text())
+                cfg.image_size = int(model_cfg.get("image_size", cfg.image_size))
+
+        return cls(cfg)
 
     def __call__(
         self,
@@ -59,6 +112,10 @@ class RTDetrV2Processor:
             arrays.append(np.asarray(resized, dtype=np.float32))
 
         stacked = np.stack(arrays, axis=0) * rescale
+        if self.config.do_normalize:
+            mean = np.asarray(self.config.image_mean, dtype=np.float32)
+            std = np.asarray(self.config.image_std, dtype=np.float32)
+            stacked = (stacked - mean) / std
         return ProcessorOutput(
             pixel_values=mx.array(stacked),
             original_sizes=original_sizes,
@@ -71,3 +128,9 @@ def _to_pil_rgb(img: ImageInput) -> Image.Image:
     if isinstance(img, np.ndarray):
         return Image.fromarray(img).convert("RGB")
     raise TypeError(f"Unsupported image type: {type(img).__name__}")
+
+
+# Register with transformers.AutoProcessor so `AutoProcessor.from_pretrained`
+# on a directory whose config.json has `model_type: rt_detr_v2` dispatches
+# here. Defined in mlx_vlm/models/base.py:417.
+install_auto_processor_patch(["rt_detr_v2"], RTDetrV2Processor)

--- a/mlx_vlm/models/rt_detr_v2/rt_detr_v2.py
+++ b/mlx_vlm/models/rt_detr_v2/rt_detr_v2.py
@@ -1,0 +1,187 @@
+"""Top-level RT-DETRv2 model.
+
+Composes the vision tower (backbone + hybrid encoder), the per-level
+projection that bridges encoder output to decoder input, the encoder
+query-selection warm-up, and the deformable-attention decoder.
+
+Weight sanitization shares its rename table with `convert.py`: that
+module is the single source of truth so the in-process loader
+(`mlx_vlm.utils.load_model`) and the offline checkpoint converter agree
+on every key.
+"""
+
+from typing import Dict, List, Tuple
+
+import mlx.core as mx
+import mlx.nn as nn
+
+from .config import ModelConfig
+from .convert import DROP_PATTERNS, TRAINING_ONLY_PATTERNS  # noqa: F401
+from .convert import is_training_only as _is_training_only  # noqa: F401
+from .convert import rename as _rename
+from .convert import should_drop as _should_drop
+from .transformer import MLP, Decoder, generate_anchors
+from .vision import VisionModel
+
+
+class _DecoderInputProj(nn.Module):
+    """1x1 Conv + BN bridging an encoder feature to `d_model`.
+
+    HF saves this as `Sequential[Conv2d, BatchNorm2d]`, so keys are
+    `.{N}.0.X` and `.{N}.1.X`; the rename pipeline maps those to
+    `.{N}.conv.X` and `.{N}.bn.X`.
+    """
+
+    def __init__(self, in_c: int, out_c: int, eps: float) -> None:
+        super().__init__()
+        self.conv = nn.Conv2d(in_c, out_c, kernel_size=1, bias=False)
+        self.bn = nn.BatchNorm(out_c, eps=eps)
+
+    def __call__(self, x: mx.array) -> mx.array:
+        return self.bn(self.conv(x))
+
+
+class _EncOutput(nn.Module):
+    """Linear + LayerNorm encoder query head.
+
+    HF saves it as `Sequential[Linear, LayerNorm]`; rename pipeline maps
+    `.0.` to `.fc.` and `.1.` to `.ln.`.
+    """
+
+    def __init__(self, d_model: int, eps: float) -> None:
+        super().__init__()
+        self.fc = nn.Linear(d_model, d_model)
+        self.ln = nn.LayerNorm(d_model, eps=eps)
+
+    def __call__(self, x: mx.array) -> mx.array:
+        return self.ln(self.fc(x))
+
+
+class Model(nn.Module):
+    def __init__(self, config: ModelConfig):
+        super().__init__()
+        self.config = config
+
+        self.vision = VisionModel(config)
+
+        d = config.d_model
+        eps = config.batch_norm_eps
+        ln_eps = config.layer_norm_eps
+
+        # decoder_in_channels gives the input width per level; some configs
+        # have encoder_hidden_dim != d_model so this is a real projection.
+        self.decoder_input_proj = [
+            _DecoderInputProj(in_c, d, eps=eps) for in_c in config.decoder_in_channels
+        ]
+
+        self.enc_output = _EncOutput(d, eps=ln_eps)
+        self.enc_score_head = nn.Linear(d, config.num_labels)
+        self.enc_bbox_head = MLP(d, d, 4, num_layers=3)
+
+        # Training-only contrastive denoising group; kept as a real
+        # parameter so the checkpoint remains fine-tunable.
+        self.denoising_class_embed = nn.Embedding(config.num_labels + 1, d)
+
+        self.decoder = Decoder(config._transformer_config)
+
+    def __call__(self, pixel_values: mx.array) -> Dict[str, mx.array]:
+        """
+        Args:
+            pixel_values: (B, image_size, image_size, 3) NHWC in [0, 1].
+        Returns dict:
+            pred_logits: (B, num_queries, num_labels)
+            pred_boxes:  (B, num_queries, 4) normalized (cx, cy, w, h) in [0, 1]
+            intermediate_logits, intermediate_reference_points: per-layer
+              trajectories for training / auxiliary losses
+            last_hidden_state: (B, num_queries, d_model)
+        """
+        enc_features = self.vision(pixel_values)
+
+        proj = [self.decoder_input_proj[i](f) for i, f in enumerate(enc_features)]
+        spatial_shapes: List[Tuple[int, int]] = [(f.shape[1], f.shape[2]) for f in proj]
+        flat = mx.concatenate(
+            [f.reshape(f.shape[0], f.shape[1] * f.shape[2], f.shape[3]) for f in proj],
+            axis=1,
+        )
+
+        # Encoder query selection: score every position, take top-K.
+        anchors, valid_mask = generate_anchors(tuple(spatial_shapes), dtype=flat.dtype)
+        memory = flat * valid_mask.astype(flat.dtype)
+        output_memory = self.enc_output(memory)
+        enc_scores = self.enc_score_head(output_memory)
+        enc_coord_logits = self.enc_bbox_head(output_memory) + anchors
+
+        K = self.config.num_queries
+        scores_max = enc_scores.max(axis=-1)
+        topk_idx = mx.argpartition(-scores_max, K - 1, axis=1)[:, :K]
+        topk_scores = mx.take_along_axis(scores_max, topk_idx, axis=1)
+        order = mx.argsort(-topk_scores, axis=1)
+        topk_idx = mx.take_along_axis(topk_idx, order, axis=1)
+
+        gather_idx_b = mx.broadcast_to(topk_idx[:, :, None], (topk_idx.shape[0], K, 4))
+        ref_points_unact = mx.take_along_axis(enc_coord_logits, gather_idx_b, axis=1)
+        gather_idx_d = mx.broadcast_to(
+            topk_idx[:, :, None], (topk_idx.shape[0], K, output_memory.shape[-1])
+        )
+        target = mx.stop_gradient(
+            mx.take_along_axis(output_memory, gather_idx_d, axis=1)
+        )
+
+        dec_out = self.decoder(
+            target=target,
+            reference_points_unact=ref_points_unact,
+            encoder_hidden_states=flat,
+            spatial_shapes=tuple(spatial_shapes),
+        )
+
+        return {
+            "pred_logits": dec_out["intermediate_logits"][:, -1],
+            "pred_boxes": dec_out["intermediate_reference_points"][:, -1],
+            "intermediate_logits": dec_out["intermediate_logits"],
+            "intermediate_reference_points": dec_out["intermediate_reference_points"],
+            "last_hidden_state": dec_out["last_hidden_state"],
+        }
+
+    @staticmethod
+    def sanitize(weights: Dict[str, mx.array]) -> Dict[str, mx.array]:
+        """Translate HF RT-DETRv2 weight keys to MLX layout.
+
+        Three transformations happen per key:
+          1. Name rewrite via the `convert.rename` pipeline (strips the
+             `model.` prefix, then applies submodule-specific rules).
+          2. Conv2d weight layout transpose: PyTorch (out, in, kH, kW) →
+             MLX NHWC (out, kH, kW, in).
+          3. Drop list: keys in `DROP_PATTERNS` are excluded. Currently
+             this is just `*.num_batches_tracked` — MLX `nn.BatchNorm`
+             has no slot for that counter and trainers re-initialise it
+             to 0 on resume.
+        """
+        out: Dict[str, mx.array] = {}
+        for k, v in weights.items():
+            if _should_drop(k):
+                continue
+            new_k = _rename(k)
+            if new_k.endswith(".conv.weight") and v.ndim == 4:
+                v = v.transpose(0, 2, 3, 1)
+            out[new_k] = v
+        return out
+
+    @staticmethod
+    def quant_predicate(path: str, module) -> bool:
+        """Layers to quantize for q4/q8 artifacts.
+
+        Skip the backbone (small, accuracy-sensitive) and any conv or
+        small embedding modules; quantize Linear layers whose dims are
+        multiples of 64.
+        """
+        if "backbone." in path:
+            return False
+        if "conv" in path:
+            return False
+        if any(k in path for k in ("query_embed", "denoising_class_embed")):
+            return False
+        if hasattr(module, "weight"):
+            shape = module.weight.shape
+            if any(d % 64 != 0 for d in shape):
+                return False
+        return isinstance(module, nn.Linear)

--- a/mlx_vlm/models/rt_detr_v2/rt_detr_v2.py
+++ b/mlx_vlm/models/rt_detr_v2/rt_detr_v2.py
@@ -16,12 +16,10 @@ import mlx.core as mx
 import mlx.nn as nn
 
 from .config import ModelConfig
-from .convert import DROP_PATTERNS, TRAINING_ONLY_PATTERNS  # noqa: F401
-from .convert import is_training_only as _is_training_only  # noqa: F401
 from .convert import rename as _rename
 from .convert import should_drop as _should_drop
 from .transformer import MLP, Decoder, generate_anchors
-from .vision import VisionModel
+from .vision import VisionTower
 
 
 class _DecoderInputProj(nn.Module):
@@ -62,7 +60,7 @@ class Model(nn.Module):
         super().__init__()
         self.config = config
 
-        self.vision = VisionModel(config)
+        self.vision = VisionTower(config)
 
         d = config.d_model
         eps = config.batch_norm_eps

--- a/mlx_vlm/models/rt_detr_v2/transformer.py
+++ b/mlx_vlm/models/rt_detr_v2/transformer.py
@@ -1,0 +1,389 @@
+"""RT-DETRv2 transformer: deformable-attention decoder and helpers.
+
+Multi-scale deformable attention runs once per feature level via the
+shared `grid_sample` Metal kernel and sums across levels with the
+softmaxed attention weights. `n_points_scale` is carried as a
+non-learnable `mx.array` buffer per layer to remain faithful to
+checkpoints that use non-uniform `n_points_list`.
+"""
+
+from typing import Optional, Tuple
+
+import mlx.core as mx
+import mlx.nn as nn
+
+from ..kernels import grid_sample
+from .config import RTDetrV2TransformerConfig
+
+# ─── helpers ───
+
+
+def inverse_sigmoid(x: mx.array, eps: float = 1e-5) -> mx.array:
+    """Numerically-stable inverse sigmoid."""
+    x = mx.clip(x, 0.0, 1.0)
+    x1 = mx.clip(x, eps, 1.0)
+    x2 = mx.clip(1.0 - x, eps, 1.0)
+    return mx.log(x1 / x2)
+
+
+class MLP(nn.Module):
+    """Multi-layer perceptron with ReLU between layers.
+
+    Field `layers` is a list of `nn.Linear` matching HF saved keys
+    `.layers.{i}.{weight,bias}` of `RTDetrV2MLPPredictionHead`.
+    """
+
+    def __init__(
+        self, input_dim: int, hidden_dim: int, output_dim: int, num_layers: int
+    ) -> None:
+        super().__init__()
+        dims = [input_dim] + [hidden_dim] * (num_layers - 1) + [output_dim]
+        self.num_layers = num_layers
+        self.layers = [nn.Linear(dims[i], dims[i + 1]) for i in range(num_layers)]
+
+    def __call__(self, x: mx.array) -> mx.array:
+        for i, layer in enumerate(self.layers):
+            x = layer(x)
+            if i < self.num_layers - 1:
+                x = nn.relu(x)
+        return x
+
+
+# ─── Multi-Scale Deformable Attention ───
+
+
+class MSDeformableAttention(nn.Module):
+    """Multi-scale deformable attention for RT-DETRv2.
+
+    Reference points are 4D `(cx, cy, w, h)` normalized to `[0, 1]`.
+    Sampling offsets are predicted per `(n_heads, n_levels, n_points)`
+    and scaled by `1/n_points * ref_wh * offset_scale` before being added
+    to the reference center. Sampling itself is done by `grid_sample`
+    (bilinear, padding=zeros, align_corners=False), once per level, and
+    the outputs are concatenated and weighted-summed by the softmaxed
+    attention weights.
+    """
+
+    def __init__(self, config: RTDetrV2TransformerConfig) -> None:
+        super().__init__()
+        d = config.d_model
+        n_heads = config.decoder_attention_heads
+        if d % n_heads != 0:
+            raise ValueError(
+                f"d_model ({d}) must be divisible by num_heads ({n_heads})"
+            )
+
+        self.d_model = d
+        self.n_heads = n_heads
+        self.n_levels = config.decoder_n_levels
+        self.n_points = config.decoder_n_points
+        self.head_dim = d // n_heads
+        self.offset_scale = config.decoder_offset_scale
+        self.method = config.decoder_method
+
+        self.sampling_offsets = nn.Linear(
+            d, n_heads * self.n_levels * self.n_points * 2
+        )
+        self.attention_weights = nn.Linear(d, n_heads * self.n_levels * self.n_points)
+        self.value_proj = nn.Linear(d, d)
+        self.output_proj = nn.Linear(d, d)
+
+        # Per-(level, point) scale = 1/n_points. Stored as a non-learnable
+        # buffer so non-uniform n_points_list configurations (where each
+        # level can have a different number of sampling points) also work.
+        self.n_points_scale = mx.array(
+            [1.0 / self.n_points] * (self.n_levels * self.n_points), dtype=mx.float32
+        )
+
+    def __call__(
+        self,
+        query: mx.array,
+        reference_points: mx.array,
+        value: mx.array,
+        spatial_shapes: Tuple[Tuple[int, int], ...],
+        position_embeddings: Optional[mx.array] = None,
+    ) -> mx.array:
+        """
+        Args:
+            query: (B, Q, D) decoder hidden states.
+            reference_points: (B, Q, 1, 4) center+wh, broadcast across levels.
+            value: (B, sum_HW, D) flattened multi-scale encoder features.
+            spatial_shapes: tuple of (H, W) per level.
+            position_embeddings: optional (B, Q, D) added to query.
+        Returns:
+            (B, Q, D)
+        """
+        if position_embeddings is not None:
+            query = query + position_embeddings
+
+        B, Q, D = query.shape
+        n_heads = self.n_heads
+        head_dim = self.head_dim
+
+        v = self.value_proj(value).reshape(B, value.shape[1], n_heads, head_dim)
+        offsets = self.sampling_offsets(query).reshape(
+            B, Q, n_heads, self.n_levels * self.n_points, 2
+        )
+        attn = self.attention_weights(query).reshape(
+            B, Q, n_heads, self.n_levels * self.n_points
+        )
+        attn = mx.softmax(attn, axis=-1)
+
+        if reference_points.shape[-1] != 4:
+            raise ValueError(
+                f"Expected 4D reference points (cx,cy,w,h), got last dim "
+                f"{reference_points.shape[-1]}"
+            )
+        n_pts_scale = self.n_points_scale.astype(query.dtype)[None, None, None, :, None]
+        ref_wh = reference_points[:, :, None, :, 2:]
+        ref_xy = reference_points[:, :, None, :, :2]
+        loc = ref_xy + offsets * n_pts_scale * ref_wh * self.offset_scale
+
+        # Per-level grid_sample calls.
+        loc_levels = mx.split(loc, self.n_levels, axis=-2)
+
+        level_sizes = [H * W for H, W in spatial_shapes]
+        offsets_running = 0
+        v_levels = []
+        for s in level_sizes:
+            v_levels.append(v[:, offsets_running : offsets_running + s, :, :])
+            offsets_running += s
+
+        sampled_per_level = []
+        for lvl, (H, W) in enumerate(spatial_shapes):
+            v_l = v_levels[lvl].reshape(B, H, W, n_heads, head_dim)
+            v_l = v_l.transpose(0, 3, 1, 2, 4).reshape(B * n_heads, H, W, head_dim)
+            samp = loc_levels[lvl]
+            samp = samp.transpose(0, 2, 1, 3, 4).reshape(
+                B * n_heads, Q, self.n_points, 2
+            )
+            if self.method == "default":
+                samp = 2.0 * samp - 1.0
+            out_l = grid_sample(v_l, samp)
+            sampled_per_level.append(out_l)
+
+        sampled = mx.concatenate(sampled_per_level, axis=-2)
+        w = attn.transpose(0, 2, 1, 3).reshape(
+            B * n_heads, Q, self.n_levels * self.n_points
+        )
+        out = (sampled * w[..., None]).sum(axis=-2)
+        out = (
+            out.reshape(B, n_heads, Q, head_dim).transpose(0, 2, 1, 3).reshape(B, Q, D)
+        )
+        return self.output_proj(out)
+
+
+# ─── Self-attention ───
+
+
+class SelfAttention(nn.Module):
+    """Decoder self-attention with position embeddings added to q,k (not v)."""
+
+    def __init__(self, d_model: int, n_heads: int) -> None:
+        super().__init__()
+        self.n_heads = n_heads
+        self.head_dim = d_model // n_heads
+        self.scale = self.head_dim**-0.5
+        self.q_proj = nn.Linear(d_model, d_model)
+        self.k_proj = nn.Linear(d_model, d_model)
+        self.v_proj = nn.Linear(d_model, d_model)
+        self.out_proj = nn.Linear(d_model, d_model)
+
+    def __call__(
+        self,
+        x: mx.array,
+        position_embeddings: Optional[mx.array] = None,
+    ) -> mx.array:
+        B, N, D = x.shape
+        qk = x + position_embeddings if position_embeddings is not None else x
+        q = (
+            self.q_proj(qk)
+            .reshape(B, N, self.n_heads, self.head_dim)
+            .transpose(0, 2, 1, 3)
+        )
+        k = (
+            self.k_proj(qk)
+            .reshape(B, N, self.n_heads, self.head_dim)
+            .transpose(0, 2, 1, 3)
+        )
+        v = (
+            self.v_proj(x)
+            .reshape(B, N, self.n_heads, self.head_dim)
+            .transpose(0, 2, 1, 3)
+        )
+        out = mx.fast.scaled_dot_product_attention(q, k, v, scale=self.scale)
+        out = out.transpose(0, 2, 1, 3).reshape(B, N, D)
+        return self.out_proj(out)
+
+
+# ─── Decoder ───
+
+
+class DecoderLayer(nn.Module):
+    """One decoder block: self-attn -> norm -> deformable cross-attn -> norm
+    -> FFN -> norm. Field names match the saved state-dict."""
+
+    def __init__(self, config: RTDetrV2TransformerConfig) -> None:
+        super().__init__()
+        d = config.d_model
+        self.self_attn = SelfAttention(d, config.decoder_attention_heads)
+        self.self_attn_layer_norm = nn.LayerNorm(d, eps=config.layer_norm_eps)
+        self.encoder_attn = MSDeformableAttention(config)
+        self.encoder_attn_layer_norm = nn.LayerNorm(d, eps=config.layer_norm_eps)
+        self.fc1 = nn.Linear(d, config.decoder_ffn_dim)
+        self.fc2 = nn.Linear(config.decoder_ffn_dim, d)
+        self.final_layer_norm = nn.LayerNorm(d, eps=config.layer_norm_eps)
+        self.activation = _resolve_activation(config.decoder_activation_function)
+
+    def __call__(
+        self,
+        x: mx.array,
+        object_queries_position_embeddings: mx.array,
+        encoder_hidden_states: mx.array,
+        reference_points: mx.array,
+        spatial_shapes: Tuple[Tuple[int, int], ...],
+    ) -> mx.array:
+        residual = x
+        x = self.self_attn(x, object_queries_position_embeddings)
+        x = residual + x
+        x = self.self_attn_layer_norm(x)
+
+        residual = x
+        x = self.encoder_attn(
+            query=x,
+            reference_points=reference_points,
+            value=encoder_hidden_states,
+            spatial_shapes=spatial_shapes,
+            position_embeddings=object_queries_position_embeddings,
+        )
+        x = residual + x
+        x = self.encoder_attn_layer_norm(x)
+
+        residual = x
+        x = self.fc2(self.activation(self.fc1(x)))
+        x = residual + x
+        x = self.final_layer_norm(x)
+        return x
+
+
+class Decoder(nn.Module):
+    """Decoder stack with iterative bbox refinement.
+
+    Per-layer `bbox_embed` (3-layer MLP) and `class_embed` (Linear) heads
+    are attached here, matching the saved keys
+    `decoder.bbox_embed.{L}.layers.{i}.{weight,bias}` and
+    `decoder.class_embed.{L}.{weight,bias}`.
+    """
+
+    def __init__(self, config: RTDetrV2TransformerConfig) -> None:
+        super().__init__()
+        self.config = config
+        d = config.d_model
+        self.layers = [DecoderLayer(config) for _ in range(config.decoder_layers)]
+
+        # 2-layer MLP that converts 4D reference points to D-dim position
+        # embeddings added to queries in each decoder layer.
+        self.query_pos_head = MLP(4, 2 * d, d, num_layers=2)
+
+        self.bbox_embed = [
+            MLP(d, d, 4, num_layers=3) for _ in range(config.decoder_layers)
+        ]
+        self.class_embed = [
+            nn.Linear(d, config.num_labels) for _ in range(config.decoder_layers)
+        ]
+
+    def __call__(
+        self,
+        target: mx.array,
+        reference_points_unact: mx.array,
+        encoder_hidden_states: mx.array,
+        spatial_shapes: Tuple[Tuple[int, int], ...],
+    ):
+        """
+        Args:
+            target: (B, Q, D) initial query content.
+            reference_points_unact: (B, Q, 4) initial reference boxes in logit
+                space (pre-sigmoid). Decoder takes sigmoid as first step.
+            encoder_hidden_states: (B, sum_HW, D) flattened encoder features.
+            spatial_shapes: per-level (H, W) tuples.
+        Returns:
+            dict with `last_hidden_state`, `intermediate_hidden_states`,
+            `intermediate_reference_points`, `intermediate_logits`.
+        """
+        hidden = target
+        ref_points = mx.sigmoid(reference_points_unact)
+
+        all_hidden = []
+        all_refs = []
+        all_logits = []
+
+        for idx, layer in enumerate(self.layers):
+            # (B, Q, 1, 4) broadcasts across feature levels in cross-attn.
+            ref_input = ref_points[:, :, None, :]
+            pos_embed = self.query_pos_head(ref_points)
+            hidden = layer(
+                x=hidden,
+                object_queries_position_embeddings=pos_embed,
+                encoder_hidden_states=encoder_hidden_states,
+                reference_points=ref_input,
+                spatial_shapes=spatial_shapes,
+            )
+
+            predicted_corners = self.bbox_embed[idx](hidden)
+            new_refs = mx.sigmoid(predicted_corners + inverse_sigmoid(ref_points))
+            ref_points = mx.stop_gradient(new_refs)
+
+            all_hidden.append(hidden)
+            all_refs.append(new_refs)
+            all_logits.append(self.class_embed[idx](hidden))
+
+        return {
+            "last_hidden_state": hidden,
+            "intermediate_hidden_states": mx.stack(all_hidden, axis=1),
+            "intermediate_reference_points": mx.stack(all_refs, axis=1),
+            "intermediate_logits": mx.stack(all_logits, axis=1),
+        }
+
+
+# ─── Anchor priors for encoder query selection ───
+
+
+def generate_anchors(
+    spatial_shapes: Tuple[Tuple[int, int], ...],
+    grid_size: float = 0.05,
+    dtype: mx.Dtype = mx.float32,
+) -> Tuple[mx.array, mx.array]:
+    """Multi-scale anchor priors used by encoder query selection.
+
+    Returns `(anchors_logit, valid_mask)` where anchors are
+    `(1, sum_HW, 4)` in logit space and the mask marks positions whose
+    sigmoid would fall in `[eps, 1-eps]`.
+    """
+    anchors_per_level = []
+    eps = 1e-2
+    for level, (h, w) in enumerate(spatial_shapes):
+        gy, gx = mx.meshgrid(
+            mx.arange(h, dtype=dtype), mx.arange(w, dtype=dtype), indexing="ij"
+        )
+        grid_xy = mx.stack([gx, gy], axis=-1)[None, ...] + 0.5
+        grid_xy = grid_xy / mx.array([w, h], dtype=dtype)[None, None, None, :]
+        wh = mx.ones_like(grid_xy) * grid_size * (2.0**level)
+        anchors_per_level.append(
+            mx.concatenate([grid_xy, wh], axis=-1).reshape(1, h * w, 4)
+        )
+    anchors = mx.concatenate(anchors_per_level, axis=1)
+    valid_mask = ((anchors > eps) & (anchors < 1 - eps)).all(axis=-1, keepdims=True)
+    anchors_logit = mx.log(anchors / (1.0 - anchors))
+    big = mx.array(mx.finfo(dtype).max, dtype=dtype)
+    anchors_logit = mx.where(valid_mask, anchors_logit, big)
+    return anchors_logit, valid_mask
+
+
+def _resolve_activation(name: str):
+    if name == "relu":
+        return nn.ReLU()
+    if name == "gelu":
+        return nn.GELU()
+    if name == "silu":
+        return nn.SiLU()
+    raise ValueError(f"Unsupported activation: {name}")

--- a/mlx_vlm/models/rt_detr_v2/transformer.py
+++ b/mlx_vlm/models/rt_detr_v2/transformer.py
@@ -79,6 +79,13 @@ class MSDeformableAttention(nn.Module):
         self.n_points = config.decoder_n_points
         self.head_dim = d // n_heads
         self.offset_scale = config.decoder_offset_scale
+        # HF supports "default" (sampling locations in [0,1] then mapped to
+        # [-1,1] for grid_sample) and "discrete" (locations used as-is).
+        if config.decoder_method not in ("default", "discrete"):
+            raise ValueError(
+                f"Unsupported decoder_method {config.decoder_method!r}; "
+                "expected 'default' or 'discrete'"
+            )
         self.method = config.decoder_method
 
         self.sampling_offsets = nn.Linear(

--- a/mlx_vlm/models/rt_detr_v2/vision.py
+++ b/mlx_vlm/models/rt_detr_v2/vision.py
@@ -1,0 +1,699 @@
+"""ResNet-vd backbone and hybrid encoder for RT-DETRv2.
+
+The vision tower for RT-DETRv2 has two parts:
+
+  - A ResNet-50-vd / ResNet-101-vd backbone returning features at three
+    strides (8, 16, 32).
+  - A hybrid encoder consisting of an AIFI transformer applied to the
+    deepest backbone level, a top-down FPN, and a bottom-up PAN. Output
+    is three feature maps at strides (8, 16, 32) all with
+    `encoder_hidden_dim` channels.
+
+BatchNorms are kept as proper layers (not folded into preceding convs at
+conversion time) so the checkpoint remains fine-tunable.
+"""
+
+from typing import Dict, List, Optional, Tuple
+
+import mlx.core as mx
+import mlx.nn as nn
+
+from .config import ModelConfig, RTDetrResNetConfig, RTDetrV2HybridEncoderConfig
+
+# ─── Backbone primitives ───
+
+
+class ConvNormLayer(nn.Module):
+    """Conv2d (no bias) + BatchNorm + activation (mirrors HF `RTDetrResNetConvLayer`)."""
+
+    def __init__(
+        self,
+        in_channels: int,
+        out_channels: int,
+        kernel_size: int = 3,
+        stride: int = 1,
+        activation: Optional[str] = "relu",
+        eps: float = 1e-5,
+    ) -> None:
+        super().__init__()
+        self.conv = nn.Conv2d(
+            in_channels,
+            out_channels,
+            kernel_size=kernel_size,
+            stride=stride,
+            padding=kernel_size // 2,
+            bias=False,
+        )
+        self.bn = nn.BatchNorm(out_channels, eps=eps)
+        self.activation = _resolve_activation(activation)
+
+    def __call__(self, x: mx.array) -> mx.array:
+        x = self.conv(x)
+        x = self.bn(x)
+        if self.activation is not None:
+            x = self.activation(x)
+        return x
+
+
+class ShortCut(nn.Module):
+    """1x1 Conv2d (no bias) + BatchNorm. Used directly in stride-1 shortcuts
+    and wrapped in `AvgPoolShortCut` for vd-style downsampling shortcuts."""
+
+    def __init__(
+        self, in_channels: int, out_channels: int, stride: int = 1, eps: float = 1e-5
+    ) -> None:
+        super().__init__()
+        self.conv = nn.Conv2d(
+            in_channels, out_channels, kernel_size=1, stride=stride, bias=False
+        )
+        self.bn = nn.BatchNorm(out_channels, eps=eps)
+
+    def __call__(self, x: mx.array) -> mx.array:
+        return self.bn(self.conv(x))
+
+
+class AvgPoolShortCut(nn.Module):
+    """vd downsampling shortcut: AvgPool 2x2 stride 2 then 1x1 conv + BN.
+
+    HF stores this as `Sequential[AvgPool2d, ShortCut]`, so the inner
+    ShortCut sits at saved key `.1.` (the AvgPool at `.0.` has no params).
+    Attribute is named `proj` since MLX attribute names cannot start with
+    a digit; the rename pipeline in `convert.py` maps `.shortcut.1.X` to
+    `.shortcut.proj.X`.
+    """
+
+    def __init__(self, in_channels: int, out_channels: int, eps: float = 1e-5) -> None:
+        super().__init__()
+        self.pool = nn.AvgPool2d(kernel_size=2, stride=2, padding=0)
+        self.proj = ShortCut(in_channels, out_channels, stride=1, eps=eps)
+
+    def __call__(self, x: mx.array) -> mx.array:
+        return self.proj(self.pool(x))
+
+
+class BottleNeckLayer(nn.Module):
+    """ResNet bottleneck (3 conv layers + shortcut + skip).
+
+    Shortcut variants (vd):
+      - `stride == 2`: AvgPool 2x2 + 1x1 conv + BN (`AvgPoolShortCut`)
+      - `stride == 1` and channels change: plain `ShortCut`
+      - `stride == 1` and channels match: identity (no params)
+    """
+
+    expansion = 4
+
+    def __init__(
+        self,
+        in_channels: int,
+        out_channels: int,
+        stride: int = 1,
+        downsample_in_bottleneck: bool = False,
+        activation: str = "relu",
+        eps: float = 1e-5,
+    ) -> None:
+        super().__init__()
+        should_apply_shortcut = (in_channels != out_channels) or (stride != 1)
+        reduces_channels = out_channels // self.expansion
+
+        if stride == 2:
+            self.shortcut: nn.Module = (
+                AvgPoolShortCut(in_channels, out_channels, eps=eps)
+                if should_apply_shortcut
+                else _Identity()
+            )
+        else:
+            self.shortcut = (
+                ShortCut(in_channels, out_channels, stride=stride, eps=eps)
+                if should_apply_shortcut
+                else _Identity()
+            )
+
+        # 1x1 -> 3x3 -> 1x1 expand. The stride-2 sits on the first 1x1 if
+        # `downsample_in_bottleneck`, otherwise on the middle 3x3.
+        first_stride = stride if downsample_in_bottleneck else 1
+        middle_stride = stride if not downsample_in_bottleneck else 1
+        self.layer = [
+            ConvNormLayer(
+                in_channels,
+                reduces_channels,
+                kernel_size=1,
+                stride=first_stride,
+                eps=eps,
+            ),
+            ConvNormLayer(
+                reduces_channels,
+                reduces_channels,
+                kernel_size=3,
+                stride=middle_stride,
+                eps=eps,
+            ),
+            ConvNormLayer(
+                reduces_channels, out_channels, kernel_size=1, activation=None, eps=eps
+            ),
+        ]
+        self.activation = _resolve_activation(activation)
+
+    def __call__(self, x: mx.array) -> mx.array:
+        residual = self.shortcut(x)
+        for layer in self.layer:
+            x = layer(x)
+        x = x + residual
+        if self.activation is not None:
+            x = self.activation(x)
+        return x
+
+
+class Stage(nn.Module):
+    """A ResNet stage: `depth` BottleNeckLayers. First block downsamples / projects."""
+
+    def __init__(
+        self,
+        config: RTDetrResNetConfig,
+        in_channels: int,
+        out_channels: int,
+        stride: int,
+        depth: int,
+    ) -> None:
+        super().__init__()
+        first = BottleNeckLayer(
+            in_channels,
+            out_channels,
+            stride=stride,
+            downsample_in_bottleneck=config.downsample_in_bottleneck,
+            activation=config.hidden_act,
+        )
+        rest = [
+            BottleNeckLayer(
+                out_channels,
+                out_channels,
+                stride=1,
+                downsample_in_bottleneck=config.downsample_in_bottleneck,
+                activation=config.hidden_act,
+            )
+            for _ in range(depth - 1)
+        ]
+        self.layers = [first, *rest]
+
+    def __call__(self, x: mx.array) -> mx.array:
+        for layer in self.layers:
+            x = layer(x)
+        return x
+
+
+class Embeddings(nn.Module):
+    """Stem: three 3x3 ConvNormLayers + a 3x3 stride-2 MaxPool (output stride 4)."""
+
+    def __init__(self, config: RTDetrResNetConfig) -> None:
+        super().__init__()
+        emb = config.embedding_size
+        self.embedder = [
+            ConvNormLayer(
+                config.num_channels,
+                emb // 2,
+                kernel_size=3,
+                stride=2,
+                activation=config.hidden_act,
+            ),
+            ConvNormLayer(
+                emb // 2,
+                emb // 2,
+                kernel_size=3,
+                stride=1,
+                activation=config.hidden_act,
+            ),
+            ConvNormLayer(
+                emb // 2, emb, kernel_size=3, stride=1, activation=config.hidden_act
+            ),
+        ]
+        self.pooler = nn.MaxPool2d(kernel_size=3, stride=2, padding=1)
+
+    def __call__(self, x: mx.array) -> mx.array:
+        for layer in self.embedder:
+            x = layer(x)
+        return self.pooler(x)
+
+
+class Encoder(nn.Module):
+    """The four staged-bottleneck stages of the ResNet body."""
+
+    def __init__(self, config: RTDetrResNetConfig) -> None:
+        super().__init__()
+        depths = config.depths
+        hidden_sizes = config.hidden_sizes
+        embedding_size = config.embedding_size
+
+        stages: List[Stage] = []
+        prev_channels = embedding_size
+        for i, (out_c, depth) in enumerate(zip(hidden_sizes, depths)):
+            if i == 0:
+                stride = 2 if config.downsample_in_first_stage else 1
+            else:
+                stride = 2
+            stages.append(
+                Stage(config, prev_channels, out_c, stride=stride, depth=depth)
+            )
+            prev_channels = out_c
+
+        self.stages = stages
+
+    def __call__(self, x: mx.array) -> Tuple[mx.array, ...]:
+        outputs: List[mx.array] = []
+        for stage in self.stages:
+            x = stage(x)
+            outputs.append(x)
+        return tuple(outputs)
+
+
+class Backbone(nn.Module):
+    """ResNet-50-vd / ResNet-101-vd backbone.
+
+    Forward returns the features selected by `out_features` (default
+    stages 2, 3, 4 at strides 8/16/32). Stage 0 (stride 4) is computed
+    but dropped from the output.
+    """
+
+    def __init__(self, config: RTDetrResNetConfig) -> None:
+        super().__init__()
+        self.config = config
+        self.embedder = Embeddings(config)
+        self.encoder = Encoder(config)
+        self._out_stage_indices = [
+            int(name.removeprefix("stage")) - 1 for name in config.out_features
+        ]
+
+    def __call__(self, pixel_values: mx.array) -> Tuple[mx.array, ...]:
+        x = self.embedder(pixel_values)
+        all_stages = self.encoder(x)
+        return tuple(all_stages[i] for i in self._out_stage_indices)
+
+
+# ─── Hybrid encoder building blocks ───
+
+
+class EncoderConvNormLayer(nn.Module):
+    """Conv2d + BatchNorm + activation with overridable padding.
+
+    Mirrors HF `RTDetrV2ConvNormLayer` (distinct from the backbone's
+    `RTDetrResNetConvLayer`). Field names are `conv` / `bn` to match the
+    saved state-dict's `conv` / `norm` (the rename pipeline maps `norm`
+    to `bn`).
+    """
+
+    def __init__(
+        self,
+        in_channels: int,
+        out_channels: int,
+        kernel_size: int,
+        stride: int = 1,
+        padding: Optional[int] = None,
+        activation: Optional[str] = None,
+        eps: float = 1e-5,
+    ) -> None:
+        super().__init__()
+        self.conv = nn.Conv2d(
+            in_channels,
+            out_channels,
+            kernel_size=kernel_size,
+            stride=stride,
+            padding=(kernel_size - 1) // 2 if padding is None else padding,
+            bias=False,
+        )
+        self.bn = nn.BatchNorm(out_channels, eps=eps)
+        self.activation = _resolve_activation(activation)
+
+    def __call__(self, x: mx.array) -> mx.array:
+        x = self.conv(x)
+        x = self.bn(x)
+        if self.activation is not None:
+            x = self.activation(x)
+        return x
+
+
+class RepVggBlock(nn.Module):
+    """RepVGG block: 3x3 conv + 1x1 conv branches summed and activated.
+
+    Branches are kept separate (not re-parameterized into a single 3x3)
+    so the checkpoint stays trainable.
+    """
+
+    def __init__(
+        self, hidden_channels: int, activation: Optional[str], eps: float
+    ) -> None:
+        super().__init__()
+        self.conv1 = EncoderConvNormLayer(
+            hidden_channels, hidden_channels, kernel_size=3, padding=1, eps=eps
+        )
+        self.conv2 = EncoderConvNormLayer(
+            hidden_channels, hidden_channels, kernel_size=1, padding=0, eps=eps
+        )
+        self.activation = _resolve_activation(activation)
+
+    def __call__(self, x: mx.array) -> mx.array:
+        y = self.conv1(x) + self.conv2(x)
+        if self.activation is not None:
+            y = self.activation(y)
+        return y
+
+
+class CSPRepLayer(nn.Module):
+    """CSPNet block built from RepVGG blocks.
+
+    Two parallel 1x1 branches; one feeds N RepVgg blocks, the other is a
+    direct path. Sum is optionally re-projected to `out_channels`; the
+    projection collapses to identity when
+    `hidden_channels == out_channels`.
+    """
+
+    def __init__(
+        self,
+        in_channels: int,
+        out_channels: int,
+        num_blocks: int,
+        hidden_expansion: float,
+        activation: Optional[str],
+        eps: float,
+    ) -> None:
+        super().__init__()
+        hidden_channels = int(out_channels * hidden_expansion)
+        self.conv1 = EncoderConvNormLayer(
+            in_channels, hidden_channels, kernel_size=1, activation=activation, eps=eps
+        )
+        self.conv2 = EncoderConvNormLayer(
+            in_channels, hidden_channels, kernel_size=1, activation=activation, eps=eps
+        )
+        self.bottlenecks = [
+            RepVggBlock(hidden_channels, activation, eps) for _ in range(num_blocks)
+        ]
+        if hidden_channels != out_channels:
+            self.conv3: nn.Module = EncoderConvNormLayer(
+                hidden_channels,
+                out_channels,
+                kernel_size=1,
+                activation=activation,
+                eps=eps,
+            )
+        else:
+            self.conv3 = _Identity()
+
+    def __call__(self, x: mx.array) -> mx.array:
+        a = self.conv1(x)
+        for b in self.bottlenecks:
+            a = b(a)
+        return self.conv3(a + self.conv2(x))
+
+
+class SinePositionEmbedding(nn.Module):
+    """2D sinusoidal position embedding for AIFI. No learnable params.
+
+    Returns a `(1, H*W, embed_dim)` tensor with `embed_dim` split into
+    `[sin(h), cos(h), sin(w), cos(w)]` quarters.
+    """
+
+    def __init__(self, embed_dim: int = 256, temperature: float = 10000.0) -> None:
+        super().__init__()
+        if embed_dim % 4 != 0:
+            raise ValueError("embed_dim must be divisible by 4")
+        self.embed_dim = embed_dim
+        self.temperature = temperature
+
+    def __call__(
+        self, height: int, width: int, dtype: mx.Dtype = mx.float32
+    ) -> mx.array:
+        grid_w = mx.arange(width, dtype=dtype)
+        grid_h = mx.arange(height, dtype=dtype)
+        gw, gh = mx.meshgrid(grid_w, grid_h)  # default "xy" indexing
+        pos_dim = self.embed_dim // 4
+        omega = mx.arange(pos_dim, dtype=dtype) / pos_dim
+        omega = 1.0 / (self.temperature**omega)
+        out_w = gw.flatten()[:, None] * omega[None, :]
+        out_h = gh.flatten()[:, None] * omega[None, :]
+        pe = mx.concatenate(
+            [mx.sin(out_h), mx.cos(out_h), mx.sin(out_w), mx.cos(out_w)], axis=1
+        )
+        return pe[None, :, :]
+
+
+class EncoderLayer(nn.Module):
+    """One AIFI transformer encoder layer.
+
+    Standard pre/post-norm MHSA + FFN. Position embedding is added to
+    q,k but not v in self-attention. Field names match the saved
+    state-dict (`fc1` / `fc2` directly with no `.mlp` wrapper,
+    `out_proj` rather than `o_proj`).
+    """
+
+    def __init__(self, config: RTDetrV2HybridEncoderConfig) -> None:
+        super().__init__()
+        d = config.encoder_hidden_dim
+        self.normalize_before = config.normalize_before
+        self.self_attn = _SelfAttention(d, config.encoder_attention_heads)
+        self.self_attn_layer_norm = nn.LayerNorm(d, eps=config.layer_norm_eps)
+        self.fc1 = nn.Linear(d, config.encoder_ffn_dim)
+        self.fc2 = nn.Linear(config.encoder_ffn_dim, d)
+        self.final_layer_norm = nn.LayerNorm(d, eps=config.layer_norm_eps)
+        activation = _resolve_activation(config.encoder_activation_function)
+        assert activation is not None, "encoder_activation_function must be set"
+        self.activation = activation
+
+    def __call__(self, x: mx.array, pos_embed: Optional[mx.array]) -> mx.array:
+        # Self-attention sub-block
+        residual = x
+        if self.normalize_before:
+            x = self.self_attn_layer_norm(x)
+        x = self.self_attn(x, pos_embed)
+        x = residual + x
+        if not self.normalize_before:
+            x = self.self_attn_layer_norm(x)
+
+        # FFN sub-block
+        residual = x
+        if self.normalize_before:
+            x = self.final_layer_norm(x)
+        x = self.fc2(self.activation(self.fc1(x)))
+        x = residual + x
+        if not self.normalize_before:
+            x = self.final_layer_norm(x)
+        return x
+
+
+class _SelfAttention(nn.Module):
+    """MHSA with position embedding added to q,k (not v)."""
+
+    def __init__(self, d_model: int, n_heads: int) -> None:
+        super().__init__()
+        self.n_heads = n_heads
+        self.head_dim = d_model // n_heads
+        self.scale = self.head_dim**-0.5
+        self.q_proj = nn.Linear(d_model, d_model)
+        self.k_proj = nn.Linear(d_model, d_model)
+        self.v_proj = nn.Linear(d_model, d_model)
+        self.out_proj = nn.Linear(d_model, d_model)
+
+    def __call__(self, x: mx.array, pos_embed: Optional[mx.array]) -> mx.array:
+        B, N, D = x.shape
+        qk = x + pos_embed if pos_embed is not None else x
+        q = (
+            self.q_proj(qk)
+            .reshape(B, N, self.n_heads, self.head_dim)
+            .transpose(0, 2, 1, 3)
+        )
+        k = (
+            self.k_proj(qk)
+            .reshape(B, N, self.n_heads, self.head_dim)
+            .transpose(0, 2, 1, 3)
+        )
+        v = (
+            self.v_proj(x)
+            .reshape(B, N, self.n_heads, self.head_dim)
+            .transpose(0, 2, 1, 3)
+        )
+        out = mx.fast.scaled_dot_product_attention(q, k, v, scale=self.scale)
+        out = out.transpose(0, 2, 1, 3).reshape(B, N, D)
+        return self.out_proj(out)
+
+
+class AIFI(nn.Module):
+    """Attention-based Intra-scale Feature Interaction: a stack of EncoderLayers
+    applied to a single flattened feature map.
+
+    The HF state-dict prefixes AIFI keys with `encoder.encoder.` (older
+    naming); the rename pipeline maps that to `vision.hybrid_encoder.aifi.`.
+    """
+
+    def __init__(self, config: RTDetrV2HybridEncoderConfig) -> None:
+        super().__init__()
+        self.position_embedding = SinePositionEmbedding(
+            embed_dim=config.encoder_hidden_dim,
+            temperature=config.positional_encoding_temperature,
+        )
+        self.layers = [EncoderLayer(config) for _ in range(config.encoder_layers)]
+
+    def __call__(self, x: mx.array) -> mx.array:
+        """Args: (B, H, W, C) NHWC. Returns: same shape."""
+        B, H, W, C = x.shape
+        x_flat = x.reshape(B, H * W, C)
+        pos = self.position_embedding(H, W, dtype=x.dtype)
+        for layer in self.layers:
+            x_flat = layer(x_flat, pos)
+        return x_flat.reshape(B, H, W, C)
+
+
+# ─── Hybrid encoder ───
+
+
+class HybridEncoder(nn.Module):
+    """AIFI on the deepest level, then top-down FPN, then bottom-up PAN.
+
+    Output: three feature maps at the original strides, all with
+    `encoder_hidden_dim` channels.
+    """
+
+    def __init__(self, config: RTDetrV2HybridEncoderConfig) -> None:
+        super().__init__()
+        self.config = config
+        self.encode_proj_layers = config.encode_proj_layers
+        num_fpn_stages = len(config.encoder_in_channels) - 1
+        num_pan_stages = num_fpn_stages
+        d = config.encoder_hidden_dim
+        act = config.activation_function
+        eps = config.batch_norm_eps
+
+        self.aifi = [AIFI(config) for _ in self.encode_proj_layers]
+
+        self.lateral_convs = [
+            EncoderConvNormLayer(d, d, kernel_size=1, activation=act, eps=eps)
+            for _ in range(num_fpn_stages)
+        ]
+        self.fpn_blocks = [
+            CSPRepLayer(
+                in_channels=d * 2,
+                out_channels=d,
+                num_blocks=3,
+                hidden_expansion=config.hidden_expansion,
+                activation=act,
+                eps=eps,
+            )
+            for _ in range(num_fpn_stages)
+        ]
+
+        self.downsample_convs = [
+            EncoderConvNormLayer(d, d, kernel_size=3, stride=2, activation=act, eps=eps)
+            for _ in range(num_pan_stages)
+        ]
+        self.pan_blocks = [
+            CSPRepLayer(
+                in_channels=d * 2,
+                out_channels=d,
+                num_blocks=3,
+                hidden_expansion=config.hidden_expansion,
+                activation=act,
+                eps=eps,
+            )
+            for _ in range(num_pan_stages)
+        ]
+
+    def __call__(self, features: Tuple[mx.array, ...]) -> Tuple[mx.array, ...]:
+        # AIFI: apply transformer encoder to each level in encode_proj_layers.
+        feats = list(features)
+        for i, lvl in enumerate(self.encode_proj_layers):
+            feats[lvl] = self.aifi[i](feats[lvl])
+
+        # Top-down FPN.
+        fpn = [feats[-1]]
+        num_fpn = len(self.lateral_convs)
+        for idx in range(num_fpn):
+            backbone_feat = feats[num_fpn - idx - 1]
+            top_feat = fpn[-1]
+            top_feat = self.lateral_convs[idx](top_feat)
+            fpn[-1] = top_feat
+            top_feat = _upsample_nearest_2x(top_feat)
+            fused = mx.concatenate([top_feat, backbone_feat], axis=-1)
+            fpn.append(self.fpn_blocks[idx](fused))
+        fpn.reverse()
+
+        # Bottom-up PAN.
+        pan = [fpn[0]]
+        num_pan = len(self.downsample_convs)
+        for idx in range(num_pan):
+            top = pan[-1]
+            up = fpn[idx + 1]
+            down = self.downsample_convs[idx](top)
+            fused = mx.concatenate([down, up], axis=-1)
+            pan.append(self.pan_blocks[idx](fused))
+        return tuple(pan)
+
+
+# ─── Encoder input projection ───
+
+
+class EncoderInputProj(nn.Module):
+    """1x1 Conv + BN, per backbone level, projecting to `encoder_hidden_dim`.
+
+    HF saves this as `Sequential[Conv2d, BatchNorm2d]` so the keys are
+    `.{N}.0.X` (conv) and `.{N}.1.X` (BN). The rename pipeline maps
+    `.0.` to `.conv.` and `.1.` to `.bn.`.
+    """
+
+    def __init__(self, in_channels: int, out_channels: int, eps: float) -> None:
+        super().__init__()
+        self.conv = nn.Conv2d(in_channels, out_channels, kernel_size=1, bias=False)
+        self.bn = nn.BatchNorm(out_channels, eps=eps)
+
+    def __call__(self, x: mx.array) -> mx.array:
+        return self.bn(self.conv(x))
+
+
+# ─── Vision tower ───
+
+
+class VisionModel(nn.Module):
+    """Backbone -> per-level input projection -> hybrid encoder."""
+
+    def __init__(self, config: ModelConfig) -> None:
+        super().__init__()
+        self.config = config
+        # `ModelConfig.__post_init__` resolves backbone_config into a
+        # `RTDetrResNetConfig` regardless of how it was passed in.
+        assert isinstance(config.backbone_config, RTDetrResNetConfig)
+        self.backbone = Backbone(config.backbone_config)
+        self.encoder_input_proj = [
+            EncoderInputProj(in_c, config.encoder_hidden_dim, eps=config.batch_norm_eps)
+            for in_c in config.encoder_in_channels
+        ]
+        self.hybrid_encoder = HybridEncoder(config._hybrid_encoder_config)
+
+    def __call__(self, pixel_values: mx.array) -> Tuple[mx.array, ...]:
+        c_features = self.backbone(pixel_values)
+        proj = tuple(p(c) for p, c in zip(self.encoder_input_proj, c_features))
+        return self.hybrid_encoder(proj)
+
+    @staticmethod
+    def sanitize(weights: Dict[str, mx.array]) -> Dict[str, mx.array]:
+        return weights
+
+
+# ─── helpers ───
+
+
+def _upsample_nearest_2x(x: mx.array) -> mx.array:
+    """Nearest-neighbour 2x upsample of an NHWC tensor along H,W."""
+    B, H, W, C = x.shape
+    x = mx.broadcast_to(x[:, :, None, :, None, :], (B, H, 2, W, 2, C))
+    return x.reshape(B, H * 2, W * 2, C)
+
+
+def _resolve_activation(name: Optional[str]):
+    if name is None:
+        return None
+    if name == "relu":
+        return nn.ReLU()
+    if name == "silu":
+        return nn.SiLU()
+    if name == "gelu":
+        return nn.GELU()
+    raise ValueError(f"Unsupported activation: {name}")
+
+
+class _Identity(nn.Module):
+    def __call__(self, x: mx.array) -> mx.array:
+        return x

--- a/mlx_vlm/models/rt_detr_v2/vision.py
+++ b/mlx_vlm/models/rt_detr_v2/vision.py
@@ -452,7 +452,8 @@ class EncoderLayer(nn.Module):
         self.fc2 = nn.Linear(config.encoder_ffn_dim, d)
         self.final_layer_norm = nn.LayerNorm(d, eps=config.layer_norm_eps)
         activation = _resolve_activation(config.encoder_activation_function)
-        assert activation is not None, "encoder_activation_function must be set"
+        if activation is None:
+            raise ValueError("encoder_activation_function must be set")
         self.activation = activation
 
     def __call__(self, x: mx.array, pos_embed: Optional[mx.array]) -> mx.array:
@@ -646,15 +647,23 @@ class EncoderInputProj(nn.Module):
 # ─── Vision tower ───
 
 
-class VisionModel(nn.Module):
-    """Backbone -> per-level input projection -> hybrid encoder."""
+class VisionTower(nn.Module):
+    """Backbone -> per-level input projection -> hybrid encoder.
+
+    This is the real vision module; `VisionModel` below is the framework
+    stub that mlx-vlm's loader looks up by name.
+    """
 
     def __init__(self, config: ModelConfig) -> None:
         super().__init__()
         self.config = config
         # `ModelConfig.__post_init__` resolves backbone_config into a
         # `RTDetrResNetConfig` regardless of how it was passed in.
-        assert isinstance(config.backbone_config, RTDetrResNetConfig)
+        if not isinstance(config.backbone_config, RTDetrResNetConfig):
+            raise TypeError(
+                "config.backbone_config must be RTDetrResNetConfig after "
+                f"ModelConfig.__post_init__, got {type(config.backbone_config).__name__}"
+            )
         self.backbone = Backbone(config.backbone_config)
         self.encoder_input_proj = [
             EncoderInputProj(in_c, config.encoder_hidden_dim, eps=config.batch_norm_eps)
@@ -666,6 +675,23 @@ class VisionModel(nn.Module):
         c_features = self.backbone(pixel_values)
         proj = tuple(p(c) for p, c in zip(self.encoder_input_proj, c_features))
         return self.hybrid_encoder(proj)
+
+
+class VisionModel(nn.Module):
+    """Framework-compatibility stub.
+
+    mlx-vlm's loader (`mlx_vlm.utils.load_model`) instantiates
+    `model_class.VisionModel(model_config.vision_config)` purely to call
+    its `sanitize` method. The real vision module lives at
+    `Model.vision` (a `VisionTower`); weight sanitization is handled by
+    `Model.sanitize` so this stub is a no-op.
+    """
+
+    def __init__(self, config=None) -> None:
+        super().__init__()
+
+    def __call__(self, *args, **kwargs):
+        return None
 
     @staticmethod
     def sanitize(weights: Dict[str, mx.array]) -> Dict[str, mx.array]:

--- a/mlx_vlm/tests/test_models.py
+++ b/mlx_vlm/tests/test_models.py
@@ -6303,5 +6303,125 @@ class TestSam3(unittest.TestCase):
         self.assertEqual(sin.shape, (64, 64))
 
 
+class TestRTDetrV2(unittest.TestCase):
+    def test_config_from_dict(self):
+        """Flat HF config dict resolves into nested sub-configs."""
+        from mlx_vlm.models.rt_detr_v2 import ModelConfig, RTDetrResNetConfig
+
+        hf_like = {
+            "model_type": "rt_detr_v2",
+            "image_size": 64,
+            "num_labels": 10,
+            "backbone_config": {
+                "model_type": "rt_detr_resnet",
+                "depths": [1, 1, 2, 1],
+                "hidden_sizes": [10, 20, 30, 40],
+            },
+            "encoder_hidden_dim": 32,
+            "encoder_in_channels": [20, 30, 40],
+            "encoder_attention_heads": 2,
+            "encoder_ffn_dim": 64,
+            "d_model": 32,
+            "num_queries": 30,
+            "decoder_layers": 2,
+            "decoder_attention_heads": 2,
+            "decoder_ffn_dim": 64,
+            "decoder_in_channels": [32, 32, 32],
+        }
+        cfg = ModelConfig.from_dict(hf_like)
+        self.assertEqual(cfg.model_type, "rt_detr_v2")
+        self.assertEqual(cfg.num_labels, 10)
+        self.assertIsInstance(cfg.backbone_config, RTDetrResNetConfig)
+        self.assertEqual(cfg.backbone_config.depths, [1, 1, 2, 1])
+        # __post_init__ rebuilds the sub-configs from flat fields
+        self.assertEqual(cfg._hybrid_encoder_config.encoder_hidden_dim, 32)
+        self.assertEqual(cfg._transformer_config.d_model, 32)
+        self.assertEqual(cfg._transformer_config.num_queries, 30)
+        self.assertEqual(cfg._transformer_config.num_labels, 10)
+        # framework-compat hooks
+        self.assertIsNone(cfg.text_config)
+        self.assertIsNone(cfg.vision_config)
+
+    def test_forward_shapes(self):
+        """End-to-end forward on a tiny config returns the documented shapes."""
+        from mlx_vlm.models.rt_detr_v2 import Model, ModelConfig
+
+        cfg = ModelConfig.from_dict(
+            {
+                "model_type": "rt_detr_v2",
+                "image_size": 64,
+                "num_labels": 10,
+                "backbone_config": {
+                    "model_type": "rt_detr_resnet",
+                    "depths": [1, 1, 2, 1],
+                    "hidden_sizes": [10, 20, 30, 40],
+                },
+                "encoder_hidden_dim": 32,
+                "encoder_in_channels": [20, 30, 40],
+                "encoder_attention_heads": 2,
+                "encoder_ffn_dim": 64,
+                "d_model": 32,
+                "num_queries": 30,
+                "decoder_layers": 2,
+                "decoder_attention_heads": 2,
+                "decoder_ffn_dim": 64,
+                "decoder_in_channels": [32, 32, 32],
+            }
+        )
+        model = Model(cfg)
+        model.eval()
+
+        pixel = mx.random.normal((2, 64, 64, 3))
+        out = model(pixel)
+        mx.eval(out["pred_logits"], out["pred_boxes"])
+
+        self.assertEqual(out["pred_logits"].shape, (2, 30, 10))
+        self.assertEqual(out["pred_boxes"].shape, (2, 30, 4))
+        # intermediate trajectories cover all decoder layers
+        self.assertEqual(out["intermediate_logits"].shape, (2, 2, 30, 10))
+        self.assertEqual(out["intermediate_reference_points"].shape, (2, 2, 30, 4))
+
+    def test_sanitize_renames_and_transposes(self):
+        """`Model.sanitize` rewrites HF keys and transposes NCHW conv weights."""
+        from mlx_vlm.models.rt_detr_v2 import Model
+
+        raw = {
+            # NCHW conv weight under the HF backbone prefix -> NHWC under
+            # vision.backbone after sanitize
+            "model.backbone.model.embedder.embedder.0.convolution.weight": mx.zeros(
+                (8, 3, 7, 7)
+            ),
+            # encoder body: `normalization` -> `bn`
+            "model.encoder.0.normalization.weight": mx.ones((16,)),
+            # vd downsampling shortcut: Sequential index 1 -> proj
+            "model.backbone.model.encoder.stages.1.layers.0.shortcut.1.convolution.weight": mx.zeros(
+                (16, 8, 1, 1)
+            ),
+            # num_batches_tracked must be dropped
+            "model.backbone.model.embedder.embedder.0.normalization.num_batches_tracked": mx.array(
+                0
+            ),
+        }
+        sanitized = Model.sanitize(raw)
+
+        self.assertNotIn(
+            "model.backbone.model.embedder.embedder.0.normalization.num_batches_tracked",
+            sanitized,
+        )
+        self.assertIn("vision.backbone.embedder.embedder.0.conv.weight", sanitized)
+        # NCHW (8, 3, 7, 7) -> NHWC (8, 7, 7, 3)
+        self.assertEqual(
+            sanitized["vision.backbone.embedder.embedder.0.conv.weight"].shape,
+            (8, 7, 7, 3),
+        )
+        # `.normalization.` rename under the encoder body
+        self.assertIn("vision.hybrid_encoder.0.bn.weight", sanitized)
+        # vd shortcut Sequential[1] -> proj
+        self.assertIn(
+            "vision.backbone.encoder.stages.1.layers.0.shortcut.proj.conv.weight",
+            sanitized,
+        )
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

MLX port of RT-DETRv2 object detection. Loads any HuggingFace `RTDetrV2ForObjectDetection` checkpoint (ResNet-50-vd or ResNet-101-vd backbone).

Validated end-to-end against `transformers.RTDetrV2ForObjectDetection`: max abs error ~2e-5 on logits, sub-pixel on bboxes for real document inputs.

## Pre-converted checkpoints

- [`mlx-community/docling-layout-heron-mlx-bf16`](https://huggingface.co/mlx-community/docling-layout-heron-mlx-bf16) — ResNet-50-vd, 86 MB
- [`mlx-community/docling-layout-heron-101-mlx-bf16`](https://huggingface.co/mlx-community/docling-layout-heron-101-mlx-bf16) — ResNet-101-vd, 154 MB

See `mlx_vlm/models/rt_detr_v2/README.md` for a copy-paste-runnable example.

## What's added

- `mlx_vlm/models/rt_detr_v2/`: backbone + hybrid encoder (AIFI + FPN + PAN) + deformable-attention decoder
- `convert.py`: HF → MLX checkpoint converter (verifies via `mlx_vlm.utils.load_model` before returning)
- `RTDetrV2Processor` auto-registered with `transformers.AutoProcessor` via `install_auto_processor_patch`
- `RTDetrV2Predictor` returning `DetectionResult` (same schema as `mlx_vlm.models.rfdetr.generate.DetectionResult`)