### PR TITLE
fix(apc): validate runtime caches and trace block stores

### DIFF
--- a/mlx_vlm/apc.py
+++ b/mlx_vlm/apc.py
@@ -51,7 +51,7 @@ import time
 from collections import OrderedDict
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple
+from typing import Any, Callable, Dict, Iterable, List, Optional, Sequence, Tuple
 
 import mlx.core as mx
 import numpy as np
@@ -3108,6 +3108,13 @@ class APCManager:
     ) -> bool:
         """Store a full prompt-cache snapshot for exact-prefix reuse."""
         if (self._exact_cache_max <= 0 and self.disk is None) or not token_ids:
+            apc_trace(
+                "store",
+                mode="exact",
+                ok=False,
+                reason="empty_tokens" if not token_ids else "no_storage_tier",
+                token_len=len(token_ids),
+            )
             return False
         token_tuple = tuple(int(t) for t in token_ids)
         copied = _clone_prompt_cache_for_apc(prompt_cache)
@@ -3128,6 +3135,8 @@ class APCManager:
             return False
         key = _sequence_hash(token_tuple, extra_hash, self.block_size)
         stored = False
+        memory_stored = False
+        disk_stored = False
         with self.lock:
             if self._exact_cache_max > 0:
                 self._exact_cache[key] = APCExactCacheEntry(
@@ -3140,22 +3149,32 @@ class APCManager:
                 while len(self._exact_cache) > self._exact_cache_max:
                     self._exact_cache.popitem(last=False)
                 stored = True
-        if stored:
-            apc_trace(
-                "store",
-                mode="exact",
-                ok=True,
-                token_len=len(token_tuple),
-                layers=len(copied),
-            )
+                memory_stored = True
         if self.disk is not None:
             try:
                 self.disk.save_exact_cache(key, token_tuple, extra_hash, copied)
                 with self.lock:
                     self.stats.disk_writes += 1
                 stored = True
+                disk_stored = True
             except Exception as e:
                 logger.warning("APC exact disk save scheduling failed: %s", e)
+                apc_trace(
+                    "reject",
+                    mode="exact",
+                    reason="disk_save_error",
+                    error=type(e).__name__,
+                    token_len=len(token_tuple),
+                )
+        apc_trace(
+            "store",
+            mode="exact",
+            ok=stored,
+            token_len=len(token_tuple),
+            layers=len(copied),
+            memory=memory_stored,
+            disk=disk_stored,
+        )
         if stored:
             with self.lock:
                 self.stats.exact_stores += 1
@@ -3312,6 +3331,10 @@ class APCManager:
             )
             new_blocks: List[APCBlock] = []
             disk_blocks: List[_DiskLayerMajorBlock] = []
+            memory_stores = 0
+            reused_blocks = 0
+            disk_stores = 0
+            skip_reason: Optional[str] = None
             per_block_tensors = len(layer_keys) + len(layer_values)
             token_tuple = tuple(int(t) for t in token_ids[:layer_major_prefix_tokens])
             layer_major_stored = False
@@ -3370,6 +3393,7 @@ class APCManager:
                 if existing is not None and existing.token_ids == chunk:
                     acquired = self._acquire_existing(existing)
                     new_blocks.append(acquired)
+                    reused_blocks += 1
                     parent = h
                     continue
                 if (
@@ -3385,6 +3409,7 @@ class APCManager:
                         n_full,
                     )
                     if self.disk is None:
+                        skip_reason = "pool_tensor_limit"
                         break
                     parent = h
                     continue
@@ -3396,6 +3421,7 @@ class APCManager:
                         n_full,
                     )
                     if self.disk is None:
+                        skip_reason = "pool_exhausted"
                         break
                     parent = h
                     continue
@@ -3417,6 +3443,7 @@ class APCManager:
                 b.ref_cnt = 1
                 self.hash_table[h] = b
                 new_blocks.append(b)
+                memory_stores += 1
                 self.stats.stores += 1
                 self.stats.served_tokens += self.block_size
                 parent = h
