### PR TITLE
fix: multi-row continuous batching with KV quant (#1567)

### DIFF
--- a/mlx_vlm/models/base.py
+++ b/mlx_vlm/models/base.py
@@ -225,6 +225,25 @@ def create_ssm_mask(h, cache=None):
     return None
 
 
+def align_attention_mask_to_scores(mask, scores: mx.array):
+    """Broadcast an attention mask onto *scores* without mis-aligning batch vs heads.
+
+    Quantized GQA expands scores to 5D ``(B, n_kv_heads, n_repeats, L, K)`` while
+    batch left-pad masks are typically 4D ``(B, 1, L, K)``. Right-aligning those
+    shapes aliases ``B`` with ``n_kv_heads`` and crashes for multi-row batches
+    (see #1567). Insert singleton dims *before* the last two axes until ranks
+    match so the layout is ``(B, 1, …, 1, L, K)``.
+    """
+    if mask is None or isinstance(mask, str):
+        return mask
+
+    # Grow rank by inserting size-1 axes immediately before (L, K).
+    while mask.ndim < scores.ndim:
+        insert_at = max(mask.ndim - 2, 0)
+        mask = mx.expand_dims(mask, axis=insert_at)
+    return mask
+
+
 def quantized_scaled_dot_product_attention(
     queries: mx.array,
     q_keys: tuple[mx.array, mx.array, mx.array],
@@ -254,6 +273,7 @@ def quantized_scaled_dot_product_attention(
             q_indices = mx.arange(kL - qL, kL)
             k_indices = mx.arange(kL)
             mask = q_indices[:, None] >= k_indices[None]
+        mask = align_attention_mask_to_scores(mask, scores)
         if mask.dtype == mx.bool_:
             scores = mx.where(mask, scores, mx.finfo(scores.dtype).min)
         else:

--- a/mlx_vlm/models/cache.py
+++ b/mlx_vlm/models/cache.py
@@ -1629,6 +1629,39 @@ class BatchQuantizedKVCache(_BaseCache):
         self._idx = 0
         self.group_size = group_size
         self.bits = bits
+        # Set by prepare() for multi-row right-pad prefill; cleared in finalize().
+        self._right_padding = None
+
+    def prepare(self, *, left_padding=None, lengths=None, right_padding=None):
+        """Batch pad lifecycle — same contract as :class:`BatchKVCache`."""
+        if left_padding is not None:
+            if self.keys is not None:
+                raise ValueError(
+                    "Left padding can only be added to an empty BatchQuantizedKVCache"
+                )
+            left_padding = mx.array(left_padding)
+            self.left_padding += left_padding
+            self.offset -= left_padding
+
+        if right_padding is not None and max(right_padding) > 0:
+            self._right_padding = mx.array(right_padding)
+
+    def finalize(self):
+        """Roll right-padding into left-padding after multi-row prefill."""
+        if self._right_padding is None:
+            return
+        padding = self._right_padding
+        if self.keys is not None:
+            # Seq axis is 2 for packed/scales/biases (B, H, S, …) — same as BatchKVCache.
+            self.keys = tuple(
+                dynamic_roll(k, padding[:, None], axis=2) for k in self.keys
+            )
+            self.values = tuple(
+                dynamic_roll(v, padding[:, None], axis=2) for v in self.values
+            )
+        self.offset -= padding
+        self.left_padding += padding
+        self._right_padding = None
 
     def update_and_fetch(self, keys: mx.array, values: mx.array):
         """Quantize incoming keys/values and append to the cache.

--- a/mlx_vlm/tests/test_batch_quantized_cache.py
+++ b/mlx_vlm/tests/test_batch_quantized_cache.py
@@ -210,6 +210,48 @@ class TestMakeMask:
         assert mx.all(mask == reference_mask).item()
 
 
+class TestPrepareFinalize:
+    """Multi-row right-pad lifecycle parity with BatchKVCache (#1567 / #1562)."""
+
+    def test_prepare_finalize_methods_exist(self):
+        cache = BatchQuantizedKVCache([0, 0], group_size=GROUP_SIZE, bits=BITS)
+        assert callable(getattr(cache, "prepare", None))
+        assert callable(getattr(cache, "finalize", None))
+
+    def test_prepare_stores_right_padding(self):
+        cache = BatchQuantizedKVCache([0, 0], group_size=GROUP_SIZE, bits=BITS)
+        cache.prepare(right_padding=[3, 0])
+        assert cache._right_padding is not None
+        assert cache._right_padding.tolist() == [3, 0]
+
+    def test_finalize_updates_left_padding_like_batch_kv(self):
+        right_padding = [2, 0]
+        quant = BatchQuantizedKVCache([0, 0], group_size=GROUP_SIZE, bits=BITS)
+        ref = BatchKVCache([0, 0])
+
+        quant.prepare(right_padding=right_padding)
+        ref.prepare(right_padding=right_padding)
+
+        k, v = _rand_kv(B, 6)
+        quant.update_and_fetch(k, v)
+        ref.update_and_fetch(k, v)
+
+        quant.finalize()
+        ref.finalize()
+
+        assert quant._right_padding is None
+        assert quant.left_padding.tolist() == ref.left_padding.tolist()
+        assert quant.offset.tolist() == ref.offset.tolist()
+
+    def test_finalize_noop_without_prepare(self):
+        cache = BatchQuantizedKVCache([1, 0], group_size=GROUP_SIZE, bits=BITS)
+        k, v = _rand_kv(B, 4)
+        cache.update_and_fetch(k, v)
+        before = cache.left_padding.tolist()
+        cache.finalize()
+        assert cache.left_padding.tolist() == before
+
+
 class TestMakeCache:
     """Test that _make_cache creates BatchQuantizedKVCache when kv_bits is set."""
 

--- a/mlx_vlm/tests/test_quant_sdpa_mask.py
+++ b/mlx_vlm/tests/test_quant_sdpa_mask.py
@@ -1,0 +1,118 @@
+"""TDD: quantized SDPA mask broadcast under GQA multi-row batching (#1567)."""
+
+from __future__ import annotations
+
+import mlx.core as mx
+
+from mlx_vlm.models.base import (
+    align_attention_mask_to_scores,
+    quantized_scaled_dot_product_attention,
+)
+from mlx_vlm.models.cache import create_causal_mask
+
+GROUP = 64
+BITS = 8
+
+
+def _quant_kv(B, n_kv, L, D, dtype=mx.float16):
+    keys = mx.random.normal((B, n_kv, L, D)).astype(dtype)
+    values = mx.random.normal((B, n_kv, L, D)).astype(dtype)
+    return (
+        mx.quantize(keys, group_size=GROUP, bits=BITS),
+        mx.quantize(values, group_size=GROUP, bits=BITS),
+    )
+
+
+class TestAlignAttentionMaskToScores:
+    def test_none_passthrough(self):
+        scores = mx.zeros((2, 8, 2, 4, 4))
+        assert align_attention_mask_to_scores(None, scores) is None
+
+    def test_str_passthrough(self):
+        scores = mx.zeros((2, 8, 2, 4, 4))
+        assert align_attention_mask_to_scores("causal", scores) == "causal"
+
+    def test_4d_batch_mask_to_5d_gqa_scores(self):
+        """Server crash geometry: mask (B,1,L,K) vs scores (B,H_kv,G,L,K)."""
+        B, H_kv, G, L, K = 2, 8, 2, 18, 18
+        scores = mx.zeros((B, H_kv, G, L, K))
+        mask = create_causal_mask(L, offset=0, left_padding=mx.array([1, 0]))
+        assert mask.shape == (B, 1, L, K)
+
+        aligned = align_attention_mask_to_scores(mask, scores)
+        assert aligned is not None
+        # Must broadcast onto scores without aliasing B onto H_kv
+        out = mx.where(aligned, scores, mx.array(-1.0))
+        mx.eval(out)
+        assert out.shape == scores.shape
+
+    def test_live_server_shapes(self):
+        """Exact shapes from #1567 concurrent curl repro."""
+        scores = mx.zeros((2, 8, 2, 18, 18))
+        mask = mx.ones((2, 1, 18, 18), dtype=mx.bool_)
+        aligned = align_attention_mask_to_scores(mask, scores)
+        mx.eval(mx.where(aligned, scores, mx.array(0.0)))
+
+    def test_2d_causal_still_broadcasts(self):
+        scores = mx.zeros((2, 8, 2, 4, 4))
+        mask = create_causal_mask(4, offset=0)  # (4, 4), no batch pad
+        aligned = align_attention_mask_to_scores(mask, scores)
+        mx.eval(mx.where(aligned, scores, mx.array(0.0)))
+
+
+class TestQuantizedSdpaMultiRowGqa:
+    def test_batch2_gqa_with_left_padding_mask(self):
+        """End-to-end quant SDPA: B=2, GQA, batch left-pad mask (the #1567 path)."""
+        B, n_q, n_kv, L, D = 2, 16, 8, 4, GROUP  # n_repeats=2
+        queries = mx.random.normal((B, n_q, L, D)).astype(mx.float16)
+        q_keys, q_values = _quant_kv(B, n_kv, L, D)
+        mask = create_causal_mask(L, offset=0, left_padding=mx.array([1, 0]))
+
+        out = quantized_scaled_dot_product_attention(
+            queries,
+            q_keys,
+            q_values,
+            scale=D**-0.5,
+            mask=mask,
+            group_size=GROUP,
+            bits=BITS,
+        )
+        mx.eval(out)
+        assert out.shape == (B, n_q, L, D)
+
+    def test_batch2_gqa_matches_server_head_layout(self):
+        """Qwen3-0.6B-like: 16 Q / 8 KV in smoke used (2,8,2,L,K) scores."""
+        B, n_q, n_kv, L, D = 2, 16, 8, 18, GROUP
+        queries = mx.random.normal((B, n_q, L, D)).astype(mx.float16)
+        q_keys, q_values = _quant_kv(B, n_kv, L, D)
+        mask = create_causal_mask(L, offset=0, left_padding=mx.array([0, 0]))
+
+        out = quantized_scaled_dot_product_attention(
+            queries,
+            q_keys,
+            q_values,
+            scale=D**-0.5,
+            mask=mask,
+            group_size=GROUP,
+            bits=BITS,
+        )
+        mx.eval(out)
+        assert out.shape == (B, n_q, L, D)
+
+    def test_batch1_gqa_still_works(self):
+        B, n_q, n_kv, L, D = 1, 16, 8, 4, GROUP
+        queries = mx.random.normal((B, n_q, L, D)).astype(mx.float16)
+        q_keys, q_values = _quant_kv(B, n_kv, L, D)
+        mask = create_causal_mask(L, offset=0, left_padding=mx.array([0]))
+
+        out = quantized_scaled_dot_product_attention(
+            queries,
+            q_keys,
+            q_values,
+            scale=D**-0.5,
+            mask=mask,
+            group_size=GROUP,
+            bits=BITS,
+        )
+        mx.eval(out)
+        assert out.shape == (B, n_q, L, D)

--- a/mlx_vlm/tests/test_quant_sdpa_mask_adversarial.py
+++ b/mlx_vlm/tests/test_quant_sdpa_mask_adversarial.py
@@ -1,0 +1,270 @@
+"""Adversarial geometry tests for multi-row quantized SDPA masks (#1567).
+
+Tries to break align_attention_mask_to_scores / quant SDPA with shapes that
+show up (or could show up) in continuous batching: GQA/MQA/MHA, decode vs
+prefill, chunked offset, windowed causal, left+right pad, additive masks,
+and awkward batch sizes.
+"""
+
+from __future__ import annotations
+
+import itertools
+
+import mlx.core as mx
+import pytest
+
+from mlx_vlm.models.base import (
+    align_attention_mask_to_scores,
+    quantized_scaled_dot_product_attention,
+)
+from mlx_vlm.models.cache import BatchKVCache, BatchQuantizedKVCache, create_causal_mask
+
+GROUP = 64
+BITS = 8
+
+
+def _quant_kv(B, n_kv, L, D, dtype=mx.float16):
+    keys = mx.random.normal((B, n_kv, L, D)).astype(dtype)
+    values = mx.random.normal((B, n_kv, L, D)).astype(dtype)
+    return (
+        mx.quantize(keys, group_size=GROUP, bits=BITS),
+        mx.quantize(values, group_size=GROUP, bits=BITS),
+    )
+
+
+def _run_sdpa(B, n_q, n_kv, L, K_cache, mask, D=GROUP):
+    """K_cache is total key length (offset + L); keys filled to K_cache."""
+    queries = mx.random.normal((B, n_q, L, D)).astype(mx.float16)
+    q_keys, q_values = _quant_kv(B, n_kv, K_cache, D)
+    out = quantized_scaled_dot_product_attention(
+        queries,
+        q_keys,
+        q_values,
+        scale=D**-0.5,
+        mask=mask,
+        group_size=GROUP,
+        bits=BITS,
+    )
+    mx.eval(out)
+    assert out.shape == (B, n_q, L, D)
+    assert mx.isfinite(out).all()
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Parametric score/mask geometries
+# ---------------------------------------------------------------------------
+
+# (B, n_q, n_kv) layouts seen or plausible in MLX VLMs
+HEAD_LAYOUTS = [
+    (2, 16, 8),  # Qwen3-0.6B-like GQA (server repro family)
+    (2, 32, 8),  # stronger GQA
+    (2, 16, 2),  # wider repeat
+    (2, 16, 1),  # MQA
+    (2, 8, 8),  # MHA n_repeats=1
+    (3, 16, 8),  # odd batch
+    (4, 16, 8),  # larger batch
+    (8, 16, 8),  # B == n_kv (latent mis-align case pre-fix)
+    (1, 16, 8),  # single row control
+]
+
+
+@pytest.mark.parametrize("B,n_q,n_kv", HEAD_LAYOUTS)
+@pytest.mark.parametrize(
+    "L,offset",
+    [
+        (1, 0),  # pure decode, empty-ish cache
+        (1, 128),  # decode after long prefill
+        (4, 0),  # short prefill
+        (18, 0),  # server curl prompt length class
+        (64, 0),  # medium prefill
+        (32, 96),  # chunked prefill: L != K
+        (128, 512),  # long context chunk
+    ],
+)
+def test_left_pad_mask_all_head_and_length_combos(B, n_q, n_kv, L, offset):
+    K = offset + L
+    # Varied per-row left pad (capped so pad < K)
+    pads = [(i * 3) % max(K, 1) for i in range(B)]
+    if K > 1:
+        pads = [min(p, K - 1) for p in pads]
+    mask = create_causal_mask(L, offset=offset, left_padding=mx.array(pads))
+    _run_sdpa(B, n_q, n_kv, L, K, mask)
+
+
+@pytest.mark.parametrize("B,n_q,n_kv", [(2, 16, 8), (3, 16, 8), (2, 16, 1)])
+def test_left_and_right_padding_together(B, n_q, n_kv):
+    L, offset = 16, 0
+    left = mx.array([2, 0] + [0] * (B - 2))
+    right = mx.array([0, 3] + [0] * (B - 2))
+    mask = create_causal_mask(
+        L, offset=offset, left_padding=left[:B], right_padding=right[:B]
+    )
+    _run_sdpa(B, n_q, n_kv, L, offset + L, mask)
+
+
+@pytest.mark.parametrize("window", [4, 8, 32])
+@pytest.mark.parametrize("B,n_q,n_kv", [(2, 16, 8), (2, 8, 8)])
+def test_sliding_window_causal_with_left_pad(window, B, n_q, n_kv):
+    L, offset = 24, 40
+    pads = mx.array([1, 0] if B == 2 else [1, 0] + [0] * (B - 2))
+    mask = create_causal_mask(
+        L, offset=offset, window_size=window, left_padding=pads[:B]
+    )
+    _run_sdpa(B, n_q, n_kv, L, offset + L, mask)
+
+
+@pytest.mark.parametrize("B,n_q,n_kv", [(2, 16, 8), (4, 32, 8)])
+def test_additive_float_mask(B, n_q, n_kv):
+    L = 12
+    causal = create_causal_mask(L, left_padding=mx.array([i % 2 for i in range(B)]))
+    mask = mx.where(
+        causal,
+        mx.array(0.0, dtype=mx.float16),
+        mx.array(-1e4, dtype=mx.float16),
+    )
+    _run_sdpa(B, n_q, n_kv, L, L, mask)
+
+
+def test_string_causal_mask_gqa_batch():
+    B, n_q, n_kv, L = 2, 16, 8, 8
+    _run_sdpa(B, n_q, n_kv, L, L, mask="causal")
+
+
+def test_none_mask_gqa_batch():
+    B, n_q, n_kv, L = 2, 16, 8, 8
+    _run_sdpa(B, n_q, n_kv, L, L, mask=None)
+
+
+# ---------------------------------------------------------------------------
+# align helper contract
+# ---------------------------------------------------------------------------
+
+
+def test_aligned_standard_batch_mask_is_b_1_1_l_k():
+    scores = mx.zeros((2, 8, 2, 18, 18))
+    mask = create_causal_mask(18, left_padding=mx.array([1, 0]))
+    aligned = align_attention_mask_to_scores(mask, scores)
+    assert aligned.shape == (2, 1, 1, 18, 18)
+
+
+def test_aligned_decode_mask_shape():
+    scores = mx.zeros((2, 8, 2, 1, 128))
+    mask = create_causal_mask(1, offset=127, left_padding=mx.array([0, 5]))
+    aligned = align_attention_mask_to_scores(mask, scores)
+    assert aligned.shape[0] == 2
+    assert aligned.shape[-2:] == (1, 128)
+    mx.eval(mx.where(aligned, scores, mx.array(0.0)))
+
+
+def test_2d_window_mask_to_5d():
+    scores = mx.zeros((2, 4, 4, 16, 16))
+    mask = create_causal_mask(16, window_size=8)  # 2D
+    aligned = align_attention_mask_to_scores(mask, scores)
+    mx.eval(mx.where(aligned, scores, mx.array(0.0)))
+
+
+# ---------------------------------------------------------------------------
+# Cache make_mask → quant SDPA (integration of the two layers)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("past", [0, 8, 64])
+@pytest.mark.parametrize("N", [1, 8, 32])
+@pytest.mark.parametrize("left_padding", [[0, 0], [3, 0], [0, 5, 1], [7, 2, 0, 4]])
+def test_batch_quantized_make_mask_into_sdpa(past, N, left_padding):
+    """Mirror real attention order: make_mask(N) at current offset, then update N tokens."""
+    B = len(left_padding)
+    n_q, n_kv = 16, 8
+    cache = BatchQuantizedKVCache(left_padding, group_size=GROUP, bits=BITS)
+    if past > 0:
+        k0 = mx.random.normal((B, n_kv, past, GROUP)).astype(mx.float16)
+        v0 = mx.random.normal((B, n_kv, past, GROUP)).astype(mx.float16)
+        cache.update_and_fetch(k0, v0)
+
+    # Same order as Qwen3 Attention: mask from pre-update offset, then append K/V.
+    mask = cache.make_mask(N)
+    k = mx.random.normal((B, n_kv, N, GROUP)).astype(mx.float16)
+    v = mx.random.normal((B, n_kv, N, GROUP)).astype(mx.float16)
+    q_keys, q_values = cache.update_and_fetch(k, v)
+    queries = mx.random.normal((B, n_q, N, GROUP)).astype(mx.float16)
+    out = quantized_scaled_dot_product_attention(
+        queries,
+        q_keys,
+        q_values,
+        scale=GROUP**-0.5,
+        mask=mask,
+        group_size=GROUP,
+        bits=BITS,
+    )
+    mx.eval(out)
+    assert out.shape == (B, n_q, N, GROUP)
+
+
+# ---------------------------------------------------------------------------
+# prepare/finalize stress
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "right_padding",
+    [
+        [1, 0],
+        [0, 5],
+        [3, 3],
+        [7, 0, 2],
+        [0, 0, 0, 9],
+    ],
+)
+def test_prepare_finalize_extreme_right_pad(right_padding):
+    B = len(right_padding)
+    quant = BatchQuantizedKVCache([0] * B, group_size=GROUP, bits=BITS)
+    ref = BatchKVCache([0] * B)
+    quant.prepare(right_padding=right_padding)
+    ref.prepare(right_padding=right_padding)
+    k = mx.random.normal((B, 4, 16, GROUP))
+    v = mx.random.normal((B, 4, 16, GROUP))
+    quant.update_and_fetch(k, v)
+    ref.update_and_fetch(k, v)
+    quant.finalize()
+    ref.finalize()
+    assert quant.left_padding.tolist() == ref.left_padding.tolist()
+    assert quant.offset.tolist() == ref.offset.tolist()
+
+
+def test_prepare_left_padding_on_empty_only():
+    cache = BatchQuantizedKVCache([0, 0], group_size=GROUP, bits=BITS)
+    cache.prepare(left_padding=[2, 1])
+    assert cache.left_padding.tolist() == [2, 1]
+    k = mx.random.normal((2, 2, 4, GROUP))
+    v = mx.random.normal((2, 2, 4, GROUP))
+    cache.update_and_fetch(k, v)
+    with pytest.raises(ValueError, match="empty"):
+        cache.prepare(left_padding=[1, 0])
+
+
+# ---------------------------------------------------------------------------
+# Brute force small grid (catch "weird" combos)
+# ---------------------------------------------------------------------------
+
+
+def test_brute_small_grid():
+    failures = []
+    for B, n_kv, n_rep, L, offset in itertools.product(
+        [1, 2, 3, 5],
+        [1, 2, 4, 8],
+        [1, 2, 4],
+        [1, 7, 16],
+        [0, 3, 33],
+    ):
+        n_q = n_kv * n_rep
+        K = offset + L
+        pads = [(i * 2) % max(1, K) for i in range(B)]
+        try:
+            mask = create_causal_mask(L, offset=offset, left_padding=mx.array(pads))
+            _run_sdpa(B, n_q, n_kv, L, K, mask)
+        except Exception as e:
+            failures.append(
+                f"B={B} n_q={n_q} n_kv={n_kv} L={L} off={offset}: {type(e).__name__}: {e}"
+            )
+    assert not failures, "Brute grid failures:\n" + "\n".join(failures[:20])


### PR DESCRIPTION
## Summary

Fixes concurrent continuous batching with `--kv-bits` (#1567).

Two overlapping chat requests against `mlx_vlm.server --kv-bits 8` crashed during prefill:

```text
ValueError: [broadcast_shapes] Shapes (2,1,18,18) and (2,8,2,18,18) cannot be broadcast.
```

**Cause:** Quantized GQA expands attention scores to 5D `(B, n_kv_heads, n_repeats, L, K)` while batch left-pad masks are 4D `(B, 1, L, K)`. Right-align broadcast aliases batch with heads and fails for `B > 1`.

**Fix:**
- `align_attention_mask_to_scores` — expand mask rank before the last two dims so it maps to score layout (SoC: attention owns score geometry)
- Wire into `quantized_scaled_dot_product_attention`
- `BatchQuantizedKVCache.prepare` / `finalize` — same multi-row pad lifecycle as `BatchKVCache`

## Test plan

- [x] `pytest mlx_vlm/tests/test_quant_sdpa_mask.py`
- [x] `pytest mlx_vlm/tests/test_batch_quantized_cache.py`
- [x] Live: two concurrent curls vs server `--kv-bits 8` on `Qwen3-0.6B-4bit` → both **HTTP 200** (was 500)

Fixes #1567  
Related: #1562