### PR TITLE
fix(qwen3_omni): pass decoded audio arrays to the processor, not raw paths/BytesIO

### DIFF
--- a/mlx_vlm/utils.py
+++ b/mlx_vlm/utils.py
@@ -1708,6 +1708,12 @@ def prepare_inputs(
                 padding=True,
                 return_attention_mask=True,
             )
+            # Hand the decoded arrays downstream (mirrors the generic branch
+            # below): process_inputs_with_fallback re-runs the HF processor,
+            # whose Whisper feature extractor does np.asarray(raw_speech) and
+            # crashes on path strings ("could not convert string to float")
+            # or BytesIO from the server's base64 decode.
+            audio = audio_arrays
 
             audio_feature_lengths = np.sum(
                 audio_inputs["attention_mask"], axis=-1, dtype=np.int32


### PR DESCRIPTION
## Bug

In the `qwen3_omni` branch of `prepare_inputs` (`mlx_vlm/utils.py`), `audio_arrays` are decoded for the standalone `feature_extractor(...)` call, but the **original** audio items are still passed through to `process_inputs_with_fallback`. The HF `Qwen3OmniMoeProcessor`'s Whisper feature extractor then does `np.asarray(raw_speech, dtype=np.float32)` and crashes:

- path strings → `could not convert string to float: '/path/to.wav'`
- `BytesIO` (the OpenAI-compatible server's base64 decode path) → `float() argument must be a string or a real number, not '_io.BytesIO'`

This makes audio input unusable for qwen3_omni models both via `generate()` with file paths and via the bundled server. Present in 0.6.3 and current `main`.

## Fix

One line (plus comment): reassign `audio = audio_arrays` after decoding — exactly what the generic (non-omni) branch a few lines below already does (`audio = [load_audio(audio_file, sr=sr) for audio_file in audio]`).

## Verification

Verified on Apple M3 Ultra (256 GB) with `mlx-community/Qwen3-Omni-30B-A3B-Instruct-4bit`:
- audio comprehension (not just ASR) through `generate()` with wav paths ✅
- through the OpenAI-compatible server with base64 `input_audio` content parts ✅
- non-omni models unaffected (the touched branch is qwen3_omni-only) ✅

We've been running this patch in production behind a module-level monkey-patch of `process_inputs_with_fallback`; upstreaming so others don't hit the same wall.