### PR TITLE
fix(qwen3_5_mtp): guard norm +1.0 shift to raw-HF layout only

### DIFF
--- a/mlx_vlm/speculative/drafters/qwen3_5_mtp/qwen3_5_mtp.py
+++ b/mlx_vlm/speculative/drafters/qwen3_5_mtp/qwen3_5_mtp.py
@@ -492,11 +492,6 @@ class Qwen3_5MTPDraftModel(nn.Module):
             "pre_fc_norm_embedding.weight",
             "pre_fc_norm_hidden.weight",
         )
-        # The RMSNorm +1.0 shift converts HF zero-centred gammas to the MLX
-        # convention. Pre-converted MLX MTP checkpoints
-        # (e.g. mlx-community/Qwen3.6-*-MTP-*) already store shifted values with
-        # bare keys, while raw-HF MTP weights carry the `mtp.` prefix. Only shift
-        # the raw-HF layout so sanitize is idempotent and does not double-shift.
         for key, value in weights.items():
             is_hf_layout = key.startswith("mtp.")
             if is_hf_layout:

--- a/mlx_vlm/speculative/drafters/qwen3_5_mtp/qwen3_5_mtp.py
+++ b/mlx_vlm/speculative/drafters/qwen3_5_mtp/qwen3_5_mtp.py
@@ -492,10 +492,16 @@ class Qwen3_5MTPDraftModel(nn.Module):
             "pre_fc_norm_embedding.weight",
             "pre_fc_norm_hidden.weight",
         )
+        # The RMSNorm +1.0 shift converts HF zero-centred gammas to the MLX
+        # convention. Pre-converted MLX MTP checkpoints
+        # (e.g. mlx-community/Qwen3.6-*-MTP-*) already store shifted values with
+        # bare keys, while raw-HF MTP weights carry the `mtp.` prefix. Only shift
+        # the raw-HF layout so sanitize is idempotent and does not double-shift.
         for key, value in weights.items():
-            if key.startswith("mtp."):
+            is_hf_layout = key.startswith("mtp.")
+            if is_hf_layout:
                 key = key[len("mtp.") :]
-            if any(key.endswith(suffix) for suffix in norm_suffixes):
+            if is_hf_layout and any(key.endswith(suffix) for suffix in norm_suffixes):
                 if value.ndim == 1 and mx.issubdtype(value.dtype, mx.floating):
                     value = value + 1.0
             out[key] = value


### PR DESCRIPTION
The MTP drafter sanitize() shifted RMSNorm weights unconditionally, so pre-converted MLX MTP checkpoints (mlx-community/Qwen3.6-*-MTP-*, bare keys) were double-shifted, corrupting the drafter and lowering speculative acceptance. Shift only mtp.-prefixed (raw-HF) weights, mirroring the target model fix in #1528. Idempotent.

Refs #1538.

All work on existing checkpoints, I got the norm tensors from the safetensors headers of a 35b sized model and verified that sanitize doesn't add extra 1.0!

all tests green