### PR TITLE
Fix APC exact disk-hit entries not promoted to in-memory LRU

### DIFF
--- a/mlx_vlm/apc.py
+++ b/mlx_vlm/apc.py
@@ -2965,10 +2965,43 @@ class APCManager:
                         and len(stored_tokens) == disk_prefix_len
                         and token_tuple[:disk_prefix_len] == stored_tokens
                     ):
+                        # Promote the disk-restored entry to the in-memory LRU
+                        # so subsequent identical requests get the fast clone
+                        # path instead of paying disk-restore latency again.
+                        # We clone before storing because the caller's copy will
+                        # be mutated in-place by generate_step as it appends
+                        # generated tokens; the stored copy must stay pristine.
                         # Disk reads and warm-cache construction intentionally
                         # happen outside the manager lock. If clear()/reset_stats()
                         # races here, the restored tensors are still valid; only
                         # the hit counter lands in the new stats window.
+                        if self._exact_cache_max > 0:
+                            storage_copy = _clone_prompt_cache_for_apc(prompt_cache)
+                            if storage_copy is not None:
+                                promote_key = _sequence_hash(
+                                    stored_tokens, extra_hash, self.block_size
+                                )
+                                with self.lock:
+                                    self.stats.exact_hits += 1
+                                    self.stats.disk_hits += 1
+                                    self.stats.hits += 1
+                                    self.stats.matched_tokens += disk_prefix_len
+                                    if promote_key not in self._exact_cache:
+                                        self._exact_cache[promote_key] = (
+                                            APCExactCacheEntry(
+                                                token_ids=stored_tokens,
+                                                extra_hash=int(extra_hash),
+                                                prompt_cache=storage_copy,
+                                                last_used=time.time(),
+                                            )
+                                        )
+                                        self._exact_cache.move_to_end(promote_key)
+                                        while (
+                                            len(self._exact_cache)
+                                            > self._exact_cache_max
+                                        ):
+                                            self._exact_cache.popitem(last=False)
+                                return prompt_cache, disk_prefix_len
                         with self.lock:
                             self.stats.exact_hits += 1
                             self.stats.disk_hits += 1

--- a/mlx_vlm/tests/test_apc.py
+++ b/mlx_vlm/tests/test_apc.py
@@ -896,3 +896,276 @@ def test_adjust_prefix_returns_zero_when_no_text_suffix_remains():
         )
         == 0
     )
