### PR TITLE
fix(rope_utils): make M-RoPE apply differentiable for training

### DIFF
--- a/mlx_vlm/models/rope_utils.py
+++ b/mlx_vlm/models/rope_utils.py
@@ -379,7 +379,7 @@ def _rotary_apply_kernel(
     )
 
 
-def _precomputed_rotary_mlx(
+def _precomputed_rotary(
     q,
     k,
     cos,

--- a/mlx_vlm/models/rope_utils.py
+++ b/mlx_vlm/models/rope_utils.py
@@ -158,6 +158,44 @@ def _mrope_apply_kernel(
     )
 
 
+def _mrope_apply_cos_sin(x, position_ids, inv_freq, position_selector, pairing):
+    """Pure-MLX cos/sin matching the fused MRoPE kernel's angle computation.
+
+    Mirrors ``_mrope_apply_kernel``: ``angle = pos * inv_freq[freq_idx]`` with
+    ``pos`` selected per-axis (via ``position_selector``) for 3D position ids.
+    Returns cos/sin already laid out for the pairing so a plain rotate matches
+    the kernel's element-wise pair rotation.
+    """
+    half_dim = inv_freq.shape[0]
+    if position_ids.ndim == 2:
+        # (b, t, half) angles; the same scalar position feeds every freq.
+        angle = position_ids.astype(mx.float32)[..., None] * inv_freq
+    else:
+        # (axis, b, t) -> select the axis feeding each freq, giving (b, t, half).
+        positions = mx.take(position_ids, position_selector, axis=0)
+        angle = positions.transpose(1, 2, 0).astype(mx.float32) * inv_freq
+    cos = mx.cos(angle)[:, None, :, :]
+    sin = mx.sin(angle)[:, None, :, :]
+    if pairing == _EVEN_ODD:
+        cos = mx.repeat(cos, repeats=2, axis=-1)
+        sin = mx.repeat(sin, repeats=2, axis=-1)
+    else:
+        cos = mx.concatenate([cos, cos], axis=-1)
+        sin = mx.concatenate([sin, sin], axis=-1)
+    return cos, sin, half_dim
+
+
+def _mrope_apply_mlx(q, k, position_ids, inv_freq, position_selector, pairing):
+    """Differentiable pure-MLX equivalent of the fused MRoPE kernel apply."""
+    cos, sin, _ = _mrope_apply_cos_sin(
+        q, position_ids, inv_freq, position_selector, pairing
+    )
+    rotate_fn = rotate_half_even_odd if pairing == _EVEN_ODD else rotate_half
+    return _apply_rotary_embedding(
+        q, k, cos, sin, rotate_fn, cast_output=True, compute_dtype=mx.float32
+    )
+
+
 def _fast_mrope_apply(
     kernel,
     q,
@@ -165,6 +203,7 @@ def _fast_mrope_apply(
     position_ids,
     inv_freq,
     position_selector,
+    pairing=_HALF_SPLIT,
 ):
     def apply_one(x):
         half_dim = inv_freq.shape[0]
@@ -180,7 +219,35 @@ def _fast_mrope_apply(
         )
         return out
 
-    return apply_one(q), apply_one(k)
+    # Wrap the kernel forward in a custom_function so value_and_grad (training)
+    # can differentiate through it: a raw CustomKernel has no VJP, so route the
+    # gradient through the pure-MLX equivalent. position_ids/inv_freq/
+    # position_selector are position constants (zero cotangent).
+    @mx.custom_function
+    def apply(q, k, position_ids, inv_freq, position_selector):
+        return apply_one(q), apply_one(k)
+
+    @apply.vjp
+    def apply_vjp(primals, cotangents, _output):
+        q, k, position_ids, inv_freq, position_selector = primals
+        _, (dq, dk) = mx.vjp(
+            lambda q, k: list(
+                _mrope_apply_mlx(
+                    q, k, position_ids, inv_freq, position_selector, pairing
+                )
+            ),
+            [q, k],
+            list(cotangents),
+        )
+        return (
+            dq,
+            dk,
+            mx.zeros_like(position_ids),
+            mx.zeros_like(inv_freq),
+            mx.zeros_like(position_selector),
+        )
+
+    return apply(q, k, position_ids, inv_freq, position_selector)
 
 
 @lru_cache(maxsize=None)
@@ -312,7 +379,55 @@ def _rotary_apply_kernel(
     )
 
 
-def _fast_rotary_apply(kernel, q, k, cos, sin, position_selector=None):
+def _precomputed_rotary_mlx(
+    q,
+    k,
+    cos,
+    sin,
+    *,
+    pairing,
+    cos_layout,
+    sectioned,
+    mrope_section,
+):
+    """Differentiable pure-MLX equivalent of ``_fast_rotary_apply``.
+
+    Reproduces the fallback layout applied to cos/sin (half->full expansion for
+    even/odd, sectioning for sectioned styles) before the element-wise rotation
+    so the gradient matches the kernel forward.
+    """
+    if sectioned:
+        cos, sin = _section_cos_sin(cos, sin, mrope_section)
+    else:
+        cos = cos[:, None, :, :]
+        sin = sin[:, None, :, :]
+
+    if pairing == _EVEN_ODD:
+        if cos_layout == _HALF_COS:
+            cos = mx.repeat(cos[..., : cos.shape[-1] // 2], repeats=2, axis=-1)
+            sin = mx.repeat(sin[..., : sin.shape[-1] // 2], repeats=2, axis=-1)
+        rotate_fn = rotate_half_even_odd
+    else:
+        rotate_fn = rotate_half
+
+    return _apply_rotary_embedding(
+        q, k, cos, sin, rotate_fn, cast_output=True, compute_dtype=mx.float32
+    )
+
+
+def _fast_rotary_apply(
+    kernel,
+    q,
+    k,
+    cos,
+    sin,
+    position_selector=None,
+    *,
+    pairing=_HALF_SPLIT,
+    cos_layout=_HALF_COS,
+    sectioned=False,
+    mrope_section=None,
+):
     def apply_one(x):
         rotary_dim = cos.shape[-1]
         slots = rotary_dim // 2 + x.shape[-1] - rotary_dim
@@ -330,7 +445,35 @@ def _fast_rotary_apply(kernel, q, k, cos, sin, position_selector=None):
         )
         return out
 
-    return apply_one(q), apply_one(k)
+    # As with _fast_mrope_apply: the CustomKernel has no VJP, so wrap the forward
+    # in a custom_function whose vjp routes through the pure-MLX equivalent.
+    # cos/sin are position constants (zero cotangent); q/k are differentiated.
+    @mx.custom_function
+    def apply(q, k, cos, sin):
+        return apply_one(q), apply_one(k)
+
+    @apply.vjp
+    def apply_vjp(primals, cotangents, _output):
+        q, k, cos, sin = primals
+        _, (dq, dk) = mx.vjp(
+            lambda q, k: list(
+                _precomputed_rotary_mlx(
+                    q,
+                    k,
+                    cos,
+                    sin,
+                    pairing=pairing,
+                    cos_layout=cos_layout,
+                    sectioned=sectioned,
+                    mrope_section=mrope_section,
+                )
+            ),
+            [q, k],
+            list(cotangents),
+        )
+        return (dq, dk, mx.zeros_like(cos), mx.zeros_like(sin))
+
+    return apply(q, k, cos, sin)
 
 
 @lru_cache(maxsize=None)
@@ -340,6 +483,7 @@ def _compiled_rotary_apply(
     cos_ndim: int,
     sectioned: bool,
     cos_layout: str,
+    mrope_section: tuple = (),
 ):
     kernel = _rotary_apply_kernel(
         rotary_dim,
@@ -351,9 +495,22 @@ def _compiled_rotary_apply(
     if kernel is None:
         return None
 
+    section = list(mrope_section) if mrope_section else None
+
     @mx.compile
     def apply(q, k, cos, sin, position_selector):
-        return _fast_rotary_apply(kernel, q, k, cos, sin, position_selector)
+        return _fast_rotary_apply(
+            kernel,
+            q,
+            k,
+            cos,
+            sin,
+            position_selector,
+            pairing=pairing,
+            cos_layout=cos_layout,
+            sectioned=sectioned,
+            mrope_section=section,
+        )
 
     return apply
 
@@ -373,6 +530,7 @@ def _compiled_mrope_apply(rotary_dim: int, position_ndim: int, pairing: str):
             position_ids,
             inv_freq,
             position_selector,
+            pairing,
         )
 
     return apply
@@ -770,6 +928,7 @@ def _maybe_fast_precomputed_rotary(
         cos.ndim,
         sectioned,
         cos_layout,
+        tuple(mrope_section) if sectioned else (),
     )
     if compiled_apply is None:
         return None

--- a/mlx_vlm/models/rope_utils.py
+++ b/mlx_vlm/models/rope_utils.py
@@ -445,9 +445,6 @@ def _fast_rotary_apply(
         )
         return out
 
-    # As with _fast_mrope_apply: the CustomKernel has no VJP, so wrap the forward
-    # in a custom_function whose vjp routes through the pure-MLX equivalent.
-    # cos/sin are position constants (zero cotangent); q/k are differentiated.
     @mx.custom_function
     def apply(q, k, cos, sin):
         return apply_one(q), apply_one(k)

--- a/mlx_vlm/models/rope_utils.py
+++ b/mlx_vlm/models/rope_utils.py
@@ -185,7 +185,7 @@ def _mrope_apply_cos_sin(x, position_ids, inv_freq, position_selector, pairing):
     return cos, sin, half_dim
 
 
-def _mrope_apply_mlx(q, k, position_ids, inv_freq, position_selector, pairing):
+def _mrope_apply(q, k, position_ids, inv_freq, position_selector, pairing):
     """Differentiable pure-MLX equivalent of the fused MRoPE kernel apply."""
     cos, sin, _ = _mrope_apply_cos_sin(
         q, position_ids, inv_freq, position_selector, pairing

--- a/mlx_vlm/models/rope_utils.py
+++ b/mlx_vlm/models/rope_utils.py
@@ -232,7 +232,7 @@ def _fast_mrope_apply(
         q, k, position_ids, inv_freq, position_selector = primals
         _, (dq, dk) = mx.vjp(
             lambda q, k: list(
-                _mrope_apply_mlx(
+                _mrope_apply(
                     q, k, position_ids, inv_freq, position_selector, pairing
                 )
             ),
@@ -454,7 +454,7 @@ def _fast_rotary_apply(
         q, k, cos, sin = primals
         _, (dq, dk) = mx.vjp(
             lambda q, k: list(
-                _precomputed_rotary_mlx(
+                _precomputed_rotary(
                     q,
                     k,
                     cos,

--- a/mlx_vlm/models/rope_utils.py
+++ b/mlx_vlm/models/rope_utils.py
@@ -232,9 +232,7 @@ def _fast_mrope_apply(
         q, k, position_ids, inv_freq, position_selector = primals
         _, (dq, dk) = mx.vjp(
             lambda q, k: list(
-                _mrope_apply(
-                    q, k, position_ids, inv_freq, position_selector, pairing
-                )
+                _mrope_apply(q, k, position_ids, inv_freq, position_selector, pairing)
             ),
             [q, k],
             list(cotangents),

--- a/mlx_vlm/tests/test_models.py
+++ b/mlx_vlm/tests/test_models.py
@@ -7000,7 +7000,7 @@ class TestMRoPETrainingVJP(unittest.TestCase):
     def _grads(self, fn, q, k):
         return mx.value_and_grad(self._sum_loss(fn), argnums=(0, 1))(q, k)
 
-    def test_fused_apply_rotary_vjp_matches_pure_mlx(self):
+    def test_fused_apply_rotary_vjp(self):
         """Fused MRoPE apply (``MRoPERotaryEmbedding.apply_rotary``) is
         differentiable and matches the known-good pure-MLX gradient."""
         from mlx_vlm.models import rope_utils

--- a/mlx_vlm/tests/test_models.py
+++ b/mlx_vlm/tests/test_models.py
@@ -6969,6 +6969,149 @@ class TestMultiImageMRoPE(unittest.TestCase):
                 )
 
 
+class TestMRoPETrainingVJP(unittest.TestCase):
+    """Regression tests for issue #1474: LoRA/fine-tuning any M-RoPE VL model
+    crashed on the first backward with ``[Primitive::vjp] Not implemented for
+    CustomKernel`` because the M-RoPE apply used a raw ``metal_kernel`` (which
+    has no VJP). The kernel forward is now wrapped in ``mx.custom_function`` with
+    a VJP routed through the pure-MLX equivalent, so ``value_and_grad`` works
+    while inference stays byte-identical.
+    """
+
+    _DIM = 64
+    _HEADS = 2
+    _SEQ = 8
+    _BSZ = 1
+
+    def _qk(self):
+        mx.random.seed(0)
+        q = mx.random.normal((self._BSZ, self._HEADS, self._SEQ, self._DIM))
+        k = mx.random.normal((self._BSZ, self._HEADS, self._SEQ, self._DIM))
+        return q, k
+
+    @staticmethod
+    def _sum_loss(fn):
+        def loss(q, k):
+            qo, ko = fn(q, k)
+            return qo.astype(mx.float32).sum() + ko.astype(mx.float32).sum()
+
+        return loss
+
+    def _grads(self, fn, q, k):
+        return mx.value_and_grad(self._sum_loss(fn), argnums=(0, 1))(q, k)
+
+    def test_fused_apply_rotary_vjp_matches_pure_mlx(self):
+        """Fused MRoPE apply (``MRoPERotaryEmbedding.apply_rotary``) is
+        differentiable and matches the known-good pure-MLX gradient."""
+        from mlx_vlm.models import rope_utils
+
+        pos_2d = mx.arange(self._SEQ, dtype=mx.int32)[None, :]
+        pos_3d = mx.broadcast_to(
+            mx.arange(self._SEQ, dtype=mx.int32)[None, None, :],
+            (3, self._BSZ, self._SEQ),
+        )
+
+        for style in ("interleaved", "chunked"):
+            for pos in (pos_2d, pos_3d):
+                with self.subTest(style=style, pos_ndim=pos.ndim):
+                    q, k = self._qk()
+
+                    rope = rope_utils.MRoPERotaryEmbedding(dim=self._DIM, style=style)
+                    _, (dq, dk) = self._grads(
+                        lambda q, k: rope.apply_rotary(q, k, pos), q, k
+                    )
+                    mx.eval(dq, dk)
+                    self.assertTrue(bool(mx.all(mx.isfinite(dq))))
+                    self.assertTrue(bool(mx.all(mx.isfinite(dk))))
+
+                    saved = rope_utils._HAS_METAL
+                    try:
+                        rope_utils._HAS_METAL = False
+                        ref = rope_utils.MRoPERotaryEmbedding(
+                            dim=self._DIM, style=style
+                        )
+                        _, (dq2, dk2) = self._grads(
+                            lambda q, k: ref.apply_rotary(q, k, pos), q, k
+                        )
+                        mx.eval(dq2, dk2)
+                    finally:
+                        rope_utils._HAS_METAL = saved
+
+                    self.assertTrue(bool(mx.allclose(dq, dq2, atol=1e-4, rtol=1e-4)))
+                    self.assertTrue(bool(mx.allclose(dk, dk2, atol=1e-4, rtol=1e-4)))
+
+    def test_precomputed_rotary_vjp_matches_pure_mlx(self):
+        """Precomputed-cos/sin apply (even/odd and sectioned kernel paths) is
+        differentiable and matches the known-good pure-MLX gradient."""
+        from mlx_vlm.models import rope_utils
+
+        mx.random.seed(1)
+        rotary_dim = self._DIM
+        ang3 = mx.random.normal((self._BSZ, self._SEQ, rotary_dim))
+        cos3, sin3 = mx.cos(ang3), mx.sin(ang3)
+        ang4 = mx.random.normal((3, self._BSZ, self._SEQ, rotary_dim))
+        cos4, sin4 = mx.cos(ang4), mx.sin(ang4)
+        mrope_section = [4, 6, 6]  # sums to rotary_dim // 2 == 32
+
+        cases = [
+            (
+                "even_odd_half",
+                lambda q, k: rope_utils.apply_rotary_pos_emb_even_odd(
+                    q, k, cos3, sin3, cos_layout="half"
+                ),
+            ),
+            (
+                "even_odd_full",
+                lambda q, k: rope_utils.apply_rotary_pos_emb_even_odd(
+                    q, k, cos3, sin3, cos_layout="full"
+                ),
+            ),
+            (
+                "sectioned_half_split",
+                lambda q, k: rope_utils.apply_multimodal_rotary_pos_emb(
+                    q,
+                    k,
+                    cos4,
+                    sin4,
+                    mrope_section=mrope_section,
+                    style="sectioned_half_split",
+                ),
+            ),
+            (
+                "sectioned_even_odd",
+                lambda q, k: rope_utils.apply_multimodal_rotary_pos_emb(
+                    q,
+                    k,
+                    cos4,
+                    sin4,
+                    mrope_section=mrope_section,
+                    style="sectioned_even_odd",
+                ),
+            ),
+        ]
+
+        for name, fn in cases:
+            with self.subTest(case=name):
+                q, k = self._qk()
+                _, (dq, dk) = self._grads(fn, q, k)
+                mx.eval(dq, dk)
+                self.assertTrue(bool(mx.all(mx.isfinite(dq))))
+                self.assertTrue(bool(mx.all(mx.isfinite(dk))))
+
+                saved = rope_utils._HAS_METAL
+                try:
+                    rope_utils._HAS_METAL = False
+                    rope_utils._compiled_rotary_apply.cache_clear()
+                    _, (dq2, dk2) = self._grads(fn, q, k)
+                    mx.eval(dq2, dk2)
+                finally:
+                    rope_utils._HAS_METAL = saved
+                    rope_utils._compiled_rotary_apply.cache_clear()
+
+                self.assertTrue(bool(mx.allclose(dq, dq2, atol=1e-4, rtol=1e-4)))
+                self.assertTrue(bool(mx.allclose(dk, dk2, atol=1e-4, rtol=1e-4)))
+
+
 class TestMiniCPMV4_6(unittest.TestCase):
     @staticmethod
     def _tiny_text_config():


### PR DESCRIPTION
The M-RoPE apply routed q/k through a raw mx.fast.metal_kernel (CustomKernel), which has no VJP. Inference worked, but the first backward in LoRA/fine-tuning of any M-RoPE VL model (Qwen2-VL, Qwen2.5-VL, GLM4V, PaddleOCR-VL, ...) crashed with  [Primitive::vjp] Not implemented for CustomKernel], per #1474.


This pr wraps both kernel entry points (_fast_mrope_apply and _fast_rotary_apply) in mx.custom_function, vjp is called with mx.vjp.

Verification: 

Grads match the pure-MLX path exactly on Qwen2-VL-2B and greedy generation is unchanged, also added TestMRoPETrainingVJP, which covers the fused and precomputed paths. 

