### PR TITLE
Enable APC with KV-cache quantization (single-request)

### DIFF
--- a/mlx_vlm/apc.py
+++ b/mlx_vlm/apc.py
@@ -221,6 +221,17 @@ def _clone_cache_entry_for_apc(
             return None
         return tuple(copied)
 
+    # Protocol fallback: any cache with dequantize_for_apc (e.g. QuantizedKVCache)
+    # is cloned by dequantizing into a plain KVCache for exact-mode storage.
+    if hasattr(c, "dequantize_for_apc"):
+        dk, dv = c.dequantize_for_apc()
+        out = lm_cache.KVCache()
+        out.keys = _copy_mlx_array(dk)
+        out.values = _copy_mlx_array(dv)
+        out.offset = dk.shape[-2]
+        eval_targets.extend([out.keys, out.values])
+        return out
+
     return None
 
 
@@ -282,6 +293,8 @@ def _cache_entry_supports_exact_apc(c: Any) -> bool:
         ),
     ):
         return True
+    if hasattr(c, "dequantize_for_apc"):
+        return True
     if isinstance(c, lm_cache.CacheList):
         return all(_cache_entry_supports_exact_apc(sub_c) for sub_c in c.caches)
     if isinstance(c, tuple):
@@ -292,7 +305,11 @@ def _cache_entry_supports_exact_apc(c: Any) -> bool:
 def _cache_entry_supports_block_apc(c: Any) -> bool:
     from .models import cache as lm_cache
 
-    return isinstance(c, lm_cache.KVCache)
+    if isinstance(c, lm_cache.KVCache):
+        return True
+    if hasattr(c, "dequantize_for_apc"):
+        return True
+    return False
 
 
 def _sequence_hash(token_ids: Sequence[int], extra_hash: int, block_size: int) -> int:
@@ -3386,18 +3403,38 @@ class APCManager:
 def make_warm_kv_cache(
     matched_blocks: List[APCBlock],
     min_capacity_tokens: Optional[int] = None,
+    kv_quant_config: Optional[dict] = None,
 ) -> List[Any]:
-    """Stitch matched blocks into per-layer ``KVCache`` instances pre-filled
+    """Stitch matched blocks into per-layer cache instances pre-filled
     with the cached prefix's K/V state. Used by the single-stream
     ``stream_generate`` path.
+
+    When *kv_quant_config* is provided (dict with ``bits`` and ``group_size``),
+    returns ``QuantizedKVCache`` instances that re-quantize the raw float
+    blocks via ``update_and_fetch``.
     """
-    from .models.cache import KVCache
+    from .models.cache import KVCache, QuantizedKVCache
 
     if not matched_blocks:
         return []
     num_layers = len(matched_blocks[0].keys)
     out: List[Any] = []
     prefix_len = sum(b.keys[0].shape[-2] for b in matched_blocks)
+
+    if kv_quant_config is not None:
+        for layer_idx in range(num_layers):
+            ks = [b.keys[layer_idx] for b in matched_blocks]
+            vs = [b.values[layer_idx] for b in matched_blocks]
+            merged_k = mx.concatenate(ks, axis=2)
+            merged_v = mx.concatenate(vs, axis=2)
+            c = QuantizedKVCache(
+                group_size=kv_quant_config["group_size"],
+                bits=kv_quant_config["bits"],
+            )
+            c.update_and_fetch(merged_k, merged_v)
+            out.append(c)
+        return out
+
     step_probe = KVCache()
     kv_step = int(getattr(step_probe, "step", getattr(KVCache, "step", 256)))
     capacity = prefix_len
@@ -3449,13 +3486,18 @@ def make_warm_kv_cache_from_layers(
 
 def make_warm_batch_kv_cache(
     matched_blocks: List[APCBlock],
+    kv_quant_config: Optional[dict] = None,
 ) -> List[Any]:
-    """Stitch matched blocks into per-layer single-row ``BatchKVCache``
-    instances pre-filled with the cached prefix's K/V state. Used by the
-    batched continuous-batching path; the resulting cache list can be
+    """Stitch matched blocks into per-layer single-row batch cache instances
+    pre-filled with the cached prefix's K/V state. Used by the batched
+    continuous-batching path; the resulting cache list can be
     ``extend()``-ed into a running batch.
+
+    When *kv_quant_config* is provided (dict with ``bits`` and ``group_size``),
+    returns ``BatchQuantizedKVCache`` instances that re-quantize the raw float
+    blocks via ``update_and_fetch``.
     """
-    from .models.cache import BatchKVCache
+    from .models.cache import BatchKVCache, BatchQuantizedKVCache
 
     if not matched_blocks:
         return []
