### PR TITLE
Fix batch_generate for different-length text-only prompts (left-padding)

### DIFF
--- a/mlx_vlm/generate.py
+++ b/mlx_vlm/generate.py
@@ -2588,6 +2588,7 @@ class PromptProcessingBatch:
         right_pad_per_row: Optional[List[int]] = None,
         suffix_lens: Optional[List[int]] = None,
         apc_mode: Optional[str] = None,
+        left_padding_override: Optional[List[int]] = None,
     ):
         self.model = model
         self.uids = uids
@@ -2610,6 +2611,20 @@ class PromptProcessingBatch:
             # right-pad and need to be rolled into left-pad by finalize()).
             left_padding = [0] * len(input_ids)
             self._input_ids = _right_pad_prompts(input_ids, max_length=max_length)
+        elif left_padding_override is not None:
+            # The caller supplied AUTHORITATIVE per-row left-padding. This is for callers that pre-pad the
+            # prompts to a uniform length BEFORE insert (e.g. batch_generate's text-only path, which
+            # tokenizes with padding=True) — there the rows are already equal length, so the length-derived
+            # value below would be all-zero and silently lose the real padding. The rows are already
+            # max_length so _left_pad_prompts is a no-op. Honored only OUTSIDE the APC right-pad branch, so
+            # existing behavior is unchanged for every caller that does not pass it.
+            if len(left_padding_override) != len(input_ids):
+                raise ValueError(
+                    f"left_padding_override has {len(left_padding_override)} entries "
+                    f"but there are {len(input_ids)} rows"
+                )
+            left_padding = list(left_padding_override)
+            self._input_ids = _left_pad_prompts(input_ids, max_length=max_length)
         else:
             left_padding = [max_length - l for l in lengths]
             self._input_ids = _left_pad_prompts(input_ids, max_length=max_length)
@@ -3078,6 +3093,11 @@ class BatchGenerator:
         )
         self._prompt_batch: Optional[PromptProcessingBatch] = None
         self._unprocessed_sequences = []
+        # Optional authoritative per-row left-padding, keyed by uid so it is immune to the length-sort
+        # (and any reorder) of _unprocessed_sequences and requires no change to that queue tuple. Set in
+        # insert(), popped when a row is drained into a prompt batch or removed. Empty for all existing
+        # callers -> behavior unchanged.
+        self._pending_left_padding: dict = {}
 
         self._prompt_tokens_counter = 0
         self._prompt_time_counter = 0
@@ -3410,6 +3430,7 @@ class BatchGenerator:
         logits_processors: Optional[
             List[Optional[List[Callable[[mx.array, mx.array], mx.array]]]]
         ] = None,
+        left_padding: Optional[List[int]] = None,
     ):
         uids = []
 
@@ -3422,9 +3443,21 @@ class BatchGenerator:
             logits_processors = [self.logits_processors] * len(prompts)
         elif len(logits_processors) != len(prompts):
             raise ValueError("Insufficient number of logits_processors provided")
+        # Optional per-row left-padding. Authoritative when the caller has pre-padded the prompts to a
+        # uniform length (so the length-derived value in PromptProcessingBatch would be all-zero and lose
+        # the real padding). Each row's value rides WITH its row inside the tuple through the length-sort
+        # below, so it can never desync from its sequence. Default None -> unchanged length-derivation.
+        if left_padding is None:
+            left_padding = [None] * len(prompts)
+        elif len(left_padding) != len(prompts):
+            raise ValueError("Insufficient number of left_padding entries provided")
 
-        for p, m, kw, lp in zip(prompts, max_tokens, prompt_kwargs, logits_processors):
+        for p, m, kw, lp, lpad in zip(
+            prompts, max_tokens, prompt_kwargs, logits_processors, left_padding
+        ):
             self._unprocessed_sequences.append((self.uid_count, p, m, kw, lp))
+            if lpad is not None:
+                self._pending_left_padding[self.uid_count] = lpad
             uids.append(self.uid_count)
             self.uid_count += 1
         # Sort in ascending order of length
@@ -3440,6 +3473,7 @@ class BatchGenerator:
             for i, (seq_uid, _, _, _, _) in enumerate(self._unprocessed_sequences):
                 if seq_uid == uid:
                     self._unprocessed_sequences.pop(i)
