### PR TITLE
Fix DiffusionGemma tool marker tokenization

### DIFF
--- a/mlx_vlm/models/diffusion_gemma/processing_diffusion_gemma.py
+++ b/mlx_vlm/models/diffusion_gemma/processing_diffusion_gemma.py
@@ -15,9 +15,51 @@ from transformers.tokenization_utils_base import PreTokenizedInput, TextInput
 
 from ..gemma4.processing_gemma4 import Gemma4Processor
 
+_TOOL_PARSER_TOKENS = {
+    "<|tool_call>",
+    "<tool_call|>",
+    '<|"|>',
+    "<|channel>",
+    "<channel|>",
+}
+
+_TOOL_PARSER_TOKEN_ATTRIBUTES = (
+    "stc_token",
+    "etc_token",
+    "escape_token",
+    "soc_token",
+    "eoc_token",
+)
+
+
+def _token_text(token):
+    return getattr(token, "content", token)
+
+
+def _make_tool_parser_tokens_non_special(tokenizer):
+    for attr in _TOOL_PARSER_TOKEN_ATTRIBUTES:
+        if _token_text(getattr(tokenizer, attr, None)) in _TOOL_PARSER_TOKENS:
+            try:
+                setattr(tokenizer, attr, None)
+            except AttributeError:
+                pass
+
+    additional_tokens = getattr(tokenizer, "additional_special_tokens", None)
+    if not additional_tokens:
+        return
+    tokenizer.additional_special_tokens = [
+        token
+        for token in additional_tokens
+        if _token_text(token) not in _TOOL_PARSER_TOKENS
+    ]
+
 
 class DiffusionGemma4Processor(Gemma4Processor):
     model_type = "diffusion_gemma"
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        _make_tool_parser_tokens_non_special(self.tokenizer)
 
     @staticmethod
     def _flatten_visual_items(values):
@@ -127,7 +169,9 @@ class DiffusionGemma4Processor(Gemma4Processor):
         # rejected by this processor, so the warning is pure noise.
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore", message=".*mel filter.*")
-            return super().from_pretrained(pretrained_model_name_or_path, **kwargs)
+            processor = super().from_pretrained(pretrained_model_name_or_path, **kwargs)
+        _make_tool_parser_tokens_non_special(processor.tokenizer)
+        return processor
 
 
 __all__ = ["DiffusionGemma4Processor"]

--- a/mlx_vlm/tests/test_diffusion_gemma.py
+++ b/mlx_vlm/tests/test_diffusion_gemma.py
@@ -5,6 +5,7 @@ import json
 import unittest
 from pathlib import Path
 from tempfile import TemporaryDirectory
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import mlx.core as mx
@@ -103,6 +104,12 @@ class TinyDiffusionGemma4Tokenizer:
     model_input_names = ["input_ids", "attention_mask"]
 
     def __init__(self):
+        self.additional_special_tokens = []
+        self.stc_token = None
+        self.etc_token = None
+        self.escape_token = None
+        self.soc_token = None
+        self.eoc_token = None
         self.special_tokens = {
             self.image_token: self.image_token_id,
             self.video_token: self.video_token_id,
@@ -111,6 +118,25 @@ class TinyDiffusionGemma4Tokenizer:
             self.pad_token: self.pad_token_id,
             self.eos_token: self.eos_token_id,
         }
+
+    @property
+    def all_special_ids(self):
+        additional_ids = [
+            self.convert_tokens_to_ids(token)
+            for token in self.additional_special_tokens
+        ]
+        attr_ids = [
+            self.convert_tokens_to_ids(token)
+            for token in (
+                self.stc_token,
+                self.etc_token,
+                self.escape_token,
+                self.soc_token,
+                self.eoc_token,
+            )
+            if token is not None
+        ]
+        return additional_ids + attr_ids
 
     def convert_tokens_to_ids(self, token):
         return self.special_tokens.get(token, self.unk_token_id)
@@ -1165,6 +1191,45 @@ class TestDiffusionGemma4(unittest.TestCase):
 
         self.assertIs(processor, sentinel)
         from_pretrained.assert_called_once()
+
+    def test_processor_demotes_tool_parser_tokens_from_specials(self):
+        from mlx_vlm.models.diffusion_gemma import DiffusionGemma4Processor
+        from mlx_vlm.models.diffusion_gemma.processing_diffusion_gemma import (
+            _TOOL_PARSER_TOKENS,
+        )
+        from mlx_vlm.models.gemma4.processing_gemma4 import Gemma4Processor
+
+        tokenizer = TinyDiffusionGemma4Tokenizer()
+        tokenizer.special_tokens.update(
+            {token: 70 + i for i, token in enumerate(_TOOL_PARSER_TOKENS)}
+        )
+        tokenizer.special_tokens["<extra_special>"] = 90
+        tokenizer.stc_token = "<|tool_call>"
+        tokenizer.etc_token = "<tool_call|>"
+        tokenizer.escape_token = '<|"|>'
+        tokenizer.soc_token = "<|channel>"
+        tokenizer.eoc_token = "<channel|>"
+        tokenizer.additional_special_tokens = ["<extra_special>"]
+
+        with patch.object(
+            Gemma4Processor,
+            "from_pretrained",
+            return_value=SimpleNamespace(tokenizer=tokenizer),
+        ):
+            processor = DiffusionGemma4Processor.from_pretrained("demo")
+
+        self.assertIs(processor.tokenizer, tokenizer)
+        self.assertEqual(tokenizer.additional_special_tokens, ["<extra_special>"])
+        self.assertEqual(tokenizer.all_special_ids, [90])
+        self.assertIsNone(tokenizer.stc_token)
+        self.assertIsNone(tokenizer.etc_token)
+        self.assertIsNone(tokenizer.escape_token)
+        self.assertIsNone(tokenizer.soc_token)
+        self.assertIsNone(tokenizer.eoc_token)
+        for token in _TOOL_PARSER_TOKENS:
+            self.assertNotEqual(
+                tokenizer.convert_tokens_to_ids(token), tokenizer.unk_token_id
+            )
 
     def test_processor_returns_video_frames_as_pixel_values(self):
         processor = tiny_diffusion_gemma_processor()


### PR DESCRIPTION
## Summary

Fixes DiffusionGemma tool-call marker leakage by changing the DiffusionGemma processor/tokenizer setup rather than the generation path.

The tokenizer for `google/diffusiongemma-26B-A4B-it` registers tool/channel delimiters like `<|tool_call>`, `<tool_call|>`, `<|channel>`, `<channel|>`, and `<|"|>` as special tokens. The diffusion streaming path builds its skip set from `tokenizer.all_special_ids`, so those structural markers were stripped before the tool parser could see them. This caused tool calls to remain as raw text and allowed the `thought` channel label to leak into content.

This PR demotes those parser markers from tokenizer special-token metadata while keeping them tokenizable as normal vocabulary tokens. That lets the existing diffusion detokenizer and tool parser behavior work without generation-specific special cases.

## Validation

- `uv run --with pytest python -m pytest mlx_vlm/tests/test_diffusion_gemma.py mlx_vlm/tests/test_gemma4_tool_parser.py mlx_vlm/tests/test_server.py::test_responses_endpoint_returns_function_call_items mlx_vlm/tests/test_server.py::test_chat_completions_streaming_tool_calls_emit_usage_chunk -q`
- `git diff --check`
- Verified against the cached real `google/diffusiongemma-26B-A4B-it` tokenizer that marker IDs leave `all_special_ids` while `convert_tokens_to_ids(...)` still resolves them.

Fixes [#1388](https://github.com/Blaizzy/mlx-vlm/issues/1388)
