### PR TITLE
Fix token_context desync that crashes continuous batching

### DIFF
--- a/mlx_vlm/generate/ar.py
+++ b/mlx_vlm/generate/ar.py
@@ -880,7 +880,13 @@ class GenerationBatch:
         if not (force or (self.logits_processors and any(self.logits_processors))):
             if not self.logits_processors:
                 self.token_context = []
-            return
+                return
+            if not self.token_context:
+                return
+            # token_context was populated while a processor was active and is
+            # still carried after that sequence left the batch. Fall through to
+            # keep it aligned with uids so filter() can reindex it safely even
+            # though no processor is currently active.
         if len(self.token_context) < len(self.uids):
             missing = len(self.uids) - len(self.token_context)
             self.token_context.extend([[] for _ in range(missing)])

--- a/mlx_vlm/tests/test_generate.py
+++ b/mlx_vlm/tests/test_generate.py
@@ -816,6 +816,121 @@ class TestBatchGenerator:
         assert [r.token for r in first] == [5, 6, 7]
         assert seen_contexts == [[30, 7]]
 
+    def test_generation_batch_extend_aligns_token_context_without_active_processor(
+        self,
+    ):
+        # A batch can carry a populated token_context while having no *active*
+        # processor: the state left behind after a guided/json-schema request
+        # (which populates token_context for the whole batch) has finished.
+        # Admitting a plain request must keep token_context aligned with uids;
+        # otherwise filter() later indexes past the end of token_context.
+        # (logits_processors=[None] is a reserved per-sequence slot with no
+        # active processor -- distinct from an empty [] processor list.)
+        sampler = lambda logprobs: mx.argmax(logprobs, axis=-1)
+        stop_criteria = lambda token: False
+        leftover = GenerationBatch(
+            model=MagicMock(),
+            uids=[0],
+            inputs=mx.array([5], dtype=mx.int32),
+            prompt_cache=[],
+            sampler=sampler,
+            stop_criteria=stop_criteria,
+            max_tokens=[8],
+            token_context=[[30]],
+            logits_processors=[None],
+        )
+        plain = GenerationBatch(
+            model=MagicMock(),
+            uids=[1],
+            inputs=mx.array([6], dtype=mx.int32),
+            prompt_cache=[],
+            sampler=sampler,
+            stop_criteria=stop_criteria,
+            max_tokens=[8],
+            logits_processors=[None],
+        )
+
+        leftover.extend(plain)
+
+        assert len(leftover.token_context) == len(leftover.uids)
+        assert leftover.token_context == [[30], []]
+
+    def test_generation_batch_filter_after_processorless_extend_does_not_raise(self):
+        # Regression: extend() of a leftover-guided batch with a plain batch used
+        # to leave token_context shorter than uids when neither side had an
+        # active processor, so the next eviction raised "IndexError: list index
+        # out of range" in filter().
+        sampler = lambda logprobs: mx.argmax(logprobs, axis=-1)
+        stop_criteria = lambda token: False
+        leftover = GenerationBatch(
+            model=MagicMock(),
+            uids=[0],
+            inputs=mx.array([5], dtype=mx.int32),
+            prompt_cache=[],
+            sampler=sampler,
+            stop_criteria=stop_criteria,
+            max_tokens=[8],
+            token_context=[[30]],
+            logits_processors=[None],
+        )
+        plain = GenerationBatch(
+            model=MagicMock(),
+            uids=[1],
+            inputs=mx.array([6], dtype=mx.int32),
+            prompt_cache=[],
+            sampler=sampler,
+            stop_criteria=stop_criteria,
+            max_tokens=[8],
+            logits_processors=[None],
+        )
+        leftover.extend(plain)
+
+        leftover.filter([1])
+
+        assert leftover.uids == [1]
+        assert len(leftover.token_context) == len(leftover.uids)
+
+    def test_generation_batch_repeated_processorless_extend_stays_aligned(self):
+        # Recurring continuous-batching scenario: a guided request leaves dead
+        # token_context behind, then several plain requests are admitted one
+        # after another. Every extend() must keep token_context aligned with
+        # uids so the eventual eviction does not IndexError in filter().
+        sampler = lambda logprobs: mx.argmax(logprobs, axis=-1)
+        stop_criteria = lambda token: False
+
+        def plain(uid, tok):
+            return GenerationBatch(
+                model=MagicMock(),
+                uids=[uid],
+                inputs=mx.array([tok], dtype=mx.int32),
+                prompt_cache=[],
+                sampler=sampler,
+                stop_criteria=stop_criteria,
+                max_tokens=[8],
+                logits_processors=[None],
+            )
+
+        leftover = GenerationBatch(
+            model=MagicMock(),
+            uids=[0],
+            inputs=mx.array([5], dtype=mx.int32),
+            prompt_cache=[],
+            sampler=sampler,
+            stop_criteria=stop_criteria,
+            max_tokens=[8],
+            token_context=[[30]],
+            logits_processors=[None],
+        )
+
+        leftover.extend(plain(1, 6))
+        leftover.extend(plain(2, 7))
+        assert len(leftover.token_context) == len(leftover.uids) == 3
+
+        # Evict everything except the last sequence.
+        leftover.filter([2])
+        assert leftover.uids == [2]
+        assert len(leftover.token_context) == len(leftover.uids)
+
     def test_generation_batch_extend_promotes_singleton_kv_cache(self):
         def make_kv_cache(value):
             c = KVCache()


### PR DESCRIPTION
Fixes #1441

## Problem

Under continuous batching, `GenerationBatch.filter()` can raise `IndexError: list index out of range` at:

```python
self.token_context = [self.token_context[idx] for idx in keep]
```

It surfaces when the batch mixes a request that uses a logits processor (e.g. `response_format` / json-schema guided decoding, which populates `token_context` for the whole batch) with plain requests: once the guided request leaves the batch no processor is active, and a plain request is then admitted via `extend()`.

## Root cause

`GenerationBatch` keeps parallel per-sequence lists (`uids`, `token_context`, `logits_processors`, …) that must satisfy the invariant `len(token_context) ∈ {0, len(uids)}` — `filter()` reindexes `token_context` with indices valid for `uids` and relies on it.

`_ensure_token_context()` only pads/truncates `token_context` to `len(uids)` when `force` or an *active* processor is present; in the all-`None` branch it returns early, leaving a non-empty `token_context` unnormalized. `extend()` only realigns the two sides when at least one has an active processor, so when neither does, `self.token_context.extend(other.token_context)` can leave `token_context` non-empty but shorter than `uids`. The next eviction → `filter()` → `IndexError`.

## Fix

Make `_ensure_token_context()` also realign a *non-empty* `token_context` to `len(uids)` when no processor is active (fall through to the existing pad/truncate instead of returning early). The `_ensure_token_context()` call already at the end of `extend()` then repairs the desync. Padding with empty contexts is correct: a plain request has no constraint history, and that empty entry is never read for a sequence without an active processor (the `_step()` processor loop is gated on `any(self.logits_processors)` and skips `None` slots).

## Tests

Adds three model-free regression tests to `TestBatchGenerator` that reproduce the exact `extend()` + `filter()` desync (a leftover-guided batch + plain request(s)) and assert `len(token_context) == len(uids)` plus no `IndexError`. They fail before the fix and pass after; the full `test_generate.py` suite stays green.

