### PR TITLE
fix(qwen3_5/moe/minicpmv4_6): guard RMSNorm +1.0 shift in sanitize()

### DIFF
--- a/mlx_vlm/models/minicpmv4_6/minicpmv4_6.py
+++ b/mlx_vlm/models/minicpmv4_6/minicpmv4_6.py
@@ -423,6 +423,15 @@ class Model(nn.Module):
         return output
 
     def sanitize(self, weights):
+        # Only shift norm weights by +1.0 when the checkpoint stores
+        # gamma-1 (indicated by MTP weights or an unsanitized conv1d axis).
+        # See mlx_vlm/models/qwen3_5/qwen3_5.py and mlx_lm/models/qwen3_5.py.
+        has_mtp_weights = any("mtp." in k for k in weights)
+        has_unsanitized_conv1d = any(
+            "conv1d.weight" in k and v.shape[-1] != 1 for k, v in weights.items()
+        )
+        should_shift_norm_weights = has_mtp_weights or has_unsanitized_conv1d
+
         sanitized_weights = {}
         norm_keys = (
             ".input_layernorm.weight",
@@ -474,7 +483,8 @@ class Model(nn.Module):
             ) and not check_array_shape(value):
                 value = value.transpose(0, 2, 3, 1)
             if any(key.endswith(suffix) for suffix in norm_keys) and value.ndim == 1:
-                value = value + 1.0
+                if should_shift_norm_weights:
+                    value = value + 1.0
 
             sanitized_weights[key] = value
 

--- a/mlx_vlm/models/qwen3_5/qwen3_5.py
+++ b/mlx_vlm/models/qwen3_5/qwen3_5.py
@@ -120,6 +120,18 @@ class Model(Qwen3VLModel):
         return inputs_embeds, special_image_mask
 
     def sanitize(self, weights):
+        # Only shift norm weights by +1.0 when the checkpoint stores
+        # gamma-1 (indicated by MTP weights or an unsanitized conv1d axis).
+        # Standard Qwen3.5/3.6 checkpoints already store gamma directly, so
+        # an unconditional +1.0 corrupts every RMSNorm weight from ~1.0 to
+        # ~2.0, producing incoherent output and broken tool calls.
+        # Mirrors the guard in mlx_lm/models/qwen3_5.py TextModel.sanitize.
+        has_mtp_weights = any("mtp." in k for k in weights)
+        has_unsanitized_conv1d = any(
+            "conv1d.weight" in k and v.shape[-1] != 1 for k, v in weights.items()
+        )
+        should_shift_norm_weights = has_mtp_weights or has_unsanitized_conv1d
+
         # ignore mtp weights
         weights = {key: value for key, value in weights.items() if "mtp." not in key}
 
@@ -140,7 +152,7 @@ class Model(Qwen3VLModel):
 
             if "conv1d.weight" in key and value.shape[-1] != 1:
                 value = value.moveaxis(2, 1)
-            if any(key.endswith(sfx) for sfx in norm_keys):
+            if should_shift_norm_weights and any(key.endswith(sfx) for sfx in norm_keys):
                 if value.ndim == 1:
                     value += 1.0
 

--- a/mlx_vlm/models/qwen3_5_moe/qwen3_5_moe.py
+++ b/mlx_vlm/models/qwen3_5_moe/qwen3_5_moe.py
@@ -18,6 +18,15 @@ class Model(Qwen3_5Model):
         self.language_model = LanguageModel(config.text_config, config)
 
     def sanitize(self, weights):
+        # Only shift norm weights by +1.0 when the checkpoint stores
+        # gamma-1 (indicated by MTP weights or an unsanitized conv1d axis).
+        # See mlx_vlm/models/qwen3_5/qwen3_5.py and mlx_lm/models/qwen3_5.py.
+        has_mtp_weights = any("mtp." in k for k in weights)
+        has_unsanitized_conv1d = any(
+            "conv1d.weight" in k and v.shape[-1] != 1 for k, v in weights.items()
+        )
+        should_shift_norm_weights = has_mtp_weights or has_unsanitized_conv1d
+
         # ignore mtp weights
         weights = {key: value for key, value in weights.items() if "mtp." not in key}
 
@@ -64,7 +73,7 @@ class Model(Qwen3_5Model):
 
             if "conv1d.weight" in key and value.shape[-1] != 1:
                 value = value.moveaxis(2, 1)
-            if any(key.endswith(sfx) for sfx in norm_keys):
+            if should_shift_norm_weights and any(key.endswith(sfx) for sfx in norm_keys):
                 if value.ndim == 1:
                     value += 1.0
 


### PR DESCRIPTION
## Problem

`sanitize()` in `qwen3_5`, `qwen3_5_moe`, and `minicpmv4_6` unconditionally adds `+1.0` to all 1-D norm weights:

```python
if any(key.endswith(sfx) for sfx in norm_keys):
    if value.ndim == 1:
        value += 1.0   # UNCONDITIONAL
```

`mlx_lm/models/qwen3_5.py` already guards this shift:

```python
should_shift_norm_weights = has_mtp_weights or has_unsanitized_conv1d
...
if should_shift_norm_weights and any(k.endswith(sfx) for sfx in norm_keys):
    if v.ndim == 1:
        weights[k] = v + 1.0   # GUARDED
```

## Impact

For standard Qwen3.5 / Qwen3.6 / MiniCPM-V4.6 checkpoints (no MTP weights, conv1d already sanitized with `shape[-1]=1`), the unconditional `+1.0` corrupts **every** RMSNorm weight from `~1.0` to `~2.0`, causing:

- Incoherent text output (number tokens instead of meaningful text)
- Broken tool calling (garbled `<tool_call>` format)
- Max logit diff of ~17.1 vs the same model loaded via `mlx_lm`

## Fix

Add the same `should_shift_norm_weights` guard as `mlx_lm` to all three models. The `+1.0` shift now only applies when the checkpoint actually stores `gamma-1` (indicated by MTP weights or an unsanitized conv1d axis).

## Verification

- VLM weight mean now matches the LLM loader (diff from ~1.0 to ~0.000085)
- Max logit diff dropped from 17.1 to 0.215
- Top-5 tokens now match the LLM loader
- Tool calling generates proper `<tool_call>` format
- E2E generation produces coherent text

## Workaround in fusion-mlx

We ship a monkey-patch ([fusion-mlx](https://github.com/dahai80/fusion-mlx) `engines/vlm.py:_patch_vlm_sanitize`) that undoes the incorrect `+1.0` when `should_shift=False`. This PR fixes it upstream so the patch is no longer needed.

Fixes #1548

🤖 Generated with [Claude Code](https://claude.com/claude-code)