### PR TITLE
feat: Gemma 4 DSpark self-speculative decoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,8 +128,9 @@ Speed up generation by drafting several candidate tokens with a small "drafter" 
 | Flag | Description |
 |------|-------------|
 | `--draft-model` | HuggingFace repo or local path for the drafter |
-| `--draft-kind` | Drafter family — `dflash` (default), `eagle3`, or `mtp` (Gemma 4) |
+| `--draft-kind` | Drafter family — `dflash` (default), `dspark` (Gemma 4 self-speculative), `eagle3`, or `mtp` (Gemma 4) |
 | `--draft-block-size` | Override the drafter's configured block size |
+| `--draft-confidence-threshold` | DSpark only — truncate the draft block where the confidence head's `P(accept)` drops below this (0 = off; lossless either way) |
 
 See [docs/usage.md](docs/usage.md) for Python API examples including batch generation.
 
@@ -229,6 +230,23 @@ mlx_vlm.generate --model mlx-community/gemma-4-31B-it-bf16 \
 mlx_vlm.server --model mlx-community/gemma-4-31B-it-bf16 \
   --draft-model RedHatAI/gemma-4-31B-it-speculator.eagle3
 ```
+
+#### Gemma 4 DSpark
+
+[DSpark](https://github.com/deepseek-ai/DeepSpec) is DeepSeek's self-speculative drafter: an EAGLE-style stack that conditions on the target's intermediate hidden states and predicts a block of tokens biased by a low-rank Markov head, plus a confidence head. The standalone checkpoint auto-detects as `--draft-kind dspark` and must target the deployed **instruct** model.
+
+```sh
+mlx_vlm.generate --model google/gemma-4-12b-it \
+  --draft-model deepseek-ai/dspark_gemma4_12b_block7 \
+  --prompt "Explain speculative decoding in 3 sentences." \
+  --max-tokens 256 --temperature 0
+
+# Server
+mlx_vlm.server --model google/gemma-4-12b-it \
+  --draft-model deepseek-ai/dspark_gemma4_12b_block7
+```
+
+Output is byte-identical to base greedy decoding. The confidence head can adaptively shorten the draft block on the single-sequence path — set `--draft-confidence-threshold` (e.g. `0.5`) to truncate speculation where `P(accept)` falls below the threshold; this only changes how far ahead the drafter speculates, never which tokens are emitted. Batched continuous decoding uses a fixed block (also lossless).
 
 ### Chat UI with Gradio
 
@@ -363,8 +381,9 @@ mlx_vlm.server --model Qwen/Qwen3.5-4B \
 - `--stt-model`: Preload a speech-to-text model at server startup
 - `--adapter-path`: Path for adapter weights to use with the preloaded model
 - `--draft-model`: Speculative drafter path or HF id (e.g. `z-lab/Qwen3.5-4B-DFlash`, `RedHatAI/gemma-4-31B-it-speculator.eagle3`, `google/gemma-4-31B-it-assistant`) — enables speculative decoding for ~2× or higher throughput
-- `--draft-kind`: Drafter family — `dflash` (default), `eagle3`, or `mtp` (Gemma 4)
+- `--draft-kind`: Drafter family — `dflash` (default), `dspark` (Gemma 4 self-speculative), `eagle3`, or `mtp` (Gemma 4)
 - `--draft-block-size`: Override the drafter's configured block size
+- `--draft-confidence-threshold`: DSpark only — truncate the draft block where `P(accept)` falls below this (0 = off; lossless either way)
 - `--host`: Host address (default: `0.0.0.0`)
 - `--port`: Port number (default: `8080`)
 - `--trust-remote-code`: Trust remote code when loading models from Hugging Face Hub

--- a/mlx_vlm/server/cli.py
+++ b/mlx_vlm/server/cli.py
@@ -173,8 +173,9 @@ def main():
         "--draft-kind",
         type=str,
         default=None,
-        choices=["dflash", "eagle3", "mtp"],
-        help="Drafter family -- 'dflash', 'eagle3', or 'mtp' (Gemma 4). "
+        choices=["dflash", "dspark", "eagle3", "mtp"],
+        help="Drafter family -- 'dflash', 'dspark' (Gemma 4 self-speculative), "
+        "'eagle3', or 'mtp' (Gemma 4). "
         "Default: auto-detected from the drafter's HF model_type.",
     )
     parser.add_argument(
@@ -182,6 +183,14 @@ def main():
         type=int,
         default=None,
         help="Override the drafter's configured block size.",
+    )
+    parser.add_argument(
+        "--draft-confidence-threshold",
+        type=float,
+        default=None,
+        help="DSpark only: truncate the draft block where the confidence head's "
+        "P(accept) drops below this threshold (0 = off, lossless either way). "
+        "Maps to the MLX_VLM_DRAFT_CONFIDENCE_THRESHOLD env var.",
     )
     parser.add_argument(
         "--top-logprobs-k",
@@ -235,6 +244,10 @@ def main():
         os.environ["MLX_VLM_DRAFT_KIND"] = args.draft_kind
     if args.draft_block_size is not None:
         os.environ["MLX_VLM_DRAFT_BLOCK_SIZE"] = str(args.draft_block_size)
+    if args.draft_confidence_threshold is not None:
+        os.environ["MLX_VLM_DRAFT_CONFIDENCE_THRESHOLD"] = str(
+            args.draft_confidence_threshold
+        )
     if args.prefill_step_size:
         os.environ["PREFILL_STEP_SIZE"] = str(args.prefill_step_size)
     os.environ["MLX_VLM_MAX_TOKENS"] = str(args.max_tokens)

--- a/mlx_vlm/speculative/drafters/__init__.py
+++ b/mlx_vlm/speculative/drafters/__init__.py
@@ -4,7 +4,7 @@ from typing import Any, Optional, Tuple
 
 from .qwen3_dflash import DFlashDraftModel
 
-KNOWN_DRAFTER_KINDS = {"dflash", "mtp", "eagle3"}
+KNOWN_DRAFTER_KINDS = {"dflash", "mtp", "eagle3", "dspark"}
 
 # Drafter HF ``model_type`` → required round-loop kind. Anything not listed
 # here falls back to ``DEFAULT_DRAFTER_KIND`` when the caller didn't pass one.
@@ -16,7 +16,30 @@ DRAFTER_KIND_BY_MODEL_TYPE = {
     "qwen3_5_mtp": "mtp",
 }
 
+# DSpark drafters declare a generic ``model_type`` (e.g. ``gemma4_text``); their
+# identity is carried by the architecture tag and draft hyper-parameters instead.
+DSPARK_ARCHITECTURE = "Gemma4DSparkModel"
+
 DEFAULT_DRAFTER_KIND = "dflash"
+
+
+def _config_is_dspark(config: Any) -> bool:
+    """A DSpark drafter checkpoint, detected from its architecture tag (preferred) or its
+    distinctive draft hyper-parameter cluster (Markov head + confidence head + mask token).
+    """
+    if config is None:
+        return False
+    architectures = _cfg_get(config, "architectures") or []
+    if DSPARK_ARCHITECTURE in architectures:
+        return True
+    return (
+        _cfg_get(config, "markov_rank") is not None
+        and _cfg_get(config, "mask_token_id") is not None
+        and _cfg_get(config, "block_size") is not None
+        and _cfg_get(config, "target_layer_ids") is not None
+        and bool(_cfg_get(config, "enable_confidence_head"))
+    )
+
 
 logger = logging.getLogger(__name__)
 
@@ -55,6 +78,29 @@ def validate_drafter_compatibility(
             f"Got draft_kind={draft_kind!r}."
         )
 
+    if draft_kind == "dspark":
+        # The DSpark drafter projects the concatenated target hidden states, so its
+        # hidden_size must equal the target's; it also needs the speculative hooks.
+        target = getattr(target_model, "language_model", target_model)
+        if not hasattr(target, "rollback_speculative_cache"):
+            raise ValueError(
+                f"Target {type(target).__name__} does not implement "
+                "rollback_speculative_cache; DSpark needs a Gemma 4 (or compatible) target."
+            )
+        draft_hidden_size = _cfg_get(draft_cfg, "hidden_size")
+        target_hidden_size = _hidden_size(getattr(target, "config", None))
+        if (
+            draft_hidden_size is not None
+            and target_hidden_size is not None
+            and draft_hidden_size != target_hidden_size
+        ):
+            raise ValueError(
+                "DSpark drafter is incompatible with the target model. "
+                f"Drafter hidden_size={draft_hidden_size!r}, "
+                f"target hidden_size={target_hidden_size!r}."
+            )
+        return
+
     if draft_kind != "mtp":
         return
 
@@ -79,15 +125,22 @@ def validate_drafter_compatibility(
         )
 
 
+def _peek_drafter_config(model_path) -> Optional[dict]:
+    """Read the drafter's HF ``config.json`` without loading weights."""
+    try:
+        with open(model_path / "config.json") as f:
+            return json.load(f)
+    except (FileNotFoundError, json.JSONDecodeError, OSError):
+        return None
+
+
 def _peek_drafter_model_type(model_path) -> Optional[str]:
     """Read the drafter's HF ``config.json`` ``model_type`` without loading
     weights. Returns ``None`` if the config can't be read."""
-    try:
-        with open(model_path / "config.json") as f:
-            config = json.load(f)
-            return config.get("model_type") or config.get("speculators_model_type")
-    except (FileNotFoundError, json.JSONDecodeError, OSError):
+    config = _peek_drafter_config(model_path)
+    if config is None:
         return None
+    return config.get("model_type") or config.get("speculators_model_type")
 
 
 def resolve_drafter_kind(model_path, kind: Optional[str] = None) -> str:
@@ -102,7 +155,29 @@ def resolve_drafter_kind(model_path, kind: Optional[str] = None) -> str:
     but forgets ``--draft-kind mtp``: rather than crashing deep inside
     ``draft_block`` with an opaque error, we pick the right kind for them.
     """
-    model_type = _peek_drafter_model_type(model_path)
+    config = _peek_drafter_config(model_path)
+    model_type = (
+        (config.get("model_type") or config.get("speculators_model_type"))
+        if config
+        else None
+    )
+    # DSpark drafters use a generic model_type; detect them by architecture/markers.
+    if _config_is_dspark(config):
+        if kind is not None and kind != "dspark":
+            logger.warning(
+                "Drafter %r is a DSpark checkpoint which requires --draft-kind='dspark'; "
+                "got --draft-kind=%r. Overriding to 'dspark'.",
+                str(model_path),
+                kind,
+            )
+        else:
+            logger.info(
+                "Auto-detected --draft-kind='dspark' for drafter %r (model_type=%r).",
+                str(model_path),
+                model_type,
+            )
+        return "dspark"
+
     expected = DRAFTER_KIND_BY_MODEL_TYPE.get(model_type)
 
     if kind is None:

--- a/mlx_vlm/speculative/drafters/gemma4_dspark/__init__.py
+++ b/mlx_vlm/speculative/drafters/gemma4_dspark/__init__.py
@@ -1,0 +1,12 @@
+from .config import Gemma4DSparkConfig
+from .dspark import Gemma4DSparkDraftModel
+
+Model = Gemma4DSparkDraftModel
+ModelConfig = Gemma4DSparkConfig
+
+__all__ = [
+    "Gemma4DSparkConfig",
+    "Gemma4DSparkDraftModel",
+    "Model",
+    "ModelConfig",
+]

--- a/mlx_vlm/speculative/drafters/gemma4_dspark/config.py
+++ b/mlx_vlm/speculative/drafters/gemma4_dspark/config.py
@@ -1,0 +1,66 @@
+import inspect
+from dataclasses import dataclass, field
+from typing import List, Optional
+
+from ....models.base import BaseModelConfig
+
+
+@dataclass
+class Gemma4DSparkConfig(BaseModelConfig):
+    """Config for the DSpark self-speculative drafter over a Gemma 4 target.
+
+    The published checkpoint (``deepseek-ai/dspark_gemma4_12b_block7``) declares
+    ``model_type=gemma4_text`` with ``architectures=["Gemma4DSparkModel"]`` and the
+    DSpark draft hyper-parameters at the top level. The draft uses Gemma 4's
+    *global* attention shape (``global_head_dim`` / ``num_global_key_value_heads``)
+    and the proportional (partial) RoPE from ``rope_parameters.full_attention``.
+    """
+
+    hidden_size: int = 3840
+    intermediate_size: int = 15360
+    num_hidden_layers: int = 5
+    num_attention_heads: int = 16
+    num_key_value_heads: int = 1
+    head_dim: int = 512
+    rms_norm_eps: float = 1e-6
+    vocab_size: int = 262144
+    max_position_embeddings: int = 262144
+    rope_theta: float = 1000000.0
+    partial_rotary_factor: float = 0.25
+    attention_k_eq_v: bool = True
+    final_logit_softcapping: Optional[float] = 30.0
+    tie_word_embeddings: bool = False
+    block_size: int = 7
+    mask_token_id: int = 4
+    markov_rank: int = 256
+    enable_confidence_head: bool = True
+    confidence_head_with_markov: bool = True
+    target_layer_ids: List[int] = field(default_factory=lambda: [5, 17, 29, 41, 46])
+    num_target_layers: int = 48
+    runtime_block_size: Optional[int] = None
+
+    @property
+    def fc_in(self) -> int:
+        return self.hidden_size * len(self.target_layer_ids)
+
+    @classmethod
+    def from_dict(cls, params: dict) -> "Gemma4DSparkConfig":
+        flat = dict(params)
+        # Gemma 4 draft runs over the global-attention shape.
+        if flat.get("global_head_dim"):
+            flat["head_dim"] = flat["global_head_dim"]
+        if flat.get("num_global_key_value_heads") is not None:
+            flat["num_key_value_heads"] = flat["num_global_key_value_heads"]
+        # Proportional RoPE lives under rope_parameters.full_attention.
+        rope = (flat.get("rope_parameters") or {}).get("full_attention") or {}
+        if rope.get("rope_theta"):
+            flat["rope_theta"] = rope["rope_theta"]
+        if "partial_rotary_factor" in rope:
+            flat["partial_rotary_factor"] = rope["partial_rotary_factor"]
+        sig = inspect.signature(cls).parameters
+        kwargs = {k: v for k, v in flat.items() if k in sig}
+        if "target_layer_ids" in kwargs:
+            kwargs["target_layer_ids"] = list(kwargs["target_layer_ids"])
+        return cls(**kwargs)
+
+    from_hf_dict = from_dict

--- a/mlx_vlm/speculative/drafters/gemma4_dspark/dspark.py
+++ b/mlx_vlm/speculative/drafters/gemma4_dspark/dspark.py
@@ -1,0 +1,281 @@
+from typing import Any, List, Optional, Tuple
+
+import mlx.core as mx
+import mlx.nn as nn
+from mlx_lm.models.cache import KVCache
+
+# DSpark draft checkpoints store plain RMSNorm weights (no Gemma "1 + weight" shift),
+# so reuse Gemma 4's no-shift norm + GeGLU + softcap primitives directly.
+from ....models.gemma4.language import (
+    RMSNormNoScale,
+    RMSNormZeroShift,
+    geglu,
+    logit_softcap,
+)
+from .config import Gemma4DSparkConfig
+from .heads import DSparkConfidenceHead, DSparkMarkovHead
+
+
+def _rotate_half(x: mx.array) -> mx.array:
+    half = x.shape[-1] // 2
+    return mx.concatenate([-x[..., half:], x[..., :half]], axis=-1)
+
+
+def _apply_rope(x: mx.array, cos: mx.array, sin: mx.array) -> mx.array:
+    """x: [b, seq, heads, hd]; cos/sin: [seq, hd] (NeoX half-split convention)."""
+    cos = cos[None, :, None, :].astype(x.dtype)
+    sin = sin[None, :, None, :].astype(x.dtype)
+    return x * cos + _rotate_half(x) * sin
+
+
+def rope_tables(
+    position_ids: mx.array, head_dim: int, theta: float, partial: float
+) -> Tuple[mx.array, mx.array]:
+    """Proportional (partial) RoPE: the first ``partial*head_dim`` dims rotate, the rest
+    pass through (zero frequency → cos 1 / sin 0). Returns cos/sin of shape [seq, head_dim].
+    """
+    rope_angles = int(partial * head_dim // 2)
+    inv_rot = 1.0 / (
+        theta ** (mx.arange(0, 2 * rope_angles, 2).astype(mx.float32) / head_dim)
+    )
+    nope = head_dim // 2 - rope_angles
+    inv_freq = (
+        mx.concatenate([inv_rot, mx.zeros((nope,), dtype=mx.float32)])
+        if nope > 0
+        else inv_rot
+    )
+    freqs = position_ids.astype(mx.float32)[:, None] * inv_freq[None, :]
+    emb = mx.concatenate([freqs, freqs], axis=-1)
+    return mx.cos(emb), mx.sin(emb)
+
+
+class Gemma4DSparkAttention(nn.Module):
+    """Gemma 4 global attention for the DSpark draft: K=V sharing, attention scale 1.0,
+    partial RoPE, q/k RMSNorm, weightless v RMSNorm. The committed context K/V live in the
+    persistent draft ``KVCache``; the proposed block's K/V are concatenated transiently so
+    only context is retained across rounds (the block is re-drafted each round)."""
+
+    def __init__(self, config: Gemma4DSparkConfig):
+        super().__init__()
+        h = config.hidden_size
+        self.nh = config.num_attention_heads
+        self.nkv = config.num_key_value_heads
+        self.hd = config.head_dim
+        self.k_eq_v = config.attention_k_eq_v
+        self.q_proj = nn.Linear(h, self.nh * self.hd, bias=False)
+        self.k_proj = nn.Linear(h, self.nkv * self.hd, bias=False)
+        self.v_proj = (
+            None if self.k_eq_v else nn.Linear(h, self.nkv * self.hd, bias=False)
+        )
+        self.o_proj = nn.Linear(self.nh * self.hd, h, bias=False)
+        self.q_norm = RMSNormZeroShift(self.hd, config.rms_norm_eps)
+        self.k_norm = RMSNormZeroShift(self.hd, config.rms_norm_eps)
+        self.v_norm = RMSNormNoScale(self.hd, config.rms_norm_eps)
+
+    def __call__(
+        self,
+        x: mx.array,
+        x_ctx: mx.array,
+        cache: KVCache,
+        cos_ctx: mx.array,
+        sin_ctx: mx.array,
+        cos_blk: mx.array,
+        sin_blk: mx.array,
+    ) -> mx.array:
+        B, L, _ = x.shape
+        S = x_ctx.shape[1]
+
+        queries = self.q_norm(self.q_proj(x).reshape(B, L, self.nh, self.hd))
+        ck = self.k_proj(x_ctx)
+        cv = ck if self.k_eq_v else self.v_proj(x_ctx)
+        pk = self.k_proj(x)
+        pv = pk if self.k_eq_v else self.v_proj(x)
+        ctx_keys = self.k_norm(ck.reshape(B, S, self.nkv, self.hd))
+        ctx_values = self.v_norm(cv.reshape(B, S, self.nkv, self.hd))
+        prop_keys = self.k_norm(pk.reshape(B, L, self.nkv, self.hd))
+        prop_values = self.v_norm(pv.reshape(B, L, self.nkv, self.hd))
+
+        queries = _apply_rope(queries, cos_blk, sin_blk).transpose(0, 2, 1, 3)
+        ctx_keys = _apply_rope(ctx_keys, cos_ctx, sin_ctx).transpose(0, 2, 1, 3)
+        prop_keys = _apply_rope(prop_keys, cos_blk, sin_blk).transpose(0, 2, 1, 3)
+        ctx_values = ctx_values.transpose(0, 2, 1, 3)  # value is not rotated
+        prop_values = prop_values.transpose(0, 2, 1, 3)
+
+        keys, values = cache.update_and_fetch(ctx_keys, ctx_values)
+        keys = mx.concatenate([keys, prop_keys], axis=2)
+        values = mx.concatenate([values, prop_values], axis=2)
+        # Whole block denoised at once → block self-attention is non-causal.
+        out = mx.fast.scaled_dot_product_attention(
+            queries, keys, values, scale=1.0, mask=None
+        )
+        return self.o_proj(out.transpose(0, 2, 1, 3).reshape(B, L, -1))
+
+
+class Gemma4MLP(nn.Module):
+    def __init__(self, config: Gemma4DSparkConfig):
+        super().__init__()
+        self.gate_proj = nn.Linear(
+            config.hidden_size, config.intermediate_size, bias=False
+        )
+        self.up_proj = nn.Linear(
+            config.hidden_size, config.intermediate_size, bias=False
+        )
+        self.down_proj = nn.Linear(
+            config.intermediate_size, config.hidden_size, bias=False
+        )
+
+    def __call__(self, x: mx.array) -> mx.array:
+        return self.down_proj(geglu(self.gate_proj(x), self.up_proj(x)))
+
+
+class Gemma4DSparkLayer(nn.Module):
+    """Gemma 4 decoder layer: four sandwich norms + per-layer ``layer_scalar``, GeGLU MLP."""
+
+    def __init__(self, config: Gemma4DSparkConfig):
+        super().__init__()
+        h, eps = config.hidden_size, config.rms_norm_eps
+        self.self_attn = Gemma4DSparkAttention(config)
+        self.mlp = Gemma4MLP(config)
+        self.input_layernorm = RMSNormZeroShift(h, eps)
+        self.post_attention_layernorm = RMSNormZeroShift(h, eps)
+        self.pre_feedforward_layernorm = RMSNormZeroShift(h, eps)
+        self.post_feedforward_layernorm = RMSNormZeroShift(h, eps)
+        self.layer_scalar = mx.ones((1,), dtype=mx.float32)
+
+    def __call__(self, x, x_ctx, cache, cos_ctx, sin_ctx, cos_blk, sin_blk) -> mx.array:
+        h = self.post_attention_layernorm(
+            self.self_attn(
+                self.input_layernorm(x),
+                x_ctx,
+                cache,
+                cos_ctx,
+                sin_ctx,
+                cos_blk,
+                sin_blk,
+            )
+        )
+        x = x + h
+        h = self.post_feedforward_layernorm(self.mlp(self.pre_feedforward_layernorm(x)))
+        x = x + h
+        return x * self.layer_scalar
+
+
+class Gemma4DSparkDraftModel(nn.Module):
+    """DSpark self-speculative drafter for a Gemma 4 target.
+
+    Conforms to the mlx-vlm speculative round-loop contract (``reset``/``make_cache``/
+    ``draft_block`` + ``config.target_layer_ids`` + ``accept_lens``/``draft_lens``). The
+    drafter is standalone — it ships its own ``embed_tokens``/``lm_head`` and does not bind
+    to the target. ``draft_block`` proposes ``block_size`` tokens via Gemma decoder layers
+    cross-attending to the projected target hidden, with a low-rank Markov logit bias chained
+    across the block; ``_last_confidence`` exposes the (advisory) acceptance scores.
+    """
+
+    def __init__(self, config: Gemma4DSparkConfig):
+        super().__init__()
+        self.config = config
+        self.embed_tokens = nn.Embedding(config.vocab_size, config.hidden_size)
+        self.lm_head = nn.Linear(config.hidden_size, config.vocab_size, bias=False)
+        self.fc = nn.Linear(config.fc_in, config.hidden_size, bias=False)
+        self.hidden_norm = RMSNormZeroShift(config.hidden_size, config.rms_norm_eps)
+        self.layers = [
+            Gemma4DSparkLayer(config) for _ in range(config.num_hidden_layers)
+        ]
+        self.norm = RMSNormZeroShift(config.hidden_size, config.rms_norm_eps)
+        self.markov_head = DSparkMarkovHead(config.vocab_size, config.markov_rank)
+        self.confidence_head = DSparkConfidenceHead(
+            config.hidden_size + config.markov_rank,
+            bias=True,
+        )
+        self.embed_scale = float(config.hidden_size) ** 0.5
+        self._last_confidence: Optional[mx.array] = None
+        self.accept_lens: List[float] = []
+        self.draft_lens: List[int] = []
+
+    def make_cache(self) -> List[KVCache]:
+        return [KVCache() for _ in self.layers]
+
+    def reset(self, target_model: Any = None) -> List[KVCache]:
+        # DSpark is standalone (own embed/head) — nothing to bind to the target.
+        self.accept_lens = []
+        self.draft_lens = []
+        self._last_confidence = None
+        return self.make_cache()
+
+    def _embed(self, ids: mx.array) -> mx.array:
+        # Gemma scales token embeddings by sqrt(hidden) in the embedding's own dtype.
+        e = self.embed_tokens(ids)
+        return e * mx.array(self.embed_scale, dtype=e.dtype)
+
+    def _rope(self, start: int, length: int) -> Tuple[mx.array, mx.array]:
+        pos = mx.arange(start, start + length)
+        return rope_tables(
+            pos,
+            self.config.head_dim,
+            self.config.rope_theta,
+            self.config.partial_rotary_factor,
+        )
+
+    def _logits(self, hidden: mx.array) -> mx.array:
+        logits = self.lm_head(hidden.astype(mx.float32))
+        softcap = self.config.final_logit_softcapping
+        if softcap:
+            logits = logit_softcap(softcap, logits)
+        return logits
+
+    def _block_hidden(
+        self, block_ids: mx.array, target_hidden: mx.array, cache: List[KVCache]
+    ) -> mx.array:
+        h = self._embed(block_ids)
+        h_ctx = self.hidden_norm(self.fc(target_hidden))
+        offset = cache[0].offset
+        S, L = h_ctx.shape[1], h.shape[1]
+        cos_ctx, sin_ctx = self._rope(offset, S)
+        cos_blk, sin_blk = self._rope(offset + S, L)
+        for layer, c in zip(self.layers, cache):
+            h = layer(h, h_ctx, c, cos_ctx, sin_ctx, cos_blk, sin_blk)
+        return self.norm(h)
+
+    def draft_block(
+        self,
+        last_bonus,
+        hidden: mx.array,
+        cache: List[KVCache],
+        block_size: int,
+        sampler,
+        token_dtype: mx.Dtype = mx.int32,
+    ) -> mx.array:
+        if isinstance(last_bonus, int):
+            anchor = mx.array([[last_bonus]], dtype=token_dtype)
+        else:
+            anchor = last_bonus.reshape(-1, 1).astype(token_dtype)
+        B = anchor.shape[0]
+        masks = mx.full(
+            (B, block_size - 1), int(self.config.mask_token_id), dtype=token_dtype
+        )
+        block_ids = mx.concatenate([anchor, masks], axis=1)
+
+        block_hidden = self._block_hidden(block_ids, hidden, cache)
+        base_logits = self._logits(block_hidden)  # [B, block_size, V]
+
+        prev = anchor[:, 0]
+        drafts, markov_embeds = [], []
+        for i in range(block_size):
+            bias, embed = self.markov_head(prev)
+            prev = sampler(base_logits[:, i] + bias).astype(token_dtype)
+            drafts.append(prev)
+            markov_embeds.append(embed)
+        draft_tokens = mx.stack(drafts, axis=1)  # [B, block_size]
+        markov_embed = mx.stack(markov_embeds, axis=1)  # [B, block_size, rank]
+        self._last_confidence = self.confidence_head(
+            block_hidden, markov_embed
+        )  # [B, block_size]
+        return draft_tokens
+
+    def sanitize(self, weights: dict) -> dict:
+        out = {}
+        for k, v in weights.items():
+            if k.startswith("model."):
+                k = k[len("model.") :]
+            out[k] = v
+        return out

--- a/mlx_vlm/speculative/drafters/gemma4_dspark/heads.py
+++ b/mlx_vlm/speculative/drafters/gemma4_dspark/heads.py
@@ -1,0 +1,39 @@
+import mlx.core as mx
+import mlx.nn as nn
+
+
+class DSparkMarkovHead(nn.Module):
+    """Low-rank (rank-r) token-transition logit bias.
+
+    ``markov_w1`` embeds a token id into r dims; ``markov_w2`` projects back to
+    vocab logits. Returns ``(logits, embed)`` so the confidence head can reuse the
+    embedding. Weight layout matches the checkpoint: ``markov_w1`` is
+    ``[vocab, rank]`` (embedding) and ``markov_w2`` is ``[vocab, rank]`` (the head,
+    an ``nn.Linear(rank, vocab)`` whose MLX weight is ``[vocab, rank]``).
+    """
+
+    def __init__(self, vocab_size: int, rank: int):
+        super().__init__()
+        self.markov_w1 = nn.Embedding(vocab_size, rank)
+        self.markov_w2 = nn.Linear(rank, vocab_size, bias=False)
+
+    def __call__(self, token_ids: mx.array) -> tuple[mx.array, mx.array]:
+        embed = self.markov_w1(token_ids)
+        logits = self.markov_w2(embed.astype(mx.float32))
+        return logits, embed
+
+
+class DSparkConfidenceHead(nn.Module):
+    """Per-draft-token acceptance score from ``[hidden ‖ markov_embed]``.
+
+    Advisory only in the lossless verify path; it gates adaptive draft length
+    when a confidence threshold is set. Gemma 4 DSpark uses a bias projection.
+    """
+
+    def __init__(self, input_dim: int, bias: bool = True):
+        super().__init__()
+        self.proj = nn.Linear(input_dim, 1, bias=bias)
+
+    def __call__(self, hidden: mx.array, markov_embed: mx.array) -> mx.array:
+        x = mx.concatenate([hidden, markov_embed], axis=-1)
+        return self.proj(x.astype(mx.float32))[..., 0]

--- a/mlx_vlm/speculative/dspark.py
+++ b/mlx_vlm/speculative/dspark.py
@@ -1,0 +1,282 @@
+"""DSpark self-speculative round loops (Gemma 4 target).
+
+DSpark drafts a block of ``K`` tokens from the anchor's own position outward, biased by a
+low-rank Markov head, then the target verifies ``[anchor, d_1..d_K]`` in one forward and a
+greedy walk accepts the longest matching prefix. Output is bit-identical to base greedy
+decoding for any draft proposal — the proposal only changes how many tokens are confirmed
+per target forward.
+
+When ``MLX_VLM_DRAFT_CONFIDENCE_THRESHOLD`` > 0, the (advisory) confidence head truncates the
+draft block where ``P(accept)`` falls below the threshold. This only shortens *speculation
+depth* before verify — the emitted stream stays lossless — so it trades acceptance for fewer
+wasted draft positions. Confidence gating is applied on the single-sequence path; batched
+continuous decoding uses a fixed block (still lossless).
+"""
+
+import os
+from typing import Any, Callable, Generator, List, Optional, Tuple
+
+import mlx.core as mx
+import mlx.nn as nn
+import numpy as np
+
+from .common import (
+    _dflash_block_total,
+    _record_speculative_round,
+    _speculative_walk,
+    _speculative_walk_batch,
+    generation_stream,
+)
+from .dflash import _dflash_committed_hidden_segments
+
+
+def _dspark_confidence_threshold() -> float:
+    raw = os.environ.get("MLX_VLM_DRAFT_CONFIDENCE_THRESHOLD")
+    if not raw:
+        return 0.0
+    try:
+        return max(0.0, float(raw))
+    except ValueError:
+        return 0.0
+
+
+def _confident_prefix_length(
+    confidence_logits: mx.array, block_size: int, threshold: float
+) -> int:
+    """Keep the draft prefix while ``sigmoid(confidence) >= threshold``.
+
+    ``threshold <= 0`` disables gating (always the full block). Truncating here is lossless:
+    the target still verifies whatever is drafted, so the emitted tokens are unchanged.
+    """
+    if threshold <= 0.0:
+        return block_size
+    probs = 1.0 / (
+        1.0 + np.exp(-np.array(confidence_logits).astype(np.float32).reshape(-1))
+    )
+    below = np.nonzero(probs < threshold)[0]
+    return int(below[0]) if below.size else block_size
+
+
+def _require_rollback(lm) -> None:
+    if not hasattr(lm, "rollback_speculative_cache"):
+        raise RuntimeError(
+            f"{type(lm).__name__} does not implement rollback_speculative_cache. "
+            "DSpark speculative decoding requires a Gemma 4 (or compatible) target."
+        )
+
+
+def _dspark_rounds(
+    model: nn.Module,
+    draft_model: nn.Module,
+    prompt_cache: List[Any],
+    hidden: mx.array,
+    *,
+    first_bonus: int,
+    max_tokens: int,
+    sampler: Callable[[mx.array], mx.array],
+    draft_block_size: Optional[int] = None,
+    token_dtype: mx.Dtype = mx.int32,
+) -> Generator[Tuple[int, None], None, None]:
+    """Single-sequence DSpark round loop: draft → (confidence gate) → verify → walk → rollback.
+
+    ``generate_step`` handles prefill, sampling the first bonus token, and packaging the
+    captured target hidden states into ``hidden``.
+    """
+    lm = model.language_model if hasattr(model, "language_model") else model
+    _require_rollback(lm)
+
+    target_layer_ids = list(draft_model.config.target_layer_ids)
+    block_total = _dflash_block_total(draft_model, draft_block_size)
+    threshold = _dspark_confidence_threshold()
+    draft_cache = draft_model.reset(model)
+
+    b = first_bonus
+    emitted = 1  # the first bonus has already been yielded by the caller
+
+    while emitted < max_tokens:
+        K = min(block_total, max_tokens - emitted)
+        if K < 1:
+            break
+
+        drafts = draft_model.draft_block(
+            b, hidden, draft_cache, K, sampler, token_dtype
+        )
+        if threshold > 0.0 and draft_model._last_confidence is not None:
+            keff = _confident_prefix_length(draft_model._last_confidence, K, threshold)
+            if keff < K:
+                drafts = drafts[:, :keff]
+        n_draft = int(drafts.shape[1])
+        mx.async_eval(drafts)
+
+        with mx.stream(generation_stream):
+            verify_input = mx.concatenate(
+                [mx.array([[b]], dtype=token_dtype), drafts], axis=1
+            )
+            verify_out = lm(
+                verify_input, cache=prompt_cache, capture_layer_ids=target_layer_ids
+            )
+            hidden = mx.concatenate(verify_out.hidden_states, axis=-1)
+            target_tokens = sampler(verify_out.logits)
+        mx.async_eval(target_tokens, hidden)
+
+        accepted, new_tokens = _speculative_walk(
+            drafts, target_tokens, max_tokens - emitted
+        )
+        _record_speculative_round(draft_model, accepted, n_draft)
+
+        for tok in new_tokens:
+            yield tok, None
+            emitted += 1
+            if emitted >= max_tokens:
+                return
+
+        if accepted < n_draft:
+            hidden = hidden[:, : accepted + 1, :]
+        b = new_tokens[-1] if new_tokens else b
+
+        if accepted < n_draft:
+            with mx.stream(generation_stream):
+                lm.rollback_speculative_cache(
+                    prompt_cache,
+                    getattr(verify_out, "gdn_states", None),
+                    accepted,
+                    n_draft + 1,
+                )
+
+        if emitted % 256 == 0:
+            mx.clear_cache()
+
+
+def _dspark_rounds_batch(
+    model: nn.Module,
+    draft_model: nn.Module,
+    prompt_cache: List[Any],
+    hidden: mx.array,
+    *,
+    first_bonus: mx.array,
+    max_tokens: int,
+    sampler: Callable[[mx.array], mx.array],
+    draft_block_size: Optional[int] = None,
+    token_dtype: mx.Dtype = mx.int32,
+    stop_check: Optional[Callable[[int, int], bool]] = None,
+) -> Generator[Tuple[List[Optional[int]], None], None, None]:
+    """Batch DSpark round loop (B > 1) with continuous batching.
+
+    Lossless, fixed block size (confidence gating is single-sequence only). When a sequence
+    finishes it is filtered out of the target caches and dropped from the active set.
+    """
+    lm = model.language_model if hasattr(model, "language_model") else model
+    _require_rollback(lm)
+
+    B = first_bonus.shape[0]
+    target_layer_ids = list(draft_model.config.target_layer_ids)
+    block_total = _dflash_block_total(draft_model, draft_block_size)
+    draft_model.reset(model)
+    draft_caches = [draft_model.make_cache() for _ in range(B)]
+
+    b = first_bonus.tolist()
+    emitted = [1] * B
+    finished = [False] * B
+    active_idx = list(range(B))
+    hidden_by_orig = [hidden[i : i + 1] for i in range(B)]
+    total_emitted = sum(emitted)
+
+    while len(active_idx) > 0:
+        remaining = [
+            max(1, max_tokens - emitted[active_idx[j]]) for j in range(len(active_idx))
+        ]
+        K = min(block_total, min(remaining))
+        if K < 1:
+            break
+
+        n_active = len(active_idx)
+        b_active = [b[active_idx[j]] for j in range(n_active)]
+        b_arr = mx.array(b_active, dtype=token_dtype)
+
+        # Draft rowwise: the drafter cache is scalar-offset; verify stays batched below.
+        draft_tokens = mx.concatenate(
+            [
+                draft_model.draft_block(
+                    int(b_active[j]),
+                    hidden_by_orig[active_idx[j]],
+                    draft_caches[active_idx[j]],
+                    K,
+                    sampler,
+                    token_dtype,
+                )
+                for j in range(n_active)
+            ],
+            axis=0,
+        )
+        mx.async_eval(draft_tokens)
+
+        with mx.stream(generation_stream):
+            verify_input = mx.concatenate([b_arr[:, None], draft_tokens], axis=1)
+            verify_out = lm(
+                verify_input, cache=prompt_cache, capture_layer_ids=target_layer_ids
+            )
+            hidden_full = mx.concatenate(verify_out.hidden_states, axis=-1)
+            target_tokens = sampler(verify_out.logits)
+        mx.async_eval(target_tokens, hidden_full)
+
+        budgets = [max_tokens - emitted[active_idx[j]] for j in range(n_active)]
+        accepted_list, new_tokens_list = _speculative_walk_batch(
+            draft_tokens, target_tokens, budgets
+        )
+        min_accepted = min(accepted_list)
+        accepted_arr = mx.array(accepted_list)
+
+        hidden_segments = _dflash_committed_hidden_segments(
+            hidden_full, new_tokens_list
+        )
+        for j in range(n_active):
+            orig = active_idx[j]
+            if hidden_segments[j].shape[1] > 0:
+                hidden_by_orig[orig] = hidden_segments[j]
+
+        for a in accepted_list:
+            _record_speculative_round(draft_model, a, K)
+
+        max_new = max(len(nt) for nt in new_tokens_list) if new_tokens_list else 0
+        for pos in range(max_new):
+            tokens_out: List[Optional[int]] = [None] * B
+            for j in range(n_active):
+                orig = active_idx[j]
+                if pos < len(new_tokens_list[j]) and not finished[orig]:
+                    tok = new_tokens_list[j][pos]
+                    tokens_out[orig] = tok
+                    emitted[orig] += 1
+                    if emitted[orig] >= max_tokens:
+                        finished[orig] = True
+                    if stop_check is not None and stop_check(orig, tok):
+                        finished[orig] = True
+            yield tokens_out, None
+
+        for j in range(n_active):
+            orig = active_idx[j]
+            if new_tokens_list[j]:
+                b[orig] = new_tokens_list[j][-1]
+
+        if min_accepted < K:
+            with mx.stream(generation_stream):
+                lm.rollback_speculative_cache(
+                    prompt_cache,
+                    getattr(verify_out, "gdn_states", None),
+                    accepted_arr,
+                    K + 1,
+                )
+
+        keep_slots = [j for j in range(n_active) if not finished[active_idx[j]]]
+        if len(keep_slots) < n_active:
+            if len(keep_slots) == 0:
+                break
+            keep_mx = mx.array(keep_slots, dtype=mx.int32)
+            for c in prompt_cache:
+                if hasattr(c, "filter"):
+                    c.filter(keep_mx)
+            active_idx = [active_idx[j] for j in keep_slots]
+
+        new_total = sum(emitted)
+        if new_total // 256 > total_emitted // 256:
+            mx.clear_cache()
+        total_emitted = new_total

--- a/mlx_vlm/speculative/utils.py
+++ b/mlx_vlm/speculative/utils.py
@@ -17,6 +17,7 @@ from .dflash import (
     _dflash_rounds,
     _dflash_rounds_batch,
 )
+from .dspark import _dspark_rounds, _dspark_rounds_batch
 from .eagle3 import _eagle3_capture_layer_ids, _eagle3_rounds, _eagle3_rounds_batch
 from .mtp import (
     _buffer_mtp_target_cache,
@@ -75,8 +76,11 @@ def get_speculative_rounds_batch(draft_kind: str):
         return _mtp_rounds_batch
     if draft_kind == "dflash":
         return _dflash_rounds_batch
+    if draft_kind == "dspark":
+        return _dspark_rounds_batch
     raise ValueError(
-        f"Unknown draft_kind {draft_kind!r}. Supported: ['dflash', 'eagle3', 'mtp']"
+        f"Unknown draft_kind {draft_kind!r}. "
+        "Supported: ['dflash', 'dspark', 'eagle3', 'mtp']"
     )
 
 
@@ -85,20 +89,22 @@ def speculative_prefill_kwargs(draft_kind: str, drafter) -> dict:
         return {"return_hidden": True, "return_shared_kv": True}
     if draft_kind == "eagle3":
         return {"capture_layer_ids": _eagle3_capture_layer_ids(drafter)}
-    if draft_kind == "dflash":
+    if draft_kind in ("dflash", "dspark"):
         return {"capture_layer_ids": list(drafter.config.target_layer_ids)}
     raise ValueError(
-        f"Unknown draft_kind {draft_kind!r}. Supported: ['dflash', 'eagle3', 'mtp']"
+        f"Unknown draft_kind {draft_kind!r}. "
+        "Supported: ['dflash', 'dspark', 'eagle3', 'mtp']"
     )
 
 
 def speculative_hidden_state(draft_kind: str, outputs):
     if draft_kind == "mtp":
         return outputs.hidden_states[-1]
-    if draft_kind in ("dflash", "eagle3"):
+    if draft_kind in ("dflash", "dspark", "eagle3"):
         return mx.concatenate(outputs.hidden_states, axis=-1)
     raise ValueError(
-        f"Unknown draft_kind {draft_kind!r}. Supported: ['dflash', 'eagle3', 'mtp']"
+        f"Unknown draft_kind {draft_kind!r}. "
+        "Supported: ['dflash', 'dspark', 'eagle3', 'mtp']"
     )
 
 
@@ -192,8 +198,11 @@ def run_speculative_server_rounds(
         )
         return
 
-    if draft_kind == "dflash":
-        yield from _dflash_rounds_batch(
+    if draft_kind in ("dflash", "dspark"):
+        rounds_batch = (
+            _dspark_rounds_batch if draft_kind == "dspark" else _dflash_rounds_batch
+        )
+        yield from rounds_batch(
             model,
             draft_model,
             prompt_cache,
@@ -208,7 +217,8 @@ def run_speculative_server_rounds(
         return
 
     raise ValueError(
-        f"Unknown draft_kind {draft_kind!r}. Supported: ['dflash', 'eagle3', 'mtp']"
+        f"Unknown draft_kind {draft_kind!r}. "
+        "Supported: ['dflash', 'dspark', 'eagle3', 'mtp']"
     )
 
 
@@ -326,17 +336,22 @@ def run_speculative_rounds(
             )
         return
 
-    if draft_kind != "dflash":
+    if draft_kind not in ("dflash", "dspark"):
         raise ValueError(
-            f"Unknown draft_kind {draft_kind!r}. Supported: ['dflash', 'eagle3', 'mtp']"
+            f"Unknown draft_kind {draft_kind!r}. "
+            "Supported: ['dflash', 'dspark', 'eagle3', 'mtp']"
         )
 
+    rounds = _dspark_rounds if draft_kind == "dspark" else _dflash_rounds
+    rounds_batch = (
+        _dspark_rounds_batch if draft_kind == "dspark" else _dflash_rounds_batch
+    )
     hidden = mx.concatenate(last_outputs.hidden_states, axis=-1)
     if B == 1:
         mx.eval(first_token)
         bonus = first_token.item()
         yield bonus, logprobs
-        yield from _dflash_rounds(
+        yield from rounds(
             model,
             draft_model,
             prompt_cache,
@@ -351,7 +366,7 @@ def run_speculative_rounds(
         mx.eval(first_token)
         first_bonus = first_token.squeeze(-1)
         yield first_bonus.tolist(), logprobs
-        yield from _dflash_rounds_batch(
+        yield from rounds_batch(
             model,
             draft_model,
             prompt_cache,

--- a/mlx_vlm/tests/test_dspark.py
+++ b/mlx_vlm/tests/test_dspark.py
@@ -1,0 +1,387 @@
+"""DSpark self-speculative drafter (Gemma 4) regressions.
+
+Covers config parsing, the drafter's checkpoint-key contract and forward path, drafter-kind
+auto-detection / routing, compatibility validation, and the losslessness of the single- and
+multi-sequence round loops against a history-independent Markov target.
+
+The real published checkpoint is exercised when ``DSPARK_GEMMA4_CONFIG`` (and, for the load
+test, ``DSPARK_GEMMA4_CKPT``) point at a local ``config.json`` / safetensors file.
+"""
+
+import json
+import os
+import struct
+from pathlib import Path
+
+import mlx.core as mx
+import numpy as np
+import pytest
+from mlx.utils import tree_flatten
+
+from mlx_vlm.models.base import LanguageModelOutput
+from mlx_vlm.speculative.drafters import (
+    DSPARK_ARCHITECTURE,
+    _config_is_dspark,
+    resolve_drafter_kind,
+    validate_drafter_compatibility,
+)
+from mlx_vlm.speculative.drafters.gemma4_dspark import Model, ModelConfig
+from mlx_vlm.speculative.dspark import (
+    _confident_prefix_length,
+    _dspark_rounds,
+    _dspark_rounds_batch,
+)
+from mlx_vlm.utils import get_model_and_args
+
+DSPARK_CONFIG_ENV = "DSPARK_GEMMA4_CONFIG"
+DSPARK_CKPT_ENV = "DSPARK_GEMMA4_CKPT"
+
+# A real DSpark Gemma 4 config (top-level draft hyper-parameters + architecture tag).
+REAL_CONFIG = {
+    "architectures": [DSPARK_ARCHITECTURE],
+    "model_type": "gemma4_text",
+    "hidden_size": 3840,
+    "num_attention_heads": 16,
+    "num_global_key_value_heads": 1,
+    "global_head_dim": 512,
+    "intermediate_size": 15360,
+    "num_hidden_layers": 5,
+    "rms_norm_eps": 1e-6,
+    "attention_k_eq_v": True,
+    "final_logit_softcapping": 30.0,
+    "block_size": 7,
+    "mask_token_id": 4,
+    "markov_rank": 256,
+    "enable_confidence_head": True,
+    "target_layer_ids": [5, 17, 29, 41, 46],
+    "vocab_size": 262144,
+    "rope_parameters": {
+        "full_attention": {"rope_theta": 1000000.0, "partial_rotary_factor": 0.25}
+    },
+}
+
+TINY_CONFIG = dict(
+    hidden_size=16,
+    num_attention_heads=4,
+    num_key_value_heads=1,
+    head_dim=16,
+    intermediate_size=24,
+    num_hidden_layers=2,
+    target_layer_ids=[0, 1],
+    rms_norm_eps=1e-6,
+    rope_theta=1e6,
+    partial_rotary_factor=0.25,
+    attention_k_eq_v=True,
+    final_logit_softcapping=30.0,
+    block_size=4,
+    mask_token_id=23,
+    markov_rank=8,
+    vocab_size=24,
+)
+
+
+def _greedy_argmax(logits):
+    return mx.argmax(logits, axis=-1).astype(mx.int32)
+
+
+# --------------------------------------------------------------------------- config
+
+
+def test_config_from_dict_maps_gemma_global_shape():
+    cfg = ModelConfig.from_dict(REAL_CONFIG)
+    assert cfg.hidden_size == 3840
+    assert cfg.head_dim == 512  # global_head_dim
+    assert cfg.num_key_value_heads == 1  # num_global_key_value_heads
+    assert cfg.rope_theta == 1000000.0
+    assert cfg.partial_rotary_factor == 0.25
+    assert cfg.block_size == 7
+    assert cfg.mask_token_id == 4
+    assert cfg.markov_rank == 256
+    assert tuple(cfg.target_layer_ids) == (5, 17, 29, 41, 46)
+    assert cfg.fc_in == 3840 * 5
+
+
+# --------------------------------------------------------------------------- drafter
+
+
+def test_drafter_param_keys_roundtrip_through_sanitize():
+    model = Model(ModelConfig.from_dict(REAL_CONFIG))
+    keys = {k for k, _ in tree_flatten(model.parameters())}
+    # Standalone drafter: own embed/head, fc projection, heads, 5 layers.
+    assert "embed_tokens.weight" in keys
+    assert "lm_head.weight" in keys
+    assert "fc.weight" in keys
+    assert "markov_head.markov_w1.weight" in keys
+    assert "markov_head.markov_w2.weight" in keys
+    assert "confidence_head.proj.weight" in keys
+    assert "confidence_head.proj.bias" in keys
+    assert "layers.4.self_attn.q_proj.weight" in keys
+    assert "layers.0.layer_scalar" in keys
+    # k_eq_v: no v_proj; weightless v_norm has no parameter.
+    assert not any("v_proj" in k for k in keys)
+    assert not any("v_norm" in k for k in keys)
+    # sanitize strips an optional leading "model." prefix and is otherwise identity.
+    prefixed = {f"model.{k}": None for k in keys}
+    assert set(model.sanitize(prefixed).keys()) == keys
+
+
+def test_draft_block_shapes_and_context_only_cache_growth():
+    cfg = ModelConfig.from_dict(TINY_CONFIG)
+    model = Model(cfg)
+    mx.eval(model.parameters())
+    cache = model.reset(None)
+    assert len(cache) == cfg.num_hidden_layers
+    assert all(c.offset == 0 for c in cache)
+
+    prompt_len = 5
+    ctx = (mx.random.normal((1, prompt_len, cfg.fc_in)) * 0.1).astype(mx.bfloat16)
+    drafts = model.draft_block(7, ctx, cache, cfg.block_size, _greedy_argmax)
+    mx.eval(drafts, model._last_confidence)
+    assert drafts.shape == (1, cfg.block_size)
+    assert model._last_confidence.shape == (1, cfg.block_size)
+    # Only the context (not the proposed block) is appended to the draft cache.
+    assert all(c.offset == prompt_len for c in cache)
+    ids = drafts.tolist()[0]
+    assert all(0 <= t < cfg.vocab_size for t in ids)
+
+
+# --------------------------------------------------------------------------- detection / routing
+
+
+def _write_config(tmp_path, config) -> Path:
+    d = Path(tmp_path)
+    (d / "config.json").write_text(json.dumps(config))
+    return d
+
+
+def test_config_is_dspark_by_architecture_and_markers():
+    assert _config_is_dspark(REAL_CONFIG)
+    # marker cluster without the architecture tag
+    markers = {k: v for k, v in REAL_CONFIG.items() if k != "architectures"}
+    assert _config_is_dspark(markers)
+    # a plain Gemma 4 text config is not DSpark
+    assert not _config_is_dspark({"model_type": "gemma4_text", "hidden_size": 3840})
+    assert not _config_is_dspark(None)
+
+
+def test_resolve_drafter_kind_autodetects_and_overrides(tmp_path):
+    path = _write_config(tmp_path, REAL_CONFIG)
+    assert resolve_drafter_kind(path, None) == "dspark"
+    # an explicit wrong kind is corrected to dspark
+    assert resolve_drafter_kind(path, "dflash") == "dspark"
+    assert resolve_drafter_kind(path, "dspark") == "dspark"
+
+
+def test_get_model_and_args_routes_to_gemma4_dspark():
+    arch, model_type = get_model_and_args(dict(REAL_CONFIG))
+    assert model_type == "gemma4_dspark"
+    assert arch.Model is Model
+
+
+def test_validate_compatibility_requires_matching_hidden_and_rollback():
+    model = Model(ModelConfig.from_dict(REAL_CONFIG))
+
+    class _LM:
+        config = {"hidden_size": 3840}
+
+        def rollback_speculative_cache(self, *a):
+            return 0
+
+    class _Target:
+        language_model = _LM()
+
+    validate_drafter_compatibility(_Target(), model, "dspark")  # ok
+
+    class _BadHidden(_LM):
+        config = {"hidden_size": 2048}
+
+    class _TargetBad:
+        language_model = _BadHidden()
+
+    with pytest.raises(ValueError, match="hidden_size"):
+        validate_drafter_compatibility(_TargetBad(), model, "dspark")
+
+    class _NoRollback:
+        config = {"hidden_size": 3840}
+
+    with pytest.raises(ValueError, match="rollback_speculative_cache"):
+        validate_drafter_compatibility(_NoRollback(), model, "dspark")
+
+
+# --------------------------------------------------------------------------- losslessness
+
+
+class _StubCache:
+    def __init__(self):
+        self.offset = 0
+
+    def trim(self, n):
+        self.offset -= n
+
+
+class _MarkovTarget:
+    """History-independent Markov target: logits at position i depend only on input_i."""
+
+    def __init__(self, transition, embed, n_targets):
+        self.transition = transition
+        self.embed = embed
+        self.n_targets = n_targets
+
+    def __call__(self, inputs, cache=None, capture_layer_ids=None, **kw):
+        L = inputs.shape[1]
+        logits = self.transition[inputs]
+        hid = self.embed[inputs]
+        if cache is not None:
+            for c in cache:
+                c.offset += L
+        n = len(capture_layer_ids) if capture_layer_ids else self.n_targets
+        return LanguageModelOutput(logits=logits, hidden_states=[hid] * n)
+
+    def rollback_speculative_cache(self, caches, gdn, accepted, block_size):
+        if isinstance(accepted, mx.array):
+            accepted = int(accepted.max().item())
+        n = int(accepted) + 1
+        trim = block_size - n
+        for c in caches:
+            if trim > 0:
+                c.trim(trim)
+        return int(accepted)
+
+
+def _markov_world(vocab, hid, n_targets, seed=0):
+    rng = np.random.default_rng(seed)
+    transition = mx.array(rng.standard_normal((vocab, vocab)).astype(np.float32))
+    embed = mx.array((rng.standard_normal((vocab, hid)) * 0.1).astype(np.float32))
+    return transition, embed, rng
+
+
+def _plain_greedy(transition, start, n):
+    out, t = [], int(start)
+    for _ in range(n):
+        t = int(mx.argmax(transition[t]).item())
+        out.append(t)
+    return out
+
+
+@pytest.mark.parametrize("threshold", [0.0, 0.5, 0.9])
+def test_dspark_rounds_lossless(monkeypatch, threshold):
+    monkeypatch.setenv("MLX_VLM_DRAFT_CONFIDENCE_THRESHOLD", str(threshold))
+    vocab, hid, nt = TINY_CONFIG["vocab_size"], TINY_CONFIG["hidden_size"], 2
+    transition, embed, rng = _markov_world(vocab, hid, nt)
+    model = Model(ModelConfig.from_dict(TINY_CONFIG))
+    mx.eval(model.parameters())
+    target = _MarkovTarget(transition, embed, nt)
+
+    prompt = mx.array(rng.integers(0, vocab, size=(1, 6)).astype(np.int32))
+    prompt_cache = [_StubCache() for _ in range(nt)]
+    for c in prompt_cache:
+        c.offset = prompt.shape[1]
+    last = int(prompt[0, -1].item())
+    first_bonus = int(mx.argmax(transition[last]).item())
+    hidden = mx.concatenate([embed[prompt]] * nt, axis=-1)
+
+    max_tokens = 30
+    out = [first_bonus]
+    for tok, _ in _dspark_rounds(
+        target,
+        model,
+        prompt_cache,
+        hidden,
+        first_bonus=first_bonus,
+        max_tokens=max_tokens,
+        sampler=_greedy_argmax,
+    ):
+        out.append(tok)
+
+    assert out == _plain_greedy(transition, last, max_tokens)
+    assert len(out) == max_tokens
+
+
+def test_dspark_rounds_batch_lossless():
+    vocab, hid, nt, B = TINY_CONFIG["vocab_size"], TINY_CONFIG["hidden_size"], 2, 3
+    transition, embed, rng = _markov_world(vocab, hid, nt, seed=1)
+    model = Model(ModelConfig.from_dict(TINY_CONFIG))
+    mx.eval(model.parameters())
+    target = _MarkovTarget(transition, embed, nt)
+
+    prompt = mx.array(rng.integers(0, vocab, size=(B, 6)).astype(np.int32))
+    prompt_cache = [_StubCache() for _ in range(nt)]
+    for c in prompt_cache:
+        c.offset = prompt.shape[1]
+    lasts = [int(prompt[i, -1].item()) for i in range(B)]
+    first_bonus = mx.array([int(mx.argmax(transition[t]).item()) for t in lasts])
+    hidden = mx.concatenate([embed[prompt]] * nt, axis=-1)
+
+    max_tokens = 20
+    seqs = [[int(first_bonus[i].item())] for i in range(B)]
+    for tokens_out, _ in _dspark_rounds_batch(
+        target,
+        model,
+        prompt_cache,
+        hidden,
+        first_bonus=first_bonus,
+        max_tokens=max_tokens,
+        sampler=_greedy_argmax,
+    ):
+        for i in range(B):
+            if tokens_out[i] is not None and len(seqs[i]) < max_tokens:
+                seqs[i].append(tokens_out[i])
+
+    for i in range(B):
+        assert seqs[i] == _plain_greedy(transition, lasts[i], max_tokens), f"row {i}"
+
+
+def test_confident_prefix_length():
+    # logits: positive → high P(accept); negative → low. threshold 0.5 == sigmoid(0).
+    logits = mx.array([[5.0, 5.0, -5.0, 5.0]])
+    assert _confident_prefix_length(logits, 4, 0.0) == 4  # gating disabled
+    assert _confident_prefix_length(logits, 4, 0.5) == 2  # truncates at first below
+    assert _confident_prefix_length(mx.array([[5.0, 5.0, 5.0, 5.0]]), 4, 0.5) == 4
+
+
+# --------------------------------------------------------------------------- real weights
+
+
+@pytest.mark.skipif(
+    not os.environ.get(DSPARK_CONFIG_ENV),
+    reason=f"set {DSPARK_CONFIG_ENV} to a real DSpark Gemma 4 config.json",
+)
+def test_real_config_param_keys_match_checkpoint_header():
+    config = json.load(open(os.environ[DSPARK_CONFIG_ENV]))
+    ckpt = os.environ.get(DSPARK_CKPT_ENV)
+    if not ckpt or not os.path.exists(ckpt):
+        pytest.skip(f"set {DSPARK_CKPT_ENV} to the matching safetensors file")
+    model = Model(ModelConfig.from_dict(config))
+    model_keys = {k for k, _ in tree_flatten(model.parameters())}
+    with open(ckpt, "rb") as f:
+        n = struct.unpack("<Q", f.read(8))[0]
+        header = json.loads(f.read(n))
+    ckpt_keys = {k for k in header if k != "__metadata__"}
+    ckpt_keys = set(model.sanitize({k: None for k in ckpt_keys}).keys())
+    assert ckpt_keys == model_keys
+
+
+@pytest.mark.skipif(
+    not os.environ.get(DSPARK_CKPT_ENV) or not os.environ.get(DSPARK_CONFIG_ENV),
+    reason=f"set {DSPARK_CONFIG_ENV} and {DSPARK_CKPT_ENV} to the real checkpoint",
+)
+def test_real_checkpoint_loads_and_drafts():
+    config = json.load(open(os.environ[DSPARK_CONFIG_ENV]))
+    ckpt = os.environ[DSPARK_CKPT_ENV]
+    if not os.path.exists(ckpt):
+        pytest.skip("checkpoint file not present")
+    cfg = ModelConfig.from_dict(config)
+    model = Model(cfg)
+    weights = model.sanitize(mx.load(ckpt))
+    model.load_weights(list(weights.items()))
+    mx.eval(model.parameters())
+
+    cache = model.reset(None)
+    ctx = (mx.random.normal((1, 8, cfg.fc_in)) * 0.1).astype(mx.bfloat16)
+    drafts = model.draft_block(5, ctx, cache, cfg.block_size, _greedy_argmax)
+    mx.eval(drafts)
+    ids = drafts.tolist()[0]
+    assert len(ids) == cfg.block_size
+    assert all(0 <= t < cfg.vocab_size for t in ids)
+    # Trained weights should not collapse the whole block to the mask token.
+    assert any(t != cfg.mask_token_id for t in ids)

--- a/mlx_vlm/utils.py
+++ b/mlx_vlm/utils.py
@@ -382,8 +382,13 @@ def get_model_and_args(config: dict):
 
     model_type = MODEL_REMAPPING.get(model_type, model_type)
 
+    # DSpark drafters declare a generic model_type (e.g. ``gemma4_text``) and are
+    # identified by their architecture tag (see speculative.drafters._config_is_dspark).
+    is_dspark = "Gemma4DSparkModel" in (config.get("architectures") or [])
     is_dflash = config.get("dflash_config", None) is not None
-    if is_dflash:
+    if is_dspark:
+        model_type = "gemma4_dspark"
+    elif is_dflash:
         model_type += "_dflash"
 
     last_err: Optional[ImportError] = None


### PR DESCRIPTION
## Gemma 4 DSpark self-speculative decoding

Adds **DSpark** (DeepSeek's self-speculative decoding, `deepseek-ai/DeepSpec`) as a fourth in-tree drafter family for Gemma 4 targets, alongside `dflash` / `eagle3` / `mtp`. Output is **byte-identical to base greedy decoding**.

DSpark is EAGLE-style: the drafter conditions on the target's intermediate hidden states (the same `capture_layer_ids` mechanism DFlash uses), projects them, and predicts a block of tokens biased by a low-rank **Markov head**, with a **confidence head** that can adaptively shorten speculation. It slots into the existing propose → verify → walk → rollback machinery — so the whole verify/accept path is reused unchanged.

### What's added

- **`speculative/drafters/gemma4_dspark/`** — a standalone drafter (ships its own `embed_tokens`/`lm_head`, unlike DFlash which binds to the target). Gemma 4 draft layers (K=V sharing, attention scale 1.0, partial RoPE, sandwich norms, GeGLU, logit softcap) run over mlx-vlm's `KVCache` with the same context/proposal split as `DFlashAttention`. Includes the Markov + confidence heads.
- **`speculative/dspark.py`** — `_dspark_rounds` (single-sequence, confidence-adaptive) and `_dspark_rounds_batch` (continuous batching), reusing `_speculative_walk` / `rollback_speculative_cache`.
- **Auto-detection & routing** — the published checkpoint declares a generic `model_type=gemma4_text`, so it's identified by its `Gemma4DSparkModel` architecture tag (+ draft-hyperparameter cluster) in `get_model_and_args` and `resolve_drafter_kind`; an explicit wrong `--draft-kind` is corrected with a warning.
- **CLI** — `--draft-kind dspark` and `--draft-confidence-threshold`.
- **Tests + README**.

### Usage

```sh
mlx_vlm.generate --model google/gemma-4-12b-it \
  --draft-model deepseek-ai/dspark_gemma4_12b_block7 \
  --prompt "Explain speculative decoding in 3 sentences." \
  --max-tokens 256 --temperature 0

