### PR TITLE
Preserve diffusion structural marker tokens

### DIFF
--- a/mlx_vlm/server/generation.py
+++ b/mlx_vlm/server/generation.py
@@ -43,6 +43,7 @@ from ..speculative.utils import (
 )
 from ..structured import ThinkingAwareLogitsProcessor
 from ..tokenizer_utils import _ServerTokenStreamer, make_streaming_detokenizer
+from ..tool_parsers import _infer_tool_parser_from_processor, load_tool_module
 from ..utils import ThinkingBudgetCriteria, load, prepare_inputs
 from .runtime import runtime
 
@@ -294,6 +295,75 @@ def get_server_thinking_start_token():
 
 def get_server_thinking_end_token():
     return os.environ.get("MLX_VLM_THINKING_END_TOKEN")
+
+
+_DIFFUSION_STRUCTURAL_MARKERS = {
+    "<|channel>",
+    "<channel|>",
+    "<|START_THINKING|>",
+    "<|END_THINKING|>",
+    "<|START_TEXT|>",
+    "<|END_TEXT|>",
+    DEFAULT_THINKING_START_TOKEN,
+    DEFAULT_THINKING_END_TOKEN,
+    # Gemma tool-call string literal delimiter.
+    '<|"|>',
+}
+
+
+def _encode_marker_token_ids(tokenizer, marker: Optional[str]) -> List[int]:
+    if not marker:
+        return []
+    try:
+        ids = tokenizer.encode(marker, add_special_tokens=False)
+    except TypeError:
+        ids = tokenizer.encode(marker)
+    except Exception:
+        return []
+    if hasattr(ids, "tolist"):
+        ids = ids.tolist()
+    if isinstance(ids, int):
+        return [ids]
+    if not isinstance(ids, (list, tuple)):
+        return []
+    return [int(token_id) for token_id in ids]
+
+
+def _diffusion_structural_marker_ids(tokenizer, processor, args) -> set:
+    markers = set(_DIFFUSION_STRUCTURAL_MARKERS)
+    if args.thinking_start_token is not None:
+        markers.add(args.thinking_start_token)
+    if args.thinking_end_token is not None:
+        markers.add(args.thinking_end_token)
+
+    tool_parser_type = _infer_tool_parser_from_processor(processor)
+    if tool_parser_type:
+        try:
+            tool_module = load_tool_module(tool_parser_type)
+        except Exception:
+            tool_module = None
+        if tool_module is not None:
+            for attr in ("tool_call_start", "tool_call_end"):
+                marker = getattr(tool_module, attr, None)
+                if marker:
+                    markers.add(marker)
+
+    unk_token_id = getattr(tokenizer, "unk_token_id", None)
+    marker_ids = set()
+    for marker in markers:
+        token_ids = _encode_marker_token_ids(tokenizer, marker)
+        if len(token_ids) != 1:
+            continue
+        token_id = token_ids[0]
+        if unk_token_id is not None and token_id == unk_token_id:
+            continue
+        marker_ids.add(token_id)
+    return marker_ids
+
+
+def _diffusion_skip_special_token_ids(tokenizer, processor, args) -> set:
+    skip_ids = set(getattr(tokenizer, "all_special_ids", None) or [])
+    return skip_ids - _diffusion_structural_marker_ids(tokenizer, processor, args)
 
 
 def get_quantized_kv_bits(model: str):
@@ -1420,8 +1490,8 @@ class ResponseGenerator:
             raw_inputs.get("attention_mask"),
             max_tokens=args.max_tokens,
             temperature=args.temperature,
-            skip_special_token_ids=set(
-                getattr(tokenizer, "all_special_ids", None) or []
+            skip_special_token_ids=_diffusion_skip_special_token_ids(
+                tokenizer, self.processor, args
             ),
             mm_token_type_ids=raw_inputs.get("mm_token_type_ids"),
         )

--- a/mlx_vlm/tests/test_server.py
+++ b/mlx_vlm/tests/test_server.py
@@ -4858,6 +4858,59 @@ class TestProcessToolCalls:
         }
 
 
+class TestDiffusionSkipSpecialTokens:
+    """Tests for diffusion detokenizer special-token preservation."""
+
+    class Tokenizer:
+        all_special_ids = [0, 1, 2, 3, 48, 49, 52, 100, 101, 200, 201]
+        unk_token_id = 0
+
+        vocab = {
+            "<pad>": [1],
+            "<eos>": [2],
+            "<mask>": [3],
+            "<|tool_call>": [48],
+            "<tool_call|>": [49],
+            '<|"|>': [52],
+            "<|channel>": [100],
+            "<channel|>": [101],
+            "<custom_think>": [200],
+            "</custom_think>": [201],
+        }
+
+        def encode(self, marker, add_special_tokens=False):
+            return self.vocab.get(marker, [self.unk_token_id])
+
+    class Processor:
+        tokenizer = SimpleNamespace(chat_template="{{ '<|tool_call>' }}")
+
+    def test_preserves_tool_channel_and_custom_thinking_markers(self):
+        args = SimpleNamespace(
+            thinking_start_token="<custom_think>",
+            thinking_end_token="</custom_think>",
+        )
+
+        skip_ids = server_generation._diffusion_skip_special_token_ids(
+            self.Tokenizer(), self.Processor(), args
+        )
+
+        assert {1, 2, 3}.issubset(skip_ids)
+        assert 0 in skip_ids
+        assert not ({48, 49, 52, 100, 101, 200, 201} & skip_ids)
+
+    def test_unknown_custom_markers_do_not_preserve_unk(self):
+        args = SimpleNamespace(
+            thinking_start_token="<unknown>",
+            thinking_end_token="</unknown>",
+        )
+
+        skip_ids = server_generation._diffusion_skip_special_token_ids(
+            self.Tokenizer(), self.Processor(), args
+        )
+
+        assert 0 in skip_ids
+
+
 class TestCountThinkingTagTokens:
     """Tests for thinking tag token counting."""
 


### PR DESCRIPTION
## Summary
- preserve diffusion detokenizer marker tokens needed by tool-call parsing and thinking/channel splitting
- keep ordinary special sentinels stripped, including unknown-marker encodings
- add regression coverage for tool/channel/custom thinking marker preservation

Fixes #1388

## Verification
- `uv run --with pytest python -m pytest mlx_vlm/tests/test_server.py::TestDiffusionSkipSpecialTokens -q`
- `uv run --with pytest python -m pytest mlx_vlm/tests/test_gemma4_tool_parser.py mlx_vlm/tests/test_cohere_tool_parser.py -q`
- `uv run --with pytest --with psutil python -m pytest -q` (1137 passed, 3 skipped, 41 subtests passed)
- `uv run --with pre-commit pre-commit run --all`