### PR TITLE
Fix MTP server target model handling

### DIFF
--- a/mlx_vlm/server/generation.py
+++ b/mlx_vlm/server/generation.py
@@ -728,6 +728,7 @@ class ResponseGenerator:
         self.model_path = model_path
         self.adapter_path = adapter_path
         self.model = None
+        self.language_model = None
         self.processor = None
         self.config = None
         self.stop_tokens = set()
@@ -748,6 +749,24 @@ class ResponseGenerator:
         self._cancel_lock = Lock()
         self._thread = Thread(target=self._run, daemon=True)
         self._thread.start()
+
+    def _target_language_model(self):
+        language_model = getattr(self.model, "language_model", None)
+        if language_model is None:
+            model_type = type(self.model).__name__
+            draft_type = type(self.draft_model).__name__ if self.draft_model else None
+            hint = (
+                " The loaded target model is the configured drafter; check that "
+                "the server --model path points at the target checkpoint, not "
+                "--draft-model."
+                if self.model is self.draft_model
+                else ""
+            )
+            raise RuntimeError(
+                "Loaded target model does not expose a language_model "
+                f"attribute (model={model_type}, draft_model={draft_type}).{hint}"
+            )
+        return language_model
 
     def stop_and_join(self):
         self._stop = True
@@ -822,6 +841,7 @@ class ResponseGenerator:
         self.stop_tokens = stop_tokens
         self.draft_model = draft_model
         self.draft_kind = draft_kind
+        self.language_model = self._target_language_model()
         self.tokenizer = (
             processor.tokenizer if hasattr(processor, "tokenizer") else processor
         )
@@ -1055,6 +1075,8 @@ class ResponseGenerator:
         """Single GPU thread: owns BatchGenerator, runs tight next() loop."""
         try:
             self._initialize_model()
+            if getattr(self, "language_model", None) is None:
+                self.language_model = self._target_language_model()
         except Exception as e:
             self._load_error = e
             self._ready.set()
@@ -1115,7 +1137,7 @@ class ResponseGenerator:
                 for rqueue, raw_inputs, prompt_tokens, args, images in new_items:
                     if batch_gen is None:
                         batch_gen = BatchGenerator(
-                            self.model.language_model,
+                            self.language_model,
                             self.processor,
                             stop_tokens=self.stop_tokens,
                             sampler=self._make_sampler(args),
@@ -1215,7 +1237,7 @@ class ResponseGenerator:
 
         generation_stream = mx.default_stream(mx.default_device())
 
-        lm = self.model.language_model
+        lm = getattr(self, "language_model", None) or self._target_language_model()
         drafter = self.draft_model
         draft_kind = self.draft_kind
         is_mtp = draft_kind == "mtp"

--- a/mlx_vlm/tests/test_server.py
+++ b/mlx_vlm/tests/test_server.py
@@ -3500,7 +3500,7 @@ class TestResponseGenerator:
 
         class FakeBatchGenerator:
             def __init__(self, *args, **kwargs):
-                del args
+                batch_state["args"] = args
                 batch_state["kwargs"] = kwargs
                 self._next_uid = 1
                 self._active = {}
@@ -3575,9 +3575,10 @@ class TestResponseGenerator:
         gen._load_error = None
         gen._cancelled = set()
         gen._cancel_lock = Lock()
+        target_lm = object()
 
         def fake_initialize_model():
-            gen.model = SimpleNamespace(language_model=object())
+            gen.model = SimpleNamespace(language_model=target_lm)
             gen.processor = SimpleNamespace()
             gen.config = SimpleNamespace()
             gen.stop_tokens = set()
@@ -3622,12 +3623,22 @@ class TestResponseGenerator:
             worker.join(timeout=2)
 
         kwargs = batch_state["kwargs"]
+        assert batch_state["args"][0] is target_lm
         assert kwargs["draft_model"] is draft_model
         assert kwargs["draft_kind"] == "mtp"
         assert kwargs["draft_block_size"] == 6
         assert kwargs["greedy_sampling"] is True
         assert kwargs["compute_logprobs"] is False
         assert batch_state["instance"].next_active_sizes == [2]
+
+    def test_target_language_model_rejects_drafter_as_target(self):
+        draft_model = SimpleNamespace()
+        gen = server.ResponseGenerator.__new__(server.ResponseGenerator)
+        gen.model = draft_model
+        gen.draft_model = draft_model
+
+        with pytest.raises(RuntimeError, match="server --model path"):
+            gen._target_language_model()
 
     def test_run_coalesces_idle_mtp_batch_generator(self, monkeypatch):
         monkeypatch.setenv("MLX_VLM_SPEC_BATCH_COALESCE_MS", "37")


### PR DESCRIPTION
## Summary
- cache the server target language model after model initialization
- use the cached target LM when constructing BatchGenerator and speculative paths
- add a guard for accidentally loading the drafter as the target model


Fixes #1317.
