### PR TITLE
Fix Gemma 4 cached vision mask overlay

### DIFF
--- a/mlx_vlm/models/gemma4/language.py
+++ b/mlx_vlm/models/gemma4/language.py
@@ -474,6 +474,8 @@ class Gemma4TextModel(nn.Module):
             return base_mask
         if mm_token_type_ids.shape[1] != base_mask.shape[-1]:
             return base_mask
+        if base_mask.shape[-2] != base_mask.shape[-1]:
+            return base_mask
 
         block_sequence_ids = self._block_sequence_ids_for_mask(mm_token_type_ids)
         q_blocks = mx.expand_dims(block_sequence_ids, -1)


### PR DESCRIPTION
## Summary
- skip Gemma 4 bidirectional vision mask overlay on cached non-square query/key masks, where the overlay shape cannot broadcast
- leaves full-sequence square vision masks unchanged

Fixes #1440.

## Validation
- `uv run python - <<PY ...` using `mlx-community/gemma-4-26b-a4b-it-4bit` config: cached non-square mask returns shape `(4, 12)` without broadcast failure
- pre-commit hooks during amend: `black`, `isort`, `autoflake`
