### PR TITLE
Move Qwen3 Omni MRoPE to request-owned kwargs

### DIFF
--- a/mlx_vlm/models/qwen3_omni_moe/qwen3_omni_moe.py
+++ b/mlx_vlm/models/qwen3_omni_moe/qwen3_omni_moe.py
@@ -226,6 +226,8 @@ class Model(nn.Module):
                 if k in ["image_grid_thw", "video_grid_thw"]
             }
         )
+        decode_lm_kwargs = dict(lm_kwargs)
+        decode_lm_kwargs.pop("position_ids", None)
 
         prompt_cache = kv_cache.make_prompt_cache(self.thinker.language_model)
         outputs = self.thinker.language_model(
@@ -276,7 +278,7 @@ class Model(nn.Module):
                 token[:, None],
                 cache=prompt_cache,
                 output_hidden_state_idx=target_layer_idx + 1,
-                **lm_kwargs,
+                **decode_lm_kwargs,
             )
             hidden_states.append(step_outputs.hidden_states)
             if token_id == thinker_eos_token_id:

--- a/mlx_vlm/models/qwen3_omni_moe/thinker.py
+++ b/mlx_vlm/models/qwen3_omni_moe/thinker.py
@@ -138,9 +138,6 @@ class Thinker(nn.Module):
         audio_feature_lengths: Optional[mx.array] = None,
         **kwargs,
     ):
-        self.language_model._position_ids = None
-        self.language_model._rope_deltas = None
-
         inputs_embeds = self.language_model.model.embed_tokens(input_ids)
         visual_pos_masks = None
         deepstack_visual_embeds = None
@@ -270,18 +267,19 @@ class Thinker(nn.Module):
                     visual_embeds_multiscale_joint.append(embed_joint)
                 visual_embeds_multiscale = tuple(visual_embeds_multiscale_joint)
 
-        if image_grid_thw is not None or video_grid_thw is not None:
-            mask = kwargs.get("mask", None)
-            position_ids, rope_deltas = self.language_model.get_rope_index(
-                input_ids, image_grid_thw, video_grid_thw, mask
-            )
-            self.language_model._position_ids = position_ids
-            self.language_model._rope_deltas = rope_deltas
+        mask = kwargs.get("mask", None)
+        position_ids, rope_deltas = self.language_model.get_rope_index(
+            input_ids, image_grid_thw, video_grid_thw, mask
+        )
+        if image_grid_thw is None and video_grid_thw is None and position_ids.ndim == 3:
+            position_ids = position_ids[0]
 
         return InputEmbeddingsFeatures(
             inputs_embeds=inputs_embeds,
             visual_pos_masks=visual_pos_masks,
             deepstack_visual_embeds=deepstack_visual_embeds,
+            position_ids=position_ids,
+            rope_deltas=rope_deltas,
         )
 
     @staticmethod
@@ -327,17 +325,16 @@ class Thinker(nn.Module):
         feature_attention_mask = kwargs.pop("feature_attention_mask", None)
         audio_feature_lengths = kwargs.pop("audio_feature_lengths", None)
 
-        inputs_embeds, visual_pos_masks, deepstack_visual_embeds = (
-            self.get_input_embeddings(
-                input_ids,
-                pixel_values=pixel_values,
-                pixel_values_videos=pixel_values_videos,
-                image_grid_thw=image_grid_thw,
-                video_grid_thw=video_grid_thw,
-                input_features=input_features,
-                feature_attention_mask=feature_attention_mask,
-                audio_feature_lengths=audio_feature_lengths,
-            )
+        input_embedding_features = self.get_input_embeddings(
+            input_ids,
+            pixel_values=pixel_values,
+            pixel_values_videos=pixel_values_videos,
+            image_grid_thw=image_grid_thw,
+            video_grid_thw=video_grid_thw,
+            input_features=input_features,
+            feature_attention_mask=feature_attention_mask,
+            audio_feature_lengths=audio_feature_lengths,
+            mask=mask,
         )
 
         kwargs = {
@@ -345,14 +342,11 @@ class Thinker(nn.Module):
             "pixel_values_videos": pixel_values_videos,
             "image_grid_thw": image_grid_thw,
             "video_grid_thw": video_grid_thw,
-            "visual_pos_masks": visual_pos_masks,
-            "deepstack_visual_embeds": deepstack_visual_embeds,
+            **input_embedding_features.to_dict(),
             **kwargs,
         }
 
-        logits = self.language_model(
-            input_ids, inputs_embeds, mask=mask, cache=cache, **kwargs
-        )
+        logits = self.language_model(input_ids, mask=mask, cache=cache, **kwargs)
 
         return logits
 

--- a/mlx_vlm/tests/test_models.py
+++ b/mlx_vlm/tests/test_models.py
@@ -7849,6 +7849,7 @@ class TestGetInputEmbeddings(unittest.TestCase):
             )
         )
         self._check_returns_input_embeddings_features(model, "qwen3_omni_moe")
+        self._assert_qwen_request_owned_mrope_kwargs(model)
 
     def test_qwen3_omni_audio_sanitize_is_idempotent_for_conv2d_weights(self):
         from mlx_vlm.models import qwen3_omni_moe


### PR DESCRIPTION
The qwen3_omni_moe thinker still keeps MRoPE state on the language model instance - get_input_embeddings resets and rewrites _position_ids/_rope_deltas on every call, so concurrent requests through the batch/server paths can clobber each other's positions. The other Qwen VL families moved to request-owned position kwargs in #1494. 

This ports the module to the same pattern: get_input_embeddings computes position_ids/rope_deltas unconditionally and returns them on InputEmbeddingsFeatures, like qwen3_vl_moe. Text-only and audio-only inputs collapse the three identical axes to 2D, grid inputs keep the 3-axis form.

Two adjustments fall out of this: the audio-path helper from #1522 drops the prompt-shaped position_ids on decode steps (rope_deltas handles continuation there), and Thinker.__call__ was unpacking the features dataclass as a tuple, which throws - it now uses the object.

qwen3_omni_moe now runs the shared request-owned mrope assertion in test_models.py. 

AI assisted with the implementation.

Tested on M3 Max.
```
python -m pytest mlx_vlm/tests/test_qwen3_omni_moe.py -q   # 1 passed
python -m pytest mlx_vlm/tests/test_models.py -q -k omni   # 3 passed
python -m pytest mlx_vlm/tests/test_rope.py -q             # 9 passed, 2 failed — the same two fail on main (qwen3_5 fully-masked rows, ernie empty rows)
```
