### PR TITLE
Guard Qwen3.5 norm weight shifts

### DIFF
--- a/mlx_vlm/models/minicpmv4_6/minicpmv4_6.py
+++ b/mlx_vlm/models/minicpmv4_6/minicpmv4_6.py
@@ -5,6 +5,11 @@ import mlx.nn as nn
 import numpy as np
 
 from ..base import InputEmbeddingsFeatures
+from ..qwen3_5.qwen3_5 import (
+    NORM_WEIGHT_SUFFIXES,
+    should_offset_norm_weight,
+    should_shift_norm_weights,
+)
 from .config import ModelConfig
 from .language import LanguageModel
 from .vision import VisionModel, check_array_shape
@@ -423,14 +428,8 @@ class Model(nn.Module):
         return output
 
     def sanitize(self, weights):
+        shift_norm_weights = should_shift_norm_weights(weights)
         sanitized_weights = {}
-        offset_norm_keys = (
-            ".input_layernorm.weight",
-            ".post_attention_layernorm.weight",
-            "model.norm.weight",
-            ".q_norm.weight",
-            ".k_norm.weight",
-        )
 
         for key, value in weights.items():
             original_key = key
@@ -484,7 +483,8 @@ class Model(nn.Module):
                 value = value.transpose(0, 2, 3, 1)
             if (
                 original_key.startswith("model.language_model.")
-                and any(key.endswith(suffix) for suffix in offset_norm_keys)
+                and should_offset_norm_weight(original_key, shift_norm_weights)
+                and any(key.endswith(suffix) for suffix in NORM_WEIGHT_SUFFIXES)
                 and value.ndim == 1
             ):
                 value = value + 1.0

--- a/mlx_vlm/models/qwen3_5/qwen3_5.py
+++ b/mlx_vlm/models/qwen3_5/qwen3_5.py
@@ -24,6 +24,28 @@ def sanitize_key(key):
     return key
 
 
+NORM_WEIGHT_SUFFIXES = (
+    ".input_layernorm.weight",
+    ".post_attention_layernorm.weight",
+    "model.norm.weight",
+    ".q_norm.weight",
+    ".k_norm.weight",
+)
+
+
+def should_shift_norm_weights(weights):
+    has_mtp_weights = any("mtp." in key for key in weights)
+    has_unsanitized_conv1d = any(
+        "conv1d.weight" in key and value.shape[-1] != 1
+        for key, value in weights.items()
+    )
+    return has_mtp_weights or has_unsanitized_conv1d
+
+
+def should_offset_norm_weight(original_key, shift_norm_weights):
+    return shift_norm_weights or not original_key.startswith("language_model.")
+
+
 class Model(Qwen3VLModel):
 
     def __init__(self, config: ModelConfig):
@@ -120,19 +142,13 @@ class Model(Qwen3VLModel):
         return inputs_embeds, special_image_mask
 
     def sanitize(self, weights):
+        shift_norm_weights = should_shift_norm_weights(weights)
+
         # ignore mtp weights
         weights = {key: value for key, value in weights.items() if "mtp." not in key}
 
         if self.config.text_config.tie_word_embeddings:
             weights.pop("lm_head.weight", None)
-
-        norm_keys = (
-            ".input_layernorm.weight",
-            ".post_attention_layernorm.weight",
-            "model.norm.weight",
-            ".q_norm.weight",
-            ".k_norm.weight",
-        )
 
         sanitized_weights = {}
         for key, value in weights.items():
@@ -141,8 +157,10 @@ class Model(Qwen3VLModel):
 
             if "conv1d.weight" in key and value.shape[-1] != 1:
                 value = value.moveaxis(2, 1)
-            if any(key.endswith(sfx) for sfx in norm_keys):
-                if value.ndim == 1 and not original_key.startswith("language_model."):
+            if any(key.endswith(sfx) for sfx in NORM_WEIGHT_SUFFIXES):
+                if value.ndim == 1 and should_offset_norm_weight(
+                    original_key, shift_norm_weights
+                ):
                     value += 1.0
 
             sanitized_weights[key] = value

--- a/mlx_vlm/models/qwen3_5_moe/qwen3_5_moe.py
+++ b/mlx_vlm/models/qwen3_5_moe/qwen3_5_moe.py
@@ -2,7 +2,12 @@ import mlx.core as mx
 import mlx.nn as nn
 
 from ..qwen3_5 import Model as Qwen3_5Model
