### PR TITLE
Fix MRoPE decode positions in plain generate for Qwen VLMs

### DIFF
--- a/mlx_vlm/models/qwen2_5_vl/language.py
+++ b/mlx_vlm/models/qwen2_5_vl/language.py
@@ -431,6 +431,14 @@ class LanguageModel(nn.Module):
             self._rope_deltas = None
             self._position_ids = None
 
+        # Plain `generate()` passes `rope_deltas` (computed by
+        # `get_input_embeddings`) only with the prefill call; decode steps
+        # arrive with no kwargs. Persist it so the decode-step position
+        # calculation below continues from the prefill deltas instead of
+        # recalculating positions from a single token.
+        if rope_deltas_kw is not None:
+            self._rope_deltas = rope_deltas_kw
+
         # Use ``_idx`` — the Python-int token counter maintained by
         # ``BatchKVCache`` — instead of syncing on ``cache[0].offset`` every
         # decode step. Rope positions count across the full (possibly padded)

--- a/mlx_vlm/models/qwen2_5_vl/language.py
+++ b/mlx_vlm/models/qwen2_5_vl/language.py
@@ -431,11 +431,6 @@ class LanguageModel(nn.Module):
             self._rope_deltas = None
             self._position_ids = None
 
-        # Plain `generate()` passes `rope_deltas` (computed by
-        # `get_input_embeddings`) only with the prefill call; decode steps
-        # arrive with no kwargs. Persist it so the decode-step position
-        # calculation below continues from the prefill deltas instead of
-        # recalculating positions from a single token.
         if rope_deltas_kw is not None:
             self._rope_deltas = rope_deltas_kw
 

--- a/mlx_vlm/models/qwen2_vl/language.py
+++ b/mlx_vlm/models/qwen2_vl/language.py
@@ -430,11 +430,7 @@ class LanguageModel(nn.Module):
             self._rope_deltas = None
             self._position_ids = None
 
-        # Plain `generate()` passes `rope_deltas` (computed by
-        # `get_input_embeddings`) only with the prefill call; decode steps
-        # arrive with no kwargs. Persist it so the decode-step position
-        # calculation below continues from the prefill deltas instead of
-        # recalculating positions from a single token.
+       
         if rope_deltas_kw is not None:
             self._rope_deltas = rope_deltas_kw
 

--- a/mlx_vlm/models/qwen2_vl/language.py
+++ b/mlx_vlm/models/qwen2_vl/language.py
@@ -430,7 +430,6 @@ class LanguageModel(nn.Module):
             self._rope_deltas = None
             self._position_ids = None
 
-       
         if rope_deltas_kw is not None:
             self._rope_deltas = rope_deltas_kw
 

--- a/mlx_vlm/models/qwen2_vl/language.py
+++ b/mlx_vlm/models/qwen2_vl/language.py
@@ -430,6 +430,14 @@ class LanguageModel(nn.Module):
             self._rope_deltas = None
             self._position_ids = None
 
+        # Plain `generate()` passes `rope_deltas` (computed by
+        # `get_input_embeddings`) only with the prefill call; decode steps
+        # arrive with no kwargs. Persist it so the decode-step position
+        # calculation below continues from the prefill deltas instead of
+        # recalculating positions from a single token.
+        if rope_deltas_kw is not None:
+            self._rope_deltas = rope_deltas_kw
+
         cache_offset = 0
         cache_offsets = None  # per-element offsets for batched caches
         if cache and cache[0] is not None:

--- a/mlx_vlm/models/qwen3_5/language.py
+++ b/mlx_vlm/models/qwen3_5/language.py
@@ -2448,11 +2448,6 @@ class LanguageModel(nn.Module):
             self._rope_deltas = None
             self._position_ids = None
 
-        # Plain `generate()` passes `rope_deltas` (computed by
-        # `get_input_embeddings`) only with the prefill call; decode steps
-        # arrive with no kwargs. Persist it so the decode-step position
-        # calculation below continues from the prefill deltas instead of
-        # recalculating positions from a single token.
         if rope_deltas_kw is not None:
             self._rope_deltas = rope_deltas_kw
 

--- a/mlx_vlm/models/qwen3_5/language.py
+++ b/mlx_vlm/models/qwen3_5/language.py
@@ -2448,6 +2448,14 @@ class LanguageModel(nn.Module):
             self._rope_deltas = None
             self._position_ids = None
 
