### PR TITLE
Fix SFT masks for Gemma4 unified

### DIFF
--- a/mlx_vlm/lora.py
+++ b/mlx_vlm/lora.py
@@ -187,6 +187,7 @@ def main(args):
             config,
             processor,
             image_resize_shape=args.image_resize_shape,
+            train_on_completions=args.train_on_completions,
         )
 
     # Setup model for training

--- a/mlx_vlm/tests/test_trainer.py
+++ b/mlx_vlm/tests/test_trainer.py
@@ -6,7 +6,12 @@ import mlx.nn as nn
 
 from mlx_vlm.trainer.datasets import VisionDataset
 from mlx_vlm.trainer.lora import LoRaLayer
-from mlx_vlm.trainer.sft_trainer import TrainingArgs, iterate_batches, train
+from mlx_vlm.trainer.sft_trainer import (
+    TrainingArgs,
+    iterate_batches,
+    train,
+    vision_language_loss_fn,
+)
 
 
 class TestDataset(unittest.TestCase):
@@ -129,6 +134,87 @@ class TestDataset(unittest.TestCase):
         self.assertEqual(dataset.config, self.mock_config)
         self.assertEqual(dataset.processor, self.mock_processor)
 
+    @patch("mlx_vlm.trainer.datasets.apply_chat_template")
+    @patch("mlx_vlm.utils.prepare_inputs")
+    def test_dataset_adds_completion_mask_from_chat_template(
+        self, mock_prepare_inputs, mock_apply_chat_template
+    ):
+        dataset = VisionDataset(
+            self.mock_hf_dataset,
+            self.mock_config,
+            self.mock_processor,
+            train_on_completions=True,
+        )
+
+        messages = [
+            {"role": "user", "content": "Use the tool."},
+            {"role": "assistant", "content": "tool call"},
+        ]
+        self.mock_hf_dataset.__getitem__.return_value = {"messages": messages}
+
+        def fake_apply_chat_template(
+            _processor, _config, conversation, add_generation_prompt, **_kwargs
+        ):
+            if add_generation_prompt:
+                self.assertEqual(conversation, messages[:-1])
+                return "prefix"
+            self.assertEqual(conversation, messages)
+            return "full"
+
+        def fake_prepare_inputs(**kwargs):
+            prompts = kwargs["prompts"]
+            if prompts == ["prefix"]:
+                return {"input_ids": mx.array([[1, 2]])}
+            return {
+                "input_ids": mx.array([[1, 2, 3, 4]]),
+                "attention_mask": mx.array([[1, 1, 1, 1]]),
+            }
+
+        mock_apply_chat_template.side_effect = fake_apply_chat_template
+        mock_prepare_inputs.side_effect = fake_prepare_inputs
+
+        result = dataset[0]
+
+        self.assertIn("completion_mask", result)
+        self.assertTrue(
+            mx.array_equal(result["completion_mask"], mx.array([[0, 0, 1, 1]]))
+        )
+
+    @patch("mlx_vlm.trainer.datasets.apply_chat_template")
+    @patch("mlx_vlm.utils.prepare_inputs")
+    def test_dataset_skips_completion_mask_when_not_training_on_completions(
+        self, mock_prepare_inputs, mock_apply_chat_template
+    ):
+        dataset = VisionDataset(
+            self.mock_hf_dataset,
+            self.mock_config,
+            self.mock_processor,
+        )
+
+        messages = [
+            {"role": "user", "content": "Use the tool."},
+            {"role": "assistant", "content": "tool call"},
+        ]
+        self.mock_hf_dataset.__getitem__.return_value = {"messages": messages}
+
+        mock_apply_chat_template.return_value = "full"
+        mock_prepare_inputs.return_value = {
+            "input_ids": mx.array([[1, 2, 3, 4]]),
+            "attention_mask": mx.array([[1, 1, 1, 1]]),
+        }
+
+        result = dataset[0]
+
+        self.assertNotIn("completion_mask", result)
+        mock_apply_chat_template.assert_called_once_with(
+            self.mock_processor,
+            self.mock_config,
+            messages,
+            add_generation_prompt=False,
+            num_images=0,
+            num_audios=0,
+        )
+
 
 class TestBatchCollation(unittest.TestCase):
     def test_iterate_batches_concatenates_variable_length_pixel_values(self):
