### PR TITLE
fix(StoppingCriteria): copy eos_token_ids to prevent caller-list aliasing

### DIFF
--- a/mlx_vlm/utils.py
+++ b/mlx_vlm/utils.py
@@ -1888,7 +1888,7 @@ class StoppingCriteria:
         if isinstance(eos_token_ids, int):
             self.eos_token_ids = [eos_token_ids]
         else:
-            self.eos_token_ids = eos_token_ids
+            self.eos_token_ids = list(eos_token_ids)
 
         self.tokenizer = tokenizer
 


### PR DESCRIPTION
## Summary

`StoppingCriteria.__init__` stores the caller's `eos_token_ids` list **by reference**, not by copy. Combined with the HuggingFace loader path — where `model.config.generation_config["eos_token_id"]` aliases the same list — every call to `add_eos_token_ids(generation_config["eos_token_id"])` (e.g. `mlx_vlm/generate/diffusion.py:615`) becomes `self.eos_token_ids.extend(self.eos_token_ids)` and the list **doubles on every request**.

## Reproducer (no model load needed)

```python
from mlx_vlm.utils import StoppingCriteria
shared = [1, 106, 50]
sc = StoppingCriteria(shared, tokenizer=None)
assert sc.eos_token_ids is shared   # aliased today

# mlx_vlm/generate/diffusion.py:615 pattern:
for _ in range(4):
    sc.add_eos_token_ids(shared)
    print(len(sc.eos_token_ids))   # 6, 12, 24, 48 ← exponential
```

With this PR: `6, 9, 12, 15` (linear, ~3 ints/request).

## Impact

In a continuously-served DiffusionEngine wrapping `stream_diffusion_generate`:
- The `eos_token_ids` list crosses 12 M ints (~3 GB Python heap) after 22 requests.
- Process RSS grows 200-3800 MB per request even though `mx.metal.get_active_memory()` stays flat (so neither `mx.clear_cache()` nor `gc.collect()` reclaim anything — the list is reachable, not garbage).
- The growing list also slows the per-token `input_ids in self.eos_token_ids` membership check; a `max_tokens=1024` request goes from 31.8 s to 6.5 s when the aliasing is broken.

## Validation

In-process probe driving `stream_diffusion_generate` for 27 requests on `mlx-community/diffusiongemma-26B-A4B-it-4bit`, mixed `max_tokens={256,1024}`, on Apple M3 Ultra:

| | RSS req 1 | RSS req 27 | Δ |
|---|---|---|---|
| unpatched | 16 496 MB | 24 401 MB | **+7 905 MB** |
| this PR | 16 491 MB | 15 138 MB | flat (0 MB/req) |

Existing `test_stopping_criteria` and `test_stopping_criteria_reset` in `mlx_vlm/tests/test_utils.py` both pass with the patch applied.

## Notes

The remaining linear growth (`add_eos_token_ids` extending by a small fixed-size list per call) is intentional and ~3 ints per request — indistinguishable from noise over thousands of requests.

I attached a defensive workaround on the downstream side as well (rapid-mlx PR #709) until this lands and rapid-mlx's mlx-vlm floor moves past the fixed release.