### PR TITLE
Make Qwen MRoPE request-local under continuous batching

### DIFF
--- a/mlx_vlm/generate/ar.py
+++ b/mlx_vlm/generate/ar.py
@@ -549,7 +549,21 @@ _SEQUENCE_ALIGNED_PROMPT_KWARGS = {
 APC_PRIVATE_PROMPT_KEYS = ("_apc_tenant", "_apc_image_hash")
 
 
-def _prompt_kwarg_row(v: mx.array, row_idx: int, batch_size: int) -> mx.array:
+def _is_mrope_position_ids_prompt_kwarg(key: str, v: mx.array) -> bool:
+    return key == "position_ids" and v.ndim == 3 and v.shape[0] == 3
+
+
+def _prompt_kwarg_batch_size(key: str, v: mx.array) -> int:
+    if _is_mrope_position_ids_prompt_kwarg(key, v):
+        return v.shape[1]
+    return v.shape[0] if v.ndim > 0 else 0
+
+
+def _prompt_kwarg_row(key: str, v: mx.array, row_idx: int, batch_size: int) -> mx.array:
+    if _is_mrope_position_ids_prompt_kwarg(key, v):
+        if v.shape[1] == batch_size:
+            return v[:, row_idx : row_idx + 1, :]
+        return v[:, :1, :]
     if v.shape[0] == batch_size:
         return v[row_idx : row_idx + 1]
     return v[:1]
@@ -569,9 +583,9 @@ def _split_prompt_kwargs_per_row(prompt_kwargs: dict, batch_size: int) -> List[d
 
     rows = [{} for _ in range(batch_size)]
     for k, v in (prompt_kwargs or {}).items():
-        if isinstance(v, mx.array) and v.ndim > 0 and v.shape[0] >= 1:
+        if isinstance(v, mx.array) and _prompt_kwarg_batch_size(k, v) >= 1:
             for i in range(batch_size):
-                rows[i][k] = _prompt_kwarg_row(v, i, batch_size)
+                rows[i][k] = _prompt_kwarg_row(k, v, i, batch_size)
         else:
             for row in rows:
                 row[k] = v
@@ -581,23 +595,51 @@ def _split_prompt_kwargs_per_row(prompt_kwargs: dict, batch_size: int) -> List[d
 def _is_sequence_aligned_prompt_kwarg(
     key: str, v: mx.array, sequence_length: int
 ) -> bool:
-    return (
-        key in _SEQUENCE_ALIGNED_PROMPT_KWARGS
-        and v.ndim >= 2
-        and v.shape[1] == sequence_length
-    )
+    if key not in _SEQUENCE_ALIGNED_PROMPT_KWARGS:
+        return False
+    if _is_mrope_position_ids_prompt_kwarg(key, v):
+        return v.shape[2] == sequence_length
+    return v.ndim >= 2 and v.shape[1] == sequence_length
 
 
 def _pad_sequence_aligned_prompt_kwarg(
-    v: mx.array, target_length: int, *, left: bool
+    key: str, v: mx.array, target_length: int, *, left: bool
 ) -> mx.array:
-    pad = target_length - v.shape[1]
+    sequence_axis = 2 if _is_mrope_position_ids_prompt_kwarg(key, v) else 1
+    pad = target_length - v.shape[sequence_axis]
     if pad <= 0:
         return v
-    pad_shape = (v.shape[0], pad) + tuple(v.shape[2:])
+    pad_shape = tuple(
+        pad if axis == sequence_axis else size for axis, size in enumerate(v.shape)
+    )
     pad_v = mx.zeros(pad_shape, dtype=v.dtype)
     parts = [pad_v, v] if left else [v, pad_v]
-    return mx.concatenate(parts, axis=1)
+    return mx.concatenate(parts, axis=sequence_axis)
+
+
+def _slice_sequence_aligned_prompt_kwarg(
+    key: str, v: mx.array, start: Optional[int] = None, stop: Optional[int] = None
+) -> mx.array:
+    sequence_axis = 2 if _is_mrope_position_ids_prompt_kwarg(key, v) else 1
+    slices = [slice(None)] * v.ndim
+    slices[sequence_axis] = slice(start, stop)
+    return v[tuple(slices)]
+
+
+def _mrope_position_ids_row(v: mx.array) -> mx.array:
+    if _is_mrope_position_ids_prompt_kwarg("position_ids", v):
+        return v
+    if v.ndim == 2:
+        return mx.broadcast_to(v[None, :, :], (3, v.shape[0], v.shape[1]))
+    return v
+
+
+def _concat_prompt_kwarg_rows(key: str, rows: List[mx.array]) -> mx.array:
+    if key == "position_ids" and any(
+        _is_mrope_position_ids_prompt_kwarg(key, row) for row in rows
+    ):
+        return mx.concatenate([_mrope_position_ids_row(row) for row in rows], axis=1)
+    return mx.concatenate(rows, axis=0)
 
 
 def _merge_prefill_prompt_kwargs(
@@ -635,17 +677,17 @@ def _merge_prefill_prompt_kwargs(
         for k, v in kw.items():
             if k == "inputs_embeds" or k in APC_PRIVATE_PROMPT_KEYS:
                 continue
-            if isinstance(v, mx.array) and v.ndim > 0 and v.shape[0] >= 1:
-                row_v = _prompt_kwarg_row(v, i, batch_size)
+            if isinstance(v, mx.array) and _prompt_kwarg_batch_size(k, v) >= 1:
+                row_v = _prompt_kwarg_row(k, v, i, batch_size)
                 if _is_sequence_aligned_prompt_kwarg(k, row_v, length):
                     row_v = _pad_sequence_aligned_prompt_kwarg(
-                        row_v, max_length, left=True
+                        k, row_v, max_length, left=True
                     )
                 per_row_keys.setdefault(k, []).append(row_v)
             elif k not in merged_kwargs:
                 merged_kwargs[k] = v
     for k, vs in per_row_keys.items():
-        merged_kwargs[k] = mx.concatenate(vs, axis=0)
+        merged_kwargs[k] = _concat_prompt_kwarg_rows(k, vs)
 
     return inputs_embeds, merged_kwargs
 
@@ -1538,9 +1580,8 @@ class PromptProcessingBatch:
             for k, v in self._prompt_kwargs.items():
                 if (
                     isinstance(v, mx.array)
-                    and v.ndim >= 2
-                    and v.shape[0] == prompt_batch
-                    and v.shape[1] == prompt_len
+                    and _prompt_kwarg_batch_size(k, v) == prompt_batch
+                    and _is_sequence_aligned_prompt_kwarg(k, v, prompt_len)
                 ):
                     self._prompt_length_aware_keys.append(k)
 
@@ -1731,7 +1772,7 @@ class PromptProcessingBatch:
             return self._prompt_kwargs
         out = dict(self._prompt_kwargs)
         for k in self._prompt_length_aware_keys:
-            out[k] = out[k][:, :n, ...]
+            out[k] = _slice_sequence_aligned_prompt_kwarg(k, out[k], stop=n)
         return out
 
     def prompt_step(self) -> int:
@@ -1760,7 +1801,9 @@ class PromptProcessingBatch:
         self._inputs_embeds = self._inputs_embeds[:, n:]
         self._input_ids = self._input_ids[:, n:]
         for k in self._prompt_length_aware_keys:
-            self._prompt_kwargs[k] = self._prompt_kwargs[k][:, n:, ...]
+            self._prompt_kwargs[k] = _slice_sequence_aligned_prompt_kwarg(
+                k, self._prompt_kwargs[k], start=n
+            )
         mx.clear_cache()
         return n
 
@@ -2349,11 +2392,14 @@ class BatchGenerator:
             for k, v in kw.items():
                 if k == "inputs_embeds" or k in self._APC_PRIVATE_KEYS:
                     continue
-                if isinstance(v, mx.array) and v.ndim > 0 and v.shape[0] >= 1:
-                    row_v = _prompt_kwarg_row(v, i, batch_size)
+                if isinstance(v, mx.array) and _prompt_kwarg_batch_size(k, v) >= 1:
+                    row_v = _prompt_kwarg_row(k, v, i, batch_size)
                     if _is_sequence_aligned_prompt_kwarg(k, row_v, full_len):
-                        row_v = row_v[:, prefix_len:, ...]
+                        row_v = _slice_sequence_aligned_prompt_kwarg(
+                            k, row_v, start=prefix_len
+                        )
                         row_v = _pad_sequence_aligned_prompt_kwarg(
+                            k,
                             row_v,
                             max_suffix_len,
                             left=False,
@@ -2362,7 +2408,7 @@ class BatchGenerator:
                 elif k not in merged_kwargs:
                     merged_kwargs[k] = v
         for k, vs in per_row_keys.items():
-            merged_kwargs[k] = mx.concatenate(vs, axis=0)
+            merged_kwargs[k] = _concat_prompt_kwarg_rows(k, vs)
 
         apc_mode = getattr(self, "apc_mode", "block")
         if apc_mode == "exact":

--- a/mlx_vlm/generate/ar.py
+++ b/mlx_vlm/generate/ar.py
@@ -1913,38 +1913,10 @@ class PromptProcessingBatch:
             gen_batch._next_top_lp = top_lp
 
         language_model = getattr(self.model, "language_model", self.model)
-        rope_deltas = self._capture_rope_deltas(language_model, len(gen_batch.uids))
+        rope_deltas = self._capture_rope_deltas_from_prompt_kwargs(
+            call_kwargs, language_model, len(gen_batch.uids)
+        )
         if rope_deltas is not None:
-            # Normalize to shape (B, 1) so extend/filter stay consistent.
-            if rope_deltas.ndim == 0:
-                rope_deltas = rope_deltas.reshape(1, 1)
-            elif rope_deltas.ndim == 1:
-                rope_deltas = rope_deltas[:, None]
-            # When a warm-start batch reuses the model's cached _rope_deltas
-            # (computed during a previous prefill with a smaller batch), the
-            # batch dim won't match this prompt batch's row count. Realign
-            # so extend()/filter() down the line stay consistent with the
-            # generation batch's row count.
-            target_b = first_tokens.shape[0]
-            if rope_deltas.shape[0] != target_b:
-                if rope_deltas.shape[0] == 1:
-                    rope_deltas = mx.broadcast_to(
-                        rope_deltas, (target_b, rope_deltas.shape[1])
-                    )
-                elif rope_deltas.shape[0] < target_b:
-                    pad = target_b - rope_deltas.shape[0]
-                    rope_deltas = mx.concatenate(
-                        [
-                            rope_deltas,
-                            mx.broadcast_to(
-                                rope_deltas[-1:],
-                                (pad, rope_deltas.shape[1]),
-                            ),
-                        ],
-                        axis=0,
-                    )
-                else:
-                    rope_deltas = rope_deltas[:target_b]
             gen_batch._rope_deltas = rope_deltas
 
         # Final prefill produces the first generated token and mutates the
@@ -2025,6 +1997,19 @@ class PromptProcessingBatch:
         rope_deltas = language_model._rope_deltas
         if rope_deltas is None:
             return mx.zeros((B, 1), dtype=mx.int32)
+        return PromptProcessingBatch._normalize_rope_deltas(rope_deltas, B)
+
+    @staticmethod
+    def _capture_rope_deltas_from_prompt_kwargs(
+        prompt_kwargs: dict, language_model, B: int
+    ):
+        rope_deltas = (prompt_kwargs or {}).get("rope_deltas")
+        if isinstance(rope_deltas, mx.array):
+            return PromptProcessingBatch._normalize_rope_deltas(rope_deltas, B)
+        return PromptProcessingBatch._capture_rope_deltas(language_model, B)
+
+    @staticmethod
+    def _normalize_rope_deltas(rope_deltas: mx.array, B: int):
         if rope_deltas.ndim == 0:
             rope_deltas = rope_deltas.reshape(1, 1)
         elif rope_deltas.ndim == 1:
@@ -3056,7 +3041,10 @@ def _generate_batch(
         input_ids, pixel_values, mask=mask, **data_kwargs
     )
 
-    gen_kwargs = {**data_kwargs, **embedding_output.to_dict()}
+    gen_kwargs = {
+        **data_kwargs,
+        **{k: v for k, v in embedding_output.to_dict().items() if v is not None},
+    }
 
     if kwargs.get("prefill_step_size", DEFAULT_PREFILL_STEP_SIZE) is not None:
         policy_kwargs = dict(gen_kwargs)

--- a/mlx_vlm/models/base.py
+++ b/mlx_vlm/models/base.py
@@ -96,26 +96,6 @@ class InputEmbeddingsFeatures:
         }
 
 
-def prompt_position_ids(position_ids: Optional[mx.array]) -> Optional[mx.array]:
-    if position_ids is None:
-        return None
-    if position_ids.ndim == 3 and position_ids.shape[0] == 3:
-        return position_ids.transpose(1, 2, 0)
-    if position_ids.ndim == 2:
-        return mx.broadcast_to(position_ids[:, :, None], (*position_ids.shape, 3))
-    return position_ids
-
-
-def language_position_ids(
-    position_ids: Optional[mx.array], inputs: mx.array
-) -> Optional[mx.array]:
-    if position_ids is not None and position_ids.ndim == 3:
-        batch_size, seq_length = inputs.shape
-        if position_ids.shape == (batch_size, seq_length, 3):
-            return position_ids.transpose(2, 0, 1)
-    return position_ids
-
-
 @dataclass
 class BaseModelConfig:
     @classmethod

--- a/mlx_vlm/models/base.py
+++ b/mlx_vlm/models/base.py
@@ -96,7 +96,7 @@ class InputEmbeddingsFeatures:
         }
 
 
-def _prompt_position_ids(position_ids: Optional[mx.array]) -> Optional[mx.array]:
+def prompt_position_ids(position_ids: Optional[mx.array]) -> Optional[mx.array]:
     if position_ids is None:
         return None
     if position_ids.ndim == 3 and position_ids.shape[0] == 3:
@@ -106,7 +106,7 @@ def _prompt_position_ids(position_ids: Optional[mx.array]) -> Optional[mx.array]
     return position_ids
 
 
-def _language_position_ids(
+def language_position_ids(
     position_ids: Optional[mx.array], inputs: mx.array
 ) -> Optional[mx.array]:
     if position_ids is not None and position_ids.ndim == 3:

--- a/mlx_vlm/models/base.py
+++ b/mlx_vlm/models/base.py
@@ -96,6 +96,26 @@ class InputEmbeddingsFeatures:
         }
 
 
+def _prompt_position_ids(position_ids: Optional[mx.array]) -> Optional[mx.array]:
+    if position_ids is None:
+        return None
+    if position_ids.ndim == 3 and position_ids.shape[0] == 3:
+        return position_ids.transpose(1, 2, 0)
+    if position_ids.ndim == 2:
+        return mx.broadcast_to(position_ids[:, :, None], (*position_ids.shape, 3))
+    return position_ids
+
+
+def _language_position_ids(
+    position_ids: Optional[mx.array], inputs: mx.array
+) -> Optional[mx.array]:
+    if position_ids is not None and position_ids.ndim == 3:
+        batch_size, seq_length = inputs.shape
+        if position_ids.shape == (batch_size, seq_length, 3):
+            return position_ids.transpose(2, 0, 1)
+    return position_ids
+
+
 @dataclass
 class BaseModelConfig:
     @classmethod

--- a/mlx_vlm/models/qwen2_5_vl/language.py
+++ b/mlx_vlm/models/qwen2_5_vl/language.py
@@ -7,7 +7,6 @@ from mlx_lm.models.activations import swiglu
 from ..base import (
     LanguageModelOutput,
     create_attention_mask,
-    language_position_ids,
     scaled_dot_product_attention,
 )
 from ..cache import KVCache
@@ -427,7 +426,6 @@ class LanguageModel(nn.Module):
         image_grid_thw = kwargs.pop("image_grid_thw", None)
         video_grid_thw = kwargs.pop("video_grid_thw", None)
         rope_deltas_kw = kwargs.pop("rope_deltas", None)
-        position_ids = language_position_ids(position_ids, inputs)
         # reset rope_deltas and position_ids when processing a new image/video
         if pixel_values is not None:
             self._rope_deltas = None

--- a/mlx_vlm/models/qwen2_5_vl/language.py
+++ b/mlx_vlm/models/qwen2_5_vl/language.py
@@ -6,6 +6,7 @@ from mlx_lm.models.activations import swiglu
 
 from ..base import (
     LanguageModelOutput,
+    _language_position_ids,
     create_attention_mask,
     scaled_dot_product_attention,
 )
@@ -35,16 +36,6 @@ class Qwen2RotaryEmbedding(MRoPERotaryEmbedding):
 
 def apply_multimodal_rotary_pos_emb(q, k, cos, sin, unqueeze_dim=1):
     return _apply_mrope(q, k, cos, sin, style="chunked", unsqueeze_dim=unqueeze_dim)
-
-
-def _language_position_ids(
-    position_ids: Optional[mx.array], inputs: mx.array
-) -> Optional[mx.array]:
-    if position_ids is not None and position_ids.ndim == 3:
-        batch_size, seq_length = inputs.shape
-        if position_ids.shape == (batch_size, seq_length, 3):
-            return position_ids.transpose(2, 0, 1)
-    return position_ids
 
 
 class Attention(nn.Module):

--- a/mlx_vlm/models/qwen2_5_vl/language.py
+++ b/mlx_vlm/models/qwen2_5_vl/language.py
@@ -37,6 +37,16 @@ def apply_multimodal_rotary_pos_emb(q, k, cos, sin, unqueeze_dim=1):
     return _apply_mrope(q, k, cos, sin, style="chunked", unsqueeze_dim=unqueeze_dim)
 
 
+def _language_position_ids(
+    position_ids: Optional[mx.array], inputs: mx.array
+) -> Optional[mx.array]:
+    if position_ids is not None and position_ids.ndim == 3:
+        batch_size, seq_length = inputs.shape
+        if position_ids.shape == (batch_size, seq_length, 3):
+            return position_ids.transpose(2, 0, 1)
+    return position_ids
+
+
 class Attention(nn.Module):
     def __init__(self, args: TextConfig):
         super().__init__()
@@ -426,6 +436,7 @@ class LanguageModel(nn.Module):
         image_grid_thw = kwargs.pop("image_grid_thw", None)
         video_grid_thw = kwargs.pop("video_grid_thw", None)
         rope_deltas_kw = kwargs.pop("rope_deltas", None)
+        position_ids = _language_position_ids(position_ids, inputs)
         # reset rope_deltas and position_ids when processing a new image/video
         if pixel_values is not None:
             self._rope_deltas = None
@@ -506,6 +517,15 @@ class LanguageModel(nn.Module):
                 position_ids = mx.arange(seq_length).reshape(1, -1)
                 position_ids = mx.broadcast_to(position_ids, (batch_size, seq_length))
                 position_ids = mx.add(position_ids, delta)
+                if (
+                    rope_deltas_kw is not None
+                    or self._position_ids is not None
+                    and self._position_ids.ndim == 3
+                ):
+                    position_ids = position_ids[None, ...]
+                    position_ids = mx.broadcast_to(
+                        position_ids, (3, batch_size, seq_length)
+                    )
 
         out = self.model(
             inputs, cache=cache, inputs_embeds=inputs_embeds, position_ids=position_ids

--- a/mlx_vlm/models/qwen2_5_vl/language.py
+++ b/mlx_vlm/models/qwen2_5_vl/language.py
@@ -6,8 +6,8 @@ from mlx_lm.models.activations import swiglu
 
 from ..base import (
     LanguageModelOutput,
-    _language_position_ids,
     create_attention_mask,
+    language_position_ids,
     scaled_dot_product_attention,
 )
 from ..cache import KVCache
@@ -427,7 +427,7 @@ class LanguageModel(nn.Module):
         image_grid_thw = kwargs.pop("image_grid_thw", None)
         video_grid_thw = kwargs.pop("video_grid_thw", None)
         rope_deltas_kw = kwargs.pop("rope_deltas", None)
-        position_ids = _language_position_ids(position_ids, inputs)
+        position_ids = language_position_ids(position_ids, inputs)
         # reset rope_deltas and position_ids when processing a new image/video
         if pixel_values is not None:
             self._rope_deltas = None

--- a/mlx_vlm/models/qwen2_5_vl/qwen2_5_vl.py
+++ b/mlx_vlm/models/qwen2_5_vl/qwen2_5_vl.py
@@ -3,7 +3,7 @@ from typing import Optional
 import mlx.core as mx
 import mlx.nn as nn
 
-from ..base import InputEmbeddingsFeatures, _prompt_position_ids
+from ..base import InputEmbeddingsFeatures, prompt_position_ids
 from . import processing_qwen2_5_vl  # noqa: F401
 from .config import ModelConfig
 from .language import LanguageModel
@@ -37,7 +37,7 @@ class Model(nn.Module):
             )
             return InputEmbeddingsFeatures(
                 inputs_embeds=self.language_model.model.embed_tokens(input_ids),
-                position_ids=_prompt_position_ids(position_ids),
+                position_ids=prompt_position_ids(position_ids),
                 rope_deltas=rope_deltas,
             )
 
@@ -71,7 +71,7 @@ class Model(nn.Module):
 
         return InputEmbeddingsFeatures(
             inputs_embeds=final_inputs_embeds,
-            position_ids=_prompt_position_ids(position_ids),
+            position_ids=prompt_position_ids(position_ids),
             rope_deltas=rope_deltas,
         )
 

--- a/mlx_vlm/models/qwen2_5_vl/qwen2_5_vl.py
+++ b/mlx_vlm/models/qwen2_5_vl/qwen2_5_vl.py
@@ -11,12 +11,12 @@ from .vision import VisionModel
 
 
 def _prompt_position_ids(position_ids: Optional[mx.array]) -> Optional[mx.array]:
-    if (
-        position_ids is not None
-        and position_ids.ndim == 3
-        and position_ids.shape[0] == 3
-    ):
+    if position_ids is None:
+        return None
+    if position_ids.ndim == 3 and position_ids.shape[0] == 3:
         return position_ids.transpose(1, 2, 0)
+    if position_ids.ndim == 2:
+        return mx.broadcast_to(position_ids[:, :, None], (*position_ids.shape, 3))
     return position_ids
 
 

--- a/mlx_vlm/models/qwen2_5_vl/qwen2_5_vl.py
+++ b/mlx_vlm/models/qwen2_5_vl/qwen2_5_vl.py
@@ -10,6 +10,16 @@ from .language import LanguageModel
 from .vision import VisionModel
 
 
+def _prompt_position_ids(position_ids: Optional[mx.array]) -> Optional[mx.array]:
+    if (
+        position_ids is not None
+        and position_ids.ndim == 3
+        and position_ids.shape[0] == 3
+    ):
+        return position_ids.transpose(1, 2, 0)
+    return position_ids
+
+
 class Model(nn.Module):
     def __init__(self, config: ModelConfig):
         super().__init__()
@@ -32,9 +42,13 @@ class Model(nn.Module):
         grid_thw = image_grid_thw if image_grid_thw is not None else video_grid_thw
 
         if pixel_values is None:
-            self.language_model._position_ids = None
+            position_ids, rope_deltas = self.language_model.get_rope_index(
+                input_ids, attention_mask=mask
+            )
             return InputEmbeddingsFeatures(
-                inputs_embeds=self.language_model.model.embed_tokens(input_ids)
+                inputs_embeds=self.language_model.model.embed_tokens(input_ids),
+                position_ids=_prompt_position_ids(position_ids),
+                rope_deltas=rope_deltas,
             )
 
         dtype = self.vision_tower.patch_embed.proj.weight.dtype
@@ -61,15 +75,15 @@ class Model(nn.Module):
             input_ids,
         )
 
-        # Pre-calculate position_ids for chunked prefill
-        if image_grid_thw is not None or video_grid_thw is not None:
-            position_ids, rope_deltas = self.language_model.get_rope_index(
-                input_ids, image_grid_thw, video_grid_thw, mask
-            )
-            self.language_model._position_ids = position_ids
-            self.language_model._rope_deltas = rope_deltas
+        position_ids, rope_deltas = self.language_model.get_rope_index(
+            input_ids, image_grid_thw, video_grid_thw, mask
+        )
 
-        return InputEmbeddingsFeatures(inputs_embeds=final_inputs_embeds)
+        return InputEmbeddingsFeatures(
+            inputs_embeds=final_inputs_embeds,
+            position_ids=_prompt_position_ids(position_ids),
+            rope_deltas=rope_deltas,
+        )
 
     @staticmethod
     def merge_input_ids_with_image_features(

--- a/mlx_vlm/models/qwen2_5_vl/qwen2_5_vl.py
+++ b/mlx_vlm/models/qwen2_5_vl/qwen2_5_vl.py
@@ -3,21 +3,11 @@ from typing import Optional
 import mlx.core as mx
 import mlx.nn as nn
 
-from ..base import InputEmbeddingsFeatures
+from ..base import InputEmbeddingsFeatures, _prompt_position_ids
 from . import processing_qwen2_5_vl  # noqa: F401
 from .config import ModelConfig
 from .language import LanguageModel
 from .vision import VisionModel
-
-
-def _prompt_position_ids(position_ids: Optional[mx.array]) -> Optional[mx.array]:
-    if position_ids is None:
-        return None
-    if position_ids.ndim == 3 and position_ids.shape[0] == 3:
-        return position_ids.transpose(1, 2, 0)
-    if position_ids.ndim == 2:
-        return mx.broadcast_to(position_ids[:, :, None], (*position_ids.shape, 3))
-    return position_ids
 
 
 class Model(nn.Module):

--- a/mlx_vlm/models/qwen2_5_vl/qwen2_5_vl.py
+++ b/mlx_vlm/models/qwen2_5_vl/qwen2_5_vl.py
@@ -3,7 +3,7 @@ from typing import Optional
 import mlx.core as mx
 import mlx.nn as nn
 
-from ..base import InputEmbeddingsFeatures, prompt_position_ids
+from ..base import InputEmbeddingsFeatures
 from . import processing_qwen2_5_vl  # noqa: F401
 from .config import ModelConfig
 from .language import LanguageModel
@@ -37,7 +37,7 @@ class Model(nn.Module):
             )
             return InputEmbeddingsFeatures(
                 inputs_embeds=self.language_model.model.embed_tokens(input_ids),
-                position_ids=prompt_position_ids(position_ids),
+                position_ids=position_ids,
                 rope_deltas=rope_deltas,
             )
 
@@ -71,7 +71,7 @@ class Model(nn.Module):
 
         return InputEmbeddingsFeatures(
             inputs_embeds=final_inputs_embeds,
-            position_ids=prompt_position_ids(position_ids),
+            position_ids=position_ids,
             rope_deltas=rope_deltas,
         )
 

--- a/mlx_vlm/models/qwen2_vl/language.py
+++ b/mlx_vlm/models/qwen2_vl/language.py
@@ -7,7 +7,6 @@ from mlx_lm.models.activations import swiglu
 from ..base import (
     LanguageModelOutput,
     create_attention_mask,
-    language_position_ids,
     scaled_dot_product_attention,
 )
 from ..cache import KVCache
@@ -426,7 +425,6 @@ class LanguageModel(nn.Module):
         image_grid_thw = kwargs.pop("image_grid_thw", None)
         video_grid_thw = kwargs.pop("video_grid_thw", None)
         rope_deltas_kw = kwargs.pop("rope_deltas", None)
-        position_ids = language_position_ids(position_ids, inputs)
         # reset rope_deltas and position_ids when processing a new image/video
         if pixel_values is not None:
             self._rope_deltas = None

--- a/mlx_vlm/models/qwen2_vl/language.py
+++ b/mlx_vlm/models/qwen2_vl/language.py
@@ -6,8 +6,8 @@ from mlx_lm.models.activations import swiglu
 
 from ..base import (
     LanguageModelOutput,
-    _language_position_ids,
     create_attention_mask,
+    language_position_ids,
     scaled_dot_product_attention,
 )
 from ..cache import KVCache
@@ -426,7 +426,7 @@ class LanguageModel(nn.Module):
         image_grid_thw = kwargs.pop("image_grid_thw", None)
         video_grid_thw = kwargs.pop("video_grid_thw", None)
         rope_deltas_kw = kwargs.pop("rope_deltas", None)
-        position_ids = _language_position_ids(position_ids, inputs)
+        position_ids = language_position_ids(position_ids, inputs)
         # reset rope_deltas and position_ids when processing a new image/video
         if pixel_values is not None:
             self._rope_deltas = None

--- a/mlx_vlm/models/qwen2_vl/language.py
+++ b/mlx_vlm/models/qwen2_vl/language.py
@@ -6,6 +6,7 @@ from mlx_lm.models.activations import swiglu
 
 from ..base import (
     LanguageModelOutput,
+    _language_position_ids,
     create_attention_mask,
     scaled_dot_product_attention,
 )
@@ -35,16 +36,6 @@ class Qwen2RotaryEmbedding(MRoPERotaryEmbedding):
 
 def apply_multimodal_rotary_pos_emb(q, k, cos, sin, unqueeze_dim=1):
     return _apply_mrope(q, k, cos, sin, style="chunked", unsqueeze_dim=unqueeze_dim)
-
-
-def _language_position_ids(
-    position_ids: Optional[mx.array], inputs: mx.array
-) -> Optional[mx.array]:
-    if position_ids is not None and position_ids.ndim == 3:
-        batch_size, seq_length = inputs.shape
-        if position_ids.shape == (batch_size, seq_length, 3):
-            return position_ids.transpose(2, 0, 1)
-    return position_ids
 
 
 class Attention(nn.Module):

--- a/mlx_vlm/models/qwen2_vl/language.py
+++ b/mlx_vlm/models/qwen2_vl/language.py
@@ -37,6 +37,16 @@ def apply_multimodal_rotary_pos_emb(q, k, cos, sin, unqueeze_dim=1):
     return _apply_mrope(q, k, cos, sin, style="chunked", unsqueeze_dim=unqueeze_dim)
 
 
+def _language_position_ids(
+    position_ids: Optional[mx.array], inputs: mx.array
+) -> Optional[mx.array]:
+    if position_ids is not None and position_ids.ndim == 3:
+        batch_size, seq_length = inputs.shape
+        if position_ids.shape == (batch_size, seq_length, 3):
+            return position_ids.transpose(2, 0, 1)
+    return position_ids
+
+
 class Attention(nn.Module):
     def __init__(self, args: TextConfig):
         super().__init__()
@@ -425,6 +435,7 @@ class LanguageModel(nn.Module):
         image_grid_thw = kwargs.pop("image_grid_thw", None)
         video_grid_thw = kwargs.pop("video_grid_thw", None)
         rope_deltas_kw = kwargs.pop("rope_deltas", None)
+        position_ids = _language_position_ids(position_ids, inputs)
         # reset rope_deltas and position_ids when processing a new image/video
         if pixel_values is not None:
             self._rope_deltas = None
@@ -499,6 +510,15 @@ class LanguageModel(nn.Module):
                 position_ids = mx.arange(seq_length).reshape(1, -1)
                 position_ids = mx.broadcast_to(position_ids, (batch_size, seq_length))
                 position_ids = mx.add(position_ids, delta)
+                if (
+                    rope_deltas_kw is not None
+                    or self._position_ids is not None
+                    and self._position_ids.ndim == 3
+                ):
+                    position_ids = position_ids[None, ...]
+                    position_ids = mx.broadcast_to(
+                        position_ids, (3, batch_size, seq_length)
+                    )
 
         out = self.model(
             inputs, cache=cache, inputs_embeds=inputs_embeds, position_ids=position_ids

--- a/mlx_vlm/models/qwen2_vl/qwen2_vl.py
+++ b/mlx_vlm/models/qwen2_vl/qwen2_vl.py
@@ -3,7 +3,7 @@ from typing import Optional
 import mlx.core as mx
 import mlx.nn as nn
 
-from ..base import InputEmbeddingsFeatures, prompt_position_ids
+from ..base import InputEmbeddingsFeatures
 from . import processing_qwen2_vl  # noqa: F401
 from .config import ModelConfig
 from .language import LanguageModel
@@ -37,7 +37,7 @@ class Model(nn.Module):
             )
             return InputEmbeddingsFeatures(
                 inputs_embeds=self.language_model.model.embed_tokens(input_ids),
-                position_ids=prompt_position_ids(position_ids),
+                position_ids=position_ids,
                 rope_deltas=rope_deltas,
             )
 
@@ -71,7 +71,7 @@ class Model(nn.Module):
 
         return InputEmbeddingsFeatures(
             inputs_embeds=final_inputs_embeds,
-            position_ids=prompt_position_ids(position_ids),
+            position_ids=position_ids,
             rope_deltas=rope_deltas,
         )
 

--- a/mlx_vlm/models/qwen2_vl/qwen2_vl.py
+++ b/mlx_vlm/models/qwen2_vl/qwen2_vl.py
@@ -3,21 +3,11 @@ from typing import Optional
 import mlx.core as mx
 import mlx.nn as nn
 
-from ..base import InputEmbeddingsFeatures
+from ..base import InputEmbeddingsFeatures, _prompt_position_ids
 from . import processing_qwen2_vl  # noqa: F401
 from .config import ModelConfig
 from .language import LanguageModel
 from .vision import VisionModel
-
-
-def _prompt_position_ids(position_ids: Optional[mx.array]) -> Optional[mx.array]:
-    if position_ids is None:
-        return None
-    if position_ids.ndim == 3 and position_ids.shape[0] == 3:
-        return position_ids.transpose(1, 2, 0)
-    if position_ids.ndim == 2:
-        return mx.broadcast_to(position_ids[:, :, None], (*position_ids.shape, 3))
-    return position_ids
 
 
 class Model(nn.Module):

--- a/mlx_vlm/models/qwen2_vl/qwen2_vl.py
+++ b/mlx_vlm/models/qwen2_vl/qwen2_vl.py
@@ -11,12 +11,12 @@ from .vision import VisionModel
 
 
 def _prompt_position_ids(position_ids: Optional[mx.array]) -> Optional[mx.array]:
-    if (
-        position_ids is not None
-        and position_ids.ndim == 3
-        and position_ids.shape[0] == 3
-    ):
+    if position_ids is None:
+        return None
+    if position_ids.ndim == 3 and position_ids.shape[0] == 3:
         return position_ids.transpose(1, 2, 0)
+    if position_ids.ndim == 2:
+        return mx.broadcast_to(position_ids[:, :, None], (*position_ids.shape, 3))
     return position_ids
 
 

--- a/mlx_vlm/models/qwen2_vl/qwen2_vl.py
+++ b/mlx_vlm/models/qwen2_vl/qwen2_vl.py
@@ -10,6 +10,16 @@ from .language import LanguageModel
 from .vision import VisionModel
 
 
+def _prompt_position_ids(position_ids: Optional[mx.array]) -> Optional[mx.array]:
+    if (
+        position_ids is not None
+        and position_ids.ndim == 3
+        and position_ids.shape[0] == 3
+    ):
+        return position_ids.transpose(1, 2, 0)
+    return position_ids
+
+
 class Model(nn.Module):
     def __init__(self, config: ModelConfig):
         super().__init__()
@@ -32,9 +42,13 @@ class Model(nn.Module):
         grid_thw = image_grid_thw if image_grid_thw is not None else video_grid_thw
 
         if pixel_values is None:
-            self.language_model._position_ids = None
+            position_ids, rope_deltas = self.language_model.get_rope_index(
+                input_ids, attention_mask=mask
+            )
             return InputEmbeddingsFeatures(
-                inputs_embeds=self.language_model.model.embed_tokens(input_ids)
+                inputs_embeds=self.language_model.model.embed_tokens(input_ids),
+                position_ids=_prompt_position_ids(position_ids),
+                rope_deltas=rope_deltas,
             )
 
         dtype = self.vision_tower.patch_embed.proj.weight.dtype
@@ -61,15 +75,15 @@ class Model(nn.Module):
             input_ids,
         )
 
-        # Pre-calculate position_ids for chunked prefill
-        if image_grid_thw is not None or video_grid_thw is not None:
-            position_ids, rope_deltas = self.language_model.get_rope_index(
-                input_ids, image_grid_thw, video_grid_thw, mask
-            )
-            self.language_model._position_ids = position_ids
-            self.language_model._rope_deltas = rope_deltas
+        position_ids, rope_deltas = self.language_model.get_rope_index(
+            input_ids, image_grid_thw, video_grid_thw, mask
+        )
 
-        return InputEmbeddingsFeatures(inputs_embeds=final_inputs_embeds)
+        return InputEmbeddingsFeatures(
+            inputs_embeds=final_inputs_embeds,
+            position_ids=_prompt_position_ids(position_ids),
+            rope_deltas=rope_deltas,
+        )
 
     @staticmethod
     def merge_input_ids_with_image_features(

--- a/mlx_vlm/models/qwen2_vl/qwen2_vl.py
+++ b/mlx_vlm/models/qwen2_vl/qwen2_vl.py
@@ -3,7 +3,7 @@ from typing import Optional
 import mlx.core as mx
 import mlx.nn as nn
 
-from ..base import InputEmbeddingsFeatures, _prompt_position_ids
+from ..base import InputEmbeddingsFeatures, prompt_position_ids
 from . import processing_qwen2_vl  # noqa: F401
 from .config import ModelConfig
 from .language import LanguageModel
@@ -37,7 +37,7 @@ class Model(nn.Module):
             )
             return InputEmbeddingsFeatures(
                 inputs_embeds=self.language_model.model.embed_tokens(input_ids),
-                position_ids=_prompt_position_ids(position_ids),
+                position_ids=prompt_position_ids(position_ids),
                 rope_deltas=rope_deltas,
             )
 
@@ -71,7 +71,7 @@ class Model(nn.Module):
 
         return InputEmbeddingsFeatures(
             inputs_embeds=final_inputs_embeds,
-            position_ids=_prompt_position_ids(position_ids),
+            position_ids=prompt_position_ids(position_ids),
             rope_deltas=rope_deltas,
         )
 

--- a/mlx_vlm/models/qwen3_5/language.py
+++ b/mlx_vlm/models/qwen3_5/language.py
@@ -7,8 +7,8 @@ from mlx_lm.models.activations import swiglu
 
 from ..base import (
     LanguageModelOutput,
-    _language_position_ids,
     create_attention_mask,
+    language_position_ids,
     scaled_dot_product_attention,
 )
 from ..cache import ArraysCache, KVCache
@@ -2439,7 +2439,7 @@ class LanguageModel(nn.Module):
         return_shared_kv = kwargs.pop("return_shared_kv", False)
         skip_logits = kwargs.pop("skip_logits", False)
         rope_deltas_kw = kwargs.pop("rope_deltas", None)
-        position_ids = _language_position_ids(position_ids, inputs)
+        position_ids = language_position_ids(position_ids, inputs)
         if (
             mask is None
             and attention_mask is not None

--- a/mlx_vlm/models/qwen3_5/language.py
+++ b/mlx_vlm/models/qwen3_5/language.py
@@ -8,7 +8,6 @@ from mlx_lm.models.activations import swiglu
 from ..base import (
     LanguageModelOutput,
     create_attention_mask,
-    language_position_ids,
     scaled_dot_product_attention,
 )
 from ..cache import ArraysCache, KVCache
@@ -2439,7 +2438,6 @@ class LanguageModel(nn.Module):
         return_shared_kv = kwargs.pop("return_shared_kv", False)
         skip_logits = kwargs.pop("skip_logits", False)
         rope_deltas_kw = kwargs.pop("rope_deltas", None)
-        position_ids = language_position_ids(position_ids, inputs)
         if (
             mask is None
             and attention_mask is not None

--- a/mlx_vlm/models/qwen3_5/language.py
+++ b/mlx_vlm/models/qwen3_5/language.py
@@ -44,6 +44,16 @@ def apply_multimodal_rotary_pos_emb(q, k, cos, sin, unqueeze_dim=1):
     return _apply_mrope(q, k, cos, sin, style="interleaved", unsqueeze_dim=unqueeze_dim)
 
 
+def _language_position_ids(
+    position_ids: Optional[mx.array], inputs: mx.array
+) -> Optional[mx.array]:
+    if position_ids is not None and position_ids.ndim == 3:
+        batch_size, seq_length = inputs.shape
+        if position_ids.shape == (batch_size, seq_length, 3):
+            return position_ids.transpose(2, 0, 1)
+    return position_ids
+
+
 class Qwen3_5RMSNormGated(nn.Module):
     def __init__(self, hidden_size: int, eps: float = 1e-6):
         super().__init__()
@@ -2438,6 +2448,7 @@ class LanguageModel(nn.Module):
         return_shared_kv = kwargs.pop("return_shared_kv", False)
         skip_logits = kwargs.pop("skip_logits", False)
         rope_deltas_kw = kwargs.pop("rope_deltas", None)
+        position_ids = _language_position_ids(position_ids, inputs)
         if (
             mask is None
             and attention_mask is not None
@@ -2548,6 +2559,15 @@ class LanguageModel(nn.Module):
                 position_ids = mx.arange(seq_length).reshape(1, -1)
                 position_ids = mx.broadcast_to(position_ids, (batch_size, seq_length))
                 position_ids = mx.add(position_ids, delta)
+                if (
+                    rope_deltas_kw is not None
+                    or self._position_ids is not None
+                    and self._position_ids.ndim == 3
+                ):
+                    position_ids = position_ids[None, ...]
+                    position_ids = mx.broadcast_to(
+                        position_ids, (3, batch_size, seq_length)
+                    )
 
         hidden_sink: Optional[List[mx.array]] = (
             [] if capture_layer_ids is not None else None

--- a/mlx_vlm/models/qwen3_5/language.py
+++ b/mlx_vlm/models/qwen3_5/language.py
@@ -7,6 +7,7 @@ from mlx_lm.models.activations import swiglu
 
 from ..base import (
     LanguageModelOutput,
+    _language_position_ids,
     create_attention_mask,
     scaled_dot_product_attention,
 )
@@ -42,16 +43,6 @@ class Qwen3_5RotaryEmbedding(MRoPERotaryEmbedding):
 
 def apply_multimodal_rotary_pos_emb(q, k, cos, sin, unqueeze_dim=1):
     return _apply_mrope(q, k, cos, sin, style="interleaved", unsqueeze_dim=unqueeze_dim)
-
-
-def _language_position_ids(
-    position_ids: Optional[mx.array], inputs: mx.array
-) -> Optional[mx.array]:
-    if position_ids is not None and position_ids.ndim == 3:
-        batch_size, seq_length = inputs.shape
-        if position_ids.shape == (batch_size, seq_length, 3):
-            return position_ids.transpose(2, 0, 1)
-    return position_ids
 
 
 class Qwen3_5RMSNormGated(nn.Module):

--- a/mlx_vlm/models/qwen3_5/qwen3_5.py
+++ b/mlx_vlm/models/qwen3_5/qwen3_5.py
@@ -3,23 +3,13 @@ from typing import Optional
 import mlx.core as mx
 import mlx.nn as nn
 
-from ..base import InputEmbeddingsFeatures
+from ..base import InputEmbeddingsFeatures, _prompt_position_ids
 from ..qwen3_vl import Model as Qwen3VLModel
 from ..qwen3_vl import processing_qwen3_vl  # noqa: F401
 from ..qwen3_vl.qwen3_vl import masked_scatter
 from .config import ModelConfig
 from .language import LanguageModel
 from .vision import VisionModel
-
-
-def _prompt_position_ids(position_ids: Optional[mx.array]) -> Optional[mx.array]:
-    if position_ids is None:
-        return None
-    if position_ids.ndim == 3 and position_ids.shape[0] == 3:
-        return position_ids.transpose(1, 2, 0)
-    if position_ids.ndim == 2:
-        return mx.broadcast_to(position_ids[:, :, None], (*position_ids.shape, 3))
-    return position_ids
 
 
 def sanitize_key(key):

--- a/mlx_vlm/models/qwen3_5/qwen3_5.py
+++ b/mlx_vlm/models/qwen3_5/qwen3_5.py
@@ -3,7 +3,7 @@ from typing import Optional
 import mlx.core as mx
 import mlx.nn as nn
 
-from ..base import InputEmbeddingsFeatures, prompt_position_ids
+from ..base import InputEmbeddingsFeatures
 from ..qwen3_vl import Model as Qwen3VLModel
 from ..qwen3_vl import processing_qwen3_vl  # noqa: F401
 from ..qwen3_vl.qwen3_vl import masked_scatter
@@ -53,7 +53,7 @@ class Model(Qwen3VLModel):
             )
             return InputEmbeddingsFeatures(
                 inputs_embeds=self.language_model.model.embed_tokens(input_ids),
-                position_ids=prompt_position_ids(position_ids),
+                position_ids=position_ids,
                 rope_deltas=rope_deltas,
             )
 
@@ -91,7 +91,7 @@ class Model(Qwen3VLModel):
 
         return InputEmbeddingsFeatures(
             inputs_embeds=inputs_embeds,
-            position_ids=prompt_position_ids(position_ids),
+            position_ids=position_ids,
             rope_deltas=rope_deltas,
         )
 

--- a/mlx_vlm/models/qwen3_5/qwen3_5.py
+++ b/mlx_vlm/models/qwen3_5/qwen3_5.py
@@ -13,12 +13,12 @@ from .vision import VisionModel
 
 
 def _prompt_position_ids(position_ids: Optional[mx.array]) -> Optional[mx.array]:
-    if (
-        position_ids is not None
-        and position_ids.ndim == 3
-        and position_ids.shape[0] == 3
-    ):
+    if position_ids is None:
+        return None
+    if position_ids.ndim == 3 and position_ids.shape[0] == 3:
         return position_ids.transpose(1, 2, 0)
+    if position_ids.ndim == 2:
+        return mx.broadcast_to(position_ids[:, :, None], (*position_ids.shape, 3))
     return position_ids
 
 

--- a/mlx_vlm/models/qwen3_5/qwen3_5.py
+++ b/mlx_vlm/models/qwen3_5/qwen3_5.py
@@ -12,6 +12,16 @@ from .language import LanguageModel
 from .vision import VisionModel
 
 
+def _prompt_position_ids(position_ids: Optional[mx.array]) -> Optional[mx.array]:
+    if (
+        position_ids is not None
+        and position_ids.ndim == 3
+        and position_ids.shape[0] == 3
+    ):
+        return position_ids.transpose(1, 2, 0)
+    return position_ids
+
+
 def sanitize_key(key):
     if key.startswith("model.language_model.visual"):
         key = key.replace("model.language_model.visual", "vision_tower", 1)
@@ -48,9 +58,13 @@ class Model(Qwen3VLModel):
         grid_thw = image_grid_thw if image_grid_thw is not None else video_grid_thw
 
         if pixel_values is None:
-            self.language_model._position_ids = None
+            position_ids, rope_deltas = self.language_model.get_rope_index(
+                input_ids, attention_mask=mask
+            )
             return InputEmbeddingsFeatures(
-                inputs_embeds=self.language_model.model.embed_tokens(input_ids)
+                inputs_embeds=self.language_model.model.embed_tokens(input_ids),
+                position_ids=_prompt_position_ids(position_ids),
+                rope_deltas=rope_deltas,
             )
 
         dtype = self.vision_tower.patch_embed.proj.weight.dtype
@@ -81,16 +95,14 @@ class Model(Qwen3VLModel):
             self.config.video_token_index,
         )
 
-        # Pre-calculate position_ids for chunked prefill
-        if image_grid_thw is not None or video_grid_thw is not None:
-            position_ids, rope_deltas = self.language_model.get_rope_index(
-                input_ids, image_grid_thw, video_grid_thw, mask
-            )
-            self.language_model._position_ids = position_ids
-            self.language_model._rope_deltas = rope_deltas
+        position_ids, rope_deltas = self.language_model.get_rope_index(
+            input_ids, image_grid_thw, video_grid_thw, mask
+        )
 
         return InputEmbeddingsFeatures(
             inputs_embeds=inputs_embeds,
+            position_ids=_prompt_position_ids(position_ids),
+            rope_deltas=rope_deltas,
         )
 
     @staticmethod

--- a/mlx_vlm/models/qwen3_5/qwen3_5.py
+++ b/mlx_vlm/models/qwen3_5/qwen3_5.py
@@ -3,7 +3,7 @@ from typing import Optional
 import mlx.core as mx
 import mlx.nn as nn
 
-from ..base import InputEmbeddingsFeatures, _prompt_position_ids
+from ..base import InputEmbeddingsFeatures, prompt_position_ids
 from ..qwen3_vl import Model as Qwen3VLModel
 from ..qwen3_vl import processing_qwen3_vl  # noqa: F401
 from ..qwen3_vl.qwen3_vl import masked_scatter
@@ -53,7 +53,7 @@ class Model(Qwen3VLModel):
             )
             return InputEmbeddingsFeatures(
                 inputs_embeds=self.language_model.model.embed_tokens(input_ids),
-                position_ids=_prompt_position_ids(position_ids),
+                position_ids=prompt_position_ids(position_ids),
                 rope_deltas=rope_deltas,
             )
 
@@ -91,7 +91,7 @@ class Model(Qwen3VLModel):
 
         return InputEmbeddingsFeatures(
             inputs_embeds=inputs_embeds,
-            position_ids=_prompt_position_ids(position_ids),
+            position_ids=prompt_position_ids(position_ids),
             rope_deltas=rope_deltas,
         )
 

--- a/mlx_vlm/models/qwen3_vl/language.py
+++ b/mlx_vlm/models/qwen3_vl/language.py
@@ -7,7 +7,6 @@ import numpy as np
 from ..base import (
     LanguageModelOutput,
     create_attention_mask,
-    language_position_ids,
     scaled_dot_product_attention,
 )
 from ..cache import KVCache
@@ -494,7 +493,6 @@ class LanguageModel(nn.Module):
         image_grid_thw = kwargs.pop("image_grid_thw", None)
         video_grid_thw = kwargs.pop("video_grid_thw", None)
         rope_deltas_kw = kwargs.pop("rope_deltas", None)
-        position_ids = language_position_ids(position_ids, inputs)
         # reset rope_deltas and position_ids when processing a new image/video
         if pixel_values is not None:
             self._rope_deltas = None

--- a/mlx_vlm/models/qwen3_vl/language.py
+++ b/mlx_vlm/models/qwen3_vl/language.py
@@ -6,6 +6,7 @@ import numpy as np
 
 from ..base import (
     LanguageModelOutput,
+    _language_position_ids,
     create_attention_mask,
     scaled_dot_product_attention,
 )
@@ -34,16 +35,6 @@ class Qwen3VLRotaryEmbedding(MRoPERotaryEmbedding):
 
 def apply_multimodal_rotary_pos_emb(q, k, cos, sin, unqueeze_dim=1):
     return _apply_mrope(q, k, cos, sin, style="interleaved", unsqueeze_dim=unqueeze_dim)
-
-
-def _language_position_ids(
-    position_ids: Optional[mx.array], inputs: mx.array
-) -> Optional[mx.array]:
-    if position_ids is not None and position_ids.ndim == 3:
-        batch_size, seq_length = inputs.shape
-        if position_ids.shape == (batch_size, seq_length, 3):
-            return position_ids.transpose(2, 0, 1)
-    return position_ids
 
 
 class Attention(nn.Module):

--- a/mlx_vlm/models/qwen3_vl/language.py
+++ b/mlx_vlm/models/qwen3_vl/language.py
@@ -6,8 +6,8 @@ import numpy as np
 
 from ..base import (
     LanguageModelOutput,
-    _language_position_ids,
     create_attention_mask,
+    language_position_ids,
     scaled_dot_product_attention,
 )
 from ..cache import KVCache
@@ -494,7 +494,7 @@ class LanguageModel(nn.Module):
         image_grid_thw = kwargs.pop("image_grid_thw", None)
         video_grid_thw = kwargs.pop("video_grid_thw", None)
         rope_deltas_kw = kwargs.pop("rope_deltas", None)
-        position_ids = _language_position_ids(position_ids, inputs)
+        position_ids = language_position_ids(position_ids, inputs)
         # reset rope_deltas and position_ids when processing a new image/video
         if pixel_values is not None:
             self._rope_deltas = None

--- a/mlx_vlm/models/qwen3_vl/language.py
+++ b/mlx_vlm/models/qwen3_vl/language.py
@@ -36,6 +36,16 @@ def apply_multimodal_rotary_pos_emb(q, k, cos, sin, unqueeze_dim=1):
     return _apply_mrope(q, k, cos, sin, style="interleaved", unsqueeze_dim=unqueeze_dim)
 
 
+def _language_position_ids(
+    position_ids: Optional[mx.array], inputs: mx.array
+) -> Optional[mx.array]:
+    if position_ids is not None and position_ids.ndim == 3:
+        batch_size, seq_length = inputs.shape
+        if position_ids.shape == (batch_size, seq_length, 3):
+            return position_ids.transpose(2, 0, 1)
+    return position_ids
+
+
 class Attention(nn.Module):
     def __init__(self, args: TextConfig):
         super().__init__()
@@ -493,6 +503,7 @@ class LanguageModel(nn.Module):
         image_grid_thw = kwargs.pop("image_grid_thw", None)
         video_grid_thw = kwargs.pop("video_grid_thw", None)
         rope_deltas_kw = kwargs.pop("rope_deltas", None)
+        position_ids = _language_position_ids(position_ids, inputs)
         # reset rope_deltas and position_ids when processing a new image/video
         if pixel_values is not None:
             self._rope_deltas = None
@@ -622,7 +633,11 @@ class LanguageModel(nn.Module):
                     delta = delta.reshape(-1, 1)
 
                 position_ids = mx.add(position_ids, delta)
-                if self._position_ids is not None and self._position_ids.ndim == 3:
+                if (
+                    rope_deltas_kw is not None
+                    or self._position_ids is not None
+                    and self._position_ids.ndim == 3
+                ):
                     position_ids = position_ids[None, ...]
                     position_ids = mx.broadcast_to(
                         position_ids, (3, batch_size, seq_length)

--- a/mlx_vlm/models/qwen3_vl/qwen3_vl.py
+++ b/mlx_vlm/models/qwen3_vl/qwen3_vl.py
@@ -4,7 +4,7 @@ import mlx.core as mx
 import mlx.nn as nn
 import numpy as np
 
-from ..base import InputEmbeddingsFeatures, _prompt_position_ids
+from ..base import InputEmbeddingsFeatures, prompt_position_ids
 from . import processing_qwen3_vl  # noqa: F401
 from .config import ModelConfig
 from .language import LanguageModel
@@ -61,7 +61,7 @@ class Model(nn.Module):
             )
             return InputEmbeddingsFeatures(
                 inputs_embeds=self.language_model.model.embed_tokens(input_ids),
-                position_ids=_prompt_position_ids(position_ids),
+                position_ids=prompt_position_ids(position_ids),
                 rope_deltas=rope_deltas,
             )
 
@@ -104,7 +104,7 @@ class Model(nn.Module):
             inputs_embeds=inputs_embeds,
             visual_pos_masks=visual_pos_masks,
             deepstack_visual_embeds=deepstack_visual_embeds,
-            position_ids=_prompt_position_ids(position_ids),
+            position_ids=prompt_position_ids(position_ids),
             rope_deltas=rope_deltas,
         )
 

--- a/mlx_vlm/models/qwen3_vl/qwen3_vl.py
+++ b/mlx_vlm/models/qwen3_vl/qwen3_vl.py
@@ -11,6 +11,16 @@ from .language import LanguageModel
 from .vision import VisionModel
 
 
+def _prompt_position_ids(position_ids: Optional[mx.array]) -> Optional[mx.array]:
+    if (
+        position_ids is not None
+        and position_ids.ndim == 3
+        and position_ids.shape[0] == 3
+    ):
+        return position_ids.transpose(1, 2, 0)
+    return position_ids
+
+
 def masked_scatter(
     final_embedding: mx.array,
     image_mask_expanded: mx.array,
@@ -56,9 +66,13 @@ class Model(nn.Module):
             pixel_values = kwargs.get("pixel_values_videos", None)
 
         if pixel_values is None:
-            self.language_model._position_ids = None
+            position_ids, rope_deltas = self.language_model.get_rope_index(
+                input_ids, attention_mask=mask
+            )
             return InputEmbeddingsFeatures(
-                inputs_embeds=self.language_model.model.embed_tokens(input_ids)
+                inputs_embeds=self.language_model.model.embed_tokens(input_ids),
+                position_ids=_prompt_position_ids(position_ids),
+                rope_deltas=rope_deltas,
             )
 
         dtype = self.vision_tower.patch_embed.proj.weight.dtype
@@ -92,18 +106,16 @@ class Model(nn.Module):
         visual_pos_masks = image_mask
         mx.eval(deepstack_visual_embeds)
 
-        # Pre-calculate position_ids for chunked prefill
-        if image_grid_thw is not None or video_grid_thw is not None:
-            position_ids, rope_deltas = self.language_model.get_rope_index(
-                input_ids, image_grid_thw, video_grid_thw, mask
-            )
-            self.language_model._position_ids = position_ids
-            self.language_model._rope_deltas = rope_deltas
+        position_ids, rope_deltas = self.language_model.get_rope_index(
+            input_ids, image_grid_thw, video_grid_thw, mask
+        )
 
         return InputEmbeddingsFeatures(
             inputs_embeds=inputs_embeds,
             visual_pos_masks=visual_pos_masks,
             deepstack_visual_embeds=deepstack_visual_embeds,
+            position_ids=_prompt_position_ids(position_ids),
+            rope_deltas=rope_deltas,
         )
 
     @staticmethod

--- a/mlx_vlm/models/qwen3_vl/qwen3_vl.py
+++ b/mlx_vlm/models/qwen3_vl/qwen3_vl.py
@@ -4,21 +4,11 @@ import mlx.core as mx
 import mlx.nn as nn
 import numpy as np
 
-from ..base import InputEmbeddingsFeatures
+from ..base import InputEmbeddingsFeatures, _prompt_position_ids
 from . import processing_qwen3_vl  # noqa: F401
 from .config import ModelConfig
 from .language import LanguageModel
 from .vision import VisionModel
-
-
-def _prompt_position_ids(position_ids: Optional[mx.array]) -> Optional[mx.array]:
-    if position_ids is None:
-        return None
-    if position_ids.ndim == 3 and position_ids.shape[0] == 3:
-        return position_ids.transpose(1, 2, 0)
-    if position_ids.ndim == 2:
-        return mx.broadcast_to(position_ids[:, :, None], (*position_ids.shape, 3))
-    return position_ids
 
 
 def masked_scatter(

--- a/mlx_vlm/models/qwen3_vl/qwen3_vl.py
+++ b/mlx_vlm/models/qwen3_vl/qwen3_vl.py
@@ -4,7 +4,7 @@ import mlx.core as mx
 import mlx.nn as nn
 import numpy as np
 
-from ..base import InputEmbeddingsFeatures, prompt_position_ids
+from ..base import InputEmbeddingsFeatures
 from . import processing_qwen3_vl  # noqa: F401
 from .config import ModelConfig
 from .language import LanguageModel
@@ -61,7 +61,7 @@ class Model(nn.Module):
             )
             return InputEmbeddingsFeatures(
                 inputs_embeds=self.language_model.model.embed_tokens(input_ids),
-                position_ids=prompt_position_ids(position_ids),
+                position_ids=position_ids,
                 rope_deltas=rope_deltas,
             )
 
@@ -104,7 +104,7 @@ class Model(nn.Module):
             inputs_embeds=inputs_embeds,
             visual_pos_masks=visual_pos_masks,
             deepstack_visual_embeds=deepstack_visual_embeds,
-            position_ids=prompt_position_ids(position_ids),
+            position_ids=position_ids,
             rope_deltas=rope_deltas,
         )
 

--- a/mlx_vlm/models/qwen3_vl/qwen3_vl.py
+++ b/mlx_vlm/models/qwen3_vl/qwen3_vl.py
@@ -12,12 +12,12 @@ from .vision import VisionModel
 
 
 def _prompt_position_ids(position_ids: Optional[mx.array]) -> Optional[mx.array]:
-    if (
-        position_ids is not None
-        and position_ids.ndim == 3
-        and position_ids.shape[0] == 3
-    ):
+    if position_ids is None:
+        return None
+    if position_ids.ndim == 3 and position_ids.shape[0] == 3:
         return position_ids.transpose(1, 2, 0)
+    if position_ids.ndim == 2:
+        return mx.broadcast_to(position_ids[:, :, None], (*position_ids.shape, 3))
     return position_ids
 
 

--- a/mlx_vlm/models/qwen3_vl_moe/language.py
+++ b/mlx_vlm/models/qwen3_vl_moe/language.py
@@ -38,6 +38,16 @@ def apply_multimodal_rotary_pos_emb(q, k, cos, sin, unqueeze_dim=1):
     return _apply_mrope(q, k, cos, sin, style="interleaved", unsqueeze_dim=unqueeze_dim)
 
 
+def _language_position_ids(
+    position_ids: Optional[mx.array], inputs: mx.array
+) -> Optional[mx.array]:
+    if position_ids is not None and position_ids.ndim == 3:
+        batch_size, seq_length = inputs.shape
+        if position_ids.shape == (batch_size, seq_length, 3):
+            return position_ids.transpose(2, 0, 1)
+    return position_ids
+
+
 class Attention(nn.Module):
     def __init__(self, args: TextConfig):
         super().__init__()
@@ -533,6 +543,7 @@ class LanguageModel(nn.Module):
         image_grid_thw = kwargs.pop("image_grid_thw", None)
         video_grid_thw = kwargs.pop("video_grid_thw", None)
         rope_deltas_kw = kwargs.pop("rope_deltas", None)
+        position_ids = _language_position_ids(position_ids, inputs)
         # reset rope_deltas when processing a new image/video
         if pixel_values is not None:
             self._rope_deltas = None
@@ -653,7 +664,11 @@ class LanguageModel(nn.Module):
                 position_ids = mx.arange(seq_length).reshape(1, -1)
                 position_ids = mx.broadcast_to(position_ids, (batch_size, seq_length))
                 position_ids = mx.add(position_ids, delta)
-                if self._position_ids is not None and self._position_ids.ndim == 3:
+                if (
+                    rope_deltas_kw is not None
+                    or self._position_ids is not None
+                    and self._position_ids.ndim == 3
+                ):
                     position_ids = position_ids[None, ...]
                     position_ids = mx.broadcast_to(
                         position_ids, (3, batch_size, seq_length)

--- a/mlx_vlm/models/qwen3_vl_moe/language.py
+++ b/mlx_vlm/models/qwen3_vl_moe/language.py
@@ -8,6 +8,7 @@ from mlx_lm.models.switch_layers import SwitchGLU
 
 from ..base import (
     LanguageModelOutput,
+    _language_position_ids,
     create_attention_mask,
     scaled_dot_product_attention,
 )
@@ -36,16 +37,6 @@ class Qwen3VLMoERotaryEmbedding(MRoPERotaryEmbedding):
 
 def apply_multimodal_rotary_pos_emb(q, k, cos, sin, unqueeze_dim=1):
     return _apply_mrope(q, k, cos, sin, style="interleaved", unsqueeze_dim=unqueeze_dim)
-
-
-def _language_position_ids(
-    position_ids: Optional[mx.array], inputs: mx.array
-) -> Optional[mx.array]:
-    if position_ids is not None and position_ids.ndim == 3:
-        batch_size, seq_length = inputs.shape
-        if position_ids.shape == (batch_size, seq_length, 3):
-            return position_ids.transpose(2, 0, 1)
-    return position_ids
 
 
 class Attention(nn.Module):

--- a/mlx_vlm/models/qwen3_vl_moe/language.py
+++ b/mlx_vlm/models/qwen3_vl_moe/language.py
@@ -8,8 +8,8 @@ from mlx_lm.models.switch_layers import SwitchGLU
 
 from ..base import (
     LanguageModelOutput,
-    _language_position_ids,
     create_attention_mask,
+    language_position_ids,
     scaled_dot_product_attention,
 )
 from ..cache import KVCache
@@ -534,7 +534,7 @@ class LanguageModel(nn.Module):
         image_grid_thw = kwargs.pop("image_grid_thw", None)
         video_grid_thw = kwargs.pop("video_grid_thw", None)
         rope_deltas_kw = kwargs.pop("rope_deltas", None)
-        position_ids = _language_position_ids(position_ids, inputs)
+        position_ids = language_position_ids(position_ids, inputs)
         # reset rope_deltas when processing a new image/video
         if pixel_values is not None:
             self._rope_deltas = None

--- a/mlx_vlm/models/qwen3_vl_moe/language.py
+++ b/mlx_vlm/models/qwen3_vl_moe/language.py
@@ -9,7 +9,6 @@ from mlx_lm.models.switch_layers import SwitchGLU
 from ..base import (
     LanguageModelOutput,
     create_attention_mask,
-    language_position_ids,
     scaled_dot_product_attention,
 )
 from ..cache import KVCache
@@ -534,7 +533,6 @@ class LanguageModel(nn.Module):
         image_grid_thw = kwargs.pop("image_grid_thw", None)
         video_grid_thw = kwargs.pop("video_grid_thw", None)
         rope_deltas_kw = kwargs.pop("rope_deltas", None)
-        position_ids = language_position_ids(position_ids, inputs)
         # reset rope_deltas when processing a new image/video
         if pixel_values is not None:
             self._rope_deltas = None

--- a/mlx_vlm/models/qwen3_vl_moe/qwen3_vl_moe.py
+++ b/mlx_vlm/models/qwen3_vl_moe/qwen3_vl_moe.py
@@ -4,7 +4,7 @@ import mlx.core as mx
 import mlx.nn as nn
 import numpy as np
 
-from ..base import InputEmbeddingsFeatures, prompt_position_ids
+from ..base import InputEmbeddingsFeatures
 from ..qwen3_vl import processing_qwen3_vl  # noqa: F401
 from .config import ModelConfig
 from .language import LanguageModel
@@ -58,7 +58,7 @@ class Model(nn.Module):
                 inputs_embeds=self.language_model.model.embed_tokens(input_ids),
                 visual_pos_masks=None,
                 deepstack_visual_embeds=None,
-                position_ids=prompt_position_ids(position_ids),
+                position_ids=position_ids,
                 rope_deltas=rope_deltas,
             )
 
@@ -101,7 +101,7 @@ class Model(nn.Module):
             inputs_embeds=inputs_embeds,
             visual_pos_masks=visual_pos_masks,
             deepstack_visual_embeds=deepstack_visual_embeds,
-            position_ids=prompt_position_ids(position_ids),
+            position_ids=position_ids,
             rope_deltas=rope_deltas,
         )
 

--- a/mlx_vlm/models/qwen3_vl_moe/qwen3_vl_moe.py
+++ b/mlx_vlm/models/qwen3_vl_moe/qwen3_vl_moe.py
@@ -4,7 +4,7 @@ import mlx.core as mx
 import mlx.nn as nn
 import numpy as np
 
-from ..base import InputEmbeddingsFeatures, _prompt_position_ids
+from ..base import InputEmbeddingsFeatures, prompt_position_ids
 from ..qwen3_vl import processing_qwen3_vl  # noqa: F401
 from .config import ModelConfig
 from .language import LanguageModel
@@ -58,7 +58,7 @@ class Model(nn.Module):
                 inputs_embeds=self.language_model.model.embed_tokens(input_ids),
                 visual_pos_masks=None,
                 deepstack_visual_embeds=None,
-                position_ids=_prompt_position_ids(position_ids),
+                position_ids=prompt_position_ids(position_ids),
                 rope_deltas=rope_deltas,
             )
 
