### PR TITLE
Decode OpenAI input_audio base64 in chat completions

### DIFF
--- a/mlx_vlm/server.py
+++ b/mlx_vlm/server.py
@@ -1,5 +1,7 @@
 import argparse
 import asyncio
+import base64
+import binascii
 import gc
 import json
 import logging
@@ -12,6 +14,7 @@ from collections import deque
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from datetime import datetime
+from io import BytesIO
 from queue import Empty as QueueEmpty
 from queue import Queue
 from threading import Event, Lock, Thread
@@ -68,6 +71,8 @@ DEFAULT_SPECULATIVE_BATCH_COALESCE_MS = 5.0
 DEFAULT_ENABLE_THINKING = False
 METRICS_HISTORY_LIMIT = 100
 METRICS_RECENT_LIMIT = 32
+_AUDIO_REFERENCE_PREFIXES = ("http://", "https://", "file://", "/", "./", "../")
+_AUDIO_REFERENCE_SUFFIXES = (".wav", ".mp3", ".flac", ".ogg", ".m4a", ".aac", ".webm")
 
 
 class PromptTooLongError(ValueError):
@@ -1735,6 +1740,43 @@ class ResponseInputAudioParam(TypedDict, total=False):
     input_audio: Required[InputAudio]
 
 
+def _looks_like_audio_reference(value: str) -> bool:
+    return value.startswith(_AUDIO_REFERENCE_PREFIXES) or value.lower().endswith(
+        _AUDIO_REFERENCE_SUFFIXES
+    )
+
+
+def _decode_input_audio_data(input_audio: InputAudio):
+    data = input_audio["data"]
+    if not isinstance(data, str):
+        return data
+
+    stripped = data.strip()
+    if stripped.startswith("data:"):
+        prefix, separator, encoded = stripped.partition(",")
+        if (
+            separator == ","
+            and ";base64" in prefix
+            and prefix.startswith("data:audio/")
+        ):
+            try:
+                return BytesIO(base64.b64decode(encoded, validate=True))
+            except (binascii.Error, ValueError) as exc:
+                raise HTTPException(
+                    status_code=400,
+                    detail="input_audio data URI is not valid base64 audio",
+                ) from exc
+        return data
+
+    if _looks_like_audio_reference(stripped):
+        return data
+
+    try:
+        return BytesIO(base64.b64decode(stripped, validate=True))
+    except (binascii.Error, ValueError):
+        return data
+
+
 class ImageUrl(TypedDict, total=False):
     url: Required[str]
 
@@ -2808,7 +2850,7 @@ async def chat_completions_endpoint(request: ChatRequest, http_request: Request)
                         elif item_type == "image_url":
                             images.append(item["image_url"]["url"])
                         elif item_type == "input_audio":
-                            audio.append(item["input_audio"]["data"])
+                            audio.append(_decode_input_audio_data(item["input_audio"]))
                 msg["content"] = extract_text_from_content(message.content)
             else:
                 msg["content"] = message.content

--- a/mlx_vlm/tests/test_server.py
+++ b/mlx_vlm/tests/test_server.py
@@ -1,3 +1,4 @@
+import base64
 import time
 from queue import Queue
 from threading import Event, Lock, Thread
