### PR TITLE
Fix Gemma 4 unified silently dropping image/video inputs (video processor rejects standard HF config keys)

### DIFF
--- a/mlx_vlm/models/gemma4/processing_gemma4.py
+++ b/mlx_vlm/models/gemma4/processing_gemma4.py
@@ -236,7 +236,7 @@ class Gemma4VideoProcessor:
         default_fps: float = 2.0,
         **kwargs,
     ):
-        # Ignore extra HF processor-config keys this processor doesn't consume.
+        # Ignore extra HF processor's config keys this processor doesn't consume.
         if max_soft_tokens not in _SUPPORTED_SOFT_TOKENS:
             raise ValueError(
                 f"`max_soft_tokens` must be one of {_SUPPORTED_SOFT_TOKENS}, "

--- a/mlx_vlm/models/gemma4/processing_gemma4.py
+++ b/mlx_vlm/models/gemma4/processing_gemma4.py
@@ -234,7 +234,9 @@ class Gemma4VideoProcessor:
         image_mean: Optional[list] = None,
         image_std: Optional[list] = None,
         default_fps: float = 2.0,
+        **kwargs,
     ):
+        # Ignore extra HF processor-config keys this processor doesn't consume.
         if max_soft_tokens not in _SUPPORTED_SOFT_TOKENS:
             raise ValueError(
                 f"`max_soft_tokens` must be one of {_SUPPORTED_SOFT_TOKENS}, "

--- a/mlx_vlm/tests/test_processors.py
+++ b/mlx_vlm/tests/test_processors.py
@@ -276,6 +276,35 @@ class TestGemma4UnifiedProcessor(unittest.TestCase):
         )
         self.assertTrue(np.all(data["video_position_ids"][0, 2:] == -1))
 
+    def test_video_processor_tolerates_extra_hf_config_keys(self):
+        # Regression: extra HF config keys must be ignored, not rejected.
+        from mlx_vlm.models.gemma4.processing_gemma4 import Gemma4VideoProcessor
+        from mlx_vlm.models.gemma4_unified.processing_gemma4_unified import (
+            Gemma4UnifiedVideoProcessor,
+        )
+
+        # The edited base class, and the unified subclass that delegates to it.
+        for cls in (Gemma4VideoProcessor, Gemma4UnifiedVideoProcessor):
+            processor = cls(
+                patch_size=16,
+                pooling_kernel_size=3,
+                max_soft_tokens=70,
+                num_frames=32,
+                do_rescale=True,
+                rescale_factor=1 / 255,
+                do_normalize=True,
+                image_mean=[0.0, 0.0, 0.0],
+                image_std=[1.0, 1.0, 1.0],
+                # extra HF keys the processor must ignore
+                do_convert_rgb=True,
+                do_sample_frames=True,
+                resample=3,
+                return_metadata=False,
+            )
+
+            self.assertEqual(processor.max_soft_tokens, 70)
+            self.assertEqual(processor.num_frames, 32)
+
     def test_audio_feature_extractor_chunks_waveforms(self):
         from mlx_vlm.models.gemma4_unified.processing_gemma4_unified import (
             Gemma4UnifiedAudioFeatureExtractor,


### PR DESCRIPTION
### Summary

On `main`, any `gemma4_unified` model whose `processor_config.json` contains a
`video_processor` block silently loses **all image and video inputs** — the
model receives only the text prompt and replies with e.g. *"I can't see any
image yet."* No error, no warning.

It's a regression from #1292 (*Add video input support for Gemma 4 12B*).

### Reproduction (no model download)

```python
from mlx_vlm.models.gemma4_unified.processing_gemma4_unified import Gemma4UnifiedVideoProcessor

# keys copied verbatim from google/gemma-4-31B-it processor_config.json -> "video_processor"
Gemma4UnifiedVideoProcessor(
    patch_size=16, pooling_kernel_size=3, max_soft_tokens=70, num_frames=32,
    do_rescale=True, rescale_factor=1/255, do_normalize=True,
    image_mean=[0, 0, 0], image_std=[1, 1, 1],
    do_convert_rgb=True, do_sample_frames=True, resample=3, return_metadata=False,
)
# TypeError: Gemma4VideoProcessor.__init__() got an unexpected keyword argument 'do_convert_rgb'
```

End-to-end (e.g. a `gemma4_unified` checkpoint that preserves the full processor config):

```
mlx_vlm.generate --model <gemma4_unified model> --image foo.png --prompt "What do you see?"
#  ->  "I can't see any image yet! Please upload or paste the image..."
```

### Root cause

`Gemma4UnifiedProcessor.from_pretrained` reads the `video_processor` block from
`processor_config.json` and builds the video processor from it:

```python
vp_config = dict(proc_config["video_processor"])      # standard HF keys
...
video_processor = Gemma4UnifiedVideoProcessor(**vp_config)
```

But `Gemma4VideoProcessor.__init__` (the parent, `models/gemma4/processing_gemma4.py`)
has a **fixed signature with no `**kwargs`** — unlike its siblings
`Gemma4ImageProcessor` and `Gemma4UnifiedAudioFeatureExtractor`, which both
accept and ignore extra keys. So standard HF keys this MLX reimplementation
doesn't consume — `do_convert_rgb`, `do_sample_frames`, `resample`,
`return_metadata` — raise `TypeError`.

That `TypeError` is then **silently swallowed** by the `AutoProcessor` patch in
`models/base.py` (`install_auto_processor_patch`), which falls back to the
default `AutoProcessor`. Since `transformers` has no `gemma4_unified` processor,
it degrades further to a bare `GemmaTokenizer` with no image processor.
`prepare_inputs` then returns only `input_ids` (no `pixel_values`), the single
`<|image|>` placeholder is never expanded into soft tokens, and the image is
dropped. The model loses its vision capabilities with no error surfaced.

### Fix

Give `Gemma4VideoProcessor.__init__` the same `**kwargs` tolerance the image and
audio processors already have, so unknown config keys are accepted and ignored.
The three processors become consistent.

### Why this scope

- Mirrors existing behavior of `Gemma4ImageProcessor` and
  `Gemma4UnifiedAudioFeatureExtractor` (both already take `**kwargs`).
- The offending keys are standard HF processor serialization — confirmed
  present in `google/gemma-4-31B-it`'s `processor_config.json` — so this affects
  any checkpoint that retains the full processor config.

### Tests

- Adds `test_video_processor_tolerates_extra_hf_config_keys` to
  `TestGemma4UnifiedProcessor`, constructing the video processor with the full
  real-world key set.
- `pytest mlx_vlm/tests/test_processors.py` → **93 passed, 1 skipped** (the
  prior 92 + the new regression test); the new test fails on `main` and passes
  with this change.
- Verified e2e on a `gemma4_unified` 12B: correctly describes a screenshot
  (OCR-level detail) and a synthetic shapes/colors/text image.

### Related

- Regression source: #1292
- Same model family, potentially related: #1277 (closed), #1008 (open — *"fails to describe image"*)