+
+
+def test_exact_disk_hit_is_promoted_to_memory(tmp_path, monkeypatch):
+    """After a disk restore, the entry is written to _exact_cache so the next
+    identical request is served from memory (disk_hits stays unchanged)."""
+    from mlx_lm.models.cache import KVCache
+
+    token_ids = list(range(40))
+    kv = KVCache()
+    kv.keys = mx.ones((1, 1, len(token_ids), 2))
+    kv.values = mx.ones((1, 1, len(token_ids), 2)) * 2
+    kv.offset = len(token_ids)
+
+    # Write to disk only (memory cache disabled).
+    monkeypatch.setenv("APC_EXACT_CACHE_ENTRIES", "0")
+    disk = DiskBlockStore(tmp_path, namespace="promotion")
+    manager = APCManager(num_blocks=1, block_size=16, disk=disk)
+    assert manager.store_exact_cache(token_ids, [kv], extra_hash=3)
+    disk._q.join()
+    manager.close()
+
+    # Restart with an in-memory cache (4 slots) so promotion has somewhere to land.
+    monkeypatch.setenv("APC_EXACT_CACHE_ENTRIES", "4")
+    disk = DiskBlockStore(tmp_path, namespace="promotion")
+    manager = APCManager(num_blocks=1, block_size=16, disk=disk)
+
+    # First lookup: cold start, disk hit.
+    warm1, matched1 = manager.lookup_exact_cache(token_ids + [999], extra_hash=3)
+    assert matched1 == len(token_ids)
+    assert warm1 is not None
+    snap1 = manager.stats_snapshot()
+    assert snap1["disk_hits"] == 1
+    assert snap1["exact_hits"] == 1
+
+    # Second lookup: must be served from memory; disk_hits must not increase.
+    warm2, matched2 = manager.lookup_exact_cache(token_ids + [999], extra_hash=3)
+    assert matched2 == len(token_ids)
+    assert warm2 is not None
+    snap2 = manager.stats_snapshot()
+    assert snap2["disk_hits"] == 1, "second hit should come from memory, not disk"
+    assert snap2["exact_hits"] == 2
+
+    # The two returned caches must be independent objects (cloned, not the same).
+    assert warm1 is not warm2
+
+    manager.close()
+
+
+def test_exact_disk_hit_promotion_skipped_when_memory_disabled(tmp_path, monkeypatch):
+    """When _exact_cache_max == 0 the disk hit still works; no promotion attempted."""
+    from mlx_lm.models.cache import KVCache
+
+    token_ids = list(range(20))
+    kv = KVCache()
+    kv.keys = mx.ones((1, 1, len(token_ids), 2))
+    kv.values = mx.ones((1, 1, len(token_ids), 2)) * 2
+    kv.offset = len(token_ids)
+
+    monkeypatch.setenv("APC_EXACT_CACHE_ENTRIES", "0")
+    disk = DiskBlockStore(tmp_path, namespace="nopromo")
+    manager = APCManager(num_blocks=1, block_size=16, disk=disk)
+    assert manager.store_exact_cache(token_ids, [kv], extra_hash=5)
+    disk._q.join()
+    manager.close()
+
+    # Restart also with memory disabled.
+    disk = DiskBlockStore(tmp_path, namespace="nopromo")
+    manager = APCManager(num_blocks=1, block_size=16, disk=disk)
+
+    warm, matched = manager.lookup_exact_cache(token_ids + [999], extra_hash=5)
+    assert matched == len(token_ids)
+    assert warm is not None
+    assert manager.stats_snapshot()["disk_hits"] == 1
+
+    # Second lookup should hit disk again (memory still disabled).
+    warm2, matched2 = manager.lookup_exact_cache(token_ids + [999], extra_hash=5)
+    assert matched2 == len(token_ids)
+    assert warm2 is not None
+    assert manager.stats_snapshot()["disk_hits"] == 2
+
+    manager.close()
+
+
+def test_exact_disk_hit_promotion_lru_eviction(tmp_path, monkeypatch):
+    """When _exact_cache_max=1 and a second distinct prefix is promoted, the
+    first promoted entry is evicted from memory and subsequent requests for it
+    go back to disk."""
+    from mlx_lm.models.cache import KVCache
+
+    def _make_kv(val, n):
+        kv = KVCache()
+        kv.keys = mx.full((1, 1, n, 2), float(val))
+        kv.values = mx.full((1, 1, n, 2), float(val) + 1)
+        kv.offset = n
+        return kv
+
+    token_ids_a = list(range(20))
+    token_ids_b = list(range(100, 120))
+
+    monkeypatch.setenv("APC_EXACT_CACHE_ENTRIES", "0")
+    disk = DiskBlockStore(tmp_path, namespace="lru-evict")
+    manager = APCManager(num_blocks=1, block_size=16, disk=disk)
+    assert manager.store_exact_cache(token_ids_a, [_make_kv(1, 20)], extra_hash=0)
+    assert manager.store_exact_cache(token_ids_b, [_make_kv(2, 20)], extra_hash=0)
+    disk._q.join()
+    manager.close()
+
+    # Restart with memory capacity = 1.
+    monkeypatch.setenv("APC_EXACT_CACHE_ENTRIES", "1")
+    disk = DiskBlockStore(tmp_path, namespace="lru-evict")
+    manager = APCManager(num_blocks=1, block_size=16, disk=disk)
+
+    # Disk hit A -> promoted to memory (sole slot).
+    warm_a, _ = manager.lookup_exact_cache(token_ids_a + [999], extra_hash=0)
+    assert warm_a is not None
+    assert manager.stats_snapshot()["disk_hits"] == 1
+
+    # Memory hit A -> disk_hits unchanged.
+    warm_a2, _ = manager.lookup_exact_cache(token_ids_a + [999], extra_hash=0)
+    assert warm_a2 is not None
+    assert manager.stats_snapshot()["disk_hits"] == 1
+
+    # Disk hit B -> promoted, evicts A from the single memory slot.
+    warm_b, _ = manager.lookup_exact_cache(token_ids_b + [999], extra_hash=0)
+    assert warm_b is not None
+    assert manager.stats_snapshot()["disk_hits"] == 2
+
+    # A is now evicted; its next lookup must hit disk again.
+    warm_a3, _ = manager.lookup_exact_cache(token_ids_a + [999], extra_hash=0)
+    assert warm_a3 is not None
+    assert manager.stats_snapshot()["disk_hits"] == 3
+
+    manager.close()
+
+
+def test_exact_lookup_memory_takes_priority_over_disk(tmp_path, monkeypatch):
+    """Memory entries take priority over the disk store.  When the same prefix
+    exists in both _exact_cache and on disk, the memory clone is returned and
+    disk_hits stays at zero.  This also verifies that the promotion guard
+    (skip insert if key already present) is implicitly exercised: because
+    store_exact_cache writes to both memory and disk, any subsequent lookup
+    hits memory first and never triggers a disk read."""
+    from mlx_lm.models.cache import KVCache
+
+    token_ids = list(range(30))
+
+    def _make_kv(val):
+        kv = KVCache()
+        kv.keys = mx.ones((1, 1, len(token_ids), 2)) * val
+        kv.values = mx.ones((1, 1, len(token_ids), 2)) * (val + 1)
+        kv.offset = len(token_ids)
+        mx.eval(kv.keys, kv.values)
+        return kv
+
+    # Seed disk-only with value 7.
+    monkeypatch.setenv("APC_EXACT_CACHE_ENTRIES", "0")
+    disk = DiskBlockStore(tmp_path, namespace="priority")
+    manager = APCManager(num_blocks=1, block_size=16, disk=disk)
+    assert manager.store_exact_cache(token_ids, [_make_kv(7)], extra_hash=0)
+    disk._q.join()
+    manager.close()
+
+    # Restart with memory enabled; store an in-memory entry with value 99.
+    # store_exact_cache also writes to disk, but the memory lookup runs first.
+    monkeypatch.setenv("APC_EXACT_CACHE_ENTRIES", "4")
+    disk = DiskBlockStore(tmp_path, namespace="priority")
+    manager = APCManager(num_blocks=1, block_size=16, disk=disk)
+    kv_mem = _make_kv(99)
+    manager.store_exact_cache(token_ids, [kv_mem], extra_hash=0)
+    assert manager.stats_snapshot()["exact_stores"] == 1
+
+    # Lookup must come from memory (no disk hit).
+    warm, matched = manager.lookup_exact_cache(token_ids + [999], extra_hash=0)
+    assert matched == len(token_ids)
+    assert warm is not None
+    snap = manager.stats_snapshot()
+    assert snap["disk_hits"] == 0
+    assert snap["exact_hits"] == 1
+    # Value should be 99 (memory), not 7 (disk).
+    _assert_allclose(warm[0].keys[..., : len(token_ids), :], kv_mem.keys)
+
+    manager.close()
+
+
+def test_exact_disk_hit_promotion_clone_is_independent_of_returned_cache(
+    tmp_path, monkeypatch
+):
+    """The clone stored in _exact_cache must be a separate object from the
+    cache returned to the caller.  Simulating token-generation mutations on the
+    returned cache (advancing offset) must not corrupt the stored entry."""
+    from mlx_lm.models.cache import KVCache
+
+    token_ids = list(range(25))
+    kv = KVCache()
+    kv.keys = mx.ones((1, 1, len(token_ids), 2))
+    kv.values = mx.ones((1, 1, len(token_ids), 2)) * 2
+    kv.offset = len(token_ids)
+
+    monkeypatch.setenv("APC_EXACT_CACHE_ENTRIES", "0")
+    disk = DiskBlockStore(tmp_path, namespace="clone-independence")
+    manager = APCManager(num_blocks=1, block_size=16, disk=disk)
+    assert manager.store_exact_cache(token_ids, [kv], extra_hash=0)
+    disk._q.join()
+    manager.close()
+
+    monkeypatch.setenv("APC_EXACT_CACHE_ENTRIES", "4")
+    disk = DiskBlockStore(tmp_path, namespace="clone-independence")
+    manager = APCManager(num_blocks=1, block_size=16, disk=disk)
+
+    # First lookup: disk hit + promotion.
+    warm1, matched = manager.lookup_exact_cache(token_ids + [999], extra_hash=0)
+    assert matched == len(token_ids)
+    assert warm1 is not None
+    assert manager.stats_snapshot()["disk_hits"] == 1
+
+    # Simulate generate_step mutating the returned cache in-place.
+    original_offset = warm1[0].offset
+    warm1[0].offset += 10  # as if 10 tokens were generated
+
+    # Second lookup: must come from memory, with the original offset intact.
+    warm2, _ = manager.lookup_exact_cache(token_ids + [999], extra_hash=0)
+    assert warm2 is not None
+    assert manager.stats_snapshot()["disk_hits"] == 1  # served from memory
+    assert (
+        warm2[0].offset == original_offset
+    ), "stored clone offset was corrupted by mutation of the returned cache"
+
+    manager.close()
+
+
+def test_exact_disk_hit_promotion_with_nonzero_extra_hash(tmp_path, monkeypatch):
+    """Promotion must use the correct key when extra_hash != 0, so the
+    promoted entry is found on subsequent lookups with the same extra_hash and
+    not accidentally served for a different extra_hash."""
+    from mlx_lm.models.cache import KVCache
+
+    token_ids = list(range(30))
+    kv = KVCache()
+    kv.keys = mx.ones((1, 1, len(token_ids), 2)) * 5
+    kv.values = mx.ones((1, 1, len(token_ids), 2)) * 6
+    kv.offset = len(token_ids)
+
+    monkeypatch.setenv("APC_EXACT_CACHE_ENTRIES", "0")
+    disk = DiskBlockStore(tmp_path, namespace="extra-hash")
+    manager = APCManager(num_blocks=1, block_size=16, disk=disk)
+    assert manager.store_exact_cache(token_ids, [kv], extra_hash=42)
+    disk._q.join()
+    manager.close()
+
+    monkeypatch.setenv("APC_EXACT_CACHE_ENTRIES", "4")
+    disk = DiskBlockStore(tmp_path, namespace="extra-hash")
+    manager = APCManager(num_blocks=1, block_size=16, disk=disk)
+
+    # Disk hit with the correct extra_hash -> promoted.
+    warm1, matched1 = manager.lookup_exact_cache(token_ids + [999], extra_hash=42)
+    assert matched1 == len(token_ids)
+    assert warm1 is not None
+    assert manager.stats_snapshot()["disk_hits"] == 1
+
+    # Second lookup with same extra_hash -> memory hit, no new disk hit.
+    warm2, matched2 = manager.lookup_exact_cache(token_ids + [999], extra_hash=42)
+    assert matched2 == len(token_ids)
+    assert warm2 is not None
+    assert manager.stats_snapshot()["disk_hits"] == 1
+
+    # Lookup with a different extra_hash -> must miss (different namespace).
+    warm_wrong, matched_wrong = manager.lookup_exact_cache(
+        token_ids + [999], extra_hash=99
+    )
+    assert matched_wrong == 0
+    assert warm_wrong is None
+
+    manager.close()


