### PR TITLE
Fix MiniCPM-V 4.6 weight sanitization

### DIFF
--- a/mlx_vlm/models/minicpmv4_6/minicpmv4_6.py
+++ b/mlx_vlm/models/minicpmv4_6/minicpmv4_6.py
@@ -424,7 +424,16 @@ class Model(nn.Module):
 
     def sanitize(self, weights):
         sanitized_weights = {}
+        offset_norm_keys = (
+            ".input_layernorm.weight",
+            ".post_attention_layernorm.weight",
+            "model.norm.weight",
+            ".q_norm.weight",
+            ".k_norm.weight",
+        )
+
         for key, value in weights.items():
+            original_key = key
             # MiniCPM-V 4.6 checkpoint namespaces are prefixed with `model.`
             # and split across language_model / vision_tower / merger.
             if key.startswith("model."):
@@ -473,6 +482,12 @@ class Model(nn.Module):
                 "embeddings.patch_embedding.weight"
             ) and not check_array_shape(value):
                 value = value.transpose(0, 2, 3, 1)
+            if (
+                original_key.startswith("model.language_model.")
+                and any(key.endswith(suffix) for suffix in offset_norm_keys)
+                and value.ndim == 1
+            ):
+                value = value + 1.0
             sanitized_weights[key] = value
 
         if self.config.text_config.tie_word_embeddings:

--- a/mlx_vlm/models/minicpmv4_6/minicpmv4_6.py
+++ b/mlx_vlm/models/minicpmv4_6/minicpmv4_6.py
@@ -424,14 +424,6 @@ class Model(nn.Module):
 
     def sanitize(self, weights):
         sanitized_weights = {}
-        norm_keys = (
-            ".input_layernorm.weight",
-            ".post_attention_layernorm.weight",
-            "model.norm.weight",
-            ".q_norm.weight",
-            ".k_norm.weight",
-        )
-
         for key, value in weights.items():
             # MiniCPM-V 4.6 checkpoint namespaces are prefixed with `model.`
             # and split across language_model / vision_tower / merger.
@@ -481,9 +473,6 @@ class Model(nn.Module):
                 "embeddings.patch_embedding.weight"
             ) and not check_array_shape(value):
                 value = value.transpose(0, 2, 3, 1)
-            if any(key.endswith(suffix) for suffix in norm_keys) and value.ndim == 1:
-                value = value + 1.0
-
             sanitized_weights[key] = value
 
         if self.config.text_config.tie_word_embeddings:

--- a/mlx_vlm/models/minicpmv4_6/minicpmv4_6.py
+++ b/mlx_vlm/models/minicpmv4_6/minicpmv4_6.py
@@ -439,7 +439,11 @@ class Model(nn.Module):
                 key = key.replace("model.", "", 1)
 
             mapped_key = None
-            if key.startswith("language_model."):
+            if key.startswith("language_model.model."):
+                mapped_key = key
+            elif key.startswith("language_model.lm_head."):
+                mapped_key = key
+            elif key.startswith("language_model."):
                 mapped_key = key.replace("language_model.", "language_model.model.", 1)
             elif key.startswith("lm_head."):
                 mapped_key = key.replace("lm_head.", "language_model.lm_head.", 1)
@@ -452,6 +456,10 @@ class Model(nn.Module):
             elif key.startswith("vit_merger.") or key.startswith("merger."):
                 mapped_key = key
             # Backward compatibility with older naming schemes.
+            elif key.startswith("llm.model."):
+                mapped_key = key.replace("llm.model.", "language_model.model.", 1)
+            elif key.startswith("llm.lm_head."):
+                mapped_key = key.replace("llm.", "language_model.", 1)
             elif key.startswith("llm."):
                 mapped_key = key.replace("llm.", "language_model.model.", 1)
             elif key.startswith("visual."):


### PR DESCRIPTION
## Summary

Fixes #1504.

MiniCPM-V 4.6 checkpoint loading now handles both current supported checkpoint layouts:

- `mlx-community/MiniCPM-V-4.6-8bit`, which stores already-nested direct language weights such as `language_model.model.*`.
- `openbmb/MiniCPM-V-4.6`, which stores HF-style weights under `model.language_model.*` and offset-style RMSNorm weights.

The sanitizer now preserves already-nested language model keys instead of rewriting them into non-existent `language_model.model.model.*` parameters. It also applies the `+1.0` norm offset only for HF-style `model.language_model.*` source weights, while leaving MLX-converted direct norm weights unchanged.

## Root Cause

The MiniCPM-V 4.6 sanitizer had two incompatible assumptions:

- It unconditionally rewrote every `language_model.*` key to `language_model.model.*`, double-prefixing current MLX-community checkpoint keys.
- Its norm handling needed to distinguish source formats: OpenBMB HF-style weights need the offset, but MLX-community converted weights already include direct norm values.

Without the prefix fix, strict loading failed. Without source-aware norm handling, generation either produced nonsense for the 8-bit checkpoint or blank output for the OpenBMB checkpoint.

## Validation

- `uv run mlx_vlm.generate --model mlx-community/MiniCPM-V-4.6-8bit --prompt "Hi" --max-tokens 100`
  - Output: `Hello! How can I help you today?`
- `uv run mlx_vlm.generate --model openbmb/MiniCPM-V-4.6 --prompt "Hi" --max-tokens 100`
  - Output: `Hello! How can I help you today?`
- `uv run python -m unittest mlx_vlm.tests.test_models.TestMiniCPMV4_6`
- Commit hook checks: `black`, `isort`, `autoflake`