### PR TITLE
Add DeepSeek V4 language model

### DIFF
--- a/mlx_vlm/convert.py
+++ b/mlx_vlm/convert.py
@@ -30,6 +30,47 @@ QUANT_RECIPES = [
 ]
 
 
+def _quantization_params(
+    q_group_size: Optional[int], q_bits: Optional[int], q_mode: str
+):
+    mode_defaults = {
+        "affine": (64, 4),
+        "mxfp4": (32, 4),
+        "nvfp4": (16, 4),
+        "mxfp8": (32, 8),
+    }
+    group_size, bits = mode_defaults[q_mode]
+    return {
+        "group_size": q_group_size or group_size,
+        "bits": q_bits or bits,
+        "mode": q_mode,
+    }
+
+
+def _preserve_existing_deepseek_v4_quantization(
+    config: dict,
+    model: nn.Module,
+    q_group_size: Optional[int],
+    q_bits: Optional[int],
+    q_mode: str,
+):
+    quantization_config = config.get("quantization_config", {})
+    if (
+        config.get("model_type") != "deepseek_v4"
+        or "quantization" in config
+        or not isinstance(quantization_config, dict)
+        or quantization_config.get("quant_method") != "fp8"
+    ):
+        return
+
+    from .models.deepseek_v4.language import make_quantization_config
+
+    quantization = make_quantization_config(model)
+    quantization.update(_quantization_params(q_group_size, q_bits, q_mode))
+    config["quantization"] = quantization
+    config["quantization_config"] = quantization
+
+
 def mixed_quant_predicate_builder(
     recipe: str, model: nn.Module
 ) -> Callable[[str, nn.Module], Union[bool, dict]]:
