### PR TITLE
docs: APC works with KV-cache quantization

### DIFF
--- a/README.md
+++ b/README.md
@@ -724,6 +724,14 @@ APC_NUM_BLOCKS=4096 \
 mlx_vlm.server --model Qwen/Qwen3-VL-4B-Instruct --port 8080
 ```
 
+APC works with KV-cache quantization (`--kv-bits`):
+
+```sh
+APC_ENABLED=1 \
+APC_NUM_BLOCKS=4096 \
+mlx_vlm.server --model Qwen/Qwen3-VL-4B-Instruct --kv-bits 8 --port 8080
+```
+
 Enable the persistent disk tier:
 
 ```sh
@@ -774,11 +782,11 @@ Common APC environment variables:
 | `APC_LAYER_MAJOR_MEMORY_MIN_TOKENS` | `50000` | Store long warm-memory prefixes as compact layer-major snapshots instead of per-block tensors |
 | `APC_HASH` | `fast` | Set to `sha256` for a stable cryptographic hash |
 
-APC is disabled automatically for models that use a custom cache layout. On the server, APC is also skipped when KV-cache quantization is enabled.
+APC is disabled automatically for models that use a custom cache layout. APC works with `--kv-bits` (including TurboQuant): the live KV cache stays quantized; the reusable APC pool stores dequantized float K/V, so pool size does not shrink with quant.
 
 #### KV Cache Quantization
 
-Reduce KV cache memory during continuous batching with `--kv-bits`. Both uniform quantization and TurboQuant are supported:
+Reduce KV cache memory during continuous batching with `--kv-bits`. Both uniform quantization and TurboQuant are supported. Compatible with Automatic Prefix Caching (`APC_ENABLED=1`).
 
 ```sh
 # Uniform 8-bit KV cache quantization


### PR DESCRIPTION
## Summary

- Remove the outdated README claim that APC is skipped when KV-cache quantization is enabled (fixed in #1534 / #1560)
- Document that APC + `--kv-bits` work together, with a short note that the live cache stays quantized and the APC pool stores float K/V
- Add a combined server example (`APC_ENABLED=1` + `--kv-bits 8`)
- Cross-link from the KV Cache Quantization section

## Test plan

- [x] Visual check of APC + KV quant README sections
- [ ] N/A code tests (docs only)

Refs: #1174, #1534, #1560