### PR TITLE
Add DeepSeek V4 MTP support

### DIFF
--- a/mlx_vlm/models/deepseek_v4/language.py
+++ b/mlx_vlm/models/deepseek_v4/language.py
@@ -225,6 +225,24 @@ def _extend_mask(mask: Optional[mx.array], pool_mask: Optional[mx.array], N: int
     return full_mask
 
 
+def _align_local_mask(mask: Optional[mx.array], local_len: int):
+    if mask is None:
+        return None
+
+    current_len = mask.shape[-1]
+    if current_len == local_len:
+        return mask
+    if current_len > local_len:
+        return mask[..., -local_len:]
+
+    pad_shape = (*mask.shape[:-1], local_len - current_len)
+    if mask.dtype == mx.bool_:
+        pad = mx.ones(pad_shape, dtype=mask.dtype)
+    else:
+        pad = mx.zeros(pad_shape, dtype=mask.dtype)
+    return mx.concatenate([pad, mask], axis=-1)
+
+
 @partial(mx.compile, shapeless=True)
 def _simple_compress_kv(kv, gate, ape, head_dim):
     weights = mx.softmax(gate.astype(mx.float32) + ape, axis=-2)
@@ -575,6 +593,7 @@ class LocalAttention(nn.Module):
         kv = self.rope(kv, offset)
         if cache is not None:
             kv, _ = cache.update_and_fetch(kv, mx.zeros((B, 1, L, 0)))
+        mask = _align_local_mask(mask, kv.shape[2])
 
         out = scaled_dot_product_attention(
             q,
@@ -669,6 +688,7 @@ class CompressedAttention(nn.Module):
         kv = self.rope(kv, offset)
         if local_cache is not None:
             kv, _ = local_cache.update_and_fetch(kv, mx.zeros((B, 1, L, 0)))
+        mask = _align_local_mask(mask, kv.shape[2])
 
         # Pool tokens into compressed KV and concatenate with local KV
         pooled = self.compressor(x, pool_cache, offset)
@@ -775,6 +795,7 @@ class SparseCompressedAttention(nn.Module):
         kv = self.rope(kv, offset)
         if local_cache is not None:
             kv, _ = local_cache.update_and_fetch(kv, mx.zeros((B, 1, L, 0)))
+        mask = _align_local_mask(mask, kv.shape[2])
 
         pooled = self.compressor(x, comp_cache, offset)
         pmask = comp_cache.make_mask(L, offset) if comp_cache is not None else None

--- a/mlx_vlm/models/deepseek_v4/language.py
+++ b/mlx_vlm/models/deepseek_v4/language.py
@@ -1,6 +1,6 @@
 import math
 from functools import partial
-from typing import Any, Dict, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 import mlx.core as mx
 import mlx.nn as nn
@@ -557,9 +557,12 @@ class LocalAttention(nn.Module):
         x: mx.array,
         mask: Optional[mx.array] = None,
         cache: Optional[Any] = None,
+        position_offset: Optional[Union[int, mx.array]] = None,
     ) -> mx.array:
         B, L, _ = x.shape
-        offset = cache.offset if cache is not None else 0
+        offset = position_offset if position_offset is not None else (
+            cache.offset if cache is not None else 0
+        )
         offset = mx.array(offset) if isinstance(offset, mx.array) else offset
 
         q = self.wq_b(self.q_norm(self.wq_a(x)))
@@ -646,11 +649,14 @@ class CompressedAttention(nn.Module):
         x: mx.array,
         mask: Optional[mx.array] = None,
         cache: Optional[Any] = None,
+        position_offset: Optional[Union[int, mx.array]] = None,
     ) -> mx.array:
         B, L, _ = x.shape
         local_cache = cache[0] if cache is not None else None
         pool_cache = cache[1] if cache is not None else None
-        offset = local_cache.offset if local_cache is not None else 0
+        offset = position_offset if position_offset is not None else (
+            local_cache.offset if local_cache is not None else 0
+        )
         offset = mx.array(offset) if isinstance(offset, mx.array) else offset
 
         q = self.wq_b(self.q_norm(self.wq_a(x)))
@@ -748,12 +754,15 @@ class SparseCompressedAttention(nn.Module):
         x: mx.array,
         mask: Optional[mx.array] = None,
         cache: Optional[Any] = None,
+        position_offset: Optional[Union[int, mx.array]] = None,
     ) -> mx.array:
         B, L, _ = x.shape
         local_cache = cache[0] if cache is not None else None
         comp_cache = cache[1] if cache is not None else None
         idx_cache = cache[2] if cache is not None else None
-        offset = local_cache.offset if local_cache is not None else 0
+        offset = position_offset if position_offset is not None else (
+            local_cache.offset if local_cache is not None else 0
+        )
         offset = mx.array(offset) if isinstance(offset, mx.array) else offset
 
         q_residual = self.q_norm(self.wq_a(x))
@@ -858,10 +867,16 @@ class DeepseekV4Block(nn.Module):
         mask: Optional[mx.array],
         cache: Optional[Any],
         input_ids: mx.array,
+        position_offset: Optional[Union[int, mx.array]] = None,
     ) -> mx.array:
         residual = h
         x, post, comb = self.attn_hc(h)
-        x = self.attn(self.attn_norm(x), mask=mask, cache=cache)
+        x = self.attn(
+            self.attn_norm(x),
+            mask=mask,
+            cache=cache,
+            position_offset=position_offset,
+        )
         h = hc_expand(x, residual, post, comb)
 
         residual = h
@@ -887,6 +902,8 @@ class DeepseekV4Model(PipelineMixin, nn.Module):
         inputs: mx.array,
         cache: Optional[Any] = None,
         inputs_embeds: Optional[mx.array] = None,
+        hidden_sink: Optional[list] = None,
+        skip_final_norm: bool = False,
     ) -> mx.array:
         h = self.embed_tokens(inputs) if inputs_embeds is None else inputs_embeds
         h = mx.broadcast_to(
@@ -929,7 +946,59 @@ class DeepseekV4Model(PipelineMixin, nn.Module):
         if pipeline_size > 1:
             h = mx.distributed.all_gather(h)[: h.shape[0]]
 
+        if hidden_sink is not None:
+            hidden_sink.append(h)
+
+        if skip_final_norm:
+            return h
+
         return self.norm(self.hc_head(h))
+
+
+def _clone_cache_tree(value):
+    if isinstance(value, mx.array):
+        return mx.array(value)
+    if isinstance(value, tuple):
+        return tuple(_clone_cache_tree(v) for v in value)
+    if isinstance(value, list):
+        return [_clone_cache_tree(v) for v in value]
+    if isinstance(value, dict):
+        return {k: _clone_cache_tree(v) for k, v in value.items()}
+    return value
+
+
+def _snapshot_cache_state(caches: List[Any]) -> List[Optional[Tuple[Any, Any]]]:
+    snapshot = []
+    for cache in caches:
+        if cache is None:
+            snapshot.append(None)
+            continue
+        state = getattr(cache, "state", None)
+        meta_state = getattr(cache, "meta_state", None)
+        snapshot.append((_clone_cache_tree(state), _clone_cache_tree(meta_state)))
+    return snapshot
+
+
+def _restore_cache_state(
+    caches: List[Any], snapshot: List[Optional[Tuple[Any, Any]]]
+) -> None:
+    for cache, entry in zip(caches, snapshot):
+        if cache is None or entry is None:
+            continue
+        state, meta_state = entry
+        if meta_state is not None and hasattr(type(cache), "meta_state"):
+            cache.meta_state = _clone_cache_tree(meta_state)
+        cache.state = _clone_cache_tree(state)
+
+
+def _iter_leaf_caches(caches):
+    for cache in caches:
+        if cache is None:
+            continue
+        if isinstance(cache, CacheList):
+            yield from _iter_leaf_caches(cache.caches)
+        else:
+            yield cache
 
 
 class LanguageModel(nn.Module):
@@ -948,10 +1017,122 @@ class LanguageModel(nn.Module):
         inputs_embeds: Optional[mx.array] = None,
         **kwargs,
     ) -> LanguageModelOutput:
-        logits = self.lm_head(
-            self.model(inputs, cache=cache, inputs_embeds=inputs_embeds)
+        return_hidden = kwargs.pop("return_hidden", False)
+        return_shared_kv = kwargs.pop("return_shared_kv", False)
+        skip_logits = kwargs.pop("skip_logits", False)
+        skip_final_norm = kwargs.pop("skip_final_norm", False)
+        hidden_sink = kwargs.pop("hidden_sink", None)
+        if return_hidden and hidden_sink is None:
+            hidden_sink = []
+
+        out = self.model(
+            inputs,
+            cache=cache,
+            inputs_embeds=inputs_embeds,
+            hidden_sink=hidden_sink,
+            skip_final_norm=skip_final_norm,
         )
-        return LanguageModelOutput(logits=logits)
+        logits = None if skip_logits else self.lm_head(out)
+        return LanguageModelOutput(
+            logits=logits,
+            hidden_states=hidden_sink,
+            shared_kv_states={} if return_shared_kv else None,
+        )
+
+    def _target_hidden(self, hidden: mx.array) -> mx.array:
+        if (
+            hidden.ndim == 3
+            and hidden.shape[-1] == self.args.hc_mult * self.args.hidden_size
+        ):
+            hidden = hidden.reshape(*hidden.shape[:-1], self.args.hc_mult, -1)
+        if hidden.ndim != 4:
+            raise ValueError(
+                "DeepSeek-V4 speculative hidden must have shape "
+                "[batch, tokens, hc_mult, hidden_size]."
+            )
+        return hidden
+
+    def speculative_logits_from_hidden(self, hidden: mx.array) -> mx.array:
+        hidden = self._target_hidden(hidden)
+        return self.lm_head(self.model.norm(self.model.hc_head(hidden)))
+
+    def speculative_draft_hidden(self, hidden: mx.array) -> mx.array:
+        return self._target_hidden(hidden)
+
+    def _speculative_verify(self, inputs: mx.array, cache, sampler=None):
+        hidden_steps = []
+        logits_steps = []
+        cache_snapshots = []
+        sample_logits = sampler is not None
+
+        for idx in range(inputs.shape[1]):
+            out = self(
+                inputs[:, idx : idx + 1],
+                cache=cache,
+                return_hidden=True,
+                return_shared_kv=True,
+                skip_logits=not sample_logits,
+            )
+            hidden_steps.append(out.hidden_states[-1])
+            if sample_logits:
+                logits_steps.append(out.logits)
+            cache_snapshots.append(_snapshot_cache_state(cache))
+
+        hidden = mx.concatenate(hidden_steps, axis=1)
+        if not sample_logits:
+            return hidden, {}, cache_snapshots
+
+        logits = mx.concatenate(logits_steps, axis=1)
+        return hidden, {}, cache_snapshots, sampler(logits)
+
+    def speculative_verify_logits(self, inputs: mx.array, cache, sampler):
+        return self._speculative_verify(inputs, cache, sampler)
+
+    def speculative_verify_hidden(self, inputs: mx.array, cache):
+        return self._speculative_verify(inputs, cache)
+
+    def rollback_speculative_cache(
+        self,
+        caches: List[Any],
+        gdn_states: Any,
+        accepted,
+        block_size: int,
+    ) -> int:
+        if isinstance(accepted, int):
+            accepted = mx.array([accepted])
+
+        max_a = int(accepted.max().item())
+        if gdn_states:
+            accepted_list = [int(a) for a in accepted.tolist()]
+            if len(set(accepted_list)) != 1:
+                raise ValueError(
+                    "DeepSeek-V4 speculative rollback requires uniform acceptance."
+                )
+            _restore_cache_state(caches, gdn_states[max_a])
+            return max_a
+
+        n = max_a + 1
+        trim = block_size - n
+        is_batch = accepted.size > 1
+        valid_ends = accepted + 1
+
+        for cache in _iter_leaf_caches(caches):
+            if trim > 0 and hasattr(cache, "trim"):
+                cache.trim(trim)
+            if is_batch and hasattr(cache, "_idx") and max_a > 0:
+                keys = getattr(cache, "keys", None)
+                values = getattr(cache, "values", None)
+                if keys is None or values is None:
+                    continue
+                kv_len = cache._idx
+                verify_start = kv_len - n
+                for bi, valid_end in enumerate(valid_ends.tolist()):
+                    start = verify_start + int(valid_end)
+                    if start < kv_len:
+                        cache.keys[bi, :, start:kv_len, :] = 0
+                        cache.values[bi, :, start:kv_len, :] = 0
+
+        return max_a
 
     @property
     def layers(self):

--- a/mlx_vlm/models/deepseek_v4/language.py
+++ b/mlx_vlm/models/deepseek_v4/language.py
@@ -988,16 +988,126 @@ def _clone_cache_tree(value):
     return value
 
 
-def _snapshot_cache_state(caches: List[Any]) -> List[Optional[Tuple[Any, Any]]]:
-    snapshot = []
-    for cache in caches:
-        if cache is None:
-            snapshot.append(None)
-            continue
-        state = getattr(cache, "state", None)
-        meta_state = getattr(cache, "meta_state", None)
-        snapshot.append((_clone_cache_tree(state), _clone_cache_tree(meta_state)))
-    return snapshot
+def _snapshot_cache_state(
+    caches: List[Any], incoming_tokens: int = 0
+) -> List[Optional[Tuple[Any, Any]]]:
+    return [_snapshot_single_cache(cache, incoming_tokens) for cache in caches]
+
+
+def _snapshot_single_cache(cache, incoming_tokens: int = 0):
+    if cache is None:
+        return None
+    if isinstance(cache, CacheList):
+        return (
+            "cache_list",
+            [_snapshot_single_cache(child, incoming_tokens) for child in cache.caches],
+        )
+    if isinstance(cache, PoolingCache):
+        remainder = int(cache.remainder)
+        total = remainder + int(incoming_tokens)
+        overwrite_len = remainder
+        if incoming_tokens > 0:
+            overwrite_len = total % cache.ratio if total >= cache.ratio else 0
+        will_overwrite_remainder = (
+            remainder > 0
+            and cache.buf_kv is not None
+            and overwrite_len > 0
+        )
+        buf_kv = cache.buf_kv[:, :overwrite_len] if will_overwrite_remainder else None
+        buf_gate = (
+            cache.buf_gate[:, :overwrite_len] if will_overwrite_remainder else None
+        )
+        pooled_len = None if cache.pooled is None else cache.pooled.shape[1]
+        return (
+            "pooling",
+            remainder,
+            _clone_cache_tree(buf_kv),
+            _clone_cache_tree(buf_gate),
+            pooled_len,
+        )
+    if isinstance(cache, RotatingKVCache):
+        return (
+            "rotating",
+            _clone_cache_tree(cache.offset),
+            int(cache._idx),
+            getattr(cache, "start_position", None),
+        )
+    return (
+        "full",
+        _clone_cache_tree(getattr(cache, "state", None)),
+        _clone_cache_tree(getattr(cache, "meta_state", None)),
+    )
+
+
+def _clear_cache_state(cache) -> None:
+    if isinstance(cache, CacheList):
+        for child in cache.caches:
+            _clear_cache_state(child)
+        return
+    if hasattr(cache, "keys"):
+        cache.keys = None
+    if hasattr(cache, "values"):
+        cache.values = None
+    if hasattr(cache, "offset"):
+        cache.offset = 0
+    if hasattr(cache, "_idx"):
+        cache._idx = 0
+    if hasattr(cache, "start_position"):
+        cache.start_position = 0
+    if hasattr(cache, "buf_kv"):
+        cache.buf_kv = None
+    if hasattr(cache, "buf_gate"):
+        cache.buf_gate = None
+    if hasattr(cache, "remainder"):
+        cache.remainder = 0
+    if hasattr(cache, "pooled"):
+        cache.pooled = None
+
+
+def _restore_single_cache(cache, snapshot) -> None:
+    if cache is None or snapshot is None:
+        return
+    kind = snapshot[0]
+    if isinstance(cache, CacheList):
+        for child, child_snapshot in zip(cache.caches, snapshot[1]):
+            _restore_single_cache(child, child_snapshot)
+        return
+    if kind == "pooling":
+        _, remainder, buf_kv, buf_gate, pooled_len = snapshot
+        cache.remainder = int(remainder)
+        if buf_kv is not None:
+            restore_len = int(buf_kv.shape[1])
+            if cache.buf_kv is None or cache.buf_kv.shape[1] < cache.ratio:
+                cache.buf_kv = mx.zeros(
+                    (buf_kv.shape[0], cache.ratio, buf_kv.shape[2]),
+                    dtype=buf_kv.dtype,
+                )
+            if cache.buf_gate is None or cache.buf_gate.shape[1] < cache.ratio:
+                cache.buf_gate = mx.zeros(
+                    (buf_gate.shape[0], cache.ratio, buf_gate.shape[2]),
+                    dtype=buf_gate.dtype,
+                )
+            cache.buf_kv[:, :restore_len] = buf_kv
+            cache.buf_gate[:, :restore_len] = buf_gate
+        if pooled_len is None:
+            cache.pooled = None
+        elif cache.pooled is not None:
+            cache.pooled = cache.pooled[:, :pooled_len]
+        return
+    if kind == "rotating":
+        _, offset, idx, start_position = snapshot
+        cache.offset = _clone_cache_tree(offset)
+        cache._idx = int(idx)
+        if start_position is not None and hasattr(cache, "start_position"):
+            cache.start_position = int(start_position)
+        return
+    _, state, meta_state = snapshot
+    if state is None:
+        _clear_cache_state(cache)
+        return
+    if meta_state is not None and hasattr(type(cache), "meta_state"):
+        cache.meta_state = _clone_cache_tree(meta_state)
+    cache.state = _clone_cache_tree(state)
 
 
 def _restore_cache_state(
@@ -1006,10 +1116,7 @@ def _restore_cache_state(
     for cache, entry in zip(caches, snapshot):
         if cache is None or entry is None:
             continue
-        state, meta_state = entry
-        if meta_state is not None and hasattr(type(cache), "meta_state"):
-            cache.meta_state = _clone_cache_tree(meta_state)
-        cache.state = _clone_cache_tree(state)
+        _restore_single_cache(cache, entry)
 
 
 def _iter_leaf_caches(caches):
@@ -1081,32 +1188,27 @@ class LanguageModel(nn.Module):
         return self._target_hidden(hidden)
 
     def _speculative_verify(self, inputs: mx.array, cache, sampler=None):
-        hidden_steps = []
-        logits_steps = []
-        cache_snapshots = []
+        cache_snapshot = _snapshot_cache_state(cache, int(inputs.shape[1]))
         sample_logits = sampler is not None
 
-        for idx in range(inputs.shape[1]):
-            out = self(
-                inputs[:, idx : idx + 1],
-                cache=cache,
-                return_hidden=True,
-                return_shared_kv=True,
-                skip_logits=not sample_logits,
-            )
-            hidden_steps.append(out.hidden_states[-1])
-            if sample_logits:
-                logits_steps.append(out.logits)
-            cache_snapshots.append(_snapshot_cache_state(cache))
-
-        hidden = mx.concatenate(hidden_steps, axis=1)
+        out = self(
+            inputs,
+            cache=cache,
+            return_hidden=True,
+            return_shared_kv=True,
+            skip_logits=not sample_logits,
+            skip_final_norm=not sample_logits,
+        )
+        hidden = out.hidden_states[-1]
+        rollback_state = (cache_snapshot, inputs)
         if not sample_logits:
-            return hidden, {}, cache_snapshots
+            return hidden, {}, rollback_state
 
-        logits = mx.concatenate(logits_steps, axis=1)
-        return hidden, {}, cache_snapshots, sampler(logits)
+        return hidden, {}, rollback_state, sampler(out.logits)
 
     def speculative_verify_logits(self, inputs: mx.array, cache, sampler):
+        # Greedy MTP verification is faster with one batched LM-head projection
+        # than with per-position deferred projections on Metal.
         return self._speculative_verify(inputs, cache, sampler)
 
     def speculative_verify_hidden(self, inputs: mx.array, cache):
@@ -1124,12 +1226,16 @@ class LanguageModel(nn.Module):
 
         max_a = int(accepted.max().item())
         if gdn_states:
+            cache_snapshot, verify_inputs = gdn_states
             accepted_list = [int(a) for a in accepted.tolist()]
             if len(set(accepted_list)) != 1:
                 raise ValueError(
                     "DeepSeek-V4 speculative rollback requires uniform acceptance."
                 )
-            _restore_cache_state(caches, gdn_states[max_a])
+            _restore_cache_state(caches, cache_snapshot)
+            keep = max_a + 1
+            if keep > 0:
+                self(verify_inputs[:, :keep], cache=caches, skip_logits=True)
             return max_a
 
         n = max_a + 1

--- a/mlx_vlm/models/deepseek_v4/language.py
+++ b/mlx_vlm/models/deepseek_v4/language.py
@@ -578,8 +578,10 @@ class LocalAttention(nn.Module):
         position_offset: Optional[Union[int, mx.array]] = None,
     ) -> mx.array:
         B, L, _ = x.shape
-        offset = position_offset if position_offset is not None else (
-            cache.offset if cache is not None else 0
+        offset = (
+            position_offset
+            if position_offset is not None
+            else (cache.offset if cache is not None else 0)
         )
         offset = mx.array(offset) if isinstance(offset, mx.array) else offset
 
@@ -673,8 +675,10 @@ class CompressedAttention(nn.Module):
         B, L, _ = x.shape
         local_cache = cache[0] if cache is not None else None
         pool_cache = cache[1] if cache is not None else None
-        offset = position_offset if position_offset is not None else (
-            local_cache.offset if local_cache is not None else 0
+        offset = (
+            position_offset
+            if position_offset is not None
+            else (local_cache.offset if local_cache is not None else 0)
         )
         offset = mx.array(offset) if isinstance(offset, mx.array) else offset
 
@@ -780,8 +784,10 @@ class SparseCompressedAttention(nn.Module):
         local_cache = cache[0] if cache is not None else None
         comp_cache = cache[1] if cache is not None else None
         idx_cache = cache[2] if cache is not None else None
-        offset = position_offset if position_offset is not None else (
-            local_cache.offset if local_cache is not None else 0
+        offset = (
+            position_offset
+            if position_offset is not None
+            else (local_cache.offset if local_cache is not None else 0)
         )
         offset = mx.array(offset) if isinstance(offset, mx.array) else offset
 
@@ -994,6 +1000,28 @@ def _snapshot_cache_state(
     return [_snapshot_single_cache(cache, incoming_tokens) for cache in caches]
 
 
+def _needs_replay_snapshot(cache, incoming_tokens: int) -> bool:
+    if cache is None:
+        return False
+    if isinstance(cache, CacheList):
+        return any(
+            _needs_replay_snapshot(child, incoming_tokens) for child in cache.caches
+        )
+    if isinstance(cache, PoolingCache):
+        return int(cache.remainder) + int(incoming_tokens) >= int(cache.ratio)
+    if isinstance(cache, RotatingKVCache):
+        return False
+    return not (hasattr(cache, "trim") and callable(cache.trim))
+
+
+def _needs_replay_snapshot_for_cache(
+    caches: Optional[List[Any]], incoming_tokens: int = 0
+) -> bool:
+    if caches is None:
+        return False
+    return any(_needs_replay_snapshot(cache, incoming_tokens) for cache in caches)
+
+
 def _snapshot_single_cache(cache, incoming_tokens: int = 0):
     if cache is None:
         return None
@@ -1009,9 +1037,7 @@ def _snapshot_single_cache(cache, incoming_tokens: int = 0):
         if incoming_tokens > 0:
             overwrite_len = total % cache.ratio if total >= cache.ratio else 0
         will_overwrite_remainder = (
-            remainder > 0
-            and cache.buf_kv is not None
-            and overwrite_len > 0
+            remainder > 0 and cache.buf_kv is not None and overwrite_len > 0
         )
         buf_kv = cache.buf_kv[:, :overwrite_len] if will_overwrite_remainder else None
         buf_gate = (
@@ -1188,7 +1214,12 @@ class LanguageModel(nn.Module):
         return self._target_hidden(hidden)
 
     def _speculative_verify(self, inputs: mx.array, cache, sampler=None):
-        cache_snapshot = _snapshot_cache_state(cache, int(inputs.shape[1]))
+        incoming_tokens = int(inputs.shape[1])
+        cache_snapshot = (
+            _snapshot_cache_state(cache, incoming_tokens)
+            if _needs_replay_snapshot_for_cache(cache, incoming_tokens)
+            else None
+        )
         sample_logits = sampler is not None
 
         out = self(
@@ -1200,7 +1231,9 @@ class LanguageModel(nn.Module):
             skip_final_norm=not sample_logits,
         )
         hidden = out.hidden_states[-1]
-        rollback_state = (cache_snapshot, inputs)
+        rollback_state = (
+            (cache_snapshot, inputs) if cache_snapshot is not None else None
+        )
         if not sample_logits:
             return hidden, {}, rollback_state
 

--- a/mlx_vlm/speculative/common.py
+++ b/mlx_vlm/speculative/common.py
@@ -27,15 +27,19 @@ def _append_arrays(value: Any, arrays: List[mx.array]) -> None:
 
 
 def _draft_sampler_state_arrays(draft_model: nn.Module) -> List[mx.array]:
+    state_fn = getattr(draft_model, "draft_eval_state", None)
+    if callable(state_fn):
+        arrays: List[mx.array] = []
+        _append_arrays(state_fn(), arrays)
+        return arrays
+
     attrs = getattr(draft_model, "sampler_state_attrs", ("_seed_token",))
     if isinstance(attrs, str):
         attrs = (attrs,)
 
     arrays = []
     for attr in attrs:
-        value = getattr(draft_model, attr, None)
-        if isinstance(value, mx.array):
-            arrays.append(value)
+        _append_arrays(getattr(draft_model, attr, None), arrays)
     return arrays
 
 
@@ -55,7 +59,13 @@ class _SpeculativeSamplerRNG:
         **kwargs,
     ):
         if not self.enabled:
-            return fn(*args, **kwargs)
+            result = fn(*args, **kwargs)
+            arrays = []
+            _append_arrays(result, arrays)
+            arrays.extend(_draft_sampler_state_arrays(self.draft_model))
+            if arrays:
+                mx.async_eval(*arrays)
+            return result
 
         self._target_rng_state = _copy_rng_state()
         _restore_rng_state(self._draft_rng_state)

--- a/mlx_vlm/speculative/drafters/__init__.py
+++ b/mlx_vlm/speculative/drafters/__init__.py
@@ -9,6 +9,7 @@ KNOWN_DRAFTER_KINDS = {"dflash", "mtp", "eagle3"}
 # Drafter HF ``model_type`` → required round-loop kind. Anything not listed
 # here falls back to ``DEFAULT_DRAFTER_KIND`` when the caller didn't pass one.
 DRAFTER_KIND_BY_MODEL_TYPE = {
+    "deepseek_v4_mtp": "mtp",
     "eagle3": "eagle3",
     "gemma4_assistant": "mtp",
     "qwen3_5_mtp": "mtp",

--- a/mlx_vlm/speculative/drafters/deepseek_v4_mtp/__init__.py
+++ b/mlx_vlm/speculative/drafters/deepseek_v4_mtp/__init__.py
@@ -1,0 +1,6 @@
+from .config import DeepseekV4MTPConfig as ModelConfig
+from .config import TextConfig
+from .deepseek_v4_mtp import DeepseekV4MTPDraftModel
+from .deepseek_v4_mtp import DeepseekV4MTPDraftModel as Model
+
+__all__ = ["DeepseekV4MTPDraftModel", "Model", "ModelConfig", "TextConfig"]

--- a/mlx_vlm/speculative/drafters/deepseek_v4_mtp/config.py
+++ b/mlx_vlm/speculative/drafters/deepseek_v4_mtp/config.py
@@ -17,18 +17,22 @@ class DeepseekV4MTPConfig(BaseModelConfig):
     model_type: str = "deepseek_v4_mtp"
     text_config: Optional[TextConfig] = None
     block_size: int = 3
+    runtime_block_size: Optional[int] = None
     tie_word_embeddings: bool = False
 
     def __post_init__(self):
         if isinstance(self.text_config, dict):
             self.text_config = TextConfig.from_dict(self.text_config)
+        if self.runtime_block_size is None and self.text_config is not None:
+            nextn_depth = getattr(self.text_config, "num_nextn_predict_layers", 1)
+            self.runtime_block_size = min(self.block_size, int(nextn_depth) + 1)
 
     @classmethod
     def from_dict(cls, params: dict) -> "DeepseekV4MTPConfig":
         flat = dict(params)
         text_config = flat.get("text_config") or {}
         nextn_depth = text_config.get("num_nextn_predict_layers", 1)
-        flat.setdefault("block_size", int(nextn_depth) + 2)
+        flat.setdefault("block_size", int(nextn_depth) + 1)
         sig = inspect.signature(cls).parameters
         return cls(**{k: v for k, v in flat.items() if k in sig})
 

--- a/mlx_vlm/speculative/drafters/deepseek_v4_mtp/config.py
+++ b/mlx_vlm/speculative/drafters/deepseek_v4_mtp/config.py
@@ -1,0 +1,35 @@
+import inspect
+from dataclasses import dataclass
+from typing import Optional
+
+from ....models.base import BaseModelConfig
+from ....models.deepseek_v4.config import ModelConfig as DeepseekV4Config
+
+
+class TextConfig:
+    @classmethod
+    def from_dict(cls, params: dict):
+        return DeepseekV4Config.from_dict(params)
+
+
+@dataclass
+class DeepseekV4MTPConfig(BaseModelConfig):
+    model_type: str = "deepseek_v4_mtp"
+    text_config: Optional[TextConfig] = None
+    block_size: int = 3
+    tie_word_embeddings: bool = False
+
+    def __post_init__(self):
+        if isinstance(self.text_config, dict):
+            self.text_config = TextConfig.from_dict(self.text_config)
+
+    @classmethod
+    def from_dict(cls, params: dict) -> "DeepseekV4MTPConfig":
+        flat = dict(params)
+        text_config = flat.get("text_config") or {}
+        nextn_depth = text_config.get("num_nextn_predict_layers", 1)
+        flat.setdefault("block_size", int(nextn_depth) + 2)
+        sig = inspect.signature(cls).parameters
+        return cls(**{k: v for k, v in flat.items() if k in sig})
+
+    from_hf_dict = from_dict

--- a/mlx_vlm/speculative/drafters/deepseek_v4_mtp/deepseek_v4_mtp.py
+++ b/mlx_vlm/speculative/drafters/deepseek_v4_mtp/deepseek_v4_mtp.py
@@ -134,6 +134,12 @@ class DeepseekV4MTPDraftModel(nn.Module):
         self._round_appended = 0
         return self._cache
 
+    def draft_eval_state(self):
+        state = [self._seed_token, self._seed_hidden]
+        for cache in self._cache:
+            state.append(cache.state)
+        return state
+
     def set_shared_kv(
         self,
         shared_kv_states: dict,

--- a/mlx_vlm/speculative/drafters/deepseek_v4_mtp/deepseek_v4_mtp.py
+++ b/mlx_vlm/speculative/drafters/deepseek_v4_mtp/deepseek_v4_mtp.py
@@ -1,0 +1,529 @@
+from dataclasses import replace
+from typing import Any, Dict, List, Optional, Tuple
+
+import mlx.core as mx
+import mlx.nn as nn
+from mlx.utils import tree_flatten
+
+from ....models.base import create_attention_mask
+from ....models.cache import RotatingKVCache
+from ....models.deepseek_v4.hyper_connection import HyperHead
+from ....models.deepseek_v4.language import DeepseekV4Block
+from .config import DeepseekV4MTPConfig
+
+
+def make_quantization_config(model):
+    mxfp4 = {"group_size": 32, "bits": 4, "mode": "mxfp4"}
+    mxfp8 = {"group_size": 32, "bits": 8, "mode": "mxfp8"}
+
+    flat_modules = tree_flatten(model.leaf_modules(), is_leaf=nn.Module.is_module)
+    experts = {
+        k: mxfp4
+        for k, _ in flat_modules
+        if "decoder.ffn.switch_mlp." in k and k.endswith("_proj")
+    }
+    mxfp8_modules = {
+        k: mxfp8
+        for k, _ in flat_modules
+        if k in ("e_proj", "h_proj")
+        or "decoder.ffn.shared_experts." in k
+        or "decoder.attn.w" in k
+    }
+
+    return {
+        "group_size": 64,
+        "bits": 8,
+        "mode": "affine",
+        **experts,
+        **mxfp8_modules,
+    }
+
+
+class DeepseekV4MTPDraftModel(nn.Module):
+    supports_greedy_draft_argmax = True
+    prefer_requested_block_size = True
+    requires_uniform_batch_acceptance = True
+
+    def __init__(self, config: DeepseekV4MTPConfig):
+        super().__init__()
+        self.config = config
+        text_config = config.text_config
+        if text_config is None:
+            raise ValueError("DeepseekV4MTPConfig.text_config must be set")
+
+        self.args = text_config
+        hidden_size = text_config.hidden_size
+        layer_config = replace(
+            text_config,
+            num_hidden_layers=1,
+            compress_ratios=[0],
+            num_hash_layers=0,
+        )
+        self.enorm = nn.RMSNorm(hidden_size, eps=text_config.rms_norm_eps)
+        self.hnorm = nn.RMSNorm(hidden_size, eps=text_config.rms_norm_eps)
+        self.e_proj = nn.Linear(hidden_size, hidden_size, bias=False)
+        self.h_proj = nn.Linear(hidden_size, hidden_size, bias=False)
+        self.decoder = DeepseekV4Block(layer_config, layer_idx=0)
+        self.hc_head = HyperHead(text_config)
+        self.norm = nn.RMSNorm(hidden_size, eps=text_config.rms_norm_eps)
+
+        self._input_embed = None
+        self._lm_head_fn = None
+        self._cache: List[RotatingKVCache] = []
+        self._seed_token: Optional[mx.array] = None
+        self._seed_hidden: Optional[mx.array] = None
+        self._next_position: Any = 0
+        self._round_appended = 0
+        self._kv_valid_len: Any = 0
+        self._position: Any = 0
+        self._draft_round = 0
+
+        self.accept_lens: List[int] = []
+        self.draft_lens: List[int] = []
+
+    @property
+    def quant_predicate(self):
+        quantization_config = make_quantization_config(self)
+
+        def predicate(path, _):
+            return quantization_config.get(path, True)
+
+        return predicate
+
+    def bind(self, target_model) -> "DeepseekV4MTPDraftModel":
+        inner = None
+        if hasattr(target_model, "embed_tokens"):
+            inner = target_model
+        elif hasattr(target_model, "model") and hasattr(
+            target_model.model, "embed_tokens"
+        ):
+            inner = target_model.model
+        elif (
+            hasattr(target_model, "language_model")
+            and hasattr(target_model.language_model, "model")
+            and hasattr(target_model.language_model.model, "embed_tokens")
+        ):
+            inner = target_model.language_model.model
+        if inner is None:
+            raise AttributeError(
+                f"Cannot find embed_tokens in {type(target_model).__name__}"
+            )
+
+        self._input_embed = inner.embed_tokens
+
+        lm = getattr(target_model, "language_model", target_model)
+        self._lm_head_fn = (
+            getattr(target_model, "lm_head", None)
+            or getattr(lm, "lm_head", None)
+            or self._input_embed.as_linear
+        )
+        return self
+
+    def make_cache(self) -> List[RotatingKVCache]:
+        return [RotatingKVCache(max_size=self.args.sliding_window)]
+
+    def reset(self, target_model) -> List[RotatingKVCache]:
+        self.bind(target_model)
+        self.accept_lens = []
+        self.draft_lens = []
+        self._draft_round = 0
+        self._cache = self.make_cache()
+        self._seed_token = None
+        self._seed_hidden = None
+        self._next_position = 0
+        self._round_appended = 0
+        return self._cache
+
+    def set_shared_kv(
+        self,
+        shared_kv_states: dict,
+        kv_offset,
+        position=None,
+        kv_valid_len=None,
+        left_padding=None,
+    ) -> None:
+        del shared_kv_states, left_padding
+        if kv_valid_len is None:
+            kv_valid_len = kv_offset
+        if position is None:
+            position = kv_valid_len
+        self._kv_valid_len = kv_valid_len
+        self._position = position
+        if not self._cache or self._cache[0].offset == 0:
+            self._next_position = kv_valid_len
+
+    def _position_ids(self, step: int = 0, length: int = 1) -> mx.array:
+        start = self._next_position
+        pos = mx.arange(length, dtype=mx.int32) + step
+        if isinstance(start, int):
+            return (pos + start)[None, :]
+        if isinstance(start, mx.array):
+            return start.astype(mx.int32)[:, None] + pos[None, :]
+        return mx.array(start, dtype=mx.int32)[:, None] + pos[None, :]
+
+    def _target_hidden(self, hidden: mx.array) -> mx.array:
+        if (
+            hidden.ndim == 3
+            and hidden.shape[-1] == self.args.hc_mult * self.args.hidden_size
+        ):
+            hidden = hidden.reshape(*hidden.shape[:-1], self.args.hc_mult, -1)
+        if hidden.ndim != 4:
+            raise ValueError(
+                "DeepSeek-V4 MTP expects target hidden shape "
+                "[batch, tokens, hc_mult, hidden_size]."
+            )
+        return hidden
+
+    def _forward_hidden(
+        self,
+        token_embed: mx.array,
+        hidden: mx.array,
+        tokens: mx.array,
+        cache: Optional[List[RotatingKVCache]],
+    ) -> Tuple[mx.array, mx.array]:
+        hidden = self._target_hidden(hidden)
+        B, L, H, D = hidden.shape
+        h_flat = hidden.reshape(B * L * H, D)
+        h_proj = self.h_proj(self.hnorm(h_flat)).reshape(B, L, H, D)
+        e_proj = self.e_proj(self.enorm(token_embed))[:, :, None, :]
+        h = e_proj + h_proj
+
+        if cache is None:
+            cache = [None]
+        mask = create_attention_mask(
+            h[:, :, 0, :],
+            cache[0],
+            window_size=self.args.sliding_window,
+            return_array=True,
+        )
+        h = self.decoder(
+            h,
+            mask,
+            cache[0],
+            tokens,
+            position_offset=self._next_position,
+        )
+        logits_hidden = self.norm(self.hc_head(h))
+        return logits_hidden, h
+
+    def _forward_tokens(
+        self,
+        tokens: mx.array,
+        hidden: mx.array,
+        token_dtype: mx.Dtype,
+    ) -> Tuple[mx.array, mx.array]:
+        token_embed = self._input_embed(tokens.astype(token_dtype))
+        logits_hidden, pre_hc_hidden = self._forward_hidden(
+            token_embed,
+            hidden[:, : tokens.shape[1], ...],
+            tokens,
+            self._cache,
+        )
+        steps = int(tokens.shape[1])
+        self._next_position = (
+            self._next_position + steps
+            if isinstance(self._next_position, int)
+            else self._next_position + steps
+        )
+        return logits_hidden, pre_hc_hidden
+
+    def _forward_token(
+        self,
+        tok: mx.array,
+        hidden: mx.array,
+        token_dtype: mx.Dtype,
+    ) -> Tuple[mx.array, mx.array]:
+        return self._forward_tokens(tok, hidden, token_dtype)
+
+    def _set_seed_from_hidden(self, hidden: mx.array, sampler, greedy: bool) -> None:
+        logits = self._lm_head_fn(hidden)
+        self._seed_token = mx.argmax(logits, axis=-1) if greedy else sampler(logits)
+        self._seed_hidden = hidden
+
+    def prefill_from_target_hidden(
+        self,
+        input_ids: mx.array,
+        hidden: mx.array,
+        bonus_token,
+        sampler,
+        token_dtype: mx.Dtype = mx.int32,
+        greedy: bool = False,
+    ) -> None:
+        if input_ids.shape[1] == 0:
+            return
+        if isinstance(bonus_token, int):
+            bonus = mx.array([[bonus_token]], dtype=token_dtype)
+        else:
+            bonus = bonus_token[:, None].astype(token_dtype)
+
+        shifted = mx.concatenate(
+            [input_ids[:, 1:].astype(token_dtype), bonus], axis=1
+        )
+        self._next_position = 0
+        logits_hidden, pre_hc_hidden = self._forward_tokens(
+            shifted,
+            hidden[:, : shifted.shape[1], ...],
+            token_dtype,
+        )
+        self._set_seed_from_hidden(logits_hidden[:, -1:, :], sampler, greedy)
+        self._seed_hidden = pre_hc_hidden[:, -1:, ...]
+
+    def accept_verified_tokens(
+        self,
+        verify_hidden: mx.array,
+        draft_tokens: mx.array,
+        accepted: int,
+        new_tokens: List[int],
+        sampler,
+        token_dtype: mx.Dtype = mx.int32,
+        greedy: bool = False,
+    ) -> None:
+        keep_appended = min(int(accepted), self._round_appended)
+        trim = self._round_appended - keep_appended
+        if trim > 0:
+            for cache in self._cache:
+                cache.trim(trim)
+            self._next_position = (
+                self._next_position - trim
+                if isinstance(self._next_position, int)
+                else self._next_position - trim
+            )
+
+        token_chunks = []
+        hidden_chunks = []
+        for draft_idx in range(keep_appended, int(accepted)):
+            token_chunks.append(draft_tokens[:, draft_idx : draft_idx + 1])
+            hidden_chunks.append(verify_hidden[:, draft_idx : draft_idx + 1, ...])
+
+        if new_tokens:
+            token_chunks.append(mx.array([[int(new_tokens[-1])]], dtype=token_dtype))
+            hidden_chunks.append(
+                verify_hidden[:, int(accepted) : int(accepted) + 1, ...]
+            )
+
+        if token_chunks:
+            tokens = mx.concatenate(token_chunks, axis=1).astype(token_dtype)
+            hiddens = mx.concatenate(hidden_chunks, axis=1)
+            logits_hidden, pre_hc_hidden = self._forward_tokens(
+                tokens, hiddens, token_dtype
+            )
+            self._set_seed_from_hidden(logits_hidden[:, -1:, :], sampler, greedy)
+            self._seed_hidden = pre_hc_hidden[:, -1:, ...]
+        self._round_appended = 0
+
+    def accept_verified_tokens_batch(
+        self,
+        verify_hidden: mx.array,
+        draft_tokens: mx.array,
+        accepted: List[int],
+        new_tokens: List[List[int]],
+        sampler,
+        token_dtype: mx.Dtype = mx.int32,
+        greedy: bool = False,
+    ) -> None:
+        """Extend the DeepSeek-V4 MTP drafter cache after batched verify."""
+        if len(accepted) <= 1:
+            self.accept_verified_tokens(
+                verify_hidden,
+                draft_tokens,
+                int(accepted[0]),
+                new_tokens[0],
+                sampler,
+                token_dtype,
+                greedy,
+            )
+            return
+
+        accepted_set = {int(a) for a in accepted}
+        if len(accepted_set) != 1:
+            raise ValueError(
+                "DeepSeek-V4 MTP batched cache update requires uniform acceptance."
+            )
+        accepted_i = accepted_set.pop()
+
+        keep_appended = min(accepted_i, self._round_appended)
+        trim = self._round_appended - keep_appended
+        if trim > 0:
+            for cache in self._cache:
+                cache.trim(trim)
+            self._next_position = (
+                self._next_position - trim
+                if isinstance(self._next_position, int)
+                else self._next_position - trim
+            )
+
+        token_chunks = []
+        hidden_chunks = []
+        for draft_idx in range(keep_appended, accepted_i):
+            token_chunks.append(draft_tokens[:, draft_idx : draft_idx + 1])
+            hidden_chunks.append(verify_hidden[:, draft_idx : draft_idx + 1, ...])
+
+        if all(new_tokens):
+            bonus = mx.array(
+                [[int(row_tokens[-1])] for row_tokens in new_tokens],
+                dtype=token_dtype,
+            )
+            token_chunks.append(bonus)
+            hidden_chunks.append(verify_hidden[:, accepted_i : accepted_i + 1, ...])
+
+        if token_chunks:
+            tokens = mx.concatenate(token_chunks, axis=1).astype(token_dtype)
+            hiddens = mx.concatenate(hidden_chunks, axis=1)
+            logits_hidden, pre_hc_hidden = self._forward_tokens(
+                tokens, hiddens, token_dtype
+            )
+            self._set_seed_from_hidden(logits_hidden[:, -1:, :], sampler, greedy)
+            self._seed_hidden = pre_hc_hidden[:, -1:, ...]
+        self._round_appended = 0
+
+    def filter_batch(self, keep) -> None:
+        if not isinstance(keep, mx.array):
+            keep = mx.array(keep, dtype=mx.int32)
+
+        for cache in self._cache:
+            if cache.keys is not None:
+                cache.keys = cache.keys[keep]
+                cache.values = cache.values[keep]
+
+        if self._seed_token is not None:
+            self._seed_token = self._seed_token[keep]
+        if self._seed_hidden is not None:
+            self._seed_hidden = self._seed_hidden[keep]
+
+        for attr in ("_next_position", "_kv_valid_len", "_position"):
+            value = getattr(self, attr)
+            if isinstance(value, mx.array) and value.ndim > 0 and value.size > 1:
+                setattr(self, attr, value[keep])
+
+    def draft_block(
+        self,
+        last_bonus,
+        hidden: mx.array,
+        cache,
+        block_size: int,
+        sampler,
+        token_dtype: mx.Dtype = mx.int32,
+        greedy: bool = False,
+    ) -> mx.array:
+        del cache
+        if self._input_embed is None or self._lm_head_fn is None:
+            raise RuntimeError(
+                "bind(target_model) must be called before draft_block() "
+                "so the drafter can use the target embeddings and LM head."
+            )
+
+        if isinstance(last_bonus, int):
+            tok = mx.array([[last_bonus]], dtype=token_dtype)
+        else:
+            tok = last_bonus[:, None].astype(token_dtype)
+
+        h_prev = hidden
+        tokens: List[mx.array] = []
+        self._round_appended = 0
+
+        if self._seed_token is not None and self._seed_hidden is not None:
+            tok = self._seed_token.astype(token_dtype)
+            h_prev = self._seed_hidden
+            tokens.append(tok)
+            self._seed_token = None
+            self._seed_hidden = None
+
+        while len(tokens) < block_size - 1:
+            logits_hidden, h_prev = self._forward_token(tok, h_prev, token_dtype)
+            self._round_appended += 1
+            logits = self._lm_head_fn(logits_hidden)
+            tok = mx.argmax(logits, axis=-1) if greedy else sampler(logits)
+            tokens.append(tok)
+
+        self._draft_round += 1
+        return mx.concatenate(tokens, axis=1)
+
+    def sanitize(self, weights: Dict[str, mx.array]) -> Dict[str, mx.array]:
+        weights = dict(weights)
+        new_weights = {}
+        for k, v in weights.items():
+            if k.startswith("mtp.0."):
+                k = k[len("mtp.0.") :]
+            elif k.startswith("mtp."):
+                k = k[len("mtp.") :]
+            new_weights[k] = v
+        weights = new_weights
+
+        new_weights = {}
+        for k, v in weights.items():
+            if "tid2eid" in k:
+                new_weights[k] = v.astype(mx.int32)
+
+            if not k.endswith(".scale"):
+                if k not in new_weights:
+                    new_weights[k] = v
+                continue
+
+            wk = k[: -len(".scale")] + ".weight"
+            weight = weights.get(wk)
+            if weight is None:
+                new_weights[k] = v
+                continue
+            if (
+                ("ffn.experts." in wk or ".ffn.experts." in wk)
+                and ".shared_experts." not in wk
+                and weight.dtype in (mx.int8, mx.uint8)
+                and v.shape[-1] * 16 == weight.shape[-1]
+            ):
+                new_weights[k + "s"] = v
+                new_weights[wk] = weight.view(mx.uint32)
+            elif weight.dtype == mx.uint8:
+                new_weights[k + "s"] = mx.repeat(mx.repeat(v, 4, -1), 128, 0)
+                new_weights[wk] = weight.view(mx.uint32)
+            else:
+                new_weights[k] = v
+        weights = new_weights
+
+        remapped = {}
+        w_remap = {"w1": "gate_proj", "w2": "down_proj", "w3": "up_proj"}
+        for k, v in weights.items():
+            nk = k
+            if nk.startswith("attn.") or nk.startswith("attn_norm."):
+                nk = f"decoder.{nk}"
+            elif nk.startswith("ffn.") or nk.startswith("ffn_norm."):
+                nk = f"decoder.{nk}"
+            nk = nk.replace(".ffn.gate.bias", ".ffn.gate.e_score_correction_bias")
+            for sub in ("attn", "ffn"):
+                for param in ("fn", "base", "scale"):
+                    nk = nk.replace(f".hc_{sub}_{param}", f".{sub}_hc.{param}")
+                    nk = nk.replace(
+                        f"hc_{sub}_{param}", f"decoder.{sub}_hc.{param}"
+                    )
+            for old, new in w_remap.items():
+                nk = nk.replace(f".shared_experts.{old}.", f".shared_experts.{new}.")
+            nk = nk.replace("hc_head_fn", "hc_head.fn")
+            nk = nk.replace("hc_head_base", "hc_head.base")
+            nk = nk.replace("hc_head_scale", "hc_head.scale")
+            remapped[nk] = v
+        weights = remapped
+
+        prefix = "decoder.ffn.experts"
+        for src, dst in (
+            ("w1", "gate_proj"),
+            ("w2", "down_proj"),
+            ("w3", "up_proj"),
+        ):
+            for suffix in ("weight", "scales"):
+                key0 = f"{prefix}.0.{src}.{suffix}"
+                if key0 in weights:
+                    stacked = [
+                        weights.pop(f"{prefix}.{e}.{src}.{suffix}")
+                        for e in range(self.args.n_routed_experts)
+                    ]
+                    weights[f"decoder.ffn.switch_mlp.{dst}.{suffix}"] = mx.stack(
+                        stacked
+                    )
+
+        prefix = "decoder.attn.wo_a"
+        for key in (f"{prefix}.weight", f"{prefix}.scales", f"{prefix}.biases"):
+            if key in weights and weights[key].ndim == 2:
+                weights[key] = weights[key].reshape(
+                    self.args.o_groups, self.args.o_lora_rank, -1
+                )
+
+        return weights

--- a/mlx_vlm/speculative/drafters/deepseek_v4_mtp/deepseek_v4_mtp.py
+++ b/mlx_vlm/speculative/drafters/deepseek_v4_mtp/deepseek_v4_mtp.py
@@ -262,9 +262,7 @@ class DeepseekV4MTPDraftModel(nn.Module):
         else:
             bonus = bonus_token[:, None].astype(token_dtype)
 
-        shifted = mx.concatenate(
-            [input_ids[:, 1:].astype(token_dtype), bonus], axis=1
-        )
+        shifted = mx.concatenate([input_ids[:, 1:].astype(token_dtype), bonus], axis=1)
         self._next_position = 0
         logits_hidden, pre_hc_hidden = self._forward_tokens(
             shifted,
@@ -497,9 +495,7 @@ class DeepseekV4MTPDraftModel(nn.Module):
             for sub in ("attn", "ffn"):
                 for param in ("fn", "base", "scale"):
                     nk = nk.replace(f".hc_{sub}_{param}", f".{sub}_hc.{param}")
-                    nk = nk.replace(
-                        f"hc_{sub}_{param}", f"decoder.{sub}_hc.{param}"
-                    )
+                    nk = nk.replace(f"hc_{sub}_{param}", f"decoder.{sub}_hc.{param}")
             for old, new in w_remap.items():
                 nk = nk.replace(f".shared_experts.{old}.", f".shared_experts.{new}.")
             nk = nk.replace("hc_head_fn", "hc_head.fn")

--- a/mlx_vlm/speculative/drafters/deepseek_v4_mtp/split.py
+++ b/mlx_vlm/speculative/drafters/deepseek_v4_mtp/split.py
@@ -1,0 +1,180 @@
+import argparse
+import glob
+import json
+import shutil
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Dict, Iterable, Optional
+
+import mlx.core as mx
+from safetensors import safe_open
+
+from ....models.deepseek_v4.config import ModelConfig as DeepseekV4Config
+from ....utils import _load_safetensors, get_model_path
+from .deepseek_v4_mtp import DeepseekV4MTPDraftModel
+
+
+def _safetensor_files(model_path: Path) -> list[Path]:
+    return [
+        Path(path)
+        for path in glob.glob(str(model_path / "*.safetensors"))
+        if not path.endswith("consolidated.safetensors")
+    ]
+
+
+def _weight_map(model_path: Path) -> Dict[str, str]:
+    index_path = model_path / "model.safetensors.index.json"
+    if not index_path.exists():
+        return {}
+    with open(index_path) as f:
+        data = json.load(f)
+    return data.get("weight_map", {})
+
+
+def _iter_mtp_keys(model_path: Path) -> Iterable[tuple[Path, list[str]]]:
+    weight_map = _weight_map(model_path)
+    if weight_map:
+        by_file: Dict[str, list[str]] = {}
+        for key, filename in weight_map.items():
+            if key.startswith("mtp."):
+                by_file.setdefault(filename, []).append(key)
+        if by_file:
+            for filename, keys in by_file.items():
+                yield model_path / filename, keys
+            return
+
+    for file in _safetensor_files(model_path):
+        with safe_open(file, framework="mlx") as f:
+            keys = [key for key in f.keys() if key.startswith("mtp.")]
+        if keys:
+            yield file, keys
+
+
+def _load_selected_tensors(file: Path, keys: list[str]) -> Dict[str, mx.array]:
+    tensors = {}
+    try:
+        with safe_open(file, framework="mlx") as f:
+            for key in keys:
+                tensors[key] = mx.array(f.get_tensor(key))
+    except (AttributeError, RuntimeError, TypeError):
+        shard = _load_safetensors(str(file))
+        tensors = {key: shard[key] for key in keys}
+    return tensors
+
+
+def _text_config(source_config: dict) -> dict:
+    return dict(source_config.get("text_config") or source_config)
+
+
+def _module_from_scales_key(key: str) -> str:
+    return key[: -len(".scales")]
+
+
+def _quantization_from_weights(weights: Dict[str, mx.array]) -> Optional[dict]:
+    mxfp4 = {"group_size": 32, "bits": 4, "mode": "mxfp4"}
+    mxfp8 = {"group_size": 32, "bits": 8, "mode": "mxfp8"}
+    quantization = {"group_size": 64, "bits": 8, "mode": "affine"}
+
+    for key in weights:
+        if not key.endswith(".scales"):
+            continue
+        module = _module_from_scales_key(key)
+        if "decoder.ffn.switch_mlp." in module and module.endswith("_proj"):
+            quantization[module] = mxfp4
+        elif (
+            module in ("e_proj", "h_proj")
+            or "decoder.ffn.shared_experts." in module
+            or "decoder.attn.w" in module
+        ):
+            quantization[module] = mxfp8
+
+    return quantization if len(quantization) > 3 else None
+
+
+def split_deepseek_v4_mtp(
+    source: str,
+    output: str,
+    *,
+    revision: Optional[str] = None,
+    block_size: Optional[int] = None,
+    force_download: bool = False,
+) -> Path:
+    """Write DeepSeek-V4 native MTP tensors into a standalone drafter folder."""
+    source_path = get_model_path(
+        source, revision=revision, force_download=force_download
+    )
+    output_path = Path(output)
+    output_path.mkdir(parents=True, exist_ok=True)
+
+    config_path = source_path / "config.json"
+    with open(config_path) as f:
+        source_config = json.load(f)
+    text_config = _text_config(source_config)
+
+    selected = {}
+    for file, keys in _iter_mtp_keys(source_path):
+        selected.update(_load_selected_tensors(file, keys))
+
+    if not selected:
+        raise ValueError(f"No mtp.* tensors found in {source_path}.")
+
+    sanitize_context = SimpleNamespace(args=DeepseekV4Config.from_dict(text_config))
+    selected = DeepseekV4MTPDraftModel.sanitize(sanitize_context, selected)
+
+    mx.save_safetensors(
+        str(output_path / "model.safetensors"),
+        selected,
+        metadata={"format": "mlx"},
+    )
+
+    depth = int(text_config.get("num_nextn_predict_layers", 1))
+    draft_config = {
+        "model_type": "deepseek_v4_mtp",
+        "text_config": text_config,
+        "block_size": int(block_size or depth + 2),
+        "tie_word_embeddings": bool(text_config.get("tie_word_embeddings", False)),
+    }
+    quantization = _quantization_from_weights(selected)
+    if quantization is not None:
+        draft_config["quantization"] = quantization
+        draft_config["quantization_config"] = quantization
+
+    with open(output_path / "config.json", "w") as f:
+        json.dump(dict(sorted(draft_config.items())), f, indent=2)
+
+    for name in (
+        "tokenizer.json",
+        "tokenizer_config.json",
+        "vocab.json",
+        "merges.txt",
+        "special_tokens_map.json",
+        "generation_config.json",
+        "chat_template.jinja",
+    ):
+        src = source_path / name
+        if src.exists():
+            shutil.copy(src, output_path / name)
+
+    return output_path
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Split DeepSeek-V4 native MTP tensors into a standalone MLX drafter."
+    )
+    parser.add_argument("--model", "--source", dest="source", required=True)
+    parser.add_argument("--output", required=True)
+    parser.add_argument("--revision", default=None)
+    parser.add_argument("--block-size", type=int, default=None)
+    parser.add_argument("--force-download", action="store_true")
+    return parser
+
+
+def main():
+    args = build_parser().parse_args()
+    output = split_deepseek_v4_mtp(**vars(args))
+    print(f"Wrote DeepSeek-V4 MTP drafter to {output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/mlx_vlm/speculative/drafters/deepseek_v4_mtp/split.py
+++ b/mlx_vlm/speculative/drafters/deepseek_v4_mtp/split.py
@@ -131,7 +131,7 @@ def split_deepseek_v4_mtp(
     draft_config = {
         "model_type": "deepseek_v4_mtp",
         "text_config": text_config,
-        "block_size": int(block_size or depth + 2),
+        "block_size": int(block_size or depth + 1),
         "tie_word_embeddings": bool(text_config.get("tie_word_embeddings", False)),
     }
     quantization = _quantization_from_weights(selected)

--- a/mlx_vlm/speculative/drafters/qwen3_5_mtp/qwen3_5_mtp.py
+++ b/mlx_vlm/speculative/drafters/qwen3_5_mtp/qwen3_5_mtp.py
@@ -105,6 +105,12 @@ class Qwen3_5MTPDraftModel(nn.Module):
         self._round_appended = 0
         return self._cache
 
+    def draft_eval_state(self):
+        state = [self._seed_token, self._seed_hidden]
+        for cache in self._cache:
+            state.append(cache.state)
+        return state
+
     def set_shared_kv(
         self,
         shared_kv_states: dict,

--- a/mlx_vlm/speculative/mtp.py
+++ b/mlx_vlm/speculative/mtp.py
@@ -350,15 +350,22 @@ def _buffer_mtp_target_cache(
     requested = int(draft_block_size or configured)
     buffer_size = max(32, min(128, max(configured, requested) * 8))
 
-    for idx, entry in enumerate(prompt_cache):
+    def buffer_entry(entry):
+        if isinstance(entry, cache.CacheList):
+            entry.caches = tuple(buffer_entry(child) for child in entry.caches)
+            return entry
         if isinstance(entry, cache.BufferedRotatingKVCache):
             entry.buffer_size = max(entry.buffer_size, buffer_size)
         elif (
             isinstance(entry, cache.RotatingKVCache) and getattr(entry, "keep", 0) == 0
         ):
-            prompt_cache[idx] = cache.BufferedRotatingKVCache.from_cache(
+            return cache.BufferedRotatingKVCache.from_cache(
                 entry, buffer_size=buffer_size
             )
+        return entry
+
+    for idx, entry in enumerate(prompt_cache):
+        prompt_cache[idx] = buffer_entry(entry)
 
 
 def _mtp_rounds(

--- a/mlx_vlm/tests/test_speculative.py
+++ b/mlx_vlm/tests/test_speculative.py
@@ -17,7 +17,13 @@ import pytest
 import mlx_vlm.models.deepseek_v4.language as deepseek_language
 import mlx_vlm.models.qwen3_5.language as qwen_language
 import mlx_vlm.speculative.mtp as mtp_utils
-from mlx_vlm.models.cache import ArraysCache, BufferedRotatingKVCache, RotatingKVCache
+from mlx_vlm.models.cache import (
+    ArraysCache,
+    BufferedRotatingKVCache,
+    CacheList,
+    PoolingCache,
+    RotatingKVCache,
+)
 from mlx_vlm.speculative.common import _SpeculativeSamplerRNG
 from mlx_vlm.speculative.drafters import (
     DEFAULT_DRAFTER_KIND,
@@ -626,6 +632,25 @@ def test_buffered_rotating_cache_matches_temporal_multitoken_tail_and_trim():
     assert buffered.trim(2) == 2
     assert buffered.offset == 5
     assert buffered.state[0].reshape(-1).tolist() == [0.0, 1.0, 2.0, 3.0, 4.0]
+
+
+def test_mtp_target_cache_buffers_cache_list_local_rotating_cache():
+    base = RotatingKVCache(max_size=4, keep=0)
+    keys = mx.arange(4, dtype=mx.float32).reshape(1, 1, 4, 1)
+    base.update_and_fetch(keys, keys)
+    prompt_cache = [CacheList(base, PoolingCache(4))]
+    draft_model = SimpleNamespace(config=SimpleNamespace(block_size=3))
+
+    mtp_utils._buffer_mtp_target_cache(prompt_cache, draft_model, None)
+
+    assert isinstance(prompt_cache[0][0], BufferedRotatingKVCache)
+    assert isinstance(prompt_cache[0][1], PoolingCache)
+    assert prompt_cache[0][0].state[0].reshape(-1).tolist() == [
+        0.0,
+        1.0,
+        2.0,
+        3.0,
+    ]
 
 
 def test_normalize_batched_shared_kv_states_repacks_left_padded_rows():
@@ -2024,20 +2049,62 @@ def test_deepseek_v4_returns_mtp_hidden_and_rolls_back_snapshot():
     cache = lm.make_cache()
     inputs = mx.array([[1, 2, 3]], dtype=mx.int32)
 
-    hidden, shared_kv, snapshots = lm.speculative_verify_hidden(inputs, cache)
+    hidden, shared_kv, rollback_state = lm.speculative_verify_hidden(inputs, cache)
     mx.eval(hidden)
 
     assert hidden.shape == (1, 3, cfg.hc_mult, cfg.hidden_size)
     assert shared_kv == {}
-    assert len(snapshots) == 3
+    assert rollback_state[1].tolist() == inputs.tolist()
     assert cache[0].offset == 3
 
-    lm.rollback_speculative_cache(cache, snapshots, accepted=0, block_size=3)
+    lm.rollback_speculative_cache(cache, rollback_state, accepted=0, block_size=3)
     assert cache[0].offset == 1
 
     logits = lm.speculative_logits_from_hidden(hidden[:, :1])
     mx.eval(logits)
     assert logits.shape == (1, 1, cfg.vocab_size)
+
+
+def test_deepseek_v4_pooling_snapshot_skips_clone_when_verify_does_not_overwrite_remainder():
+    pool = PoolingCache(4)
+    old_kv = mx.array([[[10.0]]])
+    old_gate = mx.array([[[1.0]]])
+    pool.accumulate_windows(old_kv, old_gate, offset=0)
+
+    snapshot = deepseek_language._snapshot_cache_state([pool], incoming_tokens=3)
+    assert snapshot[0][2] is None
+
+    new_kv = mx.array([[[20.0], [21.0], [22.0]]])
+    new_gate = mx.ones_like(new_kv)
+    pooled, _, _ = pool.accumulate_windows(new_kv, new_gate, offset=1)
+    pool.update_and_fetch(pooled)
+
+    deepseek_language._restore_cache_state([pool], snapshot)
+
+    assert pool.remainder == 1
+    assert pool.pooled is None
+    assert pool.buf_kv[:, :1].reshape(-1).tolist() == [10.0]
+
+
+def test_deepseek_v4_pooling_snapshot_restores_only_overwritten_prefix():
+    pool = PoolingCache(4)
+    old_kv = mx.array([[[10.0], [11.0], [12.0]]])
+    old_gate = mx.ones_like(old_kv)
+    pool.accumulate_windows(old_kv, old_gate, offset=0)
+
+    snapshot = deepseek_language._snapshot_cache_state([pool], incoming_tokens=3)
+    assert snapshot[0][2].shape == (1, 2, 1)
+
+    new_kv = mx.array([[[20.0], [21.0], [22.0]]])
+    new_gate = mx.ones_like(new_kv)
+    pooled, _, _ = pool.accumulate_windows(new_kv, new_gate, offset=3)
+    pool.update_and_fetch(pooled)
+
+    deepseek_language._restore_cache_state([pool], snapshot)
+
+    assert pool.remainder == 3
+    assert pool.pooled is None
+    assert pool.buf_kv[:, :3].reshape(-1).tolist() == [10.0, 11.0, 12.0]
 
 
 def test_deepseek_v4_language_ignores_generation_metadata_kwargs():

--- a/mlx_vlm/tests/test_speculative.py
+++ b/mlx_vlm/tests/test_speculative.py
@@ -14,6 +14,7 @@ import mlx.core as mx
 import mlx.nn as nn
 import pytest
 
+import mlx_vlm.models.deepseek_v4.language as deepseek_language
 import mlx_vlm.models.qwen3_5.language as qwen_language
 import mlx_vlm.speculative.mtp as mtp_utils
 from mlx_vlm.models.cache import ArraysCache, BufferedRotatingKVCache, RotatingKVCache
@@ -24,6 +25,11 @@ from mlx_vlm.speculative.drafters import (
     KNOWN_DRAFTER_KINDS,
     resolve_drafter_kind,
 )
+from mlx_vlm.speculative.drafters.deepseek_v4_mtp import (
+    DeepseekV4MTPDraftModel,
+)
+from mlx_vlm.speculative.drafters.deepseek_v4_mtp.config import DeepseekV4MTPConfig
+from mlx_vlm.speculative.drafters.deepseek_v4_mtp.split import split_deepseek_v4_mtp
 from mlx_vlm.speculative.drafters.eagle3 import Eagle3DraftModel
 from mlx_vlm.speculative.drafters.eagle3 import ModelConfig as Eagle3Config
 from mlx_vlm.speculative.drafters.eagle3 import TextConfig as Eagle3TextConfig
@@ -1457,6 +1463,12 @@ def test_kind_none_autodetects_mtp_for_qwen3_5_mtp(tmp_path):
     assert resolve_drafter_kind(path, "dflash") == "mtp"
 
 
+def test_kind_none_autodetects_mtp_for_deepseek_v4_mtp(tmp_path):
+    path = _make_drafter_dir(tmp_path, "deepseek_v4_mtp")
+    assert resolve_drafter_kind(path, None) == "mtp"
+    assert resolve_drafter_kind(path, "dflash") == "mtp"
+
+
 def test_kind_none_autodetects_eagle3_speculators_config(tmp_path):
     path = tmp_path / "drafter"
     path.mkdir()
@@ -1508,6 +1520,35 @@ def _tiny_qwen3_5_text_config():
             "rope_theta": 10000,
             "partial_rotary_factor": 0.25,
         },
+    )
+
+
+def _tiny_deepseek_v4_config():
+    return deepseek_language.ModelConfig(
+        vocab_size=32,
+        hidden_size=16,
+        intermediate_size=32,
+        moe_intermediate_size=4,
+        num_hidden_layers=1,
+        num_attention_heads=2,
+        num_key_value_heads=1,
+        n_shared_experts=1,
+        n_routed_experts=2,
+        num_experts_per_tok=1,
+        q_lora_rank=8,
+        qk_rope_head_dim=4,
+        head_dim=8,
+        o_groups=1,
+        o_lora_rank=8,
+        index_n_heads=1,
+        index_head_dim=8,
+        index_topk=1,
+        num_hash_layers=0,
+        hc_mult=2,
+        hc_sinkhorn_iters=2,
+        compress_ratios=[0],
+        sliding_window=16,
+        max_position_embeddings=128,
     )
 
 
@@ -1975,3 +2016,173 @@ def test_split_qwen3_5_mtp_writes_sidecar_without_index_mtp_entries(tmp_path):
     assert cfg["block_size"] == 3
     assert "fc.weight" in weights
     assert weights["pre_fc_norm_hidden.weight"][0].item() == 1.0
+
+
+def test_deepseek_v4_returns_mtp_hidden_and_rolls_back_snapshot():
+    cfg = _tiny_deepseek_v4_config()
+    lm = deepseek_language.LanguageModel(cfg)
+    cache = lm.make_cache()
+    inputs = mx.array([[1, 2, 3]], dtype=mx.int32)
+
+    hidden, shared_kv, snapshots = lm.speculative_verify_hidden(inputs, cache)
+    mx.eval(hidden)
+
+    assert hidden.shape == (1, 3, cfg.hc_mult, cfg.hidden_size)
+    assert shared_kv == {}
+    assert len(snapshots) == 3
+    assert cache[0].offset == 3
+
+    lm.rollback_speculative_cache(cache, snapshots, accepted=0, block_size=3)
+    assert cache[0].offset == 1
+
+    logits = lm.speculative_logits_from_hidden(hidden[:, :1])
+    mx.eval(logits)
+    assert logits.shape == (1, 1, cfg.vocab_size)
+
+
+def test_deepseek_v4_language_ignores_generation_metadata_kwargs():
+    cfg = _tiny_deepseek_v4_config()
+    lm = deepseek_language.LanguageModel(cfg)
+    out = lm(mx.array([[1]], dtype=mx.int32), fps=2.0, image=None, video=None)
+    mx.eval(out.logits)
+
+    assert out.logits.shape == (1, 1, cfg.vocab_size)
+
+
+def test_deepseek_v4_mtp_draft_block_smoke():
+    text_config = _tiny_deepseek_v4_config()
+    drafter = DeepseekV4MTPDraftModel(
+        DeepseekV4MTPConfig(text_config=text_config, block_size=3)
+    )
+    target = SimpleNamespace(
+        language_model=SimpleNamespace(
+            model=SimpleNamespace(embed_tokens=nn.Embedding(32, 16))
+        )
+    )
+    drafter.reset(target)
+    drafter.set_shared_kv({}, kv_offset=4, position=3, kv_valid_len=4)
+    hidden = mx.zeros((1, 1, text_config.hc_mult, 16), dtype=mx.float32)
+    tokens = drafter.draft_block(
+        7,
+        hidden,
+        None,
+        3,
+        lambda logits: mx.argmax(logits, axis=-1),
+        mx.int32,
+        greedy=True,
+    )
+    mx.eval(tokens)
+    assert tokens.shape == (1, 2)
+
+
+def test_deepseek_v4_mtp_batch_accept_updates_uniform_cache():
+    text_config = _tiny_deepseek_v4_config()
+    drafter = DeepseekV4MTPDraftModel(
+        DeepseekV4MTPConfig(text_config=text_config, block_size=3)
+    )
+    target = SimpleNamespace(
+        language_model=SimpleNamespace(
+            model=SimpleNamespace(embed_tokens=nn.Embedding(32, 16))
+        )
+    )
+    drafter.reset(target)
+    drafter.set_shared_kv({}, kv_offset=4, position=3, kv_valid_len=4)
+    hidden = mx.zeros((2, 1, text_config.hc_mult, 16), dtype=mx.float32)
+    draft_tokens = drafter.draft_block(
+        mx.array([7, 8], dtype=mx.int32),
+        hidden,
+        None,
+        3,
+        lambda logits: mx.argmax(logits, axis=-1),
+        mx.int32,
+        greedy=True,
+    )
+    verify_hidden = mx.zeros((2, 3, text_config.hc_mult, 16), dtype=mx.float32)
+    drafter.accept_verified_tokens_batch(
+        verify_hidden,
+        draft_tokens,
+        accepted=[0, 0],
+        new_tokens=[[3], [4]],
+        sampler=lambda logits: mx.argmax(logits, axis=-1),
+        token_dtype=mx.int32,
+        greedy=True,
+    )
+
+    mx.eval(drafter._seed_token)
+    assert drafter._seed_token.shape == (2, 1)
+    assert drafter._seed_hidden.shape == (2, 1, text_config.hc_mult, 16)
+    assert drafter._round_appended == 0
+    assert drafter._cache[0].offset == 1
+    assert drafter._next_position == 5
+
+
+def test_deepseek_v4_mtp_sanitize_maps_embedded_weights():
+    cfg = _tiny_deepseek_v4_config()
+    context = SimpleNamespace(args=cfg)
+    weights = {
+        "mtp.0.e_proj.weight": mx.zeros((4, 4), dtype=mx.uint8),
+        "mtp.0.e_proj.scale": mx.ones((1, 1), dtype=mx.float32),
+        "mtp.0.ffn.gate.bias": mx.zeros((cfg.n_routed_experts,)),
+        "mtp.0.hc_attn_fn": mx.ones((2, 2)),
+        "mtp.0.hc_head_scale": mx.ones((1,)),
+        "mtp.0.attn.wo_a.weight": mx.ones((cfg.o_lora_rank, 4)),
+    }
+    for expert in range(cfg.n_routed_experts):
+        for name in ("w1", "w2", "w3"):
+            weights[f"mtp.0.ffn.experts.{expert}.{name}.weight"] = mx.zeros(
+                (4, 16), dtype=mx.int8
+            )
+            weights[f"mtp.0.ffn.experts.{expert}.{name}.scale"] = mx.ones(
+                (4, 1), dtype=mx.uint8
+            )
+
+    out = DeepseekV4MTPDraftModel.sanitize(context, weights)
+
+    assert "e_proj.scales" in out
+    assert "decoder.ffn.gate.e_score_correction_bias" in out
+    assert "decoder.attn_hc.fn" in out
+    assert "hc_head.scale" in out
+    assert out["decoder.ffn.switch_mlp.gate_proj.weight"].shape[0] == (
+        cfg.n_routed_experts
+    )
+    assert out["decoder.ffn.switch_mlp.gate_proj.scales"].shape[0] == (
+        cfg.n_routed_experts
+    )
+    assert out["decoder.attn.wo_a.weight"].shape == (1, cfg.o_lora_rank, 4)
+
+
+def test_split_deepseek_v4_mtp_writes_sidecar_without_index_mtp_entries(tmp_path):
+    source = tmp_path / "source"
+    output = tmp_path / "mtp"
+    source.mkdir()
+    text_config = _tiny_deepseek_v4_config()
+    (source / "config.json").write_text(
+        json.dumps({"model_type": "deepseek_v4", **text_config.to_dict()})
+    )
+    mx.save_safetensors(
+        str(source / "mtp.safetensors"),
+        {
+            "mtp.0.e_proj.weight": mx.zeros((4, 4), dtype=mx.uint8),
+            "mtp.0.e_proj.scale": mx.ones((1, 1), dtype=mx.float32),
+            "mtp.0.attn.wq_a.weight": mx.zeros((4, 4), dtype=mx.uint8),
+            "mtp.0.attn.wq_a.scale": mx.ones((1, 1), dtype=mx.float32),
+            "mtp.0.enorm.weight": mx.zeros((text_config.hidden_size,)),
+        },
+        metadata={},
+    )
+    (source / "model.safetensors.index.json").write_text(
+        json.dumps({"weight_map": {"model.foo": "model.safetensors"}})
+    )
+
+    split_deepseek_v4_mtp(str(source), str(output))
+
+    with open(output / "config.json") as f:
+        cfg = json.load(f)
+    weights = mx.load(str(output / "model.safetensors"))
+    assert cfg["model_type"] == "deepseek_v4_mtp"
+    assert cfg["block_size"] == 3
+    assert cfg["quantization"]["e_proj"]["mode"] == "mxfp8"
+    assert cfg["quantization"]["decoder.attn.wq_a"]["mode"] == "mxfp8"
+    assert "e_proj.weight" in weights
+    assert "e_proj.scales" in weights
+    assert "enorm.weight" in weights

--- a/mlx_vlm/tests/test_speculative.py
+++ b/mlx_vlm/tests/test_speculative.py
@@ -153,6 +153,28 @@ def test_speculative_sampler_rng_can_resync_draft_after_rejected_draws():
     assert draft_model._seed_token.tolist() == expected_third.tolist()
 
 
+def test_speculative_sampler_rng_async_evals_greedy_draft_call_state(monkeypatch):
+    result_array = mx.array([1], dtype=mx.int32)
+    state_array = mx.array([2], dtype=mx.int32)
+    calls = []
+
+    def fake_async_eval(*arrays):
+        calls.append(arrays)
+
+    draft_model = SimpleNamespace(
+        draft_eval_state=lambda: {"cache": [state_array]},
+    )
+    sampler_rng = _SpeculativeSamplerRNG(draft_model, enabled=False)
+
+    monkeypatch.setattr(mx, "async_eval", fake_async_eval)
+    result = sampler_rng.draft_call(lambda: result_array)
+
+    assert result is result_array
+    assert len(calls) == 1
+    assert calls[0][0] is result_array
+    assert calls[0][1] is state_array
+
+
 def _make_conv_input(batch_size: int, layer_offset: int, length: int = 5) -> mx.array:
     rows = []
     for row in range(batch_size):

--- a/mlx_vlm/tests/test_speculative.py
+++ b/mlx_vlm/tests/test_speculative.py
@@ -31,9 +31,7 @@ from mlx_vlm.speculative.drafters import (
     KNOWN_DRAFTER_KINDS,
     resolve_drafter_kind,
 )
-from mlx_vlm.speculative.drafters.deepseek_v4_mtp import (
-    DeepseekV4MTPDraftModel,
-)
+from mlx_vlm.speculative.drafters.deepseek_v4_mtp import DeepseekV4MTPDraftModel
 from mlx_vlm.speculative.drafters.deepseek_v4_mtp.config import DeepseekV4MTPConfig
 from mlx_vlm.speculative.drafters.deepseek_v4_mtp.split import split_deepseek_v4_mtp
 from mlx_vlm.speculative.drafters.eagle3 import Eagle3DraftModel
@@ -2065,7 +2063,7 @@ def test_split_qwen3_5_mtp_writes_sidecar_without_index_mtp_entries(tmp_path):
     assert weights["pre_fc_norm_hidden.weight"][0].item() == 1.0
 
 
-def test_deepseek_v4_returns_mtp_hidden_and_rolls_back_snapshot():
+def test_deepseek_v4_returns_mtp_hidden_and_trims_without_snapshot():
     cfg = _tiny_deepseek_v4_config()
     lm = deepseek_language.LanguageModel(cfg)
     cache = lm.make_cache()
@@ -2076,7 +2074,7 @@ def test_deepseek_v4_returns_mtp_hidden_and_rolls_back_snapshot():
 
     assert hidden.shape == (1, 3, cfg.hc_mult, cfg.hidden_size)
     assert shared_kv == {}
-    assert rollback_state[1].tolist() == inputs.tolist()
+    assert rollback_state is None
     assert cache[0].offset == 3
 
     lm.rollback_speculative_cache(cache, rollback_state, accepted=0, block_size=3)
@@ -2085,6 +2083,17 @@ def test_deepseek_v4_returns_mtp_hidden_and_rolls_back_snapshot():
     logits = lm.speculative_logits_from_hidden(hidden[:, :1])
     mx.eval(logits)
     assert logits.shape == (1, 1, cfg.vocab_size)
+
+
+def test_deepseek_v4_replay_snapshot_required_only_when_pooling_can_cross_window():
+    pool = PoolingCache(4)
+    pool.accumulate_windows(mx.array([[[10.0]]]), mx.ones((1, 1, 1)), offset=0)
+
+    assert not deepseek_language._needs_replay_snapshot_for_cache([pool], 2)
+    assert deepseek_language._needs_replay_snapshot_for_cache([pool], 3)
+    assert not deepseek_language._needs_replay_snapshot_for_cache(
+        [RotatingKVCache(max_size=8)], 3
+    )
 
 
 def test_deepseek_v4_pooling_snapshot_skips_clone_when_verify_does_not_overwrite_remainder():

--- a/mlx_vlm/tests/test_speculative.py
+++ b/mlx_vlm/tests/test_speculative.py
@@ -2152,6 +2152,20 @@ def test_deepseek_v4_mtp_draft_block_smoke():
     assert tokens.shape == (1, 2)
 
 
+def test_deepseek_v4_mtp_runtime_block_size_defaults_to_native_nextn_depth():
+    text_config = _tiny_deepseek_v4_config()
+    cfg = DeepseekV4MTPConfig.from_dict(
+        {
+            "model_type": "deepseek_v4_mtp",
+            "text_config": text_config.to_dict(),
+            "block_size": 3,
+        }
+    )
+
+    assert cfg.block_size == 3
+    assert cfg.runtime_block_size == 2
+
+
 def test_deepseek_v4_mtp_batch_accept_updates_uniform_cache():
     text_config = _tiny_deepseek_v4_config()
     drafter = DeepseekV4MTPDraftModel(
@@ -2257,7 +2271,7 @@ def test_split_deepseek_v4_mtp_writes_sidecar_without_index_mtp_entries(tmp_path
         cfg = json.load(f)
     weights = mx.load(str(output / "model.safetensors"))
     assert cfg["model_type"] == "deepseek_v4_mtp"
-    assert cfg["block_size"] == 3
+    assert cfg["block_size"] == 2
     assert cfg["quantization"]["e_proj"]["mode"] == "mxfp8"
     assert cfg["quantization"]["decoder.attn.wq_a"]["mode"] == "mxfp8"
     assert "e_proj.weight" in weights

--- a/mlx_vlm/tests/test_speculative.py
+++ b/mlx_vlm/tests/test_speculative.py
@@ -2049,6 +2049,16 @@ def test_deepseek_v4_language_ignores_generation_metadata_kwargs():
     assert out.logits.shape == (1, 1, cfg.vocab_size)
 
 
+def test_deepseek_v4_local_mask_aligns_to_layer_cache_width():
+    mask = mx.array([[[[False, True, True, False, True]]]], dtype=mx.bool_)
+
+    trimmed = deepseek_language._align_local_mask(mask, 3)
+    padded = deepseek_language._align_local_mask(trimmed, 5)
+
+    assert trimmed.tolist() == [[[[True, False, True]]]]
+    assert padded.tolist() == [[[[True, True, True, False, True]]]]
+
+
 def test_deepseek_v4_mtp_draft_block_smoke():
     text_config = _tiny_deepseek_v4_config()
     drafter = DeepseekV4MTPDraftModel(


### PR DESCRIPTION
## Summary

- Add DeepSeek V4 native MTP drafter support for standalone split MTP weights.
- Add Qwen3.5-style MTP state handling where it applies to the shared speculative path.
- Add greedy MTP async-eval state handling to avoid lazy graph buildup across speculative rounds.
- Skip DeepSeek V4 verifier rollback snapshots when all touched cache entries can be safely trimmed, keeping replay snapshots only for pooling-window crossings.
- Add regression coverage for DeepSeek V4 MTP loading, verifier rollback behavior, and speculative scheduling.

## Root Cause

DeepSeek V4 checkpoints can include native `mtp.*` tensors, but the MLX-VLM speculative path did not have a DeepSeek V4 MTP drafter/split path. The greedy MTP path also skipped an async evaluation boundary, which allowed drafter seed/cache work to chain through later rounds.

The DeepSeek V4 verifier took a rollback snapshot every round. The updated verifier keeps the replay-snapshot path only when compressed pooling state may be overwritten; otherwise, normal trim rollback is enough.

## Validation

- `uv run pytest mlx_vlm/tests/test_speculative.py -q` -> `102 passed`
- No-drafter drift check across the verifier snapshot change: 2000-token greedy output is byte-identical
- MTP 2000-token run: `37.346 tokens-per-sec` vs no-drafter `27.502 tokens-per-sec`
- Block-size sweep at 160 tokens: block size 2 `37.624 tok/s`, block size 3 `36.849 tok/s`, block size 4 `29.528 tok/s`

Full `uv run pytest -q` is currently blocked in this venv because `psutil` is missing and `mlx_vlm/tests/test_smoke.py` exits during collection.