### PR TITLE
feat(apc): adapter boundary for batch/SWA kv-bits (#1559)

### DIFF
--- a/mlx_vlm/apc.py
+++ b/mlx_vlm/apc.py
@@ -49,9 +49,9 @@ import re
 import threading
 import time
 from collections import OrderedDict
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Iterable, List, Optional, Sequence, Tuple
+from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple
 
 import mlx.core as mx
 import numpy as np
@@ -154,35 +154,27 @@ def _clone_cache_entry_for_apc(
             eval_targets.extend([keys, values])
         return out
 
-    # BatchKVCache is not a KVCache subclass. With --kv-bits the batch cache
-    # factory is used even for single-row requests, so hybrid exact-mode
-    # snapshots often see BatchKVCache for the unquantized last layer.
-    # Collapse B=1 into a row KVCache (same as extract(0)); multi-row must
-    # be extracted before store.
-    if isinstance(c, lm_cache.BatchKVCache):
-        idx = int(getattr(c, "_idx", 0) or 0)
-        if c.keys is None or c.values is None or idx <= 0:
-            return lm_cache.KVCache()
-        if int(c.keys.shape[0]) != 1:
+    # Batch* caches: collapse single-row via extract, then clone the row type.
+    # Multi-row must go through snapshot_prompt_cache_row first.
+    if isinstance(
+        c,
+        (
+            lm_cache.BatchKVCache,
+            lm_cache.BatchRotatingKVCache,
+            lm_cache.BatchQuantizedKVCache,
+        ),
+    ):
+        if not c.is_single_row():
             return None
-        row = c.extract(0)
-        off = int(getattr(row, "offset", 0) or 0)
-        if row.keys is not None and row.values is not None and off > 0:
-            keys = _copy_mlx_array(row.keys[..., :off, :])
-            values = _copy_mlx_array(row.values[..., :off, :])
-            step = int(getattr(row, "step", getattr(type(row), "step", 256)) or 0)
-            keys, values = _pad_kv_for_capacity(
-                keys,
-                values,
-                offset=off,
-                min_capacity_tokens=min_capacity_tokens,
-                step=step,
-            )
-            row.keys = keys
-            row.values = values
-            row.offset = off
-            eval_targets.extend([keys, values])
-        return row
+        if c.empty():
+            if isinstance(c, lm_cache.BatchRotatingKVCache):
+                return lm_cache.RotatingKVCache(max_size=int(c.max_size))
+            return lm_cache.KVCache()
+        return _clone_cache_entry_for_apc(
+            c.extract(0),
+            min_capacity_tokens=min_capacity_tokens,
+            eval_targets=eval_targets,
+        )
 
     if isinstance(c, lm_cache.RotatingKVCache):
         out = type(c)(
@@ -320,6 +312,8 @@ def _cache_entry_supports_exact_apc(c: Any) -> bool:
         (
             lm_cache.KVCache,
             lm_cache.BatchKVCache,
+            lm_cache.BatchRotatingKVCache,
+            lm_cache.BatchQuantizedKVCache,
             lm_cache.RotatingKVCache,
             lm_cache.ChunkedKVCache,
             lm_cache.ArraysCache,
@@ -573,6 +567,15 @@ class APCStats:
     disk_writes: int = 0
     exact_hits: int = 0
     exact_stores: int = 0
+    # Additive only — do not remove existing /v1/cache/stats keys.
+    rejects: int = 0
+    rejects_by_reason: Dict[str, int] = field(default_factory=dict)
+    last_reject: Optional[Dict[str, Any]] = None
+
+    def record_reject(self, reason: str, **details: Any) -> None:
+        self.rejects += 1
+        self.rejects_by_reason[reason] = self.rejects_by_reason.get(reason, 0) + 1
+        self.last_reject = {"reason": reason, **details}
 
     def snapshot(self, num_blocks: int, block_size: int) -> dict:
         denom = self.matched_tokens + self.served_tokens
@@ -592,6 +595,11 @@ class APCStats:
             "disk_writes": self.disk_writes,
             "exact_hits": self.exact_hits,
             "exact_stores": self.exact_stores,
+            "rejects": self.rejects,
+            "rejects_by_reason": dict(self.rejects_by_reason),
+            "last_reject": (
+                dict(self.last_reject) if self.last_reject is not None else None
+            ),
         }
 
 
@@ -3093,6 +3101,12 @@ class APCManager:
                 types,
                 len(token_tuple),
             )
+            with self.lock:
+                self.stats.record_reject(
+                    "unclonable",
+                    types=types,
+                    token_len=len(token_tuple),
+                )
             return False
         key = _sequence_hash(token_tuple, extra_hash, self.block_size)
         stored = False
@@ -3804,6 +3818,103 @@ def extract_prompt_cache_from_batch(
     return out
 
 
+def _prompt_cache_is_batch_shaped(caches: Sequence[Any]) -> bool:
+    """True when every entry can row-extract (Batch* / ArraysCache layout)."""
+    if not caches:
+        return False
+    return all(callable(getattr(c, "extract", None)) for c in caches)
+
+
+def snapshot_prompt_cache_row(
+    caches: Sequence[Any],
+    batch_idx: int = 0,
+    *,
+    min_capacity_tokens: Optional[int] = None,
+) -> Optional[List[Any]]:
+    """Row-normalize a prompt cache for APC store/lookup.
+
+    Batch-shaped layouts (every entry has ``extract``) are extracted first so
+    multi-row and B=1 Batch* caches share one path. Already single-row caches
+    are cloned in place. Result never contains Batch* types; quantized layers
+    are dequantized into float KVCache (dequant-at-harvest).
+    """
+    if not caches:
+        return []
+    source: Sequence[Any] = caches
+    if _prompt_cache_is_batch_shaped(caches):
+        row = extract_prompt_cache_from_batch(caches, batch_idx)
+        if row is None:
+            return None
+        source = row
+    return _clone_prompt_cache_for_apc(source, min_capacity_tokens=min_capacity_tokens)
+
+
+def layer_kv_for_apc(
+    c: Any,
+    batch_idx: Optional[int] = None,
+) -> Tuple[Optional[mx.array], Optional[mx.array]]:
+    """Return float K/V for one layer for block-mode APC harvest.
+
+    Prefer this over slicing ``c.keys`` directly: quantized caches store keys
+    as a tuple and dense slicing raises TypeError.
+    """
+    if hasattr(c, "dequantize_for_apc"):
+        dk, dv = c.dequantize_for_apc()
+        if dk is None or dv is None:
+            return None, None
+        left_padding = getattr(c, "left_padding", None)
+        lp = 0
+        if batch_idx is not None and left_padding is not None:
+            try:
+                lp = int(left_padding[batch_idx].item())
+            except Exception:
+                lp = 0
+        if batch_idx is not None and int(dk.shape[0]) > 1:
+            return (
+                dk[batch_idx : batch_idx + 1, :, lp:, :],
+                dv[batch_idx : batch_idx + 1, :, lp:, :],
+            )
+        if lp > 0:
+            return dk[..., lp:, :], dv[..., lp:, :]
+        return dk, dv
+
+    keys = getattr(c, "keys", None)
+    values = getattr(c, "values", None)
+    if keys is None or values is None:
+        return None, None
+    # Tuple keys without dequantize_for_apc cannot be sliced as dense arrays.
+    if isinstance(keys, tuple) or isinstance(values, tuple):
+        return None, None
+
+    left_padding = getattr(c, "left_padding", None)
+    idx = getattr(c, "_idx", None)
+    if idx is None:
+        off = getattr(c, "offset", None)
+        if off is None:
+            return None, None
+        try:
+            end = int(off)
+        except Exception:
+            return None, None
+        return keys[..., :end, :], values[..., :end, :]
+
+    lp = 0
+    if batch_idx is not None and left_padding is not None:
+        try:
+            lp = int(left_padding[batch_idx].item())
+        except Exception:
+            lp = 0
+    end = int(idx)
+    if batch_idx is not None and int(keys.shape[0]) > 1:
+        return (
+            keys[batch_idx : batch_idx + 1, :, lp:end, :],
+            values[batch_idx : batch_idx + 1, :, lp:end, :],
+        )
+    if lp > 0:
+        return keys[..., lp:end, :], values[..., lp:end, :]
+    return keys[..., :end, :], values[..., :end, :]
+
+
 def harvest_blocks_from_batch_cache(
     apc_manager: "APCManager",
     batch_caches: List[Any],
@@ -3821,47 +3932,14 @@ def harvest_blocks_from_batch_cache(
     layer_keys: List[mx.array] = []
     layer_values: List[mx.array] = []
     for c in batch_caches:
-        # Protocol dispatch: quantized caches expose dequantize_for_apc()
-        # which returns raw float arrays suitable for direct slicing.
-        if hasattr(c, "dequantize_for_apc"):
-            dk, dv = c.dequantize_for_apc()
-            if dk is None or dv is None:
-                return []
-            idx = dk.shape[-2]
-            left_padding = getattr(c, "left_padding", None)
-            if left_padding is not None:
-                try:
-                    lp = int(left_padding[batch_idx].item())
-                except Exception:
-                    lp = 0
-            else:
-                lp = 0
-            layer_keys.append(dk[batch_idx : batch_idx + 1, :, lp:, :])
-            layer_values.append(dv[batch_idx : batch_idx + 1, :, lp:, :])
-            continue
-
-        keys = getattr(c, "keys", None)
-        values = getattr(c, "values", None)
-        idx = getattr(c, "_idx", None)
-        # Regular KVCache (non-batch) — e.g. from make_speculative_prompt_cache
-        # used with MTP draft model + batch_size=1. These entries carry
-        # ``offset`` instead of ``_idx`` and have no ``left_padding``.
-        if idx is None and keys is not None and values is not None:
-            idx = getattr(c, "offset", None)
-        left_padding = getattr(c, "left_padding", None)
-        if keys is None or values is None or idx is None:
+        k, v = layer_kv_for_apc(c, batch_idx=batch_idx)
+        if k is None or v is None:
             return []
-        # Pull this batch row, dropping any left-padding for this seq.
-        if left_padding is not None:
-            try:
-                lp = int(left_padding[batch_idx].item())
-            except Exception:
-                lp = 0
-        else:
-            lp = 0
-        # shape after slicing: [1, H, idx-lp, D]
-        layer_keys.append(keys[batch_idx : batch_idx + 1, :, lp:idx, :])
-        layer_values.append(values[batch_idx : batch_idx + 1, :, lp:idx, :])
+        if int(k.shape[0]) != 1:
+            k = k[batch_idx : batch_idx + 1]
+            v = v[batch_idx : batch_idx + 1]
+        layer_keys.append(k)
+        layer_values.append(v)
     return apc_manager.store_kv_blocks(
         full_token_ids,
         layer_keys,

--- a/mlx_vlm/apc.py
+++ b/mlx_vlm/apc.py
@@ -156,19 +156,16 @@ def _clone_cache_entry_for_apc(
 
     # Batch* caches: collapse single-row via extract, then clone the row type.
     # Multi-row must go through snapshot_prompt_cache_row first.
-    if isinstance(
-        c,
-        (
-            lm_cache.BatchKVCache,
-            lm_cache.BatchRotatingKVCache,
-            lm_cache.BatchQuantizedKVCache,
-        ),
+    # Includes BatchTurboQuantKVCache (turboquant module; duck-typed via extract).
+    if callable(getattr(c, "extract", None)) and callable(
+        getattr(c, "is_single_row", None)
     ):
         if not c.is_single_row():
             return None
         if c.empty():
             if isinstance(c, lm_cache.BatchRotatingKVCache):
                 return lm_cache.RotatingKVCache(max_size=int(c.max_size))
+            # BatchTurboQuant / BatchQuantized / BatchKV → empty float row
             return lm_cache.KVCache()
         return _clone_cache_entry_for_apc(
             c.extract(0),

--- a/mlx_vlm/apc.py
+++ b/mlx_vlm/apc.py
@@ -154,9 +154,8 @@ def _clone_cache_entry_for_apc(
             eval_targets.extend([keys, values])
         return out
 
-    # Batch* caches: collapse single-row via extract, then clone the row type.
-    # Multi-row must go through snapshot_prompt_cache_row first.
-    # Includes BatchTurboQuantKVCache (turboquant module; duck-typed via extract).
+    # Batch caches expose extract + is_single_row; collapse to a single-row
+    # entry before cloning. Multi-row stores should call snapshot_prompt_cache_row.
     if callable(getattr(c, "extract", None)) and callable(
         getattr(c, "is_single_row", None)
     ):
@@ -165,7 +164,6 @@ def _clone_cache_entry_for_apc(
         if c.empty():
             if isinstance(c, lm_cache.BatchRotatingKVCache):
                 return lm_cache.RotatingKVCache(max_size=int(c.max_size))
-            # BatchTurboQuant / BatchQuantized / BatchKV → empty float row
             return lm_cache.KVCache()
         return _clone_cache_entry_for_apc(
             c.extract(0),
@@ -564,7 +562,6 @@ class APCStats:
     disk_writes: int = 0
     exact_hits: int = 0
     exact_stores: int = 0
-    # Additive only — do not remove existing /v1/cache/stats keys.
     rejects: int = 0
     rejects_by_reason: Dict[str, int] = field(default_factory=dict)
     last_reject: Optional[Dict[str, Any]] = None
@@ -3830,10 +3827,9 @@ def snapshot_prompt_cache_row(
 ) -> Optional[List[Any]]:
     """Row-normalize a prompt cache for APC store/lookup.
 
-    Batch-shaped layouts (every entry has ``extract``) are extracted first so
-    multi-row and B=1 Batch* caches share one path. Already single-row caches
-    are cloned in place. Result never contains Batch* types; quantized layers
-    are dequantized into float KVCache (dequant-at-harvest).
+    Batch-shaped layouts (every entry has ``extract``) are extracted first.
+    Single-row caches are cloned in place. Quantized layers are dequantized
+    into float ``KVCache`` entries.
     """
     if not caches:
         return []

--- a/mlx_vlm/generate/ar.py
+++ b/mlx_vlm/generate/ar.py
@@ -1739,11 +1739,9 @@ class PromptProcessingBatch:
         return prefix_len + min(self._suffix_lens[batch_idx], max(0, real_done))
 
     def _apc_prompt_cache_for_store(self, batch_idx: int) -> Optional[List[Any]]:
-        # Single-request cold batches use an unbatched cache that is already
-        # row-specific, so there is nothing to extract.
-        if batch_idx == 0 and len(self.uids) == 1 and self._right_pad_per_row is None:
-            return self.prompt_cache
-        return _apc.extract_prompt_cache_from_batch(self.prompt_cache, batch_idx)
+        # Always row-normalize so exact store never sees Batch* dialects
+        # (including B=1 under --kv-bits). Single-row caches clone in place.
+        return _apc.snapshot_prompt_cache_row(self.prompt_cache, batch_idx)
 
     def _store_apc_exact_checkpoints(self) -> None:
         if self._apc_manager is None or self._apc_mode != "exact":

--- a/mlx_vlm/generate/ar.py
+++ b/mlx_vlm/generate/ar.py
@@ -1739,8 +1739,6 @@ class PromptProcessingBatch:
         return prefix_len + min(self._suffix_lens[batch_idx], max(0, real_done))
 
     def _apc_prompt_cache_for_store(self, batch_idx: int) -> Optional[List[Any]]:
-        # Always row-normalize so exact store never sees Batch* dialects
-        # (including B=1 under --kv-bits). Single-row caches clone in place.
         return _apc.snapshot_prompt_cache_row(self.prompt_cache, batch_idx)
 
     def _store_apc_exact_checkpoints(self) -> None:

--- a/mlx_vlm/generate/dispatch.py
+++ b/mlx_vlm/generate/dispatch.py
@@ -1139,19 +1139,17 @@ def stream_generate(
                     all_ids = full_input_ids_list + [
                         t.item() if hasattr(t, "item") else t for t in generated_tokens
                     ]
-                # Snapshot keys/values up to the live offset for each layer.
+                # Snapshot float K/V per layer (dequants when keys are tuples).
                 layer_keys: List[mx.array] = []
                 layer_values: List[mx.array] = []
                 ok = True
                 for c in tracked_cache:
-                    k = getattr(c, "keys", None)
-                    v = getattr(c, "values", None)
-                    off = getattr(c, "offset", None)
-                    if k is None or v is None or off is None:
+                    k, v = _apc.layer_kv_for_apc(c)
+                    if k is None or v is None:
                         ok = False
                         break
-                    layer_keys.append(k[..., :off, :])
-                    layer_values.append(v[..., :off, :])
+                    layer_keys.append(k)
+                    layer_values.append(v)
                 if ok and layer_keys:
                     new_blocks = apc_manager.store_kv_blocks(
                         all_ids,

--- a/mlx_vlm/models/cache.py
+++ b/mlx_vlm/models/cache.py
@@ -1199,7 +1199,11 @@ class BatchRotatingKVCache(_BaseCache):
         return self.keys, self.values
 
     def update_and_fetch(self, keys, values):
-        if keys.shape[2] == 1:
+        # Single-token updates normally use the in-place decode path. While
+        # right-padding bookkeeping is active (_lengths set by prepare()), the
+        # last prefill step may still be S=1; that must go through concat so
+        # pad tokens are tracked until finalize() rolls them out.
+        if keys.shape[2] == 1 and self._lengths is None:
             return self._update_in_place(keys, values)
         return self._update_concat(keys, values)
 

--- a/mlx_vlm/models/cache.py
+++ b/mlx_vlm/models/cache.py
@@ -1049,6 +1049,15 @@ class BatchKVCache(_BaseCache):
         return self.keys is None
 
     @property
+    def batch_size(self):
+        if self.keys is not None:
+            return int(self.keys.shape[0])
+        return int(self.left_padding.shape[0])
+
+    def is_single_row(self):
+        return self.batch_size == 1
+
+    @property
     def nbytes(self):
         if self.keys is None:
             return 0
@@ -1407,6 +1416,15 @@ class BatchRotatingKVCache(_BaseCache):
         return self.keys is None
 
     @property
+    def batch_size(self):
+        if self.keys is not None:
+            return int(self.keys.shape[0])
+        return int(self.left_padding.shape[0])
+
+    def is_single_row(self):
+        return self.batch_size == 1
+
+    @property
     def nbytes(self):
         if self.keys is None:
             return 0
@@ -1673,6 +1691,22 @@ class BatchQuantizedKVCache(_BaseCache):
             self.keys, self.values, self._idx, self.group_size, self.bits
         )
 
+    def extract(self, idx):
+        """Extract one batch row as a single-sequence QuantizedKVCache."""
+        cache = QuantizedKVCache(group_size=self.group_size, bits=self.bits)
+        if self.keys is None or self._idx == 0:
+            return cache
+        padding = int(self.left_padding[idx].item())
+        end = self._idx
+        cache.keys = tuple(
+            mx.contiguous(k[idx : idx + 1, :, padding:end, :]) for k in self.keys
+        )
+        cache.values = tuple(
+            mx.contiguous(v[idx : idx + 1, :, padding:end, :]) for v in self.values
+        )
+        cache.offset = int(cache.keys[0].shape[2])
+        return cache
+
     def filter(self, batch_indices: mx.array):
         """Keep only the sequences at *batch_indices*."""
         if self.keys is not None:
@@ -1784,6 +1818,15 @@ class BatchQuantizedKVCache(_BaseCache):
 
     def empty(self):
         return self.keys is None
+
+    @property
+    def batch_size(self):
+        if self.keys is not None:
+            return int(self.keys[0].shape[0])
+        return int(self.left_padding.shape[0])
+
+    def is_single_row(self):
+        return self.batch_size == 1
 
     def make_mask(self, N: int, return_array: bool = False, **kwargs):
         return create_causal_mask(

--- a/mlx_vlm/tests/test_apc_adapters.py
+++ b/mlx_vlm/tests/test_apc_adapters.py
@@ -1,0 +1,541 @@
+"""TDD tests for APC adapter boundary + batch/SWA kv-bits coverage (#1559).
+
+Follow-up to #1534. These tests define the contract before / alongside
+implementation:
+
+1. Clear batch cache APIs (``batch_size``, ``is_single_row``, ``empty``)
+2. ``BatchQuantizedKVCache.extract`` (multi-row exact path)
+3. Always row-normalize via ``snapshot_prompt_cache_row`` (no B=1 special case)
+4. Gemma-like hybrid: BatchRotating + BatchQuantized + BatchKV
+5. Reject observability (stats + reason codes)
+6. Post-decode / block harvest handles quantized ``keys`` tuples
+
+No mocking of cache behavior — same production types as server/BatchGenerator.
+"""
+
+from __future__ import annotations
+
+import mlx.core as mx
+
+from mlx_vlm.apc import (
+    APCManager,
+    _cache_entry_supports_exact_apc,
+    _clone_cache_entry_for_apc,
+    _clone_prompt_cache_for_apc,
+    extract_prompt_cache_from_batch,
+    harvest_blocks_from_batch_cache,
+    model_apc_mode,
+)
+from mlx_vlm.models.cache import (
+    ArraysCache,
+    BatchKVCache,
+    BatchQuantizedKVCache,
+    BatchRotatingKVCache,
+    KVCache,
+    QuantizedKVCache,
+    RotatingKVCache,
+)
+
+# Small dims: fast unit tests, no GPU pressure
+B, H, D = 1, 2, 32
+GROUP_SIZE = 32
+BITS = 8
+BLOCK_SIZE = 16
+SWA_MAX = 64
+
+
+def _rand_kv(batch=B, seq_len=32, heads=H, dim=D):
+    k = mx.random.normal((batch, heads, seq_len, dim))
+    v = mx.random.normal((batch, heads, seq_len, dim))
+    mx.eval(k, v)
+    return k, v
+
+
+def _max_abs_error(a: mx.array, b: mx.array) -> float:
+    return mx.max(mx.abs(a - b)).item()
+
+
+def _fill_batch_kv(left_padding, seq_len):
+    cache = BatchKVCache(list(left_padding))
+    k, v = _rand_kv(batch=len(left_padding), seq_len=seq_len)
+    cache.update_and_fetch(k, v)
+    mx.eval(cache.keys, cache.values)
+    return cache, k, v
+
+
+def _fill_batch_quant(left_padding, seq_len):
+    cache = BatchQuantizedKVCache(list(left_padding), group_size=GROUP_SIZE, bits=BITS)
+    k, v = _rand_kv(batch=len(left_padding), seq_len=seq_len)
+    cache.update_and_fetch(k, v)
+    mx.eval(cache.keys)
+    return cache, k, v
+
+
+def _fill_batch_rotating(left_padding, seq_len, max_size=SWA_MAX):
+    cache = BatchRotatingKVCache(max_size, list(left_padding))
+    k, v = _rand_kv(batch=len(left_padding), seq_len=seq_len)
+    cache.update_and_fetch(k, v)
+    mx.eval(cache.keys, cache.values)
+    return cache, k, v
+
+
+# ---------------------------------------------------------------------------
+# A — Cache API clarity (Lucas nit)
+# ---------------------------------------------------------------------------
+
+
+class TestBatchCacheIntrospection:
+    """batch_size / is_single_row / empty — no poking at _idx or keys.shape[0]."""
+
+    def test_batch_kv_empty_and_single_row(self):
+        empty = BatchKVCache([0])
+        assert empty.empty() is True
+        assert empty.batch_size == 1
+        assert empty.is_single_row() is True
+
+        multi = BatchKVCache([0, 0, 0])
+        assert multi.batch_size == 3
+        assert multi.is_single_row() is False
+
+        filled, _, _ = _fill_batch_kv([0, 0], seq_len=8)
+        assert filled.empty() is False
+        assert filled.batch_size == 2
+        assert filled.is_single_row() is False
+
+    def test_batch_quantized_empty_and_batch_size(self):
+        empty = BatchQuantizedKVCache([0, 0], group_size=GROUP_SIZE, bits=BITS)
+        assert empty.empty() is True
+        assert empty.batch_size == 2
+        assert empty.is_single_row() is False
+
+        filled, _, _ = _fill_batch_quant([0], seq_len=8)
+        assert filled.empty() is False
+        assert filled.batch_size == 1
+        assert filled.is_single_row() is True
+
+    def test_batch_rotating_empty_and_batch_size(self):
+        empty = BatchRotatingKVCache(SWA_MAX, [0, 0])
+        assert empty.empty() is True
+        assert empty.batch_size == 2
+        assert empty.is_single_row() is False
+
+        filled, _, _ = _fill_batch_rotating([0], seq_len=8)
+        assert filled.empty() is False
+        assert filled.batch_size == 1
+        assert filled.is_single_row() is True
+
+    def test_clone_uses_empty_not_private_fields(self):
+        """_clone_cache_entry_for_apc should not require poking _idx for empty."""
+        empty_bk = BatchKVCache([0])
+        eval_targets: list = []
+        cloned = _clone_cache_entry_for_apc(
+            empty_bk, min_capacity_tokens=None, eval_targets=eval_targets
+        )
+        assert isinstance(cloned, KVCache)
+        assert cloned.keys is None or int(getattr(cloned, "offset", 0) or 0) == 0
+
+
+# ---------------------------------------------------------------------------
+# A — BatchQuantizedKVCache.extract (multi-row exact)
+# ---------------------------------------------------------------------------
+
+
+class TestBatchQuantizedExtract:
+    def test_extract_returns_quantized_kv_cache(self):
+        cache, k, v = _fill_batch_quant([0, 0], seq_len=24)
+        row = cache.extract(1)
+        assert isinstance(row, QuantizedKVCache)
+        assert row.group_size == GROUP_SIZE
+        assert row.bits == BITS
+        assert row.offset == 24
+        dk, dv = row.dequantize_for_apc()
+        mx.eval(dk, dv)
+        assert dk.shape == (1, H, 24, D)
+        # Row 1 should match original float within 8-bit tolerance
+        assert _max_abs_error(dk, k[1:2]) < 0.15
+
+    def test_extract_respects_left_padding(self):
+        # left_padding=[2, 0]: row 0 has 2 pad tokens at the front of the buffer
+        cache = BatchQuantizedKVCache([2, 0], group_size=GROUP_SIZE, bits=BITS)
+        k, v = _rand_kv(batch=2, seq_len=10)
+        cache.update_and_fetch(k, v)
+        mx.eval(cache.keys)
+
+        row0 = cache.extract(0)
+        # After dropping left pad, valid tokens = _idx - pad
+        assert row0.offset == cache._idx - 2
+        row1 = cache.extract(1)
+        assert row1.offset == cache._idx
+
+    def test_extract_empty_cache(self):
+        cache = BatchQuantizedKVCache([0, 0], group_size=GROUP_SIZE, bits=BITS)
+        row = cache.extract(0)
+        assert isinstance(row, QuantizedKVCache)
+        assert row.keys is None or row.offset == 0
+
+    def test_extract_prompt_cache_from_batch_multi_row(self):
+        """Multi-row hybrid layout becomes extractable end-to-end."""
+        seq_len = 2 * BLOCK_SIZE
+        arrays = ArraysCache(2, left_padding=[0, 0])
+        arrays.cache = [
+            mx.zeros((2, seq_len, D)),
+            mx.zeros((2, seq_len, D)),
+        ]
+        batch_kv, _, _ = _fill_batch_kv([0, 0], seq_len=seq_len)
+        batch_q, _, _ = _fill_batch_quant([0, 0], seq_len=seq_len)
+
+        prompt_cache = [arrays, batch_kv, batch_q]
+        row0 = extract_prompt_cache_from_batch(prompt_cache, 0)
+        row1 = extract_prompt_cache_from_batch(prompt_cache, 1)
+        assert row0 is not None and row1 is not None
+        assert len(row0) == 3 and len(row1) == 3
+        assert isinstance(row0[1], KVCache)
+        assert isinstance(row0[2], QuantizedKVCache)
+        assert isinstance(row1[2], QuantizedKVCache)
+
+
+# ---------------------------------------------------------------------------
+# A — Always row-normalize (snapshot adapter)
+# ---------------------------------------------------------------------------
+
+
+class TestSnapshotPromptCacheRow:
+    """snapshot_prompt_cache_row is the single inbound adapter for APC stores."""
+
+    def test_api_exists(self):
+        from mlx_vlm.apc import snapshot_prompt_cache_row
+
+        assert callable(snapshot_prompt_cache_row)
+
+    def test_b1_batch_kv_collapses_to_single_row(self):
+        from mlx_vlm.apc import snapshot_prompt_cache_row
+
+        seq_len = 2 * BLOCK_SIZE
+        batch_kv, _, _ = _fill_batch_kv([0], seq_len=seq_len)
+        batch_q, _, _ = _fill_batch_quant([0], seq_len=seq_len)
+        snap = snapshot_prompt_cache_row([batch_kv, batch_q], batch_idx=0)
+        assert snap is not None
+        assert len(snap) == 2
+        # APC core never sees Batch* types
+        assert not isinstance(snap[0], BatchKVCache)
+        assert not isinstance(snap[1], BatchQuantizedKVCache)
+        assert isinstance(snap[0], KVCache)
+        assert isinstance(snap[1], KVCache)  # dequant at harvest
+        assert snap[0].offset == seq_len
+        assert snap[1].offset == seq_len
+
+    def test_multi_row_extracts_requested_index(self):
+        from mlx_vlm.apc import snapshot_prompt_cache_row
+
+        seq_len = BLOCK_SIZE
+        batch_kv, k, _ = _fill_batch_kv([0, 0], seq_len=seq_len)
+        snap0 = snapshot_prompt_cache_row([batch_kv], batch_idx=0)
+        snap1 = snapshot_prompt_cache_row([batch_kv], batch_idx=1)
+        assert snap0 is not None and snap1 is not None
+        mx.eval(snap0[0].keys, snap1[0].keys)
+        # Distinct rows
+        assert _max_abs_error(snap0[0].keys, k[0:1, :, :seq_len, :]) < 1e-5
+        assert _max_abs_error(snap1[0].keys, k[1:2, :, :seq_len, :]) < 1e-5
+        assert _max_abs_error(snap0[0].keys, snap1[0].keys) > 1e-3
+
+    def test_already_single_row_plain_kv_still_works(self):
+        """generate() path uses non-batch KVCache — snapshot must not require extract."""
+        from mlx_vlm.apc import snapshot_prompt_cache_row
+
+        cache = KVCache()
+        k, v = _rand_kv(batch=1, seq_len=20)
+        cache.update_and_fetch(k, v)
+        snap = snapshot_prompt_cache_row([cache], batch_idx=0)
+        assert snap is not None
+        assert isinstance(snap[0], KVCache)
+        assert snap[0].offset == 20
+
+    def test_store_exact_via_snapshot_multi_row(self):
+        from mlx_vlm.apc import snapshot_prompt_cache_row
+
+        seq_len = 2 * BLOCK_SIZE
+        token_ids = list(range(seq_len))
+        batch_kv, _, _ = _fill_batch_kv([0, 0], seq_len=seq_len)
+        batch_q, _, _ = _fill_batch_quant([0, 0], seq_len=seq_len)
+        prompt_cache = [batch_kv, batch_q]
+
+        manager = APCManager(num_blocks=4, block_size=BLOCK_SIZE)
+        for bi in (0, 1):
+            snap = snapshot_prompt_cache_row(prompt_cache, batch_idx=bi)
+            assert snap is not None
+            # Use distinct extra_hash so rows don't collide in exact dict
+            stored = manager.store_exact_cache(token_ids, snap, extra_hash=bi + 1)
+            assert stored is True
+
+        warm0, m0 = manager.lookup_exact_cache(token_ids + [9], extra_hash=1)
+        warm1, m1 = manager.lookup_exact_cache(token_ids + [9], extra_hash=2)
+        assert m0 == seq_len and m1 == seq_len
+        assert warm0 is not None and warm1 is not None
+
+
+# ---------------------------------------------------------------------------
+# A — Gemma-like SWA hybrid (BatchRotating + quant + full attn)
+# ---------------------------------------------------------------------------
+
+
+class TestGemmaLikeHybridExact:
+    def _gemma_like_layout(self, batch_size: int, seq_len: int):
+        """Approximate Gemma 4 hybrid serving layout under --kv-bits.
+
+        Typical pattern: SWA rotating layers + quantized full-attn layers +
+        possibly a dense last layer. Arrays not required for pure gemma SWA.
+        """
+        pads = [0] * batch_size
+        rotating, _, _ = _fill_batch_rotating(pads, seq_len=seq_len, max_size=SWA_MAX)
+        quant, _, _ = _fill_batch_quant(pads, seq_len=seq_len)
+        dense, _, _ = _fill_batch_kv(pads, seq_len=seq_len)
+        return [rotating, quant, dense]
+
+    def test_supports_exact_apc_for_batch_rotating(self):
+        cache, _, _ = _fill_batch_rotating([0], seq_len=16)
+        assert _cache_entry_supports_exact_apc(cache) is True
+
+    def test_extract_batch_rotating_then_clone(self):
+        cache, _, _ = _fill_batch_rotating([0], seq_len=20)
+        row = cache.extract(0)
+        assert isinstance(row, RotatingKVCache)
+        eval_targets: list = []
+        cloned = _clone_cache_entry_for_apc(
+            row, min_capacity_tokens=None, eval_targets=eval_targets
+        )
+        assert cloned is not None
+        assert isinstance(cloned, RotatingKVCache)
+
+    def test_b1_gemma_like_exact_store_and_lookup(self):
+        """#1559 success criterion: Gemma batch path B=1 exact store + hit."""
+        from mlx_vlm.apc import snapshot_prompt_cache_row
+
+        seq_len = 2 * BLOCK_SIZE
+        token_ids = list(range(seq_len))
+        prompt_cache = self._gemma_like_layout(batch_size=1, seq_len=seq_len)
+
+        # Layout must be recognized as exact-capable
+        assert all(_cache_entry_supports_exact_apc(c) for c in prompt_cache)
+
+        snap = snapshot_prompt_cache_row(prompt_cache, batch_idx=0)
+        assert snap is not None
+        # No Batch* types in APC storage
+        for c in snap:
+            assert not type(c).__name__.startswith("Batch")
+
+        manager = APCManager(num_blocks=4, block_size=BLOCK_SIZE)
+        assert manager.store_exact_cache(token_ids, snap, extra_hash=0) is True
+        assert manager.stats.exact_stores == 1
+
+        warm, matched = manager.lookup_exact_cache(token_ids + [99], extra_hash=0)
+        assert matched == seq_len
+        assert warm is not None
+        assert len(warm) == 3
+
+    def test_multi_row_gemma_like_exact_store(self):
+        from mlx_vlm.apc import snapshot_prompt_cache_row
+
+        seq_len = 2 * BLOCK_SIZE
+        token_ids = list(range(seq_len))
+        prompt_cache = self._gemma_like_layout(batch_size=2, seq_len=seq_len)
+
+        manager = APCManager(num_blocks=8, block_size=BLOCK_SIZE)
+        for bi in (0, 1):
+            snap = snapshot_prompt_cache_row(prompt_cache, batch_idx=bi)
+            assert snap is not None
+            assert manager.store_exact_cache(token_ids, snap, extra_hash=10 + bi)
+
+        for bi in (0, 1):
+            warm, matched = manager.lookup_exact_cache(
+                token_ids + [1], extra_hash=10 + bi
+            )
+            assert matched == seq_len
+            assert warm is not None
+
+    def test_model_apc_mode_exact_for_gemma_like_make_cache(self):
+        """model_apc_mode must return exact when make_cache yields SWA hybrid."""
+
+        class FakeGemmaLang:
+            def make_cache(self):
+                # Empty caches of the hybrid types (serving layout under kv-bits)
+                return [
+                    BatchRotatingKVCache(SWA_MAX, [0]),
+                    BatchQuantizedKVCache([0], group_size=GROUP_SIZE, bits=BITS),
+                    BatchKVCache([0]),
+                ]
+
+        assert model_apc_mode(FakeGemmaLang()) == "exact"
+
+
+# ---------------------------------------------------------------------------
+# C — Reject observability
+# ---------------------------------------------------------------------------
+
+
+class TestRejectObservability:
+    def test_stats_include_rejects_keys(self):
+        manager = APCManager(num_blocks=4, block_size=BLOCK_SIZE)
+        snap = manager.stats.snapshot(manager.num_blocks, manager.block_size)
+        assert "rejects" in snap
+        assert "rejects_by_reason" in snap
+        assert "last_reject" in snap
+        assert snap["rejects"] == 0
+        assert snap["rejects_by_reason"] == {}
+        assert snap["last_reject"] is None
+
+    def test_unclonable_exact_store_increments_rejects(self):
+        manager = APCManager(num_blocks=4, block_size=BLOCK_SIZE)
+        token_ids = list(range(BLOCK_SIZE))
+
+        class UnclonableCache:
+            """No extract, no dequantize_for_apc, not a known cache type."""
+
+            keys = "not-an-array"
+            values = "not-an-array"
+
+        stored = manager.store_exact_cache(token_ids, [UnclonableCache()])
+        assert stored is False
+        assert manager.stats.rejects >= 1
+        assert manager.stats.rejects_by_reason.get("unclonable", 0) >= 1
+        last = manager.stats.last_reject
+        assert last is not None
+        assert last.get("reason") == "unclonable"
+
+        snap = manager.stats.snapshot(manager.num_blocks, manager.block_size)
+        assert snap["rejects"] >= 1
+        assert "unclonable" in snap["rejects_by_reason"]
+
+
+# ---------------------------------------------------------------------------
+# D — Block harvest / post-decode path with quantized keys
+# ---------------------------------------------------------------------------
+
+
+class TestQuantizedBlockHarvest:
+    def test_harvest_single_row_batch_quantized(self):
+        manager = APCManager(num_blocks=8, block_size=BLOCK_SIZE)
+        seq_len = 2 * BLOCK_SIZE
+        cache, _, _ = _fill_batch_quant([0], seq_len=seq_len)
+        token_ids = list(range(seq_len))
+        blocks = harvest_blocks_from_batch_cache(
+            manager, [cache], batch_idx=0, full_token_ids=token_ids
+        )
+        assert len(blocks) == 2
+        manager.release(blocks)
+
+    def test_layer_kv_float_helper_handles_quantized_tuple_keys(self):
+        """dispatch post-decode harvest must not slice quantized tuple keys.
+
+        ``layer_kv_for_apc`` (or equivalent) returns float K/V for any supported
+        cache dialect so callers never do ``keys[..., :off, :]`` on a tuple.
+        """
+        from mlx_vlm.apc import layer_kv_for_apc
+
+        # Plain KV
+        plain = KVCache()
+        k, v = _rand_kv(batch=1, seq_len=12)
+        plain.update_and_fetch(k, v)
+        pk, pv = layer_kv_for_apc(plain)
+        assert pk is not None and pv is not None
+        assert pk.shape[-2] == 12
+
+        # Quantized single-row
+        q = QuantizedKVCache(group_size=GROUP_SIZE, bits=BITS)
+        k, v = _rand_kv(batch=1, seq_len=12)
+        q.update_and_fetch(k, v)
+        qk, qv = layer_kv_for_apc(q)
+        mx.eval(qk, qv)
+        assert qk.shape == (1, H, 12, D)
+        assert not isinstance(qk, tuple)
+
+        # Batch quantized row
+        bq, _, _ = _fill_batch_quant([0, 0], seq_len=12)
+        bk, bv = layer_kv_for_apc(bq, batch_idx=1)
+        mx.eval(bk, bv)
+        assert bk.shape[0] == 1
+        assert bk.shape[-2] <= 12
+
+    def test_layer_kv_rejects_unknown_without_crashing(self):
+        from mlx_vlm.apc import layer_kv_for_apc
+
+        class Bogus:
+            keys = (1, 2, 3)  # tuple like quantized but no dequantize_for_apc
+            values = (4, 5, 6)
+            offset = 3
+
+        assert layer_kv_for_apc(Bogus()) == (None, None)
+
+
+# ---------------------------------------------------------------------------
+# A — No B=1 special case residual in extract path
+# ---------------------------------------------------------------------------
+
+
+class TestAlwaysExtractSemantics:
+    """BatchGenerator must not short-circuit B=1; extract works for B=1 Batch*."""
+
+    def test_extract_b1_batch_rotating_equals_clone_after_extract(self):
+        cache, _, _ = _fill_batch_rotating([0], seq_len=16)
+        row = extract_prompt_cache_from_batch([cache], 0)
+        assert row is not None
+        cloned = _clone_prompt_cache_for_apc(row)
+        assert cloned is not None
+
+    def test_extract_b1_batch_quantized(self):
+        cache, _, _ = _fill_batch_quant([0], seq_len=16)
+        row = extract_prompt_cache_from_batch([cache], 0)
+        assert row is not None
+        assert isinstance(row[0], QuantizedKVCache)
+        cloned = _clone_prompt_cache_for_apc(row)
+        assert cloned is not None
+        assert isinstance(cloned[0], KVCache)
+
+    def test_snapshot_equivalent_for_b1_whether_or_not_batch(self):
+        """snapshot of BatchKV B=1 matches snapshot of equivalent KVCache content."""
+        from mlx_vlm.apc import snapshot_prompt_cache_row
+
+        seq_len = 16
+        k, v = _rand_kv(batch=1, seq_len=seq_len)
+
+        batch = BatchKVCache([0])
+        batch.update_and_fetch(k, v)
+        plain = KVCache()
+        plain.update_and_fetch(k, v)
+        mx.eval(batch.keys, plain.keys)
+
+        snap_b = snapshot_prompt_cache_row([batch], 0)
+        snap_p = snapshot_prompt_cache_row([plain], 0)
+        assert snap_b is not None and snap_p is not None
+        mx.eval(snap_b[0].keys, snap_p[0].keys)
+        assert _max_abs_error(snap_b[0].keys, snap_p[0].keys) < 1e-5
+
+
+# ---------------------------------------------------------------------------
+# Integration: store_exact_cache accepts batch caches if snapshot is used
+# (document expected call pattern for BatchGenerator refactor)
+# ---------------------------------------------------------------------------
+
+
+class TestStoreExactCallPattern:
+    def test_direct_store_of_batch_rotating_without_snapshot_may_reject_or_adapt(
+        self,
+    ):
+        """Preferred path is snapshot_prompt_cache_row first.
+
+        Direct store_exact_cache on Batch* may either:
+        - succeed by adapting internally, or
+        - reject with stats — both OK as long as snapshot path works.
+        The snapshot path is the supported contract.
+        """
+        from mlx_vlm.apc import snapshot_prompt_cache_row
+
+        seq_len = BLOCK_SIZE
+        token_ids = list(range(seq_len))
+        layout = [
+            _fill_batch_rotating([0], seq_len)[0],
+            _fill_batch_quant([0], seq_len)[0],
+        ]
+        snap = snapshot_prompt_cache_row(layout, 0)
+        manager = APCManager(num_blocks=4, block_size=BLOCK_SIZE)
+        assert snap is not None
+        assert manager.store_exact_cache(token_ids, snap) is True

--- a/mlx_vlm/tests/test_apc_adapters.py
+++ b/mlx_vlm/tests/test_apc_adapters.py
@@ -1,16 +1,7 @@
-"""TDD tests for APC adapter boundary + batch/SWA kv-bits coverage (#1559).
+"""Tests for APC adapters over batch / quantized / SWA cache layouts.
 
-Follow-up to #1534. These tests define the contract before / alongside
-implementation:
-
-1. Clear batch cache APIs (``batch_size``, ``is_single_row``, ``empty``)
-2. ``BatchQuantizedKVCache.extract`` (multi-row exact path)
-3. Always row-normalize via ``snapshot_prompt_cache_row`` (no B=1 special case)
-4. Gemma-like hybrid: BatchRotating + BatchQuantized + BatchKV
-5. Reject observability (stats + reason codes)
-6. Post-decode / block harvest handles quantized ``keys`` tuples
-
-No mocking of cache behavior — same production types as server/BatchGenerator.
+Covers row snapshot, extract, hybrid exact store/lookup, reject stats, and
+dequant-aware block harvest. Uses real cache types with small dimensions.
 """
 
 from __future__ import annotations
@@ -79,13 +70,8 @@ def _fill_batch_rotating(left_padding, seq_len, max_size=SWA_MAX):
     return cache, k, v
 
 
-# ---------------------------------------------------------------------------
-# A — Cache API clarity (Lucas nit)
-# ---------------------------------------------------------------------------
-
-
 class TestBatchCacheIntrospection:
-    """batch_size / is_single_row / empty — no poking at _idx or keys.shape[0]."""
+    """batch_size, is_single_row, and empty on batch cache types."""
 
     def test_batch_kv_empty_and_single_row(self):
         empty = BatchKVCache([0])
@@ -124,8 +110,7 @@ class TestBatchCacheIntrospection:
         assert filled.batch_size == 1
         assert filled.is_single_row() is True
 
-    def test_clone_uses_empty_not_private_fields(self):
-        """_clone_cache_entry_for_apc should not require poking _idx for empty."""
+    def test_clone_empty_batch_kv(self):
         empty_bk = BatchKVCache([0])
         eval_targets: list = []
         cloned = _clone_cache_entry_for_apc(
@@ -133,11 +118,6 @@ class TestBatchCacheIntrospection:
         )
         assert isinstance(cloned, KVCache)
         assert cloned.keys is None or int(getattr(cloned, "offset", 0) or 0) == 0
-
-
-# ---------------------------------------------------------------------------
-# A — BatchQuantizedKVCache.extract (multi-row exact)
-# ---------------------------------------------------------------------------
 
 
 class TestBatchQuantizedExtract:
@@ -194,13 +174,7 @@ class TestBatchQuantizedExtract:
         assert isinstance(row1[2], QuantizedKVCache)
 
 
-# ---------------------------------------------------------------------------
-# A — Always row-normalize (snapshot adapter)
-# ---------------------------------------------------------------------------
-
-
 class TestSnapshotPromptCacheRow:
-    """snapshot_prompt_cache_row is the single inbound adapter for APC stores."""
 
     def test_api_exists(self):
         from mlx_vlm.apc import snapshot_prompt_cache_row
@@ -220,7 +194,7 @@ class TestSnapshotPromptCacheRow:
         assert not isinstance(snap[0], BatchKVCache)
         assert not isinstance(snap[1], BatchQuantizedKVCache)
         assert isinstance(snap[0], KVCache)
-        assert isinstance(snap[1], KVCache)  # dequant at harvest
+        assert isinstance(snap[1], KVCache)
         assert snap[0].offset == seq_len
         assert snap[1].offset == seq_len
 
@@ -273,18 +247,9 @@ class TestSnapshotPromptCacheRow:
         assert warm0 is not None and warm1 is not None
 
 
-# ---------------------------------------------------------------------------
-# A — Gemma-like SWA hybrid (BatchRotating + quant + full attn)
-# ---------------------------------------------------------------------------
-
-
 class TestGemmaLikeHybridExact:
     def _gemma_like_layout(self, batch_size: int, seq_len: int):
-        """Approximate Gemma 4 hybrid serving layout under --kv-bits.
-
-        Typical pattern: SWA rotating layers + quantized full-attn layers +
-        possibly a dense last layer. Arrays not required for pure gemma SWA.
-        """
+        """SWA rotating + quantized full-attn + dense last layer."""
         pads = [0] * batch_size
         rotating, _, _ = _fill_batch_rotating(pads, seq_len=seq_len, max_size=SWA_MAX)
         quant, _, _ = _fill_batch_quant(pads, seq_len=seq_len)
@@ -307,19 +272,16 @@ class TestGemmaLikeHybridExact:
         assert isinstance(cloned, RotatingKVCache)
 
     def test_b1_gemma_like_exact_store_and_lookup(self):
-        """#1559 success criterion: Gemma batch path B=1 exact store + hit."""
         from mlx_vlm.apc import snapshot_prompt_cache_row
 
         seq_len = 2 * BLOCK_SIZE
         token_ids = list(range(seq_len))
         prompt_cache = self._gemma_like_layout(batch_size=1, seq_len=seq_len)
 
-        # Layout must be recognized as exact-capable
         assert all(_cache_entry_supports_exact_apc(c) for c in prompt_cache)
 
         snap = snapshot_prompt_cache_row(prompt_cache, batch_idx=0)
         assert snap is not None
-        # No Batch* types in APC storage
         for c in snap:
             assert not type(c).__name__.startswith("Batch")
 
@@ -367,11 +329,6 @@ class TestGemmaLikeHybridExact:
         assert model_apc_mode(FakeGemmaLang()) == "exact"
 
 
-# ---------------------------------------------------------------------------
-# C — Reject observability
-# ---------------------------------------------------------------------------
-
-
 class TestRejectObservability:
     def test_stats_include_rejects_keys(self):
         manager = APCManager(num_blocks=4, block_size=BLOCK_SIZE)
@@ -406,11 +363,6 @@ class TestRejectObservability:
         assert "unclonable" in snap["rejects_by_reason"]
 
 
-# ---------------------------------------------------------------------------
-# D — Block harvest / post-decode path with quantized keys
-# ---------------------------------------------------------------------------
-
-
 class TestQuantizedBlockHarvest:
     def test_harvest_single_row_batch_quantized(self):
         manager = APCManager(num_blocks=8, block_size=BLOCK_SIZE)
@@ -424,14 +376,8 @@ class TestQuantizedBlockHarvest:
         manager.release(blocks)
 
     def test_layer_kv_float_helper_handles_quantized_tuple_keys(self):
-        """dispatch post-decode harvest must not slice quantized tuple keys.
-
-        ``layer_kv_for_apc`` (or equivalent) returns float K/V for any supported
-        cache dialect so callers never do ``keys[..., :off, :]`` on a tuple.
-        """
         from mlx_vlm.apc import layer_kv_for_apc
 
-        # Plain KV
         plain = KVCache()
         k, v = _rand_kv(batch=1, seq_len=12)
         plain.update_and_fetch(k, v)
@@ -439,7 +385,6 @@ class TestQuantizedBlockHarvest:
         assert pk is not None and pv is not None
         assert pk.shape[-2] == 12
 
-        # Quantized single-row
         q = QuantizedKVCache(group_size=GROUP_SIZE, bits=BITS)
         k, v = _rand_kv(batch=1, seq_len=12)
         q.update_and_fetch(k, v)
@@ -448,7 +393,6 @@ class TestQuantizedBlockHarvest:
         assert qk.shape == (1, H, 12, D)
         assert not isinstance(qk, tuple)
 
-        # Batch quantized row
         bq, _, _ = _fill_batch_quant([0, 0], seq_len=12)
         bk, bv = layer_kv_for_apc(bq, batch_idx=1)
         mx.eval(bk, bv)
@@ -459,21 +403,14 @@ class TestQuantizedBlockHarvest:
         from mlx_vlm.apc import layer_kv_for_apc
 
         class Bogus:
-            keys = (1, 2, 3)  # tuple like quantized but no dequantize_for_apc
+            keys = (1, 2, 3)
             values = (4, 5, 6)
             offset = 3
 
         assert layer_kv_for_apc(Bogus()) == (None, None)
 
 
-# ---------------------------------------------------------------------------
-# A — No B=1 special case residual in extract path
-# ---------------------------------------------------------------------------
-
-
 class TestAlwaysExtractSemantics:
-    """BatchGenerator must not short-circuit B=1; extract works for B=1 Batch*."""
-
     def test_extract_b1_batch_rotating_equals_clone_after_extract(self):
         cache, _, _ = _fill_batch_rotating([0], seq_len=16)
         row = extract_prompt_cache_from_batch([cache], 0)
@@ -491,7 +428,6 @@ class TestAlwaysExtractSemantics:
         assert isinstance(cloned[0], KVCache)
 
     def test_snapshot_equivalent_for_b1_whether_or_not_batch(self):
-        """snapshot of BatchKV B=1 matches snapshot of equivalent KVCache content."""
         from mlx_vlm.apc import snapshot_prompt_cache_row
 
         seq_len = 16
@@ -510,23 +446,8 @@ class TestAlwaysExtractSemantics:
         assert _max_abs_error(snap_b[0].keys, snap_p[0].keys) < 1e-5
 
 
-# ---------------------------------------------------------------------------
-# Integration: store_exact_cache accepts batch caches if snapshot is used
-# (document expected call pattern for BatchGenerator refactor)
-# ---------------------------------------------------------------------------
-
-
 class TestStoreExactCallPattern:
-    def test_direct_store_of_batch_rotating_without_snapshot_may_reject_or_adapt(
-        self,
-    ):
-        """Preferred path is snapshot_prompt_cache_row first.
-
-        Direct store_exact_cache on Batch* may either:
-        - succeed by adapting internally, or
-        - reject with stats — both OK as long as snapshot path works.
-        The snapshot path is the supported contract.
-        """
+    def test_store_hybrid_layout_via_snapshot(self):
         from mlx_vlm.apc import snapshot_prompt_cache_row
 
         seq_len = BLOCK_SIZE
@@ -541,44 +462,28 @@ class TestStoreExactCallPattern:
         assert manager.store_exact_cache(token_ids, snap) is True
 
 
-# ---------------------------------------------------------------------------
-# A — TurboQuant batch parity (same extract / snapshot protocol)
-# ---------------------------------------------------------------------------
-
-
 def _fill_batch_turbo(left_padding, seq_len, bits=4.0):
     from mlx_vlm.turboquant import BatchTurboQuantKVCache
 
     cache = BatchTurboQuantKVCache(list(left_padding), bits=bits)
     k, v = _rand_kv(batch=len(left_padding), seq_len=seq_len)
-    # TurboQuant prefers float16-ish traffic; random float32 is fine.
     cache.update_and_fetch(k, v)
     mx.eval(cache.keys)
     return cache, k, v
 
 
 class TestBatchRotatingRightPadPrefill:
-    """S=1 prefill while right-pad bookkeeping is active must not crash.
-
-    APC multi-row warm paths with unequal suffix lengths call prepare(right_padding=…)
-    then may issue a final single-token prefill before finalize().
-    """
-
     def test_single_token_update_while_lengths_pending(self):
         cache = BatchRotatingKVCache(32, [0, 0])
-        # Prefill a few tokens
         k, v = _rand_kv(batch=2, seq_len=4)
         cache.update_and_fetch(k, v)
-        # Simulate APC mixed-prefill right-pad bookkeeping
         cache.prepare(right_padding=[1, 0], lengths=[2, 3])
         assert cache._lengths is not None
-        # Final prefill step is often S=1
         k1, v1 = _rand_kv(batch=2, seq_len=1)
         out_k, out_v = cache.update_and_fetch(k1, v1)
         assert out_k is not None
         cache.finalize()
         assert cache._lengths is None
-        # Decode path after finalize
         k2, v2 = _rand_kv(batch=2, seq_len=1)
         cache.update_and_fetch(k2, v2)
 

--- a/mlx_vlm/tests/test_apc_adapters.py
+++ b/mlx_vlm/tests/test_apc_adapters.py
@@ -557,6 +557,32 @@ def _fill_batch_turbo(left_padding, seq_len, bits=4.0):
     return cache, k, v
 
 
+class TestBatchRotatingRightPadPrefill:
+    """S=1 prefill while right-pad bookkeeping is active must not crash.
+
+    APC multi-row warm paths with unequal suffix lengths call prepare(right_padding=…)
+    then may issue a final single-token prefill before finalize().
+    """
+
+    def test_single_token_update_while_lengths_pending(self):
+        cache = BatchRotatingKVCache(32, [0, 0])
+        # Prefill a few tokens
+        k, v = _rand_kv(batch=2, seq_len=4)
+        cache.update_and_fetch(k, v)
+        # Simulate APC mixed-prefill right-pad bookkeeping
+        cache.prepare(right_padding=[1, 0], lengths=[2, 3])
+        assert cache._lengths is not None
+        # Final prefill step is often S=1
+        k1, v1 = _rand_kv(batch=2, seq_len=1)
+        out_k, out_v = cache.update_and_fetch(k1, v1)
+        assert out_k is not None
+        cache.finalize()
+        assert cache._lengths is None
+        # Decode path after finalize
+        k2, v2 = _rand_kv(batch=2, seq_len=1)
+        cache.update_and_fetch(k2, v2)
+
+
 class TestBatchTurboQuantParity:
     def test_batch_size_and_is_single_row(self):
         from mlx_vlm.turboquant import BatchTurboQuantKVCache

--- a/mlx_vlm/tests/test_apc_adapters.py
+++ b/mlx_vlm/tests/test_apc_adapters.py
@@ -539,3 +539,110 @@ class TestStoreExactCallPattern:
         manager = APCManager(num_blocks=4, block_size=BLOCK_SIZE)
         assert snap is not None
         assert manager.store_exact_cache(token_ids, snap) is True
+
+
+# ---------------------------------------------------------------------------
+# A — TurboQuant batch parity (same extract / snapshot protocol)
+# ---------------------------------------------------------------------------
+
+
+def _fill_batch_turbo(left_padding, seq_len, bits=4.0):
+    from mlx_vlm.turboquant import BatchTurboQuantKVCache
+
+    cache = BatchTurboQuantKVCache(list(left_padding), bits=bits)
+    k, v = _rand_kv(batch=len(left_padding), seq_len=seq_len)
+    # TurboQuant prefers float16-ish traffic; random float32 is fine.
+    cache.update_and_fetch(k, v)
+    mx.eval(cache.keys)
+    return cache, k, v
+
+
+class TestBatchTurboQuantParity:
+    def test_batch_size_and_is_single_row(self):
+        from mlx_vlm.turboquant import BatchTurboQuantKVCache
+
+        empty = BatchTurboQuantKVCache([0, 0], bits=4.0)
+        assert empty.empty() is True
+        assert empty.batch_size == 2
+        assert empty.is_single_row() is False
+
+        filled, _, _ = _fill_batch_turbo([0], seq_len=8)
+        assert filled.empty() is False
+        assert filled.batch_size == 1
+        assert filled.is_single_row() is True
+
+    def test_extract_returns_turboquant_kv_cache(self):
+        from mlx_vlm.turboquant import TurboQuantKVCache
+
+        cache, k, _ = _fill_batch_turbo([0, 0], seq_len=24)
+        row = cache.extract(1)
+        assert isinstance(row, TurboQuantKVCache)
+        assert row.offset == 24
+        dk, dv = row.dequantize_for_apc()
+        mx.eval(dk, dv)
+        assert dk.shape == (1, H, 24, D)
+        # TurboQuant is lossy; keep a loose bound
+        assert _max_abs_error(dk, k[1:2]) < 2.0
+
+    def test_extract_respects_left_padding(self):
+        cache, _, _ = _fill_batch_turbo([2, 0], seq_len=10)
+        row0 = cache.extract(0)
+        row1 = cache.extract(1)
+        assert row0.offset == cache._idx - 2
+        assert row1.offset == cache._idx
+
+    def test_extract_empty(self):
+        from mlx_vlm.turboquant import BatchTurboQuantKVCache, TurboQuantKVCache
+
+        cache = BatchTurboQuantKVCache([0, 0], bits=4.0)
+        row = cache.extract(0)
+        assert isinstance(row, TurboQuantKVCache)
+        assert row.keys is None or row.offset == 0
+
+    def test_snapshot_and_exact_store_multi_row(self):
+        from mlx_vlm.apc import snapshot_prompt_cache_row
+
+        seq_len = 2 * BLOCK_SIZE
+        token_ids = list(range(seq_len))
+        turbo, _, _ = _fill_batch_turbo([0, 0], seq_len=seq_len)
+        batch_kv, _, _ = _fill_batch_kv([0, 0], seq_len=seq_len)
+        prompt_cache = [turbo, batch_kv]
+
+        manager = APCManager(num_blocks=4, block_size=BLOCK_SIZE)
+        for bi in (0, 1):
+            snap = snapshot_prompt_cache_row(prompt_cache, batch_idx=bi)
+            assert snap is not None
+            for c in snap:
+                assert not type(c).__name__.startswith("Batch")
+            assert manager.store_exact_cache(token_ids, snap, extra_hash=bi + 1)
+
+        warm0, m0 = manager.lookup_exact_cache(token_ids + [9], extra_hash=1)
+        warm1, m1 = manager.lookup_exact_cache(token_ids + [9], extra_hash=2)
+        assert m0 == seq_len and m1 == seq_len
+        assert warm0 is not None and warm1 is not None
+
+    def test_extract_prompt_cache_from_batch(self):
+        from mlx_vlm.turboquant import TurboQuantKVCache
+
+        turbo, _, _ = _fill_batch_turbo([0, 0], seq_len=16)
+        row = extract_prompt_cache_from_batch([turbo], 1)
+        assert row is not None
+        assert isinstance(row[0], TurboQuantKVCache)
+        cloned = _clone_prompt_cache_for_apc(row)
+        assert cloned is not None
+        assert isinstance(cloned[0], KVCache)
+
+    def test_layer_kv_for_apc_batch_turbo(self):
+        from mlx_vlm.apc import layer_kv_for_apc
+
+        cache, _, _ = _fill_batch_turbo([0, 0], seq_len=12)
+        k, v = layer_kv_for_apc(cache, batch_idx=1)
+        mx.eval(k, v)
+        assert k is not None and v is not None
+        assert k.shape[0] == 1
+        assert k.shape[-2] <= 12
+        assert not isinstance(k, tuple)
+
+    def test_supports_exact_apc(self):
+        cache, _, _ = _fill_batch_turbo([0], seq_len=8)
+        assert _cache_entry_supports_exact_apc(cache) is True

--- a/mlx_vlm/turboquant.py
+++ b/mlx_vlm/turboquant.py
@@ -6311,6 +6311,29 @@ class BatchTurboQuantKVCache(_BaseCache):
             return None, None
         return self.dequantize()
 
+    def extract(self, idx):
+        """Extract one batch row as a single-sequence TurboQuantKVCache."""
+        cache = TurboQuantKVCache(bits=self.bits, seed=self.seed)
+        if self.keys is None or self._idx == 0:
+            return cache
+        cache.key_codec = self.key_codec
+        cache.value_codec = self.value_codec
+        padding = max(0, int(self.left_padding[idx].item()))
+        end = self._idx
+        if padding >= end:
+            return cache
+        bi = mx.array([idx])
+        keys = _filter_state(_slice_state_range(self.keys, padding, end), bi)
+        values = _filter_state(_slice_state_range(self.values, padding, end), bi)
+
+        def _contiguous(a, ndim):
+            return mx.contiguous(a)
+
+        cache.keys = _map_state(keys, _contiguous)
+        cache.values = _map_state(values, _contiguous)
+        cache.offset = _state_length(cache.keys)
+        return cache
+
     # ------------------------------------------------------------------
     # State / introspection
     # ------------------------------------------------------------------
@@ -6350,6 +6373,13 @@ class BatchTurboQuantKVCache(_BaseCache):
 
     def empty(self):
         return self.keys is None
+
+    @property
+    def batch_size(self):
+        return int(self.left_padding.shape[0])
+
+    def is_single_row(self):
+        return self.batch_size == 1
 
     def make_mask(self, N: int, return_array: bool = False, **kwargs):
         return create_causal_mask(


### PR DESCRIPTION
## Summary

Follow-up to **#1534** / **#1174**, tracking **#1559**.

Lands a durable **internal APC adapter** for exact-mode APC + `--kv-bits` on the **batch / continuous-batching** path (SWA + multi-row), without new CLI flags or on-disk format changes (dequant-at-harvest float APC pool remains).

### What this PR does
- **`snapshot_prompt_cache_row`**: always row-normalize before exact store (removes the B=1 special case in `BatchGenerator`)
- **`BatchQuantizedKVCache.extract`** + **`BatchTurboQuantKVCache.extract`**: multi-row concurrent exact path
- **`BatchRotatingKVCache`**: exact support + fix S=1 prefill while right-pad (`_lengths`) is pending (unequal multi-row SWA warm)
- Clear **`batch_size` / `is_single_row()`** on batch cache types
- Additive **reject stats**: `rejects`, `rejects_by_reason`, `last_reject` on `/v1/cache/stats`
- **`layer_kv_for_apc`**: dequant-aware harvest so post-decode block store does not dense-slice quantized tuple keys
- Unit tests: `test_apc_adapters.py`

### Explicitly out of scope (tracked elsewhere)
- **Block-mode concurrent multi-row + kv-bits** (mask / mixed prefill; fails even without APC) → **#1562**
- Full product claim that APC + kv-bits is complete for all agent/server multi-row block workloads (see #1174 clarification)
- Startup self-check, optional `APC_TRACE`, formal `APCLayerView` type, quantized APC pool / RSS shrink under kv-bits
- User-facing “fully supported” docs until #1562 is resolved or wontfix’d with limitations

### Related
- #1559 — parent follow-up issue
- #1534 — single-request APC + kv-bits (merged)
- #1174 — original request (partial after #1534)
- #1562 — block multi-row + kv-bits

## Test plan
- [x] `pytest mlx_vlm/tests/test_apc_adapters.py` (+ quantized/exact/batch suites)
- [x] CI `Test PRs` green
- [x] Smoke (local): Gemma4-e2b batch exact store/hit + multi-row (incl. unequal suffix / turbo 3.5 & 4)
- [x] Smoke (local): Qwen3.5-4B hybrid multi-row concurrent + kv8 / turbo
- [x] Smoke (local): Qwen3-0.6B block sequential warm no regression; multi-row concurrent remains #1562
- [x] Adversarial harness (manual): true neg control, extract fidelity, layout type checks — 0 hard fails on exact paths

Smoke write-ups: comments on this PR.