### PR TITLE
Add config_overrides kwarg to load() and load_model()

### DIFF
--- a/mlx_vlm/models/gemma4/config.py
+++ b/mlx_vlm/models/gemma4/config.py
@@ -54,6 +54,20 @@ class VisionConfig(BaseModelConfig):
             self.layer_types = ["full_attention"] * self.num_hidden_layers
         if self.rope_parameters is None:
             self.rope_parameters = {"rope_theta": 100.0, "rope_type": "default"}
+        # Image-token budget capacity check: the vision tower derives
+        # ``max_patches = default_output_length * pooling_kernel_size ** 2`` at
+        # construction, and the patch-position embedding table is sized to
+        # ``position_embedding_size``. Reject overrides that would request more
+        # patches than the position table can index.
+        requested_patches = self.default_output_length * self.pooling_kernel_size**2
+        if requested_patches > self.position_embedding_size:
+            max_supported = self.position_embedding_size // self.pooling_kernel_size**2
+            raise ValueError(
+                f"default_output_length={self.default_output_length} requires "
+                f"{requested_patches} patches but position_embedding_size only "
+                f"supports {self.position_embedding_size}. Reduce "
+                f"default_output_length to <= {max_supported}."
+            )
 
 
 @dataclass

--- a/mlx_vlm/tests/test_loader_config_overrides.py
+++ b/mlx_vlm/tests/test_loader_config_overrides.py
@@ -1,0 +1,121 @@
+"""Tests for the loader-side config_overrides mechanism and post-load
+processor↔model sync (Gemma 4 image-token budget plumbing)."""
+
+import logging
+from types import SimpleNamespace
+from unittest import TestCase
+
+from mlx_vlm.models.gemma4.config import VisionConfig
+from mlx_vlm.utils import _deep_merge, _sync_processor_to_model_config
+
+# ---------------------------------------------------------------------------
+# _deep_merge — pure function tests
+# ---------------------------------------------------------------------------
+
+
+class DeepMergeTests(TestCase):
+    def test_adds_missing_keys(self):
+        base = {}
+        _deep_merge(base, {"a": 1})
+        self.assertEqual(base, {"a": 1})
+
+    def test_nested_dicts_recurse_and_preserve_siblings(self):
+        # Critical for the vision_config shape: overriding default_output_length
+        # must not clobber position_embedding_size / patch_size / etc.
+        base = {"vision_config": {"default_output_length": 280, "patch_size": 16}}
+        _deep_merge(base, {"vision_config": {"default_output_length": 1120}})
+        self.assertEqual(
+            base,
+            {"vision_config": {"default_output_length": 1120, "patch_size": 16}},
+        )
+
+    def test_non_dict_values_replace_wholesale(self):
+        # Lists replace (intentional for fields like layer_types).
+        base = {"layer_types": ["full_attention", "full_attention", "full_attention"]}
+        _deep_merge(base, {"layer_types": ["sliding_window"]})
+        self.assertEqual(base, {"layer_types": ["sliding_window"]})
+
+
+# ---------------------------------------------------------------------------
+# VisionConfig — capacity validation in __post_init__
+# ---------------------------------------------------------------------------
+
+
+class VisionConfigCapacityTests(TestCase):
+    def test_default_passes(self):
+        # 280 * 3**2 = 2520 patches; position_embedding_size = 10240. OK.
+        VisionConfig()
+
+    def test_max_supported_passes(self):
+        # 1120 * 3**2 = 10080 <= 10240. The maximum Gemma 4 documented budget.
+        VisionConfig(default_output_length=1120)
+
+    def test_overflow_raises(self):
+        # 2000 * 3**2 = 18000 > 10240.
+        with self.assertRaises(ValueError) as cm:
+            VisionConfig(default_output_length=2000)
+        msg = str(cm.exception)
+        self.assertIn("position_embedding_size", msg)
+        self.assertIn("default_output_length", msg)
+
+
+# ---------------------------------------------------------------------------
+# _sync_processor_to_model_config — SimpleNamespace mocks (no real model load)
+# ---------------------------------------------------------------------------
+
+
+def _make_model_and_processor(model_budget, processor_budget):
+    model = SimpleNamespace(
+        config=SimpleNamespace(
+            vision_config=SimpleNamespace(default_output_length=model_budget),
+        ),
+    )
+    processor = SimpleNamespace(
+        image_processor=SimpleNamespace(max_soft_tokens=processor_budget),
+    )
+    return model, processor
+
+
+class SyncProcessorToModelConfigTests(TestCase):
+    def test_overwrites_processor_when_model_differs(self):
+        model, processor = _make_model_and_processor(
+            model_budget=1120, processor_budget=280
+        )
+        with self.assertLogs("mlx_vlm.utils", level=logging.WARNING) as cm:
+            _sync_processor_to_model_config(model, processor)
+        self.assertEqual(processor.image_processor.max_soft_tokens, 1120)
+        self.assertTrue(
+            any("280" in line and "1120" in line for line in cm.output),
+            f"expected before/after values in warning, got: {cm.output}",
+        )
+
+    def test_no_op_when_already_synced(self):
+        model, processor = _make_model_and_processor(
+            model_budget=1120, processor_budget=1120
+        )
+        logger = logging.getLogger("mlx_vlm.utils")
+        with self.assertNoLogs("mlx_vlm.utils", level=logging.WARNING):
+            _sync_processor_to_model_config(model, processor)
+        self.assertEqual(processor.image_processor.max_soft_tokens, 1120)
+
+    def test_no_op_for_processor_without_max_soft_tokens(self):
+        # Non-Gemma-shape processor (e.g., Qwen3-VL): image_processor has no
+        # ``max_soft_tokens`` attribute. The sync helper must be a no-op.
+        model = SimpleNamespace(
+            config=SimpleNamespace(
+                vision_config=SimpleNamespace(default_output_length=1120),
+            ),
+        )
+        processor = SimpleNamespace(image_processor=SimpleNamespace())
+        # Should not raise; should not add the attribute.
+        _sync_processor_to_model_config(model, processor)
+        self.assertFalse(hasattr(processor.image_processor, "max_soft_tokens"))
+
+    def test_no_op_for_model_without_vision_config(self):
+        # Text-only model (no vision_config on its config). No-op, no exception.
+        model = SimpleNamespace(config=SimpleNamespace())
+        processor = SimpleNamespace(
+            image_processor=SimpleNamespace(max_soft_tokens=280)
+        )
+        _sync_processor_to_model_config(model, processor)
+        self.assertEqual(processor.image_processor.max_soft_tokens, 280)

