### PR TITLE
Fix LFM2.5 VL model loading

### DIFF
--- a/mlx_vlm/models/lfm2_vl/lfm2_vl.py
+++ b/mlx_vlm/models/lfm2_vl/lfm2_vl.py
@@ -16,9 +16,7 @@ class Lfm2VlMultiModalProjector(nn.Module):
         super().__init__()
         in_channels = config.vision_config.hidden_size * (config.downsample_factor**2)
         self.projector_use_layernorm = config.projector_use_layernorm
-        self.layer_norm = (
-            nn.LayerNorm(in_channels) if self.projector_use_layernorm else None
-        )
+        self.layer_norm = nn.LayerNorm(in_channels)
         self.linear_1 = nn.Linear(
             in_channels,
             config.projector_hidden_size,

--- a/mlx_vlm/tests/test_models.py
+++ b/mlx_vlm/tests/test_models.py
@@ -2318,9 +2318,10 @@ class TestModels(unittest.TestCase):
         )
         model = lfm2_vl.Model(config)
 
-        self.assertIsNone(model.multi_modal_projector.layer_norm)
+        self.assertIsNotNone(model.multi_modal_projector.layer_norm)
+        self.assertFalse(model.multi_modal_projector.projector_use_layernorm)
         parameters = model.multi_modal_projector.parameters()
-        self.assertNotIn("layer_norm", parameters)
+        self.assertIn("layer_norm", parameters)
 
     def test_lfm2_vl_projector_skips_disabled_layernorm_branch(self):
         from mlx_vlm.models import lfm2_vl
@@ -2344,6 +2345,11 @@ class TestModels(unittest.TestCase):
         )
         projector = Lfm2VlMultiModalProjector(config)
 
+        class FailingLayerNorm(nn.Module):
+            def __call__(self, x):
+                raise AssertionError("layer_norm should be skipped")
+
+        projector.layer_norm = FailingLayerNorm()
         output = projector(mx.zeros((1, 1, 1, 2)))
 
         self.assertEqual(output.shape, (1, 1, 1, 4))

--- a/mlx_vlm/tests/test_models.py
+++ b/mlx_vlm/tests/test_models.py
@@ -5679,6 +5679,54 @@ class TestGetInputEmbeddings(unittest.TestCase):
         )
         self._check_returns_input_embeddings_features(model, "lfm2_vl")
 
+    def test_lfm2_vl_disabled_projector_layernorm_weights_load(self):
+        from mlx_vlm.models import lfm2_vl
+
+        model = lfm2_vl.Model(
+            lfm2_vl.ModelConfig(
+                text_config=lfm2_vl.TextConfig(
+                    model_type="lfm2",
+                    hidden_size=16,
+                    num_hidden_layers=1,
+                    intermediate_size=32,
+                    num_attention_heads=2,
+                    num_key_value_heads=2,
+                    vocab_size=32,
+                    layer_types=["full_attention"],
+                    block_dim=16,
+                    block_ff_dim=32,
+                    conv_dim=16,
+                    conv_dim_out=16,
+                ),
+                vision_config=lfm2_vl.VisionConfig(
+                    model_type="lfm2_vl",
+                    hidden_size=16,
+                    intermediate_size=32,
+                    num_hidden_layers=1,
+                    num_attention_heads=2,
+                    image_size=28,
+                    patch_size=14,
+                ),
+                model_type="lfm2-vl",
+                projector_hidden_size=16,
+                projector_use_layernorm=False,
+            )
+        )
+
+        self.assertIsNotNone(model.multi_modal_projector.layer_norm)
+        self.assertFalse(model.multi_modal_projector.projector_use_layernorm)
+
+        model.multi_modal_projector.load_weights(
+            [
+                ("layer_norm.weight", mx.ones((64,))),
+                ("layer_norm.bias", mx.zeros((64,))),
+                ("linear_1.weight", mx.ones((16, 64))),
+                ("linear_1.bias", mx.zeros((16,))),
+                ("linear_2.weight", mx.ones((16, 16))),
+                ("linear_2.bias", mx.zeros((16,))),
+            ]
+        )
+
     def test_molmo2_input_embeddings(self):
         from mlx_vlm.models import molmo2
 


### PR DESCRIPTION
The model is already marked as mlx-format weights and doesn't hit sanitize() -- always include the layernorm layer and then we can load the weights as expected safely as projector_use_layernorm already controls whether the layernorm is actually used. Resolves the issue with the model reported in https://github.com/Blaizzy/mlx-vlm/issues/1315