### PR TITLE
Fix Kimi VL quantized projector loading

### DIFF
--- a/mlx_vlm/tests/test_utils.py
+++ b/mlx_vlm/tests/test_utils.py
@@ -569,6 +569,73 @@ def test_load_model_uses_deepseek_v4_fp8_quantization_config():
     assert quantize.call_args.kwargs["mode"] == "affine"
 
 
+def test_load_model_quantizes_projector_with_scales_when_skip_vision():
+    safe_open = MagicMock()
+    safe_open.__enter__.return_value.metadata.return_value = {"format": "mlx"}
+
+    class FakeConfig:
+        @classmethod
+        def from_dict(cls, config):
+            return cls()
+
+    class FakeProjector(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.linear_1 = nn.Linear(64, 64, bias=False)
+
+    class FakeModel(nn.Module):
+        def __init__(self, config):
+            super().__init__()
+            self.config = config
+            self.vision_tower = nn.Linear(64, 64, bias=False)
+            self.multi_modal_projector = FakeProjector()
+            self.language_model = nn.Linear(64, 64, bias=False)
+
+        def load_weights(self, weights):
+            self.loaded_weights = weights
+
+    fake_model_class = SimpleNamespace(ModelConfig=FakeConfig, Model=FakeModel)
+    weights = {
+        "language_model.weight": mx.zeros((64, 16), dtype=mx.uint32),
+        "language_model.scales": mx.zeros((64, 1), dtype=mx.float16),
+        "multi_modal_projector.linear_1.weight": mx.zeros((64, 16), dtype=mx.uint32),
+        "multi_modal_projector.linear_1.scales": mx.zeros((64, 1), dtype=mx.float16),
+        "vision_tower.weight": mx.zeros((64, 64), dtype=mx.float16),
+    }
+    selected = {}
+
+    def fake_quantize(model, *args, **kwargs):
+        predicate = kwargs["class_predicate"]
+        selected["language"] = predicate("language_model", model.language_model)
+        selected["projector"] = predicate(
+            "multi_modal_projector.linear_1",
+            model.multi_modal_projector.linear_1,
+        )
+        selected["vision"] = predicate("vision_tower", model.vision_tower)
+
+    with (
+        patch(
+            "mlx_vlm.utils.load_config",
+            return_value={
+                "model_type": "kimi_vl",
+                "quantization": {"group_size": 64, "bits": 8},
+                "vision_config": {"skip_vision": True},
+            },
+        ),
+        patch("mlx_vlm.utils.glob.glob", return_value=["/tmp/model/model.safetensors"]),
+        patch("mlx_vlm.utils._load_safetensors", return_value=weights),
+        patch("mlx_vlm.utils.safetensors.safe_open", return_value=safe_open),
+        patch(
+            "mlx_vlm.utils.get_model_and_args",
+            return_value=(fake_model_class, "kimi_vl"),
+        ),
+        patch("mlx_vlm.utils.nn.quantize", side_effect=fake_quantize),
+    ):
+        load_model(Path("/tmp/model"), lazy=True)
+
+    assert selected == {"language": True, "projector": True, "vision": False}
+
+
 def test_load_delegates_adapter_loading_to_trainer_entrypoint():
     model = MagicMock()
     adapted_model = MagicMock()

--- a/mlx_vlm/utils.py
+++ b/mlx_vlm/utils.py
@@ -315,9 +315,17 @@ def skip_multimodal_module(path: str) -> bool:
     return any(module in path for module in multimodal_modules)
 
 
+def _has_quantized_weights(path: str, weights: Optional[Dict[str, mx.array]]) -> bool:
+    return weights is not None and f"{path}.scales" in weights
+
+
 def get_class_predicate(skip_vision=False, weights=None, quantization_config=None):
     def predicate(p, m):
-        if skip_multimodal_module(p) and skip_vision:
+        if (
+            skip_multimodal_module(p)
+            and skip_vision
+            and not _has_quantized_weights(p, weights)
+        ):
             return False
         if quantization_config is not None and p in quantization_config:
             return quantization_config[p]
@@ -586,8 +594,13 @@ python -m mlx_vlm.convert --hf-path <local_dir> --mlx-path <mlx_dir>
         )
 
         def get_class_predicate(p, m):
-            # Always skip vision and audio models
-            if skip_multimodal_module(p) and skip_vision:
+            # Skip legacy multimodal layers unless the checkpoint has quantized
+            # tensors for this exact module.
+            if (
+                skip_multimodal_module(p)
+                and skip_vision
+                and not _has_quantized_weights(p, weights)
+            ):
                 return False
             # Handle custom per layer quantizations
             if p in config["quantization"]:


### PR DESCRIPTION
## Summary

Fixes loading for MLX-format Kimi VL checkpoints where `vision_config.skip_vision` is true but the multimodal projector is still quantized.

## Root Cause

The loader skipped all multimodal modules when `skip_vision` was enabled. The `mlx-community/Kimi-VL-A3B-Thinking-8bit` checkpoint has no quantized vision tower tensors, but it does include quantized `multi_modal_projector` tensors. Because the projector stayed as plain `nn.Linear`, strict weight loading rejected the projector `.scales` and `.biases` tensors.

## Changes

- Only skip multimodal quantization when the exact module does not have quantized checkpoint tensors.
- Reuse the same logic in the shared quantization predicate.
- Add a regression test for `skip_vision=True` with a quantized projector and unquantized vision tower.

## Validation

- `uv run pytest mlx_vlm/tests/test_utils.py`
- Real checkpoint lazy load confirmed both Kimi VL projector layers become `QuantizedLinear` while the vision tower remains unquantized.
- CLI smoke test with `mlx-community/Kimi-VL-A3B-Thinking-8bit` reached generation without the previous strict load error.