### PR TITLE
Support Qwen image pixel overrides

### DIFF
--- a/mlx_vlm/models/qwen2_5_vl/processing_qwen2_5_vl.py
+++ b/mlx_vlm/models/qwen2_5_vl/processing_qwen2_5_vl.py
@@ -14,6 +14,7 @@ from transformers.processing_utils import ProcessorMixin
 from transformers.tokenization_utils_base import PreTokenizedInput, TextInput
 
 from ..base import to_mlx
+from ..qwen3_vl.processing_qwen3_vl import _pop_image_processor_kwargs
 
 
 class Qwen2_5_VLProcessor(ProcessorMixin):
@@ -75,9 +76,10 @@ class Qwen2_5_VLProcessor(ProcessorMixin):
     ) -> BatchFeature:
         image_inputs = {}
         videos_inputs = {}
+        image_kwargs = _pop_image_processor_kwargs(kwargs)
 
         if images is not None:
-            image_inputs = self.image_processor(images=images)
+            image_inputs = self.image_processor(images=images, **image_kwargs)
             image_grid_thw = image_inputs["image_grid_thw"]
 
         if videos is not None:

--- a/mlx_vlm/models/qwen2_vl/processing_qwen2_vl.py
+++ b/mlx_vlm/models/qwen2_vl/processing_qwen2_vl.py
@@ -13,6 +13,7 @@ from transformers.processing_utils import ProcessorMixin
 from transformers.tokenization_utils_base import PreTokenizedInput, TextInput
 
 from ..base import load_chat_template, to_mlx
+from ..qwen3_vl.processing_qwen3_vl import _pop_image_processor_kwargs
 
 
 class Qwen2VLProcessor(ProcessorMixin):
@@ -74,9 +75,10 @@ class Qwen2VLProcessor(ProcessorMixin):
     ) -> BatchFeature:
         image_inputs = {}
         videos_inputs = {}
+        image_kwargs = _pop_image_processor_kwargs(kwargs)
 
         if images is not None:
-            image_inputs = self.image_processor(images=images)
+            image_inputs = self.image_processor(images=images, **image_kwargs)
             image_grid_thw = image_inputs["image_grid_thw"]
 
         if videos is not None:

--- a/mlx_vlm/models/qwen3_vl/processing_qwen3_vl.py
+++ b/mlx_vlm/models/qwen3_vl/processing_qwen3_vl.py
@@ -19,6 +19,21 @@ from transformers.video_processing_utils import BaseVideoProcessor
 
 from ..base import load_chat_template, to_mlx
 
+_IMAGE_PROCESSOR_KWARGS = {
+    "min_pixels",
+    "max_pixels",
+    "resized_height",
+    "resized_width",
+}
+
+
+def _pop_image_processor_kwargs(kwargs):
+    return {
+        name: kwargs.pop(name)
+        for name in list(kwargs.keys())
+        if name in _IMAGE_PROCESSOR_KWARGS
+    }
+
 
 def _smart_resize_video(
     num_frames: int,
@@ -167,15 +182,34 @@ class Qwen3VLImageProcessor(ImageProcessingMixin):
             images = [images]
         return [_to_numpy_image(img) for img in images]
 
-    def _process_one(self, image: np.ndarray) -> Tuple[np.ndarray, List[int]]:
+    def _process_one(
+        self,
+        image: np.ndarray,
+        min_pixels: Optional[int] = None,
+        max_pixels: Optional[int] = None,
+        resized_height: Optional[int] = None,
+        resized_width: Optional[int] = None,
+    ) -> Tuple[np.ndarray, List[int]]:
         C, H, W = image.shape
-        resized_h, resized_w = _smart_resize_image(
-            H,
-            W,
-            factor=self.patch_size * self.merge_size,
-            min_pixels=self.min_pixels,
-            max_pixels=self.max_pixels,
-        )
+        factor = self.patch_size * self.merge_size
+        if (resized_height is None) != (resized_width is None):
+            raise ValueError(
+                "resized_height and resized_width must be provided together."
+            )
+        if resized_height is not None:
+            resized_h, resized_w = _smart_resize_image(
+                resized_height,
+                resized_width,
+                factor=factor,
+            )
+        else:
+            resized_h, resized_w = _smart_resize_image(
+                H,
+                W,
+                factor=factor,
+                min_pixels=self.min_pixels if min_pixels is None else min_pixels,
+                max_pixels=self.max_pixels if max_pixels is None else max_pixels,
+            )
         # Bicubic resize via PIL (same pattern as the video path).
         frame = _resize_video_frames(image[None, ...], resized_h, resized_w)[0]
 
@@ -226,8 +260,11 @@ class Qwen3VLImageProcessor(ImageProcessingMixin):
         ]
         all_patches = []
         all_thw = []