### PR DESCRIPTION
## Summary

After a server restart with a warm disk cache, disk-restored exact cache entries were never written back to `_exact_cache` (the in-memory LRU). Every subsequent request for the same prefix paid disk-restore latency (~1-2s) instead of the fast in-memory clone path (~0.05s).

### Request flow before this fix

```mermaid
sequenceDiagram
    participant C as Client
    participant L as lookup_exact_cache
    participant M as _exact_cache (memory)
    participant D as DiskBlockStore

    Note over M: empty after restart
    C->>L: request 1 (same prefix)
    L->>M: miss
    L->>D: find_exact_prefix -> hit
    D-->>L: load prompt_cache
    L-->>C: return prompt_cache (no writeback to memory)

    C->>L: request 2 (same prefix)
    L->>M: miss (still empty)
    L->>D: find_exact_prefix -> hit again
    D-->>L: load prompt_cache
    L-->>C: return prompt_cache (pays disk cost every time)
```

### Request flow after this fix

```mermaid
sequenceDiagram
    participant C as Client
    participant L as lookup_exact_cache
    participant M as _exact_cache (memory)
    participant D as DiskBlockStore

    Note over M: empty after restart
    C->>L: request 1 (same prefix)
    L->>M: miss
    L->>D: find_exact_prefix -> hit
    D-->>L: load prompt_cache
    L->>M: clone + insert into LRU
    L-->>C: return prompt_cache

    C->>L: request 2 (same prefix)
    L->>M: hit
    M-->>L: clone from memory
    L-->>C: return prompt_cache (fast path)
```

