### PR TITLE
[Fix] interleaved reasoning

### DIFF
--- a/mlx_vlm/server/openai.py
+++ b/mlx_vlm/server/openai.py
@@ -1374,6 +1374,8 @@ async def chat_completions_endpoint(request: ChatRequest, http_request: Request)
                 msg["tool_call_id"] = message.tool_call_id
             if message.name is not None:
                 msg["name"] = message.name
+            if message.reasoning is not None:
+                msg["reasoning"] = message.reasoning
 
             processed_messages.append(msg)
 

--- a/mlx_vlm/tests/test_server.py
+++ b/mlx_vlm/tests/test_server.py
@@ -2194,6 +2194,53 @@ def test_chat_completions_endpoint_flattens_text_content_parts(client):
     ]
 
 
+def test_chat_completions_endpoint_preserves_assistant_reasoning(client):
+    model = SimpleNamespace()
+    processor = SimpleNamespace()
+    config = SimpleNamespace(model_type="qwen2_vl")
+    result = GenerationResult(
+        text="done",
+        prompt_tokens=8,
+        generation_tokens=4,
+        total_tokens=12,
+        prompt_tps=10.0,
+        generation_tps=5.0,
+        peak_memory=0.1,
+    )
+
+    with (
+        patch.object(
+            server, "get_cached_model", return_value=(model, processor, config)
+        ),
+        patch.object(
+            server, "apply_chat_template", return_value="prompt"
+        ) as mock_template,
+        patch.object(server, "generate", return_value=result),
+    ):
+        response = client.post(
+            "/chat/completions",
+            json={
+                "model": "demo",
+                "messages": [
+                    {"role": "user", "content": "Hi"},
+                    {
+                        "role": "assistant",
+                        "content": "Hello",
+                        "reasoning": "Prior thought",
+                    },
+                    {"role": "user", "content": "Continue"},
+                ],
+            },
+        )
+
+    assert response.status_code == 200
+    assert mock_template.call_args.args[2][1] == {
+        "role": "assistant",
+        "content": "Hello",
+        "reasoning": "Prior thought",
+    }
+
+
 def test_anthropic_messages_endpoint_maps_text_and_images(client, monkeypatch):
     monkeypatch.setattr(server.runtime, "response_generator", None)
     model = SimpleNamespace()


### PR DESCRIPTION
## Summary
- Preserve incoming assistant `reasoning` when normalizing chat-completions messages.
- Allows clients with interleaved reasoning, such as OpenCode, to include prior assistant reasoning in the next formatted prompt.
- Add focused test coverage to ensure assistant reasoning reaches `apply_chat_template`.

## Test plan
- `python -m pytest mlx_vlm/tests/test_server.py -k "preserves_assistant_reasoning"`