### PR TITLE
Fix --system prompt ignored by one-shot generate

### DIFF
--- a/mlx_vlm/generate/dispatch.py
+++ b/mlx_vlm/generate/dispatch.py
@@ -1453,6 +1453,11 @@ def main():
 
     prompt = args.prompt
 
+    if args.system:
+        prompt = [{"role": "system", "content": args.system}] + (
+            prompt if isinstance(prompt, list) else [prompt]
+        )
+
     num_images = len(args.image) if args.image is not None else 0
     num_audios = len(args.audio) if args.audio is not None else 0
 

--- a/mlx_vlm/tests/test_cli.py
+++ b/mlx_vlm/tests/test_cli.py
@@ -66,3 +66,40 @@ def test_verbose_flag_semantics():
     assert parser.parse_args([]).verbose is True
     assert parser.parse_args(["--verbose"]).verbose is True
     assert parser.parse_args(["--no-verbose"]).verbose is False
+
+
+def _find_function_def(module: ast.Module, name: str) -> ast.FunctionDef:
+    for node in ast.walk(module):
+        if isinstance(node, ast.FunctionDef) and node.name == name:
+            return node
+    raise AssertionError(f"{name} must be defined")
+
+
+def _is_args_system(node: ast.expr) -> bool:
+    return (
+        isinstance(node, ast.Attribute)
+        and node.attr == "system"
+        and isinstance(node.value, ast.Name)
+        and node.value.id == "args"
+    )
+
+
+def test_generate_one_shot_applies_system_prompt():
+    main = _find_function_def(_load_module("mlx_vlm/generate/dispatch.py"), "main")
+
+    def _assigns_prompt(block: ast.If) -> bool:
+        return any(
+            isinstance(stmt, ast.Assign)
+            and any(
+                isinstance(target, ast.Name) and target.id == "prompt"
+                for target in stmt.targets
+            )
+            for stmt in ast.walk(block)
+        )
+
+    assert any(
+        isinstance(node, ast.If)
+        and _is_args_system(node.test)
+        and _assigns_prompt(node)
+        for node in ast.walk(main)
+    ), "one-shot generate must prepend args.system to the prompt"


### PR DESCRIPTION
### Summary

When using `mlx_vlm.generate --system "..."` in one-shot (non-interactive) mode, the system prompt is silently ignored. The `--system` flag only takes effect in `--chat` mode; outside of it, the model never receives the system turn.

### Reproduction

```
mlx_vlm.generate --model mlx-community/Qwen3.5-9B-4bit --image foo.jpg \
  --prompt "What do you see?" \
  --system "You are a cat-adjacent assistant." --verbose
```

`--verbose` prints the formatted `Prompt:`. On `main` it has no `system` block — only `user` → `assistant`:

```
<|im_start|>user
<|vision_start|><|image_pad|><|vision_end|>What do you see?<|im_end|>
<|im_start|>assistant
```

### Cause

`dispatch.main()` builds the one-shot prompt from `args.prompt` alone:

```python
prompt = args.prompt
...
prompt = apply_chat_template(processor, config, prompt, ...)
```

`args.system` is referenced only inside the `if args.chat:` branch, so one-shot generation never incorporates it.

### Fix

Prepend the system message before templating, mirroring the `--chat` path:

```python
if args.system:
    prompt = [{"role": "system", "content": args.system}] + (
        prompt if isinstance(prompt, list) else [prompt]
    )
```

`apply_chat_template` already handles a mixed list — the system dict passes through, and image/audio tokens still land on the last user turn.

### Why this scope

- Reuses existing `apply_chat_template` list handling; no template or per-model changes.
- Mirrors the established `--chat` behavior (`chat.append({"role": "system", ...})`).
- Harmless in `--chat` mode: the variable is rebuilt inside the loop, so no double system message.

### Tests

- Adds `test_generate_one_shot_applies_system_prompt` to `test_cli.py` (AST check, matching the file's existing style) — asserts `main()` prepends `args.system` to the prompt. Fails on `main`, passes with this change.
- `pytest mlx_vlm/tests/test_cli.py mlx_vlm/tests/test_prompt_utils.py mlx_vlm/tests/test_generate.py` → 117 passed.
- Verified e2e with `--verbose` on Qwen3.5 / Gemma-4 (incl. `--enable-thinking`): the `system` block now renders ahead of the user turn, with the image token correctly on the user turn.

