### PR TITLE
Fix gemma4 load for HF checkpoints with num_kv_shared_layers > 0

### DIFF
--- a/mlx_vlm/models/gemma4/language.py
+++ b/mlx_vlm/models/gemma4/language.py
@@ -759,6 +759,8 @@ class LanguageModel(nn.Module):
         for k, v in weights.items():
             if "self_attn.rotary_emb" in k:
                 continue
+            if self._is_unused_shared_kv_weight(k):
+                continue
             if any(
                 s in k for s in ["input_max", "input_min", "output_max", "output_min"]
             ):
@@ -766,6 +768,28 @@ class LanguageModel(nn.Module):
                     continue
             sanitized[k] = v
         return sanitized
+
+    def _is_unused_shared_kv_weight(self, key: str) -> bool:
+        prefix = "language_model.model.layers."
+        if not key.startswith(prefix):
+            return False
+
+        parts = key[len(prefix) :].split(".")
+        if len(parts) < 4 or parts[1] != "self_attn":
+            return False
+
+        try:
+            layer_idx = int(parts[0])
+        except ValueError:
+            return False
+        if layer_idx >= len(self.model.layers):
+            return False
+
+        attn = self.model.layers[layer_idx].self_attn
+        if not getattr(attn, "is_kv_shared_layer", False):
+            return False
+
+        return parts[2] in {"k_proj", "v_proj", "k_norm", "v_norm"}
 
     @property
     def layers(self):

--- a/mlx_vlm/models/gemma4/language.py
+++ b/mlx_vlm/models/gemma4/language.py
@@ -375,14 +375,20 @@ class Gemma4TextModel(nn.Module):
 
         self.embed_tokens = nn.Embedding(config.vocab_size, config.hidden_size)
         self.embed_scale = config.hidden_size**0.5
+        num_kv_shared = getattr(config, "num_kv_shared_layers", 0)
+        first_kv_shared = config.num_hidden_layers - num_kv_shared
         self.layers = [
-            DecoderLayer(config, layer_idx=i, kv_shared_only=kv_shared_only)
+            DecoderLayer(
+                config,
+                layer_idx=i,
+                kv_shared_only=kv_shared_only
+                or (num_kv_shared > 0 and i >= first_kv_shared),
+            )
             for i in range(config.num_hidden_layers)
         ]
         self.norm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
 
-        num_kv_shared = getattr(config, "num_kv_shared_layers", 0)
-        self.first_kv_shared_layer_idx = config.num_hidden_layers - num_kv_shared
+        self.first_kv_shared_layer_idx = first_kv_shared
         self.previous_kvs = list(range(len(self.layers)))
         if num_kv_shared > 0:
             N = len(self.layers)

--- a/mlx_vlm/tests/test_models.py
+++ b/mlx_vlm/tests/test_models.py
@@ -2940,10 +2940,7 @@ class TestModels(unittest.TestCase):
             (1, 6, config_with_audio.text_config.vocab_size),
         )
 
