### PR TITLE
fix(deepseek_v4): clamp shared-expert SwiGLU to swiglu_limit

### DIFF
--- a/mlx_vlm/models/deepseek_v4/language.py
+++ b/mlx_vlm/models/deepseek_v4/language.py
@@ -405,6 +405,7 @@ class DeepseekV4MoE(nn.Module):
         self.shared_experts = DeepseekV4MLP(
             config,
             intermediate_size=config.moe_intermediate_size * config.n_shared_experts,
+            swiglu_limit=config.swiglu_limit,
         )
         self.sharding_group = None
 

--- a/mlx_vlm/tests/test_speculative.py
+++ b/mlx_vlm/tests/test_speculative.py
@@ -2422,6 +2422,49 @@ def _tiny_deepseek_v4_config():
     )
 
 
+def test_deepseek_v4_shared_expert_applies_swiglu_limit():
+    # The shared expert must clamp gate/up pre-activations to swiglu_limit,
+    # exactly like the routed experts (reference inference/model.py MoE.__init__
+    # builds the shared Expert with swiglu_limit). Without the clamp, large
+    # pre-activations -- common with production fp4 weights -- diverge silently.
+    cfg = _tiny_deepseek_v4_config()
+    limit = cfg.swiglu_limit
+    assert limit > 0
+
+    moe = deepseek_language.DeepseekV4MoE(cfg, layer_idx=0)
+    shared = moe.shared_experts
+    assert shared.swiglu_limit == limit
+
+    hidden = cfg.hidden_size
+    inter = cfg.moe_intermediate_size * cfg.n_shared_experts
+
+    # x = ones, so gate_proj(x)[i] == sum of row i. Spread each target evenly
+    # across the input dim to hit exact, known pre-activations.
+    x = mx.ones((1, 1, hidden), dtype=mx.float32)
+    gate_targets = mx.array([limit + 5.0, -3.0, limit + 5.0, -3.0])[:inter]
+    up_targets = mx.array([limit + 5.0, -(limit + 5.0), 2.0, 2.0])[:inter]
+    shared.gate_proj.weight = mx.broadcast_to(
+        (gate_targets / hidden)[:, None], (inter, hidden)
+    )
+    shared.up_proj.weight = mx.broadcast_to(
+        (up_targets / hidden)[:, None], (inter, hidden)
+    )
+
+    gate = shared.gate_proj(x)
+    up = shared.up_proj(x)
+    clamped = shared.down_proj(
+        nn.silu(mx.minimum(gate, limit)) * mx.clip(up, -limit, limit)
+    )
+    unclamped = shared.down_proj(nn.silu(gate) * up)
+    out = shared(x)
+    mx.eval(out, clamped, unclamped)
+
+    assert mx.allclose(out, clamped, atol=1e-5)
+    # The clamp must actually change the result for these pre-activations,
+    # otherwise the test would pass even if the limit were dropped.
+    assert not mx.allclose(clamped, unclamped, atol=1e-3)
+
+
 def test_eagle3_config_uses_speculators_fields():
     cfg = Eagle3Config.from_dict(
         {

--- a/mlx_vlm/tests/test_speculative.py
+++ b/mlx_vlm/tests/test_speculative.py
@@ -2422,49 +2422,6 @@ def _tiny_deepseek_v4_config():
     )
 
 
-def test_deepseek_v4_shared_expert_applies_swiglu_limit():
-    # The shared expert must clamp gate/up pre-activations to swiglu_limit,
-    # exactly like the routed experts (reference inference/model.py MoE.__init__
-    # builds the shared Expert with swiglu_limit). Without the clamp, large
-    # pre-activations -- common with production fp4 weights -- diverge silently.
-    cfg = _tiny_deepseek_v4_config()
-    limit = cfg.swiglu_limit
-    assert limit > 0
-
-    moe = deepseek_language.DeepseekV4MoE(cfg, layer_idx=0)
-    shared = moe.shared_experts
-    assert shared.swiglu_limit == limit
-
-    hidden = cfg.hidden_size
-    inter = cfg.moe_intermediate_size * cfg.n_shared_experts
-
-    # x = ones, so gate_proj(x)[i] == sum of row i. Spread each target evenly
-    # across the input dim to hit exact, known pre-activations.
-    x = mx.ones((1, 1, hidden), dtype=mx.float32)
-    gate_targets = mx.array([limit + 5.0, -3.0, limit + 5.0, -3.0])[:inter]
-    up_targets = mx.array([limit + 5.0, -(limit + 5.0), 2.0, 2.0])[:inter]
-    shared.gate_proj.weight = mx.broadcast_to(
-        (gate_targets / hidden)[:, None], (inter, hidden)
-    )
-    shared.up_proj.weight = mx.broadcast_to(
-        (up_targets / hidden)[:, None], (inter, hidden)
-    )
-
-    gate = shared.gate_proj(x)
-    up = shared.up_proj(x)
-    clamped = shared.down_proj(
-        nn.silu(mx.minimum(gate, limit)) * mx.clip(up, -limit, limit)
-    )
-    unclamped = shared.down_proj(nn.silu(gate) * up)
-    out = shared(x)
-    mx.eval(out, clamped, unclamped)
-
-    assert mx.allclose(out, clamped, atol=1e-5)
-    # The clamp must actually change the result for these pre-activations,
-    # otherwise the test would pass even if the limit were dropped.
-    assert not mx.allclose(clamped, unclamped, atol=1e-3)
-
-
 def test_eagle3_config_uses_speculators_fields():
     cfg = Eagle3Config.from_dict(
         {


### PR DESCRIPTION
## Summary

`DeepseekV4MoE.__init__` built the shared expert **without** `swiglu_limit`, so `DeepseekV4MLP` fell back to its default `swiglu_limit=0.0` and skipped the SwiGLU gate/up clamp that the routed experts already apply via `LimitedSwiGLU(config.swiglu_limit)`.

Effect: the target model's shared-expert output diverges from the DeepSeek-V4 spec whenever a shared gate/up pre-activation exceeds `±swiglu_limit` (default `10.0`). It's silent on small activations, but a real numerical divergence with production fp4 weights.

### Fix

Pass `swiglu_limit=config.swiglu_limit` to the shared `DeepseekV4MLP` so the shared and routed expert paths clamp identically (`DeepseekV4MLP.__init__` already accepts the argument):

```diff
 self.shared_experts = DeepseekV4MLP(
     config,
     intermediate_size=config.moe_intermediate_size * config.n_shared_experts,
+    swiglu_limit=config.swiglu_limit,
 )
```

## Cross-validation against two independent references

**1. Official DeepSeek-V4** (`inference/model.py`, `class MoE.__init__`) builds the shared expert *with* the clamp:

```python
self.shared_experts = Expert(args.dim, args.moe_inter_dim, swiglu_limit=args.swiglu_limit)
```

and `Expert.forward` applies `up = clamp(up, -limit, limit); gate = clamp(gate, max=limit)` when `swiglu_limit > 0`.

**2. [antirez/ds4](https://github.com/antirez/ds4)** — an independent, from-scratch C inference engine for DeepSeek-V4 — passes the clamp `DS4_SWIGLU_CLAMP_EXP` (default `10.0f`) at **every** shared-expert SwiGLU site:

| Path | Location |
| --- | --- |
| CPU one-shot (`layer_shared_ffn_one`) | `ds4.c:7080` |
| CPU decode (`layer_shared_ffn_one_decode_scratch`) | `ds4.c:7110` |
| CPU batch (`layer_shared_ffn_batch`) | `ds4.c:7167` |
| Metal/CUDA shared expert + dispatch | `ds4.c:15531`, `14818 / 14954 / 15140` |

Its `swiglu()` (`ds4.c:7042`) implements `g = min(g, clamp); u = clip(u, -clamp, clamp); silu(g) * u` — identical semantics to `_limited_swiglu` in this file, and the default clamp (`10.0`) matches `config.swiglu_limit`.

Both references treat the shared expert exactly like the routed experts with respect to the SwiGLU clamp. This PR brings mlx-vlm in line.

## Test

Adds `test_deepseek_v4_shared_expert_applies_swiglu_limit`, which drives shared-expert gate/up pre-activations past the clamp and asserts the output matches the manually-clamped reference **and differs from the unclamped path** (so the test fails if the limit is ever dropped).

- `pytest mlx_vlm/tests/test_speculative.py -k deepseek_v4` — all green, including the new test.
- Reverting the one-line fix makes the new test fail — confirmed it's a real regression guard, not a tautology.
