### PR TITLE
make eos_token_id a config field so model loading works

### DIFF
--- a/mlx_vlm/models/molmo_point/config.py
+++ b/mlx_vlm/models/molmo_point/config.py
@@ -85,6 +85,7 @@ class ModelConfig(BaseModelConfig):
     subpatch_token_id: int = 151948
     location_token_id: int = 151949
     use_frame_special_tokens: bool = True
+    eos_token_id: Optional[List[int]] = None  # falls back to the tokenizer EOS
 
     # Point prediction config
     patch_location: Optional[str] = "3x3"
@@ -147,7 +148,3 @@ class ModelConfig(BaseModelConfig):
     @property
     def vocab_size(self):
         return self.text_config.vocab_size
-
-    @property
-    def eos_token_id(self):
-        return None  # Let the tokenizer handle EOS

--- a/mlx_vlm/tests/test_utils.py
+++ b/mlx_vlm/tests/test_utils.py
@@ -168,6 +168,20 @@ def test_apply_generation_config_defaults_preserves_model_config_signature():
     assert not hasattr(model_config, "max_new_tokens")
 
 
+def test_apply_generation_config_defaults_skips_read_only_eos_token_id():
+    class ModelConfig:
+        @property
+        def eos_token_id(self):
+            return None
+
+    model_config = apply_generation_config_defaults(
+        ModelConfig(), {"eos_token_id": 151645, "temperature": 0.7}
+    )
+
+    assert model_config.eos_token_id is None
+    assert model_config.temperature == 0.7
+
+
 def test_sanitize_weights():
     class DummyModel:
         def __init__(self, config=None):

--- a/mlx_vlm/utils.py
+++ b/mlx_vlm/utils.py
@@ -67,6 +67,11 @@ GENERATION_CONFIG_DEFAULT_KEYS = (
 def apply_generation_config_defaults(model_config, config: dict):
     for key in GENERATION_CONFIG_DEFAULT_KEYS:
         if key in config:
+            # A model config may expose a generation key as a read-only
+            # property; leave it untouched instead of crashing the load.
+            prop = getattr(type(model_config), key, None)
+            if isinstance(prop, property) and prop.fset is None:
+                continue
             setattr(model_config, key, config[key])
     return model_config
 


### PR DESCRIPTION
mlx-community/MolmoPoint-8B-fp16 failed to load with AttributeError: 
property 'eos_token_id' of 'ModelConfig' 

object has no setter, because molmo_point declared eos_token_id as a getter-only property while load_model tries to apply the repo config's value onto the model config. 

This PR replaces the property with a plain Optional[List[int]] field matching sibling models molmo and molmo2, so loading works and the config's 151645 now correctly reaches the stopping criteria and the server stop-token set instead of being permanently None. 

It also hardens apply_generation_config_defaults to skip read-only properties instead of crashing, so any future config with the same shape degrades gracefully, with a unit test covering the guard. 

Verified MolmoPoint-8B-fp16 checkpoint now loads with stopping criteria [151645], test_utils.py passes 32/32, and Qwen3-VL/LFM2 regression loads are unaffected.

Fixes the MolmoPoint issue of #1490.
