### PR TITLE
Optimize Qwen3 Omni streaming code windows

### DIFF
--- a/mlx_vlm/models/qwen3_omni_moe/qwen3_omni_moe.py
+++ b/mlx_vlm/models/qwen3_omni_moe/qwen3_omni_moe.py
@@ -664,6 +664,63 @@ class Model(nn.Module):
 
         return thinker_result, talker_wavs.astype(mx.float32)
 
+    @staticmethod
+    def _stream_decode_bounds(
+        codes_count: int,
+        decoded_len: int,
+        chunk_size: int,
+        left_context_size: int,
+    ) -> Optional[tuple[int, int, int]]:
+        context_len = min(left_context_size, decoded_len)
+        new_tokens = chunk_size - context_len
+        if codes_count - decoded_len < new_tokens:
+            return None
+        end = decoded_len + new_tokens
+        return decoded_len - context_len, end, context_len
+
+    def _decode_stream_window(
+        self,
+        codes_list: list[mx.array],
+        decoded_len: int,
+        chunk_size: int,
+        left_context_size: int,
+    ):
+        bounds = self._stream_decode_bounds(
+            len(codes_list), decoded_len, chunk_size, left_context_size
+        )
+        if bounds is None:
+            return None, decoded_len
+
+        context_start, end, context_len = bounds
+        codes_window = mx.stack(codes_list[context_start:end], axis=1).transpose(
+            0, 2, 1
+        )
+        wav_chunk, _ = self.code2wav.stream_decode(
+            codes_window,
+            chunk_size,
+            left_context_size,
+            decoded_len=context_len,
+        )
+        return wav_chunk, end
+
+    def _flush_stream_window(
+        self,
+        codes_list: list[mx.array],
+        decoded_len: int,
+        left_context_size: int,
+    ):
+        if decoded_len >= len(codes_list):
+            return None
+
+        context_start = max(0, decoded_len - left_context_size)
+        context_len = decoded_len - context_start
+        codes_window = mx.stack(codes_list[context_start:], axis=1).transpose(0, 2, 1)
+        return self.code2wav.flush_decode(
+            codes_window,
+            left_context_size,
+            decoded_len=context_len,
+        )
+
     def generate_stream(
         self,
         input_ids: mx.array,
@@ -681,6 +738,12 @@ class Model(nn.Module):
             raise ValueError("Cannot stream audio without talker module")
         if input_ids.shape[0] != 1:
             raise NotImplementedError("Streaming does not support batched inference")
+        if chunk_size <= 0:
+            raise ValueError("chunk_size must be positive")
+        if left_context_size < 0 or left_context_size >= chunk_size:
+            raise ValueError(
+                "left_context_size must be non-negative and smaller than chunk_size"
+            )
 
         speaker_id = self.config.talker_config.speaker_id.get(speaker.lower())
         if speaker_id is None:
@@ -821,19 +884,19 @@ class Model(nn.Module):
             top_p=talker_top_p,
         ):
             codes_list.append(residual_codes)
-            if len(codes_list) >= chunk_size:
-                codes_buffer = mx.stack(codes_list, axis=1).transpose(0, 2, 1)
-                wav_chunk, decoded_len = self.code2wav.stream_decode(
-                    codes_buffer, chunk_size, left_context_size, decoded_len
+            if self._stream_decode_bounds(
+                len(codes_list), decoded_len, chunk_size, left_context_size
+            ):
+                wav_chunk, decoded_len = self._decode_stream_window(
+                    codes_list, decoded_len, chunk_size, left_context_size
                 )
                 if wav_chunk is not None:
                     mx.eval(wav_chunk)
                     yield ("audio", wav_chunk.astype(mx.float32))
 
         if codes_list:
-            codes_buffer = mx.stack(codes_list, axis=1).transpose(0, 2, 1)
-            wav_chunk = self.code2wav.flush_decode(
-                codes_buffer, left_context_size, decoded_len
+            wav_chunk = self._flush_stream_window(
+                codes_list, decoded_len, left_context_size
             )
             if wav_chunk is not None:
                 mx.eval(wav_chunk)

--- a/mlx_vlm/tests/test_qwen3_omni_moe.py
+++ b/mlx_vlm/tests/test_qwen3_omni_moe.py
@@ -36,7 +36,7 @@ def _tiny_text_config(model_type="qwen3_omni_moe_text_encoder"):
     )
 
 
-def _tiny_model():
+def _tiny_model(enable_audio_output=False):
     text_config = _tiny_text_config()
     thinker_config = ThinkerConfig(
         text_config=text_config,
@@ -103,7 +103,7 @@ def _tiny_model():
             thinker_config=thinker_config,
             talker_config=talker_config,
             code2wav_config=code2wav_config,
-            enable_audio_output=False,
+            enable_audio_output=enable_audio_output,
             im_start_token_id=10,
             im_end_token_id=11,
             system_token_id=12,
@@ -160,6 +160,71 @@ class Qwen3OmniMoeTest(unittest.TestCase):
                     atol=1e-6,
                 ).item()
             )
