### PR TITLE
Add regression tests for ThinkingBudgetCriteria.apply_forced_token

### DIFF
--- a/mlx_vlm/tests/test_generate.py
+++ b/mlx_vlm/tests/test_generate.py
@@ -1442,6 +1442,55 @@ class TestThinkingBudgetCriteria:
         assert criteria.thinking_token_count == 0
         assert criteria.budget_exceeded is False
 
+    def _make_criteria(self, enable_thinking=True):
+        return ThinkingBudgetCriteria(
+            tokenizer=FakeTokenizer(),
+            thinking_budget=5,
+            thinking_end_token="</think>",
+            thinking_start_token="<think>",
+            enable_thinking=enable_thinking,
+        )
+
+    def test_apply_forced_token_safe_before_first_call(self):
+        """Regression: apply_forced_token must be safe before __call__ ever runs.
+
+        forced_token_id has to be initialised in __init__; otherwise the first
+        apply_forced_token (e.g. on the very first decode step) raises
+        AttributeError. This crashed real generations on Gemma-style models
+        whose first generated token is the thinking delimiter.
+        """
+        criteria = self._make_criteria()
+        y = mx.array([7])
+        # No __call__ yet: must be a no-op that returns the input unchanged.
+        assert criteria.apply_forced_token(y).tolist() == [7]
+
+    def test_apply_forced_token_safe_after_start_delimiter(self):
+        """Regression: the start-token early return in __call__ does not set
+        forced_token_id, so apply_forced_token must remain safe afterwards."""
+        criteria = self._make_criteria()
+        # First generated token is the start delimiter -> early return, no force.
+        assert criteria(99) is None
+        assert criteria.apply_forced_token(mx.array([7])).tolist() == [7]
+
+    def test_apply_forced_token_safe_after_end_delimiter(self):
+        """Regression: the end-token early return in __call__ does not set
+        forced_token_id, so apply_forced_token must remain safe afterwards."""
+        criteria = self._make_criteria()
+        # End delimiter resets thinking state and returns None without forcing.
+        assert criteria(100) is None
+        assert criteria.apply_forced_token(mx.array([8])).tolist() == [8]
+
+    def test_apply_forced_token_emits_forced_token_when_budget_exceeded(self):
+        """End-to-end: once the budget is exceeded, the token returned by
+        __call__ is the same one apply_forced_token injects into the stream."""
+        criteria = self._make_criteria()
+        # Burn the budget (5 tokens), then trip it on the 6th.
+        for i in range(5):
+            assert criteria(50 + i) is None
+        forced = criteria(60)  # \n forced
+        assert forced == 10
+        assert criteria.apply_forced_token(mx.array([0])).tolist() == [10]
+
 
 class TestSamplerArgs:
     """Tests for sampler argument forwarding."""


### PR DESCRIPTION
## Summary

`ThinkingBudgetCriteria` has unit tests (`TestThinkingBudgetCriteria`), but none of them call `apply_forced_token` — the method where an uninitialised `forced_token_id` previously surfaced as an `AttributeError`.

The crash path: when the first generated token is the thinking **start** or **end** delimiter, both branches in `__call__` return early without setting `forced_token_id`. On older builds (pre-`ec0f235`, e.g. the v0.4.4 release) `__init__` didn't initialise it either, so the very next `apply_forced_token` raised:

```
AttributeError: 'ThinkingBudgetCriteria' object has no attribute 'forced_token_id'
```

I hit this on Gemma-style models (`thinking_start_token="<|think|>"`, `thinking_end_token="<channel|>"`) during a ~5.8k-sample batch inference run — the exception was swallowed by the caller and silently produced empty outputs for the affected samples.

`forced_token_id` is now initialised in `__init__` on `main`, so these tests **pass as-is**. This PR just locks that behaviour in and guards against a regression, since the existing suite would not have caught it.

## What's added

Four cases in `TestThinkingBudgetCriteria`, all exercising `apply_forced_token`:
- before the first `__call__` (the bare regression);
- immediately after the **start** delimiter early-return;
- immediately after the **end** delimiter early-return;
- the budget-exceeded path, asserting the token `__call__` returns is the one `apply_forced_token` injects.

## Test plan

- [x] New tests pass against current `main` (verified by exec'ing the current `ThinkingBudgetCriteria` source directly).
- [x] Confirmed the tests **fail** (`AttributeError`) when the `__init__` initialisation is removed, i.e. they genuinely reproduce the pre-`ec0f235` crash.
- [ ] CI: `pytest mlx_vlm/tests/test_generate.py::TestThinkingBudgetCriteria`

Test-only change; no library code touched.