### PR TITLE
Allow chunked prefill for MTP speculation

### DIFF
--- a/mlx_vlm/generate/ar.py
+++ b/mlx_vlm/generate/ar.py
@@ -89,8 +89,13 @@ def _chunked_prefill_enabled(
     if any(getattr(candidate, "no_chunked_prefill", False) for candidate in candidates):
         return False
 
-    # Hidden-state speculative prefill is model-contract dependent. Keep unknown
-    # target models conservative unless they expose a chunked_prefill_policy.
+    # MTP only needs the final-position hidden state and shared K/V from the
+    # post-prefill step, so earlier prompt columns can use normal chunking.
+    if draft_kind == "mtp":
+        return True
+
+    # Other hidden-state speculative prefill is model-contract dependent. Keep
+    # unknown target models conservative unless they expose a policy.
     return draft_model is None
 
 

--- a/mlx_vlm/tests/test_generate.py
+++ b/mlx_vlm/tests/test_generate.py
@@ -1643,15 +1643,26 @@ def test_generate_step_chunks_prefill_when_model_policy_allows_speculation():
     model.chunked_prefill_policy.assert_called_once()
 
 
-def test_chunked_prefill_policy_defaults_conservative_for_speculation():
+def test_chunked_prefill_policy_defaults_to_chunking_for_mtp_speculation():
     model = SimpleNamespace(no_chunked_prefill=False)
 
     assert ar_module._chunked_prefill_enabled(model)
-    assert not ar_module._chunked_prefill_enabled(
+    assert ar_module._chunked_prefill_enabled(
         model,
         draft_model=SimpleNamespace(config=SimpleNamespace(target_layer_ids=[])),
         draft_kind="mtp",
         prefill_kwargs={"return_hidden": True, "return_shared_kv": True},
+    )
+
+
+def test_chunked_prefill_policy_stays_conservative_for_hidden_capture_speculation():
+    model = SimpleNamespace(no_chunked_prefill=False)
+
+    assert not ar_module._chunked_prefill_enabled(
+        model,
+        draft_model=SimpleNamespace(config=SimpleNamespace(target_layer_ids=[])),
+        draft_kind="dflash",
+        prefill_kwargs={"capture_layer_ids": [1, 2]},
     )
 
 


### PR DESCRIPTION
## Summary
- allow MTP speculative decoding to keep normal chunked prefill by default
- keep non-MTP hidden-capture speculation conservative unless a model policy opts in
- update chunked-prefill policy regression tests

Fixes #1293
Likely addresses #1286

## Tests
- `uv run --with pytest pytest mlx_vlm/tests/test_generate.py -k "chunked_prefill or prefill_tqdm"`
- `uv run --with pytest pytest mlx_vlm/tests/test_server.py -k "speculative or mtp"`
- `uv run --with pytest --with psutil pytest mlx_vlm/tests`