@@ -101,7 +101,7 @@ class Model(nn.Module):
             inputs_embeds=inputs_embeds,
             visual_pos_masks=visual_pos_masks,
             deepstack_visual_embeds=deepstack_visual_embeds,
-            position_ids=_prompt_position_ids(position_ids),
+            position_ids=prompt_position_ids(position_ids),
             rope_deltas=rope_deltas,
         )
 

--- a/mlx_vlm/models/qwen3_vl_moe/qwen3_vl_moe.py
+++ b/mlx_vlm/models/qwen3_vl_moe/qwen3_vl_moe.py
@@ -4,21 +4,11 @@ import mlx.core as mx
 import mlx.nn as nn
 import numpy as np
 
-from ..base import InputEmbeddingsFeatures
+from ..base import InputEmbeddingsFeatures, _prompt_position_ids
 from ..qwen3_vl import processing_qwen3_vl  # noqa: F401
 from .config import ModelConfig
 from .language import LanguageModel
 from .vision import VisionModel
-
-
-def _prompt_position_ids(position_ids: Optional[mx.array]) -> Optional[mx.array]:
-    if position_ids is None:
-        return None
-    if position_ids.ndim == 3 and position_ids.shape[0] == 3:
-        return position_ids.transpose(1, 2, 0)
-    if position_ids.ndim == 2:
-        return mx.broadcast_to(position_ids[:, :, None], (*position_ids.shape, 3))
-    return position_ids
 
 
 def masked_scatter(

--- a/mlx_vlm/models/qwen3_vl_moe/qwen3_vl_moe.py
+++ b/mlx_vlm/models/qwen3_vl_moe/qwen3_vl_moe.py
@@ -11,6 +11,16 @@ from .language import LanguageModel
 from .vision import VisionModel
 
 
+def _prompt_position_ids(position_ids: Optional[mx.array]) -> Optional[mx.array]:
+    if (
+        position_ids is not None
+        and position_ids.ndim == 3
+        and position_ids.shape[0] == 3
+    ):
+        return position_ids.transpose(1, 2, 0)
+    return position_ids
+
+
 def masked_scatter(
     final_embedding: mx.array,
     image_mask_expanded: mx.array,
@@ -51,11 +61,15 @@ class Model(nn.Module):
         grid_thw = image_grid_thw if image_grid_thw is not None else video_grid_thw
 
         if pixel_values is None:
-            self.language_model._position_ids = None
+            position_ids, rope_deltas = self.language_model.get_rope_index(
+                input_ids, attention_mask=mask
+            )
             return InputEmbeddingsFeatures(
                 inputs_embeds=self.language_model.model.embed_tokens(input_ids),
                 visual_pos_masks=None,
                 deepstack_visual_embeds=None,
+                position_ids=_prompt_position_ids(position_ids),
+                rope_deltas=rope_deltas,
             )
 
         dtype = self.vision_tower.patch_embed.proj.weight.dtype
@@ -89,18 +103,16 @@ class Model(nn.Module):
         visual_pos_masks = image_mask
         mx.eval(deepstack_visual_embeds)
 
-        # Pre-calculate position_ids for chunked prefill
-        if image_grid_thw is not None or video_grid_thw is not None:
-            position_ids, rope_deltas = self.language_model.get_rope_index(
-                input_ids, image_grid_thw, video_grid_thw, mask
-            )
-            self.language_model._position_ids = position_ids
-            self.language_model._rope_deltas = rope_deltas
+        position_ids, rope_deltas = self.language_model.get_rope_index(
+            input_ids, image_grid_thw, video_grid_thw, mask
+        )
 
         return InputEmbeddingsFeatures(
             inputs_embeds=inputs_embeds,
             visual_pos_masks=visual_pos_masks,
             deepstack_visual_embeds=deepstack_visual_embeds,
+            position_ids=_prompt_position_ids(position_ids),
+            rope_deltas=rope_deltas,
         )
 
     @staticmethod

--- a/mlx_vlm/models/qwen3_vl_moe/qwen3_vl_moe.py
+++ b/mlx_vlm/models/qwen3_vl_moe/qwen3_vl_moe.py
@@ -12,12 +12,12 @@ from .vision import VisionModel
 
 
 def _prompt_position_ids(position_ids: Optional[mx.array]) -> Optional[mx.array]:
-    if (
-        position_ids is not None
-        and position_ids.ndim == 3
-        and position_ids.shape[0] == 3
-    ):
+    if position_ids is None:
+        return None
+    if position_ids.ndim == 3 and position_ids.shape[0] == 3:
         return position_ids.transpose(1, 2, 0)
+    if position_ids.ndim == 2:
+        return mx.broadcast_to(position_ids[:, :, None], (*position_ids.shape, 3))
     return position_ids
 
 

--- a/mlx_vlm/server/generation.py
+++ b/mlx_vlm/server/generation.py
@@ -1150,7 +1150,10 @@ class ResponseGenerator:
         # Remove cache kwargs before passing to BatchGenerator
         data_kwargs.pop("vision_cache", None)
         data_kwargs.pop("_image_key", None)
-        gen_kwargs = {**data_kwargs, **embed.to_dict()}
+        gen_kwargs = {
+            **data_kwargs,
+            **{k: v for k, v in embed.to_dict().items() if v is not None},
+        }
         if images is not None:
             gen_kwargs["_apc_image_hash"] = _apc.hash_image_payload(image_ref=images)
         elif pixel_values is not None:

--- a/mlx_vlm/tests/test_generate.py
+++ b/mlx_vlm/tests/test_generate.py
@@ -434,6 +434,16 @@ class TestGenerationBatch:
             [7],
         ]
 
+    def test_capture_rope_deltas_prefers_prompt_kwargs(self):
+        from mlx_vlm.generate import PromptProcessingBatch
+
+        captured = PromptProcessingBatch._capture_rope_deltas_from_prompt_kwargs(
+            {"rope_deltas": mx.array([[5], [7]], dtype=mx.int32)},
+            SimpleNamespace(_rope_deltas=mx.array([[99], [99]], dtype=mx.int32)),
+            2,
+        )
+        assert captured.tolist() == [[5], [7]]
+
 
 # ============================================================================
 # Tests for Helper Functions
@@ -1976,6 +1986,7 @@ def test_cold_batch_left_pads_sequence_aligned_prompt_kwargs():
                 "inputs_embeds": mx.ones((1, length, 3)) * (i + 1),
                 "per_layer_inputs": mx.ones((1, length, 2, 5)) * (i + 1),
                 "attention_mask": mx.ones((1, length), dtype=mx.int32),
+                "position_ids": mx.ones((1, length, 3), dtype=mx.int32) * (i + 1),
                 "pixel_values": mx.ones((1, 3, 2, 2)) * (i + 1),
                 "keep_tensor": mx.array([[i + 1]], dtype=mx.int32),
                 "rope_deltas": mx.array([[i + 10]], dtype=mx.int32),
@@ -2004,12 +2015,15 @@ def test_cold_batch_left_pads_sequence_aligned_prompt_kwargs():
     assert captured["inputs_embeds"].shape == (4, 4, 3)
     assert prompt_kwargs["per_layer_inputs"].shape == (4, 4, 2, 5)
     assert prompt_kwargs["attention_mask"].shape == (4, 4)
+    assert prompt_kwargs["position_ids"].shape == (4, 4, 3)
     assert prompt_kwargs["pixel_values"].shape == (4, 3, 2, 2)
     assert prompt_kwargs["keep_tensor"].shape == (4, 1)
     assert prompt_kwargs["rope_deltas"].shape == (4, 1)
     assert "_apc_tenant" not in prompt_kwargs
     assert prompt_kwargs["per_layer_inputs"][0, :, 0, 0].tolist() == [0, 0, 1, 1]
     assert prompt_kwargs["per_layer_inputs"][3, :, 0, 0].tolist() == [0, 0, 0, 4]
+    assert prompt_kwargs["position_ids"][0, :, 0].tolist() == [0, 0, 1, 1]
+    assert prompt_kwargs["position_ids"][3, :, 0].tolist() == [0, 0, 0, 4]
 
 
 def test_mixed_apc_batch_strips_private_kwargs_before_prefill():

--- a/mlx_vlm/tests/test_generate.py
+++ b/mlx_vlm/tests/test_generate.py
@@ -1027,6 +1027,23 @@ class TestBatchGenerate:
                     max_tokens=5,
                 )
 
