### PR TITLE
Add HRM-Text model support

### DIFF
--- a/mlx_vlm/models/hrm_text/__init__.py
+++ b/mlx_vlm/models/hrm_text/__init__.py
@@ -1,0 +1,3 @@
+from .config import ModelConfig
+from .hrm_text import Model
+from .processing_hrm_text import HrmTextProcessor

--- a/mlx_vlm/models/hrm_text/config.py
+++ b/mlx_vlm/models/hrm_text/config.py
@@ -1,0 +1,64 @@
+from dataclasses import dataclass
+from typing import Dict, List, Optional, Union
+
+from ..base import BaseModelConfig
+from ..qwen3_5.config import sanitize_quantization_config
+
+
+@dataclass
+class ModelConfig(BaseModelConfig):
+    model_type: str = "hrm_text"
+    vocab_size: int = 151808
+    hidden_size: int = 1536
+    intermediate_size: int = 4096
+    num_hidden_layers: int = 16
+    num_attention_heads: int = 12
+    num_key_value_heads: int = 12
+    head_dim: int = 128
+    hidden_act: str = "silu"
+    max_position_embeddings: int = 2048
+    initializer_range: float = 0.02
+    rms_norm_eps: float = 1e-6
+    use_cache: bool = True
+    pad_token_id: Optional[int] = None
+    bos_token_id: Optional[int] = None
+    eos_token_id: Optional[Union[int, List[int]]] = None
+    tie_word_embeddings: bool = False
+    rope_parameters: Optional[Dict] = None
+    rope_theta: float = 10000.0
+    attention_bias: bool = False
+    attention_dropout: float = 0.0
+    mlp_bias: bool = False
+    H_cycles: int = 2
+    L_cycles: int = 3
+    L_bp_cycles: Optional[List[int]] = None
+    embedding_scale: Optional[float] = None
+    prefix_lm: bool = True
+    num_layers_per_stack: Optional[int] = None
+    quantization: Optional[Dict] = None
+    quantization_config: Optional[Dict] = None
+
+    def __post_init__(self):
+        if self.L_bp_cycles is None:
+            self.L_bp_cycles = [2]
+        if self.embedding_scale is None:
+            self.embedding_scale = 1.0 / self.initializer_range
+        if self.num_layers_per_stack is None:
+            self.num_layers_per_stack = self.num_hidden_layers
+            self.num_hidden_layers = (
+                self.num_layers_per_stack * self.H_cycles * (self.L_cycles + 1)
+            )
+        if self.rope_parameters is not None:
+            self.rope_theta = self.rope_parameters.get(
+                "rope_theta",
+                self.rope_parameters.get("theta", self.rope_theta),
+            )
+
+        quantization = self.quantization
+        self.quantization = sanitize_quantization_config(quantization)
+        if self.quantization_config == quantization:
+            self.quantization_config = self.quantization
+        else:
+            self.quantization_config = sanitize_quantization_config(
+                self.quantization_config
+            )