+                    self._pending_left_padding.pop(uid, None)
                     return True
 
             # Being prefilled
@@ -3538,6 +3572,11 @@ class BatchGenerator:
             # warm and cold rows prefill in a single forward pass.
             n = min(self.prefill_batch_size, len(self._unprocessed_sequences))
             sequences = self._unprocessed_sequences[:n]
+            # Pop any authoritative per-row left-padding for the drained uids (covers BOTH the APC and the
+            # cold paths, so nothing lingers in _pending_left_padding). Only the cold path consumes it.
+            drained_left_padding = {
+                s[0]: self._pending_left_padding.pop(s[0], None) for s in sequences
+            }
             if logger.isEnabledFor(logging.DEBUG) and os.environ.get("APC_DEBUG"):
                 logger.warning(
                     "APC admit n=%d (pending=%d)",
@@ -3574,6 +3613,14 @@ class BatchGenerator:
             max_tokens_list = [s[2] for s in sequences]
             prompt_kwargs_list = [s[3] for s in sequences]
             logits_processors = [s[4] for s in sequences]
+            # Per-row left-padding override (popped by uid above). Only forward it when at least one row
+            # supplied one; otherwise pass None so the length-derived behavior is unchanged.
+            left_padding_list = [drained_left_padding.get(s[0]) for s in sequences]
+            left_padding_override = (
+                left_padding_list
+                if any(v is not None for v in left_padding_list)
+                else None
+            )
 
             inputs_embeds, merged_kwargs = _merge_prefill_prompt_kwargs(
                 prompt_kwargs_list, input_ids
@@ -3597,6 +3644,7 @@ class BatchGenerator:
                 apc_meta=apc_meta,
                 apc_manager=self.apc_manager,
                 apc_mode=self.apc_mode,
+                left_padding_override=left_padding_override,
             )
             self._prompt_tokens_counter += self._prompt_batch.total_prompt_tokens
 
@@ -3898,11 +3946,29 @@ def _generate_batch(
             for _ in range(batch_size)
         ]
 
+    # Derive per-row left-padding from the tokenizer's attention_mask so the batched cache is pad-aware.
+    # The text-only path pre-pads the prompts to a uniform length (padding_side="left"); the rows are then
+    # equal length, so PromptProcessingBatch's length-derived left_padding is all-zero and the real padding
+    # is lost — the model attends over the pad tokens and the more-padded rows decode incorrectly. When
+    # there is no image and a 2D mask is present, the per-row leading-zero count IS the true left_padding
+    # (left padding => contiguous leading zeros). Model-agnostic: this only makes the correct padding
+    # available; each model's forward decides how to use it. Multimodal paths handle their own padding, so
+    # pass None there (behavior unchanged).
+    left_padding = None
+    if (
+        pixel_values is None
+        and mask is not None
+        and isinstance(mask, mx.array)
+        and mask.ndim == 2
+    ):
+        left_padding = (mask.shape[1] - mask.sum(axis=1)).astype(mx.int32).tolist()
+
     uids = gen.insert(
         input_ids.tolist(),
         max_tokens,
         prompt_kwargs=_split_prompt_kwargs_per_row(gen_kwargs, batch_size),
         logits_processors=logits_processors,
+        left_padding=left_padding,
     )
     results = {uid: [] for uid in uids}
 

--- a/mlx_vlm/models/qwen2_5_vl/language.py
+++ b/mlx_vlm/models/qwen2_5_vl/language.py
@@ -12,6 +12,31 @@ from ..cache import KVCache
 from .config import ModelConfig, TextConfig
 
 
+# --- Pad-aware helpers for left-padded batched text-only decode ---
+# When a batch of different-length text-only prompts is left-padded to a common length, the model must be
+# told which leading columns are padding — otherwise rope positions and causal attention treat the pad
+# tokens as real content and the more-padded rows decode incorrectly (or empty). These helpers, plus the
+# `_was_padded`-gated branches below, add that awareness while staying byte-identical to the stock forward
+# whenever there is no real padding (single / equal-length batches, where left_padding is all-zero).
+def _has_actual_padding(left_padding) -> bool:
+    """True iff any row carries REAL left-padding (>0). BatchGenerator sets left_padding=[0] even for a
+    single or equal-length batch, so `left_padding is not None` alone would fire the pad-aware path at
+    width-1 and perturb the sub-argmax numerics vs the unpadded stock forward. Type-guarded so a non-array
+    can never raise inside the hot forward; call at PREFILL only (where left_padding is authoritative)."""
+    return (
+        left_padding is not None
+        and hasattr(left_padding, "shape")
+        and bool((left_padding > 0).any().item())
+    )
+
+
+def _mask2d_from_left_padding(left_padding, length):
+    """2D [B, length] int key-padding mask: 0 at left-pad columns, 1 at real tokens — the layout
+    get_rope_index's mask-aware cumsum branch consumes."""
+    col = mx.arange(length)[None, :]
+    return (col >= left_padding[:, None]).astype(mx.int32)
+
+
 class Qwen2RotaryEmbedding:
     def __init__(
         self, dim, max_position_embeddings=2048, base=10000, rope_scaling=None
@@ -161,7 +186,12 @@ class Attention(nn.Module):
 
         cos, sin = self.rotary_emb(values, position_ids)
 
-        if mask is not None and isinstance(mask, mx.array):
+        # On a genuinely left-padded batch the mask slice must happen AFTER cache.update_and_fetch (full
+        # key length), else a [B,1,1,idx+1] decode mask truncates to width-1. Off the padded path
+        # (_vlm_was_padded False) keep the stock ordering (slice before update) so single / equal-length /
+        # image decode is byte-identical to the stock forward.
+        _was_padded = getattr(cache, "_vlm_was_padded", False)
+        if mask is not None and isinstance(mask, mx.array) and not _was_padded:
             mask = mask[..., : keys.shape[-2]]
         queries, keys = apply_multimodal_rotary_pos_emb(
             queries, keys, cos, sin, unqueeze_dim=1
@@ -169,6 +199,9 @@ class Attention(nn.Module):
 
         if cache is not None:
             keys, values = cache.update_and_fetch(keys, values)
+
+        if mask is not None and isinstance(mask, mx.array) and _was_padded:
+            mask = mask[..., : keys.shape[-2]]
 
         output = scaled_dot_product_attention(
             queries, keys, values, cache, scale=self.scale, mask=mask
@@ -243,6 +276,19 @@ class Qwen2Model(nn.Module):
 
         if cache is None:
             cache = [None] * len(self.layers)
+
+        # On a left-padded batch, build the mask from the cache's pad-aware make_mask instead of the
+        # pad-blind create_attention_mask (which receives `cache` as a LIST and produces a plain causal
+        # mask, blind to the left-padding). Off the padded path this is skipped -> stock
+        # create_attention_mask -> byte-identical.
+        if (
+            mask is None
+            and cache
+            and cache[0] is not None
+            and getattr(cache[0], "_vlm_was_padded", False)
+            and hasattr(cache[0], "make_mask")
+        ):
+            mask = cache[0].make_mask(int(h.shape[1]))
 
         if mask is None:
             mask = create_attention_mask(h, cache)
@@ -460,6 +506,33 @@ class LanguageModel(nn.Module):
         if pixel_values is not None:
             self._rope_deltas = None
             self._position_ids = None
+
+        # Left-padded batched text-only decode: gate on the sticky `_vlm_was_padded` flag. At PREFILL,
+        # decide + persist the flag ONCE (where left_padding is authoritative) and supply a 2D key-padding
+        # mask so get_rope_index takes the mask-aware cumsum branch; at DECODE, set per-row position_ids
+        # from max(offset, 0) so left-padded rows are positioned correctly. Off the padded path
+        # (single / equal-length / image) this is entirely skipped -> byte-identical to the stock forward.
+        if mask is None and cache and cache[0] is not None and inputs is not None:
+            _c0 = cache[0]
+            _lp = getattr(_c0, "left_padding", None)
+            _idx = getattr(_c0, "_idx", None)
+            if _lp is not None:
+                _L = int(inputs.shape[1])
+                if _L > 1 and _idx in (0, None):  # batched PREFILL: decide + stamp the flag
+                    _was_padded = getattr(_c0, "_vlm_was_padded", False) or _has_actual_padding(_lp)
+                    for _c in cache:  # stamp EVERY cache entry (the Attention gate reads it per-layer)
+                        if _c is not None:
+                            _c._vlm_was_padded = _was_padded
+                    if _was_padded:
+                        self._position_ids = None
+                        self._rope_deltas = None
+                        mask = _mask2d_from_left_padding(_lp, _L)
+                elif _L == 1 and _idx not in (0, None):  # batched DECODE: per-row position
+                    if getattr(_c0, "_vlm_was_padded", False):
+                        _off = getattr(_c0, "offset", None)
+                        if _off is not None and getattr(_off, "ndim", 0) > 0:
+                            _pos = mx.maximum(_off, 0).reshape(1, -1, 1)
+                            position_ids = mx.broadcast_to(_pos, (3, _pos.shape[1], 1))
 
         # Use ``_idx`` — the Python-int token counter maintained by
         # ``BatchKVCache`` — instead of syncing on ``cache[0].offset`` every

--- a/mlx_vlm/tests/test_batch_left_padding.py
+++ b/mlx_vlm/tests/test_batch_left_padding.py
@@ -1,0 +1,157 @@
+"""Tests for the batch_generate left-padding fix (text-only mixed-length batches).
+
+Bug: batch_generate tokenizes text-only prompts with padding=True/padding_side="left", producing a
+uniform-length batch, then hands it to BatchGenerator.insert. Because the rows are now equal length,
+PromptProcessingBatch derived left_padding = [max_len - len] = all-zero and lost the real padding, so the
+model ran pad-blind over the pad tokens and the more-padded rows decoded incorrectly / empty. Fix: derive
+the true per-row left_padding from the tokenizer's attention_mask and thread it (authoritative-when-provided)
+into the cache. Model-agnostic; backward compatible (unchanged when no left_padding is supplied).
+
+Model-gated tests use a local Qwen2.5-VL checkpoint if present, else skip.
+"""
+import os
+import tempfile
+from types import SimpleNamespace
+
+import mlx.core as mx
+import pytest
+
+from mlx_vlm.generate import BatchGenerator
+
+MODEL_PATH = os.environ.get("MLX_VLM_TEST_MODEL", "mlx-community/Qwen2.5-VL-3B-Instruct-4bit")
+
+
+# --------------------------- model-free invariant tests ---------------------------
+
+def test_left_padding_derivation_from_attention_mask():
+    """The derivation `left_padding = L - attention_mask.sum(axis=1)` recovers the true per-row
+    left-padding IFF the mask is binary with contiguous leading zeros (left padding). This locks the
+    invariant the fix relies on."""
+    # Rows with 2, 0, 3 leading pad columns (length 5).
+    mask = mx.array([[0, 0, 1, 1, 1], [1, 1, 1, 1, 1], [0, 0, 0, 1, 1]], dtype=mx.int32)
+    L = mask.shape[1]
+    left_padding = (L - mask.sum(axis=1)).astype(mx.int32).tolist()
+    assert left_padding == [2, 0, 3]
+    # Binary invariant: every entry is 0 or 1.
+    assert set(mask.reshape(-1).tolist()) <= {0, 1}
+    # Contiguous-leading-zeros invariant: once a 1 appears, no 0 follows (left padding only).
+    for row in mask.tolist():
+        seen_one = False
+        for v in row:
+            if v == 1:
+                seen_one = True
+            elif seen_one:
+                pytest.fail(f"non-contiguous / non-left padding in mask row {row}")
+
+
+def _bare_batch_generator():
+    """A BatchGenerator with only the attributes insert() touches (no model / weights)."""
+    bg = object.__new__(BatchGenerator)
+    bg.max_tokens = 16
+    bg.logits_processors = None
+    bg.uid_count = 0
+    bg._unprocessed_sequences = []
+    bg._pending_left_padding = {}
+    bg._wire_stack = None  # so __del__ -> close() doesn't AttributeError on GC of this bare object
+    return bg
+
+
+def test_insert_left_padding_survives_length_sort():
+    """insert() sorts the queue by prompt length. The per-row left_padding must stay bound to its own
+    sequence afterward. It is tracked by uid (sort-immune), so this verifies the plumbing end to end."""
+    bg = _bare_batch_generator()
+    prompts = [[1, 2, 3, 4], [1], [1, 2, 3, 4, 5, 6], [1, 2]]  # distinct lengths, deliberately unsorted
+    left_padding = [10, 20, 30, 40]  # distinct sentinel per row
+    uids = bg.insert(prompts, max_tokens=8, left_padding=left_padding)
+
+    # Each uid maps to the left_padding of the row it was submitted with, regardless of the sort.
+    for uid, lpad in zip(uids, left_padding):
+        assert bg._pending_left_padding[uid] == lpad
+    # The queue itself is sorted ascending by length (sort actually happened).
+    lengths = [len(t[1]) for t in bg._unprocessed_sequences]
+    assert lengths == sorted(lengths)
+
+
+def test_insert_without_left_padding_is_unchanged():
+    """Backward-compat: callers that don't pass left_padding leave _pending_left_padding empty, so the
+    downstream length-derived behavior is untouched."""
+    bg = _bare_batch_generator()
+    bg.insert([[1, 2, 3], [1, 2]], max_tokens=8)
+    assert bg._pending_left_padding == {}
+
+
+# --------------------------- model-gated end-to-end tests ---------------------------
+
+@pytest.fixture(scope="module")
+def vlm():
+    from mlx_vlm import load
+    try:
+        return load(MODEL_PATH)
+    except Exception as e:  # noqa: BLE001 — model unavailable (no local copy / no network) -> skip
+        pytest.skip(f"model unavailable ({MODEL_PATH}): {e}")
+
+
+def _tiny_png():
+    from PIL import Image
+    fd, path = tempfile.mkstemp(suffix=".png")
+    os.close(fd)
+    Image.new("RGB", (64, 64), (10, 120, 200)).save(path)
+    return path
+
+
+def test_tokenizer_emits_contiguous_left_pad_mask(vlm):
+    """Guard the tokenizer invariant against a future change: the text-only batched tokenize must emit a
+    binary attention_mask with contiguous LEADING zeros (left padding) — otherwise the L - sum derivation
+    would silently be wrong. Fails loudly if a future tokenizer/config alters padding behavior."""
+    _model, processor = vlm
+    prompts = ["Hi.", "A somewhat longer prompt that tokenizes to more tokens than the first one."]
+    tok = processor.tokenizer if hasattr(processor, "tokenizer") else processor
+    enc = tok(prompts, add_special_tokens=True, padding=True, padding_side="left",
+              return_tensors="np")
+    mask = enc["attention_mask"]
+    assert mask.ndim == 2
+    assert set(mask.reshape(-1).tolist()) <= {0, 1}, "attention_mask must be binary"
+    for row in mask.tolist():
+        seen_one = False
+        for v in row:
+            if v == 1:
+                seen_one = True
+            elif seen_one:
+                pytest.fail("attention_mask is not contiguous-leading-zero (left) padding")
+
+
+def test_batch_generate_mixed_length_text_only_matches_oracle(vlm):
+    """The crux: batch_generate on DIFFERENT-length text-only prompts must produce 0 empty rows AND match
+    the width-1 (single-prompt) greedy oracle for every row."""
+    from mlx_vlm.generate import batch_generate
+    model, proc = vlm
+    prompts = [
+        "Reply with only the word alpha.",
+        "In one short word only, name a fruit that is red. Word only.",
+        "Considering trees in temperate climates, reply with only the single word beta.",
+        "Reply with only the word gamma.",
+        "Think about the ocean and its creatures, then reply with only the single word delta.",
+        "Reply with only the word epsilon.",
+    ]
+    batched = list(batch_generate(model, proc, images=None, prompts=prompts,
+                                  max_tokens=24, verbose=False).texts)
+    assert all(t.strip() for t in batched), f"empty row(s): {batched}"
+    for i, p in enumerate(prompts):
+        oracle = batch_generate(model, proc, images=None, prompts=[p],
+                                max_tokens=24, verbose=False).texts[0]
+        assert batched[i] == oracle, f"row {i} diverged: {batched[i]!r} != oracle {oracle!r}"
+
+
+def test_batch_generate_image_path_unchanged(vlm):
+    """Multimodal regression: the image path (pixel_values is not None) does NOT derive left_padding and
+    still produces non-empty output — the fix must not perturb multimodal batching."""
+    from mlx_vlm.generate import batch_generate
+    model, proc = vlm
+    png = _tiny_png()
+    try:
+        out = batch_generate(model, proc, images=[png],
+                             prompts=["What color is this image? Answer in one word."],
+                             max_tokens=16, verbose=False)
+        assert out.texts and out.texts[0].strip(), "image path returned empty"
+    finally:
+        os.remove(png)

--- a/mlx_vlm/tests/test_generate.py
+++ b/mlx_vlm/tests/test_generate.py
@@ -643,7 +643,12 @@ class TestBatchGenerate:
         embedding_output = _EmbeddingOutput(inputs_embeds, position_ids)
 
         def fake_insert(
-            self, prompts, max_tokens, prompt_kwargs=None, logits_processors=None
+            self,
+            prompts,
+            max_tokens,
+            prompt_kwargs=None,
+            logits_processors=None,
+            left_padding=None,
         ):
             assert len(prompts) == batch_size
             assert len(prompt_kwargs) == batch_size
@@ -1325,6 +1330,7 @@ def test_cold_batch_left_pads_sequence_aligned_prompt_kwargs():
     bg = object.__new__(BatchGenerator)
     bg._generation_batch = EmptyGenerationBatch()
     bg._prompt_batch = None
+    bg._pending_left_padding = {}
     bg._prompt_tokens_counter = 0
     bg._prompt_time_counter = 0
     bg._gen_tokens_counter = 0


### PR DESCRIPTION
## Problem

`batch_generate` on **different-length text-only prompts** corrupts or empties the more-padded rows.

The text-only path tokenizes with `padding=True, padding_side="left"`, producing a **uniform-length** batch, then passes it to `BatchGenerator.insert`. Because the rows are now equal length, `PromptProcessingBatch` computes `left_padding = [max_len - len] = [0, ...]` and the real per-row padding is lost: the cache's `left_padding` is all-zero and no key-padding mask is built, so the model attends over the (left-)pad tokens and the more-padded rows decode incorrectly or empty. The tokenizer's own `attention_mask` (which encodes the padding) is produced and discarded. The lower-level `insert` path with raw variable-length ids already works because `PromptProcessingBatch` then derives correct non-zero `left_padding`.

Repro (before): 6 different-length prompts through `batch_generate` -> 1/6 empty + 4/6 mismatch vs a single-prompt (width-1) greedy decode of the same prompt.

## Fix (3 logically-separate commits)

1. **`fix(batch)` - generic plumbing (`generate.py`), model-agnostic.** Derive the true per-row `left_padding` from the tokenizer's `attention_mask` in `_generate_batch` (text-only only) and thread it through `insert(left_padding=...)` -> `PromptProcessingBatch(left_padding_override=...)`. Tracked by uid so it survives `insert`'s length-sort, **authoritative only when explicitly provided** (fully backward compatible), left as `None` on image/audio paths. Internal queue tuple unchanged.
2. **`fix(qwen2_5_vl)` - model pad-awareness (`models/qwen2_5_vl/language.py`).** Consume `left_padding`: mask-aware rope index + pad-aware decoder mask at prefill, attention-mask slice after cache update, per-row decode positions. Gated by a sticky per-cache flag, so single / equal-length / image decode is byte-identical to before.
3. **`test(batch)` - coverage.**

## Validation

- Repro (after): 0/6 empty, 6/6 byte-match to the width-1 oracle.
- Existing suite (`test_generate`, `test_apc`, `test_batch_quantized_cache`, `test_prompt_utils`, `test_sample_utils`) -> 125 passed.
- New `tests/test_batch_left_padding.py` -> 6 passed: derivation invariant (binary, contiguous leading zeros), `left_padding` survives the length-sort, backward-compat when unset, mixed-length matches oracle, image path unchanged.

Note: the branch is currently based on the v0.5.0 tag; happy to rebase onto `main`. Fix #1 is model-agnostic; only fix #2 is Qwen2.5-VL-specific.