### PR TITLE
fix(lfm2_vl): only create projector LayerNorm when projector_use_laye…

### DIFF
--- a/mlx_vlm/models/lfm2_vl/lfm2_vl.py
+++ b/mlx_vlm/models/lfm2_vl/lfm2_vl.py
@@ -16,7 +16,10 @@ class Lfm2VlMultiModalProjector(nn.Module):
         super().__init__()
         in_channels = config.vision_config.hidden_size * (config.downsample_factor**2)
         self.projector_use_layernorm = config.projector_use_layernorm
-        self.layer_norm = nn.LayerNorm(in_channels)
+        # LFM2.5-VL checkpoints set projector_use_layernorm=False and ship no
+        # layer_norm weights, so only create the module when it is enabled.
+        if self.projector_use_layernorm:
+            self.layer_norm = nn.LayerNorm(in_channels)
         self.linear_1 = nn.Linear(
             in_channels,
             config.projector_hidden_size,
@@ -224,4 +227,16 @@ class Model(nn.Module):
 
             return key
 
-        return {transform_key(k): v for k, v in weights.items()}
+        weights = {transform_key(k): v for k, v in weights.items()}
+
+        # Some older conversions include projector layer_norm weights even
+        # though projector_use_layernorm is disabled; drop them so they do
+        # not show up as unexpected parameters during strict loading.
+        if not self.config.projector_use_layernorm:
+            weights = {
+                k: v
+                for k, v in weights.items()
+                if not k.startswith("multi_modal_projector.layer_norm.")
+            }
+
+        return weights

--- a/mlx_vlm/models/lfm2_vl/lfm2_vl.py
+++ b/mlx_vlm/models/lfm2_vl/lfm2_vl.py
@@ -16,8 +16,6 @@ class Lfm2VlMultiModalProjector(nn.Module):
         super().__init__()
         in_channels = config.vision_config.hidden_size * (config.downsample_factor**2)
         self.projector_use_layernorm = config.projector_use_layernorm
-        # LFM2.5-VL checkpoints set projector_use_layernorm=False and ship no
-        # layer_norm weights, so only create the module when it is enabled.
         if self.projector_use_layernorm:
             self.layer_norm = nn.LayerNorm(in_channels)
         self.linear_1 = nn.Linear(
@@ -229,9 +227,6 @@ class Model(nn.Module):
 
         weights = {transform_key(k): v for k, v in weights.items()}
 
-        # Some older conversions include projector layer_norm weights even
-        # though projector_use_layernorm is disabled; drop them so they do
-        # not show up as unexpected parameters during strict loading.
         if not self.config.projector_use_layernorm:
             weights = {
                 k: v

--- a/mlx_vlm/tests/test_models.py
+++ b/mlx_vlm/tests/test_models.py
@@ -362,6 +362,34 @@ class TestModels(unittest.TestCase):
         )
         self.assertNotIn(f"language_model.{prefix}.experts.0.w1.weight", sanitized)
 
+    def test_lfm2_vl_projector_creates_layernorm_only_when_enabled(self):
+        from mlx_vlm.models import lfm2_vl
+        from mlx_vlm.models.lfm2_vl.lfm2_vl import Lfm2VlMultiModalProjector
+
+        def make_projector(use_layernorm):
+            config = lfm2_vl.ModelConfig(
+                model_type="lfm2-vl",
+                text_config=lfm2_vl.TextConfig(layer_types=["full_attention"]),
+                vision_config=lfm2_vl.VisionConfig(),
+                projector_use_layernorm=use_layernorm,
+            )
+            return config, Lfm2VlMultiModalProjector(config)
+
+        in_channels = 768 * (2**2)
+        x = mx.zeros((1, 4, in_channels))
+
+        # LFM2-VL checkpoints omit the flag (defaults True) and ship
+        # layer_norm weights, so the module must exist.
+        config, projector = make_projector(True)
+        self.assertIn("layer_norm", projector.parameters())
+        self.assertEqual(projector(x).shape, (1, 4, config.text_config.hidden_size))
+
+        # LFM2.5-VL checkpoints set the flag to False and ship no
+        # layer_norm weights; strict loading must not require them.
+        config, projector = make_projector(False)
+        self.assertNotIn("layer_norm", projector.parameters())
+        self.assertEqual(projector(x).shape, (1, 4, config.text_config.hidden_size))
+
     def test_deepseek_v4_language_model(self):
         from mlx_vlm.models import deepseek_v4
         from mlx_vlm.models.deepseek_v4.hyper_connection import (
@@ -2582,10 +2610,11 @@ class TestModels(unittest.TestCase):
         )
         model = lfm2_vl.Model(config)
 
-        self.assertIsNotNone(model.multi_modal_projector.layer_norm)
         self.assertFalse(model.multi_modal_projector.projector_use_layernorm)
+        # LFM2.5-VL checkpoints ship no projector layer_norm weights, so the
+        # module must not exist or strict loading would require them.
         parameters = model.multi_modal_projector.parameters()
-        self.assertIn("layer_norm", parameters)
+        self.assertNotIn("layer_norm", parameters)
 
     def test_lfm2_vl_projector_skips_disabled_layernorm_branch(self):
         from mlx_vlm.models import lfm2_vl
@@ -6174,19 +6203,30 @@ class TestGetInputEmbeddings(unittest.TestCase):
             )
         )
 
-        self.assertIsNotNone(model.multi_modal_projector.layer_norm)
         self.assertFalse(model.multi_modal_projector.projector_use_layernorm)
 
+        # Real LFM2.5-VL checkpoints ship no projector layer_norm weights.
         model.multi_modal_projector.load_weights(
             [
-                ("layer_norm.weight", mx.ones((64,))),
-                ("layer_norm.bias", mx.zeros((64,))),
                 ("linear_1.weight", mx.ones((16, 64))),
                 ("linear_1.bias", mx.zeros((16,))),
                 ("linear_2.weight", mx.ones((16, 16))),
                 ("linear_2.bias", mx.zeros((16,))),
             ]
         )
+
+        # Conversions from when the projector always created the layer_norm
+        # can carry stale weights; sanitize must drop them when disabled.
+        sanitized = model.sanitize(
+            {
+                "model.multi_modal_projector.layer_norm.weight": mx.ones((64,)),
+                "model.multi_modal_projector.layer_norm.bias": mx.zeros((64,)),
+                "model.multi_modal_projector.linear_1.weight": mx.ones((16, 64)),
+            }
+        )
+        self.assertNotIn("multi_modal_projector.layer_norm.weight", sanitized)
+        self.assertNotIn("multi_modal_projector.layer_norm.bias", sanitized)
+        self.assertIn("multi_modal_projector.linear_1.weight", sanitized)
 
     def test_molmo2_input_embeddings(self):
         from mlx_vlm.models import molmo2


### PR DESCRIPTION
All LFM2.5-VL checkpoints set projector_use_layernorm: false and ship no layer_norm weights, but the projector created the nn.LayerNorm module unconditionally, so every LFM2.5-VL repo failed to load with Missing 2 parameters: 

multi_modal_projector.layer_norm.bias/weight


This PR only creates the module when the flag is enabled, and drops stale layer_norm weights in sanitize so older conversions that still carry them keep loading. Old LFM2-VL models are unaffected since they default the flag to true and ship the weights. 

Verified that LFM2.5-VL 4bit and bf16 now load and generate correctly, LFM2-VL-450M-8bit still loads, and the full test_models.py suite passes 

Fixes the LFM2.5-VL item of #1490.