### PR TITLE
fix(gemma4): allow colon and dot in tool-call function names

### DIFF
--- a/mlx_vlm/tests/test_gemma4_tool_parser.py
+++ b/mlx_vlm/tests/test_gemma4_tool_parser.py
@@ -69,6 +69,31 @@ class TestGemma4ToolParser(unittest.TestCase):
             [{"newText": "orange", "oldText": "apple"}],
         )
 
+    # ── colon-namespaced names (MCP server:tool, agent toolsets) ──────────
+
+    def test_colon_namespaced_name(self):
+        text = _wrap(f"call:server:tool{{location:{_str('Zurich')}}}")
+        result = parse_tool_call(text)
+        self.assertEqual(result["name"], "server:tool")
+        args = json.loads(result["arguments"])
+        self.assertEqual(args, {"location": "Zurich"})
+
+    def test_colon_namespaced_name_with_multiple_args(self):
+        text = _wrap(
+            f"call:google-workspace:google-workspace{{action:{_str('list_events')},calendar_id:{_str('primary')}}}"
+        )
+        result = parse_tool_call(text)
+        self.assertEqual(result["name"], "google-workspace:google-workspace")
+        args = json.loads(result["arguments"])
+        self.assertEqual(args, {"action": "list_events", "calendar_id": "primary"})
+
+    def test_dotted_name(self):
+        text = _wrap(f"call:math.add{{a:1,b:2}}")
+        result = parse_tool_call(text)
+        self.assertEqual(result["name"], "math.add")
+        args = json.loads(result["arguments"])
+        self.assertEqual(args, {"a": 1, "b": 2})
+
     # ── arguments type ────────────────────────────────────────────────────
 
     def test_arguments_is_json_string(self):

--- a/mlx_vlm/tool_parsers/gemma4.py
+++ b/mlx_vlm/tool_parsers/gemma4.py
@@ -140,10 +140,12 @@ def _parse_array(text):
 
 # Regex that captures the function name and uses a recursive pattern to
 # match the balanced outer braces (handles arbitrary nesting).
-# Function name uses ``[\w-]+`` (alphanumerics, underscore, hyphen) per the
-# OpenAI tool name spec.
+# Function name allows alphanumerics, underscore, hyphen, plus ':' and '.' so
+# colon-namespaced toolset names (MCP ``server:tool``,
+# ``google-workspace:google-workspace``) parse instead of being dropped at the
+# first colon.
 _tool_call_regex = re.compile(
-    r"call:([\w-]+)(\{(?:[^{}]|\{(?:[^{}]|\{[^{}]*\})*\})*\})"
+    r"call:([\w.:-]+)(\{(?:[^{}]|\{(?:[^{}]|\{[^{}]*\})*\})*\})"
 )
 
 
@@ -152,7 +154,7 @@ def parse_tool_call(text, tools=None):
     match = _tool_call_regex.search(text)
     if not match:
         # Fallback: find 'call:<name>{' and then balance braces manually
-        m = re.search(r"call:([\w-]+)\{", text)
+        m = re.search(r"call:([\w.:-]+)\{", text)
         if not m:
             raise ValueError("No function call found in tool call text.")
         func_name = m.group(1)


### PR DESCRIPTION
Fixes #1365.

### Problem

The gemma4 tool-call name regex `call:([\w-]+)` matches only word characters and hyphens. Colon-namespaced names — MCP `server:tool` and agent toolsets such as Hermes's `google-workspace:google-workspace` — are dropped at the first colon, raising `No function call found` and surfacing in logs as `Invalid tool call`. The model receives no tool result, reformats, and retries, wasting turns/latency/tokens.

```python
from mlx_vlm.tool_parsers.gemma4 import parse_tool_call
parse_tool_call('call:google-workspace:google-workspace{action:<|"|>list_events<|"|>}')
# before: ValueError: No function call found in tool call text.
```

### Fix

Widen the name class to `[\w.:-]+` at both regex sites (`_tool_call_regex` and the manual-balance fallback). Also admits dotted names. Strictly additive — every previously-valid name parses identically.

### Tests

Added `test_colon_namespaced_name`, `test_colon_namespaced_name_with_multiple_args`, and `test_dotted_name`. Full suite green:

```
$ python -m unittest mlx_vlm.tests.test_gemma4_tool_parser
Ran 10 tests ... OK
```
