### PR TITLE
Fix Gemma4 unified long text prefill

### DIFF
--- a/mlx_vlm/models/gemma4/language.py
+++ b/mlx_vlm/models/gemma4/language.py
@@ -483,26 +483,40 @@ class Gemma4TextModel(nn.Module):
             mm_token_type_ids is not None
             and int(mx.sum(mm_token_type_ids == 3).item()) > 0
         )
+        has_visual_tokens = (
+            mm_token_type_ids is not None
+            and int(mx.sum((mm_token_type_ids == 1) | (mm_token_type_ids == 2)).item())
+            > 0
+        )
         # Audio spans are sequential; keep mixed image+audio prompts causal to
         # avoid the vision block overlay dominating quantized unified models.
         use_bidirectional_vision = (
             getattr(self.config, "use_bidirectional_attention", None) == "vision"
             and mm_token_type_ids is not None
+            and has_visual_tokens
             and not has_audio_tokens
             and h.shape[1] > 1
         )
         for l, c in zip(self.layers, cache):
             if l.layer_type not in mask:
-                return_array = (
-                    h.shape[1] > 1
-                    and c is not None
-                    and int(mx.max(mx.array(c.offset)).item()) > 0
-                ) or use_bidirectional_vision
                 if l.layer_type == "full_attention":
+                    # Full attention can use MLX's causal mask even when
+                    # prefilling against an existing KV prefix. Only materialize
+                    # a mask for batch left-padding or the Gemma 4 vision
+                    # bidirectional overlay.
+                    return_array = (
+                        use_bidirectional_vision
+                        or getattr(c, "left_padding", None) is not None
+                    )
                     mask["full_attention"] = create_attention_mask(
                         h, c, return_array=return_array
                     )
                 elif l.layer_type == "sliding_attention":
+                    return_array = (
+                        h.shape[1] > 1
+                        and c is not None
+                        and int(mx.max(mx.array(c.offset)).item()) > 0
+                    ) or use_bidirectional_vision
                     mask["sliding_attention"] = create_attention_mask(
                         h, c, window_size=self.window_size, return_array=return_array
                     )

--- a/mlx_vlm/models/gemma4_unified/gemma4_unified.py
+++ b/mlx_vlm/models/gemma4_unified/gemma4_unified.py
@@ -65,11 +65,13 @@ class Model(nn.Module):
         super().__init__()
         self.model_type = config.model_type
         self.config = config
-        self.no_chunked_prefill = (
+        self._base_no_chunked_prefill = (
             getattr(config.text_config, "use_bidirectional_attention", None) == "vision"
         )
+        self.no_chunked_prefill = self._base_no_chunked_prefill
 
         self.language_model = LanguageModel(config.text_config)
+        self.language_model.no_chunked_prefill = self.no_chunked_prefill
         self.vocab_size = config.text_config.vocab_size
 
         if config.vision_config is not None:
@@ -91,6 +93,46 @@ class Model(nn.Module):
             )
         else:
             self.embed_audio = None
+
+    def _should_disable_chunked_prefill(self, input_ids=None, **kwargs) -> bool:
+        """Disable chunking only when a prompt needs vision bidirectional masks."""
+        if not self._base_no_chunked_prefill:
+            return False
+
+        token_types = kwargs.get("mm_token_type_ids", None)
+        if token_types is None:
+            token_types = kwargs.get("token_type_ids", None)
+
+        if token_types is not None:
+            has_visual = int(mx.sum((token_types == 1) | (token_types == 2)).item()) > 0
+            has_audio = int(mx.sum(token_types == 3).item()) > 0
+            return has_visual and not has_audio
+
+        if input_ids is None:
+            return True
+
+        video_token_id = getattr(self.config, "video_token_id", None)
+        image_token_id = getattr(self.config, "image_token_id", None)
+        audio_token_id = getattr(self.config, "audio_token_id", None)
+        has_visual = (
+            image_token_id is not None
+            and int(mx.sum(input_ids == image_token_id).item()) > 0
+        )
+        if video_token_id is not None:
+            has_visual = (
+                has_visual or int(mx.sum(input_ids == video_token_id).item()) > 0
+            )
+        has_audio = (
+            audio_token_id is not None
+            and int(mx.sum(input_ids == audio_token_id).item()) > 0
+        )
+        return has_visual and not has_audio
+
+    def _update_chunked_prefill_mode(self, input_ids=None, **kwargs):
+        self.no_chunked_prefill = self._should_disable_chunked_prefill(
+            input_ids, **kwargs
+        )
+        self.language_model.no_chunked_prefill = self.no_chunked_prefill
 
     def _placeholder_mask(
         self,
@@ -164,6 +206,8 @@ class Model(nn.Module):
             audio_features = input_features
         if input_features_mask is not None and audio_mask is None:
             audio_mask = input_features_mask
+
+        self._update_chunked_prefill_mode(input_ids, **kwargs)
 
         if inputs_embeds is None:
             inputs_embeds = self.language_model.model.embed_tokens(input_ids)

--- a/mlx_vlm/tests/test_models.py
+++ b/mlx_vlm/tests/test_models.py
@@ -5315,6 +5315,59 @@ class TestGetInputEmbeddings(unittest.TestCase):
         )
         self._check_returns_input_embeddings_features(model, "gemma4_unified")
 
