### PR TITLE
fix: Gemma4 video processing - float32 overflow and wrong token scatter

### DIFF
--- a/mlx_vlm/models/gemma4/processing_gemma4.py
+++ b/mlx_vlm/models/gemma4/processing_gemma4.py
@@ -281,11 +281,16 @@ class Gemma4VideoProcessor:
         if target_h == H and target_w == W:
             return video
 
-        resized = np.empty((T, C, target_h, target_w), dtype=video.dtype)
+        resized = np.empty((T, C, target_h, target_w), dtype=np.uint8)
         for i, frame in enumerate(video):
             arr = np.transpose(frame, (1, 2, 0))
             if arr.dtype in (np.float32, np.float64):
-                arr = (arr * 255).clip(0, 255).astype(np.uint8)
+                if arr.max() > 1.0:
+                    arr = arr.astype(np.uint8)
+                else:
+                    arr = (arr * 255).clip(0, 255).astype(np.uint8)
+            elif arr.dtype != np.uint8:
+                arr = arr.astype(np.uint8)
             pil = Image.fromarray(arr)
             pil = pil.resize((target_w, target_h), resample=Image.BICUBIC)
             resized[i] = np.transpose(np.array(pil), (2, 0, 1))

--- a/mlx_vlm/video_generate.py
+++ b/mlx_vlm/video_generate.py
@@ -624,7 +624,7 @@ def main():
 
     kwargs["video"] = args.video
     kwargs["input_ids"] = input_ids
-    kwargs["pixel_values"] = pixel_values
+    kwargs["pixel_values_videos"] = pixel_values
     kwargs["mask"] = mask
     kwargs["temperature"] = args.temperature
     kwargs["max_tokens"] = args.max_tokens


### PR DESCRIPTION
## Summary

This PR fixes two bugs that prevent Gemma 4 video processing from producing meaningful output. Before these fixes, video recognition produced hallucinations (e.g., "gray horizontal line on dark background") because:

1. **Float32 overflow in `_resize_frames`**  
   `fetch_video()` returns float32 video frames in [0,255] range, but `_resize_frames` treats them as [0,1], multiplying by 255 again causing overflow/clipping to 255. Additionally, the output `resized` array used `dtype=video.dtype` (float32) instead of uint8, preventing the rescale step in `__call__` from triggering.

2. **Wrong token scatter**  
   Video pixel values were passed as `pixel_values` to the model, which scatters them at `image_token_id` positions. But the video prompt only has `video_token_id` tokens, so vision features were never injected into the prompt (empty video token slots).

## Changes

### `mlx_vlm/models/gemma4/processing_gemma4.py`
- Changed `_resize_frames` output dtype to `np.uint8`
- Added float32 value range detection: if max > 1.0, cast directly to uint8; otherwise multiply by 255
- Added fallback for non-uint8 non-float types

### `mlx_vlm/video_generate.py`
- Changed `kwargs["pixel_values"]` to `kwargs["pixel_values_videos"]` so the model scatters vision features at video token positions

## Verification

Tested with `mlx_vlm.video_generate --model gemma4-31B --video test.mp4 --fps 1`:
- **Before**: "a light gray horizontal line swinging left and right on a dark background" (hallucination)
- **After**: "a young man with visible abs in white underwear posing against a white background, moving left and right" (correct)