--- a/mlx_vlm/models/hrm_text/hrm_text.py
+++ b/mlx_vlm/models/hrm_text/hrm_text.py
@@ -1,0 +1,111 @@
+from typing import Optional
+
+import mlx.core as mx
+import mlx.nn as nn
+
+from ..base import InputEmbeddingsFeatures, LanguageModelOutput
+from .config import ModelConfig
+from .language import LanguageModel
+
+
+class Model(nn.Module):
+    def __init__(self, config: ModelConfig):
+        super().__init__()
+        self.config = config
+        self.model_type = config.model_type
+        self.language_model = LanguageModel(config)
+
+    def get_input_embeddings(
+        self,
+        input_ids: Optional[mx.array] = None,
+        pixel_values: Optional[mx.array] = None,
+        **kwargs,
+    ) -> InputEmbeddingsFeatures:
+        if pixel_values is not None:
+            raise ValueError("HRM-Text is a text-only model.")
+        if input_ids is None:
+            raise ValueError("input_ids are required for HRM-Text.")
+        return InputEmbeddingsFeatures(
+            inputs_embeds=self.language_model.model.embed_tokens(input_ids)
+        )
+
+    def __call__(
+        self,
+        input_ids: mx.array,
+        pixel_values: mx.array = None,
+        mask: mx.array = None,
+        cache=None,
+        **kwargs,
+    ) -> LanguageModelOutput:
+        input_embeddings_features = self.get_input_embeddings(input_ids, pixel_values)
+        return self.language_model(
+            input_ids,
+            cache=cache,
+            mask=mask,
+            inputs_embeds=input_embeddings_features.inputs_embeds,
+            **kwargs,
+        )
+
+    def sanitize(self, weights):
+        config = self.config
+
+        def transform_key(key):
+            if key.startswith("language_model."):
+                return key
+            if key.startswith("model."):
+                key = key.replace("model.", "language_model.model.", 1)
+            if key.startswith("lm_head."):
+                key = key.replace("lm_head.", "language_model.lm_head.", 1)
+            return key.replace(".attn.", ".self_attn.")
+
+        sanitized = {}
+        q_size = config.num_attention_heads * config.head_dim
+        kv_size = config.num_key_value_heads * config.head_dim
+        for key, value in weights.items():
+            key = transform_key(key)
+            if key.endswith(".self_attn.gqkv_proj.weight"):
+                prefix = key[: -len("gqkv_proj.weight")]
+                gate, query, key_weight, value_weight = mx.split(
+                    value,
+                    [q_size, 2 * q_size, 2 * q_size + kv_size],
+                    axis=0,
+                )
+                sanitized[f"{prefix}gate_proj.weight"] = gate
+                sanitized[f"{prefix}q_proj.weight"] = query
+                sanitized[f"{prefix}k_proj.weight"] = key_weight
+                sanitized[f"{prefix}v_proj.weight"] = value_weight
+                continue
+            if key.endswith(".mlp.gate_up_proj.weight"):
+                prefix = key[: -len("gate_up_proj.weight")]
+                gate, up = mx.split(value, 2, axis=0)
+                sanitized[f"{prefix}gate_proj.weight"] = gate
+                sanitized[f"{prefix}up_proj.weight"] = up
+                continue
+            if key.endswith(".self_attn.gqkv_proj.bias"):
+                prefix = key[: -len("gqkv_proj.bias")]
+                gate, query, key_bias, value_bias = mx.split(
+                    value,
+                    [q_size, 2 * q_size, 2 * q_size + kv_size],
+                    axis=0,
+                )
+                sanitized[f"{prefix}gate_proj.bias"] = gate
+                sanitized[f"{prefix}q_proj.bias"] = query
+                sanitized[f"{prefix}k_proj.bias"] = key_bias
+                sanitized[f"{prefix}v_proj.bias"] = value_bias
+                continue
+            if key.endswith(".mlp.gate_up_proj.bias"):
+                prefix = key[: -len("gate_up_proj.bias")]
+                gate, up = mx.split(value, 2, axis=0)
+                sanitized[f"{prefix}gate_proj.bias"] = gate
+                sanitized[f"{prefix}up_proj.bias"] = up
+                continue
+            sanitized[key] = value
+
+        return sanitized
+
+    @property
+    def layers(self):
+        return self.language_model.layers
+
+    def make_cache(self):
+        return self.language_model.make_cache()

