### PR TITLE
Fix trainer adapter save fallback

### DIFF
--- a/mlx_vlm/tests/test_trainer.py
+++ b/mlx_vlm/tests/test_trainer.py
@@ -223,6 +223,44 @@ class TestTrainer(unittest.TestCase):
         self.mock_optimizer.update.assert_called()
         mock_save_safetensors.assert_called()
 
+    @patch("mlx_vlm.trainer.sft_trainer.iterate_batches")
+    @patch("mlx_vlm.trainer.sft_trainer.mx.save_safetensors")
+    def test_train_uses_default_adapter_file_when_missing(
+        self, mock_save_safetensors, mock_iterate_batches
+    ):
+        mock_batch = {
+            "input_ids": mx.array([[1, 2, 3], [1, 2, 3], [1, 2, 3], [1, 2, 3]]),
+            "attention_mask": mx.array([[1, 1, 1], [1, 1, 1], [1, 1, 1], [1, 1, 1]]),
+            "pixel_values": mx.array(
+                [[[0.1, 0.2]], [[0.1, 0.2]], [[0.1, 0.2]], [[0.1, 0.2]]]
+            ),
+            "labels": mx.array([[0, 1, 2], [0, 1, 2], [0, 1, 2], [0, 1, 2]]),
+        }
+        mock_iterate_batches.return_value = iter([mock_batch])
+
+        train(
+            model=self.mock_model,
+            optimizer=self.mock_optimizer,
+            train_dataset=MagicMock(__len__=lambda self: 4),
+            val_dataset=None,
+            args=TrainingArgs(
+                iters=1,
+                batch_size=4,
+                steps_per_save=1,
+                adapter_file=None,
+            ),
+        )
+
+        saved_paths = [call.args[0] for call in mock_save_safetensors.call_args_list]
+        self.assertEqual(
+            saved_paths,
+            [
+                "adapters.safetensors",
+                "0000001_adapters.safetensors",
+                "adapters.safetensors",
+            ],
+        )
+
 
 class TestLoRaScaling(unittest.TestCase):
     """Verify LoRaLayer uses alpha/rank scaling (standard LoRA convention)."""

--- a/mlx_vlm/trainer/orpo_trainer.py
+++ b/mlx_vlm/trainer/orpo_trainer.py
@@ -3,7 +3,6 @@
 import time
 from dataclasses import dataclass, field
 from functools import partial
-from pathlib import Path
 
 import mlx.core as mx
 import mlx.nn as nn
@@ -12,7 +11,12 @@ from mlx.nn.utils import average_gradients
 from mlx.utils import tree_map
 from tqdm import tqdm
 
-from .sft_trainer import TrainingArgs, _collate_arrays, _squeeze_leading_batch_dim
+from .sft_trainer import (
+    TrainingArgs,
+    _collate_arrays,
+    _resolve_adapter_file,
+    _squeeze_leading_batch_dim,
+)
 from .utils import Colors, grad_checkpoint, save_adapter
 
 
@@ -330,6 +334,8 @@ def train_orpo(
             f"{Colors.OKBLUE}No validation dataset provided — training will run without validation.{Colors.ENDC}"
         )
 
+    adapter_file = _resolve_adapter_file(args)
+
     # Enable gradient checkpointing if requested
     if args.grad_checkpoint:
         if hasattr(model, "layers"):
@@ -471,20 +477,18 @@ def train_orpo(
 
         # Save checkpoint
         if it % args.steps_per_save == 0 and rank == 0:
-            save_adapter(model, args.adapter_file)
-            checkpoint = (
-                Path(args.adapter_file).parent / f"{it:07d}_adapters.safetensors"
-            )
+            save_adapter(model, adapter_file)
+            checkpoint = adapter_file.parent / f"{it:07d}_adapters.safetensors"
             save_adapter(model, checkpoint)
             print(
                 f"{Colors.OKBLUE}Iter {it}: Saved adapter weights to "
-                f"{args.adapter_file} and {checkpoint}.{Colors.ENDC}",
+                f"{adapter_file} and {checkpoint}.{Colors.ENDC}",
                 flush=True,
             )
 
     # Save final weights
     if rank == 0:
-        save_adapter(model, args.adapter_file)
+        save_adapter(model, adapter_file)
         print(
-            f"{Colors.OKGREEN}Saved final adapter weights to {args.adapter_file}.{Colors.ENDC}"
+            f"{Colors.OKGREEN}Saved final adapter weights to {adapter_file}.{Colors.ENDC}"
         )

--- a/mlx_vlm/trainer/sft_trainer.py
+++ b/mlx_vlm/trainer/sft_trainer.py
@@ -105,6 +105,18 @@ class TrainingArgs:
     )
 
 
+def _resolve_adapter_file(args: TrainingArgs) -> Path:
+    adapter_file = getattr(args, "adapter_file", None)
+    if adapter_file:
+        return Path(adapter_file)
+
+    adapter_path = getattr(args, "adapter_path", None)
+    if adapter_path:
+        return Path(adapter_path) / "adapters.safetensors"
+
+    return Path(TrainingArgs.__dataclass_fields__["adapter_file"].default)
+
+
 def vision_language_loss_fn(
     model, batch, train_on_completions=False, assistant_id=77091
 ):
@@ -355,6 +367,8 @@ def train(
             f"{Colors.OKBLUE}No validation dataset provided — training will run without validation.{Colors.ENDC}"
         )
 
+    adapter_file = _resolve_adapter_file(args)
+
     # Enable gradient checkpointing if requested
     if args.grad_checkpoint:
         for module in model.children().values():
@@ -499,20 +513,18 @@ def train(
 
         # Save checkpoint
         if it % args.steps_per_save == 0 and rank == 0:
-            save_adapter(model, args.adapter_file)
-            checkpoint = (
-                Path(args.adapter_file).parent / f"{it:07d}_adapters.safetensors"
-            )
+            save_adapter(model, adapter_file)
+            checkpoint = adapter_file.parent / f"{it:07d}_adapters.safetensors"
             save_adapter(model, checkpoint)
             print(
                 f"{Colors.OKBLUE}Iter {it}: Saved adapter weights to "
-                f"{args.adapter_file} and {checkpoint}.{Colors.ENDC}",
+                f"{adapter_file} and {checkpoint}.{Colors.ENDC}",
                 flush=True,
             )
 
     # Save final weights
     if rank == 0:
-        save_adapter(model, args.adapter_file)
+        save_adapter(model, adapter_file)
         print(
-            f"{Colors.OKGREEN}Saved final adapter weights to {args.adapter_file}.{Colors.ENDC}"
+            f"{Colors.OKGREEN}Saved final adapter weights to {adapter_file}.{Colors.ENDC}"
         )


### PR DESCRIPTION
## Summary
- Resolve a fallback adapter save path when trainer args provide `adapter_file=None`
- Apply the same resolved path to checkpoint and final saves in SFT and ORPO trainers
- Add a regression test for the SFT save path

Fixes #908.

## Validation
- `uv run --with pytest pytest mlx_vlm/tests/test_trainer.py -q`
- commit hooks: black, isort, autoflake