### PR TITLE
Don't specify a default model for the server

### DIFF
--- a/mlx_vlm/server/schemas.py
+++ b/mlx_vlm/server/schemas.py
@@ -9,7 +9,6 @@ if TYPE_CHECKING:
 
 from ..generate import (
     DEFAULT_MAX_TOKENS,
-    DEFAULT_MODEL_PATH,
     DEFAULT_SEED,
     DEFAULT_TEMPERATURE,
     DEFAULT_TOP_P,
@@ -593,7 +592,7 @@ StreamEvent = Union[
 
 class VLMRequest(FlexibleBaseModel):
     model: str = Field(
-        DEFAULT_MODEL_PATH,
+        ...,
         description="The path to the local model directory or Hugging Face repo.",
     )
     adapter_path: Optional[str] = Field(

--- a/mlx_vlm/tests/test_server.py
+++ b/mlx_vlm/tests/test_server.py
@@ -72,6 +72,21 @@ def test_chat_completions_endpoint_rejects_invalid_resize_shape(client, value):
     assert response.status_code == 422
 
 
+def test_chat_completions_endpoint_requires_model(client):
+    response = client.post(
+        "/chat/completions",
+        json={"messages": [{"role": "user", "content": "Hello"}]},
+    )
+
+    assert response.status_code == 422
+    detail = response.json().get("detail", [])
+    assert any(err.get("loc") == ["body", "model"] for err in detail)
+
+
+def test_chat_request_schema_requires_model():
+    assert "model" in server.ChatRequest.model_json_schema()["required"]
+
+
 def test_chat_request_schema_allows_one_or_two_resize_shape_values():
     resize_shape = server.ChatRequest.model_json_schema()["properties"]["resize_shape"]
     lengths = {


### PR DESCRIPTION
Currently the server allows omitting the `model` field in requests and will load a default model that's relatively old. This behavior is unintuitive and doesn't give any apparent indication that it happened, e.g. see https://github.com/Blaizzy/mlx-vlm/issues/1296

Instead, just require the `model` field for /v1/chat/completions so users get the proper HTTP  `422 Unprocessable Entity` response indicating the issue.

(The `--model` flag still works as normal for preloading a model into the cache at launch.)