+    def test_split_prompt_kwargs_handles_native_mrope_position_ids(self):
+        batch_size = 2
+        seq_len = 4
+        position_ids = mx.arange(3 * batch_size * seq_len, dtype=mx.int32).reshape(
+            3, batch_size, seq_len
+        )
+
+        rows = ar_module._split_prompt_kwargs_per_row(
+            {"position_ids": position_ids}, batch_size
+        )
+
+        assert len(rows) == batch_size
+        assert rows[0]["position_ids"].shape == (3, 1, seq_len)
+        assert rows[1]["position_ids"].shape == (3, 1, seq_len)
+        assert rows[0]["position_ids"].tolist() == position_ids[:, :1, :].tolist()
+        assert rows[1]["position_ids"].tolist() == position_ids[:, 1:2, :].tolist()
+
     @patch.object(ar_module, "_generate_batch")
     @patch("mlx_vlm.utils.process_image")
     def test_with_images_same_shape(
@@ -1986,7 +2003,7 @@ def test_cold_batch_left_pads_sequence_aligned_prompt_kwargs():
                 "inputs_embeds": mx.ones((1, length, 3)) * (i + 1),
                 "per_layer_inputs": mx.ones((1, length, 2, 5)) * (i + 1),
                 "attention_mask": mx.ones((1, length), dtype=mx.int32),
-                "position_ids": mx.ones((1, length, 3), dtype=mx.int32) * (i + 1),
+                "position_ids": mx.ones((3, 1, length), dtype=mx.int32) * (i + 1),
                 "pixel_values": mx.ones((1, 3, 2, 2)) * (i + 1),
                 "keep_tensor": mx.array([[i + 1]], dtype=mx.int32),
                 "rope_deltas": mx.array([[i + 10]], dtype=mx.int32),
@@ -2015,15 +2032,50 @@ def test_cold_batch_left_pads_sequence_aligned_prompt_kwargs():
     assert captured["inputs_embeds"].shape == (4, 4, 3)
     assert prompt_kwargs["per_layer_inputs"].shape == (4, 4, 2, 5)
     assert prompt_kwargs["attention_mask"].shape == (4, 4)
-    assert prompt_kwargs["position_ids"].shape == (4, 4, 3)
+    assert prompt_kwargs["position_ids"].shape == (3, 4, 4)
     assert prompt_kwargs["pixel_values"].shape == (4, 3, 2, 2)
     assert prompt_kwargs["keep_tensor"].shape == (4, 1)
     assert prompt_kwargs["rope_deltas"].shape == (4, 1)
     assert "_apc_tenant" not in prompt_kwargs
     assert prompt_kwargs["per_layer_inputs"][0, :, 0, 0].tolist() == [0, 0, 1, 1]
     assert prompt_kwargs["per_layer_inputs"][3, :, 0, 0].tolist() == [0, 0, 0, 4]
-    assert prompt_kwargs["position_ids"][0, :, 0].tolist() == [0, 0, 1, 1]
-    assert prompt_kwargs["position_ids"][3, :, 0].tolist() == [0, 0, 0, 4]
+    assert prompt_kwargs["position_ids"][0, 0].tolist() == [0, 0, 1, 1]
+    assert prompt_kwargs["position_ids"][0, 3].tolist() == [0, 0, 0, 4]
+
+
+def test_cold_batch_merges_mixed_text_and_mrope_position_ids():
+    inputs_embeds, prompt_kwargs = ar_module._merge_prefill_prompt_kwargs(
+        [
+            {
+                "inputs_embeds": mx.ones((1, 2, 3)),
+                "position_ids": mx.array([[4, 5]], dtype=mx.int32),
+            },
+            {
+                "inputs_embeds": mx.ones((1, 3, 3)) * 2,
+                "position_ids": mx.ones((3, 1, 3), dtype=mx.int32) * 7,
+            },
+        ],
+        [[1, 2], [3, 4, 5]],
+    )
+
+    assert inputs_embeds.shape == (2, 3, 3)
+    assert prompt_kwargs["position_ids"].shape == (3, 2, 3)
+    assert prompt_kwargs["position_ids"][0, 0].tolist() == [0, 4, 5]
+    assert prompt_kwargs["position_ids"][1, 0].tolist() == [0, 4, 5]
+    assert prompt_kwargs["position_ids"][2, 0].tolist() == [0, 4, 5]
+    assert prompt_kwargs["position_ids"][0, 1].tolist() == [7, 7, 7]
+
+
+def test_prompt_processing_batch_slices_native_mrope_position_ids():
+    batch = object.__new__(PromptProcessingBatch)
+    position_ids = mx.arange(3 * 2 * 5, dtype=mx.int32).reshape(3, 2, 5)
+    batch._prompt_kwargs = {"position_ids": position_ids}
+    batch._prompt_length_aware_keys = ["position_ids"]
+
+    step_kwargs = batch._prompt_kwargs_for_step(2)
+
+    assert step_kwargs["position_ids"].shape == (3, 2, 2)
+    assert step_kwargs["position_ids"].tolist() == position_ids[:, :, :2].tolist()
 
 
 def test_mixed_apc_batch_strips_private_kwargs_before_prefill():

--- a/mlx_vlm/tests/test_models.py
+++ b/mlx_vlm/tests/test_models.py
@@ -1662,6 +1662,9 @@ class TestModels(unittest.TestCase):
         self._assert_mrope_decode_uses_cache_idx(
             model.language_model, config.text_config.hidden_size
         )
+        self._assert_mrope_decode_uses_rope_deltas_kwarg(
+            model.language_model, config.text_config.hidden_size
+        )
 
     def test_qwen3_5_model_config(self):
         from mlx_vlm.models import qwen3_5, qwen3_5_moe
@@ -1707,6 +1710,42 @@ class TestModels(unittest.TestCase):
                 self.assertIn("vision_tower.blocks.0.attn.qkv", config.quantization)
                 self.assertIn("language_model.lm_head", config.quantization)
                 self.assertIs(config.quantization, config.quantization_config)
+
+    def test_qwen3_5_decode_uses_rope_deltas_kwarg(self):
+        from mlx_vlm.models import qwen3_5
+
+        text_config = qwen3_5.TextConfig(
+            model_type="qwen3_5",
+            hidden_size=16,
+            intermediate_size=32,
+            linear_num_value_heads=2,
+            linear_num_key_heads=2,
+            linear_key_head_dim=8,
+            linear_value_head_dim=8,
+            linear_conv_kernel_dim=3,
+            num_hidden_layers=1,
+            num_attention_heads=2,
+            rms_norm_eps=1e-5,
+            vocab_size=32,
+            num_key_value_heads=2,
+            max_position_embeddings=128,
+            head_dim=8,
+        )
+        config = qwen3_5.ModelConfig(
+            text_config=text_config,
+            vision_config=qwen3_5.VisionConfig(
+                model_type="qwen3_5",
+                depth=1,
+                hidden_size=16,
+                intermediate_size=32,
+                out_hidden_size=16,
+                num_heads=2,
+            ),
+            model_type="qwen3_5",
+        )
+        language_model = qwen3_5.LanguageModel(text_config, config)
+
+        self._assert_mrope_decode_uses_rope_deltas_kwarg(language_model, 16)
 
     def test_qwen3_5_sanitize_key_routes_nested_visual_weights(self):
         from mlx_vlm.models.qwen3_5.qwen3_5 import sanitize_key
@@ -1956,6 +1995,9 @@ class TestModels(unittest.TestCase):
 
         # Decode-step RoPE offset must come from cache._idx, not offset.item().
         self._assert_mrope_decode_uses_cache_idx(
+            model.language_model, config.text_config.hidden_size
+        )
+        self._assert_mrope_decode_uses_rope_deltas_kwarg(
             model.language_model, config.text_config.hidden_size
         )
 
@@ -2332,13 +2374,10 @@ class TestModels(unittest.TestCase):
 
         position_ids = captured["position_ids"]
         self.assertIsNotNone(position_ids)
-        self.assertIn(tuple(position_ids.shape), {(1, 1), (3, 1, 1)})
+        self.assertEqual(tuple(position_ids.shape), (3, 1, 1))
         # Position == cache._idx (10) + kwarg delta (5) == 15.
         # Pre-fix behavior would have read self._rope_deltas (99) -> 109.
-        if position_ids.ndim == 3:
-            self.assertEqual(position_ids[0, 0, 0].item(), 15)
-        else:
-            self.assertEqual(position_ids[0, 0].item(), 15)
+        self.assertEqual(position_ids[0, 0, 0].item(), 15)
 
     def test_glm4v_moe(self):
         from mlx_vlm.models import glm4v_moe
@@ -4912,6 +4951,30 @@ class TestGetInputEmbeddings(unittest.TestCase):
         )
         self.assertIsNotNone(result.inputs_embeds)
 