@@ -153,6 +239,33 @@ class TestBatchCollation(unittest.TestCase):
         self.assertEqual(batch["pixel_values"].shape, (5, 4))
         self.assertTrue(
             mx.array_equal(batch["image_grid_thw"], mx.array([[1, 1, 2], [1, 1, 3]]))
+        )
+
+    def test_iterate_batches_pads_completion_mask(self):
+        dataset = [
+            {
+                "input_ids": mx.array([1, 2, 3]),
+                "attention_mask": mx.array([1, 1, 1]),
+                "pixel_values": None,
+                "completion_mask": mx.array([0, 1, 1]),
+            },
+            {
+                "input_ids": mx.array([4, 5]),
+                "attention_mask": mx.array([1, 1]),
+                "pixel_values": None,
+                "completion_mask": mx.array([0, 1]),
+            },
+        ]
+
+        batch = next(iterate_batches(dataset, batch_size=2, max_seq_length=32))
+
+        self.assertIn("completion_mask", batch)
+        self.assertEqual(batch["completion_mask"].shape, (2, 32))
+        self.assertTrue(
+            mx.array_equal(batch["completion_mask"][0, :3], mx.array([0, 1, 1]))
+        )
+        self.assertTrue(
+            mx.array_equal(batch["completion_mask"][1, :2], mx.array([0, 1]))
         )
 
 
@@ -260,6 +373,99 @@ class TestTrainer(unittest.TestCase):
                 "adapters.safetensors",
             ],
         )
+
+    def test_gemma4_unified_loss_lets_model_build_internal_masks(self):
+        class DummyOutput:
+            def __init__(self, logits):
+                self.logits = logits
+
+        class CaptureModel:
+            model_type = "gemma4_unified"
+
+            def __call__(self, input_ids, pixel_values, mask, **kwargs):
+                self.mask = mask
+                self.kwargs = kwargs
+                vocab_size = 10
+                return DummyOutput(mx.zeros((*input_ids.shape, vocab_size)))
+
+        model = CaptureModel()
+        batch = {
+            "input_ids": mx.array([[1, 2, 3, 4]]),
+            "attention_mask": mx.array([[1, 1, 1, 1]]),
+            "pixel_values": None,
+        }
+
+        vision_language_loss_fn(model, batch)
+
+        self.assertIsNone(model.mask)
+
+    def test_completion_mask_is_used_without_passing_to_model(self):
+        class DummyOutput:
+            def __init__(self, logits):
+                self.logits = logits
+
+        class CaptureModel:
+            model_type = "test_model"
+
+            def __call__(self, input_ids, pixel_values, mask, **kwargs):
+                self.mask = mask
+                self.kwargs = kwargs
+                vocab_size = 10
+                return DummyOutput(mx.zeros((*input_ids.shape, vocab_size)))
+
+        model = CaptureModel()
+        batch = {
+            "input_ids": mx.array([[1, 2, 3, 4]]),
+            "attention_mask": mx.array([[1, 1, 1, 1]]),
+            "completion_mask": mx.array([[0, 0, 1, 1]]),
+            "pixel_values": None,
+        }
+
+        vision_language_loss_fn(
+            model, batch, train_on_completions=True, assistant_id=999
+        )
+
+        self.assertTrue(mx.array_equal(model.mask, mx.array([[1, 1, 1]])))
+        self.assertNotIn("completion_mask", model.kwargs)
+
+    def test_completion_mask_loss_denominator_uses_masked_token_count(self):
+        class DummyOutput:
+            def __init__(self, logits):
+                self.logits = logits
+
+        class FixedLogitsModel:
+            model_type = "test_model"
+
+            def __call__(self, input_ids, pixel_values, mask, **kwargs):
+                logits = mx.array(
+                    [
+                        [
+                            [4.0, 0.0],
+                            [0.0, 4.0],
+                            [4.0, 0.0],
+                        ]
+                    ]
+                )
+                return DummyOutput(logits=logits)
+
+        model = FixedLogitsModel()
+        batch = {
+            "input_ids": mx.array([[1, 0, 1, 0]]),
+            "attention_mask": mx.array([[1, 1, 1, 1]]),
+            "completion_mask": mx.array([[0, 0, 1, 0]]),
+            "pixel_values": None,
+        }
+
+        labels = batch["input_ids"][:, 1:]
+        logits = model(None, None, None).logits
+        ce = nn.losses.cross_entropy(logits, labels)
+        expected = ce[0, 1]
+
+        actual = vision_language_loss_fn(
+            model, batch, train_on_completions=True, assistant_id=999
+        )
+
+        self.assertAlmostEqual(actual.item(), expected.item(), places=6)
 
 
 class TestLoRaScaling(unittest.TestCase):

