### PR TITLE
[codex] Add TurboQuant rollback hook for DeepSeek V4

### DIFF
--- a/mlx_vlm/models/deepseek_v4/language.py
+++ b/mlx_vlm/models/deepseek_v4/language.py
@@ -1373,8 +1373,12 @@ class LanguageModel(nn.Module):
                 for bi, valid_end in enumerate(valid_ends.tolist()):
                     start = verify_start + int(valid_end)
                     if start < kv_len:
-                        cache.keys[bi, :, start:kv_len, :] = 0
-                        cache.values[bi, :, start:kv_len, :] = 0
+                        zero_row_tail = getattr(cache, "zero_row_tail", None)
+                        if callable(zero_row_tail):
+                            zero_row_tail(bi, start, kv_len)
+                        else:
+                            cache.keys[bi, :, start:kv_len, :] = 0
+                            cache.values[bi, :, start:kv_len, :] = 0
 
         return max_a
 

--- a/mlx_vlm/tests/test_speculative.py
+++ b/mlx_vlm/tests/test_speculative.py
@@ -2881,6 +2881,23 @@ def test_gemma4_rollback_speculative_cache_handles_turboquant_batch_tail_zero():
     assert mx.any(cache.keys.norms[1, :, 3:5] != 0).item()
 
 
+def test_deepseek_v4_rollback_speculative_cache_handles_turboquant_batch_tail_zero():
+    cache = BatchTurboQuantKVCache([0, 0], bits=3.5)
+    keys = mx.arange(2 * 1 * 5 * 8, dtype=mx.float32).reshape(2, 1, 5, 8)
+    values = keys + 100
+    cache.update_and_fetch(keys, values)
+
+    deepseek_language.LanguageModel.rollback_speculative_cache(
+        None, [cache], [], mx.array([0, 2]), block_size=3
+    )
+
+    mx.eval(cache.keys.norms, cache.keys.indices, cache.values.norms)
+    assert mx.all(cache.keys.norms[0, :, 3:5] == 0).item()
+    assert mx.all(cache.keys.indices[0, :, 3:5, :] == 0).item()
+    assert mx.all(cache.values.norms[0, :, 3:5] == 0).item()
+    assert mx.any(cache.keys.norms[1, :, 3:5] != 0).item()
+
+
 def test_qwen3_5_mtp_filter_batch_keeps_drafter_state_aligned():
     text_config = _tiny_qwen3_5_text_config()
     text_config.mtp_num_hidden_layers = 1


### PR DESCRIPTION
## Summary
- route DeepSeek V4 speculative rollback through the TurboQuant `zero_row_tail` cache hook before falling back to dense KV assignment
- add a regression for batched DeepSeek V4 rollback with `BatchTurboQuantKVCache`

## Stack
This PR is stacked on #1432, which introduces the shared TurboQuant cache hook.

## Root cause
DeepSeek V4 rollback uses the same dense `cache.keys[bi, ...] = 0` rejected-tail assignment pattern as Gemma 4. That is not valid for TurboQuant cache states, which are immutable `NamedTuple` containers with mutable array fields.

## Validation
- `uv run --with pytest pytest mlx_vlm/tests/test_speculative.py::test_gemma4_rollback_speculative_cache_handles_turboquant_batch_tail_zero mlx_vlm/tests/test_speculative.py::test_deepseek_v4_rollback_speculative_cache_handles_turboquant_batch_tail_zero`
- `uv run --with pytest pytest mlx_vlm/tests/test_speculative.py mlx_vlm/tests/test_turboquant.py`