### PR TITLE
Fix server `finish_reason` inconsistencies

### DIFF
--- a/mlx_vlm/generate.py
+++ b/mlx_vlm/generate.py
@@ -391,6 +391,9 @@ class GenerationResult:
     generation_tps: float = 0.0
     peak_memory: float = 0.0
     cached_tokens: int = 0
+    # Populated only on the terminal chunk yielded by ``stream_generate``:
+    # ``"stop"`` for eos/stop-sequence, ``"length"`` for max_tokens.
+    finish_reason: Optional[str] = None
 
 
 class PromptCacheState:
@@ -1055,6 +1058,7 @@ def stream_generate(
         tic = time.perf_counter()
 
         generated_tokens = []
+        finish_reason: Optional[str] = None
         for n, (token, logprobs) in enumerate(gen):
             if n == 0:
                 prompt_time = time.perf_counter() - tic
@@ -1082,6 +1086,7 @@ def stream_generate(
 
             # Stop generation if the token is in the eos_token_ids
             if tokenizer.stopping_criteria(token):
+                finish_reason = "stop"
                 break
 
             detokenizer.add_token(token, skip_special_token_ids=skip_special_token_ids)
@@ -1099,6 +1104,27 @@ def stream_generate(
                 peak_memory=mx.get_peak_memory() / 1e9,
                 cached_tokens=reused_prefix_len,
             )
+        else:
+            # generate_step exhausted its budget without stopping_criteria firing.
+            finish_reason = "length"
+
+        if not generated_tokens:
+            prompt_time = time.perf_counter() - tic
+            prompt_tps = total_prompt_tokens / prompt_time if prompt_time > 0 else 0.0
+            yield GenerationResult(
+                text="",
+                token=None,
+                logprobs=None,
+                prompt_tokens=total_prompt_tokens,
+                generation_tokens=0,
+                total_tokens=total_prompt_tokens,
+                prompt_tps=prompt_tps,
+                generation_tps=0.0,
+                peak_memory=mx.get_peak_memory() / 1e9,
+                cached_tokens=reused_prefix_len,
+                finish_reason="length",
+            )
+            return
 
         detokenizer.finalize()
         yield GenerationResult(
@@ -1112,6 +1138,7 @@ def stream_generate(
             generation_tps=(n + 1) / (time.perf_counter() - tic),
             peak_memory=mx.get_peak_memory() / 1e9,
             cached_tokens=reused_prefix_len,
+            finish_reason=finish_reason,
         )
 
         # Save cache state for potential reuse on next turn
@@ -1236,21 +1263,13 @@ def generate(
         text += response.text
         last_response = response
 
+    if last_response is None:
+        return GenerationResult(text=text, peak_memory=mx.get_peak_memory() / 1e9)
+
     if verbose:
         print("\n" + "=" * 10)
         if len(text) == 0:
             print("No text generated for this prompt")
-            return GenerationResult(
-                text=text,
-                token=None,
-                logprobs=None,
-                prompt_tokens=0,
-                generation_tokens=0,
-                total_tokens=0,
-                prompt_tps=0.0,
-                generation_tps=0.0,
-                peak_memory=mx.get_peak_memory() / 1e9,
-            )
         print(
             f"Prompt: {last_response.prompt_tokens} tokens, "
             f"{last_response.prompt_tps:.3f} tokens-per-sec"
@@ -1272,6 +1291,7 @@ def generate(
         generation_tps=last_response.generation_tps,
         peak_memory=last_response.peak_memory,
         cached_tokens=last_response.cached_tokens,
+        finish_reason=last_response.finish_reason,
     )
 
 

--- a/mlx_vlm/server/anthropic.py
+++ b/mlx_vlm/server/anthropic.py
@@ -564,13 +564,9 @@ async def anthropic_messages_endpoint(http_request: Request):
                             processor=processor,
                             prompt=formatted_prompt,
                             image=images,
-                            temperature=request.temperature,
-                            max_tokens=gen_args.max_tokens,
-                            top_p=request.top_p,
                             vision_cache=runtime.model_cache.get("vision_cache"),
-                            logits_processors=gen_args.logits_processors,
                             apc_manager=runtime.apc_manager,
-                            apc_tenant=gen_args.tenant_id,
+                            **gen_args.to_generate_kwargs(),
                         )
 
                         def _next_token():
@@ -606,7 +602,11 @@ async def anthropic_messages_endpoint(http_request: Request):
                         if not hasattr(token, "text"):
                             continue
 
-                        output_tokens += 1
+                        token_count = getattr(token, "generation_tokens", None)
+                        if token_count is not None:
+                            output_tokens = int(token_count)
+                        else:
+                            output_tokens += 1
                         delta = token.text
                         full_output += delta
                         accumulated += delta
@@ -909,7 +909,7 @@ async def anthropic_messages_endpoint(http_request: Request):
                 prompt_tps = getattr(result, "prompt_tps", None)
                 generation_tps = getattr(result, "generation_tps", None)
                 peak_memory = float(getattr(result, "peak_memory", 0.0) or 0.0)
-                finish_reason = "stop"
+                finish_reason = getattr(result, "finish_reason", None) or "stop"
 
             parsed_tool_calls = None
             response_text = full_text

--- a/mlx_vlm/server/anthropic.py
+++ b/mlx_vlm/server/anthropic.py
@@ -602,6 +602,8 @@ async def anthropic_messages_endpoint(http_request: Request):
                         if not hasattr(token, "text"):
                             continue
 
+                        # GenerationResult.generation_tokens is cumulative;
+                        # StreamingToken lacks the field and is counted one-at-a-time.
                         token_count = getattr(token, "generation_tokens", None)
                         if token_count is not None:
                             output_tokens = int(token_count)

--- a/mlx_vlm/server/openai.py
+++ b/mlx_vlm/server/openai.py
@@ -117,6 +117,41 @@ def _decode_input_audio_data(input_audio: InputAudio):
         return data
 
 
+def _default_finish_reason(output_tokens: int, max_tokens: int) -> str:
+    """Defensive fallback when the backend yields no terminal finish_reason."""
+    return "length" if output_tokens >= max_tokens else "stop"
+
+
+def _final_chat_chunk(
+    request_id: str,
+    model: str,
+    finish_reason: Optional[str],
+    prompt_tokens: int,
+    output_tokens: int,
+    max_tokens: int,
+) -> Tuple[ChatStreamChunk, str]:
+    finish_reason = finish_reason or _default_finish_reason(output_tokens, max_tokens)
+    return (
+        ChatStreamChunk(
+            id=request_id,
+            created=int(time.time()),
+            model=model,
+            usage={
+                "prompt_tokens": prompt_tokens,
+                "completion_tokens": output_tokens,
+                "total_tokens": prompt_tokens + output_tokens,
+            },
+            choices=[
+                ChatStreamChoice(
+                    finish_reason=finish_reason,
+                    delta=ChatMessage(role="assistant"),
+                )
+            ],
+        ),
+        finish_reason,
+    )
+
+
 def register_routes(app, deps):
     global _INHERIT_ADAPTER
     global get_cached_model, _build_gen_args, _read_tenant_id
@@ -615,10 +650,8 @@ async def responses_endpoint(request: Request):
                         "tool_calls"
                         if output_finish_reason == "tool_calls"
                         else finish_reason
-                    ) or (
-                        "length"
-                        if usage_stats["output_tokens"] >= gen_args.max_tokens
-                        else "stop"
+                    ) or _default_finish_reason(
+                        usage_stats["output_tokens"], gen_args.max_tokens
                     )
                     envelope = _build_metrics_envelope(
                         endpoint="/responses",
@@ -1138,13 +1171,11 @@ async def chat_completions_endpoint(request: ChatRequest, http_request: Request)
                             has_payload = (
                                 delta_content is not None
                                 or delta_reasoning is not None
-                                or token.finish_reason is not None
                                 or chunk_logprobs is not None
                             )
                             if has_payload:
                                 choices = [
                                     ChatStreamChoice(
-                                        finish_reason=token.finish_reason,
                                         delta=ChatMessage(
                                             role="assistant",
                                             content=delta_content,
@@ -1173,11 +1204,13 @@ async def chat_completions_endpoint(request: ChatRequest, http_request: Request)
                                 break
 
                         # Parse tool calls from full output and emit final chunk
+                        terminal_emitted = False
                         if tool_module is not None:
                             tc = process_tool_calls(full_output, tool_module, tools)
                             if tc["calls"]:
                                 tool_calls_made = True
                                 finish_reason = "tool_calls"
+                                terminal_emitted = True
                                 choices = [
                                     ChatStreamChoice(
                                         finish_reason="tool_calls",
@@ -1194,27 +1227,14 @@ async def chat_completions_endpoint(request: ChatRequest, http_request: Request)
                                     choices=choices,
                                 )
                                 yield f"data: {chunk_data.model_dump_json()}\n\n"
-                        if not tool_calls_made and finish_reason is None:
-                            finish_reason = (
-                                "length"
-                                if output_tokens >= gen_args.max_tokens
-                                else "stop"
-                            )
-                            chunk_data = ChatStreamChunk(
-                                id=request_id,
-                                created=int(time.time()),
-                                model=request.model,
-                                usage={
-                                    "prompt_tokens": ctx.prompt_tokens,
-                                    "completion_tokens": output_tokens,
-                                    "total_tokens": ctx.prompt_tokens + output_tokens,
-                                },
-                                choices=[
-                                    ChatStreamChoice(
-                                        finish_reason=finish_reason,
-                                        delta=ChatMessage(role="assistant"),
-                                    )
-                                ],
+                        if not terminal_emitted:
+                            chunk_data, finish_reason = _final_chat_chunk(
+                                request_id,
+                                request.model,
+                                finish_reason,
+                                ctx.prompt_tokens,
+                                output_tokens,
+                                gen_args.max_tokens,
                             )
                             yield f"data: {chunk_data.model_dump_json()}\n\n"
                     else:
@@ -1277,27 +1297,13 @@ async def chat_completions_endpoint(request: ChatRequest, http_request: Request)
                                 yield f"data: {chunk_data.model_dump_json()}\n\n"
                                 await asyncio.sleep(0.01)
 
-                        if finish_reason is None:
-                            finish_reason = (
-                                "length"
-                                if output_tokens >= gen_args.max_tokens
-                                else "stop"
-                            )
-                        chunk_data = ChatStreamChunk(
-                            id=request_id,
-                            created=int(time.time()),
-                            model=request.model,
-                            usage={
-                                "prompt_tokens": stream_prompt_tokens,
-                                "completion_tokens": output_tokens,
-                                "total_tokens": stream_prompt_tokens + output_tokens,
-                            },
-                            choices=[
-                                ChatStreamChoice(
-                                    finish_reason=finish_reason,
-                                    delta=ChatMessage(role="assistant"),
-                                )
-                            ],
+                        chunk_data, finish_reason = _final_chat_chunk(
+                            request_id,
+                            request.model,
+                            finish_reason,
+                            stream_prompt_tokens,
+                            output_tokens,
+                            gen_args.max_tokens,
                         )
                         yield f"data: {chunk_data.model_dump_json()}\n\n"
 
@@ -1327,12 +1333,7 @@ async def chat_completions_endpoint(request: ChatRequest, http_request: Request)
                         prompt_tps=prompt_tps,
                         generation_tps=generation_tps,
                         peak_memory_gb=peak_memory or None,
-                        finish_reason=finish_reason
-                        or (
-                            "length"
-                            if output_tokens >= gen_args.max_tokens
-                            else "stop"
-                        ),
+                        finish_reason=finish_reason,
                         image_count=len(images),
                         audio_count=len(audio),
                         structured_output=bool(gen_args.logits_processors),
@@ -1479,9 +1480,7 @@ async def chat_completions_endpoint(request: ChatRequest, http_request: Request)
                     peak_memory = float(getattr(gen_result, "peak_memory", 0.0) or 0.0)
                     prompt_tps = getattr(gen_result, "prompt_tps", None)
                     generation_tps = getattr(gen_result, "generation_tps", None)
-                    finish_reason = (
-                        getattr(gen_result, "finish_reason", None) or "stop"
-                    )
+                    finish_reason = getattr(gen_result, "finish_reason", None) or "stop"
 
                 mx.clear_cache()
                 gc.collect()
@@ -1545,7 +1544,9 @@ async def chat_completions_endpoint(request: ChatRequest, http_request: Request)
                 choices = [
                     ChatChoice(
                         finish_reason=(
-                            "tool_calls" if parsed_tool_calls else finish_reason or "stop"
+                            "tool_calls"
+                            if parsed_tool_calls
+                            else finish_reason or "stop"
                         ),
                         message=ChatMessage(
                             role="assistant",

--- a/mlx_vlm/server/openai.py
+++ b/mlx_vlm/server/openai.py
@@ -117,38 +117,28 @@ def _decode_input_audio_data(input_audio: InputAudio):
         return data
 
 
-def _default_finish_reason(output_tokens: int, max_tokens: int) -> str:
-    """Defensive fallback when the backend yields no terminal finish_reason."""
-    return "length" if output_tokens >= max_tokens else "stop"
-
-
 def _final_chat_chunk(
     request_id: str,
     model: str,
-    finish_reason: Optional[str],
+    finish_reason: str,
     prompt_tokens: int,
     output_tokens: int,
-    max_tokens: int,
-) -> Tuple[ChatStreamChunk, str]:
-    finish_reason = finish_reason or _default_finish_reason(output_tokens, max_tokens)
-    return (
-        ChatStreamChunk(
-            id=request_id,
-            created=int(time.time()),
-            model=model,
-            usage={
-                "prompt_tokens": prompt_tokens,
-                "completion_tokens": output_tokens,
-                "total_tokens": prompt_tokens + output_tokens,
-            },
-            choices=[
-                ChatStreamChoice(
-                    finish_reason=finish_reason,
-                    delta=ChatMessage(role="assistant"),
-                )
-            ],
-        ),
-        finish_reason,
+) -> ChatStreamChunk:
+    return ChatStreamChunk(
+        id=request_id,
+        created=int(time.time()),
+        model=model,
+        usage={
+            "prompt_tokens": prompt_tokens,
+            "completion_tokens": output_tokens,
+            "total_tokens": prompt_tokens + output_tokens,
+        },
+        choices=[
+            ChatStreamChoice(
+                finish_reason=finish_reason,
+                delta=ChatMessage(role="assistant"),
+            )
+        ],
     )
 
 
@@ -649,9 +639,7 @@ async def responses_endpoint(request: Request):
                     finish_reason = (
                         "tool_calls"
                         if output_finish_reason == "tool_calls"
-                        else finish_reason
-                    ) or _default_finish_reason(
-                        usage_stats["output_tokens"], gen_args.max_tokens
+                        else finish_reason or "stop"
                     )
                     envelope = _build_metrics_envelope(
                         endpoint="/responses",
@@ -1228,13 +1216,13 @@ async def chat_completions_endpoint(request: ChatRequest, http_request: Request)
                                 )
                                 yield f"data: {chunk_data.model_dump_json()}\n\n"
                         if not terminal_emitted:
-                            chunk_data, finish_reason = _final_chat_chunk(
+                            finish_reason = finish_reason or "stop"
+                            chunk_data = _final_chat_chunk(
                                 request_id,
                                 request.model,
                                 finish_reason,
                                 ctx.prompt_tokens,
                                 output_tokens,
-                                gen_args.max_tokens,
                             )
                             yield f"data: {chunk_data.model_dump_json()}\n\n"
                     else:
@@ -1297,13 +1285,13 @@ async def chat_completions_endpoint(request: ChatRequest, http_request: Request)
                                 yield f"data: {chunk_data.model_dump_json()}\n\n"
                                 await asyncio.sleep(0.01)
 
-                        chunk_data, finish_reason = _final_chat_chunk(
+                        finish_reason = finish_reason or "stop"
+                        chunk_data = _final_chat_chunk(
                             request_id,
                             request.model,
                             finish_reason,
                             stream_prompt_tokens,
                             output_tokens,
-                            gen_args.max_tokens,
                         )
                         yield f"data: {chunk_data.model_dump_json()}\n\n"
 

--- a/mlx_vlm/server/openai.py
+++ b/mlx_vlm/server/openai.py
@@ -473,6 +473,7 @@ async def responses_endpoint(request: Request):
                             None,  # audio
                             gen_args,
                         )
+                        usage_stats["input_tokens"] = ctx.prompt_tokens
 
                         output_tokens = 0
 
@@ -503,7 +504,7 @@ async def responses_endpoint(request: Request):
                                 "output_tokens": output_tokens,
                             }
 
-                            if delta is not None:
+                            if delta:
                                 yield f"event: response.output_text.delta\ndata: {ResponseOutputTextDeltaEvent(type='response.output_text.delta', item_id=message_id, output_index=0, content_index=0, delta=delta).model_dump_json()}\n\n"
                                 await asyncio.sleep(0.01)
 
@@ -517,13 +518,9 @@ async def responses_endpoint(request: Request):
                             processor=processor,
                             prompt=formatted_prompt,
                             image=images,
-                            temperature=openai_request.temperature,
-                            max_tokens=gen_args.max_tokens,
-                            top_p=openai_request.top_p,
                             vision_cache=runtime.model_cache.get("vision_cache"),
-                            logits_processors=gen_args.logits_processors,
                             apc_manager=runtime.apc_manager,
-                            apc_tenant=gen_args.tenant_id,
+                            **gen_args.to_generate_kwargs(),
                             **kwargs,
                         )
 
@@ -545,12 +542,15 @@ async def responses_endpoint(request: Request):
                                 peak_memory,
                                 float(getattr(chunk, "peak_memory", 0.0) or 0.0),
                             )
+                            chunk_finish = getattr(chunk, "finish_reason", None)
+                            if chunk_finish is not None:
+                                finish_reason = chunk_finish
                             usage_stats = {
                                 "input_tokens": chunk.prompt_tokens,
                                 "output_tokens": chunk.generation_tokens,
                             }
 
-                            if delta is not None:
+                            if delta:
                                 yield f"event: response.output_text.delta\ndata: {ResponseOutputTextDeltaEvent(type='response.output_text.delta', item_id=message_id, output_index=0, content_index=0, delta=delta).model_dump_json()}\n\n"
                                 await asyncio.sleep(0.01)
 
@@ -615,7 +615,11 @@ async def responses_endpoint(request: Request):
                         "tool_calls"
                         if output_finish_reason == "tool_calls"
                         else finish_reason
-                    ) or ("stop" if usage_stats["output_tokens"] > 0 else None)
+                    ) or (
+                        "length"
+                        if usage_stats["output_tokens"] >= gen_args.max_tokens
+                        else "stop"
+                    )
                     envelope = _build_metrics_envelope(
                         endpoint="/responses",
                         model=openai_request.model,
@@ -767,7 +771,6 @@ async def responses_endpoint(request: Request):
                         verbose=logger.isEnabledFor(logging.DEBUG),
                         vision_cache=runtime.model_cache.get("vision_cache"),
                         apc_manager=runtime.apc_manager,
-                        apc_tenant=gen_args.tenant_id,
                         **gen_args.to_generate_kwargs(),
                         **kwargs,
                     )
@@ -777,7 +780,7 @@ async def responses_endpoint(request: Request):
                     prompt_tps = getattr(result, "prompt_tps", None)
                     generation_tps = getattr(result, "generation_tps", None)
                     peak_memory = float(getattr(result, "peak_memory", 0.0) or 0.0)
-                    finish_reason = "stop"
+                    finish_reason = getattr(result, "finish_reason", None) or "stop"
 
                 mx.clear_cache()
                 gc.collect()
@@ -1191,6 +1194,29 @@ async def chat_completions_endpoint(request: ChatRequest, http_request: Request)
                                     choices=choices,
                                 )
                                 yield f"data: {chunk_data.model_dump_json()}\n\n"
+                        if not tool_calls_made and finish_reason is None:
+                            finish_reason = (
+                                "length"
+                                if output_tokens >= gen_args.max_tokens
+                                else "stop"
+                            )
+                            chunk_data = ChatStreamChunk(
+                                id=request_id,
+                                created=int(time.time()),
+                                model=request.model,
+                                usage={
+                                    "prompt_tokens": ctx.prompt_tokens,
+                                    "completion_tokens": output_tokens,
+                                    "total_tokens": ctx.prompt_tokens + output_tokens,
+                                },
+                                choices=[
+                                    ChatStreamChoice(
+                                        finish_reason=finish_reason,
+                                        delta=ChatMessage(role="assistant"),
+                                    )
+                                ],
+                            )
+                            yield f"data: {chunk_data.model_dump_json()}\n\n"
                     else:
                         # Fallback to stream_generate
                         token_iterator = stream_generate(
@@ -1199,13 +1225,9 @@ async def chat_completions_endpoint(request: ChatRequest, http_request: Request)
                             prompt=formatted_prompt,
                             image=images,
                             audio=audio,
-                            temperature=request.temperature,
-                            max_tokens=gen_args.max_tokens,
-                            top_p=request.top_p,
                             vision_cache=runtime.model_cache.get("vision_cache"),
-                            logits_processors=gen_args.logits_processors,
                             apc_manager=runtime.apc_manager,
-                            apc_tenant=gen_args.tenant_id,
+                            **gen_args.to_generate_kwargs(),
                             **kwargs,
                         )
 
@@ -1227,29 +1249,57 @@ async def chat_completions_endpoint(request: ChatRequest, http_request: Request)
                                 peak_memory,
                                 float(getattr(chunk, "peak_memory", 0.0) or 0.0),
                             )
+                            chunk_finish = getattr(chunk, "finish_reason", None)
+                            if chunk_finish is not None:
+                                finish_reason = chunk_finish
 
-                            choices = [
-                                ChatStreamChoice(
-                                    delta=ChatMessage(
-                                        role="assistant", content=chunk.text
+                            if chunk.text:
+                                choices = [
+                                    ChatStreamChoice(
+                                        delta=ChatMessage(
+                                            role="assistant", content=chunk.text
+                                        )
                                     )
+                                ]
+                                chunk_data = ChatStreamChunk(
+                                    id=request_id,
+                                    created=int(time.time()),
+                                    model=request.model,
+                                    usage={
+                                        "prompt_tokens": chunk.prompt_tokens,
+                                        "completion_tokens": chunk.generation_tokens,
+                                        "total_tokens": chunk.prompt_tokens
+                                        + chunk.generation_tokens,
+                                    },
+                                    choices=choices,
                                 )
-                            ]
-                            chunk_data = ChatStreamChunk(
-                                id=request_id,
-                                created=int(time.time()),
-                                model=request.model,
-                                usage={
-                                    "prompt_tokens": chunk.prompt_tokens,
-                                    "completion_tokens": chunk.generation_tokens,
-                                    "total_tokens": chunk.prompt_tokens
-                                    + chunk.generation_tokens,
-                                },
-                                choices=choices,
-                            )
 
-                            yield f"data: {chunk_data.model_dump_json()}\n\n"
-                            await asyncio.sleep(0.01)
+                                yield f"data: {chunk_data.model_dump_json()}\n\n"
+                                await asyncio.sleep(0.01)
+
+                        if finish_reason is None:
+                            finish_reason = (
+                                "length"
+                                if output_tokens >= gen_args.max_tokens
+                                else "stop"
+                            )
+                        chunk_data = ChatStreamChunk(
+                            id=request_id,
+                            created=int(time.time()),
+                            model=request.model,
+                            usage={
+                                "prompt_tokens": stream_prompt_tokens,
+                                "completion_tokens": output_tokens,
+                                "total_tokens": stream_prompt_tokens + output_tokens,
+                            },
+                            choices=[
+                                ChatStreamChoice(
+                                    finish_reason=finish_reason,
+                                    delta=ChatMessage(role="assistant"),
+                                )
+                            ],
+                        )
+                        yield f"data: {chunk_data.model_dump_json()}\n\n"
 
                     metrics_text = full_output or output_text
                     completion_tokens = max(
@@ -1278,7 +1328,11 @@ async def chat_completions_endpoint(request: ChatRequest, http_request: Request)
                         generation_tps=generation_tps,
                         peak_memory_gb=peak_memory or None,
                         finish_reason=finish_reason
-                        or ("stop" if output_tokens > 0 else None),
+                        or (
+                            "length"
+                            if output_tokens >= gen_args.max_tokens
+                            else "stop"
+                        ),
                         image_count=len(images),
                         audio_count=len(audio),
                         structured_output=bool(gen_args.logits_processors),
@@ -1425,7 +1479,9 @@ async def chat_completions_endpoint(request: ChatRequest, http_request: Request)
                     peak_memory = float(getattr(gen_result, "peak_memory", 0.0) or 0.0)
                     prompt_tps = getattr(gen_result, "prompt_tps", None)
                     generation_tps = getattr(gen_result, "generation_tps", None)
-                    finish_reason = "stop"
+                    finish_reason = (
+                        getattr(gen_result, "finish_reason", None) or "stop"
+                    )
 
                 mx.clear_cache()
                 gc.collect()
@@ -1488,7 +1544,9 @@ async def chat_completions_endpoint(request: ChatRequest, http_request: Request)
 
                 choices = [
                     ChatChoice(
-                        finish_reason="tool_calls" if parsed_tool_calls else "stop",
+                        finish_reason=(
+                            "tool_calls" if parsed_tool_calls else finish_reason or "stop"
+                        ),
                         message=ChatMessage(
                             role="assistant",
                             content=content if content else None,


### PR DESCRIPTION
Follow-up to #1209.

While working on generation metrics in server responses, I ran into edge cases in how the server reports `finish_reason`, as well as minor inconsistencies across batched and non-batched.

This PR contains standalone fixes that improve consistency across the board. This should also make the full metrics PR easier to review:
- https://github.com/Blaizzy/mlx-vlm/pull/1216

## Fixes

**Non-streaming endpoints reported the wrong `finish_reason`.** All three endpoints (chat completions, responses, messages) hardcoded `"stop"` on the non-streaming path. A request that hit `max_tokens` was indistinguishable from one the model decided to end. Now propagates `"length"` correctly.

**Streaming chat completions reported inconsistently across backends.** Whether `finish_reason` arrived, and on which chunk, depended on whether the request was served by continuous batching or `stream_generate`. Now: one terminal chunk carries `finish_reason`, regardless of backend.

**Tenant-scoped Responses requests crashed on the non-streaming path.** `apc_tenant` was passed twice — once explicitly, once via `**gen_args.to_generate_kwargs()`. Raised `TypeError` for any request with `tenant_id` set. Removed the duplicate.

**`stream_generate` didn't expose why it stopped.** Callers had to infer with heuristics. Added `finish_reason` to `GenerationResult` (`"stop"` for eos/stop-sequence, `"length"` for max_tokens).

**`stream_generate(max_tokens=0)` raised `UnboundLocalError`.** The terminal yield after the for loop referenced `token` and `n`, which were never bound when the loop iterated zero times. Now yields a zero-token terminal `GenerationResult` so consumers always see stream termination.

## Notes

- Anthropic streaming now honors `top_k`, `min_p`, `repetition_penalty`, `logit_bias`, `enable_thinking`, `thinking_budget`, and `thinking_start_token`. These were silently dropped before; requests that appeared to work may produce different output.
- Empty SSE deltas are no longer emitted on `/v1/responses` and the chat-completions `stream_generate` fallback.
- /v1/chat/completions wire shape changes to be more OpenAI spec compliant. `finish_reason` is now consistently sent on the final chunk instead of content chunks.
- The server's `generate()` / `stream_generate()` call sites are now routed through `**gen_args.to_generate_kwargs()` consistently.
- Tests for the new wire shapes will be included in the metrics PR.