### PR TITLE
Add Ideogram 4 local prompt expansion support

### DIFF
--- a/mlx_vlm/generate/dispatch.py
+++ b/mlx_vlm/generate/dispatch.py
@@ -118,6 +118,15 @@ def parse_arguments():
         help="Classifier-free guidance for image generation/editing.",
     )
     parser.add_argument(
+        "--prompt-expansion-model",
+        type=str,
+        default=None,
+        help=(
+            "Text model path or Hugging Face repo used to expand plain image "
+            "prompts into Ideogram 4 JSON captions."
+        ),
+    )
+    parser.add_argument(
         "--adapter-path",
         type=str,
         default=None,

--- a/mlx_vlm/generate/image.py
+++ b/mlx_vlm/generate/image.py
@@ -606,6 +606,10 @@ def run_image_generation_cli(args: Any) -> None:
             else Path("outputs") / f"image-{seed}.png"
         )
         model = load_image_model(args.model, task="generate", **load_kwargs)
+        extra = dict(getattr(args, "gen_kwargs", {}) or {})
+        prompt_expansion_model = getattr(args, "prompt_expansion_model", None)
+        if prompt_expansion_model is not None:
+            extra["prompt_expansion_model"] = prompt_expansion_model
         request = ImageGenerationRequest(
             prompt=prompt,
             seed=seed,
@@ -613,7 +617,7 @@ def run_image_generation_cli(args: Any) -> None:
             width=width,
             height=height,
             guidance=args.guidance,
-            extra=dict(getattr(args, "gen_kwargs", {}) or {}),
+            extra=extra,
         )
         result = generate_image(
             model,

--- a/mlx_vlm/models/ideogram4/README.md
+++ b/mlx_vlm/models/ideogram4/README.md
@@ -25,6 +25,24 @@ pip install -U mlx-vlm
 Accept the Hugging Face gate before first use and make a token available through
 `HF_TOKEN` or `huggingface_hub` login.
 
+## Prompting
+
+Ideogram 4 was trained on structured JSON captions. Existing JSON object prompts
+are passed through unchanged, while ordinary text prompts are wrapped into a
+minimal JSON caption by default. Set `auto_json_caption=False` to pass raw plain
+text through without wrapping.
+
+For richer captions, `prompt_expansion_model` can use any compatible local
+mlx-vlm text/VLM model to expand an ordinary prompt into structured Ideogram 4
+JSON before image generation. This is a local mlx-vlm prompt expansion path,
+not Ideogram's hosted production Magic Prompt.
+
+If the expansion model returns a valid structured JSON caption, it is used as
+the Ideogram prompt and exposed as `revised_prompt`. If its output is not a
+valid structured caption, mlx-vlm falls back to the minimal JSON caption wrapper
+unless `auto_json_caption=False` is set. Model loading and inference errors are
+raised so configuration problems are not hidden.
+
 ## CLI
 
 ### Generate an image
@@ -57,6 +75,19 @@ default local preset, or `V4_TURBO_12` for a smaller smoke test. If `--seed` is
 omitted, a random 32-bit seed is used. If `--output` is omitted, the image is
 written to `outputs/image-{seed}.png`.
 
+### Expand a plain prompt locally
+
+```sh
+python -m mlx_vlm generate_image \
+  --model ideogram-ai/ideogram-4-fp8 \
+  --prompt "A cinematic photo of a glass teapot on a rainy London cafe table" \
+  --prompt-expansion-model mlx-community/gemma-4-12B-it-4bit \
+  --size 1024x1024 \
+  --seed 42 \
+  --output outputs/ideogram4-expanded.png \
+  --gen-kwargs '{"sampler_preset":"V4_DEFAULT_20"}'
+```
+
 ## Python
 
 ### Basic generation
@@ -85,6 +116,33 @@ array = result.array
 print(array.shape, array.dtype)
 
 result.save("outputs/ideogram4.png")
+```
+
+### Expand a plain prompt locally
+
+```python
+request = ImageGenerationRequest(
+    prompt="A cinematic photo of a glass teapot on a rainy London cafe table",
+    seed=0,
+    width=1024,
+    height=1024,
+    extra={
+        "sampler_preset": "V4_DEFAULT_20",
+        "prompt_expansion_model": "mlx-community/gemma-4-12B-it-4bit",
+    },
+)
+
+result = generate_image(model, request)
+print(result.metadata["revised_prompt"])
+```
+
+To pass raw plain text without JSON wrapping:
+
+```python
+request = ImageGenerationRequest(
+    prompt="A cinematic photo of a glass teapot on a rainy London cafe table",
+    extra={"auto_json_caption": False},
+)
 ```
 
 ### Prompt shorthand
@@ -150,10 +208,13 @@ curl http://localhost:8080/v1/images/generations \
 For local file output, set `"response_format": "path"` and optionally pass
 `"output_path"` or `"output_dir"`.
 
+The API also accepts the optional Ideogram 4 fields `auto_json_caption` and
+`prompt_expansion_model`. When a prompt is wrapped or expanded, the response
+includes the resulting JSON caption in `revised_prompt`.
+
 ## Notes
 
-- The runtime does not call external prompt-expansion or safety moderation
+- The runtime does not call external hosted prompt-expansion or safety moderation
   services.
 - Plain prompts are accepted, but structured JSON captions usually give better
   quality and control.
-  

--- a/mlx_vlm/models/ideogram4/pipeline.py
+++ b/mlx_vlm/models/ideogram4/pipeline.py
@@ -18,6 +18,8 @@ from .config import (
 )
 from .download import download_model, validate_model_layout
 from .latent_norm import get_latent_norm
+from .prompting import NormalizedPrompt
+from .prompting import prepare_prompt as prepare_ideogram_prompt
 from .scheduler import get_preset, get_schedule_for_resolution, make_step_intervals
 from .transformer import LLM_TOKEN_INDICATOR, OUTPUT_IMAGE_INDICATOR
 from .weights import PRECISION, load_text_encoder, load_transformer, load_vae
@@ -103,6 +105,25 @@ class Ideogram4ImagePipeline:
         )
         return Image.fromarray(np.array(array))
 
+    def prepare_prompt(
+        self,
+        prompt: str,
+        *,
+        auto_json_caption: bool = True,
+        prompt_expansion_model: str | None = None,
+        width: int | None = None,
+        height: int | None = None,
+        warn: bool = True,
+    ) -> NormalizedPrompt:
+        return prepare_ideogram_prompt(
+            prompt,
+            auto_json_caption=auto_json_caption,
+            prompt_expansion_model=prompt_expansion_model,
+            width=width,
+            height=height,
+            warn=warn,
+        )
+
     def generate_array(
         self,
         prompt: str,
@@ -115,8 +136,18 @@ class Ideogram4ImagePipeline:
         **kwargs: Any,
     ) -> tuple[mx.array, dict[str, Any]]:
         validate_dimensions(width=width, height=height)
-        if not prompt:
+        if not prompt.strip():
             raise ValueError("prompt must not be empty")
+
+        auto_json_value = kwargs.get("auto_json_caption", True)
+        auto_json_caption = True if auto_json_value is None else bool(auto_json_value)
+        prepared_prompt = self.prepare_prompt(
+            prompt,
+            auto_json_caption=auto_json_caption,
+            prompt_expansion_model=kwargs.get("prompt_expansion_model"),
+            width=width,
+            height=height,
+        )
 
         preset = get_preset(kwargs.get("sampler_preset"))
         num_steps = int(
@@ -141,7 +172,7 @@ class Ideogram4ImagePipeline:
 
         mu = float(kwargs.get("mu", preset.mu))
         std = float(kwargs.get("std", preset.std))
-        inputs = self._build_inputs(prompt, height=height, width=width)
+        inputs = self._build_inputs(prepared_prompt.text, height=height, width=width)
         llm_features = self._encode_text(
             inputs["text_token_ids"],
             num_image_tokens=inputs["num_image_tokens"],
@@ -224,6 +255,19 @@ class Ideogram4ImagePipeline:
             "prompt_tokens": int(inputs["num_text_tokens"]),
             "architecture": "single_stream_dit",
             "weight_load": "fp8_dequantized_to_bf16",
+            "auto_json_caption": auto_json_caption,
+            "prompt_was_wrapped": prepared_prompt.was_wrapped,
+            "prompt_is_json_caption": prepared_prompt.is_json_caption,
+            "prompt_is_structured_caption": prepared_prompt.is_structured_caption,
+            "prompt_warnings": list(prepared_prompt.warnings),
+            "revised_prompt": (
+                prepared_prompt.text
+                if prepared_prompt.was_wrapped or prepared_prompt.prompt_expansion_used
+                else None
+            ),
+            "prompt_expansion_model": prepared_prompt.prompt_expansion_model,
+            "prompt_expansion_used": prepared_prompt.prompt_expansion_used,
+            "prompt_expansion_error": prepared_prompt.prompt_expansion_error,
         }
 
     def _ensure_text_encoder(self) -> None:

--- a/mlx_vlm/models/ideogram4/prompting.py
+++ b/mlx_vlm/models/ideogram4/prompting.py
@@ -1,0 +1,513 @@
+from __future__ import annotations
+
+import json
+import re
+import warnings
+from collections.abc import Mapping
+from dataclasses import dataclass
+from math import gcd
+from typing import Any
+
+_HEX_COLOR_RE = re.compile(r"^#[0-9A-F]{6}$")
+
+_COLOR_PALETTE_SCHEMA = {
+    "type": "array",
+    "items": {"type": "string", "pattern": r"^#[0-9A-F]{6}$"},
+}
+_BBOX_SCHEMA = {
+    "type": "array",
+    "items": {"type": "integer", "minimum": 0, "maximum": 1000},
+    "minItems": 4,
+    "maxItems": 4,
+}
+_OBJECT_ELEMENT_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "type": {"type": "string", "enum": ["obj"]},
+        "bbox": _BBOX_SCHEMA,
+        "desc": {"type": "string", "minLength": 1},
+        "color_palette": {**_COLOR_PALETTE_SCHEMA, "maxItems": 5},
+    },
+    "required": ["type", "desc"],
+    "additionalProperties": False,
+}
+_TEXT_ELEMENT_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "type": {"type": "string", "enum": ["text"]},
+        "bbox": _BBOX_SCHEMA,
+        "text": {"type": "string"},
+        "desc": {"type": "string", "minLength": 1},
+        "color_palette": {**_COLOR_PALETTE_SCHEMA, "maxItems": 5},
+    },
+    "required": ["type", "text", "desc"],
+    "additionalProperties": False,
+}
+_PHOTO_STYLE_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "aesthetics": {"type": "string", "minLength": 1},
+        "lighting": {"type": "string", "minLength": 1},
+        "photo": {"type": "string", "minLength": 1},
+        "medium": {"type": "string", "minLength": 1},
+        "color_palette": {**_COLOR_PALETTE_SCHEMA, "maxItems": 16},
+    },
+    "required": ["aesthetics", "lighting", "photo", "medium"],
+    "additionalProperties": False,
+}
+_ART_STYLE_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "aesthetics": {"type": "string", "minLength": 1},
+        "lighting": {"type": "string", "minLength": 1},
+        "medium": {"type": "string", "minLength": 1},
+        "art_style": {"type": "string", "minLength": 1},
+        "color_palette": {**_COLOR_PALETTE_SCHEMA, "maxItems": 16},
+    },
+    "required": ["aesthetics", "lighting", "medium", "art_style"],
+    "additionalProperties": False,
+}
+IDEOGRAM4_CAPTION_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "high_level_description": {"type": "string", "minLength": 1},
+        "style_description": {"anyOf": [_PHOTO_STYLE_SCHEMA, _ART_STYLE_SCHEMA]},
+        "compositional_deconstruction": {
+            "type": "object",
+            "properties": {
+                "background": {"type": "string", "minLength": 1},
+                "elements": {
+                    "type": "array",
+                    "items": {"anyOf": [_OBJECT_ELEMENT_SCHEMA, _TEXT_ELEMENT_SCHEMA]},
+                },
+            },
+            "required": ["background", "elements"],
+            "additionalProperties": False,
+        },
+    },
+    "required": ["compositional_deconstruction"],
+    "additionalProperties": False,
+}
+
+
+@dataclass(frozen=True, slots=True)
+class NormalizedPrompt:
+    text: str
+    is_json_caption: bool
+    is_structured_caption: bool
+    was_wrapped: bool
+    warnings: tuple[str, ...] = ()
+    prompt_expansion_model: str | None = None
+    prompt_expansion_used: bool = False
+    prompt_expansion_error: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class PromptExpansionResult:
+    text: str
+    raw_text: str
+    model: str
+
+
+class PromptExpansionCaptionError(ValueError):
+    pass
+
+
+def format_caption(caption: Mapping[str, Any]) -> str:
+    return json.dumps(caption, separators=(",", ":"), ensure_ascii=False)
+
+
+def is_structured_caption(prompt: str) -> bool:
+    caption = _parse_json_caption(prompt)
+    if caption is None:
+        return False
+    return not _caption_warnings(caption)
+
+
+def normalize_prompt(
+    prompt: str,
+    *,
+    auto_json_caption: bool = True,
+    warn: bool = True,
+) -> NormalizedPrompt:
+    stripped = prompt.strip()
+    if _looks_like_json_object(stripped):
+        caption = _loads_json_caption(stripped)
+        issues = tuple(_caption_warnings(caption))
+        if warn:
+            for issue in issues:
+                warnings.warn(issue, stacklevel=2)
+        return NormalizedPrompt(
+            text=prompt,
+            is_json_caption=True,
+            is_structured_caption=not issues,
+            was_wrapped=False,
+            warnings=issues,
+        )
+    if not auto_json_caption:
+        return NormalizedPrompt(
+            text=prompt,
+            is_json_caption=False,
+            is_structured_caption=False,
+            was_wrapped=False,
+        )
+    return NormalizedPrompt(
+        text=format_caption(_minimal_caption(stripped)),
+        is_json_caption=True,
+        is_structured_caption=True,
+        was_wrapped=True,
+    )
+
+
+def prepare_prompt(
+    prompt: str,
+    *,
+    auto_json_caption: bool = True,
+    prompt_expansion_model: str | None = None,
+    width: int | None = None,
+    height: int | None = None,
+    warn: bool = True,
+) -> NormalizedPrompt:
+    stripped = prompt.strip()
+    if _looks_like_json_object(stripped) or prompt_expansion_model is None:
+        return normalize_prompt(
+            prompt,
+            auto_json_caption=auto_json_caption,
+            warn=warn,
+        )
+
+    try:
+        expansion = generate_prompt_expansion_caption(
+            stripped,
+            model=prompt_expansion_model,
+            aspect_ratio=_aspect_ratio_from_size(width, height),
+        )
+        prepared = normalize_prompt(
+            expansion.text,
+            auto_json_caption=False,
+            warn=warn,
+        )
+        return NormalizedPrompt(
+            text=prepared.text,
+            is_json_caption=prepared.is_json_caption,
+            is_structured_caption=prepared.is_structured_caption,
+            was_wrapped=False,
+            warnings=prepared.warnings,
+            prompt_expansion_model=expansion.model,
+            prompt_expansion_used=True,
+        )
+    except PromptExpansionCaptionError as exc:
+        if not auto_json_caption:
+            raise ValueError("Prompt expansion failed") from exc
+        if warn:
+            warnings.warn(
+                "Prompt expansion failed; falling back to the minimal "
+                f"Ideogram 4 JSON caption wrapper. {exc}",
+                stacklevel=2,
+            )
+        fallback = normalize_prompt(
+            prompt,
+            auto_json_caption=True,
+            warn=warn,
+        )
+        return NormalizedPrompt(
+            text=fallback.text,
+            is_json_caption=fallback.is_json_caption,
+            is_structured_caption=fallback.is_structured_caption,
+            was_wrapped=fallback.was_wrapped,
+            warnings=fallback.warnings,
+            prompt_expansion_model=str(prompt_expansion_model),
+            prompt_expansion_used=False,
+            prompt_expansion_error=str(exc),
+        )
+
+
+def generate_prompt_expansion_caption(
+    prompt: str,
+    *,
+    model: str,
+    aspect_ratio: str | None = None,
+) -> PromptExpansionResult:
+    import gc
+
+    import mlx.core as mx
+
+    from ...generate.dispatch import generate
+    from ...prompt_utils import apply_chat_template
+    from ...structured import build_json_schema_logits_processor
+    from ...utils import load
+
+    model_obj = None
+    processor = None
+    try:
+        model_obj, processor = load(model)
+        messages = [
+            {"role": "system", "content": PROMPT_EXPANSION_SYSTEM_PROMPT},
+            {
+                "role": "user",
+                "content": _prompt_expansion_user_prompt(prompt, aspect_ratio),
+            },
+        ]
+        formatted_prompt = apply_chat_template(
+            processor,
+            model_obj.config,
+            messages,
+        )
+        tokenizer = (
+            processor.tokenizer if hasattr(processor, "tokenizer") else processor
+        )
+        logits_processor = build_json_schema_logits_processor(
+            tokenizer,
+            IDEOGRAM4_CAPTION_SCHEMA,
+        )
+        result = generate(
+            model_obj,
+            processor,
+            formatted_prompt,
+            logits_processors=[logits_processor],
+            verbose=False,
+            skip_special_tokens=True,
+        )
+        raw_text = result.text.strip()
+        return PromptExpansionResult(
+            text=format_caption(_load_prompt_expansion_caption(raw_text)),
+            raw_text=raw_text,
+            model=str(model),
+        )
+    finally:
+        del model_obj, processor
+        gc.collect()
+        mx.clear_cache()
+
+
+PROMPT_EXPANSION_SYSTEM_PROMPT = """\
+You prepare structured JSON captions for Ideogram 4 image generation. Return
+only JSON matching the provided schema. Preserve the user's intent, requested
+wording, and constraints while making the visual description more specific and
+useful to the image model.
+
+Always include a concrete high_level_description and
+compositional_deconstruction. Write descriptions as observations of the desired
+image, never as commands or as a copy of the user's request. The background must
+describe the actual scene, not a generic placeholder.
+
+Use one obj element for each explicitly named visual subject. Use one text
+element for every quoted string or other visible wording the user requests.
+Copy each text field verbatim, including capitalization, punctuation, line
+breaks, and non-ASCII characters. Do not hide requested lettering inside an obj
+description.
+
+Bounding boxes are optional. Include them only when useful for layout, using
+integer normalized [0, 1000] coordinates as [y_min, x_min, y_max, x_max] with
+y_min < y_max and x_min < x_max. If style_description is included, use exactly
+one of photo or art_style. Use only uppercase #RRGGBB values in color palettes.
+"""
+
+
+def _prompt_expansion_user_prompt(prompt: str, aspect_ratio: str | None) -> str:
+    aspect = (
+        f"\nTarget aspect ratio: {aspect_ratio}. Use it only to plan the "
+        "composition; do not add an aspect_ratio field."
+        if aspect_ratio
+        else ""
+    )
+    return f"Convert this prompt into an Ideogram 4 JSON caption:{aspect}\n{prompt}"
+
+
+def _aspect_ratio_from_size(width: int | None, height: int | None) -> str | None:
+    if not width or not height:
+        return None
+    divisor = gcd(int(width), int(height))
+    return f"{int(width) // divisor}:{int(height) // divisor}"
+
+
+def _looks_like_json_object(prompt: str) -> bool:
+    return prompt.startswith("{")
+
+
+def _parse_json_caption(prompt: str) -> dict[str, Any] | None:
+    stripped = prompt.strip()
+    if not _looks_like_json_object(stripped):
+        return None
+    try:
+        return _loads_json_caption(stripped)
+    except ValueError:
+        return None
+
+
+def _loads_json_caption(prompt: str) -> dict[str, Any]:
+    try:
+        value = json.loads(prompt)
+    except json.JSONDecodeError as exc:
+        raise ValueError("Invalid Ideogram 4 JSON caption") from exc
+    if not isinstance(value, dict):
+        raise ValueError("Ideogram 4 JSON caption must be an object")
+    return value
+
+
+def _load_prompt_expansion_caption(text: str) -> dict[str, Any]:
+    try:
+        value = json.loads(text)
+    except json.JSONDecodeError as exc:
+        raise PromptExpansionCaptionError(
+            "Prompt expansion model did not return valid JSON"
+        ) from exc
+    if not isinstance(value, dict):
+        raise PromptExpansionCaptionError(
+            "Prompt expansion model did not return a JSON object"
+        )
+    issues = _caption_warnings(value)
+    if issues:
+        raise PromptExpansionCaptionError(
+            f"Prompt expansion model returned an invalid caption: {issues[0]}"
+        )
+    return value
+
+
+def _minimal_caption(prompt: str) -> dict[str, Any]:
+    return {
+        "high_level_description": prompt,
+        "compositional_deconstruction": {
+            "background": (
+                "The setting, environment, and surrounding context implied by "
+                "the prompt."
+            ),
+            "elements": [{"type": "obj", "desc": prompt}],
+        },
+    }
+
+
+def _caption_warnings(caption: Mapping[str, Any]) -> list[str]:
+    issues: list[str] = []
+    compositional = caption.get("compositional_deconstruction")
+    if not isinstance(compositional, Mapping):
+        issues.append(
+            "Ideogram 4 JSON caption should include a "
+            "'compositional_deconstruction' object."
+        )
+    else:
+        if not _is_non_empty_string(compositional.get("background")):
+            issues.append(
+                "Ideogram 4 JSON caption should include "
+                "'compositional_deconstruction.background' as a non-empty string."
+            )
+        elements = compositional.get("elements")
+        if not isinstance(elements, list):
+            issues.append(
+                "Ideogram 4 JSON caption should include "
+                "'compositional_deconstruction.elements' as a list."
+            )
+        else:
+            for idx, element in enumerate(elements):
+                issues.extend(_element_warnings(element, idx))
+
+    style = caption.get("style_description")
+    if isinstance(style, Mapping):
+        has_photo = "photo" in style
+        has_art_style = "art_style" in style
+        if has_photo == has_art_style:
+            issues.append(
+                "Ideogram 4 JSON caption 'style_description' should include "
+                "exactly one of 'photo' or 'art_style'."
+            )
+        required = ("aesthetics", "lighting", "medium")
+        for key in required:
+            if not _is_non_empty_string(style.get(key)):
+                issues.append(
+                    "Ideogram 4 JSON caption 'style_description' should include "
+                    f"'{key}' as a non-empty string."
+                )
+        if has_photo and not _is_non_empty_string(style.get("photo")):
+            issues.append(
+                "Ideogram 4 JSON caption 'style_description.photo' should be "
+                "a non-empty string."
+            )
+        if has_art_style and not _is_non_empty_string(style.get("art_style")):
+            issues.append(
+                "Ideogram 4 JSON caption 'style_description.art_style' should be "
+                "a non-empty string."
+            )
+    elif style is not None:
+        issues.append(
+            "Ideogram 4 JSON caption 'style_description' should be an object."
+        )
+
+    issues.extend(_color_palette_warnings(caption))
+    return issues
+
+
+def _element_warnings(value: Any, idx: int) -> list[str]:
+    path = f"compositional_deconstruction.elements[{idx}]"
+    if not isinstance(value, Mapping):
+        return [f"Ideogram 4 JSON caption '{path}' should be an object."]
+
+    issues: list[str] = []
+    element_type = value.get("type")
+    if element_type not in {"obj", "text"}:
+        issues.append(
+            f"Ideogram 4 JSON caption '{path}.type' should be 'obj' or 'text'."
+        )
+    if not _is_non_empty_string(value.get("desc")):
+        issues.append(
+            f"Ideogram 4 JSON caption '{path}.desc' should be a non-empty string."
+        )
+    if element_type == "text" and not isinstance(value.get("text"), str):
+        issues.append(f"Ideogram 4 JSON caption '{path}.text' should be a string.")
+    if "bbox" in value:
+        issues.extend(_bbox_warnings(value["bbox"], f"{path}.bbox"))
+    return issues
+
+
+def _bbox_warnings(value: Any, path: str) -> list[str]:
+    if not isinstance(value, list) or len(value) != 4:
+        return [
+            f"Ideogram 4 JSON caption '{path}' should contain four integer "
+            "coordinates."
+        ]
+    if any(
+        isinstance(item, bool) or not isinstance(item, int) or not 0 <= item <= 1000
+        for item in value
+    ):
+        return [
+            f"Ideogram 4 JSON caption '{path}' coordinates should be integers "
+            "between 0 and 1000."
+        ]
+    y_min, x_min, y_max, x_max = value
+    if y_min >= y_max or x_min >= x_max:
+        return [
+            f"Ideogram 4 JSON caption '{path}' should satisfy y_min < y_max and "
+            "x_min < x_max."
+        ]
+    return []
+
+
+def _is_non_empty_string(value: Any) -> bool:
+    return isinstance(value, str) and bool(value.strip())
+
+
+def _color_palette_warnings(value: Any, path: str = "$") -> list[str]:
+    issues: list[str] = []
+    if isinstance(value, Mapping):
+        for key, nested in value.items():
+            nested_path = f"{path}.{key}"
+            if key == "color_palette":
+                issues.extend(_validate_color_palette(nested, nested_path))
+            else:
+                issues.extend(_color_palette_warnings(nested, nested_path))
+    elif isinstance(value, list):
+        for idx, nested in enumerate(value):
+            issues.extend(_color_palette_warnings(nested, f"{path}[{idx}]"))
+    return issues
+
+
+def _validate_color_palette(value: Any, path: str) -> list[str]:
+    if not isinstance(value, list):
+        return [f"Ideogram 4 JSON caption '{path}' should be a list of hex colors."]
+    issues = []
+    for idx, color in enumerate(value):
+        if not isinstance(color, str) or _HEX_COLOR_RE.fullmatch(color) is None:
+            issues.append(
+                "Ideogram 4 JSON caption "
+                f"'{path}[{idx}]' should be an uppercase #RRGGBB hex color."
+            )
+    return issues

--- a/mlx_vlm/server/openai.py
+++ b/mlx_vlm/server/openai.py
@@ -375,6 +375,13 @@ async def images_generations_endpoint(request: Request):
                         count=image_request.n,
                         seed=seed,
                     )
+                    extra = {}
+                    if image_request.auto_json_caption is not None:
+                        extra["auto_json_caption"] = image_request.auto_json_caption
+                    if image_request.prompt_expansion_model is not None:
+                        extra["prompt_expansion_model"] = (
+                            image_request.prompt_expansion_model
+                        )
                     core_request = CoreImageGenerationRequest(
                         prompt=image_request.prompt,
                         seed=seed,
@@ -383,6 +390,7 @@ async def images_generations_endpoint(request: Request):
                         height=height,
                         guidance=image_request.guidance,
                         output_format=image_request.output_format,
+                        extra=extra,
                     )
                     result = generate_image(
                         model,
@@ -400,6 +408,7 @@ async def images_generations_endpoint(request: Request):
                 height=result.height,
                 seed=result.seed,
                 path=str(result.path) if result.path is not None else None,
+                revised_prompt=result.metadata.get("revised_prompt"),
             )
             if image_request.response_format == "b64_json":
                 item.b64_json = result.to_b64_json()

--- a/mlx_vlm/server/schemas.py
+++ b/mlx_vlm/server/schemas.py
@@ -61,6 +61,17 @@ class ImageGenerationRequest(FlexibleBaseModel):
         DEFAULT_IMAGE_GUIDANCE,
         description="Classifier-free guidance scale.",
     )
+    auto_json_caption: Optional[bool] = Field(
+        None,
+        description="For Ideogram 4, wrap plain prompts into JSON captions.",
+    )
+    prompt_expansion_model: Optional[str] = Field(
+        None,
+        description=(
+            "Text model path or Hugging Face repo used to expand plain "
+            "Ideogram 4 prompts into structured JSON captions."
+        ),
+    )
     response_format: Literal["b64_json", "path"] = Field(
         "b64_json",
         description="Return base64 PNG data or write files and return local paths.",

--- a/mlx_vlm/tests/test_ideogram4.py
+++ b/mlx_vlm/tests/test_ideogram4.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib
+import json
 from argparse import Namespace
 from pathlib import Path
 from types import SimpleNamespace
@@ -23,7 +24,20 @@ from mlx_vlm.models.ideogram4.config import (
 )
 from mlx_vlm.models.ideogram4.download import validate_model_layout
 from mlx_vlm.models.ideogram4.model import Ideogram4ImageGenerationModel
-from mlx_vlm.models.ideogram4.pipeline import Ideogram4ImagePipeline
+from mlx_vlm.models.ideogram4.pipeline import (
+    Ideogram4ImagePipeline,
+    Ideogram4RuntimeConfig,
+)
+from mlx_vlm.models.ideogram4.prompting import (
+    IDEOGRAM4_CAPTION_SCHEMA,
+    NormalizedPrompt,
+    PromptExpansionCaptionError,
+    PromptExpansionResult,
+    format_caption,
+    is_structured_caption,
+    normalize_prompt,
+    prepare_prompt,
+)
 from mlx_vlm.models.ideogram4.scheduler import get_preset, make_step_intervals
 from mlx_vlm.models.ideogram4.transformer import (
     LLM_TOKEN_INDICATOR,
@@ -33,6 +47,27 @@ from mlx_vlm.models.ideogram4.transformer import (
 from mlx_vlm.models.ideogram4.weights import dequantize_fp8_weight_only
 
 image_module = importlib.import_module("mlx_vlm.generate.image")
+dispatch_module = importlib.import_module("mlx_vlm.generate.dispatch")
+prompt_utils_module = importlib.import_module("mlx_vlm.prompt_utils")
+prompting_module = importlib.import_module("mlx_vlm.models.ideogram4.prompting")
+structured_module = importlib.import_module("mlx_vlm.structured")
+utils_module = importlib.import_module("mlx_vlm.utils")
+
+EXPANDED_CAPTION = format_caption(
+    {
+        "high_level_description": "A detailed photo of a red cube.",
+        "style_description": {
+            "aesthetics": "minimal product photography",
+            "lighting": "soft studio lighting",
+            "photo": "close-up product photo",
+            "medium": "photograph",
+        },
+        "compositional_deconstruction": {
+            "background": "A quiet studio with a matte grey backdrop.",
+            "elements": [{"type": "obj", "desc": "A translucent red glass cube."}],
+        },
+    }
+)
 
 
 def _write_layout(root: Path) -> None:
@@ -98,6 +133,228 @@ def test_ideogram4_validate_model_layout_reports_missing_files(tmp_path: Path) -
         validate_model_layout(tmp_path)
 
 
+def test_ideogram4_caption_schema_matches_prompting_contract() -> None:
+    properties = IDEOGRAM4_CAPTION_SCHEMA["properties"]
+    composition = properties["compositional_deconstruction"]
+    elements = composition["properties"]["elements"]["items"]["anyOf"]
+    object_element, text_element = elements
+    style_variants = properties["style_description"]["anyOf"]
+    photo_style, art_style = style_variants
+
+    assert IDEOGRAM4_CAPTION_SCHEMA["required"] == ["compositional_deconstruction"]
+    assert composition["required"] == ["background", "elements"]
+    assert object_element["required"] == ["type", "desc"]
+    assert text_element["required"] == ["type", "text", "desc"]
+    assert object_element["properties"]["bbox"]["minItems"] == 4
+    assert object_element["properties"]["bbox"]["maxItems"] == 4
+    assert "photo" in photo_style["properties"]
+    assert "art_style" not in photo_style["properties"]
+    assert "art_style" in art_style["properties"]
+    assert "photo" not in art_style["properties"]
+
+
+def test_ideogram4_plain_prompt_wraps_as_minimal_json_caption() -> None:
+    prepared = normalize_prompt("A red cube on a marble plinth.", warn=False)
+    caption = json.loads(prepared.text)
+
+    assert prepared.was_wrapped
+    assert prepared.is_json_caption
+    assert prepared.is_structured_caption
+    assert caption["high_level_description"] == "A red cube on a marble plinth."
+    assert caption["compositional_deconstruction"]["elements"] == [
+        {"type": "obj", "desc": "A red cube on a marble plinth."}
+    ]
+    assert is_structured_caption(prepared.text)
+
+
+def test_ideogram4_json_caption_passes_through_unchanged() -> None:
+    prepared = normalize_prompt(EXPANDED_CAPTION, warn=False)
+
+    assert prepared.text == EXPANDED_CAPTION
+    assert not prepared.was_wrapped
+    assert prepared.is_json_caption
+    assert prepared.is_structured_caption
+
+
+def test_ideogram4_caption_warnings_cover_elements_and_bounding_boxes() -> None:
+    prompt = format_caption(
+        {
+            "compositional_deconstruction": {
+                "background": "A studio.",
+                "elements": [
+                    {
+                        "type": "text",
+                        "desc": "A title.",
+                        "bbox": [900, 100, 100, 800],
+                    }
+                ],
+            }
+        }
+    )
+
+    with pytest.warns(UserWarning) as records:
+        prepared = normalize_prompt(prompt)
+
+    messages = [str(record.message) for record in records]
+    assert not prepared.is_structured_caption
+    assert any(".text" in message for message in messages)
+    assert any("y_min < y_max" in message for message in messages)
+
+
+def test_ideogram4_prompt_expansion_uses_structured_generation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    tokenizer = object()
+    processor = SimpleNamespace(tokenizer=tokenizer)
+    model = SimpleNamespace(config={})
+    logits_processor = object()
+    observed: dict[str, object] = {}
+
+    def fake_load(model_id: str):
+        assert model_id == "tiny-text-model"
+        return model, processor
+
+    def fake_apply_chat_template(received_processor, config, messages):
+        assert received_processor is processor
+        assert config == {}
+        observed["messages"] = messages
+        return "formatted prompt"
+
+    def fake_build_json_schema_logits_processor(received_tokenizer, schema):
+        assert received_tokenizer is tokenizer
+        assert schema is IDEOGRAM4_CAPTION_SCHEMA
+        return logits_processor
+
+    def fake_generate(received_model, received_processor, prompt, **kwargs):
+        assert received_model is model
+        assert received_processor is processor
+        assert prompt == "formatted prompt"
+        assert kwargs["logits_processors"] == [logits_processor]
+        return SimpleNamespace(text=EXPANDED_CAPTION)
+
+    monkeypatch.setattr(utils_module, "load", fake_load)
+    monkeypatch.setattr(
+        prompt_utils_module, "apply_chat_template", fake_apply_chat_template
+    )
+    monkeypatch.setattr(
+        structured_module,
+        "build_json_schema_logits_processor",
+        fake_build_json_schema_logits_processor,
+    )
+    monkeypatch.setattr(dispatch_module, "generate", fake_generate)
+
+    result = prompting_module.generate_prompt_expansion_caption(
+        "A red cube.",
+        model="tiny-text-model",
+        aspect_ratio="1:1",
+    )
+
+    messages = observed["messages"]
+    assert isinstance(messages, list)
+    assert "visible wording" in messages[0]["content"]
+    assert "do not add an aspect_ratio field" in messages[1]["content"]
+    assert result.text == EXPANDED_CAPTION
+    assert result.model == "tiny-text-model"
+
+
+def test_ideogram4_prompt_expansion_model_expands_plain_prompt(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fake_prompt_expansion(prompt: str, **kwargs):
+        assert prompt == "A red cube."
+        assert kwargs["model"] == "tiny-text-model"
+        assert kwargs["aspect_ratio"] == "1:1"
+        return PromptExpansionResult(
+            text=EXPANDED_CAPTION,
+            raw_text=EXPANDED_CAPTION,
+            model=kwargs["model"],
+        )
+
+    monkeypatch.setattr(
+        prompting_module,
+        "generate_prompt_expansion_caption",
+        fake_prompt_expansion,
+    )
+
+    prepared = prepare_prompt(
+        "A red cube.",
+        prompt_expansion_model="tiny-text-model",
+        width=1024,
+        height=1024,
+        warn=False,
+    )
+
+    assert prepared.text == EXPANDED_CAPTION
+    assert prepared.prompt_expansion_model == "tiny-text-model"
+    assert prepared.prompt_expansion_used
+    assert not prepared.was_wrapped
+
+
+def test_ideogram4_json_caption_skips_prompt_expansion_model(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def unexpected_prompt_expansion(*args, **kwargs):  # noqa: ARG001
+        raise AssertionError("prompt expansion model should not be called")
+
+    monkeypatch.setattr(
+        prompting_module,
+        "generate_prompt_expansion_caption",
+        unexpected_prompt_expansion,
+    )
+
+    prepared = prepare_prompt(
+        EXPANDED_CAPTION,
+        prompt_expansion_model="tiny-text-model",
+        warn=False,
+    )
+
+    assert prepared.text == EXPANDED_CAPTION
+    assert not prepared.prompt_expansion_used
+    assert not prepared.was_wrapped
+
+
+def test_ideogram4_invalid_prompt_expansion_falls_back_to_minimal_caption(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fake_prompt_expansion(*args, **kwargs):  # noqa: ARG001
+        raise PromptExpansionCaptionError("bad json")
+
+    monkeypatch.setattr(
+        prompting_module,
+        "generate_prompt_expansion_caption",
+        fake_prompt_expansion,
+    )
+
+    with pytest.warns(UserWarning, match="falling back"):
+        prepared = prepare_prompt(
+            "A red cube.",
+            prompt_expansion_model="bad-model",
+        )
+
+    assert prepared.was_wrapped
+    assert not prepared.prompt_expansion_used
+    assert prepared.prompt_expansion_error == "bad json"
+
+
+def test_ideogram4_prompt_expansion_runtime_failure_is_not_hidden(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fake_prompt_expansion(*args, **kwargs):  # noqa: ARG001
+        raise RuntimeError("model failed to load")
+
+    monkeypatch.setattr(
+        prompting_module,
+        "generate_prompt_expansion_caption",
+        fake_prompt_expansion,
+    )
+
+    with pytest.raises(RuntimeError, match="model failed to load"):
+        prepare_prompt(
+            "A red cube.",
+            prompt_expansion_model="bad-model",
+        )
+
+
 @pytest.mark.parametrize("width,height", [(255, 512), (512, 2050), (2048, 256)])
 def test_ideogram4_validate_dimensions_rejects_bad_sizes(
     width: int, height: int
@@ -158,6 +415,78 @@ def test_ideogram4_build_inputs_packs_text_and_image_tokens() -> None:
     assert inputs["position_ids"].shape == (1, 3 + 16 * 16, 3)
     assert int(inputs["indicator"][0, 0].item()) == LLM_TOKEN_INDICATOR
     assert int(inputs["indicator"][0, -1].item()) == OUTPUT_IMAGE_INDICATOR
+
+
+def test_ideogram4_pipeline_uses_prepared_prompt_and_reports_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    pipeline = Ideogram4ImagePipeline.__new__(Ideogram4ImagePipeline)
+    pipeline.model_path = Path("/tmp/fake-ideogram")
+    pipeline.runtime_config = Ideogram4RuntimeConfig(
+        evict_text_encoder=False,
+        evict_transformers=False,
+    )
+    pipeline.text_encoder = object()
+    pipeline.conditional_transformer = lambda **kwargs: mx.zeros_like(kwargs["x"])
+    pipeline.unconditional_transformer = lambda **kwargs: mx.zeros_like(kwargs["x"])
+    pipeline.vae = object()
+    captured: dict[str, object] = {}
+
+    def fake_prepare_prompt(prompt: str, **kwargs):
+        assert prompt == "plain prompt"
+        assert kwargs["prompt_expansion_model"] == "tiny-text-model"
+        captured["prepare_kwargs"] = kwargs
+        return NormalizedPrompt(
+            text=EXPANDED_CAPTION,
+            is_json_caption=True,
+            is_structured_caption=True,
+            was_wrapped=False,
+            prompt_expansion_model="tiny-text-model",
+            prompt_expansion_used=True,
+        )
+
+    def fake_build_inputs(prompt: str, **kwargs):
+        captured["tokenized_prompt"] = prompt
+        return {
+            "text_token_ids": mx.array([[1]], dtype=mx.int32),
+            "position_ids": mx.zeros((1, 2, 3), dtype=mx.int32),
+            "segment_ids": mx.ones((1, 2), dtype=mx.int32),
+            "indicator": mx.ones((1, 2), dtype=mx.int32),
+            "num_text_tokens": 1,
+            "num_image_tokens": 1,
+            "grid_h": 1,
+            "grid_w": 1,
+        }
+
+    monkeypatch.setattr(pipeline, "prepare_prompt", fake_prepare_prompt)
+    monkeypatch.setattr(pipeline, "_build_inputs", fake_build_inputs)
+    monkeypatch.setattr(
+        pipeline,
+        "_encode_text",
+        lambda token_ids, num_image_tokens: mx.zeros((1, 2, 4)),
+    )
+    monkeypatch.setattr(pipeline, "_ensure_transformers_and_vae", lambda: None)
+    monkeypatch.setattr(
+        pipeline,
+        "_decode",
+        lambda z, grid_h, grid_w: mx.zeros((16, 16, 3), dtype=mx.uint8),
+    )
+
+    array, metadata = pipeline.generate_array(
+        "plain prompt",
+        steps=1,
+        width=256,
+        height=256,
+        guidance=7.0,
+        prompt_expansion_model="tiny-text-model",
+    )
+
+    assert array.shape == (16, 16, 3)
+    assert captured["tokenized_prompt"] == EXPANDED_CAPTION
+    assert metadata["revised_prompt"] == EXPANDED_CAPTION
+    assert metadata["prompt_expansion_model"] == "tiny-text-model"
+    assert metadata["prompt_expansion_used"]
+    assert metadata["prompt_is_structured_caption"]
 
 
 def test_ideogram4_tiny_transformer_forward_shape() -> None:
@@ -244,7 +573,9 @@ def test_ideogram4_model_wrapper_returns_image_result() -> None:
     assert result.variant == "ideogram-4-fp8"
 
 
-def test_image_generation_cli_forwards_gen_kwargs(tmp_path: Path) -> None:
+def test_image_generation_cli_forwards_gen_kwargs_and_prompt_expansion_model(
+    tmp_path: Path,
+) -> None:
     output_path = tmp_path / "image.png"
     args = Namespace(
         model="ideogram-ai/ideogram-4-fp8",
@@ -256,6 +587,7 @@ def test_image_generation_cli_forwards_gen_kwargs(tmp_path: Path) -> None:
         seed=7,
         guidance=1.0,
         gen_kwargs={"sampler_preset": "V4_TURBO_12"},
+        prompt_expansion_model="tiny-text-model",
     )
     result = SimpleNamespace(
         path=output_path,
@@ -276,4 +608,7 @@ def test_image_generation_cli_forwards_gen_kwargs(tmp_path: Path) -> None:
         image_module.run_image_generation_cli(args)
 
     request = mock_generate.call_args.args[1]
-    assert request.extra == {"sampler_preset": "V4_TURBO_12"}
+    assert request.extra == {
+        "sampler_preset": "V4_TURBO_12",
+        "prompt_expansion_model": "tiny-text-model",
+    }

--- a/mlx_vlm/tests/test_server.py
+++ b/mlx_vlm/tests/test_server.py
@@ -800,6 +800,52 @@ def test_images_generations_returns_b64_json(client, monkeypatch):
     assert cache_calls == [("bonsai-ternary", {"model_kind": "image_generation"})]
 
 
+def test_images_generations_forwards_prompt_expansion_model(client, monkeypatch):
+    calls = []
+
+    monkeypatch.setattr(
+        server,
+        "get_cached_model",
+        lambda model, **kwargs: (
+            SimpleNamespace(),
+            None,
+            SimpleNamespace(model_type="ideogram4"),
+        ),
+    )
+
+    def fake_generate_image(model, request, **kwargs):
+        calls.append(request)
+        result = _fake_image_result(seed=request.seed)
+        result.metadata["revised_prompt"] = '{"compositional_deconstruction":{}}'
+        return result
+
+    monkeypatch.setattr(server_openai, "generate_image", fake_generate_image)
+
+    response = client.post(
+        "/v1/images/generations",
+        json={
+            "model": "ideogram-ai/ideogram-4-fp8",
+            "prompt": "A red cube.",
+            "seed": 10,
+            "size": "256x256",
+            "steps": 1,
+            "auto_json_caption": True,
+            "prompt_expansion_model": "tiny-text-model",
+            "response_format": "b64_json",
+        },
+    )
+
+    assert response.status_code == 200
+    assert calls[0].extra == {
+        "auto_json_caption": True,
+        "prompt_expansion_model": "tiny-text-model",
+    }
+    assert (
+        response.json()["data"][0]["revised_prompt"]
+        == '{"compositional_deconstruction":{}}'
+    )
+
+
 def test_images_generations_writes_paths(client, monkeypatch, tmp_path):
     monkeypatch.setattr(
         server,


### PR DESCRIPTION
## Summary

Builds on the Ideogram 4 base-model support merged in #1281 and adds optional local prompt expansion for ordinary text prompts.

This PR adds:

- `prompt_expansion_model` support for CLI, Python image-generation requests, and the OpenAI-compatible image-generation API
- Schema-constrained Ideogram 4 JSON caption generation using an existing mlx-vlm text/VLM model
- Plain-prompt wrapping, structured-caption validation, fallback behavior, and `revised_prompt` metadata
- Ideogram 4 prompting documentation and focused test coverage

## Prompting behavior

Ideogram 4 was trained on structured JSON captions. The prompt path supports three workflows:

1. Structured JSON captions are passed through unchanged.
2. Ordinary text prompts are wrapped into a minimal JSON caption by default.
3. Ordinary text prompts can be expanded into a richer structured caption by a local mlx-vlm text/VLM model before image generation.

The expansion model uses `build_json_schema_logits_processor` with an Ideogram 4 caption schema. The prompt instructs the model to preserve requested visible text verbatim, use concrete scene descriptions, use one object element per named subject, and use normalized bounding boxes only when useful.

This is a local mlx-vlm prompt-expansion path. It does not call the hosted Ideogram Magic Prompt service.

## Usage

CLI:

```sh
python -m mlx_vlm generate_image \
  --model ideogram-ai/ideogram-4-fp8 \
  --prompt "A cinematic photo of a glass teapot on a rainy London cafe table" \
  --prompt-expansion-model mlx-community/gemma-4-12B-it-4bit \
  --size 1024x1024 \
  --output outputs/ideogram4-expanded.png
```

Python:

```python
request = ImageGenerationRequest(
    prompt="A cinematic photo of a glass teapot on a rainy London cafe table",
    width=1024,
    height=1024,
    extra={
        "prompt_expansion_model": "mlx-community/gemma-4-12B-it-4bit",
    },
)
```

The OpenAI-compatible `/v1/images/generations` request accepts the optional `auto_json_caption` and `prompt_expansion_model` fields. Wrapped or expanded captions are returned as `revised_prompt`.

## Failure behavior

- JSON object prompts skip prompt expansion.
- Invalid expansion output falls back to the minimal JSON caption wrapper unless `auto_json_caption=False` is set.
- Model loading and inference errors are raised so configuration problems are not hidden.

## Testing

```sh
python -m pytest mlx_vlm/tests/test_ideogram4.py mlx_vlm/tests/test_flux2.py mlx_vlm/tests/test_generate.py mlx_vlm/tests/test_server.py -q
# 254 passed

pre-commit run --files <changed files>
# black, isort, autoflake passed
```

A live offline smoke test also passed using cached `ideogram-ai/ideogram-4-fp8` and `mlx-community/gemma-4-12B-it-4bit` models with a 256x256 image and 10 inference steps.