### PR TITLE
tests: add regression test for single Server response header

### DIFF
--- a/tests/test_server_header.py
+++ b/tests/test_server_header.py
@@ -1,0 +1,68 @@
+"""Regression test: mlx_vlm.server must emit exactly one Server response header.
+
+Two Server headers (one from uvicorn's default + one from mlx-vlm's middleware)
+violate RFC 7231 §7.4.2 singleton-field semantics and break strict HTTP clients
+like aiohttp (used by LiteLLM and other production proxies).
+
+This test starts the server briefly and asserts the response has exactly one
+Server header, with mlx-vlm's informative version identifier.
+"""
+import subprocess
+import sys
+import time
+
+import httpx
+import pytest
+
+
+@pytest.fixture(scope="module")
+def running_server():
+    """Start mlx_vlm.server on a high port; tear down at end of module."""
+    port = 18750
+    proc = subprocess.Popen(
+        [
+            sys.executable,
+            "-m",
+            "mlx_vlm.server",
+            "--host",
+            "127.0.0.1",
+            "--port",
+            str(port),
+        ],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    # Wait for server to come up
+    for _ in range(30):
+        try:
+            httpx.get(f"http://127.0.0.1:{port}/v1/models", timeout=1)
+            break
+        except (httpx.ConnectError, httpx.ReadTimeout):
+            time.sleep(1)
+    else:
+        proc.terminate()
+        pytest.skip("Server failed to start within 30s")
+    yield f"http://127.0.0.1:{port}"
+    proc.terminate()
+    proc.wait(timeout=10)
+
+
+def test_single_server_header(running_server):
+    """Response from /v1/models has exactly one Server header."""
+    response = httpx.get(f"{running_server}/v1/models")
+    server_headers = [
+        v for k, v in response.headers.raw if k.lower() == b"server"
+    ]
+    assert len(server_headers) == 1, (
+        f"Expected one Server header, got {len(server_headers)}: "
+        f"{server_headers}"
+    )
+
+
+def test_server_header_includes_mlx_vlm_version(running_server):
+    """The single Server header includes the mlx_vlm version identifier."""
+    response = httpx.get(f"{running_server}/v1/models")
+    server_value = response.headers.get("server", "")
+    assert "mlx_vlm" in server_value.lower(), (
+        f"Expected 'mlx_vlm' in Server header, got: {server_value!r}"
+    )


### PR DESCRIPTION
## Summary

Adds a regression test for the duplicate-Server-header bug that was fixed in [commit 3f3d8c2](https://github.com/Blaizzy/mlx-vlm/commit/3f3d8c2) ("server: disable unicorn server header (#1140)").

The fix is already in `main`, but `mlx-vlm 0.5.0` on PyPI still has the bug. When the next release ships, this test ensures the fix can't silently regress in a future change.

## Background

`mlx-vlm 0.5.0` emits two `Server` HTTP response headers:
- `server: uvicorn` (uvicorn's default)
- `server: mlx_vlm/0.5.0` (added by FastAPI middleware in `mlx_vlm/server.py`)

This violates RFC 7231 §7.4.2 (Server header is a singleton field) and breaks strict HTTP clients like aiohttp, which is used by LiteLLM and other production LLM gateways. Symptom: `aiohttp.http_exceptions.BadHttpMessage: 400, message: Duplicate 'Server' header found.`

PR #1140 fixed it via `server_header=False` in the `uvicorn.run()` call. This test verifies the fix in place.

## Test approach

`tests/test_server_header.py`:
1. Starts `mlx_vlm.server` as a subprocess on a high port (18750)
2. Waits up to 30 seconds for the server to come up
3. Uses `httpx` (which preserves duplicate headers in `response.headers.raw`) to query `/v1/models`
4. Asserts exactly one `server` header in the response
5. Asserts that header contains `mlx_vlm`

## Run

```
pytest tests/test_server_header.py -v
```

## Note

If maintainers prefer the test be merged with the original fix retroactively, happy to squash. Or close this and let the next release ship without a test — the fix itself is solid; this is just regression insurance.

Found via downstream pain — see [my notes on the bug + fix path](https://github.com/funnyjas03/mlx-vlm/blob/tests/server-header-regression/README.md) (not committed; available in conversation if useful).