### PR TITLE
improved turbo quant's  prefill

### DIFF
--- a/mlx_vlm/turboquant.py
+++ b/mlx_vlm/turboquant.py
@@ -4205,7 +4205,6 @@ class _TurboQuantMSECodec:
         return self._rotate_inverse(rotated)
 
     def quantize(self, vectors: mx.array) -> TurboQuantMSEState:
-        # Fast path for single-token decode: Hadamard rotation + fused quantize
         if self.bits > 0:
             D = self.dim
             flat = vectors.reshape(-1, D).astype(mx.float32)

--- a/mlx_vlm/turboquant.py
+++ b/mlx_vlm/turboquant.py
@@ -2913,11 +2913,12 @@ def _fused_mse_quantize_kernel(bits: int, use_rht: bool = False):
         float sq = val * val;
         float sg_sum = simd_sum(sq);
 
-        threadgroup float sg_norms[8];
+        constexpr int n_sg = (Dim + 31) / 32;
+        threadgroup float sg_norms[32];
         if (sg_lid == 0) sg_norms[sg_id] = sg_sum;
         threadgroup_barrier(mem_flags::mem_threadgroup);
 
-        float total_sq = (sg_id == 0 && sg_lid < 8) ? sg_norms[sg_lid] : 0.0f;
+        float total_sq = (sg_id == 0 && sg_lid < n_sg) ? sg_norms[sg_lid] : 0.0f;
         total_sq = simd_sum(total_sq);
         // Broadcast norm to all threads
         if (sg_id == 0 && sg_lid == 0) sg_norms[0] = total_sq;
@@ -4205,7 +4206,7 @@ class _TurboQuantMSECodec:
 
     def quantize(self, vectors: mx.array) -> TurboQuantMSEState:
         # Fast path for single-token decode: Hadamard rotation + fused quantize
-        if vectors.shape[-2] == 1 and self.bits > 0 and self.use_rht:
+        if self.bits > 0:
             D = self.dim
             flat = vectors.reshape(-1, D).astype(mx.float32)
             BH = flat.shape[0]


### PR DESCRIPTION
Quantization prefill has 2 things to improve:
1. So in the load & norm of MSE quantize, a threadgroup holds 8 floats. Vec has D dims, and the threadgroup runs D threads (D/32 simdgroups). The thing is D = 256 is needed to utilize all 8 threadgroups, which is never happening, only non-power-of-2 dims (like 80, 96, 160…). Instead, I added a simdgroup count as well as sized the buffer for the max (32 simdgroups = 1024 threads)
2. For `quantize()`, the faster quantization path should be used whenever bits > 0  the existing restriction to exactly 1 token and a specific rotation type adds unnecessary slowdown for no benefit.

All 84 tests pass
Ran
```
cd mlx_vlm && uv run python -m pytest \
    tests/test_turboquant.py \
    tests/test_turboquant_rht_value_kernels.py \
    tests/test_batch_quantized_cache.py \
    tests/test_kv_cache_quantization.py
```
Gave a 2-8x improvement, to verify run below:
```
#!/usr/bin/env bash
  set -e
  W=$(mktemp -d)
  git clone -q --depth 1 https://github.com/Blaizzy/mlx-vlm     $W/orig
  git clone -q --depth 1 https://github.com/Lazarus-931/mlx-vlm $W/fork
  uv venv -q $W/v && uv pip install -q --python $W/v/bin/python mlx mlx-lm numpy
  cat > $W/b.py <<'PY'
  import importlib.util as u, sys, time, statistics as st, mlx.core as mx
  s = u.spec_from_file_location("t", sys.argv[1] + "/mlx_vlm/turboquant.py")
  t = u.module_from_spec(s); s.loader.exec_module(t)
  mx.random.seed(0); x = mx.random.normal((1, 8, 2048, 128)).astype(mx.float16); mx.eval(x)
  for bits in (2, 3, 4):
      f = lambda c=t._TurboQuantMSECodec(128, bits, 0): c.quantize(x).indices
      for _ in range(10): mx.eval(f())          # warm
      r = []
      for _ in range(30):
          t0 = time.perf_counter(); mx.eval(f()); r.append(time.perf_counter() - t0)
      print(f"  {bits}-bit  {st.median(r)*1e3:6.2f} ms")
  PY
  echo "ORIGINAL:"; $W/v/bin/python $W/b.py $W/orig
  echo "FORK:";     $W/v/bin/python $W/b.py $W/fork
```