+    def test_gemma4_unified_updates_chunked_prefill_for_visual_bidir(self):
+        from mlx_vlm.models import gemma4_unified
+
+        model = gemma4_unified.Model(
+            gemma4_unified.ModelConfig(
+                text_config=gemma4_unified.TextConfig(
+                    hidden_size=8,
+                    num_hidden_layers=1,
+                    intermediate_size=16,
+                    num_attention_heads=1,
+                    num_key_value_heads=1,
+                    num_global_key_value_heads=1,
+                    head_dim=8,
+                    global_head_dim=8,
+                    vocab_size=64,
+                    vocab_size_per_layer_input=64,
+                    hidden_size_per_layer_input=0,
+                    sliding_window=8,
+                    sliding_window_pattern=1,
+                    layer_types=["full_attention"],
+                    use_bidirectional_attention="vision",
+                ),
+                vision_config=None,
+                audio_config=None,
+                vocab_size=64,
+                hidden_size=8,
+                image_token_id=31,
+                audio_token_id=30,
+                video_token_id=29,
+            )
+        )
+
+        input_ids = mx.array([[1, 2, 3]])
+        text_only_types = mx.array([[0, 0, 0]])
+        visual_types = mx.array([[0, 1, 1, 0]])
+        mixed_audio_types = mx.array([[0, 1, 1, 3]])
+
+        model.get_input_embeddings(input_ids, mm_token_type_ids=text_only_types)
+        self.assertFalse(model.no_chunked_prefill)
+        self.assertFalse(model.language_model.no_chunked_prefill)
+
+        model.get_input_embeddings(
+            mx.array([[1, 2, 3, 4]]), mm_token_type_ids=visual_types
+        )
+        self.assertTrue(model.no_chunked_prefill)
+        self.assertTrue(model.language_model.no_chunked_prefill)
+
+        model.get_input_embeddings(
+            mx.array([[1, 2, 3, 4]]), mm_token_type_ids=mixed_audio_types
+        )
+        self.assertFalse(model.no_chunked_prefill)
+        self.assertFalse(model.language_model.no_chunked_prefill)
+
     def test_gemma4_unified_vision_tokens_use_bidirectional_mask(self):
         from mlx_vlm.models import gemma4_unified
         from mlx_vlm.models.gemma4.language import Gemma4TextModel
@@ -5344,6 +5397,62 @@ class TestGetInputEmbeddings(unittest.TestCase):
         self.assertTrue(bool(mask[0, 0, 1, 2].item()))
         self.assertFalse(bool(mask[0, 0, 0, 2].item()))
         self.assertTrue(bool(mask[0, 0, 3, 2].item()))
+
+    def test_gemma4_unified_text_only_mm_ids_keep_causal_mask(self):
+        from mlx_vlm.models import gemma4_unified
+        from mlx_vlm.models.gemma4.language import Gemma4TextModel
+
+        config = gemma4_unified.TextConfig(
+            hidden_size=8,
+            num_hidden_layers=1,
+            intermediate_size=16,
+            num_attention_heads=1,
+            num_key_value_heads=1,
+            num_global_key_value_heads=1,
+            head_dim=8,
+            global_head_dim=8,
+            vocab_size=32,
+            hidden_size_per_layer_input=0,
+            sliding_window=8,
+            sliding_window_pattern=1,
+            layer_types=["full_attention"],
+            use_bidirectional_attention="vision",
+        )
+        model = Gemma4TextModel(config)
+        hidden_states = mx.zeros((1, 4, config.hidden_size))
+        mm_token_type_ids = mx.array([[0, 0, 0, 0]])
+
+        mask = model._make_masks(hidden_states, [None], mm_token_type_ids)[0]
+
+        self.assertEqual(mask, "causal")
+
+    def test_gemma4_full_attention_cached_chunk_uses_causal_mask(self):
+        from mlx_vlm.models import cache, gemma4_unified
+        from mlx_vlm.models.gemma4.language import Gemma4TextModel
+
+        config = gemma4_unified.TextConfig(
+            hidden_size=8,
+            num_hidden_layers=1,
+            intermediate_size=16,
+            num_attention_heads=1,
+            num_key_value_heads=1,
+            num_global_key_value_heads=1,
+            head_dim=8,
+            global_head_dim=8,
+            vocab_size=32,
+            hidden_size_per_layer_input=0,
+            sliding_window=8,
+            sliding_window_pattern=1,
+            layer_types=["full_attention"],
+        )
+        model = Gemma4TextModel(config)
+        hidden_states = mx.zeros((1, 4, config.hidden_size))
+        kv_cache = cache.KVCache()
+        kv_cache.offset = 8
+
+        mask = model._make_masks(hidden_states, [kv_cache])[0]
+
+        self.assertEqual(mask, "causal")
 
     def test_gemma4_unified_audio_tokens_keep_vision_mask_causal(self):
         from mlx_vlm.models import gemma4_unified

