### PR TITLE
Port Nemotron H ModelOpt weights

### DIFF
--- a/mlx_vlm/models/nemotron_h/__init__.py
+++ b/mlx_vlm/models/nemotron_h/__init__.py
@@ -1,0 +1,4 @@
+from .config import ModelConfig
+from .nemotron_h import Model
+
+__all__ = ["Model", "ModelConfig"]

--- a/mlx_vlm/models/nemotron_h/config.py
+++ b/mlx_vlm/models/nemotron_h/config.py
@@ -1,0 +1,83 @@
+import math
+from dataclasses import asdict, dataclass
+from typing import Any, Dict, List, Optional, Tuple, Union
+
+from mlx_lm.models.nemotron_h import ModelArgs
+
+from ..base import BaseModelConfig
+
+
+def _decode_float_sentinel(value):
+    if isinstance(value, dict) and value.get("__float__") == "Infinity":
+        return math.inf
+    return value
+
+
+@dataclass
+class ModelConfig(BaseModelConfig):
+    model_type: str = "nemotron_h"
+    vocab_size: int = 131072
+    hidden_size: int = 8192
+    intermediate_size: int = 5120
+    num_hidden_layers: int = 0
+    max_position_embeddings: int = 262144
+    num_attention_heads: int = 64
+    num_key_value_heads: int = 2
+    attention_bias: bool = False
+    mamba_num_heads: int = 256
+    mamba_head_dim: int = 64
+    mamba_proj_bias: bool = False
+    ssm_state_size: int = 128
+    conv_kernel: int = 4
+    n_groups: int = 8
+    mlp_bias: bool = False
+    layer_norm_epsilon: float = 1e-5
+    use_bias: bool = False
+    use_conv_bias: bool = True
+    hybrid_override_pattern: Optional[List[str]] = None
+    layers_block_type: Optional[List[str]] = None
+    head_dim: Optional[int] = 128
+    moe_intermediate_size: Optional[int] = 5120
+    moe_shared_expert_intermediate_size: Optional[int] = 10240
+    moe_latent_size: Optional[int] = 2048
+    n_group: Optional[int] = 1
+    n_routed_experts: Optional[int] = 512
+    n_shared_experts: Optional[int] = 1
+    topk_group: Optional[int] = 1
+    num_experts_per_tok: Optional[int] = 22
+    norm_topk_prob: Optional[bool] = True
+    routed_scaling_factor: Optional[float] = 5.0
+    time_step_limit: Optional[Tuple[float, float]] = None
+    time_step_min: Optional[float] = 0.001
+    time_step_max: Optional[float] = 0.1
+    bos_token_id: Optional[int] = None
+    eos_token_id: Optional[Union[int, List[int]]] = None
+    pad_token_id: Optional[int] = None
+    dtype: Optional[str] = None
+    tie_word_embeddings: bool = False
+    quantization: Optional[Dict[str, Any]] = None
+    quantization_config: Optional[Dict[str, Any]] = None
+
+    @classmethod
+    def from_dict(cls, params):
+        params = dict(params or {})
+        if "layer_norm_epsilon" not in params and "norm_eps" in params:
+            params["layer_norm_epsilon"] = params["norm_eps"]
+
+        layers_block_type = params.get("layers_block_type")
+        if params.get("num_hidden_layers") is None and layers_block_type is not None:
+            params["num_hidden_layers"] = len(layers_block_type)
+
+        time_step_limit = params.get("time_step_limit")
+        if isinstance(time_step_limit, list):
+            params["time_step_limit"] = tuple(
+                _decode_float_sentinel(v) for v in time_step_limit
+            )
+
+        allowed = cls.__dataclass_fields__
+        return cls(**{k: v for k, v in params.items() if k in allowed})
+
+    def to_model_args(self) -> ModelArgs:
+        values = asdict(self)
+        return ModelArgs.from_dict(values)
+

--- a/mlx_vlm/models/nemotron_h/language.py
+++ b/mlx_vlm/models/nemotron_h/language.py
@@ -11,6 +11,12 @@ from ..base import LanguageModelOutput
 from .config import ModelConfig
 
 
+class _LanguageModelRoot(nn.Module):
+    def __init__(self, language_model: "LanguageModel"):
+        super().__init__()
+        self.language_model = language_model
+
+
 class LanguageModel(nn.Module):
     def __init__(self, config: ModelConfig):
         super().__init__()
@@ -23,6 +29,10 @@ class LanguageModel(nn.Module):
     @property
     def layers(self):
         return self.backbone.layers
+
+    @property
+    def _model(self):
+        return _LanguageModelRoot(self)
 
     def make_cache(self):
         caches = []
@@ -97,4 +107,3 @@ class LanguageModel(nn.Module):
             return "e_score_correction_bias" not in key and "A_log" not in key
 
         return predicate
-

--- a/mlx_vlm/models/nemotron_h/language.py
+++ b/mlx_vlm/models/nemotron_h/language.py
@@ -1,0 +1,100 @@
+from typing import Any, Optional
+
+import mlx.core as mx
+import mlx.nn as nn
+from mlx_lm.models.base import create_attention_mask, create_ssm_mask
+from mlx_lm.models.cache import ArraysCache, KVCache
+from mlx_lm.models.nemotron_h import Model as NemotronHForCausalLM
+from mlx_lm.models.nemotron_h import NemotronHModel
+
+from ..base import LanguageModelOutput
+from .config import ModelConfig
+
+
+class LanguageModel(nn.Module):
+    def __init__(self, config: ModelConfig):
+        super().__init__()
+        self.config = config
+        self.args = config.to_model_args()
+        self.model_type = self.args.model_type
+        self.backbone = NemotronHModel(self.args)
+        self.lm_head = nn.Linear(self.args.hidden_size, self.args.vocab_size, bias=False)
+
+    @property
+    def layers(self):
+        return self.backbone.layers
+
+    def make_cache(self):
+        caches = []
+        for layer in self.layers:
+            if layer.block_type == "M":
+                caches.append(ArraysCache(size=2))
+            elif layer.block_type == "*":
+                caches.append(KVCache())
+        return caches
+
+    def get_input_embeddings(self, input_ids: mx.array) -> mx.array:
+        return self.backbone.embeddings(input_ids)
+
+    def __call__(
+        self,
+        inputs: Optional[mx.array] = None,
+        *,
+        inputs_embeds: Optional[mx.array] = None,
+        cache: Optional[Any] = None,
+        output_hidden_states: bool = False,
+        **kwargs,
+    ):
+        if inputs_embeds is None:
+            if inputs is None:
+                raise ValueError("Either inputs or inputs_embeds must be provided.")
+            hidden_states = self.backbone.embeddings(inputs)
+        else:
+            hidden_states = inputs_embeds
+
+        if cache is None:
+            cache = [None] * len(self.layers)
+
+        attn_cache = (
+            cache[self.backbone.fa_idx] if self.backbone.fa_idx < len(cache) else None
+        )
+        ssm_cache = (
+            cache[self.backbone.ssm_idx] if self.backbone.ssm_idx < len(cache) else None
+        )
+        attn_mask = create_attention_mask(hidden_states, attn_cache)
+        ssm_mask = create_ssm_mask(hidden_states, ssm_cache)
+
+        all_hidden_states = [] if output_hidden_states else None
+        cache_counter = 0
+        for layer in self.layers:
+            if output_hidden_states:
+                all_hidden_states.append(hidden_states)
+
+            if layer.block_type in ("M", "*"):
+                layer_cache = cache[cache_counter]
+                cache_counter += 1
+            else:
+                layer_cache = None
+
+            mask = attn_mask if layer.block_type == "*" else ssm_mask
+            hidden_states = layer(hidden_states, mask=mask, cache=layer_cache)
+
+        hidden_states = self.backbone.norm_f(hidden_states)
+        if output_hidden_states:
+            all_hidden_states.append(hidden_states)
+
+        return LanguageModelOutput(
+            logits=self.lm_head(hidden_states),
+            hidden_states=all_hidden_states,
+        )
+
+    def sanitize(self, weights):
+        return NemotronHForCausalLM.sanitize(self, weights)
+
+    @property
+    def cast_predicate(self):
+        def predicate(key):
+            return "e_score_correction_bias" not in key and "A_log" not in key
+
+        return predicate
+

