### PR TITLE
Add YaRN support to MRoPE rotary embeddings

### DIFF
--- a/mlx_vlm/apc.py
+++ b/mlx_vlm/apc.py
@@ -2779,6 +2779,14 @@ class APCManager:
         self._exact_cache_max = max(
             0, int(os.environ.get("APC_EXACT_CACHE_ENTRIES", "2"))
         )
+        # Bound exact/hybrid cache snapshots by logical prefix tokens as well
+        # as entry count. Entry-only limits are unsafe for long-context models:
+        # four 250k-token snapshots retain roughly four times the intended KV
+        # reserve even though the LRU appears to contain only four objects.
+        # Zero preserves the historical unbounded-by-token behavior.
+        self._exact_cache_max_tokens = max(
+            0, int(os.environ.get("APC_EXACT_CACHE_MAX_TOKENS", "0"))
+        )
         self.exact_cache_guard_tokens = max(
             1, int(os.environ.get("APC_EXACT_PREFIX_GUARD_TOKENS", "16"))
         )
@@ -2885,6 +2893,40 @@ class APCManager:
                 self._release_one(b)
 
     # ---------- Public API ----------
+    def _exact_cache_tokens_locked(self) -> int:
+        return sum(len(entry.token_ids) for entry in self._exact_cache.values())
+
+    def _put_exact_cache_entry_locked(
+        self,
+        key: int,
+        entry: APCExactCacheEntry,
+    ) -> bool:
+        """Insert one exact snapshot and enforce both LRU limits.
+
+        Callers hold ``self.lock``. A snapshot larger than the entire token
+        budget is never retained in memory; disk persistence remains available
+        to callers that configured it.
+        """
+        if self._exact_cache_max <= 0:
+            return False
+        if (
+            self._exact_cache_max_tokens > 0
+            and len(entry.token_ids) > self._exact_cache_max_tokens
+        ):
+            return False
+        self._exact_cache[key] = entry
+        self._exact_cache.move_to_end(key)
+        while (
+            len(self._exact_cache) > self._exact_cache_max
+            or (
+                self._exact_cache_max_tokens > 0
+                and self._exact_cache_tokens_locked()
+                > self._exact_cache_max_tokens
+            )
+        ):
+            self._exact_cache.popitem(last=False)
+        return key in self._exact_cache
+
     def lookup_exact_cache(
         self,
         token_ids: Sequence[int],
@@ -2987,20 +3029,15 @@ class APCManager:
                                     self.stats.hits += 1
                                     self.stats.matched_tokens += disk_prefix_len
                                     if promote_key not in self._exact_cache:
-                                        self._exact_cache[promote_key] = (
+                                        self._put_exact_cache_entry_locked(
+                                            promote_key,
                                             APCExactCacheEntry(
                                                 token_ids=stored_tokens,
                                                 extra_hash=int(extra_hash),
                                                 prompt_cache=storage_copy,
                                                 last_used=time.time(),
-                                            )
+                                            ),
                                         )
-                                        self._exact_cache.move_to_end(promote_key)
-                                        while (
-                                            len(self._exact_cache)
-                                            > self._exact_cache_max
-                                        ):
-                                            self._exact_cache.popitem(last=False)
                                 return prompt_cache, disk_prefix_len
                         with self.lock:
                             self.stats.exact_hits += 1
@@ -3041,16 +3078,15 @@ class APCManager:
         stored = False
         with self.lock:
             if self._exact_cache_max > 0:
-                self._exact_cache[key] = APCExactCacheEntry(
-                    token_ids=token_tuple,
-                    extra_hash=int(extra_hash),
-                    prompt_cache=copied,
-                    last_used=time.time(),
+                stored = self._put_exact_cache_entry_locked(
+                    key,
+                    APCExactCacheEntry(
+                        token_ids=token_tuple,
+                        extra_hash=int(extra_hash),
+                        prompt_cache=copied,
+                        last_used=time.time(),
+                    ),
                 )
-                self._exact_cache.move_to_end(key)
-                while len(self._exact_cache) > self._exact_cache_max:
-                    self._exact_cache.popitem(last=False)
-                stored = True
         if self.disk is not None:
             try:
                 self.disk.save_exact_cache(key, token_tuple, extra_hash, copied)
@@ -3230,17 +3266,17 @@ class APCManager:
                 )
                 if copied is not None:
                     key = _sequence_hash(token_tuple, extra_hash, self.block_size)
-                    self._exact_cache[key] = APCExactCacheEntry(
-                        token_ids=token_tuple,
-                        extra_hash=int(extra_hash),
-                        prompt_cache=copied,
-                        last_used=time.time(),
+                    layer_major_stored = self._put_exact_cache_entry_locked(
+                        key,
+                        APCExactCacheEntry(
+                            token_ids=token_tuple,
+                            extra_hash=int(extra_hash),
+                            prompt_cache=copied,
+                            last_used=time.time(),
+                        ),
                     )
-                    self._exact_cache.move_to_end(key)
-                    while len(self._exact_cache) > self._exact_cache_max:
-                        self._exact_cache.popitem(last=False)
-                    self.stats.exact_stores += 1
-                    layer_major_stored = True
+                    if layer_major_stored:
+                        self.stats.exact_stores += 1
             parent = SEED_PARENT_HASH
             # Recompute hash chain over already-cached prefix to get parent for first new block.
             for i in range(skip_full):
@@ -3338,6 +3374,10 @@ class APCManager:
         with self.lock:
             self.stats.pool_used = sum(1 for x in self.pool if x.block_hash is not None)
             snap = self.stats.snapshot(self.num_blocks, self.block_size)
+            snap["exact_cache_entries"] = len(self._exact_cache)
+            snap["exact_cache_tokens"] = self._exact_cache_tokens_locked()
+            snap["exact_cache_max_entries"] = self._exact_cache_max
+            snap["exact_cache_max_tokens"] = self._exact_cache_max_tokens
             if self.disk is not None:
                 snap["disk_bytes"] = self.disk.disk_bytes
                 snap["disk_max_bytes"] = self.disk.max_bytes

--- a/mlx_vlm/models/qwen3_5/language.py
+++ b/mlx_vlm/models/qwen3_5/language.py
@@ -29,12 +29,14 @@ class Qwen3_5RotaryEmbedding(MRoPERotaryEmbedding):
         max_position_embeddings=2048,
         base=10000,
         mrope_section=[11, 11, 0],
+        rope_parameters=None,
     ):
         super().__init__(
             dim,
             max_position_embeddings=max_position_embeddings,
             base=base,
             mrope_section=mrope_section,
+            rope_parameters=rope_parameters,
             style="interleaved",
         )
         mx.eval(self.inv_freq)
@@ -1400,6 +1402,7 @@ class Qwen3_5Attention(nn.Module):
             max_position_embeddings=args.max_position_embeddings,
             base=args.rope_parameters["rope_theta"],
             mrope_section=args.rope_parameters["mrope_section"],
+            rope_parameters=args.rope_parameters,
         )
 
     def __call__(

--- a/mlx_vlm/models/qwen3_5/language.py
+++ b/mlx_vlm/models/qwen3_5/language.py
@@ -718,6 +718,14 @@ def _pad_row_time(x: mx.array, pad: int, target_length: int) -> mx.array:
     )
 
 
