### PR TITLE
Guard empty MRoPE position batches

### DIFF
--- a/mlx_vlm/models/ernie4_5_moe_vl/language.py
+++ b/mlx_vlm/models/ernie4_5_moe_vl/language.py
@@ -539,6 +539,13 @@ class LanguageModel(nn.Module):
                     text_pos_3d = mx.stack([text_pos, text_pos, text_pos], axis=0)
                     llm_pos_ids_list.append(text_pos_3d)
 
+                if not llm_pos_ids_list:
+                    batch_position_ids.append(
+                        mx.zeros((seq_length, 3), dtype=input_ids.dtype)
+                    )
+                    mrope_position_deltas.append(0)
+                    continue
+
                 llm_positions = mx.concatenate(llm_pos_ids_list, axis=1)  # [3, seq_len]
                 batch_position_ids.append(llm_positions.T)  # [seq_len, 3]
                 mrope_position_deltas.append(llm_positions.max() + 1 - seq_length)

--- a/mlx_vlm/models/glm4v/language.py
+++ b/mlx_vlm/models/glm4v/language.py
@@ -410,6 +410,10 @@ class LanguageModel(nn.Module):
 
                     llm_pos_ids_list.append(t_index + st_idx)
 
+                if not llm_pos_ids_list:
+                    mrope_position_deltas.append(0)
+                    continue
+
                 llm_positions = mx.concatenate(llm_pos_ids_list, axis=1).reshape(3, -1)
                 compact_max_position = llm_positions.max()
                 padded_positions = [[1] * total_input_ids.shape[1] for _ in range(3)]

--- a/mlx_vlm/models/glm4v_moe/language.py
+++ b/mlx_vlm/models/glm4v_moe/language.py
@@ -487,6 +487,10 @@ class LanguageModel(nn.Module):
 
                     llm_pos_ids_list.append(t_index + st_idx)
 
+                if not llm_pos_ids_list:
+                    mrope_position_deltas.append(0)
+                    continue
+
                 llm_positions = mx.concatenate(llm_pos_ids_list, axis=1).reshape(3, -1)
                 compact_max_position = llm_positions.max()
                 padded_positions = [[1] * total_input_ids.shape[1] for _ in range(3)]

--- a/mlx_vlm/models/glm_ocr/language.py
+++ b/mlx_vlm/models/glm_ocr/language.py
@@ -400,6 +400,10 @@ class LanguageModel(nn.Module):
                         spatial_merge_size
                     )
 
