### PR TITLE
[codex] Fix APC with MTP draft decoding

### DIFF
--- a/mlx_vlm/apc.py
+++ b/mlx_vlm/apc.py
@@ -3711,6 +3711,8 @@ def harvest_blocks_from_batch_cache(
         keys = getattr(c, "keys", None)
         values = getattr(c, "values", None)
         idx = getattr(c, "_idx", None)
+        if idx is None and keys is not None and values is not None:
+            idx = getattr(c, "offset", None)
         left_padding = getattr(c, "left_padding", None)
         if keys is None or values is None or idx is None:
             return []

--- a/mlx_vlm/generate/ar.py
+++ b/mlx_vlm/generate/ar.py
@@ -2095,7 +2095,6 @@ class BatchGenerator:
         self.draft_block_size = draft_block_size
         self.greedy_sampling = greedy_sampling or sampler is None
         if self.draft_model is not None:
-            apc_manager = None
             compute_logprobs = False
             top_logprobs_k = 0
             self.compute_logprobs = False

--- a/mlx_vlm/tests/test_apc.py
+++ b/mlx_vlm/tests/test_apc.py
@@ -813,6 +813,29 @@ def test_harvest_blocks_from_batch_cache_drops_left_padding():
     source_manager.release(full_blocks + short_blocks)
 
 
+def test_harvest_blocks_from_regular_kv_cache_uses_offset():
+    block_size = 16
+    manager = APCManager(num_blocks=8, block_size=block_size)
+    token_ids = list(range(block_size))
+    layer_keys, layer_values = _make_fake_kv(seq_len=len(token_ids))
+    caches = []
+    for keys, values in zip(layer_keys, layer_values):
+        caches.append(SimpleNamespace(keys=keys, values=values, offset=block_size))
+
+    harvested = harvest_blocks_from_batch_cache(
+        manager,
+        caches,
+        batch_idx=0,
+        full_token_ids=token_ids,
+    )
+
+    assert len(harvested) == 1
+    _assert_allclose(harvested[0].keys[0], layer_keys[0])
+    matched, matched_tokens = manager.lookup_prefix(token_ids)
+    assert matched_tokens == block_size
+    manager.release(matched + harvested)
+
+
 def test_disk_metadata_mismatch_is_a_miss(tmp_path):
     block_size = 16
     token_ids = list(range(block_size))

--- a/mlx_vlm/tests/test_generate.py
+++ b/mlx_vlm/tests/test_generate.py
@@ -507,6 +507,25 @@ class TestBatchGenerator:
         assert len(gen._generation_batch) == 0
         assert gen.uid_count == 0
 
+    def test_initialization_keeps_apc_with_draft_model(
+        self, mock_model, mock_processor
+    ):
+        apc_manager = object()
+        draft_model = object()
+
+        gen = BatchGenerator(
+            model=mock_model.language_model,
+            processor=mock_processor,
+            apc_manager=apc_manager,
+            draft_model=draft_model,
+            compute_logprobs=True,
+            top_logprobs_k=5,
+        )
+
+        assert gen.apc_manager is apc_manager
+        assert gen.compute_logprobs is False
+        assert gen.top_logprobs_k == 0
+
     def test_insert_prompts(self, mock_model, mock_processor):
         gen = BatchGenerator(
             model=mock_model.language_model,


### PR DESCRIPTION
## Summary

- keep the APC manager enabled when a draft model is configured, so MTP speculative decoding no longer silently disables APC
- allow APC block harvesting to read regular KV caches that expose `offset` instead of batched `_idx`
- add regression coverage for both the BatchGenerator APC/draft initialization path and regular KV cache harvesting

Fixes #1443.

## Root Cause

`BatchGenerator` nulled out `apc_manager` whenever `draft_model` was present. That made APC unavailable for MTP speculative decoding even when `APC_ENABLED=1`. After prefill, APC harvesting also expected batched cache entries with `_idx`, while the speculative prompt-cache path can produce regular KV caches that track length through `offset`.

## Validation

- `uv run --with pytest pytest -q mlx_vlm/tests/test_apc.py mlx_vlm/tests/test_generate.py::TestBatchGenerator`
- `uv run --with pytest --with psutil pytest -q`
- commit hooks: `black`, `isort`, `autoflake`