### PR TITLE
fix: support gemma4_unified model type (MODEL_REMAPPING + sanitize vision_embedder)

### DIFF
--- a/mlx_vlm/models/gemma4/gemma4.py
+++ b/mlx_vlm/models/gemma4/gemma4.py
@@ -224,6 +224,8 @@ class Model(nn.Module):
                 continue
             if self.audio_tower is None and ("audio_tower" in k or "embed_audio" in k):
                 continue
+            if k.startswith("vision_embedder"):
+                continue  # gemma4_unified encoder-free variant; not in standard gemma4 arch
 
             if k.startswith("model."):
                 new_key = k[len("model.") :]

--- a/mlx_vlm/utils.py
+++ b/mlx_vlm/utils.py
@@ -46,6 +46,9 @@ MODEL_REMAPPING = {
     "falcon-perception": "falcon_perception",
     "nemotronh_nano_omni_reasoning_v3": "nemotron_h_nano_omni",
     "cohere2moe": "cohere2_moe",
+    "gemma4_unified": "gemma4",
+    "gemma4_unified_text": "gemma4",
+    "gemma4_unified_audio": "gemma4",
 }
 
 MAX_FILE_SIZE_GB = 5


### PR DESCRIPTION
## Problem

Loading Gemma 4 12B+ models (e.g. \`mlx-community/gemma-4-12B-it-4bit\`) fails with:

\`\`\`
Model type gemma4_unified not supported.
\`\`\`

These models declare \`model_type: gemma4_unified\` in their \`config.json\`. Without a mapping, the load path is never entered.

After adding the remapping, load fails again because \`gemma4.sanitize()\` doesn't strip 11 \`vision_embedder.*\` weight keys that exist in the \`gemma4_unified\` checkpoint but are absent from the standard \`gemma4\` model architecture (2B/4B).

## Fix (2 parts)

**1. \`mlx_vlm/utils.py\`** — add three entries to \`MODEL_REMAPPING\`:
\`\`\`python
"gemma4_unified": "gemma4",
"gemma4_unified_text": "gemma4",
"gemma4_unified_audio": "gemma4",
\`\`\`

**2. \`mlx_vlm/models/gemma4/gemma4.py\`** — skip \`vision_embedder.*\` keys in \`sanitize()\`:
\`\`\`python
if k.startswith("vision_embedder"):
    continue  # gemma4_unified encoder-free variant; not in standard gemma4 arch
\`\`\`

This mirrors the fix in ml-explore/mlx-lm#1349 (merged).

## Verified

\`mlx-community/gemma-4-12B-it-4bit\` now loads cleanly with strict weight checking — no unexpected or missing parameters. Peak RAM ~11 GB at 4-bit on M-series.