### PR TITLE
Fix Nemotron-H Nano Omni audio crash under nvfp4 quantization

### DIFF
--- a/mlx_vlm/models/nemotron_h_nano_omni/nemotron_h_nano_omni.py
+++ b/mlx_vlm/models/nemotron_h_nano_omni/nemotron_h_nano_omni.py
@@ -122,9 +122,17 @@ class Model(nn.Module):
         if not isinstance(input_features, mx.array):
             input_features = mx.array(input_features)
         lm_head = self.language_model.lm_head
-        compute_dtype = (
-            lm_head.scales.dtype if hasattr(lm_head, "scales") else lm_head.weight.dtype
-        )
+        if hasattr(lm_head, "scales"):
+            s_dtype = lm_head.scales.dtype
+            # nvfp4 packs the per-group scales as uint8 (and other packed
+            # quant modes can use uint32), so the scales' dtype is not a
+            # usable *compute* dtype for the audio features. Fall back to
+            # bfloat16, which matches the model's declared torch_dtype.
+            compute_dtype = (
+                mx.bfloat16 if s_dtype in (mx.uint8, mx.uint32) else s_dtype
+            )
+        else:
+            compute_dtype = lm_head.weight.dtype
         input_features = input_features.astype(compute_dtype)
 
         if feature_attention_mask is not None and not isinstance(

--- a/mlx_vlm/models/nemotron_h_nano_omni/nemotron_h_nano_omni.py
+++ b/mlx_vlm/models/nemotron_h_nano_omni/nemotron_h_nano_omni.py
@@ -128,9 +128,7 @@ class Model(nn.Module):
             # quant modes can use uint32), so the scales' dtype is not a
             # usable *compute* dtype for the audio features. Fall back to
             # bfloat16, which matches the model's declared torch_dtype.
-            compute_dtype = (
-                mx.bfloat16 if s_dtype in (mx.uint8, mx.uint32) else s_dtype
-            )
+            compute_dtype = mx.bfloat16 if s_dtype in (mx.uint8, mx.uint32) else s_dtype
         else:
             compute_dtype = lm_head.weight.dtype
         input_features = input_features.astype(compute_dtype)

--- a/mlx_vlm/tests/test_nemotron_h_nano_omni.py
+++ b/mlx_vlm/tests/test_nemotron_h_nano_omni.py
@@ -140,6 +140,50 @@ def test_model_merges_sound_features_into_input_embeddings():
     )
 
 
+def test_audio_path_handles_nvfp4_uint8_lm_head_scales():
+    """Regression: nvfp4-quantized models pack lm_head.scales as uint8.
+
+    Before the fix, ``_extract_sound_features`` would cast the audio
+    ``input_features`` to ``scales.dtype`` and then crash inside the
+    subsampling Conv2d with::
+
+        ValueError: [conv] Invalid input array with type uint8.
+
+    The fix falls back to ``mx.bfloat16`` when ``scales.dtype`` is an
+    integer packing type (uint8 for nvfp4, uint32 for some other packed
+    modes). This test simulates that quant layout by attaching a uint8
+    ``scales`` attribute to a plain ``lm_head`` and verifying the audio
+    path completes without dtype error.
+    """
+    model = Model(
+        ModelConfig(
+            text_config=tiny_text_config(),
+            vision_config=tiny_vision_config(),
+            sound_config=tiny_sound_config(),
+            projector_hidden_size=32,
+            vit_hidden_size=16,
+            img_context_token_id=98,
+            sound_context_token_id=99,
+        )
+    )
+    model.eval()
+
+    # Simulate an nvfp4-quantized lm_head: presence of .scales with uint8 dtype.
+    model.language_model.lm_head.scales = mx.zeros((1,), dtype=mx.uint8)
+
+    input_ids = mx.array([[1, 99, 99, 99, 2]])
+    input_features = mx.random.normal((1, 17, 16))
+    feature_attention_mask = mx.ones((1, 17), dtype=mx.int32)
+
+    # Pre-fix: this raised ValueError from mx.conv2d.
+    output = model.get_input_embeddings(
+        input_ids,
+        input_features=input_features,
+        feature_attention_mask=feature_attention_mask,
+    )
+    assert np.isfinite(np.array(output.inputs_embeds)).all()
+
+
 def test_model_rejects_sound_token_feature_count_mismatch():
     model = Model(
         ModelConfig(


### PR DESCRIPTION
Resolves #1278.

## Bug

`Model._extract_sound_features` casts the audio mel features to `lm_head.scales.dtype`. For nvfp4-quantized models that is `uint8`, and the subsampling `Conv2d` then rejects the input:

```
ValueError: [conv] Invalid input array with type uint8.
Convolution currently only supports floating point types.
```

Crash trace ends at `ParakeetEncoderSubsamplingConv2D.__call__` (audio.py:304).

## Fix

When `lm_head.scales` is an integer packing type (`uint8` for nvfp4, `uint32` also covered for other packed modes), fall back to `mx.bfloat16` — which matches the model's declared `torch_dtype`. Float-scaled quant modes (`affine`, `mxfp4`, `mxfp8`) keep their previous behavior.

```python
lm_head = self.language_model.lm_head
if hasattr(lm_head, "scales"):
    s_dtype = lm_head.scales.dtype
    compute_dtype = (
        mx.bfloat16 if s_dtype in (mx.uint8, mx.uint32) else s_dtype
    )
else:
    compute_dtype = lm_head.weight.dtype
input_features = input_features.astype(compute_dtype)
```

## Test

New regression test `test_audio_path_handles_nvfp4_uint8_lm_head_scales` attaches a `uint8` `.scales` attribute to a synthetic `lm_head` and exercises `Model.get_input_embeddings` with audio features. The test fails on the original code with the exact `Invalid input array with type uint8` error, and passes with the fix.

```
$ uv run --with pytest --with-editable . python -m pytest \
    mlx_vlm/tests/test_nemotron_h_nano_omni.py -v
...
test_sound_feature_extractor_shapes_and_masks PASSED
test_sound_encoder_and_projection_tiny_smoke PASSED
test_model_merges_sound_features_into_input_embeddings PASSED
test_audio_path_handles_nvfp4_uint8_lm_head_scales PASSED   ← new
test_model_rejects_sound_token_feature_count_mismatch PASSED
test_sanitize_audio_and_projection_weights PASSED
6 passed
```

## Manual repro

Loaded `mlx-community/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-nvfp4` through `waybarrios/vllm-mlx` 0.31.x and sent a 30-second WAV clip via `/v1/chat/completions`. Pre-fix: 500 error with the crash above. Post-fix: clean transcription end-to-end (a 16 kHz mono WAV of `say "The quick brown fox..."` came back verbatim).

## Scope

Two files, +55 / -3 lines. The fix is localized to the dtype derivation in `_extract_sound_features`. No public API changes.