### PR TITLE
Fix APC for single requests

### DIFF
--- a/mlx_vlm/generate/ar.py
+++ b/mlx_vlm/generate/ar.py
@@ -1668,6 +1668,13 @@ class PromptProcessingBatch:
         )
         return prefix_len + min(self._suffix_lens[batch_idx], max(0, real_done))
 
+    def _apc_prompt_cache_for_store(self, batch_idx: int) -> Optional[List[Any]]:
+        # Single-request cold batches use an unbatched cache that is already
+        # row-specific, so there is nothing to extract.
+        if batch_idx == 0 and len(self.uids) == 1 and self._right_pad_per_row is None:
+            return self.prompt_cache
+        return _apc.extract_prompt_cache_from_batch(self.prompt_cache, batch_idx)
+
     def _store_apc_exact_checkpoints(self) -> None:
         if self._apc_manager is None or self._apc_mode != "exact":
             return
@@ -1679,10 +1686,7 @@ class PromptProcessingBatch:
                 continue
             if self._row_real_tokens_processed(batch_idx) != checkpoint_len:
                 continue
-            prompt_cache = _apc.extract_prompt_cache_from_batch(
-                self.prompt_cache,
-                batch_idx,
-            )
+            prompt_cache = self._apc_prompt_cache_for_store(batch_idx)
             if prompt_cache is None:
                 continue
             self._apc_manager.store_exact_cache(
@@ -1946,10 +1950,7 @@ class PromptProcessingBatch:
                     if meta is None:
                         continue
                     if self._apc_mode == "exact":
-                        prompt_cache = _apc.extract_prompt_cache_from_batch(
-                            self.prompt_cache,
-                            batch_idx,
-                        )
+                        prompt_cache = self._apc_prompt_cache_for_store(batch_idx)
                         if prompt_cache is not None:
                             self._apc_manager.store_exact_cache(
                                 meta["full_input_ids"],

--- a/mlx_vlm/tests/test_apc.py
+++ b/mlx_vlm/tests/test_apc.py
@@ -291,6 +291,50 @@ def test_exact_batch_cache_merge_and_extract_supports_arrays_and_kv():
     assert extracted[1].offset == 12
 
 
+def test_single_row_prompt_batch_exact_checkpoint_stores_without_extract():
+    from mlx_lm.models.cache import ArraysCache, KVCache, RotatingKVCache
+
+    from mlx_vlm.generate.ar import PromptProcessingBatch
+
+    token_ids = list(range(12))
+    arrays = ArraysCache(size=1)
+    arrays[0] = mx.ones((1, 3, 5))
+    kv = KVCache()
+    kv.keys = mx.ones((1, 1, len(token_ids), 4))
+    kv.values = mx.ones((1, 1, len(token_ids), 4)) * 2
+    kv.offset = len(token_ids)
+    rotating = RotatingKVCache(max_size=8, keep=0)
+    rotating.keys = mx.ones((1, 1, 8, 4)) * 3
+    rotating.values = mx.ones((1, 1, 8, 4)) * 4
+    rotating.offset = len(token_ids)
+    rotating._idx = 4
+
+    batch = PromptProcessingBatch.__new__(PromptProcessingBatch)
+    batch.uids = [0]
+    batch.prompt_cache = [arrays, kv, rotating]
+    batch._right_pad_per_row = None
+    batch._left_padding_per_row = [0]
+    batch._suffix_lens = [len(token_ids)]
+    batch._processed_prompt_columns = len(token_ids)
+    batch._apc_mode = "exact"
+    batch._apc_manager = APCManager(num_blocks=4, block_size=4)
+    batch._apc_meta = [
+        {
+            "full_input_ids": token_ids,
+            "prefix_len": 0,
+            "checkpoint_len": len(token_ids),
+            "extra_hash": 0,
+        }
+    ]
+
+    assert extract_prompt_cache_from_batch(batch.prompt_cache, 0) is None
+
+    batch._store_apc_exact_checkpoints()
+
+    assert batch._apc_meta[0]["checkpoint_done"] is True
+    assert batch._apc_manager.stats_snapshot()["exact_stores"] == 1
+
+
 def test_apc_max_pool_tensors_keeps_disk_persistence(tmp_path, monkeypatch):
     monkeypatch.setenv("APC_MAX_POOL_TENSORS", "2")
     monkeypatch.setenv("APC_DISK_SHARD_MAX_BLOCKS", "2")


### PR DESCRIPTION
Based on https://github.com/Blaizzy/mlx-vlm/pull/1287 but this is a more surgical fix for the issue. I ran a test with Qwen3.5-35B-A3B-4bit across 1k -> 128k using Ivan's contexts and verified APC is being used correctly in both single and batched requests:

```
[4k] chars=16149
  PASS single: tokens=4177 uncached_prefill_s=1.71 cached_prefill_s=0.19 speedup=9.12x delta_s=-1.52 seed_stores=2 hits=2 matched_tokens=3907 cached_progress=3907 uncached_matched=0
  PASS batch2: tokens=8358 uncached_prefill_s=2.24 cached_prefill_s=0.26 speedup=8.58x delta_s=-1.98 seed_stores=4 hits=4 matched_tokens=7818 cached_progress=7818 uncached_matched=0
Downloading 8k: https://raw.githubusercontent.com/ivanfioravanti/llm_context_benchmarks/refs/heads/master/8k.txt

[8k] chars=32649
  PASS single: tokens=8248 uncached_prefill_s=3.19 cached_prefill_s=0.26 speedup=12.31x delta_s=-2.93 seed_stores=2 hits=2 matched_tokens=7978 cached_progress=7978 uncached_matched=0
  PASS batch2: tokens=16500 uncached_prefill_s=4.63 cached_prefill_s=0.30 speedup=15.41x delta_s=-4.33 seed_stores=4 hits=4 matched_tokens=15960 cached_progress=15960 uncached_matched=0
Downloading 16k: https://raw.githubusercontent.com/ivanfioravanti/llm_context_benchmarks/refs/heads/master/16k.txt

[16k] chars=66197
  PASS single: tokens=16429 uncached_prefill_s=6.96 cached_prefill_s=0.24 speedup=29.06x delta_s=-6.72 seed_stores=2 hits=2 matched_tokens=16159 cached_progress=16159 uncached_matched=0
  PASS batch2: tokens=32862 uncached_prefill_s=10.82 cached_prefill_s=0.36 speedup=30.21x delta_s=-10.46 seed_stores=4 hits=4 matched_tokens=32322 cached_progress=32322 uncached_matched=0
Downloading 32k: https://raw.githubusercontent.com/ivanfioravanti/llm_context_benchmarks/refs/heads/master/32k.txt

[32k] chars=133813
  PASS single: tokens=32726 uncached_prefill_s=15.89 cached_prefill_s=0.28 speedup=57.50x delta_s=-15.61 seed_stores=2 hits=2 matched_tokens=32456 cached_progress=32456 uncached_matched=0
  PASS batch2: tokens=65456 uncached_prefill_s=24.37 cached_prefill_s=0.46 speedup=52.65x delta_s=-23.90 seed_stores=4 hits=4 matched_tokens=64916 cached_progress=64916 uncached_matched=0
```