### PR TITLE
[Cohere] Fix streaming thinking parsing after prompt-opened

### DIFF
--- a/mlx_vlm/server/openai.py
+++ b/mlx_vlm/server/openai.py
@@ -1455,7 +1455,8 @@ async def chat_completions_endpoint(request: ChatRequest, http_request: Request)
 
                         output_tokens = 0
                         request_id = f"chatcmpl-{uuid.uuid4()}"
-                        thinking_state = ThinkingStreamState(
+                        thinking_state = ThinkingStreamState.from_prompt(
+                            formatted_prompt,
                             gen_args.enable_thinking,
                             gen_args.thinking_start_token,
                             gen_args.thinking_end_token,
@@ -1592,7 +1593,8 @@ async def chat_completions_endpoint(request: ChatRequest, http_request: Request)
 
                         request_id = f"chatcmpl-{uuid.uuid4()}"
                         output_text = ""
-                        thinking_state = ThinkingStreamState(
+                        thinking_state = ThinkingStreamState.from_prompt(
+                            formatted_prompt,
                             gen_args.enable_thinking,
                             gen_args.thinking_start_token,
                             gen_args.thinking_end_token,

--- a/mlx_vlm/server/responses_state.py
+++ b/mlx_vlm/server/responses_state.py
@@ -58,6 +58,22 @@ class ThinkingStreamState:
         self.thinking_done = False
         self.buffer = ""
 
+    @classmethod
+    def from_prompt(
+        cls,
+        formatted_prompt: str,
+        enable_thinking: bool = False,
+        thinking_start_token: Optional[str] = None,
+        thinking_end_token: Optional[str] = None,
+    ):
+        state = cls(enable_thinking, thinking_start_token, thinking_end_token)
+        # Some prompts end with an open thinking marker, so generation starts
+        # inside reasoning and should stay there until the close marker appears.
+        state.in_thinking = state.in_thinking or formatted_prompt.rstrip().endswith(
+            state.open_markers
+        )
+        return state
+
     def feed(self, text: str) -> ThinkingStreamDelta:
         self.buffer += text or ""
         reasoning = []

--- a/mlx_vlm/tests/test_server.py
+++ b/mlx_vlm/tests/test_server.py
@@ -1823,6 +1823,68 @@ def test_chat_completions_streaming_uses_custom_thinking_markers(client, monkeyp
     assert "".join(delta.get("content") or "" for delta in deltas) == ("Custom answer.")
 
 
+def test_chat_completions_streaming_continues_prompt_thinking_block(
+    client, monkeypatch
+):
+    model = SimpleNamespace()
+    processor = SimpleNamespace()
+    config = SimpleNamespace(model_type="custom")
+    open_marker, close_marker = server.ThinkingStreamState().open_close_markers[-1]
+
+    class FakeResponseGenerator:
+        tokenizer = SimpleNamespace(decode=lambda tokens: "")
+
+        def validate_context_budget(self, prompt, images=None, audio=None, args=None):
+            return None
+
+        def generate(self, prompt, images=None, audio=None, args=None):
+            return server.GenerationContext(uid=1, prompt_tokens=8), iter(
+                [
+                    server.StreamingToken(
+                        text=f"Reasoning.{close_marker}Answer.",
+                        token=1,
+                        logprobs=0.0,
+                        finish_reason="stop",
+                    )
+                ]
+            )
+
+    monkeypatch.setattr(server.runtime, "response_generator", FakeResponseGenerator())
+
+    with (
+        patch.object(
+            server, "get_cached_model", return_value=(model, processor, config)
+        ),
+        patch.object(
+            server, "apply_chat_template", return_value=f"prompt{open_marker}"
+        ),
+    ):
+        response = client.post(
+            "/chat/completions",
+            json={
+                "model": "demo",
+                "messages": [{"role": "user", "content": "Hello"}],
+                "stream": True,
+            },
+        )
+
+    chunks = [
+        json.loads(line[len("data: ") :])
+        for line in response.text.splitlines()
+        if line.startswith("data: ") and line != "data: [DONE]"
+    ]
+    deltas = [
+        chunk["choices"][0]["delta"]
+        for chunk in chunks
+        if chunk.get("choices") and chunk["choices"][0].get("delta")
+    ]
+
+    assert response.status_code == 200
+    assert "".join(delta.get("reasoning") or "" for delta in deltas) == "Reasoning."
+    assert "".join(delta.get("content") or "" for delta in deltas) == "Answer."
+    assert close_marker not in response.text
+
+
 @pytest.mark.parametrize(
     "audio_data_factory",
     [


### PR DESCRIPTION
## Summary
- Start chat-completions streaming in reasoning mode when the formatted prompt already ends with a known thinking start marker.
- Add test coverage.

## Test plan
- `python -m pytest mlx_vlm/tests/test_server.py -k "continues_prompt_thinking_block"`