+    def _assert_qwen_request_owned_mrope_kwargs(self, model):
+        stale_position_ids = mx.array([[[9, 9, 9]]], dtype=mx.int32)
+        stale_rope_deltas = mx.array([[99]], dtype=mx.int32)
+        model.language_model._position_ids = stale_position_ids
+        model.language_model._rope_deltas = stale_rope_deltas
+
+        result = model.get_input_embeddings(
+            input_ids=mx.array([[1, 2, 3]], dtype=mx.int32)
+        )
+
+        self.assertIsNotNone(result.position_ids)
+        self.assertIsNotNone(result.rope_deltas)
+        self.assertEqual(result.position_ids.shape[0], 1)
+        self.assertEqual(result.position_ids.shape[1], 3)
+        self.assertEqual(result.rope_deltas.tolist(), [[0]])
+        self.assertTrue(
+            mx.array_equal(
+                model.language_model._position_ids, stale_position_ids
+            ).item()
+        )
+        self.assertTrue(
+            mx.array_equal(model.language_model._rope_deltas, stale_rope_deltas).item()
+        )
+
     def test_llava_input_embeddings(self):
         from mlx_vlm.models import llava
 
@@ -5048,6 +5111,7 @@ class TestGetInputEmbeddings(unittest.TestCase):
             )
         )
         self._check_returns_input_embeddings_features(model, "qwen2_vl")
