### PR TITLE
fix for #1446

### DIFF
--- a/mlx_vlm/models/qwen3_5/language.py
+++ b/mlx_vlm/models/qwen3_5/language.py
@@ -1994,44 +1994,45 @@ class LanguageModel(nn.Module):
                 valid_ends_mx = mx.array(valid_ends_list, dtype=mx.int32)
             return valid_ends_mx
 
-        # Separate trimmable (KV) caches from SSM caches.
+        def _is_ssm_cache(c):
+            return not c.is_trimmable() and not hasattr(c, "zero_row_tail")
+
         ssm_caches = []
         for c in caches:
             if c is None:
                 continue
-            if c.is_trimmable():
-                if trim > 0:
-                    c.trim(trim)
-                right_trimmed = False
-                if is_batch and max_a > 0:
-                    extra_trim_list = [max_a - a for a in accepted_list]
-                    if any(extra_trim_list):
-                        prepare = getattr(c, "prepare", None)
-                        finalize = getattr(c, "finalize", None)
-                        if (
-                            c.keys is not None
-                            and callable(prepare)
-                            and callable(finalize)
-                        ):
-                            prepare(right_padding=extra_trim_list)
-                            finalize()
-                            right_trimmed = True
-                if (
-                    is_batch
-                    and not right_trimmed
-                    and hasattr(c, "_idx")
-                    and c.keys is not None
-                    and max_a > 0
-                ):
-                    kv_len = c._idx
-                    verify_start = kv_len - n
-                    for bi, ve in enumerate(valid_ends_list):
-                        start = verify_start + ve
-                        if start < kv_len:
+            if _is_ssm_cache(c):
+                ssm_caches.append(c)
+                continue
+            if c.is_trimmable() and trim > 0:
+                c.trim(trim)
+            right_trimmed = False
+            if is_batch and max_a > 0:
+                extra_trim_list = [max_a - a for a in accepted_list]
+                if any(extra_trim_list):
+                    prepare = getattr(c, "prepare", None)
+                    finalize = getattr(c, "finalize", None)
+                    if c.keys is not None and callable(prepare) and callable(finalize):
+                        prepare(right_padding=extra_trim_list)
+                        finalize()
+                        right_trimmed = True
+            if (
+                is_batch
+                and not right_trimmed
+                and hasattr(c, "_idx")
+                and c.keys is not None
+                and max_a > 0
+            ):
+                kv_len = c._idx
+                verify_start = kv_len - n
+                for bi, ve in enumerate(valid_ends_list):
+                    start = verify_start + ve
+                    if start < kv_len:
+                        if hasattr(c, "zero_row_tail"):
+                            c.zero_row_tail(bi, start, kv_len)
+                        else:
                             c.keys[bi, :, start:kv_len, :] = 0
                             c.values[bi, :, start:kv_len, :] = 0
-            else:
-                ssm_caches.append(c)
 
         if not ssm_caches:
             return max_a

--- a/mlx_vlm/turboquant.py
+++ b/mlx_vlm/turboquant.py
@@ -6159,6 +6159,22 @@ class BatchTurboQuantKVCache(_BaseCache):
             _QuantizedStateProxy(vs, self._idx, n_heads),
         )
 
+    def zero_row_tail(self, bi: int, start: int, end: int):
+        if start >= end:
+            return
+
+        def _z(arr, ndim):
+            if ndim == 3:
+                arr[bi, :, start:end] = 0
+            else:
+                arr[bi, :, start:end, :] = 0
+            return arr
+
+        if self.keys is not None:
+            self.keys = _map_state(self.keys, _z)
+        if self.values is not None:
+            self.values = _map_state(self.values, _z)
+
     # ------------------------------------------------------------------
     # Batch operations for Batch.filter / Batch.extend
     # ------------------------------------------------------------------


### PR DESCRIPTION
fix for #1446 

`LanguageModel.rollback_speculative_cache` (qwen3_5) splits caches into trimmable-KV vs SSM/GDN using `is_trimmable()` as the SSM proxy. 

Instead,  changed to classify KV-rollback interface instead of `is_trimmable()`, also since  SSM/GDN caches are  non-trimmable and lack the tail-rollback method, this works for every full-attn variant. 

All tests pass