### PR TITLE
Qwen3.5 on CUDA: fix Metal-only crashes + chunked gated-delta prefill (8.5x faster prefill)

### DIFF
--- a/mlx_vlm/models/qwen3_5/gated_delta.py
+++ b/mlx_vlm/models/qwen3_5/gated_delta.py
@@ -1,4 +1,3 @@
-import math
 from functools import partial
 from typing import Optional
 
@@ -18,17 +17,13 @@ def _compute_g_beta(A_log, a, b, dt_bias):
 
 
 def _invert_unit_lower(Tmat: mx.array, C: int) -> mx.array:
-    """Inverse of a batched unit lower-triangular matrix ``Tmat = I + N`` with
-    ``N`` strictly-lower (hence nilpotent). Uses the log-depth identity
+    """Inverse of a batched unit lower-triangular matrix ``Tmat`` (``[..., C, C]``,
+    unit diagonal) via forward substitution, batched over all chunks/heads.
 
-        (I + N)^-1 = (I - N) * prod_{k>=1} (I + N^(2^k))
-
-    which needs only ~log2(C) batched matmuls (vs a C-step forward
-    substitution). Fewer/shallower graph nodes — important so CUDA-graph
-    capture in the batched server path doesn't choke."""
-    # Numerically-stable forward substitution (the log-depth repeated-squaring
-    # Neumann inverse overflows when N has O(1) entries, which happens with
-    # correlated keys). Sequential in C but batched over all chunks/heads.
+    Sequential in C (small, fixed) but numerically stable. A log-depth
+    repeated-squaring (Neumann) inverse is faster but overflows when N has
+    O(1) entries — exactly the regime here, since correlated keys give KK
+    off-diagonals ~1."""
     X = mx.broadcast_to(mx.eye(C, dtype=mx.float32), Tmat.shape) + mx.zeros_like(Tmat)
     rows = [X[..., 0:1, :]]
     for i in range(1, C):
@@ -73,8 +68,8 @@ def gated_delta_chunked(q, k, v, g, beta, state, mask=None, C: int = 64):
     def rc(x, D):
         return x.reshape(B, nC, C, Hv, D).transpose(0, 3, 1, 2, 4).astype(mx.float32)
 
-    q, k, v = rc(q, Dk), rc(k, Dk), rc(v, Dv)               # [B,Hv,nC,C,D]
-    g = g.reshape(B, nC, C, Hv).transpose(0, 3, 1, 2)        # [B,Hv,nC,C]
+    q, k, v = rc(q, Dk), rc(k, Dk), rc(v, Dv)  # [B,Hv,nC,C,D]
+    g = g.reshape(B, nC, C, Hv).transpose(0, 3, 1, 2)  # [B,Hv,nC,C]
     beta = beta.reshape(B, nC, C, Hv).transpose(0, 3, 1, 2)
 
     # clip g off 0: compute_g can underflow to exactly 0.0 in fp32, and
@@ -93,24 +88,29 @@ def gated_delta_chunked(q, k, v, g, beta, state, mask=None, C: int = 64):
     Tinv = _invert_unit_lower(mx.eye(C, dtype=mx.float32) + A, C)
 
     kbeta = (beta * cumg)[..., :, None] * k
-    U0 = Tinv @ (beta[..., :, None] * v)                    # [B,Hv,nC,C,Dv]
-    Kt = Tinv @ kbeta                                       # [B,Hv,nC,C,Dk]
+    U0 = Tinv @ (beta[..., :, None] * v)  # [B,Hv,nC,C,Dv]
+    Kt = Tinv @ kbeta  # [B,Hv,nC,C,Dk]
     M = dr * (q @ mx.swapaxes(k, -1, -2)) * lower_incl
     Qeff = cumg[..., :, None] * q - M @ Kt
     MU0 = M @ U0
     cumg_last = cumg[..., -1]
-    ratio_last = mx.exp(lcg[..., -1, None] - lcg)           # cumg_last/cumg_i
+    ratio_last = mx.exp(lcg[..., -1, None] - lcg)  # cumg_last/cumg_i
 
-    S = state.astype(mx.float32) if state is not None else mx.zeros(
-        (B, Hv, Dv, Dk), mx.float32
+    S = (
+        state.astype(mx.float32)
+        if state is not None
+        else mx.zeros((B, Hv, Dv, Dk), mx.float32)
     )
     ys = []
     for c in range(nC):
-        St = mx.swapaxes(S, -1, -2)                         # [B,Hv,Dk,Dv]
-        ys.append(MU0[:, :, c] + Qeff[:, :, c] @ St)        # [B,Hv,C,Dv]
+        St = mx.swapaxes(S, -1, -2)  # [B,Hv,Dk,Dv]
+        ys.append(MU0[:, :, c] + Qeff[:, :, c] @ St)  # [B,Hv,C,Dv]
         Uc = U0[:, :, c] - Kt[:, :, c] @ St
         Uscaled = ratio_last[:, :, c][..., None] * Uc
-        S = cumg_last[:, :, c][..., None, None] * S + mx.swapaxes(Uscaled, -1, -2) @ k[:, :, c]
+        S = (
+            cumg_last[:, :, c][..., None, None] * S
+            + mx.swapaxes(Uscaled, -1, -2) @ k[:, :, c]
+        )
     Y = mx.stack(ys, axis=2).transpose(0, 2, 3, 1, 4).reshape(B, Tp, Hv, Dv)[:, :T]
     Y = Y.astype(in_dtype)
     # Schedule this (large, dynamically-shaped) prefill subgraph for evaluation

--- a/mlx_vlm/models/qwen3_5/gated_delta.py
+++ b/mlx_vlm/models/qwen3_5/gated_delta.py
@@ -1,3 +1,4 @@
+import math
 from functools import partial
 from typing import Optional
 
@@ -14,6 +15,112 @@ def compute_g(A_log, a, dt_bias):
 @partial(mx.compile, shapeless=True)
 def _compute_g_beta(A_log, a, b, dt_bias):
     return compute_g(A_log, a, dt_bias), mx.sigmoid(b)
+
+
+def _invert_unit_lower(Tmat: mx.array, C: int) -> mx.array:
+    """Inverse of a batched unit lower-triangular matrix ``Tmat = I + N`` with
+    ``N`` strictly-lower (hence nilpotent). Uses the log-depth identity
+
+        (I + N)^-1 = (I - N) * prod_{k>=1} (I + N^(2^k))
+
+    which needs only ~log2(C) batched matmuls (vs a C-step forward
+    substitution). Fewer/shallower graph nodes — important so CUDA-graph
+    capture in the batched server path doesn't choke."""
+    # Numerically-stable forward substitution (the log-depth repeated-squaring
+    # Neumann inverse overflows when N has O(1) entries, which happens with
+    # correlated keys). Sequential in C but batched over all chunks/heads.
+    X = mx.broadcast_to(mx.eye(C, dtype=mx.float32), Tmat.shape) + mx.zeros_like(Tmat)
+    rows = [X[..., 0:1, :]]
+    for i in range(1, C):
+        Tij = Tmat[..., i : i + 1, :i]
+        Xj = mx.concatenate(rows, axis=-2)
+        rows.append(X[..., i : i + 1, :] - Tij @ Xj)
+    return mx.concatenate(rows, axis=-2)
+
+
+def gated_delta_chunked(q, k, v, g, beta, state, mask=None, C: int = 64):
+    """Chunked parallel gated-delta-rule prefill (scalar per-head gating).
+
+    Mathematically equivalent to the sequential ``gated_delta_ops`` recurrence
+    but replaces the per-token loop (O(T) sequential ops) with a chunked scan:
+    parallel intra-chunk matmuls + a C-length triangular solve + a T/C-step
+    inter-chunk state scan. ~20x faster than the per-token loop on CUDA, where
+    no fused Metal kernel is available. Validated to rel-err < 1e-3 (fp32) vs
+    the reference, well within bf16 precision.
+    """
+    B, T, Hk, Dk = q.shape
+    Hv, Dv = v.shape[-2:]
+    in_dtype = v.dtype
+    if (rf := Hv // Hk) > 1:
+        q = mx.repeat(q, rf, -2)
+        k = mx.repeat(k, rf, -2)
+    # masked (padding) positions: no decay, no update -> g=1, beta=0
+    if mask is not None:
+        m = mask[..., None]
+        g = mx.where(m, g, 1.0)
+        beta = mx.where(m, beta, 0.0)
+
+    pad = (C - T % C) % C
+    if pad:
+        q = mx.concatenate([q, mx.zeros((B, pad, Hv, Dk), q.dtype)], axis=1)
+        k = mx.concatenate([k, mx.zeros((B, pad, Hv, Dk), k.dtype)], axis=1)
+        v = mx.concatenate([v, mx.zeros((B, pad, Hv, Dv), v.dtype)], axis=1)
+        g = mx.concatenate([g, mx.ones((B, pad, Hv), g.dtype)], axis=1)
+        beta = mx.concatenate([beta, mx.zeros((B, pad, Hv), beta.dtype)], axis=1)
+    Tp = T + pad
+    nC = Tp // C
+
+    def rc(x, D):
+        return x.reshape(B, nC, C, Hv, D).transpose(0, 3, 1, 2, 4).astype(mx.float32)
+
+    q, k, v = rc(q, Dk), rc(k, Dk), rc(v, Dv)               # [B,Hv,nC,C,D]
+    g = g.reshape(B, nC, C, Hv).transpose(0, 3, 1, 2)        # [B,Hv,nC,C]
+    beta = beta.reshape(B, nC, C, Hv).transpose(0, 3, 1, 2)
+
+    # clip g off 0: compute_g can underflow to exactly 0.0 in fp32, and
+    # log(0)=-inf would poison the decay ratios with NaN.
+    lcg = mx.cumsum(mx.log(mx.clip(g, 1e-6, 1.0)), axis=-1)  # log cumulative decay
+    cumg = mx.exp(lcg)
+    lower_incl = mx.tril(mx.ones((C, C), mx.float32), 0)
+    strict_lower = mx.tril(mx.ones((C, C), mx.float32), -1)
+    # decay_ratio[i,j]=cumg_i/cumg_j; mask exponent to lower triangle BEFORE exp
+    # (upper triangle would overflow since g<1, and inf*0=nan).
+    diff = mx.where(lower_incl > 0, lcg[..., :, None] - lcg[..., None, :], -1e30)
+    dr = mx.exp(diff)
+
+    KK = k @ mx.swapaxes(k, -1, -2)
+    A = beta[..., :, None] * dr * KK * strict_lower
+    Tinv = _invert_unit_lower(mx.eye(C, dtype=mx.float32) + A, C)
+
+    kbeta = (beta * cumg)[..., :, None] * k
+    U0 = Tinv @ (beta[..., :, None] * v)                    # [B,Hv,nC,C,Dv]
+    Kt = Tinv @ kbeta                                       # [B,Hv,nC,C,Dk]
+    M = dr * (q @ mx.swapaxes(k, -1, -2)) * lower_incl
+    Qeff = cumg[..., :, None] * q - M @ Kt
+    MU0 = M @ U0
+    cumg_last = cumg[..., -1]
+    ratio_last = mx.exp(lcg[..., -1, None] - lcg)           # cumg_last/cumg_i
+
+    S = state.astype(mx.float32) if state is not None else mx.zeros(
+        (B, Hv, Dv, Dk), mx.float32
+    )
+    ys = []
+    for c in range(nC):
+        St = mx.swapaxes(S, -1, -2)                         # [B,Hv,Dk,Dv]
+        ys.append(MU0[:, :, c] + Qeff[:, :, c] @ St)        # [B,Hv,C,Dv]
+        Uc = U0[:, :, c] - Kt[:, :, c] @ St
+        Uscaled = ratio_last[:, :, c][..., None] * Uc
+        S = cumg_last[:, :, c][..., None, None] * S + mx.swapaxes(Uscaled, -1, -2) @ k[:, :, c]
+    Y = mx.stack(ys, axis=2).transpose(0, 2, 3, 1, 4).reshape(B, Tp, Hv, Dv)[:, :T]
+    Y = Y.astype(in_dtype)
+    # Schedule this (large, dynamically-shaped) prefill subgraph for evaluation
+    # so it is NOT folded into the server's captured CUDA graph — that capture
+    # chokes on it (cudaGraphAddDependencies). async_eval breaks the graph at
+    # this boundary without blocking the Python thread, letting graph-building
+    # for the next layer overlap with GPU compute. Decode (T==1) never calls
+    # this path, so its CUDA graphs stay intact.
+    mx.async_eval(Y, S)
+    return Y, S
 
 
 def gated_delta_update(
@@ -35,6 +142,12 @@ def gated_delta_update(
         state = mx.zeros((B, Hv, Dv, Dk), dtype=mx.float32)
 
     if not use_kernel or mx.default_device() != mx.gpu or not mx.metal.is_available():
+        # Prefill (T>1) with scalar gating: use the chunked parallel scan, which
+        # is ~20x faster than the per-token loop on backends without a fused
+        # kernel (e.g. CUDA). Decode (T==1) and vectorized gating fall back to
+        # the reference ops.
+        if q.shape[1] > 1 and g.ndim == 3:
+            return gated_delta_chunked(q, k, v, g, beta, state, mask)
         return gated_delta_ops(q, k, v, g, beta, state, mask)
     return gated_delta_kernel(q, k, v, g, beta, state, mask)
 

--- a/mlx_vlm/models/qwen3_5/language.py
+++ b/mlx_vlm/models/qwen3_5/language.py
@@ -72,12 +72,13 @@ def _qwen3_5_decode_depthwise_conv(conv_input: mx.array, weight: mx.array):
     return out.astype(conv_input.dtype)[:, None, :]
 
 
-_TARGET_VERIFY_GEMV = mx.fast.metal_kernel(
-    name="qwen3_5_target_verify_gemv",
-    input_names=["x", "weight"],
-    output_names=["out"],
-    header="#include <metal_simdgroup>\nusing namespace metal;\n",
-    source=r"""
+_TARGET_VERIFY_GEMV = (
+    mx.fast.metal_kernel(
+        name="qwen3_5_target_verify_gemv",
+        input_names=["x", "weight"],
+        output_names=["out"],
+        header="#include <metal_simdgroup>\nusing namespace metal;\n",
+        source=r"""
         uint lane = thread_position_in_grid.x;
         uint out_block = thread_position_in_grid.y;
         uint row = thread_position_in_grid.z;
@@ -145,7 +146,10 @@ _TARGET_VERIFY_GEMV = mx.fast.metal_kernel(
             }
         }
     """,
-) if mx.metal.is_available() else None
+    )
+    if mx.metal.is_available()
+    else None
+)
 
 
 def _use_target_verify_dense(linear, x: mx.array, target_verify: bool) -> bool:

--- a/mlx_vlm/models/qwen3_5/language.py
+++ b/mlx_vlm/models/qwen3_5/language.py
@@ -145,12 +145,13 @@ _TARGET_VERIFY_GEMV = mx.fast.metal_kernel(
             }
         }
     """,
-)
+) if mx.metal.is_available() else None
 
 
 def _use_target_verify_dense(linear, x: mx.array, target_verify: bool) -> bool:
     return (
-        target_verify
+        _TARGET_VERIFY_GEMV is not None
+        and target_verify
         and x.ndim == 3
         and x.shape[1] > 1
         and isinstance(linear, (nn.Linear, nn.QuantizedLinear))

--- a/mlx_vlm/models/qwen3_5/language.py
+++ b/mlx_vlm/models/qwen3_5/language.py
@@ -1204,6 +1204,10 @@ def _qwen3_5_ragged_decode_attention(
     pads: List[int],
     scale: float,
 ) -> Optional[mx.array]:
+    # Metal-only fast path; on other backends (e.g. CUDA) return None so the
+    # caller falls back to portable per-pad-group scaled_dot_product_attention.
+    if not mx.metal.is_available():
+        return None
     if (
         queries.ndim != 4
         or keys.ndim != 4


### PR DESCRIPTION
## Summary

Makes Qwen3.5 (hybrid gated-delta + attention) usable on non-Metal backends (CUDA), and removes the prefill bottleneck. Three commits:

1. **Guard the import-time target-verify Metal kernel.** `_TARGET_VERIFY_GEMV` was built with `mx.fast.metal_kernel(...)` at module import. On CUDA that raises `RuntimeError: [metal_kernel] No Metal back-end.` immediately, so the model couldn't even be imported. Built only when Metal is available, else `None`, with `_use_target_verify_dense` gated on it.

2. **Route ragged left-padded decode attention to the portable fallback on non-Metal.** The continuous-batching decode path builds Metal-only ragged-SDPA kernels, so every request with batch ≥ 2 returned HTTP 500. `_target_verify_left_padded_attention` already has a portable `scaled_dot_product_attention` fallback; the ragged helper now returns `None` on non-Metal so that path is used. Continuous batching works on CUDA (batch 2/4 verified).

3. **Chunked parallel gated-delta prefill.** 24 of 32 layers are gated-delta (linear attention). On backends without the fused Metal kernel, prefill ran as a Python `for t in range(T)` loop over the sequence (`mlx_lm.gated_delta_ops`) — ~T sequential ops per layer, ~49k sequential graph nodes for a 2048-token prompt, dominating prefill. Added `gated_delta_chunked`: parallel intra-chunk matmuls + a chunk-length unit-lower triangular solve + a T/C-step inter-chunk state scan. Used for prefill (T>1, scalar gating); decode (T==1) and vectorized gating keep the reference path.

Validated numerically vs the sequential reference to rel-err < 1e-3 (fp32, well within bf16), including the masked (left-padded) case.

## Performance

RTX PRO 6000 Blackwell (CUDA 13.3), Qwen3.5-4B bf16, greedy, CUDA graphs on.

### Prefill TTFT — before vs after (prefill-bound, 2048-token prompt)

| batch | before | after | speedup |
|---|---|---|---|
| 1 | 2090 ms | 247 ms | 8.5× |
| 2 | 4246 ms | 454 ms | 9.4× |
| 4 | crashed (HTTP 500) | 629 ms | fixed |

Decode is unchanged (141 / 420 tok/s at batch 1 / 4) — the fix only touches the T>1 prefill path.

### vs vLLM 0.20.2 and SGLang 0.5.12 (batch=1, context sweep, after fix)

Same checkpoint, same GPU, caching disabled on all engines, max_tokens=1024.

**Prefill — TTFT p50 (ms), lower is better:**

| context | mlx | vLLM | SGLang | mlx gap |
|---|---|---|---|---|
| 2K  | 248  | 62   | 59   | 4.2× |
| 4K  | 391  | 117  | 116  | 3.4× |
| 8K  | 704  | 251  | 258  | 2.8× |
| 16K | 1366 | 527  | 538  | 2.6× |
| 32K | 2916 | 1170 | 1204 | 2.5× |
| 64K | 6898 | 2853 | 2934 | 2.4× |

**Decode — tok/s (1000 / TPOT p50), higher is better:**

| context | mlx | vLLM | SGLang |
|---|---|---|---|
| 2K  | 146 | 153 | 155 |
| 4K  | 145 | 152 | 154 |
| 8K  | 141 | 150 | 151 |
| 16K | 133 | 147 | 147 |
| 32K | 121 | 140 | 140 |
| 64K | 102 | 129 | 128 |

Before these changes, prefill was ~34× behind vLLM/SGLang (and crashed at batch ≥ 2); after, it scales with the same shape and is ~2.4–4.2× behind, with the gap narrowing as context grows. Decode is within ~5% at short context and ~20% behind at 64K (the per-step full-attention over a large KV cache; the gated-delta layers keep constant-size state so they don't degrade). The remaining gap is general CUDA kernel efficiency (FlashAttention / fused gated-delta kernels), not algorithmic.

<img width="2800" height="2100" alt="benchmark_all" src="https://github.com/user-attachments/assets/37e67644-043e-4e97-a759-7db5080767f4" />


## Notes

- `g` is clipped off 0 before `log` (`compute_g` can underflow to exactly 0.0 → `log(0) = -inf`).
- The triangular inverse uses forward substitution rather than repeated-squaring Neumann: the latter overflows when keys are correlated (`KK` off-diagonals ≈ 1), which is the real-model regime.
- The chunked prefill output is scheduled with `mx.async_eval` so this large/dynamic subgraph isn't folded into the server's captured CUDA graph (that capture otherwise hits a backend `cudaGraphAddDependencies` error). Decode never calls this path, so its CUDA graphs are untouched.

All changes are non-Metal-only fallbacks; macOS/Metal behavior is unchanged (Metal kernels still used when available).