--- a/mlx_vlm/models/hrm_text/language.py
+++ b/mlx_vlm/models/hrm_text/language.py
@@ -1,0 +1,304 @@
+from typing import Optional
+
+import mlx.core as mx
+import mlx.nn as nn
+
+from ..base import (
+    LanguageModelOutput,
+    create_attention_mask,
+    scaled_dot_product_attention,
+)
+from ..cache import KVCache
+from .config import ModelConfig
+
+
+class HrmTextRMSNorm(nn.Module):
+    def __init__(self, eps: float = 1e-6):
+        super().__init__()
+        self.eps = eps
+
+    def __call__(self, x: mx.array) -> mx.array:
+        output = x.astype(mx.float32)
+        output = output * mx.rsqrt(
+            mx.mean(mx.square(output), axis=-1, keepdims=True) + self.eps
+        )
+        return output.astype(x.dtype)
+
+
+def _make_attention_mask(
+    hidden_states: mx.array,
+    cache,
+    attention_mask: Optional[mx.array] = None,
+    token_type_ids: Optional[mx.array] = None,
+    prefix_lm: bool = True,
+):
+    base_mask = create_attention_mask(hidden_states, cache)
+    if attention_mask is None and (token_type_ids is None or not prefix_lm):
+        return base_mask
+
+    B, L, _ = hidden_states.shape
+    cache_offset = cache.offset if cache is not None else 0
+    if cache_offset != 0 or L == 1:
+        causal = mx.ones((L, cache_offset + L), dtype=mx.bool_)
+    else:
+        positions = mx.arange(L)
+        causal = positions[:, None] >= positions[None, :]
+        if token_type_ids is not None and prefix_lm:
+            prefix = token_type_ids.astype(mx.int32) == 1
+            causal = causal[None, :, :] | (prefix[:, :, None] & prefix[:, None, :])
+
+    if causal.ndim == 2:
+        causal = mx.broadcast_to(causal[None, :, :], (B, *causal.shape))
+
+    if attention_mask is not None and attention_mask.ndim == 2:
+        key_mask = attention_mask.astype(mx.bool_)
+        if key_mask.shape[-1] != causal.shape[-1]:
+            key_mask = key_mask[:, -causal.shape[-1] :]
+        causal = causal & key_mask[:, None, :]
+
+    min_dtype = mx.finfo(hidden_states.dtype).min
+    return mx.where(causal[:, None, :, :], 0.0, min_dtype).astype(hidden_states.dtype)
+
+
+class HrmTextMLP(nn.Module):
+    def __init__(self, config: ModelConfig):
+        super().__init__()
+        self.gate_proj = nn.Linear(
+            config.hidden_size, config.intermediate_size, bias=config.mlp_bias
+        )
+        self.up_proj = nn.Linear(
+            config.hidden_size, config.intermediate_size, bias=config.mlp_bias
+        )
+        self.down_proj = nn.Linear(
+            config.intermediate_size, config.hidden_size, bias=config.mlp_bias
+        )
+
+    def __call__(self, x: mx.array) -> mx.array:
+        return self.down_proj(nn.silu(self.gate_proj(x)) * self.up_proj(x))
+
+
+class HrmTextAttention(nn.Module):
+    def __init__(self, config: ModelConfig):
+        super().__init__()
+        self.n_heads = config.num_attention_heads
+        self.n_kv_heads = config.num_key_value_heads
+        self.head_dim = config.head_dim
+        self.scale = self.head_dim**-0.5
+
+        dim = config.hidden_size
+        self.q_proj = nn.Linear(
+            dim, self.n_heads * self.head_dim, bias=config.attention_bias
+        )
+        self.k_proj = nn.Linear(
+            dim, self.n_kv_heads * self.head_dim, bias=config.attention_bias
+        )
+        self.v_proj = nn.Linear(
+            dim, self.n_kv_heads * self.head_dim, bias=config.attention_bias
+        )
+        self.o_proj = nn.Linear(
+            self.n_heads * self.head_dim, dim, bias=config.attention_bias
+        )
+        self.gate_proj = nn.Linear(
+            dim, self.n_heads * self.head_dim, bias=config.attention_bias
+        )
+        self.rope = nn.RoPE(
+            self.head_dim,
+            traditional=False,
+            base=config.rope_theta,
+        )
+
+    def __call__(
+        self,
+        x: mx.array,
+        mask: Optional[mx.array] = None,
+        cache: Optional[KVCache] = None,
+    ) -> mx.array:
+        B, L, _ = x.shape
+
+        queries = self.q_proj(x).reshape(B, L, self.n_heads, self.head_dim)
+        keys = self.k_proj(x).reshape(B, L, self.n_kv_heads, self.head_dim)
+        values = self.v_proj(x).reshape(B, L, self.n_kv_heads, self.head_dim)
+        gate = self.gate_proj(x).reshape(B, L, self.n_heads, self.head_dim)
+
+        queries = queries.transpose(0, 2, 1, 3)
+        keys = keys.transpose(0, 2, 1, 3)
+        values = values.transpose(0, 2, 1, 3)
+
+        offset = cache.offset if cache is not None else 0
+        queries = self.rope(queries, offset=offset)
+        keys = self.rope(keys, offset=offset)
+
+        if cache is not None:
+            keys, values = cache.update_and_fetch(keys, values)
+
+        output = scaled_dot_product_attention(
+            queries, keys, values, cache=cache, scale=self.scale, mask=mask
+        )
+        output = output.transpose(0, 2, 1, 3) * mx.sigmoid(gate)
+        output = output.reshape(B, L, -1)
+        return self.o_proj(output)
+
+
+class HrmTextDecoderLayer(nn.Module):
+    def __init__(self, config: ModelConfig):
+        super().__init__()
+        self.self_attn = HrmTextAttention(config)
+        self.mlp = HrmTextMLP(config)
+        self.input_layernorm = HrmTextRMSNorm(config.rms_norm_eps)
+        self.post_attention_layernorm = HrmTextRMSNorm(config.rms_norm_eps)
+
+    def __call__(
+        self,
+        x: mx.array,
+        mask: Optional[mx.array] = None,
+        cache: Optional[KVCache] = None,
+    ) -> mx.array:
+        h = x + self.self_attn(self.input_layernorm(x), mask=mask, cache=cache)
+        return h + self.mlp(self.post_attention_layernorm(h))
+
+
+class HrmTextStack(nn.Module):
+    def __init__(self, config: ModelConfig):
+        super().__init__()
+        self.layers = [
+            HrmTextDecoderLayer(config) for _ in range(config.num_layers_per_stack)
+        ]
+        self.final_norm = HrmTextRMSNorm(config.rms_norm_eps)
+
+    def __call__(
+        self,
+        x: mx.array,
+        mask: Optional[mx.array] = None,
+        cache=None,
+    ) -> mx.array:
+        if cache is None:
+            cache = [None] * len(self.layers)
+        for layer, layer_cache in zip(self.layers, cache):
+            x = layer(x, mask=mask, cache=layer_cache)
+        return self.final_norm(x)
+
+
+class HrmTextModel(nn.Module):
+    def __init__(self, config: ModelConfig):
+        super().__init__()
+        self.config = config
+        self.embed_tokens = nn.Embedding(config.vocab_size, config.hidden_size)
+        self.embedding_scale = config.embedding_scale
+        self.L_module = HrmTextStack(config)
+        self.H_module = HrmTextStack(config)
+        self.z_L_init = mx.zeros((config.hidden_size,))
+        raw_bp = list(config.L_bp_cycles)
+        self.L_bp_cycles_padded = [1] * max(0, config.H_cycles - len(raw_bp)) + raw_bp
+
+    @property
+    def layers(self):
+        layers = []
+        for _ in range(self.config.H_cycles):
+            for _ in range(self.config.L_cycles):
+                layers.extend(self.L_module.layers)
+            layers.extend(self.H_module.layers)
+        return layers
+
+    def __call__(
+        self,
+        inputs: mx.array,
+        inputs_embeds: Optional[mx.array] = None,
+        mask: Optional[mx.array] = None,
+        attention_mask: Optional[mx.array] = None,
+        cache=None,
+        token_type_ids: Optional[mx.array] = None,
+        **kwargs,
+    ) -> mx.array:
+        hidden_states_high = (
+            self.embed_tokens(inputs) if inputs_embeds is None else inputs_embeds
+        )
+        hidden_states_high = hidden_states_high * self.embedding_scale
+        hidden_states_low = mx.broadcast_to(
+            self.z_L_init.astype(hidden_states_high.dtype),
+            hidden_states_high.shape,
+        )
+
+        if cache is None:
+            cache = [None] * self.config.num_hidden_layers
+
+        if mask is None:
+            mask = attention_mask
+        if mask is not None and getattr(mask, "ndim", None) == 2:
+            first_cache = next((c for c in cache if c is not None), None)
+            mask = _make_attention_mask(
+                hidden_states_high,
+                first_cache,
+                attention_mask=mask,
+                token_type_ids=token_type_ids,
+                prefix_lm=self.config.prefix_lm,
+            )
+        elif mask is None:
+            first_cache = next((c for c in cache if c is not None), None)
+            mask = _make_attention_mask(
+                hidden_states_high,
+                first_cache,
+                token_type_ids=token_type_ids,
+                prefix_lm=self.config.prefix_lm,
+            )
+
+        num_layers = self.config.num_layers_per_stack
+        for high_cycle_idx in range(self.config.H_cycles):
+            for low_cycle_idx in range(self.config.L_cycles):
+                cycle_offset = (
+                    high_cycle_idx * (self.config.L_cycles + 1) + low_cycle_idx
+                ) * num_layers
+                hidden_states_low = self.L_module(
+                    hidden_states_low + hidden_states_high,
+                    mask=mask,
+                    cache=cache[cycle_offset : cycle_offset + num_layers],
+                )
+
+            cycle_offset = (
+                high_cycle_idx * (self.config.L_cycles + 1) + self.config.L_cycles
+            ) * num_layers
+            hidden_states_high = self.H_module(
+                hidden_states_high + hidden_states_low,
+                mask=mask,
+                cache=cache[cycle_offset : cycle_offset + num_layers],
+            )
+
+        return hidden_states_high
+
+
+class LanguageModel(nn.Module):
+    def __init__(self, config: ModelConfig):
+        super().__init__()
+        self.config = config
+        self.model_type = config.model_type
+        self.model = HrmTextModel(config)
+        if not config.tie_word_embeddings:
+            self.lm_head = nn.Linear(config.hidden_size, config.vocab_size, bias=False)
+
+    @property
+    def layers(self):
+        return self.model.layers
+
+    def make_cache(self):
+        return [KVCache() for _ in range(self.config.num_hidden_layers)]
+
+    def __call__(
+        self,
+        inputs: mx.array,
+        inputs_embeds: Optional[mx.array] = None,
+        cache=None,
+        mask: Optional[mx.array] = None,
+        **kwargs,
+    ) -> LanguageModelOutput:
+        out = self.model(
+            inputs,
+            inputs_embeds=inputs_embeds,
+            cache=cache,
+            mask=mask,
+            attention_mask=kwargs.get("attention_mask"),
+            token_type_ids=kwargs.get("token_type_ids"),
+        )
+        if self.config.tie_word_embeddings:
+            logits = self.model.embed_tokens.as_linear(out)
+        else:
+            logits = self.lm_head(out)
+        return LanguageModelOutput(logits=logits)