@@ -3467,14 +3509,21 @@ def make_warm_batch_kv_cache(
         vs = [b.values[layer_idx] for b in matched_blocks]
         merged_k = mx.concatenate(ks, axis=2)  # [1, H, prefix_len, D]
         merged_v = mx.concatenate(vs, axis=2)
-        c = BatchKVCache(left_padding=[0])
-        # state setter: (keys, values, offset, left_padding) → also sets _idx
-        c.state = (
-            merged_k,
-            merged_v,
-            mx.array([prefix_len]),
-            mx.array([0]),
-        )
+        if kv_quant_config is not None:
+            c = BatchQuantizedKVCache(
+                [0],
+                group_size=kv_quant_config["group_size"],
+                bits=kv_quant_config["bits"],
+            )
+            c.update_and_fetch(merged_k, merged_v)
+        else:
+            c = BatchKVCache(left_padding=[0])
+            c.state = (
+                merged_k,
+                merged_v,
+                mx.array([prefix_len]),
+                mx.array([0]),
+            )
         out.append(c)
     return out
 
@@ -3708,6 +3757,23 @@ def harvest_blocks_from_batch_cache(
     layer_keys: List[mx.array] = []
     layer_values: List[mx.array] = []
     for c in batch_caches:
+        # Protocol dispatch: quantized caches expose dequantize_for_apc()
+        # which returns raw float arrays suitable for direct slicing.
+        if hasattr(c, "dequantize_for_apc"):
+            dk, dv = c.dequantize_for_apc()
+            idx = dk.shape[-2]
+            left_padding = getattr(c, "left_padding", None)
+            if left_padding is not None:
+                try:
+                    lp = int(left_padding[batch_idx].item())
+                except Exception:
+                    lp = 0
+            else:
+                lp = 0
+            layer_keys.append(dk[batch_idx : batch_idx + 1, :, lp:, :])
+            layer_values.append(dv[batch_idx : batch_idx + 1, :, lp:, :])
+            continue
+
         keys = getattr(c, "keys", None)
         values = getattr(c, "values", None)
         idx = getattr(c, "_idx", None)

--- a/mlx_vlm/apc.py
+++ b/mlx_vlm/apc.py
@@ -154,6 +154,36 @@ def _clone_cache_entry_for_apc(
             eval_targets.extend([keys, values])
         return out
 
+    # BatchKVCache is not a KVCache subclass. With --kv-bits the batch cache
+    # factory is used even for single-row requests, so hybrid exact-mode
+    # snapshots often see BatchKVCache for the unquantized last layer.
+    # Collapse B=1 into a row KVCache (same as extract(0)); multi-row must
+    # be extracted before store.
+    if isinstance(c, lm_cache.BatchKVCache):
+        idx = int(getattr(c, "_idx", 0) or 0)
+        if c.keys is None or c.values is None or idx <= 0:
+            return lm_cache.KVCache()
+        if int(c.keys.shape[0]) != 1:
+            return None
+        row = c.extract(0)
+        off = int(getattr(row, "offset", 0) or 0)
+        if row.keys is not None and row.values is not None and off > 0:
+            keys = _copy_mlx_array(row.keys[..., :off, :])
+            values = _copy_mlx_array(row.values[..., :off, :])
+            step = int(getattr(row, "step", getattr(type(row), "step", 256)) or 0)
+            keys, values = _pad_kv_for_capacity(
+                keys,
+                values,
+                offset=off,
+                min_capacity_tokens=min_capacity_tokens,
+                step=step,
+            )
+            row.keys = keys
+            row.values = values
+            row.offset = off
+            eval_targets.extend([keys, values])
+        return row
+
     if isinstance(c, lm_cache.RotatingKVCache):
         out = type(c)(
             max_size=int(getattr(c, "max_size")),
@@ -289,6 +319,7 @@ def _cache_entry_supports_exact_apc(c: Any) -> bool:
         c,
         (
             lm_cache.KVCache,
+            lm_cache.BatchKVCache,
             lm_cache.RotatingKVCache,
             lm_cache.ChunkedKVCache,
             lm_cache.ArraysCache,
@@ -3055,6 +3086,13 @@ class APCManager:
         token_tuple = tuple(int(t) for t in token_ids)
         copied = _clone_prompt_cache_for_apc(prompt_cache)
         if copied is None:
+            types = [type(c).__name__ for c in prompt_cache]
+            logger.warning(
+                "APC exact-cache store rejected: unclonable prompt cache types %s "
+                "(token_len=%d). Exact-mode APC will not reuse this prefix.",
+                types,
+                len(token_tuple),
+            )
             return False
         key = _sequence_hash(token_tuple, extra_hash, self.block_size)
         stored = False

--- a/mlx_vlm/apc.py
+++ b/mlx_vlm/apc.py
@@ -225,6 +225,8 @@ def _clone_cache_entry_for_apc(
     # is cloned by dequantizing into a plain KVCache for exact-mode storage.
     if hasattr(c, "dequantize_for_apc"):
         dk, dv = c.dequantize_for_apc()
+        if dk is None or dv is None:
+            return lm_cache.KVCache()
         out = lm_cache.KVCache()
         out.keys = _copy_mlx_array(dk)
         out.values = _copy_mlx_array(dv)
@@ -3422,15 +3424,14 @@ def make_warm_kv_cache(
     prefix_len = sum(b.keys[0].shape[-2] for b in matched_blocks)
 
     if kv_quant_config is not None:
+        qbits = int(kv_quant_config["bits"])
+        qgroup = int(kv_quant_config["group_size"])
         for layer_idx in range(num_layers):
             ks = [b.keys[layer_idx] for b in matched_blocks]
             vs = [b.values[layer_idx] for b in matched_blocks]
             merged_k = mx.concatenate(ks, axis=2)
             merged_v = mx.concatenate(vs, axis=2)
-            c = QuantizedKVCache(
-                group_size=kv_quant_config["group_size"],
-                bits=kv_quant_config["bits"],
-            )
+            c = QuantizedKVCache(group_size=qgroup, bits=qbits)
             c.update_and_fetch(merged_k, merged_v)
             out.append(c)
         return out
@@ -3469,17 +3470,29 @@ def make_warm_kv_cache_from_layers(
     layer_keys: List[mx.array],
     layer_values: List[mx.array],
     prefix_len: int,
+    kv_quant_config: Optional[dict] = None,
 ) -> List[Any]:
-    """Build ``KVCache`` objects from already-concatenated disk-restored K/V."""
-    from .models.cache import KVCache
+    """Build cache objects from already-concatenated disk-restored K/V.
+
+    When *kv_quant_config* is provided, returns ``QuantizedKVCache`` instances.
+    """
+    from .models.cache import KVCache, QuantizedKVCache
 
     out: List[Any] = []
-    for k, v in zip(layer_keys, layer_values):
-        c = KVCache()
-        c.keys = k
-        c.values = v
-        c.offset = prefix_len
-        out.append(c)
+    if kv_quant_config is not None:
+        qbits = int(kv_quant_config["bits"])
+        qgroup = int(kv_quant_config["group_size"])
+        for k, v in zip(layer_keys, layer_values):
+            c = QuantizedKVCache(group_size=qgroup, bits=qbits)
+            c.update_and_fetch(k, v)
+            out.append(c)
+    else:
+        for k, v in zip(layer_keys, layer_values):
+            c = KVCache()
+            c.keys = k
+            c.values = v
+            c.offset = prefix_len
+            out.append(c)
     mx.clear_cache()
     return out
 
@@ -3512,8 +3525,8 @@ def make_warm_batch_kv_cache(
         if kv_quant_config is not None:
             c = BatchQuantizedKVCache(
                 [0],
-                group_size=kv_quant_config["group_size"],
-                bits=kv_quant_config["bits"],
+                group_size=int(kv_quant_config["group_size"]),
+                bits=int(kv_quant_config["bits"]),
             )
             c.update_and_fetch(merged_k, merged_v)
         else:
@@ -3531,11 +3544,16 @@ def make_warm_batch_kv_cache(
 def make_warm_batch_kv_cache_multi(
     picks: List[Optional[dict]],
     num_layers: int,
+    kv_quant_config: Optional[dict] = None,
 ) -> Tuple[List[Any], int]:
-    """Build a multi-row ``BatchKVCache`` list for mixed warm / cold prefill.
+    """Build a multi-row batch cache list for mixed warm / cold prefill.
 
     ``picks`` is per-row, with each entry being ``None`` (cold) or a dict
     with key ``matched_blocks`` (list of APCBlock) and ``prefix_len``.
+
+    When *kv_quant_config* is provided (dict with ``bits`` and ``group_size``),
+    returns ``BatchQuantizedKVCache`` instances that re-quantize the raw float
+    blocks via ``update_and_fetch``.
 
     Returns ``(cache_list, max_prefix)`` where ``max_prefix`` is the cache's
     ``_idx`` after warm-init (= max prefix_len across rows).
@@ -3545,7 +3563,7 @@ def make_warm_batch_kv_cache_multi(
       * keys[i, :, left_padding[i]:max_prefix, :] = concatenated block K
       * keys[i, :, :left_padding[i], :] = zeros (will be hidden by mask)
     """
-    from .models.cache import BatchKVCache
+    from .models.cache import BatchKVCache, BatchQuantizedKVCache
 
     B = len(picks)
     prefix_lens = [p["prefix_len"] if p else 0 for p in picks]
@@ -3601,13 +3619,21 @@ def make_warm_batch_kv_cache_multi(
 
         left_padding = [max_prefix - pl for pl in prefix_lens]
         offset = [pl for pl in prefix_lens]
-        c = BatchKVCache(left_padding=[0] * B)  # placeholder; state setter overrides
-        c.state = (
-            merged_k,
-            merged_v,
-            mx.array(offset),
-            mx.array(left_padding),
-        )
+        if kv_quant_config is not None:
+            c = BatchQuantizedKVCache(
+                left_padding,
+                group_size=int(kv_quant_config["group_size"]),
+                bits=int(kv_quant_config["bits"]),
+            )
+            c.update_and_fetch(merged_k, merged_v)
+        else:
+            c = BatchKVCache(left_padding=[0] * B)
+            c.state = (
+                merged_k,
+                merged_v,
+                mx.array(offset),
+                mx.array(left_padding),
+            )
         out.append(c)
     return out, max_prefix
 
@@ -3761,6 +3787,8 @@ def harvest_blocks_from_batch_cache(
         # which returns raw float arrays suitable for direct slicing.
         if hasattr(c, "dequantize_for_apc"):
             dk, dv = c.dequantize_for_apc()
+            if dk is None or dv is None:
+                return []
             idx = dk.shape[-2]
             left_padding = getattr(c, "left_padding", None)
             if left_padding is not None:

--- a/mlx_vlm/generate/ar.py
+++ b/mlx_vlm/generate/ar.py
@@ -2426,8 +2426,13 @@ class BatchGenerator:
                 if hasattr(self.model, "make_cache")
                 else len(self.model.layers)
             )
+            _quant_cfg = (
+                {"bits": self.kv_bits, "group_size": self.kv_group_size}
+                if self.kv_bits is not None
+                else None
+            )
             warm_cache, _ = _apc.make_warm_batch_kv_cache_multi(
-                picks, num_layers=num_layers
+                picks, num_layers=num_layers, kv_quant_config=_quant_cfg
             )
 
         apc_meta = [

--- a/mlx_vlm/generate/ar.py
+++ b/mlx_vlm/generate/ar.py
@@ -2130,11 +2130,9 @@ class BatchGenerator:
             top_logprobs_k = 0
             self.compute_logprobs = False
             self.top_logprobs_k = 0
-        # APC: opt-out for KV-quantized caches. Plain KV models use block APC;
+        # APC mode detection: plain KV models use block APC;
         # mixed/custom cache models use exact prompt-cache snapshots.
         self.apc_mode = None
-        if apc_manager is not None and kv_bits is not None:
-            apc_manager = None
         if apc_manager is not None:
             self.apc_mode = _apc.model_apc_mode(model)
             if self.apc_mode is None:

--- a/mlx_vlm/generate/dispatch.py
+++ b/mlx_vlm/generate/dispatch.py
@@ -958,9 +958,19 @@ def stream_generate(
                     input_ids = input_ids[:, prefix_len:]
                     pixel_values = None
                     kwargs.pop("cached_image_features", None)
+                    _kv_bits = kwargs.get("kv_bits")
+                    _quant_cfg = (
+                        {
+                            "bits": _kv_bits,
+                            "group_size": kwargs.get("kv_group_size", 64),
+                        }
+                        if _kv_bits is not None
+                        else None
+                    )
                     kwargs["prompt_cache"] = _apc.make_warm_kv_cache(
                         matched_blocks,
                         min_capacity_tokens=prefix_len + input_ids.shape[1] + 1,
+                        kv_quant_config=_quant_cfg,
                     )
                 else:
                     apc_manager.release(matched_blocks)

--- a/mlx_vlm/models/cache.py
+++ b/mlx_vlm/models/cache.py
@@ -118,6 +118,28 @@ class _BaseCache:
         return obj
 
 
+def _dequantize_uniform(keys_tuple, values_tuple, length, group_size, bits):
+    """Dequantize uniform-quantized K/V tuples to raw float arrays.
+
+    Shared by QuantizedKVCache and BatchQuantizedKVCache for APC storage.
+    """
+    keys = mx.dequantize(
+        keys_tuple[0][..., :length, :],
+        keys_tuple[1][..., :length, :],
+        keys_tuple[2][..., :length, :],
+        group_size=group_size,
+        bits=bits,
+    )
+    values = mx.dequantize(
+        values_tuple[0][..., :length, :],
+        values_tuple[1][..., :length, :],
+        values_tuple[2][..., :length, :],
+        group_size=group_size,
+        bits=bits,
+    )
+    return keys, values
+
+
 class QuantizedKVCache(_BaseCache):
     step = 256
 
@@ -199,6 +221,12 @@ class QuantizedKVCache(_BaseCache):
         n = min(self.offset, n)
         self.offset -= n
         return n
+
+    def dequantize_for_apc(self):
+        """Return raw float (keys, values) sliced to current offset for APC storage."""
+        return _dequantize_uniform(
+            self.keys, self.values, self.offset, self.group_size, self.bits
+        )
 
     def make_mask(self, *args, **kwargs):
         return create_attention_mask(*args, offset=self.offset, **kwargs)
@@ -1624,6 +1652,12 @@ class BatchQuantizedKVCache(_BaseCache):
         return (
             tuple(k[..., : self._idx, :] for k in self.keys),
             tuple(v[..., : self._idx, :] for v in self.values),
+        )
+
+    def dequantize_for_apc(self):
+        """Return raw float (keys, values) sliced to current _idx for APC storage."""
+        return _dequantize_uniform(
+            self.keys, self.values, self._idx, self.group_size, self.bits
         )
 
     def filter(self, batch_indices: mx.array):

--- a/mlx_vlm/models/cache.py
+++ b/mlx_vlm/models/cache.py
@@ -122,7 +122,10 @@ def _dequantize_uniform(keys_tuple, values_tuple, length, group_size, bits):
     """Dequantize uniform-quantized K/V tuples to raw float arrays.
 
     Shared by QuantizedKVCache and BatchQuantizedKVCache for APC storage.
+    Returns None, None if the cache is empty.
     """
+    if keys_tuple is None or values_tuple is None or length == 0:
+        return None, None
     keys = mx.dequantize(
         keys_tuple[0][..., :length, :],
         keys_tuple[1][..., :length, :],
@@ -223,7 +226,12 @@ class QuantizedKVCache(_BaseCache):
         return n
 
     def dequantize_for_apc(self):
-        """Return raw float (keys, values) sliced to current offset for APC storage."""
+        """Return raw float (keys, values) sliced to current offset for APC storage.
+
+        Returns (None, None) if the cache is empty.
+        """
+        if self.keys is None or self.offset == 0:
+            return None, None
         return _dequantize_uniform(
             self.keys, self.values, self.offset, self.group_size, self.bits
         )
@@ -1655,7 +1663,12 @@ class BatchQuantizedKVCache(_BaseCache):
         )
 
     def dequantize_for_apc(self):
-        """Return raw float (keys, values) sliced to current _idx for APC storage."""
+        """Return raw float (keys, values) sliced to current _idx for APC storage.
+
+        Returns (None, None) if the cache is empty.
+        """
+        if self.keys is None or self._idx == 0:
+            return None, None
         return _dequantize_uniform(
             self.keys, self.values, self._idx, self.group_size, self.bits
         )

--- a/mlx_vlm/tests/test_apc_quantized.py
+++ b/mlx_vlm/tests/test_apc_quantized.py
@@ -551,3 +551,125 @@ class TestBlockDecoupling:
         # Block should be unchanged
         assert _max_abs_error(blocks[0].keys[0], block_k_snapshot) == 0.0
         manager.release(blocks)
+
+
+# ---------------------------------------------------------------------------
+# Test 12: Empty-cache guard (regression for review finding #2)
+# ---------------------------------------------------------------------------
+
+
+class TestEmptyCacheGuard:
+    def test_dequantize_for_apc_returns_none_when_empty(self):
+        """dequantize_for_apc() returns (None, None) on an empty cache."""
+        cache = QuantizedKVCache(group_size=GROUP_SIZE, bits=BITS)
+        dk, dv = cache.dequantize_for_apc()
+        assert dk is None
+        assert dv is None
+
+    def test_batch_dequantize_for_apc_returns_none_when_empty(self):
+        """BatchQuantizedKVCache.dequantize_for_apc() returns (None, None) when empty."""
+        cache = BatchQuantizedKVCache([0], group_size=GROUP_SIZE, bits=BITS)
+        dk, dv = cache.dequantize_for_apc()
+        assert dk is None
+        assert dv is None
+
+    def test_harvest_handles_empty_quantized_cache(self):
+        """harvest_blocks_from_batch_cache returns [] for empty quantized caches."""
+        manager = APCManager(num_blocks=8, block_size=BLOCK_SIZE)
+        empty_cache = BatchQuantizedKVCache([0], group_size=GROUP_SIZE, bits=BITS)
+        token_ids = list(range(BLOCK_SIZE))
+        blocks = harvest_blocks_from_batch_cache(
+            manager, [empty_cache], batch_idx=0, full_token_ids=token_ids
+        )
+        assert blocks == []
+
+
+# ---------------------------------------------------------------------------
+# Test 13: Production path wires kv_quant_config (regression for review finding #1)
+# ---------------------------------------------------------------------------
+
+
+class TestProductionPathQuantConfig:
+    def test_make_warm_batch_kv_cache_multi_with_quant_config(self):
+        """make_warm_batch_kv_cache_multi creates BatchQuantizedKVCache when config is passed."""
+        from mlx_vlm.apc import make_warm_batch_kv_cache_multi
+
+        manager = APCManager(num_blocks=16, block_size=BLOCK_SIZE)
+        seq_len = 2 * BLOCK_SIZE
+
+        # Store blocks
+        lk = [_rand_kv(seq_len=seq_len)[0] for _ in range(2)]
+        lv = [_rand_kv(seq_len=seq_len)[1] for _ in range(2)]
+        mx.eval(lk + lv)
+
+        token_ids = list(range(seq_len))
+        blocks = manager.store_kv_blocks(token_ids, lk, lv)
+        manager.release(blocks)
+
+        matched, _ = manager.lookup_prefix(token_ids)
+        picks = [{"matched_blocks": matched, "prefix_len": seq_len}]
+
+        quant_config = {"bits": BITS, "group_size": GROUP_SIZE}
+        warm, max_prefix = make_warm_batch_kv_cache_multi(
+            picks, num_layers=2, kv_quant_config=quant_config
+        )
+
+        assert max_prefix == seq_len
+        assert len(warm) == 2
+        for c in warm:
+            assert isinstance(c, BatchQuantizedKVCache)
+            assert c._idx == seq_len
+            assert c.bits == BITS
+        manager.release(matched)
+
+    def test_make_warm_batch_kv_cache_multi_without_quant_stays_plain(self):
+        """Without kv_quant_config, make_warm_batch_kv_cache_multi returns BatchKVCache."""
+        from mlx_vlm.apc import make_warm_batch_kv_cache_multi
+        from mlx_vlm.models.cache import BatchKVCache
+
+        manager = APCManager(num_blocks=16, block_size=BLOCK_SIZE)
+        seq_len = 2 * BLOCK_SIZE
+
+        lk = [_rand_kv(seq_len=seq_len)[0] for _ in range(2)]
+        lv = [_rand_kv(seq_len=seq_len)[1] for _ in range(2)]
+        mx.eval(lk + lv)
+
+        token_ids = list(range(seq_len))
+        blocks = manager.store_kv_blocks(token_ids, lk, lv)
+        manager.release(blocks)
+
+        matched, _ = manager.lookup_prefix(token_ids)
+        picks = [{"matched_blocks": matched, "prefix_len": seq_len}]
+
+        warm, max_prefix = make_warm_batch_kv_cache_multi(
+            picks, num_layers=2, kv_quant_config=None
+        )
+
+        assert len(warm) == 2
+        for c in warm:
+            assert isinstance(c, BatchKVCache)
+        manager.release(matched)
+
+    def test_int_coercion_on_float_bits(self):
+        """Float bits value (e.g. 8.0 from JSON) doesn't crash."""
+        manager = APCManager(num_blocks=8, block_size=BLOCK_SIZE)
+        seq_len = BLOCK_SIZE
+
+        lk = [_rand_kv(seq_len=seq_len)[0]]
+        lv = [_rand_kv(seq_len=seq_len)[1]]
+        mx.eval(lk + lv)
+
+        token_ids = list(range(seq_len))
+        blocks = manager.store_kv_blocks(token_ids, lk, lv)
+        manager.release(blocks)
+
+        matched, _ = manager.lookup_prefix(token_ids)
+        # Simulate JSON-parsed config with float values
+        quant_config = {"bits": 8.0, "group_size": 32.0}
+        warm = make_warm_kv_cache(matched, kv_quant_config=quant_config)
+
+        assert len(warm) == 1
+        assert isinstance(warm[0], QuantizedKVCache)
+        assert warm[0].bits == 8
+        assert warm[0].group_size == 32
+        manager.release(matched)

--- a/mlx_vlm/tests/test_apc_quantized.py
+++ b/mlx_vlm/tests/test_apc_quantized.py
@@ -687,3 +687,212 @@ class TestProductionPathQuantConfig:
         assert warm[0].bits == 8
         assert warm[0].group_size == 32
         manager.release(matched)
+
+
+# ---------------------------------------------------------------------------
+# Test 14: Multi-row batch with mixed warm/cold rows
+# ---------------------------------------------------------------------------
+
+
+class TestMultiRowMixedWarmCold:
+    def test_mixed_picks_produces_correct_types_and_shapes(self):
+        """make_warm_batch_kv_cache_multi with some None picks (cold) works.
+
+        This is the exact production scenario: some rows hit APC (warm),
+        others miss (cold, get zero-padded). All rows must produce the
+        same cache type so extend() works.
+        """
+        from mlx_vlm.apc import make_warm_batch_kv_cache_multi
+
+        manager = APCManager(num_blocks=16, block_size=BLOCK_SIZE)
+        seq_len = 2 * BLOCK_SIZE
+        num_layers = 2
+
+        lk = [_rand_kv(seq_len=seq_len)[0] for _ in range(num_layers)]
+        lv = [_rand_kv(seq_len=seq_len)[1] for _ in range(num_layers)]
+        mx.eval(lk + lv)
+
+        token_ids = list(range(seq_len))
+        blocks = manager.store_kv_blocks(token_ids, lk, lv)
+        manager.release(blocks)
+
+        matched, _ = manager.lookup_prefix(token_ids)
+
+        # Row 0 = warm (APC hit), Row 1 = cold (miss)
+        picks = [
+            {"matched_blocks": matched, "prefix_len": seq_len},
+            None,
+        ]
+
+        quant_config = {"bits": BITS, "group_size": GROUP_SIZE}
+        warm, max_prefix = make_warm_batch_kv_cache_multi(
+            picks, num_layers=num_layers, kv_quant_config=quant_config
+        )
+
+        assert max_prefix == seq_len
+        assert len(warm) == num_layers
+        for c in warm:
+            assert isinstance(c, BatchQuantizedKVCache)
+            # _idx covers the full max_prefix (warm row content + cold row zeros)
+            assert c._idx == max_prefix
+            # left_padding: row 0 has 0 (full hit), row 1 has max_prefix (all cold)
+            lp = c.left_padding.tolist()
+            assert lp[0] == 0
+            assert lp[1] == max_prefix
+        manager.release(matched)
+
+    def test_mixed_picks_without_quant_produces_batch_kv_cache(self):
+        """Without quant config, mixed warm/cold still produces BatchKVCache."""
+        from mlx_vlm.apc import make_warm_batch_kv_cache_multi
+        from mlx_vlm.models.cache import BatchKVCache
+
+        manager = APCManager(num_blocks=16, block_size=BLOCK_SIZE)
+        seq_len = 2 * BLOCK_SIZE
+
+        lk = [_rand_kv(seq_len=seq_len)[0] for _ in range(2)]
+        lv = [_rand_kv(seq_len=seq_len)[1] for _ in range(2)]
+        mx.eval(lk + lv)
+
+        token_ids = list(range(seq_len))
+        blocks = manager.store_kv_blocks(token_ids, lk, lv)
+        manager.release(blocks)
+
+        matched, _ = manager.lookup_prefix(token_ids)
+        picks = [{"matched_blocks": matched, "prefix_len": seq_len}, None]
+
+        warm, _ = make_warm_batch_kv_cache_multi(
+            picks, num_layers=2, kv_quant_config=None
+        )
+
+        for c in warm:
+            assert isinstance(c, BatchKVCache)
+        manager.release(matched)
+
+
+# ---------------------------------------------------------------------------
+# Test 15: Harvest from batch_idx > 0
+# ---------------------------------------------------------------------------
+
+
+class TestHarvestNonZeroBatchIdx:
+    def test_harvest_batch_idx_1(self):
+        """harvest_blocks_from_batch_cache correctly extracts row 1 from multi-row cache."""
+        manager = APCManager(num_blocks=8, block_size=BLOCK_SIZE)
+        seq_len = BLOCK_SIZE
+        num_layers = 2
+
+        # Create a 2-row batch cache with different values per row
+        row0_k, row0_v = _rand_kv(batch=1, seq_len=seq_len)
+        row1_k, row1_v = _rand_kv(batch=1, seq_len=seq_len)
+        batch_k = mx.concatenate([row0_k, row1_k], axis=0)  # [2, H, seq_len, D]
+        batch_v = mx.concatenate([row0_v, row1_v], axis=0)
+        mx.eval(batch_k, batch_v)
+
+        batch_caches = []
+        for _ in range(num_layers):
+            c = BatchQuantizedKVCache([0, 0], group_size=GROUP_SIZE, bits=BITS)
+            c.update_and_fetch(batch_k, batch_v)
+            mx.eval(c.keys)
+            batch_caches.append(c)
+
+        # Harvest row 1 (not row 0)
+        token_ids = list(range(seq_len))
+        blocks = harvest_blocks_from_batch_cache(
+            manager, batch_caches, batch_idx=1, full_token_ids=token_ids
+        )
+
+        assert len(blocks) == 1
+        # Block should contain row 1's data, not row 0's
+        harvested_k = blocks[0].keys[0]
+        mx.eval(harvested_k)
+        # Verify it's closer to row1 than row0
+        error_vs_row1 = _max_abs_error(harvested_k, row1_k)
+        error_vs_row0 = _max_abs_error(harvested_k, row0_k)
+        assert error_vs_row1 < 0.1  # should match row1 within quant tolerance
+        assert error_vs_row0 > error_vs_row1  # should NOT match row0
+        manager.release(blocks)
+
+    def test_harvest_batch_idx_1_with_left_padding(self):
+        """Harvest row 1 with different left-padding per row."""
+        manager = APCManager(num_blocks=8, block_size=BLOCK_SIZE)
+        content_len = BLOCK_SIZE
+        num_layers = 2
+
+        # Row 0: left_pad=0, Row 1: left_pad=5
+        left_padding = [0, 5]
+        total_len = content_len + 5  # both rows same buffer length
+
+        batch_k = mx.random.normal((2, H, total_len, D))
+        batch_v = mx.random.normal((2, H, total_len, D))
+        mx.eval(batch_k, batch_v)
+
+        batch_caches = []
+        for _ in range(num_layers):
+            c = BatchQuantizedKVCache(left_padding, group_size=GROUP_SIZE, bits=BITS)
+            c.update_and_fetch(batch_k, batch_v)
+            mx.eval(c.keys)
+            batch_caches.append(c)
+
+        # Harvest row 1 — should skip 5 left-padding tokens
+        token_ids = list(range(content_len))
+        blocks = harvest_blocks_from_batch_cache(
+            manager, batch_caches, batch_idx=1, full_token_ids=token_ids
+        )
+
+        assert len(blocks) == 1
+        # Row 1 has content_len tokens after skipping left_pad=5
+        assert blocks[0].keys[0].shape[2] == BLOCK_SIZE
+        manager.release(blocks)
+
+
+# ---------------------------------------------------------------------------
+# Test 16: Type homogeneity — warm and cold caches are same type for extend()
+# ---------------------------------------------------------------------------
+
+
+class TestCacheTypeHomogeneity:
+    def test_warm_quantized_matches_cold_quantized_type(self):
+        """Warm APC cache (with kv_quant_config) is same type as cold cache from _make_cache.
+
+        This ensures extend() won't crash when merging warm and cold batches.
+        """
+        from mlx_vlm.apc import make_warm_batch_kv_cache_multi
+        from mlx_vlm.generate.ar import _make_cache
+        from mlx_vlm.models.cache import BatchQuantizedKVCache
+
+        manager = APCManager(num_blocks=16, block_size=BLOCK_SIZE)
+        seq_len = 2 * BLOCK_SIZE
+
+        lk = [_rand_kv(seq_len=seq_len)[0] for _ in range(2)]
+        lv = [_rand_kv(seq_len=seq_len)[1] for _ in range(2)]
+        mx.eval(lk + lv)
+
+        token_ids = list(range(seq_len))
+        blocks = manager.store_kv_blocks(token_ids, lk, lv)
+        manager.release(blocks)
+
+        matched, _ = manager.lookup_prefix(token_ids)
+        picks = [{"matched_blocks": matched, "prefix_len": seq_len}]
+
+        quant_config = {"bits": BITS, "group_size": GROUP_SIZE}
+        warm, _ = make_warm_batch_kv_cache_multi(
+            picks, num_layers=2, kv_quant_config=quant_config
+        )
+
+        # Simulate what cold path produces
+        class FakeModel:
+            class layers:
+                pass
+
+            layers = [None, None]
+
+        cold = _make_cache(FakeModel(), [0], kv_bits=BITS, kv_group_size=GROUP_SIZE)
+
+        # Both should be the same type
+        for warm_layer, cold_layer in zip(warm, cold):
+            assert type(warm_layer) == type(cold_layer), (
+                f"Type mismatch: warm={type(warm_layer).__name__}, "
+                f"cold={type(cold_layer).__name__}"
+            )
+            assert isinstance(warm_layer, BatchQuantizedKVCache)
+        manager.release(matched)

--- a/mlx_vlm/tests/test_apc_quantized.py
+++ b/mlx_vlm/tests/test_apc_quantized.py
@@ -1,0 +1,553 @@
+"""Tests for APC integration with quantized KV caches.
+
+Uses real QuantizedKVCache and BatchQuantizedKVCache objects with small
+dimensions. No mocking of cache behavior — these tests exercise the same
+code paths production uses.
+
+TDD: written BEFORE the implementation. Each test targets a specific
+behavior required for issue #1174 (APC + KV-cache quantization).
+"""
+
+from __future__ import annotations
+
+import mlx.core as mx
+
+from mlx_vlm.apc import (
+    APCManager,
+    _cache_entry_supports_block_apc,
+    _cache_entry_supports_exact_apc,
+    harvest_blocks_from_batch_cache,
+    make_warm_batch_kv_cache,
+    make_warm_kv_cache,
+    model_apc_mode,
+)
+from mlx_vlm.models.cache import BatchQuantizedKVCache, KVCache, QuantizedKVCache
+
+# Small dimensions: fast tests, no GPU pressure
+B, H, D = 1, 2, 32
+GROUP_SIZE = 32
+BITS = 8
+BLOCK_SIZE = 16
+
+
+def _rand_kv(batch=B, seq_len=32, heads=H, dim=D):
+    """Generate random K/V tensors with realistic scale."""
+    k = mx.random.normal((batch, heads, seq_len, dim))
+    v = mx.random.normal((batch, heads, seq_len, dim))
+    mx.eval(k, v)
+    return k, v
+
+
+def _max_abs_error(a: mx.array, b: mx.array) -> float:
+    return mx.max(mx.abs(a - b)).item()
+
+
+# ---------------------------------------------------------------------------
+# Test 1: QuantizedKVCache.dequantize_for_apc() roundtrip
+# ---------------------------------------------------------------------------
+
+
+class TestQuantizedCacheDequantize:
+    def test_roundtrip_within_tolerance(self):
+        """quantize → dequantize produces values within 8-bit tolerance."""
+        cache = QuantizedKVCache(group_size=GROUP_SIZE, bits=BITS)
+        k, v = _rand_kv(seq_len=64)
+        cache.update_and_fetch(k, v)
+
+        dk, dv = cache.dequantize_for_apc()
+        mx.eval(dk, dv)
+
+        assert dk.shape == k.shape
+        assert dv.shape == v.shape
+        assert dk.dtype in (mx.float16, mx.float32, mx.bfloat16)
+        # 8-bit quantization: max error should be small
+        assert _max_abs_error(dk, k) < 0.1
+        assert _max_abs_error(dv, v) < 0.1
+
+    def test_respects_offset(self):
+        """dequantize_for_apc() returns only tokens up to offset, not full buffer."""
+        cache = QuantizedKVCache(group_size=GROUP_SIZE, bits=BITS)
+        k, v = _rand_kv(seq_len=10)
+        cache.update_and_fetch(k, v)
+
+        dk, dv = cache.dequantize_for_apc()
+        mx.eval(dk, dv)
+
+        # Should be 10 tokens, not the full 256-step allocation
+        assert dk.shape[2] == 10
+        assert dv.shape[2] == 10
+
+    def test_incremental_fill(self):
+        """Works correctly after multiple update_and_fetch calls."""
+        cache = QuantizedKVCache(group_size=GROUP_SIZE, bits=BITS)
+        k1, v1 = _rand_kv(seq_len=20)
+        k2, v2 = _rand_kv(seq_len=12)
+        cache.update_and_fetch(k1, v1)
+        cache.update_and_fetch(k2, v2)
+
+        dk, dv = cache.dequantize_for_apc()
+        mx.eval(dk, dv)
+
+        assert dk.shape[2] == 32  # 20 + 12
+        assert dv.shape[2] == 32
+        # First 20 tokens should approximate k1
+        assert _max_abs_error(dk[:, :, :20, :], k1) < 0.1
+
+
+# ---------------------------------------------------------------------------
+# Test 2: BatchQuantizedKVCache.dequantize_for_apc()
+# ---------------------------------------------------------------------------
+
+
+class TestBatchQuantizedCacheDequantize:
+    def test_roundtrip(self):
+        """Batch quantized cache dequantize roundtrip."""
+        cache = BatchQuantizedKVCache([0], group_size=GROUP_SIZE, bits=BITS)
+        k, v = _rand_kv(batch=1, seq_len=48)
+        cache.update_and_fetch(k, v)
+
+        dk, dv = cache.dequantize_for_apc()
+        mx.eval(dk, dv)
+
+        assert dk.shape == (1, H, 48, D)
+        assert dv.shape == (1, H, 48, D)
+        assert _max_abs_error(dk, k) < 0.1
+        assert _max_abs_error(dv, v) < 0.1
+
+    def test_respects_idx(self):
+        """Returns only up to _idx, not full allocation."""
+        cache = BatchQuantizedKVCache([0], group_size=GROUP_SIZE, bits=BITS)
+        k, v = _rand_kv(batch=1, seq_len=7)
+        cache.update_and_fetch(k, v)
+
+        dk, dv = cache.dequantize_for_apc()
+        mx.eval(dk, dv)
+
+        assert dk.shape[2] == 7
+        assert dv.shape[2] == 7
+
+
+# ---------------------------------------------------------------------------
+# Test 3: harvest_blocks_from_batch_cache with quantized caches
+# This is THE test that catches issue #1174's crash.
+# ---------------------------------------------------------------------------
+
+
+class TestHarvestFromQuantizedCache:
+    def test_does_not_crash(self):
+        """harvest_blocks_from_batch_cache works with BatchQuantizedKVCache.
+
+        Previously crashed with: TypeError on keys[batch_idx:...] because
+        .keys is a tuple (packed, scales, biases), not an array.
+        """
+        manager = APCManager(num_blocks=8, block_size=BLOCK_SIZE)
+        seq_len = 2 * BLOCK_SIZE  # 32 tokens = 2 full blocks
+
+        cache = BatchQuantizedKVCache([0], group_size=GROUP_SIZE, bits=BITS)
+        k, v = _rand_kv(batch=1, seq_len=seq_len)
+        cache.update_and_fetch(k, v)
+        mx.eval(cache.keys)
+
+        num_layers = 4
+        batch_caches = [
+            BatchQuantizedKVCache([0], group_size=GROUP_SIZE, bits=BITS)
+            for _ in range(num_layers)
+        ]
+        for c in batch_caches:
+            ki, vi = _rand_kv(batch=1, seq_len=seq_len)
+            c.update_and_fetch(ki, vi)
+            mx.eval(c.keys)
+
+        token_ids = list(range(seq_len))
+        blocks = harvest_blocks_from_batch_cache(
+            manager, batch_caches, batch_idx=0, full_token_ids=token_ids
+        )
+
+        assert len(blocks) == 2  # 32 tokens / 16 block_size
+        for block in blocks:
+            assert len(block.keys) == num_layers
+            assert len(block.values) == num_layers
+            for k_layer in block.keys:
+                assert isinstance(k_layer, mx.array)
+                assert k_layer.shape == (1, H, BLOCK_SIZE, D)
+            for v_layer in block.values:
+                assert isinstance(v_layer, mx.array)
+                assert v_layer.shape == (1, H, BLOCK_SIZE, D)
+        manager.release(blocks)
+
+    def test_harvested_values_approximate_originals(self):
+        """Harvested float blocks approximate the original input values."""
+        manager = APCManager(num_blocks=8, block_size=BLOCK_SIZE)
+        seq_len = BLOCK_SIZE  # 1 full block
+
+        original_k, original_v = _rand_kv(batch=1, seq_len=seq_len)
+
+        batch_caches = []
+        for _ in range(2):
+            c = BatchQuantizedKVCache([0], group_size=GROUP_SIZE, bits=BITS)
+            c.update_and_fetch(original_k, original_v)
+            mx.eval(c.keys)
+            batch_caches.append(c)
+
+        token_ids = list(range(seq_len))
+        blocks = harvest_blocks_from_batch_cache(
+            manager, batch_caches, batch_idx=0, full_token_ids=token_ids
+        )
+
+        assert len(blocks) == 1
+        # Harvested block should approximate the original
+        assert _max_abs_error(blocks[0].keys[0], original_k) < 0.1
+        assert _max_abs_error(blocks[0].values[0], original_v) < 0.1
+        manager.release(blocks)
+
+    def test_with_left_padding(self):
+        """Left-padding is correctly handled when harvesting from quantized cache."""
+        manager = APCManager(num_blocks=8, block_size=BLOCK_SIZE)
+        left_pad = 3
+        content_len = 2 * BLOCK_SIZE  # enough for 2 blocks after removing padding
+
+        cache = BatchQuantizedKVCache([left_pad], group_size=GROUP_SIZE, bits=BITS)
+        k, v = _rand_kv(batch=1, seq_len=content_len + left_pad)
+        cache.update_and_fetch(k, v)
+        mx.eval(cache.keys)
+
+        batch_caches = [cache, cache]  # 2 layers, same data for simplicity
+        token_ids = list(range(content_len))
+        blocks = harvest_blocks_from_batch_cache(
+            manager, batch_caches, batch_idx=0, full_token_ids=token_ids
+        )
+
+        # 2 * BLOCK_SIZE content tokens = 2 full blocks
+        assert len(blocks) == 2
+        for block in blocks:
+            for k_layer in block.keys:
+                assert k_layer.shape[2] == BLOCK_SIZE
+        manager.release(blocks)
+
+
+# ---------------------------------------------------------------------------
+# Test 4: make_warm_kv_cache with quantization config
+# ---------------------------------------------------------------------------
+
+
+class TestRestoreIntoQuantizedCache:
+    def test_creates_quantized_cache(self):
+        """make_warm_kv_cache with kv_quant_config returns QuantizedKVCache."""
+        manager = APCManager(num_blocks=8, block_size=BLOCK_SIZE)
+        seq_len = 2 * BLOCK_SIZE
+
+        # Store blocks from plain float K/V
+        layer_keys, layer_values = _rand_kv(seq_len=seq_len)
+        # Duplicate for 3 layers
+        lk = [layer_keys, mx.array(layer_keys), mx.array(layer_keys)]
+        lv = [layer_values, mx.array(layer_values), mx.array(layer_values)]
+        mx.eval(lk + lv)
+
+        token_ids = list(range(seq_len))
+        blocks = manager.store_kv_blocks(token_ids, lk, lv)
+        manager.release(blocks)
+
+        matched, matched_tokens = manager.lookup_prefix(token_ids)
+        assert matched_tokens == seq_len
+
+        quant_config = {"bits": BITS, "group_size": GROUP_SIZE}
+        warm = make_warm_kv_cache(matched, kv_quant_config=quant_config)
+
+        assert len(warm) == 3
+        for c in warm:
+            assert isinstance(c, QuantizedKVCache)
+            assert c.offset == seq_len
+            assert c.bits == BITS
+            assert c.group_size == GROUP_SIZE
+        manager.release(matched)
+
+    def test_restored_values_approximate_stored(self):
+        """Restored quantized cache dequantizes back to stored values."""
+        manager = APCManager(num_blocks=8, block_size=BLOCK_SIZE)
+        seq_len = BLOCK_SIZE
+
+        layer_keys, layer_values = _rand_kv(seq_len=seq_len)
+        lk = [layer_keys]
+        lv = [layer_values]
+        mx.eval(lk + lv)
+
+        token_ids = list(range(seq_len))
+        blocks = manager.store_kv_blocks(token_ids, lk, lv)
+        manager.release(blocks)
+
+        matched, _ = manager.lookup_prefix(token_ids)
+        quant_config = {"bits": BITS, "group_size": GROUP_SIZE}
+        warm = make_warm_kv_cache(matched, kv_quant_config=quant_config)
+
+        dk, dv = warm[0].dequantize_for_apc()
+        mx.eval(dk, dv)
+
+        # One quantization cycle on restore
+        assert _max_abs_error(dk, layer_keys) < 0.1
+        assert _max_abs_error(dv, layer_values) < 0.1
+        manager.release(matched)
+
+
+# ---------------------------------------------------------------------------
+# Test 5: Full store→lookup→restore roundtrip with quantized caches
+# ---------------------------------------------------------------------------
+
+
+class TestFullRoundtripQuantized:
+    def test_store_quantized_lookup_restore_quantized(self):
+        """End-to-end: harvest from quantized → store → lookup → restore into quantized.
+
+        Two quantization cycles (harvest dequant + restore requant).
+        """
+        manager = APCManager(num_blocks=16, block_size=BLOCK_SIZE)
+        seq_len = 3 * BLOCK_SIZE
+        num_layers = 2
+
+        # Simulate prefill: fill quantized batch caches
+        originals_k = []
+        originals_v = []
+        batch_caches = []
+        for _ in range(num_layers):
+            c = BatchQuantizedKVCache([0], group_size=GROUP_SIZE, bits=BITS)
+            k, v = _rand_kv(batch=1, seq_len=seq_len)
+            c.update_and_fetch(k, v)
+            mx.eval(c.keys)
+            originals_k.append(k)
+            originals_v.append(v)
+            batch_caches.append(c)
+
+        # Harvest
+        token_ids = list(range(seq_len))
+        blocks = harvest_blocks_from_batch_cache(
+            manager, batch_caches, batch_idx=0, full_token_ids=token_ids
+        )
+        assert len(blocks) == 3
+        manager.release(blocks)
+
+        # Lookup
+        matched, matched_tokens = manager.lookup_prefix(token_ids)
+        assert matched_tokens == seq_len
+
+        # Restore into quantized
+        quant_config = {"bits": BITS, "group_size": GROUP_SIZE}
+        warm = make_warm_kv_cache(matched, kv_quant_config=quant_config)
+
+        assert len(warm) == num_layers
+        for i, c in enumerate(warm):
+            assert isinstance(c, QuantizedKVCache)
+            assert c.offset == seq_len
+            dk, dv = c.dequantize_for_apc()
+            mx.eval(dk, dv)
+            # Two quant cycles: slightly more error but still bounded
+            assert _max_abs_error(dk, originals_k[i]) < 0.2
+            assert _max_abs_error(dv, originals_v[i]) < 0.2
+        manager.release(matched)
+
+    def test_restored_cache_accepts_new_tokens(self):
+        """Restored quantized cache can accept additional tokens via update_and_fetch."""
+        manager = APCManager(num_blocks=8, block_size=BLOCK_SIZE)
+        seq_len = BLOCK_SIZE
+
+        cache = BatchQuantizedKVCache([0], group_size=GROUP_SIZE, bits=BITS)
+        k, v = _rand_kv(batch=1, seq_len=seq_len)
+        cache.update_and_fetch(k, v)
+        mx.eval(cache.keys)
+
+        token_ids = list(range(seq_len))
+        blocks = harvest_blocks_from_batch_cache(
+            manager, [cache], batch_idx=0, full_token_ids=token_ids
+        )
+        manager.release(blocks)
+
+        matched, _ = manager.lookup_prefix(token_ids)
+        quant_config = {"bits": BITS, "group_size": GROUP_SIZE}
+        warm = make_warm_kv_cache(matched, kv_quant_config=quant_config)
+
+        # Feed more tokens into the restored cache
+        new_k, new_v = _rand_kv(batch=1, seq_len=5)
+        warm[0].update_and_fetch(new_k, new_v)
+        assert warm[0].offset == seq_len + 5
+        manager.release(matched)
+
+
+# ---------------------------------------------------------------------------
+# Test 6: _cache_entry_supports_* with quantized types
+# ---------------------------------------------------------------------------
+
+
+class TestCacheEntrySupport:
+    def test_quantized_supports_block_apc(self):
+        """QuantizedKVCache should be recognized as block-APC compatible."""
+        cache = QuantizedKVCache(group_size=GROUP_SIZE, bits=BITS)
+        assert _cache_entry_supports_block_apc(cache) is True
+
+    def test_quantized_supports_exact_apc(self):
+        """QuantizedKVCache should be recognized as exact-APC compatible."""
+        cache = QuantizedKVCache(group_size=GROUP_SIZE, bits=BITS)
+        assert _cache_entry_supports_exact_apc(cache) is True
+
+    def test_plain_kv_still_works(self):
+        """Existing KVCache support is not broken."""
+        cache = KVCache()
+        assert _cache_entry_supports_block_apc(cache) is True
+        assert _cache_entry_supports_exact_apc(cache) is True
+
+
+# ---------------------------------------------------------------------------
+# Test 7: make_warm_batch_kv_cache with quantized config
+# ---------------------------------------------------------------------------
+
+
+class TestMakeWarmBatchQuantized:
+    def test_creates_batch_quantized_cache(self):
+        """make_warm_batch_kv_cache with kv_quant_config returns BatchQuantizedKVCache."""
+        manager = APCManager(num_blocks=8, block_size=BLOCK_SIZE)
+        seq_len = 2 * BLOCK_SIZE
+        num_layers = 2
+
+        lk = []
+        lv = []
+        for _ in range(num_layers):
+            k, v = _rand_kv(seq_len=seq_len)
+            lk.append(k)
+            lv.append(v)
+        mx.eval(lk + lv)
+
+        token_ids = list(range(seq_len))
+        blocks = manager.store_kv_blocks(token_ids, lk, lv)
+        manager.release(blocks)
+
+        matched, _ = manager.lookup_prefix(token_ids)
+        quant_config = {"bits": BITS, "group_size": GROUP_SIZE}
+        warm = make_warm_batch_kv_cache(matched, kv_quant_config=quant_config)
+
+        assert len(warm) == num_layers
+        for c in warm:
+            assert isinstance(c, BatchQuantizedKVCache)
+        manager.release(matched)
+
+
+# ---------------------------------------------------------------------------
+# Test 8: model_apc_mode with quantized caches
+# ---------------------------------------------------------------------------
+
+
+class TestModelApcModeQuantized:
+    def test_returns_block_for_quantized_model(self):
+        """model_apc_mode returns 'block' when make_cache produces QuantizedKVCache."""
+
+        class FakeModel:
+            def make_cache(self):
+                return [
+                    QuantizedKVCache(group_size=GROUP_SIZE, bits=BITS),
+                    QuantizedKVCache(group_size=GROUP_SIZE, bits=BITS),
+                ]
+
+        mode = model_apc_mode(FakeModel())
+        assert mode == "block"
+
+    def test_returns_exact_for_mixed_quantized_and_rotating(self):
+        """model_apc_mode returns 'exact' for mixed quantized + non-block-eligible."""
+        from mlx_vlm.models.cache import RotatingKVCache
+
+        class FakeHybridModel:
+            def make_cache(self):
+                return [
+                    QuantizedKVCache(group_size=GROUP_SIZE, bits=BITS),
+                    RotatingKVCache(max_size=128, keep=0),
+                    QuantizedKVCache(group_size=GROUP_SIZE, bits=BITS),
+                ]
+
+        mode = model_apc_mode(FakeHybridModel())
+        assert mode == "exact"
+
+
+# ---------------------------------------------------------------------------
+# Test 9: Guard removal regression test
+# ---------------------------------------------------------------------------
+
+
+class TestGuardRemoval:
+    def test_apc_not_disabled_when_kv_bits_set(self):
+        """The ar.py guard that kills APC when kv_bits is set must be removed.
+
+        Checks the source of BatchGenerator.__init__ to ensure the old pattern
+        'if apc_manager is not None and kv_bits is not None: apc_manager = None'
+        is no longer present.
+        """
+        import inspect
+
+        from mlx_vlm.generate.ar import BatchGenerator
+
+        source = inspect.getsource(BatchGenerator.__init__)
+        # The old guard unconditionally disabled APC when kv_bits was set
+        assert not (
+            "kv_bits is not None" in source and "apc_manager = None" in source
+        ), "Guard still disables APC when kv_bits is set"
+
+
+# ---------------------------------------------------------------------------
+# Test 10: Exact-mode store/restore with quantized entries
+# ---------------------------------------------------------------------------
+
+
+class TestExactModeQuantized:
+    def test_store_and_lookup_quantized_in_exact_cache(self):
+        """store_exact_cache / lookup_exact_cache works with QuantizedKVCache."""
+        manager = APCManager(num_blocks=4, block_size=BLOCK_SIZE)
+        token_ids = list(range(2 * BLOCK_SIZE))
+
+        # Build a prompt_cache with QuantizedKVCache entries
+        caches = []
+        for _ in range(2):
+            c = QuantizedKVCache(group_size=GROUP_SIZE, bits=BITS)
+            k, v = _rand_kv(seq_len=len(token_ids))
+            c.update_and_fetch(k, v)
+            caches.append(c)
+        mx.eval([c.keys for c in caches])
+
+        stored = manager.store_exact_cache(token_ids, caches, extra_hash=0)
+        assert stored is True
+
+        warm, matched_tokens = manager.lookup_exact_cache(
+            token_ids + [999], extra_hash=0
+        )
+        assert matched_tokens == len(token_ids)
+        assert warm is not None
+        assert len(warm) == 2
+
+
+# ---------------------------------------------------------------------------
+# Test 11: Stored blocks are decoupled from quantized source
+# ---------------------------------------------------------------------------
+
+
+class TestBlockDecoupling:
+    def test_harvested_blocks_independent_of_source_cache(self):
+        """After harvest, mutating the source cache doesn't affect stored blocks."""
+        manager = APCManager(num_blocks=8, block_size=BLOCK_SIZE)
+        seq_len = BLOCK_SIZE
+
+        cache = BatchQuantizedKVCache([0], group_size=GROUP_SIZE, bits=BITS)
+        k, v = _rand_kv(batch=1, seq_len=seq_len)
+        cache.update_and_fetch(k, v)
+        mx.eval(cache.keys)
+
+        token_ids = list(range(seq_len))
+        blocks = harvest_blocks_from_batch_cache(
+            manager, [cache], batch_idx=0, full_token_ids=token_ids
+        )
+        assert len(blocks) == 1
+
+        # Snapshot block value before mutating source
+        block_k_snapshot = mx.array(blocks[0].keys[0])
+        mx.eval(block_k_snapshot)
+
+        # Mutate source cache by adding more tokens
+        k2, v2 = _rand_kv(batch=1, seq_len=10)
+        cache.update_and_fetch(k2, v2)
+        mx.eval(cache.keys)
+
+        # Block should be unchanged
+        assert _max_abs_error(blocks[0].keys[0], block_k_snapshot) == 0.0
+        manager.release(blocks)

--- a/mlx_vlm/tests/test_apc_quantized.py
+++ b/mlx_vlm/tests/test_apc_quantized.py
@@ -573,6 +573,20 @@ class TestEmptyCacheGuard:
         assert dk is None
         assert dv is None
 
+    def test_turboquant_dequantize_for_apc_returns_none_when_empty(self):
+        """TurboQuantKVCache.dequantize_for_apc() returns (None, None) when empty."""
+        from mlx_vlm.turboquant import BatchTurboQuantKVCache, TurboQuantKVCache
+
+        cache = TurboQuantKVCache(bits=4)
+        dk, dv = cache.dequantize_for_apc()
+        assert dk is None
+        assert dv is None
+
+        batch_cache = BatchTurboQuantKVCache([0], bits=4)
+        dk, dv = batch_cache.dequantize_for_apc()
+        assert dk is None
+        assert dv is None
+
     def test_harvest_handles_empty_quantized_cache(self):
         """harvest_blocks_from_batch_cache returns [] for empty quantized caches."""
         manager = APCManager(num_blocks=8, block_size=BLOCK_SIZE)

--- a/mlx_vlm/tests/test_apc_quantized.py
+++ b/mlx_vlm/tests/test_apc_quantized.py
@@ -16,12 +16,20 @@ from mlx_vlm.apc import (
     APCManager,
     _cache_entry_supports_block_apc,
     _cache_entry_supports_exact_apc,
+    _clone_cache_entry_for_apc,
+    _clone_prompt_cache_for_apc,
     harvest_blocks_from_batch_cache,
     make_warm_batch_kv_cache,
     make_warm_kv_cache,
     model_apc_mode,
 )
-from mlx_vlm.models.cache import BatchQuantizedKVCache, KVCache, QuantizedKVCache
+from mlx_vlm.models.cache import (
+    ArraysCache,
+    BatchKVCache,
+    BatchQuantizedKVCache,
+    KVCache,
+    QuantizedKVCache,
+)
 
 # Small dimensions: fast tests, no GPU pressure
 B, H, D = 1, 2, 32
@@ -515,6 +523,63 @@ class TestExactModeQuantized:
         assert matched_tokens == len(token_ids)
         assert warm is not None
         assert len(warm) == 2
+
+    def test_hybrid_batch_kv_and_quantized_exact_store(self):
+        """Exact store works for the --kv-bits hybrid layout (pinglin / #1534).
+
+        With kv-bits, single-row continuous-batching uses batch cache classes
+        even for B=1: ArraysCache (SSM) + BatchKVCache (unquantized last
+        attention layer) + BatchQuantizedKVCache. store_exact_cache must
+        clone this mix rather than silently returning False.
+        """
+        seq_len = 2 * BLOCK_SIZE
+        token_ids = list(range(seq_len))
+
+        arrays = ArraysCache(2)
+        arrays.cache = [
+            mx.zeros((1, seq_len, D)),
+            mx.zeros((1, seq_len, D)),
+        ]
+        arrays.left_padding = mx.array([0])
+
+        batch_kv = BatchKVCache([0])
+        k, v = _rand_kv(batch=1, seq_len=seq_len)
+        batch_kv.update_and_fetch(k, v)
+
+        batch_q = BatchQuantizedKVCache([0], group_size=GROUP_SIZE, bits=BITS)
+        kq, vq = _rand_kv(batch=1, seq_len=seq_len)
+        batch_q.update_and_fetch(kq, vq)
+        mx.eval(batch_kv.keys, batch_q.keys)
+
+        prompt_cache = [arrays, batch_kv, batch_q]
+        assert all(_cache_entry_supports_exact_apc(c) for c in prompt_cache)
+
+        # Clone path: BatchKVCache collapses to KVCache; quant dequants to KVCache.
+        eval_targets: list = []
+        cloned_bk = _clone_cache_entry_for_apc(
+            batch_kv, min_capacity_tokens=None, eval_targets=eval_targets
+        )
+        assert isinstance(cloned_bk, KVCache)
+        assert cloned_bk.offset == seq_len
+
+        cloned = _clone_prompt_cache_for_apc(prompt_cache)
+        assert cloned is not None
+        assert len(cloned) == 3
+        assert isinstance(cloned[0], ArraysCache)
+        assert isinstance(cloned[1], KVCache)
+        assert isinstance(cloned[2], KVCache)
+
+        manager = APCManager(num_blocks=4, block_size=BLOCK_SIZE)
+        stored = manager.store_exact_cache(token_ids, prompt_cache, extra_hash=0)
+        assert stored is True
+        assert manager.stats.exact_stores == 1
+
+        warm, matched_tokens = manager.lookup_exact_cache(
+            token_ids + [999], extra_hash=0
+        )
+        assert matched_tokens == len(token_ids)
+        assert warm is not None
+        assert len(warm) == 3
 
 
 # ---------------------------------------------------------------------------

--- a/mlx_vlm/turboquant.py
+++ b/mlx_vlm/turboquant.py
@@ -5116,6 +5116,10 @@ class TurboQuantKVCache(_BaseCache):
         values = self.value_codec.dequantize(values_state).astype(mx.float32)
         return keys, values
 
+    def dequantize_for_apc(self):
+        """Return raw float (keys, values) for APC storage."""
+        return self.dequantize()
+
     def _apply_attention_mask(
         self,
         scores: mx.array,
@@ -6292,6 +6296,10 @@ class BatchTurboQuantKVCache(_BaseCache):
         k = self.key_codec.dequantize(keys_state).astype(mx.float32)
         v = self.value_codec.dequantize(values_state).astype(mx.float32)
         return k, v
+
+    def dequantize_for_apc(self):
+        """Return raw float (keys, values) for APC storage."""
+        return self.dequantize()
 
     # ------------------------------------------------------------------
     # State / introspection

--- a/mlx_vlm/turboquant.py
+++ b/mlx_vlm/turboquant.py
@@ -5117,7 +5117,12 @@ class TurboQuantKVCache(_BaseCache):
         return keys, values
 
     def dequantize_for_apc(self):
-        """Return raw float (keys, values) for APC storage."""
+        """Return raw float (keys, values) for APC storage.
+
+        Returns (None, None) if the cache is empty.
+        """
+        if self.keys is None or self.offset == 0:
+            return None, None
         return self.dequantize()
 
     def _apply_attention_mask(
@@ -6298,7 +6303,12 @@ class BatchTurboQuantKVCache(_BaseCache):
         return k, v
 
     def dequantize_for_apc(self):
-        """Return raw float (keys, values) for APC storage."""
+        """Return raw float (keys, values) for APC storage.
+
+        Returns (None, None) if the cache is empty.
+        """
+        if self.keys is None or self._idx == 0:
+            return None, None
         return self.dequantize()
 
     # ------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Fixes #1174: APC was unconditionally disabled when `--kv-bits` was set, forcing full prefill on every request even with identical prompts
- Adds protocol-based adapter layer (`dequantize_for_apc()`) so quantized caches participate in APC harvest/restore without changing APC internals
- Restores quantized caches on APC hit (not plain float), preserving `--kv-bits` memory savings for the cached prefix

## Approach: Store Dequantized, Restore into Quantized

Thin adapters at the APC boundary. No changes to block format, disk serialization, hashing, or eviction.

**Store:** dequantize quantized K/V at harvest time, store as raw float tensors in APC blocks (same format APC already uses)

**Restore:** load raw float tensors from APC blocks, feed through `update_and_fetch()` which re-quantizes, model gets properly quantized cache

## Changes

- `mlx_vlm/models/cache.py`: Add `_dequantize_uniform()` helper + `dequantize_for_apc()` on `QuantizedKVCache` and `BatchQuantizedKVCache`
- `mlx_vlm/turboquant.py`: Add `dequantize_for_apc()` on `TurboQuantKVCache` and `BatchTurboQuantKVCache`
- `mlx_vlm/apc.py`: Protocol dispatch in `harvest_blocks_from_batch_cache`, `kv_quant_config` param on restore functions (`make_warm_kv_cache`, `make_warm_batch_kv_cache`, `make_warm_batch_kv_cache_multi`, `make_warm_kv_cache_from_layers`), expanded support checks, quantized clone for exact-mode
- `mlx_vlm/generate/ar.py`: Remove guard that killed APC when `kv_bits` was set; wire `kv_quant_config` into batch restore path
- `mlx_vlm/generate/dispatch.py`: Wire `kv_quant_config` into single-stream restore path

## Known limitations

- Exact-mode APC with `--kv-bits` on hybrid models (Gemma 4, Qwen 3.5) in multi-row batches: the exact-mode clone dequantizes to KVCache for storage, which may cause type mismatch with cold quantized caches in concurrent-batch scenarios. Block-mode (standard models) is fully handled.
- TurboQuant restore path creates uniform `BatchQuantizedKVCache`, not `BatchTurboQuantKVCache`. TurboQuant users get correct results but lose the custom codec on the restored prefix.

## Validation
- `uv run --with pytest pytest mlx_vlm/tests/test_apc_quantized.py -q`
- `uv run --with pytest pytest mlx_vlm/tests/test_apc.py -q` (no regressions)
- `uv run --with pytest pytest mlx_vlm/tests/test_apc_exact_mode.py -q` (no regressions)
- `uv run --with pytest pytest mlx_vlm/tests/test_batch_quantized_cache.py -q` (no regressions)
- `uv run --with pytest pytest mlx_vlm/tests/test_turboquant.py -q` (no regressions)

Ref: https://github.com/Blaizzy/mlx-vlm/issues/1174