+        )
+
+    def test_stream_decode_bounds_wait_for_the_next_window(self):
+        model = _tiny_model(enable_audio_output=True)
+
+        self.assertEqual(model._stream_decode_bounds(6, 0, 6, 2), (0, 6, 0))
+        self.assertIsNone(model._stream_decode_bounds(9, 6, 6, 2))
+        self.assertEqual(model._stream_decode_bounds(10, 6, 6, 2), (4, 10, 2))
+
+    def test_generate_stream_validates_window_sizes(self):
+        model = _tiny_model(enable_audio_output=True)
+        input_ids = mx.array([[10, 13, 20, 11, 10, 14]], dtype=mx.int32)
+
+        with self.assertRaises(ValueError):
+            next(model.generate_stream(input_ids, chunk_size=0))
+        with self.assertRaises(ValueError):
+            next(model.generate_stream(input_ids, chunk_size=4, left_context_size=4))
+        with self.assertRaises(ValueError):
+            next(model.generate_stream(input_ids, chunk_size=4, left_context_size=-1))
+
+    def test_stream_window_matches_full_history_decode(self):
+        model = _tiny_model(enable_audio_output=True)
+        codes_list = [
+            mx.array([[idx % 8, (idx + 1) % 8]], dtype=mx.int32) for idx in range(12)
+        ]
+        codes_buffer = mx.stack(codes_list, axis=1).transpose(0, 2, 1)
+        chunk_size = 6
+        left_context_size = 2
+
+        decoded_len = 0
+        for _ in range(2):
+            expected, expected_len = model.code2wav.stream_decode(
+                codes_buffer,
+                chunk_size,
+                left_context_size,
+                decoded_len=decoded_len,
+            )
+            actual, actual_len = model._decode_stream_window(
+                codes_list,
+                decoded_len=decoded_len,
+                chunk_size=chunk_size,
+                left_context_size=left_context_size,
+            )
+            mx.eval(expected, actual)
+
+            self.assertEqual(actual_len, expected_len)
+            self.assertTrue(
+                bool(mx.allclose(actual, expected, rtol=1e-5, atol=1e-5).item())
+            )
+            decoded_len = actual_len
+
+        expected = model.code2wav.flush_decode(
+            codes_buffer,
+            left_context_size,
+            decoded_len=decoded_len,
+        )
+        actual = model._flush_stream_window(
+            codes_list,
+            decoded_len=decoded_len,
+            left_context_size=left_context_size,
+        )
+        mx.eval(expected, actual)
+
+        self.assertTrue(
+            bool(mx.allclose(actual, expected, rtol=1e-5, atol=1e-5).item())
         )
 
 


### PR DESCRIPTION
## Summary

Optimize Qwen3-Omni audio streaming by avoiding repeated reconstruction of the complete codec-token history.

After the first streaming window, `generate_stream()` currently stacks all generated codec frames and calls `stream_decode()` for every new frame, even when the next decode window is not ready. This overhead grows with audio duration.

## Changes

- Check whether the next Code2Wav window is ready before stacking codec frames.
- Stack only the required left context and newly decodable frames.
- Apply the same bounded-window behavior when flushing remaining frames.
- Validate invalid chunk/context configurations that cannot make decode progress.
- Preserve the existing public API, Thinker/Talker scheduling, codec tokens, audio chunk boundaries, and vocoder behavior.

## Benchmark

Model: `mlx-community/Qwen3-Omni-30B-A3B-Instruct-4bit`  
Backend: MLX / Metal  
Method: fixed codec tokens, warmup followed by 5 alternating runs per arm.

| Audio duration | Chunk / context | Before | After | Speedup |
|---:|---:|---:|---:|---:|
| 20.48s | 10 / 5 | 0.8058s | 0.7917s | **1.018x** |
| 90s | 300 / 25 | 1.5322s | 1.3783s | **1.112x** |

For the 90-second case:

- Stack calls: `827 → 4`
- Total stacked frames: `589,650 → 1,200`
- Code2Wav calls: unchanged at `4`
- Emitted samples: unchanged at `2,160,000`
- Output checksum difference: `0`

The improvement grows with sequence length. Short outputs that do not cross a streaming-window boundary are expected to see little or no change.

## Testing

- Added tests for streaming-window readiness and cursor boundaries.
- Compared repeated incremental windows and final flush against the previous full-history implementation.
- Verified matching output lengths and numerically equivalent waveforms.
- Ran 3 end-to-end audio-in/audio-out generations with 51 audio chunks per run and no failures.
- `python -m unittest mlx_vlm.tests.test_qwen3_omni_moe`
- `pre-commit run --all-files`