### PR TITLE
[codex] Skip read-only generation config defaults

### DIFF
--- a/mlx_vlm/tests/test_utils.py
+++ b/mlx_vlm/tests/test_utils.py
@@ -168,6 +168,24 @@ def test_apply_generation_config_defaults_preserves_model_config_signature():
     assert not hasattr(model_config, "max_new_tokens")
 
 
+def test_apply_generation_config_defaults_skips_read_only_properties():
+    class ModelConfig:
+        @property
+        def eos_token_id(self):
+            return [2, 3]
+
+    model_config = apply_generation_config_defaults(
+        ModelConfig(),
+        {
+            "eos_token_id": [4, 5],
+            "temperature": 1.0,
+        },
+    )
+
+    assert model_config.eos_token_id == [2, 3]
+    assert model_config.temperature == 1.0
+
+
 def test_sanitize_weights():
     class DummyModel:
         def __init__(self, config=None):

--- a/mlx_vlm/utils.py
+++ b/mlx_vlm/utils.py
@@ -66,6 +66,9 @@ GENERATION_CONFIG_DEFAULT_KEYS = (
 def apply_generation_config_defaults(model_config, config: dict):
     for key in GENERATION_CONFIG_DEFAULT_KEYS:
         if key in config:
+            descriptor = inspect.getattr_static(type(model_config), key, None)
+            if isinstance(descriptor, property) and descriptor.fset is None:
+                continue
             setattr(model_config, key, config[key])
     return model_config
 


### PR DESCRIPTION
## Summary
- Skip generation config defaults when the target model config exposes a read-only property.
- Add a regression test for read-only `eos_token_id`, matching the MolmoPoint loader failure reported in #1398.

## Root Cause
`apply_generation_config_defaults()` blindly called `setattr()` for selected generation defaults. Some model config classes expose values such as `eos_token_id` as read-only properties, so loading failed before weights were loaded.

## Validation
- `uv run --with pytest pytest mlx_vlm/tests/test_utils.py -q`
- pre-commit hooks from `git commit`: black, isort, autoflake

Note: this addresses the `mlx-vlm` read-only `eos_token_id` failure from #1398, not the full diagnostics report.