### PR TITLE
fix(apc): enable APC prefix cache with MTP speculative decoding

### DIFF
--- a/mlx_vlm/apc.py
+++ b/mlx_vlm/apc.py
@@ -3711,6 +3711,11 @@ def harvest_blocks_from_batch_cache(
         keys = getattr(c, "keys", None)
         values = getattr(c, "values", None)
         idx = getattr(c, "_idx", None)
+        # Regular KVCache (non-batch) — e.g. from make_speculative_prompt_cache
+        # used with MTP draft model + batch_size=1. These entries carry
+        # ``offset`` instead of ``_idx`` and have no ``left_padding``.
+        if idx is None and keys is not None and values is not None:
+            idx = getattr(c, "offset", None)
         left_padding = getattr(c, "left_padding", None)
         if keys is None or values is None or idx is None:
             return []

--- a/mlx_vlm/generate/ar.py
+++ b/mlx_vlm/generate/ar.py
@@ -2095,7 +2095,6 @@ class BatchGenerator:
         self.draft_block_size = draft_block_size
         self.greedy_sampling = greedy_sampling or sampler is None
         if self.draft_model is not None:
-            apc_manager = None
             compute_logprobs = False
             top_logprobs_k = 0
             self.compute_logprobs = False


### PR DESCRIPTION
Two changes to make APC block-level prefix caching work alongside speculative (MTP) decoding:

1. harvest_blocks_from_batch_cache: accept regular KVCache entries (which use `offset` instead of `_idx`) when the prompt cache was created by `make_speculative_prompt_cache` for MTP batch_size=1. Without this fallback the harvest returns [] silently because `getattr(c, "_idx", None)` is None on non-batch KVCache.

2. BatchGenerator.__init__: stop nulling `apc_manager` when `draft_model` is set. This was a defensive disable added in eb7537b ("Fix Qwen MTP batched target-verify drift", PR #1210)

Together these allow mlx_vlm.server to serve fast hot-TTFT via APC while retaining the ~2-3x decode speedup from MTP speculative decoding, rather than forcing users to choose one or the other.

Fixes: #1443