### PR TITLE
Handle BPE byte fallback tokenizers

### DIFF
--- a/mlx_vlm/tests/test_tokenizer_utils.py
+++ b/mlx_vlm/tests/test_tokenizer_utils.py
@@ -9,11 +9,13 @@ from mlx_vlm.tokenizer_utils import (
     SPMStreamingDetokenizer,
     StreamingDetokenizer,
     TokenizerWrapper,
+    _is_bpe_byte_fallback_tokenizer,
     _is_bpe_decoder,
     _is_spm_decoder,
     _is_spm_decoder_no_space,
     _match,
     _remove_space,
+    load_tokenizer,
     make_streaming_detokenizer,
 )
 
@@ -199,6 +201,34 @@ class TestIsBpeDecoder:
     def test_non_dict(self):
         assert _is_bpe_decoder("ByteLevel") is False
         assert _is_bpe_decoder(None) is False
+
+
+class TestIsBpeByteFallbackTokenizer:
+    """Tests for BPE tokenizers that use byte fallback decoding."""
+
+    def test_detects_bpe_byte_fallback_sequence(self):
+        tokenizer_content = {
+            "model": {"type": "BPE"},
+            "decoder": {
+                "type": "Sequence",
+                "decoders": [
+                    {"type": "Replace", "pattern": {"String": "▁"}, "content": " "},
+                    {"type": "ByteFallback"},
+                    {"type": "Fuse"},
+                    {"type": "Strip", "content": " ", "start": 1, "stop": 0},
+                ],
+            },
+        }
+
+        assert _is_bpe_byte_fallback_tokenizer(tokenizer_content) is True
+
+    def test_ignores_non_bpe_tokenizer(self):
+        tokenizer_content = {
+            "model": {"type": "Unigram"},
+            "decoder": {"type": "ByteFallback"},
+        }
+
+        assert _is_bpe_byte_fallback_tokenizer(tokenizer_content) is False
 
 
 # ============================================================================
@@ -711,6 +741,29 @@ class TestBPEStreamingDetokenizer:
 
         assert detokenizer.text == "Got it, the user"
 
+    def test_decodes_byte_level_chinese_tokens(self):
+        tokenizer = MockBPETokenizer()
+        tokenizer.vocab = {
+            "ç»": 0,
+            "¿": 1,
+            "æ´": 2,
+            "²": 3,
+            "ä»ķ": 4,
+            "æł¼": 5,
+            "ç»´": 6,
+            "èĬ±": 7,
+            "åĽŃ": 8,
+            "åħ¬": 9,
+            "å¯ĵ": 10,
+        }
+        detokenizer = BPEStreamingDetokenizer(tokenizer)
+
+        for token in range(11):
+            detokenizer.add_token(token)
+        detokenizer.finalize()
+
+        assert detokenizer.text == "绿洲仕格维花园公寓"
+
 
 # ============================================================================
 # Tests for TokenizerWrapper
@@ -739,6 +792,31 @@ class TestTokenizerWrapper:
         wrapper = TokenizerWrapper(tokenizer, SPMStreamingDetokenizer)
 
         assert isinstance(wrapper.detokenizer, SPMStreamingDetokenizer)
+
+    def test_load_tokenizer_uses_bpe_for_bpe_byte_fallback(self, tmp_path, monkeypatch):
+        (tmp_path / "tokenizer.json").write_text(
+            """{
+              "model": {"type": "BPE"},
+              "decoder": {
+                "type": "Sequence",
+                "decoders": [
+                  {"type": "Replace", "pattern": {"String": "▁"}, "content": " "},
+                  {"type": "ByteFallback"},
+                  {"type": "Fuse"},
+                  {"type": "Strip", "content": " ", "start": 1, "stop": 0}
+                ]
+              }
+            }"""
+        )
+
+        monkeypatch.setattr(
+            "mlx_vlm.tokenizer_utils.AutoTokenizer.from_pretrained",
+            lambda *_args, **_kwargs: MockBPETokenizer(),
+        )
+
+        wrapper = load_tokenizer(tmp_path)
+
+        assert isinstance(wrapper.detokenizer, BPEStreamingDetokenizer)
 
 
 # ============================================================================

--- a/mlx_vlm/tokenizer_utils.py
+++ b/mlx_vlm/tokenizer_utils.py
@@ -450,6 +450,22 @@ def _is_bpe_decoder(decoder):
     return isinstance(decoder, dict) and decoder.get("type", None) == "ByteLevel"
 
 
+def _has_decoder(decoder, decoder_type):
+    if isinstance(decoder, dict):
+        return decoder.get("type") == decoder_type or any(
+            _has_decoder(value, decoder_type) for value in decoder.values()
+        )
+    if isinstance(decoder, list):
+        return any(_has_decoder(value, decoder_type) for value in decoder)
+    return False
+
+
+def _is_bpe_byte_fallback_tokenizer(tokenizer_content):
+    return tokenizer_content.get("model", {}).get("type") == "BPE" and _has_decoder(
+        tokenizer_content.get("decoder"), "ByteFallback"
+    )
+
+
 def load_tokenizer(model_path, return_tokenizer=True, tokenizer_config_extra={}):
     """Load a huggingface tokenizer and try to infer the type of streaming
     detokenizer to use.
@@ -468,7 +484,9 @@ def load_tokenizer(model_path, return_tokenizer=True, tokenizer_config_extra={})
                 raise JSONDecodeError("Failed to parse tokenizer.json", e.doc, e.pos)
 
         if "decoder" in tokenizer_content:
-            if _is_spm_decoder(tokenizer_content["decoder"]):
+            if _is_bpe_byte_fallback_tokenizer(tokenizer_content):
+                detokenizer_class = BPEStreamingDetokenizer
+            elif _is_spm_decoder(tokenizer_content["decoder"]):
                 detokenizer_class = SPMStreamingDetokenizer
             elif _is_spm_decoder_no_space(tokenizer_content["decoder"]):
                 detokenizer_class = partial(SPMStreamingDetokenizer, trim_space=False)


### PR DESCRIPTION
## Summary

- detect BPE tokenizers that use a `ByteFallback` decoder and route them through `BPEStreamingDetokenizer`
- add regression coverage for byte-level Chinese text and `load_tokenizer()` detokenizer selection
- fixes mojibake output for MLX-converted Unlimited-OCR models such as `mikoy92/Unlimited-OCR-bf16-mlx`

## Tests

- `uv run --with pytest pytest mlx_vlm/tests/test_tokenizer_utils.py`
- `uv run --with pre-commit pre-commit run --files mlx_vlm/tokenizer_utils.py mlx_vlm/tests/test_tokenizer_utils.py`