--- a/mlx_vlm/models/hrm_text/processing_hrm_text.py
+++ b/mlx_vlm/models/hrm_text/processing_hrm_text.py
@@ -1,0 +1,133 @@
+from typing import Any, Optional
+
+import mlx.core as mx
+from transformers.processing_utils import ProcessorMixin
+
+from ..base import install_auto_processor_patch
+
+DIRECT_CONDITION = "<|object_ref_start|>"
+SYNTH_COT_CONDITION = "<|quad_end|><|object_ref_end|>"
+
+DEFAULT_CHAT_TEMPLATE = (
+    "{%- set condition = '<|quad_end|><|object_ref_end|>' "
+    "if enable_thinking else '<|object_ref_start|>' -%}"
+    "{{- '<|im_start|>' + condition -}}"
+    "{%- for message in messages -%}"
+    "{{- message['content'] -}}"
+    "{%- if not loop.last -%}{{- '\\n' -}}{%- endif -%}"
+    "{%- endfor -%}"
+    "{{- '<|im_end|>' -}}"
+)
+
+
+def _content_to_text(content: Any) -> str:
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts = []
+        for item in content:
+            if isinstance(item, dict):
+                text = item.get("text", "") or item.get("content", "")
+                if text:
+                    parts.append(str(text))
+            elif item is not None:
+                parts.append(str(item))
+        return "".join(parts)
+    if isinstance(content, dict):
+        return str(content.get("text", "") or content.get("content", ""))
+    return "" if content is None else str(content)
+
+
+class HrmTextProcessor(ProcessorMixin):
+    attributes = ["tokenizer"]
+    tokenizer_class = "AutoTokenizer"
+
+    def __init__(self, tokenizer, chat_template: Optional[str] = None, **kwargs):
+        self.tokenizer = tokenizer
+        self.model_type = "hrm_text"
+        self.tokenizer.chat_template = chat_template or DEFAULT_CHAT_TEMPLATE
+        super().__init__(
+            tokenizer,
+            chat_template=self.tokenizer.chat_template,
+            **kwargs,
+        )
+
+    @property
+    def chat_template(self):
+        return getattr(self.tokenizer, "chat_template", None)
+
+    @chat_template.setter
+    def chat_template(self, value):
+        self.tokenizer.chat_template = value
+
+    def apply_chat_template(
+        self,
+        conversation,
+        tokenize: bool = False,
+        add_generation_prompt: bool = True,
+        enable_thinking: bool = False,
+        condition: Optional[str] = None,
+        **kwargs,
+    ):
+        if isinstance(conversation, (str, dict)):
+            conversation = [conversation]
+
+        texts = []
+        for message in conversation:
+            if isinstance(message, str):
+                texts.append(message)
+            elif isinstance(message, dict):
+                texts.append(_content_to_text(message.get("content", "")))
+            elif message is not None:
+                texts.append(str(message))
+
+        condition = condition or (
+            SYNTH_COT_CONDITION if enable_thinking else DIRECT_CONDITION
+        )
+        rendered = f"<|im_start|>{condition}{chr(10).join(texts)}<|im_end|>"
+        if not tokenize:
+            return rendered
+        return self.tokenizer(rendered, **kwargs)
+
+    def encode(self, *args, **kwargs):
+        return self.tokenizer.encode(*args, **kwargs)
+
+    def decode(self, *args, **kwargs):
+        return self.tokenizer.decode(*args, **kwargs)
+
+    def batch_decode(self, *args, **kwargs):
+        return self.tokenizer.batch_decode(*args, **kwargs)
+
+    def __call__(self, *args, **kwargs):
+        inputs = self.tokenizer(*args, **kwargs)
+        input_ids = inputs.get("input_ids", None)
+        if input_ids is not None and "token_type_ids" not in inputs:
+            inputs["token_type_ids"] = mx.ones_like(mx.array(input_ids))
+        return inputs
+
+    @classmethod
+    def from_pretrained(cls, pretrained_model_name_or_path, **kwargs):
+        from transformers import AutoTokenizer, PreTrainedTokenizerFast
+
+        chat_template = kwargs.pop("chat_template", None)
+        try:
+            tokenizer = AutoTokenizer.from_pretrained(
+                pretrained_model_name_or_path,
+                **kwargs,
+            )
+        except (AttributeError, ValueError):
+            tokenizer = PreTrainedTokenizerFast.from_pretrained(
+                pretrained_model_name_or_path,
+                **kwargs,
+            )
+        return cls(tokenizer=tokenizer, chat_template=chat_template)
+
+
+install_auto_processor_patch("hrm_text", HrmTextProcessor)
+
+__all__ = [
+    "DEFAULT_CHAT_TEMPLATE",
+    "DIRECT_CONDITION",
+    "HrmTextProcessor",
+    "SYNTH_COT_CONDITION",
+]

