### PR TITLE
Fix TurboQuant MTP rollback tail zeroing

### DIFF
--- a/mlx_vlm/models/deepseek_v4/language.py
+++ b/mlx_vlm/models/deepseek_v4/language.py
@@ -1289,8 +1289,12 @@ class LanguageModel(nn.Module):
                 for bi, valid_end in enumerate(valid_ends.tolist()):
                     start = verify_start + int(valid_end)
                     if start < kv_len:
-                        cache.keys[bi, :, start:kv_len, :] = 0
-                        cache.values[bi, :, start:kv_len, :] = 0
+                        zero_row_tail = getattr(cache, "zero_row_tail", None)
+                        if callable(zero_row_tail):
+                            zero_row_tail(bi, start, kv_len)
+                        else:
+                            cache.keys[bi, :, start:kv_len, :] = 0
+                            cache.values[bi, :, start:kv_len, :] = 0
 
         return max_a
 

--- a/mlx_vlm/models/gemma4/language.py
+++ b/mlx_vlm/models/gemma4/language.py
@@ -786,8 +786,12 @@ class LanguageModel(nn.Module):
                 for bi in range(accepted.shape[0]):
                     start = verify_start + int(ve[bi])
                     if start < kv_len:
-                        c.keys[bi, :, start:kv_len, :] = 0
-                        c.values[bi, :, start:kv_len, :] = 0
+                        zero_row_tail = getattr(c, "zero_row_tail", None)
+                        if callable(zero_row_tail):
+                            zero_row_tail(bi, start, kv_len)
+                        else:
+                            c.keys[bi, :, start:kv_len, :] = 0
+                            c.values[bi, :, start:kv_len, :] = 0
         return max_a
 
     def sanitize(self, weights):

--- a/mlx_vlm/tests/test_speculative.py
+++ b/mlx_vlm/tests/test_speculative.py
@@ -2864,6 +2864,23 @@ def test_qwen3_5_rollback_speculative_cache_trims_batch_rows_ragged():
     assert cache.left_padding.tolist() == [0, 2]
 
 
+def test_gemma4_rollback_speculative_cache_handles_turboquant_batch_tail_zero():
+    cache = BatchTurboQuantKVCache([0, 0], bits=3.5)
+    keys = mx.arange(2 * 1 * 5 * 8, dtype=mx.float32).reshape(2, 1, 5, 8)
+    values = keys + 100
+    cache.update_and_fetch(keys, values)
+
+    gemma4_language.LanguageModel.rollback_speculative_cache(
+        None, [cache], [], mx.array([0, 2]), block_size=3
+    )
+
+    mx.eval(cache.keys.norms, cache.keys.indices, cache.values.norms)
+    assert mx.all(cache.keys.norms[0, :, 3:5] == 0).item()
+    assert mx.all(cache.keys.indices[0, :, 3:5, :] == 0).item()
+    assert mx.all(cache.values.norms[0, :, 3:5] == 0).item()
+    assert mx.any(cache.keys.norms[1, :, 3:5] != 0).item()
+
+
 def test_qwen3_5_mtp_filter_batch_keeps_drafter_state_aligned():
     text_config = _tiny_qwen3_5_text_config()
     text_config.mtp_num_hidden_layers = 1

--- a/mlx_vlm/tests/test_speculative.py
+++ b/mlx_vlm/tests/test_speculative.py
@@ -2881,6 +2881,23 @@ def test_gemma4_rollback_speculative_cache_handles_turboquant_batch_tail_zero():
     assert mx.any(cache.keys.norms[1, :, 3:5] != 0).item()
 
 
