### PR TITLE
Fix MLX-format and Gemma4 processor regressions

### DIFF
--- a/mlx_vlm/models/base.py
+++ b/mlx_vlm/models/base.py
@@ -531,37 +531,34 @@ def install_auto_processor_patch(target_model_types, processor_cls):
         import json as _json
         from pathlib import Path
 
-        try:
-            model_path = Path(pretrained_model_name_or_path)
-            is_local = model_path.exists() and model_path.is_dir()
+        model_path = Path(pretrained_model_name_or_path)
+        is_local = model_path.exists() and model_path.is_dir()
 
-            cfg = {}
-            if is_local:
-                config_path = model_path / "config.json"
-                if config_path.exists():
+        cfg = {}
+        if is_local:
+            config_path = model_path / "config.json"
+            if config_path.exists():
+                try:
                     with open(config_path, "r", encoding="utf-8") as f:
                         cfg = _json.load(f)
-            else:
-                try:
-                    from huggingface_hub import hf_hub_download
-
-                    cfg_path = hf_hub_download(
-                        pretrained_model_name_or_path, "config.json"
-                    )
-                    with open(cfg_path, "r", encoding="utf-8") as f:
-                        cfg = _json.load(f)
-                except Exception:
+                except (OSError, ValueError):
                     cfg = {}
+        else:
+            try:
+                from huggingface_hub import hf_hub_download
 