--- a/mlx_vlm/tests/test_models.py
+++ b/mlx_vlm/tests/test_models.py
@@ -5315,53 +5315,25 @@ class TestGetInputEmbeddings(unittest.TestCase):
         )
         self._check_returns_input_embeddings_features(model, "gemma4_unified")
 
-    def test_gemma4_unified_updates_chunked_prefill_for_visual_bidir(self):
-        from mlx_vlm.models import gemma4_unified
-
-        model = gemma4_unified.Model(
-            gemma4_unified.ModelConfig(
-                text_config=gemma4_unified.TextConfig(
-                    hidden_size=8,
-                    num_hidden_layers=1,
-                    intermediate_size=16,
-                    num_attention_heads=1,
-                    num_key_value_heads=1,
-                    num_global_key_value_heads=1,
-                    head_dim=8,
-                    global_head_dim=8,
-                    vocab_size=64,
-                    vocab_size_per_layer_input=64,
-                    hidden_size_per_layer_input=0,
-                    sliding_window=8,
-                    sliding_window_pattern=1,
-                    layer_types=["full_attention"],
-                    use_bidirectional_attention="vision",
-                ),
-                vision_config=None,
-                audio_config=None,
-                vocab_size=64,
-                hidden_size=8,
-                image_token_id=31,
-                audio_token_id=30,
-                video_token_id=29,
-            )
-        )
-
-        input_ids = mx.array([[1, 2, 3]])
         text_only_types = mx.array([[0, 0, 0]])
         visual_types = mx.array([[0, 1, 1, 0]])
         mixed_audio_types = mx.array([[0, 1, 1, 3]])
 
-        model.get_input_embeddings(input_ids, mm_token_type_ids=text_only_types)
+        # Text-only Gemma4 unified prompts should keep chunked prefill enabled.
+        model.get_input_embeddings(
+            mx.array([[1, 2, 3]]), mm_token_type_ids=text_only_types
+        )
         self.assertFalse(model.no_chunked_prefill)
         self.assertFalse(model.language_model.no_chunked_prefill)
 
+        # Visual token spans need the bidirectional mask overlay, so do not chunk.
         model.get_input_embeddings(
             mx.array([[1, 2, 3, 4]]), mm_token_type_ids=visual_types
         )
         self.assertTrue(model.no_chunked_prefill)
         self.assertTrue(model.language_model.no_chunked_prefill)
 
+        # Mixed audio prompts stay causal and can use chunked prefill.
         model.get_input_embeddings(
             mx.array([[1, 2, 3, 4]]), mm_token_type_ids=mixed_audio_types
         )


### PR DESCRIPTION
## Summary
- keep Gemma4 unified chunked prefill enabled for text-only prompts
- only disable chunked prefill when visual bidirectional attention is actually required
- avoid materialized Gemma4 full-attention masks for cached text-only chunks
- add regression coverage for visual, audio/mixed, text-only, and cached-mask cases

Fixes #1275

## Testing
- .venv/bin/python -m pytest mlx_vlm/tests/test_models.py -k "gemma4_unified_input_embeddings or gemma4_unified_text_only_mm_ids_keep_causal_mask or gemma4_full_attention_cached_chunk_uses_causal_mask or gemma4_unified_vision_tokens_use_bidirectional_mask or gemma4_unified_audio_tokens_keep_vision_mask_causal" -q
- .venv/bin/python -m pytest mlx_vlm/tests/test_generate.py -k "prefill_tqdm or stream_generate_forwards_verbose" -q
- CLI 65K prompt with cached gg-hf-gu/gemma-4-12b-it snapshot: exit 0
- server 65K non-stream request with cached gg-hf-gu/gemma-4-12b-it snapshot: HTTP 200