@@ -3426,9 +3453,37 @@ class APCManager:
                         disk_blocks, layer_keys, layer_values, self.block_size
                     )
                     self.stats.disk_writes += len(disk_blocks)
+                    disk_stores = len(disk_blocks)
                 except Exception as e:
                     logger.warning("APC disk save scheduling failed: %s", e)
+                    skip_reason = "disk_save_error"
+                    apc_trace(
+                        "reject",
+                        mode="block",
+                        reason=skip_reason,
+                        error=type(e).__name__,
+                        token_len=len(token_ids),
+                    )
             self.stats.pool_used = sum(1 for x in self.pool if x.block_hash is not None)
+            no_new_blocks = n_full <= skip_full
+            apc_trace(
+                "store",
+                mode="block",
+                ok=bool(
+                    memory_stores
+                    or reused_blocks
+                    or disk_stores
+                    or layer_major_stored
+                    or no_new_blocks
+                ),
+                token_len=len(token_ids),
+                full_blocks=n_full,
+                memory_blocks=memory_stores,
+                disk_blocks=disk_stores,
+                reused_blocks=reused_blocks,
+                layer_major=layer_major_stored,
+                reason=skip_reason or ("no_new_full_blocks" if no_new_blocks else "-"),
+            )
             return new_blocks
 
     def stats_snapshot(self) -> dict:
@@ -3956,9 +4011,17 @@ def harvest_blocks_from_batch_cache(
     """
     layer_keys: List[mx.array] = []
     layer_values: List[mx.array] = []
-    for c in batch_caches:
+    for layer_idx, c in enumerate(batch_caches):
         k, v = layer_kv_for_apc(c, batch_idx=batch_idx)
         if k is None or v is None:
+            with apc_manager.lock:
+                apc_manager.stats.record_reject(
+                    "no_block_harvest_adapter",
+                    mode="block",
+                    layer=layer_idx,
+                    type=type(c).__name__,
+                    token_len=len(full_token_ids),
+                )
             return []
         if int(k.shape[0]) != 1:
             k = k[batch_idx : batch_idx + 1]
@@ -4020,11 +4083,13 @@ class APCSelfCheckResult:
     notes: List[str] = field(default_factory=list)
 
 
-def classify_layer_for_apc(c: Any) -> LayerSupport:
+def classify_layer_for_apc(c: Any, *, apc_mode: str = "exact") -> LayerSupport:
     """Classify whether one prompt-cache layer can be snapshotted for APC.
 
-    Uses the same clone path as exact store so startup checks match runtime.
-    Empty layers that clone to a storage-native type count as ``empty_ok``.
+    Exact mode uses the same materialized clone path as exact store. Block mode
+    validates the adapter contract used by :func:`layer_kv_for_apc`; empty
+    runtime caches cannot yield K/V yet, so their protocol is checked without a
+    synthetic model forward.
     """
     type_name = type(c).__name__
     is_empty = False
@@ -4035,6 +4100,35 @@ def classify_layer_for_apc(c: Any) -> LayerSupport:
         except Exception:
             is_empty = False
 
+    if apc_mode == "block":
+        # Quantized caches expose an explicit dequantization adapter. Dense
+        # caches are harvested through keys/values plus either _idx (batch) or
+        # offset (single-row). This mirrors layer_kv_for_apc without requiring
+        # a forward pass merely to populate an otherwise-empty cache.
+        has_dequant = callable(getattr(c, "dequantize_for_apc", None))
+        has_dense_state = (
+            hasattr(c, "keys")
+            and hasattr(c, "values")
+            and (hasattr(c, "_idx") or hasattr(c, "offset"))
+        )
+        if not (has_dequant or has_dense_state):
+            return LayerSupport(
+                type_name=type_name,
+                status="unsupported",
+                reason="no_block_harvest_adapter",
+            )
+        return LayerSupport(
+            type_name=type_name,
+            status="empty_ok" if is_empty else "ok",
+        )
+
+    if apc_mode != "exact":
+        return LayerSupport(
+            type_name=type_name,
+            status="unsupported",
+            reason=f"unknown_mode:{apc_mode}",
+        )
+
     eval_targets: List[mx.array] = []
     try:
         copied = _clone_cache_entry_for_apc(
@@ -4042,6 +4136,8 @@ def classify_layer_for_apc(c: Any) -> LayerSupport:
             min_capacity_tokens=None,
             eval_targets=eval_targets,
         )
+        if eval_targets:
+            mx.eval(eval_targets)
     except Exception as exc:
         return LayerSupport(
             type_name=type_name,
@@ -4069,7 +4165,9 @@ def validate_prompt_cache_layout(
     layer_types = [type(c).__name__ for c in caches]
     unsupported = [
         layer
-        for layer in (classify_layer_for_apc(c) for c in caches)
+        for layer in (
+            classify_layer_for_apc(c, apc_mode=apc_mode or "exact") for c in caches
+        )
         if layer.status == "unsupported"
     ]
     return APCSelfCheckResult(
@@ -4084,10 +4182,20 @@ def validate_prompt_cache_layout(
 def self_check_model_apc(
     model: Any,
     *,
+    caches: Optional[Sequence[Any]] = None,
+    cache_factory: Optional[Callable[[], Sequence[Any]]] = None,
+    apc_mode: Optional[str] = None,
     kv_bits: Optional[float] = None,
+    kv_group_size: Optional[int] = None,
+    kv_quant_scheme: Optional[str] = None,
     log: bool = True,
 ) -> APCSelfCheckResult:
     """Dry-run APC layout check for a loaded model (or its ``language_model``).
+
+    Servers should pass ``cache_factory`` for the effective runtime layout so
+    cache construction and validation are both covered by this non-fatal
+    boundary. Direct ``caches`` and the ``make_cache`` fallback are retained for
+    standalone diagnostics and tests.
 
     Non-fatal by design: logs ERROR on failure and returns a result. Callers
     (e.g. server load) should not crash solely because the check fails.
@@ -4095,32 +4203,43 @@ def self_check_model_apc(
     notes: List[str] = []
     if kv_bits is not None:
         notes.append(f"kv_bits={kv_bits}")
+    if kv_group_size is not None:
+        notes.append(f"kv_group_size={kv_group_size}")
+    if kv_quant_scheme is not None:
+        notes.append(f"kv_quant_scheme={kv_quant_scheme}")
 
     try:
         language_model = (
             model.language_model if hasattr(model, "language_model") else model
         )
-        if not hasattr(language_model, "make_cache"):
+        resolved_mode = apc_mode or model_apc_mode(language_model)
+        if resolved_mode is None:
             result = APCSelfCheckResult(
                 ok=False,
                 apc_mode=None,
                 layer_count=0,
                 layer_types=[],
-                notes=notes + ["model has no make_cache"],
+                notes=notes + ["no APC-compatible cache layout"],
             )
         else:
-            apc_mode = model_apc_mode(language_model)
-            if apc_mode is None:
+            effective_caches = caches
+            if effective_caches is None and cache_factory is not None:
+                effective_caches = cache_factory()
+            if effective_caches is None and hasattr(language_model, "make_cache"):
+                effective_caches = language_model.make_cache()
+            if effective_caches is None:
                 result = APCSelfCheckResult(
                     ok=False,
-                    apc_mode=None,
+                    apc_mode=resolved_mode,
                     layer_count=0,
                     layer_types=[],
-                    notes=notes + ["no APC-compatible cache layout"],
+                    notes=notes + ["runtime cache layout was not supplied"],
                 )
             else:
-                caches = language_model.make_cache()
-                result = validate_prompt_cache_layout(caches, apc_mode=apc_mode)
+                result = validate_prompt_cache_layout(
+                    effective_caches,
+                    apc_mode=resolved_mode,
+                )
                 result.notes = list(notes) + list(result.notes)
     except Exception as exc:
         result = APCSelfCheckResult(
@@ -4139,7 +4258,7 @@ def self_check_model_apc(
                 result.apc_mode,
                 result.layer_count,
                 types_s,
-                f" kv_bits={kv_bits}" if kv_bits is not None else "",
+                f" {' '.join(result.notes)}" if result.notes else "",
             )
         else:
             bad = [
@@ -4161,6 +4280,8 @@ def self_check_model_apc(
         layers=result.layer_count,
         unsupported=len(result.unsupported),
         kv_bits=kv_bits,
+        kv_group_size=kv_group_size,
+        kv_quant_scheme=kv_quant_scheme,
     )
     return result
 

--- a/mlx_vlm/server/app.py
+++ b/mlx_vlm/server/app.py
@@ -778,13 +778,6 @@ def get_cached_model(
         vision_cache.clear()
         raise
 
-    # Dry-run APC layout when the shared pool is enabled (log-only; never blocks serve).
-    if runtime.apc_manager is not None:
-        try:
-            _apc.self_check_model_apc(model, kv_bits=kv_bits)
-        except Exception as exc:
-            logger.warning("APC self-check raised unexpectedly: %s", exc)
-
     cache = {
         "cache_key": cache_key,
         "model_path": model_path,

--- a/mlx_vlm/server/generation.py
+++ b/mlx_vlm/server/generation.py
@@ -970,6 +970,25 @@ class ResponseGenerator:
             raise self._load_error
         return self.model, self.processor, self.config
 
+    def _run_apc_self_check(self):
+        """Validate the exact cache layout this worker will use at runtime."""
+        language_model = getattr(self.model, "language_model", self.model)
+        apc_mode = _apc.model_apc_mode(language_model)
+        return _apc.self_check_model_apc(
+            language_model,
+            cache_factory=lambda: _make_cache(
+                language_model,
+                [0],
+                kv_bits=self.kv_bits,
+                kv_group_size=self.kv_group_size,
+                kv_quant_scheme=self.kv_quant_scheme,
+            ),
+            apc_mode=apc_mode,
+            kv_bits=self.kv_bits,
+            kv_group_size=self.kv_group_size,
+            kv_quant_scheme=self.kv_quant_scheme,
+        )
+
     def _cancel(self, uid):
         with self._cancel_lock:
             self._cancelled.add(uid)
@@ -1289,6 +1308,13 @@ class ResponseGenerator:
             print(f"Error loading model in generation thread: {e}")
             traceback.print_exc()
             return
+
+        if getattr(self, "apc_manager", None) is not None:
+            try:
+                self._run_apc_self_check()
+            except Exception as exc:
+                # Diagnostics must never prevent the model from serving.
+                logger.warning("APC runtime self-check raised unexpectedly: %s", exc)
 
         self._ready.set()
 

--- a/mlx_vlm/tests/test_apc_observability.py
+++ b/mlx_vlm/tests/test_apc_observability.py
@@ -13,6 +13,8 @@ from mlx_vlm.apc import (
     apc_trace,
     apc_trace_enabled,
     classify_layer_for_apc,
+    harvest_blocks_from_batch_cache,
+    model_apc_mode,
     self_check_model_apc,
     validate_prompt_cache_layout,
 )
@@ -75,6 +77,50 @@ class TestApcTrace:
         assert any("APC_TRACE reject" in r.message for r in caplog.records)
         assert any("unclonable" in r.message for r in caplog.records)
 
+    def test_block_store_emits_trace(self, monkeypatch, caplog):
+        monkeypatch.setenv("APC_TRACE", "1")
+        manager = APCManager(num_blocks=4, block_size=BLOCK_SIZE)
+        keys = [mx.zeros((1, 2, BLOCK_SIZE, 8), dtype=mx.float32)]
+        values = [mx.zeros((1, 2, BLOCK_SIZE, 8), dtype=mx.float32)]
+
+        with caplog.at_level(logging.INFO, logger="mlx_vlm.apc"):
+            blocks = manager.store_kv_blocks(
+                list(range(BLOCK_SIZE)),
+                keys,
+                values,
+            )
+
+        assert len(blocks) == 1
+        assert any(
+            "APC_TRACE store mode=block" in r.message and "memory_blocks=1" in r.message
+            for r in caplog.records
+        )
+        manager.release(blocks)
+
+    def test_block_harvest_reject_emits_reason(self, monkeypatch, caplog):
+        monkeypatch.setenv("APC_TRACE", "1")
+        manager = APCManager(num_blocks=4, block_size=BLOCK_SIZE)
+
+        class NoHarvestAdapter:
+            pass
+
+        with caplog.at_level(logging.INFO, logger="mlx_vlm.apc"):
+            blocks = harvest_blocks_from_batch_cache(
+                manager,
+                [NoHarvestAdapter()],
+                0,
+                list(range(BLOCK_SIZE)),
+            )
+
+        assert blocks == []
+        assert manager.stats.rejects_by_reason["no_block_harvest_adapter"] == 1
+        assert any(
+            "APC_TRACE reject" in r.message
+            and "reason=no_block_harvest_adapter" in r.message
+            and "mode=block" in r.message
+            for r in caplog.records
+        )
+
 
 class TestClassifyLayer:
     def test_plain_kv_ok(self):
@@ -114,6 +160,21 @@ class TestClassifyLayer:
         result = classify_layer_for_apc(Bogus())
         assert result.status == "unsupported"
         assert result.reason
+
+    def test_exact_clone_is_materialized(self, monkeypatch):
+        c = KVCache()
+        c.update_and_fetch(
+            mx.zeros((1, 2, 4, 8), dtype=mx.float32),
+            mx.zeros((1, 2, 4, 8), dtype=mx.float32),
+        )
+
+        def fail_eval(*args, **kwargs):
+            raise RuntimeError("materialization failed")
+
+        monkeypatch.setattr("mlx_vlm.apc.mx.eval", fail_eval)
+        result = classify_layer_for_apc(c)
+        assert result.status == "unsupported"
+        assert result.reason == "clone_error:RuntimeError"
 
 
 class TestValidateLayout:
@@ -196,3 +257,122 @@ class TestSelfCheckModel:
         result = self_check_model_apc(FakeLang())
         assert result.ok is False
         assert result.notes
+
+    def test_runtime_cache_factory_failure_is_non_fatal(self):
+        class FakeLang:
+            def make_cache(self):
+                return [KVCache()]
+
+        def fail_factory():
+            raise RuntimeError("runtime cache construction failed")
+
+        result = self_check_model_apc(
+            FakeLang(),
+            cache_factory=fail_factory,
+            apc_mode="block",
+        )
+        assert result.ok is False
+        assert "runtime cache construction failed" in result.notes[-1]
+
+    @pytest.mark.parametrize(
+        ("kv_bits", "kv_quant_scheme", "expected_type"),
+        [
+            (8, "uniform", "BatchQuantizedKVCache"),
+            (3.5, "turboquant", "BatchTurboQuantKVCache"),
+        ],
+    )
+    def test_server_worker_checks_effective_quantized_runtime_layout(
+        self,
+        kv_bits,
+        kv_quant_scheme,
+        expected_type,
+    ):
+        from mlx_vlm.server.generation import ResponseGenerator
+
+        class FakeLang:
+            def make_cache(self):
+                return [KVCache(), KVCache()]
+
+        worker = ResponseGenerator.__new__(ResponseGenerator)
+        worker.model = type("FakeVLM", (), {"language_model": FakeLang()})()
+        worker.kv_bits = kv_bits
+        worker.kv_group_size = GROUP_SIZE
+        worker.kv_quant_scheme = kv_quant_scheme
+
+        result = worker._run_apc_self_check()
+
+        assert result.ok is True
+        assert result.apc_mode == "block"
+        assert result.layer_types == [expected_type, expected_type]
+        assert f"kv_bits={kv_bits}" in result.notes
+        assert f"kv_quant_scheme={kv_quant_scheme}" in result.notes
+
+    def test_server_worker_checks_implicit_runtime_cache_layout(self):
+        from mlx_vlm.server.generation import ResponseGenerator
+
+        class FakeLang:
+            layers = [object(), object()]
+
+        language_model = FakeLang()
+        assert model_apc_mode(language_model) == "block"
+
+        worker = ResponseGenerator.__new__(ResponseGenerator)
+        worker.model = type("FakeVLM", (), {"language_model": language_model})()
+        worker.kv_bits = None
+        worker.kv_group_size = GROUP_SIZE
+        worker.kv_quant_scheme = "uniform"
+
+        result = worker._run_apc_self_check()
+
+        assert result.ok is True
+        assert result.apc_mode == "block"
+        assert result.layer_types == ["BatchKVCache", "BatchKVCache"]
+
+    @pytest.mark.parametrize(
+        ("kv_bits", "kv_quant_scheme"),
+        [(8, "uniform"), (3.5, "turboquant")],
+    )
+    def test_effective_quantized_runtime_cache_harvests_and_traces(
+        self,
+        monkeypatch,
+        caplog,
+        kv_bits,
+        kv_quant_scheme,
+    ):
+        from mlx_vlm.generate.ar import _make_cache
+
+        class FakeLang:
+            def make_cache(self):
+                return [KVCache(), KVCache()]
+
+        caches = _make_cache(
+            FakeLang(),
+            [0],
+            kv_bits=kv_bits,
+            kv_group_size=GROUP_SIZE,
+            kv_quant_scheme=kv_quant_scheme,
+        )
+        for cache in caches:
+            cache.update_and_fetch(
+                mx.random.normal((1, 2, BLOCK_SIZE, GROUP_SIZE)),
+                mx.random.normal((1, 2, BLOCK_SIZE, GROUP_SIZE)),
+            )
+
+        monkeypatch.setenv("APC_TRACE", "1")
+        manager = APCManager(num_blocks=4, block_size=BLOCK_SIZE)
+        with caplog.at_level(logging.INFO, logger="mlx_vlm.apc"):
+            blocks = harvest_blocks_from_batch_cache(
+                manager,
+                caches,
+                0,
+                list(range(BLOCK_SIZE)),
+            )
+
+        assert len(blocks) == 1
+        assert manager.stats.stores == 1
+        assert any(
+            "APC_TRACE store mode=block" in record.message
+            and "memory_blocks=1" in record.message
+            for record in caplog.records
+        )
+        manager.release(blocks)


### PR DESCRIPTION
## Summary

Follow-up to #1566 that makes APC observability exercise the same cache layout and store paths used by the server at runtime.

- run the non-fatal APC self-check inside the generation worker using the runtime `_make_cache` factory
- include KV bits, group size, and quantization scheme so uniform and TurboQuant layouts are validated
- validate block and exact APC modes through their respective adapter contracts
- materialize exact-cache clones during the check so deferred MLX failures are observed
- emit `APC_TRACE store` for block-mode, memory, disk, reused, and layer-major outcomes
- record and trace unsupported block-harvest adapters instead of returning silently
- report final exact-store outcomes, including disk-only stores and disk scheduling failures

## Root cause

The original startup check called `language_model.make_cache()` on the FastAPI thread and always exercised the exact-cache clone adapter. Continuous generation builds a different effective cache layout in the GPU worker, including batch conversion and optional uniform/TurboQuant caches. The normal block store path also had no trace event, and unsupported harvest adapters returned an empty list without a reject reason.

## Impact

Operators now see trace events for the normal block APC path, and startup diagnostics reflect the effective server cache configuration without making failures fatal. Cache construction remains on the worker that owns MLX/GPU work.

## Validation

- `pre-commit run --files mlx_vlm/apc.py mlx_vlm/server/app.py mlx_vlm/server/generation.py mlx_vlm/tests/test_apc_observability.py`
- focused observability/adapters: 62 passed
- APC + quantization + server suite: 325 passed
- full non-smoke suite: 1463 passed, 3 skipped, 49 subtests passed

Runtime coverage populates and harvests both `BatchQuantizedKVCache` and `BatchTurboQuantKVCache`, then verifies the block-store trace.