### PR TITLE
Add MiniCPM-V 4.6 language wrapper

### DIFF
--- a/mlx_vlm/models/minicpmv4_6/__init__.py
+++ b/mlx_vlm/models/minicpmv4_6/__init__.py
@@ -1,5 +1,5 @@
-from ..qwen3_5.language import LanguageModel
 from .config import ModelConfig, SliceConfig, TextConfig, VisionConfig
+from .language import LanguageModel
 from .minicpmv4_6 import Model
 from .processing_minicpmv4_6 import (
     MiniCPMVImageProcessor,

--- a/mlx_vlm/models/minicpmv4_6/language.py
+++ b/mlx_vlm/models/minicpmv4_6/language.py
@@ -1,0 +1,43 @@
+from typing import Optional
+
+import mlx.core as mx
+
+from ..qwen3_5.language import LanguageModel as Qwen35LanguageModel
+
+
+class LanguageModel(Qwen35LanguageModel):
+    def get_rope_index(
+        self,
+        input_ids: mx.array,
+        image_grid_thw: Optional[mx.array] = None,
+        video_grid_thw: Optional[mx.array] = None,
+        attention_mask: Optional[mx.array] = None,
+    ):
+        if image_grid_thw is not None or video_grid_thw is not None:
+            raise ValueError(
+                "MiniCPM-V 4.6 injects vision features through inputs_embeds and "
+                "does not support Qwen3.5-VL image_grid_thw/video_grid_thw MRoPE "
+                "inside its language model."
+            )
+
+        if attention_mask is not None:
+            position_ids = mx.cumsum(attention_mask.astype(mx.int64), axis=-1) - 1
+            position_ids = mx.where(
+                attention_mask == 0, mx.ones_like(position_ids), position_ids
+            )
+            max_position_ids = position_ids.max(axis=-1, keepdims=True)
+            position_ids = mx.broadcast_to(
+                position_ids[None, :, :], (3, *position_ids.shape)
+            )
+            mrope_position_deltas = max_position_ids + 1 - attention_mask.shape[-1]
+        else:
+            position_ids = mx.arange(input_ids.shape[1]).reshape(1, -1)
+            position_ids = mx.broadcast_to(
+                position_ids, (3, input_ids.shape[0], input_ids.shape[1])
+            )
+            mrope_position_deltas = mx.zeros(
+                [input_ids.shape[0], 1],
+                dtype=input_ids.dtype,
+            )
+
+        return position_ids, mrope_position_deltas

--- a/mlx_vlm/models/minicpmv4_6/minicpmv4_6.py
+++ b/mlx_vlm/models/minicpmv4_6/minicpmv4_6.py
@@ -5,8 +5,8 @@ import mlx.nn as nn
 import numpy as np
 
 from ..base import InputEmbeddingsFeatures
-from ..qwen3_5.language import LanguageModel as Qwen35LanguageModel
 from .config import ModelConfig
+from .language import LanguageModel
 from .vision import VisionModel, check_array_shape
 
 
@@ -202,10 +202,6 @@ class Merger(nn.Module):
             cur_h, cur_w = merged_h, merged_w
 
         return hidden, cur_h, cur_w
-
-
-class LanguageModel(Qwen35LanguageModel):
-    pass
 
 
 class Model(nn.Module):

--- a/mlx_vlm/tests/test_models.py
+++ b/mlx_vlm/tests/test_models.py
@@ -5687,6 +5687,53 @@ class TestChunkedPrefillRoPE(unittest.TestCase):
         )
 
 
+class TestMiniCPMV4_6(unittest.TestCase):
+    @staticmethod
+    def _tiny_text_config():
+        from mlx_vlm.models import minicpmv4_6
+
+        return minicpmv4_6.TextConfig(
+            model_type="qwen3_5_text",
+            hidden_size=16,
+            intermediate_size=32,
+            linear_num_value_heads=2,
+            linear_num_key_heads=2,
+            linear_key_head_dim=8,
+            linear_value_head_dim=8,
+            linear_conv_kernel_dim=4,
+            num_hidden_layers=4,
+            num_attention_heads=2,
+            rms_norm_eps=1e-5,
+            vocab_size=64,
+            num_key_value_heads=2,
+            head_dim=8,
+            max_position_embeddings=256,
+        )
+
+    def test_minicpmv4_6_language_uses_text_only_rope(self):
+        from mlx_vlm.models import minicpmv4_6
+
+        model_config = SimpleNamespace(vision_config=SimpleNamespace())
+        lm = minicpmv4_6.LanguageModel(self._tiny_text_config(), model_config)
+
+        input_ids = mx.array([[1, 2, 3, 4]], dtype=mx.int32)
+        position_ids, rope_deltas = lm.get_rope_index(input_ids)
+
+        self.assertEqual(position_ids.shape, (3, 1, input_ids.shape[1]))
+        self.assertEqual(rope_deltas.tolist(), [[0]])
+
+    def test_minicpmv4_6_language_rejects_qwen_vl_grid_rope(self):
+        from mlx_vlm.models import minicpmv4_6
+
+        model_config = SimpleNamespace(vision_config=SimpleNamespace())
+        lm = minicpmv4_6.LanguageModel(self._tiny_text_config(), model_config)
+
+        input_ids = mx.array([[1, 2, 3, 4]], dtype=mx.int32)
+        image_grid_thw = mx.array([[1, 2, 2]], dtype=mx.int32)
+        with self.assertRaisesRegex(ValueError, "does not support Qwen3.5-VL"):
+            lm.get_rope_index(input_ids, image_grid_thw=image_grid_thw)
+
+
 class TestMiniCPMO(unittest.TestCase):
     @staticmethod
     def _tiny_config():


### PR DESCRIPTION
## Summary

- add a MiniCPM-V 4.6 language wrapper that reuses the Qwen3.5 text implementation while rejecting Qwen3.5-VL grid MRoPE inputs
- route MiniCPM-V 4.6 imports and public exports through the wrapper instead of exporting Qwen3.5's language model directly
- add focused regression coverage for MiniCPM-V 4.6 text-only RoPE behavior

## Why

MiniCPM-V 4.6 uses Qwen3.5 as a text backbone and injects visual features through `inputs_embeds`; it does not use Qwen3.5-VL's image/video-grid MRoPE path. Exporting the full Qwen3.5 `LanguageModel` from `minicpmv4_6` makes that coupling too easy to hit and was the root of the `vision_config.spatial_merge_size` fragility tracked in #1202.

This keeps Qwen3.5 untouched and scopes the behavior to MiniCPM-V 4.6's language wrapper.

## Validation

- `PYTHONPYCACHEPREFIX=/private/tmp/codex-pycache python3 -m py_compile mlx_vlm/models/minicpmv4_6/language.py mlx_vlm/models/minicpmv4_6/minicpmv4_6.py mlx_vlm/models/minicpmv4_6/__init__.py mlx_vlm/tests/test_models.py`
- `uv run --with pytest pytest mlx_vlm/tests/test_models.py::TestMiniCPMV4_6 -q`
- `uv run mlx_vlm.generate --model mlx-community/MiniCPM-V-4.6-8bit --prompt "hi" --max-tokens 10`

Fixes #1202