### PR TITLE
Fix gemma4 load for mlx-format checkpoints that materialize KV-shared k/v

### DIFF
--- a/mlx_vlm/models/gemma4/gemma4.py
+++ b/mlx_vlm/models/gemma4/gemma4.py
@@ -272,6 +272,16 @@ class Model(nn.Module):
             sanitized[new_key] = v
         return sanitized
 
+    def load_weights(self, weights, strict=True):
+        # `LanguageModel.sanitize` (added in #1301) drops the unused k/v projections that
+        # some checkpoints materialize on the KV-shared layers. But `load_model` only runs
+        # `sanitize` for non-mlx-format checkpoints, so mlx-format checkpoints that still
+        # carry those weights (e.g. mlx-community/gemma-4-e4b-it-4bit) fail to load. Apply
+        # the same filter here — `load_weights` always runs — reusing the existing helper.
+        is_unused = self.language_model._is_unused_shared_kv_weight
+        weights = [(k, v) for (k, v) in weights if not is_unused(k)]
+        super().load_weights(weights, strict=strict)
+
     @property
     def quant_predicate(self):
         return self.language_model.quant_predicate

--- a/mlx_vlm/tests/test_models.py
+++ b/mlx_vlm/tests/test_models.py
@@ -3230,6 +3230,17 @@ class TestModels(unittest.TestCase):
             "language_model.model.layers.3.self_attn.v_proj.weight", weights
         )
 
+        # load_weights must drop the same unused shared-layer k/v: load_model() skips
+        # sanitize for mlx-format checkpoints, so load_weights is the path that has to
+        # tolerate quants which still materialize k/v on the KV-shared layers.
+        from mlx.utils import tree_flatten
+
+        loadable = dict(tree_flatten(shared_model.parameters()))
+        loadable["language_model.model.layers.2.self_attn.k_proj.weight"] = mx.zeros(
+            (8, 16)
+        )
+        shared_model.load_weights(list(loadable.items()))
+
     def test_gemma4_unified(self):
         import tempfile
         from pathlib import Path


### PR DESCRIPTION
### Summary

`mlx-community/gemma-4-e4b-it-4bit` (a published, mlx-format checkpoint) fails to load on `main`:

```
ValueError: Received 126 parameters not in model:
language_model.model.layers.24.self_attn.k_proj.{weight,scales,biases}
…
language_model.model.layers.41.self_attn.v_proj.{weight,scales,biases}
```

(126 = 18 KV-shared layers × 7 quantized k/v tensors.)

### Root cause

#1301 fixed loading for checkpoints whose KV-shared layers *omit* their own k/v: the builder skips creating those modules, and `LanguageModel.sanitize` drops any that a checkpoint still materializes (via `_is_unused_shared_kv_weight`).

But `load_model` only runs `sanitize` for **non-mlx-format** checkpoints:

```python
if not is_mlx_format:
    weights = sanitize_weights(model, weights)
    ...
```

mlx-format checkpoints (the mlx-community quants) skip `sanitize`, so when they materialize k/v on the KV-shared layers those tensors reach `load_weights`, which raises (the model — correctly, post-#1301 — no longer has those modules).

### Fix

Add a `load_weights` override on the gemma4 `Model` that applies the **same** `_is_unused_shared_kv_weight` filter (reusing #1301's helper). `load_weights` always runs, so this covers the mlx-format path too; genuinely-missing weights still raise under `strict`.

### Testing

- `load("mlx-community/gemma-4-e4b-it-4bit")` → loads (was `ValueError`).
- `load("mlx-community/gemma-4-E4B-it-qat-4bit")` (omitted-k/v form) → still loads (no regression).
- Extended `test_gemma4` to assert `load_weights` tolerates a materialized shared-layer k/v key (reusing #1301's `shared_model`). `python -m unittest mlx_vlm.tests.test_models.TestModels.test_gemma4` passes.
