### PR TITLE
Move linear spec handling to model backends

### DIFF
--- a/mlx_vlm/generate/dispatch.py
+++ b/mlx_vlm/generate/dispatch.py
@@ -384,7 +384,7 @@ def parse_arguments():
         type=json.loads,
         default={},
         help="Extra generation kwargs as JSON. "
-        "Example: --gen-kwargs '{\"linear_speculative\": true}'",
+        "Example: --gen-kwargs '{\"custom_arg\": true}'",
     )
     parser.add_argument(
         "--prefill-step-size",
@@ -623,17 +623,9 @@ def _use_masked_diffusion_text_path(model: nn.Module, kwargs: Dict[str, Any]) ->
 
     generation_mode = kwargs.get("generation_mode")
     if generation_mode is not None:
-        return generation_mode in (
-            "diffusion",
-            "dlm",
-            "linear_speculative",
-            "linear_spec",
-        )
+        return generation_mode != "ar"
 
-    return bool(
-        kwargs.get("linear_speculative", False)
-        or kwargs.get("linear_speculation", False)
-    )
+    return False
 
 
 def _prime_cached_prefix_rope_state(
@@ -823,9 +815,6 @@ def stream_generate(
             "num_to_transfer",
             "max_transfer_per_step",
             "stability_steps",
-            "linear_speculative",
-            "linear_speculation",
-            "generation_mode",
         }
         model_generate_kwargs = {
             key: value
@@ -853,9 +842,6 @@ def stream_generate(
             tokenizer=tokenizer,
             skip_special_tokens=skip_special_tokens,
             stats=generation_stats,
-            linear_speculative=kwargs.get("linear_speculative", False)
-            or kwargs.get("linear_speculation", False)
-            or kwargs.get("generation_mode") in ("linear_speculative", "linear_spec"),
             **model_generate_kwargs,
         )
         mx.eval(generated)

--- a/mlx_vlm/models/llada2_moe/language.py
+++ b/mlx_vlm/models/llada2_moe/language.py
@@ -366,7 +366,15 @@ class LanguageModel(nn.Module):
         tokenizer: Optional[Any] = None,
         skip_special_tokens: bool = False,
         stats: Optional[Dict[str, float]] = None,
+        **kwargs,
     ) -> mx.array:
+        generation_mode = kwargs.pop("generation_mode", None)
+        if generation_mode in ("linear_speculative", "linear_spec") or kwargs.pop(
+            "linear_speculative", False
+        ):
+            raise ValueError(
+                "LLaDA2 MoE does not support linear_speculative generation."
+            )
         if inputs.shape[0] != 1:
             raise ValueError(
                 "LLaDA2 MoE diffusion generation currently supports batch size 1."

--- a/mlx_vlm/models/nemotron_labs_diffusion/README.md
+++ b/mlx_vlm/models/nemotron_labs_diffusion/README.md
@@ -36,7 +36,8 @@ mlx_vlm.generate \
 
 ### Diffusion generation
 
-Pass `generation_mode="diffusion"` to use the masked diffusion path.
+Pass `generation_mode="diffusion"` through `--gen-kwargs` to use the masked diffusion path.
+`generation_mode` is a model-specific generation kwarg interpreted by the Nemotron backend.
 Nemotron defaults to the upstream/Transformers transfer policy with a 32-step denoising cap and a 0.9 transfer threshold.
 This native mode also uses a Transformers-parity runtime for the denoise encoder.
 The upstream mode alias `generation_mode="dlm"` is also accepted.
@@ -59,7 +60,8 @@ mlx_vlm.generate \
 
 ### Linear self-speculative generation
 
-Use `--gen-kwargs` for model-specific generation options. The bundled `linear_spec_lora` adapter is loaded automatically when available.
+Use `--gen-kwargs` for model-specific generation options. `generation_mode="linear_speculative"` is passed through to the Nemotron backend, where it enables the linear self-speculative path.
+The bundled `linear_spec_lora` adapter is loaded automatically when available.
 The upstream mode alias `generation_mode="linear_spec"` is also accepted.
 
 ```sh
@@ -177,6 +179,6 @@ print(result.text)
 - Diffusion generation uses masked block denoising. `--verbose` shows the block visualization as masks are filled.
 - The default diffusion schedule uses 32 denoising steps and a 0.9 confidence threshold. Lower `--max-denoising-steps` for speed experiments, but quality can degrade quickly.
 - Diffusion generation records model-level stats such as `diffusion_denoise_nfe`, `diffusion_post_block_nfe`, and `diffusion_tokens_per_denoise_forward`. Use `head_scoring="chunked"` to profile the non-materializing confidence scorer.
-- Diffusion and linear self-speculative generation are exposed through `generation_mode`, for example `--gen-kwargs '{"generation_mode": "diffusion"}'`.
+- Diffusion and linear self-speculative generation are exposed through the model-specific `generation_mode` kwarg, for example `--gen-kwargs '{"generation_mode": "diffusion"}'`.
 - Upstream mode names are accepted as aliases: `dlm` for diffusion and `linear_spec` for linear self-speculation.
 - The optional `linear_spec_lora` adapter included in the Hugging Face repo is used only during the diffusion draft phase of linear self-speculation.

--- a/mlx_vlm/models/nemotron_labs_diffusion/language.py
+++ b/mlx_vlm/models/nemotron_labs_diffusion/language.py
@@ -1115,6 +1115,10 @@ class LanguageModel(nn.Module):
         linear_speculative: bool = False,
         **kwargs,
     ) -> mx.array:
+        generation_mode = kwargs.get("generation_mode")
+        if generation_mode in ("linear_speculative", "linear_spec"):
+            linear_speculative = True
+
         if inputs.shape[0] != 1:
             raise ValueError(
                 "Nemotron Labs Diffusion generation currently supports batch size 1."

--- a/mlx_vlm/tests/test_diffusion_models.py
+++ b/mlx_vlm/tests/test_diffusion_models.py
@@ -226,6 +226,56 @@ class TestDiffusionModels(unittest.TestCase):
 
         self.assertLessEqual(calls["count"], 6)
 
+    def test_llada_stream_generate_ignores_extra_cli_kwargs(self):
+        from mlx_vlm.models import llada2_moe
+
+        config = llada2_moe.ModelConfig(
+            model_type="llada2_moe",
+            vocab_size=128,
+            hidden_size=64,
+            intermediate_size=128,
+            num_hidden_layers=2,
+            num_attention_heads=4,
+            num_key_value_heads=2,
+            head_dim=16,
+            rotary_dim=8,
+            num_experts=None,
+            max_position_embeddings=128,
+            pad_token_id=3,
+            eos_token_id=3,
+            mask_token_id=127,
+        )
+        model = llada2_moe.Model(config)
+
+        results = list(
+            stream_generate(
+                model,
+                _Processor(),
+                prompt="ignored",
+                input_ids=mx.array([[4]], dtype=mx.int32),
+                max_tokens=2,
+                steps=1,
+                fps=2.0,
+                temperature=0.0,
+            )
+        )
+
+        self.assertEqual(results[-1].generation_tokens, 2)
+
+        with self.assertRaisesRegex(ValueError, "does not support linear_speculative"):
+            list(
+                stream_generate(
+                    model,
+                    _Processor(),
+                    prompt="ignored",
+                    input_ids=mx.array([[4]], dtype=mx.int32),
+                    max_tokens=2,
+                    generation_mode="diffusion",
+                    linear_speculative=True,
+                    temperature=0.0,
+                )
+            )
+
     def test_nemotron_labs_diffusion(self):
         from mlx_vlm.models import nemotron_labs_diffusion
         from mlx_vlm.models.nemotron_labs_diffusion.language import (
@@ -418,7 +468,7 @@ class TestDiffusionModels(unittest.TestCase):
             )
         )
         self.assertTrue(diffusion_calls["kwargs"])
-        self.assertFalse(diffusion_calls["kwargs"]["linear_speculative"])
+        self.assertNotIn("linear_speculative", diffusion_calls["kwargs"])
         self.assertEqual(diffusion_calls["kwargs"]["steps"], 32)
         self.assertEqual(diffusion_calls["kwargs"]["threshold"], 0.9)
         self.assertEqual(diffusion_calls["kwargs"]["sampler"], "native")
@@ -439,7 +489,7 @@ class TestDiffusionModels(unittest.TestCase):
             )
         )
         self.assertTrue(diffusion_calls["kwargs"])
-        self.assertFalse(diffusion_calls["kwargs"]["linear_speculative"])
+        self.assertNotIn("linear_speculative", diffusion_calls["kwargs"])
 
         linear_calls = {}
 
@@ -457,6 +507,7 @@ class TestDiffusionModels(unittest.TestCase):
                 input_ids=mx.array([[4]], dtype=mx.int32),
                 max_tokens=2,
                 generation_mode="linear_speculative",
+                linear_speculative=True,
                 temperature=0.0,
             )
         )
@@ -465,31 +516,3 @@ class TestDiffusionModels(unittest.TestCase):
         self.assertGreaterEqual(len(results), 1)
         self.assertEqual(results[-1].generation_tokens, 2)
         self.assertEqual(results[-1].finish_reason, "stop")
-
-        linear_calls.clear()
-        list(
-            stream_generate(
-                model,
-                _Processor(),
-                prompt="ignored",
-                input_ids=mx.array([[4]], dtype=mx.int32),
-                max_tokens=2,
-                generation_mode="linear_spec",
-                temperature=0.0,
-            )
-        )
-        self.assertTrue(linear_calls["kwargs"]["linear_speculative"])
-
-        linear_calls.clear()
-        list(
-            stream_generate(
-                model,
-                _Processor(),
-                prompt="ignored",
-                input_ids=mx.array([[4]], dtype=mx.int32),
-                max_tokens=2,
-                linear_speculation=True,
-                temperature=0.0,
-            )
-        )
-        self.assertTrue(linear_calls["kwargs"]["linear_speculative"])


### PR DESCRIPTION
## Summary
- remove linear-spec-specific handling from generation dispatch
- let masked diffusion model backends receive and interpret model-specific generation kwargs
- tolerate extra CLI passthrough kwargs for LLaDA while keeping unsupported linear-spec requests explicit

## Validation
- `uv run --frozen --with pytest pytest mlx_vlm/tests/test_diffusion_models.py -q`
- CLI smoke test with `inclusionAI/LLaDA2.1-mini`