### PR TITLE
Fix stale GenerationBatch processor state

### DIFF
--- a/mlx_vlm/generate/ar.py
+++ b/mlx_vlm/generate/ar.py
@@ -1059,6 +1059,11 @@ class GenerationBatch:
         if self_has_processors or other_has_processors:
             self._ensure_token_context(force=bool(other_has_processors))
             other._ensure_token_context(force=bool(self_has_processors))
+        else:
+            self.token_context = []
+            other.token_context = []
+            self.logits_processors = []
+            other.logits_processors = []
 
         self.uids.extend(other.uids)
         self.prompt_cache = _extend_cache(self.prompt_cache, other.prompt_cache)

--- a/mlx_vlm/tests/test_generate.py
+++ b/mlx_vlm/tests/test_generate.py
@@ -816,6 +816,37 @@ class TestBatchGenerator:
         assert [r.token for r in first] == [5, 6, 7]
         assert seen_contexts == [[30, 7]]
 
+    def test_generation_batch_extend_discards_inactive_stale_processor_state(self):
+        sampler = lambda logprobs: mx.argmax(logprobs, axis=-1)
+        stop_criteria = lambda token: False
+        finished_structured = GenerationBatch(
+            model=MagicMock(),
+            uids=[0],
+            inputs=mx.array([5], dtype=mx.int32),
+            prompt_cache=[],
+            sampler=sampler,
+            stop_criteria=stop_criteria,
+            max_tokens=[2],
+            token_context=[[30]],
+            logits_processors=[None],
+        )
+        plain = GenerationBatch(
+            model=MagicMock(),
+            uids=[1],
+            inputs=mx.array([6], dtype=mx.int32),
+            prompt_cache=[],
+            sampler=sampler,
+            stop_criteria=stop_criteria,
+            max_tokens=[2],
+        )
+
+        finished_structured.extend(plain)
+
+        assert finished_structured.token_context == []
+        assert finished_structured.logits_processors == []
+        finished_structured.filter([1])
+        assert finished_structured.uids == [1]
+
     def test_generation_batch_extend_promotes_singleton_kv_cache(self):
         def make_kv_cache(value):
             c = KVCache()


### PR DESCRIPTION
## Summary
- discard stale inactive `token_context` and all-None `logits_processors` when merging generation batches with no active logits processors
- keep active structured-output processor context alignment unchanged
- add a regression for the json-schema-to-plain continuous batching desync from #1441

Fixes #1441.

## Validation
- `uv run --with pytest pytest mlx_vlm/tests/test_generate.py -q`
- local Gemma config check using `/Volumes/Extreme SSD/Models/CUDA/google--gemma-4-26B-A4B-it`: reproduced stale finished-structured + plain merge and verified `filter([1])` no longer raises
- pre-commit hooks during commit: `black`, `isort`, `autoflake`