### Why clone before storing

`generate_step` mutates the returned `prompt_cache` in-place as it appends generated tokens. Storing the same object in `_exact_cache` would corrupt the entry on the next lookup. A separate `_clone_prompt_cache_for_apc` call is required before storage.

### Why lazy promotion rather than eager loading at startup

Pre-loading disk entries at startup would block server init for several seconds per entry (each exact cache is ~40 KV tensor pairs deserialized from mmap), and `_exact_cache_max` is typically 2-16 slots while the disk store can hold gigabytes of entries across many prefixes. Choosing which entries to pre-load would require the same LRU logic anyway, applied to prompts that may never be requested again in this session. Lazy promotion is demand-driven: it pays the disk cost exactly once per session per prefix, and only for prefixes that are actually requested.

### Behavior when `_exact_cache_max == 0`

When in-memory caching is disabled, the disk-hit path is unchanged: stats are incremented and the entry is returned without any promotion attempt.

## Changes

- `mlx_vlm/apc.py`: after a successful disk hit in `lookup_exact_cache`, clone the restored cache and insert it into `_exact_cache` with LRU eviction. Falls through to the existing stats-only path when `_exact_cache_max == 0` or cloning fails.

## Tests

Six new tests in `mlx_vlm/tests/test_apc.py` (all pass, no regressions in the existing 31 tests):

| Test | What it verifies |
|---|---|
| `test_exact_disk_hit_is_promoted_to_memory` | Disk hit promoted; second request served from memory (`disk_hits` unchanged) |
| `test_exact_disk_hit_promotion_skipped_when_memory_disabled` | `_exact_cache_max=0` means every request hits disk |
| `test_exact_disk_hit_promotion_lru_eviction` | Promoting into a full cache evicts the LRU entry |
| `test_exact_lookup_memory_takes_priority_over_disk` | Memory entry wins over disk for the same key; `disk_hits=0` |
| `test_exact_disk_hit_promotion_clone_is_independent_of_returned_cache` | Mutating the returned cache does not corrupt the stored clone |
| `test_exact_disk_hit_promotion_with_nonzero_extra_hash` | Promotion key is correctly scoped by `extra_hash`; wrong hash gets no hit |

## Testing

```bash
python -m pytest mlx_vlm/tests/test_apc.py -q
# 37 passed
```