### PR TITLE
feat(apc): APC_TRACE + non-fatal layout self-check

### DIFF
--- a/README.md
+++ b/README.md
@@ -775,11 +775,12 @@ Common APC environment variables:
 | `APC_HASH` | `fast` | Set to `sha256` for a stable cryptographic hash |
 | `APC_TRACE` | unset | Set to `1` for greppable store/reject/self-check log lines |
 
-APC is disabled automatically for models that use a custom cache layout. APC works with `--kv-bits` (including TurboQuant): the live KV cache stays quantized; the reusable APC pool stores dequantized float K/V, so pool size does not shrink with quant. When APC is enabled on the server, a non-fatal layout self-check runs at model load.
+APC is disabled automatically for models that use a custom cache layout. On the server, APC is also skipped when KV-cache quantization is enabled.
+When APC is enabled on the server, a non-fatal layout self-check runs at model load.
 
 #### KV Cache Quantization
 
-Reduce KV cache memory during continuous batching with `--kv-bits`. Both uniform quantization and TurboQuant are supported. Compatible with Automatic Prefix Caching (`APC_ENABLED=1`).
+Reduce KV cache memory during continuous batching with `--kv-bits`. Both uniform quantization and TurboQuant are supported:
 
 ```sh
 # Uniform 8-bit KV cache quantization

--- a/README.md
+++ b/README.md
@@ -773,12 +773,13 @@ Common APC environment variables:
 | `APC_MAX_POOL_TENSORS` | `450000` | Stops adding memory blocks before the Metal resource limit; disk writes continue |
 | `APC_LAYER_MAJOR_MEMORY_MIN_TOKENS` | `50000` | Store long warm-memory prefixes as compact layer-major snapshots instead of per-block tensors |
 | `APC_HASH` | `fast` | Set to `sha256` for a stable cryptographic hash |
+| `APC_TRACE` | unset | Set to `1` for greppable store/reject/self-check log lines |
 
-APC is disabled automatically for models that use a custom cache layout. On the server, APC is also skipped when KV-cache quantization is enabled.
+APC is disabled automatically for models that use a custom cache layout. APC works with `--kv-bits` (including TurboQuant): the live KV cache stays quantized; the reusable APC pool stores dequantized float K/V, so pool size does not shrink with quant. When APC is enabled on the server, a non-fatal layout self-check runs at model load.
 
 #### KV Cache Quantization
 
-Reduce KV cache memory during continuous batching with `--kv-bits`. Both uniform quantization and TurboQuant are supported:
+Reduce KV cache memory during continuous batching with `--kv-bits`. Both uniform quantization and TurboQuant are supported. Compatible with Automatic Prefix Caching (`APC_ENABLED=1`).
 
 ```sh
 # Uniform 8-bit KV cache quantization

--- a/mlx_vlm/apc.py
+++ b/mlx_vlm/apc.py
@@ -63,6 +63,29 @@ DEFAULT_NUM_BLOCKS = 2048
 SEED_PARENT_HASH = 0
 
 
+def _env_truthy(name: str, default: str = "") -> bool:
+    """Return True when env var is a common truthy string (1/true/yes)."""
+    return os.environ.get(name, default).lower() in ("1", "true", "yes")
+
+
+def apc_trace_enabled() -> bool:
+    """Optional request-path tracing (``APC_TRACE=1``), sibling of ``APC_DISK_TRACE``."""
+    return _env_truthy("APC_TRACE")
+
+
+def apc_trace(event: str, **fields: Any) -> None:
+    """Emit a single greppable ``APC_TRACE`` log line when tracing is enabled.
+
+    Kept separate from stats counters: stats are always-on aggregates; trace is
+    opt-in detail for debugging store/lookup/reject/self-check paths.
+    """
+    if not apc_trace_enabled():
+        return
+    parts = " ".join(f"{key}={value}" for key, value in fields.items())
+    msg = f"APC_TRACE {event}" + (f" {parts}" if parts else "")
+    logger.info(msg)
+
+
 def _hash_use_sha256() -> bool:
     return os.environ.get("APC_HASH", "fast").lower() == "sha256"
 
