### PR TITLE
fix #1481: quantized KV cache crashes in mask-length checks

### DIFF
--- a/mlx_vlm/__init__.py
+++ b/mlx_vlm/__init__.py
@@ -3,7 +3,6 @@ import os
 os.environ["TRANSFORMERS_NO_ADVISORY_WARNINGS"] = "1"
 os.environ["TRANSFORMERS_VERBOSITY"] = "error"
 
-
 from .convert import convert
 from .generate import (
     BatchResponse,

--- a/mlx_vlm/__init__.py
+++ b/mlx_vlm/__init__.py
@@ -3,11 +3,7 @@ import os
 os.environ["TRANSFORMERS_NO_ADVISORY_WARNINGS"] = "1"
 os.environ["TRANSFORMERS_VERBOSITY"] = "error"
 
-# transformers >= 5.13 tightened AutoTokenizer.register to require a config
-# *class* (it reads ``key.__module__``); mlx_lm still registers a custom
-# tokenizer by string model_type, which raises at import time. Tolerate string
-# keys here — before mlx_lm is imported below — so mlx-vlm works across the
-# transformers 5.5–5.13 range without pinning the dependency down.
+
 try:
     from transformers.models.auto import auto_factory as _hf_auto_factory
 

--- a/mlx_vlm/__init__.py
+++ b/mlx_vlm/__init__.py
@@ -4,21 +4,6 @@ os.environ["TRANSFORMERS_NO_ADVISORY_WARNINGS"] = "1"
 os.environ["TRANSFORMERS_VERBOSITY"] = "error"
 
 
-try:
-    from transformers.models.auto import auto_factory as _hf_auto_factory
-
-    _hf_orig_register = _hf_auto_factory._LazyAutoMapping.register
-
-    def _hf_safe_register(self, key, value, exist_ok=False):
-        if isinstance(key, str):
-            self._extra_content[key] = value
-            return
-        return _hf_orig_register(self, key, value, exist_ok=exist_ok)
-
-    _hf_auto_factory._LazyAutoMapping.register = _hf_safe_register
-except Exception:  # pragma: no cover - never block import on a shim failure
-    pass
-
 from .convert import convert
 from .generate import (
     BatchResponse,

--- a/mlx_vlm/__init__.py
+++ b/mlx_vlm/__init__.py
@@ -3,6 +3,26 @@ import os
 os.environ["TRANSFORMERS_NO_ADVISORY_WARNINGS"] = "1"
 os.environ["TRANSFORMERS_VERBOSITY"] = "error"
 
+# transformers >= 5.13 tightened AutoTokenizer.register to require a config
+# *class* (it reads ``key.__module__``); mlx_lm still registers a custom
+# tokenizer by string model_type, which raises at import time. Tolerate string
+# keys here — before mlx_lm is imported below — so mlx-vlm works across the
+# transformers 5.5–5.13 range without pinning the dependency down.
+try:
+    from transformers.models.auto import auto_factory as _hf_auto_factory
+
+    _hf_orig_register = _hf_auto_factory._LazyAutoMapping.register
+
+    def _hf_safe_register(self, key, value, exist_ok=False):
+        if isinstance(key, str):
+            self._extra_content[key] = value
+            return
+        return _hf_orig_register(self, key, value, exist_ok=exist_ok)
+
+    _hf_auto_factory._LazyAutoMapping.register = _hf_safe_register
+except Exception:  # pragma: no cover - never block import on a shim failure
+    pass
+
 from .convert import convert
 from .generate import (
     BatchResponse,

--- a/mlx_vlm/models/aya_vision/language.py
+++ b/mlx_vlm/models/aya_vision/language.py
@@ -6,6 +6,7 @@ import mlx.nn as nn
 from ..base import (
     LanguageModelOutput,
     create_attention_mask,
+    kv_sequence_length,
     scaled_dot_product_attention,
 )
 from ..cache import KVCache, RotatingKVCache
@@ -67,7 +68,7 @@ class Attention(nn.Module):
             keys, values = cache.update_and_fetch(keys, values)
 
         if self.use_sliding_window and mask is not None and isinstance(mask, mx.array):
-            key_len = keys.shape[-2]
+            key_len = kv_sequence_length(keys)
             if mask.shape[-1] != key_len:
                 mask = mask[..., -key_len:]
 

--- a/mlx_vlm/models/base.py
+++ b/mlx_vlm/models/base.py
@@ -14,6 +14,7 @@ from mlx_lm.models.base import (
 from PIL import Image
 
 from ..turboquant import BatchTurboQuantKVCache, TurboQuantKVCache
+from ..turboquant import _state_length as _turboquant_state_length
 
 
 def load_chat_template(tokenizer, model_path):
@@ -188,6 +189,23 @@ class BaseImageProcessor:
     @abstractmethod
     def preprocess(self, images):
         pass
+
+
+def kv_sequence_length(keys) -> int:
+    """Sequence length of ``keys`` as returned by ``cache.update_and_fetch``.
+
+    Unquantized caches return a plain ``[B, H, S, D]`` array. Uniform
+    quantized caches (``QuantizedKVCache``/``BatchQuantizedKVCache``) return
+    a ``(packed, scales, biases)`` tuple and TurboQuant caches return
+    codec-state named tuples.
+    """
+    if isinstance(keys, mx.array):
+        return keys.shape[-2]
+    # Plain tuple/list only: TurboQuant states are NamedTuples with a
+    # different layout and get measured by their own helper.
+    if type(keys) in (tuple, list):
+        return keys[0].shape[-2]
+    return _turboquant_state_length(keys)
 
 
 def scaled_dot_product_attention(

--- a/mlx_vlm/models/ernie4_5_moe_vl/language.py
+++ b/mlx_vlm/models/ernie4_5_moe_vl/language.py
@@ -9,6 +9,7 @@ from mlx_lm.models.switch_layers import SwitchGLU
 from ..base import (
     LanguageModelOutput,
     create_attention_mask,
+    kv_sequence_length,
     scaled_dot_product_attention,
 )
 from ..cache import KVCache
@@ -170,7 +171,7 @@ class Attention(nn.Module):
             keys, values = cache.update_and_fetch(keys, values)
 
         if mask is not None and isinstance(mask, mx.array):
-            mask = mask[..., : keys.shape[-2]]
+            mask = mask[..., : kv_sequence_length(keys)]
 
         output = scaled_dot_product_attention(
             queries, keys, values, cache, scale=self.scale, mask=mask

--- a/mlx_vlm/models/gemma3/language.py
+++ b/mlx_vlm/models/gemma3/language.py
@@ -7,6 +7,7 @@ import mlx.nn as nn
 from ..base import (
     LanguageModelOutput,
     create_attention_mask,
+    kv_sequence_length,
     scaled_dot_product_attention,
 )
 from ..cache import KVCache, RotatingKVCache
@@ -81,8 +82,9 @@ class Attention(nn.Module):
 
         # Sliding window
         if mask is not None and isinstance(mask, mx.array):
-            if mask.shape[-1] != keys.shape[-2]:
-                mask = mask[..., -keys.shape[-2] :]
+            key_len = kv_sequence_length(keys)
+            if mask.shape[-1] != key_len:
+                mask = mask[..., -key_len:]
 
         output = scaled_dot_product_attention(
             queries, keys, values, cache, scale=self.scale, mask=mask

--- a/mlx_vlm/models/gemma3n/language.py
+++ b/mlx_vlm/models/gemma3n/language.py
@@ -8,6 +8,7 @@ import mlx.nn as nn
 from ..base import (
     LanguageModelOutput,
     create_attention_mask,
+    kv_sequence_length,
     scaled_dot_product_attention,
 )
 from ..cache import KVCache, RotatingKVCache
@@ -154,8 +155,10 @@ class Gemma3nAttention(nn.Module):
         queries = queries.transpose(0, 2, 1, 3)
         queries = self.rope(queries, offset=offset)
 
-        if isinstance(mask, mx.array) and mask.shape[-1] != keys.shape[-2]:
-            mask = mask[:, : keys.shape[-2]]
+        if isinstance(mask, mx.array):
+            key_len = kv_sequence_length(keys)
+            if mask.shape[-1] != key_len:
+                mask = mask[:, :key_len]
 
         output = scaled_dot_product_attention(
             queries, keys, values, cache=cache, scale=self.scale, mask=mask

--- a/mlx_vlm/models/glm4v/language.py
+++ b/mlx_vlm/models/glm4v/language.py
@@ -6,6 +6,7 @@ import mlx.nn as nn
 from ..base import (
     LanguageModelOutput,
     create_attention_mask,
+    kv_sequence_length,
     scaled_dot_product_attention,
 )
 from ..rope_utils import apply_multimodal_rotary_pos_emb as _apply_mrope
@@ -145,7 +146,7 @@ class Glm4vAttention(nn.Module):
             keys, values = cache.update_and_fetch(keys, values)
 
         if mask is not None and isinstance(mask, mx.array):
-            mask = mask[..., : keys.shape[-2]]
+            mask = mask[..., : kv_sequence_length(keys)]
 
         output = scaled_dot_product_attention(
             queries, keys, values, cache=cache, scale=self.scale, mask=mask

--- a/mlx_vlm/models/glm4v_moe/language.py
+++ b/mlx_vlm/models/glm4v_moe/language.py
@@ -7,6 +7,7 @@ from mlx_lm.models.switch_layers import SwitchGLU
 from ..base import (
     LanguageModelOutput,
     create_attention_mask,
+    kv_sequence_length,
     scaled_dot_product_attention,
 )
 from ..rope_utils import apply_multimodal_rotary_pos_emb as _apply_mrope
@@ -144,7 +145,7 @@ class Glm4vMoeAttention(nn.Module):
             keys, values = cache.update_and_fetch(keys, values)
 
         if mask is not None and isinstance(mask, mx.array):
-            mask = mask[..., : keys.shape[-2]]
+            mask = mask[..., : kv_sequence_length(keys)]
 
         output = scaled_dot_product_attention(
             queries, keys, values, cache=cache, scale=self.scale, mask=mask

--- a/mlx_vlm/models/glm_ocr/language.py
+++ b/mlx_vlm/models/glm_ocr/language.py
@@ -7,6 +7,7 @@ import numpy as np
 from ..base import (
     LanguageModelOutput,
     create_attention_mask,
+    kv_sequence_length,
     scaled_dot_product_attention,
 )
 from ..rope_utils import (
@@ -144,7 +145,7 @@ class GlmOcrAttention(nn.Module):
             keys, values = cache.update_and_fetch(keys, values)
 
         if mask is not None and isinstance(mask, mx.array):
-            mask = mask[..., : keys.shape[-2]]
+            mask = mask[..., : kv_sequence_length(keys)]
 
         output = scaled_dot_product_attention(
             queries, keys, values, cache=cache, scale=self.scale, mask=mask

--- a/mlx_vlm/models/hunyuan_vl/language.py
+++ b/mlx_vlm/models/hunyuan_vl/language.py
@@ -7,6 +7,7 @@ import numpy as np
 from ..base import (
     LanguageModelOutput,
     create_attention_mask,
+    kv_sequence_length,
     scaled_dot_product_attention,
 )
 from ..cache import KVCache
@@ -251,7 +252,7 @@ class Attention(nn.Module):
 
         # Apply mask
         if mask is not None and isinstance(mask, mx.array):
-            mask = mask[..., : keys.shape[-2]]
+            mask = mask[..., : kv_sequence_length(keys)]
 
         output = scaled_dot_product_attention(
             queries, keys, values, cache=cache, scale=self.scale, mask=mask

--- a/mlx_vlm/models/internvl_chat/language.py
+++ b/mlx_vlm/models/internvl_chat/language.py
@@ -6,6 +6,7 @@ import mlx.nn as nn
 from ..base import (
     LanguageModelOutput,
     create_attention_mask,
+    kv_sequence_length,
     scaled_dot_product_attention,
 )
 from ..cache import KVCache
@@ -79,7 +80,7 @@ class Attention(nn.Module):
             keys, values = cache.update_and_fetch(keys, values)
 
         if mask is not None and isinstance(mask, mx.array):
-            mask = mask[..., : keys.shape[-2]]
+            mask = mask[..., : kv_sequence_length(keys)]
 
         output = scaled_dot_product_attention(
             queries, keys, values, cache, scale=self.scale, mask=mask

--- a/mlx_vlm/models/llama4/language.py
+++ b/mlx_vlm/models/llama4/language.py
@@ -8,6 +8,7 @@ from mlx_lm.models.switch_layers import SwitchGLU
 from ..base import (
     LanguageModelOutput,
     create_attention_mask,
+    kv_sequence_length,
     scaled_dot_product_attention,
 )
 from ..cache import ChunkedKVCache, KVCache
@@ -101,7 +102,7 @@ class Attention(nn.Module):
             keys, values = cache.update_and_fetch(keys, values)
 
         if self.use_rope and isinstance(mask, mx.array):
-            key_len = keys.shape[-2]
+            key_len = kv_sequence_length(keys)
             if mask.shape[-1] != key_len:
                 mask = mask[..., -key_len:]
 

--- a/mlx_vlm/models/paddleocr_vl/language.py
+++ b/mlx_vlm/models/paddleocr_vl/language.py
@@ -6,6 +6,7 @@ import mlx.nn as nn
 from ..base import (
     LanguageModelOutput,
     create_attention_mask,
+    kv_sequence_length,
     scaled_dot_product_attention,
 )
 from ..cache import KVCache
@@ -87,7 +88,7 @@ class Attention(nn.Module):
             keys, values = cache.update_and_fetch(keys, values)
 
         if mask is not None and isinstance(mask, mx.array):
-            mask = mask[..., : keys.shape[-2]]
+            mask = mask[..., : kv_sequence_length(keys)]
 
         output = scaled_dot_product_attention(
             queries, keys, values, cache, scale=self.scale, mask=mask

--- a/mlx_vlm/models/paligemma/language.py
+++ b/mlx_vlm/models/paligemma/language.py
@@ -6,6 +6,7 @@ import mlx.nn as nn
 from ..base import (
     LanguageModelOutput,
     create_attention_mask,
+    kv_sequence_length,
     scaled_dot_product_attention,
 )
 from ..cache import KVCache
@@ -122,7 +123,7 @@ class Attention(nn.Module):
                 elif mask.ndim == 3:
                     mask = mask[:, None, :, :]
 
-                mask = mask[..., : keys.shape[-2]]
+                mask = mask[..., : kv_sequence_length(keys)]
                 if mask.dtype not in (mx.float16, mx.bfloat16, mx.float32):
                     mask = mask.astype(scores.dtype)
                     mask = (1.0 - mask) * mx.finfo(scores.dtype).min

--- a/mlx_vlm/tests/test_models.py
+++ b/mlx_vlm/tests/test_models.py
@@ -8247,9 +8247,7 @@ class TestQuantizedKVCacheMask(unittest.TestCase):
         quantized = mx.quantize(keys, group_size=64, bits=8)
         self.assertEqual(kv_sequence_length(quantized), 5)
 
-    def test_gemma3_generation_with_quantized_cache(self):
-        from mlx_vlm.models import gemma3
-        from mlx_vlm.models.cache import KVCache, QuantizedKVCache
+
 
         config = gemma3.TextConfig(
             model_type="gemma3",

--- a/mlx_vlm/tests/test_models.py
+++ b/mlx_vlm/tests/test_models.py
@@ -8240,7 +8240,9 @@ class TestQuantizedKVCacheMask(unittest.TestCase):
     ``update_and_fetch`` returns packed tuples instead of arrays (#1481)."""
 
     def test_kv_sequence_length(self):
+        from mlx_vlm.models import gemma3
         from mlx_vlm.models.base import kv_sequence_length
+        from mlx_vlm.models.cache import KVCache, QuantizedKVCache
 
         keys = mx.zeros((1, 2, 5, 64))
         self.assertEqual(kv_sequence_length(keys), 5)

--- a/mlx_vlm/tests/test_models.py
+++ b/mlx_vlm/tests/test_models.py
@@ -8247,8 +8247,6 @@ class TestQuantizedKVCacheMask(unittest.TestCase):
         quantized = mx.quantize(keys, group_size=64, bits=8)
         self.assertEqual(kv_sequence_length(quantized), 5)
 
-
-
         config = gemma3.TextConfig(
             model_type="gemma3",
             hidden_size=32,

--- a/mlx_vlm/tests/test_models.py
+++ b/mlx_vlm/tests/test_models.py
@@ -8233,3 +8233,53 @@ class TestDeepseekV4HISA(unittest.TestCase):
         flat = (mx.maximum(q @ pooled[:, None].swapaxes(-1, -2), 0) * wk_h).sum(1)
         ftk = mx.argpartition(-flat, kth=k - 1, axis=-1)[..., :k]
         self.assertTrue(bool(mx.array_equal(mx.sort(out, -1), mx.sort(ftk, -1))))
+
+
+class TestQuantizedKVCacheMask(unittest.TestCase):
+    """Mask-length checks must handle quantized KV caches, whose
+    ``update_and_fetch`` returns packed tuples instead of arrays (#1481)."""
+
+    def test_kv_sequence_length(self):
+        from mlx_vlm.models.base import kv_sequence_length
+
+        keys = mx.zeros((1, 2, 5, 64))
+        self.assertEqual(kv_sequence_length(keys), 5)
+        quantized = mx.quantize(keys, group_size=64, bits=8)
+        self.assertEqual(kv_sequence_length(quantized), 5)
+
+    def test_gemma3_generation_with_quantized_cache(self):
+        from mlx_vlm.models import gemma3
+        from mlx_vlm.models.cache import KVCache, QuantizedKVCache
+
+        config = gemma3.TextConfig(
+            model_type="gemma3",
+            hidden_size=32,
+            num_hidden_layers=4,
+            intermediate_size=64,
+            num_attention_heads=2,
+            num_key_value_heads=1,
+            head_dim=64,
+            vocab_size=64,
+            sliding_window=8,
+            sliding_window_pattern=2,
+        )
+        model = gemma3.LanguageModel(config)
+
+        # With --kv-bits the server quantizes global-attention layers from
+        # token 0; sliding layers keep their RotatingKVCache.
+        cache = [
+            QuantizedKVCache(group_size=64, bits=8) if isinstance(c, KVCache) else c
+            for c in model.make_cache()
+        ]
+
+        prompt = mx.arange(12)[None]  # longer than the sliding window
+        logits = model(prompt, cache=cache).logits
+        self.assertEqual(logits.shape, (1, 12, config.vocab_size))
+
+        decode = model(mx.array([[3]]), cache=cache).logits
+        chunk = model(mx.arange(4)[None], cache=cache).logits  # chunked prefill
+        mx.eval(logits, decode, chunk)
+        self.assertTrue(mx.isfinite(chunk).all().item())
+
+        # The quantized path must actually have been exercised.
+        self.assertIsInstance(cache[1].keys, tuple)


### PR DESCRIPTION
With --kv-bits, there is an array and tuple mixup. KVCache returns a tuple (packed_uint32, scales, biases) which doesn't support .shape[], so doing keys.shape[-2] on that result to get the KV sequence length causes AttributionError. 

Solution: a function to handle sequence length out of whichever representation it's handed, a mx.array, tuple or list.

All tests pass + new TestQuantizedKVCacheMask 

fixes #1481

