### PR TITLE
Fix Qwen3-VL deepstack visual embeds misaligned during chunked prefill

### DIFF
--- a/mlx_vlm/models/qwen3_vl/language.py
+++ b/mlx_vlm/models/qwen3_vl/language.py
@@ -515,7 +515,18 @@ class LanguageModel(nn.Module):
                     if isinstance(cache_offset, mx.array)
                     else int(cache_offset)
                 )
-                visual_pos_masks = visual_pos_masks[:, start : start + inputs.shape[1]]
+                window = inputs.shape[1]
+                # Slice deepstack embeds to this window too; _deepstack_process reads from offset 0.
+                if deepstack_visual_embeds is not None:
+                    n_before = int(visual_pos_masks[:, :start].sum().item())
+                    n_window = int(
+                        visual_pos_masks[:, start : start + window].sum().item()
+                    )
+                    deepstack_visual_embeds = [
+                        embeds[n_before : n_before + n_window]
+                        for embeds in deepstack_visual_embeds
+                    ]
+                visual_pos_masks = visual_pos_masks[:, start : start + window]
             else:
                 rows = []
                 for b in range(visual_pos_masks.shape[0]):

--- a/mlx_vlm/models/qwen3_vl_moe/language.py
+++ b/mlx_vlm/models/qwen3_vl_moe/language.py
@@ -559,7 +559,18 @@ class LanguageModel(nn.Module):
                     if isinstance(cache_offset, mx.array)
                     else int(cache_offset)
                 )
-                visual_pos_masks = visual_pos_masks[:, start : start + inputs.shape[1]]
+                window = inputs.shape[1]
+                # Slice deepstack embeds to this window too; _deepstack_process reads from offset 0.
+                if deepstack_visual_embeds is not None:
+                    n_before = int(visual_pos_masks[:, :start].sum().item())
+                    n_window = int(
+                        visual_pos_masks[:, start : start + window].sum().item()
+                    )
+                    deepstack_visual_embeds = [
+                        embeds[n_before : n_before + n_window]
+                        for embeds in deepstack_visual_embeds
+                    ]
+                visual_pos_masks = visual_pos_masks[:, start : start + window]
             else:
                 rows = []
                 for b in range(visual_pos_masks.shape[0]):

--- a/mlx_vlm/tests/test_models.py
+++ b/mlx_vlm/tests/test_models.py
@@ -2053,6 +2053,115 @@ class TestModels(unittest.TestCase):
                 self.assertEqual(recorder.visual_pos_masks.shape, (1, 1))
                 self.assertEqual(recorder.visual_pos_masks.tolist(), [[False]])
 
