### PR TITLE
Fix automatic prefix caching for single-request chats

### DIFF
--- a/mlx_vlm/apc.py
+++ b/mlx_vlm/apc.py
@@ -311,9 +311,9 @@ def _cache_entry_is_single_row_for_apc(c: Any) -> bool:
             lm_cache.ChunkedKVCache,
         ),
     ):
-        return _array_has_single_row(getattr(c, "keys", None)) and _array_has_single_row(
-            getattr(c, "values", None)
-        )
+        return _array_has_single_row(
+            getattr(c, "keys", None)
+        ) and _array_has_single_row(getattr(c, "values", None))
     if isinstance(c, lm_cache.ArraysCache):
         states = getattr(c, "cache", [])
         if any(
@@ -2876,7 +2876,7 @@ class APCManager:
             free_now = _free_ram_bytes()
             if free_now is not None and free_now < self._disk_min_free_ram_bytes:
                 logger.info(
-                    "APC: skipping exact disk restore " "(free RAM %.1f GB < %.1f GB)",
+                    "APC: skipping exact disk restore (free RAM %.1f GB < %.1f GB)",
                     free_now / (1 << 30),
                     self._disk_min_free_ram_bytes / (1 << 30),
                 )

--- a/mlx_vlm/apc.py
+++ b/mlx_vlm/apc.py
@@ -295,6 +295,41 @@ def _cache_entry_supports_block_apc(c: Any) -> bool:
     return isinstance(c, lm_cache.KVCache)
 
 
+def _array_has_single_row(a: Any) -> bool:
+    shape = getattr(a, "shape", None)
+    return shape is None or len(shape) == 0 or int(shape[0]) == 1
+
+
+def _cache_entry_is_single_row_for_apc(c: Any) -> bool:
+    from mlx_lm.models import cache as lm_cache
+
+    if isinstance(
+        c,
+        (
+            lm_cache.KVCache,
+            lm_cache.RotatingKVCache,
+            lm_cache.ChunkedKVCache,
+        ),
+    ):
+        return _array_has_single_row(getattr(c, "keys", None)) and _array_has_single_row(
+            getattr(c, "values", None)
+        )
+    if isinstance(c, lm_cache.ArraysCache):
+        states = getattr(c, "cache", [])
+        if any(
+            state is not None and not _array_has_single_row(state) for state in states
+        ):
+            return False
+        return _array_has_single_row(
+            getattr(c, "left_padding", None)
+        ) and _array_has_single_row(getattr(c, "lengths", None))
+    if isinstance(c, lm_cache.CacheList):
+        return all(_cache_entry_is_single_row_for_apc(sub_c) for sub_c in c.caches)
+    if isinstance(c, tuple):
+        return all(_cache_entry_is_single_row_for_apc(sub_c) for sub_c in c)
+    return False
+
+
 def _sequence_hash(token_ids: Sequence[int], extra_hash: int, block_size: int) -> int:
     h = hashlib.sha256()
     h.update(int(extra_hash & ((1 << 64) - 1)).to_bytes(8, "little"))
@@ -3546,13 +3581,17 @@ def extract_prompt_cache_from_batch(
 ) -> Optional[List[Any]]:
     """Extract one row from batch-aware caches as single-row cache objects."""
 
+    if not all(callable(getattr(c, "extract", None)) for c in batch_caches):
+        if batch_idx == 0 and all(
+            _cache_entry_is_single_row_for_apc(c) for c in batch_caches
+        ):
+            return _clone_prompt_cache_for_apc(batch_caches)
+        return None
+
     out: List[Any] = []
     eval_targets: List[mx.array] = []
     for c in batch_caches:
-        extract = getattr(c, "extract", None)
-        if not callable(extract):
-            return None
-        extracted = extract(batch_idx)
+        extracted = c.extract(batch_idx)
         out.append(extracted)
         _collect_mx_arrays(extracted.state, eval_targets)
     if eval_targets:

--- a/mlx_vlm/tests/test_apc.py
+++ b/mlx_vlm/tests/test_apc.py
@@ -291,6 +291,52 @@ def test_exact_batch_cache_merge_and_extract_supports_arrays_and_kv():
     assert extracted[1].offset == 12
 
 
+def test_extract_prompt_cache_supports_single_row_exact_cache():
+    from mlx_lm.models.cache import ArraysCache, KVCache, RotatingKVCache
+
+    token_ids = list(range(12))
+    arrays = ArraysCache(size=1)
+    arrays[0] = mx.ones((1, 3, 5))
+    kv = KVCache()
+    kv.keys = mx.ones((1, 1, len(token_ids), 4))
+    kv.values = mx.ones((1, 1, len(token_ids), 4)) * 2
+    kv.offset = len(token_ids)
+    rotating = RotatingKVCache(max_size=8, keep=0)
+    rotating.keys = mx.ones((1, 1, 8, 4)) * 3
+    rotating.values = mx.ones((1, 1, 8, 4)) * 4
+    rotating.offset = len(token_ids)
+    rotating._idx = 4
+
+    extracted = extract_prompt_cache_from_batch([arrays, kv, rotating], 0)
+
+    assert extracted is not None
+    assert extracted[0] is not arrays
+    assert extracted[1] is not kv
+    assert extracted[2] is not rotating
+    _assert_allclose(extracted[0][0], arrays[0])
+    _assert_allclose(extracted[1].keys, kv.keys)
+    _assert_allclose(extracted[1].values, kv.values)
+    _assert_allclose(extracted[2].keys, rotating.keys)
+    _assert_allclose(extracted[2].values, rotating.values)
+
+    manager = APCManager(num_blocks=4, block_size=4)
+    assert manager.store_exact_cache(token_ids, extracted)
+    assert manager.stats_snapshot()["exact_stores"] == 1
+
+
+def test_extract_prompt_cache_rejects_multi_row_without_extract():
+    from mlx_lm.models.cache import ArraysCache, KVCache
+
+    arrays = ArraysCache(size=1)
+    arrays[0] = mx.ones((2, 3, 5))
+    kv = KVCache()
+    kv.keys = mx.ones((2, 1, 8, 4))
+    kv.values = mx.ones((2, 1, 8, 4))
+    kv.offset = 8
+
+    assert extract_prompt_cache_from_batch([arrays, kv], 0) is None
+
+
 def test_apc_max_pool_tensors_keeps_disk_persistence(tmp_path, monkeypatch):
     monkeypatch.setenv("APC_MAX_POOL_TENSORS", "2")
     monkeypatch.setenv("APC_DISK_SHARD_MAX_BLOCKS", "2")


### PR DESCRIPTION
### Problem

APC silently does nothing for models that use exact-mode caching (Gemma 4, Qwen 3.5, etc.) during single-request chat. Every turn reprocesses the prompt and APC stats show zero hits. No errors or warnings either.

Plain attention models and block APC aren't affected.

### Repro

1. Load the server with Gemma 4 26B (or any other model where APC uses "exact" mode) and `APC_ENABLED=1`
2. Open /v1/cache/stats in the browser
3. Send 2 or more messages
4. Refresh stats

Expected: Non-zero `exact_stores`, `exact_hits`, `matched_tokens`

Actual:
```json
{"block_size":16,"num_blocks":2048,"pool_used":0,"lookups_hit":0,"lookups_miss":0,"matched_tokens":0,"served_tokens":0,"token_hit_rate":0.0,"evictions":0,"stores":0,"disk_hits":0,"disk_writes":0,"exact_hits":0,"exact_stores":0,"enabled":true}
```

### Fix

After prefill, APC snapshots the prompt cache so the next turn can reuse it. The snapshot step assumed a batch-aware cache and bailed quietly when it didn't find one. Single-stream caches expose a 1-row tensor directly and don't implement the batch-aware `extract()` interface so the snapshot never ran.

The simplest fix was to give single-row caches a direct deep clone instead. The batch-aware path is unchanged. Multi-row caches without a batch interface still bail — there didn't seem to be a safe way to pick a row.