### PR TITLE
Fix MiniCPM-V 4.6 prefill crash in qwen3_5 get_rope_index

### DIFF
--- a/mlx_vlm/models/qwen3_5/language.py
+++ b/mlx_vlm/models/qwen3_5/language.py
@@ -662,14 +662,24 @@ class LanguageModel(nn.Module):
         batch_size, seq_length = input_ids.shape
         position_ids = mx.arange(seq_length, dtype=mx.int32)
         position_ids = mx.broadcast_to(position_ids[None, :], (batch_size, seq_length))
-        spatial_merge_size = self.config.vision_config.spatial_merge_size
-        image_token_id = self.config.image_token_id
-        video_token_id = self.config.video_token_id
-        vision_start_token_id = self.config.vision_start_token_id
         mrope_position_deltas = []
         if input_ids is not None and (
             image_grid_thw is not None or video_grid_thw is not None
         ):
+            # All four config reads below are Qwen3.5-VL-specific:
+            # ``spatial_merge_size`` lives on ``vision_config`` (Siglip +
+            # spatial merger), and ``image_token_id`` / ``video_token_id`` /
+            # ``vision_start_token_id`` are Qwen3.5-VL's vision-marker token
+            # ids. VLMs that reuse the qwen3_5 text backbone with a different
+            # vision encoder (e.g. MiniCPM-V 4.6's perceiver resampler) inject
+            # features via ``inputs_embeds`` and never pass ``image_grid_thw``
+            # / ``video_grid_thw``, so they land in the else branch below and
+            # never need any of these values. Reading them at function entry
+            # raises AttributeError on those configs.
+            spatial_merge_size = self.config.vision_config.spatial_merge_size
+            image_token_id = self.config.image_token_id
+            video_token_id = self.config.video_token_id
+            vision_start_token_id = self.config.vision_start_token_id
             total_input_ids = input_ids
             if attention_mask is None:
                 attention_mask = mx.ones_like(input_ids)


### PR DESCRIPTION

## Summary

MiniCPM-V 4.6 crashes on every prefill, including text-only prompts. `get_rope_index` in `mlx_vlm/models/qwen3_5/language.py` reads four Qwen3.5-VL-specific config values up front but uses them only inside the image/video branch. Any VLM that reuses the qwen3_5 text backbone with a different vision encoder — MiniCPM-V 4.6, added in #1058 — hits `AttributeError` before the branch runs. Moving the reads inside the branch fixes the crash and leaves Qwen3.5-VL behavior unchanged.

## Reproduction

```bash
mlx_vlm.generate \
  --model mlx-community/MiniCPM-V-4.6-8bit \
  --prompt "hi" \
  --max-tokens 10
```

Crash:

```
File "mlx_vlm/models/qwen3_5/language.py", line 665, in get_rope_index
    spatial_merge_size = self.config.vision_config.spatial_merge_size
AttributeError: 'VisionConfig' object has no attribute 'spatial_merge_size'
```

The call path is `__call__` → `get_rope_index`. MiniCPM-V 4.6's text backbone is Qwen3.5-text (`text_config.model_type: qwen3_5_text`), so mlx-vlm correctly routes it to this file. Its vision_config is a perceiver resampler and lacks `spatial_merge_size`; its text_config lacks all three Qwen3.5-VL vision-marker token ids.

## Root cause

`get_rope_index` (line 655) reads four values up front:

```python
spatial_merge_size = self.config.vision_config.spatial_merge_size
image_token_id = self.config.image_token_id
video_token_id = self.config.video_token_id
vision_start_token_id = self.config.vision_start_token_id
```

The `if image_grid_thw is not None or video_grid_thw is not None` branch (image-token interleaving + grid-spatial merging) uses all four; the else branch — text-only / no-grid — touches none of them.

MiniCPM-V 4.6 calls `self.language_model(input_ids, inputs_embeds=…, mask=…, cache=…)` (`mlx_vlm/models/minicpmv4_6/minicpmv4_6.py:421`), injects vision features through `inputs_embeds`, and never passes `image_grid_thw` / `video_grid_thw`. `get_rope_index` therefore always takes the else branch — but the four reads at the top run before the branch decision and crash.

## Fix

Move the four reads inside the image/video branch that uses them. One-line move per read; Qwen3.5-VL behavior unchanged.

Abbreviated diff (commit also adds a short comment explaining the move):

```diff
         batch_size, seq_length = input_ids.shape
         position_ids = mx.arange(seq_length, dtype=mx.int32)
         position_ids = mx.broadcast_to(position_ids[None, :], (batch_size, seq_length))
-        spatial_merge_size = self.config.vision_config.spatial_merge_size
-        image_token_id = self.config.image_token_id
-        video_token_id = self.config.video_token_id
-        vision_start_token_id = self.config.vision_start_token_id
         mrope_position_deltas = []
         if input_ids is not None and (
             image_grid_thw is not None or video_grid_thw is not None
         ):
+            spatial_merge_size = self.config.vision_config.spatial_merge_size
+            image_token_id = self.config.image_token_id
+            video_token_id = self.config.video_token_id
+            vision_start_token_id = self.config.vision_start_token_id
             total_input_ids = input_ids
```

## Verification

Tested end-to-end against `mlx-community/MiniCPM-V-4.6-8bit` from a downstream serving application running an mlx-vlm install with this patch:

- Text-only chat (`"Say hi in 5 words."` → `"Good morning, how's it going?"`) — returns a coherent reply in 0.5 s; previously crashed.
- Image prompt against a UI settings screenshot — model reads back specific values (model alias, context-window size, temperature, top-p) in ~1.1 s. Grounding intact.

Qwen3.5-VL multimodal requests behave identically: when `image_grid_thw` / `video_grid_thw` are passed, the same branch reads the same values. Text-only Qwen3.5-VL requests now skip the four unused reads — a small win, not a regression.

## Scope and risk

- Files: `mlx_vlm/models/qwen3_5/language.py` (+14 / −4 in `get_rope_index`).
- Risk: minimal. Pure code motion — same reads, same values, same usage sites; only the read point moves inside the branch that uses them.
- No public API change; no schema change; no new dependencies.

## Related work

- `#1058` — Add MiniCPM-V 4.6 support. Added the `minicpmv4_6/` family handler but delegated language to `qwen3_5/language.py`; this PR closes the unguarded coupling that change exposed.
- `#1135` — Refactor MRoPE handling. Touches `get_rope_index` call sites but not the function body; no overlap with this PR.