+                if not llm_pos_ids_list:
+                    mrope_position_deltas.append(0)
+                    continue
+
                 llm_positions = np.concatenate(llm_pos_ids_list, axis=1).reshape(3, -1)
                 position_ids_np[:, batch_idx, valid_indices] = llm_positions
                 mrope_position_deltas.append(

--- a/mlx_vlm/models/paddleocr_vl/language.py
+++ b/mlx_vlm/models/paddleocr_vl/language.py
@@ -329,6 +329,10 @@ class LanguageModel(nn.Module):
 
                     llm_pos_ids_list.append(t_index + st_idx)
 
+                if not llm_pos_ids_list:
+                    mrope_position_deltas.append(0)
+                    continue
+
                 llm_positions = mx.concatenate(llm_pos_ids_list, axis=1).reshape(3, -1)
                 compact_max_position = llm_positions.max()
                 padded_positions = [[1] * total_input_ids.shape[1] for _ in range(3)]

--- a/mlx_vlm/models/qwen2_5_vl/language.py
+++ b/mlx_vlm/models/qwen2_5_vl/language.py
@@ -355,6 +355,10 @@ class LanguageModel(nn.Module):
 
                     llm_pos_ids_list.append(t_index + st_idx)
 
+                if not llm_pos_ids_list:
+                    mrope_position_deltas.append(0)
+                    continue
+
                 llm_positions = mx.concatenate(llm_pos_ids_list, axis=1).reshape(3, -1)
                 compact_max_position = llm_positions.max()
                 padded_positions = [[1] * total_input_ids.shape[1] for _ in range(3)]

--- a/mlx_vlm/models/qwen2_vl/language.py
+++ b/mlx_vlm/models/qwen2_vl/language.py
@@ -355,6 +355,10 @@ class LanguageModel(nn.Module):
 
                     llm_pos_ids_list.append(t_index + st_idx)
 
+                if not llm_pos_ids_list:
+                    mrope_position_deltas.append(0)
+                    continue
+
                 llm_positions = mx.concatenate(llm_pos_ids_list, axis=1).reshape(3, -1)
                 compact_max_position = llm_positions.max()
                 padded_positions = [[1] * total_input_ids.shape[1] for _ in range(3)]

--- a/mlx_vlm/models/qwen3_5/language.py
+++ b/mlx_vlm/models/qwen3_5/language.py
@@ -2363,6 +2363,10 @@ class LanguageModel(nn.Module):
 
                     llm_pos_ids_list.append(t_index + st_idx)
 
+                if not llm_pos_ids_list:
+                    mrope_position_deltas.append(0)
+                    continue
+
                 llm_positions = mx.concatenate(llm_pos_ids_list, axis=1).reshape(3, -1)
                 compact_max_position = llm_positions.max()
                 padded_positions = [[1] * total_input_ids.shape[1] for _ in range(3)]

--- a/mlx_vlm/models/qwen3_omni_moe/language.py
+++ b/mlx_vlm/models/qwen3_omni_moe/language.py
@@ -427,6 +427,10 @@ class LanguageModel(nn.Module):
 
                     llm_pos_ids_list.append(t_index + st_idx)
 
+                if not llm_pos_ids_list:
+                    mrope_position_deltas.append(0)
+                    continue
+
                 llm_positions = mx.concatenate(llm_pos_ids_list, axis=1).reshape(3, -1)
                 compact_max_position = llm_positions.max()
                 padded_positions = [[1] * total_input_ids.shape[1] for _ in range(3)]

--- a/mlx_vlm/models/qwen3_vl/language.py
+++ b/mlx_vlm/models/qwen3_vl/language.py
@@ -420,6 +420,10 @@ class LanguageModel(nn.Module):
 
                     llm_pos_ids_list.append(t_index + st_idx)
 
+                if not llm_pos_ids_list:
+                    mrope_position_deltas.append(0)
+                    continue
+
                 llm_positions = mx.concatenate(llm_pos_ids_list, axis=1).reshape(3, -1)
                 compact_max_position = llm_positions.max()
                 padded_positions = [[1] * total_input_ids.shape[1] for _ in range(3)]

--- a/mlx_vlm/models/qwen3_vl_moe/language.py
+++ b/mlx_vlm/models/qwen3_vl_moe/language.py
@@ -460,6 +460,10 @@ class LanguageModel(nn.Module):
 
                     llm_pos_ids_list.append(t_index + st_idx)
 
+                if not llm_pos_ids_list:
+                    mrope_position_deltas.append(0)
+                    continue
+
                 llm_positions = mx.concatenate(llm_pos_ids_list, axis=1).reshape(3, -1)
                 compact_max_position = llm_positions.max()
                 padded_positions = [[1] * total_input_ids.shape[1] for _ in range(3)]

--- a/mlx_vlm/tests/test_rope.py
+++ b/mlx_vlm/tests/test_rope.py
@@ -1,0 +1,116 @@
+import importlib
+from types import SimpleNamespace
+
+import mlx.core as mx
+import pytest
+
+QWEN_STYLE_MODULES = [
+    "mlx_vlm.models.glm4v.language",
+    "mlx_vlm.models.glm4v_moe.language",
+    "mlx_vlm.models.paddleocr_vl.language",
+    "mlx_vlm.models.qwen2_vl.language",
+    "mlx_vlm.models.qwen2_5_vl.language",
+    "mlx_vlm.models.qwen3_5.language",
+    "mlx_vlm.models.qwen3_omni_moe.language",
+    "mlx_vlm.models.qwen3_vl.language",
+    "mlx_vlm.models.qwen3_vl_moe.language",
+]
+
+
+def _mrope_config():
+    return SimpleNamespace(
+        vision_config=SimpleNamespace(spatial_merge_size=2),
+        image_token_id=101,
+        video_token_id=102,
+        vision_start_token_id=100,
+    )
+
+
+@pytest.mark.parametrize("module_name", QWEN_STYLE_MODULES)
+def test_mrope_rope_index_handles_fully_masked_rows(module_name):
+    module = importlib.import_module(module_name)
+    lm = module.LanguageModel.__new__(module.LanguageModel)
+    lm.config = _mrope_config()
+
+    input_ids = mx.array(
+        [
+            [0, 0, 0, 0],
+            [10, 100, 101, 11],
+        ],
+        dtype=mx.int32,
+    )
+    attention_mask = mx.array(
+        [
+            [0, 0, 0, 0],
+            [1, 1, 1, 1],
+        ],
+        dtype=mx.int32,
+    )
+    image_grid_thw = mx.array([[1, 2, 2]], dtype=mx.int32)
+
+    position_ids, rope_deltas = lm.get_rope_index(
+        input_ids,
+        image_grid_thw=image_grid_thw,
+        attention_mask=attention_mask,
+    )
+    mx.eval(position_ids, rope_deltas)
+
+    assert position_ids.shape == (3, 2, 4)
+    assert rope_deltas.shape == (2, 1)
+    assert rope_deltas.tolist()[0] == [0]
+
+
+def test_glm_ocr_rope_index_handles_fully_masked_rows():
+    module = importlib.import_module("mlx_vlm.models.glm_ocr.language")
+    lm = module.LanguageModel.__new__(module.LanguageModel)
+    lm.config = SimpleNamespace(
+        vision_config=SimpleNamespace(spatial_merge_size=2),
+        image_token_id=101,
+        video_token_id=102,
+    )
+
+    input_ids = mx.array(
+        [
+            [0, 0, 0, 0],
+            [10, 101, 11, 12],
+        ],
+        dtype=mx.int32,
+    )
+    attention_mask = mx.array(
+        [
+            [0, 0, 0, 0],
+            [1, 1, 1, 1],
+        ],
+        dtype=mx.int32,
+    )
+    image_grid_thw = mx.array([[1, 2, 2]], dtype=mx.int32)
+
+    position_ids, rope_deltas = lm.get_rope_index(
+        input_ids,
+        image_grid_thw=image_grid_thw,
+        attention_mask=attention_mask,
+    )
+    mx.eval(position_ids, rope_deltas)
+
+    assert position_ids.shape == (3, 2, 4)
+    assert rope_deltas.shape == (2, 1)
+    assert rope_deltas.tolist()[0] == [0]
+
+
+def test_ernie_mrope_rope_index_handles_empty_rows():
+    module = importlib.import_module("mlx_vlm.models.ernie4_5_moe_vl.language")
+    lm = module.LanguageModel.__new__(module.LanguageModel)
+    lm.config = _mrope_config()
+
+    input_ids = mx.zeros((2, 0), dtype=mx.int32)
+    image_grid_thw = mx.zeros((0, 3), dtype=mx.int32)
+
+    position_ids, rope_deltas = lm.get_rope_index(
+        input_ids,
+        image_grid_thw=image_grid_thw,
+    )
+    mx.eval(position_ids, rope_deltas)
+
+    assert position_ids.shape == (2, 0, 3)
+    assert rope_deltas.shape == (2,)
+    assert rope_deltas.tolist() == [0, 0]


### PR DESCRIPTION
## Summary

- Add empty `llm_pos_ids_list` guards across MRoPE `get_rope_index` implementations before calling `mx.concatenate` / `np.concatenate`.
- Preserve existing padded/default position ids and emit a zero rope delta for rows that have no compact tokens in the current slice.
- Add focused regression coverage for fully masked rows across Qwen-style, GLM OCR, and Ernie MRoPE paths.

## Context

Refs #1346. The crash there happens when a chunked, mixed-length vision batch can produce a row with no non-padding tokens in the current prefill slice, leaving `llm_pos_ids_list` empty before concatenation.

## Validation

- `uv run --with pytest pytest mlx_vlm/tests/test_rope.py`