### PR TITLE
Fix thinking enabled by default for chat templates

### DIFF
--- a/mlx_vlm/prompt_utils.py
+++ b/mlx_vlm/prompt_utils.py
@@ -1,3 +1,4 @@
+import inspect
 import json
 from enum import Enum
 from functools import partial
@@ -666,6 +667,17 @@ def get_chat_template(
 
     chat_template_override = kwargs.get("chat_template", None)
 
+    def _supports_template_kw(template_processor: Any, name: str) -> bool:
+        try:
+            signature = inspect.signature(template_processor.apply_chat_template)
+        except (TypeError, ValueError):
+            return False
+
+        return name in signature.parameters or any(
+            parameter.kind == inspect.Parameter.VAR_KEYWORD
+            for parameter in signature.parameters.values()
+        )
+
     try:
         template_processor = None
         if (
@@ -698,12 +710,18 @@ def get_chat_template(
         if template_processor is None:
             return _messages_to_plain_prompt()
 
+        template_kwargs = dict(kwargs)
+        if "enable_thinking" not in template_kwargs and _supports_template_kw(
+            template_processor, "enable_thinking"
+        ):
+            template_kwargs["enable_thinking"] = False
+
         try:
             return template_processor.apply_chat_template(
                 messages,
                 tokenize=tokenize,
                 add_generation_prompt=add_generation_prompt,
-                **kwargs,
+                **template_kwargs,
             )
         except ValueError as e:
             if chat_template_override is None and _missing_template_error(e):

--- a/mlx_vlm/tests/test_prompt_utils.py
+++ b/mlx_vlm/tests/test_prompt_utils.py
@@ -560,6 +560,61 @@ def test_apply_chat_template_uses_generic_text_model_fallback():
     assert result == "templated"
 
 
+def test_apply_chat_template_defaults_thinking_disabled_when_supported():
+    class ThinkingProcessor:
+        chat_template = "{{ messages }}"
+
+        def __init__(self):
+            self.kwargs = None
+
+        def apply_chat_template(
+            self, messages, tokenize=False, add_generation_prompt=True, **kwargs
+        ):
+            self.kwargs = kwargs
+            if kwargs.get("enable_thinking") is False:
+                return "<|im_start|>assistant\n<think>\n\n</think>\n\n"
+            return "<|im_start|>assistant\n<think>\n"
+
+    processor = ThinkingProcessor()
+    result = apply_chat_template(
+        processor,
+        {"model_type": "qwen3_5_moe"},
+        "Describe this image.",
+        num_images=1,
+    )
+
+    assert processor.kwargs["enable_thinking"] is False
+    assert result.endswith("<think>\n\n</think>\n\n")
+
+
+def test_apply_chat_template_preserves_explicit_thinking_enabled():
+    class ThinkingProcessor:
+        chat_template = "{{ messages }}"
+
+        def __init__(self):
+            self.kwargs = None
+
+        def apply_chat_template(
+            self, messages, tokenize=False, add_generation_prompt=True, **kwargs
+        ):
+            self.kwargs = kwargs
+            if kwargs.get("enable_thinking") is False:
+                return "<|im_start|>assistant\n<think>\n\n</think>\n\n"
+            return "<|im_start|>assistant\n<think>\n"
+
+    processor = ThinkingProcessor()
+    result = apply_chat_template(
+        processor,
+        {"model_type": "qwen3_5_moe"},
+        "Describe this image.",
+        num_images=1,
+        enable_thinking=True,
+    )
+
+    assert processor.kwargs["enable_thinking"] is True
+    assert result.endswith("<think>\n")
+
+
 class TestModelSpecificPromptContracts:
     """Guard model-specific multimodal message formats from regressions."""
 


### PR DESCRIPTION
Right now there's a gap where a chat template can enable thinking to true when unspecified, but mlx-vlm api/cli/server defaults thinking to false unless `--enable-thinking` or equivalent is provided. This change aligns the default chat template behavior to match mlx-vlm defaults when the chat template supports it.

This fixes the `mlx-community/Qwen3.5-35B-A3B-bf16` issue reported in https://github.com/Blaizzy/mlx-vlm/issues/1315, where the generation cap is small and enable_thinking=False from the api level, but thinking is enabled by default in the chat template and the thinking token length exceeds the generation cap.