### PR TITLE
Fix PaddleOCR-VL stale mRoPE state under batching

### DIFF
--- a/mlx_vlm/generate/ar.py
+++ b/mlx_vlm/generate/ar.py
@@ -2002,9 +2002,17 @@ class PromptProcessingBatch:
         if rope_deltas.shape[0] == 1 and B > 1:
             rope_deltas = mx.broadcast_to(rope_deltas, (B, 1))
         if rope_deltas.shape[0] != B:
-            raise RuntimeError(
-                f"_rope_deltas shape {rope_deltas.shape} does not match prefill batch size {B}"
-            )
+            if rope_deltas.shape[0] > B:
+                rope_deltas = rope_deltas[:B]
+            else:
+                pad = B - rope_deltas.shape[0]
+                rope_deltas = mx.concatenate(
+                    [
+                        rope_deltas,
+                        mx.broadcast_to(rope_deltas[-1:], (pad, rope_deltas.shape[1])),
+                    ],
+                    axis=0,
+                )
         return rope_deltas
 
 

--- a/mlx_vlm/models/paddleocr_vl/language.py
+++ b/mlx_vlm/models/paddleocr_vl/language.py
@@ -418,9 +418,14 @@ class LanguageModel(nn.Module):
                 or self._rope_deltas is None
                 or cache is None
             ):
-                if self._position_ids is not None:
+                batch_size, seq_length = inputs.shape
+                cached_position_ids_match = (
+                    self._position_ids is not None
+                    and self._position_ids.shape[1] == batch_size
+                    and self._position_ids.shape[2] >= cache_offset + seq_length
+                )
+                if cached_position_ids_match:
                     # Use stored position_ids, sliced for current chunk
-                    seq_length = inputs.shape[1]
                     position_ids = self._position_ids[
                         :, :, cache_offset : cache_offset + seq_length
                     ]

--- a/mlx_vlm/models/paddleocr_vl/paddleocr_vl.py
+++ b/mlx_vlm/models/paddleocr_vl/paddleocr_vl.py
@@ -32,6 +32,7 @@ class Model(nn.Module):
 
         if pixel_values is None:
             self.language_model._position_ids = None
+            self.language_model._rope_deltas = None
             return InputEmbeddingsFeatures(
                 inputs_embeds=self.language_model.model.embed_tokens(input_ids)
             )

--- a/mlx_vlm/tests/test_generate.py
+++ b/mlx_vlm/tests/test_generate.py
@@ -424,8 +424,15 @@ class TestGenerationBatch:
         ]
         # Falcon OCR singleton: (1, 1) broadcasts to (B, 1).
         assert self._capture(mx.array([[5]], dtype=mx.int32), 4).tolist() == [[5]] * 4
-        with pytest.raises(RuntimeError, match="does not match"):
-            self._capture(mx.array([[5], [7]], dtype=mx.int32), 3)
+        assert self._capture(mx.array([[5], [7]], dtype=mx.int32), 3).tolist() == [
+            [5],
+            [7],
+            [7],
+        ]
+        assert self._capture(mx.array([[5], [7], [9]], dtype=mx.int32), 2).tolist() == [
+            [5],
+            [7],
+        ]
 
 
 # ============================================================================

--- a/mlx_vlm/tests/test_models.py
+++ b/mlx_vlm/tests/test_models.py
@@ -5688,6 +5688,97 @@ class TestGetInputEmbeddings(unittest.TestCase):
         )
         self._check_returns_input_embeddings_features(model, "paddleocr_vl")
 