+        self._assert_qwen_request_owned_mrope_kwargs(model)
 
     def test_qwen2_5_vl_input_embeddings(self):
         from mlx_vlm.models import qwen2_5_vl
@@ -5083,6 +5147,7 @@ class TestGetInputEmbeddings(unittest.TestCase):
             )
         )
         self._check_returns_input_embeddings_features(model, "qwen2_5_vl")
+        self._assert_qwen_request_owned_mrope_kwargs(model)
 
     def test_qwen3_vl_input_embeddings(self):
         from mlx_vlm.models import qwen3_vl
@@ -5120,6 +5185,7 @@ class TestGetInputEmbeddings(unittest.TestCase):
             )
         )
         self._check_returns_input_embeddings_features(model, "qwen3_vl")
+        self._assert_qwen_request_owned_mrope_kwargs(model)
 
     def test_paligemma_input_embeddings(self):
         from mlx_vlm.models import paligemma
@@ -6411,6 +6477,42 @@ class TestGetInputEmbeddings(unittest.TestCase):
             )
         )
         self._check_returns_input_embeddings_features(model, "qwen3_vl_moe")
+        self._assert_qwen_request_owned_mrope_kwargs(model)
+
+    def test_qwen3_5_input_embeddings_owns_mrope_kwargs(self):
+        from mlx_vlm.models import qwen3_5
+
+        model = qwen3_5.Model(
+            qwen3_5.ModelConfig(
+                text_config=qwen3_5.TextConfig(
+                    model_type="qwen3_5",
+                    hidden_size=16,
+                    intermediate_size=32,
+                    linear_num_value_heads=2,
+                    linear_num_key_heads=2,
+                    linear_key_head_dim=8,
+                    linear_value_head_dim=8,
+                    linear_conv_kernel_dim=3,
+                    num_hidden_layers=1,
+                    num_attention_heads=2,
+                    rms_norm_eps=1e-5,
+                    vocab_size=32,
+                    num_key_value_heads=2,
+                    max_position_embeddings=128,
+                    head_dim=8,
+                ),
+                vision_config=qwen3_5.VisionConfig(
+                    model_type="qwen3_5",
+                    depth=1,
+                    hidden_size=16,
+                    intermediate_size=32,
+                    out_hidden_size=16,
+                    num_heads=2,
+                ),
+                model_type="qwen3_5",
+            )
+        )
+        self._assert_qwen_request_owned_mrope_kwargs(model)
 
     def test_qwen3_omni_moe_input_embeddings(self):
         from mlx_vlm.models import qwen3_omni_moe