--- a/mlx_vlm/models/nemotron_h/modelopt.py
+++ b/mlx_vlm/models/nemotron_h/modelopt.py
@@ -2,6 +2,34 @@ import mlx.core as mx
 import mlx.nn as nn
 
 
+class ModelOptMXFP8Linear(nn.Linear):
+    """Static ModelOpt FP8 linear that quantizes to MLX-native MXFP8."""
+
+    def to_quantized(
+        self,
+        group_size: int = None,
+        bits: int = None,
+        mode: str = "affine",
+        quantize_input: bool = False,
+    ):
+        del group_size, bits, mode
+        return super().to_quantized(
+            group_size=32,
+            bits=8,
+            mode="mxfp8",
+            quantize_input=quantize_input,
+        )
+
+    @classmethod
+    def from_linear(cls, linear: nn.Linear):
+        output_dims, input_dims = linear.weight.shape
+        layer = cls(input_dims, output_dims, bias="bias" in linear)
+        layer.weight = linear.weight
+        if "bias" in linear:
+            layer.bias = linear.bias
+        return layer
+
+
 class ModelOptNVFP4SwitchLinear(nn.Module):
     """Routed expert linear for ModelOpt NVFP4 W4A16 weights."""
 
@@ -81,6 +109,31 @@ def _uses_modelopt_nvfp4(quantization_config):
         ):
             return True
     return False
+
+
+def _replace_with_mxfp8_linear(module, name):
+    linear = getattr(module, name, None)
+    if isinstance(linear, nn.Linear) and not isinstance(linear, ModelOptMXFP8Linear):
+        setattr(module, name, ModelOptMXFP8Linear.from_linear(linear))
+
+
+def install_modelopt_mxfp8_linears(root, quantization_config):
+    if not _uses_modelopt_nvfp4(quantization_config):
+        return
+
+    layers = getattr(root.language_model.backbone, "layers", [])
+    for layer in layers:
+        mixer = getattr(layer, "mixer", None)
+        if mixer is None:
+            continue
+        if getattr(layer, "block_type", None) == "M":
+            _replace_with_mxfp8_linear(mixer, "in_proj")
+            _replace_with_mxfp8_linear(mixer, "out_proj")
+        elif getattr(layer, "block_type", None) == "E":
+            shared_experts = getattr(mixer, "shared_experts", None)
+            if shared_experts is not None:
+                _replace_with_mxfp8_linear(shared_experts, "up_proj")
+                _replace_with_mxfp8_linear(shared_experts, "down_proj")
 
 
 def install_modelopt_nvfp4_switch_linears(root, quantization_config):