-from ..qwen3_5.qwen3_5 import sanitize_key
+from ..qwen3_5.qwen3_5 import (
+    NORM_WEIGHT_SUFFIXES,
+    sanitize_key,
+    should_offset_norm_weight,
+    should_shift_norm_weights,
+)
 from .config import ModelConfig
 from .language import LanguageModel
 from .vision import VisionModel
@@ -18,6 +23,8 @@ class Model(Qwen3_5Model):
         self.language_model = LanguageModel(config.text_config, config)
 
     def sanitize(self, weights):
+        shift_norm_weights = should_shift_norm_weights(weights)
+
         # ignore mtp weights
         weights = {key: value for key, value in weights.items() if "mtp." not in key}
 
@@ -50,14 +57,6 @@ class Model(Qwen3_5Model):
                         ]
                     )
 
-        norm_keys = (
-            ".input_layernorm.weight",
-            ".post_attention_layernorm.weight",
-            "model.norm.weight",
-            ".q_norm.weight",
-            ".k_norm.weight",
-        )
-
         sanitized_weights = {}
         for key, value in weights.items():
             original_key = key
@@ -65,8 +64,10 @@ class Model(Qwen3_5Model):
 
             if "conv1d.weight" in key and value.shape[-1] != 1:
                 value = value.moveaxis(2, 1)
-            if any(key.endswith(sfx) for sfx in norm_keys):
-                if value.ndim == 1 and not original_key.startswith("language_model."):
+            if any(key.endswith(sfx) for sfx in NORM_WEIGHT_SUFFIXES):
+                if value.ndim == 1 and should_offset_norm_weight(
+                    original_key, shift_norm_weights
+                ):
                     value += 1.0
 
             sanitized_weights[key] = value

--- a/mlx_vlm/tests/test_models.py
+++ b/mlx_vlm/tests/test_models.py
@@ -2415,6 +2415,76 @@ class TestModels(unittest.TestCase):
             "language_model.lm_head.weight",
         )
 
+    def test_qwen3_5_sanitize_preserves_converted_norm_weights(self):
+        from mlx_vlm.models import qwen3_5, qwen3_5_moe
+
+        for model_module in (qwen3_5, qwen3_5_moe):
+            with self.subTest(model_type=model_module.__name__):
+                context = SimpleNamespace(
+                    config=SimpleNamespace(
+                        text_config=SimpleNamespace(
+                            tie_word_embeddings=False,
+                            num_hidden_layers=1,
+                            num_experts=0,
+                        )
+                    )
+                )
+                weights = {
+                    "language_model.model.layers.0.input_layernorm.weight": mx.ones(
+                        (2,)
+                    ),
+                    "language_model.model.layers.0.linear_attn.conv1d.weight": mx.zeros(
+                        (4, 3, 1)
+                    ),
+                }
+
+                sanitized = model_module.Model.sanitize(context, weights)
+
+                self.assertEqual(
+                    sanitized[
+                        "language_model.model.layers.0.input_layernorm.weight"
+                    ].tolist(),
+                    [1.0, 1.0],
+                )
+
+    def test_qwen3_5_sanitize_offsets_source_norm_weights_when_needed(self):
+        from mlx_vlm.models import qwen3_5, qwen3_5_moe
+
+        for model_module in (qwen3_5, qwen3_5_moe):
+            with self.subTest(model_type=model_module.__name__):
+                context = SimpleNamespace(
+                    config=SimpleNamespace(
+                        text_config=SimpleNamespace(
+                            tie_word_embeddings=False,
+                            num_hidden_layers=1,
+                            num_experts=0,
+                        )
+                    )
+                )
+                weights = {
+                    "model.language_model.layers.0.input_layernorm.weight": mx.zeros(
+                        (2,)
+                    ),
+                    "model.language_model.layers.0.linear_attn.conv1d.weight": mx.zeros(
+                        (4, 1, 3)
+                    ),
+                }
+
+                sanitized = model_module.Model.sanitize(context, weights)
+
+                self.assertEqual(
+                    sanitized[
+                        "language_model.model.layers.0.input_layernorm.weight"
+                    ].tolist(),
+                    [1.0, 1.0],
+                )
+                self.assertEqual(
+                    sanitized[
+                        "language_model.model.layers.0.linear_attn.conv1d.weight"
+                    ].shape,
+                    (4, 3, 1),
+                )
+
     def test_qwen3_5_rotary_inv_freq_is_thread_safe(self):
         if not mx.metal.is_available():
             self.skipTest("requires Metal streams")
