### PR TITLE
adding hisa to dsa based models(currently only deepseek)

### DIFF
--- a/mlx_vlm/models/deepseek_v4/config.py
+++ b/mlx_vlm/models/deepseek_v4/config.py
@@ -43,6 +43,8 @@ class ModelConfig(BaseModelConfig):
     index_n_heads: int = 64
     index_head_dim: int = 128
     index_topk: int = 512
+    index_block: int = 64  # HISA
+    index_keep: int = 16  # HISA
     num_nextn_predict_layers: int = 1
     tie_word_embeddings: bool = False
     bos_token_id: Optional[int] = None

--- a/mlx_vlm/models/deepseek_v4/hisa_kernel.py
+++ b/mlx_vlm/models/deepseek_v4/hisa_kernel.py
@@ -5,9 +5,6 @@ Replaces the indexer's flat O(Np) top-k scan with a two-stage hierarchy:
   2. fine:   gather only the kept blocks' positions and score them -- tiled over L so
              the candidate tensor stays bounded (memory flat in L) -- then top-k.
 
-Implemented entirely in MLX: the tiled `matmul` uses MLX's optimized GEMM, which
-benchmarks faster than a hand-written Metal kernel here while keeping memory flat
-in L. Matches the exact flat top-k in the keep-all limit; approximates it otherwise.
 
 paper: https://arxiv.org/abs/2603.28458
 """

--- a/mlx_vlm/models/deepseek_v4/hisa_kernel.py
+++ b/mlx_vlm/models/deepseek_v4/hisa_kernel.py
@@ -1,0 +1,83 @@
+"""HISA — Hierarchical Indexing for Sparse Attention (deepseek_v4), batched L>=1.
+
+Replaces the indexer's flat O(Np) top-k scan with a two-stage hierarchy:
+  1. coarse: score block-mean representatives, causal-mask future blocks, keep top-Kb;
+  2. fine:   gather only the kept blocks' positions and score them -- tiled over L so
+             the candidate tensor stays bounded (memory flat in L) -- then top-k.
+
+Implemented entirely in MLX: the tiled `matmul` uses MLX's optimized GEMM, which
+benchmarks faster than a hand-written Metal kernel here while keeping memory flat
+in L. Matches the exact flat top-k in the keep-all limit; approximates it otherwise.
+
+paper: https://arxiv.org/abs/2603.28458
+"""
+
+import mlx.core as mx
+
+
+def hisa_select(
+    q,
+    pooled,
+    weights,
+    scale,
+    k,
+    index_block,
+    index_keep,
+    valid_len=None,
+    fine_chunk=512,
+):
+    """Batched (for L>=1) HISA selection. Returns top-k prefix indices (B, L, k).
+
+    q:       (B, n_heads, L, head_dim)   pre-rotated queries
+    pooled:  (B, Np, head_dim)           compressed prefix keys
+    weights: (B, L, n_heads)             = weights_proj(x) * n_heads**-0.5
+    scale:   head_dim ** -0.5
+    valid_len: (B, L) int32 = #causally-visible pooled positions per query;
+               None => all Np (decode / no future).
+    fine_chunk: tile size over L for the fine stage (bounds peak memory).
+    """
+
+    B, _, L, D = q.shape
+    Np = pooled.shape[1]
+    b = index_block
+    nb = Np // b
+    usable = nb * b
+    q = q.astype(mx.float32)
+    pooled = pooled.astype(mx.float32)
+    if valid_len is None:
+        valid_len = mx.full((B, L), Np, dtype=mx.int32)
+    valid_len = valid_len.astype(mx.int32)
+
+    wk = weights.astype(mx.float32) * scale  # (B,L,H): per-head mult, scale folded in
+    wk_h = wk.transpose(0, 2, 1)[..., None]  # (B,H,L,1)
+
+    rep = pooled[:, :usable].reshape(B, nb, b, D).mean(axis=2)  # (B,nb,D)
+    cs = mx.maximum(q @ rep[:, None].swapaxes(-1, -2), 0)  # (B,H,L,nb)
+    cscore = (cs * wk_h).sum(axis=1)  # (B,L,nb)
+    block_start = mx.arange(nb) * b
+    cscore = mx.where(block_start[None, None] < valid_len[..., None], cscore, -1e30)
+    Kb = min(index_keep, nb)
+    top_blk = mx.argpartition(-cscore, kth=Kb - 1, axis=-1)[..., :Kb].astype(mx.int32)
+
+    C = Kb * b
+    chunk = fine_chunk or L
+    parts = []
+    for s in range(0, L, chunk):
+        e = min(s + chunk, L)
+        pos_c = (top_blk[:, s:e, :, None] * b + mx.arange(b)).reshape(B, e - s, C)
+        idx = mx.broadcast_to(
+            pos_c.reshape(B, (e - s) * C)[..., None], (B, (e - s) * C, D)
+        )
+        cand = mx.take_along_axis(pooled, idx, axis=1).reshape(B, e - s, C, D)
+        qbl = q[:, :, s:e].transpose(0, 2, 1, 3)  # (B,chunk,H,D)
+        fs = mx.maximum(mx.matmul(qbl, cand.swapaxes(-1, -2)), 0)  # (B,chunk,H,C)
+        oc = (fs * wk[:, s:e][..., None]).sum(axis=2)  # (B,chunk,C)
+        oc = mx.where(pos_c < valid_len[:, s:e][..., None], oc, -1e30)  # causal
+        if chunk < L:
+            mx.eval(oc)  # free chunk intermediates
+        parts.append(oc)
+    fscore = parts[0] if len(parts) == 1 else mx.concatenate(parts, axis=1)
+
+    sel = mx.argpartition(-fscore, kth=k - 1, axis=-1)[..., :k]  # (B,L,k)
+    pos = (top_blk[..., None] * b + mx.arange(b)).reshape(B, L, C)
+    return mx.take_along_axis(pos, sel, axis=-1)  # (B,L,k)

--- a/mlx_vlm/models/deepseek_v4/language.py
+++ b/mlx_vlm/models/deepseek_v4/language.py
@@ -17,6 +17,7 @@ from ..base import (
 )
 from ..cache import CacheList, PoolingCache, RotatingKVCache
 from .config import ModelConfig
+from .hisa_kernel import hisa_select
 from .hyper_connection import HyperConnection, HyperHead, hc_expand
 
 
@@ -568,6 +569,32 @@ class Indexer(nn.Module):
             and self.index_keep * self.index_block >= k
         ):
             return self._hisa_select(q, pooled, x, k)
+
+        # HISA batched path for L > 1 (prefill / speculative decode). Honors the
+        # causal mask via valid_len = #visible pooled positions per query (the
+        # pool mask is contiguous-causal, so the count is the visibility cutoff).
+        if (
+            L > 1
+            and self.index_block > 0
+            and Np >= self.index_block * self.index_keep
+            and self.index_keep * self.index_block >= k
+        ):
+            if pmask is None:
+                valid_len = mx.full((B, L), Np, dtype=mx.int32)
+            else:
+                pm = pmask if pmask.ndim == 3 else pmask[None]
+                valid_len = mx.broadcast_to(pm, (B, L, pm.shape[-1])).sum(-1)
+            weights = self.weights_proj(x).astype(mx.float32) * (self.n_heads**-0.5)
+            return hisa_select(
+                q,
+                pooled,
+                weights,
+                self.scale,
+                k,
+                self.index_block,
+                self.index_keep,
+                valid_len,
+            )
 
         scores = q.astype(mx.float32) @ pooled[:, None].swapaxes(-1, -2).astype(
             mx.float32

--- a/mlx_vlm/models/deepseek_v4/language.py
+++ b/mlx_vlm/models/deepseek_v4/language.py
@@ -492,6 +492,47 @@ class Indexer(nn.Module):
         self.weights_proj = nn.Linear(config.hidden_size, self.n_heads, bias=False)
         self.compressor = Compressor(config, compress_ratio, self.head_dim)
         self.scale = self.head_dim**-0.5
+        self.index_block = getattr(config, "index_block", 0)
+        self.index_keep = getattr(config, "index_keep", 0)
+
+    def _hisa_select(self, q: mx.array, pooled: mx.array, x: mx.array, k: int):
+        """HISA hierarchical decode selection: coarse block filter -> fine top-k.
+
+        q: (B, n_heads, 1, head_dim); pooled: (B, Np, head_dim). Returns (B, 1, k)
+        indices into the prefix, matching the flat path's output. Scans n_blocks
+        coarse reps + index_keep*index_block fine candidates instead of all Np.
+
+        paper: https://arxiv.org/abs/2603.28458
+        """
+
+        B, Np, hd = pooled.shape
+        b = self.index_block
+        nb = Np // b
+        usable = nb * b
+        w = self.weights_proj(x).astype(mx.float32) * (
+            self.n_heads**-0.5
+        )  # (B,1,n_heads)
+        wq = w.swapaxes(-1, -2)[..., None]  # (B,n_heads,1,1)
+
+        # coarse: score block-mean representatives
+        rep = pooled[:, :usable].reshape(B, nb, b, hd).mean(axis=2)  # (B,nb,hd)
+        cs = mx.maximum(
+            q.astype(mx.float32) @ rep[:, None].swapaxes(-1, -2).astype(mx.float32), 0
+        )
+        cscore = (cs * self.scale * wq).sum(axis=1)  # (B,1,nb)
+        Kb = min(self.index_keep, nb)
+        top_blk = mx.argpartition(-cscore, kth=Kb - 1, axis=-1)[..., :Kb]  # (B,1,Kb)
+
+        # fine: score only positions inside the retained blocks
+        pos = (top_blk[..., None] * b + mx.arange(b)).reshape(B, 1, Kb * b)
+        idx = mx.broadcast_to(pos.reshape(B, Kb * b)[..., None], (B, Kb * b, hd))
+        cand = mx.take_along_axis(pooled, idx, axis=1)  # (B,Kb*b,hd)
+        fs = mx.maximum(
+            q.astype(mx.float32) @ cand[:, None].swapaxes(-1, -2).astype(mx.float32), 0
+        )
+        fscore = (fs * self.scale * wq).sum(axis=1)  # (B,1,Kb*b)
+        sel = mx.argpartition(-fscore, kth=k - 1, axis=-1)[..., :k]  # (B,1,k)
+        return mx.take_along_axis(pos, sel, axis=-1)
 
     def __call__(
         self,
@@ -510,20 +551,36 @@ class Indexer(nn.Module):
         q = q.transpose(0, 2, 1, 3)
         q = position_rope(q, offset)
 
+        Np = pooled.shape[1]
+        k = min(self.index_topk, Np)
+        pmask = pool_cache.make_mask(L, offset) if pool_cache is not None else None
+
+        # HISA hierarchical decode fast-path happends only when there is no mask to honor
+        # (single-token decode within the pool window => pmask is None), the
+        # prefix is long enough to block, and there are enough fine candidates.
+
+        if (
+            L == 1
+            and pmask is None
+            and pool_cache is not None
+            and self.index_block > 0
+            and Np >= self.index_block * self.index_keep
+            and self.index_keep * self.index_block >= k
+        ):
+            return self._hisa_select(q, pooled, x, k)
+
         scores = q.astype(mx.float32) @ pooled[:, None].swapaxes(-1, -2).astype(
             mx.float32
         )
         scores = mx.maximum(scores, 0) * self.scale
         weights = self.weights_proj(x).astype(mx.float32) * (self.n_heads**-0.5)
         scores = (scores * weights.swapaxes(-1, -2)[..., None]).sum(axis=1)
-        pmask = pool_cache.make_mask(L, offset) if pool_cache is not None else None
         if pmask is not None:
             scores = mx.where(
                 pmask if pmask.ndim == 3 else pmask[None],
                 scores,
                 mx.finfo(scores.dtype).min,
             )
-        k = min(self.index_topk, pooled.shape[1])
         return mx.argpartition(-scores, kth=k - 1, axis=-1)[..., :k]
 
 

--- a/mlx_vlm/tests/test_models.py
+++ b/mlx_vlm/tests/test_models.py
@@ -7861,3 +7861,20 @@ class TestDeepseekV4HISA(unittest.TestCase):
             ix._hisa_select(q, pooled, x, k), self._flat_select(ix, q, pooled, x, k), k
         )
         self.assertGreaterEqual(r, 0.7)
+
+    def test_hisa_batched_l_gt_1_matches_flat(self):
+        # L>1 batched HISA (hisa_kernel.hisa_select): keep-all must return the
+        # exact flat per-query top-k for every query position.
+        from mlx_vlm.models.deepseek_v4.hisa_kernel import hisa_select
+
+        mx.random.seed(2)
+        H, Dh, Np, k, block = 8, 64, 512, 16, 64
+        scale = Dh**-0.5
+        q = mx.random.normal((1, H, 4, Dh))  # L = 4 queries
+        pooled = mx.random.normal((1, Np, Dh))
+        weights = mx.random.normal((1, 4, H)) * (H**-0.5)
+        out = hisa_select(q, pooled, weights, scale, k, block, index_keep=Np // block)
+        wk_h = (weights * scale).transpose(0, 2, 1)[..., None]
+        flat = (mx.maximum(q @ pooled[:, None].swapaxes(-1, -2), 0) * wk_h).sum(1)
+        ftk = mx.argpartition(-flat, kth=k - 1, axis=-1)[..., :k]
+        self.assertTrue(bool(mx.array_equal(mx.sort(out, -1), mx.sort(ftk, -1))))

--- a/mlx_vlm/tests/test_models.py
+++ b/mlx_vlm/tests/test_models.py
@@ -7771,3 +7771,93 @@ class TestRTDetrV2(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TestDeepseekV4HISA(unittest.TestCase):
+    """HISA hierarchical indexer (deepseek_v4): block-coarse -> token-fine
+    selection must match the flat top-k scan in the keep-all limit and recover
+    most of the top-k when relevance is block-clustered."""
+
+    @staticmethod
+    def _indexer(
+        index_block,
+        index_keep,
+        index_topk=32,
+        n_heads=8,
+        head_dim=64,
+        hidden=256,
+        q_lora_rank=64,
+        seed=0,
+    ):
+        from mlx_vlm.models.deepseek_v4.config import ModelConfig
+        from mlx_vlm.models.deepseek_v4.language import Indexer
+
+        mx.random.seed(seed)
+        cfg = ModelConfig(
+            hidden_size=hidden,
+            q_lora_rank=q_lora_rank,
+            index_n_heads=n_heads,
+            index_head_dim=head_dim,
+            index_topk=index_topk,
+            index_block=index_block,
+            index_keep=index_keep,
+        )
+        ix = Indexer(cfg, compress_ratio=4)
+        mx.eval(ix.parameters())
+        return ix
+
+    @staticmethod
+    def _flat_select(ix, q, pooled, x, k):
+        f32 = mx.float32
+        s = mx.maximum(q.astype(f32) @ pooled[:, None].swapaxes(-1, -2).astype(f32), 0)
+        s = s * ix.scale
+        w = ix.weights_proj(x).astype(f32) * (ix.n_heads**-0.5)
+        s = (s * w.swapaxes(-1, -2)[..., None]).sum(axis=1)
+        return mx.argpartition(-s, kth=k - 1, axis=-1)[..., :k]
+
+    @staticmethod
+    def _recall(a, b, k):
+        a, b = a.reshape(-1, k).tolist(), b.reshape(-1, k).tolist()
+        return sum(len(set(x) & set(y)) for x, y in zip(a, b)) / (len(a) * k)
+
+    def test_hisa_equals_flat_when_all_blocks_kept(self):
+        Np, block = 512, 64
+        ix = self._indexer(index_block=block, index_keep=Np // block, index_topk=32)
+        mx.random.seed(1)
+        q = mx.random.normal((2, ix.n_heads, 1, ix.head_dim))
+        pooled = mx.random.normal((2, Np, ix.head_dim))
+        x = mx.random.normal((2, 1, 256))
+        k = min(ix.index_topk, Np)
+        hisa = ix._hisa_select(q, pooled, x, k)
+        flat = self._flat_select(ix, q, pooled, x, k)
+        self.assertEqual(self._recall(hisa, flat, k), 1.0)
+
+    def test_hisa_shape_and_valid_indices(self):
+        Np = 2048
+        ix = self._indexer(index_block=64, index_keep=8, index_topk=32)
+        mx.random.seed(1)
+        q = mx.random.normal((2, ix.n_heads, 1, ix.head_dim))
+        pooled = mx.random.normal((2, Np, ix.head_dim))
+        x = mx.random.normal((2, 1, 256))
+        k = min(ix.index_topk, Np)
+        out = ix._hisa_select(q, pooled, x, k)
+        self.assertEqual(out.shape, (2, 1, k))
+        self.assertGreaterEqual(int(out.min()), 0)
+        self.assertLess(int(out.max()), Np)
+
+    def test_hisa_high_recall_on_clustered_prefix(self):
+        Np, block = 4096, 64
+        ix = self._indexer(index_block=block, index_keep=8, index_topk=64)
+        mx.random.seed(1)
+        nb = Np // block
+        dc = mx.random.normal((nb, 1, ix.head_dim)) * 2.0
+        pooled = (dc + mx.random.normal((nb, block, ix.head_dim))).reshape(
+            1, Np, ix.head_dim
+        )
+        q = mx.random.normal((1, ix.n_heads, 1, ix.head_dim))
+        x = mx.random.normal((1, 1, 256))
+        k = ix.index_topk
+        r = self._recall(
+            ix._hisa_select(q, pooled, x, k), self._flat_select(ix, q, pooled, x, k), k
+        )
+        self.assertGreaterEqual(r, 0.7)


### PR DESCRIPTION
<html><head></head><body><p>Implementing HISA (Hierarchical Indexing for Sparse Attention) for DSA models, currently only for DeepSeek.</p>
<p>HISA promises 2–8× improvements, and I believe this holds at ~685B parameters (fp8) or ~700B, as the paper tested with GLM-5.</p>
<p>For verification, I used small randomly initialized weights through the DeepSeek path (~7GB). Improvements still showed — up to 1.40× at 128K context — and I expect the full gains to materialize at the parameter scales the paper targets.</p>
<p>Results:</p>

context | flat ms/tok | HISA ms/tok | speedup | peak GB
-- | -- | -- | -- | --
16k | 8.50 | 8.88 | 0.96× | 2.6
32k | 9.68 | 9.34 | 1.04× | 3.2
65k | 12.18 | 10.18 | 1.20× | 4.4
128k | 17.03 | 11.98 | 1.42× | 6.7

This also includes tests for accuracy against vanilla indexer 


<p>We do get 0.96× for smaller context windows, but I think it's fine considering the likelihood of that usage, and this is an overall net positive change.</p>
<p>Paper: https://arxiv.org/abs/2603.28458</p>
<p>To verify against my fork:</p>
<pre><code class="language-bash">#!/usr/bin/env bash
# HISA perf: upstream main (flat) vs fork (HISA), random-init small deepseek_v4,
# swept over context. Apple Silicon &gt;=16GB, needs uv + git.
set -euo pipefail
W=$(mktemp -d)
git clone -q --depth 1 https://github.com/Blaizzy/mlx-vlm     "$W/main"
git clone -q --depth 1 https://github.com/Lazarus-931/mlx-vlm "$W/fork"
cat &gt; "$W/b.py" &lt;&lt;'PY'
import time, numpy as np, mlx.core as mx
from mlx_vlm.models.deepseek_v4 import Model, ModelConfig
N = 12
cfg = ModelConfig(vocab_size=2000, hidden_size=1024, intermediate_size=1024,
    moe_intermediate_size=512, num_hidden_layers=N, num_attention_heads=16,
    num_key_value_heads=1, n_routed_experts=16, num_experts_per_tok=2,
    q_lora_rank=256, head_dim=128, o_groups=4, o_lora_rank=256,
    index_n_heads=64, index_head_dim=128, index_topk=512,
    compress_ratios=[0] + [4] * (N - 2) + [0], max_position_embeddings=262144)
m = Model(cfg); m.eval(); mx.eval(m.parameters())
def ms(T):
    c = m.make_cache(); p = 0
    while p &lt; T:
        n = min(256, T - p); mx.eval(m(mx.array(np.random.randint(0, 2000, (1, n))), cache=c).logits); p += n
    for _ in range(4): mx.eval(m(mx.array([[0]]), cache=c).logits)
    t = time.perf_counter()
    for _ in range(20): mx.eval(m(mx.array([[0]]), cache=c).logits)
    return (time.perf_counter() - t) / 20 * 1e3
for T in (16384, 32768, 65536):
    print(T, round(ms(T), 2), flush=True)
PY
run() { uv venv -q "$1/.venv"; uv pip install -q -e "$1" --python "$1/.venv/bin/python"; "$1/.venv/bin/python" "$W/b.py"; }
run "$W/main" &gt; "$W/m.txt"
run "$W/fork" &gt; "$W/f.txt"
echo; printf "| context | main flat | fork HISA | speedup |\n|--:|--:|--:|--:|\n"
join "$W/m.txt" "$W/f.txt" | awk '{printf "| %d | %.2f ms | %.2f ms | %.2fx |\n", $1, $2, $3, $2/$3}'
</code></pre></body></html>