-    def test_gemma4_sanitize_drops_unused_shared_kv_weights(self):
-        from mlx_vlm.models import gemma4
-
-        text_config = gemma4.TextConfig(
+        shared_text_config = gemma4.TextConfig(
             model_type="gemma4_text",
             hidden_size=16,
             num_hidden_layers=4,
@@ -2959,30 +2956,18 @@ class TestModels(unittest.TestCase):
             sliding_window=32,
             sliding_window_pattern=2,
         )
-        model = gemma4.Model(
+        shared_model = gemma4.Model(
             gemma4.ModelConfig(
-                text_config=text_config,
-                vision_config=gemma4.VisionConfig(
-                    hidden_size=16,
-                    num_hidden_layers=1,
-                    intermediate_size=32,
-                    num_attention_heads=2,
-                    num_key_value_heads=2,
-                    head_dim=8,
-                    patch_size=16,
-                    pooling_kernel_size=2,
-                    default_output_length=4,
-                    position_embedding_size=64,
-                    use_clipped_linears=False,
-                ),
+                text_config=shared_text_config,
+                vision_config=vision_config,
                 model_type="gemma4",
-                vocab_size=32,
-                image_token_id=31,
+                vocab_size=config.vocab_size,
+                image_token_id=config.image_token_id,
                 audio_config=None,
             )
         )
 
-        weights = model.sanitize(
+        weights = shared_model.sanitize(
             {
                 "model.language_model.layers.1.self_attn.k_proj.weight": mx.zeros(
                     (8, 16)
@@ -3002,7 +2987,7 @@ class TestModels(unittest.TestCase):
                 ),
             }
         )
-        weights = model.language_model.sanitize(weights)
+        weights = shared_model.language_model.sanitize(weights)
 
         self.assertIn("language_model.model.layers.1.self_attn.k_proj.weight", weights)
         self.assertIn("language_model.model.layers.2.self_attn.q_proj.weight", weights)

--- a/mlx_vlm/tests/test_models.py
+++ b/mlx_vlm/tests/test_models.py
@@ -2993,9 +2993,7 @@ class TestModels(unittest.TestCase):
                 "model.language_model.layers.2.self_attn.v_proj.weight": mx.zeros(
                     (8, 16)
                 ),
-                "model.language_model.layers.2.self_attn.k_norm.weight": mx.zeros(
-                    (8,)
-                ),
+                "model.language_model.layers.2.self_attn.k_norm.weight": mx.zeros((8,)),
                 "model.language_model.layers.2.self_attn.q_proj.weight": mx.zeros(
                     (16, 16)
                 ),

--- a/mlx_vlm/tests/test_models.py
+++ b/mlx_vlm/tests/test_models.py
@@ -2940,6 +2940,87 @@ class TestModels(unittest.TestCase):
             (1, 6, config_with_audio.text_config.vocab_size),
         )
 
+    def test_gemma4_sanitize_drops_unused_shared_kv_weights(self):
+        from mlx_vlm.models import gemma4
+
+        text_config = gemma4.TextConfig(
+            model_type="gemma4_text",
+            hidden_size=16,
+            num_hidden_layers=4,
+            intermediate_size=32,
+            num_attention_heads=2,
+            num_key_value_heads=1,
+            head_dim=8,
+            global_head_dim=8,
+            vocab_size=32,
+            vocab_size_per_layer_input=32,
+            hidden_size_per_layer_input=8,
+            num_kv_shared_layers=2,
+            sliding_window=32,
+            sliding_window_pattern=2,
+        )
+        model = gemma4.Model(
+            gemma4.ModelConfig(
+                text_config=text_config,
+                vision_config=gemma4.VisionConfig(
+                    hidden_size=16,
+                    num_hidden_layers=1,
+                    intermediate_size=32,
+                    num_attention_heads=2,
+                    num_key_value_heads=2,
+                    head_dim=8,
+                    patch_size=16,
+                    pooling_kernel_size=2,
+                    default_output_length=4,
+                    position_embedding_size=64,
+                    use_clipped_linears=False,
+                ),
+                model_type="gemma4",
+                vocab_size=32,
+                image_token_id=31,
+                audio_config=None,
+            )
+        )
+
+        weights = model.sanitize(
+            {
+                "model.language_model.layers.1.self_attn.k_proj.weight": mx.zeros(
+                    (8, 16)
+                ),
+                "model.language_model.layers.2.self_attn.k_proj.weight": mx.zeros(
+                    (8, 16)
+                ),
+                "model.language_model.layers.2.self_attn.v_proj.weight": mx.zeros(
+                    (8, 16)
+                ),
+                "model.language_model.layers.2.self_attn.k_norm.weight": mx.zeros(
+                    (8,)
+                ),
+                "model.language_model.layers.2.self_attn.q_proj.weight": mx.zeros(
+                    (16, 16)
+                ),
+                "model.language_model.layers.3.self_attn.v_proj.weight": mx.zeros(
+                    (8, 16)
+                ),
+            }
+        )
+        weights = model.language_model.sanitize(weights)
+
+        self.assertIn("language_model.model.layers.1.self_attn.k_proj.weight", weights)
+        self.assertIn("language_model.model.layers.2.self_attn.q_proj.weight", weights)
+        self.assertNotIn(
+            "language_model.model.layers.2.self_attn.k_proj.weight", weights
+        )
+        self.assertNotIn(
+            "language_model.model.layers.2.self_attn.v_proj.weight", weights
+        )
+        self.assertNotIn(
+            "language_model.model.layers.2.self_attn.k_norm.weight", weights
+        )
+        self.assertNotIn(
+            "language_model.model.layers.3.self_attn.v_proj.weight", weights
+        )
+
     def test_gemma4_unified(self):
         import tempfile
         from pathlib import Path


### PR DESCRIPTION
## Summary

Loading `google/gemma-4-*` HF checkpoints (e.g. `gemma-4-E2B-it-qat-q4_0-unquantized`) fails with `ValueError: Missing 60 parameters`, listing `k_proj` / `v_proj` / `k_norm` weights for the upper layers.

These layers are KV-shared: when `num_kv_shared_layers > 0`, the last `num_kv_shared_layers` layers reuse KV from an earlier layer of the same `layer_type` and don't ship their own K/V tensors in the checkpoint.

The `Attention` class already handles this via `kv_shared_only=True` (skips creating `k_proj` / `v_proj` / `k_norm` / `v_norm`). But `Gemma4TextModel.__init__` only forwarded the module-level `kv_shared_only` flag uniformly to every `DecoderLayer`, so during conversion (with default `kv_shared_only=False`) every layer still allocated its own KV modules → `load_weights` raised.

This PR sets `kv_shared_only=True` for layers in the shared range (`i >= num_hidden_layers - num_kv_shared_layers`), matching what the `Attention` class expects.

For `gemma-4-E2B-it-qat-q4_0-unquantized`: `num_hidden_layers=35`, `num_kv_shared_layers=20` → layers 15..34 are shared → 20 × {k_proj, v_proj, k_norm} = 60 missing tensors, which matches the error exactly.

## Verification

Patched in-place against `mlx-vlm 0.6.1` on a Linux/RTX-PRO-6000 box, then ran `python -m mlx_vlm convert --hf-path google/gemma-4-E2B-it-qat-q4_0-unquantized --mlx-path /tmp/out -q --q-bits 4`. Model loads cleanly, quantization runs, output safetensors written (4.33 GB), upload to `mlx-community/gemma-4-E2B-it-qat-4bit` succeeds.

## Test plan

- [ ] CI passes
- [ ] `python -m mlx_vlm convert --hf-path google/gemma-4-E2B-it-qat-q4_0-unquantized --mlx-path /tmp/out -q --q-bits 4` succeeds
- [ ] Inference on a non-KV-shared model (e.g. an earlier gemma model) still works — `kv_shared_only` path is additive, default config (`num_kv_shared_layers=0`) is unchanged