+        image_kwargs = {
+            name: kwargs[name] for name in _IMAGE_PROCESSOR_KWARGS if name in kwargs
+        }
         for v in imgs:
-            patches, thw = self._process_one(v)
+            patches, thw = self._process_one(v, **image_kwargs)
             all_patches.append(patches)
             all_thw.append(thw)
         return {
@@ -544,9 +581,10 @@ class Qwen3VLProcessor(ProcessorMixin):
     ) -> BatchFeature:
         image_inputs = {}
         videos_inputs = {}
+        image_kwargs = _pop_image_processor_kwargs(kwargs)
 
         if images is not None:
-            image_inputs = self.image_processor(images=images)
+            image_inputs = self.image_processor(images=images, **image_kwargs)
             image_grid_thw = image_inputs["image_grid_thw"]
         else:
             image_grid_thw = None

--- a/mlx_vlm/tests/test_processors.py
+++ b/mlx_vlm/tests/test_processors.py
@@ -711,6 +711,43 @@ class TestQwen2_5VLProcessor(_ProcessorTestBase, unittest.TestCase):
     def _image_call_args(self):
         return {"text": ["<|image_pad|> Describe"], "images": [_make_image()]}
 
+    def test_forwards_image_pixel_kwargs_to_image_processor(self):
+        p = self._make_processor()
+        seen = {}
+
+        class ImageProcessor:
+            model_input_names = ["pixel_values"]
+            merge_size = 2
+
+            def __call__(self, images=None, **kwargs):
+                seen.update(kwargs)
+                return {
+                    "pixel_values": np.zeros((1, 3, 224, 224), dtype=np.float32),
+                    "image_grid_thw": np.array([[1, 16, 16]], dtype=np.int64),
+                }
+
+        class Tokenizer:
+            model_input_names = ["input_ids", "attention_mask"]
+
+            def __call__(self, text, **kwargs):
+                if "max_pixels" in kwargs:
+                    raise AssertionError("max_pixels leaked into tokenizer kwargs")
+                return {
+                    "input_ids": [list(range(10)) for _ in text],
+                    "attention_mask": [[1] * 10 for _ in text],
+                }
+
+        p.image_processor = ImageProcessor()
+        p.tokenizer = Tokenizer()
+
+        p(
+            text=["<|image_pad|> Describe"],
+            images=[_make_image()],
+            max_pixels=1280 * 28 * 28,
+        )
+
+        self.assertEqual(seen["max_pixels"], 1280 * 28 * 28)
+
 
 class TestQwen3VLProcessor(_ProcessorTestBase, unittest.TestCase):
     def _make_processor(self):
@@ -735,6 +772,33 @@ class TestQwen3VLProcessor(_ProcessorTestBase, unittest.TestCase):
 
     def _image_call_args(self):
         return {"text": ["<|image_pad|> Describe"], "images": [_make_image()]}
+
+    def test_image_processor_honors_per_call_max_pixels(self):
+        from mlx_vlm.models.qwen3_vl.processing_qwen3_vl import Qwen3VLImageProcessor
+
+        image = np.zeros((3, 1200, 1200), dtype=np.uint8)
+        processor = Qwen3VLImageProcessor(
+            patch_size=14,
+            merge_size=2,
+            max_pixels=12845056,
+        )
+
+        default_grid = processor(images=[image])["image_grid_thw"][0]
+        capped_grid = processor(
+            images=[image],
+            max_pixels=1280 * 28 * 28,
+        )[
+            "image_grid_thw"
+        ][0]
+
+        self.assertGreater(
+            default_grid[1] * default_grid[2],
+            capped_grid[1] * capped_grid[2],
+        )
+        self.assertLessEqual(
+            capped_grid[1] * 14 * capped_grid[2] * 14,
+            1280 * 28 * 28,
+        )
 
 
 class TestQwen3OmniMoeProcessor(_ProcessorTestBase, unittest.TestCase):


### PR DESCRIPTION
## Summary
- plumb Qwen image pixel sizing kwargs (`min_pixels`, `max_pixels`, `resized_height`, `resized_width`) from Qwen2/Qwen2.5/Qwen3 processors into the image processor
- make `Qwen3VLImageProcessor` honor per-call image sizing overrides instead of always using checkpoint defaults
- add regression coverage for Qwen2.5 forwarding and the per-call `max_pixels` grid change

## Why
Fixes #1175. Qwen2.5-VL checkpoints can set `max_pixels` to the architectural ceiling, which is much larger than Qwen's typical-use recommendation. The image path had an override-shaped API but did not actually forward or apply the override, so users had to mutate `processor.image_processor.max_pixels` between calls.

## Tests
- `uv run python -m unittest mlx_vlm.tests.test_processors -v`
- `uv run python -m unittest mlx_vlm.tests.test_processors.TestQwen2_5VLProcessor mlx_vlm.tests.test_processors.TestQwen3VLProcessor -v`
- `git diff --check`