+        # Plain `generate()` passes `rope_deltas` (computed by
+        # `get_input_embeddings`) only with the prefill call; decode steps
+        # arrive with no kwargs. Persist it so the decode-step position
+        # calculation below continues from the prefill deltas instead of
+        # recalculating positions from a single token.
+        if rope_deltas_kw is not None:
+            self._rope_deltas = rope_deltas_kw
+
         cache_offset = 0
         cache_offsets = None  # per-element offsets for batched caches
         c0 = None

--- a/mlx_vlm/models/qwen3_vl/language.py
+++ b/mlx_vlm/models/qwen3_vl/language.py
@@ -498,11 +498,6 @@ class LanguageModel(nn.Module):
             self._rope_deltas = None
             self._position_ids = None
 
-        # Plain `generate()` passes `rope_deltas` (computed by
-        # `get_input_embeddings`) only with the prefill call; decode steps
-        # arrive with no kwargs. Persist it so the decode-step position
-        # calculation below continues from the prefill deltas instead of
-        # recalculating positions from a single token.
         if rope_deltas_kw is not None:
             self._rope_deltas = rope_deltas_kw
 

--- a/mlx_vlm/models/qwen3_vl/language.py
+++ b/mlx_vlm/models/qwen3_vl/language.py
@@ -498,6 +498,14 @@ class LanguageModel(nn.Module):
             self._rope_deltas = None
             self._position_ids = None
 
+        # Plain `generate()` passes `rope_deltas` (computed by
+        # `get_input_embeddings`) only with the prefill call; decode steps
+        # arrive with no kwargs. Persist it so the decode-step position
+        # calculation below continues from the prefill deltas instead of
+        # recalculating positions from a single token.
+        if rope_deltas_kw is not None:
+            self._rope_deltas = rope_deltas_kw
+
         # Use ``cache._idx`` — the Python-int token counter — instead of
         # syncing on ``cache[0].offset``. See Qwen2.5-VL for details.
         cache_offset = 0

--- a/mlx_vlm/models/qwen3_vl_moe/language.py
+++ b/mlx_vlm/models/qwen3_vl_moe/language.py
@@ -537,12 +537,7 @@ class LanguageModel(nn.Module):
         if pixel_values is not None:
             self._rope_deltas = None
             self._position_ids = None
-
-        # Plain `generate()` passes `rope_deltas` (computed by
-        # `get_input_embeddings`) only with the prefill call; decode steps
-        # arrive with no kwargs. Persist it so the decode-step position
-        # calculation below continues from the prefill deltas instead of
-        # recalculating positions from a single token.
+            
         if rope_deltas_kw is not None:
             self._rope_deltas = rope_deltas_kw
 

--- a/mlx_vlm/models/qwen3_vl_moe/language.py
+++ b/mlx_vlm/models/qwen3_vl_moe/language.py
@@ -537,7 +537,7 @@ class LanguageModel(nn.Module):
         if pixel_values is not None:
             self._rope_deltas = None
             self._position_ids = None
-            
+
         if rope_deltas_kw is not None:
             self._rope_deltas = rope_deltas_kw
 

--- a/mlx_vlm/models/qwen3_vl_moe/language.py
+++ b/mlx_vlm/models/qwen3_vl_moe/language.py
@@ -538,6 +538,14 @@ class LanguageModel(nn.Module):
             self._rope_deltas = None
             self._position_ids = None
 
+        # Plain `generate()` passes `rope_deltas` (computed by
+        # `get_input_embeddings`) only with the prefill call; decode steps
+        # arrive with no kwargs. Persist it so the decode-step position
+        # calculation below continues from the prefill deltas instead of
+        # recalculating positions from a single token.
+        if rope_deltas_kw is not None:
+            self._rope_deltas = rope_deltas_kw
+
         # Use ``cache._idx`` — the Python-int token counter — instead of
         # syncing on ``cache[0].offset``. See Qwen2.5-VL for details.
         cache_offset = 0

--- a/mlx_vlm/tests/test_models.py
+++ b/mlx_vlm/tests/test_models.py
@@ -8822,3 +8822,148 @@ class TestQuantizedKVCacheMask(unittest.TestCase):
 
         # The quantized path must actually have been exercised.
         self.assertIsInstance(cache[1].keys, tuple)
