### PR TITLE
Fix Phi 3.5 VL eos tokens

### DIFF
--- a/mlx_vlm/models/phi3_v/config.py
+++ b/mlx_vlm/models/phi3_v/config.py
@@ -3,6 +3,8 @@ from typing import Dict, List, Optional, Union
 
 from ..base import BaseModelConfig
 
+PHI3_V_CHAT_EOS_TOKEN_IDS = [2, 32000, 32007]
+
 
 @dataclass
 class ModelConfig(BaseModelConfig):
@@ -28,7 +30,22 @@ class ModelConfig(BaseModelConfig):
     rope_scaling: Optional[Dict[str, Union[float, str]]] = None
     max_position_embeddings: int = 131072
     original_max_position_embeddings: int = 4096
-    eos_token_id: Optional[List[int]] = None
+    eos_token_id: Optional[Union[int, List[int]]] = None
+
+    def __post_init__(self):
+        if isinstance(self.eos_token_id, int):
+            eos_token_ids = [self.eos_token_id]
+        elif self.eos_token_id is None:
+            eos_token_ids = []
+        else:
+            eos_token_ids = list(self.eos_token_id)
+
+        if self.vocab_size > max(PHI3_V_CHAT_EOS_TOKEN_IDS):
+            for token_id in PHI3_V_CHAT_EOS_TOKEN_IDS:
+                if token_id not in eos_token_ids:
+                    eos_token_ids.append(token_id)
+
+        self.eos_token_id = eos_token_ids or self.eos_token_id
 
 
 @dataclass

--- a/mlx_vlm/tests/test_models.py
+++ b/mlx_vlm/tests/test_models.py
@@ -1823,6 +1823,28 @@ class TestModels(unittest.TestCase):
                 )
                 self.assertEqual(explicit.eos_token_id, 248046)
 
+    def test_phi3_v_model_config_uses_chat_control_eos_token_ids(self):
+        from mlx_vlm.models import phi3_v
+
+        config = phi3_v.ModelConfig.from_dict(
+            {
+                "model_type": "phi3_v",
+                "vocab_size": 32064,
+                "eos_token_id": 2,
+            }
+        )
+        self.assertEqual(config.eos_token_id, [2, 32000, 32007])
+
+        explicit = phi3_v.ModelConfig(
+            model_type="phi3_v",
+            vocab_size=32064,
+            eos_token_id=[2, 32007, 32000],
+        )
+        self.assertEqual(explicit.eos_token_id, [2, 32007, 32000])
+
+        tiny = phi3_v.ModelConfig(model_type="phi3_v", vocab_size=1000)
+        self.assertIsNone(tiny.eos_token_id)
+
     def test_qwen3_vl_moe(self):
         from mlx_vlm.models import qwen3_vl_moe
 


### PR DESCRIPTION
The config for this model doesn't agree with the tokenizer config, so manually add the EOS tokens from the tokenizer.

The more general solution to this requires changes to utils.py to hack around it, so while this isn't ideal it seems better than the alternative. Resolves the Phi 3.5 VL issue reported in https://github.com/Blaizzy/mlx-vlm/issues/1315