--- a/mlx_vlm/tests/test_models.py
+++ b/mlx_vlm/tests/test_models.py
@@ -4963,10 +4963,8 @@ class TestGetInputEmbeddings(unittest.TestCase):
 
         self.assertIsNotNone(result.position_ids)
         self.assertIsNotNone(result.rope_deltas)
-        self.assertEqual(result.position_ids.shape, (1, 3, 3))
-        self.assertEqual(result.position_ids[:, :, 0].tolist(), [[0, 1, 2]])
-        self.assertEqual(result.position_ids[:, :, 1].tolist(), [[0, 1, 2]])
-        self.assertEqual(result.position_ids[:, :, 2].tolist(), [[0, 1, 2]])
+        self.assertEqual(result.position_ids.shape, (1, 3))
+        self.assertEqual(result.position_ids.tolist(), [[0, 1, 2]])
         self.assertEqual(result.rope_deltas.tolist(), [[0]])
         self.assertTrue(
             mx.array_equal(

--- a/mlx_vlm/tests/test_models.py
+++ b/mlx_vlm/tests/test_models.py
@@ -4963,8 +4963,10 @@ class TestGetInputEmbeddings(unittest.TestCase):
 
         self.assertIsNotNone(result.position_ids)
         self.assertIsNotNone(result.rope_deltas)
-        self.assertEqual(result.position_ids.shape[0], 1)
-        self.assertEqual(result.position_ids.shape[1], 3)
+        self.assertEqual(result.position_ids.shape, (1, 3, 3))
+        self.assertEqual(result.position_ids[:, :, 0].tolist(), [[0, 1, 2]])
+        self.assertEqual(result.position_ids[:, :, 1].tolist(), [[0, 1, 2]])
+        self.assertEqual(result.position_ids[:, :, 2].tolist(), [[0, 1, 2]])
         self.assertEqual(result.rope_deltas.tolist(), [[0]])
         self.assertTrue(
             mx.array_equal(

--- a/mlx_vlm/tests/test_server.py
+++ b/mlx_vlm/tests/test_server.py
@@ -4821,6 +4821,35 @@ class TestResponseGenerator:
             pixel_values=pixel_values
         )
 
+    def test_gpu_embed_drops_none_embedding_fields(self):
+        class Embed:
+            def to_dict(self):
+                return {
+                    "inputs_embeds": mx.zeros((1, 2, 4)),
+                    "position_ids": None,
+                    "rope_deltas": None,
+                }
+
+        class Model:
+            def get_input_embeddings(
+                self, input_ids, pixel_values, mask=None, **kwargs
+            ):
+                return Embed()
+
+        response_generator = SimpleNamespace(model=Model(), vision_cache=None)
+
+        _, gen_kwargs = server.ResponseGenerator._gpu_embed(
+            response_generator,
+            {
+                "input_ids": mx.array([[1, 2]]),
+                "attention_mask": mx.array([[1, 1]]),
+            },
+            images=None,
+        )
+
+        assert "position_ids" not in gen_kwargs
+        assert "rope_deltas" not in gen_kwargs
+
     def test_gpu_embed_prefers_image_ref_for_apc_hash(self):
         class Embed:
             def to_dict(self):


### PR DESCRIPTION
## Summary

- Pass Qwen `position_ids` and `rope_deltas` through request-owned prompt kwargs instead of mutating shared language model state.
- Keep Qwen `position_ids` in their raw model layouts: text-only requests can carry `(B, L)`, while multimodal MRoPE requests carry native `(3, B, L)`.
- Teach the batcher to split, pad, concatenate, and chunk native Qwen MRoPE `position_ids` on their correct batch and sequence axes.
- Merge mixed text/image Qwen batches by expanding text-only 2D `position_ids` into native MRoPE rows only when needed for a mixed batch.
- Drop `None` embedding fields before server/generation prompt kwargs assembly.

## Root Cause

Qwen VL MRoPE metadata is request-specific, but the previous path could store it on shared `language_model` fields. Under continuous batching, one request could overwrite or clear that state while another request was still decoding.

Once that state moved into request kwargs, the generic batcher still assumed sequence-aligned tensors were batch-major `(B, L, ...)`. Qwen multimodal MRoPE `position_ids` are native `(3, B, L)`, and text-only Qwen requests can be `(B, L)`. During live testing with `Qwen/Qwen3.5-35B-A3B`, mixed text/image batching exposed that mismatch as a rank/axis concatenate failure.

## Reproducible Example

Start the live server from the repo root:

```bash
PYTHONUNBUFFERED=1 TOKENIZERS_PARALLELISM=false \
  uv run mlx_vlm.server \
    --host 127.0.0.1 \
    --port 18080 \
    --model Qwen/Qwen3.5-35B-A3B \
    --max-tokens 32 \
    --log-level DEBUG
```

In another terminal, run overlapping text-only and image requests against the OpenAI-compatible endpoint:

```bash
uv run python - <<'PY'
import asyncio
import json
from pathlib import Path

import httpx

base_url = "http://127.0.0.1:18080/v1/chat/completions"
model = "Qwen/Qwen3.5-35B-A3B"
image = str((Path.cwd() / "examples/images/cats.jpg").resolve())

cases = [
    ("image-a", 0.0, [
        {"role": "user", "content": [
            {"type": "text", "text": "Describe this image in exactly five words."},
            {"type": "input_image", "image_url": image},
        ]},
    ], 10),
    ("text-a", 0.2, [
        {"role": "user", "content": "Reply with exactly these words: alpha beta gamma delta."},
    ], 8),
    ("image-b", 0.4, [
        {"role": "user", "content": [
            {"type": "text", "text": "What animal is visible? Answer in one word."},
            {"type": "input_image", "image_url": image},
        ]},
    ], 6),
    ("text-b", 0.6, [
        {"role": "user", "content": "Reply with exactly: green"},
    ], 4),
]

async def run_case(client, name, delay, messages, max_tokens):
    await asyncio.sleep(delay)
    payload = {
        "model": model,
        "messages": messages,
        "stream": True,
        "max_tokens": max_tokens,
        "temperature": 0.0,
        "enable_thinking": False,
        "stream_options": {"include_usage": True},
    }
    text = []
    usage = None
    async with client.stream("POST", base_url, json=payload, timeout=None) as resp:
        resp.raise_for_status()
        async for line in resp.aiter_lines():
            if not line.startswith("data: "):
                continue
            data = line[6:]
            if data == "[DONE]":
                break
            event = json.loads(data)
            if event.get("error"):
                raise RuntimeError(event["error"])
            usage = event.get("usage") or usage
            for choice in event.get("choices", []):
                chunk = (choice.get("delta") or {}).get("content")
                if chunk:
                    text.append(chunk)
    output = "".join(text)
    if not output or usage is None:
        raise RuntimeError(f"{name}: empty stream output={output!r} usage={usage!r}")
    print(name, output, usage)

async def main():
    async with httpx.AsyncClient(timeout=None) as client:
        await asyncio.gather(*(run_case(client, *case) for case in cases))

asyncio.run(main())
PY
```

Before this fix, the mixed continuous batch can fail in the generation thread with a `position_ids` concatenate error because text-only rows are rank 2 while multimodal MRoPE rows are rank 3. After this fix, all requests should stream content and usage successfully.

## Validation

- `python3 -m py_compile` on touched implementation and test files
- `git diff --check`
- Focused generation/server tests for prompt kwarg splitting, merging, chunked slicing, APC mixed prefill, and embedding field filtering
- Focused Qwen input-embedding tests for Qwen2-VL, Qwen2.5-VL, Qwen3-VL, Qwen3-VL-MoE, and Qwen3.5
- Focused Qwen decode tests for explicit `rope_deltas` kwargs
- Live server test with `Qwen/Qwen3.5-35B-A3B`: 6 overlapping streaming requests, 3 image and 3 text-only, all completed with content and usage after the batcher change

Fixes #1415
