### PR TITLE
Fix Gemma 4 namespaced tool calls

### DIFF
--- a/mlx_vlm/tests/test_gemma4_tool_parser.py
+++ b/mlx_vlm/tests/test_gemma4_tool_parser.py
@@ -69,6 +69,22 @@ class TestGemma4ToolParser(unittest.TestCase):
             [{"newText": "orange", "oldText": "apple"}],
         )
 
+    def test_colon_namespaced_name(self):
+        text = _wrap(
+            f"call:google-workspace:google-workspace{{action:{_str('list_events')}}}"
+        )
+        result = parse_tool_call(text)
+        self.assertEqual(result["name"], "google-workspace:google-workspace")
+        args = json.loads(result["arguments"])
+        self.assertEqual(args, {"action": "list_events"})
+
+    def test_dotted_namespaced_name(self):
+        text = _wrap(f"call:mcp.calendar:list_events{{limit:5}}")
+        result = parse_tool_call(text)
+        self.assertEqual(result["name"], "mcp.calendar:list_events")
+        args = json.loads(result["arguments"])
+        self.assertEqual(args, {"limit": 5})
+
     # ── arguments type ────────────────────────────────────────────────────
 
     def test_arguments_is_json_string(self):

--- a/mlx_vlm/tool_parsers/gemma4.py
+++ b/mlx_vlm/tool_parsers/gemma4.py
@@ -140,10 +140,9 @@ def _parse_array(text):
 
 # Regex that captures the function name and uses a recursive pattern to
 # match the balanced outer braces (handles arbitrary nesting).
-# Function name uses ``[\w-]+`` (alphanumerics, underscore, hyphen) per the
-# OpenAI tool name spec.
+# Function name accepts common namespaced tool ids used by MCP and agents.
 _tool_call_regex = re.compile(
-    r"call:([\w-]+)(\{(?:[^{}]|\{(?:[^{}]|\{[^{}]*\})*\})*\})"
+    r"call:([\w.:-]+)(\{(?:[^{}]|\{(?:[^{}]|\{[^{}]*\})*\})*\})"
 )
 
 
@@ -152,7 +151,7 @@ def parse_tool_call(text, tools=None):
     match = _tool_call_regex.search(text)
     if not match:
         # Fallback: find 'call:<name>{' and then balance braces manually
-        m = re.search(r"call:([\w-]+)\{", text)
+        m = re.search(r"call:([\w.:-]+)\{", text)
         if not m:
             raise ValueError("No function call found in tool call text.")
         func_name = m.group(1)


### PR DESCRIPTION
## Summary
- widen the Gemma 4 tool-call name parser to accept namespaced tool ids with `.`, `:`, `_`, and `-`
- keep the manual brace-balancing fallback aligned with the main regex
- add regressions for colon- and dotted-namespaced tool calls

Fixes #1365.

## Validation
- `uv run --with pytest pytest mlx_vlm/tests/test_gemma4_tool_parser.py -q`
- pre-commit during commit: `black`, `isort`, `autoflake`