### PR TITLE
fixes #1400: Remove mx.clear_cache()/gc.collect() from streaming

### DIFF
--- a/mlx_vlm/server/openai.py
+++ b/mlx_vlm/server/openai.py
@@ -1100,9 +1100,6 @@ async def responses_endpoint(request: Request):
                             stream=True,
                             error="stream_closed_before_completion",
                         )
-                    mx.clear_cache()
-                    gc.collect()
-                    print("Stream finished, cleared cache.")
 
             return StreamingResponse(
                 stream_generator(),
@@ -1730,9 +1727,6 @@ async def chat_completions_endpoint(request: ChatRequest, http_request: Request)
                             stream=True,
                             error="stream_closed_before_completion",
                         )
-                    mx.clear_cache()
-                    gc.collect()
-                    print("Stream finished, cleared cache.")
 
             return StreamingResponse(
                 stream_generator(),


### PR DESCRIPTION
Upstream v0.6.3 also added gc.collect() and a debug print alongside the clear_cache call; all three removed from both streaming finally blocks in /responses and /chat/completions.