### PR TITLE
Fix silent text drop / image misalignment for multi-<image> prompts in prepare_inputs

### DIFF
--- a/mlx_vlm/tests/test_utils.py
+++ b/mlx_vlm/tests/test_utils.py
@@ -8,10 +8,12 @@ from unittest.mock import MagicMock, patch
 
 import mlx.core as mx
 import mlx.nn as nn
+import numpy as np
 import pytest
 from mlx_lm.utils import quantize_model
 
 from mlx_vlm.convert import _preserve_existing_deepseek_v4_quantization
+from mlx_vlm.models.base import BaseImageProcessor
 from mlx_vlm.models.text_only import TextOnlyModel
 from mlx_vlm.utils import (
     StoppingCriteria,
@@ -403,6 +405,87 @@ def test_prepare_inputs():
     )
     assert "input_ids" in inputs
     assert mx.array_equal(inputs["input_ids"], mx.array([[1, 2, 3]]))
+
+
+class _DummyBaseImageProcessor(BaseImageProcessor):
+    """BaseImageProcessor subclass that skips the transformers-backed __init__."""
+
+    def __init__(self):
+        pass
+
+    def preprocess(self, images):
+        return [np.zeros((3, 2, 2), dtype=np.float32) for _ in images]
+
+
+class _MockBaseImageProcessorProcessor:
+    """Processor whose ``image_processor`` triggers the BaseImageProcessor path."""
+
+    def __init__(self):
+        self.image_token = "<image>"
+        self.pad_token = "[PAD]"
+        self.pad_token_id = 0
+        self.eos_token = "[EOS]"
+        self.image_processor = _DummyBaseImageProcessor()
+
+    def __call__(self, text=None, **kwargs):
+        # One token per whitespace-delimited word keeps assertions predictable.
+        return SimpleNamespace(input_ids=[1] * len((text or "").split()))
+
+
+def test_prepare_inputs_base_image_processor_interleaves_and_validates():
+    """The BaseImageProcessor branch must keep all text, emit one image token per
+    "<image>" sentinel, and reject a sentinel/image-count mismatch with a clear
+    error instead of silently dropping text or misaligning ``pixel_values``."""
+
+    processor = _MockBaseImageProcessorProcessor()
+    image = mx.zeros((3, 224, 224))
+
+    # Single image: behaviour is unchanged (one image token, one pixel value).
+    inputs = prepare_inputs(
+        processor,
+        prompts="hello <image> world",
+        images=[image],
+        image_token_index=99,
+    )
+    assert mx.array_equal(inputs["input_ids"], mx.array([[1, 99, 1]]))
+    assert inputs["pixel_values"].shape[0] == 1
+
+    # Two sentinels + two images: previously the text after the second "<image>"
+    # was dropped and only one image token was inserted. Now all three text
+    # chunks survive and two image tokens line up with the two pixel values.
+    inputs = prepare_inputs(
+        processor,
+        prompts="a <image> b <image> c",
+        images=[image, image],
+        image_token_index=99,
+    )
+    assert mx.array_equal(inputs["input_ids"], mx.array([[1, 99, 1, 99, 1]]))
+    assert int((inputs["input_ids"] == 99).sum()) == 2
+    assert inputs["pixel_values"].shape[0] == 2
+
+    # Too few images for the sentinels -> clear error (was a silent mismatch).
+    with pytest.raises(
+        ValueError,
+        match="Number of image tokens in prompt_token_ids.*does not match number of images",
+    ):
+        prepare_inputs(
+            processor,
+            prompts="a <image> b <image> c",
+            images=[image],
+            image_token_index=99,
+        )
+
+    # Image supplied but no sentinel -> clear error (was an IndexError).
+    with pytest.raises(
+        ValueError,
+        match="Number of image tokens in prompt_token_ids.*does not match number of images",
+    ):
+        prepare_inputs(
+            processor,
+            prompts="no image token here",
+            images=[image],
+            image_token_index=99,
+        )
 
 
 def test_process_inputs_with_fallback():

