### PR TITLE
[codex] Fix Gemma 4 variable image soft tokens

### DIFF
--- a/mlx_vlm/generate/dispatch.py
+++ b/mlx_vlm/generate/dispatch.py
@@ -165,6 +165,13 @@ def parse_arguments():
         help="Resize shape for the image.",
     )
     parser.add_argument(
+        "--vision-soft-tokens-per-image",
+        type=int,
+        choices=(70, 140, 280, 560, 1120),
+        default=None,
+        help="Gemma 4 image soft-token budget per image.",
+    )
+    parser.add_argument(
         "--prompt",
         type=str,
         nargs="+",
@@ -1547,6 +1554,13 @@ def main():
             }
             if args.resize_shape is not None:
                 stream_kwargs["resize_shape"] = args.resize_shape
+            vision_soft_tokens_per_image = getattr(
+                args, "vision_soft_tokens_per_image", None
+            )
+            if vision_soft_tokens_per_image is not None:
+                stream_kwargs["vision_soft_tokens_per_image"] = (
+                    vision_soft_tokens_per_image
+                )
             if args.prefill_step_size is not None:
                 stream_kwargs["prefill_step_size"] = args.prefill_step_size
             if is_masked_text_diffusion:
@@ -1617,6 +1631,11 @@ def main():
         }
         if args.resize_shape is not None:
             gen_kwargs["resize_shape"] = args.resize_shape
+        vision_soft_tokens_per_image = getattr(
+            args, "vision_soft_tokens_per_image", None
+        )
+        if vision_soft_tokens_per_image is not None:
+            gen_kwargs["vision_soft_tokens_per_image"] = vision_soft_tokens_per_image
         if args.prefill_step_size is not None:
             gen_kwargs["prefill_step_size"] = args.prefill_step_size
         if is_masked_diffusion_text_model(model):

--- a/mlx_vlm/models/gemma4/README.md
+++ b/mlx_vlm/models/gemma4/README.md
@@ -98,6 +98,17 @@ python -m mlx_vlm.generate \
   --temperature 1.0 --top-p 0.95 --top-k 64
 ```
 
+For text-dense images, increase the image soft-token budget:
+
+```sh
+python -m mlx_vlm.generate \
+  --model google/gemma-4-e4b-it \
+  --image path/to/slide.png \
+  --prompt "Transcribe all visible text." \
+  --vision-soft-tokens-per-image 1120 \
+  --max-tokens 500
+```
+
 ### Audio understanding (2B/4B only)
 
 ```sh
@@ -189,6 +200,7 @@ result = generate(
     processor=processor,
     prompt=prompt,
     image=image,
+    vision_soft_tokens_per_image=1120,
     max_tokens=500,
     temperature=1.0,
     top_p=0.95,

--- a/mlx_vlm/models/gemma4/gemma4.py
+++ b/mlx_vlm/models/gemma4/gemma4.py
@@ -10,10 +10,21 @@ from .language import LanguageModel, RMSNormNoScale
 from .vision import VisionModel
 
 
-def masked_scatter(input_tensor, mask, source):
+def masked_scatter(input_tensor, mask, source, allow_truncate=False):
     mask_flat = mask.flatten().astype(mx.int32)
+    n_mask = int(mask_flat.sum().item())
+    if source.size < n_mask or (source.size != n_mask and not allow_truncate):
+        hidden_size = input_tensor.shape[-1]
+        n_tokens = n_mask // hidden_size
+        n_features = source.size // hidden_size
+        raise ValueError(
+            "Multimodal features and tokens do not match: "
+            f"tokens {n_tokens}, features {n_features}"
+        )
+    if n_mask == 0:
+        return input_tensor
     indices = mx.cumsum(mask_flat) - 1
-    aligned = source.flatten()[indices % source.size]
+    aligned = source.flatten()[indices]
     return mx.where(mask_flat, aligned, input_tensor.flatten()).reshape(
         input_tensor.shape
     )
@@ -102,7 +113,9 @@ class Model(nn.Module):
                 per_layer_inputs_tokens
             )
 
-        def _scatter(source, token_id, encode, cached_kw=None, key_kw=None):
+        def _scatter(
+            source, token_id, encode, cached_kw=None, key_kw=None, allow_truncate=False
+        ):
             if source is None or token_id is None:
                 return inputs_embeds
             vision_cache = kwargs.get("vision_cache", None) if key_kw else None
