### PR TITLE
feat(dspark): DeepSeek-V4 Flash/Pro DSpark self-speculative drafter

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ MLX-VLM is a package for inference and fine-tuning of Vision Language Models (VL
   - [Speculative Decoding](#speculative-decoding)
     - [DFlash (Qwen3.5)](#dflash-qwen35)
     - [Gemma 4 MTP](#gemma-4-mtp)
+    - [DeepSeek-V4 DSpark](#deepseek-v4-dspark)
   - [Chat UI with Gradio](#chat-ui-with-gradio)
   - [Python Script](#python-script)
   - [Server (FastAPI)](#server-fastapi)
@@ -123,13 +124,14 @@ Requests can override the server defaults with `enable_thinking`, `thinking_budg
 
 ### Speculative Decoding
 
-Speed up generation by drafting several candidate tokens with a small "drafter" model and verifying them in a single target forward pass. Three drafter families are supported.
+Speed up generation by drafting several candidate tokens with a small "drafter" model and verifying them in a single target forward pass. Several drafter families are supported.
 
 | Flag | Description |
 |------|-------------|
 | `--draft-model` | HuggingFace repo or local path for the drafter |
-| `--draft-kind` | Drafter family — `dflash` (default), `eagle3`, or `mtp` (Gemma 4) |
+| `--draft-kind` | Drafter family — `dflash` (default), `dspark` (DeepSeek-V4 self-speculative), `eagle3`, or `mtp` (Gemma 4) |
 | `--draft-block-size` | Override the drafter's configured block size |
+| `--draft-confidence-threshold` | DSpark only — truncate the draft block where the confidence head's `P(accept)` drops below this (0 = off; lossless either way) |
 
 See [docs/usage.md](docs/usage.md) for Python API examples including batch generation.
 
@@ -229,6 +231,31 @@ mlx_vlm.generate --model mlx-community/gemma-4-31B-it-bf16 \
 mlx_vlm.server --model mlx-community/gemma-4-31B-it-bf16 \
   --draft-model RedHatAI/gemma-4-31B-it-speculator.eagle3
 ```
+
+#### DeepSeek-V4 DSpark
+
+[DSpark](https://github.com/deepseek-ai/DeepSpec) is DeepSeek's self-speculative drafter: an EAGLE-style stack that conditions on the target's intermediate hidden states and predicts a block of tokens biased by a low-rank Markov head, plus a confidence head. It ships for DeepSeek-V4 (Flash and Pro), reusing the in-tree MoE and Hyper-Connection primitives and adding a windowed MLA cross-attention; one config drives both sizes. Output is byte-identical to base greedy decoding.
+
+The draft stack lives under the `mtp.*` namespace of the base fp8/fp4 checkpoint, so it is first split into a standalone bf16 drafter (the same pattern as DeepSeek-V4 MTP):
+
+```sh
+# One-time: extract + dequantize the mtp.* draft into a standalone drafter folder
+python -m mlx_vlm.speculative.drafters.deepseek_v4_dspark.split \
+  --model deepseek-ai/DeepSeek-V4-Flash-DSpark \
+  --output ./deepseek-v4-flash-dspark-drafter
+
+# Then decode with --draft-kind dspark (auto-detected from the split folder)
+mlx_vlm.generate --model deepseek-ai/DeepSeek-V4-Flash \
+  --draft-model ./deepseek-v4-flash-dspark-drafter \
+  --prompt "Explain speculative decoding in 3 sentences." \
+  --max-tokens 256 --temperature 0
+
+# Server
+mlx_vlm.server --model deepseek-ai/DeepSeek-V4-Flash \
+  --draft-model ./deepseek-v4-flash-dspark-drafter
+```
+
+The confidence head can adaptively shorten the draft block on the single-sequence path — set `--draft-confidence-threshold` (e.g. `0.5`) to truncate speculation where `P(accept)` falls below the threshold; this only changes how far ahead the drafter speculates, never which tokens are emitted. Batched continuous decoding uses a fixed block (also lossless).
 
 ### Chat UI with Gradio
 
@@ -363,8 +390,9 @@ mlx_vlm.server --model Qwen/Qwen3.5-4B \
 - `--stt-model`: Preload a speech-to-text model at server startup
 - `--adapter-path`: Path for adapter weights to use with the preloaded model
 - `--draft-model`: Speculative drafter path or HF id (e.g. `z-lab/Qwen3.5-4B-DFlash`, `RedHatAI/gemma-4-31B-it-speculator.eagle3`, `google/gemma-4-31B-it-assistant`) — enables speculative decoding for ~2× or higher throughput
-- `--draft-kind`: Drafter family — `dflash` (default), `eagle3`, or `mtp` (Gemma 4)
+- `--draft-kind`: Drafter family — `dflash` (default), `dspark` (DeepSeek-V4 self-speculative), `eagle3`, or `mtp` (Gemma 4)
 - `--draft-block-size`: Override the drafter's configured block size
+- `--draft-confidence-threshold`: DSpark only — truncate the draft block where `P(accept)` falls below this (0 = off; lossless either way)
 - `--host`: Host address (default: `0.0.0.0`)
 - `--port`: Port number (default: `8080`)
 - `--trust-remote-code`: Trust remote code when loading models from Hugging Face Hub

--- a/mlx_vlm/models/deepseek_v4/language.py
+++ b/mlx_vlm/models/deepseek_v4/language.py
@@ -1014,6 +1014,7 @@ class DeepseekV4Model(PipelineMixin, nn.Module):
         cache: Optional[Any] = None,
         inputs_embeds: Optional[mx.array] = None,
         hidden_sink: Optional[list] = None,
+        capture_layer_ids: Optional[List[int]] = None,
         skip_final_norm: bool = False,
     ) -> mx.array:
         h = self.embed_tokens(inputs) if inputs_embeds is None else inputs_embeds
@@ -1043,8 +1044,17 @@ class DeepseekV4Model(PipelineMixin, nn.Module):
         if pipeline_rank < pipeline_size - 1:
             h = mx.distributed.recv_like(h, (pipeline_rank + 1))
 
-        for layer, layer_cache in zip(self.pipeline_layers, cache):
+        capture_set = set(capture_layer_ids) if capture_layer_ids else set()
+        for local_idx, (layer, layer_cache) in enumerate(
+            zip(self.pipeline_layers, cache)
+        ):
             h = layer(h, mask, layer_cache, inputs)
+            if hidden_sink is not None and (self.start_idx + local_idx) in capture_set:
+                # DSpark self-speculation conditions on the per-layer residual
+                # reduced over the hc_mult Hyper-Connection copies — the same
+                # `h.mean(dim=2)` the reference Transformer.forward captures at
+                # each dspark_target_layer_id.
+                hidden_sink.append(h.mean(axis=2))
 
         if pipeline_rank != 0:
             h = mx.distributed.send(h, (pipeline_rank - 1) % pipeline_size)
@@ -1057,7 +1067,9 @@ class DeepseekV4Model(PipelineMixin, nn.Module):
         if pipeline_size > 1:
             h = mx.distributed.all_gather(h)[: h.shape[0]]
 
-        if hidden_sink is not None:
+        # Capture-style speculation (DSpark) collects per-layer hiddens above;
+        # the last-layer full-hc hidden is only the MTP "last hidden" path.
+        if hidden_sink is not None and not capture_set:
             hidden_sink.append(h)
 
         if skip_final_norm:
@@ -1259,8 +1271,9 @@ class LanguageModel(nn.Module):
         return_shared_kv = kwargs.pop("return_shared_kv", False)
         skip_logits = kwargs.pop("skip_logits", False)
         skip_final_norm = kwargs.pop("skip_final_norm", False)
+        capture_layer_ids = kwargs.pop("capture_layer_ids", None)
         hidden_sink = kwargs.pop("hidden_sink", None)
-        if return_hidden and hidden_sink is None:
+        if (return_hidden or capture_layer_ids) and hidden_sink is None:
             hidden_sink = []
 
         out = self.model(
@@ -1268,6 +1281,7 @@ class LanguageModel(nn.Module):
             cache=cache,
             inputs_embeds=inputs_embeds,
             hidden_sink=hidden_sink,
+            capture_layer_ids=capture_layer_ids,
             skip_final_norm=skip_final_norm,
         )
         logits = None if skip_logits else self.lm_head(out)

--- a/mlx_vlm/server/cli.py
+++ b/mlx_vlm/server/cli.py
@@ -173,8 +173,9 @@ def main():
         "--draft-kind",
         type=str,
         default=None,
-        choices=["dflash", "eagle3", "mtp"],
-        help="Drafter family -- 'dflash', 'eagle3', or 'mtp' (Gemma 4). "
+        choices=["dflash", "dspark", "eagle3", "mtp"],
+        help="Drafter family -- 'dflash', 'dspark' (DeepSeek-V4 "
+        "self-speculative), 'eagle3', or 'mtp' (Gemma 4). "
         "Default: auto-detected from the drafter's HF model_type.",
     )
     parser.add_argument(
@@ -182,6 +183,14 @@ def main():
         type=int,
         default=None,
         help="Override the drafter's configured block size.",
+    )
+    parser.add_argument(
+        "--draft-confidence-threshold",
+        type=float,
+        default=None,
+        help="DSpark only: truncate the draft block where the confidence head's "
+        "P(accept) drops below this threshold (0 = off, lossless either way). "
+        "Maps to the MLX_VLM_DRAFT_CONFIDENCE_THRESHOLD env var.",
     )
     parser.add_argument(
         "--top-logprobs-k",
@@ -235,6 +244,10 @@ def main():
         os.environ["MLX_VLM_DRAFT_KIND"] = args.draft_kind
     if args.draft_block_size is not None:
         os.environ["MLX_VLM_DRAFT_BLOCK_SIZE"] = str(args.draft_block_size)
+    if args.draft_confidence_threshold is not None:
+        os.environ["MLX_VLM_DRAFT_CONFIDENCE_THRESHOLD"] = str(
+            args.draft_confidence_threshold
+        )
     if args.prefill_step_size:
         os.environ["PREFILL_STEP_SIZE"] = str(args.prefill_step_size)
     os.environ["MLX_VLM_MAX_TOKENS"] = str(args.max_tokens)

--- a/mlx_vlm/speculative/drafters/__init__.py
+++ b/mlx_vlm/speculative/drafters/__init__.py
@@ -4,11 +4,12 @@ from typing import Any, Optional, Tuple
 
 from .qwen3_dflash import DFlashDraftModel
 
-KNOWN_DRAFTER_KINDS = {"dflash", "mtp", "eagle3"}
+KNOWN_DRAFTER_KINDS = {"dflash", "mtp", "eagle3", "dspark"}
 
 # Drafter HF ``model_type`` → required round-loop kind. Anything not listed
 # here falls back to ``DEFAULT_DRAFTER_KIND`` when the caller didn't pass one.
 DRAFTER_KIND_BY_MODEL_TYPE = {
+    "deepseek_v4_dspark": "dspark",
     "deepseek_v4_mtp": "mtp",
     "eagle3": "eagle3",
     "gemma4_assistant": "mtp",
@@ -17,6 +18,19 @@ DRAFTER_KIND_BY_MODEL_TYPE = {
 }
 
 DEFAULT_DRAFTER_KIND = "dflash"
+
+
+def _config_is_dspark(config: Any) -> bool:
+    """A DSpark drafter checkpoint, detected from its model type or its distinctive draft
+    hyper-parameters. The DeepSeek-V4 drafter is split out of the base ``mtp.*`` namespace
+    into a ``deepseek_v4_dspark`` folder carrying the ``dspark_block_size`` hyper-parameter.
+    """
+    if config is None:
+        return False
+    if _cfg_get(config, "model_type") == "deepseek_v4_dspark":
+        return True
+    return bool(_cfg_get(config, "dspark_block_size"))
+
 
 logger = logging.getLogger(__name__)
 
@@ -55,6 +69,30 @@ def validate_drafter_compatibility(
             f"Got draft_kind={draft_kind!r}."
         )
 
+    if draft_kind == "dspark":
+        # The DSpark drafter projects the concatenated target hidden states, so its
+        # hidden_size must equal the target's; it also needs the speculative hooks.
+        target = getattr(target_model, "language_model", target_model)
+        if not hasattr(target, "rollback_speculative_cache"):
+            raise ValueError(
+                f"Target {type(target).__name__} does not implement "
+                "rollback_speculative_cache; DSpark needs a DeepSeek-V4 "
+                "(or compatible) target."
+            )
+        draft_hidden_size = _cfg_get(draft_cfg, "hidden_size")
+        target_hidden_size = _hidden_size(getattr(target, "config", None))
+        if (
+            draft_hidden_size is not None
+            and target_hidden_size is not None
+            and draft_hidden_size != target_hidden_size
+        ):
+            raise ValueError(
+                "DSpark drafter is incompatible with the target model. "
+                f"Drafter hidden_size={draft_hidden_size!r}, "
+                f"target hidden_size={target_hidden_size!r}."
+            )
+        return
+
     if draft_kind != "mtp":
         return
 
@@ -79,15 +117,22 @@ def validate_drafter_compatibility(
         )
 
 
+def _peek_drafter_config(model_path) -> Optional[dict]:
+    """Read the drafter's HF ``config.json`` without loading weights."""
+    try:
+        with open(model_path / "config.json") as f:
+            return json.load(f)
+    except (FileNotFoundError, json.JSONDecodeError, OSError):
+        return None
+
+
 def _peek_drafter_model_type(model_path) -> Optional[str]:
     """Read the drafter's HF ``config.json`` ``model_type`` without loading
     weights. Returns ``None`` if the config can't be read."""
-    try:
-        with open(model_path / "config.json") as f:
-            config = json.load(f)
-            return config.get("model_type") or config.get("speculators_model_type")
-    except (FileNotFoundError, json.JSONDecodeError, OSError):
+    config = _peek_drafter_config(model_path)
+    if config is None:
         return None
+    return config.get("model_type") or config.get("speculators_model_type")
 
 
 def resolve_drafter_kind(model_path, kind: Optional[str] = None) -> str:
@@ -102,7 +147,29 @@ def resolve_drafter_kind(model_path, kind: Optional[str] = None) -> str:
     but forgets ``--draft-kind mtp``: rather than crashing deep inside
     ``draft_block`` with an opaque error, we pick the right kind for them.
     """
-    model_type = _peek_drafter_model_type(model_path)
+    config = _peek_drafter_config(model_path)
+    model_type = (
+        (config.get("model_type") or config.get("speculators_model_type"))
+        if config
+        else None
+    )
+    # DSpark drafters are detected by model_type / the dspark_* hyper-parameters.
+    if _config_is_dspark(config):
+        if kind is not None and kind != "dspark":
+            logger.warning(
+                "Drafter %r is a DSpark checkpoint which requires --draft-kind='dspark'; "
+                "got --draft-kind=%r. Overriding to 'dspark'.",
+                str(model_path),
+                kind,
+            )
+        else:
+            logger.info(
+                "Auto-detected --draft-kind='dspark' for drafter %r (model_type=%r).",
+                str(model_path),
+                model_type,
+            )
+        return "dspark"
+
     expected = DRAFTER_KIND_BY_MODEL_TYPE.get(model_type)
 
     if kind is None:

--- a/mlx_vlm/speculative/drafters/deepseek_v4_dspark/__init__.py
+++ b/mlx_vlm/speculative/drafters/deepseek_v4_dspark/__init__.py
@@ -1,0 +1,12 @@
+from .config import DeepseekV4DSparkConfig
+from .dspark import DeepseekV4DSparkDraftModel
+
+Model = DeepseekV4DSparkDraftModel
+ModelConfig = DeepseekV4DSparkConfig
+
+__all__ = [
+    "DeepseekV4DSparkConfig",
+    "DeepseekV4DSparkDraftModel",
+    "Model",
+    "ModelConfig",
+]

--- a/mlx_vlm/speculative/drafters/deepseek_v4_dspark/attention.py
+++ b/mlx_vlm/speculative/drafters/deepseek_v4_dspark/attention.py
@@ -1,0 +1,282 @@
+"""DSpark draft attention for a DeepSeek-V4 target.
+
+A faithful port of the reference ``inference/model.py::DSparkAttention`` (the
+``compress_ratio == 0`` windowed MLA variant): low-rank Q (``wq_a -> q_norm -> wq_b``)
+with a per-head RMS, a single shared KV head, a sliding-window KV ring buffer, top-k
+sparse attention with a denominator sink, and a grouped low-rank output projection.
+
+The reference's TileLang ``sparse_attn`` kernel and interleaved-pair RoPE are reimplemented
+in plain MLX here (the draft block is tiny — K≈5 query positions — so a dense formulation
+is ample). There is no KV compressor/indexer; those live on the base target. The window is
+passed in (not module-state) so the speculative round loop can keep one per sequence.
+"""
+
+from typing import Optional, Tuple
+
+import mlx.core as mx
+import mlx.nn as nn
+
+from .config import DeepseekV4DSparkConfig
+
+
+class RMSNorm(nn.Module):
+    """fp32 RMSNorm matching the reference (compute in fp32, cast back)."""
+
+    def __init__(self, dim: int, eps: float = 1e-6):
+        super().__init__()
+        self.weight = mx.ones((dim,), dtype=mx.float32)
+        self.eps = eps
+
+    def __call__(self, x: mx.array) -> mx.array:
+        dtype = x.dtype
+        xf = x.astype(mx.float32)
+        xf = xf * mx.rsqrt(mx.mean(xf * xf, axis=-1, keepdims=True) + self.eps)
+        return (self.weight * xf).astype(dtype)
+
+
+def precompute_rope(
+    dim: int, seqlen: int, base: float = 10000.0
+) -> Tuple[mx.array, mx.array]:
+    """No-YaRN RoPE tables. Returns ``(cos, sin)`` each ``[seqlen, dim/2]``."""
+    freqs = 1.0 / (base ** (mx.arange(0, dim, 2).astype(mx.float32) / dim))
+    t = mx.arange(seqlen).astype(mx.float32)
+    theta = mx.outer(t, freqs)
+    return mx.cos(theta), mx.sin(theta)
+
+
+def apply_rotary_emb(
+    x: mx.array, cos: mx.array, sin: mx.array, inverse: bool = False
+) -> mx.array:
+    """Interleaved-pair RoPE (reference ``apply_rotary_emb``): consecutive dims are
+    (real, imag). ``x`` is ``[b, s, rd]`` or ``[b, s, h, rd]`` with position axis 1."""
+    rd = x.shape[-1]
+    half = rd // 2
+    seqlen = x.shape[1]
+    xf = x.astype(mx.float32).reshape(*x.shape[:-1], half, 2)
+    xr, xi = xf[..., 0], xf[..., 1]
+    if x.ndim == 3:
+        c = cos.reshape(1, seqlen, half)
+        s = sin.reshape(1, seqlen, half)
+    else:
+        c = cos.reshape(1, seqlen, 1, half)
+        s = sin.reshape(1, seqlen, 1, half)
+    if inverse:
+        s = -s
+    out = mx.stack([xr * c - xi * s, xr * s + xi * c], axis=-1).reshape(x.shape)
+    return out.astype(x.dtype)
+
+
+def _rope_last(
+    x: mx.array, cos: mx.array, sin: mx.array, rd: int, inverse: bool = False
+) -> mx.array:
+    """Rotate only the last ``rd`` dims (the rope slice); pass the nope dims through."""
+    return mx.concatenate(
+        [x[..., :-rd], apply_rotary_emb(x[..., -rd:], cos, sin, inverse)], axis=-1
+    )
+
+
+def sparse_attn(
+    q: mx.array,
+    kv: mx.array,
+    attn_sink: mx.array,
+    topk_idxs: mx.array,
+    softmax_scale: float,
+) -> mx.array:
+    """Top-k gathered single-KV-head attention with a denominator-only sink.
+
+    q: ``[b, m, h, d]``; kv: ``[b, n, d]``; attn_sink: ``[h]``; topk_idxs: ``[b, m, t]``
+    (``-1`` masks a slot). Returns ``[b, m, h, d]``.
+    """
+    b, m, h, d = q.shape
+    t = topk_idxs.shape[-1]
+
+    mask = topk_idxs != -1
+    safe = mx.where(mask, topk_idxs, 0).astype(mx.int32)
+    flat = safe.reshape(b, m * t)
+    idx_exp = mx.broadcast_to(flat[:, :, None], (b, m * t, d)).astype(mx.int32)
+    kv_g = mx.take_along_axis(kv.astype(mx.float32), idx_exp, axis=1).reshape(
+        b, m, t, d
+    )
+
+    qf = q.astype(mx.float32)
+    scores = mx.matmul(qf, mx.swapaxes(kv_g, -1, -2)) * softmax_scale  # [b, m, h, t]
+    scores = mx.where(mask[:, :, None, :], scores, -mx.array(float("inf")))
+
+    smax = mx.max(scores, axis=-1, keepdims=True)
+    ex = mx.exp(scores - smax)
+    num = mx.matmul(ex, kv_g)
+    sink = mx.exp(attn_sink[None, None, :, None] - smax)
+    denom = mx.sum(ex, axis=-1, keepdims=True) + sink
+    return (num / denom).astype(q.dtype)
+
+
+def _dspark_topk_idxs(
+    window_size: int, bsz: int, block_size: int, start_pos: int
+) -> mx.array:
+    win = mx.arange(min(window_size, start_pos + 1))
+    block = window_size + mx.arange(block_size)
+    row = mx.concatenate([win, block]).astype(mx.int32)
+    return mx.broadcast_to(row[None, None, :], (bsz, block_size, row.shape[0]))
+
+
+class DSparkKVCache:
+    """Sliding-window ring buffer for the drafter's shared single-head KV.
+
+    Plain object (not an ``nn.Module``) so it never lands in a parameter tree. Slot
+    ``p % window_size`` holds the KV for absolute position ``p``; attention is order-
+    agnostic over the window, so the ring ordering is irrelevant to correctness.
+    """
+
+    def __init__(self, window_size: int):
+        self.window_size = window_size
+        self.window: Optional[mx.array] = None  # [b, win, head_dim]
+
+    def prefill(self, main_kv: mx.array) -> None:
+        b, seqlen, d = main_kv.shape
+        win = self.window_size
+        if seqlen <= win:
+            pad = mx.zeros((b, win - seqlen, d), dtype=main_kv.dtype)
+            self.window = mx.concatenate([main_kv, pad], axis=1)
+        else:
+            cutoff = seqlen % win
+            last = main_kv[:, seqlen - win :]
+            self.window = mx.concatenate(
+                [last[:, win - cutoff :], last[:, : win - cutoff]], axis=1
+            )
+
+    def update(self, position: int, v: mx.array) -> None:
+        win = self.window_size
+        sel = mx.arange(win) == (position % win)
+        self.window = mx.where(sel[None, :, None], v[:, None, :], self.window)
+
+    def read(self) -> mx.array:
+        return self.window
+
+
+class DSparkAttention(nn.Module):
+    def __init__(self, config: DeepseekV4DSparkConfig, max_seq_len: int = 8192):
+        super().__init__()
+        self.n_heads = config.num_attention_heads
+        self.head_dim = config.head_dim
+        self.rope_head_dim = config.qk_rope_head_dim
+        self.o_lora_rank = config.o_lora_rank
+        self.n_groups = config.o_groups
+        self.window_size = config.sliding_window
+        self.eps = config.rms_norm_eps
+        self.softmax_scale = config.head_dim**-0.5
+
+        self.wq_a = nn.Linear(config.hidden_size, config.q_lora_rank, bias=False)
+        self.q_norm = RMSNorm(config.q_lora_rank, config.rms_norm_eps)
+        self.wq_b = nn.Linear(
+            config.q_lora_rank, self.n_heads * self.head_dim, bias=False
+        )
+        self.wkv = nn.Linear(config.hidden_size, self.head_dim, bias=False)
+        self.kv_norm = RMSNorm(self.head_dim, config.rms_norm_eps)
+        self.wo_a = nn.Linear(
+            self.n_heads * self.head_dim // self.n_groups,
+            self.n_groups * self.o_lora_rank,
+            bias=False,
+        )
+        self.wo_b = nn.Linear(
+            self.n_groups * self.o_lora_rank, config.hidden_size, bias=False
+        )
+        self.attn_sink = mx.zeros((self.n_heads,), dtype=mx.float32)
+
+        cos, sin = precompute_rope(self.rope_head_dim, max_seq_len, config.rope_theta)
+        self._cos, self._sin = cos, sin
+
+    def _main_kv(self, main_x: mx.array, start_pos: int) -> mx.array:
+        rd = self.rope_head_dim
+        seqlen = main_x.shape[1]
+        main_kv = self.kv_norm(self.wkv(main_x))
+        return _rope_last(
+            main_kv,
+            self._cos[start_pos : start_pos + seqlen],
+            self._sin[start_pos : start_pos + seqlen],
+            rd,
+        )
+
+    def __call__(
+        self,
+        x: mx.array,
+        start_pos: int,
+        main_x: mx.array,
+        window: DSparkKVCache,
+    ) -> mx.array:
+        rd = self.rope_head_dim
+        b, seqlen, _ = main_x.shape
+
+        main_kv = self._main_kv(main_x, start_pos)
+        if start_pos == 0:
+            window.prefill(main_kv)
+            return x
+
+        _, block_size, _ = x.shape
+        bcos = self._cos[start_pos + seqlen : start_pos + seqlen + block_size]
+        bsin = self._sin[start_pos + seqlen : start_pos + seqlen + block_size]
+
+        q = self.wq_b(self.q_norm(self.wq_a(x))).reshape(
+            b, block_size, self.n_heads, self.head_dim
+        )
+        q = q * mx.rsqrt(mx.mean(q * q, axis=-1, keepdims=True) + self.eps)
+        q = _rope_last(q, bcos, bsin, rd)
+        kv = _rope_last(self.kv_norm(self.wkv(x)), bcos, bsin, rd)
+
+        window.update(start_pos, main_kv[:, 0])
+        kv_full = mx.concatenate([window.read(), kv], axis=1)
+        topk = _dspark_topk_idxs(self.window_size, b, block_size, start_pos)
+        o = sparse_attn(q, kv_full, self.attn_sink, topk, self.softmax_scale)
+        o = _rope_last(o, bcos, bsin, rd, inverse=True)
+
+        o = o.reshape(b, block_size, self.n_groups, -1)
+        wo_a = self.wo_a.weight.reshape(self.n_groups, self.o_lora_rank, -1)
+        # out[..,g,r] = sum_d o[..,g,d] * wo_a[g,r,d]
+        o = mx.sum(o[..., None, :] * wo_a[None, None, :, :, :], axis=-1)
+        return self.wo_b(o.reshape(b, block_size, self.n_groups * self.o_lora_rank))
+
+    def advance_window(
+        self, main_x: mx.array, position: int, window: DSparkKVCache
+    ) -> None:
+        """Append one committed token's main KV to the window without drafting."""
+        main_kv = self._main_kv(main_x[:, None, :], position)
+        window.update(position, main_kv[:, 0])
+
+    def seed_window(self, main_x: mx.array, window: DSparkKVCache) -> None:
+        """Vectorized initial window fill from the full committed context (positions 0..S-1)."""
+        window.prefill(self._main_kv(main_x, 0))
+
+    def draft(
+        self, x: mx.array, block_start: int, win_valid: int, window: DSparkKVCache
+    ) -> mx.array:
+        """Draft a block attending to the already-seeded window (eager round-loop path).
+
+        Unlike :meth:`__call__` decode, no anchor main KV is added — the committed context
+        is already in ``window`` (the round loop feeds it via :meth:`advance_window` /
+        :meth:`seed_window`). The block's ``block_size`` query slots sit at rope positions
+        ``block_start .. block_start + block_size - 1``; ``win_valid`` is the number of valid
+        window positions (``min(window_size, committed)``).
+        """
+        rd = self.rope_head_dim
+        b, block_size, _ = x.shape
+        bcos = self._cos[block_start : block_start + block_size]
+        bsin = self._sin[block_start : block_start + block_size]
+
+        q = self.wq_b(self.q_norm(self.wq_a(x))).reshape(
+            b, block_size, self.n_heads, self.head_dim
+        )
+        q = q * mx.rsqrt(mx.mean(q * q, axis=-1, keepdims=True) + self.eps)
+        q = _rope_last(q, bcos, bsin, rd)
+        kv = _rope_last(self.kv_norm(self.wkv(x)), bcos, bsin, rd)
+
+        kv_full = mx.concatenate([window.read(), kv], axis=1)
+        win = mx.arange(min(self.window_size, win_valid))
+        block = self.window_size + mx.arange(block_size)
+        row = mx.concatenate([win, block]).astype(mx.int32)
+        topk = mx.broadcast_to(row[None, None, :], (b, block_size, row.shape[0]))
+        o = sparse_attn(q, kv_full, self.attn_sink, topk, self.softmax_scale)
+        o = _rope_last(o, bcos, bsin, rd, inverse=True)
+
+        o = o.reshape(b, block_size, self.n_groups, -1)
+        wo_a = self.wo_a.weight.reshape(self.n_groups, self.o_lora_rank, -1)
+        o = mx.sum(o[..., None, :] * wo_a[None, None, :, :, :], axis=-1)
+        return self.wo_b(o.reshape(b, block_size, self.n_groups * self.o_lora_rank))

--- a/mlx_vlm/speculative/drafters/deepseek_v4_dspark/config.py
+++ b/mlx_vlm/speculative/drafters/deepseek_v4_dspark/config.py
@@ -1,0 +1,99 @@
+import inspect
+from dataclasses import dataclass, field
+from typing import List, Optional
+
+from ....models.base import BaseModelConfig
+
+
+@dataclass
+class DeepseekV4DSparkConfig(BaseModelConfig):
+    """Config for the DSpark self-speculative drafter over a DeepSeek-V4 target.
+
+    The DeepSeek-V4-{Flash,Pro}-DSpark checkpoints ship the draft stack under the
+    ``mtp.*`` namespace of the bundled fp8/fp4 weights and declare the DSpark draft
+    hyper-parameters (``dspark_block_size`` / ``dspark_target_layer_ids`` / ...) on the
+    base ``deepseek_v4`` config. Field names follow the HF/mlx-vlm target config
+    (``hidden_size`` / ``num_attention_heads`` style) so the reused primitives —
+    :class:`DeepseekV4MoE`, :class:`HyperConnection`, :class:`HyperHead` — read it
+    directly. The same config drives both Flash and Pro (only the dims differ).
+    """
+
+    model_type: str = "deepseek_v4_dspark"
+    vocab_size: int = 129280
+    hidden_size: int = 4096
+    num_attention_heads: int = 64
+    num_key_value_heads: int = 1
+    head_dim: int = 512
+    qk_rope_head_dim: int = 64
+    q_lora_rank: int = 1024
+    o_lora_rank: int = 1024
+    o_groups: int = 8
+    attention_bias: bool = False
+    sliding_window: int = 128
+    rms_norm_eps: float = 1e-6
+    rope_theta: float = 10000.0
+    max_position_embeddings: int = 1048576
+
+    # MoE (consumed by the reused DeepseekV4MoE / MoEGate)
+    moe_intermediate_size: int = 2048
+    n_routed_experts: int = 256
+    n_shared_experts: int = 1
+    num_experts_per_tok: int = 6
+    num_hash_layers: int = 3
+    scoring_func: str = "sqrtsoftplus"
+    routed_scaling_factor: float = 1.5
+    norm_topk_prob: bool = True
+    swiglu_limit: float = 10.0
+
+    # Hyper-Connections (consumed by the reused HyperConnection / HyperHead)
+    hc_mult: int = 4
+    hc_sinkhorn_iters: int = 20
+    hc_eps: float = 1e-6
+
+    # DSpark draft stack
+    num_hidden_layers: int = (
+        43  # base depth; draft layer_id = num_hidden_layers + stage
+    )
+    n_mtp_layers: int = 3
+    block_size: int = 5
+    noise_token_id: int = 128799
+    markov_rank: int = 256
+    target_layer_ids: List[int] = field(default_factory=lambda: [40, 41, 42])
+    tie_word_embeddings: bool = False
+    runtime_block_size: Optional[int] = None
+
+    @property
+    def fc_in(self) -> int:
+        """Input width of the stage-0 ``main_proj`` (concatenated target hiddens)."""
+        return self.hidden_size * len(self.target_layer_ids)
+
+    @property
+    def confidence_in(self) -> int:
+        return self.hidden_size + self.markov_rank
+
+    @classmethod
+    def from_dict(cls, params: dict) -> "DeepseekV4DSparkConfig":
+        flat = dict(params)
+        # DSpark draft hyper-parameters are namespaced ``dspark_*`` on the base config.
+        alias = {
+            "dspark_block_size": "block_size",
+            "dspark_noise_token_id": "noise_token_id",
+            "dspark_markov_rank": "markov_rank",
+            "dspark_target_layer_ids": "target_layer_ids",
+            "sliding_window": "sliding_window",
+        }
+        for src, dst in alias.items():
+            if src in flat and dst not in flat:
+                flat[dst] = flat[src]
+        # The published configs only carry the base-MTP depth (num_nextn_predict_layers);
+        # the DSpark draft depth is a distinct field (default 3) confirmable from the
+        # checkpoint's mtp.N count at load.
+        if "n_mtp_layers" not in flat and flat.get("num_nextn_predict_layers"):
+            flat["n_mtp_layers"] = flat["num_nextn_predict_layers"]
+        sig = inspect.signature(cls).parameters
+        kwargs = {k: v for k, v in flat.items() if k in sig}
+        if "target_layer_ids" in kwargs:
+            kwargs["target_layer_ids"] = list(kwargs["target_layer_ids"])
+        return cls(**kwargs)
+
+    from_hf_dict = from_dict

--- a/mlx_vlm/speculative/drafters/deepseek_v4_dspark/dspark.py
+++ b/mlx_vlm/speculative/drafters/deepseek_v4_dspark/dspark.py
@@ -1,0 +1,359 @@
+"""DSpark self-speculative drafter for a DeepSeek-V4 target.
+
+Ports the reference ``inference/model.py`` draft stack (``Transformer.forward_spec`` +
+``DSparkBlock``) into mlx-vlm, reusing the in-tree DeepSeek-V4 primitives that are
+numerically identical to the reference:
+
+* :class:`DeepseekV4MoE` — the hash/score MoE (draft blocks sit at ``layer_id >=
+  num_hash_layers`` so they score-route); exact-match verified vs the reference MoE.
+* :class:`HyperConnection` / :class:`HyperHead` / :func:`hc_expand` — the Hyper-Connection
+  pre/post/head mixing; match the reference ``hc_pre``/``hc_post``/``hc_head`` to ~1e-6.
+* :class:`DSparkMarkovHead` / :class:`DSparkConfidenceHead` — the low-rank Markov logit bias
+  and (bias-free) confidence projection.
+
+Only the windowed MLA cross-attention (``DSparkAttention``) and the RoPE/RMSNorm helpers are
+ported fresh (no in-tree equivalent). The drafter exposes two drivers over the same weights:
+
+* ``forward_spec`` / ``advance`` — the reference windowed API (parity oracle target).
+* ``draft_block`` / ``reset`` / ``make_cache`` — the mlx-vlm speculative round-loop contract
+  (``speculative/dspark.py``). Losslessness comes from the target verify+walk, so the eager
+  ``draft_block`` conditioning need not match ``forward_spec`` bit-for-bit.
+"""
+
+from typing import Any, List, Optional, Tuple
+
+import mlx.core as mx
+import mlx.nn as nn
+
+from ....models.deepseek_v4.hyper_connection import (
+    HyperConnection,
+    HyperHead,
+    hc_expand,
+)
+from ....models.deepseek_v4.language import DeepseekV4MoE
+from .attention import DSparkAttention, DSparkKVCache, RMSNorm
+from .config import DeepseekV4DSparkConfig
+from .heads import DSparkConfidenceHead, DSparkMarkovHead
+
+
+def _sample(logits: mx.array, temperature: float) -> mx.array:
+    """argmax at temperature 0, else Gumbel-max (matches the reference sampler)."""
+    if temperature == 0:
+        return mx.argmax(logits, axis=-1).astype(mx.int32)
+    probs = mx.softmax(logits.astype(mx.float32) / max(temperature, 1e-5), axis=-1)
+    g = mx.random.uniform(shape=probs.shape).astype(mx.float32)
+    return mx.argmax(probs / (-mx.log(g + 1e-20)), axis=-1).astype(mx.int32)
+
+
+class _DSparkWindowCache:
+    """Per-sequence draft state: one sliding window per block + the committed offset."""
+
+    def __init__(self, n_blocks: int, window_size: int):
+        self.windows = [DSparkKVCache(window_size) for _ in range(n_blocks)]
+        self.offset = 0
+
+
+class DeepseekV4DSparkBlock(nn.Module):
+    """One DSpark draft stage: HC(attn) + HC(MoE), with windowed cross-attention.
+
+    Mirrors the reference ``DSparkBlock``/``Block``. Reuses ``DeepseekV4MoE`` for the FFN and
+    ``HyperConnection``/``HyperHead`` for the residual mixing; only ``DSparkAttention`` is the
+    ported windowed MLA. Stage 0 carries ``main_proj``/``main_norm`` (projects the captured
+    target hiddens); the last stage carries the LM-head norm + Markov/confidence heads.
+    """
+
+    def __init__(
+        self, config: DeepseekV4DSparkConfig, stage_id: int, max_seq_len: int = 8192
+    ):
+        super().__init__()
+        self.config = config
+        self.stage_id = stage_id
+        self.is_last = stage_id == config.n_mtp_layers - 1
+        self.block_size = config.block_size
+        self.noise_token_id = config.noise_token_id
+        self.hc_mult = config.hc_mult
+        self.temperature = getattr(config, "temperature", 0.0)
+        layer_id = (
+            config.num_hidden_layers + stage_id
+        )  # >= num_hash_layers → score routing
+
+        self.attn = DSparkAttention(config, max_seq_len)
+        self.ffn = DeepseekV4MoE(config, layer_id)
+        # The official shared expert applies the SwiGLU clamp (reference Expert with
+        # swiglu_limit); DeepseekV4MoE leaves it at the no-clamp default, so set it here.
+        self.ffn.shared_experts.swiglu_limit = config.swiglu_limit
+        self.attn_norm = RMSNorm(config.hidden_size, config.rms_norm_eps)
+        self.ffn_norm = RMSNorm(config.hidden_size, config.rms_norm_eps)
+        self.attn_hc = HyperConnection(config)
+        self.ffn_hc = HyperConnection(config)
+
+        if stage_id == 0:
+            self.main_proj = nn.Linear(config.fc_in, config.hidden_size, bias=False)
+            self.main_norm = RMSNorm(config.hidden_size, config.rms_norm_eps)
+
+        if self.is_last:
+            self.norm = RMSNorm(config.hidden_size, config.rms_norm_eps)
+            self.markov_head = DSparkMarkovHead(config.vocab_size, config.markov_rank)
+            self.confidence_head = DSparkConfidenceHead(
+                config.confidence_in, bias=False
+            )
+            self.hc_head = HyperHead(config)
+
+    def _hc_block(self, x: mx.array, attn_call, input_ids: mx.array) -> mx.array:
+        residual = x
+        h, post, comb = self.attn_hc(x)
+        h = attn_call(self.attn_norm(h))
+        x = hc_expand(h, residual, post, comb)
+
+        residual = x
+        h, post, comb = self.ffn_hc(x)
+        h = self.ffn(self.ffn_norm(h), input_ids)
+        return hc_expand(h, residual, post, comb)
+
+    def __call__(
+        self,
+        x: mx.array,
+        start_pos: int,
+        input_ids: mx.array,
+        main_x: mx.array,
+        window: DSparkKVCache,
+    ) -> mx.array:
+        if start_pos == 0:
+            return self.attn(x, 0, main_x, window)  # prefill: seed window only
+        return self._hc_block(
+            x, lambda h: self.attn(h, start_pos, main_x, window), input_ids
+        )
+
+    def forward_draft(
+        self,
+        x: mx.array,
+        block_start: int,
+        win_valid: int,
+        input_ids: mx.array,
+        window: DSparkKVCache,
+    ) -> mx.array:
+        return self._hc_block(
+            x, lambda h: self.attn.draft(h, block_start, win_valid, window), input_ids
+        )
+
+    def advance(self, main_x: mx.array, position: int, window: DSparkKVCache) -> None:
+        self.attn.advance_window(main_x, position, window)
+
+    def forward_embed(
+        self, main_hidden: mx.array, input_ids: mx.array, embed: nn.Module
+    ) -> Tuple[mx.array, mx.array]:
+        """Stage-0 only: project the main hidden + embed the draft block (anchor + noise)."""
+        main_x = self.main_norm(self.main_proj(main_hidden))
+        b = input_ids.shape[0]
+        anchor = input_ids.reshape(b, 1).astype(mx.int32)
+        noise = mx.full((b, self.block_size - 1), self.noise_token_id, dtype=mx.int32)
+        draft_ids = mx.concatenate([anchor, noise], axis=1)
+        x = embed(draft_ids)
+        x = mx.broadcast_to(
+            x[:, :, None, :], (b, self.block_size, self.hc_mult, x.shape[-1])
+        )
+        return mx.contiguous(x), main_x
+
+    def forward_head(
+        self, x: mx.array, input_ids: mx.array, head: nn.Module
+    ) -> Tuple[mx.array, mx.array, mx.array]:
+        """Last-stage only: draft tokens + (Markov-biased) logits + confidence."""
+        x = self.hc_head(x)
+        logits = head(self.norm(x).astype(mx.float32))  # [b, block_size, vocab]
+        prev = input_ids.astype(mx.int32)
+        out_ids, biased, markov_embeds = [prev], [], []
+        for i in range(self.block_size):
+            bias, membed = self.markov_head(prev)
+            li = logits[:, i] + bias
+            biased.append(li)
+            markov_embeds.append(membed)
+            prev = _sample(li, self.temperature)
+            out_ids.append(prev)
+        output_ids = mx.stack(out_ids, axis=1)
+        logits_out = mx.stack(biased, axis=1)
+        markov_embed = mx.stack(markov_embeds, axis=1)
+        confidence = self.confidence_head(x, markov_embed)
+        return output_ids, logits_out, confidence
+
+
+class DeepseekV4DSparkDraftModel(nn.Module):
+    def __init__(self, config: DeepseekV4DSparkConfig, max_seq_len: int = 8192):
+        super().__init__()
+        self.config = config
+        self.max_seq_len = max_seq_len
+        self.embed = nn.Embedding(config.vocab_size, config.hidden_size)
+        self.head = nn.Linear(config.hidden_size, config.vocab_size, bias=False)
+        self.blocks = [
+            DeepseekV4DSparkBlock(config, i, max_seq_len)
+            for i in range(config.n_mtp_layers)
+        ]
+        self._spec_cache = self.make_cache()
+        self._last_confidence: Optional[mx.array] = None
+        self.accept_lens: List[float] = []
+        self.draft_lens: List[int] = []
+
+    # ---- reference windowed API (parity oracle target) ----------------------------
+
+    def forward_spec(
+        self,
+        input_ids: mx.array,
+        main_hidden: mx.array,
+        start_pos: int = 0,
+        cache: Optional[_DSparkWindowCache] = None,
+    ) -> Optional[Tuple[mx.array, mx.array, mx.array]]:
+        """Prefill (start_pos==0) seeds the window and returns None; decode drafts a block."""
+        cache = cache if cache is not None else self._spec_cache
+        h, main_x = self.blocks[0].forward_embed(main_hidden, input_ids, self.embed)
+        for blk, window in zip(self.blocks, cache.windows):
+            h = blk(h, start_pos, input_ids, main_x, window)
+        if start_pos == 0:
+            return None
+        return self.blocks[-1].forward_head(h, input_ids, self.head)
+
+    def advance(
+        self,
+        main_hidden: mx.array,
+        position: int,
+        cache: Optional[_DSparkWindowCache] = None,
+    ) -> None:
+        """Slide every block's window over one committed token at ``position``."""
+        cache = cache if cache is not None else self._spec_cache
+        mh = main_hidden.reshape(main_hidden.shape[0], -1)
+        b0 = self.blocks[0]
+        main_x = b0.main_norm(b0.main_proj(mh))
+        for blk, window in zip(self.blocks, cache.windows):
+            blk.advance(main_x, position, window)
+
+    # ---- mlx-vlm speculative round-loop contract ----------------------------------
+
+    def make_cache(self) -> _DSparkWindowCache:
+        return _DSparkWindowCache(len(self.blocks), self.config.sliding_window)
+
+    def reset(self, target_model: Any = None) -> _DSparkWindowCache:
+        # DSpark is standalone (own embed/head) — nothing to bind to the target.
+        self.accept_lens = []
+        self.draft_lens = []
+        self._last_confidence = None
+        return self.make_cache()
+
+    def _extend_window(self, cache: _DSparkWindowCache, main_x: mx.array) -> None:
+        """Fold the committed context (projected ``main_x`` [B, S, dim]) into each window."""
+        S = main_x.shape[1]
+        if cache.offset == 0:
+            for blk, window in zip(self.blocks, cache.windows):
+                blk.attn.seed_window(main_x, window)
+        else:
+            for pos in range(S):
+                for blk, window in zip(self.blocks, cache.windows):
+                    blk.advance(main_x[:, pos], cache.offset + pos, window)
+        cache.offset += S
+
+    def draft_block(
+        self,
+        last_bonus,
+        hidden: mx.array,
+        cache: _DSparkWindowCache,
+        block_size: int,
+        sampler,
+        token_dtype: mx.Dtype = mx.int32,
+    ) -> mx.array:
+        if isinstance(last_bonus, int):
+            anchor = mx.array([last_bonus], dtype=token_dtype)
+        else:
+            anchor = last_bonus.reshape(-1).astype(token_dtype)
+        B = hidden.shape[0]
+
+        b0 = self.blocks[0]
+        main_x = b0.main_norm(b0.main_proj(hidden))  # [B, S, dim]
+        self._extend_window(cache, main_x)
+        block_start = win_valid = cache.offset
+
+        noise = mx.full(
+            (B, block_size - 1), int(self.config.noise_token_id), dtype=token_dtype
+        )
+        draft_ids = mx.concatenate([anchor[:, None], noise], axis=1)  # [B, block_size]
+        h = self.embed(draft_ids)
+        h = mx.contiguous(
+            mx.broadcast_to(
+                h[:, :, None, :], (B, block_size, self.config.hc_mult, h.shape[-1])
+            )
+        )
+        for blk, window in zip(self.blocks, cache.windows):
+            h = blk.forward_draft(h, block_start, win_valid, draft_ids, window)
+
+        last = self.blocks[-1]
+        x = last.hc_head(h)  # [B, block_size, dim]
+        base_logits = self.head(last.norm(x).astype(mx.float32))  # [B, block_size, V]
+
+        prev = anchor
+        drafts, markov_embeds = [], []
+        for i in range(block_size):
+            bias, embed = last.markov_head(prev)
+            prev = sampler(base_logits[:, i] + bias).astype(token_dtype)
+            drafts.append(prev)
+            markov_embeds.append(embed)
+        draft_tokens = mx.stack(drafts, axis=1)  # [B, block_size]
+        markov_embed = mx.stack(markov_embeds, axis=1)
+        self._last_confidence = last.confidence_head(x, markov_embed)  # [B, block_size]
+        return draft_tokens
+
+    # ---- checkpoint loading --------------------------------------------------------
+
+    def sanitize(self, weights: dict) -> dict:
+        return _sanitize(weights, self.config)
+
+
+def _sanitize(weights: dict, config: DeepseekV4DSparkConfig) -> dict:
+    """Map a DeepSeek-V4-DSpark checkpoint (``mtp.N.*`` + ``embed``/``head``) to this
+    drafter's param tree, reusing the target's MTP conventions:
+
+    * ``mtp.N.*`` -> ``blocks.N.*``; base-model keys dropped.
+    * hc renames ``hc_{attn,ffn}_{fn,base,scale}`` -> ``{attn,ffn}_hc.{...}``,
+      ``hc_head_*`` -> ``hc_head.*``.
+    * ``ffn.gate.bias`` -> ``ffn.gate.e_score_correction_bias``;
+      ``ffn.shared_experts.{w1,w2,w3}`` -> ``{gate,down,up}_proj``;
+      per-expert ``ffn.experts.{e}.{w1,w2,w3}`` -> stacked
+      ``ffn.switch_mlp.{gate,down,up}_proj``.
+
+    fp8/fp4 dequant of the bundled quantized weights is handled at load time
+    (Phase 3 / real-weight path); ``.scale``/``.scales`` siblings pass through here.
+    """
+    w_remap = {"w1": "gate_proj", "w2": "down_proj", "w3": "up_proj"}
+
+    # 1. keep only embed/head/mtp.*; rename mtp.N -> blocks.N with the inline subs.
+    remapped = {}
+    for k, v in weights.items():
+        if k in ("embed.weight", "head.weight"):
+            remapped[k] = v
+            continue
+        if not k.startswith("mtp."):
+            continue
+        nk = "blocks." + k[len("mtp.") :]
+        nk = nk.replace(".ffn.gate.bias", ".ffn.gate.e_score_correction_bias")
+        for sub in ("attn", "ffn"):
+            for param in ("fn", "base", "scale"):
+                nk = nk.replace(f".hc_{sub}_{param}", f".{sub}_hc.{param}")
+        nk = nk.replace(".hc_head_fn", ".hc_head.fn")
+        nk = nk.replace(".hc_head_base", ".hc_head.base")
+        nk = nk.replace(".hc_head_scale", ".hc_head.scale")
+        for old, new in w_remap.items():
+            nk = nk.replace(f".shared_experts.{old}.", f".shared_experts.{new}.")
+        remapped[nk] = v
+    weights = remapped
+
+    # 2. stack per-expert routed weights into switch_mlp.{gate,down,up}_proj.
+    for stage in range(config.n_mtp_layers):
+        prefix = f"blocks.{stage}.ffn.experts"
+        for src, dst in w_remap.items():
+            for suffix in ("weight", "scales"):
+                key0 = f"{prefix}.0.{src}.{suffix}"
+                if key0 in weights:
+                    stacked = [
+                        weights.pop(f"{prefix}.{e}.{src}.{suffix}")
+                        for e in range(config.n_routed_experts)
+                    ]
+                    weights[f"blocks.{stage}.ffn.switch_mlp.{dst}.{suffix}"] = mx.stack(
+                        stacked
+                    )
+
+    return weights

--- a/mlx_vlm/speculative/drafters/deepseek_v4_dspark/heads.py
+++ b/mlx_vlm/speculative/drafters/deepseek_v4_dspark/heads.py
@@ -1,0 +1,40 @@
+import mlx.core as mx
+import mlx.nn as nn
+
+
+class DSparkMarkovHead(nn.Module):
+    """Low-rank (rank-r) token-transition logit bias.
+
+    ``markov_w1`` embeds a token id into r dims; ``markov_w2`` projects back to
+    vocab logits. Returns ``(logits, embed)`` so the confidence head can reuse the
+    embedding. Weight layout matches the checkpoint: ``markov_w1`` is
+    ``[vocab, rank]`` (embedding) and ``markov_w2`` is ``[vocab, rank]`` (the head,
+    an ``nn.Linear(rank, vocab)`` whose MLX weight is ``[vocab, rank]``).
+    """
+
+    def __init__(self, vocab_size: int, rank: int):
+        super().__init__()
+        self.markov_w1 = nn.Embedding(vocab_size, rank)
+        self.markov_w2 = nn.Linear(rank, vocab_size, bias=False)
+
+    def __call__(self, token_ids: mx.array) -> tuple[mx.array, mx.array]:
+        embed = self.markov_w1(token_ids)
+        logits = self.markov_w2(embed.astype(mx.float32))
+        return logits, embed
+
+
+class DSparkConfidenceHead(nn.Module):
+    """Per-draft-token acceptance score from ``[hidden ‖ markov_embed]``.
+
+    Advisory only in the lossless verify path; it gates adaptive draft length
+    when a confidence threshold is set. DeepSeek-V4 DSpark uses a bias-free
+    projection (the reference ``inference/model.py`` ``DSparkConfidenceHead``).
+    """
+
+    def __init__(self, input_dim: int, bias: bool = False):
+        super().__init__()
+        self.proj = nn.Linear(input_dim, 1, bias=bias)
+
+    def __call__(self, hidden: mx.array, markov_embed: mx.array) -> mx.array:
+        x = mx.concatenate([hidden, markov_embed], axis=-1)
+        return self.proj(x.astype(mx.float32))[..., 0]

--- a/mlx_vlm/speculative/drafters/deepseek_v4_dspark/split.py
+++ b/mlx_vlm/speculative/drafters/deepseek_v4_dspark/split.py
@@ -1,0 +1,173 @@
+"""Split a DeepSeek-V4-{Flash,Pro}-DSpark checkpoint's ``mtp.*`` draft stack into a
+standalone ``deepseek_v4_dspark`` drafter folder.
+
+DSpark extends DeepSeek native MTP, so the draft blocks ship under the ``mtp.*`` namespace
+of the base fp8/fp4 checkpoint (alongside the shared ``embed``/``head``). This mirrors
+``deepseek_v4_mtp.split`` but, like the reference dspark-mlx loader, **dequantizes the draft
+to bf16** rather than keeping it quantized: the ported ``DSparkAttention`` does manual
+grouped ``wo_a`` math (no quantized matmul), and the reference itself runs the drafter in
+bf16/fp32. The structural ``mtp.N.* -> blocks.N.*`` remap + expert stacking is left to
+``DeepseekV4DSparkDraftModel.sanitize`` at load time.
+"""
+
+import argparse
+import json
+import shutil
+from pathlib import Path
+from typing import Dict, Optional
+
+import mlx.core as mx
+from safetensors import safe_open
+
+from ....utils import get_model_path
+from ..deepseek_v4_mtp.split import (
+    _iter_mtp_keys,
+    _load_selected_tensors,
+    _safetensor_files,
+    _text_config,
+)
+
+
+def _load_shared_keys(model_path: Path, keys) -> Dict[str, mx.array]:
+    """Find the shared top-level tensors (``embed.weight`` / ``head.weight``) across shards."""
+    found: Dict[str, mx.array] = {}
+    for file in _safetensor_files(model_path):
+        with safe_open(file, framework="mlx") as f:
+            present = [k for k in keys if k in f.keys() and k not in found]
+        if present:
+            found.update(_load_selected_tensors(file, present))
+    return found
+
+
+def _dequant_to_bf16(weights: Dict[str, mx.array]) -> Dict[str, mx.array]:
+    """Dequantize the fp8(e4m3, 128x128 block) / fp4(e2m1, per-32 group) draft weights to
+    bf16, dropping the ``.scale`` siblings. Mirrors the base model's scale handling
+    (``DeepseekV4MoE`` quant config: mxfp4 experts, mxfp8 attention/shared) inverted via
+    ``mx.dequantize``. Unquantized tensors (norms, hc params, sinks, embed/head) pass through.
+    """
+    out: Dict[str, mx.array] = {}
+    for k, v in weights.items():
+        if k.endswith(".scale"):
+            continue
+        out[k] = v
+
+    for k, v in weights.items():
+        if not k.endswith(".scale"):
+            continue
+        wk = k[: -len(".scale")] + ".weight"
+        weight = weights.get(wk)
+        if weight is None:
+            out[k] = v
+            continue
+        is_fp4_expert = (
+            "ffn.experts." in wk
+            and ".shared_experts." not in wk
+            and weight.dtype in (mx.int8, mx.uint8)
+            and v.shape[-1] * 16 == weight.shape[-1]
+        )
+        if is_fp4_expert:
+            out[wk] = mx.dequantize(
+                weight.view(mx.uint32), v, group_size=32, bits=4, mode="mxfp4"
+            ).astype(mx.bfloat16)
+        elif weight.dtype == mx.uint8:
+            scales = mx.repeat(mx.repeat(v, 4, -1), 128, 0)
+            out[wk] = mx.dequantize(
+                weight.view(mx.uint32), scales, group_size=32, bits=8, mode="mxfp8"
+            ).astype(mx.bfloat16)
+        else:
+            out[wk] = weight  # already dequantized / unquantized
+    return out
+
+
+def _n_mtp_layers(keys) -> int:
+    stages = {int(k.split(".")[1]) for k in keys if k.startswith("mtp.")}
+    return (max(stages) + 1) if stages else 0
+
+
+def split_deepseek_v4_dspark(
+    source: str,
+    output: str,
+    *,
+    revision: Optional[str] = None,
+    force_download: bool = False,
+) -> Path:
+    """Write the DeepSeek-V4 DSpark draft (``mtp.*`` + ``embed``/``head``) to a standalone
+    bf16 drafter folder routable as ``model_type='deepseek_v4_dspark'``."""
+    source_path = get_model_path(
+        source, revision=revision, force_download=force_download
+    )
+    output_path = Path(output)
+    output_path.mkdir(parents=True, exist_ok=True)
+
+    with open(source_path / "config.json") as f:
+        source_config = json.load(f)
+    text_config = _text_config(source_config)
+
+    selected = {}
+    for file, keys in _iter_mtp_keys(source_path):
+        keys = [
+            k for k in keys if not k.endswith("tid2eid")
+        ]  # draft blocks score-route
+        selected.update(_load_selected_tensors(file, keys))
+    if not selected:
+        raise ValueError(f"No mtp.* tensors found in {source_path}.")
+    # embed/head are shared with the base; pull them from wherever they live.
+    selected.update(_load_shared_keys(source_path, ("embed.weight", "head.weight")))
+
+    selected = _dequant_to_bf16(selected)
+    n_mtp = _n_mtp_layers(selected)
+
+    mx.save_safetensors(
+        str(output_path / "model.safetensors"),
+        selected,
+        metadata={"format": "mlx"},
+    )
+
+    draft_config = {
+        k: v
+        for k, v in text_config.items()
+        if k
+        not in ("quantization", "quantization_config", "architectures", "model_type")
+    }
+    draft_config["model_type"] = "deepseek_v4_dspark"
+    if n_mtp:
+        draft_config["n_mtp_layers"] = n_mtp
+    with open(output_path / "config.json", "w") as f:
+        json.dump(dict(sorted(draft_config.items())), f, indent=2)
+
+    for name in (
+        "tokenizer.json",
+        "tokenizer_config.json",
+        "vocab.json",
+        "merges.txt",
+        "special_tokens_map.json",
+        "generation_config.json",
+        "chat_template.jinja",
+    ):
+        src = source_path / name
+        if src.exists():
+            shutil.copy(src, output_path / name)
+
+    return output_path
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Split a DeepSeek-V4-DSpark checkpoint's mtp.* draft into a "
+        "standalone bf16 MLX drafter."
+    )
+    parser.add_argument("--model", "--source", dest="source", required=True)
+    parser.add_argument("--output", required=True)
+    parser.add_argument("--revision", default=None)
+    parser.add_argument("--force-download", action="store_true")
+    return parser
+
+
+def main():
+    args = build_parser().parse_args()
+    output = split_deepseek_v4_dspark(**vars(args))
+    print(f"Wrote DeepSeek-V4 DSpark drafter to {output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/mlx_vlm/speculative/dspark.py
+++ b/mlx_vlm/speculative/dspark.py
@@ -1,0 +1,282 @@
+"""DSpark self-speculative round loops.
+
+DSpark drafts a block of ``K`` tokens from the anchor's own position outward, biased by a
+low-rank Markov head, then the target verifies ``[anchor, d_1..d_K]`` in one forward and a
+greedy walk accepts the longest matching prefix. Output is bit-identical to base greedy
+decoding for any draft proposal — the proposal only changes how many tokens are confirmed
+per target forward.
+
+When ``MLX_VLM_DRAFT_CONFIDENCE_THRESHOLD`` > 0, the (advisory) confidence head truncates the
+draft block where ``P(accept)`` falls below the threshold. This only shortens *speculation
+depth* before verify — the emitted stream stays lossless — so it trades acceptance for fewer
+wasted draft positions. Confidence gating is applied on the single-sequence path; batched
+continuous decoding uses a fixed block (still lossless).
+"""
+
+import os
+from typing import Any, Callable, Generator, List, Optional, Tuple
+
+import mlx.core as mx
+import mlx.nn as nn
+import numpy as np
+
+from .common import (
+    _dflash_block_total,
+    _record_speculative_round,
+    _speculative_walk,
+    _speculative_walk_batch,
+    generation_stream,
+)
+from .dflash import _dflash_committed_hidden_segments
+
+
+def _dspark_confidence_threshold() -> float:
+    raw = os.environ.get("MLX_VLM_DRAFT_CONFIDENCE_THRESHOLD")
+    if not raw:
+        return 0.0
+    try:
+        return max(0.0, float(raw))
+    except ValueError:
+        return 0.0
+
+
+def _confident_prefix_length(
+    confidence_logits: mx.array, block_size: int, threshold: float
+) -> int:
+    """Keep the draft prefix while ``sigmoid(confidence) >= threshold``.
+
+    ``threshold <= 0`` disables gating (always the full block). Truncating here is lossless:
+    the target still verifies whatever is drafted, so the emitted tokens are unchanged.
+    """
+    if threshold <= 0.0:
+        return block_size
+    probs = 1.0 / (
+        1.0 + np.exp(-np.array(confidence_logits).astype(np.float32).reshape(-1))
+    )
+    below = np.nonzero(probs < threshold)[0]
+    return int(below[0]) if below.size else block_size
+
+
+def _require_rollback(lm) -> None:
+    if not hasattr(lm, "rollback_speculative_cache"):
+        raise RuntimeError(
+            f"{type(lm).__name__} does not implement rollback_speculative_cache. "
+            "DSpark speculative decoding requires a DeepSeek-V4 (or compatible) target."
+        )
+
+
+def _dspark_rounds(
+    model: nn.Module,
+    draft_model: nn.Module,
+    prompt_cache: List[Any],
+    hidden: mx.array,
+    *,
+    first_bonus: int,
+    max_tokens: int,
+    sampler: Callable[[mx.array], mx.array],
+    draft_block_size: Optional[int] = None,
+    token_dtype: mx.Dtype = mx.int32,
+) -> Generator[Tuple[int, None], None, None]:
+    """Single-sequence DSpark round loop: draft → (confidence gate) → verify → walk → rollback.
+
+    ``generate_step`` handles prefill, sampling the first bonus token, and packaging the
+    captured target hidden states into ``hidden``.
+    """
+    lm = model.language_model if hasattr(model, "language_model") else model
+    _require_rollback(lm)
+
+    target_layer_ids = list(draft_model.config.target_layer_ids)
+    block_total = _dflash_block_total(draft_model, draft_block_size)
+    threshold = _dspark_confidence_threshold()
+    draft_cache = draft_model.reset(model)
+
+    b = first_bonus
+    emitted = 1  # the first bonus has already been yielded by the caller
+
+    while emitted < max_tokens:
+        K = min(block_total, max_tokens - emitted)
+        if K < 1:
+            break
+
+        drafts = draft_model.draft_block(
+            b, hidden, draft_cache, K, sampler, token_dtype
+        )
+        if threshold > 0.0 and draft_model._last_confidence is not None:
+            keff = _confident_prefix_length(draft_model._last_confidence, K, threshold)
+            if keff < K:
+                drafts = drafts[:, :keff]
+        n_draft = int(drafts.shape[1])
+        mx.async_eval(drafts)
+
+        with mx.stream(generation_stream):
+            verify_input = mx.concatenate(
+                [mx.array([[b]], dtype=token_dtype), drafts], axis=1
+            )
+            verify_out = lm(
+                verify_input, cache=prompt_cache, capture_layer_ids=target_layer_ids
+            )
+            hidden = mx.concatenate(verify_out.hidden_states, axis=-1)
+            target_tokens = sampler(verify_out.logits)
+        mx.async_eval(target_tokens, hidden)
+
+        accepted, new_tokens = _speculative_walk(
+            drafts, target_tokens, max_tokens - emitted
+        )
+        _record_speculative_round(draft_model, accepted, n_draft)
+
+        for tok in new_tokens:
+            yield tok, None
+            emitted += 1
+            if emitted >= max_tokens:
+                return
+
+        if accepted < n_draft:
+            hidden = hidden[:, : accepted + 1, :]
+        b = new_tokens[-1] if new_tokens else b
+
+        if accepted < n_draft:
+            with mx.stream(generation_stream):
+                lm.rollback_speculative_cache(
+                    prompt_cache,
+                    getattr(verify_out, "gdn_states", None),
+                    accepted,
+                    n_draft + 1,
+                )
+
+        if emitted % 256 == 0:
+            mx.clear_cache()
+
+
+def _dspark_rounds_batch(
+    model: nn.Module,
+    draft_model: nn.Module,
+    prompt_cache: List[Any],
+    hidden: mx.array,
+    *,
+    first_bonus: mx.array,
+    max_tokens: int,
+    sampler: Callable[[mx.array], mx.array],
+    draft_block_size: Optional[int] = None,
+    token_dtype: mx.Dtype = mx.int32,
+    stop_check: Optional[Callable[[int, int], bool]] = None,
+) -> Generator[Tuple[List[Optional[int]], None], None, None]:
+    """Batch DSpark round loop (B > 1) with continuous batching.
+
+    Lossless, fixed block size (confidence gating is single-sequence only). When a sequence
+    finishes it is filtered out of the target caches and dropped from the active set.
+    """
+    lm = model.language_model if hasattr(model, "language_model") else model
+    _require_rollback(lm)
+
+    B = first_bonus.shape[0]
+    target_layer_ids = list(draft_model.config.target_layer_ids)
+    block_total = _dflash_block_total(draft_model, draft_block_size)
+    draft_model.reset(model)
+    draft_caches = [draft_model.make_cache() for _ in range(B)]
+
+    b = first_bonus.tolist()
+    emitted = [1] * B
+    finished = [False] * B
+    active_idx = list(range(B))
+    hidden_by_orig = [hidden[i : i + 1] for i in range(B)]
+    total_emitted = sum(emitted)
+
+    while len(active_idx) > 0:
+        remaining = [
+            max(1, max_tokens - emitted[active_idx[j]]) for j in range(len(active_idx))
+        ]
+        K = min(block_total, min(remaining))
+        if K < 1:
+            break
+
+        n_active = len(active_idx)
+        b_active = [b[active_idx[j]] for j in range(n_active)]
+        b_arr = mx.array(b_active, dtype=token_dtype)
+
+        # Draft rowwise: the drafter cache is scalar-offset; verify stays batched below.
+        draft_tokens = mx.concatenate(
+            [
+                draft_model.draft_block(
+                    int(b_active[j]),
+                    hidden_by_orig[active_idx[j]],
+                    draft_caches[active_idx[j]],
+                    K,
+                    sampler,
+                    token_dtype,
+                )
+                for j in range(n_active)
+            ],
+            axis=0,
+        )
+        mx.async_eval(draft_tokens)
+
+        with mx.stream(generation_stream):
+            verify_input = mx.concatenate([b_arr[:, None], draft_tokens], axis=1)
+            verify_out = lm(
+                verify_input, cache=prompt_cache, capture_layer_ids=target_layer_ids
+            )
+            hidden_full = mx.concatenate(verify_out.hidden_states, axis=-1)
+            target_tokens = sampler(verify_out.logits)
+        mx.async_eval(target_tokens, hidden_full)
+
+        budgets = [max_tokens - emitted[active_idx[j]] for j in range(n_active)]
+        accepted_list, new_tokens_list = _speculative_walk_batch(
+            draft_tokens, target_tokens, budgets
+        )
+        min_accepted = min(accepted_list)
+        accepted_arr = mx.array(accepted_list)
+
+        hidden_segments = _dflash_committed_hidden_segments(
+            hidden_full, new_tokens_list
+        )
+        for j in range(n_active):
+            orig = active_idx[j]
+            if hidden_segments[j].shape[1] > 0:
+                hidden_by_orig[orig] = hidden_segments[j]
+
+        for a in accepted_list:
+            _record_speculative_round(draft_model, a, K)
+
+        max_new = max(len(nt) for nt in new_tokens_list) if new_tokens_list else 0
+        for pos in range(max_new):
+            tokens_out: List[Optional[int]] = [None] * B
+            for j in range(n_active):
+                orig = active_idx[j]
+                if pos < len(new_tokens_list[j]) and not finished[orig]:
+                    tok = new_tokens_list[j][pos]
+                    tokens_out[orig] = tok
+                    emitted[orig] += 1
+                    if emitted[orig] >= max_tokens:
+                        finished[orig] = True
+                    if stop_check is not None and stop_check(orig, tok):
+                        finished[orig] = True
+            yield tokens_out, None
+
+        for j in range(n_active):
+            orig = active_idx[j]
+            if new_tokens_list[j]:
+                b[orig] = new_tokens_list[j][-1]
+
+        if min_accepted < K:
+            with mx.stream(generation_stream):
+                lm.rollback_speculative_cache(
+                    prompt_cache,
+                    getattr(verify_out, "gdn_states", None),
+                    accepted_arr,
+                    K + 1,
+                )
+
+        keep_slots = [j for j in range(n_active) if not finished[active_idx[j]]]
+        if len(keep_slots) < n_active:
+            if len(keep_slots) == 0:
+                break
+            keep_mx = mx.array(keep_slots, dtype=mx.int32)
+            for c in prompt_cache:
+                if hasattr(c, "filter"):
+                    c.filter(keep_mx)
+            active_idx = [active_idx[j] for j in keep_slots]
+
+        new_total = sum(emitted)
+        if new_total // 256 > total_emitted // 256:
+            mx.clear_cache()
+        total_emitted = new_total

--- a/mlx_vlm/speculative/utils.py
+++ b/mlx_vlm/speculative/utils.py
@@ -17,6 +17,7 @@ from .dflash import (
     _dflash_rounds,
     _dflash_rounds_batch,
 )
+from .dspark import _dspark_rounds, _dspark_rounds_batch
 from .eagle3 import _eagle3_capture_layer_ids, _eagle3_rounds, _eagle3_rounds_batch
 from .mtp import (
     _buffer_mtp_target_cache,
@@ -75,8 +76,11 @@ def get_speculative_rounds_batch(draft_kind: str):
         return _mtp_rounds_batch
     if draft_kind == "dflash":
         return _dflash_rounds_batch
+    if draft_kind == "dspark":
+        return _dspark_rounds_batch
     raise ValueError(
-        f"Unknown draft_kind {draft_kind!r}. Supported: ['dflash', 'eagle3', 'mtp']"
+        f"Unknown draft_kind {draft_kind!r}. "
+        "Supported: ['dflash', 'dspark', 'eagle3', 'mtp']"
     )
 
 
@@ -85,20 +89,22 @@ def speculative_prefill_kwargs(draft_kind: str, drafter) -> dict:
         return {"return_hidden": True, "return_shared_kv": True}
     if draft_kind == "eagle3":
         return {"capture_layer_ids": _eagle3_capture_layer_ids(drafter)}
-    if draft_kind == "dflash":
+    if draft_kind in ("dflash", "dspark"):
         return {"capture_layer_ids": list(drafter.config.target_layer_ids)}
     raise ValueError(
-        f"Unknown draft_kind {draft_kind!r}. Supported: ['dflash', 'eagle3', 'mtp']"
+        f"Unknown draft_kind {draft_kind!r}. "
+        "Supported: ['dflash', 'dspark', 'eagle3', 'mtp']"
     )
 
 
 def speculative_hidden_state(draft_kind: str, outputs):
     if draft_kind == "mtp":
         return outputs.hidden_states[-1]
-    if draft_kind in ("dflash", "eagle3"):
+    if draft_kind in ("dflash", "dspark", "eagle3"):
         return mx.concatenate(outputs.hidden_states, axis=-1)
     raise ValueError(
-        f"Unknown draft_kind {draft_kind!r}. Supported: ['dflash', 'eagle3', 'mtp']"
+        f"Unknown draft_kind {draft_kind!r}. "
+        "Supported: ['dflash', 'dspark', 'eagle3', 'mtp']"
     )
 
 
@@ -192,8 +198,11 @@ def run_speculative_server_rounds(
         )
         return
 
-    if draft_kind == "dflash":
-        yield from _dflash_rounds_batch(
+    if draft_kind in ("dflash", "dspark"):
+        rounds_batch = (
+            _dspark_rounds_batch if draft_kind == "dspark" else _dflash_rounds_batch
+        )
+        yield from rounds_batch(
             model,
             draft_model,
             prompt_cache,
@@ -208,7 +217,8 @@ def run_speculative_server_rounds(
         return
 
     raise ValueError(
-        f"Unknown draft_kind {draft_kind!r}. Supported: ['dflash', 'eagle3', 'mtp']"
+        f"Unknown draft_kind {draft_kind!r}. "
+        "Supported: ['dflash', 'dspark', 'eagle3', 'mtp']"
     )
 
 
@@ -326,17 +336,22 @@ def run_speculative_rounds(
             )
         return
 
-    if draft_kind != "dflash":
+    if draft_kind not in ("dflash", "dspark"):
         raise ValueError(
-            f"Unknown draft_kind {draft_kind!r}. Supported: ['dflash', 'eagle3', 'mtp']"
+            f"Unknown draft_kind {draft_kind!r}. "
+            "Supported: ['dflash', 'dspark', 'eagle3', 'mtp']"
         )
 
+    rounds = _dspark_rounds if draft_kind == "dspark" else _dflash_rounds
+    rounds_batch = (
+        _dspark_rounds_batch if draft_kind == "dspark" else _dflash_rounds_batch
+    )
     hidden = mx.concatenate(last_outputs.hidden_states, axis=-1)
     if B == 1:
         mx.eval(first_token)
         bonus = first_token.item()
         yield bonus, logprobs
-        yield from _dflash_rounds(
+        yield from rounds(
             model,
             draft_model,
             prompt_cache,
@@ -351,7 +366,7 @@ def run_speculative_rounds(
         mx.eval(first_token)
         first_bonus = first_token.squeeze(-1)
         yield first_bonus.tolist(), logprobs
-        yield from _dflash_rounds_batch(
+        yield from rounds_batch(
             model,
             draft_model,
             prompt_cache,

--- a/mlx_vlm/tests/test_deepseek_v4_dspark.py
+++ b/mlx_vlm/tests/test_deepseek_v4_dspark.py
@@ -1,0 +1,621 @@
+"""Tests for the DeepSeek-V4 DSpark self-speculative drafter.
+
+Covers config mapping (Flash/Pro-driven), the checkpoint sanitize key roundtrip, draft_block
+shapes, numerical parity of ``forward_spec`` against the dspark-mlx reference drafter (the
+validated MLX port of the official ``inference/model.py``; env/import-gated), and the
+losslessness of the single- and batched round loops.
+"""
+
+import json
+import os
+from pathlib import Path
+
+import mlx.core as mx
+import numpy as np
+import pytest
+from mlx.utils import tree_flatten, tree_unflatten
+
+from mlx_vlm.models.base import LanguageModelOutput
+from mlx_vlm.speculative.drafters import (
+    _config_is_dspark,
+    resolve_drafter_kind,
+    validate_drafter_compatibility,
+)
+from mlx_vlm.speculative.drafters.deepseek_v4_dspark import (
+    DeepseekV4DSparkConfig as ModelConfig,
+)
+from mlx_vlm.speculative.drafters.deepseek_v4_dspark import (
+    DeepseekV4DSparkDraftModel as Model,
+)
+from mlx_vlm.speculative.dspark import _dspark_rounds, _dspark_rounds_batch
+from mlx_vlm.utils import get_model_and_args
+
+# Tiny config that exercises every path (score-routed MoE, HC, windowed attn, 2 stages).
+TINY_CONFIG = dict(
+    model_type="deepseek_v4_dspark",
+    vocab_size=32,
+    hidden_size=16,
+    num_attention_heads=4,
+    num_key_value_heads=1,
+    head_dim=16,
+    qk_rope_head_dim=8,
+    q_lora_rank=16,
+    o_lora_rank=8,
+    o_groups=2,
+    sliding_window=8,
+    rope_theta=10000.0,
+    moe_intermediate_size=16,
+    n_routed_experts=4,
+    n_shared_experts=1,
+    num_experts_per_tok=2,
+    num_hash_layers=0,
+    scoring_func="sqrtsoftplus",
+    routed_scaling_factor=1.5,
+    norm_topk_prob=True,
+    swiglu_limit=10.0,
+    hc_mult=4,
+    hc_sinkhorn_iters=20,
+    num_hidden_layers=2,
+    n_mtp_layers=2,
+    block_size=4,
+    noise_token_id=31,
+    markov_rank=8,
+    target_layer_ids=[0, 1],
+)
+
+
+def _greedy_argmax(logits):
+    return mx.argmax(logits, axis=-1).astype(mx.int32)
+
+
+# --------------------------------------------------------------------------- config
+
+
+def test_config_from_dict_maps_dspark_fields():
+    cfg = ModelConfig.from_dict(
+        {
+            "model_type": "deepseek_v4",
+            "hidden_size": 7168,
+            "num_hidden_layers": 61,
+            "num_attention_heads": 128,
+            "n_routed_experts": 384,
+            "o_groups": 16,
+            "q_lora_rank": 1536,
+            "sliding_window": 128,
+            "dspark_block_size": 5,
+            "dspark_noise_token_id": 128799,
+            "dspark_target_layer_ids": [58, 59, 60],
+            "dspark_markov_rank": 512,
+        }
+    )
+    # Pro-scale dims absorbed; dspark_* fields mapped to the drafter's plain names.
+    assert cfg.hidden_size == 7168
+    assert cfg.n_routed_experts == 384
+    assert cfg.o_groups == 16
+    assert cfg.block_size == 5
+    assert cfg.noise_token_id == 128799
+    assert cfg.target_layer_ids == [58, 59, 60]
+    assert cfg.markov_rank == 512
+    assert cfg.fc_in == 7168 * 3
+
+
+def test_config_defaults_are_flash_scale():
+    cfg = ModelConfig()
+    assert cfg.hidden_size == 4096
+    assert cfg.num_hidden_layers == 43
+    assert cfg.n_routed_experts == 256
+    assert cfg.n_mtp_layers == 3
+    assert cfg.fc_in == 4096 * 3
+
+
+# --------------------------------------------------------------------------- routing
+
+
+def test_config_is_dspark_detects_deepseek_v4():
+    assert _config_is_dspark({"model_type": "deepseek_v4_dspark"})
+    # the base combined checkpoint carries the dspark_* hyper-parameters
+    assert _config_is_dspark({"model_type": "deepseek_v4", "dspark_block_size": 5})
+    # a plain DeepSeek-V4 base config (the target) is NOT a DSpark drafter
+    assert not _config_is_dspark({"model_type": "deepseek_v4", "hidden_size": 4096})
+
+
+def test_resolve_drafter_kind_for_deepseek_v4_dspark(tmp_path):
+    d = Path(tmp_path)
+    (d / "config.json").write_text(json.dumps({"model_type": "deepseek_v4_dspark"}))
+    assert resolve_drafter_kind(d, None) == "dspark"
+    assert resolve_drafter_kind(d, "dspark") == "dspark"
+    # a mistaken kind is corrected to dspark
+    assert resolve_drafter_kind(d, "mtp") == "dspark"
+
+
+def test_get_model_and_args_routes_to_deepseek_v4_dspark():
+    arch, model_type = get_model_and_args(dict(TINY_CONFIG))
+    assert model_type == "deepseek_v4_dspark"
+    assert arch.Model is Model
+
+
+def test_validate_compatibility_requires_matching_hidden_and_rollback():
+    model = Model(ModelConfig.from_dict(TINY_CONFIG))
+
+    class _LM:
+        config = {"hidden_size": TINY_CONFIG["hidden_size"]}
+
+        def rollback_speculative_cache(self, *a):
+            return 0
+
+    class _Target:
+        language_model = _LM()
+
+    validate_drafter_compatibility(_Target(), model, "dspark")  # ok
+
+    class _BadHidden(_LM):
+        config = {"hidden_size": 2048}
+
+    class _TargetBad:
+        language_model = _BadHidden()
+
+    with pytest.raises(ValueError, match="hidden_size"):
+        validate_drafter_compatibility(_TargetBad(), model, "dspark")
+
+    class _NoRollback:
+        config = {"hidden_size": TINY_CONFIG["hidden_size"]}
+
+    with pytest.raises(ValueError, match="rollback_speculative_cache"):
+        validate_drafter_compatibility(_NoRollback(), model, "dspark")
+
+
+# --------------------------------------------------------------------------- sanitize
+
+
+def _drafter_key_to_checkpoint(key: str):
+    """Invert sanitize: a drafter param path -> the checkpoint key(s) that produce it."""
+    if key in ("embed.weight", "head.weight"):
+        return [key]
+    assert key.startswith("blocks.")
+    ck = "mtp." + key[len("blocks.") :]
+    ck = ck.replace(".ffn.gate.e_score_correction_bias", ".ffn.gate.bias")
+    for sub in ("attn", "ffn"):
+        for p in ("fn", "base", "scale"):
+            ck = ck.replace(f".{sub}_hc.{p}", f".hc_{sub}_{p}")
+    ck = (
+        ck.replace(".hc_head.fn", ".hc_head_fn")
+        .replace(".hc_head.base", ".hc_head_base")
+        .replace(".hc_head.scale", ".hc_head_scale")
+        .replace(".shared_experts.gate_proj.", ".shared_experts.w1.")
+        .replace(".shared_experts.down_proj.", ".shared_experts.w2.")
+        .replace(".shared_experts.up_proj.", ".shared_experts.w3.")
+    )
+    return [ck]
+
+
+def test_drafter_param_keys_roundtrip_through_sanitize():
+    cfg = ModelConfig.from_dict(TINY_CONFIG)
+    model = Model(cfg)
+    mx.eval(model.parameters())
+    params = dict(tree_flatten(model.parameters()))
+
+    # Build a synthetic checkpoint (mtp.* + per-expert experts) from the param tree.
+    checkpoint = {}
+    w_inv = {"gate_proj": "w1", "down_proj": "w2", "up_proj": "w3"}
+    for key, value in params.items():
+        if ".ffn.switch_mlp." in key:
+            stage = key.split(".")[1]
+            proj = key.split(".")[4]  # gate_proj / down_proj / up_proj
+            for e in range(cfg.n_routed_experts):
+                ck = f"mtp.{stage}.ffn.experts.{e}.{w_inv[proj]}.weight"
+                checkpoint[ck] = value[e]
+        else:
+            for ck in _drafter_key_to_checkpoint(key):
+                checkpoint[ck] = value
+    # base-model keys must be dropped
+    checkpoint["model.layers.0.attn.wkv.weight"] = mx.zeros((4, 4))
+
+    out = model.sanitize(checkpoint)
+    assert set(out.keys()) == set(params.keys())
+    # the stacked routed experts are reconstructed at full [E, ...] shape
+    sm = "blocks.0.ffn.switch_mlp.gate_proj.weight"
+    assert out[sm].shape == params[sm].shape
+
+
+# --------------------------------------------------------------------------- draft_block
+
+
+def test_draft_block_shapes_and_window_growth():
+    cfg = ModelConfig.from_dict(TINY_CONFIG)
+    model = Model(cfg)
+    mx.eval(model.parameters())
+    cache = model.reset(None)
+    assert len(cache.windows) == cfg.n_mtp_layers
+    assert cache.offset == 0
+
+    prompt_len = 5
+    ctx = (mx.random.normal((1, prompt_len, cfg.fc_in)) * 0.1).astype(mx.float32)
+    drafts = model.draft_block(7, ctx, cache, cfg.block_size, _greedy_argmax)
+    mx.eval(drafts, model._last_confidence)
+    assert drafts.shape == (1, cfg.block_size)
+    assert model._last_confidence.shape == (1, cfg.block_size)
+    # Only the committed context advances the window offset (not the drafted block).
+    assert cache.offset == prompt_len
+    assert all(0 <= t < cfg.vocab_size for t in drafts.tolist()[0])
+
+    # A second round advances the window by the newly committed segment.
+    seg = (mx.random.normal((1, 3, cfg.fc_in)) * 0.1).astype(mx.float32)
+    model.draft_block(
+        int(drafts[0, -1].item()), seg, cache, cfg.block_size, _greedy_argmax
+    )
+    assert cache.offset == prompt_len + 3
+
+
+# --------------------------------------------------------------------------- losslessness
+
+
+class _StubCache:
+    def __init__(self):
+        self.offset = 0
+
+    def trim(self, n):
+        self.offset -= n
+
+
+class _MarkovTarget:
+    """History-independent Markov target: logits at position i depend only on input_i."""
+
+    def __init__(self, transition, embed, n_targets):
+        self.transition = transition
+        self.embed = embed
+        self.n_targets = n_targets
+
+    def __call__(self, inputs, cache=None, capture_layer_ids=None, **kw):
+        L = inputs.shape[1]
+        logits = self.transition[inputs]
+        hid = self.embed[inputs]
+        if cache is not None:
+            for c in cache:
+                c.offset += L
+        n = len(capture_layer_ids) if capture_layer_ids else self.n_targets
+        return LanguageModelOutput(logits=logits, hidden_states=[hid] * n)
+
+    def rollback_speculative_cache(self, caches, gdn, accepted, block_size):
+        if isinstance(accepted, mx.array):
+            accepted = int(accepted.max().item())
+        n = int(accepted) + 1
+        trim = block_size - n
+        for c in caches:
+            if trim > 0:
+                c.trim(trim)
+        return int(accepted)
+
+
+def _markov_world(vocab, hid, n_targets, seed=0):
+    rng = np.random.default_rng(seed)
+    transition = mx.array(rng.standard_normal((vocab, vocab)).astype(np.float32))
+    embed = mx.array((rng.standard_normal((vocab, hid)) * 0.1).astype(np.float32))
+    return transition, embed, rng
+
+
+def _plain_greedy(transition, start, n):
+    out, t = [], int(start)
+    for _ in range(n):
+        t = int(mx.argmax(transition[t]).item())
+        out.append(t)
+    return out
+
+
+@pytest.mark.parametrize("threshold", [0.0, 0.5, 0.9])
+def test_dspark_rounds_lossless(monkeypatch, threshold):
+    monkeypatch.setenv("MLX_VLM_DRAFT_CONFIDENCE_THRESHOLD", str(threshold))
+    vocab, hid, nt = TINY_CONFIG["vocab_size"], TINY_CONFIG["hidden_size"], 2
+    transition, embed, rng = _markov_world(vocab, hid, nt)
+    model = Model(ModelConfig.from_dict(TINY_CONFIG))
+    mx.eval(model.parameters())
+    target = _MarkovTarget(transition, embed, nt)
+
+    prompt = mx.array(rng.integers(0, vocab, size=(1, 6)).astype(np.int32))
+    prompt_cache = [_StubCache() for _ in range(nt)]
+    for c in prompt_cache:
+        c.offset = prompt.shape[1]
+    last = int(prompt[0, -1].item())
+    first_bonus = int(mx.argmax(transition[last]).item())
+    hidden = mx.concatenate([embed[prompt]] * nt, axis=-1)
+
+    max_tokens = 30
+    out = [first_bonus]
+    for tok, _ in _dspark_rounds(
+        target,
+        model,
+        prompt_cache,
+        hidden,
+        first_bonus=first_bonus,
+        max_tokens=max_tokens,
+        sampler=_greedy_argmax,
+    ):
+        out.append(tok)
+
+    assert out == _plain_greedy(transition, last, max_tokens)
+    assert len(out) == max_tokens
+
+
+def test_dspark_rounds_batch_lossless():
+    vocab, hid, nt, B = TINY_CONFIG["vocab_size"], TINY_CONFIG["hidden_size"], 2, 3
+    transition, embed, rng = _markov_world(vocab, hid, nt, seed=1)
+    model = Model(ModelConfig.from_dict(TINY_CONFIG))
+    mx.eval(model.parameters())
+    target = _MarkovTarget(transition, embed, nt)
+
+    prompt = mx.array(rng.integers(0, vocab, size=(B, 6)).astype(np.int32))
+    prompt_cache = [_StubCache() for _ in range(nt)]
+    for c in prompt_cache:
+        c.offset = prompt.shape[1]
+    lasts = [int(prompt[i, -1].item()) for i in range(B)]
+    first_bonus = mx.array([int(mx.argmax(transition[t]).item()) for t in lasts])
+    hidden = mx.concatenate([embed[prompt]] * nt, axis=-1)
+
+    max_tokens = 20
+    seqs = [[int(first_bonus[i].item())] for i in range(B)]
+    for tokens_out, _ in _dspark_rounds_batch(
+        target,
+        model,
+        prompt_cache,
+        hidden,
+        first_bonus=first_bonus,
+        max_tokens=max_tokens,
+        sampler=_greedy_argmax,
+    ):
+        for i in range(B):
+            if tokens_out[i] is not None and len(seqs[i]) < max_tokens:
+                seqs[i].append(tokens_out[i])
+
+    for i in range(B):
+        assert seqs[i] == _plain_greedy(transition, lasts[i], max_tokens), f"row {i}"
+
+
+# --------------------------------------------------------------------------- split
+
+
+def _synthetic_source_checkpoint(tmp_path) -> Path:
+    """A tiny bf16 'combined' checkpoint: mtp.* draft + shared embed/head + a base key."""
+    cfg = ModelConfig.from_dict(TINY_CONFIG)
+    model = Model(cfg)
+    mx.eval(model.parameters())
+    params = dict(tree_flatten(model.parameters()))
+
+    w_inv = {"gate_proj": "w1", "down_proj": "w2", "up_proj": "w3"}
+    checkpoint = {}
+    for key, value in params.items():
+        if ".ffn.switch_mlp." in key:
+            stage, proj = key.split(".")[1], key.split(".")[4]
+            for e in range(cfg.n_routed_experts):
+                checkpoint[f"mtp.{stage}.ffn.experts.{e}.{w_inv[proj]}.weight"] = value[
+                    e
+                ].astype(mx.bfloat16)
+        else:
+            for ck in _drafter_key_to_checkpoint(key):
+                checkpoint[ck] = value.astype(mx.bfloat16)
+    # a base-model tensor that split must drop
+    checkpoint["model.layers.0.attn.wkv.weight"] = mx.zeros((4, 4), dtype=mx.bfloat16)
+
+    src = Path(tmp_path) / "source"
+    src.mkdir()
+    mx.save_safetensors(str(src / "model.safetensors"), checkpoint)
+    source_config = {
+        k: v
+        for k, v in TINY_CONFIG.items()
+        if k
+        not in (
+            "model_type",
+            "block_size",
+            "noise_token_id",
+            "markov_rank",
+            "target_layer_ids",
+            "n_mtp_layers",
+        )
+    }
+    source_config["model_type"] = "deepseek_v4"
+    source_config["dspark_block_size"] = TINY_CONFIG["block_size"]
+    source_config["dspark_noise_token_id"] = TINY_CONFIG["noise_token_id"]
+    source_config["dspark_markov_rank"] = TINY_CONFIG["markov_rank"]
+    source_config["dspark_target_layer_ids"] = TINY_CONFIG["target_layer_ids"]
+    (src / "config.json").write_text(json.dumps(source_config))
+    return src
+
+
+def test_split_extracts_dequantized_drafter(tmp_path):
+    from mlx_vlm.speculative.drafters.deepseek_v4_dspark.split import (
+        split_deepseek_v4_dspark,
+    )
+
+    src = _synthetic_source_checkpoint(tmp_path)
+    out = split_deepseek_v4_dspark(str(src), str(Path(tmp_path) / "drafter"))
+
+    out_config = json.loads((out / "config.json").read_text())
+    assert out_config["model_type"] == "deepseek_v4_dspark"
+    assert out_config["n_mtp_layers"] == TINY_CONFIG["n_mtp_layers"]
+    assert "quantization" not in out_config and "quantization_config" not in out_config
+
+    weights = mx.load(str(out / "model.safetensors"))
+    # base-model tensors are dropped; mtp.* + shared embed/head are kept
+    assert not any(k.startswith("model.layers.") for k in weights)
+    assert "embed.weight" in weights and "head.weight" in weights
+    assert any(k.startswith("mtp.0.") for k in weights)
+
+    # the split drafter loads and drafts through the package's own sanitize
+    cfg = ModelConfig.from_dict(out_config)
+    drafter = Model(cfg)
+    sanitized = drafter.sanitize(weights)
+    assert set(sanitized.keys()) == {k for k, _ in tree_flatten(drafter.parameters())}
+    drafter.load_weights(list(sanitized.items()))
+    mx.eval(drafter.parameters())
+    cache = drafter.reset(None)
+    ctx = (mx.random.normal((1, 5, cfg.fc_in)) * 0.1).astype(mx.bfloat16)
+    drafts = drafter.draft_block(7, ctx, cache, cfg.block_size, _greedy_argmax)
+    mx.eval(drafts)
+    assert drafts.shape == (1, cfg.block_size)
+
+
+# --------------------------------------------------------------------- real weights (gated)
+
+_SOURCE_ENV = "DSPARK_DEEPSEEK_V4_SOURCE"
+
+
+@pytest.mark.skipif(
+    not os.environ.get(_SOURCE_ENV),
+    reason=f"set {_SOURCE_ENV} to a DeepSeek-V4-DSpark checkpoint dir/repo",
+)
+def test_real_checkpoint_splits_loads_and_drafts(tmp_path):
+    from mlx_vlm.speculative.drafters.deepseek_v4_dspark.split import (
+        split_deepseek_v4_dspark,
+    )
+
+    out = split_deepseek_v4_dspark(os.environ[_SOURCE_ENV], str(Path(tmp_path) / "d"))
+    cfg = ModelConfig.from_dict(json.loads((out / "config.json").read_text()))
+    drafter = Model(cfg)
+    weights = drafter.sanitize(mx.load(str(out / "model.safetensors")))
+    drafter.load_weights(list(weights.items()))
+    mx.eval(drafter.parameters())
+
+    cache = drafter.reset(None)
+    ctx = (mx.random.normal((1, 8, cfg.fc_in)) * 0.1).astype(mx.bfloat16)
+    drafts = drafter.draft_block(5, ctx, cache, cfg.block_size, _greedy_argmax)
+    mx.eval(drafts)
+    ids = drafts.tolist()[0]
+    assert len(ids) == cfg.block_size
+    assert all(0 <= t < cfg.vocab_size for t in ids)
+    assert len(set(ids)) > 1  # trained weights shouldn't collapse the block
+
+
+# --------------------------------------------------------- numerical parity (oracle-gated)
+
+
+def _make_oracle_args():
+    """Equivalent DSparkArgs for the dspark-mlx reference drafter."""
+    from dspark_mlx.model.config import DSparkArgs
+
+    return DSparkArgs(
+        dim=TINY_CONFIG["hidden_size"],
+        moe_inter_dim=TINY_CONFIG["moe_intermediate_size"],
+        n_layers=TINY_CONFIG["num_hidden_layers"],
+        n_mtp_layers=TINY_CONFIG["n_mtp_layers"],
+        n_hash_layers=0,
+        n_heads=TINY_CONFIG["num_attention_heads"],
+        n_routed_experts=TINY_CONFIG["n_routed_experts"],
+        n_shared_experts=1,
+        n_activated_experts=TINY_CONFIG["num_experts_per_tok"],
+        score_func="sqrtsoftplus",
+        route_scale=TINY_CONFIG["routed_scaling_factor"],
+        swiglu_limit=TINY_CONFIG["swiglu_limit"],
+        q_lora_rank=TINY_CONFIG["q_lora_rank"],
+        head_dim=TINY_CONFIG["head_dim"],
+        rope_head_dim=TINY_CONFIG["qk_rope_head_dim"],
+        o_groups=TINY_CONFIG["o_groups"],
+        o_lora_rank=TINY_CONFIG["o_lora_rank"],
+        window_size=TINY_CONFIG["sliding_window"],
+        vocab_size=TINY_CONFIG["vocab_size"],
+        hc_mult=TINY_CONFIG["hc_mult"],
+        hc_sinkhorn_iters=TINY_CONFIG["hc_sinkhorn_iters"],
+        dspark_block_size=TINY_CONFIG["block_size"],
+        dspark_noise_token_id=TINY_CONFIG["noise_token_id"],
+        dspark_target_layer_ids=tuple(TINY_CONFIG["target_layer_ids"]),
+        dspark_markov_rank=TINY_CONFIG["markov_rank"],
+        temperature=0.0,
+    )
+
+
+def _bridge_oracle_key(name: str) -> str:
+    """dspark-mlx DSparkDrafter param path -> this drafter's param path."""
+    nk = name.replace(".ffn.gate.bias", ".ffn.gate.e_score_correction_bias")
+    for a, b in (
+        (".hc_attn_fn", ".attn_hc.fn"),
+        (".hc_attn_base", ".attn_hc.base"),
+        (".hc_attn_scale", ".attn_hc.scale"),
+        (".hc_ffn_fn", ".ffn_hc.fn"),
+        (".hc_ffn_base", ".ffn_hc.base"),
+        (".hc_ffn_scale", ".ffn_hc.scale"),
+        (".hc_head_fn", ".hc_head.fn"),
+        (".hc_head_base", ".hc_head.base"),
+        (".hc_head_scale", ".hc_head.scale"),
+        (".shared_experts.w1.", ".shared_experts.gate_proj."),
+        (".shared_experts.w2.", ".shared_experts.down_proj."),
+        (".shared_experts.w3.", ".shared_experts.up_proj."),
+    ):
+        nk = nk.replace(a, b)
+    if nk.endswith(".ffn.w1"):
+        nk = nk[: -len(".w1")] + ".switch_mlp.gate_proj.weight"
+    elif nk.endswith(".ffn.w3"):
+        nk = nk[: -len(".w3")] + ".switch_mlp.up_proj.weight"
+    elif nk.endswith(".ffn.w2"):
+        nk = nk[: -len(".w2")] + ".switch_mlp.down_proj.weight"
+    return nk
+
+
+@pytest.mark.parametrize("ctx_scale", [1.0, 2.0])
+def test_forward_spec_matches_dspark_mlx_oracle(ctx_scale):
+    """Numerical parity vs the validated dspark-mlx reference (== official model.py)."""
+    pytest.importorskip("dspark_mlx")
+    from dspark_mlx.model.drafter import DSparkDrafter
+
+    mx.random.seed(11)
+    args = _make_oracle_args()
+    oracle = DSparkDrafter(args, max_seq_len=64)
+    mine = Model(ModelConfig.from_dict(TINY_CONFIG), max_seq_len=64)
+    mx.eval(oracle.parameters(), mine.parameters())
+
+    # Identical random weights into both (large shared-expert weights trip the clamp).
+    rand = {}
+    for k, v in tree_flatten(oracle.parameters()):
+        scale = 4.0 if ".shared_experts." in k else (0.5 if ".ffn.w" in k else 0.2)
+        rand[k] = (mx.random.normal(v.shape) * scale).astype(v.dtype)
+    oracle.update(tree_unflatten(list(rand.items())))
+    mine.update(tree_unflatten([(_bridge_oracle_key(k), v) for k, v in rand.items()]))
+    mx.eval(oracle.parameters(), mine.parameters())
+
+    S = 6
+    ctx = (mx.random.normal((1, S, args.main_proj_in)) * ctx_scale).astype(mx.float32)
+    anchor = mx.array([7], dtype=mx.int32)
+
+    oracle.forward_spec(anchor, ctx, start_pos=0)
+    o_ids, o_logits, o_conf = oracle.forward_spec(
+        anchor, ctx[:, -1:, :], start_pos=S - 1
+    )
+    mine.forward_spec(anchor, ctx, start_pos=0)
+    m_ids, m_logits, m_conf = mine.forward_spec(anchor, ctx[:, -1:, :], start_pos=S - 1)
+    mx.eval(o_ids, o_logits, o_conf, m_ids, m_logits, m_conf)
+
+    assert bool(mx.all(o_ids == m_ids).item())
+    assert mx.max(mx.abs(o_logits - m_logits)).item() < 1e-3
+    assert mx.max(mx.abs(o_conf - m_conf)).item() < 1e-3
+
+
+def test_advance_window_matches_dspark_mlx_oracle():
+    """Parity of the advance/multi-step windowing path vs the reference."""
+    pytest.importorskip("dspark_mlx")
+    from dspark_mlx.model.drafter import DSparkDrafter
+
+    mx.random.seed(13)
+    args = _make_oracle_args()
+    oracle = DSparkDrafter(args, max_seq_len=64)
+    mine = Model(ModelConfig.from_dict(TINY_CONFIG), max_seq_len=64)
+    mx.eval(oracle.parameters(), mine.parameters())
+    rand = {}
+    for k, v in tree_flatten(oracle.parameters()):
+        rand[k] = (mx.random.normal(v.shape) * 0.2).astype(v.dtype)
+    oracle.update(tree_unflatten(list(rand.items())))
+    mine.update(tree_unflatten([(_bridge_oracle_key(k), v) for k, v in rand.items()]))
+    mx.eval(oracle.parameters(), mine.parameters())
+
+    S0 = 4
+    full = mx.random.normal((1, S0 + 2, args.main_proj_in)).astype(mx.float32)
+    seed, c1, c2 = full[:, :S0], full[:, S0], full[:, S0 + 1]
+    anchor = mx.array([9], dtype=mx.int32)
+
+    for drafter in (oracle, mine):
+        drafter.forward_spec(anchor, seed, start_pos=0)
+        drafter.advance(c1, S0)
+        drafter.advance(c2, S0 + 1)
+
+    o = oracle.forward_spec(anchor, full[:, S0 + 1 : S0 + 2], start_pos=S0 + 1)
+    m = mine.forward_spec(anchor, full[:, S0 + 1 : S0 + 2], start_pos=S0 + 1)
+    mx.eval(*o, *m)
+
+    assert bool(mx.all(o[0] == m[0]).item())
+    assert mx.max(mx.abs(o[1] - m[1])).item() < 1e-3
+    assert mx.max(mx.abs(o[2] - m[2])).item() < 1e-3

--- a/mlx_vlm/tests/test_speculative.py
+++ b/mlx_vlm/tests/test_speculative.py
@@ -3056,6 +3056,71 @@ def test_deepseek_v4_returns_mtp_hidden_and_trims_without_snapshot():
     assert logits.shape == (1, 1, cfg.vocab_size)
 
 
+def _tiny_deepseek_v4_capture_config(num_hidden_layers=2):
+    cfg = _tiny_deepseek_v4_config()
+    cfg.num_hidden_layers = num_hidden_layers
+    cfg.compress_ratios = [0] * num_hidden_layers
+    return cfg
+
+
+def test_deepseek_v4_capture_layer_ids_returns_hc_mean_per_layer():
+    cfg = _tiny_deepseek_v4_capture_config(num_hidden_layers=2)
+    lm = deepseek_language.LanguageModel(cfg)
+    inputs = mx.array([[1, 2, 3, 4]], dtype=mx.int32)
+
+    out = lm(inputs, cache=lm.make_cache(), capture_layer_ids=[0, 1])
+    mx.eval(out.logits, *out.hidden_states)
+
+    # One reduced hidden per target layer, each [B, L, hidden] (the hc_mult
+    # Hyper-Connection copies are averaged away), not [B, L, hc_mult * hidden].
+    assert len(out.hidden_states) == 2
+    for h in out.hidden_states:
+        assert h.shape == (1, 4, cfg.hidden_size)
+
+    # Capture is additive — it must not perturb the base logits.
+    plain = lm(inputs, cache=lm.make_cache())
+    mx.eval(plain.logits)
+    assert mx.allclose(out.logits, plain.logits, atol=1e-5)
+
+
+def test_deepseek_v4_capture_matches_mtp_last_hidden_mean():
+    # The last layer's capture must equal the MTP full-hc hidden reduced over
+    # the hc_mult copies (reference Transformer.forward: h.mean(dim=2)).
+    cfg = _tiny_deepseek_v4_capture_config(num_hidden_layers=1)
+    lm = deepseek_language.LanguageModel(cfg)
+    inputs = mx.array([[1, 2, 3]], dtype=mx.int32)
+
+    mtp = lm(inputs, cache=lm.make_cache(), return_hidden=True)
+    cap = lm(inputs, cache=lm.make_cache(), capture_layer_ids=[0])
+    mx.eval(mtp.hidden_states[-1], cap.hidden_states[0])
+
+    assert mtp.hidden_states[-1].shape == (1, 3, cfg.hc_mult, cfg.hidden_size)
+    assert cap.hidden_states[0].shape == (1, 3, cfg.hidden_size)
+    assert mx.allclose(
+        mtp.hidden_states[-1].mean(axis=2), cap.hidden_states[0], atol=1e-5
+    )
+
+
+def test_deepseek_v4_capture_preserves_layer_order_and_mtp_path():
+    cfg = _tiny_deepseek_v4_capture_config(num_hidden_layers=2)
+    lm = deepseek_language.LanguageModel(cfg)
+    inputs = mx.array([[5, 6, 7]], dtype=mx.int32)
+
+    both = lm(inputs, cache=lm.make_cache(), capture_layer_ids=[0, 1])
+    last_only = lm(inputs, cache=lm.make_cache(), capture_layer_ids=[1])
+    mx.eval(both.hidden_states[1], last_only.hidden_states[0])
+
+    # Hiddens are emitted in increasing layer-id order, so [0,1][1] == [1][0].
+    assert len(last_only.hidden_states) == 1
+    assert mx.allclose(both.hidden_states[1], last_only.hidden_states[0], atol=1e-5)
+
+    # With no capture requested, the MTP full-hc last-hidden path is intact.
+    mtp = lm(inputs, cache=lm.make_cache(), return_hidden=True)
+    mx.eval(mtp.hidden_states[-1])
+    assert len(mtp.hidden_states) == 1
+    assert mtp.hidden_states[-1].shape == (1, 3, cfg.hc_mult, cfg.hidden_size)
+
+
 def test_deepseek_v4_replay_snapshot_required_only_when_pooling_can_cross_window():
     pool = PoolingCache(4)
     pool.accumulate_windows(mx.array([[[10.0]]]), mx.ones((1, 1, 1)), offset=0)


### PR DESCRIPTION
## DeepSeek-V4 Flash/Pro DSpark self-speculative decoding

Adds [DSpark](https://github.com/deepseek-ai/DeepSpec) self-speculative decoding for **DeepSeek-V4 (Flash and Pro)**. Self-contained against `main` — it brings its own DSpark round loop + dispatch wiring (the generic foundation also shared with the separate Gemma 4 DSpark PR #1465, but this PR does not depend on it). One config drives both sizes. Output is byte-identical to base greedy decoding.

> Independent of #1465: both PRs introduce the generic DSpark foundation (`speculative/dspark.py` round loop, the `dspark` dispatch kind, the CLI flag). They can be reviewed and merged in either order; whichever lands second has a trivial overlap on those shared files.

### How it works
DSpark is an EAGLE-style drafter that conditions on the target's intermediate hidden states, drafts a block of tokens biased by a low-rank Markov head, and exposes a confidence head; the target verifies losslessly. The DeepSeek-V4 draft is the windowed-MLA + hash-MoE + Hyper-Connection realization that ships under the `mtp.*` namespace of the base fp8/fp4 checkpoint.

### Target change
`mlx_vlm/models/deepseek_v4/language.py`: add `capture_layer_ids` to `DeepseekV4Model`/`LanguageModel` so the target exposes per-layer hiddens at the DSpark target layers. Each captured hidden is the Hyper-Connection copies reduced via `h.mean(axis=2)` — matching the reference `Transformer.forward`. Capture is **additive**: base logits and the existing MTP last-hidden path are unchanged.

### Drafter — reuse over re-implementation
`mlx_vlm/speculative/drafters/deepseek_v4_dspark/`. Reuse-vs-port decided by numerical micro-probes, not assumption:

| Component | Decision | Parity vs reference |
|-----------|----------|---------------------|
| `DeepseekV4MoE` (hash/score MoE) | **reuse** | exact (0.0) |
| `HyperConnection` / `HyperHead` / `hc_expand` | **reuse** | ~1e-6 |
| Markov / confidence heads | **reuse** (bias-free for V4) | identical |
| Windowed MLA cross-attention + RoPE/RMSNorm | **port** (no in-tree equivalent) | — |

The drafter exposes both the reference windowed API (`forward_spec`/`advance`) and the mlx-vlm round-loop contract (`draft_block`/`reset`/`make_cache`). It also corrects a shared-expert SwiGLU clamp the official spec applies but `DeepseekV4MoE` currently omits.

### Wiring + real-weight path
- Routes `model_type=deepseek_v4_dspark` to the package and maps it to the `dspark` round-loop kind (same model_type→package convention as `deepseek_v4_mtp`). CLI: `--draft-kind dspark`, `--draft-confidence-threshold`.
- `split.py` extracts the `mtp.*` draft + shared `embed`/`head` from the base fp8/fp4 checkpoint and **dequantizes to bf16** (the reference runs a bf16/fp32 drafter; the ported attention does manual grouped `wo_a` math), mirroring `deepseek_v4_mtp.split`.

```sh
python -m mlx_vlm.speculative.drafters.deepseek_v4_dspark.split \
  --model deepseek-ai/DeepSeek-V4-Flash-DSpark --output ./dsv4-flash-dspark-drafter
mlx_vlm.generate --model deepseek-ai/DeepSeek-V4-Flash \
  --draft-model ./dsv4-flash-dspark-drafter --max-tokens 256 --temperature 0 \
  --prompt "Explain speculative decoding in 3 sentences."
```

### Validation
The validator is **numerical parity against [dspark-mlx](https://github.com/popfido/dspark-mlx)** — the validated MLX port of the official `inference/model.py` (which is CUDA/tilelang-bound and can't run on Mac). On identical random weights, the ported `forward_spec` matches the reference drafter:

- tokens **identical**; logits **~1.8e-7**; confidence **~2.4e-7**
- shared-expert clamp tripped: tokens identical, confidence ~3.4e-4
- `advance`/multi-step windowing: logits ~1.5e-7

`mlx_vlm/tests/test_deepseek_v4_dspark.py`: config mapping (Flash/Pro), sanitize key roundtrip, `draft_block` shapes, single/batch **losslessness** (output == base greedy via a Markov-stub target), routing, the split path, and oracle-gated `forward_spec`/`advance` parity (skipped if `dspark_mlx` isn't importable).

### Test plan
- [x] `pytest mlx_vlm/tests/test_deepseek_v4_dspark.py` — 16 passed, 1 skipped (CI); 11 passed with the parity oracle on path
- [x] `pytest mlx_vlm/tests/test_speculative.py` — no regressions (166 passed / 1 skipped together with the DSpark suite + oracle)
- [x] pre-commit (black 24.2.0 / isort / autoflake) clean
- [ ] **Real-weight run on a DeepSeek-V4-DSpark checkpoint** — gated behind `DSPARK_DEEPSEEK_V4_SOURCE` (`test_real_checkpoint_splits_loads_and_drafts`). The fp8/fp4 dequant in `split` follows the base model's quantization-config inverse but is validated on-machine, not in CI. **Benchmark numbers (speedup / acceptance) to follow once run on real weights.**