--- a/mlx_vlm/utils.py
+++ b/mlx_vlm/utils.py
@@ -1766,15 +1766,35 @@ def prepare_inputs(
             for prompt in prompts
         ]
 
+        # Each "<image>" sentinel splits the prompt into one extra chunk, so the
+        # number of image tokens a prompt embeds is ``len(chunks) - 1``. Validate
+        # the total against the images provided so a sentinel/image count mismatch
+        # surfaces as a clear error here instead of silently dropping the trailing
+        # text or misaligning ``pixel_values`` further down the model.
+        total_image_tokens = sum(len(chunks) - 1 for chunks in text_chunks)
+        if total_image_tokens != len(images):
+            raise ValueError(
+                f"Number of image tokens in prompt_token_ids ({total_image_tokens}) "
+                f"does not match number of images ({len(images)})"
+            )
+
+        # Interleave every text chunk with an image token so prompts with multiple
+        # "<image>" sentinels keep all of their text and emit one image slot per
+        # image (the previous code only ever inserted a single token between the
+        # first two chunks, discarding any text after the second sentinel).
+        token_id_lists = []
+        for chunks in text_chunks:
+            ids = list(chunks[0])
+            for chunk in chunks[1:]:
+                ids += [image_token_index] + list(chunk)
+            token_id_lists.append(ids)
+
         # Find the maximum length for padding
-        max_length = max(
-            sum(len(chunk) for chunk in chunks) + 1 for chunks in text_chunks
-        )
+        max_length = max(len(ids) for ids in token_id_lists)
 
         # Pad and create input_ids
         input_ids = []
-        for chunks in text_chunks:
-            ids = chunks[0] + [image_token_index] + chunks[1]
+        for ids in token_id_lists:
             padding = [processor.pad_token_id] * (max_length - len(ids))
             input_ids.append(mx.array(ids + padding))
 


### PR DESCRIPTION
## Problem

In `prepare_inputs`, the `BaseImageProcessor` path builds `input_ids` by hardcoding a single image token between the first two text chunks:

```python
ids = chunks[0] + [image_token_index] + chunks[1]
```

`chunks` comes from `prompt.split("<image>")`, so this only ever handles a prompt with **exactly one** `<image>` sentinel. Other cases fail silently or with an opaque error:

- **Two or more `<image>` sentinels** → every chunk after the second (`chunks[2:]`) is **silently dropped**, and only **one** image token is inserted even though `pixel_values = preprocess(images=images)` stacks **all** the images. The model then receives `input_ids` with one image slot but N image features — a silent shape/count misalignment, i.e. a wrong answer with no error.
- **An image but no `<image>` sentinel** → `chunks` has one element, so `chunks[1]` raises a bare `IndexError`.
- The `max_length = ... + 1` padding math also assumes exactly one inserted token.

The other (`process_inputs_with_fallback`) path already guards this via the processor, raising `ValueError("Number of image tokens in prompt_token_ids (X) does not match number of images (Y)")`. The `BaseImageProcessor` path had no such check.

## Fix

- **Interleave** every text chunk with an image token (one per `<image>` sentinel) so multi-image prompts keep all of their text and emit exactly one image slot per image.
- **Validate** the total sentinel count against the number of images up front, raising the **same** clear `ValueError` the fallback path already uses, instead of dropping text / misaligning features / `IndexError`-ing.
- Compute `max_length` from the actual interleaved sequences.

Single-image prompts are unaffected — the produced `input_ids` are byte-for-byte identical to before.

## Tests

Adds `test_prepare_inputs_base_image_processor_interleaves_and_validates`, which exercises the `BaseImageProcessor` branch (previously uncovered) across single-image, multi-image, too-few-images, and no-sentinel cases. The multi-image assertion is **red on `main`** (the old code emits one image token) and green here.

```
mlx_vlm/tests/test_utils.py::test_prepare_inputs_base_image_processor_interleaves_and_validates PASSED
205 passed, 2 skipped
```

`black` / `isort` / `autoflake` (pre-commit) all clean.