--- a/mlx_vlm/trainer/datasets.py
+++ b/mlx_vlm/trainer/datasets.py
@@ -2,6 +2,7 @@ import json
 import warnings
 
 import mlx.core as mx
+import numpy as np
 
 from ..models.base import to_mlx
 from ..prompt_utils import MODEL_CONFIG, apply_chat_template
@@ -18,11 +19,61 @@ class VisionDataset:
         config,
         processor,
         image_resize_shape=None,
+        train_on_completions=False,
     ):
         self.dataset = hf_dataset
         self.processor = processor
         self.config = config
         self.image_resize_shape = image_resize_shape
+        self.train_on_completions = train_on_completions
+
+    def _token_length(self, prompt, images, audio, image_token_index):
+        from mlx_vlm.utils import prepare_inputs, process_inputs_with_fallback
+
+        model_type = self.config.get("model_type")
+        inputs = None
+        if model_type in NATIVE_PREPROCESS_MODELS:
+            try:
+                inputs = process_inputs_with_fallback(
+                    processor=self.processor,
+                    prompts=[prompt],
+                    images=images if images else None,
+                    audio=audio if audio else None,
+                    add_special_tokens=False,
+                )
+                if "images" in inputs and "pixel_values" not in inputs:
+                    inputs["pixel_values"] = inputs.pop("images")
+            except Exception:
+                pass
+
+        if inputs is None:
+            inputs = prepare_inputs(
+                processor=self.processor,
+                images=images if images else None,
+                audio=audio if audio else None,
+                prompts=[prompt],
+                image_token_index=image_token_index,
+                resize_shape=self.image_resize_shape,
+            )
+
+        return np.array(inputs["input_ids"]).reshape(-1).shape[0]
+
+    def _completion_prefix(self, conversation, num_images, num_audios):
+        if not isinstance(conversation, list) or not conversation:
+            return None
+
+        last = conversation[-1]
+        if not isinstance(last, dict) or last.get("role") != "assistant":
+            return None
+
+        return apply_chat_template(
+            self.processor,
+            self.config,
+            conversation[:-1],
+            add_generation_prompt=True,
+            num_images=num_images,
+            num_audios=num_audios,
+        )
 
     def __len__(self):
         if hasattr(self.dataset, "__len__"):
@@ -52,6 +103,7 @@ class VisionDataset:
         num_audios = len(audio)
 
         prompts = []
+        completion_prefixes = [] if self.train_on_completions else None
         if isinstance(conversations, list) and isinstance(conversations[0], list):
             for conversation in conversations:
                 if model_type == "pixtral":
@@ -70,6 +122,10 @@ class VisionDataset:
                     num_audios=num_audios,
                 )
                 prompts.append(prompt)
+                if self.train_on_completions:
+                    completion_prefixes.append(
+                        self._completion_prefix(conversation, num_images, num_audios)
+                    )
 
         else:
             if model_type == "pixtral":
@@ -83,6 +139,10 @@ class VisionDataset:
                 num_audios=num_audios,
             )
             prompts.append(prompt)
