### PR TITLE
Unify diffusion generation path

### DIFF
--- a/mlx_vlm/generate/diffusion.py
+++ b/mlx_vlm/generate/diffusion.py
@@ -141,31 +141,34 @@ class _DiffusionRedrawer:
         self.rows = _terminal_rows_for_text(text)
 
 
-def _is_diffusion_config(config: Any) -> bool:
-    # Block-diffusion models declare the canvas length the denoising loop
-    # operates on; that trait is what the shared engine drives, so detection
-    # is not tied to a hardcoded model type.
+def _has_engine_diffusion_config(config: Any) -> bool:
+    # Engine-driven diffusion models declare the canvas length the denoising
+    # loop operates on; that trait is what the shared engine drives, so
+    # detection is not tied to a hardcoded model type.
     return getattr(config, "canvas_length", None) is not None
 
 
-def _is_block_diffusion_model(model: nn.Module) -> bool:
-    """True for canvas models driven by the shared diffusion engine."""
-    return _is_diffusion_config(getattr(model, "config", None)) and all(
+def _has_engine_diffusion_hooks(model: nn.Module) -> bool:
+    """True for models driven directly by the shared diffusion engine."""
+    return _has_engine_diffusion_config(getattr(model, "config", None)) and all(
         callable(getattr(model, method, None)) for method in BLOCK_DIFFUSION_METHODS
     )
 
 
-def _is_masked_diffusion_model(model: nn.Module) -> bool:
-    """True for masked-diffusion text models that own their generate loop."""
+def _has_model_diffusion_generator(model: nn.Module) -> bool:
+    """True for diffusion models that expose generation on the language model."""
     config = getattr(model, "config", None)
-    return getattr(config, "mask_token_id", None) is not None
+    language_model = getattr(model, "language_model", None)
+    return getattr(config, "mask_token_id", None) is not None and callable(
+        getattr(language_model, "generate", None)
+    )
 
 
-def _use_masked_diffusion_model(
+def _uses_model_diffusion_generator(
     model: nn.Module,
     kwargs: Optional[Dict[str, Any]] = None,
 ) -> bool:
-    if not _is_masked_diffusion_model(model):
+    if not _has_model_diffusion_generator(model):
         return False
 
     config = getattr(model, "config", None)
@@ -184,13 +187,7 @@ def is_diffusion_model(
     kwargs: Optional[Dict[str, Any]] = None,
 ) -> bool:
     """True when this request should use the unified diffusion path."""
-    return _is_block_diffusion_model(model) or _use_masked_diffusion_model(
-        model, kwargs
-    )
-
-
-def is_masked_diffusion_model(model: nn.Module) -> bool:
-    return _is_masked_diffusion_model(model)
+    return _diffusion_stream_strategy(model, kwargs) is not None
 
 
 def diffusion_generation_family(
@@ -208,28 +205,23 @@ def diffusion_generation_family(
 
 
 def diffusion_kwargs_from_args(args: Any, config: Any) -> Dict[str, Any]:
-    is_block_config = _is_diffusion_config(config)
-    is_masked_config = getattr(config, "mask_token_id", None) is not None
-    if not is_block_config and not is_masked_config:
+    if not (
+        _has_engine_diffusion_config(config)
+        or getattr(config, "mask_token_id", None) is not None
+    ):
         return {}
 
     kwargs = {}
     if args.max_denoising_steps is not None:
         kwargs["max_denoising_steps"] = args.max_denoising_steps
-
-    if is_block_config:
-        if args.diffusion_full_canvas:
-            kwargs["diffusion_full_canvas"] = True
-        if args.diffusion_min_canvas_length is not None:
-            kwargs["diffusion_min_canvas_length"] = args.diffusion_min_canvas_length
-        if getattr(args, "diffusion_max_canvas_length", None) is not None:
-            kwargs["diffusion_max_canvas_length"] = args.diffusion_max_canvas_length
-        if args.diffusion_sampler != "confidence-threshold":
-            kwargs["diffusion_sampler"] = args.diffusion_sampler
-        if args.threshold is not None:
-            kwargs["diffusion_threshold"] = args.threshold
-        return kwargs
-
+    if args.diffusion_full_canvas:
+        kwargs["diffusion_full_canvas"] = True
+    if args.diffusion_min_canvas_length is not None:
+        kwargs["diffusion_min_canvas_length"] = args.diffusion_min_canvas_length
+    if getattr(args, "diffusion_max_canvas_length", None) is not None:
+        kwargs["diffusion_max_canvas_length"] = args.diffusion_max_canvas_length
+    if args.diffusion_sampler != "confidence-threshold":
+        kwargs["diffusion_sampler"] = args.diffusion_sampler
     if getattr(args, "block_length", None) is not None:
         kwargs["block_length"] = args.block_length
     if getattr(args, "num_to_transfer", None) is not None:
@@ -237,6 +229,7 @@ def diffusion_kwargs_from_args(args: Any, config: Any) -> Dict[str, Any]:
     if getattr(args, "max_transfer_per_step", None) is not None:
         kwargs["max_transfer_per_step"] = args.max_transfer_per_step
     if args.threshold is not None:
+        kwargs["diffusion_threshold"] = args.threshold
         kwargs["threshold"] = args.threshold
     if getattr(args, "min_threshold", None) is not None:
         kwargs["min_threshold"] = args.min_threshold
@@ -254,7 +247,7 @@ class DiffusionOutputHandler:
         self.verbose = verbose
         self.live_mode = bool(
             kwargs.get("diffusion_show_unmasking", False)
-            and _is_block_diffusion_model(model)
+            and _has_engine_diffusion_hooks(model)
         )
         self.width = kwargs.get(
             "diffusion_unmasking_width", DEFAULT_DIFFUSION_UNMASKING_WIDTH
@@ -1026,7 +1019,7 @@ def stream_diffusion_generate(
     yield make_result(detokenizer.last_segment, finish_reason=finish_reason)
 
 
-def stream_masked_diffusion_generate(
+def _stream_model_diffusion_generate(
     model: nn.Module,
     processor: PreTrainedTokenizer,
     tokenizer: PreTrainedTokenizer,
@@ -1208,6 +1201,117 @@ def stream_masked_diffusion_generate(
     yield from pending_results
 
 
+def _stream_model_diffusion_from_kwargs(
+    model: nn.Module,
+    processor: PreTrainedTokenizer,
+    tokenizer: PreTrainedTokenizer,
+    input_ids: mx.array,
+    pixel_values: Optional[mx.array],
+    attention_mask: Optional[mx.array],
+    skip_special_token_ids,
+    kwargs: Dict[str, Any],
+    *,
+    skip_special_tokens: bool = False,
+    verbose: bool = False,
+    on_result: Optional[Callable[[GenerationResult], bool]] = None,
+) -> Generator[GenerationResult, None, None]:
+    max_denoising_steps = kwargs.pop("max_denoising_steps", None)
+    block_length = kwargs.pop("block_length", None)
+    yield from _stream_model_diffusion_generate(
+        model,
+        processor,
+        tokenizer,
+        input_ids,
+        pixel_values,
+        attention_mask,
+        max_tokens=kwargs.pop("max_tokens", 2048),
+        temperature=kwargs.pop("temperature", DEFAULT_TEMPERATURE),
+        top_p=kwargs.pop("top_p", None),
+        top_k=kwargs.pop("top_k", None),
+        skip_special_token_ids=skip_special_token_ids,
+        skip_special_tokens=skip_special_tokens,
+        max_denoising_steps=max_denoising_steps,
+        block_length=block_length,
+        verbose=verbose,
+        on_result=on_result,
+        **kwargs,
+    )
+
+
+def _stream_engine_diffusion_from_kwargs(
+    model: nn.Module,
+    processor: PreTrainedTokenizer,
+    tokenizer: PreTrainedTokenizer,
+    input_ids: mx.array,
+    pixel_values: Optional[mx.array],
+    attention_mask: Optional[mx.array],
+    skip_special_token_ids,
+    kwargs: Dict[str, Any],
+    *,
+    skip_special_tokens: bool = False,
+    verbose: bool = False,
+    on_result: Optional[Callable[[GenerationResult], bool]] = None,
+) -> Generator[GenerationResult, None, None]:
+    del skip_special_tokens, verbose
+    max_denoising_steps = kwargs.pop("max_denoising_steps", None)
+    diffusion_full_canvas = kwargs.pop("diffusion_full_canvas", False)
+    diffusion_min_canvas_length = kwargs.pop("diffusion_min_canvas_length", None)
+    diffusion_max_canvas_length = kwargs.pop("diffusion_max_canvas_length", None)
+    diffusion_static_cache = kwargs.pop("diffusion_static_cache", False)
+    diffusion_sampler = kwargs.pop("diffusion_sampler", "confidence-threshold")
+    diffusion_threshold = kwargs.pop("diffusion_threshold", None)
+    diffusion_compile = kwargs.pop("diffusion_compile", False)
+    diffusion_show_unmasking = kwargs.pop("diffusion_show_unmasking", False)
+    diffusion_unmasking_interval = kwargs.pop("diffusion_unmasking_interval", 1)
+    diffusion_unmasking_width = kwargs.pop(
+        "diffusion_unmasking_width", DEFAULT_DIFFUSION_UNMASKING_WIDTH
+    )
+    mm_token_type_ids = kwargs.pop("mm_token_type_ids", None)
+    prefill_step_size = kwargs.pop("prefill_step_size", None)
+    results = stream_diffusion_generate(
+        model,
+        processor,
+        tokenizer,
+        input_ids,
+        pixel_values,
+        attention_mask,
+        max_tokens=kwargs.get("max_tokens", 2048),
+        temperature=kwargs.get("temperature", DEFAULT_TEMPERATURE),
+        skip_special_token_ids=skip_special_token_ids,
+        max_denoising_steps=max_denoising_steps,
+        diffusion_full_canvas=diffusion_full_canvas,
+        diffusion_min_canvas_length=diffusion_min_canvas_length,
+        diffusion_max_canvas_length=diffusion_max_canvas_length,
+        diffusion_static_cache=diffusion_static_cache,
+        diffusion_sampler=diffusion_sampler,
+        diffusion_threshold=diffusion_threshold,
+        diffusion_compile=diffusion_compile,
+        diffusion_show_unmasking=diffusion_show_unmasking,
+        diffusion_unmasking_interval=diffusion_unmasking_interval,
+        diffusion_unmasking_width=diffusion_unmasking_width,
+        mm_token_type_ids=mm_token_type_ids,
+        prefill_step_size=prefill_step_size,
+    )
+    try:
+        for result in results:
+            if on_result is not None and not on_result(result):
+                break
+            yield result
+    finally:
+        results.close()
+
+
+def _diffusion_stream_strategy(
+    model: nn.Module,
+    kwargs: Optional[Dict[str, Any]] = None,
+):
+    if _uses_model_diffusion_generator(model, kwargs):
+        return _stream_model_diffusion_from_kwargs
+    if _has_engine_diffusion_hooks(model):
+        return _stream_engine_diffusion_from_kwargs
+    return None
+
+
 def stream_diffusion_generate_from_kwargs(
     model: nn.Module,
     processor: PreTrainedTokenizer,
@@ -1230,77 +1334,22 @@ def stream_diffusion_generate_from_kwargs(
     if seed is not None:
         mx.random.seed(seed)
 
-    if _use_masked_diffusion_model(model, kwargs):
-        max_denoising_steps = kwargs.pop("max_denoising_steps", None)
-        block_length = kwargs.pop("block_length", None)
-        with wired_limit(model, [generation_stream]):
-            yield from stream_masked_diffusion_generate(
-                model,
-                processor,
-                tokenizer,
-                input_ids,
-                pixel_values,
-                attention_mask,
-                max_tokens=kwargs.pop("max_tokens", 2048),
-                temperature=kwargs.pop("temperature", DEFAULT_TEMPERATURE),
-                top_p=kwargs.pop("top_p", None),
-                top_k=kwargs.pop("top_k", None),
-                skip_special_token_ids=skip_special_token_ids,
-                skip_special_tokens=skip_special_tokens,
-                max_denoising_steps=max_denoising_steps,
-                block_length=block_length,
-                verbose=verbose,
-                on_result=on_result,
-                **kwargs,
-            )
-            mx.clear_cache()
-        return
+    stream_strategy = _diffusion_stream_strategy(model, kwargs)
+    if stream_strategy is None:
+        raise ValueError("Model does not support diffusion generation.")
 
-    max_denoising_steps = kwargs.pop("max_denoising_steps", None)
-    diffusion_full_canvas = kwargs.pop("diffusion_full_canvas", False)
-    diffusion_min_canvas_length = kwargs.pop("diffusion_min_canvas_length", None)
-    diffusion_max_canvas_length = kwargs.pop("diffusion_max_canvas_length", None)
-    diffusion_static_cache = kwargs.pop("diffusion_static_cache", False)
-    diffusion_sampler = kwargs.pop("diffusion_sampler", "confidence-threshold")
-    diffusion_threshold = kwargs.pop("diffusion_threshold", None)
-    diffusion_compile = kwargs.pop("diffusion_compile", False)
-    diffusion_show_unmasking = kwargs.pop("diffusion_show_unmasking", False)
-    diffusion_unmasking_interval = kwargs.pop("diffusion_unmasking_interval", 1)
-    diffusion_unmasking_width = kwargs.pop(
-        "diffusion_unmasking_width", DEFAULT_DIFFUSION_UNMASKING_WIDTH
-    )
-    mm_token_type_ids = kwargs.pop("mm_token_type_ids", None)
-    prefill_step_size = kwargs.pop("prefill_step_size", None)
     with wired_limit(model, [generation_stream]):
-        results = stream_diffusion_generate(
+        yield from stream_strategy(
             model,
             processor,
             tokenizer,
             input_ids,
             pixel_values,
             attention_mask,
-            max_tokens=kwargs.get("max_tokens", 2048),
-            temperature=kwargs.get("temperature", DEFAULT_TEMPERATURE),
             skip_special_token_ids=skip_special_token_ids,
-            max_denoising_steps=max_denoising_steps,
-            diffusion_full_canvas=diffusion_full_canvas,
-            diffusion_min_canvas_length=diffusion_min_canvas_length,
-            diffusion_max_canvas_length=diffusion_max_canvas_length,
-            diffusion_static_cache=diffusion_static_cache,
-            diffusion_sampler=diffusion_sampler,
-            diffusion_threshold=diffusion_threshold,
-            diffusion_compile=diffusion_compile,
-            diffusion_show_unmasking=diffusion_show_unmasking,
-            diffusion_unmasking_interval=diffusion_unmasking_interval,
-            diffusion_unmasking_width=diffusion_unmasking_width,
-            mm_token_type_ids=mm_token_type_ids,
-            prefill_step_size=prefill_step_size,
+            kwargs=kwargs,
+            skip_special_tokens=skip_special_tokens,
+            verbose=verbose,
+            on_result=on_result,
         )
-        try:
-            for result in results:
-                if on_result is not None and not on_result(result):
-                    break
-                yield result
-        finally:
-            results.close()
         mx.clear_cache()

--- a/mlx_vlm/generate/diffusion.py
+++ b/mlx_vlm/generate/diffusion.py
@@ -1064,84 +1064,13 @@ def _stream_model_diffusion_generate(
     diffusion_show_unmasking = kwargs.get("diffusion_show_unmasking", False)
 
     generation_stats = {}
-    emitted_text = ""
-    generation_tic = time.perf_counter()
     pending_results: List[GenerationResult] = []
-    model_streamed_results = False
-
-    def make_result(
-        text: str,
-        tokens: List[int],
-        *,
-        diffusion_block_complete: bool = False,
-        finish_reason: Optional[str] = None,
-    ) -> GenerationResult:
-        prompt_time = generation_stats.get("prompt_time") or 0.0
-        generation_time = max(time.perf_counter() - generation_tic - prompt_time, 1e-9)
-        generated_tokens = len(tokens)
-        return GenerationResult(
-            text=text,
-            token=tokens[-1] if tokens else None,
-            logprobs=None,
-            prompt_tokens=input_ids.size,
-            generation_tokens=generated_tokens,
-            total_tokens=input_ids.size + generated_tokens,
-            prompt_tps=input_ids.size / prompt_time if prompt_time > 0 else 0.0,
-            generation_tps=generated_tokens / generation_time,
-            peak_memory=mx.get_peak_memory() / 1e9,
-            finish_reason=finish_reason,
-            diffusion_canvas_tokens=generated_tokens,
-            diffusion_block_complete=diffusion_block_complete,
-            text_already_printed=bool(generation_stats.get("text_already_printed")),
-        )
 
     def emit(result: GenerationResult) -> bool:
         if on_result is not None:
             return bool(on_result(result))
         pending_results.append(result)
         return True
-
-    def emit_model_result(result: GenerationResult) -> bool:
-        nonlocal model_streamed_results
-        model_streamed_results = True
-        return emit(result)
-
-    def flush(
-        tokens: List[int],
-        *,
-        diffusion_block_complete: bool = False,
-        finish_reason: Optional[str] = None,
-    ) -> bool:
-        nonlocal emitted_text
-        text = (
-            tokenizer.decode(tokens, skip_special_tokens=skip_special_tokens)
-            if tokens
-            else ""
-        )
-        if text.startswith(emitted_text):
-            delta = text[len(emitted_text) :]
-        elif not emitted_text:
-            delta = text
-        else:
-            # Retokenization changed already-emitted text; resync on the final
-            # chunk and keep intermediate streaming conservative.
-            delta = "" if finish_reason is None else text
-
-        result = make_result(
-            delta,
-            tokens,
-            diffusion_block_complete=diffusion_block_complete,
-            finish_reason=finish_reason,
-        )
-        if not delta and not finish_reason and not diffusion_block_complete:
-            return True
-
-        if text.startswith(emitted_text):
-            emitted_text = text
-        return emit(result)
-
-    def on_block(tokens):
-        return flush([int(token) for token in tokens], diffusion_block_complete=True)
 
     top_p_arg = None if top_p is None or top_p >= 1.0 else top_p
     top_k_arg = None if top_k is None or top_k <= 0 else top_k
@@ -1162,26 +1091,16 @@ def _stream_model_diffusion_generate(
         skip_special_tokens=skip_special_tokens,
         skip_special_token_ids=skip_special_token_ids,
         stats=generation_stats,
-        on_block=on_block,
-        on_result=emit_model_result,
+        on_result=emit,
         **tuned_kwargs,
         **kwargs,
     )
     mx.eval(generated)
 
-    if model_streamed_results:
-        yield from pending_results
-        return
-
     if generation_stats.get("text_already_printed"):
         for result in pending_results:
             result.text_already_printed = True
 
-    tokens = [int(token) for token in generated[0].tolist()]
-    finish_reason = (
-        "stop" if tokens and tokenizer.stopping_criteria(tokens[-1]) else "length"
-    )
-    flush(tokens, finish_reason=finish_reason)
     yield from pending_results
 
 

--- a/mlx_vlm/generate/diffusion.py
+++ b/mlx_vlm/generate/diffusion.py
@@ -31,15 +31,6 @@ DEFAULT_DIFFUSION_MAX_DENOISING_STEPS = 48
 DEFAULT_DIFFUSION_UNMASKING_WIDTH = 0
 DEFAULT_DIFFUSION_CONFIDENCE_THRESHOLD = 0.9
 
-BLOCK_DIFFUSION_METHODS = (
-    "diffusion_decoder_logits",
-    "diffusion_decoder_masks",
-    "diffusion_prefill_cache",
-    "diffusion_prepare_self_conditioning",
-    "diffusion_self_conditioning",
-    "diffusion_update_cache",
-)
-
 
 def _diffusion_display_limit(requested_width: Optional[int] = None) -> Optional[int]:
     terminal_width = shutil.get_terminal_size((120, 20)).columns
@@ -148,20 +139,14 @@ def _has_engine_diffusion_config(config: Any) -> bool:
     return getattr(config, "canvas_length", None) is not None
 
 
-def _has_engine_diffusion_hooks(model: nn.Module) -> bool:
-    """True for models driven directly by the shared diffusion engine."""
-    return _has_engine_diffusion_config(getattr(model, "config", None)) and all(
-        callable(getattr(model, method, None)) for method in BLOCK_DIFFUSION_METHODS
-    )
-
-
 def _has_model_diffusion_generator(model: nn.Module) -> bool:
     """True for diffusion models that expose generation on the language model."""
     config = getattr(model, "config", None)
     language_model = getattr(model, "language_model", None)
-    return getattr(config, "mask_token_id", None) is not None and callable(
-        getattr(language_model, "generate", None)
-    )
+    return (
+        _has_engine_diffusion_config(config)
+        or getattr(config, "mask_token_id", None) is not None
+    ) and callable(getattr(language_model, "generate", None))
 
 
 def _uses_model_diffusion_generator(
@@ -247,7 +232,8 @@ class DiffusionOutputHandler:
         self.verbose = verbose
         self.live_mode = bool(
             kwargs.get("diffusion_show_unmasking", False)
-            and _has_engine_diffusion_hooks(model)
+            and _has_model_diffusion_generator(model)
+            and not callable(getattr(model, "make_unmasking_visualizer", None))
         )
         self.width = kwargs.get(
             "diffusion_unmasking_width", DEFAULT_DIFFUSION_UNMASKING_WIDTH
@@ -1039,28 +1025,25 @@ def _stream_model_diffusion_generate(
     on_result: Optional[Callable[[GenerationResult], bool]] = None,
     **kwargs,
 ) -> Generator[GenerationResult, None, None]:
-    del processor, attention_mask, skip_special_token_ids
     if input_ids.shape[0] != 1:
-        raise ValueError(
-            "Masked diffusion streaming generation only supports batch size 1."
-        )
-    if pixel_values is not None:
+        raise ValueError("Diffusion streaming generation only supports batch size 1.")
+    if pixel_values is not None and not (
+        _has_engine_diffusion_config(getattr(model, "config", None))
+        or getattr(getattr(model, "config", None), "vision_config", None) is not None
+    ):
         model_type = getattr(getattr(model, "config", None), "model_type", "This model")
         raise ValueError(f"{model_type} is a text-only model.")
 
     config = getattr(model, "config", None)
     if max_denoising_steps is None:
-        max_denoising_steps = kwargs.pop(
-            "steps", getattr(config, "default_diffusion_steps", 32)
-        )
+        max_denoising_steps = kwargs.pop("steps", None)
+        if max_denoising_steps is None and not _has_engine_diffusion_config(config):
+            max_denoising_steps = getattr(config, "default_diffusion_steps", 32)
     else:
         kwargs.pop("steps", None)
 
-    block_length = (
-        block_length
-        if block_length is not None
-        else getattr(config, "default_block_length", None) or 32
-    )
+    if block_length is None and not _has_engine_diffusion_config(config):
+        block_length = getattr(config, "default_block_length", None) or 32
 
     tuned_kwargs = {}
     for key, config_attr in (
@@ -1078,26 +1061,13 @@ def _stream_model_diffusion_generate(
         if value is not None:
             tuned_kwargs[key] = value
 
-    diffusion_show_unmasking = kwargs.pop("diffusion_show_unmasking", False)
-    for key in (
-        "diffusion_full_canvas",
-        "diffusion_min_canvas_length",
-        "diffusion_max_canvas_length",
-        "diffusion_static_cache",
-        "diffusion_sampler",
-        "diffusion_threshold",
-        "diffusion_compile",
-        "diffusion_unmasking_interval",
-        "diffusion_unmasking_width",
-        "mm_token_type_ids",
-        "prefill_step_size",
-    ):
-        kwargs.pop(key, None)
+    diffusion_show_unmasking = kwargs.get("diffusion_show_unmasking", False)
 
     generation_stats = {}
     emitted_text = ""
     generation_tic = time.perf_counter()
     pending_results: List[GenerationResult] = []
+    model_reported_results = False
 
     def make_result(
         text: str,
@@ -1126,6 +1096,8 @@ def _stream_model_diffusion_generate(
         )
 
     def emit(result: GenerationResult) -> bool:
+        nonlocal model_reported_results
+        model_reported_results = True
         if on_result is not None:
             return bool(on_result(result))
         pending_results.append(result)
@@ -1180,14 +1152,23 @@ def _stream_model_diffusion_generate(
         top_k=top_k_arg,
         eos_early_stop=True,
         visualize=bool(verbose or diffusion_show_unmasking),
+        processor=processor,
         tokenizer=tokenizer,
+        attention_mask=attention_mask,
+        pixel_values=pixel_values,
         skip_special_tokens=skip_special_tokens,
+        skip_special_token_ids=skip_special_token_ids,
         stats=generation_stats,
         on_block=on_block,
+        on_result=emit,
         **tuned_kwargs,
         **kwargs,
     )
     mx.eval(generated)
+
+    if model_reported_results:
+        yield from pending_results
+        return
 
     if generation_stats.get("text_already_printed"):
         for result in pending_results:
@@ -1238,77 +1219,12 @@ def _stream_model_diffusion_from_kwargs(
     )
 
 
-def _stream_engine_diffusion_from_kwargs(
-    model: nn.Module,
-    processor: PreTrainedTokenizer,
-    tokenizer: PreTrainedTokenizer,
-    input_ids: mx.array,
-    pixel_values: Optional[mx.array],
-    attention_mask: Optional[mx.array],
-    skip_special_token_ids,
-    kwargs: Dict[str, Any],
-    *,
-    skip_special_tokens: bool = False,
-    verbose: bool = False,
-    on_result: Optional[Callable[[GenerationResult], bool]] = None,
-) -> Generator[GenerationResult, None, None]:
-    del skip_special_tokens, verbose
-    max_denoising_steps = kwargs.pop("max_denoising_steps", None)
-    diffusion_full_canvas = kwargs.pop("diffusion_full_canvas", False)
-    diffusion_min_canvas_length = kwargs.pop("diffusion_min_canvas_length", None)
-    diffusion_max_canvas_length = kwargs.pop("diffusion_max_canvas_length", None)
-    diffusion_static_cache = kwargs.pop("diffusion_static_cache", False)
-    diffusion_sampler = kwargs.pop("diffusion_sampler", "confidence-threshold")
-    diffusion_threshold = kwargs.pop("diffusion_threshold", None)
-    diffusion_compile = kwargs.pop("diffusion_compile", False)
-    diffusion_show_unmasking = kwargs.pop("diffusion_show_unmasking", False)
-    diffusion_unmasking_interval = kwargs.pop("diffusion_unmasking_interval", 1)
-    diffusion_unmasking_width = kwargs.pop(
-        "diffusion_unmasking_width", DEFAULT_DIFFUSION_UNMASKING_WIDTH
-    )
-    mm_token_type_ids = kwargs.pop("mm_token_type_ids", None)
-    prefill_step_size = kwargs.pop("prefill_step_size", None)
-    results = stream_diffusion_generate(
-        model,
-        processor,
-        tokenizer,
-        input_ids,
-        pixel_values,
-        attention_mask,
-        max_tokens=kwargs.get("max_tokens", 2048),
-        temperature=kwargs.get("temperature", DEFAULT_TEMPERATURE),
-        skip_special_token_ids=skip_special_token_ids,
-        max_denoising_steps=max_denoising_steps,
-        diffusion_full_canvas=diffusion_full_canvas,
-        diffusion_min_canvas_length=diffusion_min_canvas_length,
-        diffusion_max_canvas_length=diffusion_max_canvas_length,
-        diffusion_static_cache=diffusion_static_cache,
-        diffusion_sampler=diffusion_sampler,
-        diffusion_threshold=diffusion_threshold,
-        diffusion_compile=diffusion_compile,
-        diffusion_show_unmasking=diffusion_show_unmasking,
-        diffusion_unmasking_interval=diffusion_unmasking_interval,
-        diffusion_unmasking_width=diffusion_unmasking_width,
-        mm_token_type_ids=mm_token_type_ids,
-        prefill_step_size=prefill_step_size,
-    )
-    try:
-        for result in results:
-            if on_result is not None and not on_result(result):
-                break
-            yield result
-    finally:
-        results.close()
-
-
 def _diffusion_stream_strategy(
     model: nn.Module,
     kwargs: Optional[Dict[str, Any]] = None,
 ):
     if _uses_model_diffusion_generator(model, kwargs):
         return _stream_model_diffusion_from_kwargs
-    if _has_engine_diffusion_hooks(model):
-        return _stream_engine_diffusion_from_kwargs
     return None
 
 

--- a/mlx_vlm/generate/diffusion.py
+++ b/mlx_vlm/generate/diffusion.py
@@ -4,7 +4,7 @@ import logging
 import os
 import shutil
 import time
-from typing import Any, Dict, Generator, List, Optional
+from typing import Any, Callable, Dict, Generator, List, Optional
 
 import mlx.core as mx
 import mlx.nn as nn
@@ -148,54 +148,104 @@ def _is_diffusion_config(config: Any) -> bool:
     return getattr(config, "canvas_length", None) is not None
 
 
-def is_diffusion_model(model: nn.Module) -> bool:
-    """True for block-diffusion canvas models driven by the shared engine."""
+def _is_block_diffusion_model(model: nn.Module) -> bool:
+    """True for canvas models driven by the shared diffusion engine."""
     return _is_diffusion_config(getattr(model, "config", None)) and all(
         callable(getattr(model, method, None)) for method in BLOCK_DIFFUSION_METHODS
     )
 
 
-def is_masked_diffusion_model(model: nn.Module) -> bool:
+def _is_masked_diffusion_model(model: nn.Module) -> bool:
     """True for masked-diffusion text models that own their generate loop."""
     config = getattr(model, "config", None)
     return getattr(config, "mask_token_id", None) is not None
 
 
-def diffusion_generation_family(model: nn.Module) -> Optional[str]:
-    """Classify how a model generates, for request routing.
+def _use_masked_diffusion_model(
+    model: nn.Module,
+    kwargs: Optional[Dict[str, Any]] = None,
+) -> bool:
+    if not _is_masked_diffusion_model(model):
+        return False
 
-    Returns ``"block"`` for canvas-denoising models the shared engine drives,
-    ``"masked"`` for masked-diffusion text models that run their own
-    ``generate()`` loop (unless the checkpoint defaults to autoregressive
-    generation, like nemotron), and ``None`` for ordinary autoregressive
-    models.
+    config = getattr(model, "config", None)
+    if getattr(config, "default_generation_mode", None) != "ar":
+        return True
+
+    generation_mode = (kwargs or {}).get("generation_mode")
+    if generation_mode is not None:
+        return generation_mode != "ar"
+
+    return False
+
+
+def is_diffusion_model(
+    model: nn.Module,
+    kwargs: Optional[Dict[str, Any]] = None,
+) -> bool:
+    """True when this request should use the unified diffusion path."""
+    return _is_block_diffusion_model(model) or _use_masked_diffusion_model(
+        model, kwargs
+    )
+
+
+def is_masked_diffusion_model(model: nn.Module) -> bool:
+    return _is_masked_diffusion_model(model)
+
+
+def diffusion_generation_family(
+    model: nn.Module,
+    kwargs: Optional[Dict[str, Any]] = None,
+) -> Optional[str]:
+    """Backward-compatible diffusion router.
+
+    New callers should use :func:`is_diffusion_model` and the unified stream
+    adapter directly.
     """
-    if is_diffusion_model(model):
-        return "block"
-    if is_masked_diffusion_model(model):
-        config = getattr(model, "config", None)
-        if getattr(config, "default_generation_mode", None) != "ar":
-            return "masked"
+    if is_diffusion_model(model, kwargs):
+        return "diffusion"
     return None
 
 
 def diffusion_kwargs_from_args(args: Any, config: Any) -> Dict[str, Any]:
-    if not _is_diffusion_config(config):
+    is_block_config = _is_diffusion_config(config)
+    is_masked_config = getattr(config, "mask_token_id", None) is not None
+    if not is_block_config and not is_masked_config:
         return {}
 
     kwargs = {}
     if args.max_denoising_steps is not None:
         kwargs["max_denoising_steps"] = args.max_denoising_steps
-    if args.diffusion_full_canvas:
-        kwargs["diffusion_full_canvas"] = True
-    if args.diffusion_min_canvas_length is not None:
-        kwargs["diffusion_min_canvas_length"] = args.diffusion_min_canvas_length
-    if getattr(args, "diffusion_max_canvas_length", None) is not None:
-        kwargs["diffusion_max_canvas_length"] = args.diffusion_max_canvas_length
-    if args.diffusion_sampler != "confidence-threshold":
-        kwargs["diffusion_sampler"] = args.diffusion_sampler
+
+    if is_block_config:
+        if args.diffusion_full_canvas:
+            kwargs["diffusion_full_canvas"] = True
+        if args.diffusion_min_canvas_length is not None:
+            kwargs["diffusion_min_canvas_length"] = args.diffusion_min_canvas_length
+        if getattr(args, "diffusion_max_canvas_length", None) is not None:
+            kwargs["diffusion_max_canvas_length"] = args.diffusion_max_canvas_length
+        if args.diffusion_sampler != "confidence-threshold":
+            kwargs["diffusion_sampler"] = args.diffusion_sampler
+        if args.threshold is not None:
+            kwargs["diffusion_threshold"] = args.threshold
+        return kwargs
+
+    if getattr(args, "block_length", None) is not None:
+        kwargs["block_length"] = args.block_length
+    if getattr(args, "num_to_transfer", None) is not None:
+        kwargs["num_to_transfer"] = args.num_to_transfer
+    if getattr(args, "max_transfer_per_step", None) is not None:
+        kwargs["max_transfer_per_step"] = args.max_transfer_per_step
     if args.threshold is not None:
-        kwargs["diffusion_threshold"] = args.threshold
+        kwargs["threshold"] = args.threshold
+    if getattr(args, "min_threshold", None) is not None:
+        kwargs["min_threshold"] = args.min_threshold
+    if getattr(args, "editing_threshold", None) is not None:
+        kwargs["editing_threshold"] = args.editing_threshold
+    if getattr(args, "max_post_steps", None) is not None:
+        kwargs["max_post_steps"] = args.max_post_steps
+    if getattr(args, "stability_steps", None) is not None:
+        kwargs["stability_steps"] = args.stability_steps
     return kwargs
 
 
@@ -203,7 +253,8 @@ class DiffusionOutputHandler:
     def __init__(self, model: nn.Module, kwargs: Dict[str, Any], verbose: bool):
         self.verbose = verbose
         self.live_mode = bool(
-            kwargs.get("diffusion_show_unmasking", False) and is_diffusion_model(model)
+            kwargs.get("diffusion_show_unmasking", False)
+            and _is_block_diffusion_model(model)
         )
         self.width = kwargs.get(
             "diffusion_unmasking_width", DEFAULT_DIFFUSION_UNMASKING_WIDTH
@@ -975,6 +1026,188 @@ def stream_diffusion_generate(
     yield make_result(detokenizer.last_segment, finish_reason=finish_reason)
 
 
+def stream_masked_diffusion_generate(
+    model: nn.Module,
+    processor: PreTrainedTokenizer,
+    tokenizer: PreTrainedTokenizer,
+    input_ids: mx.array,
+    pixel_values: Optional[mx.array],
+    attention_mask: Optional[mx.array],
+    *,
+    max_tokens: int,
+    skip_special_token_ids,
+    skip_special_tokens: bool = False,
+    temperature: float = DEFAULT_TEMPERATURE,
+    top_p: Optional[float] = None,
+    top_k: Optional[int] = None,
+    max_denoising_steps: Optional[int] = None,
+    block_length: Optional[int] = None,
+    verbose: bool = False,
+    on_result: Optional[Callable[[GenerationResult], bool]] = None,
+    **kwargs,
+) -> Generator[GenerationResult, None, None]:
+    del processor, attention_mask, skip_special_token_ids
+    if input_ids.shape[0] != 1:
+        raise ValueError(
+            "Masked diffusion streaming generation only supports batch size 1."
+        )
+    if pixel_values is not None:
+        model_type = getattr(getattr(model, "config", None), "model_type", "This model")
+        raise ValueError(f"{model_type} is a text-only model.")
+
+    config = getattr(model, "config", None)
+    if max_denoising_steps is None:
+        max_denoising_steps = kwargs.pop(
+            "steps", getattr(config, "default_diffusion_steps", 32)
+        )
+    else:
+        kwargs.pop("steps", None)
+
+    block_length = (
+        block_length
+        if block_length is not None
+        else getattr(config, "default_block_length", None) or 32
+    )
+
+    tuned_kwargs = {}
+    for key, config_attr in (
+        ("threshold", "default_diffusion_threshold"),
+        ("min_threshold", "default_diffusion_min_threshold"),
+        ("editing_threshold", "default_diffusion_editing_threshold"),
+        ("num_to_transfer", "default_diffusion_num_to_transfer"),
+        ("max_transfer_per_step", "default_diffusion_max_transfer_per_step"),
+        ("max_post_steps", "default_diffusion_max_post_steps"),
+        ("stability_steps", "default_diffusion_stability_steps"),
+    ):
+        value = kwargs.pop(key, None)
+        if value is None:
+            value = getattr(config, config_attr, None)
+        if value is not None:
+            tuned_kwargs[key] = value
+
+    diffusion_show_unmasking = kwargs.pop("diffusion_show_unmasking", False)
+    for key in (
+        "diffusion_full_canvas",
+        "diffusion_min_canvas_length",
+        "diffusion_max_canvas_length",
+        "diffusion_static_cache",
+        "diffusion_sampler",
+        "diffusion_threshold",
+        "diffusion_compile",
+        "diffusion_unmasking_interval",
+        "diffusion_unmasking_width",
+        "mm_token_type_ids",
+        "prefill_step_size",
+    ):
+        kwargs.pop(key, None)
+
+    generation_stats = {}
+    emitted_text = ""
+    generation_tic = time.perf_counter()
+    pending_results: List[GenerationResult] = []
+
+    def make_result(
+        text: str,
+        tokens: List[int],
+        *,
+        diffusion_block_complete: bool = False,
+        finish_reason: Optional[str] = None,
+    ) -> GenerationResult:
+        prompt_time = generation_stats.get("prompt_time") or 0.0
+        generation_time = max(time.perf_counter() - generation_tic - prompt_time, 1e-9)
+        generated_tokens = len(tokens)
+        return GenerationResult(
+            text=text,
+            token=tokens[-1] if tokens else None,
+            logprobs=None,
+            prompt_tokens=input_ids.size,
+            generation_tokens=generated_tokens,
+            total_tokens=input_ids.size + generated_tokens,
+            prompt_tps=input_ids.size / prompt_time if prompt_time > 0 else 0.0,
+            generation_tps=generated_tokens / generation_time,
+            peak_memory=mx.get_peak_memory() / 1e9,
+            finish_reason=finish_reason,
+            diffusion_canvas_tokens=generated_tokens,
+            diffusion_block_complete=diffusion_block_complete,
+            text_already_printed=bool(generation_stats.get("text_already_printed")),
+        )
+
+    def emit(result: GenerationResult) -> bool:
+        if on_result is not None:
+            return bool(on_result(result))
+        pending_results.append(result)
+        return True
+
+    def flush(
+        tokens: List[int],
+        *,
+        diffusion_block_complete: bool = False,
+        finish_reason: Optional[str] = None,
+    ) -> bool:
+        nonlocal emitted_text
+        text = (
+            tokenizer.decode(tokens, skip_special_tokens=skip_special_tokens)
+            if tokens
+            else ""
+        )
+        if text.startswith(emitted_text):
+            delta = text[len(emitted_text) :]
+        elif not emitted_text:
+            delta = text
+        else:
+            # Retokenization changed already-emitted text; resync on the final
+            # chunk and keep intermediate streaming conservative.
+            delta = "" if finish_reason is None else text
+
+        result = make_result(
+            delta,
+            tokens,
+            diffusion_block_complete=diffusion_block_complete,
+            finish_reason=finish_reason,
+        )
+        if not delta and not finish_reason and not diffusion_block_complete:
+            return True
+
+        if text.startswith(emitted_text):
+            emitted_text = text
+        return emit(result)
+
+    def on_block(tokens):
+        return flush([int(token) for token in tokens], diffusion_block_complete=True)
+
+    top_p_arg = None if top_p is None or top_p >= 1.0 else top_p
+    top_k_arg = None if top_k is None or top_k <= 0 else top_k
+    generated = model.language_model.generate(
+        input_ids,
+        temperature=temperature,
+        block_length=block_length,
+        steps=max_denoising_steps,
+        gen_length=max_tokens,
+        top_p=top_p_arg,
+        top_k=top_k_arg,
+        eos_early_stop=True,
+        visualize=bool(verbose or diffusion_show_unmasking),
+        tokenizer=tokenizer,
+        skip_special_tokens=skip_special_tokens,
+        stats=generation_stats,
+        on_block=on_block,
+        **tuned_kwargs,
+        **kwargs,
+    )
+    mx.eval(generated)
+
+    if generation_stats.get("text_already_printed"):
+        for result in pending_results:
+            result.text_already_printed = True
+
+    tokens = [int(token) for token in generated[0].tolist()]
+    finish_reason = (
+        "stop" if tokens and tokenizer.stopping_criteria(tokens[-1]) else "length"
+    )
+    flush(tokens, finish_reason=finish_reason)
+    yield from pending_results
+
+
 def stream_diffusion_generate_from_kwargs(
     model: nn.Module,
     processor: PreTrainedTokenizer,
@@ -984,7 +1217,45 @@ def stream_diffusion_generate_from_kwargs(
     attention_mask: Optional[mx.array],
     skip_special_token_ids,
     kwargs: Dict[str, Any],
+    *,
+    skip_special_tokens: bool = False,
+    verbose: bool = False,
+    on_result: Optional[Callable[[GenerationResult], bool]] = None,
 ) -> Generator[GenerationResult, None, None]:
+    if kwargs.get("logits_processors") is not None:
+        raise ValueError(
+            "Structured response_format is not supported with diffusion models."
+        )
+    seed = kwargs.pop("seed", None)
+    if seed is not None:
+        mx.random.seed(seed)
+
+    if _use_masked_diffusion_model(model, kwargs):
+        max_denoising_steps = kwargs.pop("max_denoising_steps", None)
+        block_length = kwargs.pop("block_length", None)
+        with wired_limit(model, [generation_stream]):
+            yield from stream_masked_diffusion_generate(
+                model,
+                processor,
+                tokenizer,
+                input_ids,
+                pixel_values,
+                attention_mask,
+                max_tokens=kwargs.pop("max_tokens", 2048),
+                temperature=kwargs.pop("temperature", DEFAULT_TEMPERATURE),
+                top_p=kwargs.pop("top_p", None),
+                top_k=kwargs.pop("top_k", None),
+                skip_special_token_ids=skip_special_token_ids,
+                skip_special_tokens=skip_special_tokens,
+                max_denoising_steps=max_denoising_steps,
+                block_length=block_length,
+                verbose=verbose,
+                on_result=on_result,
+                **kwargs,
+            )
+            mx.clear_cache()
+        return
+
     max_denoising_steps = kwargs.pop("max_denoising_steps", None)
     diffusion_full_canvas = kwargs.pop("diffusion_full_canvas", False)
     diffusion_min_canvas_length = kwargs.pop("diffusion_min_canvas_length", None)
@@ -1001,7 +1272,7 @@ def stream_diffusion_generate_from_kwargs(
     mm_token_type_ids = kwargs.pop("mm_token_type_ids", None)
     prefill_step_size = kwargs.pop("prefill_step_size", None)
     with wired_limit(model, [generation_stream]):
-        yield from stream_diffusion_generate(
+        results = stream_diffusion_generate(
             model,
             processor,
             tokenizer,
@@ -1025,4 +1296,11 @@ def stream_diffusion_generate_from_kwargs(
             mm_token_type_ids=mm_token_type_ids,
             prefill_step_size=prefill_step_size,
         )
+        try:
+            for result in results:
+                if on_result is not None and not on_result(result):
+                    break
+                yield result
+        finally:
+            results.close()
         mx.clear_cache()

--- a/mlx_vlm/generate/diffusion.py
+++ b/mlx_vlm/generate/diffusion.py
@@ -1067,7 +1067,7 @@ def _stream_model_diffusion_generate(
     emitted_text = ""
     generation_tic = time.perf_counter()
     pending_results: List[GenerationResult] = []
-    model_reported_results = False
+    model_streamed_results = False
 
     def make_result(
         text: str,
@@ -1096,12 +1096,15 @@ def _stream_model_diffusion_generate(
         )
 
     def emit(result: GenerationResult) -> bool:
-        nonlocal model_reported_results
-        model_reported_results = True
         if on_result is not None:
             return bool(on_result(result))
         pending_results.append(result)
         return True
+
+    def emit_model_result(result: GenerationResult) -> bool:
+        nonlocal model_streamed_results
+        model_streamed_results = True
+        return emit(result)
 
     def flush(
         tokens: List[int],
@@ -1160,13 +1163,13 @@ def _stream_model_diffusion_generate(
         skip_special_token_ids=skip_special_token_ids,
         stats=generation_stats,
         on_block=on_block,
-        on_result=emit,
+        on_result=emit_model_result,
         **tuned_kwargs,
         **kwargs,
     )
     mx.eval(generated)
 
-    if model_reported_results:
+    if model_streamed_results:
         yield from pending_results
         return
 

--- a/mlx_vlm/generate/dispatch.py
+++ b/mlx_vlm/generate/dispatch.py
@@ -647,28 +647,8 @@ from .diffusion import (
     DiffusionOutputHandler,
     diffusion_kwargs_from_args,
     is_diffusion_model,
-    is_masked_diffusion_model,
     stream_diffusion_generate_from_kwargs,
 )
-
-
-def is_masked_diffusion_text_model(model: nn.Module) -> bool:
-    return is_masked_diffusion_model(model)
-
-
-def _use_masked_diffusion_text_path(model: nn.Module, kwargs: Dict[str, Any]) -> bool:
-    if not is_masked_diffusion_text_model(model):
-        return False
-
-    config = getattr(model, "config", None)
-    if getattr(config, "default_generation_mode", None) != "ar":
-        return True
-
-    generation_mode = kwargs.get("generation_mode")
-    if generation_mode is not None:
-        return generation_mode != "ar"
-
-    return False
 
 
 def _prime_cached_prefix_rope_state(
@@ -803,107 +783,18 @@ def stream_generate(
         }
         kwargs.update(data_kwargs)
 
-    if _use_masked_diffusion_text_path(model, kwargs):
-        config = getattr(model, "config", None)
-        if image is not None or audio is not None or video is not None:
-            model_type = config.model_type if config else "This model"
-            raise ValueError(f"{model_type} is a text-only model.")
-
-        max_tokens = kwargs.get("max_tokens", DEFAULT_MAX_TOKENS)
-        temperature = kwargs.get("temperature", DEFAULT_TEMPERATURE)
-        top_p = kwargs.get("top_p", DEFAULT_TOP_P)
-        top_k = kwargs.get("top_k", DEFAULT_TOP_K)
-        max_denoising_steps = kwargs.get("max_denoising_steps")
-        if max_denoising_steps is None:
-            max_denoising_steps = kwargs.get(
-                "steps", getattr(config, "default_diffusion_steps", 32)
-            )
-        # Sampler knobs resolve as: explicit kwarg > config default_diffusion_*
-        # attribute > the model generate()'s own reference defaults (omitted
-        # here). Forcing shared defaults broke checkpoints whose reference
-        # generation differs (e.g. LLaDA2.0 corrupts with editing enabled).
-        tuned_kwargs = {}
-        for key, config_attr in (
-            ("threshold", "default_diffusion_threshold"),
-            ("min_threshold", "default_diffusion_min_threshold"),
-            ("editing_threshold", "default_diffusion_editing_threshold"),
-            ("num_to_transfer", "default_diffusion_num_to_transfer"),
-            ("max_transfer_per_step", "default_diffusion_max_transfer_per_step"),
-            ("max_post_steps", "default_diffusion_max_post_steps"),
-            ("stability_steps", "default_diffusion_stability_steps"),
-        ):
-            value = kwargs.get(key)
-            if value is None:
-                value = getattr(config, config_attr, None)
-            if value is not None:
-                tuned_kwargs[key] = value
-
-        generation_stats = {}
-        handled_generation_kwargs = {
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "top_k",
-            "max_denoising_steps",
-            "steps",
-            "block_length",
-            "threshold",
-            "min_threshold",
-            "editing_threshold",
-            "max_post_steps",
-            "num_to_transfer",
-            "max_transfer_per_step",
-            "stability_steps",
-        }
-        model_generate_kwargs = {
-            key: value
-            for key, value in kwargs.items()
-            if key not in handled_generation_kwargs
-        }
-        tic = time.perf_counter()
-        generated = model.language_model.generate(
+    if is_diffusion_model(model, kwargs):
+        yield from stream_diffusion_generate_from_kwargs(
+            model,
+            processor,
+            tokenizer,
             input_ids,
-            temperature=temperature,
-            block_length=kwargs.get("block_length", 32),
-            steps=max_denoising_steps,
-            gen_length=max_tokens,
-            top_p=None if top_p is None or top_p >= 1.0 else top_p,
-            top_k=None if top_k is None or top_k <= 0 else top_k,
-            eos_early_stop=True,
-            visualize=verbose,
-            tokenizer=tokenizer,
+            pixel_values,
+            mask,
+            skip_special_token_ids,
+            kwargs,
             skip_special_tokens=skip_special_tokens,
-            stats=generation_stats,
-            **tuned_kwargs,
-            **model_generate_kwargs,
-        )
-        mx.eval(generated)
-        total_time = time.perf_counter() - tic
-        prompt_time = generation_stats.get("prompt_time", 0.0)
-        prompt_tps = input_ids.size / prompt_time if prompt_time > 0 else 0.0
-        generation_time = max(total_time - prompt_time, 1e-9)
-        generated_tokens = generated[0].tolist()
-        text = tokenizer.decode(
-            generated_tokens, skip_special_tokens=skip_special_tokens
-        )
-
-        yield GenerationResult(
-            text=text,
-            token=generated_tokens[-1] if generated_tokens else None,
-            logprobs=None,
-            prompt_tokens=input_ids.size,
-            generation_tokens=len(generated_tokens),
-            total_tokens=input_ids.size + len(generated_tokens),
-            prompt_tps=prompt_tps,
-            generation_tps=len(generated_tokens) / generation_time,
-            peak_memory=mx.get_peak_memory() / 1e9,
-            finish_reason=(
-                "stop"
-                if generated_tokens
-                and tokenizer.stopping_criteria(generated_tokens[-1])
-                else "length"
-            ),
-            text_already_printed=bool(generation_stats.get("text_already_printed")),
+            verbose=verbose,
         )
         return
 
@@ -945,19 +836,6 @@ def stream_generate(
             prefix_len,
             multimodal_token_ids,
         )
-
-    if is_diffusion_model(model):
-        yield from stream_diffusion_generate_from_kwargs(
-            model,
-            processor,
-            tokenizer,
-            input_ids,
-            pixel_values,
-            mask,
-            skip_special_token_ids,
-            kwargs,
-        )
-        return
 
     if apc_manager is not None:
         apc_mode = _apc.model_apc_mode(model.language_model)
@@ -1539,7 +1417,6 @@ def main():
         from ..vision_cache import VisionFeatureCache
 
         vision_cache = VisionFeatureCache()
-        is_masked_text_diffusion = is_masked_diffusion_text_model(model)
         chat = []
         if args.system:
             chat.append({"role": "system", "content": args.system})
@@ -1571,25 +1448,6 @@ def main():
                 stream_kwargs["resize_shape"] = args.resize_shape
             if args.prefill_step_size is not None:
                 stream_kwargs["prefill_step_size"] = args.prefill_step_size
-            if is_masked_text_diffusion:
-                if args.max_denoising_steps is not None:
-                    stream_kwargs["max_denoising_steps"] = args.max_denoising_steps
-                if args.block_length is not None:
-                    stream_kwargs["block_length"] = args.block_length
-                if args.num_to_transfer is not None:
-                    stream_kwargs["num_to_transfer"] = args.num_to_transfer
-                if args.max_transfer_per_step is not None:
-                    stream_kwargs["max_transfer_per_step"] = args.max_transfer_per_step
-                if args.threshold is not None:
-                    stream_kwargs["threshold"] = args.threshold
-                if args.min_threshold is not None:
-                    stream_kwargs["min_threshold"] = args.min_threshold
-                if args.editing_threshold is not None:
-                    stream_kwargs["editing_threshold"] = args.editing_threshold
-                if args.max_post_steps is not None:
-                    stream_kwargs["max_post_steps"] = args.max_post_steps
-                if args.stability_steps is not None:
-                    stream_kwargs["stability_steps"] = args.stability_steps
             stream_kwargs.update(diffusion_kwargs_from_args(args, config))
 
             diffusion_output = DiffusionOutputHandler(model, stream_kwargs, True)
@@ -1641,25 +1499,6 @@ def main():
             gen_kwargs["resize_shape"] = args.resize_shape
         if args.prefill_step_size is not None:
             gen_kwargs["prefill_step_size"] = args.prefill_step_size
-        if is_masked_diffusion_text_model(model):
-            if args.max_denoising_steps is not None:
-                gen_kwargs["max_denoising_steps"] = args.max_denoising_steps
-            if args.block_length is not None:
-                gen_kwargs["block_length"] = args.block_length
-            if args.num_to_transfer is not None:
-                gen_kwargs["num_to_transfer"] = args.num_to_transfer
-            if args.max_transfer_per_step is not None:
-                gen_kwargs["max_transfer_per_step"] = args.max_transfer_per_step
-            if args.threshold is not None:
-                gen_kwargs["threshold"] = args.threshold
-            if args.min_threshold is not None:
-                gen_kwargs["min_threshold"] = args.min_threshold
-            if args.editing_threshold is not None:
-                gen_kwargs["editing_threshold"] = args.editing_threshold
-            if args.max_post_steps is not None:
-                gen_kwargs["max_post_steps"] = args.max_post_steps
-            if args.stability_steps is not None:
-                gen_kwargs["stability_steps"] = args.stability_steps
         gen_kwargs.update(diffusion_kwargs_from_args(args, config))
         if draft_model is not None:
             gen_kwargs["draft_model"] = draft_model

--- a/mlx_vlm/models/diffusion_gemma/diffusion_gemma.py
+++ b/mlx_vlm/models/diffusion_gemma/diffusion_gemma.py
@@ -44,6 +44,9 @@ class _LanguageModelView:
         logits = self._parent._softcap(logits)
         return LanguageModelOutput(logits=logits, hidden_states=[hidden_states])
 
+    def generate(self, input_ids: mx.array, **kwargs):
+        return self._parent.generate(input_ids, **kwargs)
+
     @property
     def quant_predicate(self):
         def predicate(path, m):
@@ -197,6 +200,133 @@ class Model(nn.Module):
         )
         logits = self.model.decoder.embed_tokens.as_linear(hidden_states)
         return self._softcap(logits)
+
+    def generate(
+        self,
+        input_ids: mx.array,
+        temperature: float = 0.0,
+        block_length: int = None,
+        steps: int = None,
+        gen_length: int = 2048,
+        top_p=None,
+        top_k=None,
+        eos_early_stop: bool = True,
+        visualize: bool = False,
+        processor=None,
+        tokenizer=None,
+        attention_mask: mx.array = None,
+        pixel_values: mx.array = None,
+        mm_token_type_ids: mx.array = None,
+        skip_special_tokens: bool = False,
+        skip_special_token_ids=None,
+        stats: dict = None,
+        on_block=None,
+        on_result=None,
+        **kwargs,
+    ) -> mx.array:
+        del top_p, top_k, eos_early_stop
+        from ...generate.diffusion import stream_diffusion_generate
+
+        tokenizer = tokenizer or processor
+        processor = processor or tokenizer
+        if tokenizer is None:
+            raise ValueError("A tokenizer is required for DiffusionGemma generation.")
+
+        max_denoising_steps = kwargs.pop("max_denoising_steps", steps)
+        diffusion_threshold = kwargs.pop("diffusion_threshold", None)
+        if diffusion_threshold is None:
+            diffusion_threshold = kwargs.pop("threshold", None)
+        else:
+            kwargs.pop("threshold", None)
+
+        # ``block_length`` is the masked-diffusion spelling. Treat it as a
+        # canvas cap only when the caller did not use the canvas-specific name.
+        if (
+            block_length is not None
+            and kwargs.get("diffusion_max_canvas_length") is None
+        ):
+            kwargs["diffusion_max_canvas_length"] = block_length
+
+        if mm_token_type_ids is None:
+            mm_token_type_ids = kwargs.pop("mm_token_type_ids", None)
+        else:
+            kwargs.pop("mm_token_type_ids", None)
+
+        results = stream_diffusion_generate(
+            self,
+            processor,
+            tokenizer,
+            input_ids,
+            pixel_values,
+            attention_mask,
+            max_tokens=gen_length,
+            temperature=temperature,
+            skip_special_token_ids=skip_special_token_ids or [],
+            max_denoising_steps=max_denoising_steps,
+            diffusion_full_canvas=kwargs.pop("diffusion_full_canvas", False),
+            diffusion_min_canvas_length=kwargs.pop("diffusion_min_canvas_length", None),
+            diffusion_max_canvas_length=kwargs.pop("diffusion_max_canvas_length", None),
+            diffusion_static_cache=kwargs.pop("diffusion_static_cache", False),
+            diffusion_sampler=kwargs.pop("diffusion_sampler", "confidence-threshold"),
+            diffusion_threshold=diffusion_threshold,
+            diffusion_compile=kwargs.pop("diffusion_compile", False),
+            diffusion_show_unmasking=(
+                visualize or kwargs.pop("diffusion_show_unmasking", False)
+            ),
+            diffusion_unmasking_interval=kwargs.pop("diffusion_unmasking_interval", 1),
+            diffusion_unmasking_width=kwargs.pop("diffusion_unmasking_width", 0),
+            mm_token_type_ids=mm_token_type_ids,
+            prefill_step_size=kwargs.pop("prefill_step_size", None),
+        )
+
+        generated_tokens = []
+        terminal_result = None
+        try:
+            for result in results:
+                terminal_result = result
+                if on_result is not None and not on_result(result):
+                    break
+                if (
+                    result.token is not None
+                    and not result.is_draft
+                    and not result.diffusion_block_complete
+                    and result.finish_reason is None
+                ):
+                    generated_tokens.append(int(result.token))
+                if (
+                    result.diffusion_block_complete
+                    and on_result is None
+                    and on_block is not None
+                ):
+                    if not on_block(generated_tokens):
+                        break
+        finally:
+            results.close()
+
+        if (
+            terminal_result is not None
+            and terminal_result.finish_reason == "stop"
+            and terminal_result.token is not None
+            and (not generated_tokens or generated_tokens[-1] != terminal_result.token)
+        ):
+            generated_tokens.append(int(terminal_result.token))
+
+        if stats is not None and terminal_result is not None:
+            if terminal_result.prompt_tps:
+                stats["prompt_time"] = terminal_result.prompt_tokens / max(
+                    terminal_result.prompt_tps, 1e-9
+                )
+            stats["diffusion_canvas_tokens"] = float(
+                terminal_result.diffusion_canvas_tokens
+            )
+            stats["diffusion_denoising_steps"] = float(
+                terminal_result.diffusion_denoising_steps
+            )
+            stats["diffusion_work_tokens"] = float(
+                terminal_result.diffusion_work_tokens
+            )
+
+        return mx.array([generated_tokens], dtype=input_ids.dtype)
 
     # Model-owned live unmasking view, like the nemotron/llada visualizers.
     make_unmasking_visualizer = staticmethod(make_unmasking_visualizer)

--- a/mlx_vlm/models/llada2_moe/language.py
+++ b/mlx_vlm/models/llada2_moe/language.py
@@ -5,6 +5,7 @@ from typing import Any, Callable, Dict, List, Optional, Tuple
 import mlx.core as mx
 import mlx.nn as nn
 
+from ...generate.common import GenerationResult
 from ..activations import swiglu
 from ..base import LanguageModelOutput, scaled_dot_product_attention
 from ..cache import KVCache, StaticPrefixKVCache
@@ -365,8 +366,10 @@ class LanguageModel(nn.Module):
         visualize: bool = False,
         tokenizer: Optional[Any] = None,
         skip_special_tokens: bool = False,
+        skip_special_token_ids=None,
         stats: Optional[Dict[str, float]] = None,
         on_block: Optional[Callable[[List[int]], bool]] = None,
+        on_result: Optional[Callable[[GenerationResult], bool]] = None,
         **kwargs,
     ) -> mx.array:
         generation_mode = kwargs.pop("generation_mode", None)
@@ -426,7 +429,74 @@ class LanguageModel(nn.Module):
         display_end = prompt_length + gen_length
         prompt_tic = time.perf_counter()
         recorded_prompt_time = False
+        generation_tic = prompt_tic
+        emitted_text = ""
+        callback_stopped = False
         prefix_cache = [StaticPrefixKVCache(total_length) for _ in self.layers]
+
+        def decode_generated(tokens: List[int]) -> str:
+            if not tokens:
+                return ""
+            if tokenizer is not None:
+                return tokenizer.decode(
+                    tokens,
+                    skip_special_tokens=skip_special_tokens,
+                )
+            return " ".join(str(token_id) for token_id in tokens)
+
+        def emit_result(
+            tokens: List[int],
+            *,
+            diffusion_block_complete: bool = False,
+            finish_reason: Optional[str] = None,
+        ) -> bool:
+            nonlocal emitted_text
+            if on_result is None:
+                return True
+
+            text = decode_generated(tokens)
+            if text.startswith(emitted_text):
+                delta = text[len(emitted_text) :]
+            elif not emitted_text:
+                delta = text
+            else:
+                delta = "" if finish_reason is None else text
+
+            if not delta and finish_reason is None and not diffusion_block_complete:
+                return True
+
+            if text.startswith(emitted_text):
+                emitted_text = text
+
+            prompt_time = (stats or {}).get("prompt_time") or 0.0
+            generation_time = max(
+                time.perf_counter() - generation_tic - prompt_time,
+                1e-9,
+            )
+            generated_tokens = len(tokens)
+            return bool(
+                on_result(
+                    GenerationResult(
+                        text=delta,
+                        token=tokens[-1] if tokens else None,
+                        logprobs=None,
+                        prompt_tokens=inputs.size,
+                        generation_tokens=generated_tokens,
+                        total_tokens=inputs.size + generated_tokens,
+                        prompt_tps=(
+                            inputs.size / prompt_time if prompt_time > 0 else 0.0
+                        ),
+                        generation_tps=generated_tokens / generation_time,
+                        peak_memory=mx.get_peak_memory() / 1e9,
+                        finish_reason=finish_reason,
+                        diffusion_canvas_tokens=generated_tokens,
+                        diffusion_block_complete=diffusion_block_complete,
+                        text_already_printed=bool(
+                            (stats or {}).get("text_already_printed")
+                        ),
+                    )
+                )
+            )
 
         def project_hidden(hidden_states: mx.array) -> mx.array:
             if self.config.tie_word_embeddings:
@@ -567,7 +637,7 @@ class LanguageModel(nn.Module):
             mx.eval(
                 self.model(x[:, block_start:current_window_end], cache=prefix_cache)
             )
-            if on_block is not None:
+            if on_result is not None or on_block is not None:
                 # Report the generated tokens so far (clipped at the first
                 # EOS, like the final return); a False return stops early.
                 block_end = min(current_window_end, prompt_length + gen_length)
@@ -580,7 +650,14 @@ class LanguageModel(nn.Module):
                     ),
                     None,
                 )
-                if not on_block(so_far[:eos_cut] if eos_cut is not None else so_far):
+                so_far = so_far[:eos_cut] if eos_cut is not None else so_far
+                keep_going = (
+                    emit_result(so_far, diffusion_block_complete=True)
+                    if on_result is not None
+                    else on_block(so_far)
+                )
+                if not keep_going:
+                    callback_stopped = True
                     break
             if eos_early_stop:
                 generated = x[0, prompt_length:current_window_end]
@@ -610,6 +687,13 @@ class LanguageModel(nn.Module):
             print(final_text, end="", flush=True)
             if stats is not None:
                 stats["text_already_printed"] = True
+        if on_result is not None and not callback_stopped:
+            finish_reason = (
+                "stop"
+                if end > 0 and generated_ids[end - 1] in eos_token_ids
+                else "length"
+            )
+            emit_result(generated_ids[:end], finish_reason=finish_reason)
         return generated[:, :end]
 
     def sanitize(self, weights: Dict[str, mx.array]) -> Dict[str, mx.array]:

--- a/mlx_vlm/models/nemotron_labs_diffusion/language.py
+++ b/mlx_vlm/models/nemotron_labs_diffusion/language.py
@@ -1,11 +1,12 @@
 import sys
 import time
 from pathlib import Path
-from typing import Any, Dict, Optional, Tuple
+from typing import Any, Callable, Dict, List, Optional, Tuple
 
 import mlx.core as mx
 import mlx.nn as nn
 
+from ...generate.common import GenerationResult
 from ..activations import swiglu
 from ..base import (
     LanguageModelOutput,
@@ -1099,6 +1100,7 @@ class LanguageModel(nn.Module):
         tokenizer: Optional[Any] = None,
         skip_special_tokens: bool = False,
         stats: Optional[Dict[str, float]] = None,
+        on_result: Optional[Callable[[GenerationResult], bool]] = None,
         linear_speculative: bool = False,
         **kwargs,
     ) -> mx.array:
@@ -1113,6 +1115,10 @@ class LanguageModel(nn.Module):
 
         eos_id = self.config.eos_token_id if eos_id is None else eos_id
         mask_id = self.config.mask_token_id if mask_id is None else mask_id
+        eos_token_ids = (
+            set(eos_id) if isinstance(eos_id, (list, tuple, set)) else {eos_id}
+        )
+        generation_tic = time.perf_counter()
         if linear_speculative:
             if not self._linear_spec_lora_loaded:
                 model_path = getattr(self, "model_path", None)
@@ -1130,11 +1136,41 @@ class LanguageModel(nn.Module):
                 threshold=0.0,
                 stats=stats,
             )
-            return output[:, inputs.shape[1] :]
+            generated = output[:, inputs.shape[1] :]
+            if on_result is not None:
+                tokens = generated[0].tolist()
+                text = (
+                    tokenizer.decode(tokens, skip_special_tokens=skip_special_tokens)
+                    if tokenizer is not None
+                    else " ".join(str(token_id) for token_id in tokens)
+                )
+                prompt_time = (stats or {}).get("prompt_time") or 0.0
+                generation_time = max(
+                    time.perf_counter() - generation_tic - prompt_time,
+                    1e-9,
+                )
+                finish_reason = (
+                    "stop" if tokens and tokens[-1] in eos_token_ids else "length"
+                )
+                on_result(
+                    GenerationResult(
+                        text=text,
+                        token=tokens[-1] if tokens else None,
+                        logprobs=None,
+                        prompt_tokens=inputs.size,
+                        generation_tokens=len(tokens),
+                        total_tokens=inputs.size + len(tokens),
+                        prompt_tps=(
+                            inputs.size / prompt_time if prompt_time > 0 else 0.0
+                        ),
+                        generation_tps=len(tokens) / generation_time,
+                        peak_memory=mx.get_peak_memory() / 1e9,
+                        finish_reason=finish_reason,
+                        diffusion_canvas_tokens=len(tokens),
+                    )
+                )
+            return generated
 
-        eos_token_ids = (
-            set(eos_id) if isinstance(eos_id, (list, tuple, set)) else {eos_id}
-        )
         if block_length <= 0:
             raise ValueError("block_length must be a positive integer.")
         steps = max(1, int(steps))
@@ -1255,7 +1291,79 @@ class LanguageModel(nn.Module):
         generated_blocks = []
         prompt_tic = time.perf_counter()
         recorded_prompt_time = False
+        generation_tic = prompt_tic
+        emitted_text = ""
+        callback_stopped = False
         cache = self.make_cache()
+
+        def decode_generated(tokens: List[int]) -> str:
+            if not tokens:
+                return ""
+            if tokenizer is not None:
+                return tokenizer.decode(
+                    tokens,
+                    skip_special_tokens=skip_special_tokens,
+                )
+            return " ".join(str(token_id) for token_id in tokens)
+
+        def emit_result(
+            tokens: List[int],
+            *,
+            diffusion_block_complete: bool = False,
+            finish_reason: Optional[str] = None,
+        ) -> bool:
+            nonlocal emitted_text
+            if on_result is None:
+                return True
+
+            text = decode_generated(tokens)
+            if text.startswith(emitted_text):
+                delta = text[len(emitted_text) :]
+            elif not emitted_text:
+                delta = text
+            else:
+                delta = "" if finish_reason is None else text
+
+            if not delta and finish_reason is None and not diffusion_block_complete:
+                return True
+
+            if text.startswith(emitted_text):
+                emitted_text = text
+
+            prompt_time = (stats or {}).get("prompt_time") or 0.0
+            generation_time = max(
+                time.perf_counter() - generation_tic - prompt_time,
+                1e-9,
+            )
+            generated_tokens = len(tokens)
+            denoise_steps = int((stats or {}).get("diffusion_denoise_nfe", 0.0))
+            work_tokens = int((stats or {}).get("diffusion_accepted_tokens", 0.0))
+            return bool(
+                on_result(
+                    GenerationResult(
+                        text=delta,
+                        token=tokens[-1] if tokens else None,
+                        logprobs=None,
+                        prompt_tokens=inputs.size,
+                        generation_tokens=generated_tokens,
+                        total_tokens=inputs.size + generated_tokens,
+                        prompt_tps=(
+                            inputs.size / prompt_time if prompt_time > 0 else 0.0
+                        ),
+                        generation_tps=generated_tokens / generation_time,
+                        peak_memory=mx.get_peak_memory() / 1e9,
+                        finish_reason=finish_reason,
+                        diffusion_canvas_tokens=generated_tokens,
+                        diffusion_denoising_steps=denoise_steps,
+                        diffusion_work_tokens=work_tokens,
+                        diffusion_block_complete=diffusion_block_complete,
+                        text_already_printed=bool(
+                            (stats or {}).get("text_already_printed")
+                        ),
+                    )
+                )
+            )
+
         prefill_hidden = self.model(
             inputs,
             cache=cache,
@@ -1498,6 +1606,12 @@ class LanguageModel(nn.Module):
                 eos_index = _first_token_index(generated_block[0], eos_token_ids)
                 if eos_index is not None:
                     end_length = total_generated - current_block_length + eos_index + 1
+            if on_result is not None:
+                so_far = mx.concatenate(generated_blocks, axis=1)[0].tolist()
+                if end_length is not None:
+                    so_far = so_far[:end_length]
+                if not emit_result(so_far, diffusion_block_complete=True):
+                    callback_stopped = True
                     break
             if end_length is not None:
                 break
@@ -1546,6 +1660,14 @@ class LanguageModel(nn.Module):
             print(final_text, end="", flush=True)
             if stats is not None:
                 stats["text_already_printed"] = True
+        if on_result is not None and not callback_stopped:
+            generated_ids = generated[0].tolist()
+            finish_reason = (
+                "stop"
+                if end > 0 and generated_ids[end - 1] in eos_token_ids
+                else "length"
+            )
+            emit_result(generated_ids[:end], finish_reason=finish_reason)
         return generated[:, :end]
 
     def ar_generate(

--- a/mlx_vlm/server/app.py
+++ b/mlx_vlm/server/app.py
@@ -215,6 +215,29 @@ def _build_gen_args(
             "frequency_context_size",
             DEFAULT_REPETITION_CONTEXT_SIZE,
         ),
+        max_denoising_steps=_request_field_or_default(
+            request, "max_denoising_steps", None
+        ),
+        block_length=_request_field_or_default(request, "block_length", None),
+        num_to_transfer=_request_field_or_default(request, "num_to_transfer", None),
+        max_transfer_per_step=_request_field_or_default(
+            request, "max_transfer_per_step", None
+        ),
+        editing_threshold=_request_field_or_default(request, "editing_threshold", None),
+        max_post_steps=_request_field_or_default(request, "max_post_steps", None),
+        stability_steps=_request_field_or_default(request, "stability_steps", None),
+        diffusion_full_canvas=_request_field_or_default(
+            request, "diffusion_full_canvas", None
+        ),
+        diffusion_min_canvas_length=_request_field_or_default(
+            request, "diffusion_min_canvas_length", None
+        ),
+        diffusion_max_canvas_length=_request_field_or_default(
+            request, "diffusion_max_canvas_length", None
+        ),
+        diffusion_sampler=_request_field_or_default(request, "diffusion_sampler", None),
+        threshold=_request_field_or_default(request, "threshold", None),
+        min_threshold=_request_field_or_default(request, "min_threshold", None),
         logit_bias=logit_bias,
         enable_thinking=enable_thinking,
         thinking_budget=_request_field_or_default(

--- a/mlx_vlm/server/generation.py
+++ b/mlx_vlm/server/generation.py
@@ -31,8 +31,10 @@ from ..generate import (
     _make_cache,
     _merge_prefill_prompt_kwargs,
 )
-from ..generate.common import generation_stream, wired_limit
-from ..generate.diffusion import diffusion_generation_family, stream_diffusion_generate
+from ..generate.diffusion import (
+    is_diffusion_model,
+    stream_diffusion_generate_from_kwargs,
+)
 from ..sample_utils import make_logits_processors, make_sampler, top_p_sampling
 from ..speculative.utils import (
     make_speculative_prompt_cache,
@@ -759,6 +761,38 @@ class StreamingToken:
     token_count: int = 1
 
 
+class _DiffusionBlockEmitter:
+    """Incrementally group diffusion results into block streaming tokens."""
+
+    def __init__(self):
+        self.block_text: List[str] = []
+        self.last_token = 0
+        self.emitted_tokens = 0
+
+    def feed(self, result) -> "Generator[StreamingToken, None, None]":
+        if result.is_draft:
+            return
+        if result.text:
+            self.block_text.append(result.text)
+        if result.token is not None:
+            self.last_token = int(result.token)
+        if not result.diffusion_block_complete and not result.finish_reason:
+            return
+        if result.finish_reason or self.block_text:
+            token_count = max(result.generation_tokens - self.emitted_tokens, 0)
+            self.emitted_tokens = result.generation_tokens
+            yield StreamingToken(
+                text="".join(self.block_text),
+                token=self.last_token,
+                logprobs=None,
+                finish_reason=result.finish_reason,
+                peak_memory=result.peak_memory,
+                prompt_tps=result.prompt_tps,
+                token_count=token_count,
+            )
+            self.block_text = []
+
+
 def _diffusion_block_chunks(results) -> "Generator[StreamingToken, None, None]":
     """Group diffusion engine results into block-by-block streaming tokens.
 
@@ -767,33 +801,12 @@ def _diffusion_block_chunks(results) -> "Generator[StreamingToken, None, None]":
     block becomes one StreamingToken; the final token carries the finish
     reason (plus any text flushed by detokenizer finalization).
     """
-    block_text: List[str] = []
-    last_token = 0
-    emitted_tokens = 0
+    emitter = _DiffusionBlockEmitter()
     for result in results:
-        if result.is_draft:
-            continue
-        if result.text:
-            block_text.append(result.text)
-        if result.token is not None:
-            last_token = int(result.token)
-        if not result.diffusion_block_complete and not result.finish_reason:
-            continue
-        if result.finish_reason or block_text:
-            token_count = max(result.generation_tokens - emitted_tokens, 0)
-            emitted_tokens = result.generation_tokens
-            yield StreamingToken(
-                text="".join(block_text),
-                token=last_token,
-                logprobs=None,
-                finish_reason=result.finish_reason,
-                peak_memory=result.peak_memory,
-                prompt_tps=result.prompt_tps,
-                token_count=token_count,
-            )
-            block_text = []
-        if result.finish_reason:
-            return
+        for chunk in emitter.feed(result):
+            yield chunk
+            if chunk.finish_reason:
+                return
 
 
 class _TokenIterator:
@@ -1240,11 +1253,9 @@ class ResponseGenerator:
 
         self._ready.set()
 
-        # Diffusion models cannot run through the AR batch generator; each
-        # family gets its own per-request generator in the diffusion lane.
-        diffusion_family = diffusion_generation_family(self.model)
-        if diffusion_family is not None:
-            self._run_diffusion(diffusion_family)
+        # Diffusion models cannot run through the AR batch generator.
+        if is_diffusion_model(self.model):
+            self._run_diffusion()
             return
 
         if self.draft_model is not None and self.draft_kind != "mtp":
@@ -1392,7 +1403,7 @@ class ResponseGenerator:
         if batch_gen is not None and callable(getattr(batch_gen, "close", None)):
             batch_gen.close()
 
-    def _run_diffusion(self, family: str):
+    def _run_diffusion(self):
         """GPU thread loop for diffusion models.
 
         Diffusion generation runs one request at a time (batch size 1).
@@ -1400,11 +1411,6 @@ class ResponseGenerator:
         block, plus a final item carrying the finish reason. Non-streaming
         endpoints aggregate the same items into a single response.
         """
-        generate_request = (
-            self._generate_diffusion
-            if family == "block"
-            else self._generate_masked_diffusion
-        )
         uid_counter = 0
         cancelled: set = set()
         while not self._stop:
@@ -1422,7 +1428,9 @@ class ResponseGenerator:
                     uid = uid_counter
                     rqueue.put(GenerationContext(uid=uid, prompt_tokens=prompt_tokens))
                     try:
-                        generate_request(uid, rqueue, raw_inputs, args, cancelled)
+                        self._generate_diffusion(
+                            uid, rqueue, raw_inputs, args, cancelled
+                        )
                         rqueue.put(None)
                     except Exception as e:
                         logger.exception("Error in diffusion generation")
@@ -1438,13 +1446,6 @@ class ResponseGenerator:
                 gc.collect()
 
     def _generate_diffusion(self, uid, rqueue, raw_inputs, args, cancelled):
-        if args.logits_processors is not None:
-            raise ValueError(
-                "Structured response_format is not supported with diffusion models."
-            )
-        if args.seed is not None:
-            mx.random.seed(args.seed)
-
         input_ids = raw_inputs.get("input_ids")
         if input_ids is not None and input_ids.ndim == 1:
             input_ids = input_ids[None]
@@ -1457,140 +1458,48 @@ class ResponseGenerator:
             else set()
         )
 
-        results = stream_diffusion_generate(
-            self.model,
-            self.processor,
-            tokenizer,
-            input_ids,
-            raw_inputs.get("pixel_values"),
-            raw_inputs.get("attention_mask"),
-            max_tokens=args.max_tokens,
-            temperature=args.temperature,
-            skip_special_token_ids=skip_special_token_ids,
-            mm_token_type_ids=raw_inputs.get("mm_token_type_ids"),
-        )
-        try:
-            with wired_limit(self.model, [generation_stream]):
-                for chunk in _diffusion_block_chunks(results):
-                    rqueue.put(chunk)
-                    if chunk.finish_reason:
-                        break
-                    cancelled |= self._drain_cancellations()
-                    if uid in cancelled:
-                        cancelled.discard(uid)
-                        break
-        finally:
-            results.close()
-
-    def _generate_masked_diffusion(self, uid, rqueue, raw_inputs, args, cancelled):
-        """Generate with a masked-diffusion text model (llada, nemotron).
-
-        The model's own blocking generate loop runs the diffusion; an
-        ``on_block`` callback streams each completed block back as one
-        StreamingToken (models without the hook fall back to a single final
-        chunk).
-        """
-        if args.logits_processors is not None:
-            raise ValueError(
-                "Structured response_format is not supported with diffusion models."
-            )
+        stream_kwargs = {
+            "max_tokens": args.max_tokens,
+            "temperature": args.temperature,
+            "top_p": args.top_p,
+            "top_k": args.top_k,
+            "mm_token_type_ids": raw_inputs.get("mm_token_type_ids"),
+        }
         if args.seed is not None:
-            mx.random.seed(args.seed)
+            stream_kwargs["seed"] = args.seed
+        if args.logits_processors is not None:
+            stream_kwargs["logits_processors"] = args.logits_processors
 
-        input_ids = raw_inputs.get("input_ids")
-        if input_ids is not None and input_ids.ndim == 1:
-            input_ids = input_ids[None]
-        tokenizer = self.tokenizer
-        if hasattr(tokenizer, "stopping_criteria"):
-            tokenizer.stopping_criteria.reset(self.config.eos_token_id)
+        emitter = _DiffusionBlockEmitter()
 
-        config = self.config
-        gen_stats: dict = {}
-        emitted_text = ""
-        emitted_tokens = 0
-
-        def flush(tokens, finish_reason=None):
-            nonlocal emitted_text, emitted_tokens
-            text = (
-                tokenizer.decode(tokens, skip_special_tokens=args.skip_special_tokens)
-                if tokens
-                else ""
-            )
-            if text.startswith(emitted_text):
-                delta = text[len(emitted_text) :]
-            elif not emitted_text:
-                delta = text
-            else:
-                # Retokenization changed already-emitted text; nothing safe
-                # to stream for this block. The final flush resyncs.
-                delta = "" if finish_reason is None else text
-            if not delta and not finish_reason:
-                return
-            prompt_time = gen_stats.get("prompt_time") or 0.0
-            rqueue.put(
-                StreamingToken(
-                    text=delta,
-                    token=tokens[-1] if tokens else 0,
-                    logprobs=None,
-                    finish_reason=finish_reason,
-                    peak_memory=mx.get_peak_memory() / 1e9,
-                    prompt_tps=(
-                        input_ids.size / prompt_time if prompt_time > 0 else None
-                    ),
-                    token_count=max(len(tokens) - emitted_tokens, 0),
-                )
-            )
-            if text.startswith(emitted_text):
-                emitted_text = text
-            emitted_tokens = max(len(tokens), emitted_tokens)
-
-        def on_block(tokens):
-            flush(tokens)
+        def on_result(result):
+            for chunk in emitter.feed(result):
+                rqueue.put(chunk)
+                if chunk.finish_reason:
+                    return False
             cancelled.update(self._drain_cancellations())
             if uid in cancelled:
                 cancelled.discard(uid)
                 return False
             return True
 
-        # Sampler knobs resolve as: config default_diffusion_* attribute >
-        # the model generate()'s own reference defaults (omitted here).
-        tuned_kwargs = {}
-        for key, config_attr in (
-            ("threshold", "default_diffusion_threshold"),
-            ("min_threshold", "default_diffusion_min_threshold"),
-            ("editing_threshold", "default_diffusion_editing_threshold"),
-            ("num_to_transfer", "default_diffusion_num_to_transfer"),
-            ("max_transfer_per_step", "default_diffusion_max_transfer_per_step"),
-            ("max_post_steps", "default_diffusion_max_post_steps"),
-            ("stability_steps", "default_diffusion_stability_steps"),
-        ):
-            value = getattr(config, config_attr, None)
-            if value is not None:
-                tuned_kwargs[key] = value
-
-        with wired_limit(self.model, [generation_stream]):
-            generated = self.model.language_model.generate(
-                input_ids,
-                temperature=args.temperature,
-                block_length=getattr(config, "default_block_length", None) or 32,
-                steps=getattr(config, "default_diffusion_steps", None) or 32,
-                gen_length=args.max_tokens,
-                top_p=(None if args.top_p is None or args.top_p >= 1.0 else args.top_p),
-                eos_early_stop=True,
-                visualize=False,
-                tokenizer=tokenizer,
-                skip_special_tokens=args.skip_special_tokens,
-                stats=gen_stats,
-                on_block=on_block,
-                **tuned_kwargs,
-            )
-            mx.eval(generated)
-
-        tokens = generated[0].tolist()
-        finish_reason = (
-            "stop" if tokens and tokenizer.stopping_criteria(tokens[-1]) else "length"
+        results = stream_diffusion_generate_from_kwargs(
+            self.model,
+            self.processor,
+            tokenizer,
+            input_ids,
+            raw_inputs.get("pixel_values"),
+            raw_inputs.get("attention_mask"),
+            skip_special_token_ids,
+            stream_kwargs,
+            skip_special_tokens=args.skip_special_tokens,
+            on_result=on_result,
         )
-        flush(tokens, finish_reason=finish_reason)
+        try:
+            for _ in results:
+                pass
+        finally:
+            results.close()
 
     def _run_speculative(self):
         """GPU thread loop with DFlash, EAGLE-3, or MTP speculative decoding.

--- a/mlx_vlm/server/generation.py
+++ b/mlx_vlm/server/generation.py
@@ -1502,6 +1502,9 @@ class ResponseGenerator:
             "top_k": args.top_k,
             "mm_token_type_ids": raw_inputs.get("mm_token_type_ids"),
         }
+        prefill_step_size = get_prefill_step_size()
+        if prefill_step_size > 0:
+            stream_kwargs["prefill_step_size"] = prefill_step_size
         if args.seed is not None:
             stream_kwargs["seed"] = args.seed
         if args.logits_processors is not None:

--- a/mlx_vlm/server/generation.py
+++ b/mlx_vlm/server/generation.py
@@ -793,6 +793,7 @@ class StreamingToken:
     finish_reason: Optional[str]
     peak_memory: float = 0.0
     prompt_tps: Optional[float] = None
+    generation_tps: Optional[float] = None
     top_logprobs: Optional[List[Tuple[int, float]]] = None
     cached_tokens: int = 0
     token_count: int = 1
@@ -825,6 +826,7 @@ class _DiffusionBlockEmitter:
                 finish_reason=result.finish_reason,
                 peak_memory=result.peak_memory,
                 prompt_tps=result.prompt_tps,
+                generation_tps=result.generation_tps,
                 token_count=token_count,
             )
             self.block_text = []

--- a/mlx_vlm/server/generation.py
+++ b/mlx_vlm/server/generation.py
@@ -631,6 +631,19 @@ class GenerationArguments:
     presence_context_size: Optional[int] = DEFAULT_REPETITION_CONTEXT_SIZE
     frequency_penalty: Optional[float] = None
     frequency_context_size: Optional[int] = DEFAULT_REPETITION_CONTEXT_SIZE
+    max_denoising_steps: Optional[int] = None
+    block_length: Optional[int] = None
+    num_to_transfer: Optional[int] = None
+    max_transfer_per_step: Optional[int] = None
+    editing_threshold: Optional[float] = None
+    max_post_steps: Optional[int] = None
+    stability_steps: Optional[int] = None
+    diffusion_full_canvas: Optional[bool] = None
+    diffusion_min_canvas_length: Optional[int] = None
+    diffusion_max_canvas_length: Optional[int] = None
+    diffusion_sampler: Optional[str] = None
+    threshold: Optional[float] = None
+    min_threshold: Optional[float] = None
     logit_bias: Optional[dict] = None
     enable_thinking: bool = DEFAULT_ENABLE_THINKING
     thinking_budget: Optional[int] = None
@@ -642,6 +655,29 @@ class GenerationArguments:
     # cached blocks from one tenant can't be reused (or detected via timing)
     # by another. None = no salt = single-tenant behaviour.
     tenant_id: Optional[str] = None
+
+    def diffusion_kwargs(self) -> dict:
+        """Diffusion-only generation kwargs explicitly supplied by a request."""
+        kw = {}
+        for key in (
+            "max_denoising_steps",
+            "block_length",
+            "num_to_transfer",
+            "max_transfer_per_step",
+            "editing_threshold",
+            "max_post_steps",
+            "stability_steps",
+            "diffusion_full_canvas",
+            "diffusion_min_canvas_length",
+            "diffusion_max_canvas_length",
+            "diffusion_sampler",
+            "threshold",
+            "min_threshold",
+        ):
+            value = getattr(self, key)
+            if value is not None:
+                kw[key] = value
+        return kw
 
     def to_generate_kwargs(self) -> dict:
         """Convert to kwargs dict for generate()/stream_generate()."""
@@ -679,6 +715,7 @@ class GenerationArguments:
             kw["logits_processors"] = self.logits_processors
         if self.tenant_id is not None:
             kw["apc_tenant"] = self.tenant_id
+        kw.update(self.diffusion_kwargs())
         return kw
 
     def to_template_kwargs(self) -> dict:
@@ -1469,6 +1506,7 @@ class ResponseGenerator:
             stream_kwargs["seed"] = args.seed
         if args.logits_processors is not None:
             stream_kwargs["logits_processors"] = args.logits_processors
+        stream_kwargs.update(args.diffusion_kwargs())
 
         emitter = _DiffusionBlockEmitter()
 

--- a/mlx_vlm/server/schemas.py
+++ b/mlx_vlm/server/schemas.py
@@ -640,6 +640,60 @@ class VLMRequest(FlexibleBaseModel):
         default_factory=get_server_max_tokens,
         description="Maximum number of tokens to generate.",
     )
+    max_denoising_steps: Optional[int] = Field(
+        None,
+        description="Maximum denoising steps for diffusion generation.",
+    )
+    block_length: Optional[int] = Field(
+        None,
+        description="Block length for masked diffusion text generation.",
+    )
+    num_to_transfer: Optional[int] = Field(
+        None,
+        description="Target number of masked tokens to transfer per diffusion step.",
+    )
+    max_transfer_per_step: Optional[int] = Field(
+        None,
+        description="Maximum masked tokens to transfer per diffusion step.",
+    )
+    editing_threshold: Optional[float] = Field(
+        None,
+        description="Confidence threshold for masked diffusion post-fill edits.",
+    )
+    max_post_steps: Optional[int] = Field(
+        None,
+        description="Maximum masked diffusion post-fill editing steps per block.",
+    )
+    stability_steps: Optional[int] = Field(
+        None,
+        description="Stop masked diffusion post-fill refinement after stable steps.",
+    )
+    diffusion_full_canvas: Optional[bool] = Field(
+        None,
+        description="Use the checkpoint canvas length for diffusion generation.",
+    )
+    diffusion_min_canvas_length: Optional[int] = Field(
+        None,
+        description="Minimum active canvas length for diffusion generation.",
+    )
+    diffusion_max_canvas_length: Optional[int] = Field(
+        None,
+        description="Maximum active canvas length for diffusion generation.",
+    )
+    diffusion_sampler: Optional[Literal["entropy-bound", "confidence-threshold"]] = (
+        Field(
+            None,
+            description="Canvas update sampler for diffusion generation.",
+        )
+    )
+    threshold: Optional[float] = Field(
+        None,
+        description="Token probability threshold for diffusion confidence transfer.",
+    )
+    min_threshold: Optional[float] = Field(
+        None,
+        description="Lowest token probability threshold for masked diffusion transfer.",
+    )
     temperature: float = Field(
         DEFAULT_TEMPERATURE, description="Temperature for sampling."
     )

--- a/mlx_vlm/tests/test_diffusion_gemma.py
+++ b/mlx_vlm/tests/test_diffusion_gemma.py
@@ -1751,7 +1751,11 @@ class TestDiffusionGemma4Quantized(unittest.TestCase):
         args.threshold = 0.7
         self.assertEqual(
             diffusion_kwargs_from_args(args, model.config),
-            {"diffusion_sampler": "entropy-bound", "diffusion_threshold": 0.7},
+            {
+                "diffusion_sampler": "entropy-bound",
+                "diffusion_threshold": 0.7,
+                "threshold": 0.7,
+            },
         )
 
     def test_stream_generate_with_quantized_embeddings(self):

--- a/mlx_vlm/tests/test_diffusion_gemma.py
+++ b/mlx_vlm/tests/test_diffusion_gemma.py
@@ -691,6 +691,35 @@ class TestDiffusionGemma4(unittest.TestCase):
         self.assertEqual(responses[-1].diffusion_denoising_steps, 1)
         self.assertEqual(responses[-1].diffusion_work_tokens, 3)
 
+    def test_stream_generate_uses_model_owned_generator(self):
+        from mlx_vlm.generate import stream_generate
+        from mlx_vlm.models.diffusion_gemma import Model, ModelConfig
+
+        mx.random.seed(0)
+        config = ModelConfig.from_dict(tiny_config_dict())
+        model = Model(config)
+        original_generate = model.language_model.generate
+        calls = {"count": 0}
+
+        def counted_generate(*args, **kwargs):
+            calls["count"] += 1
+            return original_generate(*args, **kwargs)
+
+        model.language_model.generate = counted_generate
+        responses = list(
+            stream_generate(
+                model,
+                FakeProcessor(),
+                "",
+                input_ids=mx.array([[2, 3]], dtype=mx.int32),
+                max_tokens=2,
+                max_denoising_steps=1,
+            )
+        )
+
+        self.assertEqual(calls["count"], 1)
+        self.assertEqual(responses[-1].generation_tokens, 2)
+
     def test_generate_verbose_omits_diffusion_work_stats(self):
         from mlx_vlm.generate import generate
         from mlx_vlm.models.diffusion_gemma import Model, ModelConfig

--- a/mlx_vlm/tests/test_diffusion_models.py
+++ b/mlx_vlm/tests/test_diffusion_models.py
@@ -588,6 +588,27 @@ class TestMaskedDiffusionServerLane(unittest.TestCase):
 
         self.assertEqual(len(calls), 1)
 
+    def test_stream_generate_keeps_final_result_after_block_callbacks(self):
+        mx.random.seed(0)
+        model = self._tiny_llada()
+
+        responses = list(
+            stream_generate(
+                model,
+                _Processor(),
+                prompt="ignored",
+                input_ids=mx.array([[4, 5]], dtype=mx.int32),
+                max_tokens=8,
+                max_denoising_steps=4,
+                block_length=4,
+                temperature=0.0,
+            )
+        )
+
+        self.assertTrue(any(result.diffusion_block_complete for result in responses))
+        self.assertFalse(responses[-1].diffusion_block_complete)
+        self.assertIsNotNone(responses[-1].finish_reason)
+
     def test_llada_unmasking_visualizes_current_block(self):
         from mlx_vlm.models.llada2_moe import language as llada_language
 

--- a/mlx_vlm/tests/test_diffusion_models.py
+++ b/mlx_vlm/tests/test_diffusion_models.py
@@ -660,17 +660,28 @@ class TestMaskedDiffusionServerLane(unittest.TestCase):
         self.assertEqual(drawn[-1], "4\n6")
 
     def test_diffusion_generation_family_routing(self):
-        from mlx_vlm.generate.diffusion import diffusion_generation_family
+        from mlx_vlm.generate.diffusion import (
+            diffusion_generation_family,
+            is_diffusion_model,
+        )
 
         model = self._tiny_llada()
-        self.assertEqual(diffusion_generation_family(model), "masked")
+        self.assertTrue(is_diffusion_model(model))
+        self.assertEqual(diffusion_generation_family(model), "diffusion")
 
         # Mask-token models that default to AR stay on the batch generator.
         model.config.default_generation_mode = "ar"
+        self.assertFalse(is_diffusion_model(model))
         self.assertIsNone(diffusion_generation_family(model))
+        self.assertTrue(is_diffusion_model(model, {"generation_mode": "diffusion"}))
+        self.assertEqual(
+            diffusion_generation_family(model, {"generation_mode": "diffusion"}),
+            "diffusion",
+        )
         model.config.default_generation_mode = None
 
         model.config.mask_token_id = None
+        self.assertFalse(is_diffusion_model(model))
         self.assertIsNone(diffusion_generation_family(model))
 
     def test_diffusion_generation_family_block(self):
@@ -679,7 +690,7 @@ class TestMaskedDiffusionServerLane(unittest.TestCase):
         from mlx_vlm.tests.test_diffusion_gemma import tiny_config_dict
 
         model = Model(ModelConfig.from_dict(tiny_config_dict()))
-        self.assertEqual(diffusion_generation_family(model), "block")
+        self.assertEqual(diffusion_generation_family(model), "diffusion")
 
 
 if __name__ == "__main__":

--- a/mlx_vlm/tests/test_diffusion_models.py
+++ b/mlx_vlm/tests/test_diffusion_models.py
@@ -4,6 +4,7 @@ import unittest
 import mlx.core as mx
 from mlx.utils import tree_map
 
+from mlx_vlm.generate.common import GenerationResult
 from mlx_vlm.generate.dispatch import stream_generate
 from mlx_vlm.models.cache import StaticPrefixKVCache
 
@@ -95,6 +96,16 @@ class TestDiffusionModels(unittest.TestCase):
         def generate(input_ids, **kwargs):
             generate_kwargs.update(kwargs)
             kwargs["stats"]["prompt_time"] = 1.0
+            kwargs["on_result"](
+                GenerationResult(
+                    text="decoded",
+                    token=3,
+                    prompt_tokens=input_ids.size,
+                    generation_tokens=3,
+                    total_tokens=input_ids.size + 3,
+                    finish_reason="stop",
+                )
+            )
             return mx.array([[1, 2, 3]], dtype=mx.int32)
 
         model.language_model.generate = generate
@@ -432,6 +443,21 @@ class TestDiffusionModels(unittest.TestCase):
         self.assertLessEqual(spec_generated.shape[1], 3)
         self.assertGreaterEqual(spec_nfe, 1)
 
+        spec_results = list(
+            stream_generate(
+                model,
+                _Processor(),
+                prompt="ignored",
+                input_ids=mx.array([[4]], dtype=mx.int32),
+                max_tokens=2,
+                generation_mode="linear_speculative",
+                linear_speculative=True,
+                temperature=0.0,
+            )
+        )
+        self.assertGreaterEqual(len(spec_results), 1)
+        self.assertEqual(spec_results[-1].generation_tokens, 2)
+
         def unexpected_diffusion_generate(*args, **kwargs):
             raise AssertionError("Default Nemotron generation should use AR")
 
@@ -453,6 +479,16 @@ class TestDiffusionModels(unittest.TestCase):
         def diffusion_generate(input_ids, **kwargs):
             diffusion_calls["kwargs"] = kwargs
             kwargs["stats"]["prompt_time"] = 1.0
+            kwargs["on_result"](
+                GenerationResult(
+                    text="decoded",
+                    token=3,
+                    prompt_tokens=input_ids.size,
+                    generation_tokens=2,
+                    total_tokens=input_ids.size + 2,
+                    finish_reason="stop",
+                )
+            )
             return mx.array([[5, 3]], dtype=mx.int32)
 
         model.language_model.generate = diffusion_generate
@@ -499,6 +535,16 @@ class TestDiffusionModels(unittest.TestCase):
         def generate(input_ids, **kwargs):
             linear_calls["kwargs"] = kwargs
             kwargs["stats"]["prompt_time"] = 1.0
+            kwargs["on_result"](
+                GenerationResult(
+                    text="decoded",
+                    token=3,
+                    prompt_tokens=input_ids.size,
+                    generation_tokens=2,
+                    total_tokens=input_ids.size + 2,
+                    finish_reason="stop",
+                )
+            )
             return mx.array([[5, 3]], dtype=mx.int32)
 
         model.language_model.generate = generate
@@ -588,7 +634,33 @@ class TestMaskedDiffusionServerLane(unittest.TestCase):
 
         self.assertEqual(len(calls), 1)
 
-    def test_stream_generate_keeps_final_result_after_block_callbacks(self):
+    def test_generate_invokes_on_result_with_generation_results(self):
+        mx.random.seed(0)
+        model = self._tiny_llada()
+        results = []
+        blocks = []
+
+        generated = model.language_model.generate(
+            mx.array([[4, 5]], dtype=mx.int32),
+            gen_length=8,
+            block_length=4,
+            steps=4,
+            eos_early_stop=False,
+            eos_id=999,
+            tokenizer=_Tokenizer(),
+            on_block=lambda tokens: blocks.append(tokens) or True,
+            on_result=lambda result: results.append(result) or True,
+        )
+
+        self.assertEqual(generated.shape[0], 1)
+        self.assertFalse(blocks)
+        self.assertTrue(results)
+        self.assertTrue(all(isinstance(result, GenerationResult) for result in results))
+        self.assertTrue(any(result.diffusion_block_complete for result in results))
+        self.assertFalse(results[-1].diffusion_block_complete)
+        self.assertEqual(results[-1].finish_reason, "length")
+
+    def test_stream_generate_yields_llada_model_owned_results(self):
         mx.random.seed(0)
         model = self._tiny_llada()
 

--- a/mlx_vlm/tests/test_server.py
+++ b/mlx_vlm/tests/test_server.py
@@ -847,6 +847,7 @@ def test_response_generator_diffusion_forwards_generation_options(monkeypatch):
         "stream_diffusion_generate_from_kwargs",
         fake_stream_diffusion_generate_from_kwargs,
     )
+    monkeypatch.setattr(server_generation, "get_prefill_step_size", lambda: 2048)
     args = server.GenerationArguments(
         max_tokens=4,
         temperature=0.0,
@@ -896,6 +897,7 @@ def test_response_generator_diffusion_forwards_generation_options(monkeypatch):
         "top_p": 1.0,
         "top_k": 0,
         "mm_token_type_ids": "types",
+        "prefill_step_size": 2048,
         "seed": 123,
         "max_denoising_steps": 7,
         "block_length": 16,

--- a/mlx_vlm/tests/test_server.py
+++ b/mlx_vlm/tests/test_server.py
@@ -886,6 +886,7 @@ def test_response_generator_diffusion_forwards_generation_options(monkeypatch):
     chunk = rqueue.get(timeout=1)
     assert chunk.text == "ok"
     assert chunk.finish_reason == "length"
+    assert chunk.generation_tps == 5.0
     assert captured["input_ids"].tolist() == [[11, 12]]
     assert captured["pixel_values"] == "pixels"
     assert captured["attention_mask"] == "mask"

--- a/mlx_vlm/tests/test_server.py
+++ b/mlx_vlm/tests/test_server.py
@@ -795,6 +795,124 @@ def test_models_endpoint_deduplicates_loaded_model_from_hf_cache(client, monkeyp
     ) == 1
 
 
+def test_response_generator_diffusion_forwards_generation_options(monkeypatch):
+    gen = _unstarted_response_generator()
+    gen.model = SimpleNamespace()
+    gen.processor = SimpleNamespace()
+    gen.config = SimpleNamespace(eos_token_id=3)
+    gen.tokenizer = SimpleNamespace(all_special_ids=[0])
+    captured = {}
+
+    def fake_stream_diffusion_generate_from_kwargs(
+        model,
+        processor,
+        tokenizer,
+        input_ids,
+        pixel_values,
+        attention_mask,
+        skip_special_token_ids,
+        kwargs,
+        *,
+        skip_special_tokens=False,
+        on_result=None,
+    ):
+        captured.update(
+            model=model,
+            processor=processor,
+            tokenizer=tokenizer,
+            input_ids=input_ids,
+            pixel_values=pixel_values,
+            attention_mask=attention_mask,
+            skip_special_token_ids=skip_special_token_ids,
+            kwargs=dict(kwargs),
+            skip_special_tokens=skip_special_tokens,
+        )
+        on_result(
+            GenerationResult(
+                text="ok",
+                token=7,
+                prompt_tokens=2,
+                generation_tokens=1,
+                total_tokens=3,
+                prompt_tps=10.0,
+                generation_tps=5.0,
+                finish_reason="length",
+            )
+        )
+        if False:
+            yield None
+
+    monkeypatch.setattr(
+        server_generation,
+        "stream_diffusion_generate_from_kwargs",
+        fake_stream_diffusion_generate_from_kwargs,
+    )
+    args = server.GenerationArguments(
+        max_tokens=4,
+        temperature=0.0,
+        top_p=1.0,
+        top_k=0,
+        seed=123,
+        max_denoising_steps=7,
+        block_length=16,
+        num_to_transfer=3,
+        max_transfer_per_step=2,
+        editing_threshold=0.8,
+        max_post_steps=5,
+        stability_steps=1,
+        diffusion_full_canvas=True,
+        diffusion_min_canvas_length=4,
+        diffusion_max_canvas_length=8,
+        diffusion_sampler="entropy-bound",
+        threshold=0.7,
+        min_threshold=0.4,
+    )
+    rqueue = Queue()
+
+    gen._generate_diffusion(
+        uid=1,
+        rqueue=rqueue,
+        raw_inputs={
+            "input_ids": mx.array([[11, 12]], dtype=mx.int32),
+            "pixel_values": "pixels",
+            "attention_mask": "mask",
+            "mm_token_type_ids": "types",
+        },
+        args=args,
+        cancelled=set(),
+    )
+
+    chunk = rqueue.get(timeout=1)
+    assert chunk.text == "ok"
+    assert chunk.finish_reason == "length"
+    assert captured["input_ids"].tolist() == [[11, 12]]
+    assert captured["pixel_values"] == "pixels"
+    assert captured["attention_mask"] == "mask"
+    assert captured["skip_special_token_ids"] == {0}
+    assert captured["skip_special_tokens"] is True
+    assert captured["kwargs"] == {
+        "max_tokens": 4,
+        "temperature": 0.0,
+        "top_p": 1.0,
+        "top_k": 0,
+        "mm_token_type_ids": "types",
+        "seed": 123,
+        "max_denoising_steps": 7,
+        "block_length": 16,
+        "num_to_transfer": 3,
+        "max_transfer_per_step": 2,
+        "editing_threshold": 0.8,
+        "max_post_steps": 5,
+        "stability_steps": 1,
+        "diffusion_full_canvas": True,
+        "diffusion_min_canvas_length": 4,
+        "diffusion_max_canvas_length": 8,
+        "diffusion_sampler": "entropy-bound",
+        "threshold": 0.7,
+        "min_threshold": 0.4,
+    }
+
+
 @pytest.mark.parametrize(
     ("method", "path"),
     [
@@ -4566,6 +4684,46 @@ class TestResponseGenerator:
         args = server._build_gen_args(req)
         assert args.max_tokens == 256
         assert args.enable_thinking is True
+
+    def test_build_gen_args_preserves_diffusion_options(self):
+        req = server.ChatRequest(
+            model="demo",
+            messages=[server.ChatMessage(role="user", content="hi")],
+            max_denoising_steps=7,
+            block_length=16,
+            num_to_transfer=3,
+            max_transfer_per_step=2,
+            editing_threshold=0.8,
+            max_post_steps=5,
+            stability_steps=1,
+            diffusion_full_canvas=True,
+            diffusion_min_canvas_length=4,
+            diffusion_max_canvas_length=8,
+            diffusion_sampler="entropy-bound",
+            threshold=0.7,
+            min_threshold=0.4,
+        )
+
+        args = server._build_gen_args(req)
+
+        expected = {
+            "max_denoising_steps": 7,
+            "block_length": 16,
+            "num_to_transfer": 3,
+            "max_transfer_per_step": 2,
+            "editing_threshold": 0.8,
+            "max_post_steps": 5,
+            "stability_steps": 1,
+            "diffusion_full_canvas": True,
+            "diffusion_min_canvas_length": 4,
+            "diffusion_max_canvas_length": 8,
+            "diffusion_sampler": "entropy-bound",
+            "threshold": 0.7,
+            "min_threshold": 0.4,
+        }
+        assert args.diffusion_kwargs() == expected
+        for key, value in expected.items():
+            assert args.to_generate_kwargs()[key] == value
 
     def test_build_gen_args_uses_model_generation_config_when_omitted(
         self, monkeypatch


### PR DESCRIPTION
## Summary
- Route Diffusion Gemma and masked-diffusion models through one diffusion stream adapter.
- Remove separate block/masked branching from CLI and server generation paths.
- Keep model-specific denoising behind the shared adapter while preserving block streaming.

## Validation
- `uv run python -m unittest mlx_vlm.tests.test_diffusion_models mlx_vlm.tests.test_diffusion_gemma`
- `uv run python -m py_compile mlx_vlm/generate/diffusion.py mlx_vlm/generate/dispatch.py mlx_vlm/server/generation.py mlx_vlm/tests/test_diffusion_models.py`
- `git diff --check`