### PR TITLE
minimax_m3_vl: add pack_shared_expert config override for mixed-precision quantization

### DIFF
--- a/mlx_vlm/models/minimax_m3_vl/config.py
+++ b/mlx_vlm/models/minimax_m3_vl/config.py
@@ -94,6 +94,10 @@ class TextConfig(BaseModelConfig):
     index_local_blocks: Optional[int] = None
     attention_output_gate: bool = False
     architectures: Optional[List[str]] = None
+    # None = derive from dims (pack when shared_intermediate_size ==
+    # intermediate_size). False forces the unpacked layout so the shared
+    # expert can carry different (higher) quantization bits than the bank.
+    pack_shared_expert: Optional[bool] = None
 
     def __post_init__(self):
         if self.num_key_value_heads is None:

--- a/mlx_vlm/models/minimax_m3_vl/language.py
+++ b/mlx_vlm/models/minimax_m3_vl/language.py
@@ -1725,8 +1725,12 @@ class MiniMaxSparseMoeBlock(nn.Module):
         self.scoring_func = args.scoring_func
         self.shared_expert_index = args.num_local_experts
         self.pack_shared_expert = (
-            args.n_shared_experts == 1
-            and args.shared_intermediate_size == args.intermediate_size
+            (
+                args.n_shared_experts == 1
+                and args.shared_intermediate_size == args.intermediate_size
+            )
+            if getattr(args, "pack_shared_expert", None) is None
+            else args.pack_shared_expert
         )
 
         self.gate = nn.Linear(args.hidden_size, args.num_local_experts, bias=False)

--- a/mlx_vlm/models/minimax_m3_vl/minimax_m3_vl.py
+++ b/mlx_vlm/models/minimax_m3_vl/minimax_m3_vl.py
@@ -37,8 +37,12 @@ def _pack_uint8_weight(weight: mx.array) -> mx.array:
 def _sanitize_moe_weights(weights: dict, args):
     num_experts = args.num_local_experts
     pack_shared = (
-        args.n_shared_experts == 1
-        and args.shared_intermediate_size == args.intermediate_size
+        (
+            args.n_shared_experts == 1
+            and args.shared_intermediate_size == args.intermediate_size
+        )
+        if getattr(args, "pack_shared_expert", None) is None
+        else args.pack_shared_expert
     )
 
     def expert_keys(prefix, name, suffix):


### PR DESCRIPTION
## What

Adds an optional `pack_shared_expert` field to MiniMax M3 `TextConfig` (default `None` = existing dim-derived behavior). Setting it to `false` in `text_config` forces the already-existing unpacked MoE layout (separate `shared_experts` MiniMaxMLP module) even when `shared_intermediate_size == intermediate_size`.

## Why

For quantized checkpoints, the packed layout welds the always-on shared expert into the same SwitchLinear tensor as the 128 routed experts, so it must share their bit-width. The shared expert processes 100% of tokens (vs ~3% per routed expert at top-4/128), so in low-bit mixed-precision quants (e.g. 3-bit routed experts) it is by far the highest-leverage tensor to hold at higher precision — but the packed layout makes that impossible.

With this flag a convert-time `quant_predicate` can assign e.g. 8-bit to `shared_experts` and 3-bit to `switch_mlp`, at +0.4% model size.

## Changes (3 files, backward compatible)

- `config.py`: new optional `TextConfig.pack_shared_expert` field
- `language.py`: `MiniMaxSparseMoeBlock` honors the override (`getattr` guarded)
- `minimax_m3_vl.py`: `_sanitize_moe_weights` honors the override

## Validation

- Packed vs unpacked forward outputs match to fp roundoff (max |logit diff| 7.75e-07) on a shrunken-config model with identical HF-style source weights routed through both sanitize paths.
- Used in production for avlp12 MiniMax-M3 VL quantized builds (426B, multimodality retained): 3/6/8-bit routed experts with 8-bit shared expert; long-context (16K) KL vs 8-bit reference 0.0011-0.0087 nats, NIAH 3/3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)