+def test_deepseek_v4_rollback_speculative_cache_handles_turboquant_batch_tail_zero():
+    cache = BatchTurboQuantKVCache([0, 0], bits=3.5)
+    keys = mx.arange(2 * 1 * 5 * 8, dtype=mx.float32).reshape(2, 1, 5, 8)
+    values = keys + 100
+    cache.update_and_fetch(keys, values)
+
+    deepseek_language.LanguageModel.rollback_speculative_cache(
+        None, [cache], [], mx.array([0, 2]), block_size=3
+    )
+
+    mx.eval(cache.keys.norms, cache.keys.indices, cache.values.norms)
+    assert mx.all(cache.keys.norms[0, :, 3:5] == 0).item()
+    assert mx.all(cache.keys.indices[0, :, 3:5, :] == 0).item()
+    assert mx.all(cache.values.norms[0, :, 3:5] == 0).item()
+    assert mx.any(cache.keys.norms[1, :, 3:5] != 0).item()
+
+
 def test_qwen3_5_mtp_filter_batch_keeps_drafter_state_aligned():
     text_config = _tiny_qwen3_5_text_config()
     text_config.mtp_num_hidden_layers = 1

--- a/mlx_vlm/turboquant.py
+++ b/mlx_vlm/turboquant.py
@@ -4106,6 +4106,21 @@ def _filter_state(state, batch_indices: mx.array):
     return _map_state(state, lambda a, ndim: a[batch_indices])
 
 
+def _zero_state_row_tail(state, batch_index: int, start: int, end: int):
+    """Zero a single batch row over the token range [start, end)."""
+    if state is None or start >= end:
+        return state
+
+    def _zero(a, ndim):
+        if ndim == 3:
+            a[batch_index, :, start:end] = 0
+        else:
+            a[batch_index, :, start:end, :] = 0
+        return a
+
+    return _map_state(state, _zero)
+
+
 def _pad_state_tokens(state, left: int, right: int):
     """Pad along the token dimension (index 2)."""
     if left == 0 and right == 0:
@@ -6062,6 +6077,12 @@ class TurboQuantKVCache(_BaseCache):
         self._cached_state_offset = -1
         return n
 
+    def zero_row_tail(self, batch_index: int, start: int, end: int):
+        self.keys = _zero_state_row_tail(self.keys, batch_index, start, end)
+        self.values = _zero_state_row_tail(self.values, batch_index, start, end)
+        self._cached_state = None
+        self._cached_state_offset = -1
+
     def make_mask(self, *args, **kwargs):
         return create_attention_mask(*args, offset=self.offset, **kwargs)
 
@@ -6183,6 +6204,10 @@ class BatchTurboQuantKVCache(_BaseCache):
                 self.values = _map_state(self.values, _trim)
             self._idx -= min_lp
             self.left_padding -= min_lp
+
+    def zero_row_tail(self, batch_index: int, start: int, end: int):
+        self.keys = _zero_state_row_tail(self.keys, batch_index, start, end)
+        self.values = _zero_state_row_tail(self.values, batch_index, start, end)
 
     def extend(self, other: "BatchTurboQuantKVCache"):
         if self.keys is None and other.keys is None:


### PR DESCRIPTION
## Summary
- add TurboQuant cache support for zeroing a single batch row tail without indexing immutable state tuples
- route Gemma 4 speculative rollback through that cache hook before falling back to dense KV assignment
- add a regression for batched Gemma 4 rollback with `BatchTurboQuantKVCache`

## Root cause
Gemma 4 MTP rollback zeroed rejected per-row KV tail tokens with direct `c.keys[bi, ...] = 0` writes. That works for dense caches, but TurboQuant stores cache state as `NamedTuple` objects such as `TurboQuantMSEState`, so direct tuple indexing raises `object does not support item assignment`.

Fixes #1428.

## Validation
- `uv run --with pytest pytest mlx_vlm/tests/test_speculative.py::test_gemma4_rollback_speculative_cache_handles_turboquant_batch_tail_zero mlx_vlm/tests/test_speculative.py::test_deepseek_v4_rollback_speculative_cache_handles_turboquant_batch_tail_zero`
- `uv run --with pytest pytest mlx_vlm/tests/test_speculative.py mlx_vlm/tests/test_turboquant.py`