+            if self.train_on_completions:
+                completion_prefixes.append(
+                    self._completion_prefix(conversations, num_images, num_audios)
+                )
 
         image_token_index = self.config.get("image_token_index") or self.config.get(
             "image_token_id"
@@ -118,6 +178,20 @@ class VisionDataset:
             )
 
         inputs = to_mlx(inputs)
+        completion_mask = None
+        if completion_prefixes and any(
+            prefix is not None for prefix in completion_prefixes
+        ):
+            rows = []
+            for row_idx, prefix in enumerate(completion_prefixes):
+                row = mx.zeros_like(inputs["input_ids"][row_idx])
+                if prefix is not None:
+                    prefix_len = self._token_length(
+                        prefix, images, audio, image_token_index
+                    )
+                    row = mx.where(mx.arange(row.shape[0]) >= prefix_len, 1, row)
+                rows.append(row)
+            completion_mask = mx.stack(rows)
 
         return {
             "pixel_values": inputs.get("pixel_values"),
@@ -125,10 +199,21 @@ class VisionDataset:
             "attention_mask": inputs.get(
                 "attention_mask", mx.ones_like(inputs["input_ids"])
             ),
+            **(
+                {"completion_mask": completion_mask}
+                if completion_mask is not None
+                else {}
+            ),
             **{
                 k: v
                 for k, v in inputs.items()
-                if k not in ["input_ids", "pixel_values", "attention_mask"]
+                if k
+                not in [
+                    "input_ids",
+                    "pixel_values",
+                    "attention_mask",
+                    "completion_mask",
+                ]
             },
         }
 

--- a/mlx_vlm/trainer/sft_trainer.py
+++ b/mlx_vlm/trainer/sft_trainer.py
@@ -117,6 +117,17 @@ def _resolve_adapter_file(args: TrainingArgs) -> Path:
     return Path(TrainingArgs.__dataclass_fields__["adapter_file"].default)
 
 
+def _model_type(model):
+    model_type = getattr(model, "model_type", None)
+    if model_type is not None:
+        return model_type
+
+    config = getattr(model, "config", None)
+    if isinstance(config, dict):
+        return config.get("model_type")
+    return getattr(config, "model_type", None)
+
+
 def vision_language_loss_fn(
     model, batch, train_on_completions=False, assistant_id=77091
 ):
