### PR TITLE
Add Moondream2 model support

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Some models have detailed documentation with prompt formats, examples, and best 
 | Phi-4 Multimodal | [Docs](https://github.com/Blaizzy/mlx-vlm/blob/main/mlx_vlm/models/phi4mm/README.md) |
 | MolmoPoint | [Docs](https://github.com/Blaizzy/mlx-vlm/blob/main/mlx_vlm/models/molmo_point/README.md) |
 | LocateAnything | [Docs](https://github.com/Blaizzy/mlx-vlm/blob/main/mlx_vlm/models/locateanything/README.md) |
+| Moondream2 | [Docs](https://github.com/Blaizzy/mlx-vlm/blob/main/mlx_vlm/models/moondream2/README.md) |
 | Moondream3 | [Docs](https://github.com/Blaizzy/mlx-vlm/blob/main/mlx_vlm/models/moondream3/README.md) |
 | Gemma 4 | [Docs](https://github.com/Blaizzy/mlx-vlm/blob/main/mlx_vlm/models/gemma4/README.md) |
 | Falcon-OCR | [Docs](https://github.com/Blaizzy/mlx-vlm/blob/main/mlx_vlm/models/falcon_ocr/README.md) |

--- a/mlx_vlm/models/moondream2/README.md
+++ b/mlx_vlm/models/moondream2/README.md
@@ -1,0 +1,69 @@
+# Moondream2
+
+Moondream2 is a compact vision-language model for visual question answering, image captioning, and visual reasoning. It uses a ViT-style vision encoder with a Transformer decoder for efficient multimodal understanding.
+
+## Supported Models
+
+| Model ID | Notes |
+|---|---|
+| `vikhyatk/moondream2` | Official Moondream2 repository |
+
+## Model
+
+| | |
+|---|---|
+| **Model ID** | `vikhyatk/moondream2` |
+| **Architecture** | ViT-style vision encoder + Transformer decoder |
+| **Vision Encoder** | 27 layers, 1152 dim, 16 heads, patch size 14, crop size 378 |
+| **Language Model** | 24 layers, 2048 dim, 32 heads |
+| **Tasks** | Visual question answering, image description, visual reasoning |
+
+## CLI Usage
+
+```bash
+python -m mlx_vlm.generate \
+    --model vikhyatk/moondream2 \
+    --image path/to/image.jpg \
+    --prompt "Describe this image" \
+    --max-tokens 200
+```
+
+With custom parameters:
+
+```bash
+python -m mlx_vlm.generate \
+    --model vikhyatk/moondream2 \
+    --image path/to/image.jpg \
+    --prompt "How many objects are in this image?" \
+    --max-tokens 100 \
+    --temp 0.0
+```
+
+## Python Usage
+
+```python
+from mlx_vlm import load, generate
+
+model, processor = load("vikhyatk/moondream2")
+
+output = generate(
+    model,
+    processor,
+    "Describe this image",
+    ["path/to/image.jpg"],
+    max_tokens=200,
+)
+print(output)
+```
+
+## Architecture
+
+- **Vision**: ViT-style encoder with multi-crop support. Images are patchified into 14x14 patches on 378x378 crops, then projected to the language hidden size.
+- **Language**: Transformer decoder with 24 layers, 2048 hidden size, and 32 attention heads.
+- **Prompt format**: Registered as a prompt-only model in MLX-VLM.
+- **Weight loading**: Includes a sanitize mapping for the official Moondream2 checkpoint key layout.
+
+## Notes
+
+- Region-model weights are ignored by the current text-generation path.
+- Multi-crop image processing follows the Moondream2 crop reconstruction flow.

--- a/mlx_vlm/models/moondream2/__init__.py
+++ b/mlx_vlm/models/moondream2/__init__.py
@@ -1,0 +1,4 @@
+from .config import ModelConfig, TextConfig, VisionConfig
+from .language import LanguageModel
+from .moondream2 import Model
+from .vision import VisionModel

--- a/mlx_vlm/models/moondream2/config.py
+++ b/mlx_vlm/models/moondream2/config.py
@@ -1,0 +1,65 @@
+import inspect
+from dataclasses import dataclass, field
+
+from ..base import BaseModelConfig
+
+
+@dataclass
+class TextConfig(BaseModelConfig):
+    model_type: str = "moondream2"
+    hidden_size: int = 2048
+    intermediate_size: int = 8192
+    num_hidden_layers: int = 24
+    vocab_size: int = 51200
+    max_position_embeddings: int = 2048
+    num_attention_heads: int = 32
+    num_key_value_heads: int = 32
+    rope_theta: float = 10000.0
+    rope_traditional: bool = False
+    partial_rotary_factor: float = 0.5
+    rms_norm_eps: float = 1e-5
+
+
+@dataclass
+class VisionConfig(BaseModelConfig):
+    model_type: str = "moondream2_vision"
+    hidden_size: int = 1152
+    intermediate_size: int = 4304
+    num_hidden_layers: int = 27
+    num_attention_heads: int = 16
+    patch_size: int = 14
+    crop_size: int = 378
+    max_crops: int = 12
+    overlap_margin: int = 4
+    in_channels: int = 3
+    proj_inner_dim: int = 8192
+    proj_out_dim: int = 2048
+    attention_bias: bool = True
+    layer_norm_eps: float = 1e-5
+
+
+@dataclass
+class ModelConfig(BaseModelConfig):
+    text_config: TextConfig = field(default_factory=TextConfig)
+    vision_config: VisionConfig = field(default_factory=VisionConfig)
+    model_type: str = "moondream2"
+    eos_token_id: int = 0
+    bos_token_id: int = 0
+
+    def __post_init__(self):
+        if isinstance(self.text_config, dict):
+            self.text_config = TextConfig(
+                **{
+                    k: v
+                    for k, v in self.text_config.items()
+                    if k in inspect.signature(TextConfig).parameters
+                }
+            )
+        if isinstance(self.vision_config, dict):
+            self.vision_config = VisionConfig(
+                **{
+                    k: v
+                    for k, v in self.vision_config.items()
+                    if k in inspect.signature(VisionConfig).parameters
+                }
+            )

--- a/mlx_vlm/models/moondream2/image_crops.py
+++ b/mlx_vlm/models/moondream2/image_crops.py
@@ -1,0 +1,174 @@
+"""Multi-crop image processing for Moondream3.
+
+Splits images into overlapping crops for high-resolution encoding.
+"""
+
+import math
+
+import numpy as np
+from PIL import Image
+
+
+def select_crop_grid(image_width, image_height, crop_size, max_crops, overlap_margin):
+    """Select the optimal crop grid layout for an image.
+
+    Returns:
+        (rows, cols) grid layout, or None if single global crop suffices.
+    """
+    patch_size = 14
+    effective_crop = crop_size - 2 * overlap_margin * patch_size
+
+    if effective_crop <= 0:
+        return None
+
+    best_layout = None
+    best_score = float("inf")
+
+    for rows in range(1, max_crops + 1):
+        for cols in range(1, max_crops + 1):
+            total_crops = rows * cols + 1  # +1 for global
+            if total_crops > max_crops:
+                continue
+
+            # Effective resolution covered
+            eff_h = rows * effective_crop + 2 * overlap_margin * patch_size
+            eff_w = cols * effective_crop + 2 * overlap_margin * patch_size
+
+            # Scale factor to cover the image
+            scale_h = eff_h / image_height
+            scale_w = eff_w / image_width
+
+            # We want the scale to be close to 1 (covering image well)
+            # while minimizing number of crops
+            aspect_ratio = image_width / image_height
+            grid_ratio = cols / rows
+
+            # Penalize aspect ratio mismatch and over/under-coverage
+            ratio_diff = abs(math.log(aspect_ratio / grid_ratio))
+            scale_diff = abs(math.log(min(scale_h, scale_w)))
+            score = ratio_diff + 0.5 * scale_diff + 0.1 * total_crops
+
+            if score < best_score:
+                best_score = score
+                best_layout = (rows, cols)
+
+    return best_layout
+
+
+def create_crops(image, crop_size, max_crops, overlap_margin):
+    """Create multi-resolution crops from an image.
+
+    Args:
+        image: PIL Image
+        crop_size: size of each crop (378)
+        max_crops: maximum number of crops including global
+        overlap_margin: overlap in patches between adjacent crops
+
+    Returns:
+        crops: list of numpy arrays (H, W, C) normalized to [-1, 1]
+        layout: (rows, cols) or None for single crop
+    """
+    width, height = image.size
+    patch_size = 14
+
+    # Always create global crop
+    global_img = image.resize((crop_size, crop_size), Image.BICUBIC)
+    global_crop = np.array(global_img).astype(np.float32)
+    global_crop = (global_crop / 255.0 - 0.5) / 0.5  # normalize to [-1, 1]
+
+    crops = [global_crop]
+
+    # Check if we need local crops
+    if max_crops <= 1:
+        return crops, None
+
+    layout = select_crop_grid(width, height, crop_size, max_crops, overlap_margin)
+    if layout is None:
+        return crops, None
+
+    rows, cols = layout
+    if rows * cols + 1 > max_crops:
+        return crops, None
+
+    # Calculate overlap in pixels
+    overlap_pixels = overlap_margin * patch_size
+
+    # Calculate the region each crop covers (with overlap)
+    effective_size = crop_size - 2 * overlap_pixels
+
+    for r in range(rows):
+        for c in range(cols):
+            # Source region in original image coordinates
+            src_y = (
+                r
+                * (
+                    height
+                    - crop_size * height / (rows * effective_size + 2 * overlap_pixels)
+                )
+                if rows > 1
+                else 0
+            )
+            src_x = (
+                c
+                * (
+                    width
+                    - crop_size * width / (cols * effective_size + 2 * overlap_pixels)
+                )
+                if cols > 1
+                else 0
+            )
+
+            # Simpler approach: evenly distribute crops
+            if rows > 1:
+                src_y = (
+                    r
+                    * (height - crop_size * height / (rows * crop_size / crop_size))
+                    / max(rows - 1, 1)
+                )
+            else:
+                src_y = 0
+            if cols > 1:
+                src_x = (
+                    c
+                    * (width - crop_size * width / (cols * crop_size / crop_size))
+                    / max(cols - 1, 1)
+                )
+            else:
+                src_x = 0
+
+            # Scale: map crop_size pixels to image region
+            scale_x = (
+                width / (cols * (crop_size - 2 * overlap_pixels) + 2 * overlap_pixels)
+                if cols > 0
+                else 1
+            )
+            scale_y = (
+                height / (rows * (crop_size - 2 * overlap_pixels) + 2 * overlap_pixels)
+                if rows > 0
+                else 1
+            )
+            scale = max(scale_x, scale_y)
+
+            crop_w = int(crop_size * scale)
+            crop_h = int(crop_size * scale)
+
+            # Center the crop grid
+            total_w = cols * (crop_size - 2 * overlap_pixels) + 2 * overlap_pixels
+            total_h = rows * (crop_size - 2 * overlap_pixels) + 2 * overlap_pixels
+
+            x0 = int(c * (crop_size - 2 * overlap_pixels) * scale)
+            y0 = int(r * (crop_size - 2 * overlap_pixels) * scale)
+
+            x0 = min(x0, max(width - crop_w, 0))
+            y0 = min(y0, max(height - crop_h, 0))
+            x1 = min(x0 + crop_w, width)
+            y1 = min(y0 + crop_h, height)
+
+            crop_img = image.crop((x0, y0, x1, y1))
+            crop_img = crop_img.resize((crop_size, crop_size), Image.BICUBIC)
+
+            crop_arr = np.array(crop_img).astype(np.float32)
+            crop_arr = (crop_arr / 255.0 - 0.5) / 0.5
+            crops.append(crop_arr)
+
+    return crops, layout

--- a/mlx_vlm/models/moondream2/language.py
+++ b/mlx_vlm/models/moondream2/language.py
@@ -1,0 +1,155 @@
+from typing import Optional
+
+import mlx.core as mx
+import mlx.nn as nn
+
+from ..base import LanguageModelOutput, create_attention_mask
+from ..cache import KVCache
+from .config import TextConfig
+
+
+class Attention(nn.Module):
+    def __init__(self, config: TextConfig):
+        super().__init__()
+        dim = config.hidden_size
+        self.n_heads = config.num_attention_heads
+        self.n_kv_heads = config.num_key_value_heads
+        self.head_dim = dim // self.n_heads
+        self.scale = self.head_dim**-0.5
+
+        qkv_dim = (self.n_heads + 2 * self.n_kv_heads) * self.head_dim
+        self.qkv = nn.Linear(dim, qkv_dim, bias=True)
+        self.proj = nn.Linear(dim, dim, bias=True)
+
+        rope_dim = int(self.head_dim * config.partial_rotary_factor)
+        self.rope = nn.RoPE(
+            rope_dim,
+            traditional=config.rope_traditional,
+            base=config.rope_theta,
+        )
+
+    def __call__(
+        self,
+        x: mx.array,
+        mask: Optional[mx.array] = None,
+        cache: Optional[KVCache] = None,
+    ) -> mx.array:
+        B, L, _ = x.shape
+
+        qkv = self.qkv(x)
+        q_dim = self.n_heads * self.head_dim
+        kv_dim = self.n_kv_heads * self.head_dim
+        queries, keys, values = mx.split(qkv, [q_dim, q_dim + kv_dim], axis=-1)
+
+        queries = queries.reshape(B, L, self.n_heads, self.head_dim).transpose(
+            0, 2, 1, 3
+        )
+        keys = keys.reshape(B, L, self.n_kv_heads, self.head_dim).transpose(0, 2, 1, 3)
+        values = values.reshape(B, L, self.n_kv_heads, self.head_dim).transpose(
+            0, 2, 1, 3
+        )
+
+        if cache is not None:
+            queries = self.rope(queries, offset=cache.offset)
+            keys = self.rope(keys, offset=cache.offset)
+            keys, values = cache.update_and_fetch(keys, values)
+        else:
+            queries = self.rope(queries)
+            keys = self.rope(keys)
+
+        output = mx.fast.scaled_dot_product_attention(
+            queries, keys, values, scale=self.scale, mask=mask
+        )
+        output = output.transpose(0, 2, 1, 3).reshape(B, L, -1)
+        return self.proj(output)
+
+
+class MLP(nn.Module):
+    def __init__(self, config: TextConfig):
+        super().__init__()
+        self.fc1 = nn.Linear(config.hidden_size, config.intermediate_size, bias=True)
+        self.fc2 = nn.Linear(config.intermediate_size, config.hidden_size, bias=True)
+        self.act = nn.GELU(approx="tanh")
+
+    def __call__(self, x: mx.array) -> mx.array:
+        return self.fc2(self.act(self.fc1(x)))
+
+
+class TransformerBlock(nn.Module):
+    def __init__(self, config: TextConfig):
+        super().__init__()
+        self.ln = nn.LayerNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.attn = Attention(config)
+        self.mlp = MLP(config)
+
+    def __call__(
+        self,
+        x: mx.array,
+        mask: Optional[mx.array] = None,
+        cache: Optional[KVCache] = None,
+    ) -> mx.array:
+        h = self.ln(x)
+        return x + self.attn(h, mask, cache) + self.mlp(h)
+
+
+class TextModel(nn.Module):
+    def __init__(self, config: TextConfig):
+        super().__init__()
+        self.config = config
+        self.embed_tokens = nn.Embedding(config.vocab_size, config.hidden_size)
+        self.layers = [
+            TransformerBlock(config) for _ in range(config.num_hidden_layers)
+        ]
+        self.post_ln = nn.LayerNorm(config.hidden_size, eps=config.rms_norm_eps)
+
+    def __call__(
+        self,
+        inputs: mx.array,
+        inputs_embeds: Optional[mx.array] = None,
+        mask: Optional[mx.array] = None,
+        cache=None,
+    ):
+        h = self.embed_tokens(inputs) if inputs_embeds is None else inputs_embeds
+
+        if cache is None:
+            cache = [None] * len(self.layers)
+
+        if mask is None:
+            mask = create_attention_mask(h, cache[0])
+
+        for layer, c in zip(self.layers, cache):
+            h = layer(h, mask, c)
+
+        return self.post_ln(h)
+
+
+class LanguageModel(nn.Module):
+    def __init__(self, config: TextConfig):
+        super().__init__()
+        self.config = config
+        self.model_type = config.model_type
+        self.model = TextModel(config)
+        self.lm_head = nn.Linear(config.hidden_size, config.vocab_size, bias=True)
+
+    def __call__(
+        self,
+        inputs: mx.array,
+        inputs_embeds: Optional[mx.array] = None,
+        mask: Optional[mx.array] = None,
+        cache=None,
+        **kwargs,
+    ):
+        out = self.model(inputs, inputs_embeds=inputs_embeds, mask=mask, cache=cache)
+        return LanguageModelOutput(logits=self.lm_head(out))
+
+    @property
+    def layers(self):
+        return self.model.layers
+
+    @property
+    def head_dim(self):
+        return self.config.hidden_size // self.config.num_attention_heads
+
+    @property
+    def n_kv_heads(self):
+        return self.config.num_key_value_heads

--- a/mlx_vlm/models/moondream2/moondream2.py
+++ b/mlx_vlm/models/moondream2/moondream2.py
@@ -1,0 +1,162 @@
+from typing import Optional
+
+import mlx.core as mx
+import mlx.nn as nn
+
+from ..base import InputEmbeddingsFeatures
+from .config import ModelConfig
+from .language import LanguageModel
+from .vision import VisionModel
+
+
+class Model(nn.Module):
+    def __init__(self, config: ModelConfig):
+        super().__init__()
+        self.config = config
+        self.model_type = config.model_type
+        self.vision = VisionModel(config.vision_config)
+        self.text = LanguageModel(config.text_config)
+
+    def __call__(
+        self,
+        inputs: mx.array,
+        inputs_embeds: Optional[mx.array] = None,
+        pixel_values: Optional[mx.array] = None,
+        mask: Optional[mx.array] = None,
+        cache=None,
+        **kwargs,
+    ):
+        if inputs_embeds is None:
+            input_embeddings_features = self.get_input_embeddings(
+                inputs, pixel_values, **kwargs
+            )
+            inputs_embeds = input_embeddings_features.inputs_embeds
+            if input_embeddings_features.attention_mask_4d is not None:
+                mask = input_embeddings_features.attention_mask_4d
+
+        return self.text(inputs, inputs_embeds=inputs_embeds, mask=mask, cache=cache)
+
+    def get_input_embeddings(
+        self,
+        inputs: mx.array,
+        pixel_values: Optional[mx.array] = None,
+        **kwargs,
+    ):
+        inputs_embeds = self.text.model.embed_tokens(inputs)
+
+        if pixel_values is None:
+            return InputEmbeddingsFeatures(inputs_embeds=inputs_embeds)
+
+        num_crops = kwargs.get("num_crops", None)
+        crop_layouts = kwargs.get("crop_layouts", None)
+
+        dtype = inputs_embeds.dtype
+        pixel_values = pixel_values.astype(dtype)
+
+        image_features = self.vision(
+            pixel_values,
+            num_crops=num_crops,
+            crop_layouts=crop_layouts,
+        )
+
+        bos_embed = inputs_embeds[:, :1, :]
+        num_vision_tokens = image_features.shape[1]
+        text_start = 1 + num_vision_tokens
+
+        if inputs_embeds.shape[1] > text_start:
+            text_embeds = inputs_embeds[:, text_start:, :]
+            final_embeds = mx.concatenate(
+                [bos_embed, image_features, text_embeds], axis=1
+            )
+        else:
+            final_embeds = mx.concatenate([bos_embed, image_features], axis=1)
+
+        prefix_len = 1 + num_vision_tokens
+        seq_len = final_embeds.shape[1]
+        attention_mask_4d = self._create_prefix_attention_mask(seq_len, prefix_len)
+
+        return InputEmbeddingsFeatures(
+            inputs_embeds=final_embeds,
+            attention_mask_4d=attention_mask_4d,
+        )
+
+    def _create_prefix_attention_mask(
+        self, seq_len: int, prefix_len: int
+    ) -> Optional[mx.array]:
+        causal = mx.triu(mx.full((seq_len, seq_len), -mx.inf), k=1)
+        causal[:prefix_len, :prefix_len] = 0.0
+        return causal.reshape(1, 1, seq_len, seq_len)
+
+    def sanitize(self, weights):
+        sanitized = {}
+
+        for k, v in weights.items():
+            new_key = k
+
+            if "position_ids" in new_key:
+                continue
+
+            if new_key.startswith("region_model."):
+                continue
+
+            if new_key.startswith("vision_encoder.encoder.model.visual."):
+                new_key = (
+                    "vision.encoder."
+                    + new_key[len("vision_encoder.encoder.model.visual.") :]
+                )
+                new_key = new_key.replace("patch_embed.linear.", "patch_emb.")
+                new_key = new_key.replace("pos_embed", "pos_emb")
+                new_key = new_key.replace(".norm1.", ".ln1.")
+                new_key = new_key.replace(".norm2.", ".ln2.")
+                new_key = new_key.replace("norm.", "post_ln.")
+
+            elif new_key.startswith("vision_encoder.projection.mlp."):
+                new_key = (
+                    "vision.proj_mlp."
+                    + new_key[len("vision_encoder.projection.mlp.") :]
+                )
+
+            elif new_key == "text_model.transformer.embd.wte.weight":
+                new_key = "text.model.embed_tokens.weight"
+
+            elif new_key.startswith("text_model.transformer.h."):
+                new_key = (
+                    "text.model.layers." + new_key[len("text_model.transformer.h.") :]
+                )
+                new_key = new_key.replace(".mixer.Wqkv.", ".attn.qkv.")
+                new_key = new_key.replace(".mixer.out_proj.", ".attn.proj.")
+
+            elif new_key.startswith("text_model.lm_head.ln."):
+                new_key = (
+                    "text.model.post_ln." + new_key[len("text_model.lm_head.ln.") :]
+                )
+
+            elif new_key.startswith("text_model.lm_head.linear."):
+                new_key = "text.lm_head." + new_key[len("text_model.lm_head.linear.") :]
+
+            sanitized[new_key] = v
+
+        return sanitized
+
+    @property
+    def layers(self):
+        return self.text.model.layers
+
+    @property
+    def head_dim(self):
+        return (
+            self.config.text_config.hidden_size
+            // self.config.text_config.num_attention_heads
+        )
+
+    @property
+    def n_kv_heads(self):
+        return self.config.text_config.num_key_value_heads
+
+    @property
+    def language_model(self):
+        return self.text
+
+    @property
+    def vision_model(self):
+        return self.vision

--- a/mlx_vlm/models/moondream2/vision.py
+++ b/mlx_vlm/models/moondream2/vision.py
@@ -1,0 +1,186 @@
+from typing import Optional
+
+import mlx.core as mx
+import mlx.nn as nn
+
+from .config import VisionConfig
+
+
+class Attention(nn.Module):
+    def __init__(self, config: VisionConfig):
+        super().__init__()
+        self.num_heads = config.num_attention_heads
+        self.head_dim = config.hidden_size // config.num_attention_heads
+        self.scale = self.head_dim**-0.5
+        self.qkv = nn.Linear(
+            config.hidden_size, 3 * config.hidden_size, bias=config.attention_bias
+        )
+        self.proj = nn.Linear(
+            config.hidden_size, config.hidden_size, bias=config.attention_bias
+        )
+
+    def __call__(self, x: mx.array, mask: Optional[mx.array] = None) -> mx.array:
+        B, L, _ = x.shape
+        qkv = self.qkv(x)
+        q, k, v = mx.split(qkv, 3, axis=-1)
+
+        q = q.reshape(B, L, self.num_heads, self.head_dim).transpose(0, 2, 1, 3)
+        k = k.reshape(B, L, self.num_heads, self.head_dim).transpose(0, 2, 1, 3)
+        v = v.reshape(B, L, self.num_heads, self.head_dim).transpose(0, 2, 1, 3)
+
+        output = mx.fast.scaled_dot_product_attention(
+            q, k, v, scale=self.scale, mask=mask
+        )
+        output = output.transpose(0, 2, 1, 3).reshape(B, L, -1)
+        return self.proj(output)
+
+
+class MLP(nn.Module):
+    def __init__(self, config: VisionConfig):
+        super().__init__()
+        self.fc1 = nn.Linear(config.hidden_size, config.intermediate_size, bias=True)
+        self.fc2 = nn.Linear(config.intermediate_size, config.hidden_size, bias=True)
+        self.act = nn.GELU(approx="tanh")
+
+    def __call__(self, x: mx.array) -> mx.array:
+        return self.fc2(self.act(self.fc1(x)))
+
+
+class EncoderBlock(nn.Module):
+    def __init__(self, config: VisionConfig):
+        super().__init__()
+        self.ln1 = nn.LayerNorm(config.hidden_size, eps=config.layer_norm_eps)
+        self.attn = Attention(config)
+        self.ln2 = nn.LayerNorm(config.hidden_size, eps=config.layer_norm_eps)
+        self.mlp = MLP(config)
+
+    def __call__(self, x: mx.array, mask: Optional[mx.array] = None) -> mx.array:
+        x = x + self.attn(self.ln1(x), mask)
+        x = x + self.mlp(self.ln2(x))
+        return x
+
+
+class VisionEncoder(nn.Module):
+    def __init__(self, config: VisionConfig):
+        super().__init__()
+        self.config = config
+        patch_dim = config.patch_size * config.patch_size * config.in_channels
+        num_patches = (config.crop_size // config.patch_size) ** 2
+
+        self.patch_emb = nn.Linear(patch_dim, config.hidden_size, bias=True)
+        self.pos_emb = mx.zeros((1, num_patches, config.hidden_size))
+        self.blocks = [EncoderBlock(config) for _ in range(config.num_hidden_layers)]
+        self.post_ln = nn.LayerNorm(config.hidden_size, eps=config.layer_norm_eps)
+
+    def _patchify(self, x: mx.array) -> mx.array:
+        B, H, W, C = x.shape
+        P = self.config.patch_size
+        pH = H // P
+        pW = W // P
+        x = x.reshape(B, pH, P, pW, P, C)
+        x = x.transpose(0, 1, 3, 5, 2, 4)
+        x = x.reshape(B, pH * pW, C * P * P)
+        return x
+
+    def __call__(self, x: mx.array) -> mx.array:
+        x = self._patchify(x)
+        x = self.patch_emb(x)
+        x = x + self.pos_emb
+        for block in self.blocks:
+            x = block(x)
+        x = self.post_ln(x)
+        return x
+
+
+class VisionProjection(nn.Module):
+    def __init__(self, config: VisionConfig):
+        super().__init__()
+        self.fc1 = nn.Linear(2 * config.hidden_size, config.proj_inner_dim, bias=True)
+        self.fc2 = nn.Linear(config.proj_inner_dim, config.proj_out_dim, bias=True)
+        self.act = nn.GELU(approx="tanh")
+
+    def __call__(self, x: mx.array) -> mx.array:
+        return self.fc2(self.act(self.fc1(x)))
+
+
+class VisionModel(nn.Module):
+    def __init__(self, config: VisionConfig):
+        super().__init__()
+        self.config = config
+        self.encoder = VisionEncoder(config)
+        self.proj_mlp = VisionProjection(config)
+
+    def _reconstruct_local_features(
+        self, local_features: list, layout: tuple
+    ) -> mx.array:
+        rows, cols = layout
+        grid_size = self.config.crop_size // self.config.patch_size
+        margin = self.config.overlap_margin
+
+        crop_rows = []
+        idx = 0
+        for r in range(rows):
+            row_features = []
+            for c in range(cols):
+                feat = local_features[idx]
+                feat = feat.reshape(grid_size, grid_size, -1)
+
+                top = margin if r > 0 else 0
+                bottom = grid_size - (margin if r < rows - 1 else 0)
+                left = margin if c > 0 else 0
+                right = grid_size - (margin if c < cols - 1 else 0)
+                feat = feat[top:bottom, left:right, :]
+                row_features.append(feat)
+                idx += 1
+            crop_rows.append(mx.concatenate(row_features, axis=1))
+
+        full_grid = mx.concatenate(crop_rows, axis=0)
+
+        H, W, D = full_grid.shape
+        pool_h = H / grid_size
+        pool_w = W / grid_size
+
+        pooled = mx.zeros((grid_size, grid_size, D), dtype=full_grid.dtype)
+        for i in range(grid_size):
+            h_start = int(round(i * pool_h))
+            h_end = int(round((i + 1) * pool_h))
+            h_end = max(h_end, h_start + 1)
+            for j in range(grid_size):
+                w_start = int(round(j * pool_w))
+                w_end = int(round((j + 1) * pool_w))
+                w_end = max(w_end, w_start + 1)
+                pooled[i, j] = full_grid[h_start:h_end, w_start:w_end].mean(axis=(0, 1))
+
+        return pooled.reshape(-1, D)
+
+    def __call__(
+        self,
+        pixel_values: mx.array,
+        num_crops: Optional[list] = None,
+        crop_layouts: Optional[list] = None,
+    ) -> mx.array:
+        all_features = self.encoder(pixel_values)
+
+        if num_crops is None:
+            global_feats = all_features
+            combined = mx.concatenate([global_feats, global_feats], axis=-1)
+            return self.proj_mlp(combined)
+
+        batch_features = []
+        crop_idx = 0
+        for i, nc in enumerate(num_crops):
+            global_feats = all_features[crop_idx]
+
+            if nc > 1:
+                local_feats = [all_features[crop_idx + j] for j in range(1, nc)]
+                layout = crop_layouts[i] if crop_layouts else (1, nc - 1)
+                reconstructed = self._reconstruct_local_features(local_feats, layout)
+            else:
+                reconstructed = global_feats
+
+            combined = mx.concatenate([global_feats, reconstructed], axis=-1)
+            projected = self.proj_mlp(combined)
+            batch_features.append(projected)
+            crop_idx += nc
+
+        return mx.stack(batch_features)

--- a/mlx_vlm/prompt_utils.py
+++ b/mlx_vlm/prompt_utils.py
@@ -94,6 +94,7 @@ MODEL_CONFIG = {
     # Prompt-only models
     "florence2": MessageFormat.PROMPT_ONLY,
     "molmo": MessageFormat.PROMPT_ONLY,
+    "moondream2": MessageFormat.PROMPT_ONLY,
     "moondream3": MessageFormat.PROMPT_ONLY,
     "falcon_ocr": MessageFormat.PROMPT_ONLY,
     "paligemma": MessageFormat.PROMPT_WITH_IMAGE_TOKEN,

--- a/mlx_vlm/tests/test_models.py
+++ b/mlx_vlm/tests/test_models.py
@@ -4190,6 +4190,60 @@ class TestModels(unittest.TestCase):
             config.text_config.num_hidden_layers,
         )
 
+    def test_moondream2(self):
+        from mlx_vlm.models import moondream2
+
+        text_config = moondream2.TextConfig(
+            model_type="moondream2",
+            hidden_size=64,
+            intermediate_size=128,
+            num_hidden_layers=2,
+            num_attention_heads=4,
+            num_key_value_heads=4,
+            vocab_size=256,
+            partial_rotary_factor=0.5,
+            rms_norm_eps=1e-5,
+        )
+
+        vision_config = moondream2.VisionConfig(
+            model_type="moondream2_vision",
+            hidden_size=32,
+            intermediate_size=64,
+            num_hidden_layers=2,
+            num_attention_heads=4,
+            patch_size=14,
+            crop_size=28,
+            in_channels=3,
+            proj_inner_dim=64,
+            proj_out_dim=64,
+            attention_bias=True,
+            layer_norm_eps=1e-5,
+        )
+
+        config = moondream2.ModelConfig(
+            text_config=text_config,
+            vision_config=vision_config,
+            model_type="moondream2",
+        )
+        model = moondream2.Model(config)
+
+        self.language_test_runner(
+            model.language_model,
+            text_config.model_type,
+            text_config.vocab_size,
+            text_config.num_hidden_layers,
+        )
+
+        batch_size = 1
+        crop_size = vision_config.crop_size
+        pixel_values = mx.random.uniform(shape=(batch_size, crop_size, crop_size, 3))
+        features = model.vision.encoder(pixel_values)
+        grid_size = crop_size // vision_config.patch_size
+        num_patches = grid_size * grid_size
+        self.assertEqual(
+            features.shape, (batch_size, num_patches, vision_config.hidden_size)
+        )
+
     def test_moondream3(self):
         from mlx_vlm.models import moondream3
 


### PR DESCRIPTION
## Summary
- Add Moondream2 model package with config, language model, vision model, image crops, and model wrapper
- Register Moondream2 as a prompt-only model
- Add README docs entry and model test coverage

## Testing
- python -m py_compile mlx_vlm/models/moondream2/config.py mlx_vlm/models/moondream2/moondream2.py mlx_vlm/models/moondream2/language.py mlx_vlm/models/moondream2/vision.py mlx_vlm/models/moondream2/__init__.py mlx_vlm/tests/test_models.py
- git diff --cached --check