@@ -8741,6 +8811,54 @@ class TestMiniCPMV4_6(unittest.TestCase):
         image_grid_thw = mx.array([[1, 2, 2]], dtype=mx.int32)
         with self.assertRaisesRegex(ValueError, "does not support Qwen3.5-VL"):
             lm.get_rope_index(input_ids, image_grid_thw=image_grid_thw)
+
+    def test_minicpmv4_6_sanitize_preserves_converted_norm_weights(self):
+        from mlx_vlm.models import minicpmv4_6
+
+        context = SimpleNamespace(
+            config=SimpleNamespace(
+                text_config=SimpleNamespace(tie_word_embeddings=False)
+            )
+        )
+        weights = {
+            "language_model.model.layers.0.input_layernorm.weight": mx.ones((2,)),
+            "language_model.model.layers.0.linear_attn.conv1d.weight": mx.zeros(
+                (4, 3, 1)
+            ),
+        }
+
+        sanitized = minicpmv4_6.Model.sanitize(context, weights)
+
+        self.assertEqual(
+            sanitized["language_model.model.layers.0.input_layernorm.weight"].tolist(),
+            [1.0, 1.0],
+        )
+
+    def test_minicpmv4_6_sanitize_offsets_source_norm_weights_when_needed(self):
+        from mlx_vlm.models import minicpmv4_6
+
+        context = SimpleNamespace(
+            config=SimpleNamespace(
+                text_config=SimpleNamespace(tie_word_embeddings=False)
+            )
+        )
+        weights = {
+            "model.language_model.layers.0.input_layernorm.weight": mx.zeros((2,)),
+            "model.language_model.layers.0.linear_attn.conv1d.weight": mx.zeros(
+                (4, 1, 3)
+            ),
+        }
+
+        sanitized = minicpmv4_6.Model.sanitize(context, weights)
+
+        self.assertEqual(
+            sanitized["language_model.model.layers.0.input_layernorm.weight"].tolist(),
+            [1.0, 1.0],
+        )
+        self.assertEqual(
+            sanitized["language_model.model.layers.0.linear_attn.conv1d.weight"].shape,
+            (4, 3, 1),
+        )
 
 
 class TestMiniCPMO(unittest.TestCase):


### PR DESCRIPTION
## Summary

Fixes #1548.

- Adds a shared Qwen3.5 sanitizer guard so RMSNorm weights are offset for source/HF-style keys while preserving already-converted `language_model.*` MLX keys.
- Applies the same guarded norm-offset helper to Qwen3.5 MoE and MiniCPM-V 4.6 sanitizer paths.
- Adds focused sanitizer tests for converted MLX-format weights and source-style weights that still require Conv1D conversion.

## Root cause

The Qwen3.5 VLM sanitizer shifted matching 1-D norm weights by `+1.0` even for already-converted MLX checkpoint keys. Converted MLX checkpoints with sanitized Conv1D weights do not need that offset, so the unconditional shift could corrupt norm weights.

## Validation

- `uv run python -m unittest mlx_vlm.tests.test_models.TestQwen35NormSanitization mlx_vlm.tests.test_models.TestModels.test_qwen3_5_sanitize_preserves_converted_norm_weights mlx_vlm.tests.test_models.TestModels.test_qwen3_5_sanitize_offsets_source_norm_weights_when_needed mlx_vlm.tests.test_models.TestMiniCPMV4_6.test_minicpmv4_6_sanitize_preserves_converted_norm_weights mlx_vlm.tests.test_models.TestMiniCPMV4_6.test_minicpmv4_6_sanitize_offsets_source_norm_weights_when_needed`
- `uv run python -m compileall -q mlx_vlm/models/qwen3_5 mlx_vlm/models/qwen3_5_moe mlx_vlm/models/minicpmv4_6 mlx_vlm/tests/test_models.py`
- GitHub Actions: `Test PRs/test` passed on commit `2b7f05a3`