### PR TITLE
perf(turboquant): RHT-correct L=1 value kernels (keep the fast path under RHT)

### DIFF
--- a/mlx_vlm/tests/test_turboquant_rht_value_kernels.py
+++ b/mlx_vlm/tests/test_turboquant_rht_value_kernels.py
@@ -1,0 +1,108 @@
+"""RHT-path equivalence for the L=1 value Metal kernels.
+
+The single-token value kernels (``_metal_mse_weighted_sum`` and friends)
+compute the weighted value sum in the codec's *rotated* space. They used to
+hard-code ``matmul(weighted_rot, rotation)`` to undo that rotation, which is
+only correct for the dense-rotation codec — so #1244 disabled them whenever
+the codec uses the Randomized Hadamard Transform (``use_rht``), falling back
+to the slower einsum path for every RHT decode.
+
+The wrappers now apply the codec's RHT-aware inverse (via ``signs``), so the
+fast kernel path is valid under RHT too. These tests pin that the kernel and
+einsum paths agree, and that RHT decode actually takes the kernel path.
+"""
+
+import mlx.core as mx
+import pytest
+
+import mlx_vlm.turboquant as tq
+from mlx_vlm.turboquant import _TurboQuantMSECodec
+
+
+def _codec_and_state(dim: int, bits: int, n_heads: int, n_tokens: int, seed: int):
+    mx.random.seed(seed)
+    values = mx.random.normal((1, n_heads, n_tokens, dim))
+    codec = _TurboQuantMSECodec(dim, bits, seed=seed)
+    return codec, codec.quantize(values)
+
+
+def _dequant_weighted_sum(codec, state, weights):
+    """Math ground truth: weighted sum over the codec's own dequantized values."""
+    deq = codec.dequantize(state)  # (1, H, T, D)
+    return mx.einsum("bhmlt,bhtd->bhmld", weights, deq)
+
+
+@pytest.mark.parametrize("dim", [64, 128, 256])
+@pytest.mark.parametrize("bits", [2, 3, 4, 8])
+@pytest.mark.parametrize("n_repeats", [1, 4])
+def test_rht_weighted_sum_matches_einsum_and_dequant(dim, bits, n_repeats, monkeypatch):
+    if not mx.metal.is_available():
+        pytest.skip("Metal kernels are unavailable on this host")
+
+    n_heads, n_tokens = 2, 24
+    codec, state = _codec_and_state(dim, bits, n_heads, n_tokens, seed=0)
+    # power-of-2 dim -> the RHT path that #1244 disabled for these kernels
+    assert codec.use_rht is True
+
+    weights = mx.softmax(
+        mx.random.normal((1, n_heads, n_repeats, 1, n_tokens)), axis=-1
+    )
+
+    kernel_out = codec.weighted_sum(weights, state)  # Metal -> RHT kernel fast path
+    truth = _dequant_weighted_sum(codec, state, weights)
+
+    # Force the einsum fallback by hiding Metal, then compare paths.
+    monkeypatch.setattr(tq, "_metal_available", lambda: False)
+    einsum_out = codec.weighted_sum(weights, state)
+
+    assert kernel_out.shape == einsum_out.shape == truth.shape
+    assert mx.max(mx.abs(kernel_out - einsum_out)).item() < 1e-4
+    assert mx.max(mx.abs(kernel_out - truth)).item() < 1e-3
+
+
+@pytest.mark.parametrize("dim", [64, 128])
+@pytest.mark.parametrize("bits", [3, 4])
+def test_rht_weighted_sum_stats_matches_einsum(dim, bits, monkeypatch):
+    if not mx.metal.is_available():
+        pytest.skip("Metal kernels are unavailable on this host")
+
+    n_heads, n_repeats, n_tokens = 2, 4, 24
+    codec, state = _codec_and_state(dim, bits, n_heads, n_tokens, seed=1)
+    assert codec.use_rht is True
+
+    scores = mx.random.normal((1, n_heads, n_repeats, 1, n_tokens))
+
+    out_k, denom_k, max_k = codec.weighted_sum_stats_from_scores(scores, state)
+
+    monkeypatch.setattr(tq, "_metal_available", lambda: False)
+    out_e, denom_e, max_e = codec.weighted_sum_stats_from_scores(scores, state)
+
+    assert mx.max(mx.abs(out_k - out_e)).item() < 1e-4
+    assert mx.max(mx.abs(denom_k - denom_e)).item() < 1e-4
+    assert mx.max(mx.abs(max_k - max_e)).item() < 1e-4
+
+
+def test_rht_weighted_sum_takes_kernel_path_not_unpack(monkeypatch):
+    """Under RHT the fast kernel must run — never the einsum fallback (which unpacks).
+
+    Regression guard for the perf goal: before this fix the RHT codec skipped
+    the kernel and fell through to einsum, calling ``_unpack_lowbit``.
+    """
+    if not mx.metal.is_available():
+        pytest.skip("Metal kernels are unavailable on this host")
+
+    n_heads, n_repeats, n_tokens, dim = 2, 4, 24, 64
+    codec, state = _codec_and_state(dim, 4, n_heads, n_tokens, seed=2)
+    assert codec.use_rht is True
+
+    weights = mx.softmax(
+        mx.random.normal((1, n_heads, n_repeats, 1, n_tokens)), axis=-1
+    )
+
+    def fail(*args, **kwargs):
+        raise AssertionError("RHT weighted_sum should use the Metal kernel, not unpack")
+
+    monkeypatch.setattr(tq, "_unpack_lowbit", fail)
+    output = codec.weighted_sum(weights, state)
+    mx.eval(output)
+    assert output.shape == (1, n_heads, n_repeats, 1, dim)

