### PR TITLE
Fix diffusion detok marker preservation

### DIFF
--- a/mlx_vlm/server/generation.py
+++ b/mlx_vlm/server/generation.py
@@ -54,6 +54,72 @@ DEFAULT_ENABLE_THINKING = False
 METRICS_HISTORY_LIMIT = 100
 METRICS_RECENT_LIMIT = 32
 
+# Thinking / channel delimiter special tokens the server's thinking splitter
+# anchors on (see ThinkingStreamState._DEFAULT_OPEN_CLOSE_MARKERS and
+# app._count_thinking_tag_tokens). The channel *name* (e.g. "thought") is plain
+# text; only these bracket tokens are registered special tokens.
+_THINKING_MARKER_TOKENS = (
+    "<|channel>",
+    "<channel|>",
+    "<think>",
+    "</think>",
+    "<|START_THINKING|>",
+    "<|END_THINKING|>",
+)
+
+
+def _structural_marker_strings(processor) -> set:
+    """Special-token strings the server's parsers must still see after
+    detokenization: tool-call delimiters (from whichever tool parser this model
+    uses) and thinking/channel delimiters."""
+    markers = set()
+    try:
+        from ..tool_parsers import _infer_tool_parser_from_processor, load_tool_module
+
+        parser_type = _infer_tool_parser_from_processor(processor)
+        if parser_type:
+            module = load_tool_module(parser_type)
+            for attr in ("tool_call_start", "tool_call_end", "_ESCAPE"):
+                value = getattr(module, attr, None)
+                if isinstance(value, str) and value:
+                    markers.add(value)
+    except Exception:
+        logger.debug(
+            "Could not infer tool-call markers for diffusion detok", exc_info=True
+        )
+    markers.update(_THINKING_MARKER_TOKENS)
+    return markers
+
+
+def _diffusion_skip_special_token_ids(tokenizer, processor) -> set:
+    """Special-token ids to drop on the diffusion detokenization path.
+
+    The diffusion canvas is fixed-length and legitimately contains pad/mask/EOS
+    sentinel special tokens, so (unlike the autoregressive path) we strip
+    special tokens by id. But we must NOT strip the tool-call/channel delimiters
+    the server's tool parser and thinking splitter anchor on, or they arrive as
+    inert text (issue #1351). So: all_special_ids minus those marker ids.
+    """
+    all_special = set(getattr(tokenizer, "all_special_ids", None) or [])
+    if not all_special:
+        return all_special
+    convert = getattr(tokenizer, "convert_tokens_to_ids", None)
+    if convert is None:
+        return all_special
+    unk = getattr(tokenizer, "unk_token_id", None)
+    preserve = set()
+    for marker in _structural_marker_strings(processor):
+        try:
+            token_id = convert(marker)
+        except Exception:
+            continue
+        # Only spare genuine single special tokens. Unknown markers map to the
+        # <unk> id on many tokenizers, and <unk> is itself usually in
+        # all_special_ids -- never un-strip it.
+        if isinstance(token_id, int) and token_id in all_special and token_id != unk:
+            preserve.add(token_id)
+    return all_special - preserve
+
 
 class PromptTooLongError(ValueError):
     """Raised when a request exceeds the configured server context budget."""
@@ -1420,8 +1486,8 @@ class ResponseGenerator:
             raw_inputs.get("attention_mask"),
             max_tokens=args.max_tokens,
             temperature=args.temperature,
-            skip_special_token_ids=set(
-                getattr(tokenizer, "all_special_ids", None) or []
+            skip_special_token_ids=_diffusion_skip_special_token_ids(
+                tokenizer, self.processor
             ),
             mm_token_type_ids=raw_inputs.get("mm_token_type_ids"),
         )