@@ -655,6 +656,120 @@ def test_chat_completions_streaming_forwards_explicit_sampling_args(
     assert captured["args"].min_p == 0.08
     assert captured["args"].repetition_penalty == 1.15
     assert captured["args"].logit_bias == {12: -1.5}
+
+
+@pytest.mark.parametrize(
+    "audio_data_factory",
+    [
+        lambda raw: base64.b64encode(raw).decode("ascii"),
+        lambda raw: f"data:audio/wav;base64,{base64.b64encode(raw).decode('ascii')}",
+    ],
+)
+def test_chat_completions_decodes_input_audio_base64(client, audio_data_factory):
+    raw_audio = b"RIFF$\x00\x00\x00WAVEfmt "
+    captured = {}
+
+    def fake_generate(prompt, images=None, audio=None, **kwargs):
+        captured["audio"] = audio
+        return SimpleNamespace(
+            text="audio ok",
+            prompt_tokens=8,
+            generation_tokens=4,
+            total_tokens=12,
+            prompt_tps=10.0,
+            generation_tps=5.0,
+            peak_memory=0.1,
+        )
+
+    with (
+        patch.object(
+            server,
+            "get_cached_model",
+            return_value=(
+                SimpleNamespace(),
+                SimpleNamespace(),
+                SimpleNamespace(model_type="qwen2_vl"),
+            ),
+        ),
+        patch.object(server, "apply_chat_template", return_value="prompt"),
+        patch.object(server, "generate", side_effect=fake_generate),
+    ):
+        response = client.post(
+            "/chat/completions",
+            json={
+                "model": "demo",
+                "messages": [
+                    {
+                        "role": "user",
+                        "content": [
+                            {"type": "text", "text": "Describe the audio."},
+                            {
+                                "type": "input_audio",
+                                "input_audio": {
+                                    "data": audio_data_factory(raw_audio),
+                                    "format": "wav",
+                                },
+                            },
+                        ],
+                    }
+                ],
+            },
+        )
+
+    assert response.status_code == 200
+    assert captured["audio"][0].getvalue() == raw_audio
+
+
+def test_chat_completions_preserves_input_audio_references(client):
+    audio_path = "/tmp/audio.wav"
+    captured = {}
+
+    def fake_generate(prompt, images=None, audio=None, **kwargs):
+        captured["audio"] = audio
+        return SimpleNamespace(
+            text="audio ok",
+            prompt_tokens=8,
+            generation_tokens=4,
+            total_tokens=12,
+            prompt_tps=10.0,
+            generation_tps=5.0,
+            peak_memory=0.1,
+        )
+
+    with (
+        patch.object(
+            server,
+            "get_cached_model",
+            return_value=(
+                SimpleNamespace(),
+                SimpleNamespace(),
+                SimpleNamespace(model_type="qwen2_vl"),
+            ),
+        ),
+        patch.object(server, "apply_chat_template", return_value="prompt"),
+        patch.object(server, "generate", side_effect=fake_generate),
+    ):
+        response = client.post(
+            "/chat/completions",
+            json={
+                "model": "demo",
+                "messages": [
+                    {
+                        "role": "user",
+                        "content": [
+                            {"type": "text", "text": "Describe the audio."},
+                            {
+                                "type": "input_audio",
+                                "input_audio": {"data": audio_path, "format": "wav"},
+                            },
+                        ],
+                    }
+                ],
+            },
+        )
+
+    assert response.status_code == 200
+    assert captured["audio"] == [audio_path]
 
 
 def test_chat_completions_endpoint_flattens_text_content_parts(client):


### PR DESCRIPTION
## Summary

Fix `/v1/chat/completions` handling for OpenAI-style `input_audio` content blocks by decoding base64 audio data before it is passed to the audio loader.

The current server extracts `input_audio["data"]` and forwards that string as the audio input. For OpenAI-compatible requests this field is commonly base64-encoded audio bytes, so the loader treats the base64 string as a path-like audio reference and fails with an unsupported file format error. This PR decodes bare base64 and `data:audio/...;base64,...` values into `BytesIO` objects while preserving existing URL/path references.

## Background

Atlas RAN-474 Phase 1 captured a decoder reproduction in `docs/dev/current/ran-474/evidence/decoder-reproduction.md`: the same WAV bytes load successfully when passed as a filesystem path, but fail when the base64 string is passed through the server path as though it were a file path/URL.

## Tests

```bash
uv run --with pytest --with fastapi --with httpx --with mlx --with huggingface_hub --with pydantic --with typing_extensions --with numpy --with uvicorn pytest mlx_vlm/tests/test_server.py::test_chat_completions_decodes_input_audio_base64 mlx_vlm/tests/test_server.py::test_chat_completions_preserves_input_audio_references -q
```

Result: `3 passed, 2 warnings`.

```bash
uv run python -m py_compile mlx_vlm/server.py mlx_vlm/tests/test_server.py
```

Result: passed.