+    def test_qwen3_vl_deepstack_embeds_aligned_on_chunked_prefill(self):
+        """Chunked prefill must realign deepstack embeds per window; otherwise later
+        chunks reuse the first chunk's embeds (offset resets to 0). #856 / #1323."""
+        from types import SimpleNamespace
+
+        from mlx_vlm.models import qwen3_vl, qwen3_vl_moe
+
+        cases = [
+            (
+                qwen3_vl,
+                qwen3_vl.TextConfig(
+                    model_type="qwen3_vl_text",
+                    hidden_size=8,
+                    num_hidden_layers=1,
+                    intermediate_size=16,
+                    num_attention_heads=2,
+                    num_key_value_heads=1,
+                    rms_norm_eps=1e-5,
+                    head_dim=4,
+                    vocab_size=32,
+                    rope_theta=1000,
+                    max_position_embeddings=1000,
+                    tie_word_embeddings=False,
+                    rope_scaling={"rope_type": "mrope", "mrope_section": [2, 1, 1]},
+                ),
+            ),
+            (
+                qwen3_vl_moe,
+                qwen3_vl_moe.TextConfig(
+                    model_type="qwen3_vl_moe_text",
+                    hidden_size=8,
+                    num_hidden_layers=1,
+                    intermediate_size=16,
+                    num_attention_heads=2,
+                    num_key_value_heads=1,
+                    rms_norm_eps=1e-5,
+                    head_dim=4,
+                    vocab_size=32,
+                    decoder_sparse_step=1,
+                    mlp_only_layers=[],
+                    num_experts_per_tok=1,
+                    num_experts=1,
+                    moe_intermediate_size=8,
+                    rope_theta=1000,
+                    max_position_embeddings=1000,
+                    tie_word_embeddings=False,
+                    rope_scaling={"rope_type": "mrope", "mrope_section": [2, 1, 1]},
+                ),
+            ),
+        ]
+
+        class Recorder(nn.Module):
+            def __init__(self, hidden_size):
+                super().__init__()
+                self.hidden_size = hidden_size
+                self.visual_pos_masks = None
+                self.deepstack_visual_embeds = None
+
+            def __call__(
+                self,
+                inputs,
+                *,
+                visual_pos_masks=None,
+                deepstack_visual_embeds=None,
+                **kwargs,
+            ):
+                self.visual_pos_masks = visual_pos_masks
+                self.deepstack_visual_embeds = deepstack_visual_embeds
+                return mx.zeros(
+                    (inputs.shape[0], inputs.shape[1], self.hidden_size),
+                    dtype=mx.float32,
+                )
+
+        H = 8
+        # 10 positions, vision tokens at {1,2,4,5,7}; marker embed row i == i+1.
+        full_mask = mx.array(
+            [[False, True, True, False, True, True, False, True, False, False]]
+        )
+        embeds = mx.concatenate(
+            [mx.full((1, H), float(i + 1)) for i in range(5)], axis=0
+        )
+
+        for model_module, text_config in cases:
+            with self.subTest(model_type=text_config.model_type):
+                language_model = model_module.LanguageModel(text_config)
+                language_model.model = Recorder(H)
+
+                # Second chunk: window [4:7); 2 vision tokens precede it -> embeds[2:4].
+                start, window = 4, 3
+                language_model(
+                    mx.zeros((1, window), dtype=mx.int64),
+                    inputs_embeds=mx.zeros((1, window, H)),
+                    cache=[SimpleNamespace(offset=start)],
+                    position_ids=mx.zeros((3, 1, window), dtype=mx.int64),
+                    visual_pos_masks=full_mask,
+                    deepstack_visual_embeds=[embeds],
+                )
+
+                recorder = language_model.model
+                self.assertEqual(recorder.visual_pos_masks.shape, (1, window))
+                self.assertEqual(
+                    recorder.visual_pos_masks.tolist(), [[True, True, False]]
+                )
+                self.assertEqual(recorder.deepstack_visual_embeds[0].shape, (2, H))
+                self.assertEqual(
+                    recorder.deepstack_visual_embeds[0].tolist(),
+                    embeds[2:4].tolist(),
+                )
+
     def _run_deepstack_multi_image_assertions(self, deepstack_fn):
         """Shared assertions for qwen3_vl / qwen3_vl_moe `_deepstack_process`.
 


### PR DESCRIPTION
### Summary

Qwen3-VL / Qwen3-VL-MoE lose most of their visual detail on any prompt that
triggers **chunked prefill** — the default for prompts longer than                                                                                                                                                              
`prefill_step_size` (2048), i.e. essentially every high-res or multi-image
input. Symptoms range from degraded OCR / object recall to total collapse into
repetition.

### Reproduction

`mlx-community/Qwen3-VL-2B-Instruct-4bit` on the bundled
`examples/images/demo_pdf1_page1.png`. `--prefill-step-size 256` forces chunking
on a small image so it's obvious; it also fires at the default 2048 for any image
over ~2048 vision tokens (e.g. two images, ~3.5k tokens).

```
# chunked (buggy) — loops, reads nothing:
mlx_vlm.generate --model mlx-community/Qwen3-VL-2B-Instruct-4bit \
  --image examples/images/demo_pdf1_page1.png --temperature 0 \
  --prefill-step-size 256 --prompt "Transcribe all visible text."
# -> 108年8月 \n 108年11月 \n 108年10月 \n 108年11月 ...   (repeats forever)

# no chunking (correct) — reads the document:
mlx_vlm.generate ... --prefill-step-size 1000000 ...
# -> 高雄醫學大學 108 學年度行事曆 ...  | 選次 | 日 | 一 | 二 | ...
```

The added unit test reproduces it with no model download.

### Root cause

During chunked prefill, `LanguageModel.__call__` slices `visual_pos_masks` to the
current window but forwards the **full** `deepstack_visual_embeds` to every chunk:

```python
visual_pos_masks = visual_pos_masks[:, start : start + inputs.shape[1]]   # sliced
...
out = self.model(..., visual_pos_masks=visual_pos_masks,
                  deepstack_visual_embeds=deepstack_visual_embeds)          # NOT sliced
```

`_deepstack_process` reads `visual_embeds[offset : offset + n_visual]` with
`offset` reset to `0` on every call, so every chunk past the first re-applies the
*first* chunk's deepstack features to later vision tokens. The length guard
(`sample_embeds.shape[0] != n_visual`) doesn't catch it — the slice is the right
length, just the wrong rows.

### Fix

Realign `deepstack_visual_embeds` to each window by slicing it by the number of
vision tokens before the window (mirroring the existing `visual_pos_masks`
slice). Applied to both `qwen3_vl` and `qwen3_vl_moe`. Decode and non-chunked
prefill are unaffected (no-op).

### Scope

Fixes the single-sequence path (`mlx_vlm.generate`), which is what #856
exercises. The batched continuous-batching path slices the mask per row, but
realigning the concatenated per-row deepstack array under chunked prefill is
more involved — left as a follow-up; it's unaligned but safe today (guarded by
the existing length check).

### Tests

- Adds `test_qwen3_vl_deepstack_embeds_aligned_on_chunked_prefill` to `TestModels`
  (pure-Python tiny configs, no weights), covering both `qwen3_vl` and
  `qwen3_vl_moe`: drives `LanguageModel.__call__` through a mid-prompt chunk
  window and asserts the deepstack embeds are sliced to that window. Fails on
  `main` (`AssertionError: (5, 8) != (2, 8)` — the full embeds are forwarded),
  passes with this change.
- `pytest mlx_vlm/tests/test_models.py` → **148 passed, 26 subtests**.
- Verified e2e on `mlx-community/Qwen3-VL-2B-Instruct-4bit` (Apple M5) with
  `examples/images/demo_pdf1_page1.png`:
  - `--prefill-step-size 256`: on `main` the model collapses into a
    `108年8月 / 108年11月 / …` loop and reads nothing; with the fix it transcribes
    the document and matches the non-chunked (`--prefill-step-size 1000000`)
    reference.
  - Default `prefill_step_size=2048`, two images (~3.5k vision tokens, so it
    chunks): on `main` it emits empty table rows; with the fix it transcribes
    correctly.

### Notes

#1323 attributes the recall loss to #1210 / MRoPE, but the MRoPE position ids are
bit-identical to HF transformers for single- and multi-image; the root cause is
this deepstack misalignment. #1325 fixed the `visual_pos_masks` slice but left
`deepstack_visual_embeds` unaligned during prefill.

Fixes #856
