### PR TITLE
Reject empty OpenAI server inputs

### DIFF
--- a/mlx_vlm/server/openai.py
+++ b/mlx_vlm/server/openai.py
@@ -12,7 +12,7 @@ import uuid
 from datetime import datetime
 from io import BytesIO
 from pathlib import Path
-from typing import List, Optional, Tuple
+from typing import Any, List, Optional, Tuple
 
 import mlx.core as mx
 from fastapi import HTTPException, Request
@@ -94,6 +94,67 @@ _count_thinking_tag_tokens = None
 _make_logprob_content = None
 _AUDIO_REFERENCE_PREFIXES = ("http://", "https://", "file://", "/", "./", "../")
 _AUDIO_REFERENCE_SUFFIXES = (".wav", ".mp3", ".flac", ".ogg", ".m4a", ".aac", ".webm")
+_MISSING_INPUT_DETAIL = (
+    "Request must include at least one non-empty message content or media input."
+)
+
+
+def _has_non_empty_text(value: Any) -> bool:
+    return isinstance(value, str) and bool(value.strip())
+
+
+def _content_has_effective_input(content: Any) -> bool:
+    if _has_non_empty_text(content):
+        return True
+    if content is None:
+        return False
+    if isinstance(content, list):
+        for item in content:
+            if not isinstance(item, dict):
+                continue
+            item_type = item.get("type")
+            if item_type in ("text", "input_text", "output_text"):
+                if _has_non_empty_text(item.get("text")) or _has_non_empty_text(
+                    item.get("content")
+                ):
+                    return True
+            elif item_type in ("image_url", "input_image"):
+                image = item.get("image_url") or item.get("file_id")
+                if isinstance(image, dict):
+                    image = image.get("url")
+                if image:
+                    return True
+            elif item_type == "input_audio":
+                input_audio = item.get("input_audio")
+                if isinstance(input_audio, dict) and input_audio.get("data"):
+                    return True
+            elif _content_has_effective_input(item.get("content")):
+                return True
+        return False
+    if isinstance(content, dict):
+        return _content_has_effective_input([content])
+    return bool(str(content).strip())
+
+
+def _message_has_effective_input(message: Any) -> bool:
+    if hasattr(message, "model_dump"):
+        message = message.model_dump(exclude_none=True)
+    if not isinstance(message, dict):
+        return False
+    return (
+        _content_has_effective_input(message.get("content"))
+        or bool(message.get("tool_calls"))
+        or _has_non_empty_text(message.get("reasoning_content"))
+        or _has_non_empty_text(message.get("reasoning"))
+    )
+
+
+def _ensure_effective_input(messages, *, images=None, audio=None):
+    if any(image for image in (images or [])) or any(item for item in (audio or [])):
+        return
+    if any(_message_has_effective_input(message) for message in messages or []):
+        return
+    raise HTTPException(status_code=400, detail=_MISSING_INPUT_DETAIL)
 
 
 def _runtime_cache_get(key, default=None, *, kind=None):
@@ -596,10 +657,6 @@ async def responses_input_tokens_endpoint(request: Request):
     body = await request.json()
     openai_request = OpenAIRequest(**body)
     try:
-        model, processor, config = get_cached_model(
-            openai_request.model, _adapter_path_or_inherit(openai_request)
-        )
-        del model
         current_input_items = _normalize_response_input(openai_request.input)
         prompt_items = (
             _response_chain_items(openai_request.previous_response_id)
@@ -610,6 +667,12 @@ async def responses_input_tokens_endpoint(request: Request):
             chat_messages.insert(
                 0, {"role": "system", "content": openai_request.instructions}
             )
+        _ensure_effective_input(chat_messages, images=images)
+
+        model, processor, config = get_cached_model(
+            openai_request.model, _adapter_path_or_inherit(openai_request)
+        )
+        del model
         chat_tools, _ = _response_tool_registry(openai_request.tools)
         gen_args = _build_gen_args(
             openai_request, processor, tenant_id=_read_tenant_id(request)
@@ -749,11 +812,6 @@ async def responses_endpoint(request: Request):
     openai_request = OpenAIRequest(**body)
 
     try:
-        # Get model, processor, config - loading if necessary
-        model, processor, config = get_cached_model(
-            openai_request.model, _adapter_path_or_inherit(openai_request)
-        )
-
         kwargs = {}
 
         if openai_request.input is None:
@@ -771,6 +829,12 @@ async def responses_endpoint(request: Request):
             chat_messages.insert(0, {"role": "system", "content": instructions})
         elif chat_messages and chat_messages[0].get("role") in ("system", "developer"):
             instructions = chat_messages[0].get("content")
+        _ensure_effective_input(chat_messages, images=images)
+
+        # Get model, processor, config - loading if necessary
+        model, processor, config = get_cached_model(
+            openai_request.model, _adapter_path_or_inherit(openai_request)
+        )
 
         chat_tools, tool_registry = _response_tool_registry(openai_request.tools)
         tool_parser_type = _infer_tool_parser_from_processor(processor)
@@ -1394,7 +1458,6 @@ async def chat_completions_endpoint(request: ChatRequest, http_request: Request)
             if "adapter_path" in request.model_fields_set
             else _INHERIT_ADAPTER
         )
-        model, processor, config = get_cached_model(request.model, adapter_path)
 
         kwargs = {}
 
@@ -1461,6 +1524,10 @@ async def chat_completions_endpoint(request: ChatRequest, http_request: Request)
                 msg["reasoning"] = message.reasoning_content
 
             processed_messages.append(msg)
+
+        _ensure_effective_input(processed_messages, images=images, audio=audio)
+
+        model, processor, config = get_cached_model(request.model, adapter_path)
 
         # Detect tool parser from chat template
         tools = getattr(request, "tools", None)

--- a/mlx_vlm/tests/test_server.py
+++ b/mlx_vlm/tests/test_server.py
@@ -87,6 +87,49 @@ def test_chat_completions_endpoint_requires_model(client):
     assert any(err.get("loc") == ["body", "model"] for err in detail)
 
 
+@pytest.mark.parametrize(
+    "messages",
+    [
+        [],
+        [{"role": "user", "content": ""}],
+        [{"role": "user", "content": " \n\t "}],
+        [{"role": "user", "content": [{"type": "text", "text": " "}]}],
+    ],
+)
+def test_chat_completions_endpoint_rejects_empty_effective_input(client, messages):
+    with patch.object(server_openai, "get_cached_model") as mock_get_cached_model:
+        response = client.post(
+            "/chat/completions",
+            json={"model": "demo", "messages": messages},
+        )
+
+    assert response.status_code == 400
+    assert "non-empty message content" in response.json()["detail"]
+    mock_get_cached_model.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "input_value",
+    [
+        "",
+        " \n\t ",
+        [],
+        [{"role": "user", "content": ""}],
+        [{"role": "user", "content": [{"type": "input_text", "text": " "}]}],
+    ],
+)
+def test_responses_endpoint_rejects_empty_effective_input(client, input_value):
+    with patch.object(server_openai, "get_cached_model") as mock_get_cached_model:
+        response = client.post(
+            "/v1/responses",
+            json={"model": "demo", "input": input_value},
+        )
+
+    assert response.status_code == 400
+    assert "non-empty message content" in response.json()["detail"]
+    mock_get_cached_model.assert_not_called()
+
+
 def test_chat_request_schema_requires_model():
     assert "model" in server.ChatRequest.model_json_schema()["required"]
 


### PR DESCRIPTION
## Summary

Fixes #1485.

- Reject chat/completions requests that have no effective input before loading the model or entering generation.
- Apply the same guard to Responses API generation and input-token counting.
- Treat text, image, and audio parts as valid effective input so image-only VLM prompts remain supported.
- Add regression coverage for empty messages, whitespace-only content, and empty Responses API inputs.

## Root Cause

Degenerate OpenAI-compatible requests could produce an empty prompt sequence and reach model generation, where Qwen-family attention reshaped a zero-length tensor and surfaced as HTTP 500.

## Validation

- `uv run --with pytest pytest mlx_vlm/tests/test_server.py -q`
- `uv run python -m compileall -q mlx_vlm/server/openai.py mlx_vlm/tests/test_server.py`