### PR TITLE
fix(convert): don't abort conversion when a processor lacks save_pretrained

### DIFF
--- a/mlx_vlm/convert.py
+++ b/mlx_vlm/convert.py
@@ -71,6 +71,29 @@ def _preserve_existing_deepseek_v4_quantization(
     config["quantization_config"] = quantization
 
 
+def _save_processor(processor, mlx_path: Path) -> None:
+    """Save processor files, tolerating processors without ``save_pretrained``.
+
+    Some custom mlx-vlm processors (e.g. moondream3's ``Moondream3Processor``)
+    are plain classes registered via ``install_auto_processor_patch`` and don't
+    implement ``save_pretrained``. Skipping the save in that case lets conversion
+    proceed to ``save_config``, which writes the model ``config.json`` (including
+    the ``quantization`` block) -- otherwise a quantized checkpoint is written
+    with a config that has no quantization and fails to load.
+
+    Processors that do implement ``save_pretrained`` are saved normally; genuine
+    save failures are left to propagate rather than producing a broken artifact.
+    """
+    save_pretrained = getattr(processor, "save_pretrained", None)
+    if not callable(save_pretrained):
+        print(
+            f"[WARNING] {type(processor).__name__} has no save_pretrained(); "
+            "skipping processor save."
+        )
+        return
+    save_pretrained(mlx_path)
+
+
 def mixed_quant_predicate_builder(
     recipe: str, model: nn.Module
 ) -> Callable[[str, nn.Module], Union[bool, dict]]:
@@ -242,7 +265,7 @@ def convert(
                 shutil.rmtree(dest)
             shutil.copytree(item, dest)
 
-    processor.save_pretrained(mlx_path)
+    _save_processor(processor, mlx_path)
 
     save_config(config, config_path=mlx_path / "config.json")
 

--- a/mlx_vlm/tests/test_utils.py
+++ b/mlx_vlm/tests/test_utils.py
@@ -11,7 +11,7 @@ import mlx.nn as nn
 import pytest
 from mlx_lm.utils import quantize_model
 
-from mlx_vlm.convert import _preserve_existing_deepseek_v4_quantization
+from mlx_vlm.convert import _preserve_existing_deepseek_v4_quantization, _save_processor
 from mlx_vlm.models.text_only import TextOnlyModel
 from mlx_vlm.utils import (
     StoppingCriteria,
@@ -285,6 +285,39 @@ def test_convert_preserves_existing_deepseek_v4_quantization():
         "bits": 8,
         "mode": "mxfp8",
     }
+
+
+def test_save_processor_without_save_pretrained_does_not_raise():
+    """A processor lacking save_pretrained must be skipped, not crash convert.
+
+    Regression for custom processors (e.g. moondream3's Moondream3Processor)
+    that are plain classes: a missing save_pretrained used to abort conversion
+    before save_config() could write the quantization block.
+    """
+
+    class NoSaveProcessor:
+        pass
+
+    # Must return cleanly so the caller can still run save_config afterwards.
+    _save_processor(NoSaveProcessor(), Path("/nonexistent/does-not-matter"))
+
+
+def test_save_processor_calls_save_pretrained():
+    processor = MagicMock()
+    mlx_path = Path("/tmp/mlx-convert-out")
+
+    _save_processor(processor, mlx_path)
+
+    processor.save_pretrained.assert_called_once_with(mlx_path)
+
+
+def test_save_processor_propagates_save_pretrained_failure():
+    processor = MagicMock()
+    processor.save_pretrained.side_effect = RuntimeError("boom")
+
+    # A genuine save failure must surface rather than yield a broken artifact.
+    with pytest.raises(RuntimeError, match="boom"):
+        _save_processor(processor, Path("/tmp/mlx-convert-out"))
 
 
 def test_prepare_inputs():


### PR DESCRIPTION
## Summary

`mlx_vlm.convert` aborts when the model's processor doesn't implement `save_pretrained`. Many custom processors registered via `install_auto_processor_patch` are plain classes (e.g. moondream3's `Moondream3Processor`), and `convert()` calls `processor.save_pretrained(mlx_path)` immediately **before** `save_config()`. So the missing method raises `AttributeError`, `save_config()` never runs, and the output directory is left with quantized weights but a `config.json` that has **no `quantization` block** — the resulting checkpoint then fails to load (the loader builds full-precision layers against quantized weights).

## Repro

```
mlx_vlm.convert --hf-path <moondream3> --mlx-path out -q --q-bits 4
# ... [INFO] Quantizing -> save_weights OK ...
# AttributeError: 'Moondream3Processor' object has no attribute 'save_pretrained'
# -> out/config.json has no "quantization"; load() then fails.
```

## Fix

Route the processor save through a small `_save_processor()` helper:

- If the processor has **no** `save_pretrained`, skip it with a warning (its files are non-critical — e.g. moondream3 loads its tokenizer from a separate repo) and let conversion continue to `save_config()`.
- Otherwise save normally and **let genuine save failures propagate** — don't mask serialization/permission errors behind a broken artifact.

`save_config()` ordering is unchanged (still last), so the quantization-bearing `config.json` stays authoritative even for processors whose `save_pretrained` writes their own config files.

## Tests

Adds three unit tests in `mlx_vlm/tests/test_utils.py` for the helper: missing method (skipped), present method (called once with the path), and a failing save (propagates).
