### PR TITLE
fix(utils): merge eos_token_id into model config instead of overwriti…

### DIFF
--- a/mlx_vlm/tests/test_utils.py
+++ b/mlx_vlm/tests/test_utils.py
@@ -168,6 +168,29 @@ def test_apply_generation_config_defaults_preserves_model_config_signature():
     assert not hasattr(model_config, "max_new_tokens")
 
 
+def test_apply_generation_config_defaults_extends_model_eos_token_ids():
+    class ModelConfig:
+        eos_token_id = [2, 32000, 32007]  # e.g. phi3_v chat terminators
+
+    model_config = apply_generation_config_defaults(
+        ModelConfig(), {"eos_token_id": [2, 5], "temperature": 0.7}
+    )
+
+    assert model_config.eos_token_id == [2, 32000, 32007, 5]
+    assert model_config.temperature == 0.7
+
+
+def test_apply_generation_config_defaults_sets_eos_when_model_has_none():
+    class ModelConfig:
+        eos_token_id = None
+
+    model_config = apply_generation_config_defaults(
+        ModelConfig(), {"eos_token_id": [1, 106]}
+    )
+
+    assert model_config.eos_token_id == [1, 106]
+
+
 def test_sanitize_weights():
     class DummyModel:
         def __init__(self, config=None):

--- a/mlx_vlm/utils.py
+++ b/mlx_vlm/utils.py
@@ -64,10 +64,37 @@ GENERATION_CONFIG_DEFAULT_KEYS = (
 )
 
 
+def _merge_eos_token_ids(existing, new):
+    """Union of already-known EOS ids and config-provided ones.
+
+    EOS ids are a set of stop conditions, so the config value must extend
+    what the model config already knows, not replace it. Model configs may
+    compute extra chat terminators at construction time (e.g. phi3_v appends
+    ``PHI3_V_CHAT_EOS_TOKEN_IDS`` in ``__post_init__``) that the raw config
+    does not contain.
+    """
+
+    def _as_list(value):
+        if value is None:
+            return []
+        if isinstance(value, (int, str)):
+            return [value]
+        return list(value)
+
+    merged = _as_list(existing)
+    for token_id in _as_list(new):
+        if token_id not in merged:
+            merged.append(token_id)
+    return merged if merged else None
+
+
 def apply_generation_config_defaults(model_config, config: dict):
     for key in GENERATION_CONFIG_DEFAULT_KEYS:
         if key in config:
-            setattr(model_config, key, config[key])
+            value = config[key]
+            if key == "eos_token_id":
+                value = _merge_eos_token_ids(getattr(model_config, key, None), value)
+            setattr(model_config, key, value)
     return model_config
 
 


### PR DESCRIPTION
For Phi-3.5, after a prompt, and response i'd keep printing <|end|><|endoftext|><|end|><|endoftext|>... until it hit the token limit.

Why: the model stops when it emits one of the stop tokens in its config. Phi-3.5 has three of them, but while loading the model we replace that list with the single value from generation_config.json, which is a token this model never emits. So nothing ever matched and generation ran until the cap.

Fix: add the value from generation_config.json to the existing stop tokens instead of replacing them. Sampling settings like temperature are untouched.

All tests green and same prompt now stops 

this was raised in #1490 