### PR TITLE
Fix(qwen3_omni_moe): enable audio input (mask key + audio placeholder)

### DIFF
--- a/mlx_vlm/models/qwen3_omni_moe/qwen3_omni_moe.py
+++ b/mlx_vlm/models/qwen3_omni_moe/qwen3_omni_moe.py
@@ -68,6 +68,9 @@ class Model(nn.Module):
         audio_feature_lengths: Optional[mx.array] = None,
         **kwargs,
     ):
+        # prepare_inputs passes the audio mask as `feature_attention_mask`.
+        if input_features_mask is None:
+            input_features_mask = kwargs.get("feature_attention_mask")
         return self.thinker.get_input_embeddings(
             input_ids=input_ids,
             pixel_values=pixel_values,

--- a/mlx_vlm/prompt_utils.py
+++ b/mlx_vlm/prompt_utils.py
@@ -343,6 +343,9 @@ class MessageFormatter:
             image_tokens = [image_builder()] * num_images
             content = image_tokens + content if image_first else content + image_tokens
 
+        if role == "user" and not skip_audio_token and num_audios > 0:
+            content = content + [MessageBuilder.audio_message()] * num_audios
+
         return {"role": role, "content": content}
 
     def _format_text_only(


### PR DESCRIPTION
Qwen3-Omni audio input crashes on `main`. Two small things are wrong:

**1. The audio mask is dropped (param-name mismatch).**
`prepare_inputs` writes the mask as `feature_attention_mask`, but `Model.get_input_embeddings` only reads `input_features_mask` (a key only gemma4/gemma3n set). So the mask lands in `**kwargs`, stays `None`, and `get_audio_features` skips its 2-D reshape — the audio tower gets a 4-D `input_features` and breaks:

```
File ".../qwen3_omni_moe/audio.py", line 234, in __call__
    padded_feature[i, :, :chunk_len] = input_features[:, start_idx:end_idx]
ValueError: [broadcast_shapes] Shapes (1,1,100,288) and (1,128,100) cannot be broadcast.
```

Fix: accept either key in `get_input_embeddings`.

**2. No audio placeholder is inserted into the prompt.**
qwen3_omni_moe uses `_format_list_with_image`, which inserts image tokens but not audio ones, so `{"type": "audio"}` is silently dropped. The prompt ends up with zero audio tokens and the audio features have nowhere to scatter:

```
File ".../qwen3_omni_moe/thinker.py", line 176, in masked_scatter
ValueError: [broadcast_shapes] Shapes (75776) and (0) cannot be broadcast.
```

Fix: insert the audio placeholder, mirroring what the sibling `_format_list_with_image_type` already does. It's guarded by `num_audios > 0` (which `apply_chat_template` defaults to 0), so text- and image-only prompts are untouched.

**Tested** on `Qwen3-Omni-30B-A3B-Instruct-4bit`: transcription now works and matches the spoken text across a handful of clips, and image-only / text-only prompts behave exactly as before.

Related: #1007 — the path error reported there is the step just before this; same area.

---

## Diff (6 lines, for reference)

`mlx_vlm/models/qwen3_omni_moe/qwen3_omni_moe.py` — in `get_input_embeddings`:
```python
if input_features_mask is None:
    input_features_mask = kwargs.get("feature_attention_mask")
```

`mlx_vlm/prompt_utils.py` — in `_format_list_with_image`, after the image block:
```python
if role == "user" and not skip_audio_token and num_audios > 0:
    content = content + [MessageBuilder.audio_message()] * num_audios
```