+
+
+class TestQwenMRoPEDecodeContinuation(unittest.TestCase):
+    """Regression tests for MRoPE decode positions in plain generation.
+
+    ``generate()`` forwards ``position_ids``/``rope_deltas`` (computed by
+    ``get_input_embeddings``) only with the prefill call; decode steps reach
+    the language model with no position kwargs. The language model must
+    persist the prefill ``rope_deltas`` so decode positions continue in the
+    compressed MRoPE space instead of restarting from a single-token
+    recalculation (#1505, #1526).
+    """
+
+    def _tiny_qwen3_vl(self):
+        from mlx_vlm.models import qwen3_vl
+
+        text_config = qwen3_vl.TextConfig(
+            model_type="qwen3_vl_text",
+            hidden_size=64,
+            num_hidden_layers=2,
+            intermediate_size=128,
+            num_attention_heads=4,
+            num_key_value_heads=2,
+            rms_norm_eps=1e-5,
+            head_dim=16,
+            vocab_size=1000,
+            rope_theta=1000,
+            max_position_embeddings=1000,
+            tie_word_embeddings=False,
+            norm_topk_prob=True,
+            rope_scaling={"rope_type": "mrope", "mrope_section": [4, 2, 2]},
+        )
+        vision_config = qwen3_vl.VisionConfig(
+            model_type="qwen3_vl",
+            depth=2,
+            hidden_size=64,
+            intermediate_size=128,
+            out_hidden_size=64,
+            num_heads=4,
+            patch_size=14,
+            in_channels=3,
+            spatial_merge_size=2,
+            temporal_patch_size=2,
+            num_position_embeddings=144,
+            deepstack_visual_indexes=[],
+        )
+        config = qwen3_vl.ModelConfig(
+            text_config=text_config,
+            vision_config=vision_config,
+            model_type="qwen3_vl",
+            image_token_id=998,
+            video_token_id=999,
+            vocab_size=1000,
+        )
+        return qwen3_vl.Model(config).language_model
+
+    def _tiny_qwen2_5_vl(self):
+        from mlx_vlm.models import qwen2_5_vl
+
+        text_config = qwen2_5_vl.TextConfig(
+            model_type="qwen2_5_vl",
+            hidden_size=64,
+            num_hidden_layers=2,
+            intermediate_size=128,
+            num_attention_heads=4,
+            rms_norm_eps=1e-6,
+            vocab_size=1000,
+            num_key_value_heads=2,
+            max_position_embeddings=1000,
+            rope_theta=1000.0,
+            rope_traditional=False,
+            rope_scaling={"type": "mrope", "mrope_section": [4, 2, 2]},
+            tie_word_embeddings=False,
+        )
+        vision_config = qwen2_5_vl.VisionConfig(
+            model_type="qwen2_5_vl",
+            depth=2,
+            hidden_size=64,
+            intermediate_size=128,
+            out_hidden_size=64,
+            num_heads=4,
+            image_size=384,
+            vocab_size=1000,
+            mlp_ratio=2.0,
+            in_channels=3,
+            layer_norm_eps=1e-6,
+            spatial_patch_size=14,
+            spatial_merge_size=2,
+            patch_size=14,
+            temporal_patch_size=2,
+            tokens_per_second=2,
+            window_size=112,
+            fullatt_block_indexes=[0],
+        )
+        config = qwen2_5_vl.ModelConfig(
+            text_config=text_config,
+            vision_config=vision_config,
+            model_type="qwen2_5_vl",
+            image_token_id=998,
+            video_token_id=999,
+            vocab_size=1000,
+        )
+        return qwen2_5_vl.Model(config).language_model
+
+    def _decode_logits(self, lm, with_delta_kwarg):
+        from mlx_vlm.models import cache as cache_mod
+
+        lm._rope_deltas = None
+        lm._position_ids = None
+        prompt_cache = cache_mod.make_prompt_cache(lm)
+
+        ids = mx.array([[3, 5, 7, 11, 13, 17]])
+        # Vision-compressed prompt positions: max position 2 for 6 tokens,
+        # so rope_delta = (2 + 1) - 6 = -3.
+        pos_row = mx.array([0, 1, 1, 2, 2, 2])
+        positions = mx.broadcast_to(pos_row[None, None, :], (3, 1, 6))
+        delta = mx.array([[-3]])
+
+        prefill_kwargs = {"rope_deltas": delta} if with_delta_kwarg else {}
+        lm(ids, cache=prompt_cache, position_ids=positions, **prefill_kwargs)
+
+        step = mx.array([[19]])
+        if with_delta_kwarg:
+            # The generate() decode flow: no position kwargs at all.
+            out = lm(step, cache=prompt_cache)
+        else:
+            # Ground truth: cache offset (6) + delta (-3) = position 3.
+            decode_positions = mx.full((3, 1, 1), 3, dtype=positions.dtype)
+            out = lm(step, cache=prompt_cache, position_ids=decode_positions)
+        mx.eval(out.logits)
+        return out.logits
+
+    def test_qwen3_vl_decode_continues_prefill_rope_deltas(self):
+        lm = self._tiny_qwen3_vl()
+        mx.eval(lm.parameters())
+        reference = self._decode_logits(lm, with_delta_kwarg=False)
+        subject = self._decode_logits(lm, with_delta_kwarg=True)
+        self.assertTrue(mx.allclose(reference, subject, atol=1e-5).item())
+
+    def test_qwen2_5_vl_decode_continues_prefill_rope_deltas(self):
+        lm = self._tiny_qwen2_5_vl()
+        mx.eval(lm.parameters())
+        reference = self._decode_logits(lm, with_delta_kwarg=False)
+        subject = self._decode_logits(lm, with_delta_kwarg=True)
+        self.assertTrue(mx.allclose(reference, subject, atol=1e-5).item())

