### PR TITLE
Fix DiffusionGemma long-context prefill

### DIFF
--- a/mlx_vlm/generate/diffusion.py
+++ b/mlx_vlm/generate/diffusion.py
@@ -425,6 +425,64 @@ def _diffusion_static_cache_length(
     return prompt_length + cached_canvas_tokens
 
 
+def _diffusion_has_visual_token_types(mm_token_type_ids: Optional[mx.array]) -> bool:
+    if mm_token_type_ids is None:
+        return False
+    return bool(mx.any((mm_token_type_ids == 1) | (mm_token_type_ids == 2)).item())
+
+
+def _diffusion_should_chunk_prefill(
+    *,
+    prefill_step_size: Optional[int],
+    prompt_length: int,
+    has_padding: bool,
+    use_static_cache: bool,
+    pixel_values: Optional[mx.array],
+    mm_token_type_ids: Optional[mx.array],
+) -> bool:
+    if prefill_step_size is None or prompt_length <= prefill_step_size:
+        return False
+    if has_padding or use_static_cache or pixel_values is not None:
+        return False
+    # Visual spans can use bidirectional attention inside the whole block. Keep
+    # those prompts on the existing single prefill until chunking can split on
+    # visual-block boundaries without changing attention semantics.
+    return not _diffusion_has_visual_token_types(mm_token_type_ids)
+
+
+def _diffusion_prefill_cache(
+    model: nn.Module,
+    input_ids: mx.array,
+    *,
+    attention_mask: Optional[mx.array],
+    kv_cache,
+    pixel_values: Optional[mx.array],
+    mm_token_type_ids: Optional[mx.array],
+    prefill_step_size: Optional[int],
+    chunk_prefill: bool,
+):
+    if not chunk_prefill:
+        _, kv_cache = model.model.encoder(
+            input_ids,
+            attention_mask=attention_mask,
+            cache=kv_cache,
+            pixel_values=pixel_values,
+            mm_token_type_ids=mm_token_type_ids,
+        )
+        return kv_cache
+
+    for start in range(0, input_ids.shape[1], prefill_step_size):
+        end = min(start + prefill_step_size, input_ids.shape[1])
+        _, kv_cache = model.model.encoder(
+            input_ids[:, start:end],
+            attention_mask=None,
+            cache=kv_cache,
+        )
+        mx.eval([c.state for c in kv_cache])
+        mx.clear_cache()
+    return kv_cache
+
+
 def _diffusion_stable_and_confident(
     accepted_canvas: mx.array,
     processed_logits: mx.array,
@@ -542,6 +600,7 @@ def stream_diffusion_generate(
     diffusion_unmasking_interval: int = 1,
     diffusion_unmasking_width: int = DEFAULT_DIFFUSION_UNMASKING_WIDTH,
     mm_token_type_ids: Optional[mx.array] = None,
+    prefill_step_size: Optional[int] = None,
 ) -> Generator[GenerationResult, None, None]:
     if input_ids.shape[0] != 1:
         raise ValueError(
@@ -591,6 +650,10 @@ def stream_diffusion_generate(
         raise ValueError(f"Unsupported diffusion sampler: {diffusion_sampler!r}.")
     if not 0.0 <= diffusion_threshold <= 1.0:
         raise ValueError("diffusion_threshold must be between 0 and 1.")
+    if prefill_step_size is not None:
+        prefill_step_size = int(prefill_step_size)
+        if prefill_step_size <= 0:
+            raise ValueError("prefill_step_size must be a positive integer.")
 
     sampler_config = _diffusion_config_dict(
         generation_config.get("sampler_config", None)
@@ -647,6 +710,14 @@ def stream_diffusion_generate(
         cached_sequence_length = prompt_length
         kv_cache = model.make_cache()
     detokenizer = make_streaming_detokenizer(processor)
+    chunk_prefill = _diffusion_should_chunk_prefill(
+        prefill_step_size=prefill_step_size,
+        prompt_length=prompt_length,
+        has_padding=has_padding,
+        use_static_cache=use_static_cache,
+        pixel_values=pixel_values,
+        mm_token_type_ids=mm_token_type_ids,
+    )
 
     generated_tokens = 0
     diffusion_canvas_tokens = 0
@@ -707,14 +778,23 @@ def stream_diffusion_generate(
         while generated_tokens < max_new_tokens:
             canvas_index += 1
             unprocessed_input_ids = input_ids if is_prefill else current_canvas
-            encoder_attention_mask = attention_mask if is_prefill else None
-            _, kv_cache = model.model.encoder(
-                unprocessed_input_ids,
-                attention_mask=encoder_attention_mask,
-                cache=kv_cache,
-                pixel_values=pixel_values if is_prefill else None,
-                mm_token_type_ids=mm_token_type_ids if is_prefill else None,
-            )
+            if is_prefill:
+                kv_cache = _diffusion_prefill_cache(
+                    model,
+                    unprocessed_input_ids,
+                    attention_mask=attention_mask if has_padding else None,
+                    kv_cache=kv_cache,
+                    pixel_values=pixel_values,
+                    mm_token_type_ids=mm_token_type_ids,
+                    prefill_step_size=prefill_step_size,
+                    chunk_prefill=chunk_prefill,
+                )
+            else:
+                _, kv_cache = model.model.encoder(
+                    unprocessed_input_ids,
+                    attention_mask=None,
+                    cache=kv_cache,
+                )
 
             if is_prefill:
                 mx.eval([c.state for c in kv_cache])
@@ -1039,6 +1119,7 @@ def stream_diffusion_generate_from_kwargs(
         "diffusion_unmasking_width", DEFAULT_DIFFUSION_UNMASKING_WIDTH
     )
     mm_token_type_ids = kwargs.pop("mm_token_type_ids", None)
+    prefill_step_size = kwargs.pop("prefill_step_size", None)
     with wired_limit(model, [generation_stream]):
         yield from stream_diffusion_generate(
             model,
@@ -1062,5 +1143,6 @@ def stream_diffusion_generate_from_kwargs(
             diffusion_unmasking_interval=diffusion_unmasking_interval,
             diffusion_unmasking_width=diffusion_unmasking_width,
             mm_token_type_ids=mm_token_type_ids,
+            prefill_step_size=prefill_step_size,
         )
         mx.clear_cache()

--- a/mlx_vlm/tests/test_diffusion_gemma.py
+++ b/mlx_vlm/tests/test_diffusion_gemma.py
@@ -70,6 +70,23 @@ class FakeProcessor:
         self.detokenizer = NaiveStreamingDetokenizer(self.tokenizer)
 
 
+class RecordingEncoder:
+    def __init__(self, inner):
+        self.inner = inner
+        self.input_lengths = []
+        self.attention_masks = []
+        self.mm_token_type_ids = []
+
+    def __getattr__(self, name):
+        return getattr(self.inner, name)
+
+    def __call__(self, input_ids, *args, **kwargs):
+        self.input_lengths.append(input_ids.shape[1])
+        self.attention_masks.append(kwargs.get("attention_mask"))
+        self.mm_token_type_ids.append(kwargs.get("mm_token_type_ids"))
+        return self.inner(input_ids, *args, **kwargs)
+
+
 class TinyDiffusionGemma4Tokenizer:
     image_token = "<image>"
     image_token_id = 60
@@ -548,6 +565,112 @@ class TestDiffusionGemma4(unittest.TestCase):
         self.assertEqual(responses[-1].diffusion_canvas_tokens, 3)
         self.assertEqual(responses[-1].diffusion_denoising_steps, 1)
         self.assertEqual(responses[-1].diffusion_work_tokens, 3)
+
+    def test_stream_generate_chunks_diffusion_prefill(self):
+        from mlx_vlm.generate import stream_generate
+        from mlx_vlm.models.diffusion_gemma import Model, ModelConfig
+
+        mx.random.seed(0)
+        config = ModelConfig.from_dict(tiny_config_dict())
+        model = Model(config)
+        recorder = RecordingEncoder(model.model.encoder)
+        model.model.encoder = recorder
+        processor = FakeProcessor()
+
+        responses = list(
+            stream_generate(
+                model,
+                processor,
+                "",
+                input_ids=mx.array([[2, 3, 4, 5, 6]], dtype=mx.int32),
+                max_tokens=1,
+                max_denoising_steps=1,
+                prefill_step_size=2,
+            )
+        )
+
+        self.assertEqual(responses[-1].generation_tokens, 1)
+        self.assertEqual(recorder.input_lengths, [2, 2, 1])
+        self.assertEqual(recorder.attention_masks, [None, None, None])
+
+    def test_chunked_diffusion_prefill_matches_unchunked_tokens(self):
+        from mlx_vlm.generate import stream_generate
+        from mlx_vlm.models.diffusion_gemma import Model, ModelConfig
+
+        def generated_tokens(prefill_step_size):
+            mx.random.seed(42)
+            model = Model(ModelConfig.from_dict(tiny_config_dict()))
+            responses = list(
+                stream_generate(
+                    model,
+                    FakeProcessor(),
+                    "",
+                    input_ids=mx.array([[2, 3, 4, 5, 6]], dtype=mx.int32),
+                    max_tokens=3,
+                    max_denoising_steps=1,
+                    prefill_step_size=prefill_step_size,
+                )
+            )
+            return [r.token for r in responses if r.token is not None]
+
+        self.assertEqual(generated_tokens(None), generated_tokens(2))
+
+    def test_stream_generate_keeps_padded_diffusion_prefill_unchunked(self):
+        from mlx_vlm.generate import stream_generate
+        from mlx_vlm.models.diffusion_gemma import Model, ModelConfig
+
+        mx.random.seed(0)
+        config = ModelConfig.from_dict(tiny_config_dict())
+        model = Model(config)
+        recorder = RecordingEncoder(model.model.encoder)
+        model.model.encoder = recorder
+        processor = FakeProcessor()
+
+        responses = list(
+            stream_generate(
+                model,
+                processor,
+                "",
+                input_ids=mx.array([[2, 3, 4, 5, 0]], dtype=mx.int32),
+                mask=mx.array([[1, 1, 1, 1, 0]], dtype=mx.bool_),
+                max_tokens=1,
+                max_denoising_steps=1,
+                prefill_step_size=2,
+            )
+        )
+
+        self.assertEqual(responses[-1].generation_tokens, 1)
+        self.assertEqual(recorder.input_lengths, [5])
+        self.assertIsNotNone(recorder.attention_masks[0])
+
+    def test_stream_generate_keeps_visual_diffusion_prefill_unchunked(self):
+        from mlx_vlm.generate import stream_generate
+        from mlx_vlm.models.diffusion_gemma import Model, ModelConfig
+
+        mx.random.seed(0)
+        config = ModelConfig.from_dict(tiny_config_dict())
+        model = Model(config)
+        recorder = RecordingEncoder(model.model.encoder)
+        model.model.encoder = recorder
+        processor = FakeProcessor()
+        mm_token_type_ids = mx.array([[0, 1, 1, 0, 0]], dtype=mx.int32)
+
+        responses = list(
+            stream_generate(
+                model,
+                processor,
+                "",
+                input_ids=mx.array([[2, 3, 4, 5, 6]], dtype=mx.int32),
+                mm_token_type_ids=mm_token_type_ids,
+                max_tokens=1,
+                max_denoising_steps=1,
+                prefill_step_size=2,
+            )
+        )
+
+        self.assertEqual(responses[-1].generation_tokens, 1)
+        self.assertEqual(recorder.input_lengths, [5])
+        self.assertIs(recorder.mm_token_type_ids[0], mm_token_type_ids)
 
     def test_decoder_masks_skip_no_padding_short_context(self):
         from mlx_vlm.models.diffusion_gemma import Model, ModelConfig


### PR DESCRIPTION
## Summary

Fix DiffusionGemma long-context generation by honoring the existing `prefill_step_size` setting in the block-diffusion prefill path.

## Root Cause

DiffusionGemma was prefilling the entire prompt in one encoder call. For ~100K-token prompts, the full-attention layers attempted to allocate a dense attention score workspace of roughly 313 GB, causing Metal allocation failure before generation started.

## Changes

- Add chunked prefill for safe text-only, no-padding DiffusionGemma prompts.
- Keep padded, static-cache, and visual-token prompts on the existing unchunked path to preserve attention semantics.
- Avoid materializing the all-ones attention mask for no-padding prefill.
- Add tiny-model tests for chunking, fallback behavior, and chunked-vs-unchunked token equivalence.

## Validation

- `uv run pytest mlx_vlm/tests/test_diffusion_gemma.py -q`
- `uv run pytest mlx_vlm/tests/test_diffusion_models.py::TestMaskedDiffusionServerLane::test_diffusion_generation_family_block -q`
- `uv run pre-commit run --all-files`
- Real generate smoke: ~99K rendered prompt tokens + `--max-tokens 500` completed with `--prefill-step-size 2048`.