@@ -570,6 +593,7 @@ class APCStats:
         self.rejects += 1
         self.rejects_by_reason[reason] = self.rejects_by_reason.get(reason, 0) + 1
         self.last_reject = {"reason": reason, **details}
+        apc_trace("reject", reason=reason, **details)
 
     def snapshot(self, num_blocks: int, block_size: int) -> dict:
         denom = self.matched_tokens + self.served_tokens
@@ -2061,7 +2085,7 @@ class DiskBlockStore:
         """
         if not block_hashes:
             return None
-        trace = os.environ.get("APC_DISK_TRACE", "").lower() in ("1", "true", "yes")
+        trace = _env_truthy("APC_DISK_TRACE")
         trace_t0 = time.perf_counter()
 
         entries: List[Tuple[Path, int]] = []
@@ -3116,6 +3140,14 @@ class APCManager:
                 while len(self._exact_cache) > self._exact_cache_max:
                     self._exact_cache.popitem(last=False)
                 stored = True
+        if stored:
+            apc_trace(
+                "store",
+                mode="exact",
+                ok=True,
+                token_len=len(token_tuple),
+                layers=len(copied),
+            )
         if self.disk is not None:
             try:
                 self.disk.save_exact_cache(key, token_tuple, extra_hash, copied)
@@ -3965,6 +3997,172 @@ def model_apc_mode(language_model: Any) -> Optional[str]:
 
 def model_supports_apc(language_model: Any) -> bool:
     return model_apc_mode(language_model) is not None
+
+
+@dataclass(frozen=True)
+class LayerSupport:
+    """Per-layer result from :func:`classify_layer_for_apc`."""
+
+    type_name: str
+    status: str  # "ok" | "empty_ok" | "unsupported"
+    reason: Optional[str] = None
+
+
+@dataclass
+class APCSelfCheckResult:
+    """Outcome of a dry-run layout check (startup self-check / diagnostics)."""
+
+    ok: bool
+    apc_mode: Optional[str]
+    layer_count: int
+    layer_types: List[str]
+    unsupported: List[LayerSupport] = field(default_factory=list)
+    notes: List[str] = field(default_factory=list)
+
+
+def classify_layer_for_apc(c: Any) -> LayerSupport:
+    """Classify whether one prompt-cache layer can be snapshotted for APC.
+
+    Uses the same clone path as exact store so startup checks match runtime.
+    Empty layers that clone to a storage-native type count as ``empty_ok``.
+    """
+    type_name = type(c).__name__
+    is_empty = False
+    empty_fn = getattr(c, "empty", None)
+    if callable(empty_fn):
+        try:
+            is_empty = bool(empty_fn())
+        except Exception:
+            is_empty = False
+
+    eval_targets: List[mx.array] = []
+    try:
+        copied = _clone_cache_entry_for_apc(
+            c,
+            min_capacity_tokens=None,
+            eval_targets=eval_targets,
+        )
+    except Exception as exc:
+        return LayerSupport(
+            type_name=type_name,
+            status="unsupported",
+            reason=f"clone_error:{type(exc).__name__}",
+        )
+    if copied is None:
+        return LayerSupport(
+            type_name=type_name,
+            status="unsupported",
+            reason="unclonable",
+        )
+    return LayerSupport(
+        type_name=type_name,
+        status="empty_ok" if is_empty else "ok",
+    )
+
+
+def validate_prompt_cache_layout(
+    caches: Sequence[Any],
+    *,
+    apc_mode: Optional[str] = None,
+) -> APCSelfCheckResult:
+    """Validate a prompt-cache layout for APC without running a model forward."""
+    layer_types = [type(c).__name__ for c in caches]
+    unsupported = [
+        layer
+        for layer in (classify_layer_for_apc(c) for c in caches)
+        if layer.status == "unsupported"
+    ]
+    return APCSelfCheckResult(
+        ok=not unsupported,
+        apc_mode=apc_mode,
+        layer_count=len(caches),
+        layer_types=layer_types,
+        unsupported=unsupported,
+    )
+
+
+def self_check_model_apc(
+    model: Any,
+    *,
+    kv_bits: Optional[float] = None,
+    log: bool = True,
+) -> APCSelfCheckResult:
+    """Dry-run APC layout check for a loaded model (or its ``language_model``).
+
+    Non-fatal by design: logs ERROR on failure and returns a result. Callers
+    (e.g. server load) should not crash solely because the check fails.
+    """
+    notes: List[str] = []
+    if kv_bits is not None:
+        notes.append(f"kv_bits={kv_bits}")
+
+    try:
+        language_model = (
+            model.language_model if hasattr(model, "language_model") else model
+        )
+        if not hasattr(language_model, "make_cache"):
+            result = APCSelfCheckResult(
+                ok=False,
+                apc_mode=None,
+                layer_count=0,
+                layer_types=[],
+                notes=notes + ["model has no make_cache"],
+            )
+        else:
+            apc_mode = model_apc_mode(language_model)
+            if apc_mode is None:
+                result = APCSelfCheckResult(
+                    ok=False,
+                    apc_mode=None,
+                    layer_count=0,
+                    layer_types=[],
+                    notes=notes + ["no APC-compatible cache layout"],
+                )
+            else:
+                caches = language_model.make_cache()
+                result = validate_prompt_cache_layout(caches, apc_mode=apc_mode)
+                result.notes = list(notes) + list(result.notes)
+    except Exception as exc:
+        result = APCSelfCheckResult(
+            ok=False,
+            apc_mode=None,
+            layer_count=0,
+            layer_types=[],
+            notes=notes + [f"self-check failed: {type(exc).__name__}: {exc}"],
+        )
+
+    if log:
+        types_s = ",".join(result.layer_types) if result.layer_types else "-"
+        if result.ok:
+            logger.info(
+                "APC self-check ok mode=%s layers=%d types=[%s]%s",
+                result.apc_mode,
+                result.layer_count,
+                types_s,
+                f" kv_bits={kv_bits}" if kv_bits is not None else "",
+            )
+        else:
+            bad = [
+                f"{layer.type_name}:{layer.reason or layer.status}"
+                for layer in result.unsupported
+            ]
+            logger.error(
+                "APC self-check failed mode=%s layers=%d unsupported=%s notes=%s",
+                result.apc_mode,
+                result.layer_count,
+                bad or result.notes,
+                result.notes,
+            )
+
+    apc_trace(
+        "self_check",
+        ok=result.ok,
+        mode=result.apc_mode,
+        layers=result.layer_count,
+        unsupported=len(result.unsupported),
+        kv_bits=kv_bits,
+    )
+    return result
 
 
 def from_env(model_namespace: Optional[str] = None) -> Optional[APCManager]:

--- a/mlx_vlm/server/app.py
+++ b/mlx_vlm/server/app.py
@@ -778,6 +778,13 @@ def get_cached_model(
         vision_cache.clear()
         raise
 
+    # Dry-run APC layout when the shared pool is enabled (log-only; never blocks serve).
+    if runtime.apc_manager is not None:
+        try:
+            _apc.self_check_model_apc(model, kv_bits=kv_bits)
+        except Exception as exc:
+            logger.warning("APC self-check raised unexpectedly: %s", exc)
+
     cache = {
         "cache_key": cache_key,
         "model_path": model_path,

--- a/mlx_vlm/tests/test_apc_observability.py
+++ b/mlx_vlm/tests/test_apc_observability.py
@@ -1,0 +1,198 @@
+"""TDD: APC_TRACE + layout self-check (observability hygiene)."""
+
+from __future__ import annotations
+
+import logging
+
+import mlx.core as mx
+import pytest
+
+from mlx_vlm.apc import (
+    APCManager,
+    APCSelfCheckResult,
+    apc_trace,
+    apc_trace_enabled,
+    classify_layer_for_apc,
+    self_check_model_apc,
+    validate_prompt_cache_layout,
+)
+from mlx_vlm.models.cache import (
+    BatchKVCache,
+    BatchQuantizedKVCache,
+    BatchRotatingKVCache,
+    KVCache,
+    QuantizedKVCache,
+)
+
+BLOCK_SIZE = 16
+GROUP_SIZE = 64
+BITS = 8
+
+
+@pytest.fixture(autouse=True)
+def _clear_apc_trace_env(monkeypatch):
+    monkeypatch.delenv("APC_TRACE", raising=False)
+    yield
+    monkeypatch.delenv("APC_TRACE", raising=False)
+
+
+class TestApcTrace:
+    def test_disabled_by_default(self):
+        assert apc_trace_enabled() is False
+
+    def test_enabled_by_env(self, monkeypatch):
+        monkeypatch.setenv("APC_TRACE", "1")
+        assert apc_trace_enabled() is True
+        monkeypatch.setenv("APC_TRACE", "true")
+        assert apc_trace_enabled() is True
+        monkeypatch.setenv("APC_TRACE", "0")
+        assert apc_trace_enabled() is False
+
+    def test_trace_emits_logger_info_when_enabled(self, monkeypatch, caplog):
+        monkeypatch.setenv("APC_TRACE", "1")
+        with caplog.at_level(logging.INFO, logger="mlx_vlm.apc"):
+            apc_trace("store", mode="exact", ok=True, token_len=32)
+        assert any("APC_TRACE store" in r.message for r in caplog.records)
+        assert any("mode=exact" in r.message for r in caplog.records)
+        assert any("token_len=32" in r.message for r in caplog.records)
+
+    def test_trace_silent_when_disabled(self, caplog):
+        with caplog.at_level(logging.INFO, logger="mlx_vlm.apc"):
+            apc_trace("store", mode="exact", ok=True)
+        assert not any("APC_TRACE" in r.message for r in caplog.records)
+
+    def test_reject_records_emit_trace(self, monkeypatch, caplog):
+        monkeypatch.setenv("APC_TRACE", "1")
+        manager = APCManager(num_blocks=4, block_size=BLOCK_SIZE)
+        token_ids = list(range(BLOCK_SIZE))
+
+        class UnclonableCache:
+            keys = "not-an-array"
+            values = "not-an-array"
+
+        with caplog.at_level(logging.INFO, logger="mlx_vlm.apc"):
+            assert manager.store_exact_cache(token_ids, [UnclonableCache()]) is False
+        assert any("APC_TRACE reject" in r.message for r in caplog.records)
+        assert any("unclonable" in r.message for r in caplog.records)
+
+
+class TestClassifyLayer:
+    def test_plain_kv_ok(self):
+        c = KVCache()
+        c.update_and_fetch(
+            mx.zeros((1, 2, 4, 8), dtype=mx.float32),
+            mx.zeros((1, 2, 4, 8), dtype=mx.float32),
+        )
+        result = classify_layer_for_apc(c)
+        assert result.status == "ok"
+        assert result.type_name == "KVCache"
+
+    def test_quantized_with_dequant_ok(self):
+        # Last dim must be divisible by group_size for mx.quantize.
+        c = QuantizedKVCache(group_size=GROUP_SIZE, bits=BITS)
+        c.update_and_fetch(
+            mx.random.normal((1, 2, 8, GROUP_SIZE)),
+            mx.random.normal((1, 2, 8, GROUP_SIZE)),
+        )
+        result = classify_layer_for_apc(c)
+        assert result.status == "ok"
+
+    def test_batch_quantized_empty_ok(self):
+        c = BatchQuantizedKVCache([0], group_size=GROUP_SIZE, bits=BITS)
+        result = classify_layer_for_apc(c)
+        assert result.status in ("ok", "empty_ok")
+
+    def test_batch_rotating_empty_ok(self):
+        c = BatchRotatingKVCache(32, [0])
+        result = classify_layer_for_apc(c)
+        assert result.status in ("ok", "empty_ok")
+
+    def test_unsupported_opaque_type(self):
+        class Bogus:
+            pass
+
+        result = classify_layer_for_apc(Bogus())
+        assert result.status == "unsupported"
+        assert result.reason
+
+
+class TestValidateLayout:
+    def test_all_supported_layout_ok(self):
+        caches = [
+            BatchRotatingKVCache(32, [0]),
+            BatchQuantizedKVCache([0], group_size=GROUP_SIZE, bits=BITS),
+            BatchKVCache([0]),
+        ]
+        result = validate_prompt_cache_layout(caches, apc_mode="exact")
+        assert isinstance(result, APCSelfCheckResult)
+        assert result.ok is True
+        assert result.apc_mode == "exact"
+        assert result.layer_count == 3
+        assert result.unsupported == []
+
+    def test_mixed_unsupported_not_ok(self):
+        class Bogus:
+            pass
+
+        result = validate_prompt_cache_layout([KVCache(), Bogus()], apc_mode="block")
+        assert result.ok is False
+        assert len(result.unsupported) == 1
+        assert result.unsupported[0].type_name == "Bogus"
+
+
+class TestSelfCheckModel:
+    def test_supported_model_ok(self, caplog):
+        class FakeLang:
+            def make_cache(self):
+                return [
+                    BatchRotatingKVCache(32, [0]),
+                    BatchQuantizedKVCache([0], group_size=GROUP_SIZE, bits=BITS),
+                    BatchKVCache([0]),
+                ]
+
+        with caplog.at_level(logging.INFO, logger="mlx_vlm.apc"):
+            result = self_check_model_apc(FakeLang(), kv_bits=8.0)
+        assert result.ok is True
+        assert result.apc_mode == "exact"
+        assert any("APC self-check ok" in r.message for r in caplog.records)
+
+    def test_unsupported_model_logs_error(self, caplog):
+        class FakeLang:
+            def make_cache(self):
+                class Bogus:
+                    pass
+
+                return [Bogus()]
+
+        with caplog.at_level(logging.ERROR, logger="mlx_vlm.apc"):
+            result = self_check_model_apc(FakeLang())
+        assert result.ok is False
+        assert any("APC self-check" in r.message for r in caplog.records)
+
+    def test_no_make_cache_not_ok(self, caplog):
+        class NoCache:
+            pass
+
+        result = self_check_model_apc(NoCache())
+        assert result.ok is False
+
+    def test_unwraps_language_model(self):
+        class FakeLang:
+            def make_cache(self):
+                return [KVCache()]
+
+        class VLM:
+            language_model = FakeLang()
+
+        result = self_check_model_apc(VLM())
+        assert result.ok is True
+        assert result.apc_mode == "block"
+
+    def test_does_not_raise_on_failure(self):
+        class FakeLang:
+            def make_cache(self):
+                raise RuntimeError("boom")
+
+        result = self_check_model_apc(FakeLang())
+        assert result.ok is False
+        assert result.notes


### PR DESCRIPTION
## Summary

Hygiene follow-up after #1534 / #1560 (tracker leftover from #1559 §C/§E):

- **`APC_TRACE=1`**: greppable store/reject/self-check log lines (same spirit as `APC_DISK_TRACE`)
- **Layout self-check**: dry-run `make_cache` → clone path used by exact store; classify unsupported types
- **Server**: runs self-check at model load when APC is enabled (**log-only**, never blocks serve)
- **README**: document `APC_TRACE` + self-check only (APC + kv-bits docs remain in **#1565**)

Design: optional env only; stats stay separate from trace; self-check reuses `_clone_cache_entry_for_apc` so checks match runtime store behavior.

## Test plan

- [x] `pytest mlx_vlm/tests/test_apc_observability.py`
- [x] `pytest mlx_vlm/tests/test_apc_adapters.py` (no regression)

Refs: #1559, #1174