### PR TITLE
Respect generation_config sampling defaults

### DIFF
--- a/mlx_vlm/server/app.py
+++ b/mlx_vlm/server/app.py
@@ -110,11 +110,20 @@ def _build_gen_args(
         "enable_thinking",
         get_server_enable_thinking(),
     )
+    default_temperature = _model_config_field_or_default(
+        processor, "temperature", DEFAULT_TEMPERATURE
+    )
+    default_top_p = _model_config_field_or_default(processor, "top_p", DEFAULT_TOP_P)
+    default_top_k = _model_config_field_or_default(processor, "top_k", 0)
+    if _model_config_field_or_default(processor, "do_sample", None) is False:
+        default_temperature = 0.0
     args = GenerationArguments(
         max_tokens=max_tokens,
-        temperature=getattr(request, "temperature", DEFAULT_TEMPERATURE),
-        top_p=getattr(request, "top_p", DEFAULT_TOP_P),
-        top_k=getattr(request, "top_k", 0),
+        temperature=_request_field_or_default(
+            request, "temperature", default_temperature
+        ),
+        top_p=_request_field_or_default(request, "top_p", default_top_p),
+        top_k=_request_field_or_default(request, "top_k", default_top_k),
         min_p=getattr(request, "min_p", 0.0),
         seed=getattr(request, "seed", None),
         logprobs=bool(getattr(request, "logprobs", False)),
@@ -154,6 +163,13 @@ def _request_field_or_default(request, field_name: str, default):
         return default
     value = getattr(request, field_name, default)
     return default if value is None else value
+
+
+def _model_config_field_or_default(processor, field_name: str, default):
+    config = runtime.model_cache.get("config")
+    if config is None and processor is not None:
+        config = getattr(processor, "config", None)
+    return getattr(config, field_name, default)
 
 
 def _read_tenant_id(http_request) -> Optional[str]:

--- a/mlx_vlm/tests/test_server.py
+++ b/mlx_vlm/tests/test_server.py
@@ -4087,6 +4087,47 @@ class TestResponseGenerator:
         assert args.max_tokens == 256
         assert args.enable_thinking is True
 
+    def test_build_gen_args_uses_model_generation_config_when_omitted(
+        self, monkeypatch
+    ):
+        monkeypatch.setitem(
+            server.runtime.model_cache,
+            "config",
+            SimpleNamespace(temperature=1.0, top_p=0.95, top_k=64),
+        )
+        req = server.ChatRequest(
+            model="demo",
+            messages=[server.ChatMessage(role="user", content="hi")],
+        )
+
+        args = server._build_gen_args(req)
+
+        assert args.temperature == 1.0
+        assert args.top_p == 0.95
+        assert args.top_k == 64
+
+    def test_build_gen_args_request_sampling_overrides_model_generation_config(
+        self, monkeypatch
+    ):
+        monkeypatch.setitem(
+            server.runtime.model_cache,
+            "config",
+            SimpleNamespace(temperature=1.0, top_p=0.95, top_k=64),
+        )
+        req = server.ChatRequest(
+            model="demo",
+            messages=[server.ChatMessage(role="user", content="hi")],
+            temperature=0.0,
+            top_p=1.0,
+            top_k=0,
+        )
+
+        args = server._build_gen_args(req)
+
+        assert args.temperature == 0.0
+        assert args.top_p == 1.0
+        assert args.top_k == 0
+
     def test_build_gen_args_defaults_penalty_context_sizes_when_omitted(self):
         req = server.ChatRequest(
             model="demo",

--- a/mlx_vlm/tests/test_utils.py
+++ b/mlx_vlm/tests/test_utils.py
@@ -16,8 +16,10 @@ from mlx_vlm.models.text_only import TextOnlyModel
 from mlx_vlm.utils import (
     StoppingCriteria,
     _load_safetensors,
+    apply_generation_config_defaults,
     get_model_and_args,
     load,
+    load_config,
     load_image,
     load_model,
     load_processor,
@@ -113,6 +115,57 @@ class MockProcessor:
             return inputs
         else:
             raise ValueError(f"Unsupported return_tensors: {return_tensors}")
+
+
+def test_load_config_applies_generation_config_sampling_defaults(tmp_path):
+    (tmp_path / "config.json").write_text(
+        json.dumps({"model_type": "demo", "eos_token_id": 1}),
+        encoding="utf-8",
+    )
+    (tmp_path / "generation_config.json").write_text(
+        json.dumps(
+            {
+                "eos_token_id": [2, 3],
+                "do_sample": True,
+                "temperature": 1.0,
+                "top_p": 0.95,
+                "top_k": 64,
+                "max_new_tokens": 4096,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    config = load_config(tmp_path)
+
+    assert config["eos_token_id"] == [2, 3]
+    assert config["do_sample"] is True
+    assert config["temperature"] == 1.0
+    assert config["top_p"] == 0.95
+    assert config["top_k"] == 64
+    assert "max_new_tokens" not in config
+
+
+def test_apply_generation_config_defaults_preserves_model_config_signature():
+    class ModelConfig:
+        pass
+
+    model_config = apply_generation_config_defaults(
+        ModelConfig(),
+        {
+            "temperature": 1.0,
+            "top_p": 0.95,
+            "top_k": 64,
+            "do_sample": True,
+            "max_new_tokens": 4096,
+        },
+    )
+
+    assert model_config.temperature == 1.0
+    assert model_config.top_p == 0.95
+    assert model_config.top_k == 64
+    assert model_config.do_sample is True
+    assert not hasattr(model_config, "max_new_tokens")
 
 
 def test_sanitize_weights():

--- a/mlx_vlm/utils.py
+++ b/mlx_vlm/utils.py
@@ -54,6 +54,21 @@ MODEL_CONVERSION_DTYPES = ["float16", "bfloat16", "float32"]
 
 SAFETENSORS_DTYPE_FALLBACKS = {"F8_E8M0": "U8"}
 
+GENERATION_CONFIG_DEFAULT_KEYS = (
+    "eos_token_id",
+    "temperature",
+    "top_p",
+    "top_k",
+    "do_sample",
+)
+
+
+def apply_generation_config_defaults(model_config, config: dict):
+    for key in GENERATION_CONFIG_DEFAULT_KEYS:
+        if key in config:
+            setattr(model_config, key, config[key])
+    return model_config
+
 
 def _e4m3_decode_table() -> mx.array:
     """Return a 256-entry ``float32`` LUT mapping every E4M3FN byte to its value.
@@ -505,6 +520,7 @@ python -m mlx_vlm.convert --hf-path <local_dir> --mlx-path <mlx_dir>
     model_config = model_class.ModelConfig.from_dict(config)
     modules = ["text", "vision", "perceiver", "projector", "audio"]
     model_config = update_module_configs(model_config, model_class, config, modules)
+    model_config = apply_generation_config_defaults(model_config, config)
 
     model = model_class.Model(model_config)
 
@@ -857,8 +873,9 @@ def load_config(model_path: Union[str, Path], **kwargs) -> dict:
             except json.JSONDecodeError:
                 pass
 
-            if eos_token_id := generation_config.get("eos_token_id", False):
-                config["eos_token_id"] = eos_token_id
+            for key in GENERATION_CONFIG_DEFAULT_KEYS:
+                if key in generation_config:
+                    config[key] = generation_config[key]
 
         return config
 


### PR DESCRIPTION
## Summary
- carry `temperature`, `top_p`, `top_k`, and `do_sample` from `generation_config.json` into loaded model config
- use model generation defaults for server requests when clients omit sampling params
- preserve explicit request sampling overrides

## Root cause
`load_config()` only copied `eos_token_id` from `generation_config.json`, and server request construction fell back to hardcoded defaults when sampling parameters were not provided. Models that ship sampling recommendations were therefore served greedily unless every request repeated those values.

Fixes #1331.

## Validation
- `uv run --with pytest python -m pytest mlx_vlm/tests/test_utils.py mlx_vlm/tests/test_server.py`
- `uv run --with pytest python -m pytest -s mlx_vlm/tests --ignore=mlx_vlm/tests/test_smoke.py --ignore=mlx_vlm/tests/test_utils.py`
- GitHub Actions `test` check passed on commit `814580ab`
- commit hooks: `black`, `isort`, `autoflake`