### PR TITLE
Add prefill policy support for diffusion models

### DIFF
--- a/mlx_vlm/generate/ar.py
+++ b/mlx_vlm/generate/ar.py
@@ -33,6 +33,7 @@ from .common import (
     DEFAULT_KV_GROUP_SIZE,
     DEFAULT_KV_QUANT_SCHEME,
     DEFAULT_QUANTIZED_KV_START,
+    _chunked_prefill_enabled,
     generation_stream,
     maybe_quantize_kv_cache,
     wired_limit,
@@ -50,48 +51,6 @@ DEFAULT_PREFILL_STEP_SIZE = 2048
 DEFAULT_COMPLETION_BATCH_SIZE = 32
 DEFAULT_PREFILL_BATCH_SIZE = 8
 DEFAULT_BATCH_CACHE_EVAL_INTERVAL = 50
-
-
-def _policy_enabled(policy) -> bool:
-    return bool(getattr(policy, "enabled", policy))
-
-
-def _chunked_prefill_enabled(
-    model,
-    *,
-    input_ids=None,
-    inputs_embeds=None,
-    prompt_cache=None,
-    draft_model=None,
-    draft_kind=None,
-    prefill_kwargs=None,
-) -> bool:
-    prefill_kwargs = prefill_kwargs or {}
-    candidates = [model]
-    language_model = getattr(model, "language_model", None)
-    if language_model is not None and language_model is not model:
-        candidates.append(language_model)
-
-    for candidate in candidates:
-        policy = getattr(candidate, "chunked_prefill_policy", None)
-        if callable(policy):
-            return _policy_enabled(
-                policy(
-                    input_ids=input_ids,
-                    inputs_embeds=inputs_embeds,
-                    prompt_cache=prompt_cache,
-                    draft_model=draft_model,
-                    draft_kind=draft_kind,
-                    prefill_kwargs=prefill_kwargs,
-                )
-            )
-
-    if any(getattr(candidate, "no_chunked_prefill", False) for candidate in candidates):
-        return False
-
-    # Hidden-state speculative prefill is model-contract dependent. Keep unknown
-    # target models conservative unless they expose a chunked_prefill_policy.
-    return draft_model is None
 
 
 def _get_batch_cache_eval_interval() -> int:

--- a/mlx_vlm/generate/common.py
+++ b/mlx_vlm/generate/common.py
@@ -20,6 +20,48 @@ DEFAULT_QUANTIZED_KV_START = 5000
 generation_stream = mx.new_thread_local_stream(mx.default_device())
 
 
+def _policy_enabled(policy) -> bool:
+    return bool(getattr(policy, "enabled", policy))
+
+
+def _chunked_prefill_enabled(
+    model,
+    *,
+    input_ids=None,
+    inputs_embeds=None,
+    prompt_cache=None,
+    draft_model=None,
+    draft_kind=None,
+    prefill_kwargs=None,
+) -> bool:
+    prefill_kwargs = prefill_kwargs or {}
+    candidates = [model]
+    language_model = getattr(model, "language_model", None)
+    if language_model is not None and language_model is not model:
+        candidates.append(language_model)
+
+    for candidate in candidates:
+        policy = getattr(candidate, "chunked_prefill_policy", None)
+        if callable(policy):
+            return _policy_enabled(
+                policy(
+                    input_ids=input_ids,
+                    inputs_embeds=inputs_embeds,
+                    prompt_cache=prompt_cache,
+                    draft_model=draft_model,
+                    draft_kind=draft_kind,
+                    prefill_kwargs=prefill_kwargs,
+                )
+            )
+
+    if any(getattr(candidate, "no_chunked_prefill", False) for candidate in candidates):
+        return False
+
+    # Hidden-state speculative prefill is model-contract dependent. Keep unknown
+    # target models conservative unless they expose a chunked_prefill_policy.
+    return draft_model is None
+
+
 def maybe_quantize_kv_cache(
     prompt_cache,
     quantized_kv_start,

--- a/mlx_vlm/generate/diffusion.py
+++ b/mlx_vlm/generate/diffusion.py
@@ -12,7 +12,12 @@ import mlx.nn as nn
 from transformers import PreTrainedTokenizer
 
 from ..tokenizer_utils import make_streaming_detokenizer
-from .common import GenerationResult, generation_stream, wired_limit
+from .common import (
+    GenerationResult,
+    _chunked_prefill_enabled,
+    generation_stream,
+    wired_limit,
+)
 
 logger = logging.getLogger("mlx_vlm.generate")
 
@@ -425,31 +430,6 @@ def _diffusion_static_cache_length(
     return prompt_length + cached_canvas_tokens
 
 
-def _diffusion_has_visual_token_types(mm_token_type_ids: Optional[mx.array]) -> bool:
-    if mm_token_type_ids is None:
-        return False
-    return bool(mx.any((mm_token_type_ids == 1) | (mm_token_type_ids == 2)).item())
-
-
-def _diffusion_should_chunk_prefill(
-    *,
-    prefill_step_size: Optional[int],
-    prompt_length: int,
-    has_padding: bool,
-    use_static_cache: bool,
-    pixel_values: Optional[mx.array],
-    mm_token_type_ids: Optional[mx.array],
-) -> bool:
-    if prefill_step_size is None or prompt_length <= prefill_step_size:
-        return False
-    if has_padding or use_static_cache or pixel_values is not None:
-        return False
-    # Visual spans can use bidirectional attention inside the whole block. Keep
-    # those prompts on the existing single prefill until chunking can split on
-    # visual-block boundaries without changing attention semantics.
-    return not _diffusion_has_visual_token_types(mm_token_type_ids)
-
-
 def _diffusion_prefill_cache(
     model: nn.Module,
     input_ids: mx.array,
@@ -710,13 +690,22 @@ def stream_diffusion_generate(
         cached_sequence_length = prompt_length
         kv_cache = model.make_cache()
     detokenizer = make_streaming_detokenizer(processor)
-    chunk_prefill = _diffusion_should_chunk_prefill(
-        prefill_step_size=prefill_step_size,
-        prompt_length=prompt_length,
-        has_padding=has_padding,
-        use_static_cache=use_static_cache,
-        pixel_values=pixel_values,
-        mm_token_type_ids=mm_token_type_ids,
+    prefill_policy_kwargs = {
+        "attention_mask": attention_mask,
+        "has_padding": has_padding,
+        "use_static_cache": use_static_cache,
+        "pixel_values": pixel_values,
+        "mm_token_type_ids": mm_token_type_ids,
+    }
+    chunk_prefill = (
+        prefill_step_size is not None
+        and prompt_length > prefill_step_size
+        and _chunked_prefill_enabled(
+            model,
+            input_ids=input_ids,
+            prompt_cache=kv_cache,
+            prefill_kwargs=prefill_policy_kwargs,
+        )
     )
 
     generated_tokens = 0

--- a/mlx_vlm/models/diffusion_gemma/diffusion_gemma.py
+++ b/mlx_vlm/models/diffusion_gemma/diffusion_gemma.py
@@ -107,6 +107,19 @@ class Model(nn.Module):
     def make_cache(self, max_size=None):
         return self.model.encoder.make_cache(max_size=max_size)
 
+    def chunked_prefill_policy(
+        self,
+        *,
+        input_ids=None,
+        inputs_embeds=None,
+        prompt_cache=None,
+        draft_model=None,
+        draft_kind=None,
+        prefill_kwargs=None,
+    ) -> bool:
+        del input_ids, inputs_embeds, prompt_cache, draft_model, draft_kind
+        return self.model.encoder.chunked_prefill_policy(prefill_kwargs=prefill_kwargs)
+
     # Model-owned live unmasking view, like the nemotron/llada visualizers.
     make_unmasking_visualizer = staticmethod(make_unmasking_visualizer)
 

--- a/mlx_vlm/models/diffusion_gemma/language.py
+++ b/mlx_vlm/models/diffusion_gemma/language.py
@@ -559,6 +559,39 @@ class EncoderModel(nn.Module):
                 caches.append(RotatingKVCache(max_size=self.text_config.sliding_window))
         return caches
 
+    def chunked_prefill_policy(
+        self,
+        *,
+        input_ids=None,
+        inputs_embeds=None,
+        prompt_cache=None,
+        draft_model=None,
+        draft_kind=None,
+        prefill_kwargs=None,
+    ) -> bool:
+        del input_ids, inputs_embeds, prompt_cache, draft_model, draft_kind
+        prefill_kwargs = prefill_kwargs or {}
+        if bool(prefill_kwargs.get("has_padding", False)):
+            return False
+        attention_mask = prefill_kwargs.get("attention_mask", None)
+        if attention_mask is not None and not bool(mx.all(attention_mask).item()):
+            return False
+        if bool(prefill_kwargs.get("use_static_cache", False)):
+            return False
+        if prefill_kwargs.get("pixel_values", None) is not None:
+            return False
+
+        token_types = prefill_kwargs.get("mm_token_type_ids", None)
+        if token_types is not None:
+            # Visual spans can use bidirectional attention inside the whole
+            # block. Keep those prompts on the single prefill path until
+            # chunking can split on visual-block boundaries.
+            has_visual = bool(mx.any((token_types == 1) | (token_types == 2)).item())
+            if has_visual:
+                return False
+
+        return True
+
     def get_image_features(self, pixel_values):
         if self.vision_tower is None or self.embed_vision is None:
             raise ValueError(
@@ -763,6 +796,19 @@ class LanguageModel(nn.Module):
 
     def make_cache(self, max_size: Optional[int] = None):
         return self.model.encoder.make_cache(max_size=max_size)
+
+    def chunked_prefill_policy(
+        self,
+        *,
+        input_ids=None,
+        inputs_embeds=None,
+        prompt_cache=None,
+        draft_model=None,
+        draft_kind=None,
+        prefill_kwargs=None,
+    ) -> bool:
+        del input_ids, inputs_embeds, prompt_cache, draft_model, draft_kind
+        return self.model.encoder.chunked_prefill_policy(prefill_kwargs=prefill_kwargs)
 
     def __call__(
         self,

--- a/mlx_vlm/tests/test_diffusion_gemma.py
+++ b/mlx_vlm/tests/test_diffusion_gemma.py
@@ -593,6 +593,37 @@ class TestDiffusionGemma4(unittest.TestCase):
         self.assertEqual(recorder.input_lengths, [2, 2, 1])
         self.assertEqual(recorder.attention_masks, [None, None, None])
 
+    def test_stream_generate_honors_diffusion_chunked_prefill_policy(self):
+        from mlx_vlm.generate import stream_generate
+        from mlx_vlm.models.diffusion_gemma import Model, ModelConfig
+
+        mx.random.seed(0)
+        config = ModelConfig.from_dict(tiny_config_dict())
+        model = Model(config)
+        recorder = RecordingEncoder(model.model.encoder)
+        model.model.encoder = recorder
+        processor = FakeProcessor()
+
+        with patch.object(
+            model, "chunked_prefill_policy", return_value=False
+        ) as policy:
+            responses = list(
+                stream_generate(
+                    model,
+                    processor,
+                    "",
+                    input_ids=mx.array([[2, 3, 4, 5, 6]], dtype=mx.int32),
+                    max_tokens=1,
+                    max_denoising_steps=1,
+                    prefill_step_size=2,
+                )
+            )
+
+        self.assertEqual(responses[-1].generation_tokens, 1)
+        self.assertEqual(recorder.input_lengths, [5])
+        policy.assert_called_once()
+        self.assertFalse(policy.call_args.kwargs["prefill_kwargs"]["has_padding"])
+
     def test_chunked_diffusion_prefill_matches_unchunked_tokens(self):
         from mlx_vlm.generate import stream_generate
         from mlx_vlm.models.diffusion_gemma import Model, ModelConfig


### PR DESCRIPTION
This aligns the AR and diffusion paths to both use model-specified prefill policy, which allows us to push the model-specific handling of e.g. visual tokens into the model implementation itself instead of the top-level diffusion generator. Resolves https://github.com/Blaizzy/mlx-vlm/issues/1349