### PR TITLE
Add optional API key for the server

### DIFF
--- a/mlx_vlm/server/app.py
+++ b/mlx_vlm/server/app.py
@@ -2,6 +2,7 @@ import asyncio
 import gc
 import logging
 import os
+import secrets
 import sys
 import time
 from contextlib import asynccontextmanager
@@ -54,8 +55,29 @@ from .schemas import ChatLogprobContent, ModelsResponse, TopLogprob
 
 DEFAULT_SERVER_HOST = "0.0.0.0"
 DEFAULT_SERVER_PORT = 8080
+SERVER_API_KEY_ENV = "MLX_VLM_SERVER_API_KEY"
 
 logger = logging.getLogger("mlx_vlm.server")
+
+
+def _server_api_key() -> Optional[str]:
+    key = os.environ.get(SERVER_API_KEY_ENV)
+    return key if key else None
+
+
+def _require_management_api_key(request: Request) -> None:
+    api_key = _server_api_key()
+    if api_key is None:
+        return
+
+    expected = f"Bearer {api_key}"
+    supplied = request.headers.get("Authorization", "")
+    if not secrets.compare_digest(supplied, expected):
+        raise HTTPException(
+            status_code=401,
+            detail="Invalid API key",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
 
 
 def _cache_group_for_cache(cache: dict) -> str:
@@ -841,10 +863,11 @@ async def add_server_header(request: Request, call_next):
 
 
 @app.get("/health")
-async def health_check():
+async def health_check(request: Request):
     """
     Check if the server is healthy and what model is loaded.
     """
+    _require_management_api_key(request)
     runtime = _server_runtime_snapshot()
     return {
         "status": "healthy",
@@ -862,7 +885,8 @@ async def health_check():
 
 @app.get("/metrics")
 @app.get("/v1/metrics", include_in_schema=False)
-async def metrics_endpoint():
+async def metrics_endpoint(request: Request):
+    _require_management_api_key(request)
     payload = runtime.metrics.snapshot()
     payload["server"] = _server_runtime_snapshot()
     return payload
@@ -870,8 +894,9 @@ async def metrics_endpoint():
 
 @app.get("/v1/cache/stats")
 @app.get("/cache/stats", include_in_schema=False)
-async def apc_cache_stats():
+async def apc_cache_stats(request: Request):
     """Return Automatic Prefix Cache statistics (or ``enabled=false``)."""
+    _require_management_api_key(request)
     if runtime.apc_manager is None:
         return {"enabled": False}
     snap = runtime.apc_manager.stats_snapshot()
@@ -881,7 +906,8 @@ async def apc_cache_stats():
 
 @app.post("/v1/cache/reset")
 @app.post("/cache/reset", include_in_schema=False)
-async def apc_cache_reset():
+async def apc_cache_reset(request: Request):
+    _require_management_api_key(request)
     if runtime.apc_manager is None:
         return {"enabled": False}
     runtime.apc_manager.clear()
@@ -889,10 +915,11 @@ async def apc_cache_reset():
 
 
 @app.post("/unload")
-async def unload_model_endpoint():
+async def unload_model_endpoint(request: Request):
     """
     Unload the currently loaded model from memory.
     """
+    _require_management_api_key(request)
     snapshot = _server_runtime_snapshot()
     unloaded_info = {
         "model_name": snapshot["loaded_model"],

--- a/mlx_vlm/server/cli.py
+++ b/mlx_vlm/server/cli.py
@@ -175,6 +175,16 @@ def main():
         ),
     )
     parser.add_argument(
+        "--api-key",
+        type=str,
+        default=None,
+        help=(
+            "Optional bearer token required for management endpoints such as "
+            "/health, /metrics, /cache/stats, /cache/reset, and /unload. "
+            "Maps to the MLX_VLM_SERVER_API_KEY env var."
+        ),
+    )
+    parser.add_argument(
         "--reload",
         action="store_true",
         default=False,
@@ -220,6 +230,8 @@ def main():
     os.environ["QUANTIZED_KV_START"] = str(args.quantized_kv_start)
     if args.top_logprobs_k is not None:
         os.environ["TOP_LOGPROBS_K"] = str(args.top_logprobs_k)
+    if args.api_key:
+        os.environ["MLX_VLM_SERVER_API_KEY"] = args.api_key
 
     log_level = getattr(logging, args.log_level.upper(), logging.INFO)
     logging.basicConfig(

--- a/mlx_vlm/tests/test_server.py
+++ b/mlx_vlm/tests/test_server.py
@@ -756,6 +756,62 @@ def test_models_endpoint_deduplicates_loaded_model_from_hf_cache(client, monkeyp
     ) == 1
 
 
+@pytest.mark.parametrize(
+    ("method", "path"),
+    [
+        ("get", "/health"),
+        ("get", "/metrics"),
+        ("get", "/v1/metrics"),
+        ("get", "/cache/stats"),
+        ("get", "/v1/cache/stats"),
+        ("post", "/cache/reset"),
+        ("post", "/v1/cache/reset"),
+        ("post", "/unload"),
+    ],
+)
+def test_management_endpoints_allow_requests_without_configured_api_key(
+    client, monkeypatch, method, path
+):
+    monkeypatch.delenv("MLX_VLM_SERVER_API_KEY", raising=False)
+
+    response = getattr(client, method)(path)
+
+    assert response.status_code == 200
+
+
+@pytest.mark.parametrize(
+    ("method", "path"),
+    [
+        ("get", "/health"),
+        ("get", "/metrics"),
+        ("get", "/v1/metrics"),
+        ("get", "/cache/stats"),
+        ("get", "/v1/cache/stats"),
+        ("post", "/cache/reset"),
+        ("post", "/v1/cache/reset"),
+        ("post", "/unload"),
+    ],
+)
+def test_management_endpoints_require_configured_api_key(
+    client, monkeypatch, method, path
+):
+    monkeypatch.setenv("MLX_VLM_SERVER_API_KEY", "secret-token")
+
+    missing = getattr(client, method)(path)
+    invalid = getattr(client, method)(
+        path,
+        headers={"Authorization": "Bearer wrong-token"},
+    )
+    valid = getattr(client, method)(
+        path,
+        headers={"Authorization": "Bearer secret-token"},
+    )
+
+    assert missing.status_code == 401
+    assert invalid.status_code == 401
+    assert valid.status_code == 200
+
+
 def _fake_image_result(*, seed: int, output_path=None) -> ImageGenerationResult:
     image = Image.new("RGB", (16, 16), (seed % 255, 8, 16))
     data = ImageGenerationResult(
@@ -4412,6 +4468,7 @@ class TestResponseGenerator:
             "MLX_VLM_THINKING_BUDGET",
             "MLX_VLM_THINKING_START_TOKEN",
             "MLX_VLM_THINKING_END_TOKEN",
+            "MLX_VLM_SERVER_API_KEY",
             "PREFILL_STEP_SIZE",
             "KV_GROUP_SIZE",
             "KV_QUANT_SCHEME",
@@ -4436,6 +4493,8 @@ class TestResponseGenerator:
                 "<|START_THINKING|>",
                 "--thinking-eos-token",
                 "<|END_THINKING|>",
+                "--api-key",
+                "admin-token",
             ],
         )
         run_calls = []
@@ -4452,6 +4511,7 @@ class TestResponseGenerator:
             assert os.environ["MLX_VLM_THINKING_BUDGET"] == "128"
             assert os.environ["MLX_VLM_THINKING_START_TOKEN"] == "<|START_THINKING|>"
             assert os.environ["MLX_VLM_THINKING_END_TOKEN"] == "<|END_THINKING|>"
+            assert os.environ["MLX_VLM_SERVER_API_KEY"] == "admin-token"
             assert run_calls[0][1]["host"] == "127.0.0.1"
         finally:
             for env_var in (
@@ -4463,6 +4523,7 @@ class TestResponseGenerator:
                 "MLX_VLM_THINKING_BUDGET",
                 "MLX_VLM_THINKING_START_TOKEN",
                 "MLX_VLM_THINKING_END_TOKEN",
+                "MLX_VLM_SERVER_API_KEY",
             ):
                 os.environ.pop(env_var, None)
 


### PR DESCRIPTION
This adds optional auth via `MLX_VLM_SERVER_API_KEY` or `mlx_vlm.server --api-key`, as originally done in https://github.com/Blaizzy/mlx-vlm/pull/948 but has diverged quite a bit.

With a key, these endpoints require `Authorization: Bearer <key>`: /health, /metrics, /v1/metrics, /cache/stats, /v1/cache/stats, /cache/reset, /v1/cache/reset, /unload.