### PR TITLE
fix(server): honor per-request top_k/min_p (and seed) in the batched sampler

### DIFF
--- a/mlx_vlm/generate/ar.py
+++ b/mlx_vlm/generate/ar.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import contextlib
 import functools
 import logging
+import math
 import os
 import sys
 import time
@@ -45,6 +46,7 @@ DEFAULT_TEMPERATURE = 0.0
 DEFAULT_TOP_P = 1.0
 DEFAULT_TOP_K = 0
 DEFAULT_MIN_P = 0.0
+DEFAULT_SEED = 0
 DEFAULT_REPETITION_CONTEXT_SIZE = 20
 DEFAULT_PREFILL_STEP_SIZE = 2048
 DEFAULT_COMPLETION_BATCH_SIZE = 32
@@ -125,14 +127,47 @@ def _position_keys(seed: int, row_ids: List[int], positions: List[int]) -> mx.ar
 
 
 class _PositionedTargetSampler:
-    """Sampler with stateless target draws keyed by generated-token position."""
+    """Sampler with stateless target draws keyed by generated-token position.
 
-    def __init__(self, *, temperature: float, top_p: float, seed: int):
+    Optional top-k truncation and min-p filtering mirror
+    ``mlx_lm.sample_utils.apply_top_k`` / ``apply_min_p``: excluded tokens are
+    masked to -inf on every row's normalized logprobs (vectorized across the
+    batch) before the temperature/top-p draw.
+    """
+
+    def __init__(
+        self,
+        *,
+        temperature: float,
+        top_p: float,
+        seed: Optional[int],
+        top_k: int = DEFAULT_TOP_K,
+        min_p: float = DEFAULT_MIN_P,
+    ):
         self.temperature = float(temperature)
         self.top_p = float(top_p)
-        self.seed = int(seed)
+        self.top_k = int(top_k or 0)
+        # An out-of-domain min_p would mask every token (even the argmax);
+        # clamp instead of erroring mid-batch on the GPU thread.
+        self.min_p = min(max(float(min_p or 0.0), 0.0), 1.0)
+        self.seed = DEFAULT_SEED if seed is None else int(seed)
+
+    def _filter_logprobs(self, logprobs: mx.array) -> mx.array:
+        """Mask tokens excluded by top-k/min-p with -inf, per row."""
+        neg_inf = mx.array(-float("inf"), logprobs.dtype)
+        if 0 < self.top_k < logprobs.shape[-1]:
+            mask_idx = mx.argpartition(-logprobs, kth=self.top_k - 1, axis=-1)[
+                ..., self.top_k :
+            ]
+            logprobs = mx.put_along_axis(logprobs, mask_idx, neg_inf, axis=-1)
+        if self.min_p > 0:
+            top_logprobs = mx.max(logprobs, axis=-1, keepdims=True)
+            scaled_min_p = top_logprobs + math.log(self.min_p)
+            logprobs = mx.where(logprobs < scaled_min_p, neg_inf, logprobs)
+        return logprobs
 
     def __call__(self, logprobs: mx.array) -> mx.array:
+        logprobs = self._filter_logprobs(logprobs)
         if self.top_p > 0 and self.top_p < 1.0:
             return top_p_sampling(logprobs, self.top_p, self.temperature)
         return mx.random.categorical(logprobs * (1 / self.temperature))
@@ -146,6 +181,7 @@ class _PositionedTargetSampler:
     ) -> mx.array:
         if logprobs.shape[0] != len(row_ids) or len(row_ids) != len(positions):
             raise ValueError("row_ids and positions must match logprobs batch size.")
+        logprobs = self._filter_logprobs(logprobs)
         keys = _position_keys(self.seed, row_ids, positions)
         if self.top_p > 0 and self.top_p < 1.0:
             return mx.vmap(self._sample_top_p_one, in_axes=(0, 0))(logprobs, keys)
@@ -173,6 +209,36 @@ class _PositionedTargetSampler:
 def _generate_module_override(name: str, fallback):
     generate_module = sys.modules.get("mlx_vlm.generate")
     return getattr(generate_module, name, fallback) if generate_module else fallback
