### PR TITLE
bugfix: bucketed=true leads to poor quality generations, set to false

### DIFF
--- a/mlx_vlm/models/bonsai/model.py
+++ b/mlx_vlm/models/bonsai/model.py
@@ -120,7 +120,7 @@ class BonsaiImageGenerationModel(ImageGenerationModel):
             token=kwargs.pop("token", None),
             evict_text_encoder=kwargs.pop("evict_text_encoder", True),
             evict_transformer=kwargs.pop("evict_transformer", False),
-            bucketed_seq_len=kwargs.pop("bucketed_seq_len", True),
+            bucketed_seq_len=kwargs.pop("bucketed_seq_len", False),
             tiled_vae=kwargs.pop("tiled_vae", "auto"),
             max_sequence_length=kwargs.pop("max_sequence_length", 512),
         )

--- a/mlx_vlm/models/bonsai/pipeline.py
+++ b/mlx_vlm/models/bonsai/pipeline.py
@@ -38,7 +38,7 @@ TiledVAE = Literal["auto", "on", "off"]
 class BonsaiRuntimeConfig:
     evict_text_encoder: bool = True
     evict_transformer: bool = False
-    bucketed_seq_len: bool = True
+    bucketed_seq_len: bool = False
     tiled_vae: TiledVAE = "auto"
     max_sequence_length: int = 512
 
@@ -72,7 +72,7 @@ class BonsaiImage:
         token: str | None = None,
         evict_text_encoder: bool = True,
         evict_transformer: bool = False,
-        bucketed_seq_len: bool = True,
+        bucketed_seq_len: bool = False,
         tiled_vae: TiledVAE = "auto",
         max_sequence_length: int = 512,
     ) -> "BonsaiImage":

--- a/mlx_vlm/models/bonsai/prompt.py
+++ b/mlx_vlm/models/bonsai/prompt.py
@@ -23,7 +23,7 @@ def encode_prompt(
     text_encoder: Qwen3TextEncoder,
     max_sequence_length: int = 512,
     hidden_state_layers: tuple[int, ...] = (9, 18, 27),
-    bucketed: bool = True,
+    bucketed: bool = False,
 ) -> tuple[mx.array, mx.array]:
     true_len = tokenizer.count_tokens(prompt) if bucketed else max_sequence_length
     effective_max = _pick_bucket(


### PR DESCRIPTION
Hi @Blaizzy! Many thanks for adding bonsai image support to mlx-vlm! We had a small bug in our original code, when bucketing to too short seq lengths for text, image quality deteriorates a bit. This PR is meant to fix that :) Let me know if you have any questions!

Thanks,
Evan
