### PR TITLE
perf(qwen3-omni): early-exit the thinker hidden-state extraction

### DIFF
--- a/mlx_vlm/models/qwen3_omni_moe/language.py
+++ b/mlx_vlm/models/qwen3_omni_moe/language.py
@@ -247,6 +247,13 @@ class Qwen3VLMoEModel(nn.Module):
             mask = create_attention_mask(
                 h, cache[0] if cache and cache[0] is not None else cache
             )
+        if early_exit_layer is not None and (
+            early_exit_layer < 0 or early_exit_layer >= len(self.layers)
+        ):
+            raise ValueError(
+                "early_exit_layer must be in "
+                f"[0, {len(self.layers) - 1}], got {early_exit_layer}"
+            )
 
         all_hidden_states = [] if output_hidden_states else None
         position_embeddings = None
@@ -493,6 +500,33 @@ class LanguageModel(nn.Module):
                 )
             return position_ids, mrope_position_deltas
 
+    def hidden_state_at_layer(
+        self,
+        inputs: mx.array,
+        target_layer_idx: int,
+        inputs_embeds: Optional[mx.array] = None,
+        image_grid_thw: Optional[mx.array] = None,
+        video_grid_thw: Optional[mx.array] = None,
+    ):
+        early_exit_layer = target_layer_idx - 1
+        if early_exit_layer < 0 or early_exit_layer >= len(self.model.layers):
+            raise ValueError(
+                "target_layer_idx must be in "
+                f"[1, {len(self.model.layers)}], got {target_layer_idx}"
+            )
+
+        position_ids, rope_deltas = self.get_rope_index(
+            inputs, image_grid_thw, video_grid_thw, None
+        )
+        self._rope_deltas = rope_deltas
+
+        return self.model(
+            inputs,
+            inputs_embeds=inputs_embeds,
+            position_ids=position_ids,
+            early_exit_layer=early_exit_layer,
+        )
+
     def __call__(
         self,
         inputs: mx.array,
@@ -569,17 +603,6 @@ class LanguageModel(nn.Module):
         visual_pos_masks = kwargs.get("visual_pos_masks", None)
         deepstack_visual_embeds = kwargs.get("deepstack_visual_embeds", None)
         output_hidden_states = kwargs.pop("output_hidden_states", False)
-        early_exit_layer = kwargs.pop("early_exit_layer", None)
-        if early_exit_layer is not None:
-            if output_hidden_states:
-                raise ValueError(
-                    "early_exit_layer cannot be used with output_hidden_states"
-                )
-            if early_exit_layer < 0 or early_exit_layer >= len(self.model.layers):
-                raise ValueError(
-                    "early_exit_layer must be in "
-                    f"[0, {len(self.model.layers) - 1}], got {early_exit_layer}"
-                )
 
         out = self.model(
             inputs,
@@ -589,14 +612,7 @@ class LanguageModel(nn.Module):
             visual_pos_masks=visual_pos_masks,
             deepstack_visual_embeds=deepstack_visual_embeds,
             output_hidden_states=output_hidden_states,
-            early_exit_layer=early_exit_layer,
         )
-
-        # Early-exit path: ``out`` is the raw hidden state of ``early_exit_layer``
-        # (no norm, no lm_head, so no logits). Return it as a 1-element
-        # hidden_states list to match the LanguageModelOutput contract.
-        if early_exit_layer is not None:
-            return LanguageModelOutput(logits=None, hidden_states=[out])
 
         if output_hidden_states:
             hidden_states, all_hidden_states = out

--- a/mlx_vlm/models/qwen3_omni_moe/language.py
+++ b/mlx_vlm/models/qwen3_omni_moe/language.py
@@ -500,33 +500,6 @@ class LanguageModel(nn.Module):
                 )
             return position_ids, mrope_position_deltas
 