--- a/mlx_vlm/prompt_utils.py
+++ b/mlx_vlm/prompt_utils.py
@@ -93,6 +93,7 @@ MODEL_CONFIG = {
     "paligemma": MessageFormat.PROMPT_WITH_IMAGE_TOKEN,
     "laguna": MessageFormat.TEXT_ONLY,
     "deepseek_v4": MessageFormat.TEXT_ONLY,
+    "hrm_text": MessageFormat.TEXT_ONLY,
 }
 
 # Models that don't support multi-image

--- a/mlx_vlm/tests/test_models.py
+++ b/mlx_vlm/tests/test_models.py
@@ -159,6 +159,82 @@ class TestModels(unittest.TestCase):
         self.assertEqual(type(cache[0]).__name__, "KVCache")
         self.assertEqual(type(cache[1]).__name__, "RotatingKVCache")
 
+    def test_hrm_text_language_model(self):
+        from mlx_vlm.models import hrm_text
+
+        config = hrm_text.ModelConfig(
+            model_type="hrm_text",
+            vocab_size=128,
+            hidden_size=32,
+            intermediate_size=64,
+            num_hidden_layers=2,
+            num_attention_heads=4,
+            num_key_value_heads=4,
+            head_dim=8,
+            max_position_embeddings=128,
+            H_cycles=2,
+            L_cycles=2,
+            embedding_scale=1.0,
+        )
+        model = hrm_text.Model(config)
+
+        self.language_test_runner(
+            model.language_model,
+            config.model_type,
+            config.vocab_size,
+            config.num_hidden_layers,
+        )
+
+        inputs = mx.array([[1, 2, 3]])
+        embeddings = model.get_input_embeddings(inputs)
+        self.assertEqual(embeddings.inputs_embeds.shape, (1, 3, config.hidden_size))
+
+        cache = model.make_cache()
+        self.assertEqual(len(cache), config.num_hidden_layers)
+        self.assertEqual(type(cache[0]).__name__, "KVCache")
+
+        fused = {
+            "model.L_module.layers.0.attn.gqkv_proj.weight": mx.zeros((128, 32)),
+            "model.L_module.layers.0.mlp.gate_up_proj.weight": mx.zeros((128, 32)),
+        }
+        sanitized = model.sanitize(fused)
+        self.assertEqual(
+            sanitized[
+                "language_model.model.L_module.layers.0.self_attn.gate_proj.weight"
+            ].shape,
+            (32, 32),
+        )
+        self.assertEqual(
+            sanitized[
+                "language_model.model.L_module.layers.0.self_attn.q_proj.weight"
+            ].shape,
+            (32, 32),
+        )
+        self.assertEqual(
+            sanitized[
+                "language_model.model.L_module.layers.0.self_attn.k_proj.weight"
+            ].shape,
+            (32, 32),
+        )
+        self.assertEqual(
+            sanitized[
+                "language_model.model.L_module.layers.0.self_attn.v_proj.weight"
+            ].shape,
+            (32, 32),
+        )
+        self.assertEqual(
+            sanitized[
+                "language_model.model.L_module.layers.0.mlp.gate_proj.weight"
+            ].shape,
+            (64, 32),
+        )
+        self.assertEqual(
+            sanitized[
+                "language_model.model.L_module.layers.0.mlp.up_proj.weight"
+            ].shape,
+            (64, 32),
+        )
+
     def test_deepseek_v4_language_model(self):
         from mlx_vlm.models import deepseek_v4
         from mlx_vlm.models.deepseek_v4.hyper_connection import (


### PR DESCRIPTION
## Summary
- add native MLX implementation for sapientinc/HRM-Text-1B
- add HRM-Text processor/chat-template fallback from the model README
- propagate token_type_ids for PrefixLM prompt masking
- add HRM-Text smoke coverage for forward, cache, and fused weight sanitization

## Tests
- uv run python -m pytest mlx_vlm/tests/test_models.py -k hrm_text -q
- uv run python -m py_compile mlx_vlm/models/hrm_text/*.py mlx_vlm/prompt_utils.py mlx_vlm/utils.py
- uv run mlx_vlm.generate --model sapientinc/HRM-Text-1B --prompt "Write a long story" --temperature 0.0 --enable-thinking --max-tokens 20