+def _qwen3_5_fully_padded_row_output(
+    hidden_states: mx.array, row: int, pad: int
+) -> mx.array:
+    """Return a shape-preserving placeholder for a row with no query tokens."""
+    empty_row = hidden_states[row : row + 1, pad:]
+    return _pad_row_time(empty_row, pad, hidden_states.shape[1])
+
+
 def _qwen3_5_left_padding_info(cache):
     left_padding = getattr(cache, "left_padding", None)
     if not (
@@ -1872,14 +1880,21 @@ class Qwen3_5Model(nn.Module):
                         else:
                             current_cache.append(_extract_row_cache(cache_entry, row))
 
-                    row_out = self(
-                        row_inputs,
-                        inputs_embeds=row_embeds,
-                        cache=current_cache,
-                        position_ids=row_position_ids,
-                    )
-                    if pad > 0:
-                        row_out = _pad_row_time(row_out, pad, h.shape[1])
+                    if pad >= h.shape[1]:
+                        # An exact APC hit can leave a row with no uncached query
+                        # tokens while another row in the same batch still needs
+                        # prefill. Do not recursively forward a zero-length sequence:
+                        # Qwen3.5 linear attention cannot infer its reshape dimension.
+                        row_out = _qwen3_5_fully_padded_row_output(h, row, pad)
+                    else:
+                        row_out = self(
+                            row_inputs,
+                            inputs_embeds=row_embeds,
+                            cache=current_cache,
+                            position_ids=row_position_ids,
+                        )
+                        if pad > 0:
+                            row_out = _pad_row_time(row_out, pad, h.shape[1])
                     row_outputs.append(row_out)
                     for i, cache_entry in enumerate(current_cache):
                         row_caches[i].append(cache_entry)

--- a/mlx_vlm/models/rope_utils.py
+++ b/mlx_vlm/models/rope_utils.py
@@ -1,4 +1,5 @@
 from functools import lru_cache
+import math
 from typing import Optional, Sequence
 
 import mlx.core as mx
@@ -550,6 +551,60 @@ def compute_inv_freq(dim: int, base: float):
     return 1.0 / (base ** (mx.arange(0, dim, 2).astype(mx.float32) / dim))
 
 
+def _rope_type(config: Optional[dict]) -> str:
+    if not config:
+        return "default"
+    return config.get("type") or config.get("rope_type", "default")
+
+
+def compute_yarn_inv_freq(
+    dim: int,
+    base: float,
+    *,
+    scaling_factor: float = 1.0,
+    original_max_position_embeddings: int = 4096,
+    beta_fast: float = 32,
+    beta_slow: float = 1,
+    mscale: float = 1,
+    mscale_all_dim: float = 0,
+):
+    def yarn_find_correction_dim(num_rotations):
+        return (
+            dim
+            * math.log(original_max_position_embeddings / (num_rotations * 2 * math.pi))
+        ) / (2 * math.log(base))
+
+    def yarn_find_correction_range():
+        low = math.floor(yarn_find_correction_dim(beta_fast))
+        high = math.ceil(yarn_find_correction_dim(beta_slow))
+        return max(low, 0), min(high, dim - 1)
+
+    def yarn_get_mscale(scale=1, multiplier=1):
+        if scale <= 1:
+            return 1.0
+        return 0.1 * multiplier * math.log(scale) + 1.0
+
+    def yarn_linear_ramp_mask(min_val, max_val, half_dim):
+        if min_val == max_val:
+            max_val += 0.001
+        linear_func = (mx.arange(half_dim, dtype=mx.float32) - min_val) / (
+            max_val - min_val
+        )
+        return mx.clip(linear_func, 0, 1)
+
+    freq_extra = base ** (mx.arange(0, dim, 2, dtype=mx.float32) / dim)
+    freq_inter = scaling_factor * freq_extra
+    low, high = yarn_find_correction_range()
+    freq_mask = 1.0 - yarn_linear_ramp_mask(low, high, dim // 2)
+    freqs = (freq_inter * freq_extra) / (
+        freq_inter * freq_mask + freq_extra * (1 - freq_mask)
+    )
+    attention_scaling = yarn_get_mscale(scaling_factor, mscale) / yarn_get_mscale(
+        scaling_factor, mscale_all_dim
+    )
+    return 1.0 / freqs, attention_scaling
+
+
 @mx.compile
 def _apply_selected_mrope_frequency_layout(freqs, position_selector):
     indices = mx.broadcast_to(
@@ -687,8 +742,24 @@ class MRoPERotaryEmbedding(nn.Module):
         self.max_position_embeddings = max_position_embeddings
         self.base = base
         self.style = style
-        self._inv_freq = compute_inv_freq(dim, base)
-        self.attention_scaling = attention_scaling
+        rope_config = rope_parameters or rope_scaling or {}
+        if _rope_type(rope_config) in ("yarn", "deepseek_yarn", "telechat3-yarn"):
+            self._inv_freq, yarn_attention_scaling = compute_yarn_inv_freq(
+                dim,
+                base,
+                scaling_factor=rope_config["factor"],
+                original_max_position_embeddings=rope_config.get(
+                    "original_max_position_embeddings", max_position_embeddings
+                ),
+                beta_fast=rope_config.get("beta_fast", 32),
+                beta_slow=rope_config.get("beta_slow", 1),
+                mscale=rope_config.get("mscale", 1),
+                mscale_all_dim=rope_config.get("mscale_all_dim", 0),
+            )
+            self.attention_scaling = attention_scaling * yarn_attention_scaling
+        else:
+            self._inv_freq = compute_inv_freq(dim, base)
+            self.attention_scaling = attention_scaling
         self.cast_output = cast_output
         self._mrope_section = list(
             mrope_section

--- a/mlx_vlm/tests/test_apc.py
+++ b/mlx_vlm/tests/test_apc.py
@@ -558,6 +558,50 @@ def test_exact_cache_supports_mixed_kv_and_arrays_cache():
     )
 
 
+def test_exact_cache_enforces_total_token_budget(monkeypatch):
+    monkeypatch.setenv("APC_EXACT_CACHE_ENTRIES", "8")
+    monkeypatch.setenv("APC_EXACT_CACHE_MAX_TOKENS", "64")
+    manager = APCManager(num_blocks=4, block_size=16)
+
+    assert manager.store_exact_cache(
+        list(range(16)),
+        _make_exact_row_cache(16),
+        extra_hash=1,
+    )
+    assert manager.store_exact_cache(
+        list(range(24)),
+        _make_exact_row_cache(24),
+        extra_hash=2,
+    )
+    assert manager.store_exact_cache(
+        list(range(32)),
+        _make_exact_row_cache(32),
+        extra_hash=3,
+    )
+
+    stats = manager.stats_snapshot()
+    assert stats["exact_cache_entries"] == 2
+    assert stats["exact_cache_tokens"] == 56
+    assert stats["exact_cache_max_entries"] == 8
+    assert stats["exact_cache_max_tokens"] == 64
+    assert manager.lookup_exact_cache(
+        list(range(17)),
+        extra_hash=1,
+    )[1] == 0
+    assert manager.lookup_exact_cache(
+        list(range(25)),
+        extra_hash=2,
+    )[1] == 24
+
+    # A single snapshot larger than the full reserve is not retained.
+    assert not manager.store_exact_cache(
+        list(range(65)),
+        _make_exact_row_cache(65),
+        extra_hash=4,
+    )
+    assert manager.stats_snapshot()["exact_cache_tokens"] == 56
+
+
 def test_exact_cache_supports_rotating_and_chunked_kv_cache():
     from mlx_lm.models.cache import ChunkedKVCache, KVCache, RotatingKVCache
 

--- a/mlx_vlm/tests/test_models.py
+++ b/mlx_vlm/tests/test_models.py
@@ -10,6 +10,10 @@ import numpy as np
 from mlx.utils import tree_map
 
 
+def _max_diff(a, b):
+    return mx.max(mx.abs(a.astype(mx.float32) - b.astype(mx.float32))).item()
+
+
 class TestModels(unittest.TestCase):
     def language_test_runner(self, model, model_type, vocab_size, num_layers):
         self.assertEqual(model.model_type, model_type)
@@ -1708,6 +1712,83 @@ class TestModels(unittest.TestCase):
                 self.assertIn("language_model.lm_head", config.quantization)
                 self.assertIs(config.quantization, config.quantization_config)
 
+    def test_qwen3_5_model_config_accepts_yarn_rope_parameters(self):
+        from mlx_vlm.models import qwen3_5, qwen3_5_moe
+
+        rope_parameters = {
+            "rope_type": "yarn",
+            "factor": 4.0,
+            "original_max_position_embeddings": 262144,
+            "mrope_section": [11, 11, 10],
+            "rope_theta": 1000000.0,
+            "partial_rotary_factor": 0.25,
+        }
+        qwen3_5_text_config = {
+            "model_type": "qwen3_5",
+            "hidden_size": 128,
+            "intermediate_size": 256,
+            "linear_num_value_heads": 2,
+            "linear_num_key_heads": 2,
+            "linear_key_head_dim": 16,
+            "linear_value_head_dim": 16,
+            "linear_conv_kernel_dim": 4,
+            "num_hidden_layers": 2,
+            "num_attention_heads": 4,
+            "rms_norm_eps": 1e-6,
+            "vocab_size": 256,
+            "num_key_value_heads": 2,
+            "max_position_embeddings": 1010000,
+            "head_dim": 64,
+            "rope_parameters": dict(rope_parameters),
+        }
+        qwen3_5_moe_text_config = {
+            "model_type": "qwen3_5_moe",
+            "hidden_size": 128,
+            "num_hidden_layers": 2,
+            "num_attention_heads": 4,
+            "linear_num_value_heads": 2,
+            "linear_num_key_heads": 2,
+            "linear_key_head_dim": 16,
+            "linear_value_head_dim": 16,
+            "linear_conv_kernel_dim": 4,
+            "num_experts": 4,
+            "num_experts_per_tok": 2,
+            "shared_expert_intermediate_size": 64,
+            "moe_intermediate_size": 64,
+            "rms_norm_eps": 1e-6,
+            "vocab_size": 256,
+            "num_key_value_heads": 2,
+            "max_position_embeddings": 1010000,
+            "head_dim": 64,
+            "rope_parameters": dict(rope_parameters),
+        }
+
+        for model_module, text_config in (
+            (qwen3_5, qwen3_5_text_config),
+            (qwen3_5_moe, qwen3_5_moe_text_config),
+        ):
+            with self.subTest(model_type=model_module.__name__):
+                config = model_module.ModelConfig.from_dict(
+                    {
+                        "model_type": model_module.__name__.rsplit(".", 1)[-1],
+                        "text_config": text_config,
+                        "vision_config": {},
+                    }
+                )
+
+                self.assertEqual(config.text_config.rope_parameters["type"], "yarn")
+                self.assertEqual(config.text_config.rope_parameters["factor"], 4.0)
+                self.assertEqual(
+                    config.text_config.rope_parameters[
+                        "original_max_position_embeddings"
+                    ],
+                    262144,
+                )
+                self.assertEqual(
+                    config.text_config.rope_parameters["mrope_section"],
+                    [11, 11, 10],
+                )
+
     def test_qwen3_5_sanitize_key_routes_nested_visual_weights(self):
         from mlx_vlm.models.qwen3_5.qwen3_5 import sanitize_key
 
@@ -1752,6 +1833,37 @@ class TestModels(unittest.TestCase):
         thread.join()
 
         self.assertEqual(errors, [])
+
+    def test_qwen3_5_rotary_embedding_forwards_yarn_parameters(self):
+        from mlx_vlm.models.qwen3_5.language import Qwen3_5RotaryEmbedding
+        from mlx_vlm.models.rope_utils import compute_yarn_inv_freq
+
+        rope_parameters = {
+            "type": "yarn",
+            "factor": 4.0,
+            "original_max_position_embeddings": 262144,
+            "mrope_section": [2, 3, 3],
+        }
+
+        rotary = Qwen3_5RotaryEmbedding(
+            dim=16,
+            max_position_embeddings=1010000,
+            base=1000000.0,
+            mrope_section=rope_parameters["mrope_section"],
+            rope_parameters=rope_parameters,
+        )
+        expected_inv_freq, expected_attention_scaling = compute_yarn_inv_freq(
+            16,
+            1000000.0,
+            scaling_factor=rope_parameters["factor"],
+            original_max_position_embeddings=rope_parameters[
+                "original_max_position_embeddings"
+            ],
+        )
+
+        mx.eval(rotary.inv_freq, expected_inv_freq)
+        self.assertLess(_max_diff(rotary.inv_freq, expected_inv_freq), 1e-7)
+        self.assertEqual(rotary.attention_scaling, expected_attention_scaling)
 
     def test_qwen3_5_model_config_promotes_text_eos_token_id(self):
         from mlx_vlm.models import qwen3_5, qwen3_5_moe

--- a/mlx_vlm/tests/test_qwen3_5_padding.py
+++ b/mlx_vlm/tests/test_qwen3_5_padding.py
@@ -1,0 +1,17 @@
+import mlx.core as mx
+
+from mlx_vlm.models.qwen3_5.language import _qwen3_5_fully_padded_row_output
+
+
+def test_qwen3_5_fully_cached_batch_row_keeps_shape_without_forwarding():
+    hidden_states = mx.ones((3, 4, 8))
+
+    output = _qwen3_5_fully_padded_row_output(
+        hidden_states,
+        row=1,
+        pad=hidden_states.shape[1],
+    )
+    mx.eval(output)
+
+    assert output.shape == (1, 4, 8)
+    assert output.tolist() == [[[0.0] * 8] * 4]

--- a/mlx_vlm/tests/test_rope_utils.py
+++ b/mlx_vlm/tests/test_rope_utils.py
@@ -1,6 +1,7 @@
 import mlx.core as mx
 import mlx.nn as nn
 import pytest
+from mlx_lm.models.rope_utils import YarnRoPE
 from mlx.utils import tree_flatten
 
 import mlx_vlm.models.rope_utils as rope_utils
@@ -65,6 +66,64 @@ def test_mrope_rotary_embedding_evals_private_helper_arrays_on_init(monkeypatch)
     assert len(eval_args) == 1
     assert eval_args[0][0] is eager_arrays[0]
     assert eval_args[0][1] is eager_arrays[1]
+
+
+def test_mrope_yarn_inv_freq_matches_mlx_lm_yarn_rope():
+    dim = 16
+    base = 1_000_000.0
+    factor = 4.0
+    original_max_position_embeddings = 262_144
+
+    inv_freq, attention_scaling = rope_utils.compute_yarn_inv_freq(
+        dim,
+        base,
+        scaling_factor=factor,
+        original_max_position_embeddings=original_max_position_embeddings,
+    )
+    reference = YarnRoPE(
+        dim,
+        traditional=False,
+        base=base,
+        scaling_factor=factor,
+        original_max_position_embeddings=original_max_position_embeddings,
+    )
+
+    mx.eval(inv_freq, reference._freqs)
+    assert _max_diff(inv_freq, 1.0 / reference._freqs) < 1e-7
+    assert attention_scaling == reference.mscale
+
+
+def test_mrope_rotary_embedding_uses_yarn_rope_parameters():
+    dim = 16
+    base = 1_000_000.0
+    rope_parameters = {
+        "rope_type": "yarn",
+        "factor": 4.0,
+        "original_max_position_embeddings": 262_144,
+        "mrope_section": [2, 3, 3],
+    }
+
+    rotary = MRoPERotaryEmbedding(
+        dim=dim,
+        base=base,
+        max_position_embeddings=1_010_000,
+        rope_parameters=rope_parameters,
+        style="interleaved",
+    )
+    reference = YarnRoPE(
+        dim,
+        traditional=False,
+        base=base,
+        scaling_factor=rope_parameters["factor"],
+        original_max_position_embeddings=rope_parameters[
+            "original_max_position_embeddings"
+        ],
+    )
+
+    mx.eval(rotary.inv_freq, reference._freqs)
+    assert _max_diff(rotary.inv_freq, 1.0 / reference._freqs) < 1e-7
+    assert rotary.attention_scaling == reference.mscale
+    assert rotary.mrope_section == rope_parameters["mrope_section"]
 
 
 def test_proportional_rope_evals_private_helper_arrays_on_init(monkeypatch):


### PR DESCRIPTION
## Summary

- add YaRN inverse-frequency and attention-scaling support to the shared `MRoPERotaryEmbedding` path
- pass Qwen3.5/Qwen3.6 `rope_parameters` through to the shared rotary constructor
- cover the math against MLX-LM `YarnRoPE` and add Qwen3.5/Qwen3.5-MoE config/constructor tests

Closes #1478

## Notes

This keeps non-YaRN MRoPE behavior on the existing default `compute_inv_freq(dim, base)` path. The YaRN branch accepts either `type` or `rope_type` through the existing config normalization and uses `factor`, `original_max_position_embeddings`, optional `beta_fast` / `beta_slow`, `mscale`, and `mscale_all_dim`.

Local runtime validation also confirmed this class of fix with a Qwen3.6-27B 8-bit model at 1M context, but the patch intentionally avoids hardcoding model paths, runtime flags, or any specific target context policy.

## Tests

```bash
PYTHONPATH=/Users/aiapi/src/mlx-vlm uv run --with pytest python -m pytest \
  mlx_vlm/tests/test_rope_utils.py \
  mlx_vlm/tests/test_models.py::TestModels::test_qwen3_5_model_config \
  mlx_vlm/tests/test_models.py::TestModels::test_qwen3_5_model_config_accepts_yarn_rope_parameters \
  mlx_vlm/tests/test_models.py::TestModels::test_qwen3_5_rotary_inv_freq_is_thread_safe \
  mlx_vlm/tests/test_models.py::TestModels::test_qwen3_5_rotary_embedding_forwards_yarn_parameters \
  mlx_vlm/tests/test_models.py::TestModels::test_qwen3_5_model_config_promotes_text_eos_token_id -q
```

Result: `29 passed, 2 warnings, 6 subtests passed`.

```bash
PYTHONPATH=/Users/aiapi/src/mlx-vlm uv run python -m py_compile \
  mlx_vlm/models/rope_utils.py \
  mlx_vlm/models/qwen3_5/language.py \
  mlx_vlm/tests/test_rope_utils.py \
  mlx_vlm/tests/test_models.py
```