+    def test_paddleocr_vl_text_only_clears_mrope_state(self):
+        from mlx_vlm.models import paddleocr_vl
+
+        model = paddleocr_vl.Model(
+            paddleocr_vl.ModelConfig(
+                text_config=paddleocr_vl.TextConfig(
+                    model_type="paddleocr_vl",
+                    hidden_size=4,
+                    num_hidden_layers=1,
+                    intermediate_size=8,
+                    num_attention_heads=2,
+                    num_key_value_heads=1,
+                    vocab_size=10,
+                    head_dim=2,
+                ),
+                vision_config=paddleocr_vl.VisionConfig(
+                    model_type="paddleocr_vl",
+                    hidden_size=4,
+                    intermediate_size=8,
+                    num_hidden_layers=1,
+                    num_attention_heads=2,
+                ),
+                model_type="paddleocr_vl",
+                image_token_id=9,
+                vision_start_token_id=8,
+            )
+        )
+
+        model.language_model._position_ids = mx.array([[[0, 1]]], dtype=mx.int32)
+        model.language_model._rope_deltas = mx.array([[4]], dtype=mx.int32)
+
+        model.get_input_embeddings(mx.array([[1, 2]], dtype=mx.int32))
+
+        self.assertIsNone(model.language_model._position_ids)
+        self.assertIsNone(model.language_model._rope_deltas)
+
+    def test_paddleocr_vl_prefill_recomputes_stale_position_ids(self):
+        from mlx_vlm.models import paddleocr_vl
+
+        text_config = paddleocr_vl.TextConfig(
+            model_type="paddleocr_vl",
+            hidden_size=4,
+            num_hidden_layers=1,
+            intermediate_size=8,
+            num_attention_heads=2,
+            num_key_value_heads=1,
+            vocab_size=10,
+            head_dim=2,
+        )
+        config = paddleocr_vl.ModelConfig(
+            text_config=text_config,
+            vision_config=paddleocr_vl.VisionConfig(
+                model_type="paddleocr_vl",
+                hidden_size=4,
+                intermediate_size=8,
+                num_hidden_layers=1,
+                num_attention_heads=2,
+            ),
+            model_type="paddleocr_vl",
+            image_token_id=9,
+            vision_start_token_id=8,
+        )
+        lm = paddleocr_vl.LanguageModel(text_config, config)
+
+        captured = {}
+
+        class _CapturingInnerModel:
+            class _Embed:
+                def __call__(self, inputs):
+                    return mx.zeros((inputs.shape[0], inputs.shape[1], 4))
+
+            embed_tokens = _Embed()
+
+            def __call__(self, inputs, inputs_embeds=None, position_ids=None, **kwargs):
+                captured["position_ids"] = position_ids
+                return mx.zeros((inputs.shape[0], inputs.shape[1], 4))
+
+        lm.model = _CapturingInnerModel()
+        lm.lm_head = lambda x: x
+        lm._position_ids = mx.array([[[0, 1, 2]]], dtype=mx.int32)
+        lm._rope_deltas = mx.array([[3]], dtype=mx.int32)
+
+        class _Cache:
+            _idx = 0
+            offset = mx.array(0)
+
+        lm(mx.array([[1, 2], [3, 4]], dtype=mx.int32), cache=[_Cache()])
+
+        self.assertEqual(captured["position_ids"].shape, (3, 2, 2))
+        self.assertEqual(lm._rope_deltas.tolist(), [[0], [0]])
+
     def test_phi3_v_input_embeddings(self):
         from mlx_vlm.models import phi3_v
         from mlx_vlm.models.base import InputEmbeddingsFeatures


### PR DESCRIPTION
Closes #1283.

## Summary
- realign captured `_rope_deltas` to the active prefill batch instead of raising before existing generation-batch handling can run
- recompute PaddleOCR-VL cached `_position_ids` when the stored batch/window no longer matches the current prefill
- clear both cached `_position_ids` and `_rope_deltas` for text-only PaddleOCR-VL inputs

## Tests
- `uv run --with pytest --with-editable . python -m pytest mlx_vlm/tests/test_generate.py::TestGenerationBatch mlx_vlm/tests/test_models.py::TestGetInputEmbeddings -k 'paddleocr_vl or rope_deltas'`\n- `uv run --with black --with-editable . black --fast --check mlx_vlm/generate/ar.py mlx_vlm/models/paddleocr_vl/language.py mlx_vlm/models/paddleocr_vl/paddleocr_vl.py mlx_vlm/tests/test_generate.py mlx_vlm/tests/test_models.py`\n- `uv run --with pytest --with psutil --with-editable . python -m pytest mlx_vlm/tests` -> 952 passed, 2 skipped\n