-    def hidden_state_at_layer(
-        self,
-        inputs: mx.array,
-        target_layer_idx: int,
-        inputs_embeds: Optional[mx.array] = None,
-        image_grid_thw: Optional[mx.array] = None,
-        video_grid_thw: Optional[mx.array] = None,
-    ):
-        early_exit_layer = target_layer_idx - 1
-        if early_exit_layer < 0 or early_exit_layer >= len(self.model.layers):
-            raise ValueError(
-                "target_layer_idx must be in "
-                f"[1, {len(self.model.layers)}], got {target_layer_idx}"
-            )
-
-        position_ids, rope_deltas = self.get_rope_index(
-            inputs, image_grid_thw, video_grid_thw, None
-        )
-        self._rope_deltas = rope_deltas
-
-        return self.model(
-            inputs,
-            inputs_embeds=inputs_embeds,
-            position_ids=position_ids,
-            early_exit_layer=early_exit_layer,
-        )
-
     def __call__(
         self,
         inputs: mx.array,

--- a/mlx_vlm/models/qwen3_omni_moe/language.py
+++ b/mlx_vlm/models/qwen3_omni_moe/language.py
@@ -570,6 +570,16 @@ class LanguageModel(nn.Module):
         deepstack_visual_embeds = kwargs.get("deepstack_visual_embeds", None)
         output_hidden_states = kwargs.pop("output_hidden_states", False)
         early_exit_layer = kwargs.pop("early_exit_layer", None)
+        if early_exit_layer is not None:
+            if output_hidden_states:
+                raise ValueError(
+                    "early_exit_layer cannot be used with output_hidden_states"
+                )
+            if early_exit_layer < 0 or early_exit_layer >= len(self.model.layers):
+                raise ValueError(
+                    "early_exit_layer must be in "
+                    f"[0, {len(self.model.layers) - 1}], got {early_exit_layer}"
+                )
 
         out = self.model(
             inputs,

--- a/mlx_vlm/models/qwen3_omni_moe/language.py
+++ b/mlx_vlm/models/qwen3_omni_moe/language.py
@@ -233,6 +233,7 @@ class Qwen3VLMoEModel(nn.Module):
         visual_pos_masks: Optional[mx.array] = None,
         deepstack_visual_embeds: Optional[mx.array] = None,
         output_hidden_states: bool = False,
+        early_exit_layer: Optional[int] = None,
     ):
         if inputs_embeds is None:
             h = self.embed_tokens(inputs)
@@ -269,6 +270,11 @@ class Qwen3VLMoEModel(nn.Module):
                     visual_pos_masks,
                     deepstack_visual_embeds[layer_idx],
                 )
+
+            # Return this layer's hidden state directly: same tensor as
+            # output_hidden_states[early_exit_layer + 1], minus the unused tail.
+            if early_exit_layer is not None and layer_idx == early_exit_layer:
+                return h
 
             if layer_idx % 4 == 0:
                 mx.eval(h)
@@ -563,6 +569,7 @@ class LanguageModel(nn.Module):
         visual_pos_masks = kwargs.get("visual_pos_masks", None)
         deepstack_visual_embeds = kwargs.get("deepstack_visual_embeds", None)
         output_hidden_states = kwargs.pop("output_hidden_states", False)
+        early_exit_layer = kwargs.pop("early_exit_layer", None)
 
         out = self.model(
             inputs,
@@ -572,7 +579,14 @@ class LanguageModel(nn.Module):
             visual_pos_masks=visual_pos_masks,
             deepstack_visual_embeds=deepstack_visual_embeds,
             output_hidden_states=output_hidden_states,
+            early_exit_layer=early_exit_layer,
         )
+
+        # Early-exit path: ``out`` is the raw hidden state of ``early_exit_layer``
+        # (no norm, no lm_head, so no logits). Return it as a 1-element
+        # hidden_states list to match the LanguageModelOutput contract.
+        if early_exit_layer is not None:
+            return LanguageModelOutput(logits=None, hidden_states=[out])
 
         if output_hidden_states:
             hidden_states, all_hidden_states = out

--- a/mlx_vlm/models/qwen3_omni_moe/qwen3_omni_moe.py
+++ b/mlx_vlm/models/qwen3_omni_moe/qwen3_omni_moe.py
@@ -135,15 +135,22 @@ class Model(nn.Module):
         )
         inputs_embeds = input_embedding_features.inputs_embeds
 
