### PR TITLE
Constrain transformers below 5.13

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 mlx>=0.31.2
-transformers>=5.5.0
+transformers>=5.5.0,<5.13.0
 datasets>=2.19.1
 miniaudio>=1.59
 tqdm>=4.66.2


### PR DESCRIPTION
## Summary

- constrain `transformers` to `>=5.5.0,<5.13.0`

## Root Cause

The failing PR check resolved `transformers-5.13.0` with `mlx-lm-0.31.3`. During pytest collection, importing `mlx_lm` reaches `AutoTokenizer.register("NewlineTokenizer", ...)`; Transformers 5.13 now expects a config class and raises `AttributeError: 'str' object has no attribute '__module__'`.

## Validation

- `git diff --check`
- parsed `requirements.txt` with `packaging.requirements.Requirement`
- confirmed the new spec includes `5.5.0` and excludes `5.13.0`

I could not run the full pytest suite locally because this Python environment does not have `pytest`, `mlx`, `mlx_lm`, or `transformers` installed.