### PR TITLE
Fix Qwen3.5 TurboQuant batch rollback trim

### DIFF
--- a/mlx_vlm/tests/test_speculative.py
+++ b/mlx_vlm/tests/test_speculative.py
@@ -2864,6 +2864,25 @@ def test_qwen3_5_rollback_speculative_cache_trims_batch_rows_ragged():
     assert cache.left_padding.tolist() == [0, 2]
 
 
+def test_qwen3_5_rollback_speculative_cache_handles_turboquant_batch_kv():
+    cache = BatchTurboQuantKVCache([0, 0], bits=3.5)
+    keys = mx.arange(2 * 1 * 7 * 8, dtype=mx.float32).reshape(2, 1, 7, 8)
+    values = keys + 100
+    cache.update_and_fetch(keys, values)
+
+    qwen_language.LanguageModel.rollback_speculative_cache(
+        None, [cache], [], mx.array([0, 2]), block_size=5
+    )
+
+    mx.eval(cache.keys.norms, cache.keys.indices, cache.values.norms, cache.offset)
+    assert cache._idx == 5
+    assert cache.offset.tolist() == [5, 5]
+    assert mx.all(cache.keys.norms[0, :, 3:5] == 0).item()
+    assert mx.all(cache.keys.indices[0, :, 3:5, :] == 0).item()
+    assert mx.all(cache.values.norms[0, :, 3:5] == 0).item()
+    assert mx.any(cache.keys.norms[1, :, 3:5] != 0).item()
+
+
 def test_gemma4_rollback_speculative_cache_handles_turboquant_batch_tail_zero():
     cache = BatchTurboQuantKVCache([0, 0], bits=3.5)
     keys = mx.arange(2 * 1 * 5 * 8, dtype=mx.float32).reshape(2, 1, 5, 8)

--- a/mlx_vlm/tests/test_turboquant.py
+++ b/mlx_vlm/tests/test_turboquant.py
@@ -165,6 +165,25 @@ def test_batch_turboquant_filter_supports_uniform_single_item_offsets():
     assert cache.left_padding.tolist() == [0]
 
 
+def test_batch_turboquant_cache_supports_uniform_right_trim():
+    cache = BatchTurboQuantKVCache([0, 1], bits=3.5)
+    keys = mx.ones((2, 2, 5, 8), dtype=mx.float16)
+    values = mx.ones((2, 2, 5, 8), dtype=mx.float16)
+
+    cache.update_and_fetch(keys, values)
+    trimmed = cache.trim(2)
+
+    assert trimmed == 2
+    assert cache.is_trimmable()
+    assert cache._idx == 3
+    assert cache.offset.tolist() == [3, 2]
+    state_keys, state_values, offset, left_padding = cache.state
+    assert state_keys.norms.shape[2] == 3
+    assert state_values.norms.shape[2] == 3
+    assert offset.tolist() == [3, 2]
+    assert left_padding.tolist() == [0, 1]
+
+
 def test_batch_turboquant_extend_pads_shorter_uniform_batch():
     longer = BatchTurboQuantKVCache([0], bits=3.5)
     shorter = BatchTurboQuantKVCache([0], bits=3.5)

--- a/mlx_vlm/turboquant.py
+++ b/mlx_vlm/turboquant.py
@@ -6321,10 +6321,13 @@ class BatchTurboQuantKVCache(_BaseCache):
         self.seed = int(v[2])
 
     def is_trimmable(self):
-        return False
+        return True
 
     def trim(self, n):
-        return 0
+        n = min(self._idx, n)
+        self._idx -= n
+        self.offset -= n
+        return n
 
     def empty(self):
         return self.keys is None


### PR DESCRIPTION
## Summary
- make `BatchTurboQuantKVCache` support uniform right trim like other batch KV caches
- keep Qwen3.5 speculative rollback on the KV path for TurboQuant batch caches so global trim and per-row `zero_row_tail` both apply
- add regressions for TurboQuant batch trim and Qwen3.5 rollback with `BatchTurboQuantKVCache`

## Root cause
Qwen3.5 rollback now recognizes TurboQuant batch caches as KV caches via `zero_row_tail`, but `BatchTurboQuantKVCache.trim()` still returned `0` and left `_idx` / `offset` unchanged. When speculative rollback had a global rejected suffix (`trim > 0`), the cache kept rejected tokens and per-row tail zeroing happened at the wrong positions.

## Validation
- `uv run --with pytest pytest mlx_vlm/tests/test_turboquant.py::test_batch_turboquant_cache_supports_uniform_right_trim mlx_vlm/tests/test_speculative.py::test_qwen3_5_rollback_speculative_cache_handles_turboquant_batch_kv`
- `uv run --with pytest pytest mlx_vlm/tests/test_speculative.py mlx_vlm/tests/test_turboquant.py`