### PR TITLE
Fix using structured output with thinking enabled

### DIFF
--- a/mlx_vlm/server/app.py
+++ b/mlx_vlm/server/app.py
@@ -222,6 +222,8 @@ def _extract_response_format_schema(request) -> Optional[Union[str, dict]]:
     format_type = response_format.get("type")
     if format_type in (None, "text"):
         return None
+    if format_type in ("json_object", "object"):
+        return {"type": "object"}
     if format_type != "json_schema":
         raise ValueError(f"Unsupported response_format type: {format_type!r}")
 

--- a/mlx_vlm/server/generation.py
+++ b/mlx_vlm/server/generation.py
@@ -38,6 +38,7 @@ from ..speculative.utils import (
     speculative_hidden_state,
     speculative_prefill_kwargs,
 )
+from ..structured import ThinkingAwareLogitsProcessor
 from ..tokenizer_utils import _ServerTokenStreamer, make_streaming_detokenizer
 from ..utils import ThinkingBudgetCriteria, load, prepare_inputs
 from .runtime import runtime
@@ -891,7 +892,7 @@ class ResponseGenerator:
         )
 
     def _make_logits_processors(
-        self, args: GenerationArguments
+        self, args: GenerationArguments, input_ids: Optional[mx.array] = None
     ) -> List[Callable[[mx.array, mx.array], mx.array]]:
         processors = make_logits_processors(
             args.logit_bias,
@@ -903,8 +904,62 @@ class ResponseGenerator:
             args.frequency_context_size,
         )
         if args.logits_processors is not None:
-            processors.extend(args.logits_processors)
+            request_processors = args.logits_processors
+            if input_ids is not None and self._prompt_has_open_thinking(
+                args, input_ids
+            ):
+                request_processors = self._wrap_processors_until_thinking_done(
+                    args, request_processors
+                )
+            processors.extend(request_processors)
         return processors
