### PR TITLE
Track APC cached tokens for generation metrics

### DIFF
--- a/mlx_vlm/generate.py
+++ b/mlx_vlm/generate.py
@@ -385,6 +385,7 @@ class GenerationResult:
     prompt_tps: float = 0.0
     generation_tps: float = 0.0
     peak_memory: float = 0.0
+    cached_tokens: int = 0
 
 
 class PromptCacheState:
@@ -1089,6 +1090,7 @@ def stream_generate(
                 prompt_tps=prompt_tps,
                 generation_tps=(n + 1) / (time.perf_counter() - tic),
                 peak_memory=mx.get_peak_memory() / 1e9,
+                cached_tokens=reused_prefix_len,
             )
 
         detokenizer.finalize()
@@ -1102,6 +1104,7 @@ def stream_generate(
             prompt_tps=prompt_tps,
             generation_tps=(n + 1) / (time.perf_counter() - tic),
             peak_memory=mx.get_peak_memory() / 1e9,
+            cached_tokens=reused_prefix_len,
         )
 
         # Save cache state for potential reuse on next turn
@@ -1261,6 +1264,7 @@ def generate(
         prompt_tps=last_response.prompt_tps,
         generation_tps=last_response.generation_tps,
         peak_memory=last_response.peak_memory,
+        cached_tokens=last_response.cached_tokens,
     )
 
 
@@ -1561,6 +1565,7 @@ class PromptProgress:
     prompt_tokens: int
     prompt_tps: float = 0.0
     prompt_time: float = 0.0
+    cached_tokens: int = 0
 
 
 class GenerationBatch:
@@ -1955,13 +1960,17 @@ class PromptProcessingBatch:
         self._apc_harvest_enabled = True
         self._prompt_time_s = 0.0
         self._prompt_tokens_per_row: List[int] = []
+        self._cached_tokens_per_row: List[int] = []
         for idx, suffix_len in enumerate(lengths):
             full_input_ids = None
+            prefix_len = 0
             if idx < len(self._apc_meta) and self._apc_meta[idx] is not None:
                 full_input_ids = self._apc_meta[idx].get("full_input_ids")
+                prefix_len = int(self._apc_meta[idx].get("prefix_len") or 0)
             self._prompt_tokens_per_row.append(
                 len(full_input_ids) if full_input_ids is not None else suffix_len
             )
+            self._cached_tokens_per_row.append(prefix_len)
 
         if warm_cache is not None:
             self.prompt_cache = warm_cache
@@ -2134,9 +2143,12 @@ class PromptProcessingBatch:
                 prompt_tokens=prompt_tokens,
                 prompt_tps=prompt_tokens / self._prompt_time_s,
                 prompt_time=self._prompt_time_s,
+                cached_tokens=cached_tokens,
             )
-            for uid, prompt_tokens in zip(
-                self._prompt_uids, self._prompt_tokens_per_row
+            for uid, prompt_tokens, cached_tokens in zip(
+                self._prompt_uids,
+                self._prompt_tokens_per_row,
+                self._cached_tokens_per_row,
             )
         ]
 

--- a/mlx_vlm/server/generation.py
+++ b/mlx_vlm/server/generation.py
@@ -489,6 +489,7 @@ class StreamingToken:
     peak_memory: float = 0.0
     prompt_tps: Optional[float] = None
     top_logprobs: Optional[List[Tuple[int, float]]] = None
+    cached_tokens: int = 0
 
 
 class ResponseGenerator:
@@ -875,6 +876,7 @@ class ResponseGenerator:
                         ),
                         "gen_kwargs": gen_kwargs if has_embeds else None,
                         "prompt_tps": None,
+                        "cached_tokens": 0,
                     }
 
                 if not active or batch_gen is None:
@@ -1140,6 +1142,9 @@ class ResponseGenerator:
         for prompt_response in prompt_responses:
             if prompt_response.uid in active:
                 active[prompt_response.uid]["prompt_tps"] = prompt_response.prompt_tps
+                active[prompt_response.uid]["cached_tokens"] = getattr(
+                    prompt_response, "cached_tokens", 0
+                )
         if not responses:
             return
 
@@ -1167,6 +1172,7 @@ class ResponseGenerator:
                     peak_memory=mx.get_peak_memory() / 1e9 if r.finish_reason else 0,
                     prompt_tps=info.get("prompt_tps"),
                     top_logprobs=getattr(r, "top_logprobs", None),