mlx_vlm.server --model google/gemma-4-12b-it \
  --draft-model deepseek-ai/dspark_gemma4_12b_block7
```

### Lossless + adaptive

The confidence head truncates the draft block where `P(accept)` drops below `--draft-confidence-threshold` (env `MLX_VLM_DRAFT_CONFIDENCE_THRESHOLD`). This only changes **how far ahead the drafter speculates** before the target verifies — never which tokens are emitted — so output stays lossless. Confidence gating is applied on the single-sequence path; batched continuous decoding uses a fixed block (also lossless).

### Testing

`mlx_vlm/tests/test_dspark.py` (14 tests) + no regressions in `test_speculative.py` (147):

- **Losslessness** — `_dspark_rounds` and `_dspark_rounds_batch` produce output bit-identical to plain greedy against a history-independent Markov target, at confidence thresholds 0 / 0.5 / 0.9 and batch size 3.
- **Real checkpoint** *(env-gated on `DSPARK_GEMMA4_CONFIG` / `DSPARK_GEMMA4_CKPT`)* — the trained `dspark_gemma4_12b_block7` weights load with **all 74 keys matching** the module, and `draft_block` produces non-degenerate drafts.
- Config parsing, drafter-kind auto-detection/override, `get_model_and_args` routing (normal models unaffected), and compatibility validation.

```
161 passed (14 DSpark + 147 existing speculative), no regressions
```

### Benchmark note

DSpark acceptance is largely target-size-independent and set by the draft + task. Reference figures for the Gemma 4 backbone (from the `dspark-mlx` eager loop / the DSpark paper's acceptance band) on GSM8K, greedy:

| target | accepted length (τ) | acceptance | speedup |
|---|---|---|---|
| Gemma 4-12B-it (bf16) | ~5.84 | ~69% | ~2.06× |

This PR verifies **correctness** (lossless decode + real-weight load + key parity); end-to-end throughput on an mlx-vlm Gemma-4 target depends on hardware and the ~24 GB instruct model, and is left to measure on-device.

### Scope / limitations

- Gemma 4 only for now. Other DSpark backbones (Qwen3, DeepSeek-V4) can follow the same pattern.
- Why not port Qwen3
  - Port a dense Qwen3 target into mlx-vlm with the two spec hooks — substantial, and duplicates what mlx-lm already owns (mlx-vlm deliberately defers dense text to mlx-lm).
  - A DSpark drafter trained for Qwen3.5 — doesn't exist yet.
- Confidence-adaptive truncation is single-sequence; batched decoding uses a fixed block (still lossless).
- The drafter must target the deployed **instruct** model.

Based on `deepseek-ai/DeepSpec` (`dspark/*`); companion to the `dspark-mlx` package.