+
+    def _thinking_token_ids(self, args: GenerationArguments) -> Tuple[int, int]:
+        tokenizer = self.tokenizer
+        thinking_start_token = args.thinking_start_token or DEFAULT_THINKING_START_TOKEN
+        thinking_end_token = args.thinking_end_token or DEFAULT_THINKING_END_TOKEN
+        thinking_start_token_id = tokenizer.encode(
+            thinking_start_token, add_special_tokens=False
+        )[-1]
+        thinking_end_token_id = tokenizer.encode(
+            thinking_end_token, add_special_tokens=False
+        )[-1]
+        return thinking_start_token_id, thinking_end_token_id
+
+    def _prompt_has_open_thinking(
+        self, args: GenerationArguments, input_ids: mx.array
+    ) -> bool:
+        if not args.enable_thinking:
+            return False
+        thinking_start_token_id, thinking_end_token_id = self._thinking_token_ids(args)
+        tokens = input_ids.flatten().tolist()
+        try:
+            last_start = len(tokens) - 1 - tokens[::-1].index(thinking_start_token_id)
+        except ValueError:
+            return False
+        try:
+            last_end = len(tokens) - 1 - tokens[::-1].index(thinking_end_token_id)
+        except ValueError:
+            last_end = -1
+        return last_start > last_end
+
+    def _wrap_processors_until_thinking_done(
+        self,
+        args: GenerationArguments,
+        processors: List[Callable[[mx.array, mx.array], mx.array]],
+    ) -> List[Callable[[mx.array, mx.array], mx.array]]:
+        thinking_start_token = args.thinking_start_token or DEFAULT_THINKING_START_TOKEN
+        thinking_end_token = args.thinking_end_token or DEFAULT_THINKING_END_TOKEN
+        return [
+            ThinkingAwareLogitsProcessor(
+                processor=processor,
+                tokenizer=self.tokenizer,
+                thinking_start_token=thinking_start_token,
+                thinking_end_token=thinking_end_token,
+                enable_thinking=True,
+            )
+            for processor in processors
+        ]
 
     def _make_thinking_budget_criteria(
         self, args: GenerationArguments, input_ids: mx.array
@@ -914,12 +969,7 @@ class ResponseGenerator:
         tokenizer = self.tokenizer
         thinking_start_token = args.thinking_start_token or DEFAULT_THINKING_START_TOKEN
         thinking_end_token = args.thinking_end_token or DEFAULT_THINKING_END_TOKEN
-        thinking_start_token_id = tokenizer.encode(
-            thinking_start_token, add_special_tokens=False
-        )[-1]
-        enable_thinking = bool(args.enable_thinking) and (
-            thinking_start_token_id in input_ids.flatten().tolist()
-        )
+        enable_thinking = self._prompt_has_open_thinking(args, input_ids)
         return ThinkingBudgetCriteria(
             tokenizer=tokenizer,
             thinking_budget=args.thinking_budget,
@@ -1111,7 +1161,9 @@ class ResponseGenerator:
                             [input_ids.squeeze(0).tolist()],
                             max_tokens=args.max_tokens,
                             prompt_kwargs=[gen_kwargs],
-                            logits_processors=[self._make_logits_processors(args)],
+                            logits_processors=[
+                                self._make_logits_processors(args, input_ids)
+                            ],
                             thinking_budget_criteria=[thinking_budget_criteria],
                         )
                     except Exception as e:

--- a/mlx_vlm/structured.py
+++ b/mlx_vlm/structured.py
@@ -91,6 +91,107 @@ class LLGuidanceLogitsProcessor:
         return self._apply_bitmask(logits)
 
 
+class ThinkingAwareLogitsProcessor:
+    """Delay a logits processor until model thinking has ended.
+
+    Structured grammars constrain the final answer, not the private thinking
+    tokens. This wrapper keeps the wrapped processor inactive until it observes
+    the configured thinking end token, then lets the wrapped processor constrain
+    the next sampled token as the first token of the final answer.
+    """
+
+    def __init__(
+        self,
+        processor,
+        tokenizer,
+        thinking_start_token: str = "<think>",
+        thinking_end_token: str = "</think>",
+        enable_thinking: bool = False,
+    ) -> None:
+        self.processor = processor
+        self.tokenizer = tokenizer
+        self.thinking_start_token = thinking_start_token
+        self.thinking_end_token = thinking_end_token
+        self.enable_thinking = enable_thinking
+        self._active = not enable_thinking
+        self._active_context: list[int] = []
+
+        self.thinking_start_token_id = tokenizer.encode(
+            thinking_start_token, add_special_tokens=False
+        )[-1]
+        self.thinking_end_token_id = tokenizer.encode(
+            thinking_end_token, add_special_tokens=False
+        )[-1]
+
+    def clone(self) -> "ThinkingAwareLogitsProcessor":
+        processor = (
+            self.processor.clone()
+            if hasattr(self.processor, "clone")
+            else self.processor
+        )
+        return ThinkingAwareLogitsProcessor(
+            processor=processor,
+            tokenizer=self.tokenizer,
+            thinking_start_token=self.thinking_start_token,
+            thinking_end_token=self.thinking_end_token,
+            enable_thinking=self.enable_thinking,
+        )
+
+    def reset(self):
+        self._active = not self.enable_thinking
+        self._active_context = []
+        if hasattr(self.processor, "reset"):
+            self.processor.reset()
+
+    def _activate_if_thinking_done(self, token_id: int) -> bool:
+        if self._active:
+            return False
+        if token_id == self.thinking_end_token_id:
+            self._active = True
+            self._active_context = []
+            return True
+        return False
+
+    def _delegate_process_last_token(
+        self, last_token: int, logits: mx.array
+    ) -> mx.array:
+        if hasattr(self.processor, "process_last_token"):
+            return self.processor.process_last_token(last_token, logits)
+
+        self._active_context.append(last_token)
+        return self.processor(mx.array(self._active_context), logits)
+
+    def process_last_token(self, last_token: int, logits: mx.array) -> mx.array:
+        if not self._active:
+            activated = self._activate_if_thinking_done(last_token)
+            if not activated:
+                return logits
+            return self._delegate_process_last_token(last_token, logits)
+
+        return self._delegate_process_last_token(last_token, logits)
+
+    def _last_token_from_input_ids(self, input_ids: mx.array) -> int | None:
+        if input_ids.ndim == 0:
+            return int(input_ids.item())
+        if input_ids.ndim == 1:
+            if input_ids.shape[0] == 0:
+                return None
+            return int(input_ids[-1].item())
+        if input_ids.shape[-1] == 0:
+            return None
+        return int(input_ids.reshape(-1, input_ids.shape[-1])[0, -1].item())
+
+    def __call__(self, input_ids: mx.array, logits: mx.array) -> mx.array:
+        if self._active:
+            return self.processor(input_ids, logits)
+
+        token_id = self._last_token_from_input_ids(input_ids)
+        if token_id is not None and self._activate_if_thinking_done(token_id):
+            return self.processor(input_ids, logits)
+
+        return logits
+
+
 def _serialize_schema(schema: str | dict[str, Any]) -> str:
     if isinstance(schema, str):
         return schema
@@ -117,5 +218,12 @@ def build_json_schema_logits_processor(tokenizer, schema: str | dict[str, Any]):
         llg_tokenizer = llguidance.hf.from_tokenizer(tokenizer)
         _llg_tokenizer_cache[id(tokenizer)] = llg_tokenizer
 
-    grammar = llg.grammar_from("json_schema", _serialize_schema(schema))
+    schema_text = _serialize_schema(schema)
+    if hasattr(llg, "JsonCompiler"):
+        grammar = llg.JsonCompiler(
+            separators=(", ", ": "),
+            whitespace_pattern="",
+        ).compile(schema_text)
+    else:
+        grammar = llg.grammar_from("json_schema", schema_text)
     return LLGuidanceLogitsProcessor(grammar, llg_tokenizer)

--- a/mlx_vlm/tests/test_server.py
+++ b/mlx_vlm/tests/test_server.py
@@ -3954,6 +3954,70 @@ class TestResponseGenerator:
         assert calls == [({5: -0.5}, 1.2, 512, 0.2, 256, 0.3, 128)]
         assert processors == ["repetition-processor", custom_processor]
 
+    def test_server_generation_delays_structured_processors_for_thinking_prompt(
+        self, monkeypatch
+    ):
+        class SimpleTokenizer:
+            def encode(self, text, add_special_tokens=False):
+                return {"<think>": [10], "</think>": [20]}[text]
+
+        repetition_processor = lambda tokens, logits: logits
+        structured_processor = lambda tokens, logits: logits
+
+        monkeypatch.setattr(
+            server_generation,
+            "make_logits_processors",
+            lambda *_args: [repetition_processor],
+        )
+
+        gen = server.ResponseGenerator.__new__(server.ResponseGenerator)
+        gen.tokenizer = SimpleTokenizer()
+        args = server.GenerationArguments(
+            enable_thinking=True,
+            thinking_start_token="<think>",
+            thinking_end_token="</think>",
+            logits_processors=[structured_processor],
+        )
+
+        processors = gen._make_logits_processors(
+            args,
+            mx.array([[1, 10, 3]], dtype=mx.int32),
+        )
+
+        assert processors[0] is repetition_processor
+        assert isinstance(processors[1], server_generation.ThinkingAwareLogitsProcessor)
+        assert processors[1].processor is structured_processor
+
+    def test_server_generation_keeps_structured_processors_active_without_open_thinking(
+        self, monkeypatch
+    ):
+        class SimpleTokenizer:
+            def encode(self, text, add_special_tokens=False):
+                return {"<think>": [10], "</think>": [20]}[text]
+
+        structured_processor = lambda tokens, logits: logits
+        monkeypatch.setattr(
+            server_generation,
+            "make_logits_processors",
+            lambda *_args: [],
+        )
+
+        gen = server.ResponseGenerator.__new__(server.ResponseGenerator)
+        gen.tokenizer = SimpleTokenizer()
+        args = server.GenerationArguments(
+            enable_thinking=True,
+            thinking_start_token="<think>",
+            thinking_end_token="</think>",
+            logits_processors=[structured_processor],
+        )
+
+        processors = gen._make_logits_processors(
+            args,
+            mx.array([[1, 10, 3, 20]], dtype=mx.int32),
+        )
+
+        assert processors == [structured_processor]
+
     def test_build_gen_args_from_openai_request(self):
         req = SimpleNamespace(
             max_output_tokens=128,

--- a/mlx_vlm/tests/test_server.py
+++ b/mlx_vlm/tests/test_server.py
@@ -4277,6 +4277,24 @@ class TestResponseGenerator:
 
         assert schema["required"] == ["animal"]
 
+    @pytest.mark.parametrize("format_type", ["json_object", "object"])
+    def test_extract_chat_response_format_json_object_aliases(self, format_type):
+        req = SimpleNamespace(
+            response_format={"type": format_type},
+            text=None,
+        )
+
+        assert server._extract_response_format_schema(req) == {"type": "object"}
+
+    @pytest.mark.parametrize("format_type", ["json_object", "object"])
+    def test_extract_responses_text_format_json_object_aliases(self, format_type):
+        req = SimpleNamespace(
+            response_format=None,
+            text={"format": {"type": format_type}},
+        )
+
+        assert server._extract_response_format_schema(req) == {"type": "object"}
+
     def test_build_structured_logits_processors_uses_tokenizer(self):
         req = SimpleNamespace(
             response_format={
@@ -4286,6 +4304,24 @@ class TestResponseGenerator:
                     "schema": {"type": "object"},
                 },
             },
+            text=None,
+        )
+        proc = SimpleNamespace(tokenizer=object())
+
+        with patch.object(
+            server, "build_json_schema_logits_processor", return_value="processor"
+        ) as mock_build:
+            processors = server._build_structured_logits_processors(req, proc)
+
+        assert processors == ["processor"]
+        assert mock_build.call_args.args[1] == {"type": "object"}
+
+    @pytest.mark.parametrize("format_type", ["json_object", "object"])
+    def test_build_structured_logits_processors_for_json_object_aliases(
+        self, format_type
+    ):
+        req = SimpleNamespace(
+            response_format={"type": format_type},
             text=None,
         )
         proc = SimpleNamespace(tokenizer=object())

--- a/mlx_vlm/tests/test_structured.py
+++ b/mlx_vlm/tests/test_structured.py
@@ -1,0 +1,128 @@
+import sys
+import types
+
+import mlx.core as mx
+
+from mlx_vlm import structured
+from mlx_vlm.structured import ThinkingAwareLogitsProcessor
+
+
+class TinyThinkingTokenizer:
+    def encode(self, text, add_special_tokens=False):
+        return {
+            "<think>": [10],
+            "</think>": [20],
+        }[text]
+
+
+class RecordingProcessor:
+    def __init__(self):
+        self.calls = []
+
+    def clone(self):
+        clone = RecordingProcessor()
+        clone.calls.append(("cloned", None))
+        return clone
+
+    def process_last_token(self, token, logits):
+        self.calls.append(("process_last_token", token))
+        return logits + 1
+
+    def __call__(self, input_ids, logits):
+        self.calls.append(("call", input_ids.tolist()))
+        return logits + 2
+
+
+def test_thinking_aware_processor_passes_logits_until_thinking_ends():
+    inner = RecordingProcessor()
+    processor = ThinkingAwareLogitsProcessor(
+        inner,
+        TinyThinkingTokenizer(),
+        enable_thinking=True,
+    )
+    logits = mx.zeros((1, 3), dtype=mx.float32)
+
+    out = processor.process_last_token(11, logits)
+    mx.eval(out)
+    assert out.tolist() == logits.tolist()
+    assert inner.calls == []
+
+    out = processor.process_last_token(20, logits)
+    mx.eval(out)
+    assert out.tolist() == (logits + 1).tolist()
+    assert inner.calls == [("process_last_token", 20)]
+
+    out = processor.process_last_token(3, logits)
+    mx.eval(out)
+    assert out.tolist() == (logits + 1).tolist()
+    assert inner.calls[-1] == ("process_last_token", 3)
+
+
+def test_thinking_aware_processor_delegates_immediately_without_thinking():
+    inner = RecordingProcessor()
+    processor = ThinkingAwareLogitsProcessor(
+        inner,
+        TinyThinkingTokenizer(),
+        enable_thinking=False,
+    )
+    logits = mx.zeros((1, 3), dtype=mx.float32)
+
+    out = processor(mx.array([1, 2, 3]), logits)
+    mx.eval(out)
+
+    assert out.tolist() == (logits + 2).tolist()
+    assert inner.calls == [("call", [1, 2, 3])]
+
+
+def test_thinking_aware_processor_clone_resets_phase_state():
+    inner = RecordingProcessor()
+    processor = ThinkingAwareLogitsProcessor(
+        inner,
+        TinyThinkingTokenizer(),
+        enable_thinking=True,
+    )
+    processor.process_last_token(20, mx.zeros((1, 3), dtype=mx.float32))
+
+    clone = processor.clone()
+    out = clone.process_last_token(11, mx.zeros((1, 3), dtype=mx.float32))
+    mx.eval(out)
+
+    assert isinstance(clone.processor, RecordingProcessor)
+    assert clone.processor is not inner
+    assert clone.processor.calls == [("cloned", None)]
+    assert out.tolist() == [[0.0, 0.0, 0.0]]
+
+
+def test_json_schema_processor_uses_compact_whitespace_pattern(monkeypatch):
+    observed = {}
+    fake_llguidance = types.ModuleType("llguidance")
+    fake_llguidance.__path__ = []
+    fake_hf = types.ModuleType("llguidance.hf")
+
+    class FakeJsonCompiler:
+        def __init__(self, **kwargs):
+            observed["compiler_kwargs"] = kwargs
+
+        def compile(self, schema_text):
+            observed["schema_text"] = schema_text
+            return "compiled grammar"
+
+    fake_llguidance.JsonCompiler = FakeJsonCompiler
+    fake_llguidance.grammar_from = lambda *_args: "fallback grammar"
+    fake_hf.from_tokenizer = lambda tokenizer: "llg-tokenizer"
+    fake_llguidance.hf = fake_hf
+    monkeypatch.setitem(sys.modules, "llguidance", fake_llguidance)
+    monkeypatch.setitem(sys.modules, "llguidance.hf", fake_hf)
+    structured._llg_tokenizer_cache.clear()
+
+    processor = structured.build_json_schema_logits_processor(
+        object(),
+        {"type": "object"},
+    )
+
+    assert processor.grammar == "compiled grammar"
+    assert observed["compiler_kwargs"] == {
+        "separators": (", ", ": "),
+        "whitespace_pattern": "",
+    }
+    assert observed["schema_text"] == '{"type": "object"}'


### PR DESCRIPTION
Right now the thinking budget can inject a `</think>` token (or equivalent) when using a thinking budget that breaks the output schema when using structured outputs. This makes it so we only apply the schema after the thinking section when thinking is enabled. Resolves https://github.com/Blaizzy/mlx-vlm/issues/1294