@@ -125,28 +136,6 @@ def vision_language_loss_fn(
     attention_mask = batch["attention_mask"]
 
     batch_size, seq_length = input_ids.shape
-
-    if train_on_completions:
-        weight_mask = mx.ones_like(attention_mask)
-
-        assistant_response_index = np.full((batch_size,), -1, dtype=np.int32)
-        input_ids_np = np.array(input_ids)
-        for row_idx, row in enumerate(input_ids_np):
-            positions = np.where(row == assistant_id)[0]
-            if positions.size > 0:
-                assistant_response_index[row_idx] = positions[0]
-
-        range_matrix = mx.repeat(
-            mx.expand_dims(mx.arange(seq_length), 0), batch_size, axis=0
-        )
-        assistant_mask = range_matrix <= mx.array(assistant_response_index).reshape(
-            -1, 1
-        )
-        weight_mask = mx.where(assistant_mask, mx.zeros_like(weight_mask), weight_mask)[
-            :, 1:
-        ]
-    else:
-        weight_mask = None
 
     input_ids = input_ids[:, :-1]
     attention_mask = attention_mask[:, :-1]
@@ -158,10 +147,13 @@ def vision_language_loss_fn(
     kwargs = {
         k: v
         for k, v in batch.items()
-        if k not in ["input_ids", "pixel_values", "attention_mask"]
+        if k not in ["input_ids", "pixel_values", "attention_mask", "completion_mask"]
     }
 
-    outputs = model(input_ids, pixel_values, attention_mask, **kwargs)
+    model_attention_mask = (
+        None if _model_type(model) == "gemma4_unified" else attention_mask
+    )
+    outputs = model(input_ids, pixel_values, model_attention_mask, **kwargs)
     logits = outputs.logits.astype(mx.float32)
 
     def align_logits_with_labels(logits, labels):
@@ -178,19 +170,36 @@ def vision_language_loss_fn(
     seq_len = input_ids.shape[1]
     lengths = mx.minimum(lengths, seq_len)
     length_mask = mx.arange(seq_len)[None, :] < lengths[:, None]
+    loss_mask = length_mask
 
-    ce = (
-        nn.losses.cross_entropy(
-            logits,
-            labels,
-            weights=weight_mask,
-        )
-        * length_mask
-    )
-    ntoks = length_mask.sum()
-    ce = ce.sum() / ntoks
+    if train_on_completions:
+        if "completion_mask" in batch:
+            loss_mask = loss_mask * batch["completion_mask"][:, 1:]
+        else:
+            completion_mask = mx.ones_like(batch["attention_mask"])
 
-    return (ce * length_mask).sum() / length_mask.sum()
+            assistant_response_index = np.full((batch_size,), -1, dtype=np.int32)
+            input_ids_np = np.array(batch["input_ids"])
+            for row_idx, row in enumerate(input_ids_np):
+                positions = np.where(row == assistant_id)[0]
+                if positions.size > 0:
+                    assistant_response_index[row_idx] = positions[0]
+
+            range_matrix = mx.repeat(
+                mx.expand_dims(mx.arange(seq_length), 0), batch_size, axis=0
+            )
+            assistant_mask = range_matrix <= mx.array(assistant_response_index).reshape(
+                -1, 1
+            )
+            completion_mask = mx.where(
+                assistant_mask,
+                mx.zeros_like(completion_mask),
+                completion_mask,
+            )
+            loss_mask = loss_mask * completion_mask[:, 1:]
+
+    ce = nn.losses.cross_entropy(logits, labels)
+    return (ce * loss_mask).sum() / mx.maximum(loss_mask.sum(), 1)
 
 
 def iterate_batches(dataset, batch_size, max_seq_length, train=False):
@@ -226,6 +235,8 @@ def iterate_batches(dataset, batch_size, max_seq_length, train=False):
 
             input_ids_batch = np.zeros((len(items), padded_len), dtype=np.int32)
             attention_mask_batch = np.zeros((len(items), padded_len), dtype=np.int32)
+            has_completion_mask = any("completion_mask" in item for item in items)
+            completion_mask_batch = np.zeros((len(items), padded_len), dtype=np.int32)
 
             for i, item in enumerate(items):
                 arr = np.array(_squeeze_leading_batch_dim(item["input_ids"])).reshape(
@@ -242,6 +253,12 @@ def iterate_batches(dataset, batch_size, max_seq_length, train=False):
                 else:
                     attention_mask_batch[i, :L] = 1
 
+                if "completion_mask" in item:
+                    completion_mask = np.array(
+                        _squeeze_leading_batch_dim(item["completion_mask"])
+                    ).reshape(-1)
+                    completion_mask_batch[i, :L] = completion_mask[:L]
+
             pixel_values_batch = None
             if "pixel_values" in items[0] and items[0]["pixel_values"] is not None:
                 pixel_values_batch = _collate_arrays(
@@ -253,11 +270,19 @@ def iterate_batches(dataset, batch_size, max_seq_length, train=False):
                 "attention_mask": mx.array(attention_mask_batch),
                 "pixel_values": pixel_values_batch,
             }
+            if has_completion_mask:
+                batch["completion_mask"] = mx.array(completion_mask_batch)
 
             extra_keys = [
                 k
                 for k in items[0]
-                if k not in ("input_ids", "attention_mask", "pixel_values")
+                if k
+                not in (
+                    "input_ids",
+                    "attention_mask",
+                    "completion_mask",
+                    "pixel_values",
+                )
             ]
             for k in extra_keys:
                 vals = [_squeeze_leading_batch_dim(item[k]) for item in items]


### PR DESCRIPTION
This fixes two SFT masking issues:

1. Gemma4 unified should build its own causal/sliding attention masks during SFT. Passing the trainer's 2D padding attention mask as the model mask bypasses the model's internal causal mask construction.

2. train_on_completions should prefer a completion mask derived from the chat template instead of relying only on a hard-coded assistant token id.

Tests:
- python -m unittest mlx_vlm.tests.test_trainer