### PR TITLE
Validate MTP drafter compatibility

### DIFF
--- a/mlx_vlm/generate.py
+++ b/mlx_vlm/generate.py
@@ -632,6 +632,9 @@ def generate_step(
     # Speculative decoding setup
     last_outputs = None
     if draft_model is not None:
+        from .speculative.drafters import validate_drafter_compatibility
+
+        validate_drafter_compatibility(model, draft_model, draft_kind)
         if draft_kind == "mtp":
             # MTP drafter consumes target's last-layer hidden + shared K/V
             # (per layer-type) rather than per-layer hidden captures.
@@ -3393,7 +3396,7 @@ def main():
 
     draft_model = None
     if args.draft_model is not None:
-        from .speculative.drafters import load_drafter
+        from .speculative.drafters import load_drafter, validate_drafter_compatibility
 
         print(f"Loading drafter ({args.draft_kind or 'auto'}): {args.draft_model}")
         draft_model, resolved_kind = load_drafter(
@@ -3407,6 +3410,7 @@ def main():
                 f"using {resolved_kind!r} instead of {args.draft_kind!r}."
             )
         args.draft_kind = resolved_kind
+        validate_drafter_compatibility(model, draft_model, args.draft_kind)
 
     prompt = args.prompt
 

--- a/mlx_vlm/generate.py
+++ b/mlx_vlm/generate.py
@@ -3487,7 +3487,15 @@ def main():
                 f"using {resolved_kind!r} instead of {args.draft_kind!r}."
             )
         args.draft_kind = resolved_kind
-        validate_drafter_compatibility(model, draft_model, args.draft_kind)
+        try:
+            validate_drafter_compatibility(model, draft_model, args.draft_kind)
+        except ValueError as e:
+            print(
+                "Speculative drafter is incompatible with the target model; "
+                f"falling back to autoregressive generation. {e}"
+            )
+            draft_model = None
+            args.draft_kind = None
 
     prompt = args.prompt
 

--- a/mlx_vlm/server/generation.py
+++ b/mlx_vlm/server/generation.py
@@ -57,6 +57,15 @@ def _get_draft_block_size_from_env():
     return int(draft_block_size_str) if draft_block_size_str else None
 
 
+def _notify_queues(queues, *items):
+    for queue in queues:
+        for item in items:
+            try:
+                queue.put(item)
+            except Exception:
+                break
+
+
 def get_prefill_step_size():
     return int(os.environ.get("PREFILL_STEP_SIZE", DEFAULT_PREFILL_STEP_SIZE))
 
@@ -1233,9 +1242,9 @@ class ResponseGenerator:
                 traceback.print_exc()
                 error_queues = {id(rqueue): rqueue for rqueue in rqueues.values()}
                 error_queues.update({id(rqueue): rqueue for rqueue, *_ in pending})
-                for rqueue in error_queues.values():
-                    rqueue.put(e)
-                    rqueue.put(None)
+                _notify_queues(error_queues.values(), e, None)
+                mx.clear_cache()
+                gc.collect()
 
     def _step(self, batch_gen, active, gen_kwargs=None):
         """One batch generation step: prefill + decode."""

--- a/mlx_vlm/server/generation.py
+++ b/mlx_vlm/server/generation.py
@@ -592,7 +592,10 @@ class ResponseGenerator:
         draft_kind = os.environ.get("MLX_VLM_DRAFT_KIND")
         draft_model_path = os.environ.get("MLX_VLM_DRAFT_MODEL")
         if draft_model_path:
-            from ..speculative.drafters import load_drafter
+            from ..speculative.drafters import (
+                load_drafter,
+                validate_drafter_compatibility,
+            )
 
             print(
                 f"Loading speculative drafter ({draft_kind or 'auto'}): "
@@ -607,6 +610,7 @@ class ResponseGenerator:
                     f"using {resolved_kind!r} instead of {draft_kind!r}."
                 )
             draft_kind = resolved_kind
+            validate_drafter_compatibility(model, draft_model, draft_kind)
             print("Drafter ready — speculative decoding enabled.")
 
         self.model = model

