### PR TITLE
fix: handle array-valued offset in BatchQuantizedKVCache.make_mask

### DIFF
--- a/mlx_vlm/models/cache.py
+++ b/mlx_vlm/models/cache.py
@@ -387,7 +387,10 @@ class BatchQuantizedKVCache(_BaseCache):
     def make_mask(self, *args, **kwargs):
         from mlx_lm.models.cache import create_attention_mask
 
-        return create_attention_mask(*args, offset=self.offset, **kwargs)
+        offset = self.offset
+        if isinstance(offset, mx.array):
+            offset = int(offset.item()) if offset.ndim == 0 else int(offset[0])
+        return create_attention_mask(*args, offset=offset, **kwargs)
 
 
 def make_prompt_cache(

--- a/mlx_vlm/tests/test_batch_quantized_cache.py
+++ b/mlx_vlm/tests/test_batch_quantized_cache.py
@@ -232,5 +232,31 @@ class TestBatchGeneratorIntegration:
         assert gen.kv_bits is None
 
 
+class TestMakeMask:
+    def test_make_mask_with_scalar_array_offset(self):
+        cache = BatchQuantizedKVCache([0], group_size=GROUP_SIZE, bits=BITS)
+        k, v = _rand_kv(1, 5)
+        cache.update_and_fetch(k, v)
+        mx.eval(cache.offset)
+        mask = cache.make_mask(3, return_array=True, window_size=None)
+        assert mask is not None
+
+    def test_make_mask_with_1d_array_offset(self):
+        cache = BatchQuantizedKVCache([2, 0], group_size=GROUP_SIZE, bits=BITS)
+        k, v = _rand_kv(2, 5)
+        cache.update_and_fetch(k, v)
+        mx.eval(cache.offset)
+        mask = cache.make_mask(3, return_array=True, window_size=None)
+        assert mask is not None
+
+    def test_make_mask_returns_none_for_single_token(self):
+        cache = BatchQuantizedKVCache([0], group_size=GROUP_SIZE, bits=BITS)
+        k, v = _rand_kv(1, 5)
+        cache.update_and_fetch(k, v)
+        mx.eval(cache.offset)
+        result = cache.make_mask(1, return_array=False, window_size=None)
+        assert result is None or isinstance(result, (mx.array, str))
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Problem

`BatchQuantizedKVCache` stores `self.offset` as an `mx.array` (initialized in `__init__` as `mx.array([-lp for lp in left_padding])`). When `make_mask()` passes this array to `create_attention_mask()`, it reaches `create_causal_mask()` which calls `mx.arange(offset + N)`. Since `mx.arange` requires an `int`, this raises:

```
TypeError: arange(): incompatible function arguments
```

This causes a crash when using `--kv-bits` with the OpenAI-compatible server (`mlx_vlm.server`).

Related: #882 (same issue identified but closed without fix).

## Fix

Convert the array-valued offset to `int` in `make_mask()` before passing it to `create_attention_mask()`:
- For scalar arrays (single batch, `ndim == 0`): use `.item()`
- For 1D arrays (multi-batch): take the first element

## Testing

- Added 3 new tests in `TestMakeMask` class covering scalar array offset, 1d array offset, and single-token mask generation
- All 19 tests in `test_batch_quantized_cache.py` pass
- All 664 tests in the test suite pass
- `pre-commit` (black, isort, autoflake) passes

## Reproduction

```bash
python -m mlx_vlm.server --model mlx-community/gemma-4-26b-a4b-it-5bit \
  --port 9090 --max-kv-size 131072 --kv-bits 8
# Then send any chat completion request → TypeError
```