### PR TITLE
feat(utils): actionable error and [torch] extra for processors that n…

### DIFF
--- a/mlx_vlm/tests/test_utils.py
+++ b/mlx_vlm/tests/test_utils.py
@@ -755,6 +755,19 @@ def test_load_processor_propagates_auto_processor_errors():
             load_processor(Path("/tmp/model"), eos_token_ids=2)
 
 
+def test_load_processor_gives_install_hint_for_missing_backends():
+    backend_error = ImportError(
+        "PixtralProcessor requires the Torchvision library but it was not found"
+    )
+    with patch(
+        "mlx_vlm.utils.AutoProcessor.from_pretrained", side_effect=backend_error
+    ):
+        with pytest.raises(ImportError, match=r"mlx-vlm\[torch\]") as exc_info:
+            load_processor(Path("/tmp/model"), eos_token_ids=2)
+
+    assert exc_info.value.__cause__ is backend_error
+
+
 def test_text_only_model_provides_input_embeddings_and_wraps_logits():
     class TinyInner(nn.Module):
         def __init__(self):

--- a/mlx_vlm/utils.py
+++ b/mlx_vlm/utils.py
@@ -938,7 +938,17 @@ def load_processor(
     model_path, add_detokenizer=True, eos_token_ids=None, **kwargs
 ) -> ProcessorMixin:
 
-    processor = AutoProcessor.from_pretrained(model_path, **kwargs)
+    try:
+        processor = AutoProcessor.from_pretrained(model_path, **kwargs)
+    except ImportError as e:
+        # transformers raises ImportError when a processor needs a backend
+        # that mlx-vlm does not depend on (e.g. Pixtral-family image
+        # processors require torch and torchvision in transformers v5).
+        raise ImportError(
+            f"The processor for {model_path} requires packages that are not "
+            "installed. Install them with `pip install mlx-vlm[torch]` "
+            "(or `pip install torch torchvision`)."
+        ) from e
     if add_detokenizer:
         detokenizer_class = load_tokenizer(model_path, return_tokenizer=False)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,3 +46,6 @@ dependencies = {file = ["requirements.txt"]}
 ui = ["gradio>=5.19.0"]
 cuda = ["mlx-cuda"]
 cpu = ["mlx-cpu"]
+# Some processors (e.g. the Pixtral family) need torch-backed image
+# processing in transformers v5.
+torch = ["torch", "torchvision"]


### PR DESCRIPTION

Pixtral-family models (pixtral, Apriel, Devstral) fail to load on a default mlx-vlm install because transformers v5 only ships torch-backed image processors for them, surfacing as a raw ImportError from deep inside transformers with no hint about what to install.

Catch the backend ImportError in load_processor and re-raise with the exact install command, and add a `torch` extra so
`pip install mlx-vlm[torch]` pulls torch + torchvision. 

All test_utils.py tests pass, including a new one for this error path.