### PR TITLE
Fix color shift from tiled VAE in Flux.2 models

### DIFF
--- a/mlx_vlm/models/flux2/model.py
+++ b/mlx_vlm/models/flux2/model.py
@@ -233,8 +233,8 @@ class Flux2ImageEditModel(ImageEditModel):
             force_download=kwargs.pop("force_download", False),
             evict_text_encoder=kwargs.pop("evict_text_encoder", True),
             evict_transformer=kwargs.pop("evict_transformer", False),
-            bucketed_seq_len=kwargs.pop("bucketed_seq_len", True),
-            tiled_vae=kwargs.pop("tiled_vae", "auto"),
+            bucketed_seq_len=kwargs.pop("bucketed_seq_len", False),
+            tiled_vae=kwargs.pop("tiled_vae", "off"),
             max_sequence_length=kwargs.pop("max_sequence_length", 512),
         )
         return cls(pipeline=pipeline, model_id=str(model))

--- a/mlx_vlm/models/flux2/pipeline.py
+++ b/mlx_vlm/models/flux2/pipeline.py
@@ -12,7 +12,6 @@ import numpy as np
 from PIL import Image
 
 from mlx_vlm.models.flux2.config import Flux2Variant, get_variant, validate_dimensions
-from mlx_vlm.models.flux2.constants import ModelConfig
 from mlx_vlm.models.flux2.download import download_model, validate_model_layout
 from mlx_vlm.models.flux2.latent import (
     pack_latents,
@@ -565,7 +564,7 @@ def _load_reference_image(
 def _reference_image_array(image: Image.Image) -> mx.array:
     array = np.asarray(image).astype(np.float32) / 127.5 - 1.0
     array = np.transpose(array, (2, 0, 1))[None, ...]
-    return mx.array(array).astype(ModelConfig.precision)
+    return mx.array(array)
 
 
 def _crop_to_even_spatial(latents: mx.array) -> mx.array:

--- a/mlx_vlm/tests/test_flux2.py
+++ b/mlx_vlm/tests/test_flux2.py
@@ -4,7 +4,9 @@ import importlib
 from pathlib import Path
 
 import mlx.core as mx
+import numpy as np
 import pytest
+from PIL import Image
 
 import mlx_vlm.models.flux2.download as download_module
 from mlx_vlm.generate.edit_image import (
@@ -23,7 +25,12 @@ from mlx_vlm.models.flux2.config import (
 )
 from mlx_vlm.models.flux2.download import DOWNLOAD_PATTERNS, validate_model_layout
 from mlx_vlm.models.flux2.model import Flux2ImageEditModel, Flux2ImageGenerationModel
-from mlx_vlm.models.flux2.pipeline import Flux2Image, Flux2ImageEdit, Flux2RuntimeConfig
+from mlx_vlm.models.flux2.pipeline import (
+    Flux2Image,
+    Flux2ImageEdit,
+    Flux2RuntimeConfig,
+    _reference_image_array,
+)
 
 image_module = importlib.import_module("mlx_vlm.generate.image")
 
@@ -277,3 +284,35 @@ def test_flux2_standard_edit_model_reports_non_kv_path() -> None:
 
     assert result.variant == "flux2-klein-9b"
     assert result.metadata["uses_reference_kv_cache"] is False
+
+
+def test_flux2_edit_model_defaults_to_untiled_vae_decode(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls = []
+
+    def fake_from_pretrained(cls, variant, **kwargs):  # noqa: ARG001
+        calls.append(kwargs)
+        return _fake_edit_pipeline("flux2-klein-9b-kv")
+
+    monkeypatch.setattr(
+        Flux2ImageEdit, "from_pretrained", classmethod(fake_from_pretrained)
+    )
+
+    Flux2ImageEditModel.from_model_id("flux2-klein-9b-kv")
+    Flux2ImageEditModel.from_model_id(
+        "flux2-klein-9b-kv", bucketed_seq_len=True, tiled_vae="auto"
+    )
+
+    assert calls[0]["tiled_vae"] == "off"
+    assert calls[0]["bucketed_seq_len"] is False
+    assert calls[1]["tiled_vae"] == "auto"
+    assert calls[1]["bucketed_seq_len"] is True
+
+
+def test_flux2_reference_image_array_keeps_float32_input() -> None:
+    image = Image.new("RGB", (1, 1), color=(255, 127, 0))
+    array = _reference_image_array(image)
+
+    assert array.dtype == mx.float32
+    assert np.array(array).shape == (1, 3, 1, 1)


### PR DESCRIPTION
The tiled VAE from the Bonsai model (which shares backbone components) causes color shifting when decoding for Flux.2 models, so disable it by default.