@@ -157,6 +198,10 @@ def convert(
 
     if quantize:
         from mlx_lm.utils import quantize_model
+
+        _preserve_existing_deepseek_v4_quantization(
+            config, model, q_group_size, q_bits, q_mode
+        )
 
         print("[INFO] Quantizing")
         config.setdefault("vision_config", {})

--- a/mlx_vlm/models/cache.py
+++ b/mlx_vlm/models/cache.py
@@ -2,17 +2,13 @@ from typing import Any, List, Optional, Tuple
 
 import mlx.core as mx
 import mlx.nn as nn
-from mlx_lm.models.cache import (
-    ArraysCache,
-    BatchKVCache,
-    BatchRotatingKVCache,
-    CacheList,
-    ChunkedKVCache,
-    KVCache,
-    QuantizedKVCache,
-    RotatingKVCache,
-    _BaseCache,
-)
+from mlx_lm.models.cache import ArraysCache  # noqa: F401
+from mlx_lm.models.cache import BatchKVCache  # noqa: F401
+from mlx_lm.models.cache import BatchRotatingKVCache  # noqa: F401
+from mlx_lm.models.cache import CacheList  # noqa: F401
+from mlx_lm.models.cache import ChunkedKVCache  # noqa: F401
+from mlx_lm.models.cache import QuantizedKVCache  # noqa: F401
+from mlx_lm.models.cache import KVCache, RotatingKVCache, _BaseCache
 
 
 class BufferedRotatingKVCache(RotatingKVCache):
@@ -390,6 +386,557 @@ class BatchQuantizedKVCache(_BaseCache):
         return create_causal_mask(
             N, offset=self._idx, left_padding=self.left_padding, **kwargs
         )
+
+
+class PoolingCache(_BaseCache):
+    """Cache for pooled (compressed) KV tokens with a remainder buffer.
+
+    Stores two things:
+      1. A growing pool of compressed tokens (step-allocated).
+      2. A small remainder buffer of tokens not yet forming a full window.
+    """
+
+    def __init__(self, ratio: int):
+        self.ratio = ratio
+
+        self.buf_kv = None
+        self.buf_gate = None
+        self.remainder = 0
+
+        self.pooled = None
+
+    @property
+    def offset(self):
+        return 0 if self.pooled is None else self.pooled.shape[1]
+
+    def accumulate_windows(self, kv: mx.array, gate: mx.array, offset):
+        B, L, D1 = kv.shape
+        _, _, D2 = gate.shape
+
+        if self.buf_kv is None:
+            self.buf_kv = mx.zeros((B, self.ratio, D1), dtype=kv.dtype)
+            self.buf_gate = mx.zeros((B, self.ratio, D2), dtype=gate.dtype)
+
+        # Prompt mode
+        if L > 1:
+            total = L + self.remainder
+            usable = (total // self.ratio) * self.ratio
+            new_remainder = total % self.ratio
+
+            if usable > 0:
+                r_kv = mx.concatenate(
+                    [
+                        self.buf_kv[:, : self.remainder],
+                        kv[:, : (usable - self.remainder)],
+                    ],
+                    axis=1,
+                )
+                r_gate = mx.concatenate(
+                    [
+                        self.buf_gate[:, : self.remainder],
+                        gate[:, : (usable - self.remainder)],
+                    ],
+                    axis=1,
+                )
+                r_base = offset - self.remainder
+                self.remainder = 0
+            else:
+                r_kv = mx.zeros((B, 0, D1), dtype=kv.dtype)
+                r_gate = mx.zeros((B, 0, D2), dtype=gate.dtype)
+                r_base = 0
+
+            if new_remainder > 0:
+                self.buf_kv[:, self.remainder : new_remainder] = kv[:, -new_remainder:]
+                self.buf_gate[:, self.remainder : new_remainder] = gate[
+                    :, -new_remainder:
+                ]
+            self.remainder = new_remainder
+
+            return r_kv, r_gate, r_base
+
+        # Decode mode
+        else:
+            self.buf_kv[:, self.remainder : self.remainder + 1] = kv
+            self.buf_gate[:, self.remainder : self.remainder + 1] = gate
+            self.remainder = (self.remainder + 1) % self.ratio
+
+            if self.remainder == 0:
+                r_kv = self.buf_kv
+                r_gate = self.buf_gate
+                r_base = offset - self.ratio + 1
+            else:
+                r_kv = mx.zeros((B, 0, D1), dtype=kv.dtype)
+                r_gate = mx.zeros((B, 0, D2), dtype=gate.dtype)
+                r_base = 0
+
+            return r_kv, r_gate, r_base
+
+    def update_and_fetch(self, px: mx.array):
+        if px.shape[1] == 0:
+            if self.pooled is None:
+                return mx.zeros((px.shape[0], 0, px.shape[-1]), dtype=px.dtype)
+            return self.pooled
+
+        if self.pooled is None:
+            self.pooled = px
+        else:
+            self.pooled = mx.concatenate([self.pooled, px], axis=1)
+        return self.pooled
+
+    def make_mask(self, L: int = 1, offset: int = 0):
+        """Build a causal validity mask for pooled positions.
+
+        Query at absolute position ``offset + j`` can attend to pooled token
+        ``i`` iff ``i < (offset + j) // ratio``.
+
+        Returns ``(N, P)`` bool mask, or ``None`` when every pooled position
+        is visible to every query (common during decode).
+        """
+        if self.pooled is None or L == 1:
+            return None
+
+        pool_idx = mx.arange(self.pooled.shape[1])
+        query_idx = mx.arange(offset + 1, offset + L + 1)
+        return pool_idx < query_idx[:, None] // self.ratio
+
+    @property
+    def state(self):
+        buf_kv = self.buf_kv[:, : self.remainder] if self.remainder > 0 else None
+        buf_gate = self.buf_gate[:, : self.remainder] if self.remainder > 0 else None
+        return (buf_kv, buf_gate, self.pooled)
+
+    @state.setter
+    def state(self, v):
+        buf_kv, buf_gate, pooled = v
+        self.remainder = 0
+        self.buf_kv = self.buf_gate = None
+        if buf_kv is not None:
+            self.accumulate_windows(buf_kv, buf_gate, 0)
+        self.pooled = pooled
+
+    @property
+    def meta_state(self):
+        return self.ratio
+
+    @meta_state.setter
+    def meta_state(self, v):
+        self.ratio = v
+
+    def is_trimmable(self):
+        return self.pooled is None
+
+    def trim(self, n):
+        n = min(self.remainder, n)
+        self.remainder -= n
+        return n
+
+    def size(self):
+        return 0 if self.pooled is None else self.pooled.shape[1]
+
+    def empty(self):
+        return self.pooled is None and self.remainder == 0
+
+    @property
+    def nbytes(self):
+        total = 0
+        if self.buf_kv is not None:
+            total += self.buf_kv.nbytes + self.buf_gate.nbytes
+        if self.pooled is not None:
+            total += self.pooled.nbytes
+        return total
+
+    @classmethod
+    def merge(cls, caches):
+        return BatchPoolingCache.merge(caches)
+
+
+class BatchPoolingCache(_BaseCache):
+    """Batched pooling cache with per-element variable-length tracking."""
+
+    def __init__(self, ratio: int, left_padding: List[int]):
+        self.ratio = ratio
+
+        if not all(p == 0 for p in left_padding):
+            raise RuntimeError("BatchPoolingCache does not support left padding")
+
+        batch_size = len(left_padding)
+
+        self.buf_kv = None
+        self.buf_gate = None
+        self.remainder = [0] * batch_size
+
+        self.pooled = None
+        self._pool_lengths = [0] * batch_size
+
+        self._lengths = [2**31] * batch_size
+        self._processed = [0] * batch_size
+
+    @property
+    def offset(self):
+        return mx.array(self._pool_lengths, dtype=mx.int32)
+
+    def prepare(self, *, lengths=None, right_padding=None, left_padding=None):
+        if left_padding is not None:
+            raise RuntimeError("BatchPoolingCache does not support left padding")
+        if lengths is not None:
+            self._lengths = [
+                processed + length
+                for processed, length in zip(self._processed, lengths)
+            ]
+
+    def finalize(self):
+        self._lengths = [2**31] * len(self._pool_lengths)
+
+    def accumulate_windows(self, kv: mx.array, gate: mx.array, offset):
+        B, L, D1 = kv.shape
+        _, _, D2 = gate.shape
+        ratio = self.ratio
+
+        if self.buf_kv is None:
+            self.buf_kv = mx.zeros((B, ratio, D1), dtype=kv.dtype)
+            self.buf_gate = mx.zeros((B, ratio, D2), dtype=gate.dtype)
+
+        valid_lengths = [
+            min(length - processed, L)
+            for length, processed in zip(self._lengths, self._processed)
+        ]
+        if max(valid_lengths) != L:
+            raise RuntimeError()
+        for i in range(B):
+            self._processed[i] += valid_lengths[i]
+
+        totals = [vl + r for vl, r in zip(valid_lengths, self.remainder)]
+        usable = [(t // ratio) * ratio for t in totals]
+        max_usable = max(usable)
+        new_remainder = [t % ratio for t in totals]
+
+        # No sequence produced a full window yet
+        if max_usable == 0:
+            for i in range(B):
+                r = self.remainder[i]
+                vl = valid_lengths[i]
+                self.buf_kv[i, r : r + vl] = kv[i, :vl]
+                self.buf_gate[i, r : r + vl] = gate[i, :vl]
+            self.remainder = new_remainder
+
+            r_kv = mx.zeros((B, 0, D1), dtype=kv.dtype)
+            r_gate = mx.zeros((B, 0, D2), dtype=gate.dtype)
+            r_base = 0
+            return r_kv, r_gate, r_base
+
+        # At least one sequence completed a window
+        r_kv = mx.zeros((B, max_usable, D1), dtype=kv.dtype)
+        r_gate = mx.zeros((B, max_usable, D2), dtype=gate.dtype)
+        r_base = [0] * B
+
+        new_buf_kv = mx.zeros_like(self.buf_kv)
+        new_buf_gate = mx.zeros_like(self.buf_gate)
+
+        for i in range(B):
+            r = self.remainder[i]
+            vl = valid_lengths[i]
+            u = usable[i]
+            nr = new_remainder[i]
+
+            if u > 0:
+                # Tokens from the buffer (the leftover from last call)
+                if r > 0:
+                    r_kv[i, :r] = self.buf_kv[i, :r]
+                    r_gate[i, :r] = self.buf_gate[i, :r]
+
+                # Tokens from the new input that complete full windows
+                consume = u - r
+                r_kv[i, r : r + consume] = kv[i, :consume]
+                r_gate[i, r : r + consume] = gate[i, :consume]
+
+                r_base[i] = (
+                    offset[i] - r if isinstance(offset, mx.array) else offset - r
+                )
+
+            # Fill new remainder buffer from the tail of the input
+            if nr > 0:
+                if u > 0:
+                    # Old remainder was consumed into usable output;
+                    # new remainder is purely from the tail of new input.
+                    new_buf_kv[i, :nr] = kv[i, vl - nr : vl]
+                    new_buf_gate[i, :nr] = gate[i, vl - nr : vl]
+                else:
+                    # No full window produced: carry over old buffer and
+                    # append any new valid tokens.
+                    if r > 0:
+                        new_buf_kv[i, :r] = self.buf_kv[i, :r]
+                        new_buf_gate[i, :r] = self.buf_gate[i, :r]
+                    if vl > 0:
+                        new_buf_kv[i, r : r + vl] = kv[i, :vl]
+                        new_buf_gate[i, r : r + vl] = gate[i, :vl]
+
+        self.buf_kv = new_buf_kv
+        self.buf_gate = new_buf_gate
+        self.remainder = new_remainder
+
+        r_base = mx.array(r_base)
+        return r_kv, r_gate, r_base
+
+    def update_and_fetch(self, px: mx.array):
+        B, N, D = px.shape
+
+        if N == 0:
+            if self.pooled is None:
+                return mx.zeros((B, 0, D), dtype=px.dtype)
+            return self.pooled
+
+        # Derive how many new pooled tokens each sequence actually produced.
+        new_counts = [
+            (self._processed[i] - self.remainder[i]) // self.ratio
+            - self._pool_lengths[i]
+            for i in range(B)
+        ]
+        max_new = max(new_counts)
+        if max_new == 0:
+            if self.pooled is None:
+                return mx.zeros((B, 0, D), dtype=px.dtype)
+            return self.pooled
+
+        max_pool = max(self._pool_lengths) + max_new
+
+        if self.pooled is None:
+            self.pooled = mx.zeros((B, max_pool, D), dtype=px.dtype)
+        elif self.pooled.shape[1] < max_pool:
+            pad = mx.zeros((B, max_pool - self.pooled.shape[1], D), dtype=px.dtype)
+            self.pooled = mx.concatenate([self.pooled, pad], axis=1)
+
+        for i in range(B):
+            nc = new_counts[i]
+            if nc > 0:
+                pl = self._pool_lengths[i]
+                self.pooled[i, pl : pl + nc] = px[i, :nc]
+                self._pool_lengths[i] = pl + nc
+
+        return self.pooled
+
+    def make_mask(self, L: int = 1, offset=0):
+        if self.pooled is None:
+            return None
+
+        B, P, _ = self.pooled.shape
+        pool_lengths = mx.array(self._pool_lengths)
+
+        # Length based mask
+        pool_idx = mx.arange(P)[None, None, :]
+        valid = pool_idx < pool_lengths[:, None, None]
+
+        # Decode so no need for causal masking
+        if L == 1:
+            if all(pl == P for pl in self._pool_lengths):
+                return None
+            return valid
+
+        # Prompt so we need to combine with causal
+        if isinstance(offset, mx.array):
+            query_pos = offset[:, None] + mx.arange(1, L + 1)
+        else:
+            query_pos = offset + mx.arange(offset + 1, offset + L + 1)[None]
+
+        causal = pool_idx < (query_pos[..., None] // self.ratio)
+        mask = causal & valid
+        return mask
+
+    @property
+    def state(self):
+        return (self.buf_kv, self.buf_gate, self.pooled)
+
+    @state.setter
+    def state(self, v):
+        self.buf_kv, self.buf_gate, self.pooled = v
+
+    @property
+    def meta_state(self):
+        return (self.ratio, self.remainder, self._pool_lengths, self._processed)
+
+    @meta_state.setter
+    def meta_state(self, v):
+        self.ratio, self.remainder, self._pool_lengths, self._processed = v
+
+    def is_trimmable(self):
+        return self.pooled is None
+
+    def trim(self, n):
+        n = min(min(self.remainder), n)
+        for i in range(len(self.remainder)):
+            self.remainder[i] -= n
+            self._processed[i] -= n
+        return n
+
+    def size(self):
+        return 0 if self.pooled is None else self.pooled.shape[1]
+
+    def empty(self):
+        return self.pooled is None and all(r == 0 for r in self.remainder)
+
+    @property
+    def nbytes(self):
+        total = 0
+        if self.buf_kv is not None:
+            total += self.buf_kv.nbytes + self.buf_gate.nbytes
+        if self.pooled is not None:
+            total += self.pooled.nbytes
+        return total
+
+    def filter(self, batch_indices):
+        if isinstance(batch_indices, mx.array):
+            idx_list = batch_indices.tolist()
+        else:
+            idx_list = list(batch_indices)
+
+        if self.buf_kv is not None:
+            self.buf_kv = self.buf_kv[batch_indices]
+            self.buf_gate = self.buf_gate[batch_indices]
+        if self.pooled is not None:
+            self.pooled = self.pooled[batch_indices]
+
+        self.remainder = [self.remainder[i] for i in idx_list]
+        self._pool_lengths = [self._pool_lengths[i] for i in idx_list]
+        self._lengths = [self._lengths[i] for i in idx_list]
+        self._processed = [self._processed[i] for i in idx_list]
+
+    def extend(self, other):
+        # Merge the remainder buffers
+        if self.buf_kv is None and other.buf_kv is None:
+            pass
+        elif self.buf_kv is not None and other.buf_kv is not None:
+            self.buf_kv = mx.concatenate([self.buf_kv, other.buf_kv], axis=0)
+            self.buf_gate = mx.concatenate([self.buf_gate, other.buf_gate], axis=0)
+        elif self.buf_kv is None:
+            B = len(self.remainder)
+            D1 = other.buf_kv.shape[2]
+            D2 = other.buf_gate.shape[2]
+            self.buf_kv = mx.concatenate(
+                [mx.zeros((B, self.ratio, D1), dtype=other.buf_kv.dtype), other.buf_kv],
+                axis=0,
+            )
+            self.buf_gate = mx.concatenate(
+                [
+                    mx.zeros((B, self.ratio, D2), dtype=other.buf_gate.dtype),
+                    other.buf_gate,
+                ],
+                axis=0,
+            )
+        else:
+            B2 = len(other.remainder)
+            D1 = self.buf_kv.shape[2]
+            D2 = self.buf_gate.shape[2]
+            self.buf_kv = mx.concatenate(
+                [self.buf_kv, mx.zeros((B2, self.ratio, D1), dtype=self.buf_kv.dtype)],
+                axis=0,
+            )
+            self.buf_gate = mx.concatenate(
+                [
+                    self.buf_gate,
+                    mx.zeros((B2, self.ratio, D2), dtype=self.buf_gate.dtype),
+                ],
+                axis=0,
+            )
+
+        # Merge the pooled buffers
+        if self.pooled is None and other.pooled is None:
+            pass
+        else:
+            B1 = len(self.remainder)
+            B2 = len(other.remainder)
+            P1 = 0 if self.pooled is None else self.pooled.shape[1]
+            P2 = 0 if other.pooled is None else other.pooled.shape[1]
+            max_P = max(P1, P2)
+
+            if max_P > 0:
+                if self.pooled is not None:
+                    D = self.pooled.shape[2]
+                else:
+                    D = other.pooled.shape[2]
+                dt = (self.pooled if self.pooled is not None else other.pooled).dtype
+
+                def pad_pool(pooled, B, P):
+                    if pooled is None:
+                        return mx.zeros((B, max_P, D), dtype=dt)
+                    if P < max_P:
+                        pad = mx.zeros((pooled.shape[0], max_P - P, D), dtype=dt)
+                        return mx.concatenate([pooled, pad], axis=1)
+                    return pooled
+
+                self.pooled = mx.concatenate(
+                    [pad_pool(self.pooled, B1, P1), pad_pool(other.pooled, B2, P2)],
+                    axis=0,
+                )
+
+        self.remainder = self.remainder + other.remainder
+        self._pool_lengths = self._pool_lengths + other._pool_lengths
+        self._lengths = self._lengths + other._lengths
+        self._processed = self._processed + other._processed
+
+    def extract(self, idx):
+        cache = PoolingCache(self.ratio)
+        pl = self._pool_lengths[idx]
+        r = self.remainder[idx]
+
+        if self.pooled is not None and pl > 0:
+            cache.pooled = mx.contiguous(self.pooled[idx : idx + 1, :pl])
+
+        if self.buf_kv is not None and r > 0:
+            cache.buf_kv = mx.contiguous(self.buf_kv[idx : idx + 1])
+            cache.buf_gate = mx.contiguous(self.buf_gate[idx : idx + 1])
+            cache.remainder = r
+
+        return cache
+
+    @classmethod
+    def merge(cls, caches):
+        """Merge a list of PoolingCache instances into a BatchPoolingCache."""
+        B = len(caches)
+        if not all(c.ratio == caches[0].ratio for c in caches):
+            raise ValueError(
+                "BatchPoolingCache can only merge caches with the same ratio"
+            )
+        ratio = caches[0].ratio
+        batch_cache = cls(ratio, [0] * B)
+
+        # Check if all caches are empty
+        if all(c.empty() for c in caches):
+            return batch_cache
+
+        # Merge pooled buffers
+        pool_sizes = [c.size() for c in caches]
+        max_pool = max(pool_sizes)
+        if max_pool > 0:
+            D = next(c.pooled.shape[2] for c in caches if c.pooled is not None)
+            dt = next(c.pooled.dtype for c in caches if c.pooled is not None)
+            pooled = mx.zeros((B, max_pool, D), dtype=dt)
+            for i, c in enumerate(caches):
+                if c.pooled is not None:
+                    ps = c.pooled.shape[1]
+                    pooled[i, :ps] = c.pooled[0]
+            batch_cache.pooled = pooled
+
+        batch_cache._pool_lengths = pool_sizes
+        batch_cache.remainder = [c.remainder for c in caches]
+        batch_cache._processed = [
+            c.remainder + ps * ratio for c, ps in zip(caches, pool_sizes)
+        ]
+
+        # Merge remainder buffers
+        has_buf = any(c.buf_kv is not None for c in caches)
+        if has_buf:
+            D1 = next(c.buf_kv.shape[2] for c in caches if c.buf_kv is not None)
+            D2 = next(c.buf_gate.shape[2] for c in caches if c.buf_gate is not None)
+            dt = next(c.buf_kv.dtype for c in caches if c.buf_kv is not None)
+            buf_kv = mx.zeros((B, ratio, D1), dtype=dt)
+            buf_gate = mx.zeros((B, ratio, D2), dtype=dt)
+            for i, c in enumerate(caches):
+                if c.buf_kv is not None and c.remainder > 0:
+                    buf_kv[i, : c.remainder] = c.buf_kv[0, : c.remainder]
+                    buf_gate[i, : c.remainder] = c.buf_gate[0, : c.remainder]
+            batch_cache.buf_kv = buf_kv
+            batch_cache.buf_gate = buf_gate
+
+        return batch_cache
 
 
 def make_prompt_cache(

--- a/mlx_vlm/models/deepseek_v4/__init__.py
+++ b/mlx_vlm/models/deepseek_v4/__init__.py
@@ -1,3 +1,5 @@
+import mlx_vlm.models.deepseek_v4.processing_deepseek_v4  # noqa: F401 (installs processor patch)
+
 from .config import ModelConfig
 from .deepseek_v4 import Model
 

--- a/mlx_vlm/models/deepseek_v4/__init__.py
+++ b/mlx_vlm/models/deepseek_v4/__init__.py
@@ -1,0 +1,4 @@
+from .config import ModelConfig
+from .deepseek_v4 import Model
+
+__all__ = ["Model", "ModelConfig"]

--- a/mlx_vlm/models/deepseek_v4/config.py
+++ b/mlx_vlm/models/deepseek_v4/config.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, field
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Union
 
 from ..base import BaseModelConfig
 
@@ -45,6 +45,9 @@ class ModelConfig(BaseModelConfig):
     index_topk: int = 512
     num_nextn_predict_layers: int = 1
     tie_word_embeddings: bool = False
+    bos_token_id: Optional[int] = None
+    eos_token_id: Optional[Union[int, List[int]]] = None
+    pad_token_id: Optional[int] = None
     topk_method: str = "noaux_tc"
 
     def __post_init__(self):

--- a/mlx_vlm/models/deepseek_v4/config.py
+++ b/mlx_vlm/models/deepseek_v4/config.py
@@ -1,0 +1,66 @@
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional
+
+from ..base import BaseModelConfig
+
+
+@dataclass
+class ModelConfig(BaseModelConfig):
+    model_type: str = "deepseek_v4"
+    vocab_size: int = 129280
+    hidden_size: int = 4096
+    intermediate_size: int = 18432
+    moe_intermediate_size: int = 2048
+    num_hidden_layers: int = 43
+    num_attention_heads: int = 64
+    num_key_value_heads: int = 1
+    n_shared_experts: int = 1
+    n_routed_experts: int = 256
+    routed_scaling_factor: float = 1.5
+    q_lora_rank: int = 1024
+    qk_rope_head_dim: int = 64
+    num_experts_per_tok: int = 6
+    norm_topk_prob: bool = True
+    hidden_act: str = "silu"
+    max_position_embeddings: int = 1048576
+    rms_norm_eps: float = 1e-6
+    rope_theta: float = 10000.0
+    rope_scaling: Optional[Dict] = None
+    attention_bias: bool = False
+    attention_dropout: float = 0.0
+    head_dim: int = 512
+    scoring_func: str = "sqrtsoftplus"
+    compress_ratios: List[int] = field(default_factory=list)
+    compress_rope_theta: float = 160000.0
+    hc_mult: int = 4
+    hc_sinkhorn_iters: int = 20
+    hc_eps: float = 1e-6
+    num_hash_layers: int = 3
+    swiglu_limit: float = 10.0
+    sliding_window: int = 128
+    o_groups: int = 8
+    o_lora_rank: int = 1024
+    index_n_heads: int = 64
+    index_head_dim: int = 128
+    index_topk: int = 512
+    num_nextn_predict_layers: int = 1
+    tie_word_embeddings: bool = False
+    topk_method: str = "noaux_tc"
+
+    def __post_init__(self):
+        if not self.compress_ratios:
+            n = self.num_hidden_layers
+            self.compress_ratios = (
+                [0]
+                + [4 if i % 2 else 128 for i in range(max(n - 2, 0))]
+                + ([0] if n >= 2 else [])
+            )
+        self.compress_ratios = list(self.compress_ratios[: self.num_hidden_layers])
+        if len(self.compress_ratios) != self.num_hidden_layers:
+            raise ValueError(
+                "`compress_ratios` must have one entry per hidden layer, "
+                f"got {len(self.compress_ratios)} for {self.num_hidden_layers} layers."
+            )
+        bad = [r for r in self.compress_ratios if r not in (0, 4, 128)]
+        if bad:
+            raise ValueError(f"Unsupported DeepSeek-V4 compress ratios: {bad}")

--- a/mlx_vlm/models/deepseek_v4/deepseek_v4.py
+++ b/mlx_vlm/models/deepseek_v4/deepseek_v4.py
@@ -1,0 +1,63 @@
+from typing import Optional
+
+import mlx.core as mx
+import mlx.nn as nn
+
+from ..base import InputEmbeddingsFeatures, LanguageModelOutput
+from .config import ModelConfig
+from .language import LanguageModel
+
+
+class Model(nn.Module):
+    def __init__(self, config: ModelConfig):
+        super().__init__()
+        self.config = config
+        self.model_type = config.model_type
+        self.language_model = LanguageModel(config)
+
+    def get_input_embeddings(
+        self,
+        input_ids: Optional[mx.array] = None,
+        pixel_values: Optional[mx.array] = None,
+        **kwargs,
+    ) -> InputEmbeddingsFeatures:
+        return InputEmbeddingsFeatures(
+            inputs_embeds=self.language_model.model.embed_tokens(input_ids)
+        )
+
+    def __call__(
+        self,
+        input_ids: mx.array,
+        pixel_values: mx.array = None,
+        mask: mx.array = None,
+        cache=None,
+        **kwargs,
+    ) -> LanguageModelOutput:
+        return self.language_model(input_ids, cache=cache, **kwargs)
+
+    def sanitize(self, weights):
+        weights = self.language_model.sanitize(weights)
+
+        def transform_key(key):
+            if key.startswith("language_model."):
+                return key
+            if key.startswith("model.") or key.startswith("lm_head."):
+                return f"language_model.{key}"
+            return key
+
+        return {transform_key(k): v for k, v in weights.items()}
+
+    @property
+    def quant_predicate(self):
+        return self.language_model.quant_predicate
+
+    @property
+    def cast_predicate(self):
+        return self.language_model.cast_predicate
+
+    @property
+    def layers(self):
+        return self.language_model.layers
+
+    def make_cache(self):
+        return self.language_model.make_cache()

--- a/mlx_vlm/models/deepseek_v4/hyper_connection.py
+++ b/mlx_vlm/models/deepseek_v4/hyper_connection.py
@@ -1,0 +1,285 @@
+# Copyright (c) 2026 Apple Inc.
+
+from typing import Tuple
+
+import mlx.core as mx
+import mlx.nn as nn
+
+
+def _make_hc_sinkhorn_collapse_kernel():
+    """Fused sinkhorn + collapse: eliminates one dispatch per HC cycle.
+
+    1. BRANCHLESS SINKHORN: all 32 lanes in simd group 0 execute identical
+       instructions. Lanes >= HC use multiplicative mask (active=0) instead
+       of divergent branches - eliminates SIMD serialization.
+    2. PARALLEL SINKHORN: lanes 0-3 each own one comb row. Column norm
+       via simd_sum() - free SIMD shuffle.
+    3. NATIVE bfloat4 LOADS: single 64-bit load yields 4 bfloat16 values;
+       cast to float4 is a free hardware conversion.
+    4. FMA CHAINS: collapse uses fused multiply-add for 3 of 4 terms.
+    """
+    if mx.default_device() != mx.gpu or not mx.metal.is_available():
+        return None
+
+    source = """
+        uint tid  = thread_position_in_threadgroup.x;
+        uint row  = threadgroup_position_in_grid.x;
+        uint lane = tid % 32;
+        uint sg   = tid / 32;
+
+        constexpr int MIX      = (2 + HC) * HC;
+        constexpr int BASE_OFF = 2 * HC;
+        constexpr float EPS = EPS_INT * 1e-9;
+
+        const device float* mix      = (const device float*)mixes + row * MIX;
+        device float*       post_out = (device float*)post + row * HC;
+        device float*       comb_out = (device float*)comb + row * HC * HC;
+
+        threadgroup float pre_shared[HC];
+
+        // ================================================================
+        // PHASE 1: Branchless sinkhorn on simd group 0
+        //   All 32 lanes execute identical instructions. Lanes >= HC
+        //   compute on clamped indices but multiply by active=0, so they
+        //   contribute zero to simd_sum. No divergent branches in the loop.
+        // ================================================================
+        if (sg == 0) {
+            const float pre_scale  = scale[0];
+            const float post_scale = scale[1];
+            const float comb_scale = scale[2];
+
+            const float active = (lane < (uint)HC) ? 1.0f : 0.0f;
+            const uint  llane  = metal::min(lane, (uint)(HC - 1));
+
+            // Pre/post sigmoids: all lanes compute, only active lanes write
+            float pre_z  = mix[llane]      * pre_scale  + base[llane];
+            float post_z = mix[HC + llane] * post_scale + base[HC + llane];
+            float pre_v  = 1.0f / (1.0f + metal::fast::exp(-pre_z)) + EPS;
+            float post_v = 2.0f / (1.0f + metal::fast::exp(-post_z));
+
+            if (lane < (uint)HC) {
+                pre_shared[lane] = pre_v;
+                post_out[lane]   = post_v;
+            }
+
+            // Comb softmax: load + mask. Inactive lanes load row 0 (safe)
+            // but multiply by active=0 so they hold zeros.
+            float4 v = (*(const device float4*)(mix  + BASE_OFF + llane * HC)
+                            * comb_scale
+                      + *(const device float4*)(base + BASE_OFF + llane * HC))
+                     * active;
+
+            float row_max = metal::max(metal::max(v.x, v.y),
+                                       metal::max(v.z, v.w));
+            float4 e = metal::fast::exp(v - row_max) * active;
+            float4 r = e * (1.0f / (e.x + e.y + e.z + e.w + EPS))
+                     + EPS * active;
+
+            // Initial column normalization
+            float4 col_inv = 1.0f / (float4(
+                simd_sum(r.x), simd_sum(r.y),
+                simd_sum(r.z), simd_sum(r.w)
+            ) + EPS);
+            r *= col_inv;
+
+            // Sinkhorn iterations: zero branches in the loop body
+            for (int iter = 1; iter < ITERS; ++iter) {
+                // Row norm + re-clamp inactive lanes
+                r *= (1.0f / (r.x + r.y + r.z + r.w + EPS)) * active;
+
+                // Col norm via simd_sum
+                col_inv = 1.0f / (float4(
+                    simd_sum(r.x), simd_sum(r.y),
+                    simd_sum(r.z), simd_sum(r.w)
+                ) + EPS);
+                r *= col_inv;
+            }
+
+            if (lane < (uint)HC) {
+                *(device float4*)(comb_out + lane * HC) = r;
+            }
+        }
+
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+
+        // ================================================================
+        // PHASE 2: Collapse - all 256 threads, vectorized
+        // ================================================================
+        const float p0 = pre_shared[0];
+        const float p1 = pre_shared[1];
+        const float p2 = pre_shared[2];
+        const float p3 = pre_shared[3];
+
+        const device T* x_row  = (const device T*)x_in
+                                         + row * (HC * D);
+        device U*       out_row = (device U*)collapsed
+                                         + row * D;
+
+        using T4 = vec<T, 4>;
+        using U4 = vec<U, 4>;
+        const device T4* x_row0 = (const device T4*)(x_row + 0*D);
+        const device T4* x_row1 = (const device T4*)(x_row + 1*D);
+        const device T4* x_row2 = (const device T4*)(x_row + 2*D);
+        const device T4* x_row3 = (const device T4*)(x_row + 3*D);
+        device U4*       out4   = (device U4*)out_row;
+
+        constexpr uint D4 = (uint)D / 4;
+
+        for (uint d4 = tid; d4 < D4; d4 += 256) {
+            float4 x0 = float4(x_row0[d4]);
+            float4 x1 = float4(x_row1[d4]);
+            float4 x2 = float4(x_row2[d4]);
+            float4 x3 = float4(x_row3[d4]);
+
+            float4 result = fma(float4(p0), x0,
+                            fma(float4(p1), x1,
+                            fma(float4(p2), x2, float4(p3) * x3)));
+
+            out4[d4] = U4(result);
+        }
+
+        // Scalar tail for D not divisible by 4
+        #if (D % 4) != 0
+        for (uint d = D4 * 4 + tid; d < (uint)D; d += 256) {
+            float val = p0*(float)x_row[0*D+d] + p1*(float)x_row[1*D+d]
+                      + p2*(float)x_row[2*D+d] + p3*(float)x_row[3*D+d];
+            out_row[d] = (U)val;
+        }
+        #endif
+    """
+
+    return mx.fast.metal_kernel(
+        name="hc_sinkhorn_collapse",
+        input_names=["x_in", "mixes", "scale", "base"],
+        output_names=["collapsed", "post", "comb"],
+        source=source,
+        ensure_row_contiguous=True,
+    )
+
+
+_hc_sinkhorn_collapse_kernel = _make_hc_sinkhorn_collapse_kernel()
+
+
+def _hc_kernel(x, y, mixes, scale, base, hc_mult, sinkhorn_iters, eps):
+    B, L, H, D = x.shape
+
+    return _hc_sinkhorn_collapse_kernel(
+        inputs=[x, mixes, scale, base],
+        template=[
+            ("T", x.dtype),
+            ("U", x.dtype),
+            ("HC", hc_mult),
+            ("ITERS", sinkhorn_iters),
+            ("D", D),
+            ("EPS_INT", round(eps / 1e-9)),
+        ],
+        grid=(B * L * 256, 1, 1),
+        threadgroup=(256, 1, 1),
+        output_shapes=[(B, L, D), (B, L, hc_mult), (B, L, hc_mult, hc_mult)],
+        output_dtypes=[x.dtype, mx.float32, mx.float32],
+    )
+
+
+@mx.compile
+def _hc_split_sinkhorn_ops(
+    mixes: mx.array,
+    scale: mx.array,
+    base: mx.array,
+    hc_mult: int,
+    sinkhorn_iters: int,
+    eps: float,
+) -> Tuple[mx.array, mx.array, mx.array]:
+    mixes = mixes.astype(mx.float32)
+    scale = scale.astype(mx.float32)
+    base = base.astype(mx.float32)
+    pre_scale, post_scale, comb_scale = scale[0], scale[1], scale[2]
+
+    pre = mx.sigmoid(mixes[..., :hc_mult] * pre_scale + base[:hc_mult]) + eps
+    post = 2 * mx.sigmoid(
+        mixes[..., hc_mult : 2 * hc_mult] * post_scale + base[hc_mult : 2 * hc_mult]
+    )
+    comb = mixes[..., 2 * hc_mult :].reshape(
+        *mixes.shape[:-1], hc_mult, hc_mult
+    ) * comb_scale + base[2 * hc_mult :].reshape(hc_mult, hc_mult)
+    comb = mx.softmax(comb, axis=-1, precise=True) + eps
+    comb = comb / (comb.sum(axis=-2, keepdims=True) + eps)
+    for _ in range(max(sinkhorn_iters - 1, 0)):
+        comb = comb / (comb.sum(axis=-1, keepdims=True) + eps)
+        comb = comb / (comb.sum(axis=-2, keepdims=True) + eps)
+    return pre, post, comb
+
+
+def _hc_ops(x, y, mixes, scale, base, hc_mult, sinkhorn_iters, eps):
+    pre, post, comb = _hc_split_sinkhorn_ops(
+        mixes, scale, base, hc_mult, sinkhorn_iters, eps
+    )
+    return (pre[..., None] * y).sum(axis=2).astype(x.dtype), post, comb
+
+
+class HyperConnection(nn.Module):
+    def __init__(self, config):
+        super().__init__()
+        self.hc_mult = config.hc_mult
+        self.sinkhorn_iters = config.hc_sinkhorn_iters
+        self.hc_eps = config.hc_eps
+        self.norm_eps = config.rms_norm_eps
+
+        mix = (2 + self.hc_mult) * self.hc_mult
+        self.fn = mx.zeros((mix, self.hc_mult * config.hidden_size), dtype=mx.float32)
+        self.base = mx.zeros((mix,), dtype=mx.float32)
+        self.scale = mx.ones((3,), dtype=mx.float32)
+
+    def __call__(self, x: mx.array):
+        B, L, H, D = x.shape
+        y = x.astype(mx.float32)
+        z = mx.fast.rms_norm(y.flatten(-2), None, self.norm_eps)
+        mixes = z @ self.fn.T
+
+        use_ops = (
+            self.training
+            or mx.default_device() != mx.gpu
+            or not mx.metal.is_available()
+        )
+        hc_func = _hc_ops if use_ops else _hc_kernel
+
+        return hc_func(
+            x,
+            y,
+            mixes,
+            self.scale,
+            self.base,
+            self.hc_mult,
+            self.sinkhorn_iters,
+            self.hc_eps,
+        )
+
+
+@mx.compile
+def _hc_expand_op(x, residual, post, comb):
+    y = post[..., None] * x[:, :, None, :].astype(mx.float32)
+    y = y + mx.matmul(comb.swapaxes(-1, -2), residual.astype(mx.float32))
+    return y.astype(x.dtype)
+
+
+def hc_expand(x, residual, post, comb):
+    return _hc_expand_op(x, residual, post, comb)
+
+
+class HyperHead(nn.Module):
+    def __init__(self, config):
+        super().__init__()
+        self.hc_mult = config.hc_mult
+        self.norm_eps = config.rms_norm_eps
+        self.hc_eps = config.hc_eps
+        self.fn = mx.zeros(
+            (self.hc_mult, self.hc_mult * config.hidden_size), dtype=mx.float32
+        )
+        self.base = mx.zeros((self.hc_mult,), dtype=mx.float32)
+        self.scale = mx.ones((1,), dtype=mx.float32)
+
+    def __call__(self, x: mx.array):
+        y = x.astype(mx.float32)
+        z = mx.fast.rms_norm(y.flatten(-2), None, self.norm_eps)
+        mixes = z @ self.fn.T
+        pre = mx.sigmoid(mixes * self.scale + self.base) + self.hc_eps
+        return (pre[..., None] * y).sum(axis=2).astype(x.dtype)

--- a/mlx_vlm/models/deepseek_v4/language.py
+++ b/mlx_vlm/models/deepseek_v4/language.py
@@ -1,0 +1,1134 @@
+import math
+from functools import partial
+from typing import Any, Dict, Optional, Tuple, Union
+
+import mlx.core as mx
+import mlx.nn as nn
+from mlx.nn.layers.distributed import shard_inplace, shard_linear, sum_gradients
+from mlx.utils import tree_flatten
+from mlx_lm.models.mla import MultiLinear
+from mlx_lm.models.pipeline import PipelineMixin
+from mlx_lm.models.switch_layers import SwitchGLU
+
+from ..base import (
+    LanguageModelOutput,
+    create_attention_mask,
+    scaled_dot_product_attention,
+)
+from ..cache import CacheList, PoolingCache, RotatingKVCache
+from .config import ModelConfig
+from .hyper_connection import HyperConnection, HyperHead, hc_expand
+
+
+def make_quantization_config(model):
+    mxfp4 = {"group_size": 32, "bits": 4, "mode": "mxfp4"}
+    mxfp8 = {"group_size": 32, "bits": 8, "mode": "mxfp8"}
+
+    flat_modules = tree_flatten(model.leaf_modules(), is_leaf=nn.Module.is_module)
+    experts = {
+        k: mxfp4
+        for k, _ in flat_modules
+        if ".ffn.switch_mlp." in k and k.endswith("_proj")
+    }
+    shared_experts = {k: mxfp8 for k, _ in flat_modules if ".ffn.shared_experts." in k}
+    attn = {
+        k: mxfp8 for k, _ in flat_modules if ".attn.w" in k or ".attn.indexer.wq" in k
+    }
+
+    return {
+        "group_size": 64,
+        "bits": 8,
+        "mode": "affine",
+        **experts,
+        **shared_experts,
+        **attn,
+    }
+
+
+def _score_func(scores: mx.array, func: str) -> mx.array:
+    if func == "softmax":
+        return mx.softmax(scores, axis=-1, precise=True)
+    if func == "sigmoid":
+        return mx.sigmoid(scores)
+    if func == "sqrtsoftplus":
+        return mx.sqrt(nn.softplus(scores))
+    raise ValueError(f"Unsupported DeepSeek-V4 scoring function: {func}")
+
+
+@mx.compile
+def _expert_select(
+    logits: mx.array,
+    e_score_correction_bias: mx.array,
+    top_k: int,
+    routed_scaling_factor: float,
+    norm_topk_prob: bool,
+    scoring_func: str,
+) -> Tuple[mx.array, mx.array]:
+    logits = logits.astype(mx.float32)
+    scores = _score_func(logits, scoring_func)
+    biased = scores + e_score_correction_bias
+    inds = mx.argpartition(-biased, kth=top_k - 1, axis=-1)[..., :top_k].astype(
+        mx.int32
+    )
+    weights = mx.take_along_axis(scores, inds, axis=-1)
+    if scoring_func != "softmax" and norm_topk_prob:
+        weights = weights / (weights.sum(axis=-1, keepdims=True) + 1e-20)
+    weights = weights * routed_scaling_factor
+    return inds, weights
+
+
+@mx.compile
+def _hash_expert_select(
+    input_ids: mx.array,
+    logits: mx.array,
+    tid2eid: mx.array,
+    routed_scaling_factor: float,
+    norm_topk_prob: bool,
+    scoring_func: str,
+) -> Tuple[mx.array, mx.array]:
+    logits = logits.astype(mx.float32)
+    scores = _score_func(logits, scoring_func)
+    inds = tid2eid[input_ids].astype(mx.int32)
+    weights = mx.take_along_axis(scores, inds, axis=-1)
+    if scoring_func != "softmax" and norm_topk_prob:
+        weights = weights / (weights.sum(axis=-1, keepdims=True) + 1e-20)
+    weights = weights * routed_scaling_factor
+    return inds, weights
+
+
+@mx.compile
+def _limited_swiglu(gate: mx.array, up: mx.array, limit: float) -> mx.array:
+    if limit and limit > 0:
+        gate = mx.minimum(gate, limit)
+        up = mx.clip(up, -limit, limit)
+    return nn.silu(gate) * up
+
+
+class LimitedSwiGLU(nn.Module):
+    def __init__(self, limit: float):
+        super().__init__()
+        self.limit = limit
+
+    def __call__(self, x, gate):
+        return _limited_swiglu(gate, x, self.limit)
+
+
+class DeepseekV4RoPE(nn.Module):
+    def __init__(
+        self,
+        dims: int,
+        base: float,
+        scaling_config: Optional[Dict] = None,
+        max_position_embeddings: int = 1048576,
+        freq_scale: int = 1,
+    ):
+        super().__init__()
+        self.dims = dims
+        self.freq_scale = freq_scale
+
+        inv_freq = 1.0 / (base ** (mx.arange(0, dims, 2, dtype=mx.float32) / dims))
+        rope_type = None
+        if scaling_config is not None:
+            rope_type = scaling_config.get("type") or scaling_config.get("rope_type")
+
+        if rope_type in ("yarn", "deepseek_yarn"):
+            factor = scaling_config["factor"]
+            original_max_position_embeddings = scaling_config[
+                "original_max_position_embeddings"
+            ]
+            beta_fast = scaling_config.get("beta_fast", 32)
+            beta_slow = scaling_config.get("beta_slow", 1)
+
+            def correction_dim(num_rotations):
+                return (
+                    dims
+                    * math.log(
+                        original_max_position_embeddings / (num_rotations * 2 * math.pi)
+                    )
+                    / (2 * math.log(base))
+                )
+
+            low = max(math.floor(correction_dim(beta_fast)), 0)
+            high = min(math.ceil(correction_dim(beta_slow)), dims - 1)
+            if low == high:
+                high += 0.001
+
+            ramp = (mx.arange(dims // 2, dtype=mx.float32) - low) / (high - low)
+            smooth = 1 - mx.clip(ramp, 0, 1)
+            inv_freq = inv_freq / factor * (1 - smooth) + inv_freq * smooth
+
+        elif rope_type not in (None, "default"):
+            raise ValueError(f"Unsupported DeepSeek-V4 RoPE type: {rope_type}")
+
+        self._freqs = 1.0 / inv_freq
+        self._freqs_cache = {}
+
+    def _get_freqs(self, head_dim: int, inverse: bool):
+        key = (head_dim, inverse)
+        if key not in self._freqs_cache:
+            f = self._freqs
+            if self.freq_scale != 1:
+                f = f / self.freq_scale
+            if inverse:
+                f = -f
+            nope_pairs = (head_dim - self.dims) // 2
+            if nope_pairs > 0:
+                f = mx.concatenate([mx.full((nope_pairs,), mx.inf), f])
+            self._freqs_cache[key] = f
+        return self._freqs_cache[key]
+
+    def __call__(
+        self,
+        x: mx.array,
+        offset: Any = 0,
+        inverse: bool = False,
+    ) -> mx.array:
+        head_dim = x.shape[-1]
+        freqs = self._get_freqs(head_dim, inverse)
+        offset = offset // self.freq_scale if self.freq_scale != 1 else offset
+        return mx.fast.rope(
+            x,
+            head_dim,
+            traditional=True,
+            base=None,
+            scale=1.0,
+            offset=offset,
+            freqs=freqs,
+        )
+
+
+def _apply_score_mask(scores: mx.array, mask: Optional[mx.array]) -> mx.array:
+    if mask is None:
+        return scores
+    if mask.dtype == mx.bool_:
+        return mx.where(mask, scores, mx.finfo(scores.dtype).min)
+    return scores + mask.astype(scores.dtype)
+
+
+def _extend_mask(mask: Optional[mx.array], pool_mask: Optional[mx.array], N: int):
+    if mask is None:
+        return None
+
+    if mask.ndim == 2:
+        mask = mask[None, None]
+    B, H, L, S = mask.shape
+
+    if pool_mask is None:
+        pool_mask = mx.ones((B, H, L, N - S), dtype=mx.bool_)
+    elif pool_mask.ndim == 2:
+        pool_mask = mx.broadcast_to(pool_mask, (B, H, L, N - S))
+    elif pool_mask.ndim == 3:
+        pool_mask = mx.broadcast_to(pool_mask[:, None], (B, H, L, N - S))
+
+    full_mask = mx.concatenate([mask, pool_mask], axis=-1)
+
+    return full_mask
+
+
+@partial(mx.compile, shapeless=True)
+def _simple_compress_kv(kv, gate, ape, head_dim):
+    weights = mx.softmax(gate.astype(mx.float32) + ape, axis=-2)
+    weights = weights.astype(kv.dtype)
+    return (kv * weights).sum(axis=-2)
+
+
+@mx.compile
+def _overlap_compress_kv(kv, gate, ape, head_dim):
+    B, L, R, D = kv.shape
+
+    gate = gate + ape.astype(gate.dtype)
+
+    kv_0 = mx.zeros((B, 1, R, D // 2), dtype=kv.dtype)
+    kv_a, kv_b = mx.split(kv, 2, axis=-1)
+    kv_a = mx.concatenate([kv_0, kv_a[:, :-1]], axis=1)
+    kv = mx.concatenate([kv_a, kv_b], axis=2)
+
+    gate_0 = mx.full((B, 1, R, D // 2), -mx.inf, dtype=kv.dtype)
+    gate_a, gate_b = mx.split(gate, 2, axis=-1)
+    gate_a = mx.concatenate([gate_0, gate_a[:, :-1]], axis=1)
+    gate = mx.concatenate([gate_a, gate_b], axis=2)
+
+    weights = mx.softmax(gate, axis=-2, precise=True)
+    return (kv * weights).sum(axis=-2)
+
+
+@partial(mx.compile, shapeless=True)
+def _split_softmax(log_normalizer, logits_a, logits_b, sinks=None):
+    if sinks is not None:
+        log_normalizer = mx.logaddexp(log_normalizer, sinks)
+    weights_a = mx.exp(logits_a - log_normalizer)
+    weights_b = mx.exp(logits_b - log_normalizer)
+    return weights_a, weights_b
+
+
+def _sparse_pooled_attention(
+    q: mx.array,
+    local_kv: mx.array,
+    pooled: mx.array,
+    topk: mx.array,
+    local_mask: Optional[mx.array],
+    pooled_mask: Optional[mx.array],
+    scale: float,
+    sinks: Optional[mx.array],
+) -> mx.array:
+    B, H, L, D = q.shape
+    idx = topk[:, None, :, :, None]
+    pooled = mx.take_along_axis(
+        mx.broadcast_to(pooled[:, None, None], (B, 1, L, pooled.shape[1], D)),
+        mx.broadcast_to(idx, idx.shape[:-1] + (D,)),
+        axis=3,
+    )
+
+    q_scaled = q * scale
+    local_scores = q_scaled @ local_kv.swapaxes(-1, -2)
+    local_scores = _apply_score_mask(local_scores, local_mask)
+    normalizer = mx.logsumexp(local_scores, -1, keepdims=True)
+
+    pooled_sq = pooled.squeeze(1)
+    q_bl = q_scaled.transpose(0, 2, 1, 3)
+    pooled_scores = q_bl @ pooled_sq.swapaxes(-1, -2)
+    pooled_scores = pooled_scores.transpose(0, 2, 1, 3)
+    pooled_scores = _apply_score_mask(pooled_scores, pooled_mask)
+    normalizer = mx.logaddexp(
+        normalizer, mx.logsumexp(pooled_scores, -1, keepdims=True)
+    )
+
+    local_weights, pooled_weights = _split_softmax(
+        normalizer,
+        local_scores,
+        pooled_scores,
+        sinks[None, :, None, None] if sinks is not None else None,
+    )
+
+    out = local_weights @ local_kv
+    pw_bl = pooled_weights.transpose(0, 2, 1, 3)
+    out = out + (pw_bl @ pooled_sq).transpose(0, 2, 1, 3)
+    return out.astype(q.dtype)
+
+
+class MoEGate(nn.Module):
+    def __init__(self, config: ModelConfig, layer_idx: int):
+        super().__init__()
+        self.top_k = config.num_experts_per_tok
+        self.num_experts = config.n_routed_experts
+        self.hidden_dim = config.hidden_size
+        self.hash = layer_idx < config.num_hash_layers
+        self.scoring_func = config.scoring_func
+        self.routed_scaling_factor = config.routed_scaling_factor
+        self.norm_topk_prob = config.norm_topk_prob
+        self.weight = mx.zeros((self.num_experts, self.hidden_dim))
+        if self.hash:
+            self.tid2eid = mx.zeros((config.vocab_size, self.top_k), dtype=mx.int32)
+        else:
+            self.e_score_correction_bias = mx.zeros(
+                (self.num_experts,), dtype=mx.float32
+            )
+
+    def __call__(self, x: mx.array, input_ids: Optional[mx.array] = None):
+        logits = x @ self.weight.T
+
+        if self.hash:
+            if input_ids is None:
+                raise ValueError("DeepSeek-V4 hash routing requires input_ids.")
+            inds, weights = _hash_expert_select(
+                input_ids,
+                logits,
+                self.tid2eid,
+                self.routed_scaling_factor,
+                self.norm_topk_prob,
+                self.scoring_func,
+            )
+        else:
+            inds, weights = _expert_select(
+                logits,
+                self.e_score_correction_bias,
+                self.top_k,
+                self.routed_scaling_factor,
+                self.norm_topk_prob,
+                self.scoring_func,
+            )
+
+        return inds, weights
+
+
+class DeepseekV4MLP(nn.Module):
+    def __init__(
+        self,
+        config: ModelConfig,
+        intermediate_size: Optional[int] = None,
+        swiglu_limit: float = 0.0,
+    ):
+        super().__init__()
+        hidden_size = config.hidden_size
+        intermediate_size = intermediate_size or config.intermediate_size
+        self.gate_proj = nn.Linear(hidden_size, intermediate_size, bias=False)
+        self.up_proj = nn.Linear(hidden_size, intermediate_size, bias=False)
+        self.down_proj = nn.Linear(intermediate_size, hidden_size, bias=False)
+        self.swiglu_limit = swiglu_limit
+
+    def __call__(self, x: mx.array) -> mx.array:
+        return self.down_proj(
+            _limited_swiglu(self.gate_proj(x), self.up_proj(x), self.swiglu_limit)
+        )
+
+
+class DeepseekV4MoE(nn.Module):
+    def __init__(self, config: ModelConfig, layer_idx: int):
+        super().__init__()
+        self.config = config
+        self.gate = MoEGate(config, layer_idx)
+        self.switch_mlp = SwitchGLU(
+            config.hidden_size,
+            config.moe_intermediate_size,
+            config.n_routed_experts,
+            activation=LimitedSwiGLU(config.swiglu_limit),
+        )
+        self.shared_experts = DeepseekV4MLP(
+            config,
+            intermediate_size=config.moe_intermediate_size * config.n_shared_experts,
+        )
+        self.sharding_group = None
+
+    def __call__(self, x: mx.array, input_ids: mx.array) -> mx.array:
+        if self.sharding_group is not None:
+            x = sum_gradients(self.sharding_group)(x)
+
+        inds, scores = self.gate(x, input_ids)
+        y = self.switch_mlp(x, inds)
+        y = (y * scores[..., None].astype(y.dtype)).sum(-2)
+        y = y + self.shared_experts(x)
+
+        if self.sharding_group is not None:
+            y = mx.distributed.all_sum(y, group=self.sharding_group)
+        return y
+
+
+class Compressor(nn.Module):
+    def __init__(self, config: ModelConfig, compress_ratio: int, head_dim: int):
+        super().__init__()
+        self.compress_ratio = compress_ratio
+        self.head_dim = head_dim
+        self.rope_head_dim = config.qk_rope_head_dim
+        self.overlap = compress_ratio == 4
+        self.out_dim = head_dim * (2 if self.overlap else 1)
+        self.wkv = nn.Linear(config.hidden_size, self.out_dim, bias=False)
+        self.wgate = nn.Linear(config.hidden_size, self.out_dim, bias=False)
+        self.ape = mx.zeros((compress_ratio, self.out_dim), dtype=mx.float32)
+        self.norm = nn.RMSNorm(head_dim, eps=config.rms_norm_eps)
+        self.rope = DeepseekV4RoPE(
+            config.qk_rope_head_dim,
+            config.compress_rope_theta,
+            config.rope_scaling,
+            config.max_position_embeddings,
+            freq_scale=compress_ratio,
+        )
+
+    def __call__(
+        self,
+        x: mx.array,
+        pool_cache: Optional[PoolingCache],
+        offset: Union[int, mx.array],
+    ) -> mx.array:
+        B, _, _ = x.shape
+        kv = self.wkv(x)
+        gate = self.wgate(x)
+        if pool_cache is None:
+            usable = (kv.shape[1] // self.compress_ratio) * self.compress_ratio
+            ready_kv, ready_gate = kv[:, :usable], gate[:, :usable]
+            pool_base = offset
+        else:
+            ready_kv, ready_gate, pool_base = pool_cache.accumulate_windows(
+                kv, gate, offset
+            )
+
+        if ready_kv.size == 0:
+            new_pooled = mx.zeros((B, 0, self.head_dim), dtype=x.dtype)
+        else:
+            compress_func = (
+                _overlap_compress_kv if self.overlap else _simple_compress_kv
+            )
+            kv = mx.unflatten(ready_kv, 1, (-1, self.compress_ratio))
+            gate = mx.unflatten(ready_gate, 1, (-1, self.compress_ratio))
+            new_pooled = compress_func(kv, gate, self.ape, self.head_dim)
+            new_pooled = self.norm(new_pooled)
+            new_pooled = self.rope(
+                new_pooled[:, None],
+                offset=pool_base,
+            ).squeeze(1)
+
+        if pool_cache is not None:
+            new_pooled = pool_cache.update_and_fetch(new_pooled)
+
+        return new_pooled
+
+
+class Indexer(nn.Module):
+    def __init__(self, config: ModelConfig, compress_ratio: int):
+        super().__init__()
+        self.n_heads = config.index_n_heads
+        self.head_dim = config.index_head_dim
+        self.index_topk = config.index_topk
+        self.wq_b = nn.Linear(
+            config.q_lora_rank, self.n_heads * self.head_dim, bias=False
+        )
+        self.weights_proj = nn.Linear(config.hidden_size, self.n_heads, bias=False)
+        self.compressor = Compressor(config, compress_ratio, self.head_dim)
+        self.scale = self.head_dim**-0.5
+
+    def __call__(
+        self,
+        x: mx.array,
+        q_residual: mx.array,
+        position_rope: DeepseekV4RoPE,
+        pool_cache: Optional[PoolingCache],
+        offset: Union[int, mx.array],
+    ):
+        B, L, _ = x.shape
+        pooled = self.compressor(x, pool_cache, offset)
+        if pooled.shape[1] == 0:
+            return None
+
+        q = self.wq_b(q_residual).reshape(B, L, self.n_heads, self.head_dim)
+        q = q.transpose(0, 2, 1, 3)
+        q = position_rope(q, offset)
+
+        scores = q.astype(mx.float32) @ pooled[:, None].swapaxes(-1, -2).astype(
+            mx.float32
+        )
+        scores = mx.maximum(scores, 0) * self.scale
+        weights = self.weights_proj(x).astype(mx.float32) * (self.n_heads**-0.5)
+        scores = (scores * weights.swapaxes(-1, -2)[..., None]).sum(axis=1)
+        pmask = pool_cache.make_mask(L, offset) if pool_cache is not None else None
+        if pmask is not None:
+            scores = mx.where(
+                pmask if pmask.ndim == 3 else pmask[None],
+                scores,
+                mx.finfo(scores.dtype).min,
+            )
+        k = min(self.index_topk, pooled.shape[1])
+        return mx.argpartition(-scores, kth=k - 1, axis=-1)[..., :k]
+
+
+class LocalAttention(nn.Module):
+    """DeepSeek V4 attention with no KV compression."""
+
+    def __init__(self, config: ModelConfig, layer_idx: int):
+        super().__init__()
+        self.config = config
+        self.layer_idx = layer_idx
+        self.compress_ratio = 0
+        self.hidden_size = config.hidden_size
+        self.n_heads = config.num_attention_heads
+        self.head_dim = config.head_dim
+        self.o_groups = config.o_groups
+        self.o_lora_rank = config.o_lora_rank
+        self.scale = self.head_dim**-0.5
+
+        self.wq_a = nn.Linear(config.hidden_size, config.q_lora_rank, bias=False)
+        self.q_norm = nn.RMSNorm(config.q_lora_rank, eps=config.rms_norm_eps)
+        self.wq_b = nn.Linear(
+            config.q_lora_rank, self.n_heads * self.head_dim, bias=False
+        )
+        self.wkv = nn.Linear(config.hidden_size, self.head_dim, bias=False)
+        self.kv_norm = nn.RMSNorm(self.head_dim, eps=config.rms_norm_eps)
+        self.wo_a = MultiLinear(
+            self.n_heads * self.head_dim // config.o_groups,
+            config.o_lora_rank,
+            config.o_groups,
+        )
+        self.wo_b = nn.Linear(
+            config.o_groups * config.o_lora_rank,
+            config.hidden_size,
+            bias=config.attention_bias,
+        )
+        self.attn_sink = mx.zeros((self.n_heads,), dtype=mx.float32)
+
+        self.rope = DeepseekV4RoPE(
+            config.qk_rope_head_dim,
+            config.rope_theta,
+            None,
+            config.max_position_embeddings,
+        )
+
+        self.sharding_group = None
+
+    def __call__(
+        self,
+        x: mx.array,
+        mask: Optional[mx.array] = None,
+        cache: Optional[Any] = None,
+    ) -> mx.array:
+        B, L, _ = x.shape
+        offset = cache.offset if cache is not None else 0
+        offset = mx.array(offset) if isinstance(offset, mx.array) else offset
+
+        q = self.wq_b(self.q_norm(self.wq_a(x)))
+        q = q.reshape(B, L, self.n_heads, self.head_dim)
+        q = mx.fast.rms_norm(q, None, self.config.rms_norm_eps)
+        q = q.transpose(0, 2, 1, 3)
+        q = self.rope(q, offset)
+
+        kv = self.kv_norm(self.wkv(x)).reshape(B, 1, L, self.head_dim)
+        kv = self.rope(kv, offset)
+        if cache is not None:
+            kv, _ = cache.update_and_fetch(kv, mx.zeros((B, 1, L, 0)))
+
+        out = scaled_dot_product_attention(
+            q,
+            kv,
+            kv,
+            cache=cache,
+            scale=self.scale,
+            mask=mask,
+            sinks=self.attn_sink.astype(q.dtype),
+        )
+        out = self.rope(out, offset, inverse=True)
+
+        out = out.reshape(B, self.o_groups, -1, L, self.head_dim)
+        out = out.transpose(0, 1, 3, 2, 4).flatten(-2)
+        out = self.wo_a(out)
+        out = out.transpose(0, 2, 1, 3).flatten(-2)
+        out = self.wo_b(out)
+
+        if self.sharding_group is not None:
+            out = mx.distributed.all_sum(out, group=self.sharding_group)
+
+        return out
+
+
+class CompressedAttention(nn.Module):
+    """DeepSeek V4 attention with pooled KV compression."""
+
+    def __init__(self, config: ModelConfig, layer_idx: int):
+        super().__init__()
+        self.config = config
+        self.layer_idx = layer_idx
+        self.compress_ratio = config.compress_ratios[layer_idx]
+        self.hidden_size = config.hidden_size
+        self.n_heads = config.num_attention_heads
+        self.head_dim = config.head_dim
+        self.o_groups = config.o_groups
+        self.o_lora_rank = config.o_lora_rank
+        self.scale = self.head_dim**-0.5
+
+        self.wq_a = nn.Linear(config.hidden_size, config.q_lora_rank, bias=False)
+        self.q_norm = nn.RMSNorm(config.q_lora_rank, eps=config.rms_norm_eps)
+        self.wq_b = nn.Linear(
+            config.q_lora_rank, self.n_heads * self.head_dim, bias=False
+        )
+        self.wkv = nn.Linear(config.hidden_size, self.head_dim, bias=False)
+        self.kv_norm = nn.RMSNorm(self.head_dim, eps=config.rms_norm_eps)
+        self.wo_a = MultiLinear(
+            self.n_heads * self.head_dim // config.o_groups,
+            config.o_lora_rank,
+            config.o_groups,
+        )
+        self.wo_b = nn.Linear(
+            config.o_groups * config.o_lora_rank,
+            config.hidden_size,
+            bias=config.attention_bias,
+        )
+        self.attn_sink = mx.zeros((self.n_heads,), dtype=mx.float32)
+
+        # Compressed layers use Yarn-scaled RoPE
+        self.rope = DeepseekV4RoPE(
+            config.qk_rope_head_dim,
+            config.compress_rope_theta,
+            config.rope_scaling,
+            config.max_position_embeddings,
+        )
+        self.compressor = Compressor(config, self.compress_ratio, self.head_dim)
+
+        self.sharding_group = None
+
+    def __call__(
+        self,
+        x: mx.array,
+        mask: Optional[mx.array] = None,
+        cache: Optional[Any] = None,
+    ) -> mx.array:
+        B, L, _ = x.shape
+        local_cache = cache[0] if cache is not None else None
+        pool_cache = cache[1] if cache is not None else None
+        offset = local_cache.offset if local_cache is not None else 0
+        offset = mx.array(offset) if isinstance(offset, mx.array) else offset
+
+        q = self.wq_b(self.q_norm(self.wq_a(x)))
+        q = q.reshape(B, L, self.n_heads, self.head_dim)
+        q = mx.fast.rms_norm(q, None, self.config.rms_norm_eps)
+        q = q.transpose(0, 2, 1, 3)
+        q = self.rope(q, offset)
+
+        kv = self.kv_norm(self.wkv(x)).reshape(B, 1, L, self.head_dim)
+        kv = self.rope(kv, offset)
+        if local_cache is not None:
+            kv, _ = local_cache.update_and_fetch(kv, mx.zeros((B, 1, L, 0)))
+
+        # Pool tokens into compressed KV and concatenate with local KV
+        pooled = self.compressor(x, pool_cache, offset)
+        pooled_mask = None
+        if pooled.shape[1] > 0:
+            pooled_mask = (
+                pool_cache.make_mask(L, offset) if pool_cache is not None else None
+            )
+            kv = mx.concatenate([kv, pooled[:, None]], axis=2)
+
+        mask = _extend_mask(mask, pooled_mask, kv.shape[2])
+
+        out = scaled_dot_product_attention(
+            q,
+            kv,
+            kv,
+            cache=local_cache,
+            scale=self.scale,
+            mask=mask,
+            sinks=self.attn_sink.astype(q.dtype),
+        )
+        out = self.rope(out, offset, inverse=True)
+
+        out = out.reshape(B, self.o_groups, -1, L, self.head_dim)
+        out = out.transpose(0, 1, 3, 2, 4).flatten(-2)
+        out = self.wo_a(out)
+        out = out.transpose(0, 2, 1, 3).flatten(-2)
+        out = self.wo_b(out)
+
+        if self.sharding_group is not None:
+            out = mx.distributed.all_sum(out, group=self.sharding_group)
+
+        return out
+
+
+class SparseCompressedAttention(nn.Module):
+    """DeepSeek V4 attention with sparse indexed pooled KV compression."""
+
+    def __init__(self, config: ModelConfig, layer_idx: int):
+        super().__init__()
+        self.config = config
+        self.layer_idx = layer_idx
+        self.compress_ratio = config.compress_ratios[layer_idx]
+        self.hidden_size = config.hidden_size
+        self.n_heads = config.num_attention_heads
+        self.head_dim = config.head_dim
+        self.o_groups = config.o_groups
+        self.o_lora_rank = config.o_lora_rank
+        self.scale = self.head_dim**-0.5
+
+        self.wq_a = nn.Linear(config.hidden_size, config.q_lora_rank, bias=False)
+        self.q_norm = nn.RMSNorm(config.q_lora_rank, eps=config.rms_norm_eps)
+        self.wq_b = nn.Linear(
+            config.q_lora_rank, self.n_heads * self.head_dim, bias=False
+        )
+        self.wkv = nn.Linear(config.hidden_size, self.head_dim, bias=False)
+        self.kv_norm = nn.RMSNorm(self.head_dim, eps=config.rms_norm_eps)
+        self.wo_a = MultiLinear(
+            self.n_heads * self.head_dim // config.o_groups,
+            config.o_lora_rank,
+            config.o_groups,
+        )
+        self.wo_b = nn.Linear(
+            config.o_groups * config.o_lora_rank,
+            config.hidden_size,
+            bias=config.attention_bias,
+        )
+        self.attn_sink = mx.zeros((self.n_heads,), dtype=mx.float32)
+
+        self.rope = DeepseekV4RoPE(
+            config.qk_rope_head_dim,
+            config.compress_rope_theta,
+            config.rope_scaling,
+            config.max_position_embeddings,
+        )
+        self.compressor = Compressor(config, self.compress_ratio, self.head_dim)
+        self.indexer = Indexer(config, self.compress_ratio)
+
+        self.sharding_group = None
+
+    def __call__(
+        self,
+        x: mx.array,
+        mask: Optional[mx.array] = None,
+        cache: Optional[Any] = None,
+    ) -> mx.array:
+        B, L, _ = x.shape
+        local_cache = cache[0] if cache is not None else None
+        comp_cache = cache[1] if cache is not None else None
+        idx_cache = cache[2] if cache is not None else None
+        offset = local_cache.offset if local_cache is not None else 0
+        offset = mx.array(offset) if isinstance(offset, mx.array) else offset
+
+        q_residual = self.q_norm(self.wq_a(x))
+        q = self.wq_b(q_residual).reshape(B, L, self.n_heads, self.head_dim)
+        q = mx.fast.rms_norm(q, None, self.config.rms_norm_eps)
+        q = q.transpose(0, 2, 1, 3)
+        q = self.rope(q, offset)
+
+        kv = self.kv_norm(self.wkv(x)).reshape(B, 1, L, self.head_dim)
+        kv = self.rope(kv, offset)
+        if local_cache is not None:
+            kv, _ = local_cache.update_and_fetch(kv, mx.zeros((B, 1, L, 0)))
+
+        pooled = self.compressor(x, comp_cache, offset)
+        pmask = comp_cache.make_mask(L, offset) if comp_cache is not None else None
+        topk = self.indexer(x, q_residual, self.rope, idx_cache, offset)
+        sinks = self.attn_sink.astype(q.dtype)
+
+        # Local attention
+        if pooled.shape[1] == 0:
+            out = scaled_dot_product_attention(
+                q,
+                kv,
+                kv,
+                cache=local_cache,
+                scale=self.scale,
+                mask=mask,
+                sinks=sinks,
+            )
+
+        # Compressed attention
+        elif pooled.shape[1] <= self.indexer.index_topk:
+            full_kv = mx.concatenate([kv, pooled[:, None]], axis=2)
+            mask = _extend_mask(mask, pmask, full_kv.shape[2])
+            out = scaled_dot_product_attention(
+                q,
+                full_kv,
+                full_kv,
+                cache=local_cache,
+                scale=self.scale,
+                mask=mask,
+                sinks=sinks,
+            )
+
+        # Sparse compressed attention
+        else:
+            sparse_mask = None
+            if pmask is not None:
+                sparse_mask = mx.take_along_axis(
+                    pmask[None] if pmask.ndim == 2 else pmask,
+                    topk,
+                    axis=2,
+                )[:, None]
+            out = _sparse_pooled_attention(
+                q,
+                kv,
+                pooled,
+                topk,
+                mask,
+                sparse_mask,
+                self.scale,
+                sinks,
+            )
+
+        out = self.rope(out, offset, inverse=True)
+
+        out = out.reshape(B, self.o_groups, -1, L, self.head_dim)
+        out = out.transpose(0, 1, 3, 2, 4).flatten(-2)
+        out = self.wo_a(out)
+        out = out.transpose(0, 2, 1, 3).flatten(-2)
+        out = self.wo_b(out)
+
+        if self.sharding_group is not None:
+            out = mx.distributed.all_sum(out, group=self.sharding_group)
+
+        return out
+
+
+def v4_attention_factory(config: ModelConfig, layer_idx: int) -> nn.Module:
+    """Instantiate the appropriate attention module for a given layer."""
+    ratio = config.compress_ratios[layer_idx]
+    if ratio == 0:
+        return LocalAttention(config, layer_idx)
+    if ratio == 128:
+        return CompressedAttention(config, layer_idx)
+    return SparseCompressedAttention(config, layer_idx)
+
+
+class DeepseekV4Block(nn.Module):
+    def __init__(self, config: ModelConfig, layer_idx: int):
+        super().__init__()
+        self.attn = v4_attention_factory(config, layer_idx)
+        self.ffn = DeepseekV4MoE(config, layer_idx)
+        self.attn_norm = nn.RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.ffn_norm = nn.RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.attn_hc = HyperConnection(config)
+        self.ffn_hc = HyperConnection(config)
+
+    def __call__(
+        self,
+        h: mx.array,
+        mask: Optional[mx.array],
+        cache: Optional[Any],
+        input_ids: mx.array,
+    ) -> mx.array:
+        residual = h
+        x, post, comb = self.attn_hc(h)
+        x = self.attn(self.attn_norm(x), mask=mask, cache=cache)
+        h = hc_expand(x, residual, post, comb)
+
+        residual = h
+        x, post, comb = self.ffn_hc(h)
+        x = self.ffn(self.ffn_norm(x), input_ids)
+        return hc_expand(x, residual, post, comb)
+
+
+class DeepseekV4Model(PipelineMixin, nn.Module):
+    def __init__(self, config: ModelConfig):
+        super().__init__()
+        self.args = config
+        self.vocab_size = config.vocab_size
+        self.embed_tokens = nn.Embedding(config.vocab_size, config.hidden_size)
+        self.layers = [
+            DeepseekV4Block(config, idx) for idx in range(config.num_hidden_layers)
+        ]
+        self.norm = nn.RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.hc_head = HyperHead(config)
+
+    def __call__(self, inputs: mx.array, cache: Optional[Any] = None) -> mx.array:
+        h = self.embed_tokens(inputs)
+        h = mx.broadcast_to(
+            h[:, :, None, :],
+            (h.shape[0], h.shape[1], self.args.hc_mult, h.shape[2]),
+        )
+        h = mx.contiguous(h)
+
+        pipeline_rank = self.pipeline_rank
+        pipeline_size = self.pipeline_size
+
+        if cache is None:
+            cache = [None] * len(self.pipeline_layers)
+
+        first_cache = cache[0]
+        mask_cache = (
+            first_cache[0] if isinstance(first_cache, CacheList) else first_cache
+        )
+        mask = create_attention_mask(
+            h[:, :, 0, :],
+            mask_cache,
+            window_size=self.args.sliding_window,
+            return_array=True,
+        )
+
+        if pipeline_rank < pipeline_size - 1:
+            h = mx.distributed.recv_like(h, (pipeline_rank + 1))
+
+        for layer, layer_cache in zip(self.pipeline_layers, cache):
+            h = layer(h, mask, layer_cache, inputs)
+
+        if pipeline_rank != 0:
+            h = mx.distributed.send(h, (pipeline_rank - 1) % pipeline_size)
+            cache_item = cache[-1]
+            if isinstance(cache_item, CacheList):
+                cache_item = cache_item[0]
+            if cache_item is not None:
+                cache_item.keys = mx.depends(cache_item.keys, h)
+
+        if pipeline_size > 1:
+            h = mx.distributed.all_gather(h)[: h.shape[0]]
+
+        return self.norm(self.hc_head(h))
+
+
+class LanguageModel(nn.Module):
+    def __init__(self, config: ModelConfig):
+        super().__init__()
+        self.args = config
+        self.config = config
+        self.model_type = config.model_type
+        self.model = DeepseekV4Model(config)
+        self.lm_head = nn.Linear(config.hidden_size, config.vocab_size, bias=False)
+
+    def __call__(
+        self,
+        inputs: Optional[mx.array] = None,
+        cache: Optional[Any] = None,
+        input_embeddings: Optional[mx.array] = None,
+        inputs_embeds: Optional[mx.array] = None,
+        **kwargs,
+    ) -> LanguageModelOutput:
+        if inputs is None:
+            inputs = kwargs.get("input_ids")
+        if inputs_embeds is not None or input_embeddings is not None:
+            raise NotImplementedError(
+                "DeepSeek V4 does not support input embeddings yet."
+            )
+        logits = self.lm_head(self.model(inputs, cache))
+        return LanguageModelOutput(logits=logits)
+
+    @property
+    def layers(self):
+        return self.model.pipeline_layers
+
+    @property
+    def cast_predicate(self):
+        def predicate(k):
+            return not (
+                "attn_sink" in k
+                or "e_score_correction_bias" in k
+                or ".attn_hc." in k
+                or ".ffn_hc." in k
+                or ".hc_head." in k
+            )
+
+        return predicate
+
+    @property
+    def quant_predicate(self):
+        quantization_config = make_quantization_config(self)
+
+        def predicate(path, _):
+            path = path.removeprefix("language_model.")
+            return quantization_config.get(path, True)
+
+        return predicate
+
+    def make_cache(self):
+        caches = []
+        for layer in self.layers:
+            ratio = layer.attn.compress_ratio
+            if ratio == 0:
+                caches.append(RotatingKVCache(max_size=self.args.sliding_window))
+            elif isinstance(layer.attn, SparseCompressedAttention):
+                caches.append(
+                    CacheList(
+                        RotatingKVCache(max_size=self.args.sliding_window),
+                        PoolingCache(ratio),
+                        PoolingCache(ratio),
+                    )
+                )
+            else:
+                caches.append(
+                    CacheList(
+                        RotatingKVCache(max_size=self.args.sliding_window),
+                        PoolingCache(ratio),
+                    )
+                )
+        return caches
+
+    def sanitize(self, weights: Dict[str, mx.array]) -> Dict[str, mx.array]:
+        n_layers = self.args.num_hidden_layers
+
+        new_weights = {}
+        for k, v in weights.items():
+            if k.startswith("mtp."):
+                continue
+            parts = k.split(".")
+            if len(parts) >= 2 and parts[0] == "layers":
+                try:
+                    if int(parts[1]) >= n_layers:
+                        continue
+                except ValueError:
+                    pass
+            new_weights[k] = v
+        weights = new_weights
+
+        new_weights = {}
+        for k, v in weights.items():
+            if "tid2eid" in k:
+                new_weights[k] = v.astype(mx.int32)
+
+            if not k.endswith(".scale"):
+                if k not in new_weights:
+                    new_weights[k] = v
+                continue
+
+            wk = k[: -len(".scale")] + ".weight"
+            weight = weights.get(wk)
+            if weight is None:
+                new_weights[k] = v
+                continue
+            if (
+                ".ffn.experts." in wk
+                and ".shared_experts." not in wk
+                and weight.dtype in (mx.int8, mx.uint8)
+                and v.shape[-1] * 16 == weight.shape[-1]
+            ):
+                new_weights[k + "s"] = v
+                new_weights[wk] = weight.view(mx.uint32)
+            elif weight.dtype == mx.uint8:
+                new_weights[k + "s"] = mx.repeat(mx.repeat(v, 4, -1), 128, 0)
+                new_weights[wk] = weight.view(mx.uint32)
+            else:
+                new_weights[k] = v
+        weights = new_weights
+
+        top_remap = {
+            "embed.weight": "model.embed_tokens.weight",
+            "norm.weight": "model.norm.weight",
+            "head.weight": "lm_head.weight",
+            "hc_head_fn": "model.hc_head.fn",
+            "hc_head_base": "model.hc_head.base",
+            "hc_head_scale": "model.hc_head.scale",
+        }
+        for old, new in top_remap.items():
+            if old in weights:
+                weights[new] = weights.pop(old)
+
+        remapped = {}
+        w_remap = {"w1": "gate_proj", "w2": "down_proj", "w3": "up_proj"}
+        for k, v in weights.items():
+            nk = "model." + k if k.startswith("layers.") else k
+            nk = nk.replace(".ffn.gate.bias", ".ffn.gate.e_score_correction_bias")
+            for sub in ("attn", "ffn"):
+                for param in ("fn", "base", "scale"):
+                    nk = nk.replace(f".hc_{sub}_{param}", f".{sub}_hc.{param}")
+            for old, new in w_remap.items():
+                nk = nk.replace(f".shared_experts.{old}.", f".shared_experts.{new}.")
+            remapped[nk] = v
+        weights = remapped
+
+        for layer_idx in range(n_layers):
+            prefix = f"model.layers.{layer_idx}.ffn.experts"
+            for src, dst in (
+                ("w1", "gate_proj"),
+                ("w2", "down_proj"),
+                ("w3", "up_proj"),
+            ):
+                for suffix in ("weight", "scales"):
+                    key0 = f"{prefix}.0.{src}.{suffix}"
+                    if key0 in weights:
+                        stacked = [
+                            weights.pop(f"{prefix}.{e}.{src}.{suffix}")
+                            for e in range(self.args.n_routed_experts)
+                        ]
+                        weights[
+                            f"model.layers.{layer_idx}.ffn.switch_mlp.{dst}.{suffix}"
+                        ] = mx.stack(stacked)
+
+        for layer_idx in range(n_layers):
+            prefix = f"model.layers.{layer_idx}.attn.wo_a"
+            for key in (f"{prefix}.weight", f"{prefix}.scales", f"{prefix}.biases"):
+                if key in weights and weights[key].ndim == 2:
+                    weights[key] = weights[key].reshape(
+                        self.args.o_groups, self.args.o_lora_rank, -1
+                    )
+
+        return weights
+
+    def shard(self, group: Optional[mx.distributed.Group] = None):
+        group = group or mx.distributed.init()
+        N = group.size()
+        rank = group.rank()
+        for layer in self.model.layers:
+            layer.attn.sharding_group = group
+            layer.attn.wq_b = shard_linear(
+                layer.attn.wq_b,
+                "all-to-sharded",
+                segments=self.args.o_groups,
+                group=group,
+            )
+            shard_inplace(layer.attn.wo_a, "sharded-to-all", group=group)
+            layer.attn.attn_sink = mx.split(layer.attn.attn_sink, N)[rank]
+            layer.attn.n_heads //= N
+
+            layer.ffn.sharding_group = group
+            shard_inplace(
+                layer.ffn.shared_experts.gate_proj, "all-to-sharded", group=group
+            )
+            shard_inplace(
+                layer.ffn.shared_experts.down_proj, "sharded-to-all", group=group
+            )
+            shard_inplace(
+                layer.ffn.shared_experts.up_proj, "all-to-sharded", group=group
+            )
+            shard_inplace(layer.ffn.switch_mlp.gate_proj, "all-to-sharded", group=group)
+            shard_inplace(layer.ffn.switch_mlp.down_proj, "sharded-to-all", group=group)
+            shard_inplace(layer.ffn.switch_mlp.up_proj, "all-to-sharded", group=group)

--- a/mlx_vlm/models/deepseek_v4/language.py
+++ b/mlx_vlm/models/deepseek_v4/language.py
@@ -882,8 +882,13 @@ class DeepseekV4Model(PipelineMixin, nn.Module):
         self.norm = nn.RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
         self.hc_head = HyperHead(config)
 
-    def __call__(self, inputs: mx.array, cache: Optional[Any] = None) -> mx.array:
-        h = self.embed_tokens(inputs)
+    def __call__(
+        self,
+        inputs: mx.array,
+        cache: Optional[Any] = None,
+        inputs_embeds: Optional[mx.array] = None,
+    ) -> mx.array:
+        h = self.embed_tokens(inputs) if inputs_embeds is None else inputs_embeds
         h = mx.broadcast_to(
             h[:, :, None, :],
             (h.shape[0], h.shape[1], self.args.hc_mult, h.shape[2]),
@@ -940,17 +945,12 @@ class LanguageModel(nn.Module):
         self,
         inputs: Optional[mx.array] = None,
         cache: Optional[Any] = None,
-        input_embeddings: Optional[mx.array] = None,
         inputs_embeds: Optional[mx.array] = None,
         **kwargs,
     ) -> LanguageModelOutput:
-        if inputs is None:
-            inputs = kwargs.get("input_ids")
-        if inputs_embeds is not None or input_embeddings is not None:
-            raise NotImplementedError(
-                "DeepSeek V4 does not support input embeddings yet."
-            )
-        logits = self.lm_head(self.model(inputs, cache))
+        logits = self.lm_head(
+            self.model(inputs, cache=cache, inputs_embeds=inputs_embeds)
+        )
         return LanguageModelOutput(logits=logits)
 
     @property

--- a/mlx_vlm/models/deepseek_v4/processing_deepseek_v4.py
+++ b/mlx_vlm/models/deepseek_v4/processing_deepseek_v4.py
@@ -1,0 +1,88 @@
+from pathlib import Path
+from typing import Optional
+
+from transformers.processing_utils import ProcessorMixin
+
+from ..base import install_auto_processor_patch
+
+
+def load_deepseek_v4_chat_template(model_path, **kwargs) -> Optional[str]:
+    local_path = Path(model_path)
+    if local_path.exists():
+        template_path = local_path / "chat_template.jinja"
+        if template_path.exists():
+            return template_path.read_text(encoding="utf-8")
+        return None
+
+    try:
+        from huggingface_hub import hf_hub_download
+
+        download_kwargs = {
+            key: kwargs[key]
+            for key in ("revision", "token", "local_files_only")
+            if key in kwargs
+        }
+        template_path = hf_hub_download(
+            repo_id=str(model_path),
+            filename="chat_template.jinja",
+            **download_kwargs,
+        )
+        return Path(template_path).read_text(encoding="utf-8")
+    except Exception:
+        return None
+
+
+class DeepseekV4Processor(ProcessorMixin):
+    attributes = ["tokenizer"]
+    tokenizer_class = "AutoTokenizer"
+
+    def __init__(self, tokenizer, chat_template: Optional[str] = None, **kwargs):
+        self.tokenizer = tokenizer
+        if chat_template is not None:
+            self.tokenizer.chat_template = chat_template
+        super().__init__(
+            tokenizer, chat_template=getattr(tokenizer, "chat_template", None), **kwargs
+        )
+
+    @property
+    def chat_template(self):
+        return getattr(self.tokenizer, "chat_template", None)
+
+    @chat_template.setter
+    def chat_template(self, value):
+        self.tokenizer.chat_template = value
+
+    def apply_chat_template(self, *args, **kwargs):
+        return self.tokenizer.apply_chat_template(*args, **kwargs)
+
+    def encode(self, *args, **kwargs):
+        return self.tokenizer.encode(*args, **kwargs)
+
+    def decode(self, *args, **kwargs):
+        return self.tokenizer.decode(*args, **kwargs)
+
+    def batch_decode(self, *args, **kwargs):
+        return self.tokenizer.batch_decode(*args, **kwargs)
+
+    def __call__(self, *args, **kwargs):
+        return self.tokenizer(*args, **kwargs)
+
+    @classmethod
+    def from_pretrained(cls, pretrained_model_name_or_path, **kwargs):
+        from transformers import AutoTokenizer
+
+        chat_template = kwargs.pop("chat_template", None)
+        tokenizer = AutoTokenizer.from_pretrained(
+            pretrained_model_name_or_path, **kwargs
+        )
+        if chat_template is None:
+            chat_template = load_deepseek_v4_chat_template(
+                pretrained_model_name_or_path,
+                **kwargs,
+            )
+        return cls(tokenizer=tokenizer, chat_template=chat_template)
+
+
+install_auto_processor_patch("deepseek_v4", DeepseekV4Processor)
+
+__all__ = ["DeepseekV4Processor", "load_deepseek_v4_chat_template"]

--- a/mlx_vlm/models/deepseek_v4/processing_deepseek_v4.py
+++ b/mlx_vlm/models/deepseek_v4/processing_deepseek_v4.py
@@ -5,6 +5,26 @@ from transformers.processing_utils import ProcessorMixin
 
 from ..base import install_auto_processor_patch
 
+DEFAULT_CHAT_TEMPLATE = (
+    "{{- '<｜begin▁of▁sentence｜>' -}}"
+    "{%- if messages[0]['role'] == 'system' -%}"
+    "{{- messages[0]['content'] -}}"
+    "{%- set start = 1 -%}"
+    "{%- else -%}"
+    "{%- set start = 0 -%}"
+    "{%- endif -%}"
+    "{%- for m in messages[start:] -%}"
+    "{%- if m['role'] == 'user' -%}"
+    "{{- '<｜User｜>' + m['content'] -}}"
+    "{%- elif m['role'] == 'assistant' -%}"
+    "{{- '<｜Assistant｜>' + m['content'] + '<｜end▁of▁sentence｜>' -}}"
+    "{%- endif -%}"
+    "{%- endfor -%}"
+    "{%- if add_generation_prompt -%}"
+    "{{- '<｜Assistant｜></think>' -}}"
+    "{%- endif -%}"
+)
+
 
 def load_deepseek_v4_chat_template(model_path, **kwargs) -> Optional[str]:
     local_path = Path(model_path)
@@ -38,11 +58,13 @@ class DeepseekV4Processor(ProcessorMixin):
 
     def __init__(self, tokenizer, chat_template: Optional[str] = None, **kwargs):
         self.tokenizer = tokenizer
-        if chat_template is not None:
-            self.tokenizer.chat_template = chat_template
-        super().__init__(
-            tokenizer, chat_template=getattr(tokenizer, "chat_template", None), **kwargs
+        chat_template = (
+            chat_template
+            or getattr(tokenizer, "chat_template", None)
+            or DEFAULT_CHAT_TEMPLATE
         )
+        self.tokenizer.chat_template = chat_template
+        super().__init__(tokenizer, chat_template=chat_template, **kwargs)
 
     @property
     def chat_template(self):
@@ -85,4 +107,8 @@ class DeepseekV4Processor(ProcessorMixin):
 
 install_auto_processor_patch("deepseek_v4", DeepseekV4Processor)
 
-__all__ = ["DeepseekV4Processor", "load_deepseek_v4_chat_template"]
+__all__ = [
+    "DEFAULT_CHAT_TEMPLATE",
+    "DeepseekV4Processor",
+    "load_deepseek_v4_chat_template",
+]

--- a/mlx_vlm/models/deepseek_v4/processing_deepseek_v4.py
+++ b/mlx_vlm/models/deepseek_v4/processing_deepseek_v4.py
@@ -91,12 +91,17 @@ class DeepseekV4Processor(ProcessorMixin):
 
     @classmethod
     def from_pretrained(cls, pretrained_model_name_or_path, **kwargs):
-        from transformers import AutoTokenizer
+        from transformers import AutoTokenizer, PreTrainedTokenizerFast
 
         chat_template = kwargs.pop("chat_template", None)
-        tokenizer = AutoTokenizer.from_pretrained(
-            pretrained_model_name_or_path, **kwargs
-        )
+        try:
+            tokenizer = AutoTokenizer.from_pretrained(
+                pretrained_model_name_or_path, **kwargs
+            )
+        except (AttributeError, ValueError):
+            tokenizer = PreTrainedTokenizerFast.from_pretrained(
+                pretrained_model_name_or_path, **kwargs
+            )
         if chat_template is None:
             chat_template = load_deepseek_v4_chat_template(
                 pretrained_model_name_or_path,

--- a/mlx_vlm/prompt_utils.py
+++ b/mlx_vlm/prompt_utils.py
@@ -92,6 +92,7 @@ MODEL_CONFIG = {
     "falcon_ocr": MessageFormat.PROMPT_ONLY,
     "paligemma": MessageFormat.PROMPT_WITH_IMAGE_TOKEN,
     "laguna": MessageFormat.TEXT_ONLY,
+    "deepseek_v4": MessageFormat.TEXT_ONLY,
 }
 
 # Models that don't support multi-image

--- a/mlx_vlm/tests/test_models.py
+++ b/mlx_vlm/tests/test_models.py
@@ -215,6 +215,11 @@ class TestModels(unittest.TestCase):
             hc_mult=2,
             hc_sinkhorn_iters=2,
         )
+        loaded_config = deepseek_v4.ModelConfig.from_dict(
+            {"model_type": "deepseek_v4", "eos_token_id": 1}
+        )
+        self.assertEqual(loaded_config.eos_token_id, 1)
+
         model = deepseek_v4.Model(config)
 
         self.language_test_runner(
@@ -223,6 +228,10 @@ class TestModels(unittest.TestCase):
             config.vocab_size,
             config.num_hidden_layers,
         )
+        inputs = mx.array([[1, 2, 3]])
+        inputs_embeds = model.language_model.model.embed_tokens(inputs)
+        out = model.language_model(inputs, inputs_embeds=inputs_embeds)
+        self.assertEqual(out.logits.shape, (1, 3, config.vocab_size))
 
         cache = model.make_cache()
         self.assertEqual(type(cache[0]).__name__, "RotatingKVCache")

--- a/mlx_vlm/tests/test_models.py
+++ b/mlx_vlm/tests/test_models.py
@@ -159,6 +159,89 @@ class TestModels(unittest.TestCase):
         self.assertEqual(type(cache[0]).__name__, "KVCache")
         self.assertEqual(type(cache[1]).__name__, "RotatingKVCache")
 
+    def test_deepseek_v4_language_model(self):
+        from mlx_vlm.models import deepseek_v4
+        from mlx_vlm.models.deepseek_v4.hyper_connection import (
+            _hc_split_sinkhorn_ops,
+            hc_expand,
+        )
+        from mlx_vlm.models.deepseek_v4.language import DeepseekV4RoPE
+
+        rope = DeepseekV4RoPE(4, 10000)
+        x = mx.random.uniform(shape=(1, 2, 3, 4))
+        y = rope(x, offset=1)
+        y_inv = rope(y, offset=1, inverse=True)
+        self.assertTrue(mx.allclose(y_inv, x, rtol=1e-5, atol=1e-5))
+
+        mixes = mx.random.normal((2, 3, 8), dtype=mx.float32)
+        scale = mx.array([1.2, 0.7, 1.1], dtype=mx.float32)
+        base = mx.random.normal((8,), dtype=mx.float32)
+        _, _, comb = _hc_split_sinkhorn_ops(mixes, scale, base, 2, 20, 1e-6)
+        self.assertTrue(mx.allclose(comb.sum(-1), mx.ones_like(comb.sum(-1)), atol=0.1))
+
+        post = mx.random.normal((2, 3, 2), dtype=mx.float32)
+        block_out = mx.random.normal((2, 3, 8), dtype=mx.bfloat16)
+        comb = mx.random.normal((2, 3, 2, 2), dtype=mx.float32)
+        residual = mx.random.normal((2, 3, 2, 8), dtype=mx.bfloat16)
+        expected = post[..., None] * block_out[:, :, None, :].astype(mx.float32)
+        expected = expected + mx.matmul(
+            comb.swapaxes(-1, -2), residual.astype(mx.float32)
+        )
+        actual = hc_expand(block_out, residual, post, comb)
+        self.assertTrue(mx.allclose(actual, expected.astype(block_out.dtype)))
+
+        config = deepseek_v4.ModelConfig(
+            model_type="deepseek_v4",
+            vocab_size=128,
+            hidden_size=64,
+            num_hidden_layers=4,
+            num_attention_heads=4,
+            num_key_value_heads=1,
+            q_lora_rank=16,
+            o_lora_rank=8,
+            o_groups=2,
+            head_dim=16,
+            qk_rope_head_dim=4,
+            sliding_window=16,
+            compress_ratios=[0, 0, 4, 0],
+            index_n_heads=4,
+            index_head_dim=8,
+            index_topk=4,
+            moe_intermediate_size=16,
+            n_routed_experts=4,
+            n_shared_experts=1,
+            num_experts_per_tok=2,
+            num_hash_layers=1,
+            hc_mult=2,
+            hc_sinkhorn_iters=2,
+        )
+        model = deepseek_v4.Model(config)
+
+        self.language_test_runner(
+            model.language_model,
+            config.model_type,
+            config.vocab_size,
+            config.num_hidden_layers,
+        )
+
+        cache = model.make_cache()
+        self.assertEqual(type(cache[0]).__name__, "RotatingKVCache")
+        self.assertEqual(type(cache[2]).__name__, "CacheList")
+
+        weight = mx.to_fp8(mx.ones((128, 128), dtype=mx.float32))
+        converted = model.sanitize(
+            {
+                "layers.0.attn.wkv.weight": weight,
+                "layers.0.attn.wkv.scale": mx.full((1, 1), 127, dtype=mx.uint8),
+            }
+        )
+        wkey = "language_model.model.layers.0.attn.wkv.weight"
+        skey = "language_model.model.layers.0.attn.wkv.scales"
+        self.assertIn(wkey, converted)
+        self.assertIn(skey, converted)
+        self.assertTrue(mx.all(converted[wkey] == weight.view(mx.uint32)))
+        self.assertEqual(converted[skey].shape, (128, 4))
+
     def test_llava_bunny(self):
         from mlx_vlm.models import llava_bunny
 

--- a/mlx_vlm/tests/test_processors.py
+++ b/mlx_vlm/tests/test_processors.py
@@ -1774,6 +1774,32 @@ class TestDeepseekV4Processor(unittest.TestCase):
 
         self.assertEqual(processor.chat_template, "{{ explicit }}")
 
+    def test_from_pretrained_uses_default_chat_template_when_missing(self):
+        import tempfile
+
+        from mlx_vlm.models.deepseek_v4.processing_deepseek_v4 import (
+            DEFAULT_CHAT_TEMPLATE,
+            DeepseekV4Processor,
+        )
+
+        tokenizer = self.MockTokenizer()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with (
+                patch(
+                    "transformers.AutoTokenizer.from_pretrained", return_value=tokenizer
+                ),
+                patch.object(
+                    DeepseekV4Processor,
+                    "check_argument_for_proper_class",
+                    return_value=None,
+                ),
+            ):
+                processor = DeepseekV4Processor.from_pretrained(tmpdir)
+
+        self.assertEqual(processor.chat_template, DEFAULT_CHAT_TEMPLATE)
+        self.assertIn("<｜Assistant｜></think>", processor.chat_template)
+
     def test_patch_intercepts(self):
         import json
         import tempfile

--- a/mlx_vlm/tests/test_processors.py
+++ b/mlx_vlm/tests/test_processors.py
@@ -1684,6 +1684,129 @@ class TestDotsVLPatch(unittest.TestCase):
         )
 
 
+class TestDeepseekV4Processor(unittest.TestCase):
+    class MockTokenizer:
+        chat_template = None
+        model_input_names = ["input_ids", "attention_mask"]
+
+        def __call__(self, text, **kwargs):
+            return {"input_ids": [0], "attention_mask": [1]}
+
+        def apply_chat_template(self, *args, **kwargs):
+            return "templated"
+
+        def encode(self, text, **kwargs):
+            return [0]
+
+        def decode(self, ids, **kwargs):
+            return "decoded"
+
+        def batch_decode(self, ids, **kwargs):
+            return ["decoded"] * len(ids)
+
+    def test_loads_local_chat_template_jinja(self):
+        import tempfile
+        from pathlib import Path
+
+        from mlx_vlm.models.deepseek_v4.processing_deepseek_v4 import (
+            load_deepseek_v4_chat_template,
+        )
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            (Path(tmpdir) / "chat_template.jinja").write_text(
+                "{{ messages[0]['content'] }}",
+                encoding="utf-8",
+            )
+
+            self.assertEqual(
+                load_deepseek_v4_chat_template(tmpdir),
+                "{{ messages[0]['content'] }}",
+            )
+
+    def test_from_pretrained_sets_local_chat_template(self):
+        import tempfile
+        from pathlib import Path
+
+        from mlx_vlm.models.deepseek_v4.processing_deepseek_v4 import (
+            DeepseekV4Processor,
+        )
+
+        tokenizer = self.MockTokenizer()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            (Path(tmpdir) / "chat_template.jinja").write_text(
+                "{{ messages[0]['content'] }}",
+                encoding="utf-8",
+            )
+            with (
+                patch(
+                    "transformers.AutoTokenizer.from_pretrained", return_value=tokenizer
+                ),
+                patch.object(
+                    DeepseekV4Processor,
+                    "check_argument_for_proper_class",
+                    return_value=None,
+                ),
+            ):
+                processor = DeepseekV4Processor.from_pretrained(tmpdir)
+
+        self.assertEqual(processor.chat_template, "{{ messages[0]['content'] }}")
+
+    def test_from_pretrained_prefers_explicit_chat_template(self):
+        from mlx_vlm.models.deepseek_v4.processing_deepseek_v4 import (
+            DeepseekV4Processor,
+        )
+
+        tokenizer = self.MockTokenizer()
+
+        with (
+            patch("transformers.AutoTokenizer.from_pretrained", return_value=tokenizer),
+            patch.object(
+                DeepseekV4Processor,
+                "check_argument_for_proper_class",
+                return_value=None,
+            ),
+        ):
+            processor = DeepseekV4Processor.from_pretrained(
+                "repo/name",
+                chat_template="{{ explicit }}",
+            )
+
+        self.assertEqual(processor.chat_template, "{{ explicit }}")
+
+    def test_patch_intercepts(self):
+        import json
+        import tempfile
+        from pathlib import Path
+
+        from transformers import AutoProcessor
+
+        from mlx_vlm.models.deepseek_v4.processing_deepseek_v4 import (
+            DeepseekV4Processor,
+        )
+
+        tokenizer = self.MockTokenizer()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            (Path(tmpdir) / "config.json").write_text(
+                json.dumps({"model_type": "deepseek_v4"}),
+                encoding="utf-8",
+            )
+            with (
+                patch(
+                    "transformers.AutoTokenizer.from_pretrained", return_value=tokenizer
+                ),
+                patch.object(
+                    DeepseekV4Processor,
+                    "check_argument_for_proper_class",
+                    return_value=None,
+                ),
+            ):
+                processor = AutoProcessor.from_pretrained(tmpdir)
+
+        self.assertIsInstance(processor, DeepseekV4Processor)
+
+
 class TestPatchChainsForUnknownModelType(unittest.TestCase):
     def test_falls_through(self):
         import importlib

--- a/mlx_vlm/tests/test_utils.py
+++ b/mlx_vlm/tests/test_utils.py
@@ -1,4 +1,6 @@
 import base64
+import json
+import struct
 from io import BytesIO
 from pathlib import Path
 from types import SimpleNamespace
@@ -12,6 +14,7 @@ from mlx_lm.utils import quantize_model
 from mlx_vlm.models.text_only import TextOnlyModel
 from mlx_vlm.utils import (
     StoppingCriteria,
+    _load_safetensors,
     get_model_and_args,
     load,
     load_image,
@@ -429,6 +432,92 @@ def test_load_model_routes_text_models_through_existing_loader():
         model = load_model(Path("/tmp/model"), lazy=True, strict=False)
 
     assert getattr(model, "_is_text_model", False) is True
+
+
+def test_load_safetensors_reinterprets_f8_e8m0_header(tmp_path):
+    path = tmp_path / "model.safetensors"
+    header = {
+        "weight": {
+            "dtype": "F8_E8M0",
+            "shape": [1],
+            "data_offsets": [0, 1],
+        }
+    }
+    header_bytes = json.dumps(header, separators=(",", ":")).encode("utf-8")
+    path.write_bytes(struct.pack("<Q", len(header_bytes)) + header_bytes + b"\x00")
+
+    loaded = {"weight": mx.array([1], dtype=mx.uint8)}
+
+    def fake_mx_load(file_path):
+        current = json.loads(path.read_bytes()[8 : 8 + len(header_bytes)])
+        if current["weight"]["dtype"] == "F8_E8M0":
+            raise RuntimeError("unsupported dtype F8_E8M0")
+        assert current["weight"]["dtype"] == "U8"
+        return loaded
+
+    with patch("mlx_vlm.utils.mx.load", side_effect=fake_mx_load):
+        assert _load_safetensors(str(path)) is loaded
+
+    restored = json.loads(path.read_bytes()[8 : 8 + len(header_bytes)])
+    assert restored["weight"]["dtype"] == "F8_E8M0"
+
+
+def test_load_model_uses_deepseek_v4_fp8_quantization_config():
+    safe_open = MagicMock()
+    safe_open.__enter__.return_value.metadata.return_value = {"format": "mlx"}
+
+    class FakeConfig:
+        @classmethod
+        def from_dict(cls, config):
+            return cls()
+
+    class FakeDeepseekV4Model(nn.Module):
+        def __init__(self, config):
+            super().__init__()
+            self.config = config
+            self.language_model = nn.Linear(2, 2, bias=False)
+
+        def load_weights(self, weights):
+            self.loaded_weights = weights
+
+    fake_model_class = SimpleNamespace(
+        ModelConfig=FakeConfig, Model=FakeDeepseekV4Model
+    )
+    quantization = {
+        "group_size": 64,
+        "bits": 8,
+        "mode": "affine",
+        "language_model.weight": {"group_size": 64, "bits": 8, "mode": "affine"},
+    }
+
+    with (
+        patch(
+            "mlx_vlm.utils.load_config",
+            return_value={
+                "model_type": "deepseek_v4",
+                "quantization_config": {"quant_method": "fp8"},
+            },
+        ),
+        patch("mlx_vlm.utils.glob.glob", return_value=["/tmp/model/model.safetensors"]),
+        patch("mlx_vlm.utils._load_safetensors", return_value={}),
+        patch("mlx_vlm.utils.safetensors.safe_open", return_value=safe_open),
+        patch(
+            "mlx_vlm.utils.get_model_and_args",
+            return_value=(fake_model_class, "deepseek_v4"),
+        ),
+        patch(
+            "mlx_vlm.models.deepseek_v4.language.make_quantization_config",
+            return_value=quantization,
+        ) as make_quantization_config,
+        patch("mlx_vlm.utils.nn.quantize") as quantize,
+    ):
+        model = load_model(Path("/tmp/model"), lazy=True)
+
+    make_quantization_config.assert_called_once_with(model)
+    quantize.assert_called_once()
+    assert quantize.call_args.kwargs["group_size"] == 64
+    assert quantize.call_args.kwargs["bits"] == 8
+    assert quantize.call_args.kwargs["mode"] == "affine"
 
 
 def test_load_delegates_adapter_loading_to_trainer_entrypoint():

--- a/mlx_vlm/tests/test_utils.py
+++ b/mlx_vlm/tests/test_utils.py
@@ -11,6 +11,7 @@ import mlx.nn as nn
 import pytest
 from mlx_lm.utils import quantize_model
 
+from mlx_vlm.convert import _preserve_existing_deepseek_v4_quantization
 from mlx_vlm.models.text_only import TextOnlyModel
 from mlx_vlm.utils import (
     StoppingCriteria,
@@ -244,6 +245,45 @@ def test_quantize_module():
         "group_size": 64,
         "bits": 4,
         "mode": "affine",
+    }
+
+
+def test_convert_preserves_existing_deepseek_v4_quantization():
+    config = {
+        "model_type": "deepseek_v4",
+        "quantization_config": {"quant_method": "fp8"},
+    }
+    existing_quantization = {
+        "group_size": 64,
+        "bits": 8,
+        "mode": "affine",
+        "language_model.model.layers.0.attn.wkv": {
+            "group_size": 32,
+            "bits": 8,
+            "mode": "mxfp8",
+        },
+    }
+
+    with patch(
+        "mlx_vlm.models.deepseek_v4.language.make_quantization_config",
+        return_value=existing_quantization,
+    ):
+        _preserve_existing_deepseek_v4_quantization(
+            config,
+            model=MagicMock(),
+            q_group_size=64,
+            q_bits=4,
+            q_mode="affine",
+        )
+
+    assert config["quantization"] is config["quantization_config"]
+    assert config["quantization"]["group_size"] == 64
+    assert config["quantization"]["bits"] == 4
+    assert config["quantization"]["mode"] == "affine"
+    assert config["quantization"]["language_model.model.layers.0.attn.wkv"] == {
+        "group_size": 32,
+        "bits": 8,
+        "mode": "mxfp8",
     }
 
 

--- a/mlx_vlm/utils.py
+++ b/mlx_vlm/utils.py
@@ -4,6 +4,7 @@ import inspect
 import json
 import logging
 import math
+import struct
 from io import BytesIO
 from pathlib import Path
 from textwrap import dedent
@@ -49,6 +50,8 @@ MODEL_REMAPPING = {
 MAX_FILE_SIZE_GB = 5
 
 MODEL_CONVERSION_DTYPES = ["float16", "bfloat16", "float32"]
+
+SAFETENSORS_DTYPE_FALLBACKS = {"F8_E8M0": "U8"}
 
 
 def quantize_activations(model: nn.Module) -> nn.Module:
@@ -246,7 +249,7 @@ python -m mlx_vlm.convert --hf-path <local_dir> --mlx-path <mlx_dir>
 
     weights = {}
     for wf in weight_files:
-        weights.update(mx.load(wf))
+        weights.update(_load_safetensors(wf))
 
     with safetensors.safe_open(weight_files[0], framework="np") as f:
         is_mlx_format = f.metadata() and f.metadata().get("format") == "mlx"
@@ -307,6 +310,10 @@ python -m mlx_vlm.convert --hf-path <local_dir> --mlx-path <mlx_dir>
                 quantization = {"group_size": 32, "bits": 4, "mode": "affine"}
             elif quant_method == "mxfp4":
                 quantization = {"group_size": 32, "bits": 4, "mode": "mxfp4"}
+            elif quant_method == "fp8" and config.get("model_type") == "deepseek_v4":
+                from .models.deepseek_v4.language import make_quantization_config
+
+                quantization = make_quantization_config(model)
             elif quant_method in ("awq", "gptq", "bitnet"):
                 logging.warning(
                     "Quantization method %s is not supported in mlx_vlm.load_model()",
@@ -371,6 +378,50 @@ python -m mlx_vlm.convert --hf-path <local_dir> --mlx-path <mlx_dir>
 
     model.eval()
     return model
+
+
+def _load_safetensors(path: str) -> dict:
+    try:
+        return mx.load(path)
+    except RuntimeError as e:
+        if not any(dtype in str(e) for dtype in SAFETENSORS_DTYPE_FALLBACKS):
+            raise
+        load_error = e
+
+    with open(path, "r+b") as f:
+        header_len = struct.unpack("<Q", f.read(8))[0]
+        original_header = f.read(header_len)
+        header = json.loads(original_header)
+        changed = False
+
+        for tensor_info in header.values():
+            if not isinstance(tensor_info, dict):
+                continue
+            dtype = tensor_info.get("dtype")
+            if dtype in SAFETENSORS_DTYPE_FALLBACKS:
+                tensor_info["dtype"] = SAFETENSORS_DTYPE_FALLBACKS[dtype]
+                changed = True
+
+        if not changed:
+            raise load_error
+
+        patched_header = json.dumps(header, separators=(",", ":")).encode("utf-8")
+        if len(patched_header) > header_len:
+            raise RuntimeError(
+                f"Cannot reinterpret unsupported safetensors dtype in {path}: "
+                "patched header is larger than the original header."
+            )
+
+        try:
+            f.seek(8)
+            f.write(patched_header)
+            f.write(b" " * (header_len - len(patched_header)))
+            f.flush()
+            return mx.load(path)
+        finally:
+            f.seek(8)
+            f.write(original_header)
+            f.flush()
 
 
 def sanitize_weights(model_obj, weights, config=None):


### PR DESCRIPTION
## Summary
- Add a first-class DeepSeek V4 language-only model package following the existing LM-only wrapper pattern.
- Add pooled compressed-cache support required by DeepSeek V4 compressed attention.
- Register DeepSeek V4 as a text-only prompt format and cover the model with focused tests.

## Validation
- `uv run --with ruff ruff check mlx_vlm/models/deepseek_v4 mlx_vlm/models/cache.py mlx_vlm/prompt_utils.py mlx_vlm/tests/test_models.py`
- `uv run --with pytest python -m pytest mlx_vlm/tests/test_models.py::TestModels::test_deepseek_v4_language_model -q`
