### PR TITLE
[codex] Add reasoning_content chat responses

### DIFF
--- a/mlx_vlm/server/openai.py
+++ b/mlx_vlm/server/openai.py
@@ -1374,6 +1374,8 @@ async def chat_completions_endpoint(request: ChatRequest, http_request: Request)
                 msg["name"] = message.name
             if message.reasoning is not None:
                 msg["reasoning"] = message.reasoning
+            if message.reasoning_content is not None:
+                msg["reasoning_content"] = message.reasoning_content
 
             processed_messages.append(msg)
 

--- a/mlx_vlm/server/schemas.py
+++ b/mlx_vlm/server/schemas.py
@@ -268,6 +268,13 @@ class ChatMessage(FlexibleBaseModel):
     reasoning: Optional[str] = Field(
         None, description="Thinking/reasoning content (when thinking is enabled)."
     )
+    reasoning_content: Optional[str] = Field(
+        None,
+        description=(
+            "OpenAI-compatible thinking/reasoning content "
+            "(when thinking is enabled)."
+        ),
+    )
     tool_calls: Optional[List[Any]] = Field(
         None, description="Tool calls made by the assistant."
     )
@@ -275,6 +282,12 @@ class ChatMessage(FlexibleBaseModel):
         None, description="ID of the tool call this message is a response to."
     )
     name: Optional[str] = Field(None, description="Name of the tool/function.")
+
+    def model_post_init(self, __context):
+        if self.reasoning_content is None and self.reasoning is not None:
+            self.reasoning_content = self.reasoning
+        elif self.reasoning is None and self.reasoning_content is not None:
+            self.reasoning = self.reasoning_content
 
 
 class OpenAIRequest(FlexibleBaseModel):

--- a/mlx_vlm/tests/test_server.py
+++ b/mlx_vlm/tests/test_server.py
@@ -1948,7 +1948,49 @@ def test_chat_completions_streaming_uses_custom_thinking_markers(client, monkeyp
     assert "".join(delta.get("reasoning") or "" for delta in deltas) == (
         "Custom reasoning."
     )
+    assert "".join(delta.get("reasoning_content") or "" for delta in deltas) == (
+        "Custom reasoning."
+    )
     assert "".join(delta.get("content") or "" for delta in deltas) == ("Custom answer.")
+
+
+def test_chat_completions_non_streaming_emits_reasoning_content(client):
+    model = SimpleNamespace()
+    processor = SimpleNamespace()
+    config = SimpleNamespace(model_type="custom")
+    result = GenerationResult(
+        text="<analysis>Custom reasoning.</analysis>Custom answer.",
+        prompt_tokens=8,
+        generation_tokens=4,
+        total_tokens=12,
+        prompt_tps=10.0,
+        generation_tps=5.0,
+        peak_memory=0.1,
+    )
+
+    with (
+        patch.object(
+            server, "get_cached_model", return_value=(model, processor, config)
+        ),
+        patch.object(server, "apply_chat_template", return_value="prompt"),
+        patch.object(server, "generate", return_value=result),
+    ):
+        response = client.post(
+            "/chat/completions",
+            json={
+                "model": "demo",
+                "messages": [{"role": "user", "content": "Hello"}],
+                "enable_thinking": True,
+                "thinking_start_token": "<analysis>",
+                "thinking_end_token": "</analysis>",
+            },
+        )
+
+    assert response.status_code == 200
+    message = response.json()["choices"][0]["message"]
+    assert message["reasoning_content"] == "Custom reasoning."
+    assert message["reasoning"] == "Custom reasoning."
+    assert message["content"] == "Custom answer."
 
 
 @pytest.mark.parametrize(
@@ -2354,7 +2396,7 @@ def test_chat_completions_endpoint_preserves_assistant_reasoning(client):
                     {
                         "role": "assistant",
                         "content": "Hello",
-                        "reasoning": "Prior thought",
+                        "reasoning_content": "Prior thought",
                     },
                     {"role": "user", "content": "Continue"},
                 ],
@@ -2366,6 +2408,7 @@ def test_chat_completions_endpoint_preserves_assistant_reasoning(client):
         "role": "assistant",
         "content": "Hello",
         "reasoning": "Prior thought",
+        "reasoning_content": "Prior thought",
     }
 
 
@@ -4884,6 +4927,14 @@ class TestChatMessageSchema:
         msg = server.ChatMessage(
             role="assistant", content="answer", reasoning="thought"
         )
+        assert msg.reasoning == "thought"
+        assert msg.reasoning_content == "thought"
+
+    def test_reasoning_content_field(self):
+        msg = server.ChatMessage(
+            role="assistant", content="answer", reasoning_content="thought"
+        )
+        assert msg.reasoning_content == "thought"
         assert msg.reasoning == "thought"
 
 


### PR DESCRIPTION
## Summary

- Add `reasoning_content` to OpenAI-compatible chat message objects while keeping `reasoning` as a backward-compatible alias.
- Preserve prior assistant reasoning under both keys when building chat-template messages.
- Add server coverage for streaming deltas, non-streaming final messages, and schema alias behavior.

## Root Cause

The server emitted thinking tokens under `reasoning`, but common OpenAI-compatible clients expect `reasoning_content`, so interleaved reasoning state could be dropped between turns.

## Validation

- `python3 -m compileall mlx_vlm/server/schemas.py mlx_vlm/server/openai.py mlx_vlm/tests/test_server.py`
- `uv run --with pytest pytest mlx_vlm/tests/test_server.py -q`