### PR TITLE
Support Gemma 4 variable soft-token budgets

### DIFF
--- a/mlx_vlm/models/gemma4/processing_gemma4.py
+++ b/mlx_vlm/models/gemma4/processing_gemma4.py
@@ -491,10 +491,15 @@ class Gemma4Processor(ProcessorMixin):
             )
 
         # ── Process images ──────────────────────────────────────────────
+        image_kwargs = dict(kwargs.pop("images_kwargs", None) or {})
+        for _k in ("max_soft_tokens", "patch_size", "pooling_kernel_size"):
+            if _k in kwargs:
+                image_kwargs[_k] = kwargs.pop(_k)
+
         image_inputs = {}
         if images is not None:
             images = self.image_processor.fetch_images(images)
-            image_data, num_soft_tokens = self.image_processor(images)
+            image_data, num_soft_tokens = self.image_processor(images, **image_kwargs)
             image_inputs = image_data
 
             if text is not None and num_soft_tokens is not None:

--- a/mlx_vlm/models/gemma4/vision.py
+++ b/mlx_vlm/models/gemma4/vision.py
@@ -414,8 +414,10 @@ class VisionModel(nn.Module):
             self.std_bias = mx.zeros((config.hidden_size,))
             self.std_scale = mx.ones((config.hidden_size,))
 
-    def _patch_positions_single(self, H, W):
+    def _patch_positions_single(self, H, W, max_patches=None):
         """Compute patch positions and padding mask for a single image."""
+        if max_patches is None:
+            max_patches = self.max_patches
         pH = H // self.patch_size
         pW = W // self.patch_size
         num_patches = pH * pW
@@ -425,14 +427,14 @@ class VisionModel(nn.Module):
         gx, gy = np.meshgrid(grid_x, grid_y, indexing="xy")
         real_positions = np.stack([gx.flatten(), gy.flatten()], axis=-1)
 
-        num_padding = self.max_patches - num_patches
+        num_padding = max_patches - num_patches
         if num_padding > 0:
             pad_positions = np.full((num_padding, 2), -1, dtype=np.int64)
             patch_positions = np.concatenate([real_positions, pad_positions], axis=0)
         else:
-            patch_positions = real_positions[: self.max_patches]
+            patch_positions = real_positions[:max_patches]
 
-        padding_mask = np.zeros(self.max_patches, dtype=bool)
+        padding_mask = np.zeros(max_patches, dtype=bool)
         if num_padding > 0:
             padding_mask[num_patches:] = True
 
@@ -457,26 +459,22 @@ class VisionModel(nn.Module):
         B, C, H, W = pixel_values.shape
         all_same_size = True
 
