### PR TITLE
Fix MolmoPoint EOS config

### DIFF
--- a/mlx_vlm/models/molmo_point/config.py
+++ b/mlx_vlm/models/molmo_point/config.py
@@ -1,6 +1,6 @@
 import inspect
 from dataclasses import dataclass
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, List, Optional, Tuple, Union
 
 from ..base import BaseModelConfig
 
@@ -71,6 +71,7 @@ class ModelConfig(BaseModelConfig):
     text_config: TextConfig = None
     vision_config: VisionConfig = None
     adapter_config: AdapterConfig = None
+    eos_token_id: Optional[Union[int, List[int]]] = None
 
     # Token IDs
     image_start_token_id: int = 151936
@@ -147,7 +148,3 @@ class ModelConfig(BaseModelConfig):
     @property
     def vocab_size(self):
         return self.text_config.vocab_size
-
-    @property
-    def eos_token_id(self):
-        return None  # Let the tokenizer handle EOS

--- a/mlx_vlm/tests/test_models.py
+++ b/mlx_vlm/tests/test_models.py
@@ -2804,6 +2804,23 @@ class TestModels(unittest.TestCase):
             config.text_config.num_hidden_layers,
         )
 
+    def test_molmo_point_config_accepts_eos_token_id(self):
+        from mlx_vlm.models import molmo_point
+        from mlx_vlm.utils import apply_generation_config_defaults
+
+        config = molmo_point.ModelConfig.from_dict(
+            {
+                "model_type": "molmo_point",
+                "eos_token_id": 151645,
+            }
+        )
+
+        self.assertEqual(config.eos_token_id, 151645)
+
+        apply_generation_config_defaults(config, {"eos_token_id": [151645, 151646]})
+
+        self.assertEqual(config.eos_token_id, [151645, 151646])
+
     def test_molmo2_sanitizes_non_finite_image_features(self):
         from mlx_vlm.models.molmo2.molmo2 import (
             MAX_FLOAT16_IMAGE_FEATURE,


### PR DESCRIPTION
## Summary

- Add `eos_token_id` as a real MolmoPoint `ModelConfig` field.
- Remove the read-only MolmoPoint `eos_token_id` property that blocked loader defaults.
- Add a regression test for MolmoPoint `from_dict()` and generation config default updates.

## Root cause

`mlx-community/MolmoPoint-8B-fp16` ships `eos_token_id` in its config/generation config. During load, `apply_generation_config_defaults()` assigns that value onto the model config, but MolmoPoint exposed `eos_token_id` as a property without a setter, causing model load to fail before generation.

## Validation

- `uv run python -m unittest mlx_vlm.tests.test_models.TestModels.test_molmo_point_config_accepts_eos_token_id`
- `uv run python - <<'PY' ... load('mlx-community/MolmoPoint-8B-fp16', trust_remote_code=True, lazy=True) ... PY`

The real MolmoPoint load path now returns `LOAD_OK` with `MolmoPointProcessor` and `eos_token_id: 151645`.

Closes #1495