--- a/mlx_vlm/models/nemotron_h/modelopt.py
+++ b/mlx_vlm/models/nemotron_h/modelopt.py
@@ -1,0 +1,105 @@
+import mlx.core as mx
+import mlx.nn as nn
+
+
+class ModelOptNVFP4SwitchLinear(nn.Module):
+    """Routed expert linear for ModelOpt NVFP4 W4A16 weights."""
+
+    def __init__(
+        self,
+        input_dims: int,
+        output_dims: int,
+        num_experts: int,
+        group_size: int = 16,
+        bits: int = 4,
+    ):
+        super().__init__()
+        if input_dims % group_size != 0:
+            raise ValueError("ModelOpt NVFP4 input dimensions must be divisible by 16.")
+        self.group_size = group_size
+        self.bits = bits
+        self.mode = "nvfp4"
+        self.weight = mx.zeros(
+            (num_experts, output_dims, input_dims * bits // 32), dtype=mx.uint32
+        )
+        self.scales = mx.zeros(
+            (num_experts, output_dims, input_dims // group_size), dtype=mx.uint8
+        )
+        self.global_scale = mx.ones((num_experts,), dtype=mx.float32)
+        self.freeze()
+
+    @property
+    def input_dims(self):
+        return self.scales.shape[2] * self.group_size
+
+    @property
+    def output_dims(self):
+        return self.weight.shape[1]
+
+    @property
+    def num_experts(self):
+        return self.weight.shape[0]
+
+    def __call__(self, x, indices, sorted_indices=False):
+        out = mx.gather_qmm(
+            x,
+            self["weight"],
+            self["scales"],
+            rhs_indices=indices,
+            transpose=True,
+            group_size=self.group_size,
+            bits=self.bits,
+            mode=self.mode,
+            sorted_indices=sorted_indices,
+        )
+        scale = self["global_scale"][indices].astype(out.dtype)
+        while scale.ndim < out.ndim:
+            scale = mx.expand_dims(scale, -1)
+        return out * scale
+
+    @classmethod
+    def from_switch_linear(cls, linear):
+        return cls(linear.input_dims, linear.output_dims, linear.num_experts)
+
+
+def _uses_modelopt_nvfp4(quantization_config):
+    if not isinstance(quantization_config, dict):
+        return False
+    if quantization_config.get("mode") == "nvfp4" and quantization_config.get(
+        "group_size"
+    ) == 16:
+        return True
+    if quantization_config.get("quant_method") != "modelopt":
+        return False
+
+    for group in (quantization_config.get("config_groups") or {}).values():
+        weights = group.get("weights") or {}
+        if (
+            weights.get("type") == "float"
+            and weights.get("num_bits") == 4
+            and weights.get("group_size") == 16
+        ):
+            return True
+    return False
+
+
+def install_modelopt_nvfp4_switch_linears(root, quantization_config):
+    if not _uses_modelopt_nvfp4(quantization_config):
+        return
+
+    layers = getattr(root.language_model.backbone, "layers", [])
+    for layer in layers:
+        if getattr(layer, "block_type", None) != "E":
+            continue
+        switch_mlp = getattr(layer.mixer, "switch_mlp", None)
+        if switch_mlp is None:
+            continue
+        for name in ("fc1", "fc2"):
+            module = getattr(switch_mlp, name, None)
+            if module is None or isinstance(module, ModelOptNVFP4SwitchLinear):
+                continue
+            setattr(
+                switch_mlp,
+                name,
+                ModelOptNVFP4SwitchLinear.from_switch_linear(module),
+            )

--- a/mlx_vlm/models/nemotron_h/nemotron_h.py
+++ b/mlx_vlm/models/nemotron_h/nemotron_h.py
@@ -1,0 +1,112 @@
+from typing import Optional
+
+import mlx.core as mx
+import mlx.nn as nn
+
+from ..base import InputEmbeddingsFeatures, LanguageModelOutput
+from .config import ModelConfig
+from .language import LanguageModel
+from .modelopt import install_modelopt_nvfp4_switch_linears
+
+
+class Model(nn.Module):
+    _is_text_model = True
+
+    def __init__(self, config: ModelConfig):
+        super().__init__()
+        self.config = config
+        self.model_type = config.model_type
+        self.language_model = LanguageModel(config)
+        install_modelopt_nvfp4_switch_linears(self, config.quantization_config)
+
+    @property
+    def layers(self):
+        return self.language_model.layers
+
+    def make_cache(self):
+        return self.language_model.make_cache()
+
+    def get_input_embeddings(
+        self,
+        input_ids: Optional[mx.array] = None,
+        pixel_values: Optional[mx.array] = None,
+        **kwargs,
+    ):
+        if pixel_values is not None:
+            raise ValueError("Nemotron H is a text-only model.")
+        if (
+            kwargs.get("input_features") is not None
+            or kwargs.get("audio_values") is not None
+        ):
+            raise ValueError("Nemotron H is a text-only model.")
+        if input_ids is None:
+            raise ValueError("input_ids are required for Nemotron H.")
+        return InputEmbeddingsFeatures(
+            inputs_embeds=self.language_model.get_input_embeddings(input_ids)
+        )
+
+    def __call__(
+        self,
+        input_ids: mx.array,
+        pixel_values: Optional[mx.array] = None,
+        attention_mask: Optional[mx.array] = None,
+        **kwargs,
+    ) -> LanguageModelOutput:
+        if pixel_values is not None:
+            raise ValueError("Nemotron H is a text-only model.")
+        if attention_mask is not None:
+            kwargs.setdefault("mask", attention_mask)
+        return self.language_model(input_ids, **kwargs)
+
+    @staticmethod
+    def _prefixed_key(key: str) -> str:
+        if key.startswith("language_model."):
+            return key
+        if key.startswith("backbone.") or key.startswith("lm_head."):
+            return f"language_model.{key}"
+        return key
+
+    def sanitize(self, weights):
+        sanitized = {}
+        for key, value in weights.items():
+            if key.startswith("mtp."):
+                continue
+            if key.endswith(
+                (".input_scale", ".weight_scale_2", ".k_scale", ".v_scale")
+            ):
+                continue
+            key = self._prefixed_key(key)
+            if "conv1d.weight" in key and value.shape[-1] != 1:
+                value = value.moveaxis(2, 1)
+            sanitized[key] = value
+
+        weights = sanitized
+        for layer_idx in range(self.config.num_hidden_layers):
+            prefix = f"language_model.backbone.layers.{layer_idx}.mixer"
+            for hf_name, mlx_name in (("down_proj", "fc2"), ("up_proj", "fc1")):
+                expert_prefix = f"{prefix}.experts.0.{hf_name}"
+                if f"{expert_prefix}.weight" not in weights:
+                    continue
+
+                stacked_prefix = f"{prefix}.switch_mlp.{mlx_name}"
+                for suffix in ("weight", "scales", "global_scale"):
+                    first_key = f"{expert_prefix}.{suffix}"
+                    if first_key not in weights:
+                        continue
+                    weights[f"{stacked_prefix}.{suffix}"] = mx.stack(
+                        [
+                            weights.pop(
+                                f"{prefix}.experts.{expert_idx}.{hf_name}.{suffix}"
+                            )
+                            for expert_idx in range(self.config.n_routed_experts)
+                        ]
+                    )
+
+        return weights
+
+    @property
+    def cast_predicate(self):
+        return self.language_model.cast_predicate
+
+
+__all__ = ["Model", "LanguageModel", "ModelConfig"]

--- a/mlx_vlm/models/nemotron_h/nemotron_h.py
+++ b/mlx_vlm/models/nemotron_h/nemotron_h.py
@@ -6,7 +6,10 @@ import mlx.nn as nn
 from ..base import InputEmbeddingsFeatures, LanguageModelOutput
 from .config import ModelConfig
 from .language import LanguageModel
-from .modelopt import install_modelopt_nvfp4_switch_linears
+from .modelopt import (
+    install_modelopt_mxfp8_linears,
+    install_modelopt_nvfp4_switch_linears,
+)
 
 
 class Model(nn.Module):
@@ -17,6 +20,7 @@ class Model(nn.Module):
         self.config = config
         self.model_type = config.model_type
         self.language_model = LanguageModel(config)
+        install_modelopt_mxfp8_linears(self, config.quantization_config)
         install_modelopt_nvfp4_switch_linears(self, config.quantization_config)
 
     @property

--- a/mlx_vlm/tests/test_nemotron_h.py
+++ b/mlx_vlm/tests/test_nemotron_h.py
@@ -1,10 +1,15 @@
 import math
 
 import mlx.core as mx
+import mlx.nn as nn
 
 from mlx_vlm.models.nemotron_h.config import ModelConfig
 from mlx_vlm.models.nemotron_h.nemotron_h import Model
-from mlx_vlm.utils import _transform_modelopt_weights, get_model_and_args
+from mlx_vlm.utils import (
+    _infer_quantization_from_weights,
+    _transform_modelopt_weights,
+    get_model_and_args,
+)
 
 
 def tiny_config(**kwargs):
@@ -176,6 +181,24 @@ def test_modelopt_mixed_transform_uses_mxfp8_overrides():
     assert transformed[f"{nvfp4_prefix}.weight"].dtype == mx.uint32
     assert transformed[f"{nvfp4_prefix}.scales"].dtype == mx.uint8
     assert f"{nvfp4_prefix}.global_scale" in transformed
+
+
+def test_quantization_inference_detects_saved_mxfp8_weights():
+    path = "language_model.backbone.layers.0.mixer.in_proj"
+    module = nn.Linear(8192, 35072, bias=False)
+    weights = {
+        f"{path}.weight": mx.zeros((35072, 2048), dtype=mx.uint32),
+        f"{path}.scales": mx.zeros((35072, 256), dtype=mx.uint8),
+    }
+
+    inferred = _infer_quantization_from_weights(
+        path,
+        module,
+        weights,
+        {"group_size": 16, "bits": 4, "mode": "nvfp4"},
+    )
+
+    assert inferred == {"group_size": 32, "bits": 8, "mode": "mxfp8"}
 
 
 def test_nemotron_h_sanitize_stacks_expert_weights_and_scales():

--- a/mlx_vlm/tests/test_nemotron_h.py
+++ b/mlx_vlm/tests/test_nemotron_h.py
@@ -4,7 +4,11 @@ import mlx.core as mx
 
 from mlx_vlm.models.nemotron_h.config import ModelConfig
 from mlx_vlm.models.nemotron_h.nemotron_h import Model
-from mlx_vlm.utils import _transform_modelopt_weights, get_model_and_args
+from mlx_vlm.utils import (
+    _modelopt_mlx_quantization_config,
+    _transform_modelopt_weights,
+    get_model_and_args,
+)
 
 
 def tiny_config(**kwargs):
@@ -176,6 +180,47 @@ def test_modelopt_mixed_transform_uses_mxfp8_overrides():
     assert transformed[f"{nvfp4_prefix}.weight"].dtype == mx.uint32
     assert transformed[f"{nvfp4_prefix}.scales"].dtype == mx.uint8
     assert f"{nvfp4_prefix}.global_scale" in transformed
+
+
+def test_modelopt_converted_config_uses_fp8_targets():
+    fp8_prefix = "backbone.layers.0.mixer.in_proj"
+    nvfp4_prefix = "backbone.layers.1.mixer.experts.0.up_proj"
+    weights = {
+        f"language_model.{fp8_prefix}.weight": mx.zeros((2, 8), dtype=mx.uint32),
+        f"language_model.{fp8_prefix}.scales": mx.zeros((2, 1), dtype=mx.uint8),
+    }
+
+    quantization = _modelopt_mlx_quantization_config(
+        {
+            "quant_method": "modelopt",
+            "config_groups": {
+                "group_0": {
+                    "weights": {"dynamic": False, "num_bits": 8, "type": "float"},
+                    "targets": [fp8_prefix],
+                },
+                "group_1": {
+                    "weights": {
+                        "dynamic": False,
+                        "group_size": 16,
+                        "num_bits": 4,
+                        "type": "float",
+                    },
+                    "targets": [nvfp4_prefix],
+                },
+            },
+        },
+        weights,
+    )
+
+    assert quantization["group_size"] == 16
+    assert quantization["bits"] == 4
+    assert quantization["mode"] == "nvfp4"
+    assert quantization[f"language_model.{fp8_prefix}"] == {
+        "group_size": 32,
+        "bits": 8,
+        "mode": "mxfp8",
+    }
+    assert f"language_model.{nvfp4_prefix}" not in quantization
 
 
 def test_nemotron_h_sanitize_stacks_expert_weights_and_scales():

--- a/mlx_vlm/tests/test_nemotron_h.py
+++ b/mlx_vlm/tests/test_nemotron_h.py
@@ -1,15 +1,10 @@
 import math
 
 import mlx.core as mx
-import mlx.nn as nn
 
 from mlx_vlm.models.nemotron_h.config import ModelConfig
 from mlx_vlm.models.nemotron_h.nemotron_h import Model
-from mlx_vlm.utils import (
-    _infer_quantization_from_weights,
-    _transform_modelopt_weights,
-    get_model_and_args,
-)
+from mlx_vlm.utils import _transform_modelopt_weights, get_model_and_args
 
 
 def tiny_config(**kwargs):
@@ -181,24 +176,6 @@ def test_modelopt_mixed_transform_uses_mxfp8_overrides():
     assert transformed[f"{nvfp4_prefix}.weight"].dtype == mx.uint32
     assert transformed[f"{nvfp4_prefix}.scales"].dtype == mx.uint8
     assert f"{nvfp4_prefix}.global_scale" in transformed
-
-
-def test_quantization_inference_detects_saved_mxfp8_weights():
-    path = "language_model.backbone.layers.0.mixer.in_proj"
-    module = nn.Linear(8192, 35072, bias=False)
-    weights = {
-        f"{path}.weight": mx.zeros((35072, 2048), dtype=mx.uint32),
-        f"{path}.scales": mx.zeros((35072, 256), dtype=mx.uint8),
-    }
-
-    inferred = _infer_quantization_from_weights(
-        path,
-        module,
-        weights,
-        {"group_size": 16, "bits": 4, "mode": "nvfp4"},
-    )
-
-    assert inferred == {"group_size": 32, "bits": 8, "mode": "mxfp8"}
 
 
 def test_nemotron_h_sanitize_stacks_expert_weights_and_scales():

--- a/mlx_vlm/tests/test_nemotron_h.py
+++ b/mlx_vlm/tests/test_nemotron_h.py
@@ -1,8 +1,11 @@
 import math
 
 import mlx.core as mx
+import mlx.nn as nn
+from mlx.utils import tree_flatten
 
 from mlx_vlm.models.nemotron_h.config import ModelConfig
+from mlx_vlm.models.nemotron_h.modelopt import ModelOptMXFP8Linear
 from mlx_vlm.models.nemotron_h.nemotron_h import Model
 from mlx_vlm.utils import (
     _modelopt_mlx_quantization_config,
@@ -68,6 +71,43 @@ def test_nemotron_h_config_normalizes_ultra_fields():
     assert config.num_hidden_layers == 3
     assert args.hybrid_override_pattern == ["M", "E", "*"]
     assert args.time_step_limit == (0.0, math.inf)
+
+
+def test_nemotron_h_language_model_exposes_text_model_contract():
+    model = Model(tiny_config())
+    quantization_root = model.language_model._model
+
+    assert quantization_root.language_model is model.language_model
+    assert "language_model.backbone.embeddings" in {
+        path
+        for path, _ in tree_flatten(
+            quantization_root.leaf_modules(), is_leaf=nn.Module.is_module
+        )
+    }
+
+
+def test_modelopt_static_fp8_linears_quantize_as_mxfp8():
+    model = Model(
+        tiny_config(
+            layers_block_type=["mamba"],
+            num_hidden_layers=1,
+            quantization_config={"group_size": 16, "bits": 4, "mode": "nvfp4"},
+        )
+    )
+    mixer = model.language_model.backbone.layers[0].mixer
+
+    assert isinstance(mixer.in_proj, ModelOptMXFP8Linear)
+    assert isinstance(mixer.out_proj, ModelOptMXFP8Linear)
+
+    quantized = ModelOptMXFP8Linear(32, 64, bias=False).to_quantized(
+        group_size=16,
+        bits=4,
+        mode="nvfp4",
+    )
+
+    assert quantized.group_size == 32
+    assert quantized.bits == 8
+    assert quantized.mode == "mxfp8"
 
 
 def test_modelopt_nvfp4_transform_remaps_to_mlx_scales():

--- a/mlx_vlm/tests/test_nemotron_h.py
+++ b/mlx_vlm/tests/test_nemotron_h.py
@@ -1,0 +1,211 @@
+import math
+
+import mlx.core as mx
+
+from mlx_vlm.models.nemotron_h.config import ModelConfig
+from mlx_vlm.models.nemotron_h.nemotron_h import Model
+from mlx_vlm.utils import _transform_modelopt_weights, get_model_and_args
+
+
+def tiny_config(**kwargs):
+    values = dict(
+        model_type="nemotron_h",
+        vocab_size=16,
+        hidden_size=4,
+        intermediate_size=8,
+        num_hidden_layers=1,
+        max_position_embeddings=32,
+        num_attention_heads=1,
+        num_key_value_heads=1,
+        attention_bias=False,
+        mamba_num_heads=1,
+        mamba_head_dim=4,
+        mamba_proj_bias=False,
+        ssm_state_size=4,
+        conv_kernel=2,
+        n_groups=1,
+        mlp_bias=False,
+        layer_norm_epsilon=1e-5,
+        use_bias=False,
+        use_conv_bias=False,
+        layers_block_type=["moe"],
+        moe_intermediate_size=3,
+        moe_shared_expert_intermediate_size=None,
+        moe_latent_size=None,
+        n_group=1,
+        n_routed_experts=2,
+        n_shared_experts=None,
+        topk_group=1,
+        num_experts_per_tok=1,
+        norm_topk_prob=True,
+        routed_scaling_factor=1.0,
+    )
+    values.update(kwargs)
+    return ModelConfig(**values)
+
+
+def test_get_model_and_args_routes_nemotron_h_module():
+    model_class, model_type = get_model_and_args({"model_type": "nemotron_h"})
+
+    assert model_class.__name__ == "mlx_vlm.models.nemotron_h"
+    assert model_type == "nemotron_h"
+
+
+def test_nemotron_h_config_normalizes_ultra_fields():
+    config = ModelConfig.from_dict(
+        {
+            "model_type": "nemotron_h",
+            "layers_block_type": ["mamba", "moe", "attention"],
+            "time_step_limit": [0.0, {"__float__": "Infinity"}],
+        }
+    )
+    args = config.to_model_args()
+
+    assert config.num_hidden_layers == 3
+    assert args.hybrid_override_pattern == ["M", "E", "*"]
+    assert args.time_step_limit == (0.0, math.inf)
+
+
+def test_modelopt_nvfp4_transform_remaps_to_mlx_scales():
+    prefix = "backbone.layers.0.mixer.experts.0.up_proj"
+    weights = {
+        f"{prefix}.weight": mx.array([[1, 2, 3, 4]], dtype=mx.uint8),
+        f"{prefix}.weight_scale": mx.array([[8]], dtype=mx.uint8),
+        f"{prefix}.weight_scale_2": mx.array(0.5, dtype=mx.float32),
+        f"{prefix}.input_scale": mx.array(1.0, dtype=mx.float32),
+    }
+
+    transformed, quantization = _transform_modelopt_weights(
+        weights,
+        {"quant_method": "modelopt"},
+    )
+
+    assert quantization["quant_method"] == "modelopt"
+    assert quantization["group_size"] == 16
+    assert quantization["bits"] == 4
+    assert quantization["mode"] == "nvfp4"
+    assert transformed[f"{prefix}.weight"].dtype == mx.uint32
+    assert transformed[f"{prefix}.weight"].shape == (1, 1)
+    assert transformed[f"{prefix}.scales"].dtype == mx.uint8
+    assert transformed[f"{prefix}.global_scale"].shape == ()
+    assert f"{prefix}.weight_scale" not in transformed
+    assert f"{prefix}.weight_scale_2" not in transformed
+    assert f"{prefix}.input_scale" not in transformed
+
+
+def test_modelopt_fp8_transform_requantizes_to_mxfp8():
+    prefix = "backbone.layers.0.mixer.in_proj"
+    weights = {
+        f"{prefix}.weight": mx.to_fp8(mx.ones((2, 32), dtype=mx.float32)),
+        f"{prefix}.weight_scale": mx.array(0.5, dtype=mx.float32),
+        f"{prefix}.input_scale": mx.array(1.0, dtype=mx.float32),
+    }
+
+    transformed, quantization = _transform_modelopt_weights(
+        weights,
+        {
+            "quant_method": "modelopt",
+            "config_groups": {
+                "group_0": {
+                    "weights": {"dynamic": False, "num_bits": 8, "type": "float"},
+                    "targets": [prefix],
+                }
+            },
+        },
+    )
+
+    assert quantization["group_size"] == 32
+    assert quantization["bits"] == 8
+    assert quantization["mode"] == "mxfp8"
+    assert quantization[f"language_model.{prefix}"] == {
+        "group_size": 32,
+        "bits": 8,
+        "mode": "mxfp8",
+    }
+    assert transformed[f"{prefix}.weight"].dtype == mx.uint32
+    assert transformed[f"{prefix}.weight"].shape == (2, 8)
+    assert transformed[f"{prefix}.scales"].dtype == mx.uint8
+    assert transformed[f"{prefix}.scales"].shape == (2, 1)
+    assert f"{prefix}.weight_scale" not in transformed
+    assert f"{prefix}.input_scale" not in transformed
+
+
+def test_modelopt_mixed_transform_uses_mxfp8_overrides():
+    fp8_prefix = "backbone.layers.0.mixer.in_proj"
+    nvfp4_prefix = "backbone.layers.1.mixer.experts.0.up_proj"
+    weights = {
+        f"{fp8_prefix}.weight": mx.to_fp8(mx.ones((2, 32), dtype=mx.float32)),
+        f"{fp8_prefix}.weight_scale": mx.array(0.5, dtype=mx.float32),
+        f"{nvfp4_prefix}.weight": mx.array([[1, 2, 3, 4]], dtype=mx.uint8),
+        f"{nvfp4_prefix}.weight_scale": mx.array([[8]], dtype=mx.uint8),
+        f"{nvfp4_prefix}.weight_scale_2": mx.array(0.5, dtype=mx.float32),
+    }
+
+    transformed, quantization = _transform_modelopt_weights(
+        weights,
+        {
+            "quant_method": "modelopt",
+            "config_groups": {
+                "group_0": {
+                    "weights": {"dynamic": False, "num_bits": 8, "type": "float"},
+                    "targets": [fp8_prefix],
+                },
+                "group_1": {
+                    "weights": {
+                        "dynamic": False,
+                        "group_size": 16,
+                        "num_bits": 4,
+                        "type": "float",
+                    },
+                    "targets": [nvfp4_prefix],
+                },
+            },
+        },
+    )
+
+    assert quantization["group_size"] == 16
+    assert quantization["bits"] == 4
+    assert quantization["mode"] == "nvfp4"
+    assert quantization[f"language_model.{fp8_prefix}"] == {
+        "group_size": 32,
+        "bits": 8,
+        "mode": "mxfp8",
+    }
+    assert transformed[f"{fp8_prefix}.weight"].dtype == mx.uint32
+    assert transformed[f"{fp8_prefix}.scales"].dtype == mx.uint8
+    assert transformed[f"{nvfp4_prefix}.weight"].dtype == mx.uint32
+    assert transformed[f"{nvfp4_prefix}.scales"].dtype == mx.uint8
+    assert f"{nvfp4_prefix}.global_scale" in transformed
+
+
+def test_nemotron_h_sanitize_stacks_expert_weights_and_scales():
+    model = Model(tiny_config())
+    prefix = "backbone.layers.0.mixer"
+    weights = {
+        f"{prefix}.experts.0.up_proj.weight": mx.ones((3, 4)),
+        f"{prefix}.experts.1.up_proj.weight": mx.ones((3, 4)) * 2,
+        f"{prefix}.experts.0.up_proj.scales": mx.ones((3, 1), dtype=mx.uint8),
+        f"{prefix}.experts.1.up_proj.scales": mx.ones((3, 1), dtype=mx.uint8) * 2,
+        f"{prefix}.experts.0.up_proj.global_scale": mx.array(1.0),
+        f"{prefix}.experts.1.up_proj.global_scale": mx.array(2.0),
+        f"{prefix}.experts.0.down_proj.weight": mx.ones((4, 3)) * 3,
+        f"{prefix}.experts.1.down_proj.weight": mx.ones((4, 3)) * 4,
+        f"{prefix}.experts.0.down_proj.scales": mx.ones((4, 1), dtype=mx.uint8) * 3,
+        f"{prefix}.experts.1.down_proj.scales": mx.ones((4, 1), dtype=mx.uint8) * 4,
+        f"{prefix}.experts.0.down_proj.global_scale": mx.array(3.0),
+        f"{prefix}.experts.1.down_proj.global_scale": mx.array(4.0),
+        "mtp.layers.0.norm.weight": mx.ones((4,)),
+        "backbone.layers.0.mixer.gate.weight": mx.ones((2, 4)),
+    }
+
+    sanitized = model.sanitize(weights)
+
+    out_prefix = "language_model.backbone.layers.0.mixer.switch_mlp"
+    assert sanitized[f"{out_prefix}.fc1.weight"].shape == (2, 3, 4)
+    assert sanitized[f"{out_prefix}.fc1.scales"].shape == (2, 3, 1)
+    assert sanitized[f"{out_prefix}.fc1.global_scale"].shape == (2,)
+    assert sanitized[f"{out_prefix}.fc2.weight"].shape == (2, 4, 3)
+    assert sanitized[f"{out_prefix}.fc2.scales"].shape == (2, 4, 1)
+    assert sanitized[f"{out_prefix}.fc2.global_scale"].shape == (2,)
+    assert "mtp.layers.0.norm.weight" not in sanitized
+    assert "language_model.backbone.layers.0.mixer.gate.weight" in sanitized

--- a/mlx_vlm/tests/test_utils.py
+++ b/mlx_vlm/tests/test_utils.py
@@ -15,6 +15,7 @@ from mlx_vlm.convert import _preserve_existing_deepseek_v4_quantization
 from mlx_vlm.models.text_only import TextOnlyModel
 from mlx_vlm.utils import (
     StoppingCriteria,
+    _get_weight_files,
     _load_safetensors,
     get_model_and_args,
     load,
@@ -172,6 +173,18 @@ def test_update_module_configs():
 
     assert updated.text_config == "text_config"
     assert updated.vision_config == "vision_config"
+
+
+def test_get_weight_files_prefers_safetensors_index(tmp_path):
+    current = tmp_path / "model-00001-of-00002.safetensors"
+    stale = tmp_path / "model-00001-of-00001.safetensors"
+    current.write_bytes(b"")
+    stale.write_bytes(b"")
+    (tmp_path / "model.safetensors.index.json").write_text(
+        json.dumps({"weight_map": {"model.weight": current.name}})
+    )
+
+    assert _get_weight_files(tmp_path) == [str(current)]
 
 
 def test_quantize_module():

--- a/mlx_vlm/utils.py
+++ b/mlx_vlm/utils.py
@@ -461,63 +461,6 @@ def _has_quantized_weights(path: str, weights: Optional[Dict[str, mx.array]]) ->
     return weights is not None and f"{path}.scales" in weights
 
 
-def _quantization_matches_weight_shapes(
-    module: nn.Module,
-    weight: mx.array,
-    scales: mx.array,
-    quantization: Dict[str, Any],
-) -> bool:
-    if not hasattr(module, "weight") or module.weight.ndim < 2:
-        return False
-
-    bits = quantization.get("bits")
-    group_size = quantization.get("group_size")
-    if bits is None or group_size is None:
-        return False
-
-    *prefix_shape, input_dims = module.weight.shape
-    if input_dims % group_size != 0:
-        return False
-
-    return (
-        tuple(weight.shape) == (*prefix_shape, input_dims * bits // 32)
-        and tuple(scales.shape) == (*prefix_shape, input_dims // group_size)
-    )
-
-
-def _infer_quantization_from_weights(
-    path: str,
-    module: nn.Module,
-    weights: Optional[Dict[str, mx.array]],
-    quantization: Dict[str, Any],
-) -> Optional[Dict[str, Any]]:
-    if weights is None:
-        return None
-
-    weight = weights.get(f"{path}.weight")
-    scales = weights.get(f"{path}.scales")
-    if weight is None or scales is None:
-        return None
-
-    default = {
-        "group_size": quantization.get("group_size"),
-        "bits": quantization.get("bits"),
-        "mode": quantization.get("mode", "affine"),
-    }
-    candidates = [
-        default,
-        {"group_size": 32, "bits": 8, "mode": "mxfp8"},
-        {"group_size": 16, "bits": 4, "mode": "nvfp4"},
-        {"group_size": 32, "bits": 4, "mode": "mxfp4"},
-    ]
-
-    for candidate in candidates:
-        if _quantization_matches_weight_shapes(module, weight, scales, candidate):
-            return candidate
-
-    return None
-
-
 def get_class_predicate(skip_vision=False, weights=None, quantization_config=None):
     def predicate(p, m):
         if (
@@ -533,9 +476,7 @@ def get_class_predicate(skip_vision=False, weights=None, quantization_config=Non
         if hasattr(m, "weight") and m.weight.size % 64 != 0:
             return False
         if weights is not None:
-            return _infer_quantization_from_weights(
-                p, m, weights, quantization_config or {}
-            ) or f"{p}.scales" in weights
+            return f"{p}.scales" in weights
         return True
 
     return predicate
@@ -822,10 +763,6 @@ python -m mlx_vlm.convert --hf-path <local_dir> --mlx-path <mlx_dir>
             # Skip layers not divisible by 64
             if hasattr(m, "weight") and m.weight.size % 64 != 0:
                 return False
-            if inferred := _infer_quantization_from_weights(
-                p, m, weights, config["quantization"]
-            ):
-                return inferred
             # Handle legacy models which may not have everything quantized
             return f"{p}.scales" in weights
 

--- a/mlx_vlm/utils.py
+++ b/mlx_vlm/utils.py
@@ -293,6 +293,29 @@ def _modelopt_quantization_key(prefix: str) -> str:
     return prefix
 
 
+def _modelopt_mlx_quantization_config(
+    quantization_config: Dict[str, Any],
+    weights: Optional[Dict[str, mx.array]] = None,
+) -> Dict[str, Any]:
+    nvfp4_targets = _modelopt_targets(quantization_config, 4)
+    fp8_targets = _modelopt_targets(quantization_config, 8)
+
+    mlx_quantization = dict(quantization_config)
+    mlx_quantization.update(
+        _MODEL_OPT_NVFP4_QUANTIZATION
+        if nvfp4_targets
+        else _MODEL_OPT_MXFP8_QUANTIZATION
+    )
+
+    for target in fp8_targets:
+        key = _modelopt_quantization_key(target)
+        if weights is not None and f"{key}.scales" not in weights:
+            continue
+        mlx_quantization[key] = dict(_MODEL_OPT_MXFP8_QUANTIZATION)
+
+    return mlx_quantization
+
+
 def _transform_modelopt_weights(
     weights: Dict[str, mx.array],
     quantization_config: Optional[Dict[str, Any]],
@@ -392,7 +415,7 @@ def _transform_modelopt_weights(
             continue
         new_weights[key] = value
 
-    mlx_quantization = dict(quantization_config)
+    mlx_quantization = _modelopt_mlx_quantization_config(quantization_config)
     mlx_quantization.update(
         _MODEL_OPT_NVFP4_QUANTIZATION
         if transformed_nvfp4
@@ -574,6 +597,33 @@ def get_model_path(
     return model_path
 
 
+def _get_weight_files(model_path: Path) -> List[str]:
+    index_path = model_path / "model.safetensors.index.json"
+    if index_path.exists():
+        with open(index_path, encoding="utf-8") as f:
+            weight_map = json.load(f).get("weight_map", {})
+
+        weight_files = [
+            str(model_path / filename)
+            for filename in sorted(set(weight_map.values()))
+            if not filename.endswith("consolidated.safetensors")
+        ]
+        missing = [wf for wf in weight_files if not Path(wf).exists()]
+        if missing:
+            raise FileNotFoundError(
+                "The safetensors index references missing weight files: "
+                + ", ".join(missing)
+            )
+        if weight_files:
+            return weight_files
+
+    return [
+        wf
+        for wf in sorted(glob.glob(str(model_path / "*.safetensors")))
+        if not wf.endswith("consolidated.safetensors")
+    ]
+
+
 def load_model(model_path: Path, lazy: bool = False, **kwargs) -> nn.Module:
     """
     Load and initialize the model from a given path.
@@ -598,12 +648,9 @@ def load_model(model_path: Path, lazy: bool = False, **kwargs) -> nn.Module:
     """
     config = load_config(model_path, **kwargs)
 
-    # Find all .safetensors files in the model_path, excluding consolidated model weights
-    weight_files = [
-        wf
-        for wf in glob.glob(str(model_path / "*.safetensors"))
-        if not wf.endswith("consolidated.safetensors")
-    ]
+    # Find .safetensors files, preferring the index when present so stale shards
+    # left in a reused conversion directory are not loaded.
+    weight_files = _get_weight_files(model_path)
 
     if not weight_files:
         logging.error(f"No safetensors found in {model_path}")
@@ -716,9 +763,8 @@ python -m mlx_vlm.convert --hf-path <local_dir> --mlx-path <mlx_dir>
             elif quant_method == "modelopt" and any(
                 key.endswith(".scales") for key in weights
             ):
-                quantization = config.get(
-                    "quantization",
-                    {"group_size": 16, "bits": 4, "mode": "nvfp4"},
+                quantization = _modelopt_mlx_quantization_config(
+                    quantization_config, weights
                 )
             elif quant_method in ("awq", "gptq", "bitnet"):
                 logging.warning(

--- a/mlx_vlm/utils.py
+++ b/mlx_vlm/utils.py
@@ -461,6 +461,63 @@ def _has_quantized_weights(path: str, weights: Optional[Dict[str, mx.array]]) ->
     return weights is not None and f"{path}.scales" in weights
 
 
+def _quantization_matches_weight_shapes(
+    module: nn.Module,
+    weight: mx.array,
+    scales: mx.array,
+    quantization: Dict[str, Any],
+) -> bool:
+    if not hasattr(module, "weight") or module.weight.ndim < 2:
+        return False
+
+    bits = quantization.get("bits")
+    group_size = quantization.get("group_size")
+    if bits is None or group_size is None:
+        return False
+
+    *prefix_shape, input_dims = module.weight.shape
+    if input_dims % group_size != 0:
+        return False
+
+    return (
+        tuple(weight.shape) == (*prefix_shape, input_dims * bits // 32)
+        and tuple(scales.shape) == (*prefix_shape, input_dims // group_size)
+    )
+
+
+def _infer_quantization_from_weights(
+    path: str,
+    module: nn.Module,
+    weights: Optional[Dict[str, mx.array]],
+    quantization: Dict[str, Any],
+) -> Optional[Dict[str, Any]]:
+    if weights is None:
+        return None
+
+    weight = weights.get(f"{path}.weight")
+    scales = weights.get(f"{path}.scales")
+    if weight is None or scales is None:
+        return None
+
+    default = {
+        "group_size": quantization.get("group_size"),
+        "bits": quantization.get("bits"),
+        "mode": quantization.get("mode", "affine"),
+    }
+    candidates = [
+        default,
+        {"group_size": 32, "bits": 8, "mode": "mxfp8"},
+        {"group_size": 16, "bits": 4, "mode": "nvfp4"},
+        {"group_size": 32, "bits": 4, "mode": "mxfp4"},
+    ]
+
+    for candidate in candidates:
+        if _quantization_matches_weight_shapes(module, weight, scales, candidate):
+            return candidate
+
+    return None
+
+
 def get_class_predicate(skip_vision=False, weights=None, quantization_config=None):
     def predicate(p, m):
         if (
@@ -476,7 +533,9 @@ def get_class_predicate(skip_vision=False, weights=None, quantization_config=Non
         if hasattr(m, "weight") and m.weight.size % 64 != 0:
             return False
         if weights is not None:
-            return f"{p}.scales" in weights
+            return _infer_quantization_from_weights(
+                p, m, weights, quantization_config or {}
+            ) or f"{p}.scales" in weights
         return True
 
     return predicate
@@ -763,6 +822,10 @@ python -m mlx_vlm.convert --hf-path <local_dir> --mlx-path <mlx_dir>
             # Skip layers not divisible by 64
             if hasattr(m, "weight") and m.weight.size % 64 != 0:
                 return False
+            if inferred := _infer_quantization_from_weights(
+                p, m, weights, config["quantization"]
+            ):
+                return inferred
             # Handle legacy models which may not have everything quantized
             return f"{p}.scales" in weights
 

--- a/mlx_vlm/utils.py
+++ b/mlx_vlm/utils.py
@@ -52,7 +52,7 @@ MAX_FILE_SIZE_GB = 5
 
 MODEL_CONVERSION_DTYPES = ["float16", "bfloat16", "float32"]
 
-SAFETENSORS_DTYPE_FALLBACKS = {"F8_E8M0": "U8"}
+SAFETENSORS_DTYPE_FALLBACKS = {"F8_E4M3": "U8", "F8_E8M0": "U8"}
 
 
 def _e4m3_decode_table() -> mx.array:
@@ -261,6 +261,148 @@ def _transform_compressed_tensors_weights(
         return _transform_compressed_tensors_int4_weights(weights, quantization_config)
 
     return weights, None
+
+
+_MODEL_OPT_MXFP8_QUANTIZATION = {"group_size": 32, "bits": 8, "mode": "mxfp8"}
+_MODEL_OPT_NVFP4_QUANTIZATION = {"group_size": 16, "bits": 4, "mode": "nvfp4"}
+
+
+def _modelopt_targets(quantization_config: Dict[str, Any], bits: int) -> set[str]:
+    targets: set[str] = set()
+    for group in (quantization_config.get("config_groups") or {}).values():
+        weights_cfg = group.get("weights") or {}
+        if (
+            weights_cfg.get("type") == "float"
+            and weights_cfg.get("num_bits") == bits
+        ):
+            targets.update(group.get("targets") or [])
+    return targets
+
+
+def _modelopt_target_key(prefix: str) -> str:
+    if prefix.startswith("language_model."):
+        return prefix[len("language_model.") :]
+    return prefix
+
+
+def _modelopt_quantization_key(prefix: str) -> str:
+    if prefix.startswith("language_model."):
+        return prefix
+    if prefix.startswith(("backbone.", "lm_head.")):
+        return f"language_model.{prefix}"
+    return prefix
+
+
+def _transform_modelopt_weights(
+    weights: Dict[str, mx.array],
+    quantization_config: Optional[Dict[str, Any]],
+) -> Tuple[Dict[str, mx.array], Optional[Dict[str, Any]]]:
+    """Normalize ModelOpt tensors to MLX quantized tensor names.
+
+    ModelOpt stores NVFP4 weights as:
+
+    - ``<p>.weight`` packed uint8 E2M1 values, two values per byte
+    - ``<p>.weight_scale`` FP8 E4M3 block scales, one per 16 input values
+    - ``<p>.weight_scale_2`` FP32 per-tensor global scale
+
+    Nemotron H installs custom routed-expert modules that apply the global scale
+    after the quantized matmul. Keeping the scale separate avoids decoding every
+    block-scale tensor to float32 during load, which is prohibitively expensive
+    for 550B-class checkpoints.
+
+    ModelOpt static FP8 linears store:
+
+    - ``<p>.weight`` raw E4M3 bytes
+    - ``<p>.weight_scale`` FP32 per-tensor scale
+
+    Those are dequantized once during load and immediately requantized to MLX's
+    native ``mxfp8`` format so generation uses ``QuantizedLinear`` instead of
+    decoding FP8 weights inside every forward pass.
+    """
+    if quantization_config is None:
+        return weights, None
+    if quantization_config.get("quant_method") != "modelopt":
+        return weights, None
+
+    new_weights = {}
+    transformed_nvfp4 = False
+    transformed_fp8_prefixes: set[str] = set()
+    fp8_targets = _modelopt_targets(quantization_config, 8)
+
+    for key in [k for k in weights.keys() if k.endswith(".weight")]:
+        if key not in weights:
+            continue
+
+        prefix = key[: -len(".weight")]
+        scale_key = f"{prefix}.weight_scale"
+        global_scale_key = f"{prefix}.weight_scale_2"
+
+        if scale_key in weights and global_scale_key in weights:
+            value = weights.pop(key)
+            new_weights[key] = value.view(mx.uint32)
+            new_weights[f"{prefix}.scales"] = weights.pop(scale_key)
+            new_weights[f"{prefix}.global_scale"] = weights.pop(global_scale_key)
+            weights.pop(f"{prefix}.input_scale", None)
+            transformed_nvfp4 = True
+            continue
+
+        target_key = _modelopt_target_key(prefix)
+        is_fp8_target = target_key in fp8_targets or (
+            not fp8_targets
+            and scale_key in weights
+            and global_scale_key not in weights
+            and weights[key].dtype == mx.uint8
+        )
+        if not is_fp8_target or scale_key not in weights:
+            continue
+        if weights[key].shape[-1] % _MODEL_OPT_MXFP8_QUANTIZATION["group_size"] != 0:
+            raise ValueError(
+                "ModelOpt FP8 weights require input dimensions divisible by "
+                f"{_MODEL_OPT_MXFP8_QUANTIZATION['group_size']}: {key} has shape "
+                f"{weights[key].shape}"
+            )
+
+        value = weights.pop(key)
+        scale = weights.pop(scale_key).astype(mx.bfloat16)
+        weights.pop(f"{prefix}.input_scale", None)
+        dense = mx.from_fp8(value.astype(mx.uint8), dtype=mx.bfloat16) * scale
+        qweight, scales, *_ = mx.quantize(
+            dense,
+            group_size=_MODEL_OPT_MXFP8_QUANTIZATION["group_size"],
+            bits=_MODEL_OPT_MXFP8_QUANTIZATION["bits"],
+            mode=_MODEL_OPT_MXFP8_QUANTIZATION["mode"],
+        )
+        mx.eval(qweight, scales)
+        new_weights[key] = qweight
+        new_weights[f"{prefix}.scales"] = scales
+        transformed_fp8_prefixes.add(prefix)
+        del dense, value, scale
+
+    if not transformed_nvfp4 and not transformed_fp8_prefixes:
+        return weights, None
+
+    for key in list(weights.keys()):
+        value = weights.pop(key)
+        if key.endswith((".weight_scale_2", ".input_scale")):
+            continue
+        if (
+            key.endswith(".weight_scale")
+            and f"{key[: -len('.weight_scale')]}.weight_scale_2" in weights
+        ):
+            continue
+        new_weights[key] = value
+
+    mlx_quantization = dict(quantization_config)
+    mlx_quantization.update(
+        _MODEL_OPT_NVFP4_QUANTIZATION
+        if transformed_nvfp4
+        else _MODEL_OPT_MXFP8_QUANTIZATION
+    )
+    for prefix in transformed_fp8_prefixes:
+        mlx_quantization[_modelopt_quantization_key(prefix)] = dict(
+            _MODEL_OPT_MXFP8_QUANTIZATION
+        )
+    return new_weights, mlx_quantization
 
 
 def quantize_activations(model: nn.Module) -> nn.Module:
@@ -519,6 +661,10 @@ python -m mlx_vlm.convert --hf-path <local_dir> --mlx-path <mlx_dir>
     weights, transformed_quantization = _transform_compressed_tensors_weights(
         weights, quantization_config
     )
+    if transformed_quantization is None:
+        weights, transformed_quantization = _transform_modelopt_weights(
+            weights, quantization_config
+        )
     if transformed_quantization is not None:
         config["quantization"] = transformed_quantization
         config["quantization_config"] = transformed_quantization
@@ -567,6 +713,13 @@ python -m mlx_vlm.convert --hf-path <local_dir> --mlx-path <mlx_dir>
                 from .models.deepseek_v4.language import make_quantization_config
 
                 quantization = make_quantization_config(model)
+            elif quant_method == "modelopt" and any(
+                key.endswith(".scales") for key in weights
+            ):
+                quantization = config.get(
+                    "quantization",
+                    {"group_size": 16, "bits": 4, "mode": "nvfp4"},
+                )
             elif quant_method in ("awq", "gptq", "bitnet"):
                 logging.warning(
                     "Quantization method %s is not supported in mlx_vlm.load_model()",
@@ -588,7 +741,7 @@ python -m mlx_vlm.convert --hf-path <local_dir> --mlx-path <mlx_dir>
         # TODO: Re-upload the models with the new quantization config and remove this
         skip_vision = config.get("vision_config", {}).get("skip_vision", False)
         quantized_model = (
-            model.language_model._model
+            getattr(model.language_model, "_model", model)
             if getattr(model, "_is_text_model", False)
             else model
         )

--- a/mlx_vlm/utils.py
+++ b/mlx_vlm/utils.py
@@ -787,7 +787,7 @@ python -m mlx_vlm.convert --hf-path <local_dir> --mlx-path <mlx_dir>
         # TODO: Re-upload the models with the new quantization config and remove this
         skip_vision = config.get("vision_config", {}).get("skip_vision", False)
         quantized_model = (
-            getattr(model.language_model, "_model", model)
+            model.language_model._model
             if getattr(model, "_is_text_model", False)
             else model
         )


### PR DESCRIPTION
## Summary

Adds Nemotron-H text-model support for NVIDIA Nemotron 3 Ultra ModelOpt checkpoints, including config normalization, a text-only language wrapper, and custom routed expert handling for ModelOpt NVFP4 tensors.

The loader now normalizes ModelOpt weights before model-specific sanitization. Static ModelOpt FP8 linears are dequantized once during load and requantized to MLX-native `mxfp8`, avoiding per-forward FP8 decoding. Routed NVFP4 expert weights are remapped to MLX packed weights plus scales while preserving the per-expert global scale for the custom switch linear path.

## Impact

Users can load `nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-NVFP4` through `mlx_vlm.generate`. Generation uses native MLX quantized matmuls for static FP8 linears and custom `gather_qmm` for routed NVFP4 experts.

## Validation

- `uv run pytest -q mlx_vlm/tests/test_nemotron_h.py mlx_vlm/tests/test_utils.py::test_load_model_routes_text_models_through_existing_loader`
- `uv run mlx_vlm.generate --model nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-NVFP4 --prompt "hi" --max-tokens 1 --temperature 0`
