### PR TITLE
[codex] Skip read-only generation config defaults

### DIFF
--- a/mlx_vlm/tests/test_utils.py
+++ b/mlx_vlm/tests/test_utils.py
@@ -168,6 +168,24 @@ def test_apply_generation_config_defaults_preserves_model_config_signature():
     assert not hasattr(model_config, "max_new_tokens")
 
 
+def test_apply_generation_config_defaults_skips_read_only_properties():
+    class ModelConfig:
+        @property
+        def eos_token_id(self):
+            return None
+
+    model_config = apply_generation_config_defaults(
+        ModelConfig(),
+        {
+            "eos_token_id": [2, 3],
+            "temperature": 1.0,
+        },
+    )
+
+    assert model_config.eos_token_id is None
+    assert model_config.temperature == 1.0
+
+
 def test_sanitize_weights():
     class DummyModel:
         def __init__(self, config=None):

--- a/mlx_vlm/utils.py
+++ b/mlx_vlm/utils.py
@@ -66,6 +66,9 @@ GENERATION_CONFIG_DEFAULT_KEYS = (
 def apply_generation_config_defaults(model_config, config: dict):
     for key in GENERATION_CONFIG_DEFAULT_KEYS:
         if key in config:
+            attr = inspect.getattr_static(type(model_config), key, None)
+            if isinstance(attr, property) and attr.fset is None:
+                continue
             setattr(model_config, key, config[key])
     return model_config
 


### PR DESCRIPTION
## Summary
- Skip generation config default assignment for read-only `ModelConfig` properties.
- Add a regression test covering read-only `eos_token_id`, matching the MolmoPoint load crash reported in #1449.

## Root Cause
`apply_generation_config_defaults` copied selected `generation_config.json` keys onto every model config with `setattr`. MolmoPoint exposes `eos_token_id` as a read-only property so loading a checkpoint whose generation config includes `eos_token_id` raised `AttributeError` before model construction completed.

## Validation
- `uv run --with pytest pytest mlx_vlm/tests/test_utils.py -q`
- `python3 -m py_compile mlx_vlm/utils.py mlx_vlm/tests/test_utils.py`
- `git diff --check`
- `uv run --with pytest --with psutil pytest mlx_vlm/tests -q`

Fixes the MolmoPoint load-crash portion of #1449.