### PR TITLE
Fix Qwen3.5 MoE gate-up sanitization

### DIFF
--- a/mlx_vlm/models/qwen3_5_moe/qwen3_5_moe.py
+++ b/mlx_vlm/models/qwen3_5_moe/qwen3_5_moe.py
@@ -1,4 +1,3 @@
-import mlx.core as mx
 import mlx.nn as nn
 
 from ..qwen3_5 import Model as Qwen3_5Model
@@ -28,9 +27,13 @@ class Model(Qwen3_5Model):
             prefix = f"model.language_model.layers.{l}.mlp"
             # process gate_up_proj [num_experts, 2 * intermediate_size, hidden_size]
             gate_up_weight = weights.pop(f"{prefix}.experts.gate_up_proj")
-            gate_weight, up_weights = mx.split(gate_up_weight, 2, axis=-2)
-            weights[f"{prefix}.switch_mlp.gate_proj.weight"] = gate_weight
-            weights[f"{prefix}.switch_mlp.up_proj.weight"] = up_weights
+            mid = gate_up_weight.shape[-2] // 2
+            weights[f"{prefix}.switch_mlp.gate_proj.weight"] = gate_up_weight[
+                ..., :mid, :
+            ]
+            weights[f"{prefix}.switch_mlp.up_proj.weight"] = gate_up_weight[
+                ..., mid:, :
+            ]
             # down_proj
             weights[f"{prefix}.switch_mlp.down_proj.weight"] = weights.pop(
                 f"{prefix}.experts.down_proj"

--- a/mlx_vlm/tests/test_models.py
+++ b/mlx_vlm/tests/test_models.py
@@ -1730,6 +1730,48 @@ class TestModels(unittest.TestCase):
             "language_model.lm_head.weight",
         )
 
+    def test_qwen3_5_moe_sanitize_slices_gate_up_proj(self):
+        from mlx_vlm.models import qwen3_5_moe
+
+        model = qwen3_5_moe.Model.__new__(qwen3_5_moe.Model)
+        model.config = SimpleNamespace(
+            text_config=SimpleNamespace(
+                num_hidden_layers=1,
+                tie_word_embeddings=False,
+            )
+        )
+        gate_up = mx.arange(2 * 8 * 4, dtype=mx.float32).reshape(2, 8, 4)
+        down = mx.ones((2, 4, 4), dtype=mx.float32)
+        weights = {
+            "model.language_model.layers.0.mlp.experts.gate_up_proj": gate_up,
+            "model.language_model.layers.0.mlp.experts.down_proj": down,
+        }
+
+        original_split = mx.split
+
+        def fail_split(*args, **kwargs):
+            raise AssertionError("sanitize should slice gate_up_proj, not split it")
+
+        try:
+            mx.split = fail_split
+            sanitized = model.sanitize(weights)
+        finally:
+            mx.split = original_split
+
+        prefix = "language_model.model.layers.0.mlp.switch_mlp"
+        self.assertEqual(
+            sanitized[f"{prefix}.gate_proj.weight"].tolist(),
+            gate_up[..., :4, :].tolist(),
+        )
+        self.assertEqual(
+            sanitized[f"{prefix}.up_proj.weight"].tolist(),
+            gate_up[..., 4:, :].tolist(),
+        )
+        self.assertEqual(
+            sanitized[f"{prefix}.down_proj.weight"].tolist(),
+            down.tolist(),
+        )
+
     def test_qwen3_5_rotary_inv_freq_is_thread_safe(self):
         if not mx.metal.is_available():
             self.skipTest("requires Metal streams")

--- a/mlx_vlm/tests/test_models.py
+++ b/mlx_vlm/tests/test_models.py
@@ -1730,48 +1730,6 @@ class TestModels(unittest.TestCase):
             "language_model.lm_head.weight",
         )
 
-    def test_qwen3_5_moe_sanitize_slices_gate_up_proj(self):
-        from mlx_vlm.models import qwen3_5_moe
-
-        model = qwen3_5_moe.Model.__new__(qwen3_5_moe.Model)
-        model.config = SimpleNamespace(
-            text_config=SimpleNamespace(
-                num_hidden_layers=1,
-                tie_word_embeddings=False,
-            )
-        )
-        gate_up = mx.arange(2 * 8 * 4, dtype=mx.float32).reshape(2, 8, 4)
-        down = mx.ones((2, 4, 4), dtype=mx.float32)
-        weights = {
-            "model.language_model.layers.0.mlp.experts.gate_up_proj": gate_up,
-            "model.language_model.layers.0.mlp.experts.down_proj": down,
-        }
-
-        original_split = mx.split
-
-        def fail_split(*args, **kwargs):
-            raise AssertionError("sanitize should slice gate_up_proj, not split it")
-
-        try:
-            mx.split = fail_split
-            sanitized = model.sanitize(weights)
-        finally:
-            mx.split = original_split
-
-        prefix = "language_model.model.layers.0.mlp.switch_mlp"
-        self.assertEqual(
-            sanitized[f"{prefix}.gate_proj.weight"].tolist(),
-            gate_up[..., :4, :].tolist(),
-        )
-        self.assertEqual(
-            sanitized[f"{prefix}.up_proj.weight"].tolist(),
-            gate_up[..., 4:, :].tolist(),
-        )
-        self.assertEqual(
-            sanitized[f"{prefix}.down_proj.weight"].tolist(),
-            down.tolist(),
-        )
-
     def test_qwen3_5_rotary_inv_freq_is_thread_safe(self):
         if not mx.metal.is_available():
             self.skipTest("requires Metal streams")


### PR DESCRIPTION
## Summary

Fix Qwen3.5-MoE weight sanitization to slice `experts.gate_up_proj` into gate/up projection weights instead of using `mx.split`.

Fixes #1448.

## Root Cause

The Qwen3.5-MoE sanitizer rewrote the fused expert `gate_up_proj` tensor with `mx.split`. This diverged from `mlx_lm`'s sanitizer and could keep the giant fused expert tensor tied to a multi-output split graph during later quantization/materialization.

## Changes

- Replace `mx.split` with explicit slicing for the gate/up halves.
- Remove the now-unused `mlx.core` import from the model file.

## Validation

- `.venv/bin/python -m pytest mlx_vlm/tests/test_models.py::TestModels::test_qwen3_5_sanitize_key_routes_nested_visual_weights mlx_vlm/tests/test_models.py::TestModels::test_qwen3_5_model_config -q`
- Commit hooks: `black`, `isort`, `autoflake`