### PR TITLE
Add LFM2 MoE language model

### DIFF
--- a/mlx_vlm/models/lfm2_moe/__init__.py
+++ b/mlx_vlm/models/lfm2_moe/__init__.py
@@ -1,0 +1,4 @@
+from .config import ModelConfig
+from .lfm2_moe import Model
+
+__all__ = ["Model", "ModelConfig"]

--- a/mlx_vlm/models/lfm2_moe/config.py
+++ b/mlx_vlm/models/lfm2_moe/config.py
@@ -1,0 +1,48 @@
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional, Union
+
+from ..base import BaseModelConfig
+
+
+@dataclass
+class ModelConfig(BaseModelConfig):
+    model_type: str
+    vocab_size: int
+    hidden_size: int
+    intermediate_size: int
+    moe_intermediate_size: int
+    num_hidden_layers: int
+    num_experts: int
+    num_experts_per_tok: int
+    norm_topk_prob: bool
+    num_attention_heads: int
+    num_key_value_heads: int
+    max_position_embeddings: int
+    use_expert_bias: bool
+    num_dense_layers: int
+    norm_eps: float
+    conv_bias: bool
+    conv_L_cache: int
+    rope_theta: float = 1000000.0
+    rope_parameters: Optional[Dict[str, Any]] = None
+    full_attn_idxs: Optional[List[int]] = None
+    layer_types: Optional[List[str]] = None
+    tie_word_embeddings: bool = True
+    bos_token_id: Optional[int] = None
+    eos_token_id: Optional[Union[int, List[int]]] = None
+    pad_token_id: Optional[int] = None
+    routed_scaling_factor: float = 1.0
+
+    def __post_init__(self):
+        if self.rope_parameters is not None and "rope_theta" in self.rope_parameters:
+            self.rope_theta = self.rope_parameters["rope_theta"]
+
+        if self.num_key_value_heads is None:
+            self.num_key_value_heads = self.num_attention_heads
+
+        if self.full_attn_idxs is None:
+            self.full_attn_idxs = [
+                i
+                for i, layer_type in enumerate(self.layer_types)
+                if layer_type == "full_attention"
+            ]

--- a/mlx_vlm/models/lfm2_moe/language.py
+++ b/mlx_vlm/models/lfm2_moe/language.py
@@ -1,0 +1,112 @@
+from typing import Optional
+
+import mlx.core as mx
+import mlx.nn as nn
+from mlx_lm.models.cache import ArraysCache, KVCache
+from mlx_lm.models.lfm2_moe import Lfm2Model
+
+from ..base import LanguageModelOutput
+from .config import ModelConfig
+
+
+class LanguageModel(nn.Module):
+    def __init__(self, args: ModelConfig):
+        super().__init__()
+        self.args = args
+        self.config = args
+        self.model_type = args.model_type
+        self.model = Lfm2Model(args)
+        if not args.tie_word_embeddings:
+            self.lm_head = nn.Linear(args.hidden_size, args.vocab_size, bias=False)
+
+    def __call__(
+        self,
+        inputs: Optional[mx.array] = None,
+        cache=None,
+        input_embeddings: Optional[mx.array] = None,
+        inputs_embeds: Optional[mx.array] = None,
+        **kwargs,
+    ) -> LanguageModelOutput:
+        if inputs is None:
+            inputs = kwargs.get("input_ids")
+        if inputs_embeds is None:
+            inputs_embeds = input_embeddings
+
+        out = self.model(inputs, cache, inputs_embeds)
+        if self.args.tie_word_embeddings:
+            out = self.model.embed_tokens.as_linear(out)
+        else:
+            out = self.lm_head(out)
+        return LanguageModelOutput(logits=out)
+
+    def sanitize(self, weights):
+        if self.args.tie_word_embeddings:
+            weights.pop("lm_head.weight", None)
+
+        sanitized_weights = {}
+        for name, param in weights.items():
+            if "conv.weight" in name and param.shape[-1] > param.shape[1]:
+                param = param.transpose(0, 2, 1)
+
+            replacements = {
+                "w1.weight": "gate_proj.weight",
+                "w2.weight": "down_proj.weight",
+                "w3.weight": "up_proj.weight",
+            }
+            for old, new in replacements.items():
+                if old in name:
+                    name = name.replace(old, new)
+
+            sanitized_weights[name] = param
+
+        return self._stack_experts(sanitized_weights)
+
+    def _stack_experts(self, weights):
+        for layer_idx in range(self.args.num_hidden_layers):
+            prefix = f"model.layers.{layer_idx}.feed_forward"
+            for proj in ["gate_proj", "down_proj", "up_proj"]:
+                for suffix in ["weight", "scales", "biases"]:
+                    first_key = f"{prefix}.experts.0.{proj}.{suffix}"
+                    if first_key not in weights:
+                        continue
+                    weights[f"{prefix}.switch_mlp.{proj}.{suffix}"] = mx.stack(
+                        [
+                            weights.pop(f"{prefix}.experts.{e}.{proj}.{suffix}")
+                            for e in range(self.args.num_experts)
+                        ]
+                    )
+        return weights
+
+    @property
+    def quant_predicate(self):
+        def predicate(path, _):
+            if path.endswith("feed_forward.gate"):
+                return {"group_size": 64, "bits": 8}
+            return True
+
+        return predicate
+
+    @property
+    def cast_predicate(self):
+        def predicate(k):
+            return "expert_bias" not in k
+
+        return predicate
+
+    @property
+    def layers(self):
+        return self.model.layers
+
+    @property
+    def head_dim(self):
+        return self.args.hidden_size // self.args.num_attention_heads
+
+    @property
+    def n_kv_heads(self):
+        return self.args.num_key_value_heads
+
+    def make_cache(self):
+        return [
+            KVCache() if layer.is_attention_layer else ArraysCache(size=1)
+            for layer in self.layers
+        ]