+        pool_sq = self.pooling_kernel_size**2
+        output_length = self.default_output_length
+
         if all_same_size:
             num_real = (H // self.patch_size) * (W // self.patch_size)
-            num_real = min(num_real, self.max_patches)
-            positions, padding_mask, _ = self._patch_positions_single(H, W)
+            output_length = num_real // pool_sq
+            positions, padding_mask, _ = self._patch_positions_single(
+                H, W, max_patches=num_real
+            )
             # Tile for batch
             patch_positions = mx.array(np.tile(positions[None], (B, 1, 1)))
             padding_positions = mx.array(np.tile(padding_mask[None], (B, 1)))
 
             inputs_embeds = self.patch_embedder(
-                pixel_values,
-                patch_positions[:, :num_real],
-                padding_positions[:, :num_real],
+                pixel_values, patch_positions, padding_positions
             )
-
-            num_padding = self.max_patches - num_real
-            if num_padding > 0:
-                pad_embeds = mx.zeros(
-                    (B, num_padding, inputs_embeds.shape[-1]), dtype=inputs_embeds.dtype
-                )
-                inputs_embeds = mx.concatenate([inputs_embeds, pad_embeds], axis=1)
         else:
             # Per-image processing for different sizes (shouldn't happen with padding)
             all_embeds = []
@@ -517,10 +515,13 @@ class VisionModel(nn.Module):
         hidden_states = self.encoder(inputs_embeds, patch_positions, attn_mask)
 
         pooled, pool_mask = self.pooler(
-            hidden_states, patch_positions, padding_positions
+            hidden_states,
+            patch_positions,
+            padding_positions,
+            output_length=output_length,
         )
 
-        if pool_mask.shape[1] == self.default_output_length:
+        if pool_mask.shape[1] == output_length:
             valid_mask = pool_mask
         else:
             valid_mask = ~pool_mask

--- a/mlx_vlm/tests/test_models.py
+++ b/mlx_vlm/tests/test_models.py
@@ -3171,6 +3171,103 @@ class TestModels(unittest.TestCase):
         output = model(input_ids_with_img, pixel_values=pixel_values)
         self.assertEqual(output.logits.shape, (1, 6, config.text_config.vocab_size))
 
+        def image(h, w):
+            return np.zeros((h, w, 3), dtype=np.uint8)
+
+        image_processor = gemma4.Gemma4ImageProcessor()
+        for h, w in ((1125, 1500), (1650, 1275), (480, 640)):
+            counts = []
+            for budget in (280, 560, 1120):
+                _, soft_tokens = image_processor(
+                    image(h, w),
+                    max_soft_tokens=budget,
+                )
+                self.assertLessEqual(soft_tokens[0], budget)
+                counts.append(soft_tokens[0])
+            self.assertTrue(counts[0] < counts[1] < counts[2])
+
+        _, soft_tokens = image_processor(image(1125, 1500))
+        self.assertLessEqual(soft_tokens[0], 280)
+
+        tiny_image_processor = gemma4.Gemma4ImageProcessor(
+            patch_size=vision_config.patch_size,
+            pooling_kernel_size=vision_config.pooling_kernel_size,
+            max_soft_tokens=vision_config.default_output_length,
+        )
+        tiny_tower = gemma4.VisionModel(vision_config)
+        tiny_tower.eval()
+        variable_image = image(256, 256)
+        for budget in (
+            vision_config.default_output_length,
+            vision_config.default_output_length * 4,
+        ):
+            data, soft_tokens = tiny_image_processor(
+                variable_image,
+                max_soft_tokens=budget,
+                patch_size=vision_config.patch_size,
+                pooling_kernel_size=vision_config.pooling_kernel_size,
+            )
+            output = tiny_tower(mx.array(data["pixel_values"]))
+            mx.eval(output)
+            self.assertEqual(output.shape[1], soft_tokens[0])
+
+        image_token, image_token_id = "<image>", 100
+        tokenizer_kwargs = []
+
+        class _Tokenizer:
+            def __call__(self, text=None, **kwargs):
+                tokenizer_kwargs.append(kwargs)
+                return {
+                    "input_ids": [
+                        [image_token_id] * prompt.count(image_token) for prompt in text
+                    ]
+                }
+
+        proc = gemma4.Gemma4Processor.__new__(gemma4.Gemma4Processor)
+        proc.tokenizer = _Tokenizer()
+        proc.image_processor = tiny_image_processor
+        proc.video_processor = None
+        proc.feature_extractor = None
+        proc.image_token = image_token
+        proc.image_token_id = image_token_id
+        proc.boi_token = "<boi>"
+        proc.eoi_token = "<eoi>"
+        proc.image_seq_length = vision_config.default_output_length
+        proc.audio_token = ""
+        proc.boa_token = ""
+        proc.eoa_token = ""
+        proc.audio_token_id = None
+        proc.full_image_sequence = (
+            "<boi>" + image_token * vision_config.default_output_length + "<eoi>"
+        )
+        proc.full_audio_sequence = None
+
+        threaded_counts = []
+        for budget in (
+            vision_config.default_output_length,
+            vision_config.default_output_length * 4,
+        ):
+            output = proc(
+                images=[variable_image],
+                text=[f"{image_token} describe"],
+                images_kwargs={
+                    "max_soft_tokens": budget,
+                    "patch_size": vision_config.patch_size,
+                    "pooling_kernel_size": vision_config.pooling_kernel_size,
+                },
+                return_mm_token_type_ids=False,
+            )
+            ids = np.array(output["input_ids"][0])
+            threaded_counts.append(int((ids == image_token_id).sum()))
+
+        self.assertTrue(threaded_counts[0] < threaded_counts[1])
+        self.assertTrue(
+            all(
+                "images_kwargs" not in kwargs and "max_soft_tokens" not in kwargs
+                for kwargs in tokenizer_kwargs
+            )
+        )
+
         # Quantized save/load regression for per-layer projection.
         quant_model = gemma4.Model(config)
 


### PR DESCRIPTION
## Summary
- threads Gemma 4 image-side kwargs such as `max_soft_tokens` through `Gemma4Processor` without passing them to the tokenizer
- derives the Gemma 4 vision encoder/pooler output length from the resized image shape so non-default soft-token budgets stay aligned with placeholder expansion
- folds the variable soft-token regression coverage into `TestModels.test_gemma4` and removes the standalone test module

## Root Cause
The image processor could resize images for higher soft-token budgets, but `VisionModel` still sized patch positions and pooled output from the default budget. That left processor placeholder counts and vision features out of sync for budgets above 280.

## Validation
- `uv run --with pytest python -m pytest mlx_vlm/tests/test_models.py::TestModels::test_gemma4`
- Full-precision `google/gemma-4-26b-a4b-it` BF16 checkpoint with `max_soft_tokens=1120`: image tokens `1064`, pixel values `(1, 3, 1344, 1824)`, embeddings `(1, 1090, 2816)`, full language forward last logits `(1, 262144)`, peak memory `52.75 GB`

Fixes #1425