### PR TITLE
Fix Gemma 4 bare namespaced tool calls

### DIFF
--- a/mlx_vlm/tests/test_gemma4_tool_parser.py
+++ b/mlx_vlm/tests/test_gemma4_tool_parser.py
@@ -111,6 +111,12 @@ class TestGemma4ToolParser(unittest.TestCase):
         args = json.loads(result["arguments"])
         self.assertEqual(args, {"city": "Austin"})
 
+    def test_bare_namespaced_function_syntax(self):
+        result = parse_tool_call("mcp.calendar:list_events{limit:5}")
+        self.assertEqual(result["name"], "mcp.calendar:list_events")
+        args = json.loads(result["arguments"])
+        self.assertEqual(args, {"limit": 5})
+
     def test_process_tool_calls_handles_raw_diffusion_gemma_output(self):
         result = process_tool_calls(
             _wrap(f"call:get_weather{{city:{_str('Austin')}}}"),

--- a/mlx_vlm/tool_parsers/gemma4.py
+++ b/mlx_vlm/tool_parsers/gemma4.py
@@ -152,7 +152,7 @@ def parse_tool_call(text, tools=None):
     )
     if text.startswith(":"):
         text = f"call{text}"
-    elif not text.startswith("call:") and re.match(r"^[\w-]+\{", text):
+    elif not text.startswith("call:") and re.match(r"^[\w.:-]+\{", text):
         text = f"call:{text}"
 
     # Try recursive-group regex first for well-formed calls


### PR DESCRIPTION
## Summary

Fixes Gemma 4 tool-call parsing for bare namespaced function names such as `mcp.calendar:list_events{limit:5}`.

Closes #1459

## Root Cause

The parser already accepted dotted and colon-delimited function names on `call:`-prefixed paths, but the bare-name normalization still used the narrower `^[\w-]+\{` regex. As a result, bare namespaced calls were never normalized to `call:<name>{...}` and failed with `No function call found in tool call text.`

## Changes

- Align bare-call normalization with the supported Gemma 4 function-name grammar by allowing `.`, `:`, and `-`.
- Add a regression test for bare MCP-style namespaced calls.

## Validation

- `uv run --with pytest pytest mlx_vlm/tests/test_gemma4_tool_parser.py` passed: 14 passed.
- Commit hooks passed: `black`, `isort`, `autoflake`.
