### PR TITLE
Fix Gemma 4 MTP rollback crash when accepted is a list (#1260)

### DIFF
--- a/mlx_vlm/models/gemma4/language.py
+++ b/mlx_vlm/models/gemma4/language.py
@@ -642,6 +642,11 @@ class LanguageModel(nn.Module):
         del gdn_states  # API-parity placeholder; Gemma 4 has no SSM/GDN state.
         if isinstance(accepted, int):
             accepted = mx.array([accepted])
+        elif isinstance(accepted, (list, tuple)):
+            # The batched MTP path (speculative/mtp.py) passes ``accepted`` as a
+            # plain Python list, which has no ``.max()``. Convert so the
+            # mx-array ops below work, matching the qwen3_5 rollback hook.
+            accepted = mx.array(accepted)
 
         max_a = int(accepted.max().item())
         n = max_a + 1


### PR DESCRIPTION
## Summary

Fixes #1260.

The batched MTP speculative path in `speculative/mtp.py` passes the per-row accepted counts to `rollback_speculative_cache` as a plain Python list:

```python
lm.rollback_speculative_cache(
    prompt_cache, verify.gdn_states, accepted_list, bs
)
```

But `gemma4`'s hook only guarded the `int` case before calling `accepted.max()`, so a single non-streaming `/chat/completions` request with an MTP drafter (e.g. `mlx-community/gemma-4-e4b-it-4bit` + its `*-assistant-bf16` drafter) raises:

```
AttributeError: 'list' object has no attribute 'max'
```

## Fix

Convert `list`/`tuple` inputs to an `mx.array`, so the existing array ops (`.max()`, `.size`, `+ 1`, `.shape`) work. This mirrors the `qwen3_5` rollback hook, which already handles `int`, `mx.array`, and plain list inputs.

```python
if isinstance(accepted, int):
    accepted = mx.array([accepted])
elif isinstance(accepted, (list, tuple)):
    accepted = mx.array(accepted)
```

Minimal, additive change — no behavior change for the existing `int`/`mx.array` paths.