--- a/mlx_vlm/server/generation.py
+++ b/mlx_vlm/server/generation.py
@@ -703,8 +703,17 @@ class ResponseGenerator:
                     f"using {resolved_kind!r} instead of {draft_kind!r}."
                 )
             draft_kind = resolved_kind
-            validate_drafter_compatibility(model, draft_model, draft_kind)
-            print("Drafter ready — speculative decoding enabled.")
+            try:
+                validate_drafter_compatibility(model, draft_model, draft_kind)
+            except ValueError as e:
+                print(
+                    "Speculative drafter is incompatible with the target model; "
+                    f"falling back to autoregressive generation. {e}"
+                )
+                draft_model = None
+                draft_kind = None
+            else:
+                print("Drafter ready — speculative decoding enabled.")
 
         self.model = model
         self.processor = processor

--- a/mlx_vlm/speculative/drafters/__init__.py
+++ b/mlx_vlm/speculative/drafters/__init__.py
@@ -1,6 +1,6 @@
 import json
 import logging
-from typing import Optional, Tuple
+from typing import Any, Optional, Tuple
 
 from .qwen3_dflash import DFlashDraftModel
 
@@ -17,6 +17,64 @@ DRAFTER_KIND_BY_MODEL_TYPE = {
 DEFAULT_DRAFTER_KIND = "dflash"
 
 logger = logging.getLogger(__name__)
+
+
+def _cfg_get(config: Any, key: str, default: Any = None) -> Any:
+    if isinstance(config, dict):
+        return config.get(key, default)
+    return getattr(config, key, default)
+
+
+def _hidden_size(config: Any) -> Any:
+    return _cfg_get(_cfg_get(config, "text_config", config), "hidden_size")
+
+
+def validate_drafter_compatibility(
+    target_model: Any,
+    draft_model: Any,
+    draft_kind: Optional[str],
+) -> None:
+    """Validate that a loaded drafter can safely pair with a target model.
+
+    This intentionally uses architecture/config fields instead of repository
+    names, so quantized MLX conversions and local checkpoints remain accepted.
+    """
+    draft_cfg = getattr(draft_model, "config", None)
+    if draft_cfg is None:
+        return
+
+    model_type = _cfg_get(draft_cfg, "model_type")
+    expected_kind = DRAFTER_KIND_BY_MODEL_TYPE.get(model_type)
+    if expected_kind is None and "mtp" in str(model_type).lower():
+        expected_kind = "mtp"
+    if expected_kind is not None and draft_kind != expected_kind:
+        raise ValueError(
+            f"Drafter model_type={model_type!r} requires draft_kind={expected_kind!r}. "
+            f"Got draft_kind={draft_kind!r}."
+        )
+
+    if draft_kind != "mtp":
+        return
+
+    draft_hidden_size = (
+        _cfg_get(draft_cfg, "backbone_hidden_size")
+        or _cfg_get(draft_cfg, "target_hidden_size")
+        or _hidden_size(draft_cfg)
+    )
+    target = getattr(target_model, "language_model", target_model)
+    target_hidden_size = _hidden_size(getattr(target, "config", None))
+
+    if (
+        draft_hidden_size is not None
+        and target_hidden_size is not None
+        and draft_hidden_size != target_hidden_size
+    ):
+        raise ValueError(
+            "Drafter is incompatible with the target model. "
+            "Use the drafter checkpoint for the same target family and size. "
+            f"Drafter target hidden_size={draft_hidden_size!r}, "
+            f"target hidden_size={target_hidden_size!r}."
+        )
 
 
 def _peek_drafter_model_type(model_path) -> Optional[str]:
@@ -95,6 +153,7 @@ __all__ = [
     "KNOWN_DRAFTER_KINDS",
     "DRAFTER_KIND_BY_MODEL_TYPE",
     "DEFAULT_DRAFTER_KIND",
+    "validate_drafter_compatibility",
     "resolve_drafter_kind",
     "load_drafter",
 ]

--- a/mlx_vlm/tests/test_server.py
+++ b/mlx_vlm/tests/test_server.py
@@ -171,6 +171,206 @@ def test_speculative_server_reads_batch_coalesce_env(monkeypatch):
     assert server.get_speculative_batch_coalesce_s() == pytest.approx(0.005)
 
 
+def _unstarted_response_generator():
+    gen = server.ResponseGenerator.__new__(server.ResponseGenerator)
+    gen.model_path = "demo"
+    gen.adapter_path = None
+    gen.model = None
+    gen.processor = None
+    gen.config = None
+    gen.stop_tokens = set()
+    gen.vision_cache = None
+    gen.draft_model = None
+    gen.draft_kind = None
+    gen.kv_bits = None
+    gen.kv_group_size = server.DEFAULT_KV_GROUP_SIZE
+    gen.kv_quant_scheme = server.DEFAULT_KV_QUANT_SCHEME
+    gen.quantized_kv_start = server.DEFAULT_QUANTIZED_KV_START
+    gen.top_logprobs_k = 0
+    gen.apc_manager = None
+    gen.tokenizer = None
+    gen.requests = Queue()
+    gen._stop = False
+    gen._ready = Event()
+    gen._load_error = None
+    gen._cancelled = set()
+    gen._cancel_lock = Lock()
+    return gen
+
+
+def test_server_demotes_incompatible_mtp_drafter_to_ar(monkeypatch):
+    target_config = SimpleNamespace(
+        model_type="gemma4_text",
+        hidden_size=5376,
+        eos_token_id=[],
+    )
+    model = SimpleNamespace(language_model=SimpleNamespace(config=target_config))
+    processor = SimpleNamespace(tokenizer=SimpleNamespace())
+    drafter = SimpleNamespace(
+        config=SimpleNamespace(
+            model_type="gemma4_assistant",
+            backbone_hidden_size=1536,
+        )
+    )
+    gen = _unstarted_response_generator()
+
+    monkeypatch.setenv("MLX_VLM_DRAFT_MODEL", "assistant")
+    monkeypatch.setenv("MLX_VLM_DRAFT_KIND", "mtp")
+    monkeypatch.setattr(
+        server_generation,
+        "load_model_resources",
+        lambda *_args, **_kwargs: (model, processor, target_config),
+    )
+    monkeypatch.setattr(
+        "mlx_vlm.speculative.drafters.load_drafter",
+        lambda *_args, **_kwargs: (drafter, "mtp"),
+    )
+
+    gen._initialize_model()
+
+    assert gen.model is model
+    assert gen.processor is processor
+    assert gen.draft_model is None
+    assert gen.draft_kind is None
+
+
+def test_server_serves_ar_requests_after_drafter_mismatch(monkeypatch):
+    class FakeDetokenizer:
+        def __init__(self):
+            self.last_segment = ""
+
+        def add_token(self, token):
+            self.last_segment = str(token)
+
+        def finalize(self):
+            pass
+
+    class FakeBatchGenerator:
+        def __init__(self, *args, **kwargs):
+            self.unprocessed_prompts = []
+            self.has_pending_prompts = False
+
+        def insert(self, *args, **kwargs):
+            return (1,)
+
+        def next(self, **kwargs):
+            return [], [
+                SimpleNamespace(
+                    uid=1,
+                    token=7,
+                    token_logprob=0.0,
+                    finish_reason="length",
+                )
+            ]
+
+    target_config = SimpleNamespace(
+        model_type="gemma4_text",
+        hidden_size=5376,
+        eos_token_id=[],
+    )
+    model = SimpleNamespace(language_model=SimpleNamespace(config=target_config))
+    processor = SimpleNamespace(tokenizer=SimpleNamespace())
+    drafter = SimpleNamespace(
+        config=SimpleNamespace(
+            model_type="gemma4_assistant",
+            backbone_hidden_size=1536,
+        )
+    )
+    gen = _unstarted_response_generator()
+
+    monkeypatch.setenv("MLX_VLM_DRAFT_MODEL", "assistant")
+    monkeypatch.setenv("MLX_VLM_DRAFT_KIND", "mtp")
+    monkeypatch.setattr(server_generation, "BatchGenerator", FakeBatchGenerator)
+    monkeypatch.setattr(
+        server_generation,
+        "make_streaming_detokenizer",
+        lambda _processor: FakeDetokenizer(),
+    )
+    monkeypatch.setattr(
+        server_generation,
+        "load_model_resources",
+        lambda *_args, **_kwargs: (model, processor, target_config),
+    )
+    monkeypatch.setattr(
+        "mlx_vlm.speculative.drafters.load_drafter",
+        lambda *_args, **_kwargs: (drafter, "mtp"),
+    )
+    gen._gpu_embed = lambda raw_inputs, images=None: (
+        mx.array([[raw_inputs["token"]]], dtype=mx.int32),
+        {},
+    )
+
+    rqueue = Queue()
+    gen.requests.put(
+        (
+            rqueue,
+            {"token": 1},
+            1,
+            server.GenerationArguments(max_tokens=1),
+            None,
+        )
+    )
+    worker = Thread(target=gen._run, daemon=True)
+    worker.start()
+    try:
+        ctx = rqueue.get(timeout=1)
+        token = rqueue.get(timeout=1)
+        done = rqueue.get(timeout=1)
+    finally:
+        gen._stop = True
+        gen.requests.put(None)
+        worker.join(timeout=2)
+
+    assert isinstance(ctx, server.GenerationContext)
+    assert token.text == "7"
+    assert token.finish_reason == "length"
+    assert done is None
+    assert gen.draft_model is None
+    assert gen.draft_kind is None
+
+
+def test_speculative_thread_exception_reaches_client_queue(monkeypatch):
+    gen = _unstarted_response_generator()
+    gen.model = SimpleNamespace(language_model=SimpleNamespace())
+    gen.processor = SimpleNamespace()
+    gen.draft_model = SimpleNamespace(
+        config=SimpleNamespace(target_layer_ids=[1, 2]), accept_lens=[]
+    )
+    gen.draft_kind = "dflash"
+    gen.stop_tokens = set()
+
+    rqueue = Queue()
+    pending = [
+        (
+            rqueue,
+            {"input_ids": mx.array([[1]], dtype=mx.int32)},
+            1,
+            server.GenerationArguments(max_tokens=2),
+            None,
+        )
+    ]
+    calls = {"count": 0}
+
+    def collect_pending_requests(**_kwargs):
+        calls["count"] += 1
+        if calls["count"] == 1:
+            return pending, False
+        return [], True
+
+    error = RuntimeError("speculative prefill failed")
+    gen._collect_pending_requests = collect_pending_requests
+    gen._gpu_embed = MagicMock(side_effect=error)
+    monkeypatch.setattr(
+        "mlx_vlm.speculative.utils.speculative_prefill_kwargs",
+        lambda *_args, **_kwargs: {},
+    )
+
+    gen._run_speculative()
+
+    assert rqueue.get(timeout=1) is error
+    assert rqueue.get(timeout=1) is None
+
+
 def test_models_endpoint_lists_single_file_safetensors_models(client, monkeypatch):
     def repo(repo_id, file_names):
         return SimpleNamespace(

--- a/mlx_vlm/tests/test_server.py
+++ b/mlx_vlm/tests/test_server.py
@@ -371,6 +371,101 @@ def test_speculative_thread_exception_reaches_client_queue(monkeypatch):
     assert rqueue.get(timeout=1) is None
 
 
+def test_speculative_thread_exception_skips_broken_queues(monkeypatch):
+    gen = _unstarted_response_generator()
+    gen.model = SimpleNamespace(language_model=SimpleNamespace())
+    gen.processor = SimpleNamespace()
+    gen.draft_model = SimpleNamespace(
+        config=SimpleNamespace(target_layer_ids=[1, 2]), accept_lens=[]
+    )
+    gen.draft_kind = "dflash"
+    gen.stop_tokens = set()
+
+    class BrokenQueue:
+        def put(self, item):
+            raise RuntimeError("client went away")
+
+    good_queue = Queue()
+    pending = [
+        (
+            BrokenQueue(),
+            {"input_ids": mx.array([[1]], dtype=mx.int32)},
+            1,
+            server.GenerationArguments(max_tokens=2),
+            None,
+        ),
+        (
+            good_queue,
+            {"input_ids": mx.array([[1]], dtype=mx.int32)},
+            1,
+            server.GenerationArguments(max_tokens=2),
+            None,
+        ),
+    ]
+    calls = {"count": 0}
+
+    def collect_pending_requests(**_kwargs):
+        calls["count"] += 1
+        if calls["count"] == 1:
+            return pending, False
+        return [], True
+
+    error = RuntimeError("speculative prefill failed")
+    gen._collect_pending_requests = collect_pending_requests
+    gen._gpu_embed = MagicMock(side_effect=error)
+
+    gen._run_speculative()
+
+    assert good_queue.get(timeout=1) is error
+    assert good_queue.get(timeout=1) is None
+
+
+def test_speculative_thread_exception_clears_runtime_cache(monkeypatch):
+    gen = _unstarted_response_generator()
+    gen.model = SimpleNamespace(language_model=SimpleNamespace())
+    gen.processor = SimpleNamespace()
+    gen.draft_model = SimpleNamespace(
+        config=SimpleNamespace(target_layer_ids=[1, 2]), accept_lens=[]
+    )
+    gen.draft_kind = "dflash"
+    gen.stop_tokens = set()
+    rqueue = Queue()
+
+    calls = {"clear_cache": 0, "collect": 0}
+    collect_calls = {"count": 0}
+
+    def collect_pending_requests(**_kwargs):
+        collect_calls["count"] += 1
+        if collect_calls["count"] > 1:
+            return [], True
+        return [
+            (
+                rqueue,
+                {"input_ids": mx.array([[1]], dtype=mx.int32)},
+                1,
+                server.GenerationArguments(max_tokens=2),
+                None,
+            )
+        ], False
+
+    gen._collect_pending_requests = collect_pending_requests
+    gen._gpu_embed = MagicMock(side_effect=RuntimeError("boom"))
+    monkeypatch.setattr(
+        server_generation.mx,
+        "clear_cache",
+        lambda: calls.__setitem__("clear_cache", calls["clear_cache"] + 1),
+    )
+    monkeypatch.setattr(
+        server_generation.gc,
+        "collect",
+        lambda: calls.__setitem__("collect", calls["collect"] + 1),
+    )
+
+    gen._run_speculative()
+
+    assert calls == {"clear_cache": 1, "collect": 1}
+
+
 def test_models_endpoint_lists_single_file_safetensors_models(client, monkeypatch):
     def repo(repo_id, file_names):
         return SimpleNamespace(

--- a/mlx_vlm/tests/test_speculative.py
+++ b/mlx_vlm/tests/test_speculative.py
@@ -217,35 +217,49 @@ def _make_drafter_dir(tmp_path: Path, model_type: str | None) -> Path:
     return d
 
 
-def _make_gemma4_target_config(
-    *,
-    hidden_size: int = 5376,
-):
+def _make_target_config(hidden_size: int):
     return SimpleNamespace(
-        model_type="gemma4_text",
+        model_type="target_text",
         hidden_size=hidden_size,
     )
 
 
-def _make_gemma4_assistant_config(
-    *,
-    backbone_hidden_size: int = 5376,
-):
+def _make_target_model(hidden_size: int):
     return SimpleNamespace(
-        model_type="gemma4_assistant",
-        backbone_hidden_size=backbone_hidden_size,
+        language_model=SimpleNamespace(config=_make_target_config(hidden_size))
     )
 
 
-def _make_qwen_mtp_config(
-    *,
-    hidden_size: int = 2560,
-    model_type: str = "qwen3_5_mtp",
-):
-    return SimpleNamespace(
-        model_type=model_type,
-        text_config=SimpleNamespace(hidden_size=hidden_size),
-    )
+def _make_drafter_config(model_type: str, hidden_size: int, *, field: str):
+    kwargs = {"model_type": model_type}
+    if field == "backbone_hidden_size":
+        kwargs["backbone_hidden_size"] = hidden_size
+    elif field == "target_hidden_size":
+        kwargs["target_hidden_size"] = hidden_size
+    elif field == "text_config.hidden_size":
+        kwargs["text_config"] = SimpleNamespace(hidden_size=hidden_size)
+    else:
+        raise ValueError(f"Unknown hidden-size field: {field}")
+    return SimpleNamespace(**kwargs)
+
+
+MTP_DRAFTER_COMPAT_CASES = [
+    pytest.param(
+        "gemma4_assistant",
+        "backbone_hidden_size",
+        id="backbone-hidden-size",
+    ),
+    pytest.param(
+        "qwen3_5_mtp",
+        "text_config.hidden_size",
+        id="text-config-hidden-size",
+    ),
+    pytest.param(
+        "custom_mtp",
+        "target_hidden_size",
+        id="target-hidden-size",
+    ),
+]
 
 
 def test_qwen_rollback_speculative_cache_flattens_batch_per_layer():
@@ -1593,72 +1607,48 @@ def test_kind_none_autodetects_eagle3_speculators_config(tmp_path):
     assert resolve_drafter_kind(path, "dflash") == "eagle3"
 
 
-def test_gemma4_assistant_compatibility_accepts_matching_target():
-    target = SimpleNamespace(
-        language_model=SimpleNamespace(config=_make_gemma4_target_config())
+@pytest.mark.parametrize("model_type,hidden_size_field", MTP_DRAFTER_COMPAT_CASES)
+def test_mtp_drafter_compatibility_accepts_matching_target(
+    model_type, hidden_size_field
+):
+    target = _make_target_model(hidden_size=4096)
+    drafter = SimpleNamespace(
+        config=_make_drafter_config(model_type, 4096, field=hidden_size_field)
     )
-    drafter = SimpleNamespace(config=_make_gemma4_assistant_config())
 
     validate_drafter_compatibility(target, drafter, "mtp")
 
 
-def test_gemma4_assistant_compatibility_rejects_wrong_target_size():
-    target_31b = SimpleNamespace(
-        language_model=SimpleNamespace(config=_make_gemma4_target_config())
-    )
-    e2b_drafter = SimpleNamespace(
-        config=_make_gemma4_assistant_config(backbone_hidden_size=1536)
+@pytest.mark.parametrize("model_type,hidden_size_field", MTP_DRAFTER_COMPAT_CASES)
+def test_mtp_drafter_compatibility_rejects_mismatched_target(
+    model_type, hidden_size_field
+):
+    target = _make_target_model(hidden_size=5376)
+    drafter = SimpleNamespace(
+        config=_make_drafter_config(model_type, 1536, field=hidden_size_field)
     )
 
     with pytest.raises(ValueError, match="incompatible with the target model") as exc:
-        validate_drafter_compatibility(target_31b, e2b_drafter, "mtp")
+        validate_drafter_compatibility(target, drafter, "mtp")
 
     message = str(exc.value)
     assert "Drafter target hidden_size=1536" in message
     assert "target hidden_size=5376" in message
 
 
-def test_mtp_drafter_compatibility_rejects_wrong_target_size():
-    target = SimpleNamespace(
-        language_model=SimpleNamespace(config=_make_gemma4_target_config())
-    )
-    drafter = SimpleNamespace(config=_make_qwen_mtp_config())
-
-    with pytest.raises(ValueError, match="incompatible with the target model") as exc:
-        validate_drafter_compatibility(target, drafter, "mtp")
-
-    message = str(exc.value)
-    assert "Drafter target hidden_size=2560" in message
-    assert "target hidden_size=5376" in message
-
-
-def test_mtp_drafter_compatibility_accepts_matching_text_hidden_size():
-    target = SimpleNamespace(
-        language_model=SimpleNamespace(
-            config=_make_gemma4_target_config(hidden_size=2560)
-        )
-    )
-    drafter = SimpleNamespace(config=_make_qwen_mtp_config())
-
-    validate_drafter_compatibility(target, drafter, "mtp")
-
-
-def test_drafter_compatibility_requires_expected_kind():
-    target = SimpleNamespace(
-        language_model=SimpleNamespace(config=_make_gemma4_target_config())
-    )
-    drafter = SimpleNamespace(config=_make_gemma4_assistant_config())
-
-    with pytest.raises(ValueError, match="requires draft_kind='mtp'"):
-        validate_drafter_compatibility(target, drafter, "dflash")
-
-
-def test_mtp_model_type_requires_mtp_kind_without_static_mapping():
-    target = SimpleNamespace(
-        language_model=SimpleNamespace(config=_make_gemma4_target_config())
-    )
+@pytest.mark.parametrize(
+    "model_type",
+    [
+        "gemma4_assistant",
+        "qwen3_5_mtp",
+        "deepseek_v4_mtp",
+        "custom_mtp",
+    ],
+)
+def test_mtp_drafter_compatibility_requires_mtp_kind(model_type):
+    target = _make_target_model(hidden_size=4096)
     drafter = SimpleNamespace(
-        config=_make_qwen_mtp_config(model_type="deepseek_v4_mtp")
+        config=_make_drafter_config(model_type, 4096, field="text_config.hidden_size")
     )
 
     with pytest.raises(ValueError, match="requires draft_kind='mtp'"):
@@ -1666,9 +1656,7 @@ def test_mtp_model_type_requires_mtp_kind_without_static_mapping():
 
 
 def test_drafter_compatibility_ignores_unknown_backbone_free_drafters():
-    target = SimpleNamespace(
-        language_model=SimpleNamespace(config=_make_gemma4_target_config())
-    )
+    target = _make_target_model(hidden_size=5376)
     drafter = SimpleNamespace(
         config=SimpleNamespace(model_type="custom_drafter", hidden_size=1536)
     )

--- a/mlx_vlm/tests/test_speculative.py
+++ b/mlx_vlm/tests/test_speculative.py
@@ -23,6 +23,7 @@ from mlx_vlm.speculative.drafters import (
     DRAFTER_KIND_BY_MODEL_TYPE,
     KNOWN_DRAFTER_KINDS,
     resolve_drafter_kind,
+    validate_drafter_compatibility,
 )
 from mlx_vlm.speculative.drafters.eagle3 import Eagle3DraftModel
 from mlx_vlm.speculative.drafters.eagle3 import ModelConfig as Eagle3Config
@@ -180,6 +181,37 @@ def _make_drafter_dir(tmp_path: Path, model_type: str | None) -> Path:
     cfg = {} if model_type is None else {"model_type": model_type}
     (d / "config.json").write_text(json.dumps(cfg))
     return d
+
+
+def _make_gemma4_target_config(
+    *,
+    hidden_size: int = 5376,
+):
+    return SimpleNamespace(
+        model_type="gemma4_text",
+        hidden_size=hidden_size,
+    )
+
+
+def _make_gemma4_assistant_config(
+    *,
+    backbone_hidden_size: int = 5376,
+):
+    return SimpleNamespace(
+        model_type="gemma4_assistant",
+        backbone_hidden_size=backbone_hidden_size,
+    )
+
+
+def _make_qwen_mtp_config(
+    *,
+    hidden_size: int = 2560,
+    model_type: str = "qwen3_5_mtp",
+):
+    return SimpleNamespace(
+        model_type=model_type,
+        text_config=SimpleNamespace(hidden_size=hidden_size),
+    )
 
 
 def test_qwen_rollback_speculative_cache_flattens_batch_per_layer():
@@ -1463,6 +1495,89 @@ def test_kind_none_autodetects_eagle3_speculators_config(tmp_path):
     (path / "config.json").write_text(json.dumps({"speculators_model_type": "eagle3"}))
     assert resolve_drafter_kind(path, None) == "eagle3"
     assert resolve_drafter_kind(path, "dflash") == "eagle3"
+
+
+def test_gemma4_assistant_compatibility_accepts_matching_target():
+    target = SimpleNamespace(
+        language_model=SimpleNamespace(config=_make_gemma4_target_config())
+    )
+    drafter = SimpleNamespace(config=_make_gemma4_assistant_config())
+
+    validate_drafter_compatibility(target, drafter, "mtp")
+
+
+def test_gemma4_assistant_compatibility_rejects_wrong_target_size():
+    target_31b = SimpleNamespace(
+        language_model=SimpleNamespace(config=_make_gemma4_target_config())
+    )
+    e2b_drafter = SimpleNamespace(
+        config=_make_gemma4_assistant_config(backbone_hidden_size=1536)
+    )
+
+    with pytest.raises(ValueError, match="incompatible with the target model") as exc:
+        validate_drafter_compatibility(target_31b, e2b_drafter, "mtp")
+
+    message = str(exc.value)
+    assert "Drafter target hidden_size=1536" in message
+    assert "target hidden_size=5376" in message
+
+
+def test_mtp_drafter_compatibility_rejects_wrong_target_size():
+    target = SimpleNamespace(
+        language_model=SimpleNamespace(config=_make_gemma4_target_config())
+    )
+    drafter = SimpleNamespace(config=_make_qwen_mtp_config())
+
+    with pytest.raises(ValueError, match="incompatible with the target model") as exc:
+        validate_drafter_compatibility(target, drafter, "mtp")
+
+    message = str(exc.value)
+    assert "Drafter target hidden_size=2560" in message
+    assert "target hidden_size=5376" in message
+
+
+def test_mtp_drafter_compatibility_accepts_matching_text_hidden_size():
+    target = SimpleNamespace(
+        language_model=SimpleNamespace(
+            config=_make_gemma4_target_config(hidden_size=2560)
+        )
+    )
+    drafter = SimpleNamespace(config=_make_qwen_mtp_config())
+
+    validate_drafter_compatibility(target, drafter, "mtp")
+
+
+def test_drafter_compatibility_requires_expected_kind():
+    target = SimpleNamespace(
+        language_model=SimpleNamespace(config=_make_gemma4_target_config())
+    )
+    drafter = SimpleNamespace(config=_make_gemma4_assistant_config())
+
+    with pytest.raises(ValueError, match="requires draft_kind='mtp'"):
+        validate_drafter_compatibility(target, drafter, "dflash")
+
+
+def test_mtp_model_type_requires_mtp_kind_without_static_mapping():
+    target = SimpleNamespace(
+        language_model=SimpleNamespace(config=_make_gemma4_target_config())
+    )
+    drafter = SimpleNamespace(
+        config=_make_qwen_mtp_config(model_type="deepseek_v4_mtp")
+    )
+
+    with pytest.raises(ValueError, match="requires draft_kind='mtp'"):
+        validate_drafter_compatibility(target, drafter, "dflash")
+
+
+def test_drafter_compatibility_ignores_unknown_backbone_free_drafters():
+    target = SimpleNamespace(
+        language_model=SimpleNamespace(config=_make_gemma4_target_config())
+    )
+    drafter = SimpleNamespace(
+        config=SimpleNamespace(model_type="custom_drafter", hidden_size=1536)
+    )
+
+    validate_drafter_compatibility(target, drafter, "dflash")
 
 
 def test_model_loader_uses_speculators_model_type_for_eagle3_config():


### PR DESCRIPTION
## Summary
- add drafter compatibility validation before speculative generation starts
- enforce known drafter kind mappings and infer MTP kind for MTP model types
- reject MTP drafters whose target hidden size does not match the loaded target model

Closes #1142

## Validation
- uv run --with pytest pytest mlx_vlm/tests/test_speculative.py -q
- uv run --with ruff ruff check mlx_vlm/speculative/drafters/__init__.py mlx_vlm/tests/test_speculative.py mlx_vlm/server/generation.py
- python3 -m py_compile mlx_vlm/speculative/drafters/__init__.py mlx_vlm/generate.py mlx_vlm/server/generation.py mlx_vlm/tests/test_speculative.py
- config-only Hugging Face sweep: 18 matching MTP pairs passed, 48 mismatched pairs rejected, 0 unexpected errors