--- a/mlx_vlm/turboquant.py
+++ b/mlx_vlm/turboquant.py
@@ -1329,12 +1329,30 @@ def _metal_polar_turbo_score(
     return mx.expand_dims(scores, axis=3)
 
 
+def _value_rotate_inverse(
+    weighted_rot: mx.array, rotation: mx.array, signs: Optional[mx.array]
+) -> mx.array:
+    """Undo the codec rotation on a Metal value-kernel result.
+
+    The L=1 value kernels return the weighted value sum in the codec's
+    *rotated* space. Map it back to model space with the same inverse the
+    codec uses: an explicit Randomized Hadamard inverse when the codec runs
+    with RHT (``signs`` provided), otherwise the dense-rotation matmul.
+    Mirrors ``_TurboQuantMSECodec._rotate_inverse`` so the kernel fast path
+    stays valid under RHT instead of being skipped for the einsum fallback.
+    """
+    if signs is not None:
+        return _rht_inverse(weighted_rot, signs)
+    return mx.matmul(weighted_rot, rotation)
+
+
 def _metal_mse_weighted_sum(
     weights: mx.array,
     state: TurboQuantMSEState,
     bits: int,
     codebook: mx.array,
     rotation: mx.array,
+    signs: Optional[mx.array] = None,
 ) -> Optional[mx.array]:
     if (
         bits <= 0
@@ -1374,7 +1392,7 @@ def _metal_mse_weighted_sum(
                 output_shapes=[(B, H, R, D)],
                 output_dtypes=[mx.float32],
             )[0]
-            output = mx.matmul(weighted_rot, rotation)
+            output = _value_rotate_inverse(weighted_rot, rotation, signs)
             return mx.expand_dims(output, axis=3)
 
     kernel = _mse_weighted_rot_kernel()
@@ -1398,7 +1416,7 @@ def _metal_mse_weighted_sum(
         output_shapes=[(B, H, R, D)],
         output_dtypes=[mx.float32],
     )[0]
-    output = mx.matmul(weighted_rot, rotation)
+    output = _value_rotate_inverse(weighted_rot, rotation, signs)
     return mx.expand_dims(output, axis=3)
 
 
@@ -1408,6 +1426,7 @@ def _metal_mse_weighted_sum_from_scores(
     bits: int,
     codebook: mx.array,
     rotation: mx.array,
+    signs: Optional[mx.array] = None,
 ) -> Optional[mx.array]:
     if (
         bits <= 0
@@ -1454,7 +1473,7 @@ def _metal_mse_weighted_sum_from_scores(
         output_shapes=[(B, H, R, D)],
         output_dtypes=[mx.float32],
     )[0]
-    output = mx.matmul(weighted_rot, rotation)
+    output = _value_rotate_inverse(weighted_rot, rotation, signs)
     return mx.expand_dims(output, axis=3)
 
 
@@ -1465,6 +1484,7 @@ def _metal_mse_weighted_sum_sum_from_scores(
     codebook: mx.array,
     rotation: mx.array,
     max_scores: mx.array,
+    signs: Optional[mx.array] = None,
 ) -> Optional[mx.array]:
     if (
         bits <= 0
@@ -1509,7 +1529,7 @@ def _metal_mse_weighted_sum_sum_from_scores(
         output_shapes=[(B, H, R, D)],
         output_dtypes=[mx.float32],
     )[0]
-    output = mx.matmul(weighted_rot, rotation)
+    output = _value_rotate_inverse(weighted_rot, rotation, signs)
     return mx.expand_dims(output, axis=3)
 
 
@@ -4287,13 +4307,14 @@ class _TurboQuantMSECodec:
         return self.score_prepared(self.prepare_queries(queries), state)
 
     def weighted_sum(self, weights: mx.array, state: TurboQuantMSEState) -> mx.array:
-        if not self.use_rht and weights.shape[-2] == 1:
+        if weights.shape[-2] == 1:
             fast_output = _metal_mse_weighted_sum(
                 weights,
                 state,
                 self.bits,
                 self.codebook,
                 self.rotation,
+                self.signs,
             )
             if fast_output is not None:
                 return fast_output
@@ -4311,27 +4332,27 @@ class _TurboQuantMSECodec:
     def weighted_sum_from_scores(
         self, scores: mx.array, state: TurboQuantMSEState
     ) -> mx.array:
-        if not self.use_rht:
-            fast_output = _metal_mse_weighted_sum_from_scores(
-                scores,
-                state,
-                self.bits,
-                self.codebook,
-                self.rotation,
-            )
-            if fast_output is not None:
-                return fast_output
+        fast_output = _metal_mse_weighted_sum_from_scores(
+            scores,
+            state,
+            self.bits,
+            self.codebook,
+            self.rotation,
+            self.signs,
+        )
+        if fast_output is not None:
+            return fast_output
         return self.weighted_sum(mx.softmax(scores, axis=-1), state)
 
     def weighted_sum_stats_from_scores(
         self, scores: mx.array, state: TurboQuantMSEState
     ) -> tuple[mx.array, mx.array, mx.array]:
         max_scores = mx.max(scores, axis=-1)
-        # Metal kernel fast path: only for single-query decode (L=1).
-        # Skip under RHT: these L=1 value kernels undo the codec rotation with
-        # matmul(., rotation) and do not implement the RHT inverse, so they
-        # corrupt the output when use_rht is set (the codec default).
-        if not self.use_rht and scores.ndim == 5 and scores.shape[-2] == 1:
+        # Metal kernel fast path: only for single-query decode (L=1). The
+        # kernel returns the weighted sum in rotated space; the wrapper applies
+        # the codec's RHT-aware inverse (via ``signs``), so this stays valid
+        # whether or not the codec uses RHT.
+        if scores.ndim == 5 and scores.shape[-2] == 1:
             max_scores_2d = max_scores.reshape(
                 max_scores.shape[0],
                 max_scores.shape[1],
@@ -4344,6 +4365,7 @@ class _TurboQuantMSECodec:
                 self.codebook,
                 self.rotation,
                 max_scores_2d,
+                self.signs,
             )
             if fast_output is not None:
                 denom = mx.sum(mx.exp(scores - max_scores[..., None]), axis=-1)


### PR DESCRIPTION
## Summary

Follow-up to #1244. That PR made the single-token (L=1) value Metal kernels **correct** under RHT by *declining* them — every RHT decode falls back to the slower einsum path. This PR makes the kernels themselves RHT-correct so the fast path stays engaged.

**Root cause.** `_metal_mse_weighted_sum` / `_metal_mse_weighted_sum_from_scores` / `_metal_mse_weighted_sum_sum_from_scores` return the weighted value sum in the codec's *rotated* space and undid it with a hard-coded `matmul(weighted_rot, rotation)`. That inverse is only valid for the dense-rotation codec; under the Randomized Hadamard Transform (`use_rht`, the default for power-of-2 head dims) the correct inverse is `_rht_inverse`. The kernel computes `weighted_rot` correctly regardless of rotation type — only the post-kernel inverse was wrong, which is exactly why #1244 had to skip it.

**Fix.** Thread the codec's RHT `signs` into the three wrappers and apply the matching inverse through a small `_value_rotate_inverse` helper (`_rht_inverse` when signs are set, else the dense matmul) — mirroring `_TurboQuantMSECodec._rotate_inverse` and the already-correct fused-decode path (`value_codec._rotate_inverse(out_rotated)`). The `not self.use_rht` guards from #1244 are dropped so RHT decode takes the kernel again.

Prod-mode fused-decode call sites pass no `signs` (default `None`) → identical dense matmul, **byte-for-byte unchanged**.

## Verification

New `mlx_vlm/tests/test_turboquant_rht_value_kernels.py`:

- **Equivalence** — kernel path vs einsum fallback vs dequantize ground truth across dims `{64,128,256}` × bits `{2,3,4,8}` × repeats `{1,4}`, plus the `weighted_sum_stats_from_scores` decode path. Agreement `<1e-4` (kernel vs einsum) and `<1e-3` (kernel vs dequant truth).
- **Kernel-path guard** — asserts RHT `weighted_sum` runs the Metal kernel and never the einsum fallback (which unpacks low-bit indices). This test **fails on `main` today** (RHT is skipped) and passes here.
- Existing `test_turboquant.py` suite: **23 passed**, no regressions.

## Benchmark (M-series, L=1 value reconstruction, dim=128 bits=4 B=4 H=8 repeats=4)

| context T | einsum fallback | RHT kernel | speedup |
|---|---|---|---|
| 512  | 1.85 ms | 0.53 ms | **3.5×** |
| 2048 | 3.05 ms | 0.43 ms | **7.0×** |
| 8192 | 15.56 ms | 1.14 ms | **13.7×** |

The gap grows with context length because the einsum fallback re-unpacks every token each decode step.

## Scope / risk

Low. Kernel math is unchanged; only the post-kernel inverse moves to the RHT-aware `_value_rotate_inverse`. The dense-rotation and prod-mode paths are untouched (no `signs` → same matmul).
