### PR TITLE
fix: fallback to defaults

### DIFF
--- a/mlx_vlm/server/app.py
+++ b/mlx_vlm/server/app.py
@@ -13,7 +13,11 @@ from fastapi.middleware.cors import CORSMiddleware
 from huggingface_hub import scan_cache_dir
 
 from .. import apc as _apc
-from ..generate import DEFAULT_TEMPERATURE, DEFAULT_TOP_P
+from ..generate import (
+    DEFAULT_REPETITION_CONTEXT_SIZE,
+    DEFAULT_TEMPERATURE,
+    DEFAULT_TOP_P,
+)
 from ..structured import build_json_schema_logits_processor
 from ..tool_parsers import _infer_tool_parser_from_processor
 from ..version import __version__
@@ -106,11 +110,23 @@ def _build_gen_args(
         top_k=getattr(request, "top_k", 0),
         min_p=getattr(request, "min_p", 0.0),
         repetition_penalty=getattr(request, "repetition_penalty", None),
-        repetition_context_size=getattr(request, "repetition_context_size", None),
+        repetition_context_size=_request_field_or_default(
+            request,
+            "repetition_context_size",
+            DEFAULT_REPETITION_CONTEXT_SIZE,
+        ),
         presence_penalty=getattr(request, "presence_penalty", None),
-        presence_context_size=getattr(request, "presence_context_size", None),
+        presence_context_size=_request_field_or_default(
+            request,
+            "presence_context_size",
+            DEFAULT_REPETITION_CONTEXT_SIZE,
+        ),
         frequency_penalty=getattr(request, "frequency_penalty", None),
-        frequency_context_size=getattr(request, "frequency_context_size", None),
+        frequency_context_size=_request_field_or_default(
+            request,
+            "frequency_context_size",
+            DEFAULT_REPETITION_CONTEXT_SIZE,
+        ),
         logit_bias=logit_bias,
         enable_thinking=enable_thinking,
         thinking_budget=getattr(request, "thinking_budget", None),

--- a/mlx_vlm/tests/test_server.py
+++ b/mlx_vlm/tests/test_server.py
@@ -2288,6 +2288,72 @@ class TestResponseGenerator:
         assert args.max_tokens == 256
         assert args.enable_thinking is True
 
+    def test_build_gen_args_defaults_penalty_context_sizes_when_omitted(self):
+        req = server.ChatRequest(
+            model="demo",
+            messages=[server.ChatMessage(role="user", content="hi")],
+            repetition_penalty=1.1,
+            presence_penalty=0.2,
+            frequency_penalty=0.3,
+        )
+
+        args = server._build_gen_args(req)
+
+        assert (
+            args.repetition_context_size
+            == server_generation.DEFAULT_REPETITION_CONTEXT_SIZE
+        )
+        assert (
+            args.presence_context_size
+            == server_generation.DEFAULT_REPETITION_CONTEXT_SIZE
+        )
+        assert (
+            args.frequency_context_size
+            == server_generation.DEFAULT_REPETITION_CONTEXT_SIZE
+        )
+
+    def test_build_gen_args_defaults_penalty_context_sizes_when_null(self):
+        req = server.ChatRequest(
+            model="demo",
+            messages=[server.ChatMessage(role="user", content="hi")],
+            repetition_penalty=1.1,
+            repetition_context_size=None,
+            presence_penalty=0.2,
+            presence_context_size=None,
+            frequency_penalty=0.3,
+            frequency_context_size=None,
+        )
+
+        args = server._build_gen_args(req)
+
+        assert (
+            args.repetition_context_size
+            == server_generation.DEFAULT_REPETITION_CONTEXT_SIZE
+        )
+        assert (
+            args.presence_context_size
+            == server_generation.DEFAULT_REPETITION_CONTEXT_SIZE
+        )
+        assert (
+            args.frequency_context_size
+            == server_generation.DEFAULT_REPETITION_CONTEXT_SIZE
+        )
+
+    def test_build_gen_args_preserves_explicit_penalty_context_sizes(self):
+        req = server.ChatRequest(
+            model="demo",
+            messages=[server.ChatMessage(role="user", content="hi")],
+            repetition_context_size=64,
+            presence_context_size=32,
+            frequency_context_size=16,
+        )
+
+        args = server._build_gen_args(req)
+
+        assert args.repetition_context_size == 64
+        assert args.presence_context_size == 32
+        assert args.frequency_context_size == 16
+
     def test_build_gen_args_uses_server_thinking_default_when_omitted(
         self, monkeypatch
     ):


### PR DESCRIPTION
## Summary

Fixes an issue where `mlx-vlm/server/app.py` unintentionally overrides the default `repetition_context_size`.

`mlx-vlm` already defines a default context size of `20` in:

`mlx_vlm/server/generation.py`

However, when a request does not include `repetition_context_size`, the app layer was passing `None`, which overwrote the intended default.

## What changed

- Avoid passing `None` for `repetition_context_size` when the request omits it.
- Preserve the default value of `20` defined in the generation layer.
- Ensure omitted request parameters do not override existing defaults.

## Why

introduced a bug : #1214 

f210f6c30f44 changed _build_gen_args() to always pass request values into GenerationArguments:

```python
  repetition_context_size=getattr(request, "repetition_context_size", None)
```

That is the bug. For Pydantic request models, omitted optional fields still exist as attributes with value None. So this does not mean **use the dataclass default if absent** --- it means **explicitly override the dataclass default with None.**