### PR TITLE
Improve speculative prefill when using MTP drafters

### DIFF
--- a/mlx_vlm/generate/ar.py
+++ b/mlx_vlm/generate/ar.py
@@ -338,25 +338,14 @@ def generate_step(
 
     # Speculative decoding setup
     last_outputs = None
+    speculative_prefill_capture_kwargs = {}
     if draft_model is not None:
         from ..speculative.drafters import validate_drafter_compatibility
 
         validate_drafter_compatibility(model, draft_model, draft_kind)
-        if draft_kind == "mtp":
-            # MTP drafter consumes target's last-layer hidden + shared K/V
-            # (per layer-type) rather than per-layer hidden captures.
-            kwargs["return_hidden"] = True
-            kwargs["return_shared_kv"] = True
-        elif draft_kind == "eagle3":
-            kwargs["capture_layer_ids"] = list(
-                getattr(
-                    draft_model.config,
-                    "capture_layer_ids",
-                    draft_model.config.target_layer_ids,
-                )
-            )
-        else:
-            kwargs["capture_layer_ids"] = list(draft_model.config.target_layer_ids)
+        speculative_prefill_capture_kwargs = speculative_prefill_kwargs(
+            draft_kind, draft_model
+        )
         # Reset stale mRoPE state from any previous generation.
         lm = model.language_model if hasattr(model, "language_model") else model
         if hasattr(lm, "_position_ids"):
@@ -367,18 +356,22 @@ def generate_step(
     def _step(y, inputs_embeds=None):
         nonlocal tokens, kwargs, last_outputs, target_sample_position
 
+        step_kwargs = kwargs
+        if speculative_prefill_capture_kwargs:
+            step_kwargs = {**kwargs, **speculative_prefill_capture_kwargs}
+
         with mx.stream(generation_stream):
-            if "decoder_input_ids" in kwargs:
+            if "decoder_input_ids" in step_kwargs:
                 outputs = model.language_model(
                     cache=prompt_cache,
-                    **kwargs,
+                    **step_kwargs,
                 )
             else:
                 outputs = model.language_model(
                     y,
                     inputs_embeds=inputs_embeds,
                     cache=prompt_cache,
-                    **kwargs,
+                    **step_kwargs,
                 )
 
             last_outputs = outputs
@@ -430,6 +423,9 @@ def generate_step(
                 if k != "inputs_embeds" and v is not None
             }
         )
+        policy_kwargs = kwargs
+        if speculative_prefill_capture_kwargs:
+            policy_kwargs = {**kwargs, **speculative_prefill_capture_kwargs}
         if prefill_step_size is not None and not _chunked_prefill_enabled(
             model,
             input_ids=input_ids,
@@ -437,7 +433,7 @@ def generate_step(
             prompt_cache=prompt_cache,
             draft_model=draft_model,
             draft_kind=draft_kind,
-            prefill_kwargs=kwargs,
+            prefill_kwargs=policy_kwargs,
         ):
             prefill_step_size = None
         checkpoint_len = (

--- a/mlx_vlm/models/qwen3_5/language.py
+++ b/mlx_vlm/models/qwen3_5/language.py
@@ -1929,6 +1929,28 @@ class LanguageModel(nn.Module):
         if not args.tie_word_embeddings:
             self.lm_head = nn.Linear(args.hidden_size, args.vocab_size, bias=False)
 
+    def chunked_prefill_policy(
+        self,
+        *,
+        input_ids=None,
+        inputs_embeds=None,
+        prompt_cache=None,
+        draft_model=None,
+        draft_kind=None,
+        prefill_kwargs=None,
+    ) -> bool:
+        del input_ids, inputs_embeds, prompt_cache
+        prefill_kwargs = prefill_kwargs or {}
+        if draft_model is None:
+            return True
+        if draft_kind == "mtp":
+            return bool(prefill_kwargs.get("return_hidden", False)) and bool(
+                prefill_kwargs.get("return_shared_kv", False)
+            )
+        if draft_kind in ("dflash", "eagle3"):
+            return prefill_kwargs.get("capture_layer_ids") is not None
+        return draft_kind is None
+
     def rollback_speculative_cache(
         self,
         caches: List[Any],

--- a/mlx_vlm/server/generation.py
+++ b/mlx_vlm/server/generation.py
@@ -29,6 +29,7 @@ from ..generate import (
     DEFAULT_TOP_P,
     BatchGenerator,
     _make_cache,
+    _chunked_prefill_enabled,
     _merge_prefill_prompt_kwargs,
 )
 from ..sample_utils import top_p_sampling
@@ -104,6 +105,93 @@ def get_speculative_batch_coalesce_s():
         return max(0.0, float(raw)) / 1000.0
     except ValueError:
         return DEFAULT_SPECULATIVE_BATCH_COALESCE_MS / 1000.0
+
+
+def _sequence_aligned_prefill_keys(
+    prompt_kwargs: dict, *, batch_size: int, sequence_length: int
+) -> List[str]:
+    return [
+        k
+        for k, v in (prompt_kwargs or {}).items()
+        if isinstance(v, mx.array)
+        and v.ndim >= 2
+        and v.shape[0] == batch_size
+        and v.shape[1] == sequence_length
+    ]
+
+
+def _slice_prefill_kwargs(prompt_kwargs: dict, keys: List[str], n: int) -> dict:
+    if not keys:
+        return prompt_kwargs
+    out = dict(prompt_kwargs)
+    for key in keys:
+        if key in out:
+            out[key] = out[key][:, :n, ...]
+    return out
+
+
+def _drop_prefill_kwargs(prompt_kwargs: dict, keys: List[str], n: int) -> dict:
+    if not keys:
+        return prompt_kwargs
+    out = dict(prompt_kwargs)
+    for key in keys:
+        if key in out:
+            out[key] = out[key][:, n:, ...]
+    return out
+
+
+def _run_chunked_speculative_prefill(
+    lm,
+    input_ids: mx.array,
+    inputs_embeds: mx.array,
+    prompt_cache,
+    prompt_kwargs: dict,
+    speculative_kwargs: dict,
+    *,
+    prefill_step_size: Optional[int],
+    generation_stream,
+) -> Tuple[object, mx.array]:
+    """Prefill target cache in chunks, capturing speculative state only at end."""
+    remaining_input_ids = input_ids
+    remaining_embeds = inputs_embeds
+    remaining_kwargs = dict(prompt_kwargs or {})
+    sequence_keys = _sequence_aligned_prefill_keys(
+        remaining_kwargs,
+        batch_size=input_ids.shape[0],
+        sequence_length=inputs_embeds.shape[1],
+    )
+
+    if (
+        prefill_step_size is not None
+        and prefill_step_size > 0
+        and remaining_embeds.shape[1] > prefill_step_size
+    ):
+        while remaining_embeds.shape[1] > 1:
+            n_to_process = min(prefill_step_size, remaining_embeds.shape[1] - 1)
+            chunk_kwargs = _slice_prefill_kwargs(
+                remaining_kwargs, sequence_keys, n_to_process
+            )
+            with mx.stream(generation_stream):
+                lm(
+                    remaining_input_ids[:, :n_to_process],
+                    cache=prompt_cache,
+                    inputs_embeds=remaining_embeds[:, :n_to_process],
+                    n_to_process=n_to_process,
+                    **chunk_kwargs,
+                )
+            mx.eval([c.state for c in prompt_cache])
+            remaining_input_ids = remaining_input_ids[:, n_to_process:]
+            remaining_embeds = remaining_embeds[:, n_to_process:]
+            remaining_kwargs = _drop_prefill_kwargs(
+                remaining_kwargs, sequence_keys, n_to_process
+            )
+            mx.clear_cache()
+
+    final_kwargs = {**remaining_kwargs, **speculative_kwargs}
+    final_kwargs["inputs_embeds"] = remaining_embeds
+    with mx.stream(generation_stream):
+        out = lm(remaining_input_ids, cache=prompt_cache, **final_kwargs)
+    return out, remaining_input_ids
 
 
 def _position_seed(seed: int, row_id: int, position: int) -> int:
@@ -1293,12 +1381,30 @@ class ResponseGenerator:
                     make_cache=_make_cache,
                 )
 
-                lm_call_kwargs = {**prefill_kwargs, **prompt_kwargs}
-                lm_call_kwargs["inputs_embeds"] = inputs_embeds_mx
+                prefill_step_size = get_prefill_step_size()
+                policy_kwargs = {**prompt_kwargs, **prefill_kwargs}
+                if not _chunked_prefill_enabled(
+                    self.model,
+                    input_ids=input_mx,
+                    inputs_embeds=inputs_embeds_mx,
+                    prompt_cache=prompt_cache,
+                    draft_model=drafter,
+                    draft_kind=draft_kind,
+                    prefill_kwargs=policy_kwargs,
+                ):
+                    prefill_step_size = None
 
                 prompt_started = time.perf_counter()
-                with mx.stream(generation_stream):
-                    out = lm(input_mx, cache=prompt_cache, **lm_call_kwargs)
+                out, input_mx = _run_chunked_speculative_prefill(
+                    lm,
+                    input_mx,
+                    inputs_embeds_mx,
+                    prompt_cache,
+                    prompt_kwargs,
+                    prefill_kwargs,
+                    prefill_step_size=prefill_step_size,
+                    generation_stream=generation_stream,
+                )
                 hidden = speculative_hidden_state(draft_kind, out)
                 shared_kv_states = out.shared_kv_states if is_mtp else None
                 sample_row_ids = [0] * B

--- a/mlx_vlm/server/generation.py
+++ b/mlx_vlm/server/generation.py
@@ -28,8 +28,8 @@ from ..generate import (
     DEFAULT_THINKING_START_TOKEN,
     DEFAULT_TOP_P,
     BatchGenerator,
-    _make_cache,
     _chunked_prefill_enabled,
+    _make_cache,
     _merge_prefill_prompt_kwargs,
 )
 from ..sample_utils import top_p_sampling


### PR DESCRIPTION
This change re-enables chunked prefill when using speculative decoding. We use a separate policy for the last prefill chunk so we can capture the hidden states needed by the drafter. Resolves https://github.com/Blaizzy/mlx-vlm/issues/1293

Results on `Qwen/Qwen3.6-27B` with various drafters on my M5 Max:
| temp | draft                | mode         | prefill | wall_s | prompt_tps | gen_tps | peak_gb | tokens | acceptance                                   |
| ---- | -------------------- | ------------ | ------- | ------ | ---------- | ------- | ------- | ------ | ---------------------------------------------|
| 0    | -                    | baseline     | 2048    | 17.63  | 684.76     | 9.16    | 58.45   |        |                                              |
| 0.2  | -                    | baseline     | 2048    | 16.48  | 695.10     | 9.24    | 58.45   |        |                                              |
| 0.6  | -                    | baseline     | 2048    | 16.62  | 674.02     | 9.20    | 58.45   |        |                                              |
| 1    | -                    | baseline     | 2048    | 16.69  | 654.29     | 9.21    | 58.45   |        |                                              |
| 0    | Qwen3.6-27B-MTP-bf16 | spec-chunked | 2048    | 7.43   | 669.22     | 27.32   | 59.33   | ok     | 2.28 accepted drafts/round, 76.7% of drafted |
| 0.2  | Qwen3.6-27B-MTP-bf16 | spec-chunked | 2048    | 7.72   | 618.51     | 26.86   | 59.33   | ok     | 2.26 accepted drafts/round, 75.2% of drafted |
| 0.6  | Qwen3.6-27B-MTP-bf16 | spec-chunked | 2048    | 8.85   | 580.73     | 22.42   | 59.33   | ok     | 1.72 accepted drafts/round, 57.4% of drafted |
| 1    | Qwen3.6-27B-MTP-bf16 | spec-chunked | 2048    | 8.46   | 617.10     | 23.30   | 59.33   | ok     | 1.82 accepted drafts/round, 60.7% of drafted |
| 0    | Qwen3.6-27B-MTP-5bit | spec-chunked | 2048    | 7.68   | 619.17     | 27.10   | 58.75   | ok     | 2.20 accepted drafts/round, 74.6% of drafted |
| 0.2  | Qwen3.6-27B-MTP-5bit | spec-chunked | 2048    | 7.53   | 636.49     | 27.50   | 58.75   | ok     | 2.26 accepted drafts/round, 75.2% of drafted |
| 0.6  | Qwen3.6-27B-MTP-5bit | spec-chunked | 2048    | 8.86   | 618.22     | 21.71   | 58.75   | ok     | 1.72 accepted drafts/round, 57.4% of drafted |
| 1    | Qwen3.6-27B-MTP-5bit | spec-chunked | 2048    | 8.07   | 636.94     | 24.62   | 58.75   | ok     | 1.89 accepted drafts/round, 62.9% of drafted |
| 0    | Qwen3.6-27B-MTP-4bit | spec-chunked | 2048    | 7.53   | 636.66     | 27.46   | 58.69   | ok     | 2.20 accepted drafts/round, 73.3% of drafted |
| 0.2  | Qwen3.6-27B-MTP-4bit | spec-chunked | 2048    | 7.28   | 638.02     | 28.97   | 58.70   | ok     | 2.34 accepted drafts/round, 78.1% of drafted |
| 0.6  | Qwen3.6-27B-MTP-4bit | spec-chunked | 2048    | 8.28   | 643.34     | 23.51   | 58.70   | ok     | 1.72 accepted drafts/round, 57.4% of drafted |
| 1    | Qwen3.6-27B-MTP-4bit | spec-chunked | 2048    | 7.93   | 649.26     | 25.02   | 58.70   | ok     | 1.89 accepted drafts/round, 62.9% of drafted |