### PR TITLE
fix(qwen3_5): skip fully-padded rows in chunked batch prefill (#1558)

### DIFF
--- a/mlx_vlm/models/qwen3_5/language.py
+++ b/mlx_vlm/models/qwen3_5/language.py
@@ -716,6 +716,20 @@ def _pad_row_time(x: mx.array, pad: int, target_length: int) -> mx.array:
     )
 
 
+def _restore_batch_padding_metadata(cache_entry, offsets, steps: int):
+    if offsets is None:
+        return cache_entry
+    if not (
+        hasattr(cache_entry, "offset")
+        and hasattr(cache_entry, "left_padding")
+        and hasattr(cache_entry, "_idx")
+    ):
+        return cache_entry
+    cache_entry.offset = offsets + steps
+    cache_entry.left_padding = cache_entry._idx - cache_entry.offset
+    return cache_entry
+
+
 def _qwen3_5_left_padding_info(cache):
     left_padding = getattr(cache, "left_padding", None)
     if not (
@@ -1852,8 +1866,30 @@ class Qwen3_5Model(nn.Module):
             if has_left_padding or int(query_left_padding.max().item()) > 0:
                 row_outputs = []
                 row_caches = [[] for _ in cache]
+                batch_offsets = []
+                for cache_entry in cache:
+                    offsets = getattr(cache_entry, "offset", None)
+                    if (
+                        isinstance(offsets, mx.array)
+                        and offsets.ndim > 0
+                        and offsets.size >= h.shape[0]
+                    ):
+                        batch_offsets.append(offsets[: h.shape[0]])
+                    else:
+                        batch_offsets.append(None)
                 for row, pad in enumerate(query_left_padding.tolist()):
                     pad = min(max(int(pad), 0), h.shape[1])
+                    current_cache = []
+                    for cache_entry in cache:
+                        if cache_entry is None:
+                            current_cache.append(None)
+                        else:
+                            current_cache.append(_extract_row_cache(cache_entry, row))
+                    if pad == h.shape[1]:
+                        row_outputs.append(mx.zeros_like(h[row : row + 1]))
+                        for i, cache_entry in enumerate(current_cache):
+                            row_caches[i].append(cache_entry)
+                        continue
                     row_inputs = inputs[row : row + 1, pad:]
                     row_embeds = h[row : row + 1, pad:]
                     row_position_ids = None
@@ -1862,12 +1898,6 @@ class Qwen3_5Model(nn.Module):
                             row_position_ids = position_ids[row : row + 1, pad:]
                         else:
                             row_position_ids = position_ids[:, row : row + 1, pad:]
-                    current_cache = []
-                    for cache_entry in cache:
-                        if cache_entry is None:
-                            current_cache.append(None)
-                        else:
-                            current_cache.append(_extract_row_cache(cache_entry, row))
 
                     row_out = self(
                         row_inputs,
@@ -1885,7 +1915,11 @@ class Qwen3_5Model(nn.Module):
                     if cache[i] is None:
                         continue
                     if hasattr(cache[i].__class__, "merge"):
-                        cache[i] = cache[i].__class__.merge(entries)
+                        cache[i] = _restore_batch_padding_metadata(
+                            cache[i].__class__.merge(entries),
+                            batch_offsets[i],
+                            h.shape[1],
+                        )
                 return mx.concatenate(row_outputs, axis=0)
 
         fa_mask = _create_qwen3_5_attention_mask(h, cache[self.fa_idx])

--- a/mlx_vlm/tests/test_speculative.py
+++ b/mlx_vlm/tests/test_speculative.py
@@ -920,6 +920,66 @@ def test_qwen3_5_single_row_batch_cache_matches_singleton_cache():
     assert isinstance(batch_cache[1], BatchKVCache)
 
 
+def _qwen3_5_hybrid_batch_model():
+    text_config = _tiny_qwen3_5_text_config()
+    text_config.num_hidden_layers = 2
+    text_config.full_attention_interval = 2
+    return qwen_language.Qwen3_5Model(text_config), text_config
+
+
+def _qwen3_5_batch_cache(left_padding):
+    arrays = ArraysCache(size=2)
+    arrays.left_padding = mx.array(left_padding, dtype=mx.int32)
+    return [arrays, BatchKVCache(list(left_padding))]
+
+
+def test_qwen3_5_fully_padded_prefill_row_survives_chunks():
+    model, text_config = _qwen3_5_hybrid_batch_model()
+    cache = _qwen3_5_batch_cache([5, 0])
+
+    first = model(mx.array([[0, 0, 0], [1, 2, 3]], dtype=mx.int32), cache=cache)
+    mx.eval(first, cache[1].offset, cache[1].left_padding)
+    assert first.shape == (2, 3, text_config.hidden_size)
+    assert cache[1].offset.tolist() == [-2, 3]
+    assert cache[1].left_padding.tolist() == [5, 0]
+
+    second = model(mx.array([[0, 0, 4], [4, 5, 6]], dtype=mx.int32), cache=cache)
+    mx.eval(second, cache[1].offset, cache[1].left_padding)
+    assert second.shape == (2, 3, text_config.hidden_size)
+    assert cache[1].offset.tolist() == [1, 6]
+    assert cache[1].left_padding.tolist() == [5, 0]
+
+
+def test_qwen3_5_all_rows_fully_padded_prefill():
+    model, text_config = _qwen3_5_hybrid_batch_model()
+    cache = _qwen3_5_batch_cache([5, 5])
+    out = model(mx.array([[0, 0, 0], [0, 0, 0]], dtype=mx.int32), cache=cache)
+    mx.eval(out)
+    assert out.shape == (2, 3, text_config.hidden_size)
+
+
+def test_qwen3_5_partially_padded_rows_match_unbatched():
+    model, text_config = _qwen3_5_hybrid_batch_model()
+    mx.eval(model.parameters())
+
+    batched = model(
+        mx.array([[0, 7, 8], [1, 2, 3]], dtype=mx.int32),
+        cache=_qwen3_5_batch_cache([1, 0]),
+    )
+    row0 = model(
+        mx.array([[7, 8]], dtype=mx.int32),
+        cache=[ArraysCache(size=2), KVCache()],
+    )
+    row1 = model(
+        mx.array([[1, 2, 3]], dtype=mx.int32),
+        cache=[ArraysCache(size=2), KVCache()],
+    )
+    mx.eval(batched, row0, row1)
+
+    assert bool(mx.array_equal(batched[0:1, 1:], row0).item())
+    assert bool(mx.array_equal(batched[1:2], row1).item())
+
+
 def test_qwen3_5_single_row_quantized_batch_cache_keeps_prompt_state():
     text_config = _tiny_qwen3_5_text_config()
     text_config.hidden_size = 64


### PR DESCRIPTION

this fixes #1555 

When requests are getting batched, the structured req joins later, and grammer processor lands in the wrong row. To fix, I padded logits_processors with Nones up to the row count whenever any processor is active, same as token_context already does. 

Checked the issue repro lines up ([None, None, [proc]]) and test_generate.py stays green with a new regression test.