--- a/mlx_vlm/utils.py
+++ b/mlx_vlm/utils.py
@@ -20,6 +20,8 @@ from PIL import Image, ImageOps
 from transformers import AutoProcessor
 from transformers.processing_utils import ProcessorMixin
 
+_logger = logging.getLogger(__name__)
+
 from .models.base import BaseImageProcessor
 from .tokenizer_utils import load_tokenizer
 from .trainer.utils import apply_lora_layers
@@ -191,7 +193,71 @@ def get_model_path(
     return model_path
 
 
-def load_model(model_path: Path, lazy: bool = False, **kwargs) -> nn.Module:
+def _deep_merge(base: dict, overrides: dict) -> None:
+    """Recursively merge ``overrides`` into ``base`` in place.
+
+    Nested dicts are merged key-by-key; non-dict values replace. Lists replace
+    wholesale (intentional for config fields like ``layer_types``). The caller
+    owns ``base``; ``overrides`` is not mutated.
+    """
+    for key, value in overrides.items():
+        if isinstance(value, dict) and isinstance(base.get(key), dict):
+            _deep_merge(base[key], value)
+        else:
+            base[key] = value
+
+
+def _sync_processor_to_model_config(model: nn.Module, processor) -> None:
+    """Sync processor image-token budget to the model's vision config.
+
+    Some VLMs (Gemma 4 is the only example in mlx-vlm 0.5.0) store the image
+    token budget in both the vision config (model side, drives
+    ``VisionModel.max_patches`` at construction) and the preprocessor config
+    (processor side, drives ``Gemma4ImageProcessor``'s resize math). When these
+    disagree:
+
+    * processor > model: the processor emits more soft tokens than the vision
+      tower can absorb, causing a shape mismatch or silent truncation.
+    * processor < model: the model carries unused vision capacity (safe, but
+      wasteful).
+
+    Making the model side the source of truth fixes both directions. This
+    helper is defensive: a no-op when the processor does not expose
+    ``max_soft_tokens`` (i.e. every non-Gemma4 processor in the repo today) and
+    a no-op when the values already agree.
+
+    The helper deliberately does NOT also write ``processor.image_seq_length``.
+    The image-bearing path uses dynamic ``num_soft_tokens`` from the
+    processor's per-image return; the only consumer of the precomputed
+    ``Gemma4Processor.full_image_sequence`` is the no-image text fallback,
+    which remains internally consistent at construction time.
+    """
+    vision_config = getattr(getattr(model, "config", None), "vision_config", None)
+    image_processor = getattr(processor, "image_processor", None)
+    if vision_config is None or image_processor is None:
+        return
+
+    budget = getattr(vision_config, "default_output_length", None)
+    if budget is None or not hasattr(image_processor, "max_soft_tokens"):
+        return
+
+    current = image_processor.max_soft_tokens
+    if current != budget:
+        _logger.warning(
+            "Syncing processor image-token budget %d -> %d to match model "
+            "vision_config.default_output_length",
+            current,
+            budget,
+        )
+        image_processor.max_soft_tokens = budget
+
+
+def load_model(
+    model_path: Path,
+    lazy: bool = False,
+    config_overrides: Optional[dict] = None,
+    **kwargs,
+) -> nn.Module:
     """
     Load and initialize the model from a given path.
 
@@ -214,6 +280,8 @@ def load_model(model_path: Path, lazy: bool = False, **kwargs) -> nn.Module:
         ValueError: If the model class or args class are not found or cannot be instantiated.
     """
     config = load_config(model_path, **kwargs)
+    if config_overrides:
+        _deep_merge(config, config_overrides)
 
     # Find all .safetensors files in the model_path, excluding consolidated model weights
     weight_files = [
@@ -410,6 +478,7 @@ def load(
     lazy: bool = False,
     revision: Optional[str] = None,
     strict: bool = True,
+    config_overrides: Optional[dict] = None,
     **kwargs,
 ) -> Tuple[nn.Module, ProcessorMixin]:
     """
@@ -428,6 +497,16 @@ def load(
             a tag, or a commit hash. Default: ``None``.
         strict (bool): Whether or not to raise an exception if weights don't
             match. Default: ``True``.
+        config_overrides (dict, optional): Nested dict of values to deep-merge
+            into the model config before construction. Useful for tuning
+            per-model knobs at load time without editing the on-disk config.
+            For example, to raise Gemma 4's image-token budget for OCR/document
+            workloads::
+
+                load(model_id, config_overrides={"vision_config":
+                    {"default_output_length": 1120}})
+
+            Default: ``None`` (no override).
         quantize_activations (bool, optional): If True, convert QuantizedLinear layers
             to QQLinear layers for activation quantization. Only supported for models
             quantized with 'nvfp4' or 'mxfp8' modes. Default: ``False``.
@@ -443,7 +522,9 @@ def load(
     model_path = get_model_path(
         path_or_hf_repo, force_download=force_download, revision=revision
     )
-    model = load_model(model_path, lazy, strict=strict, **kwargs)
+    model = load_model(
+        model_path, lazy, strict=strict, config_overrides=config_overrides, **kwargs
+    )
     if adapter_path is not None:
         model = apply_lora_layers(model, adapter_path)
         model.eval()
@@ -457,6 +538,8 @@ def load(
 
     if image_processor is not None:
         processor.image_processor = image_processor
+
+    _sync_processor_to_model_config(model, processor)
 
     return model, processor
 


### PR DESCRIPTION
## What this fixes

Gemma 4 stores its image token budget in two places that must agree:

- **Model side** — `vision_config.default_output_length` in the on-disk config, used by `VisionModel.__init__` to derive `max_patches` and by `VisionPooler` to set `default_output_length`, both **at construction time** (`mlx_vlm/models/gemma4/vision.py:400–407`, `:335–340`).
- **Processor side** — `max_soft_tokens` on `Gemma4ImageProcessor`, controlling the aspect-ratio-preserving resize math (`mlx_vlm/models/gemma4/processing_gemma4.py:73`, `:149–155`). Persisted in `preprocessor_config.json::max_soft_tokens`; defaults to 280 if absent.

Today there is no public mechanism to override either of these at load time, and no synchronization step that catches a mismatch if a model card publishes them with different values. The cheatsheet workaround is to monkey-patch four attributes after `load()` (`processor.image_processor.max_soft_tokens`, `model.vision_tower.max_patches`, `model.vision_tower.default_output_length`, `model.vision_tower.pooler.default_output_length`), which is fragile across model versions and easy to forget.

## What this PR does

Three changes, all on the loader path:

1. **`load(..., config_overrides=...)` and `load_model(..., config_overrides=...)`** — a generic, model-agnostic kwarg that deep-merges into the loaded config dict before `ModelConfig.from_dict(...)`. All derived attributes (`vision_tower.max_patches`, `pooler.default_output_length`, ...) come out right at construction without post-hoc mutation.

2. **`_sync_processor_to_model_config(model, processor)`** — a post-load helper that makes the model-side vision config the source of truth for the processor's `max_soft_tokens`. Defensive: no-op when the processor doesn't expose `max_soft_tokens` (i.e. every non-Gemma processor today), no-op when values already agree, `logger.warning` when the helper does change a value. Closes the dual-storage gap for both `config_overrides` callers and any future model card that ships mismatched values.

3. **`VisionConfig.__post_init__` capacity validation** — fail fast on `default_output_length * pooling_kernel_size ** 2 > position_embedding_size` with a clear error pointing at the maximum supported value. Catches bad overrides before they reach the model and crash with a downstream broadcast-shape error.

After this PR, the four-attribute monkey-patch collapses to a single load call:

```python
model, processor = load(
    \"mlx-community/gemma-4-26b-a4b-it-8bit\",
    config_overrides={\"vision_config\": {\"default_output_length\": 1120}},
)
```

## Why a loader override (vs. fixing the `mlx-community/` model card configs)

The two are complementary, not substitutes:

- **Model card defaults** set a workload-neutral floor (280 is reasonable for general image-understanding workloads).
- **A loader override** lets callers tune for workload-specific OCR / document understanding without re-publishing model cards.

The processor / vision tower coupling is also genuinely a wrapper-side concern: model cards can't enforce that processor + vision tower stay in sync, but the loader can.

## Why this matters

At the default budget of 280 (≈803px-equivalent edge / 645K-pixel ceiling), a 3440×1440 source frame is compressed ~6.2× horizontally. Terminal text and document content become structurally illegible to the vision encoder, and the language head fabricates plausible specifics rather than declining cleanly. Bumping the budget to 1120 (~1610px-equivalent edge / 2.6M-pixel ceiling, fully supported by Gemma 4's `position_embedding_size=10240`) drops compression to ~2.1× and restores faithful extraction.

Supporting evidence:

- **Google's vision-capabilities docs** (`ai.google.dev/gemma/docs/capabilities/vision`) recommend a higher budget for OCR / document understanding.
- **vLLM Gemma 4 recipe** (`docs.vllm.ai/projects/recipes/en/latest/Google/Gemma4.html`) exposes this knob. This PR brings mlx-vlm to parity with vLLM on the runtime control plane.
- **Local OCR validation** on `mlx-community/gemma-4-26b-a4b-it-8bit`: at the default budget=280, a 3440×1440 SoundCloud feed frame produced a hallucinated track listing (different artist + title than what was on screen); the same model at budget=1120 extracted the actual track lines, listening history, and playback timestamps verbatim.

Open ecosystem issues that share the same plumbing gap (mentioned for context only, not in scope here):

- ollama/ollama#15626 — license-plate OCR `YRSGNB` (wrong, budget=280) vs `YRSGNBY` (correct, budget=560).
- ggml-org/llama.cpp#21550 — `--image-min-tokens` / `--image-max-tokens` flags exist but server crashes near budget=1120 on large images.

Possibly related: #943 (4-bit Gemma 4 vision producing garbled output) — the same vision-budget-resize-ratio mechanism could be a contributor at the q4 quant, but I'm not claiming a fix without a dedicated repro.

## Scope

Intentionally Python API only. Enabling `config_overrides` from `generate.py`, `server.py`, and `chat.py` requires adding `--config-overrides` JSON flags plus argparse / request-schema handling, which is mechanically distinct and best done as a follow-up PR with its own tests. **`--processor-kwargs` is deliberately not extended** to cover the image budget: per-call processor kwargs would let the processor emit more soft tokens than the construction-locked vision tower can absorb. The safe shape for budget changes is load-time only.

The vLLM-style per-call budget variation would require runtime plumbing through `VisionModel.__call__` (padding-mask sizing, pooler output-length forwarding) and significant interaction with the vision cache and batch merging paths. Also deferred.

## Tests

10 new unit tests in `mlx_vlm/tests/test_loader_config_overrides.py`, all pure construction / mock-based (no weight downloads):

- 3 × `_deep_merge` — adds missing keys, recurses on nested dicts without clobbering siblings, replaces non-dict values wholesale.
- 3 × `VisionConfig.__post_init__` — default config passes, `default_output_length=1120` (the documented max) passes, `default_output_length=2000` raises `ValueError` mentioning `position_embedding_size`.
- 4 × `_sync_processor_to_model_config` — overwrites and warns on mismatch, no-op + no warning when already synced, no-op for processors without `max_soft_tokens` (e.g. Qwen-shape), no-op for text-only models without a `vision_config`.

Full suite locally on a fresh checkout of this branch: **695 passed (685 upstream + 10 new), 1 skipped, 0 failed** via `python -m pytest mlx_vlm/tests/ --ignore=mlx_vlm/tests/test_smoke.py` (smoke needs `--model-path`). Pre-commit (black, isort, autoflake) all pass on the patched files.

Integration validation on `mlx-community/gemma-4-26b-a4b-it-4bit` (Apple Silicon M5 Pro):

- Phase 1 (baseline, no overrides): `vision_config.default_output_length=280`, `vision_tower.max_patches=2520`, `processor.image_processor.max_soft_tokens=280` — all consistent.
- Phase 2 (`config_overrides={\"vision_config\": {\"default_output_length\": 1120}}`): `vision_config.default_output_length=1120`, `vision_tower.max_patches=10080`, `pooler.default_output_length=1120`, `processor.image_processor.max_soft_tokens=1120` — all consistent, sync warning fires once on the processor delta.
- Phase 3 (`default_output_length=2000`): `ValueError: default_output_length=2000 requires 18000 patches but position_embedding_size only supports 10240. Reduce default_output_length to <= 1137.`

Happy to take feedback on the API shape — naming the kwarg `config_overrides` matches HF/transformers ecosystem patterns, but I'm open to `config_override` (singular) or splitting into `model_config_overrides` / `processor_overrides` if the maintainers prefer.