-            model_type = str(cfg.get("model_type", "")).lower()
-            if model_type in target_model_types:
-                kwargs.setdefault("trust_remote_code", True)
-                return processor_cls.from_pretrained(
-                    pretrained_model_name_or_path, **kwargs
-                )
-        except Exception:
-            # On any failure, fall back to previous behavior
-            pass
+                cfg_path = hf_hub_download(pretrained_model_name_or_path, "config.json")
+                with open(cfg_path, "r", encoding="utf-8") as f:
+                    cfg = _json.load(f)
+            except Exception:
+                cfg = {}
+
+        model_type = str(cfg.get("model_type", "")).lower()
+        if model_type in target_model_types:
+            kwargs.setdefault("trust_remote_code", True)
+            return processor_cls.from_pretrained(
+                pretrained_model_name_or_path, **kwargs
+            )
 
         # Chain to the prior from_pretrained
         return previous_from_pretrained.__func__(

--- a/mlx_vlm/models/gemma4/processing_gemma4.py
+++ b/mlx_vlm/models/gemma4/processing_gemma4.py
@@ -445,13 +445,24 @@ class Gemma4Processor(ProcessorMixin):
         else:
             self.full_audio_sequence = None
 
-        super().__init__(
-            image_processor=image_processor,
-            tokenizer=tokenizer,
-            video_processor=video_processor,
-            chat_template=chat_template,
-            **kwargs,
-        )
+        try:
+            super().__init__(
+                image_processor=image_processor,
+                tokenizer=tokenizer,
+                video_processor=video_processor,
+                chat_template=chat_template,
+                **kwargs,
+            )
+        except TypeError as e:
+            if "Unexpected keyword argument video_processor" not in str(e):
+                raise
+            super().__init__(
+                image_processor=image_processor,
+                tokenizer=tokenizer,
+                chat_template=chat_template,
+                **kwargs,
+            )
+            self.video_processor = video_processor
 
         self.feature_extractor = feature_extractor
 

--- a/mlx_vlm/tests/test_processors.py
+++ b/mlx_vlm/tests/test_processors.py
@@ -305,6 +305,32 @@ class TestGemma4UnifiedProcessor(unittest.TestCase):
             self.assertEqual(processor.max_soft_tokens, 70)
             self.assertEqual(processor.num_frames, 32)
 
+    def test_processor_retains_video_processor_when_hf_rejects_kwarg(self):
+        from transformers.processing_utils import ProcessorMixin
+
+        from mlx_vlm.models.gemma4.processing_gemma4 import Gemma4Processor
+
+        calls = []
+        video_processor = object()
+
+        def fake_processor_init(processor, **kwargs):
+            calls.append(kwargs)
+            if "video_processor" in kwargs:
+                raise TypeError("Unexpected keyword argument video_processor.")
+            for key, value in kwargs.items():
+                setattr(processor, key, value)
+
+        with patch.object(ProcessorMixin, "__init__", fake_processor_init):
+            processor = Gemma4Processor(
+                image_processor=object(),
+                tokenizer=self._Tokenizer(),
+                video_processor=video_processor,
+            )
+
+        self.assertIn("video_processor", calls[0])
+        self.assertNotIn("video_processor", calls[1])
+        self.assertIs(processor.video_processor, video_processor)
+
     def test_audio_feature_extractor_chunks_waveforms(self):
         from mlx_vlm.models.gemma4_unified.processing_gemma4_unified import (
             Gemma4UnifiedAudioFeatureExtractor,

--- a/mlx_vlm/tests/test_utils.py
+++ b/mlx_vlm/tests/test_utils.py
@@ -14,6 +14,7 @@ from mlx_vlm.convert import _preserve_existing_deepseek_v4_quantization
 from mlx_vlm.models.text_only import TextOnlyModel
 from mlx_vlm.utils import (
     StoppingCriteria,
+    _is_mlx_safetensors_format,
     _load_safetensors,
     apply_generation_config_defaults,
     get_model_and_args,
@@ -566,6 +567,54 @@ def test_load_model_forwards_strict_to_load_weights():
     assert model.loaded_strict is False
 
 
+def test_is_mlx_safetensors_format_detects_metadata(tmp_path):
+    path = tmp_path / "model.safetensors"
+    header = {
+        "__metadata__": {"format": "mlx"},
+        "weight": {"dtype": "F16", "shape": [0], "data_offsets": [0, 0]},
+    }
+    header_bytes = json.dumps(header, separators=(",", ":")).encode("utf-8")
+    path.write_bytes(struct.pack("<Q", len(header_bytes)) + header_bytes)
+
+    assert _is_mlx_safetensors_format([str(path)]) is True
+    assert _is_mlx_safetensors_format([str(tmp_path / "missing.safetensors")]) is False
+
+
+def test_load_model_skips_sanitize_for_mlx_format_safetensors():
+    class FakeConfig:
+        @classmethod
+        def from_dict(cls, config):
+            return cls()
+
+    class FakeModel(nn.Module):
+        def __init__(self, config):
+            super().__init__()
+            self.config = config
+
+        def sanitize(self, weights):
+            raise AssertionError("MLX-format safetensors must not be sanitized")
+
+        def load_weights(self, weights, strict=True):
+            self.loaded_weights = weights
+
+    fake_model_class = SimpleNamespace(ModelConfig=FakeConfig, Model=FakeModel)
+    weights = {"weight": mx.zeros((1,), dtype=mx.float16)}
+
+    with (
+        patch("mlx_vlm.utils.load_config", return_value={"model_type": "fake"}),
+        patch("mlx_vlm.utils.glob.glob", return_value=["/tmp/model/model.safetensors"]),
+        patch("mlx_vlm.utils._load_safetensors", return_value=weights),
+        patch("mlx_vlm.utils._is_mlx_safetensors_format", return_value=True),
+        patch(
+            "mlx_vlm.utils.get_model_and_args",
+            return_value=(fake_model_class, "fake"),
+        ),
+    ):
+        model = load_model(Path("/tmp/model"), lazy=True)
+
+    assert model.loaded_weights == list(weights.items())
+
+
 def test_load_safetensors_reinterprets_f8_e8m0_header(tmp_path):
     path = tmp_path / "model.safetensors"
     header = {
@@ -737,6 +786,30 @@ def test_load_processor_propagates_auto_processor_errors():
     with patch("mlx_vlm.utils.AutoProcessor.from_pretrained", side_effect=ValueError):
         with pytest.raises(ValueError):
             load_processor(Path("/tmp/model"), eos_token_ids=2)
+
+
+def test_auto_processor_patch_propagates_matched_processor_errors(tmp_path):
+    from transformers import AutoProcessor
+
+    from mlx_vlm.models.base import install_auto_processor_patch
+
+    (tmp_path / "config.json").write_text(
+        json.dumps({"model_type": "matched_model"}),
+        encoding="utf-8",
+    )
+    previous_from_pretrained = AutoProcessor.from_pretrained
+
+    class BrokenProcessor:
+        @classmethod
+        def from_pretrained(cls, pretrained_model_name_or_path, **kwargs):
+            raise RuntimeError("real processor failure")
+
+    try:
+        install_auto_processor_patch("matched_model", BrokenProcessor)
+        with pytest.raises(RuntimeError, match="real processor failure"):
+            AutoProcessor.from_pretrained(tmp_path)
+    finally:
+        AutoProcessor.from_pretrained = previous_from_pretrained
 
 
 def test_text_only_model_provides_input_embeddings_and_wraps_logits():

--- a/mlx_vlm/utils.py
+++ b/mlx_vlm/utils.py
@@ -562,19 +562,21 @@ python -m mlx_vlm.convert --hf-path <local_dir> --mlx-path <mlx_dir>
         config["quantization_config"] = transformed_quantization
 
     # Sanitize weights
-    weights = sanitize_weights(model, weights)
+    is_mlx_format = _is_mlx_safetensors_format(weight_files)
+    if not is_mlx_format:
+        weights = sanitize_weights(model, weights)
 
-    if hasattr(model_class, "VisionModel"):
+    if not is_mlx_format and hasattr(model_class, "VisionModel"):
         if hasattr(model_config, "vision_config"):
             weights = sanitize_weights(
                 model_class.VisionModel, weights, model_config.vision_config
             )
-    if hasattr(model_class, "LanguageModel"):
+    if not is_mlx_format and hasattr(model_class, "LanguageModel"):
         if hasattr(model_config, "text_config"):
             weights = sanitize_weights(
                 model_class.LanguageModel, weights, model_config.text_config
             )
-    if hasattr(model_class, "AudioModel"):
+    if not is_mlx_format and hasattr(model_class, "AudioModel"):
         if hasattr(model_config, "audio_config"):
             weights = sanitize_weights(
                 model_class.AudioModel, weights, model_config.audio_config
@@ -713,6 +715,21 @@ def _load_safetensors(path: str) -> dict:
             f.seek(8)
             f.write(original_header)
             f.flush()
+
+
+def _is_mlx_safetensors_format(weight_files: List[str]) -> bool:
+    """Return True when any safetensors file declares MLX-converted weights."""
+    for path in weight_files:
+        try:
+            with open(path, "rb") as f:
+                header_len = struct.unpack("<Q", f.read(8))[0]
+                header = json.loads(f.read(header_len))
+            metadata = header.get("__metadata__") or {}
+            if metadata.get("format") == "mlx":
+                return True
+        except (OSError, struct.error, json.JSONDecodeError, UnicodeDecodeError):
+            continue
+    return False
 
 
 def sanitize_weights(model_obj, weights, config=None):


### PR DESCRIPTION
## Summary
- skip weight sanitization for safetensors that declare `__metadata__.format == "mlx"` to avoid corrupting already-converted MLX weights
- keep Gemma 4 processors usable when Transformers rejects `video_processor` as a constructor kwarg in torch-less environments
- stop masking matched custom processor construction errors behind the stock AutoProcessor fallback

Fixes #1521
Fixes #1520

## Tests
- `uv run --with pytest pytest mlx_vlm/tests/test_utils.py -q`
- `uv run --with pytest pytest mlx_vlm/tests/test_processors.py -q`
- `uv run --with pytest --with psutil pytest mlx_vlm/tests -q`

🤖 Generated with Codex automation.