### PR TITLE
Improve Responses API reasoning and tool stream events

### DIFF
--- a/mlx_vlm/server/openai.py
+++ b/mlx_vlm/server/openai.py
@@ -887,6 +887,13 @@ async def responses_endpoint(request: Request):
                         if tool_module is not None and chat_tools
                         else None
                     )
+                    thinking_state = ThinkingStreamState(
+                        gen_args.enable_thinking,
+                        gen_args.thinking_start_token,
+                        gen_args.thinking_end_token,
+                    )
+                    reasoning_item_id = f"rs_{uuid.uuid4().hex}"
+                    streamed_reasoning = ""
 
                     if runtime.response_generator is not None:
                         # generate() blocks on _cpu_preprocess + queue.get;
@@ -913,8 +920,23 @@ async def responses_endpoint(request: Request):
                             if token is None:
                                 break
                             output_tokens += getattr(token, "token_count", 1)
-                            delta = token.text
-                            full_text += delta
+                            raw_delta = token.text
+                            full_text += raw_delta
+                            thinking_delta = thinking_state.feed(raw_delta)
+                            if thinking_delta.reasoning:
+                                streamed_reasoning += thinking_delta.reasoning
+                                yield _response_sse_event(
+                                    "response.reasoning_text.delta",
+                                    {
+                                        "type": "response.reasoning_text.delta",
+                                        "response_id": response_id,
+                                        "item_id": reasoning_item_id,
+                                        "output_index": 0,
+                                        "content_index": 0,
+                                        "delta": thinking_delta.reasoning,
+                                    },
+                                )
+                            delta = thinking_delta.content
                             in_tool_call, delta = suppress_tool_call_content(
                                 full_text, in_tool_call, tc_start, delta
                             )
@@ -948,8 +970,23 @@ async def responses_endpoint(request: Request):
                             if chunk is None or not hasattr(chunk, "text"):
                                 continue
 
-                            delta = chunk.text
-                            full_text += delta
+                            raw_delta = chunk.text
+                            full_text += raw_delta
+                            thinking_delta = thinking_state.feed(raw_delta)
+                            if thinking_delta.reasoning:
+                                streamed_reasoning += thinking_delta.reasoning
+                                yield _response_sse_event(
+                                    "response.reasoning_text.delta",
+                                    {
+                                        "type": "response.reasoning_text.delta",
+                                        "response_id": response_id,
+                                        "item_id": reasoning_item_id,
+                                        "output_index": 0,
+                                        "content_index": 0,
+                                        "delta": thinking_delta.reasoning,
+                                    },
+                                )
+                            delta = thinking_delta.content
                             in_tool_call, delta = suppress_tool_call_content(
                                 full_text, in_tool_call, tc_start, delta
                             )
@@ -975,11 +1012,29 @@ async def responses_endpoint(request: Request):
                             tool_registry,
                             gen_args.thinking_start_token,
                             gen_args.thinking_end_token,
+                            reasoning_item_id,
                         )
                     )
                     tool_output_items = [
-                        item for item in output_items if item.get("type") != "message"
+                        item
+                        for item in output_items
+                        if item.get("type") not in ("message", "reasoning")
                     ]
+                    reasoning_output_items = [
+                        item for item in output_items if item.get("type") == "reasoning"
+                    ]
+                    if streamed_reasoning:
+                        yield _response_sse_event(
+                            "response.reasoning_text.done",
+                            {
+                                "type": "response.reasoning_text.done",
+                                "response_id": response_id,
+                                "item_id": reasoning_item_id,
+                                "output_index": 0,
+                                "content_index": 0,
+                                "text": streamed_reasoning,
+                            },
+                        )
 
                     # Send response.output_text.done event (to match the openai pipeline)
                     yield f"event: response.output_text.done\ndata: {ResponseOutputTextDoneEvent(type='response.output_text.done', item_id=message_id, output_index=0, content_index=0, text=clean_text).model_dump_json()}\n\n"
@@ -998,14 +1053,26 @@ async def responses_endpoint(request: Request):
                         role="assistant",
                         content=[final_content_part] if clean_text else [],
                     )
-                    yield f"event: response.output_item.done\ndata: {ResponseOutputItemDoneEvent(type='response.output_item.done', output_index=0, item=final_message_item).model_dump_json()}\n\n"
+                    message_output_items = [
+                        item for item in output_items if item.get("type") == "message"
+                    ]
+                    final_message_payload = (
+                        message_output_items[0]
+                        if message_output_items
+                        else final_message_item.model_dump()
+                    )
+                    yield f"event: response.output_item.done\ndata: {ResponseOutputItemDoneEvent(type='response.output_item.done', output_index=0, item=final_message_payload).model_dump_json()}\n\n"
 
                     completed_output = []
-                    if clean_text:
+                    completed_output.extend(reasoning_output_items)
+                    if message_output_items:
+                        completed_output.extend(message_output_items)
+                    elif clean_text:
                         completed_output.append(final_message_item.model_dump())