+
+
+def _default_sampler(
+    *,
+    temperature: float,
+    top_p: float,
+    min_p: float,
+    top_k: int,
+    seed: Optional[int],
+) -> Callable[[mx.array], mx.array]:
+    """Build the default sampler for generate_step.
+
+    Seeded calls get the positioned sampler (stateless, reproducible draws,
+    now covering top-k/min-p as well); unseeded calls keep mlx_lm's
+    make_sampler so their global-RNG behavior is unchanged.
+    """
+    if seed is not None and temperature > 0:
+        return _PositionedTargetSampler(
+            temperature=temperature,
+            top_p=top_p,
+            seed=seed,
+            top_k=top_k,
+            min_p=min_p,
+        )
+    return _generate_module_override("make_sampler", make_sampler)(
+        temp=temperature,
+        top_p=top_p,
+        min_p=min_p,
+        top_k=top_k,
+    )
 
 
 def normalize_resize_shape(values):
@@ -290,24 +356,13 @@ def generate_step(
 
     sampler_is_greedy = sampler is None and temperature == 0
     if sampler is None:
-        if (
-            seed is not None
-            and temperature > 0
-            and min_p == DEFAULT_MIN_P
-            and top_k == DEFAULT_TOP_K
-        ):
-            sampler = _PositionedTargetSampler(
-                temperature=temperature,
-                top_p=top_p,
-                seed=seed,
-            )
-        else:
-            sampler = _generate_module_override("make_sampler", make_sampler)(
-                temp=temperature,
-                top_p=top_p,
-                min_p=min_p,
-                top_k=top_k,
-            )
+        sampler = _default_sampler(
+            temperature=temperature,
+            top_p=top_p,
+            min_p=min_p,
+            top_k=top_k,
+            seed=seed,
+        )
 
     processors = _generate_module_override(
         "make_logits_processors", make_logits_processors

--- a/mlx_vlm/server/app.py
+++ b/mlx_vlm/server/app.py
@@ -118,6 +118,7 @@ def _build_gen_args(
     )
     default_top_p = _model_config_field_or_default(processor, "top_p", DEFAULT_TOP_P)
     default_top_k = _model_config_field_or_default(processor, "top_k", 0)
+    default_min_p = _model_config_field_or_default(processor, "min_p", 0.0)
     if _model_config_field_or_default(processor, "do_sample", None) is False:
         default_temperature = 0.0
     args = GenerationArguments(
@@ -127,7 +128,7 @@ def _build_gen_args(
         ),
         top_p=_request_field_or_default(request, "top_p", default_top_p),
         top_k=_request_field_or_default(request, "top_k", default_top_k),
-        min_p=getattr(request, "min_p", 0.0),
+        min_p=_request_field_or_default(request, "min_p", default_min_p),
         seed=getattr(request, "seed", None),
         logprobs=bool(getattr(request, "logprobs", False)),
         repetition_penalty=getattr(request, "repetition_penalty", None),

--- a/mlx_vlm/server/generation.py
+++ b/mlx_vlm/server/generation.py
@@ -22,7 +22,6 @@ from ..generate import (
     DEFAULT_PREFILL_STEP_SIZE,
     DEFAULT_QUANTIZED_KV_START,
     DEFAULT_REPETITION_CONTEXT_SIZE,
-    DEFAULT_SEED,
     DEFAULT_TEMPERATURE,
     DEFAULT_THINKING_END_TOKEN,
     DEFAULT_THINKING_START_TOKEN,
@@ -32,9 +31,9 @@ from ..generate import (
     _make_cache,
     _merge_prefill_prompt_kwargs,
 )
+from ..generate.ar import _PositionedTargetSampler
 from ..generate.common import generation_stream, wired_limit
 from ..generate.diffusion import diffusion_generation_family, stream_diffusion_generate
-from ..sample_utils import top_p_sampling
 from ..speculative.utils import (
     make_speculative_prompt_cache,
     run_speculative_server_rounds,
@@ -194,71 +193,6 @@ def _run_chunked_speculative_prefill(
     with mx.stream(generation_stream):
         out = lm(remaining_input_ids, cache=prompt_cache, **final_kwargs)
     return out, remaining_input_ids
-
-
-def _position_seed(seed: int, row_id: int, position: int) -> int:
-    x = (int(seed) ^ 0x9E3779B9) & 0xFFFFFFFF
-    x = (x + (int(row_id) + 1) * 0x85EBCA6B) & 0xFFFFFFFF
-    x = (x ^ ((int(position) + 1) * 0xC2B2AE35)) & 0xFFFFFFFF
-    x ^= x >> 16
-    x = (x * 0x7FEB352D) & 0xFFFFFFFF
-    x ^= x >> 15
-    return int(x & 0xFFFFFFFF)
-
-
-def _position_keys(seed: int, row_ids: List[int], positions: List[int]) -> mx.array:
-    return mx.stack(
-        [
-            mx.random.key(_position_seed(seed, row, pos))
-            for row, pos in zip(row_ids, positions)
-        ]
-    )
-
-
-class _PositionedTargetSampler:
-    """Server sampler with stateless target draws for ragged verification."""
-
-    def __init__(self, *, temperature: float, top_p: float, seed: Optional[int]):
-        self.temperature = float(temperature)
-        self.top_p = float(top_p)
-        self.seed = DEFAULT_SEED if seed is None else int(seed)
-
-    def __call__(self, logprobs: mx.array) -> mx.array:
-        if self.top_p > 0 and self.top_p < 1.0:
-            return top_p_sampling(logprobs, self.top_p, self.temperature)
-        return mx.random.categorical(logprobs * (1 / self.temperature))
-
-    def sample_target(
-        self,
-        logprobs: mx.array,
-        *,
-        row_ids: List[int],
-        positions: List[int],
-    ) -> mx.array:
-        if logprobs.shape[0] != len(row_ids) or len(row_ids) != len(positions):
-            raise ValueError("row_ids and positions must match logprobs batch size.")
-        keys = _position_keys(self.seed, row_ids, positions)
-        if self.top_p > 0 and self.top_p < 1.0:
-            return mx.vmap(self._sample_top_p_one, in_axes=(0, 0))(logprobs, keys)
-        return mx.vmap(self._sample_one, in_axes=(0, 0))(logprobs, keys)
-
-    def _sample_one(self, logprobs: mx.array, key: mx.array) -> mx.array:
-        return mx.random.categorical(logprobs * (1 / self.temperature), key=key)
-
-    def _sample_top_p_one(self, logprobs: mx.array, key: mx.array) -> mx.array:
-        if logprobs.dtype == mx.bfloat16:
-            logprobs = logprobs.astype(mx.float32)
-        probs = mx.softmax(logprobs / self.temperature, axis=-1)
-        sorted_indices = mx.argsort(probs, axis=-1)
-        sorted_probs = mx.take_along_axis(probs, sorted_indices, axis=-1)
-        cumulative_probs = mx.cumsum(sorted_probs, axis=-1)
-        top_probs = mx.where(
-            cumulative_probs > 1 - self.top_p,
-            sorted_probs,
-            mx.zeros_like(sorted_probs),
-        )
-        sampled_pos = mx.random.categorical(mx.log(top_probs), key=key)
-        return mx.take_along_axis(sorted_indices, sampled_pos[..., None], axis=-1)[0]
 
 
 def _sample_last_token(
@@ -1034,6 +968,8 @@ class ResponseGenerator:
             temperature=args.temperature,
             top_p=args.top_p,
             seed=args.seed,
+            top_k=args.top_k,
+            min_p=args.min_p,
         )
 
     def _make_logits_processors(

--- a/mlx_vlm/tests/test_positioned_sampler.py
+++ b/mlx_vlm/tests/test_positioned_sampler.py
@@ -1,0 +1,308 @@
+"""Regression tests for _PositionedTargetSampler top-k / min-p / seed support.
+
+The server's continuous-batching decode (GenerationBatch._step ->
+_sample_with_positions -> sampler.sample_target) historically honored only
+temperature and top_p: per-request top_k and min_p were silently dropped, so
+a request with top_k=1 at temperature=2.0 produced the same gibberish as an
+unconstrained request. These tests pin the contract that top-k truncation
+and min-p filtering (mirroring mlx_lm.sample_utils) apply to every row's
+normalized logprobs before the categorical/top-p draw, in both the
+positioned (sample_target) and plain (__call__) paths, and that per-request
+seeds keep working alongside the filters.
+"""
+
+import unittest
+
+import mlx.core as mx
+
+from mlx_vlm.generate import ar as generate_ar
+from mlx_vlm.server import generation as server_generation
+
+# The class is duplicated between the generate and server layers; both must
+# honor the full parameter set, so every behavioral test runs against both.
+SAMPLER_VARIANTS = [
+    ("generate_ar", generate_ar._PositionedTargetSampler),
+    ("server_generation", server_generation._PositionedTargetSampler),
+]
+
+
+def _normalized_logprobs(probs):
+    """Rows of probabilities -> normalized logprobs, as GenerationBatch._step
+    feeds the sampler (logits - logsumexp)."""
+    logits = mx.log(mx.array(probs))
+    return logits - mx.logsumexp(logits, axis=-1, keepdims=True)
+
+
+def _tiled_draws(sampler, row_probs, n_draws):
+    """Sample the same distribution at n distinct positions in one batched
+    sample_target call (distinct positions -> distinct stateless keys)."""
+    logprobs = mx.broadcast_to(
+        _normalized_logprobs([row_probs]), (n_draws, len(row_probs))
+    )
+    tokens = sampler.sample_target(
+        logprobs, row_ids=[0] * n_draws, positions=list(range(n_draws))
+    )
+    mx.eval(tokens)
+    return tokens.tolist()
+
+
+class TestTopK(unittest.TestCase):
+    def test_top_k_one_is_greedy_even_at_high_temperature(self):
+        """The acceptance criterion for the server bug: top_k=1 must pin every
+        row to its argmax no matter the temperature. Rows peak at different
+        tokens to prove truncation is per-row, not batch-global."""
+        for name, cls in SAMPLER_VARIANTS:
+            with self.subTest(sampler=name):
+                sampler = cls(temperature=5.0, top_p=1.0, seed=0, top_k=1)
+                logprobs = _normalized_logprobs(
+                    [
+                        [0.80, 0.05, 0.05, 0.05, 0.05],
+                        [0.05, 0.05, 0.05, 0.05, 0.80],
+                    ]
+                )
+                tokens = sampler.sample_target(
+                    logprobs, row_ids=[0, 0], positions=[3, 7]
+                )
+                mx.eval(tokens)
+                self.assertEqual(tokens.tolist(), [0, 4])
+
+    def test_top_k_restricts_candidates_but_still_samples(self):
+        """With top_k=3 at high temperature, draws across many positions must
+        stay inside the top-3 token set yet hit more than one of them —
+        truncation without collapsing to greedy."""
+        row = [0.40, 0.25, 0.15, 0.10, 0.06, 0.04]
+        for name, cls in SAMPLER_VARIANTS:
+            with self.subTest(sampler=name):
+                sampler = cls(temperature=5.0, top_p=1.0, seed=0, top_k=3)
+                draws = _tiled_draws(sampler, row, 200)
+                self.assertTrue(set(draws).issubset({0, 1, 2}), draws)
+                self.assertGreaterEqual(len(set(draws)), 2, draws)
+
+    def test_top_k_at_or_above_vocab_is_a_no_op(self):
+        """top_k >= vocab must not raise and must draw exactly what the
+        unconstrained sampler draws for the same seed and positions."""
+        row = [0.40, 0.25, 0.15, 0.10, 0.06, 0.04]
+        for name, cls in SAMPLER_VARIANTS:
+            with self.subTest(sampler=name):
+                unconstrained = cls(temperature=2.0, top_p=1.0, seed=9)
+                oversized = cls(temperature=2.0, top_p=1.0, seed=9, top_k=99)
+                self.assertEqual(
+                    _tiled_draws(oversized, row, 64),
+                    _tiled_draws(unconstrained, row, 64),
+                )
+
+    def test_top_k_applies_in_plain_call_path(self):
+        """__call__ (the non-positioned fallback used when row ids/positions
+        are unavailable) must apply the same truncation."""
+        for name, cls in SAMPLER_VARIANTS:
+            with self.subTest(sampler=name):
+                sampler = cls(temperature=5.0, top_p=1.0, seed=0, top_k=1)
+                logprobs = _normalized_logprobs(
+                    [
+                        [0.80, 0.05, 0.05, 0.05, 0.05],
+                        [0.05, 0.05, 0.05, 0.05, 0.80],
+                    ]
+                )
+                tokens = sampler(logprobs)
+                mx.eval(tokens)
+                self.assertEqual(tokens.tolist(), [0, 4])
+
+    def test_top_k_composes_with_top_p_draw(self):
+        """top_k truncation must happen before the top-p draw path
+        (0 < top_p < 1 routes through _sample_top_p_one)."""
+        row = [0.40, 0.25, 0.15, 0.10, 0.06, 0.04]
+        for name, cls in SAMPLER_VARIANTS:
+            with self.subTest(sampler=name):
+                sampler = cls(temperature=5.0, top_p=0.999, seed=0, top_k=2)
+                draws = _tiled_draws(sampler, row, 200)
+                self.assertTrue(set(draws).issubset({0, 1}), draws)
+
+
+class TestMinP(unittest.TestCase):
+    def test_min_p_filters_below_scaled_threshold(self):
+        """min_p=0.5 with top probability 0.5 keeps only tokens with
+        p >= 0.25 (mlx_lm semantics: threshold scales with the top token's
+        probability on the unscaled distribution). Survivors {0, 1} must both
+        appear across draws — filtering, not greedy collapse."""
+        row = [0.50, 0.30, 0.10, 0.05, 0.05]
+        for name, cls in SAMPLER_VARIANTS:
+            with self.subTest(sampler=name):
+                sampler = cls(temperature=3.0, top_p=1.0, seed=0, min_p=0.5)
+                draws = _tiled_draws(sampler, row, 200)
+                self.assertTrue(set(draws).issubset({0, 1}), draws)
+                self.assertEqual(set(draws), {0, 1}, draws)
+
+    def test_min_p_one_keeps_only_the_top_token(self):
+        """min_p=1.0 leaves just the argmax (threshold == top probability)."""
+        for name, cls in SAMPLER_VARIANTS:
+            with self.subTest(sampler=name):
+                sampler = cls(temperature=4.0, top_p=1.0, seed=0, min_p=1.0)
+                draws = _tiled_draws(sampler, [0.50, 0.30, 0.10, 0.05, 0.05], 50)
+                self.assertEqual(set(draws), {0})
+
+    def test_min_p_applies_in_plain_call_path(self):
+        for name, cls in SAMPLER_VARIANTS:
+            with self.subTest(sampler=name):
+                sampler = cls(temperature=4.0, top_p=1.0, seed=0, min_p=1.0)
+                logprobs = _normalized_logprobs([[0.50, 0.30, 0.10, 0.05, 0.05]])
+                for _ in range(20):
+                    tokens = sampler(logprobs)
+                    mx.eval(tokens)
+                    self.assertEqual(tokens.tolist(), [0])
+
+    def test_min_p_is_independent_per_row(self):
+        """Each row's threshold must come from that row's own top probability
+        (vectorized across the batch, not computed batch-globally)."""
+        for name, cls in SAMPLER_VARIANTS:
+            with self.subTest(sampler=name):
+                sampler = cls(temperature=3.0, top_p=1.0, seed=0, min_p=0.5)
+                logprobs = _normalized_logprobs(
+                    [
+                        # top p=0.9 -> threshold 0.45 -> survivor {0} only
+                        [0.90, 0.04, 0.03, 0.02, 0.01],
+                        # top p=0.4 -> threshold 0.2 -> survivors {3, 4}
+                        [0.10, 0.05, 0.05, 0.40, 0.40],
+                    ]
+                )
+                for pos in range(50):
+                    tokens = sampler.sample_target(
+                        logprobs, row_ids=[0, 0], positions=[pos, pos]
+                    )
+                    mx.eval(tokens)
+                    row0, row1 = tokens.tolist()
+                    self.assertEqual(row0, 0)
+                    self.assertIn(row1, (3, 4))
+
+    def test_min_p_handles_bfloat16_logprobs(self):
+        """The decode loop can hand the sampler bfloat16 logprobs; filtering
+        must preserve dtype handling and still constrain the candidate set."""
+        row = [0.50, 0.30, 0.10, 0.05, 0.05]
+        for name, cls in SAMPLER_VARIANTS:
+            with self.subTest(sampler=name):
+                sampler = cls(temperature=3.0, top_p=1.0, seed=0, min_p=0.5, top_k=0)
+                logprobs = mx.broadcast_to(
+                    _normalized_logprobs([row]).astype(mx.bfloat16), (100, len(row))
+                )
+                tokens = sampler.sample_target(
+                    logprobs, row_ids=[0] * 100, positions=list(range(100))
+                )
+                mx.eval(tokens)
+                self.assertTrue(set(tokens.tolist()).issubset({0, 1}))
+
+
+class TestSeed(unittest.TestCase):
+    def test_same_seed_reproduces_the_stream(self):
+        """Pin of existing behavior: positioned draws are a pure function of
+        (seed, row_id, position), so a fresh sampler with the same seed must
+        replay the same tokens."""
+        row = [1.0 / 256] * 256
+        for name, cls in SAMPLER_VARIANTS:
+            with self.subTest(sampler=name):
+                a = _tiled_draws(cls(temperature=2.0, top_p=1.0, seed=11), row, 64)
+                b = _tiled_draws(cls(temperature=2.0, top_p=1.0, seed=11), row, 64)
+                self.assertEqual(a, b)
+
+    def test_different_seeds_diverge(self):
+        """Per-request seed must actually change the sampled stream (the
+        companion server bug: every request collapsed onto DEFAULT_SEED)."""
+        row = [1.0 / 256] * 256
+        for name, cls in SAMPLER_VARIANTS:
+            with self.subTest(sampler=name):
+                a = _tiled_draws(cls(temperature=2.0, top_p=1.0, seed=1), row, 64)
+                b = _tiled_draws(cls(temperature=2.0, top_p=1.0, seed=2), row, 64)
+                self.assertNotEqual(a, b)
+
+    def test_seed_reproducible_with_filters_active(self):
+        """Seed and top_k/min_p must compose: same seed + same filters replay
+        identically, different seeds still diverge inside the filtered set."""
+        row = [0.30, 0.20, 0.15, 0.12, 0.08, 0.06, 0.05, 0.04]
+        for name, cls in SAMPLER_VARIANTS:
+            with self.subTest(sampler=name):
+                kwargs = dict(temperature=3.0, top_p=1.0, top_k=4, min_p=0.2)
+                a = _tiled_draws(cls(seed=7, **kwargs), row, 64)
+                b = _tiled_draws(cls(seed=7, **kwargs), row, 64)
+                c = _tiled_draws(cls(seed=8, **kwargs), row, 64)
+                self.assertEqual(a, b)
+                self.assertNotEqual(a, c)
+                self.assertTrue(set(a + c).issubset({0, 1, 2, 3}))
+
+
+class TestDefaultPathUnchanged(unittest.TestCase):
+    """With filters disabled (top_k=0, min_p=0.0) the positioned draw must
+    stay byte-identical to the pre-top-k/min-p implementation.
+
+    Expected tokens were captured by running these exact scenarios against
+    v0.6.3 (commit 5a4222a, mlx 0.31.2) before the filters existed; regenerate
+    them the same way if the underlying mlx RNG ever changes.
+    """
+
+    def _fixture_logprobs(self):
+        logits = mx.array(
+            [[((r * 5 + v * 3) % 7) * 0.5 for v in range(8)] for r in range(4)],
+            dtype=mx.float32,
+        )
+        return logits - mx.logsumexp(logits, axis=-1, keepdims=True)
+
+    def test_categorical_path_pinned(self):
+        for name, cls in SAMPLER_VARIANTS:
+            with self.subTest(sampler=name):
+                sampler = cls(temperature=0.7, top_p=1.0, seed=42)
+                tokens = sampler.sample_target(
+                    self._fixture_logprobs(),
+                    row_ids=[0, 0, 0, 0],
+                    positions=[2, 9, 17, 33],
+                )
+                mx.eval(tokens)
+                self.assertEqual(tokens.tolist(), [6, 2, 5, 7])
+
+    def test_top_p_path_pinned(self):
+        for name, cls in SAMPLER_VARIANTS:
+            with self.subTest(sampler=name):
+                sampler = cls(temperature=0.9, top_p=0.85, seed=7)
+                tokens = sampler.sample_target(
+                    self._fixture_logprobs(),
+                    row_ids=[0, 0, 0, 0],
+                    positions=[0, 1, 2, 3],
+                )
+                mx.eval(tokens)
+                self.assertEqual(tokens.tolist(), [4, 5, 1, 3])
+
+
+class TestDefaultSamplerSelection(unittest.TestCase):
+    """generate_step's default-sampler choice, extracted as
+    generate_ar._default_sampler. Historically a seeded call that also set
+    top_k/min_p silently dropped the seed (fell back to mlx_lm's
+    make_sampler); now the positioned sampler carries all four knobs."""
+
+    def test_seeded_call_with_filters_keeps_positioned_sampler(self):
+        sampler = generate_ar._default_sampler(
+            temperature=1.0, top_p=0.9, min_p=0.2, top_k=4, seed=11
+        )
+        self.assertIsInstance(sampler, generate_ar._PositionedTargetSampler)
+        self.assertEqual(sampler.temperature, 1.0)
+        self.assertEqual(sampler.top_p, 0.9)
+        self.assertEqual(sampler.top_k, 4)
+        self.assertEqual(sampler.min_p, 0.2)
+        self.assertEqual(sampler.seed, 11)
+
+    def test_unseeded_call_falls_back_to_make_sampler(self):
+        """Seedless library calls keep mlx_lm's global-RNG sampler so their
+        run-to-run nondeterminism is unchanged."""
+        sampler = generate_ar._default_sampler(
+            temperature=1.0, top_p=0.9, min_p=0.0, top_k=0, seed=None
+        )
+        self.assertNotIsInstance(sampler, generate_ar._PositionedTargetSampler)
+        self.assertTrue(callable(sampler))
+
+    def test_temperature_zero_is_greedy_even_with_seed(self):
+        sampler = generate_ar._default_sampler(
+            temperature=0.0, top_p=1.0, min_p=0.0, top_k=0, seed=3
+        )
+        logprobs = _normalized_logprobs([[0.05, 0.80, 0.05, 0.05, 0.05]])
+        tokens = sampler(logprobs)
+        mx.eval(tokens)
+        self.assertEqual(tokens.tolist(), [1])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/mlx_vlm/tests/test_server.py
+++ b/mlx_vlm/tests/test_server.py
@@ -203,6 +203,25 @@ def test_positioned_target_sampler_is_batch_grouping_invariant():
     assert batched.tolist() == [single_0.item(), single_1.item()]
 
 
+def test_make_sampler_forwards_top_k_min_p_and_seed():
+    """Regression: the batched path dropped per-request top_k/min_p because
+    _make_sampler built the positioned sampler from temperature/top_p/seed
+    only, even though GenerationArguments carried all five knobs."""
+    gen = server.ResponseGenerator.__new__(server.ResponseGenerator)
+    args = server_generation.GenerationArguments(
+        temperature=0.8, top_p=0.9, top_k=5, min_p=0.25, seed=11
+    )
+
+    sampler = gen._make_sampler(args)
+
+    assert isinstance(sampler, server_generation._PositionedTargetSampler)
+    assert sampler.temperature == 0.8
+    assert sampler.top_p == 0.9
+    assert sampler.top_k == 5
+    assert sampler.min_p == 0.25
+    assert sampler.seed == 11
+
+
 def test_speculative_server_dispatches_eagle3_batch_loop():
     assert (
         speculative_utils.get_speculative_rounds_batch("eagle3")
@@ -4130,6 +4149,41 @@ class TestResponseGenerator:
         assert args.temperature == 0.0
         assert args.top_p == 1.0
         assert args.top_k == 0
+
+    def test_build_gen_args_min_p_default_from_model_generation_config(
+        self, monkeypatch
+    ):
+        monkeypatch.setitem(
+            server.runtime.model_cache,
+            "config",
+            SimpleNamespace(min_p=0.05),
+        )
+        req = server.ChatRequest(
+            model="demo",
+            messages=[server.ChatMessage(role="user", content="hi")],
+        )
+
+        args = server._build_gen_args(req)
+
+        assert args.min_p == 0.05
+
+    def test_build_gen_args_request_min_p_overrides_model_generation_config(
+        self, monkeypatch
+    ):
+        monkeypatch.setitem(
+            server.runtime.model_cache,
+            "config",
+            SimpleNamespace(min_p=0.05),
+        )
+        req = server.ChatRequest(
+            model="demo",
+            messages=[server.ChatMessage(role="user", content="hi")],
+            min_p=0.0,
+        )
+
+        args = server._build_gen_args(req)
+
+        assert args.min_p == 0.0
 
     def test_build_gen_args_defaults_penalty_context_sizes_when_omitted(self):
         req = server.ChatRequest(

--- a/mlx_vlm/tests/test_utils.py
+++ b/mlx_vlm/tests/test_utils.py
@@ -124,6 +124,7 @@ def test_load_config_applies_generation_config_sampling_defaults(tmp_path):
         "temperature": 1.0,
         "top_p": 0.95,
         "top_k": 64,
+        "min_p": 0.02,
         "max_new_tokens": 4096,
     }
     (tmp_path / "config.json").write_text(
@@ -143,6 +144,7 @@ def test_load_config_applies_generation_config_sampling_defaults(tmp_path):
     assert config["temperature"] == 1.0
     assert config["top_p"] == 0.95
     assert config["top_k"] == 64
+    assert config["min_p"] == 0.02
     assert "max_new_tokens" not in config
 
 
@@ -156,6 +158,7 @@ def test_apply_generation_config_defaults_preserves_model_config_signature():
             "temperature": 1.0,
             "top_p": 0.95,
             "top_k": 64,
+            "min_p": 0.02,
             "do_sample": True,
             "max_new_tokens": 4096,
         },
@@ -164,6 +167,7 @@ def test_apply_generation_config_defaults_preserves_model_config_signature():
     assert model_config.temperature == 1.0
     assert model_config.top_p == 0.95
     assert model_config.top_k == 64
+    assert model_config.min_p == 0.02
     assert model_config.do_sample is True
     assert not hasattr(model_config, "max_new_tokens")
 

--- a/mlx_vlm/utils.py
+++ b/mlx_vlm/utils.py
@@ -59,6 +59,7 @@ GENERATION_CONFIG_DEFAULT_KEYS = (
     "temperature",
     "top_p",
     "top_k",
+    "min_p",
     "do_sample",
 )
 


### PR DESCRIPTION
## Problem

When `mlx_vlm.server` serves an LM/VLM, per-request `top_k` and `min_p` are silently ignored, and per-request `seed` doesn't vary output. A client sending `top_k=1` or `min_p=0.6` gets the same result as sending neither — a 200 OK with the wrong sampling.

## Root cause

The server runs continuous batching unconditionally for LM/VLM models, and its batched sampler `_PositionedTargetSampler` only implemented `temperature`/`top_p`. `_make_sampler` constructed it with only those (plus `seed`), so `top_k`/`min_p` never reached the sampler. The non-batched `stream_generate` path forwards them via `to_generate_kwargs`, but that path isn't reachable for an LM/VLM since batching can't be disabled. There were also two copies of the sampler — the one in `server/generation.py` had drifted from `generate/ar.py`.

## Fix

- Extend `_PositionedTargetSampler` to apply top-k (argpartition mask) and min-p (log-threshold mask) per row, vectorized over the batch, before the temperature/top-p draw — mirroring `mlx_lm.sample_utils`.
- Thread `top_k`/`min_p` through `_make_sampler`: seeded calls get the positioned (stateless, reproducible) sampler now covering them; unseeded calls keep `mlx_lm`'s sampler.
- Consolidate the duplicate sampler into `generate/ar.py`.
- Extend the generation_config sampling defaults (#1337) with `min_p`, and make `#1337`'s `top_k` default actually bind (it was inert without this sampler fix).

## Testing

- New regression tests in `mlx_vlm/tests/test_positioned_sampler.py` plus server/utils tests.
- Verified live against `Qwen3-VL-8B-Instruct-8bit` with continuous batching: `top_k=1` at `temperature=2.0` now matches greedy output byte-for-byte (previously multilingual token soup), `min_p=0.6` visibly constrains sampling, seeds reproduce/diverge as expected, and the default temperature/top_p-only path draws byte-identical tokens to the previous implementation (pinned in tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
