### PR TITLE
Fix Qwen quantized KV cache prompt state

### DIFF
--- a/mlx_vlm/models/qwen3_5/language.py
+++ b/mlx_vlm/models/qwen3_5/language.py
@@ -687,10 +687,13 @@ def _extract_row_cache(cache_entry, row: int):
 
 def _is_single_row_batch_cache(cache_entry) -> bool:
     left_padding = getattr(cache_entry, "left_padding", None)
+    # Quantized batch caches must update in place; the singleton shortcut
+    # rebuilds only plain BatchKVCache state after the row-wise forward.
     return (
         isinstance(left_padding, mx.array)
         and left_padding.ndim > 0
         and left_padding.size == 1
+        and not hasattr(cache_entry, "bits")
     )
 
 
@@ -1419,10 +1422,20 @@ class Qwen3_5Attention(nn.Module):
         kv_seq_len = keys.shape[-2]
 
         if position_ids is None:
-            kv_seq_len += cache.offset + 1
-            position_ids = mx.arange(cache.offset, cache.offset + L)
-            position_ids = mx.expand_dims(position_ids, axis=0)
-            position_ids = mx.tile(position_ids, (3, 1, 1))
+            cache_offset = cache.offset
+            if isinstance(cache_offset, mx.array) and cache_offset.ndim > 0:
+                offsets = mx.maximum(cache_offset[:B], 0)
+                kv_seq_len = kv_seq_len + offsets + 1
+                position_ids = offsets[:, None] + mx.arange(L)[None, :]
+                position_ids = mx.expand_dims(position_ids, axis=0)
+                position_ids = mx.tile(position_ids, (3, 1, 1))
+            else:
+                if isinstance(cache_offset, mx.array):
+                    cache_offset = int(cache_offset.item())
+                kv_seq_len += cache_offset + 1
+                position_ids = mx.arange(cache_offset, cache_offset + L)
+                position_ids = mx.expand_dims(position_ids, axis=0)
+                position_ids = mx.tile(position_ids, (3, 1, 1))
         else:
             kv_seq_len += cache.offset + 1 if cache is not None else 0
 

--- a/mlx_vlm/tests/test_speculative.py
+++ b/mlx_vlm/tests/test_speculative.py
@@ -23,6 +23,7 @@ import mlx_vlm.speculative.mtp as mtp_utils
 from mlx_vlm.models.cache import (
     ArraysCache,
     BatchKVCache,
+    BatchQuantizedKVCache,
     BufferedRotatingKVCache,
     CacheList,
     KVCache,
@@ -77,6 +78,7 @@ from mlx_vlm.speculative.utils import (
     _speculative_walk_deferred_greedy,
     speculative_prefill_kwargs,
 )
+from mlx_vlm.turboquant import BatchTurboQuantKVCache
 from mlx_vlm.utils import get_model_and_args
 
 speculative_utils = importlib.import_module("mlx_vlm.speculative.utils")
@@ -916,6 +918,50 @@ def test_qwen3_5_single_row_batch_cache_matches_singleton_cache():
 
     assert bool(mx.array_equal(singleton_decode, batch_decode).item())
     assert isinstance(batch_cache[1], BatchKVCache)
+
+
+def test_qwen3_5_single_row_quantized_batch_cache_keeps_prompt_state():
+    text_config = _tiny_qwen3_5_text_config()
+    text_config.hidden_size = 64
+    text_config.intermediate_size = 128
+    text_config.num_hidden_layers = 2
+    text_config.num_attention_heads = 2
+    text_config.num_key_value_heads = 1
+    text_config.head_dim = 32
+    text_config.full_attention_interval = 2
+    model = qwen_language.Qwen3_5Model(text_config)
+
+    batch_arrays = ArraysCache(size=2)
+    batch_arrays.left_padding = mx.array([0], dtype=mx.int32)
+    quantized_cache = BatchQuantizedKVCache([0], group_size=32, bits=8)
+    prompt_cache = [batch_arrays, quantized_cache]
+
+    prompt = mx.array([[1, 2, 3]], dtype=mx.int32)
+    model(prompt, cache=prompt_cache)
+    mx.eval(prompt_cache[1].state)
+
+    assert prompt_cache[1] is quantized_cache
+    assert quantized_cache.keys is not None
+    assert quantized_cache._idx == 3
+    assert quantized_cache.offset.tolist() == [3]
+
+    decode = mx.array([[4]], dtype=mx.int32)
+    model(decode, cache=prompt_cache)
+    mx.eval(prompt_cache[1].state)
+
+    assert prompt_cache[1] is quantized_cache
+    assert quantized_cache._idx == 4
+    assert quantized_cache.offset.tolist() == [4]
+
+
+def test_qwen3_5_single_row_shortcut_skips_quantized_batch_caches():
+    assert qwen_language._is_single_row_batch_cache(BatchKVCache([0]))
+    assert not qwen_language._is_single_row_batch_cache(
+        BatchQuantizedKVCache([0], group_size=32, bits=8)
+    )
+    assert not qwen_language._is_single_row_batch_cache(
+        BatchTurboQuantKVCache([0], bits=3.5)
+    )
 
 
 def test_speculative_walk_accepts_until_first_mismatch():


### PR DESCRIPTION
## Summary
- keep Qwen3.5/3.6 quantized batch KV caches on their in-place update path instead of the single-row BatchKVCache shortcut
- handle batched cache offsets when attention builds fallback position ids
- add regressions for quantized single-row Qwen batch cache state retention and shortcut routing

Fixes #1310.

## Verification
- `.venv/bin/python -m pytest mlx_vlm/tests/test_speculative.py -q`
- `.venv/bin/python -m pytest mlx_vlm/tests/test_batch_quantized_cache.py -q`
- `.venv/bin/python -m pytest mlx_vlm/tests/test_turboquant.py -q`
- `.venv/bin/python -m pytest mlx_vlm/tests/test_server.py -q`
- real server smoke: `mlx-community/Qwen3.6-27B-mxfp8 --kv-bits 8 --kv-quant-scheme uniform --kv-group-size 64` returned `73914`
- real server smoke: `mlx-community/Qwen3.6-27B-mxfp8 --kv-bits 4 --kv-quant-scheme turboquant` returned `73914`