### PR TITLE
fix(gemma4): recognize bare namespaced tool-call names

### DIFF
--- a/mlx_vlm/tests/test_gemma4_tool_parser.py
+++ b/mlx_vlm/tests/test_gemma4_tool_parser.py
@@ -87,6 +87,31 @@ class TestGemma4ToolParser(unittest.TestCase):
         args = json.loads(result["arguments"])
         self.assertEqual(args, {"limit": 5})
 
+    # ── bare namespaced names (no ``call:`` prefix) ───────────────────────
+    # The ``call:``-prefixed paths accept ``.``/``:`` in names, but the
+    # bare-name normalization that re-adds a missing ``call:`` prefix must
+    # recognize the same character set, otherwise a namespaced name emitted
+    # without the prefix fails to parse.
+
+    def test_bare_dotted_namespaced_name(self):
+        result = parse_tool_call("mcp.calendar{limit:5}")
+        self.assertEqual(result["name"], "mcp.calendar")
+        args = json.loads(result["arguments"])
+        self.assertEqual(args, {"limit": 5})
+
+    def test_bare_colon_namespaced_name(self):
+        text = _wrap(f"google-workspace:list_events{{action:{_str('list_events')}}}")
+        result = parse_tool_call(text)
+        self.assertEqual(result["name"], "google-workspace:list_events")
+        args = json.loads(result["arguments"])
+        self.assertEqual(args, {"action": "list_events"})
+
+    def test_bare_dotted_and_colon_namespaced_name(self):
+        result = parse_tool_call("mcp.calendar:list_events{limit:5}")
+        self.assertEqual(result["name"], "mcp.calendar:list_events")
+        args = json.loads(result["arguments"])
+        self.assertEqual(args, {"limit": 5})
+
     # ── arguments type ────────────────────────────────────────────────────
 
     def test_arguments_is_json_string(self):

--- a/mlx_vlm/tool_parsers/gemma4.py
+++ b/mlx_vlm/tool_parsers/gemma4.py
@@ -7,6 +7,12 @@ tool_call_end = "<tool_call|>"
 
 _ESCAPE = '<|"|>'
 
+# Character class for a (possibly namespaced) tool/function name. Defined once
+# because every regex that recognizes a name must accept the same characters;
+# letting them drift is how bare namespaced names (e.g. ``mcp.calendar:get``)
+# silently regressed after the ``call:``-prefixed paths gained ``.``/``:`` support.
+_NAME_CHARS = r"[\w.:-]+"
+
 
 def _find_matching_brace(text, start):
     """Find the index of the closing '}' that matches the '{' at *start*,
@@ -142,7 +148,7 @@ def _parse_array(text):
 # match the balanced outer braces (handles arbitrary nesting).
 # Function name accepts common namespaced tool ids used by MCP and agents.
 _tool_call_regex = re.compile(
-    r"call:([\w.:-]+)(\{(?:[^{}]|\{(?:[^{}]|\{[^{}]*\})*\})*\})"
+    r"call:(" + _NAME_CHARS + r")(\{(?:[^{}]|\{(?:[^{}]|\{[^{}]*\})*\})*\})"
 )
 
 
@@ -152,14 +158,14 @@ def parse_tool_call(text, tools=None):
     )
     if text.startswith(":"):
         text = f"call{text}"
-    elif not text.startswith("call:") and re.match(r"^[\w-]+\{", text):
+    elif not text.startswith("call:") and re.match(r"^" + _NAME_CHARS + r"\{", text):
         text = f"call:{text}"
 
     # Try recursive-group regex first for well-formed calls
     match = _tool_call_regex.search(text)
     if not match:
         # Fallback: find 'call:<name>{' and then balance braces manually
-        m = re.search(r"call:([\w.:-]+)\{", text)
+        m = re.search(r"call:(" + _NAME_CHARS + r")\{", text)
         if not m:
             raise ValueError("No function call found in tool call text.")
         func_name = m.group(1)


### PR DESCRIPTION
## Summary

The Gemma 4 tool-call parser accepts namespaced function names (dotted / colon ids used by MCP and agents, e.g. `mcp.calendar:list_events`) on the `call:`-prefixed paths — that support was added in #1379. However, the **bare-name normalization** that re-adds a missing `call:` prefix still used a narrower `[\w-]+` character class:

```python
elif not text.startswith("call:") and re.match(r"^[\w-]+\{", text):
    text = f"call:{text}"
```

So when the model emits a namespaced name **without** the `call:` literal, the prefix is never added and parsing fails:

```python
parse_tool_call("mcp.calendar:list_events{limit:5}")
# ValueError: No function call found in tool call text.
```

This is inconsistent: a bare *simple* name (`get_weather{...}`) parses fine, and the same namespaced name *with* the `call:` prefix parses fine — only the bare *namespaced* form fails.

## Root cause

The tool-name character class is duplicated across three regexes. #1379 widened two of them (`_tool_call_regex` and the manual-balance fallback) from `[\w-]+` to `[\w.:-]+` but the bare-name detection regex was missed. Keeping three copies in sync by hand is what let them drift.

## Fix

Define the character class once and reuse it in all three name-matching regexes, so they can't drift again:

```python
_NAME_CHARS = r"[\w.:-]+"
```

The bare-name path now recognizes the same characters the parse paths already accept, which is the actual behavior fix. No other behavior changes — the branch only fires when the text is already believed to be a tool call and lacks a `call:` prefix.

## Tests

Added three cases to `test_gemma4_tool_parser.py` for the previously-broken bare namespaced forms (dotted, colon, dotted+colon). They are **red** on `main` (all raise `ValueError`) and **green** with this change; the existing 13 cases (snake_case, hyphenated, `call:`-prefixed namespaced, bare simple, error path) continue to pass.

```
16 passed in 0.9s
```

`pre-commit` (black / isort / autoflake) is clean.