### PR TITLE
add gemma3_text model type reusing gemma3 language internals

### DIFF
--- a/mlx_vlm/models/gemma3_text/__init__.py
+++ b/mlx_vlm/models/gemma3_text/__init__.py
@@ -1,0 +1,4 @@
+from .config import ModelConfig
+from .gemma3_text import Model
+
+__all__ = ["Model", "ModelConfig"]

--- a/mlx_vlm/models/gemma3_text/config.py
+++ b/mlx_vlm/models/gemma3_text/config.py
@@ -1,0 +1,8 @@
+from dataclasses import dataclass
+
+from ..gemma3.config import TextConfig
+
+
+@dataclass
+class ModelConfig(TextConfig):
+    pass

--- a/mlx_vlm/models/gemma3_text/gemma3_text.py
+++ b/mlx_vlm/models/gemma3_text/gemma3_text.py
@@ -1,0 +1,45 @@
+from typing import Optional
+
+import mlx.core as mx
+import mlx.nn as nn
+
+from ..base import InputEmbeddingsFeatures, LanguageModelOutput
+from ..gemma3.language import LanguageModel
+from .config import ModelConfig
+
+
+class Model(nn.Module):
+    def __init__(self, config: ModelConfig):
+        super().__init__()
+        self.config = config
+        self.model_type = config.model_type
+        self.language_model = LanguageModel(config)
+
+    def get_input_embeddings(
+        self,
+        input_ids: Optional[mx.array] = None,
+        pixel_values: Optional[mx.array] = None,
+        **kwargs,
+    ) -> InputEmbeddingsFeatures:
+        return InputEmbeddingsFeatures(
+            inputs_embeds=self.language_model.model.embed_tokens(input_ids)
+        )
+
+    def __call__(
+        self,
+        input_ids: mx.array,
+        pixel_values: mx.array = None,
+        mask: mx.array = None,
+        cache=None,
+        **kwargs,
+    ) -> LanguageModelOutput:
+        return self.language_model(input_ids, cache=cache, **kwargs)
+
+    def sanitize(self, weights):
+        if not any(k.startswith("language_model.") for k in weights):
+            weights = {f"language_model.{k}": v for k, v in weights.items()}
+        return self.language_model.sanitize(weights)
+
+    @property
+    def layers(self):
+        return self.language_model.layers

--- a/mlx_vlm/tests/test_models.py
+++ b/mlx_vlm/tests/test_models.py
@@ -767,6 +767,66 @@ class TestModels(unittest.TestCase):
         self.assertEqual(logits.shape, (1, 4, config.vocab_size))
         self.assertTrue(mx.all(mx.isfinite(logits)).item())
 
+    def test_gemma3_text_language_model(self):
+        from mlx_vlm.models import gemma3_text
+
+        config = gemma3_text.ModelConfig.from_dict(
+            {
+                "model_type": "gemma3_text",
+                "hidden_size": 64,
+                "num_hidden_layers": 6,
+                "intermediate_size": 128,
+                "num_attention_heads": 4,
+                "head_dim": 16,
+                "rms_norm_eps": 1e-6,
+                "vocab_size": 128,
+                "num_key_value_heads": 2,
+                "rope_global_base_freq": 1000000.0,
+                "rope_local_base_freq": 10000.0,
+                "query_pre_attn_scalar": 16,
+                "sliding_window": 8,
+                "sliding_window_pattern": 3,
+                "max_position_embeddings": 256,
+            }
+        )
+
+        model = gemma3_text.Model(config)
+
+        self.language_test_runner(
+            model.language_model,
+            config.model_type,
+            config.vocab_size,
+            config.num_hidden_layers,
+        )
+
+        cache = model.language_model.make_cache()
+        self.assertEqual(len(cache), config.num_hidden_layers)
+        self.assertEqual(type(cache[0]).__name__, "RotatingKVCache")
+        self.assertEqual(type(cache[2]).__name__, "KVCache")
+        self.assertEqual(type(cache[5]).__name__, "KVCache")
+
+        inputs = mx.array([[1, 2, 3]])
+        embeddings = model.get_input_embeddings(inputs)
+        self.assertEqual(embeddings.inputs_embeds.shape, (1, 3, config.hidden_size))
+
+        sanitized = model.sanitize(
+            {"model.embed_tokens.weight": mx.zeros((config.vocab_size, 64))}
+        )
+        self.assertIn("language_model.model.embed_tokens.weight", sanitized)
+        self.assertIn("language_model.lm_head.weight", sanitized)
+
+        resanitized = model.sanitize(dict(sanitized))
+        self.assertEqual(set(resanitized), set(sanitized))
+
+        logits = model(mx.array([[1, 2, 3, 4] * 4]), cache=cache).logits
+        self.assertEqual(logits.shape, (1, 16, config.vocab_size))
+        self.assertTrue(mx.all(mx.isfinite(logits)).item())
+
+        nxt = mx.argmax(logits[:, -1:, :], axis=-1)
+        logits = model(nxt, cache=cache).logits
+        self.assertEqual(logits.shape, (1, 1, config.vocab_size))
+        self.assertTrue(mx.all(mx.isfinite(logits)).item())
+
     def test_llava_bunny(self):
         from mlx_vlm.models import llava_bunny
 


### PR DESCRIPTION
 Refactor to move gemma3 text models from mlx-lm's dependency to full mlx-vlm native support

Gemma3 text-only checkpoints (gemma-3-1b etc.) now load and run natively through mlx-vlm instead of routing through the text_only.py mlx-lm fallback.

Verified bit-exact parity against mlx-lm's gemma3_text with shared weights (prefill at T=1/8/20/33, crossing the sliding window, and cached decode across the window boundary).

All tests gtg!