### PR TITLE
fix(qwen3-omni): eval mRoPE position_ids before the thinker forward

### DIFF
--- a/mlx_vlm/models/qwen3_omni_moe/language.py
+++ b/mlx_vlm/models/qwen3_omni_moe/language.py
@@ -564,9 +564,6 @@ class LanguageModel(nn.Module):
         deepstack_visual_embeds = kwargs.get("deepstack_visual_embeds", None)
         output_hidden_states = kwargs.pop("output_hidden_states", False)
 
-        # `generate_step` only force-evals the sampled token/logprobs, so lazy mRoPE
-        # `position_ids` can survive across calls and be reused with stale values.
-        # `position_ids` is small (3 x batch x seq_len), so materialize it before forward.
         if position_ids is not None:
             mx.eval(position_ids)
 

--- a/mlx_vlm/models/qwen3_omni_moe/language.py
+++ b/mlx_vlm/models/qwen3_omni_moe/language.py
@@ -564,6 +564,12 @@ class LanguageModel(nn.Module):
         deepstack_visual_embeds = kwargs.get("deepstack_visual_embeds", None)
         output_hidden_states = kwargs.pop("output_hidden_states", False)
 
+        # generate_step only evals y/logprobs, not these lazy mRoPE position_ids,
+        # so without this they alias across calls and the 2nd+ generation decodes
+        # to token 0. The array is tiny, so the eval is effectively free.
+        if position_ids is not None:
+            mx.eval(position_ids)
+
         out = self.model(
             inputs,
             cache=cache,

--- a/mlx_vlm/models/qwen3_omni_moe/language.py
+++ b/mlx_vlm/models/qwen3_omni_moe/language.py
@@ -564,9 +564,9 @@ class LanguageModel(nn.Module):
         deepstack_visual_embeds = kwargs.get("deepstack_visual_embeds", None)
         output_hidden_states = kwargs.pop("output_hidden_states", False)
 
-        # generate_step only evals y/logprobs, not these lazy mRoPE position_ids,
-        # so without this they alias across calls and the 2nd+ generation decodes
-        # to token 0. The array is tiny, so the eval is effectively free.
+        # `generate_step` only force-evals the sampled token/logprobs, so lazy mRoPE
+        # `position_ids` can survive across calls and be reused with stale values.
+        # `position_ids` is small (3 x batch x seq_len), so materialize it before forward.
         if position_ids is not None:
             mx.eval(position_ids)
 


### PR DESCRIPTION
While running Qwen3-Omni locally I hit a reproducible bug: only the *first*
generation in a process is correct. Every generation after it decodes garbage —
the thinker just emits token 0 (`"!"`) over and over.

### Repro

```python
from mlx_vlm import load
from mlx_vlm.generate import generate_step
from mlx_vlm.models.qwen3_omni_moe.omni_utils import prepare_omni_inputs

model, processor = load("Qwen/Qwen3-Omni-30B-A3B-Instruct")  # 4-bit, M3 Max

def ids():
    conv = [{"role": "user", "content": [{"type": "text", "text": "Say a short hello."}]}]
    return prepare_omni_inputs(processor, conv)[0]["input_ids"]

for i in range(3):
    out = [int(t) for t, _ in zip(generate_step(ids(), model.thinker, None, None,
                                                 max_tokens=8, eos_tokens=[151645]), range(8))]
    print(i, out)
# 0 -> [13048, 1052, 0, 61804, ...]   "Hi there! ..."   correct
# 1 -> [0, 0, 0, 0, 0, 0, 0, 0]       "!!!!!!!!"         garbage
# 2 -> [0, 0, 0, 0, 0, 0, 0, 0]       "!!!!!!!!"         garbage
```

It's not Talker/audio specific — bare `generate_step` reproduces it, and a plain
manual decode loop (no `generate_step`) does *not*, which is what pointed at the
generation path rather than the weights or the cache.

### Cause

The thinker's `LanguageModel.__call__` in `models/qwen3_omni_moe/language.py`
builds the mRoPE `position_ids` (via `get_rope_index`) as lazy arrays and never
evaluates them — it relies on `generate_step` to realize them downstream. But
`generate_step` only force-evals `y`/`logprobs`, not `position_ids`. So the
`position_ids` lazy graph survives and aliases into the next `generate_step`
call; from the second call on, the positions fed into RoPE are wrong and the
logits collapse onto token 0.

I confirmed this by adding a throwaway `position_ids.tolist()` (which forces
evaluation) right before the forward — that alone made all three calls correct.

### Fix

Evaluate `position_ids` before the decoder forward so each call starts from a
materialized array instead of a shared lazy graph:

```python
if position_ids is not None:
    mx.eval(position_ids)
```

`position_ids` is a `3 x seq_len` int array, so this is effectively free, and
it's a no-op when there's nothing pending.

### Testing

- Bare `generate_step` x3: was correct/garbage/garbage, now correct x3.
- `generate_stream`: turn 2+ was `"!!!!"`, now every turn returns correct text
  and Talker audio across several consecutive turns.

Happy to add a regression test if you'd like one — the natural check is "two
generations in a row from the same model don't diverge," though it needs the
Qwen3-Omni weights to exercise the mRoPE path.