@@ -121,7 +134,12 @@ class Model(nn.Module):
             mask_expanded = mx.broadcast_to(
                 mx.expand_dims(input_ids == token_id, -1), inputs_embeds.shape
             )
-            return masked_scatter(inputs_embeds, mask_expanded, features)
+            return masked_scatter(
+                inputs_embeds,
+                mask_expanded,
+                features,
+                allow_truncate=allow_truncate,
+            )
 
         def _encode_vision(pixels):
             return self.embed_vision(self.vision_tower(pixels))
@@ -156,6 +174,7 @@ class Model(nn.Module):
                 audio_features,
                 self.config.audio_token_id,
                 _encode_audio,
+                allow_truncate=True,
             )
 
         return InputEmbeddingsFeatures(

--- a/mlx_vlm/models/gemma4/processing_gemma4.py
+++ b/mlx_vlm/models/gemma4/processing_gemma4.py
@@ -471,6 +471,8 @@ class Gemma4Processor(ProcessorMixin):
         videos: Optional[List] = None,
         fps: Optional[Union[float, List[float]]] = None,
         return_mm_token_type_ids: bool = True,
+        max_soft_tokens: Optional[int] = None,
+        vision_soft_tokens_per_image: Optional[int] = None,
         **kwargs,
     ) -> BatchFeature:
         if text is None and images is None and audio is None and videos is None:
@@ -494,7 +496,24 @@ class Gemma4Processor(ProcessorMixin):
         image_inputs = {}
         if images is not None:
             images = self.image_processor.fetch_images(images)
-            image_data, num_soft_tokens = self.image_processor(images)
+            if (
+                max_soft_tokens is not None
+                and vision_soft_tokens_per_image is not None
+                and max_soft_tokens != vision_soft_tokens_per_image
+            ):
+                raise ValueError(
+                    "`max_soft_tokens` and `vision_soft_tokens_per_image` must "
+                    "match when both are provided."
+                )
+            image_max_soft_tokens = (
+                vision_soft_tokens_per_image
+                if vision_soft_tokens_per_image is not None
+                else max_soft_tokens
+            )
+            image_kwargs = {}
+            if image_max_soft_tokens is not None:
+                image_kwargs["max_soft_tokens"] = image_max_soft_tokens
+            image_data, num_soft_tokens = self.image_processor(images, **image_kwargs)
             image_inputs = image_data
 
             if text is not None and num_soft_tokens is not None:
@@ -749,6 +768,8 @@ class Gemma4Processor(ProcessorMixin):
             "truncation",
             "max_length",
             "fps",
+            "max_soft_tokens",
+            "vision_soft_tokens_per_image",
         ):
             if key in kwargs:
                 processor_kwargs[key] = kwargs.pop(key)

--- a/mlx_vlm/models/gemma4/vision.py
+++ b/mlx_vlm/models/gemma4/vision.py
@@ -362,8 +362,13 @@ class VisionPooler(nn.Module):
         )
 
         length = output_length or self.default_output_length
+        if length > hidden_states.shape[1]:
+            raise ValueError(
+                f"Cannot output more soft tokens (requested {length}) than there "
+                f"are patches ({hidden_states.shape[1]})."
+            )
         if hidden_states.shape[1] == length:
-            mask = padding_positions
+            mask = ~padding_positions
         else:
             hidden_states, mask = self._avg_pool_by_positions(
                 hidden_states, patch_positions, length
@@ -414,29 +419,39 @@ class VisionModel(nn.Module):
             self.std_bias = mx.zeros((config.hidden_size,))
             self.std_scale = mx.ones((config.hidden_size,))
 
-    def _patch_positions_single(self, H, W):
+    def _patch_positions_single(self, H, W, max_patches=None):
         """Compute patch positions and padding mask for a single image."""
         pH = H // self.patch_size
         pW = W // self.patch_size
         num_patches = pH * pW
+        max_patches = max_patches or self.max_patches
 
         grid_x = np.arange(pW)
         grid_y = np.arange(pH)
         gx, gy = np.meshgrid(grid_x, grid_y, indexing="xy")
         real_positions = np.stack([gx.flatten(), gy.flatten()], axis=-1)
 
-        num_padding = self.max_patches - num_patches
+        num_padding = max_patches - num_patches
         if num_padding > 0:
             pad_positions = np.full((num_padding, 2), -1, dtype=np.int64)
             patch_positions = np.concatenate([real_positions, pad_positions], axis=0)
         else:
-            patch_positions = real_positions[: self.max_patches]
+            patch_positions = real_positions[:max_patches]
 
-        padding_mask = np.zeros(self.max_patches, dtype=bool)
+        padding_mask = np.zeros(max_patches, dtype=bool)
         if num_padding > 0:
             padding_mask[num_patches:] = True
 
         return patch_positions.astype(np.int32), padding_mask, num_patches
+
+    def _output_length_for_patches(self, num_patches):
+        pool_area = self.pooling_kernel_size**2
+        if num_patches % pool_area != 0:
+            raise ValueError(
+                f"Cannot pool {num_patches} patches with pooling kernel "
+                f"{self.pooling_kernel_size}."
+            )
+        return num_patches // pool_area
 
     def __call__(self, pixel_values) -> mx.array:
         # Handle list of different-sized images: process each individually
@@ -459,24 +474,18 @@ class VisionModel(nn.Module):
 
         if all_same_size:
             num_real = (H // self.patch_size) * (W // self.patch_size)
-            num_real = min(num_real, self.max_patches)
-            positions, padding_mask, _ = self._patch_positions_single(H, W)
+            output_length = self._output_length_for_patches(num_real)
+            positions, padding_mask, _ = self._patch_positions_single(
+                H, W, max_patches=num_real
+            )
             # Tile for batch
             patch_positions = mx.array(np.tile(positions[None], (B, 1, 1)))
             padding_positions = mx.array(np.tile(padding_mask[None], (B, 1)))
 
             inputs_embeds = self.patch_embedder(
-                pixel_values,
-                patch_positions[:, :num_real],
-                padding_positions[:, :num_real],
+                pixel_values, patch_positions, padding_positions
             )
 
-            num_padding = self.max_patches - num_real
-            if num_padding > 0:
-                pad_embeds = mx.zeros(
-                    (B, num_padding, inputs_embeds.shape[-1]), dtype=inputs_embeds.dtype
-                )
-                inputs_embeds = mx.concatenate([inputs_embeds, pad_embeds], axis=1)
         else:
             # Per-image processing for different sizes (shouldn't happen with padding)
             all_embeds = []
@@ -485,16 +494,15 @@ class VisionModel(nn.Module):
             for i in range(B):
                 img = pixel_values[i : i + 1]
                 _, _, h, w = img.shape
-                pos, pad_mask, n_real = self._patch_positions_single(h, w)
+                n_real = (h // self.patch_size) * (w // self.patch_size)
+                output_length = self._output_length_for_patches(n_real)
+                pos, pad_mask, _ = self._patch_positions_single(
+                    h, w, max_patches=n_real
+                )
                 pos_mx = mx.array(pos[None])
                 pad_mx = mx.array(pad_mask[None])
-                n_real = min(n_real, self.max_patches)
 
-                emb = self.patch_embedder(img, pos_mx[:, :n_real], pad_mx[:, :n_real])
-                n_pad = self.max_patches - n_real
-                if n_pad > 0:
-                    pad_emb = mx.zeros((1, n_pad, emb.shape[-1]), dtype=emb.dtype)
-                    emb = mx.concatenate([emb, pad_emb], axis=1)
+                emb = self.patch_embedder(img, pos_mx, pad_mx)
                 all_embeds.append(emb)
                 all_positions.append(pos_mx)
                 all_padding.append(pad_mx)
@@ -516,14 +524,12 @@ class VisionModel(nn.Module):
 
         hidden_states = self.encoder(inputs_embeds, patch_positions, attn_mask)
 
-        pooled, pool_mask = self.pooler(
-            hidden_states, patch_positions, padding_positions
+        pooled, valid_mask = self.pooler(
+            hidden_states,
+            patch_positions,
+            padding_positions,
+            output_length=output_length,
         )
-
-        if pool_mask.shape[1] == self.default_output_length:
-            valid_mask = pool_mask
-        else:
-            valid_mask = ~pool_mask
 
         all_real = []
         for i in range(B):

--- a/mlx_vlm/tests/test_gemma4_variable_soft_tokens.py
+++ b/mlx_vlm/tests/test_gemma4_variable_soft_tokens.py
@@ -1,0 +1,177 @@
+import unittest
+
+import mlx.core as mx
+import numpy as np
+
+from mlx_vlm.models.gemma4.config import VisionConfig
+from mlx_vlm.models.gemma4.gemma4 import masked_scatter
+from mlx_vlm.models.gemma4.processing_gemma4 import Gemma4Processor
+from mlx_vlm.models.gemma4.vision import VisionModel
+
+
+class TestGemma4VariableSoftTokens(unittest.TestCase):
+    class _ImageProcessor:
+        model_input_names = ["pixel_values"]
+
+        def __init__(self):
+            self.seen_max_soft_tokens = None
+
+        def fetch_images(self, images):
+            return images
+
+        def __call__(self, images, **kwargs):
+            self.seen_max_soft_tokens = kwargs.get("max_soft_tokens")
+            return {"pixel_values": np.zeros((1, 3, 4, 4), dtype=np.float32)}, [3]
+
+    class _Tokenizer:
+        model_input_names = ["input_ids", "attention_mask"]
+        image_token = "<image>"
+        image_token_id = 7
+        boi_token = "<boi>"
+        eoi_token = "<eoi>"
+        audio_token = "<audio>"
+        audio_token_id = 8
+        boa_token = "<boa>"
+        eoa_token = "<eoa>"
+        video_token = "<video>"
+        video_token_id = 9
+        chat_template = "mock"
+
+        @property
+        def init_kwargs(self):
+            return {}
+
+        def convert_tokens_to_ids(self, token):
+            return {
+                self.image_token: self.image_token_id,
+                self.audio_token: self.audio_token_id,
+                self.video_token: self.video_token_id,
+            }.get(token, 0)
+
+        def add_special_tokens(self, tokens):
+            return None
+
+        def __call__(self, text, **kwargs):
+            texts = [text] if isinstance(text, str) else text
+            input_ids = []
+            for item in texts:
+                ids = []
+                i = 0
+                while i < len(item):
+                    if item.startswith(self.image_token, i):
+                        ids.append(self.image_token_id)
+                        i += len(self.image_token)
+                    else:
+                        ids.append(1)
+                        i += 1
+                input_ids.append(ids)
+            return {
+                "input_ids": input_ids,
+                "attention_mask": [[1] * len(ids) for ids in input_ids],
+            }
+
+    def test_processor_accepts_vision_soft_tokens_alias(self):
+        image_processor = self._ImageProcessor()
+        tokenizer = self._Tokenizer()
+        processor = Gemma4Processor.__new__(Gemma4Processor)
+        processor.image_processor = image_processor
+        processor.tokenizer = tokenizer
+        processor.video_processor = None
+        processor.feature_extractor = None
+        processor.image_token = tokenizer.image_token
+        processor.image_token_id = tokenizer.image_token_id
+        processor.boi_token = tokenizer.boi_token
+        processor.eoi_token = tokenizer.eoi_token
+        processor.audio_token = tokenizer.audio_token
+        processor.audio_token_id = tokenizer.audio_token_id
+        processor.boa_token = tokenizer.boa_token
+        processor.eoa_token = tokenizer.eoa_token
+        processor.video_token = tokenizer.video_token
+        processor.video_token_id = tokenizer.video_token_id
+        processor.full_image_sequence = (
+            f"{processor.boi_token}{processor.image_token * 280}{processor.eoi_token}"
+        )
+        processor.full_audio_sequence = None
+
+        result = processor(
+            images=["image.png"],
+            text="<image> transcribe",
+            vision_soft_tokens_per_image=1120,
+        )
+
+        self.assertEqual(image_processor.seen_max_soft_tokens, 1120)
+        self.assertEqual(
+            result["input_ids"][0].tolist().count(self._Tokenizer.image_token_id), 3
+        )
+
+    def test_processor_rejects_conflicting_soft_token_aliases(self):
+        image_processor = self._ImageProcessor()
+        tokenizer = self._Tokenizer()
+        processor = Gemma4Processor.__new__(Gemma4Processor)
+        processor.image_processor = image_processor
+        processor.tokenizer = tokenizer
+        processor.video_processor = None
+        processor.feature_extractor = None
+        processor.image_token = tokenizer.image_token
+        processor.image_token_id = tokenizer.image_token_id
+        processor.boi_token = tokenizer.boi_token
+        processor.eoi_token = tokenizer.eoi_token
+        processor.audio_token = tokenizer.audio_token
+        processor.audio_token_id = tokenizer.audio_token_id
+        processor.boa_token = tokenizer.boa_token
+        processor.eoa_token = tokenizer.eoa_token
+        processor.video_token = tokenizer.video_token
+        processor.video_token_id = tokenizer.video_token_id
+        processor.full_image_sequence = (
+            f"{processor.boi_token}{processor.image_token * 280}{processor.eoi_token}"
+        )
+        processor.full_audio_sequence = None
+
+        with self.assertRaisesRegex(ValueError, "must match"):
+            processor(
+                images=["image.png"],
+                text="<image> transcribe",
+                max_soft_tokens=280,
+                vision_soft_tokens_per_image=1120,
+            )
+
+    def test_vision_tower_accepts_more_patches_than_default_output_length(self):
+        config = VisionConfig(
+            hidden_size=4,
+            intermediate_size=8,
+            num_hidden_layers=0,
+            num_attention_heads=1,
+            num_key_value_heads=1,
+            head_dim=4,
+            patch_size=2,
+            pooling_kernel_size=2,
+            default_output_length=2,
+            position_embedding_size=64,
+        )
+        model = VisionModel(config)
+        pixel_values = mx.ones((1, 3, 8, 8))
+
+        features = model(pixel_values)
+
+        self.assertEqual(features.shape, (1, 4, 4))
+
+    def test_masked_scatter_rejects_mismatched_feature_count(self):
+        inputs = mx.zeros((1, 3, 2))
+        mask = mx.array([[[False, False], [True, True], [True, True]]])
+        features = mx.ones((1, 1, 2))
+
+        with self.assertRaisesRegex(ValueError, "features and tokens do not match"):
+            masked_scatter(inputs, mask, features)
+
+    def test_masked_scatter_can_truncate_extra_features_when_requested(self):
+        inputs = mx.zeros((1, 3, 2))
+        mask = mx.array([[[False, False], [True, True], [False, False]]])
+        features = mx.array([[[1.0, 2.0], [3.0, 4.0]]])
+
+        output = masked_scatter(inputs, mask, features, allow_truncate=True)
+
+        self.assertEqual(output.tolist(), [[[0.0, 0.0], [1.0, 2.0], [0.0, 0.0]]])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Fixes Gemma 4 image runs that use a non-default soft-token budget such as `1120`.

- add `vision_soft_tokens_per_image` as a processor/generate alias for image `max_soft_tokens`
- derive the Gemma 4 vision tower output length from the processed image patch grid instead of the config default
- require image/video feature counts to match prompt image/video token slots before scatter, while preserving the existing audio truncation path
- document the CLI/Python usage and add regression coverage for the issue

## Root Cause

The image processor could resize and prompt-expand for a non-default soft-token budget, but the vision tower still padded/truncated around `default_output_length`. That made the tower produce the default number of pooled features even when the prompt contained more image token slots. A manual workaround that changed the tower default without changing the pooler default could then invert the pool mask and produce empty visual features.

## Validation

- `.venv/bin/python -m black --check --target-version py312 mlx_vlm/generate/dispatch.py mlx_vlm/models/gemma4/gemma4.py mlx_vlm/models/gemma4/processing_gemma4.py mlx_vlm/models/gemma4/vision.py mlx_vlm/tests/test_gemma4_variable_soft_tokens.py`
- `.venv/bin/python -m isort --check-only --profile=black mlx_vlm/generate/dispatch.py mlx_vlm/models/gemma4/gemma4.py mlx_vlm/models/gemma4/processing_gemma4.py mlx_vlm/models/gemma4/vision.py mlx_vlm/tests/test_gemma4_variable_soft_tokens.py`
- `git diff --check`
- `.venv/bin/python -m pytest mlx_vlm/tests -q`

Fixes #1425.