+                    cached_tokens=info.get("cached_tokens", 0),
                 )
             )
 

--- a/mlx_vlm/tests/test_generate.py
+++ b/mlx_vlm/tests/test_generate.py
@@ -17,6 +17,7 @@ from mlx_vlm.generate import (
     BatchStats,
     GenerationBatch,
     GenerationResult,
+    PromptProcessingBatch,
     _left_pad_prompts,
     _prime_cached_prefix_rope_state,
     normalize_resize_shape,
@@ -530,6 +531,29 @@ class TestBatchGenerator:
         assert prompt_responses[0].prompt_tokens == len(prompt)
         assert prompt_responses[0].prompt_tps == pytest.approx(15.0)
         assert prompt_responses[0].prompt_time == pytest.approx(0.2)
+        assert prompt_responses[0].cached_tokens == 0
+
+    def test_prompt_progress_reports_apc_cached_tokens(self):
+        batch = PromptProcessingBatch(
+            model=SimpleNamespace(),
+            uids=[1, 2],
+            input_ids=[[4, 5], [6, 7, 8]],
+            max_tokens=[1, 1],
+            inputs_embeds=mx.ones((2, 3, 4)),
+            prompt_kwargs={},
+            prefill_step_size=None,
+            warm_cache=[],
+            apc_meta=[
+                {"full_input_ids": [1, 2, 3, 4, 5], "prefix_len": 3},
+                None,
+            ],
+        )
+        batch.record_prompt_time(0.5)
+
+        progress = batch.prompt_progress()
+
+        assert [p.prompt_tokens for p in progress] == [5, 3]
+        assert [p.cached_tokens for p in progress] == [3, 0]
 
     def test_response_dataclass(self):
         response = GenerationBatch.Response(

--- a/mlx_vlm/tests/test_server.py
+++ b/mlx_vlm/tests/test_server.py
@@ -1966,7 +1966,7 @@ class TestResponseGenerator:
                 (str(uid * 10 + 1), "length"),
             ]
 
-    def test_step_attaches_prompt_tps_from_prompt_progress(self):
+    def test_step_attaches_prompt_metrics_from_prompt_progress(self):
         class SimpleTokenizer:
             vocab = {"hi": 0}
 
@@ -1976,7 +1976,7 @@ class TestResponseGenerator:
         class PromptProgressBatch:
             def next(self, **kwargs):
                 return (
-                    [SimpleNamespace(uid=1, prompt_tps=184.431)],
+                    [SimpleNamespace(uid=1, prompt_tps=184.431, cached_tokens=7)],
                     [
                         SimpleNamespace(
                             uid=1,
@@ -2001,6 +2001,7 @@ class TestResponseGenerator:
                     server.make_streaming_detokenizer(processor),
                 ),
                 "prompt_tps": None,
+                "cached_tokens": 0,
             }
         }
 
@@ -2008,6 +2009,7 @@ class TestResponseGenerator:
 
         item = rqueue.get()
         assert item.prompt_tps == pytest.approx(184.431)
+        assert item.cached_tokens == 7
         assert rqueue.get() is None
 
     def test_generate_arguments_to_generate_kwargs(self):


### PR DESCRIPTION
## Summary

This is groundwork for a follow-up PR to add generation metrics to the server.

Currently, APC cached-token count is not carried through generation results. Server code can see prompt token totals and throughput, but it cannot reliably tell how many prompt tokens came from APC.

## Changes

This PR threads the APC cached-token count through generation internals:

- Adds `cached_tokens` to `GenerationResult`, `PromptProgress`, `StreamingToken`
- Captures APC `prefix_len` per request row during prompt batch setup

The important decision here is to use APC’s per-row `prefix_len` directly. That keeps the value scoped to the request the client made, instead of deriving it later from batched tensor shapes, padding, or suffix lengths. It also avoids treating cache accounting as a batch-level metric.

## Related

This PR takes a different approach than https://github.com/Blaizzy/mlx-vlm/pull/1151, which reads cached tokens back from `apc_meta` when building prompt progress.

That works, but `apc_meta` is operational state that may be consumed or cleared as the prompt batch advances. This PR snapshots the per-request cached-token count when the prompt batch is built, then carries it through the existing generation metric types. That keeps server metrics tied to request-level generation state instead of APC’s internal lifecycle.