### PR TITLE
Fix logits processor alignment in mixed generation batches

### DIFF
--- a/mlx_vlm/generate/ar.py
+++ b/mlx_vlm/generate/ar.py
@@ -1104,6 +1104,14 @@ class GenerationBatch:
         if self_has_processors or other_has_processors:
             self._ensure_token_context(force=bool(other_has_processors))
             other._ensure_token_context(force=bool(self_has_processors))
+            if len(self.logits_processors) < len(self.uids):
+                self.logits_processors.extend(
+                    [None] * (len(self.uids) - len(self.logits_processors))
+                )
+            if len(other.logits_processors) < len(other.uids):
+                other.logits_processors.extend(
+                    [None] * (len(other.uids) - len(other.logits_processors))
+                )
         else:
             self.token_context = []
             other.token_context = []

--- a/mlx_vlm/tests/test_generate.py
+++ b/mlx_vlm/tests/test_generate.py
@@ -857,6 +857,49 @@ class TestBatchGenerator:
         finished_structured.filter([1])
         assert finished_structured.uids == [1]
 
+    def test_generation_batch_extend_restores_plain_processor_slots(self):
+        sampler = lambda logprobs: mx.argmax(logprobs, axis=-1)
+        stop_criteria = lambda token: False
+        plain = GenerationBatch(
+            model=MagicMock(),
+            uids=[0],
+            inputs=mx.array([5], dtype=mx.int32),
+            prompt_cache=[],
+            sampler=sampler,
+            stop_criteria=stop_criteria,
+            max_tokens=[2],
+        )
+        second_plain = GenerationBatch(
+            model=MagicMock(),
+            uids=[1],
+            inputs=mx.array([6], dtype=mx.int32),
+            prompt_cache=[],
+            sampler=sampler,
+            stop_criteria=stop_criteria,
+            max_tokens=[2],
+        )
+        processor = lambda tokens, logits: logits
+        structured = GenerationBatch(
+            model=MagicMock(),
+            uids=[2],
+            inputs=mx.array([7], dtype=mx.int32),
+            prompt_cache=[],
+            sampler=sampler,
+            stop_criteria=stop_criteria,
+            max_tokens=[2],
+            token_context=[[30]],
+            logits_processors=[[processor]],
+        )
+
+        plain.extend(second_plain)
+        assert plain.logits_processors == []
+
+        plain.extend(structured)
+
+        assert plain.uids == [0, 1, 2]
+        assert plain.logits_processors == [None, None, [processor]]
+        assert plain.token_context == [[], [], [30]]
+
     def test_generation_batch_extend_promotes_singleton_kv_cache(self):
         def make_kv_cache(value):
             c = KVCache()


### PR DESCRIPTION
Fixes #1574 

### Summary

Fix logits processor alignment when structured and unstructured requests are merged into the same generation batch.

### Problem

When batches containing no active logits processors are merged, their `logits_processors` list is compacted to an empty list.

If a structured request is subsequently appended, its processor is added without placeholder entries for the existing plain requests.
This shifts the processor to the first row of the combined batch instead of keeping it aligned with the structured request's UID.

As a result, structured-output constraints may be applied to an unrelated request during continuous batching.

### Fix

Restore `None` placeholders for existing batch rows before concatenating logits processors whenever either batch contains an active processor.

This keeps `uids`, `token_context`, and `logits_processors` aligned without changing the compact representation used when no processors are active.

### Tests

Added a regression test covering this merge sequence:

1. Merge two unstructured generation batches.
2. Append a structured generation batch.
3. Verify that the structured processor remains assigned to its own row.