### PR TITLE
Fix inference cancellation on stream abort

### DIFF
--- a/mlx_vlm/server/generation.py
+++ b/mlx_vlm/server/generation.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass
 from queue import Empty as QueueEmpty
 from queue import Queue
 from threading import Event, Lock, Thread
-from typing import Callable, Iterator, List, Optional, Tuple
+from typing import Callable, List, Optional, Tuple
 
 import mlx.core as mx
 from fastapi import HTTPException
@@ -492,6 +492,70 @@ class StreamingToken:
     cached_tokens: int = 0
 
 
+class _TokenIterator:
+    """Closeable iterator over queued tokens for one generation request.
+
+    close() cancels unfinished requests and is safe while another thread is
+    blocked in __next__ waiting for the next token.
+    """
+
+    def __init__(self, rqueue, uid, cancel_fn, queue_timeout):
+        self._rqueue = rqueue
+        self._uid = uid
+        self._cancel_fn = cancel_fn
+        self._queue_timeout = queue_timeout
+        self._ended = False
+        self._closed = False
+        self._lock = Lock()
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        if self._ended:
+            raise StopIteration
+        try:
+            item = self._rqueue.get(timeout=self._queue_timeout)
+        except QueueEmpty as exc:
+            # Consumer is stalled or upstream is wedged — treat as cancel.
+            self.close()
+            label = (
+                "without a timeout"
+                if self._queue_timeout is None
+                else f"for {self._queue_timeout:g}s"
+            )
+            raise RuntimeError(
+                "Timed out waiting "
+                f"{label} for the next generated token. "
+                "Increase MLX_VLM_TOKEN_QUEUE_TIMEOUT for long "
+                "prefills, or reduce the prompt size."
+            ) from exc
+        if item is None:
+            self._ended = True
+            raise StopIteration
+        if isinstance(item, Exception):
+            self._ended = True
+            raise item
+        if getattr(item, "finish_reason", None):
+            self._ended = True
+        return item
+
+    def close(self):
+        with self._lock:
+            if self._closed:
+                return
+            self._closed = True
+        if not self._ended:
+            self._cancel_fn(self._uid)
+
+    def __del__(self):
+        # Mirror generator semantics: implicit close on GC.
+        try:
+            self.close()
+        except Exception:
+            pass
+
+
 class ResponseGenerator:
     """
     Continuous batching for concurrent requests via a single GPU thread.
@@ -608,7 +672,7 @@ class ResponseGenerator:
         images: Optional[List] = None,
         audio: Optional[List] = None,
         args: Optional[GenerationArguments] = None,
-    ) -> Tuple[GenerationContext, Iterator[StreamingToken]]:
+    ) -> Tuple[GenerationContext, "_TokenIterator"]:
         self.wait_until_ready()
         args = args or GenerationArguments(max_tokens=get_server_max_tokens())
         if self.draft_model is not None and args.logits_processors is not None:
@@ -630,46 +694,9 @@ class ResponseGenerator:
         if isinstance(ctx, Exception):
             raise ctx
 
-        uid = ctx.uid
-
-        def token_iterator():
-            # Mark ended before yielding the final token so a consumer that
-            # closes immediately after seeing finish_reason isn't treated
-            # as a client abort.
-            ended = False
-            queue_timeout = get_token_queue_timeout()
-            try:
-                while True:
-                    try:
-                        item = rqueue.get(timeout=queue_timeout)
-                    except QueueEmpty as exc:
-                        timeout_label = (
-                            "without a timeout"
-                            if queue_timeout is None
-                            else f"for {queue_timeout:g}s"
-                        )
-                        raise RuntimeError(
-                            "Timed out waiting "
-                            f"{timeout_label} for the next generated token. "
-                            "Increase MLX_VLM_TOKEN_QUEUE_TIMEOUT for long "
-                            "prefills, or reduce the prompt size."
-                        ) from exc
-                    if item is None:
-                        ended = True
-                        break
-                    if isinstance(item, Exception):
-                        ended = True
-                        raise item
-                    if getattr(item, "finish_reason", None):
-                        ended = True
-                    yield item
-                    if ended:
-                        break
-            finally:
-                if not ended:
-                    self._cancel(uid)
-
-        return ctx, token_iterator()
+        return ctx, _TokenIterator(
+            rqueue, ctx.uid, self._cancel, get_token_queue_timeout()
+        )
 
     def _cpu_preprocess(self, prompt, images=None, audio=None) -> dict:
         """CPU-only: tokenize text, load/resize images. Thread-safe."""

--- a/mlx_vlm/tests/test_server.py
+++ b/mlx_vlm/tests/test_server.py
@@ -1644,6 +1644,46 @@ class TestResponseGenerator:
 
         assert cancelled == ["req-1"]
 
+    def test_token_iterator_close_cancels_while_next_blocks(self):
+        cancelled = []
+        result = []
+
+        class BlockingQueue(Queue):
+            def __init__(self):
+                super().__init__()
+                self.waiting = Event()
+
+            def get(self, *args, **kwargs):
+                self.waiting.set()
+                return super().get(*args, **kwargs)
+
+        rqueue = BlockingQueue()
+        token_iter = server_generation._TokenIterator(
+            rqueue,
+            "req-1",
+            cancelled.append,
+            None,
+        )
+
+        def consume():
+            try:
+                result.append(next(token_iter))
+            except Exception as exc:
+                result.append(exc)
+
+        thread = Thread(target=consume)
+        thread.start()
+        assert rqueue.waiting.wait(timeout=1.0)
+
+        token_iter.close()
+
+        assert cancelled == ["req-1"]
+
+        rqueue.put(None)
+        thread.join(timeout=1.0)
+        assert not thread.is_alive()
+        assert isinstance(result[0], StopIteration)
+
     def test_token_iterator_waits_past_timeout_for_delayed_token(self, monkeypatch):
         import threading
 


### PR DESCRIPTION
Currently, when a streaming client aborts the connection, the server does not reliably cancel the underlying inference request.

The endpoints already call `token_iter.close()` from their stream cleanup paths. However, `ResponseGenerator.generate()` returns a Python generator, and in the continuous batching path one thread may be blocked in `next(token_iter)` while another thread calls `close()` during disconnect cleanup.

CPython rejects that with `ValueError: generator already executing`. The endpoint cleanup catches and ignores the exception, so cancellation is never signaled and inference may continue until `max_tokens`.

## Reproduction

1. Monitor GPU usage (`macmon`, `btop`, etc.) in one terminal.
2. Start `mlx-vlm.server` in another.
3. Send a long streaming request:
   ```sh
   curl -N http://localhost:8000/v1/chat/completions \
     -H 'Content-Type: application/json' \
     -d '{
       "model": "...",
       "stream": true,
       "messages": [
         {
           "role": "user",
           "content": "Write a very long essay about penguins."
         }
       ],
       "max_tokens": 4096
     }'
   ```
4. Press `Ctrl+C` while tokens are streaming.

Before this fix, GPU activity continues long after disconnect. After this fix, stream close cancels the active request and GPU activity drops shortly after.

## Fix

This PR replaces the generator returned by `ResponseGenerator.generate()` with a small closeable iterator. Callers keep the same contract.

The iterator preserves the previous behavior for queued tokens, terminal sentinels, queued exceptions, and token queue timeouts. The key change is that `close()` can now safely cancel an unfinished request even while another thread is blocked in `__next__()`.

## Note

An alternative would be to patch each streaming endpoint to call `ResponseGenerator._cancel(ctx.uid)` directly on disconnect.

This PR keeps cancellation inside the token iterator lifecycle instead. Endpoints already express the intended behavior by closing the iterator in `finally`; the bug was that the old generator implementation could not reliably honor that contract under cross-thread cleanup.

That keeps private cancellation details out of the OpenAI/Anthropic handlers and makes future streaming callers less likely to miss cancellation.