### PR TITLE
Enable APC with speculative batching

### DIFF
--- a/mlx_vlm/apc.py
+++ b/mlx_vlm/apc.py
@@ -3710,10 +3710,13 @@ def harvest_blocks_from_batch_cache(
     for c in batch_caches:
         keys = getattr(c, "keys", None)
         values = getattr(c, "values", None)
-        idx = getattr(c, "_idx", None)
         left_padding = getattr(c, "left_padding", None)
-        if keys is None or values is None or idx is None:
+        if keys is None or values is None:
             return []
+
+        if batch_idx < 0 or batch_idx >= keys.shape[0]:
+            return []
+
         # Pull this batch row, dropping any left-padding for this seq.
         if left_padding is not None:
             try:
@@ -3722,6 +3725,27 @@ def harvest_blocks_from_batch_cache(
                 lp = 0
         else:
             lp = 0
+
+        idx = getattr(c, "_idx", None)
+        if idx is None:
+            # Regular KVCache (non-batch), e.g. singleton speculative prefill,
+            # carries ``offset`` instead of ``_idx``.
+            offset = getattr(c, "offset", None)
+            if offset is None:
+                return []
+            try:
+                if isinstance(offset, mx.array) and offset.ndim > 0:
+                    idx = lp + int(offset[batch_idx].item())
+                else:
+                    idx = int(offset.item()) if hasattr(offset, "item") else int(offset)
+            except Exception:
+                return []
+        elif isinstance(idx, mx.array):
+            try:
+                idx = int(idx.item()) if idx.ndim == 0 else int(idx[batch_idx].item())
+            except Exception:
+                return []
+
         # shape after slicing: [1, H, idx-lp, D]
         layer_keys.append(keys[batch_idx : batch_idx + 1, :, lp:idx, :])
         layer_values.append(values[batch_idx : batch_idx + 1, :, lp:idx, :])

--- a/mlx_vlm/generate/ar.py
+++ b/mlx_vlm/generate/ar.py
@@ -2095,7 +2095,6 @@ class BatchGenerator:
         self.draft_block_size = draft_block_size
         self.greedy_sampling = greedy_sampling or sampler is None
         if self.draft_model is not None:
-            apc_manager = None
             compute_logprobs = False
             top_logprobs_k = 0
             self.compute_logprobs = False

--- a/mlx_vlm/server/generation.py
+++ b/mlx_vlm/server/generation.py
@@ -1217,10 +1217,6 @@ class ResponseGenerator:
             self._run_diffusion(diffusion_family)
             return
 
-        if self.draft_model is not None and self.draft_kind != "mtp":
-            self._run_speculative()
-            return
-
         generation_stream = mx.default_stream(mx.default_device())
 
         batch_gen = None
@@ -1237,7 +1233,7 @@ class ResponseGenerator:
                     if (
                         not active_batch
                         and self.draft_model is not None
-                        and self.draft_kind == "mtp"
+                        and self.draft_kind is not None
                     )
                     else 0.0
                 )

--- a/mlx_vlm/tests/test_apc.py
+++ b/mlx_vlm/tests/test_apc.py
@@ -813,6 +813,35 @@ def test_harvest_blocks_from_batch_cache_drops_left_padding():
     source_manager.release(full_blocks + short_blocks)
 
 
+def test_harvest_blocks_from_batch_cache_accepts_singleton_kv_offset():
+    from mlx_lm.models.cache import KVCache
+
+    block_size = 16
+    manager = APCManager(num_blocks=8, block_size=block_size)
+    token_ids = list(range(2 * block_size))
+    layer_keys, layer_values = _make_fake_kv(seq_len=len(token_ids))
+
+    caches = []
+    for keys, values in zip(layer_keys, layer_values):
+        c = KVCache()
+        c.keys = keys
+        c.values = values
+        c.offset = len(token_ids)
+        caches.append(c)
+
+    harvested = harvest_blocks_from_batch_cache(
+        manager,
+        caches,
+        batch_idx=0,
+        full_token_ids=token_ids,
+    )
+
+    assert len(harvested) == 2
+    matched, matched_tokens = manager.lookup_prefix(token_ids)
+    assert matched_tokens == 2 * block_size
+    manager.release(matched + harvested)
+
+
 def test_disk_metadata_mismatch_is_a_miss(tmp_path):
     block_size = 16
     token_ids = list(range(block_size))

--- a/mlx_vlm/tests/test_generate.py
+++ b/mlx_vlm/tests/test_generate.py
@@ -507,6 +507,29 @@ class TestBatchGenerator:
         assert len(gen._generation_batch) == 0
         assert gen.uid_count == 0
 
+    @pytest.mark.parametrize("draft_kind", ["dflash", "eagle3", "mtp"])
+    def test_speculative_initialization_keeps_apc_manager(
+        self, mock_model, mock_processor, draft_kind
+    ):
+        manager = apc_module.APCManager(num_blocks=4, block_size=16)
+        gen = BatchGenerator(
+            model=mock_model.language_model,
+            processor=mock_processor,
+            apc_manager=manager,
+            draft_model=SimpleNamespace(),
+            draft_kind=draft_kind,
+            compute_logprobs=True,
+            top_logprobs_k=4,
+        )
+
+        try:
+            assert gen.apc_manager is manager
+            assert gen.apc_mode == "block"
+            assert gen.compute_logprobs is False
+            assert gen.top_logprobs_k == 0
+        finally:
+            gen.close()
+
     def test_insert_prompts(self, mock_model, mock_processor):
         gen = BatchGenerator(
             model=mock_model.language_model,

--- a/mlx_vlm/tests/test_server.py
+++ b/mlx_vlm/tests/test_server.py
@@ -3878,9 +3878,13 @@ class TestResponseGenerator:
                 (str(uid * 10 + 1), "length"),
             ]
 
-    def test_run_routes_mtp_through_batch_generator(self, monkeypatch):
+    @pytest.mark.parametrize("draft_kind", ["dflash", "eagle3", "mtp"])
+    def test_run_routes_speculative_through_batch_generator(
+        self, monkeypatch, draft_kind
+    ):
         batch_state = {}
         draft_model = object()
+        apc_manager = object()
 
         class FakeDetokenizer:
             def __init__(self):
@@ -3964,7 +3968,7 @@ class TestResponseGenerator:
         gen.kv_quant_scheme = server.DEFAULT_KV_QUANT_SCHEME
         gen.quantized_kv_start = server.DEFAULT_QUANTIZED_KV_START
         gen.top_logprobs_k = 0
-        gen.apc_manager = None
+        gen.apc_manager = apc_manager
         gen.tokenizer = SimpleNamespace()
         gen.requests = Queue()
         gen._stop = False
@@ -3979,11 +3983,13 @@ class TestResponseGenerator:
             gen.config = SimpleNamespace()
             gen.stop_tokens = set()
             gen.draft_model = draft_model
-            gen.draft_kind = "mtp"
+            gen.draft_kind = draft_kind
             gen.tokenizer = SimpleNamespace()
 
         gen._initialize_model = fake_initialize_model
-        gen._run_speculative = lambda: pytest.fail("MTP should use BatchGenerator")
+        gen._run_speculative = lambda: pytest.fail(
+            "Speculative decoding should use BatchGenerator"
+        )
         gen._gpu_embed = lambda raw_inputs, images=None: (
             mx.array([[raw_inputs["request_id"]]], dtype=mx.int32),
             {},
@@ -4020,13 +4026,14 @@ class TestResponseGenerator:
 
         kwargs = batch_state["kwargs"]
         assert kwargs["draft_model"] is draft_model
-        assert kwargs["draft_kind"] == "mtp"
+        assert kwargs["draft_kind"] == draft_kind
+        assert kwargs["apc_manager"] is apc_manager
         assert kwargs["draft_block_size"] == 6
         assert kwargs["greedy_sampling"] is True
         assert kwargs["compute_logprobs"] is False
         assert batch_state["instance"].next_active_sizes == [2]
 
-    def test_run_coalesces_idle_mtp_batch_generator(self, monkeypatch):
+    def test_run_coalesces_idle_speculative_batch_generator(self, monkeypatch):
         monkeypatch.setenv("MLX_VLM_SPEC_BATCH_COALESCE_MS", "37")
         calls = []
         draft_model = object()
@@ -4044,7 +4051,7 @@ class TestResponseGenerator:
             gen.config = SimpleNamespace()
             gen.stop_tokens = set()
             gen.draft_model = draft_model
-            gen.draft_kind = "mtp"
+            gen.draft_kind = "dflash"
             gen.tokenizer = SimpleNamespace()
 
         def fake_collect_pending_requests(*, active, idle_timeout=0.1, coalesce_s=0.0):
@@ -4053,7 +4060,9 @@ class TestResponseGenerator:
             return [], True
 
         gen._initialize_model = fake_initialize_model
-        gen._run_speculative = lambda: pytest.fail("MTP should use BatchGenerator")
+        gen._run_speculative = lambda: pytest.fail(
+            "Speculative decoding should use BatchGenerator"
+        )
         gen._collect_pending_requests = fake_collect_pending_requests
 
         gen._run()


### PR DESCRIPTION
## Summary

Enable APC to work with speculative decoding across the batched server path.

- keep `apc_manager` enabled when `BatchGenerator` is configured with any supported draft kind
- route server speculative decoding for `dflash`, `eagle3`, and `mtp` through the APC-aware `BatchGenerator` path
- teach APC batch harvesting to fall back to `offset` for singleton regular `KVCache` entries used by speculative prefill
- add regression coverage for singleton KV harvesting, APC retention with all draft kinds, and server routing/passing APC into `BatchGenerator`

## Fixes

Fixes #1443.

- fixes APC being disabled whenever a draft model is present in `BatchGenerator`
- fixes APC harvest silently returning no blocks for singleton speculative `KVCache` entries that expose `offset` instead of `_idx`
- fixes non-MTP server speculative paths bypassing the APC-aware batched generation path

## Root Cause

`BatchGenerator` disabled APC whenever a draft model was present, which prevented prefix lookup/store in the same path used for MTP server decoding. Singleton MTP speculative prefill can also produce regular `KVCache` entries with `offset` instead of batched `_idx`, so APC harvest silently skipped those caches. Non-MTP server speculative decoding used a separate `_run_speculative` lane, so it also bypassed the APC-aware `BatchGenerator` path.

## Validation

- `python -m compileall -q mlx_vlm/apc.py mlx_vlm/generate/ar.py mlx_vlm/server/generation.py mlx_vlm/tests/test_apc.py mlx_vlm/tests/test_generate.py mlx_vlm/tests/test_server.py`
- `git diff --check`

Focused pytest collection is currently blocked in my local shell by an MLX import abort while loading `mlx_vlm/tests/test_generate.py`: `Failed to load the default metallib`.