--- a/mlx_vlm/tests/test_models.py
+++ b/mlx_vlm/tests/test_models.py
@@ -8878,54 +8878,6 @@ class TestQwenMRoPEDecodeContinuation(unittest.TestCase):
         )
         return qwen3_vl.Model(config).language_model
 
-    def _tiny_qwen2_5_vl(self):
-        from mlx_vlm.models import qwen2_5_vl
-
-        text_config = qwen2_5_vl.TextConfig(
-            model_type="qwen2_5_vl",
-            hidden_size=64,
-            num_hidden_layers=2,
-            intermediate_size=128,
-            num_attention_heads=4,
-            rms_norm_eps=1e-6,
-            vocab_size=1000,
-            num_key_value_heads=2,
-            max_position_embeddings=1000,
-            rope_theta=1000.0,
-            rope_traditional=False,
-            rope_scaling={"type": "mrope", "mrope_section": [4, 2, 2]},
-            tie_word_embeddings=False,
-        )
-        vision_config = qwen2_5_vl.VisionConfig(
-            model_type="qwen2_5_vl",
-            depth=2,
-            hidden_size=64,
-            intermediate_size=128,
-            out_hidden_size=64,
-            num_heads=4,
-            image_size=384,
-            vocab_size=1000,
-            mlp_ratio=2.0,
-            in_channels=3,
-            layer_norm_eps=1e-6,
-            spatial_patch_size=14,
-            spatial_merge_size=2,
-            patch_size=14,
-            temporal_patch_size=2,
-            tokens_per_second=2,
-            window_size=112,
-            fullatt_block_indexes=[0],
-        )
-        config = qwen2_5_vl.ModelConfig(
-            text_config=text_config,
-            vision_config=vision_config,
-            model_type="qwen2_5_vl",
-            image_token_id=998,
-            video_token_id=999,
-            vocab_size=1000,
-        )
-        return qwen2_5_vl.Model(config).language_model
-
     def _decode_logits(self, lm, with_delta_kwarg):
         from mlx_vlm.models import cache as cache_mod
 
@@ -8956,13 +8908,6 @@ class TestQwenMRoPEDecodeContinuation(unittest.TestCase):
 
     def test_qwen3_vl_decode_continues_prefill_rope_deltas(self):
         lm = self._tiny_qwen3_vl()
-        mx.eval(lm.parameters())
-        reference = self._decode_logits(lm, with_delta_kwarg=False)
-        subject = self._decode_logits(lm, with_delta_kwarg=True)
-        self.assertTrue(mx.allclose(reference, subject, atol=1e-5).item())
-
-    def test_qwen2_5_vl_decode_continues_prefill_rope_deltas(self):
-        lm = self._tiny_qwen2_5_vl()
         mx.eval(lm.parameters())
         reference = self._decode_logits(lm, with_delta_kwarg=False)
         subject = self._decode_logits(lm, with_delta_kwarg=True)


### PR DESCRIPTION
Since #1486, all Qwen VLMs generate broken output with plain generate() like "This is is is is…" at temperature 0 (see #1505 and #1526). 

The problem: generate() only passes rope_deltas with the first (prefill) call, and decode steps pass nothing. The model used to remember this value internally, but #1486 removed that, so during decode it recomputes positions from a single token and gets them wrong, and every token after that is generated at the wrong position. 

when `rope_delta` is being passed, if we save on the model, decode can keep using it. Everything else is unaffected, and all verifications show models produce exactly the same otuput as 0.6.3 version, reg. tests fail on main and pass with this fix. 

But, Qwen3.5/3.6 checkpoints have a second, unrelated bug that will be fixed in a upcoming pr, both needs this fix. 

