### PR TITLE
Accept qwen3_5_vision / qwen3_5_moe_vision vision model_type

### DIFF
--- a/mlx_vlm/models/qwen3_vl/vision.py
+++ b/mlx_vlm/models/qwen3_vl/vision.py
@@ -197,7 +197,13 @@ class VisionModel(nn.Module):
         self.config = config
         self.model_type = config.model_type
 
-        if self.model_type not in ["qwen3_vl", "qwen3_5", "qwen3_5_moe"]:
+        if self.model_type not in [
+            "qwen3_vl",
+            "qwen3_5",
+            "qwen3_5_moe",
+            "qwen3_5_vision",
+            "qwen3_5_moe_vision",
+        ]:
             raise ValueError(f"Unsupported model type: {self.model_type}")
 
         self.spatial_merge_size = config.spatial_merge_size


### PR DESCRIPTION
## What
Add `qwen3_5_vision` and `qwen3_5_moe_vision` to the allowed `model_type` list in `Qwen3VLVisionModel`.

## Why
Qwen3.5-VL checkpoints (e.g. the [Hcompany/Holo-3.1](https://huggingface.co/collections/Hcompany/holo31) computer-use family) report a vision-tower `model_type` of `qwen3_5_vision` (dense) or `qwen3_5_moe_vision` (MoE) in `vision_config`. The current guard only allows `["qwen3_vl", "qwen3_5", "qwen3_5_moe"]`, so loading/converting these models fails with:

```
ValueError: Unsupported model type: qwen3_5_vision
```

…even though the vision tower is the already-supported Qwen3-VL tower (the `qwen3_5` module subclasses it unchanged).

## Verification
With this one-line allow-list addition, converted **Holo-3.1-4B** (dense), **Holo-3.1-9B** (dense), and **Holo-3.1-35B-A3B** (MoE) to MLX via `mlx_vlm.convert` and confirmed correct multimodal output on a UI screenshot (button grounding + on-screen text OCR) across all three.

No behavior change for existing models — purely widens the accepted vision `model_type` set.