### PR TITLE
Fix APC splitting on multimodal inputs

### DIFF
--- a/mlx_vlm/apc.py
+++ b/mlx_vlm/apc.py
@@ -341,6 +341,91 @@ def hash_image_payload(
     return int.from_bytes(digest[:8], "little", signed=True)
 
 
+def multimodal_token_ids_from_config(config: Any) -> set[int]:
+    """Return token IDs that represent media placeholders in a prompt."""
+    ids: set[int] = set()
+    for attr in (
+        "image_token_id",
+        "image_token_index",
+        "video_token_id",
+        "video_token_index",
+    ):
+        token_id = getattr(config, attr, None)
+        if token_id is not None:
+            ids.add(int(token_id))
+    return ids
+
+
+def media_token_spans(
+    token_ids: Sequence[int],
+    media_token_ids: Iterable[int],
+) -> Tuple[Tuple[int, int], ...]:
+    """Return contiguous media-token spans as half-open ``(start, end)`` ranges."""
+    media_ids = {int(token_id) for token_id in media_token_ids}
+    if not media_ids:
+        return ()
+
+    spans: list[tuple[int, int]] = []
+    start: Optional[int] = None
+    for idx, token_id in enumerate(token_ids):
+        if int(token_id) in media_ids:
+            if start is None:
+                start = idx
+        elif start is not None:
+            spans.append((start, idx))
+            start = None
+    if start is not None:
+        spans.append((start, len(token_ids)))
+    return tuple(spans)
+
+
+def media_safe_prefix_min(
+    token_ids: Sequence[int],
+    media_token_ids: Iterable[int],
+) -> int:
+    """Minimum prefix length that leaves a text-only suffix.
+
+    APC restore paths consume full prompt-level image/video feature tensors. Until
+    media-feature slicing is model-aware, restored prefixes must include every
+    media placeholder token so the suffix can be embedded as text-only.
+    """
+    spans = media_token_spans(token_ids, media_token_ids)
+    if not spans:
+        return 0
+    return max(end for _start, end in spans)
+
+
+def prefix_leaves_text_only_suffix(
+    token_ids: Sequence[int],
+    prefix_len: int,
+    media_token_ids: Iterable[int],
+) -> bool:
+    return int(prefix_len) >= media_safe_prefix_min(token_ids, media_token_ids)
+
+
+def adjust_prefix_to_text_suffix_boundary(
+    token_ids: Sequence[int],
+    desired_prefix_len: int,
+    media_token_ids: Iterable[int],
+    *,
+    max_prefix_tokens: Optional[int] = None,
+) -> int:
+    """Move an APC prefix forward until its suffix contains no media tokens.
+
+    Returns ``0`` when no useful safe prefix exists within ``max_prefix_tokens``.
+    """
+    max_len = (
+        len(token_ids) - 1 if max_prefix_tokens is None else int(max_prefix_tokens)
+    )
+    if max_len <= 0:
+        return 0
+    desired = max(1, int(desired_prefix_len))
+    prefix_len = max(desired, media_safe_prefix_min(token_ids, media_token_ids))
+    if prefix_len > max_len:
+        return 0
+    return prefix_len
+
+
 @dataclass
 class APCBlock:
     """One fixed-size KV block. Holds per-layer K/V slabs once committed."""

--- a/mlx_vlm/apc.py
+++ b/mlx_vlm/apc.py
@@ -403,6 +403,19 @@ def prefix_leaves_text_only_suffix(
     return int(prefix_len) >= media_safe_prefix_min(token_ids, media_token_ids)
 
 
+def prefix_contains_media_tokens(
+    token_ids: Sequence[int],
+    prefix_len: int,
+    media_token_ids: Iterable[int],
+) -> bool:
+    """Return whether the prefix itself contains media placeholder tokens."""
+    media_ids = {int(token_id) for token_id in media_token_ids}
+    if not media_ids or prefix_len <= 0:
+        return False
+    prefix_end = min(int(prefix_len), len(token_ids))
+    return any(int(token_id) in media_ids for token_id in token_ids[:prefix_end])
+
+
 def adjust_prefix_to_text_suffix_boundary(
     token_ids: Sequence[int],
     desired_prefix_len: int,

--- a/mlx_vlm/generate/ar.py
+++ b/mlx_vlm/generate/ar.py
@@ -2150,6 +2150,15 @@ class BatchGenerator:
             self._apc_media_token_ids(),
         )
 
+    def _apc_prefix_has_media_tokens(
+        self, ids_list: List[int], prefix_len: int
+    ) -> bool:
+        return _apc.prefix_contains_media_tokens(
+            ids_list,
+            prefix_len,
+            self._apc_media_token_ids(),
+        )
+
     def _apc_exact_checkpoint_len(self, ids_list: List[int]) -> int:
         if self.apc_manager is None or getattr(self, "apc_mode", "block") != "exact":
             return 0
@@ -2196,6 +2205,10 @@ class BatchGenerator:
         matched, prefix_len = self.apc_manager.lookup_prefix(
             ids_list, extra_hash=extra_hash
         )
+        if prefix_len > 0 and self._apc_prefix_has_media_tokens(ids_list, prefix_len):
+            self.apc_manager.release(matched)
+            matched = []
+            prefix_len = 0
         exact_cache = None
         exact_prefix_len = 0
         if prefix_len < len(ids_list):

--- a/mlx_vlm/generate/ar.py
+++ b/mlx_vlm/generate/ar.py
@@ -2136,6 +2136,30 @@ class BatchGenerator:
         tenant = prompt_kwargs.get("_apc_tenant")
         return _apc.tenant_scoped_hash(tenant, img)
 
+    def _apc_media_token_ids(self) -> set[int]:
+        return _apc.multimodal_token_ids_from_config(self.model.config)
+
+    def _apc_safe_prefix_lookup_min(self, ids_list: List[int]) -> int:
+        safe_min = _apc.media_safe_prefix_min(ids_list, self._apc_media_token_ids())
+        return max(0, safe_min - 1)
+
+    def _apc_suffix_is_text_only(self, ids_list: List[int], prefix_len: int) -> bool:
+        return _apc.prefix_leaves_text_only_suffix(
+            ids_list,
+            prefix_len,
+            self._apc_media_token_ids(),
+        )
+
+    def _apc_exact_checkpoint_len(self, ids_list: List[int]) -> int:
+        if self.apc_manager is None or getattr(self, "apc_mode", "block") != "exact":
+            return 0
+        return _apc.adjust_prefix_to_text_suffix_boundary(
+            ids_list,
+            len(ids_list) - self.apc_manager.exact_cache_guard_tokens,
+            self._apc_media_token_ids(),
+            max_prefix_tokens=len(ids_list) - 1,
+        )
+
     def _apc_pick_for(self, sequence) -> Optional[dict]:
         """Look up an APC prefix for ``sequence``. Returns dict with matched
         blocks + suffix metadata when there is a usable hit, else None.
@@ -2145,27 +2169,21 @@ class BatchGenerator:
         uid, ids_list, max_toks, prompt_kwargs, lps, criteria = sequence
         if not ids_list or len(ids_list) < 2:
             return None
-        # v1/v2: don't trim a prefix that contains image tokens — re-running
-        # vision merging on the suffix is the cheap path here.
-        image_token_id = getattr(self.model.config, "image_token_id", None) or getattr(
-            self.model.config, "image_token_index", None
-        )
+        safe_lookup_min = self._apc_safe_prefix_lookup_min(ids_list)
         extra_hash = self._apc_extra_hash(prompt_kwargs or {})
         apc_mode = getattr(self, "apc_mode", "block")
         if apc_mode == "exact":
             exact_cache, exact_prefix_len = self.apc_manager.lookup_exact_cache(
                 ids_list,
                 extra_hash=extra_hash,
+                min_prefix_tokens=safe_lookup_min,
             )
             if (
                 exact_cache is not None
                 and exact_prefix_len > 0
                 and exact_prefix_len < len(ids_list)
             ):
-                if (
-                    image_token_id is not None
-                    and image_token_id in ids_list[:exact_prefix_len]
-                ):
+                if not self._apc_suffix_is_text_only(ids_list, exact_prefix_len):
                     return None
                 return {
                     "matched_blocks": [],
@@ -2184,7 +2202,7 @@ class BatchGenerator:
             exact_cache, exact_prefix_len = self.apc_manager.lookup_exact_cache(
                 ids_list,
                 extra_hash=extra_hash,
-                min_prefix_tokens=prefix_len,
+                min_prefix_tokens=max(prefix_len, safe_lookup_min),
             )
         warm_cache = None
         disk_prefix_len = 0
@@ -2192,7 +2210,7 @@ class BatchGenerator:
             warm_cache, disk_prefix_len = self.apc_manager.lookup_prefix_disk_cache(
                 ids_list,
                 extra_hash=extra_hash,
-                min_prefix_tokens=max(prefix_len, exact_prefix_len),
+                min_prefix_tokens=max(prefix_len, exact_prefix_len, safe_lookup_min),
                 allow_memory_overlap=max(prefix_len, exact_prefix_len) > 0,
             )
         if disk_prefix_len > max(
@@ -2200,10 +2218,7 @@ class BatchGenerator:
         ) and disk_prefix_len < len(ids_list):
             if matched:
                 self.apc_manager.release(matched)
-            if (
-                image_token_id is not None
-                and image_token_id in ids_list[:disk_prefix_len]
-            ):
+            if not self._apc_suffix_is_text_only(ids_list, disk_prefix_len):
                 return None
             return {
                 "matched_blocks": [],
@@ -2215,10 +2230,7 @@ class BatchGenerator:
         if exact_prefix_len > prefix_len and exact_prefix_len < len(ids_list):
             if matched:
                 self.apc_manager.release(matched)
-            if (
-                image_token_id is not None
-                and image_token_id in ids_list[:exact_prefix_len]
-            ):
+            if not self._apc_suffix_is_text_only(ids_list, exact_prefix_len):
                 return None
             return {
                 "matched_blocks": [],
@@ -2228,7 +2240,7 @@ class BatchGenerator:
                 "full_input_ids": list(ids_list),
             }
         if prefix_len > 0 and prefix_len < len(ids_list):
-            if image_token_id is not None and image_token_id in ids_list[:prefix_len]:
+            if not self._apc_suffix_is_text_only(ids_list, prefix_len):
                 self.apc_manager.release(matched)
                 return None
             return {
@@ -2359,14 +2371,7 @@ class BatchGenerator:
                     else self._apc_extra_hash(prompt_kwargs_list[i] or {})
                 ),
                 "apc_blocks": picks[i].get("matched_blocks", []) if picks[i] else [],
-                "checkpoint_len": (
-                    max(
-                        1,
-                        len(full_ids[i]) - self.apc_manager.exact_cache_guard_tokens,
-                    )
-                    if apc_mode == "exact"
-                    else 0
-                ),
+                "checkpoint_len": self._apc_exact_checkpoint_len(full_ids[i]),
             }
             for i in range(len(sequences))
         ]
@@ -2418,14 +2423,7 @@ class BatchGenerator:
                     "prefix_len": 0,
                     "extra_hash": extra_hash,
                     "apc_blocks": [],
-                    "checkpoint_len": (
-                        max(
-                            1,
-                            len(ids_list) - self.apc_manager.exact_cache_guard_tokens,
-                        )
-                        if getattr(self, "apc_mode", "block") == "exact"
-                        else 0
-                    ),
+                    "checkpoint_len": self._apc_exact_checkpoint_len(list(ids_list)),
                 }
             )
         return meta

--- a/mlx_vlm/generate/dispatch.py
+++ b/mlx_vlm/generate/dispatch.py
@@ -901,6 +901,20 @@ def stream_generate(
     apc_extra_hash = 0
     apc_mode: Optional[str] = None
 
+    multimodal_token_ids = _apc.multimodal_token_ids_from_config(model.config)
+    apc_safe_prefix_min = _apc.media_safe_prefix_min(
+        full_input_ids_list,
+        multimodal_token_ids,
+    )
+    apc_safe_prefix_lookup_min = max(0, apc_safe_prefix_min - 1)
+
+    def _apc_suffix_is_text_only(prefix_len: int) -> bool:
+        return _apc.prefix_leaves_text_only_suffix(
+            full_input_ids_list,
+            prefix_len,
+            multimodal_token_ids,
+        )
+
     if is_diffusion_model(model):
         yield from stream_diffusion_generate_from_kwargs(
             model,
@@ -926,21 +940,14 @@ def stream_generate(
     if prompt_cache_state is not None and prompt_cache_state.cache is not None:
         prefix_len = prompt_cache_state.find_prefix_length(full_input_ids_list)
         if prefix_len > 0 and prefix_len < input_ids.shape[1]:
-            if _prime_cached_prefix_rope_state(model, input_ids, mask, kwargs):
+            if _apc_suffix_is_text_only(prefix_len) and _prime_cached_prefix_rope_state(
+                model, input_ids, mask, kwargs
+            ):
                 reused_prefix_len = prefix_len
                 # Trim to only new tokens
                 input_ids = input_ids[:, prefix_len:]
-                # Only skip vision if no image tokens in the new (trimmed) tokens
-                image_token_id = getattr(
-                    model.config, "image_token_id", None
-                ) or getattr(model.config, "image_token_index", None)
-                new_ids = input_ids.flatten().tolist()
-                has_image_in_new = (
-                    image_token_id is not None and image_token_id in new_ids
-                )
-                if not has_image_in_new:
-                    pixel_values = None
-                    kwargs.pop("cached_image_features", None)
+                pixel_values = None
+                kwargs.pop("cached_image_features", None)
                 # Reuse the saved KV cache (trimmed to prefix length)
                 kv_cache = prompt_cache_state.cache
                 # Trim cache to prefix_len in case it includes generated tokens
@@ -961,22 +968,19 @@ def stream_generate(
             exact_prompt_cache, exact_prefix_len = apc_manager.lookup_exact_cache(
                 full_input_ids_list,
                 extra_hash=apc_extra_hash,
+                min_prefix_tokens=apc_safe_prefix_lookup_min,
             )
             if (
                 exact_prompt_cache is not None
                 and exact_prefix_len > 0
                 and exact_prefix_len < input_ids.shape[1]
+                and _apc_suffix_is_text_only(exact_prefix_len)
                 and _prime_cached_prefix_rope_state(model, input_ids, mask, kwargs)
             ):
                 reused_prefix_len = exact_prefix_len
                 input_ids = input_ids[:, exact_prefix_len:]
-                image_token_id = getattr(
-                    model.config, "image_token_id", None
-                ) or getattr(model.config, "image_token_index", None)
-                new_ids = input_ids.flatten().tolist()
-                if image_token_id is None or image_token_id not in new_ids:
-                    pixel_values = None
-                    kwargs.pop("cached_image_features", None)
+                pixel_values = None
+                kwargs.pop("cached_image_features", None)
                 kwargs["prompt_cache"] = exact_prompt_cache
         else:
             matched_blocks, prefix_len = apc_manager.lookup_prefix(
@@ -988,7 +992,7 @@ def stream_generate(
                 exact_prompt_cache, exact_prefix_len = apc_manager.lookup_exact_cache(
                     full_input_ids_list,
                     extra_hash=apc_extra_hash,
-                    min_prefix_tokens=prefix_len,
+                    min_prefix_tokens=max(prefix_len, apc_safe_prefix_lookup_min),
                 )
             disk_prompt_cache = None
             disk_prefix_len = 0
@@ -997,7 +1001,11 @@ def stream_generate(
                     apc_manager.lookup_prefix_disk_cache(
                         full_input_ids_list,
                         extra_hash=apc_extra_hash,
-                        min_prefix_tokens=max(prefix_len, exact_prefix_len),
+                        min_prefix_tokens=max(
+                            prefix_len,
+                            exact_prefix_len,
+                            apc_safe_prefix_lookup_min,
+                        ),
                         allow_memory_overlap=max(prefix_len, exact_prefix_len) > 0,
                     )
                 )
@@ -1007,45 +1015,36 @@ def stream_generate(
             ):
                 if matched_blocks:
                     apc_manager.release(matched_blocks)
-                if _prime_cached_prefix_rope_state(model, input_ids, mask, kwargs):
+                if _apc_suffix_is_text_only(
+                    disk_prefix_len
+                ) and _prime_cached_prefix_rope_state(model, input_ids, mask, kwargs):
                     reused_prefix_len = disk_prefix_len
                     input_ids = input_ids[:, disk_prefix_len:]
-                    image_token_id = getattr(
-                        model.config, "image_token_id", None
-                    ) or getattr(model.config, "image_token_index", None)
-                    new_ids = input_ids.flatten().tolist()
-                    if image_token_id is None or image_token_id not in new_ids:
-                        pixel_values = None
-                        kwargs.pop("cached_image_features", None)
+                    pixel_values = None
+                    kwargs.pop("cached_image_features", None)
                     kwargs["prompt_cache"] = disk_prompt_cache
             elif (
                 exact_prefix_len > prefix_len and exact_prefix_len < input_ids.shape[1]
             ):
                 if matched_blocks:
                     apc_manager.release(matched_blocks)
-                if _prime_cached_prefix_rope_state(model, input_ids, mask, kwargs):
+                if _apc_suffix_is_text_only(
+                    exact_prefix_len
+                ) and _prime_cached_prefix_rope_state(model, input_ids, mask, kwargs):
                     reused_prefix_len = exact_prefix_len
                     input_ids = input_ids[:, exact_prefix_len:]
-                    image_token_id = getattr(
-                        model.config, "image_token_id", None
-                    ) or getattr(model.config, "image_token_index", None)
-                    new_ids = input_ids.flatten().tolist()
-                    if image_token_id is None or image_token_id not in new_ids:
-                        pixel_values = None
-                        kwargs.pop("cached_image_features", None)
+                    pixel_values = None
+                    kwargs.pop("cached_image_features", None)
                     kwargs["prompt_cache"] = exact_prompt_cache
             elif prefix_len > 0 and prefix_len < input_ids.shape[1]:
-                if _prime_cached_prefix_rope_state(model, input_ids, mask, kwargs):
+                if _apc_suffix_is_text_only(
+                    prefix_len
+                ) and _prime_cached_prefix_rope_state(model, input_ids, mask, kwargs):
                     apc_blocks_in_use = matched_blocks
                     reused_prefix_len = prefix_len
                     input_ids = input_ids[:, prefix_len:]
-                    image_token_id = getattr(
-                        model.config, "image_token_id", None
-                    ) or getattr(model.config, "image_token_index", None)
-                    new_ids = input_ids.flatten().tolist()
-                    if image_token_id is None or image_token_id not in new_ids:
-                        pixel_values = None
-                        kwargs.pop("cached_image_features", None)
+                    pixel_values = None
+                    kwargs.pop("cached_image_features", None)
                     kwargs["prompt_cache"] = _apc.make_warm_kv_cache(
                         matched_blocks,
                         min_capacity_tokens=prefix_len + input_ids.shape[1] + 1,
@@ -1090,10 +1089,14 @@ def stream_generate(
         exact_checkpoint_len = None
         exact_checkpoint = None
         if apc_manager is not None and apc_mode == "exact" and reused_prefix_len == 0:
-            exact_checkpoint_len = max(
-                1,
+            exact_checkpoint_len = _apc.adjust_prefix_to_text_suffix_boundary(
+                full_input_ids_list,
                 len(full_input_ids_list) - apc_manager.exact_cache_guard_tokens,
+                multimodal_token_ids,
+                max_prefix_tokens=len(full_input_ids_list) - 1,
             )
+            if exact_checkpoint_len <= 0:
+                exact_checkpoint_len = None
 
             def exact_checkpoint(prefix_len: int, prompt_cache: List[Any]) -> None:
                 apc_manager.store_exact_cache(

--- a/mlx_vlm/generate/dispatch.py
+++ b/mlx_vlm/generate/dispatch.py
@@ -915,6 +915,13 @@ def stream_generate(
             multimodal_token_ids,
         )
 
+    def _apc_prefix_has_media_tokens(prefix_len: int) -> bool:
+        return _apc.prefix_contains_media_tokens(
+            full_input_ids_list,
+            prefix_len,
+            multimodal_token_ids,
+        )
+
     if is_diffusion_model(model):
         yield from stream_diffusion_generate_from_kwargs(
             model,
@@ -986,6 +993,10 @@ def stream_generate(
             matched_blocks, prefix_len = apc_manager.lookup_prefix(
                 full_input_ids_list, extra_hash=apc_extra_hash
             )
+            if prefix_len > 0 and _apc_prefix_has_media_tokens(prefix_len):
+                apc_manager.release(matched_blocks)
+                matched_blocks = []
+                prefix_len = 0
             exact_prompt_cache = None
             exact_prefix_len = 0
             if prefix_len < input_ids.shape[1]:

--- a/mlx_vlm/tests/test_apc.py
+++ b/mlx_vlm/tests/test_apc.py
@@ -4,6 +4,7 @@ import os
 import shutil
 import subprocess
 import sys
+from types import SimpleNamespace
 
 import mlx.core as mx
 import numpy as np
@@ -838,3 +839,60 @@ def test_disk_metadata_mismatch_is_a_miss(tmp_path):
     assert warm is None
     assert matched_tokens == 0
     manager.close()
+
+
+def test_multimodal_token_ids_from_config():
+    config = SimpleNamespace(
+        image_token_id=None,
+        image_token_index=42,
+        video_token_id=77,
+        video_token_index=None,
+    )
+
+    assert apc_module.multimodal_token_ids_from_config(config) == {42, 77}
+
+
+def test_media_token_spans_are_contiguous_ranges():
+    token_ids = [1, 42, 42, 2, 77, 77, 77, 3]
+
+    assert apc_module.media_token_spans(token_ids, {42, 77}) == (
+        (1, 3),
+        (4, 7),
+    )
+
+
+def test_prefix_must_leave_text_only_suffix():
+    token_ids = [1, 42, 42, 2, 77, 77, 3]
+
+    assert not apc_module.prefix_leaves_text_only_suffix(token_ids, 3, {42, 77})
+    assert not apc_module.prefix_leaves_text_only_suffix(token_ids, 5, {42, 77})
+    assert apc_module.prefix_leaves_text_only_suffix(token_ids, 6, {42, 77})
+    assert apc_module.prefix_leaves_text_only_suffix(token_ids, 7, {42, 77})
+
+
+def test_adjust_prefix_moves_after_media_span():
+    token_ids = [1] + [42] * 3072 + [2] * 30
+
+    assert (
+        apc_module.adjust_prefix_to_text_suffix_boundary(
+            token_ids,
+            desired_prefix_len=2958,
+            media_token_ids={42},
+            max_prefix_tokens=len(token_ids) - 1,
+        )
+        == 3073
+    )
+
+
+def test_adjust_prefix_returns_zero_when_no_text_suffix_remains():
+    token_ids = [1, 42, 42]
+
+    assert (
+        apc_module.adjust_prefix_to_text_suffix_boundary(
+            token_ids,
+            desired_prefix_len=1,
+            media_token_ids={42},
+            max_prefix_tokens=len(token_ids) - 1,
+        )
+        == 0
+    )


### PR DESCRIPTION
This change makes APC restore multimodal prompt prefixes only at safe text boundaries so repeated VL prompts can reuse cached work without splitting image-token spans.

With this change, requests using the same image and text prefix will hit the cache:

```
Benchmark: repeated-image
Model: mlx-community/Qwen3.6-27B-4bit
Image: synthetic_2048x1536.png
Request | Cached prompt tokens | Uncached prompt tokens | Output tokens | Wall time | Prompt tok/s | MLX peak
      1 |                    0 |                  3,097 |             1 |      7.12s |       440.86 |    19.24 GB
  APC request 1: {"disk_blocks_indexed": 0, "disk_bytes": 355567727, "disk_exact_indexed": 1, "disk_files": 1, "disk_hits": 0, "disk_writes": 2, "exact_hits": 0, "exact_stores": 2, "lookups_hit": 0, "lookups_miss": 0, "matched_tokens": 0}
      2 |                3,076 |                     21 |             1 |      0.31s |     20672.88 |    19.01 GB
  APC request 2: {"disk_blocks_indexed": 0, "disk_bytes": 712577360, "disk_exact_indexed": 2, "disk_files": 2, "disk_hits": 1, "disk_writes": 0, "exact_hits": 1, "exact_stores": 0, "lookups_hit": 1, "lookups_miss": 0, "matched_tokens": 3076}
Second request speedup: 23.25x
```