### PR TITLE
turboquant: guard L=1 value kernels behind `not use_rht` (fix masked decode under RHT)

### DIFF
--- a/mlx_vlm/turboquant.py
+++ b/mlx_vlm/turboquant.py
@@ -4287,7 +4287,7 @@ class _TurboQuantMSECodec:
         return self.score_prepared(self.prepare_queries(queries), state)
 
     def weighted_sum(self, weights: mx.array, state: TurboQuantMSEState) -> mx.array:
-        if weights.shape[-2] == 1:
+        if not self.use_rht and weights.shape[-2] == 1:
             fast_output = _metal_mse_weighted_sum(
                 weights,
                 state,
@@ -4327,8 +4327,11 @@ class _TurboQuantMSECodec:
         self, scores: mx.array, state: TurboQuantMSEState
     ) -> tuple[mx.array, mx.array, mx.array]:
         max_scores = mx.max(scores, axis=-1)
-        # Metal kernel fast path: only for single-query decode (L=1)
-        if scores.ndim == 5 and scores.shape[-2] == 1:
+        # Metal kernel fast path: only for single-query decode (L=1).
+        # Skip under RHT: these L=1 value kernels undo the codec rotation with
+        # matmul(., rotation) and do not implement the RHT inverse, so they
+        # corrupt the output when use_rht is set (the codec default).
+        if not self.use_rht and scores.ndim == 5 and scores.shape[-2] == 1:
             max_scores_2d = max_scores.reshape(
                 max_scores.shape[0],
                 max_scores.shape[1],


### PR DESCRIPTION
## Summary

`_TurboQuantMSECodec.weighted_sum` and `weighted_sum_stats_from_scores` call the
L=1 value-reconstruction Metal kernels (`_metal_mse_weighted_sum`,
`_metal_mse_weighted_sum_sum_from_scores`) **without** the `if not self.use_rht`
guard that the sibling `weighted_sum_from_scores` already has.

Those kernels finish with `matmul(weighted_rot, rotation)` to undo the codec
rotation — correct only for a plain rotation. `_TurboQuantMSECodec` defaults to
`use_rht=True` (randomized Hadamard transform), whose inverse is
`_rht_inverse(.; signs)`, not `matmul(.; rotation)`. So under RHT these kernels
apply the wrong inverse transform and return essentially uncorrelated output
(**~140% reconstruction error at every bit depth, 2–8**).

## Impact

- The slow / masked single-query (`L=1`) `decode_attention` path is corrupt.
- It's latent for the common decode path (which uses the fused
  `_fused_mse_decode_kernel` when `mask` is `None`/`"causal"`); it only surfaces
  when an **array mask** forces the slow path — e.g. continuous-batching decode
  with per-request left-padding (`B > 1`), which then produces garbage.

## Fix

Add `not self.use_rht and` to the two L=1 guards, mirroring the existing
`weighted_sum_from_scores`. Under RHT this takes the correct
einsum + `_rotate_inverse` fallback; with a plain rotation (`use_rht=False`) the
kernels still run.

## Verification

```
# _TurboQuantMSECodec, 8-bit, single-query decode through the masked path
array-mask decode error:  before = 140.0%   after = 1.2%
```

End-to-end on `mlx-community/Llama-3.2-1B-Instruct-4bit`, continuous-batching
decode (`B>1`, left-padded) produces coherent output after the fix; before it is
garbage.

## Note

Conservative fix (fall back to the correct math) matching the existing
`weighted_sum_from_scores` behavior. A deeper fix would teach the kernels the
RHT inverse so the RHT path could keep using the fast kernels.