-        lm_kwargs = {
-            k: v for k, v in kwargs.items() if k in ["image_grid_thw", "video_grid_thw"]
-        }
-
-        hidden_states = self.thinker.language_model.hidden_state_at_layer(
+        # Transformers prepends input embeddings as hidden_states[0].
+        early_exit_layer = target_layer_idx - 1
+        language_model = self.thinker.language_model
+        position_ids, rope_deltas = language_model.get_rope_index(
             input_ids,
-            target_layer_idx,
+            kwargs.get("image_grid_thw"),
+            kwargs.get("video_grid_thw"),
+            None,
+        )
+        language_model._rope_deltas = rope_deltas
+
+        hidden_states = language_model.model(
+            input_ids,
             inputs_embeds=inputs_embeds,
-            **lm_kwargs,
+            position_ids=position_ids,
+            early_exit_layer=early_exit_layer,
         )
 
         return hidden_states, inputs_embeds

--- a/mlx_vlm/models/qwen3_omni_moe/qwen3_omni_moe.py
+++ b/mlx_vlm/models/qwen3_omni_moe/qwen3_omni_moe.py
@@ -142,11 +142,11 @@ class Model(nn.Module):
         outputs = self.thinker.language_model(
             input_ids,
             inputs_embeds=inputs_embeds,
-            output_hidden_states=True,
+            early_exit_layer=target_layer_idx,
             **lm_kwargs,
         )
 
-        hidden_states = outputs.hidden_states[target_layer_idx + 1]
+        hidden_states = outputs.hidden_states[0]
 
         return hidden_states, inputs_embeds
 

--- a/mlx_vlm/models/qwen3_omni_moe/qwen3_omni_moe.py
+++ b/mlx_vlm/models/qwen3_omni_moe/qwen3_omni_moe.py
@@ -139,21 +139,12 @@ class Model(nn.Module):
             k: v for k, v in kwargs.items() if k in ["image_grid_thw", "video_grid_thw"]
         }
 
-        early_exit_layer = target_layer_idx - 1
-        if early_exit_layer < 0:
-            raise ValueError(
-                f"target_layer_idx must be greater than 0, got {target_layer_idx}"
-            )
-
-        # Transformers prepends input embeddings as hidden_states[0].
-        outputs = self.thinker.language_model(
+        hidden_states = self.thinker.language_model.hidden_state_at_layer(
             input_ids,
+            target_layer_idx,
             inputs_embeds=inputs_embeds,
-            early_exit_layer=early_exit_layer,
             **lm_kwargs,
         )
-
-        hidden_states = outputs.hidden_states[0]
 
         return hidden_states, inputs_embeds
 

--- a/mlx_vlm/models/qwen3_omni_moe/qwen3_omni_moe.py
+++ b/mlx_vlm/models/qwen3_omni_moe/qwen3_omni_moe.py
@@ -139,10 +139,17 @@ class Model(nn.Module):
             k: v for k, v in kwargs.items() if k in ["image_grid_thw", "video_grid_thw"]
         }
 
+        early_exit_layer = target_layer_idx - 1
+        if early_exit_layer < 0:
+            raise ValueError(
+                f"target_layer_idx must be greater than 0, got {target_layer_idx}"
+            )
+
+        # Transformers prepends input embeddings as hidden_states[0].
         outputs = self.thinker.language_model(
             input_ids,
             inputs_embeds=inputs_embeds,
-            early_exit_layer=target_layer_idx,
+            early_exit_layer=early_exit_layer,
             **lm_kwargs,
         )
 


### PR DESCRIPTION
### What

`extract_thinker_hidden_states` runs a full thinker forward
(`output_hidden_states=True` — all 48 layers, plus the final norm and `lm_head`)
only to read one layer's hidden state, `accept_hidden_layer` (24 by default),
which is all the Talker conditions on. Everything computed past that layer is
discarded.

This adds an opt-in `early_exit_layer` to the thinker `LanguageModel` that
returns as soon as that layer is computed, and points
`extract_thinker_hidden_states` at it instead of indexing the full
`output_hidden_states` list.

### Why it's safe

The returned tensor is exactly what `output_hidden_states[early_exit_layer + 1]`
would hold — same layers in the same order, just stopped before the unused tail.
A direct comparison on Qwen3-Omni-30B-A3B-Instruct-4bit gives
`max|Δ| = 0.0`. It defaults to `None`, so existing callers and `generate_step`
are untouched.

### Speedup

The extraction forward drops from 52 ms to 29 ms (~1.8x) on the same model /
M3 Max, since it skips half the decoder stack plus the `lm_head` projection. It
runs once per Talker turn, so it's on the audio path.