--- a/mlx_vlm/tests/test_diffusion_special_tokens.py
+++ b/mlx_vlm/tests/test_diffusion_special_tokens.py
@@ -1,0 +1,144 @@
+"""Regression tests for issue #1351.
+
+The diffusion detokenization path used to strip *all* ``tokenizer.all_special_ids``
+by id, deleting the ``<|tool_call>``/``<|channel>`` markers the server's gemma4
+tool parser and thinking splitter anchor on. The fix narrows the skip set to
+preserve those structural markers while still dropping pad/mask/EOS sentinels.
+"""
+
+import unittest
+
+from mlx_vlm.server.generation import (
+    _diffusion_skip_special_token_ids,
+    _structural_marker_strings,
+)
+from mlx_vlm.server.responses_state import _split_thinking, process_tool_calls
+from mlx_vlm.tokenizer_utils import NaiveStreamingDetokenizer
+from mlx_vlm.tool_parsers import load_tool_module
+
+
+class _FakeProcessor:
+    """Minimal processor whose chat template makes the gemma4 parser get inferred."""
+
+    def __init__(self, chat_template="{{ '<|tool_call>' }}"):
+        self.chat_template = chat_template
+
+
+class _StubTokenizer:
+    """Tiny id<->piece tokenizer good enough for skip-set + detok tests."""
+
+    def __init__(self):
+        self.vocab_map = {
+            0: "<pad>",
+            1: "<eos>",
+            2: "<unk>",
+            10: "<|tool_call>",
+            11: "<tool_call|>",
+            20: "<|channel>",
+            21: "<channel|>",
+            30: "thought",
+            31: "weighing it",
+            32: "call:get_weather{city:Austin}",
+            33: "Sunny.",
+        }
+        # pad/eos/unk plus the four bracket markers are all "special".
+        self.all_special_ids = [0, 1, 2, 10, 11, 20, 21]
+        self.unk_token_id = 2
+        self._tok2id = {v: k for k, v in self.vocab_map.items()}
+
+    def decode(self, ids, skip_special_tokens=False):
+        return "".join(self.vocab_map.get(int(i), "") for i in ids)
+
+    def convert_tokens_to_ids(self, token):
+        return self._tok2id.get(token, self.unk_token_id)
+
+
+class TestDiffusionSkipSpecialTokenIds(unittest.TestCase):
+    def test_preserves_markers_but_strips_other_specials(self):
+        tok = _StubTokenizer()
+        skip = _diffusion_skip_special_token_ids(tok, _FakeProcessor())
+        # Tool-call + channel marker ids must NOT be skipped.
+        for marker_id in (10, 11, 20, 21):
+            self.assertNotIn(marker_id, skip)
+        # pad/eos/unk are still stripped.
+        for noise_id in (0, 1, 2):
+            self.assertIn(noise_id, skip)
+
+    def test_unk_guard(self):
+        """A marker absent from the vocab maps to <unk>; <unk> must stay stripped."""
+        tok = _StubTokenizer()
+        # Drop the channel markers from the vocab so they resolve to <unk>.
+        for piece in ("<|channel>", "<channel|>"):
+            tok._tok2id.pop(piece, None)
+        skip = _diffusion_skip_special_token_ids(tok, _FakeProcessor())
+        self.assertIn(tok.unk_token_id, skip)
+
+    def test_no_convert_method_falls_back_to_all_special(self):
+        class _NoConvert:
+            all_special_ids = [0, 1, 2]
+
+        skip = _diffusion_skip_special_token_ids(_NoConvert(), _FakeProcessor())
+        self.assertEqual(skip, {0, 1, 2})
+
+    def test_empty_all_special_ids(self):
+        class _Empty:
+            all_special_ids = []
+
+        self.assertEqual(
+            _diffusion_skip_special_token_ids(_Empty(), _FakeProcessor()), set()
+        )
+
+    def test_structural_markers_include_tool_and_channel(self):
+        markers = _structural_marker_strings(_FakeProcessor())
+        self.assertIn("<|tool_call>", markers)
+        self.assertIn("<tool_call|>", markers)
+        self.assertIn("<|channel>", markers)
+        self.assertIn("<channel|>", markers)
+
+
+class TestMarkersSurviveDetokenization(unittest.TestCase):
+    def _detok(self, tok, token_ids, skip):
+        d = NaiveStreamingDetokenizer(tok)
+        d.reset()
+        for t in token_ids:
+            d.add_token(t, skip_special_token_ids=skip)
+        d.finalize()
+        return d.text
+
+    def test_tool_call_markers_survive_and_parse(self):
+        tok = _StubTokenizer()
+        skip = _diffusion_skip_special_token_ids(tok, _FakeProcessor())
+        # <|tool_call> call:get_weather{...} <tool_call|>  + a stripped <eos>
+        text = self._detok(tok, [10, 32, 11, 1], skip)
+        self.assertIn("<|tool_call>", text)
+        self.assertIn("<tool_call|>", text)
+        self.assertNotIn("<eos>", text)
+
+        gemma4 = load_tool_module("gemma4")
+        result = process_tool_calls(text, gemma4, tools=None)
+        self.assertEqual(len(result["calls"]), 1)
+        self.assertEqual(result["calls"][0]["function"]["name"], "get_weather")
+
+    def test_channel_markers_survive_and_split(self):
+        tok = _StubTokenizer()
+        skip = _diffusion_skip_special_token_ids(tok, _FakeProcessor())
+        # <|channel> thought <reasoning> <channel|> <content>
+        text = self._detok(tok, [20, 30, 31, 21, 33], skip)
+        self.assertIn("<|channel>", text)
+        reasoning, content = _split_thinking(text)
+        self.assertEqual(content, "Sunny.")
+        self.assertNotIn("thought", content)
+
+    def test_old_blanket_skip_set_reproduces_the_bug(self):
+        """Guard: the previous behaviour (strip all_special_ids) loses the call."""
+        tok = _StubTokenizer()
+        blanket = set(tok.all_special_ids)
+        text = self._detok(tok, [10, 32, 11], blanket)
+        self.assertNotIn("<|tool_call>", text)
+        gemma4 = load_tool_module("gemma4")
+        result = process_tool_calls(text, gemma4, tools=None)
+        self.assertEqual(result["calls"], [])  # tool_calls: null, as reported
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #1351
Closes #1388

## Summary
- narrow diffusion detokenizer special-token skipping so parser structural markers survive
- preserve tool-call, channel, and thinking delimiters while still stripping pad/eos/unk-style sentinels
- add mock-tokenizer regression tests for marker preservation and the old blanket-strip failure

## Notes
- based on the scoped patch from closed contributor PR #1387

## Tests
- `uv run --with pytest python -m pytest -q mlx_vlm/tests/test_diffusion_special_tokens.py`
- `uv run --with pytest python -m pytest -q mlx_vlm/tests/test_tokenizer_utils.py mlx_vlm/tests/test_structured.py`
- `uv run --with pre-commit pre-commit run --all-files`
- `uv run --with pytest python -m pytest -q mlx_vlm/tests --ignore=mlx_vlm/tests/test_smoke.py --ignore=mlx_vlm/tests/test_utils.py`