--- a/mlx_vlm/models/lfm2_moe/lfm2_moe.py
+++ b/mlx_vlm/models/lfm2_moe/lfm2_moe.py
@@ -1,0 +1,69 @@
+from typing import Optional
+
+import mlx.core as mx
+import mlx.nn as nn
+
+from ..base import InputEmbeddingsFeatures, LanguageModelOutput
+from .config import ModelConfig
+from .language import LanguageModel
+
+
+class Model(nn.Module):
+    def __init__(self, config: ModelConfig):
+        super().__init__()
+        self.config = config
+        self.model_type = config.model_type
+        self.language_model = LanguageModel(config)
+
+    def get_input_embeddings(
+        self,
+        input_ids: Optional[mx.array] = None,
+        pixel_values: Optional[mx.array] = None,
+        **kwargs,
+    ) -> InputEmbeddingsFeatures:
+        return InputEmbeddingsFeatures(
+            inputs_embeds=self.language_model.model.embed_tokens(input_ids)
+        )
+
+    def __call__(
+        self,
+        input_ids: mx.array,
+        pixel_values: mx.array = None,
+        mask: mx.array = None,
+        cache=None,
+        **kwargs,
+    ) -> LanguageModelOutput:
+        input_embeddings_features = self.get_input_embeddings(input_ids, pixel_values)
+        return self.language_model(
+            input_ids,
+            cache=cache,
+            inputs_embeds=input_embeddings_features.inputs_embeds,
+            **kwargs,
+        )
+
+    def sanitize(self, weights):
+        weights = self.language_model.sanitize(weights)
+
+        def transform_key(key):
+            if key.startswith("language_model."):
+                return key
+            if key.startswith("model.") or key.startswith("lm_head."):
+                return f"language_model.{key}"
+            return key
+
+        return {transform_key(k): v for k, v in weights.items()}
+
+    @property
+    def quant_predicate(self):
+        return self.language_model.quant_predicate
+
+    @property
+    def cast_predicate(self):
+        return self.language_model.cast_predicate
+
+    @property
+    def layers(self):
+        return self.language_model.layers
+
+    def make_cache(self):
+        return self.language_model.make_cache()

--- a/mlx_vlm/tests/test_models.py
+++ b/mlx_vlm/tests/test_models.py
@@ -159,6 +159,93 @@ class TestModels(unittest.TestCase):
         self.assertEqual(type(cache[0]).__name__, "KVCache")
         self.assertEqual(type(cache[1]).__name__, "RotatingKVCache")
 
