### PR TITLE
Improve diffusion unmasking visualization

### DIFF
--- a/mlx_vlm/generate/diffusion.py
+++ b/mlx_vlm/generate/diffusion.py
@@ -11,9 +11,9 @@ import mlx.nn as nn
 from transformers import PreTrainedTokenizer
 
 from ..models.diffusion_visualizer import (
-    _clip_display_width,
-    _display_width,
-    _escape_carriage_returns,
+    clip_display_width,
+    display_width,
+    escape_carriage_returns,
 )
 from ..tokenizer_utils import make_streaming_detokenizer
 from .common import (
@@ -54,11 +54,11 @@ def _format_diffusion_draft_line(
     response: GenerationResult,
     requested_width: Optional[int] = None,
 ) -> str:
-    text = _escape_carriage_returns(response.draft_text)
+    text = escape_carriage_returns(response.draft_text)
     width = _diffusion_display_limit(requested_width)
     if width is None:
         return text
-    return _clip_display_width(text, width)
+    return clip_display_width(text, width)
 
 
 def _print_diffusion_draft(
@@ -76,12 +76,12 @@ def _format_diffusion_live_text(
     preserve_newlines: bool = True,
 ) -> str:
     width = _diffusion_display_limit(requested_width)
-    text = _escape_carriage_returns(text)
+    text = escape_carriage_returns(text)
     if not preserve_newlines:
         text = text.replace("\n", "\\n")
     if width is None:
         return text
-    return _clip_display_width(text, width)
+    return clip_display_width(text, width)
 
 
 def _print_diffusion_live_text(
@@ -106,7 +106,7 @@ def _terminal_rows_for_text(text: str, columns: Optional[int] = None) -> int:
     columns = max(1, columns)
     rows = 0
     for line in text.split("\n"):
-        width = _display_width(line)
+        width = display_width(line)
         rows += max(1, (width + columns - 1) // columns)
     return rows
 
@@ -523,7 +523,7 @@ def _decode_diffusion_masked_draft(
 
     flush_tokens()
     text = " ".join(piece for piece in pieces if piece)
-    return _escape_carriage_returns(text)
+    return escape_carriage_returns(text)
 
 
 def stream_diffusion_generate(

--- a/mlx_vlm/generate/diffusion.py
+++ b/mlx_vlm/generate/diffusion.py
@@ -4,13 +4,17 @@ import logging
 import os
 import shutil
 import time
-import unicodedata
 from typing import Any, Dict, Generator, List, Optional, Tuple
 
 import mlx.core as mx
 import mlx.nn as nn
 from transformers import PreTrainedTokenizer
 
+from ..models.diffusion_visualizer import (
+    _clip_display_width,
+    _display_width,
+    _escape_carriage_returns,
+)
 from ..tokenizer_utils import make_streaming_detokenizer
 from .common import (
     GenerationResult,
@@ -25,41 +29,6 @@ DEFAULT_TEMPERATURE = 0.0
 DEFAULT_DIFFUSION_MIN_CANVAS_LENGTH = 64
 DEFAULT_DIFFUSION_MAX_DENOISING_STEPS = 48
 DEFAULT_DIFFUSION_UNMASKING_WIDTH = 0
-
-
-def _display_width(text: str) -> int:
-    width = 0
-    for char in text:
-        if unicodedata.combining(char):
-            continue
-        width += 2 if unicodedata.east_asian_width(char) in ("F", "W") else 1
-    return width
-
-
-def _clip_display_width(text: str, max_width: int) -> str:
-    if max_width <= 0:
-        return ""
-
-    out = []
-    width = 0
-    clipped = False
-    for char in text:
-        if unicodedata.combining(char):
-            char_width = 0
-        else:
-            char_width = 2 if unicodedata.east_asian_width(char) in ("F", "W") else 1
-        if width + char_width > max_width:
-            clipped = True
-            break
-        out.append(char)
-        width += char_width
-
-    if clipped and max_width >= 3:
-        while out and _display_width("".join(out)) > max_width - 3:
-            out.pop()
-        out.append("...")
-
-    return "".join(out)
 
 
 def _diffusion_display_limit(requested_width: Optional[int] = None) -> Optional[int]:
@@ -85,10 +54,11 @@ def _format_diffusion_draft_line(
     response: GenerationResult,
     requested_width: Optional[int] = None,
 ) -> str:
+    text = _escape_carriage_returns(response.draft_text)
     width = _diffusion_display_limit(requested_width)
     if width is None:
-        return response.draft_text
-    return _clip_display_width(response.draft_text, width)
+        return text
+    return _clip_display_width(text, width)
 
 
 def _print_diffusion_draft(
@@ -103,10 +73,10 @@ def _format_diffusion_live_text(
     text: str,
     requested_width: Optional[int] = None,
     *,
-    preserve_newlines: bool = False,
+    preserve_newlines: bool = True,
 ) -> str:
     width = _diffusion_display_limit(requested_width)
-    text = text.replace("\r", "\\r")
+    text = _escape_carriage_returns(text)
     if not preserve_newlines:
         text = text.replace("\n", "\\n")
     if width is None:
@@ -553,8 +523,7 @@ def _decode_diffusion_masked_draft(
 
     flush_tokens()
     text = " ".join(piece for piece in pieces if piece)
-    text = text.replace("\r", "\\r").replace("\n", "\\n")
-    return text
+    return _escape_carriage_returns(text)
 
 
 def stream_diffusion_generate(

--- a/mlx_vlm/models/diffusion_gemma/visualizer.py
+++ b/mlx_vlm/models/diffusion_gemma/visualizer.py
@@ -19,6 +19,7 @@ from typing import Any, Dict, Optional
 from ..diffusion_visualizer import (
     _CanvasRedrawer,
     _display_width,
+    _escape_carriage_returns,
     _take_display_width,
     _wrap_text,
 )
@@ -37,7 +38,7 @@ class DiffusionGemma4Visualizer:
         if not canvas:
             return
         self.redrawer.draw(
-            canvas.replace("\r", "\\r"),
+            _escape_carriage_returns(canvas),
             wrap_width=self.wrap_width if self.wrap_width else None,
         )
 
@@ -138,6 +139,7 @@ def install_output_handler_patch() -> None:
 __all__ = [
     "_CanvasRedrawer",
     "_display_width",
+    "_escape_carriage_returns",
     "_take_display_width",
     "_wrap_text",
     "DiffusionGemma4Visualizer",

--- a/mlx_vlm/models/diffusion_gemma/visualizer.py
+++ b/mlx_vlm/models/diffusion_gemma/visualizer.py
@@ -18,10 +18,10 @@ from typing import Any, Dict, Optional
 
 from ..diffusion_visualizer import (
     _CanvasRedrawer,
-    _display_width,
-    _escape_carriage_returns,
     _take_display_width,
     _wrap_text,
+    display_width,
+    escape_carriage_returns,
 )
 
 
@@ -38,7 +38,7 @@ class DiffusionGemma4Visualizer:
         if not canvas:
             return
         self.redrawer.draw(
-            _escape_carriage_returns(canvas),
+            escape_carriage_returns(canvas),
             wrap_width=self.wrap_width if self.wrap_width else None,
         )
 
@@ -138,11 +138,11 @@ def install_output_handler_patch() -> None:
 
 __all__ = [
     "_CanvasRedrawer",
-    "_display_width",
-    "_escape_carriage_returns",
     "_take_display_width",
     "_wrap_text",
     "DiffusionGemma4Visualizer",
+    "display_width",
+    "escape_carriage_returns",
     "install_output_handler_patch",
     "make_unmasking_visualizer",
 ]

--- a/mlx_vlm/models/diffusion_visualizer.py
+++ b/mlx_vlm/models/diffusion_visualizer.py
@@ -8,9 +8,11 @@ models. The diffusion_gemma package builds its text-stream visualizer on
 the same ``_CanvasRedrawer``.
 
 Rendering lives with the models; the shared generation engine in
-``mlx_vlm.generate.diffusion`` keeps its own draft-text redrawer untouched.
+``mlx_vlm.generate.diffusion`` only reuses the terminal text helpers for its
+fallback draft-text redrawer.
 """
 
+import re
 import shutil
 import time
 import unicodedata
@@ -24,6 +26,41 @@ def _display_width(text: str) -> int:
             continue
         width += 2 if unicodedata.east_asian_width(char) in ("F", "W") else 1
     return width
+
+
+def _escape_carriage_returns(text: str) -> str:
+    return text.replace("\r", "\\r")
+
+
+def _clip_display_width(text: str, max_width: int) -> str:
+    if max_width <= 0:
+        return ""
+
+    if "\n" in text:
+        return "\n".join(
+            _clip_display_width(line, max_width) for line in text.split("\n")
+        )
+
+    out = []
+    width = 0
+    clipped = False
+    for char in text:
+        if unicodedata.combining(char):
+            char_width = 0
+        else:
+            char_width = 2 if unicodedata.east_asian_width(char) in ("F", "W") else 1
+        if width + char_width > max_width:
+            clipped = True
+            break
+        out.append(char)
+        width += char_width
+
+    if clipped and max_width >= 3:
+        while out and _display_width("".join(out)) > max_width - 3:
+            out.pop()
+        out.append("...")
+
+    return "".join(out)
 
 
 def _take_display_width(text: str, width: int) -> str:
@@ -49,15 +86,24 @@ def _wrap_text(text: str, width: int) -> str:
     for raw_line in text.split("\n"):
         line = ""
         line_width = 0
-        for word in raw_line.split(" "):
+        for word in re.findall(r" *[^ ]+| +", raw_line):
             word_width = _display_width(word)
-            separator = 1 if line else 0
-            if line_width + separator + word_width <= width:
-                line += (" " if separator else "") + word
-                line_width += separator + word_width
+            if line and line_width + word_width > width:
+                wrapped_lines.append(line.rstrip(" "))
+                line = ""
+                line_width = 0
+                word = word.lstrip(" ")
+                word_width = _display_width(word)
+                if not word:
+                    continue
+
+            if line_width + word_width <= width:
+                line += word
+                line_width += word_width
                 continue
+
             if line:
-                wrapped_lines.append(line)
+                wrapped_lines.append(line.rstrip(" "))
             while word_width > width:
                 head = _take_display_width(word, width)
                 wrapped_lines.append(head)
@@ -186,7 +232,7 @@ class DiffusionUnmaskingVisualizer:
         piece = self.tokenizer.decode(
             [token_id], skip_special_tokens=self.skip_special_tokens
         )
-        return piece.replace("\n", "\\n") or " "
+        return _escape_carriage_returns(piece) or " "
 
     def visualize(self, tokens: Any, force: bool = False) -> None:
         if not self.active:

--- a/mlx_vlm/models/diffusion_visualizer.py
+++ b/mlx_vlm/models/diffusion_visualizer.py
@@ -19,7 +19,7 @@ import unicodedata
 from typing import Any, Optional
 
 
-def _display_width(text: str) -> int:
+def display_width(text: str) -> int:
     width = 0
     for char in text:
         if unicodedata.combining(char):
@@ -28,17 +28,17 @@ def _display_width(text: str) -> int:
     return width
 
 
-def _escape_carriage_returns(text: str) -> str:
+def escape_carriage_returns(text: str) -> str:
     return text.replace("\r", "\\r")
 
 
-def _clip_display_width(text: str, max_width: int) -> str:
+def clip_display_width(text: str, max_width: int) -> str:
     if max_width <= 0:
         return ""
 
     if "\n" in text:
         return "\n".join(
-            _clip_display_width(line, max_width) for line in text.split("\n")
+            clip_display_width(line, max_width) for line in text.split("\n")
         )
 
     out = []
@@ -56,7 +56,7 @@ def _clip_display_width(text: str, max_width: int) -> str:
         width += char_width
 
     if clipped and max_width >= 3:
-        while out and _display_width("".join(out)) > max_width - 3:
+        while out and display_width("".join(out)) > max_width - 3:
             out.pop()
         out.append("...")
 
@@ -67,7 +67,7 @@ def _take_display_width(text: str, width: int) -> str:
     taken = ""
     taken_width = 0
     for char in text:
-        char_width = _display_width(char)
+        char_width = display_width(char)
         if taken_width + char_width > width:
             break
         taken += char
@@ -87,13 +87,13 @@ def _wrap_text(text: str, width: int) -> str:
         line = ""
         line_width = 0
         for word in re.findall(r" *[^ ]+| +", raw_line):
-            word_width = _display_width(word)
+            word_width = display_width(word)
             if line and line_width + word_width > width:
                 wrapped_lines.append(line.rstrip(" "))
                 line = ""
                 line_width = 0
                 word = word.lstrip(" ")
-                word_width = _display_width(word)
+                word_width = display_width(word)
                 if not word:
                     continue
 
@@ -108,7 +108,7 @@ def _wrap_text(text: str, width: int) -> str:
                 head = _take_display_width(word, width)
                 wrapped_lines.append(head)
                 word = word[len(head) :]
-                word_width = _display_width(word)
+                word_width = display_width(word)
             line = word
             line_width = word_width
         wrapped_lines.append(line)
@@ -232,7 +232,7 @@ class DiffusionUnmaskingVisualizer:
         piece = self.tokenizer.decode(
             [token_id], skip_special_tokens=self.skip_special_tokens
         )
-        return _escape_carriage_returns(piece) or " "
+        return escape_carriage_returns(piece) or " "
 
     def visualize(self, tokens: Any, force: bool = False) -> None:
         if not self.active:

--- a/mlx_vlm/models/llada2_moe/language.py
+++ b/mlx_vlm/models/llada2_moe/language.py
@@ -424,7 +424,6 @@ class LanguageModel(nn.Module):
         x = mx.concatenate([inputs, x[:, prompt_length:]], axis=1)
         prefill_blocks = prompt_length // block_length
         display_end = prompt_length + gen_length
-        visualizer.visualize(x[:, prompt_length:display_end], force=True)
         prompt_tic = time.perf_counter()
         recorded_prompt_time = False
         prefix_cache = [StaticPrefixKVCache(total_length) for _ in self.layers]
@@ -465,6 +464,17 @@ class LanguageModel(nn.Module):
             prompt_mask = block_start + block_positions < prompt_length
             block_cache = [StaticPrefixKVCache.from_prefix(c) for c in prefix_cache]
             eos_block_index = None
+            block_display_end = min(current_window_end, display_end)
+
+            def visualize_current_block(force: bool = False) -> None:
+                if not visualizer.active or block_display_end <= prompt_length:
+                    return
+                visualizer.visualize(
+                    x[:, prompt_length:block_display_end],
+                    force=force,
+                )
+
+            visualize_current_block(force=True)
 
             post_steps = 0
             stable_steps = 0
@@ -538,7 +548,7 @@ class LanguageModel(nn.Module):
                 cur_x = mx.concatenate([cur_x[:, :-block_length], new_block], axis=1)
                 if visualizer.active and bool(final_mask.any().item()):
                     x = mx.concatenate([cur_x, x[:, current_window_end:]], axis=1)
-                    visualizer.visualize(x[:, prompt_length:display_end])
+                    visualize_current_block()
 
                 has_edit = bool(edit_mask.any().item())
                 if eos_early_stop and eos_block_index is None and not has_active:

--- a/mlx_vlm/tests/test_diffusion_gemma.py
+++ b/mlx_vlm/tests/test_diffusion_gemma.py
@@ -975,7 +975,7 @@ class TestDiffusionGemma4(unittest.TestCase):
 
         self.assertEqual(transfer.tolist(), [[False, True, True, True]])
 
-    def test_unmasking_display_has_no_prefix_or_real_newlines(self):
+    def test_unmasking_display_has_no_prefix_and_preserves_newlines(self):
         from mlx_vlm.generate import GenerationResult
         from mlx_vlm.generate.diffusion import (
             _format_diffusion_draft_line,
@@ -984,15 +984,41 @@ class TestDiffusionGemma4(unittest.TestCase):
 
         draft = GenerationResult(
             is_draft=True,
-            draft_text="[Mask] Hello",
+            draft_text="[Mask]\nHello",
             diffusion_canvas_index=1,
             diffusion_step=1,
             diffusion_total_steps=4,
         )
 
-        self.assertEqual(_format_diffusion_draft_line(draft, 80), "[Mask] Hello")
+        self.assertEqual(_format_diffusion_draft_line(draft, 80), "[Mask]\nHello")
         self.assertEqual(
-            _format_diffusion_live_text("hello\nworld", 80), "hello\\nworld"
+            _format_diffusion_live_text("hello\nworld", 80),
+            "hello\nworld",
+        )
+        self.assertEqual(
+            _format_diffusion_live_text(
+                "hello\nworld",
+                80,
+                preserve_newlines=False,
+            ),
+            "hello\\nworld",
+        )
+
+    def test_diffusion_masked_draft_decode_preserves_newlines(self):
+        from mlx_vlm.generate.diffusion import _decode_diffusion_masked_draft
+
+        class NewlineTokenizer:
+            def decode(self, tokens, skip_special_tokens=False):
+                return "hello\nworld"
+
+        self.assertEqual(
+            _decode_diffusion_masked_draft(
+                NewlineTokenizer(),
+                [1],
+                [True],
+                skip_special_token_ids=[],
+            ),
+            "hello\nworld",
         )
 
     def test_unmasking_display_is_untrimmed_by_default(self):
@@ -1121,6 +1147,19 @@ class TestDiffusionVisualization(unittest.TestCase):
         # A single overlong word is hard-split.
         self.assertEqual(_wrap_text("abcdef", 3), "abc\ndef")
 
+    def test_wrap_text_preserves_code_block_indentation(self):
+        from mlx_vlm.models.diffusion_gemma.visualizer import _wrap_text
+
+        code = (
+            "import random\n\n"
+            "def calculate_pi_monte_carlo(iterations):\n"
+            "    inside_circle = 0\n"
+            "    \n"
+            "    for _ in range(iterations):"
+        )
+
+        self.assertEqual(_wrap_text(code, 80), code)
+
     def test_redrawer_overwrites_frames_in_place(self):
         import contextlib
         import io
@@ -1217,16 +1256,16 @@ class TestDiffusionVisualization(unittest.TestCase):
         visualizer.redrawer = FakeRedrawer()
 
         class FakeDraft:
-            draft_text = "[Mask] world"
+            draft_text = "[Mask]\nworld"
 
-        visualizer.handle_text("Hello.")
+        visualizer.handle_text("Hello.\n")
         visualizer.handle_draft(FakeDraft())
-        self.assertEqual(drawn[-1], "Hello.[Mask] world")
+        self.assertEqual(drawn[-1], "Hello.\n[Mask]\nworld")
 
         visualizer.handle_text(" Bye.")
-        self.assertEqual(drawn[-1], "Hello. Bye.")
+        self.assertEqual(drawn[-1], "Hello.\n Bye.")
 
-        visualizer.finish("Hello. Bye.")
+        visualizer.finish("Hello.\n Bye.")
         self.assertIn("<finish>", drawn)
 
     def test_output_handler_delegates_to_model_visualizer(self):

--- a/mlx_vlm/tests/test_diffusion_models.py
+++ b/mlx_vlm/tests/test_diffusion_models.py
@@ -588,6 +588,40 @@ class TestMaskedDiffusionServerLane(unittest.TestCase):
 
         self.assertEqual(len(calls), 1)
 
+    def test_unmasking_visualizer_preserves_decoded_newlines(self):
+        from mlx_vlm.models.diffusion_visualizer import DiffusionUnmaskingVisualizer
+
+        class NewlineTokenizer:
+            def decode(self, tokens, skip_special_tokens=False):
+                token = int(tokens[0])
+                if token == 5:
+                    return "\n"
+                return str(token)
+
+        visualizer = DiffusionUnmaskingVisualizer(
+            active=True,
+            mask_id=127,
+            eos_token_ids=[],
+            tokenizer=NewlineTokenizer(),
+            min_interval=0.0,
+        )
+        drawn = []
+
+        class FakeRedrawer:
+            def throttled(self):
+                return False
+
+            def draw(self, text, force=False):
+                drawn.append(text)
+
+            def finish(self):
+                pass
+
+        visualizer.redrawer = FakeRedrawer()
+        visualizer.visualize(mx.array([[4, 5, 6]], dtype=mx.int32), force=True)
+
+        self.assertEqual(drawn[-1], "4\n6")
+
     def test_diffusion_generation_family_routing(self):
         from mlx_vlm.generate.diffusion import diffusion_generation_family
 

--- a/mlx_vlm/tests/test_diffusion_models.py
+++ b/mlx_vlm/tests/test_diffusion_models.py
@@ -588,6 +588,43 @@ class TestMaskedDiffusionServerLane(unittest.TestCase):
 
         self.assertEqual(len(calls), 1)
 
+    def test_llada_unmasking_visualizes_current_block(self):
+        from mlx_vlm.models.llada2_moe import language as llada_language
+
+        mx.random.seed(0)
+        model = self._tiny_llada()
+        calls = []
+        original_visualizer = llada_language.DiffusionUnmaskingVisualizer
+
+        class FakeVisualizer:
+            def __init__(self, **kwargs):
+                self.active = True
+
+            def visualize(self, tokens, force=False):
+                calls.append((tokens.shape[1], force))
+
+            def finish(self):
+                pass
+
+        llada_language.DiffusionUnmaskingVisualizer = FakeVisualizer
+        try:
+            model.language_model.generate(
+                mx.array([[4, 5, 6, 7]], dtype=mx.int32),
+                gen_length=8,
+                block_length=4,
+                steps=1,
+                eos_early_stop=False,
+                visualize=True,
+                mask_id=127,
+                eos_id=999,
+            )
+        finally:
+            llada_language.DiffusionUnmaskingVisualizer = original_visualizer
+
+        force_lengths = [length for length, force in calls if force]
+        self.assertEqual(force_lengths, [4, 8])
+        self.assertEqual(calls[0], (4, True))
+
     def test_unmasking_visualizer_preserves_decoded_newlines(self):
         from mlx_vlm.models.diffusion_visualizer import DiffusionUnmaskingVisualizer
 


### PR DESCRIPTION
## Summary

- Preserve real newlines in diffusion draft/live visualization output, including decoded newline tokens from masked-diffusion models.
- Preserve code-block indentation by keeping leading space runs intact during visualizer wrapping.
- Scope LLaDA2 MoE live `[MASK]` preview to the active generation block while keeping committed text visible, matching the DiffusionGemma-style per-block view.
- Promote shared terminal text helpers to public names: `display_width`, `clip_display_width`, and `escape_carriage_returns`.

## Why

Diffusion unmasking output should look like the text being generated. Escaping newlines and collapsing leading spaces made multi-line/code-like output hard to read, while LLaDA showed `[MASK]` placeholders all the way out to `max_tokens` instead of only the current block.

## Validation

- `.venv/bin/python -m py_compile mlx_vlm/models/diffusion_visualizer.py mlx_vlm/generate/diffusion.py mlx_vlm/models/diffusion_gemma/visualizer.py mlx_vlm/models/llada2_moe/language.py mlx_vlm/tests/test_diffusion_gemma.py mlx_vlm/tests/test_diffusion_models.py`
- `.venv/bin/pytest mlx_vlm/tests/test_diffusion_gemma.py -q` -> `50 passed, 1 skipped`
- `.venv/bin/pytest mlx_vlm/tests/test_diffusion_models.py -q` -> `10 passed, 9 subtests passed`
- `git diff --check`