+                    tool_start_index = len(completed_output)
                     completed_output.extend(tool_output_items)
                     for output_index, tool_item in enumerate(
-                        tool_output_items, start=1
+                        tool_output_items, start=tool_start_index
                     ):
                         yield _response_sse_event(
                             "response.output_item.added",
@@ -1015,6 +1082,21 @@ async def responses_endpoint(request: Request):
                                 "item": tool_item,
                             },
                         )
+                        if tool_item.get("type") == "function_call":
+                            yield _response_sse_event(
+                                "response.function_call_arguments.done",
+                                {
+                                    "type": "response.function_call_arguments.done",
+                                    "response_id": response_id,
+                                    "item_id": tool_item.get("id")
+                                    or tool_item.get("call_id"),
+                                    "output_index": output_index,
+                                    "call_id": tool_item.get("call_id"),
+                                    "name": tool_item.get("name"),
+                                    "arguments": tool_item.get("arguments") or "{}",
+                                    "item": tool_item,
+                                },
+                            )
                         yield _response_sse_event(
                             "response.output_item.done",
                             {

--- a/mlx_vlm/server/responses_state.py
+++ b/mlx_vlm/server/responses_state.py
@@ -303,10 +303,12 @@ def _response_output_items_from_text(
     tool_registry: Dict[str, str],
     thinking_start_token: Optional[str] = None,
     thinking_end_token: Optional[str] = None,
+    reasoning_item_id: Optional[str] = None,
 ) -> Tuple[List[Dict[str, Any]], str, Optional[str], str]:
     reasoning, content = _split_thinking(
         full_text, thinking_start_token, thinking_end_token
     )
+    reasoning_items = _reasoning_output_items(reasoning, reasoning_item_id)
     if tool_module is not None and chat_tools:
         tc = process_tool_calls(full_text, tool_module, chat_tools)
         if tc["calls"]:
@@ -319,7 +321,7 @@ def _response_output_items_from_text(
                 thinking_end_token,
             )
             remaining = re.sub(r"<\|[^>]+\|>|<[^>]+>", "", remaining).strip()
-            return items, remaining, reasoning, "tool_calls"
+            return reasoning_items + items, remaining, reasoning, "tool_calls"
     item = {
         "id": message_id,
         "type": "message",
@@ -329,7 +331,22 @@ def _response_output_items_from_text(
     }
     if reasoning:
         item["reasoning"] = reasoning
-    return [item], content, reasoning, "stop"
+    return reasoning_items + [item], content, reasoning, "stop"
+
+
+def _reasoning_output_items(
+    reasoning: Optional[str],
+    item_id: Optional[str] = None,
+) -> List[Dict[str, Any]]:
+    if not reasoning:
+        return []
+    return [
+        {
+            "id": item_id or f"rs_{uuid.uuid4().hex}",
+            "type": "reasoning",
+            "summary": [{"type": "summary_text", "text": reasoning}],
+        }
+    ]
 
 
 def _normalize_response_input(input_value: Any) -> List[Dict[str, Any]]:

--- a/mlx_vlm/tests/test_server.py
+++ b/mlx_vlm/tests/test_server.py
@@ -1465,6 +1465,37 @@ def test_responses_endpoint_returns_function_call_items(client):
     )
 
 
+def test_responses_endpoint_returns_reasoning_items(client):
+    server.response_store.clear()
+    server.response_store_order.clear()
+    model = SimpleNamespace()
+    processor = SimpleNamespace()
+    config = SimpleNamespace(model_type="qwen2_vl")
+    result = GenerationResult(
+        text="<think>Check briefly.</think>\n\nDone.",
+        prompt_tokens=8,
+        generation_tokens=4,
+    )
+
+    with (
+        patch.object(
+            server, "get_cached_model", return_value=(model, processor, config)
+        ),
+        patch.object(server, "apply_chat_template", return_value="prompt"),
+        patch.object(server, "generate", return_value=result),
+    ):
+        response = client.post(
+            "/v1/responses", json={"model": "demo", "input": "hello"}
+        )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert [item["type"] for item in payload["output"]] == ["reasoning", "message"]
+    assert payload["output"][0]["summary"][0]["text"] == "Check briefly."
+    assert payload["output"][1]["content"][0]["text"] == "Done."
+    assert payload["output_text"] == "Done."
+
+
 def test_responses_endpoint_returns_native_shell_call_items(client):
     server.response_store.clear()
     server.response_store_order.clear()
@@ -1504,6 +1535,21 @@ def test_responses_endpoint_returns_native_shell_call_items(client):
     payload = response.json()
     assert payload["output"][0]["type"] == "shell_call"
     assert payload["output"][0]["action"] == {"type": "exec", "command": "pwd"}
+
+
+def _sse_events(body):
+    events = []
+    for block in body.split("\n\n"):
+        event_type = None
+        data = None
+        for line in block.splitlines():
+            if line.startswith("event: "):
+                event_type = line.removeprefix("event: ")
+            elif line.startswith("data: "):
+                data = json.loads(line.removeprefix("data: "))
+        if event_type and data:
+            events.append((event_type, data))
+    return events
 
 
 def test_responses_streaming_emits_native_tool_call_items(client):
@@ -1553,6 +1599,121 @@ def test_responses_streaming_emits_native_tool_call_items(client):
     assert '"type": "shell_call"' in body
     assert '"command": "pwd"' in body
     assert "<tool_call>" not in body
+
+
+def test_responses_streaming_emits_reasoning_events(client):
+    server.response_store.clear()
+    server.response_store_order.clear()
+    model = SimpleNamespace()
+    processor = SimpleNamespace()
+    config = SimpleNamespace(model_type="qwen2_vl")
+    chunks = [
+        GenerationResult(text="<think>Check", prompt_tokens=8, generation_tokens=1),
+        GenerationResult(
+            text=" briefly.</think>\n\nDone.",
+            prompt_tokens=8,
+            generation_tokens=4,
+            finish_reason="stop",
+        ),
+    ]
+
+    with (
+        patch.object(
+            server, "get_cached_model", return_value=(model, processor, config)
+        ),
+        patch.object(server, "apply_chat_template", return_value="prompt"),
+        patch.object(server, "stream_generate", return_value=iter(chunks)),
+        patch.object(server.runtime, "response_generator", None),
+    ):
+        response = client.post(
+            "/v1/responses",
+            json={"model": "demo", "input": "hello", "stream": True},
+        )
+
+    assert response.status_code == 200
+    events = _sse_events(response.text)
+    reasoning = [
+        data["delta"]
+        for event_type, data in events
+        if event_type == "response.reasoning_text.delta"
+    ]
+    text_deltas = [
+        data["delta"]
+        for event_type, data in events
+        if event_type == "response.output_text.delta"
+    ]
+    completed = next(
+        data["response"]
+        for event_type, data in events
+        if event_type == "response.completed"
+    )
+
+    assert "".join(reasoning) == "Check briefly."
+    assert "".join(text_deltas) == "Done."
+    assert [item["type"] for item in completed["output"]] == ["reasoning", "message"]
+    assert completed["output"][0]["summary"][0]["text"] == "Check briefly."
+    assert completed["output_text"] == "Done."
+
+
+def test_responses_streaming_emits_function_call_arguments_done(client):
+    server.response_store.clear()
+    server.response_store_order.clear()
+    model = SimpleNamespace()
+    processor = SimpleNamespace()
+    config = SimpleNamespace(model_type="qwen2_vl")
+    chunks = [
+        GenerationResult(
+            text='<tool_call>{"name":"get_weather","arguments":{"location":"SF"}}</tool_call>',
+            prompt_tokens=8,
+            generation_tokens=4,
+            finish_reason="stop",
+        )
+    ]
+    tool_module = SimpleNamespace(
+        tool_call_start="<tool_call>",
+        tool_call_end="</tool_call>",
+        parse_tool_call=lambda call, tools: json.loads(call),
+    )
+
+    with (
+        patch.object(
+            server, "get_cached_model", return_value=(model, processor, config)
+        ),
+        patch.object(server, "apply_chat_template", return_value="prompt"),
+        patch.object(server, "stream_generate", return_value=iter(chunks)),
+        patch.object(server, "_infer_tool_parser_from_processor", return_value="demo"),
+        patch.object(server, "load_tool_module", return_value=tool_module),
+        patch.object(server.runtime, "response_generator", None),
+    ):
+        response = client.post(
+            "/v1/responses",
+            json={
+                "model": "demo",
+                "input": "weather?",
+                "stream": True,
+                "tools": [
+                    {
+                        "type": "function",
+                        "name": "get_weather",
+                        "parameters": {
+                            "type": "object",
+                            "properties": {"location": {"type": "string"}},
+                        },
+                    }
+                ],
+            },
+        )
+
+    assert response.status_code == 200
+    events = _sse_events(response.text)
+    done = next(
+        data
+        for event_type, data in events
+        if event_type == "response.function_call_arguments.done"
+    )
+    assert done["item_id"].startswith("fc_")
+    assert done["name"] == "get_weather"
+    assert done["arguments"] == '{"location": "SF"}'
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Hi! This tightens a few Responses API shapes in the OpenAI-compatible server.

What changed:
- Return thinking blocks as `reasoning` output items with `summary` text, while keeping visible text in the message item.
- Stream thinking through `response.reasoning_text.delta/done` instead of mixing it into `response.output_text.delta`.
- Emit `response.function_call_arguments.done` for streamed function calls once arguments are parsed.

I kept this small and covered the new behavior in the existing server tests.

Tests:
- `.venv/bin/python -m pytest -q mlx_vlm/tests/test_server.py`
- `.venv/bin/pre-commit run --files mlx_vlm/server/responses_state.py mlx_vlm/server/openai.py mlx_vlm/tests/test_server.py`