+    def test_lfm2_moe_language_model(self):
+        from mlx_vlm.models import lfm2_moe
+
+        config = lfm2_moe.ModelConfig(
+            model_type="lfm2_moe",
+            vocab_size=128,
+            hidden_size=64,
+            intermediate_size=128,
+            moe_intermediate_size=32,
+            num_hidden_layers=2,
+            num_experts=4,
+            num_experts_per_tok=2,
+            norm_topk_prob=True,
+            num_attention_heads=4,
+            num_key_value_heads=2,
+            max_position_embeddings=128,
+            use_expert_bias=True,
+            num_dense_layers=1,
+            norm_eps=1e-5,
+            conv_bias=False,
+            conv_L_cache=3,
+            layer_types=["conv", "full_attention"],
+            tie_word_embeddings=True,
+        )
+
+        model = lfm2_moe.Model(config)
+
+        self.language_test_runner(
+            model.language_model,
+            config.model_type,
+            config.vocab_size,
+            config.num_hidden_layers,
+        )
+
+        inputs = mx.array([[1, 2, 3]])
+        embeddings = model.get_input_embeddings(inputs)
+        self.assertEqual(embeddings.inputs_embeds.shape, (1, 3, config.hidden_size))
+
+        cache = model.make_cache()
+        self.assertEqual(type(cache[0]).__name__, "ArraysCache")
+        self.assertEqual(type(cache[1]).__name__, "KVCache")
+
+    def test_lfm2_moe_sanitize_stacks_experts(self):
+        from mlx_vlm.models import lfm2_moe
+
+        config = lfm2_moe.ModelConfig(
+            model_type="lfm2_moe",
+            vocab_size=128,
+            hidden_size=64,
+            intermediate_size=128,
+            moe_intermediate_size=32,
+            num_hidden_layers=2,
+            num_experts=2,
+            num_experts_per_tok=1,
+            norm_topk_prob=True,
+            num_attention_heads=4,
+            num_key_value_heads=2,
+            max_position_embeddings=128,
+            use_expert_bias=True,
+            num_dense_layers=1,
+            norm_eps=1e-5,
+            conv_bias=False,
+            conv_L_cache=3,
+            layer_types=["conv", "full_attention"],
+        )
+        model = lfm2_moe.Model(config)
+        prefix = "model.layers.1.feed_forward"
+        weights = {
+            f"{prefix}.experts.0.w1.weight": mx.ones((32, 64)),
+            f"{prefix}.experts.1.w1.weight": mx.zeros((32, 64)),
+            f"{prefix}.experts.0.w2.weight": mx.ones((64, 32)),
+            f"{prefix}.experts.1.w2.weight": mx.zeros((64, 32)),
+            f"{prefix}.experts.0.w3.weight": mx.ones((32, 64)),
+            f"{prefix}.experts.1.w3.weight": mx.zeros((32, 64)),
+        }
+
+        sanitized = model.sanitize(weights)
+
+        self.assertIn(f"language_model.{prefix}.switch_mlp.gate_proj.weight", sanitized)
+        self.assertIn(f"language_model.{prefix}.switch_mlp.down_proj.weight", sanitized)
+        self.assertIn(f"language_model.{prefix}.switch_mlp.up_proj.weight", sanitized)
+        self.assertEqual(
+            sanitized[f"language_model.{prefix}.switch_mlp.gate_proj.weight"].shape,
+            (2, 32, 64),
+        )
+        self.assertNotIn(f"language_model.{prefix}.experts.0.w1.weight", sanitized)
+
     def test_deepseek_v4_language_model(self):
         from mlx_vlm.models import deepseek_v4
         from mlx_vlm.models.deepseek_v4.hyper_connection import (


### PR DESCRIPTION
## Summary
- Add a standalone `lfm2_moe` language model package mirroring the existing language-model wrapper pattern.
- Wrap `mlx_lm.models.lfm2_moe.Lfm2Model` with MLX-VLM `LanguageModelOutput`, embeddings, cache creation, quant/cast predicates, and sanitization.
- Add focused model tests for forward pass, input embeddings, cache shape, and expert weight stacking.

## Validation
- `uv run pytest mlx_vlm/tests/test_models.py -k 'lfm2_moe'`
- `git diff --check HEAD^ HEAD`
