### PR TITLE
[codex] Fix models endpoint for loaded local models

### DIFF
--- a/mlx_vlm/server/app.py
+++ b/mlx_vlm/server/app.py
@@ -3,6 +3,7 @@ import gc
 import logging
 import os
 import sys
+import time
 from contextlib import asynccontextmanager
 from threading import Lock
 from types import SimpleNamespace
@@ -12,6 +13,7 @@ import mlx.core as mx
 from fastapi import FastAPI, HTTPException, Request
 from fastapi.middleware.cors import CORSMiddleware
 from huggingface_hub import scan_cache_dir
+from huggingface_hub.errors import CacheNotFound
 
 from .. import apc as _apc
 from ..generate import (
@@ -608,15 +610,25 @@ def models_endpoint():
         )
         return required_files.issubset(file_names) and has_weights
 
-    # Scan the cache directory for downloaded mlx models
-    hf_cache_info = _server_package_attr("scan_cache_dir", scan_cache_dir)()
-    downloaded_models = [repo for repo in hf_cache_info.repos if probably_mlx_lm(repo)]
+    # Scan the cache directory for downloaded mlx models when it exists.
+    try:
+        hf_cache_info = _server_package_attr("scan_cache_dir", scan_cache_dir)()
+        downloaded_models = [
+            repo for repo in hf_cache_info.repos if probably_mlx_lm(repo)
+        ]
+    except CacheNotFound:
+        downloaded_models = []
 
     # Create a list of available models
     models = [
         {"id": repo.repo_id, "object": "model", "created": int(repo.last_modified)}
         for repo in downloaded_models
     ]
+    loaded_model = runtime.model_cache.get("model_path")
+    if loaded_model and all(model["id"] != loaded_model for model in models):
+        models.append(
+            {"id": loaded_model, "object": "model", "created": int(time.time())}
+        )
 
     response = {"object": "list", "data": models}
 

--- a/mlx_vlm/tests/test_server.py
+++ b/mlx_vlm/tests/test_server.py
@@ -518,6 +518,70 @@ def test_models_endpoint_lists_single_file_safetensors_models(client, monkeypatc
     assert "missing/weights" not in ids
 
 
+def test_models_endpoint_includes_loaded_local_model_without_hf_cache(
+    client, monkeypatch
+):
+    monkeypatch.setattr(
+        server,
+        "scan_cache_dir",
+        MagicMock(side_effect=server.CacheNotFound("missing cache", "/missing")),
+    )
+    monkeypatch.setitem(server.runtime.model_cache, "model_path", "/models/local-qwen")
+
+    response = client.get("/v1/models")
+
+    assert response.status_code == 200
+    assert response.json()["data"] == [
+        {
+            "id": "/models/local-qwen",
+            "object": "model",
+            "created": response.json()["data"][0]["created"],
+        }
+    ]
+
+
+def test_models_endpoint_deduplicates_loaded_model_from_hf_cache(client, monkeypatch):
+    def repo(repo_id, file_names):
+        return SimpleNamespace(
+            repo_id=repo_id,
+            repo_type="model",
+            last_modified=123.0,
+            refs={
+                "main": SimpleNamespace(
+                    files=[
+                        SimpleNamespace(file_path=SimpleNamespace(name=file_name))
+                        for file_name in file_names
+                    ]
+                )
+            },
+        )
+
+    monkeypatch.setattr(
+        server,
+        "scan_cache_dir",
+        lambda: SimpleNamespace(
+            repos=[
+                repo(
+                    "local/sharded-model",
+                    [
+                        "config.json",
+                        "model.safetensors.index.json",
+                        "tokenizer_config.json",
+                    ],
+                ),
+            ]
+        ),
+    )
+    monkeypatch.setitem(server.runtime.model_cache, "model_path", "local/sharded-model")
+
+    response = client.get("/v1/models")
+
+    assert response.status_code == 200
+    assert [model["id"] for model in response.json()["data"]].count(
+        "local/sharded-model"
+    ) == 1
+
+
 def _fake_image_result(*, seed: int, output_path=None) -> ImageGenerationResult:
     image = Image.new("RGB", (16, 16), (seed % 255, 8, 16))
     data = ImageGenerationResult(


### PR DESCRIPTION
## Summary

Fixes the `/v1/models` endpoint when the server is running an already loaded local model but the Hugging Face cache directory is missing or does not include that local path.

## Root Cause

The endpoint only scanned `huggingface_hub.scan_cache_dir()`. That raises `CacheNotFound` when `~/.cache/huggingface/hub` is absent, and it also meant locally loaded models outside the HF cache were omitted from the response.

## Changes

- Catch `CacheNotFound` and return a normal model list instead of a 500.
- Include `runtime.model_cache["model_path"]` in `/v1/models` when a model is already loaded.
- Avoid duplicating the loaded model when it is also present in the HF cache scan.
- Add server regression coverage for the missing-cache and deduplication cases.

Fixes #1132
Fixes #1133

## Validation

- `uv run --with pytest pytest mlx_vlm/tests/test_server.py -k 'models_endpoint'`
- `uv run --with pytest pytest mlx_vlm/tests/test_server.py`
- `uv run --with pytest --with psutil pytest`