### PR TITLE
perf(qwen3_5): add exact 8-bit MTP verification

### DIFF
--- a/mlx_vlm/models/qwen3_5/language.py
+++ b/mlx_vlm/models/qwen3_5/language.py
@@ -222,6 +222,11 @@ def _target_verify_qlinear_header(bits: int, group_size: int) -> str:
           x_thread[i + 6] = x[i + 6] / 64.0f;
           x_thread[i + 7] = x[i + 7] / 8.0f;
         }
+      } else if (BITS == 8) {
+        for (int i = 0; i < VALUES_PER_THREAD; ++i) {
+          sum += x[i];
+          x_thread[i] = x[i];
+        }
       }
       return sum;
     }
@@ -259,6 +264,10 @@ def _target_verify_qlinear_header(bits: int, group_size: int) -> str:
           accum += (wb[3] & 0xc0) * xt[6];
           accum += (wb[4] & 0x7) * (xt[6] * 256.0f);
           accum += (wb[4] & 0xf8) * xt[7];
+        }
+      } else if (BITS == 8) {
+        for (int i = 0; i < VALUES_PER_THREAD; ++i) {
+          accum += x_thread[i] * w[i];
         }
       }
       return scale * accum + sum * bias;
@@ -473,7 +482,8 @@ def _can_target_verify_quantized(linear, x: mx.array) -> bool:
         not isinstance(linear, nn.QuantizedLinear)
         or x.ndim != 3
         or x.shape[1] < 1
-        or linear.bits not in (4, 5)
+        or linear.bits not in (4, 5, 8)
+        or linear.group_size not in (32, 64, 128)
         or linear.mode != "affine"
         or linear.biases is None
         or x.dtype not in (mx.bfloat16, mx.float16)
@@ -516,12 +526,9 @@ def _target_verify_quantized_linear(linear, x: mx.array) -> Optional[mx.array]:
     return out
 
 
-def _decode_quantized_linears_fused(linears, x: mx.array):
-    if (
-        x.ndim != 3
-        or x.shape[1] != 1
-        or len(linears) != 4
-        or not all(isinstance(linear, nn.QuantizedLinear) for linear in linears)
+def _quantized_linears_fused_parameters(linears, x: mx.array):
+    if not linears or not all(
+        isinstance(linear, nn.QuantizedLinear) for linear in linears
     ):
         return None
 
@@ -541,7 +548,7 @@ def _decode_quantized_linears_fused(linears, x: mx.array):
     cache_key = tuple(
         (id(linear.weight), id(linear.scales), id(linear.biases)) for linear in linears
     )
-    cached = getattr(first, "_qwen3_5_fused_decode_linears", None)
+    cached = getattr(first, "_qwen3_5_fused_linears", None)
     if cached is None or cached[0] != cache_key:
         weights = mx.concatenate([linear.weight for linear in linears], axis=0)
         scales = mx.concatenate([linear.scales for linear in linears], axis=0)
@@ -553,9 +560,20 @@ def _decode_quantized_linears_fused(linears, x: mx.array):
             split_indices.append(offset)
         mx.eval(weights, scales, biases)
         cached = (cache_key, weights, scales, biases, split_indices)
-        first._qwen3_5_fused_decode_linears = cached
+        first._qwen3_5_fused_linears = cached
 
-    _, weights, scales, biases, split_indices = cached
+    return first, *cached[1:]
+
+
+def _decode_quantized_linears_fused(linears, x: mx.array):
+    if x.ndim != 3 or x.shape[1] != 1 or len(linears) != 4:
+        return None
+
+    fused = _quantized_linears_fused_parameters(linears, x)
+    if fused is None:
+        return None
+
+    first, weights, scales, biases, split_indices = fused
     output = mx.quantized_matmul(
         x,
         weights,
@@ -566,6 +584,43 @@ def _decode_quantized_linears_fused(linears, x: mx.array):
         bits=first.bits,
         mode=first.mode,
     )
+    return tuple(mx.split(output, split_indices, axis=-1))
+
+
+def _target_verify_quantized_linears_fused(linears, x: mx.array):
+    if (
+        x.ndim != 3
+        or x.shape[1] <= 1
+        or len(linears) < 2
+        or not all(
+            _can_target_verify_quantized(linear, x) and "bias" not in linear
+            for linear in linears
+        )
+    ):
+        return None
+
+    fused = _quantized_linears_fused_parameters(linears, x)
+    if fused is None:
+        return None
+
+    first, weights, scales, biases, split_indices = fused
+    B, T, K = x.shape
+    N = weights.shape[0]
+    x = mx.contiguous(x)
+    kernel = _target_verify_qmv_kernel(first.bits, first.group_size, x.dtype, T, K, N)
+    output = kernel(
+        inputs=[x, weights, scales, biases],
+        template=[
+            ("T", x.dtype),
+            ("VERIFY_T", int(T)),
+            ("K_SIZE", int(K)),
+            ("N_SIZE", int(N)),
+        ],
+        grid=(32, 2 * (N // 8), B),
+        threadgroup=(32, 2, 1),
+        output_shapes=[(B, T, N)],
+        output_dtypes=[x.dtype],
+    )[0]
     return tuple(mx.split(output, split_indices, axis=-1))
 
 
@@ -625,8 +680,6 @@ def _target_verify_linear(linear, x: mx.array, target_verify: bool) -> mx.array:
         return linear(x)
 
     if isinstance(linear, nn.QuantizedLinear):
-        if x.shape[0] == 1:
-            return linear(x)
         out = _target_verify_quantized_linear(linear, x)
         if out is not None:
             return out
@@ -654,6 +707,10 @@ def _target_verify_linears(linears, x: mx.array, target_verify: bool):
             return out
         return tuple(linear(x) for linear in linears)
 
+    if len(linears) == 3:
+        out = _target_verify_quantized_linears_fused(linears, x)
+        if out is not None:
+            return out
     return tuple(_target_verify_linear(linear, x, target_verify) for linear in linears)
 
 

--- a/mlx_vlm/tests/test_speculative.py
+++ b/mlx_vlm/tests/test_speculative.py
@@ -574,31 +574,39 @@ def test_qwen_target_verify_gemv_kernel_matches_singleton_dense_gemv():
 
 
 def test_qwen_target_verify_quantized_linear_matches_singleton_path():
-    mx.random.seed(15)
-    linear = nn.QuantizedLinear(512, 16, bias=False, group_size=32, bits=4)
-    linear.scales = linear.scales.astype(mx.bfloat16)
-    linear.biases = linear.biases.astype(mx.bfloat16)
-    x = mx.random.normal((2, 3, 512)).astype(mx.bfloat16)
+    for bits in (4, 5, 8):
+        for group_size in (32, 64, 128):
+            mx.random.seed(150 + bits + group_size)
+            linear = nn.QuantizedLinear(
+                512, 16, bias=False, group_size=group_size, bits=bits
+            )
+            linear.scales = linear.scales.astype(mx.bfloat16)
+            linear.biases = linear.biases.astype(mx.bfloat16)
+            x = mx.random.normal((2, 3, 512)).astype(mx.bfloat16)
 
-    ref = qwen_language._target_verify_timewise(linear, x)
-    out = qwen_language._target_verify_linear(linear, x, target_verify=True)
-    mx.eval(ref, out)
+            ref = qwen_language._target_verify_singletons(linear, x)
+            out = qwen_language._target_verify_linear(linear, x, target_verify=True)
+            mx.eval(ref, out)
 
-    assert bool(mx.array_equal(ref, out).item())
+            assert bool(mx.array_equal(ref, out).item())
 
 
-def test_qwen_target_verify_quantized_linear_matches_singleton_batch_path():
-    mx.random.seed(17)
-    linear = nn.QuantizedLinear(512, 16, bias=False, group_size=32, bits=4)
-    linear.scales = linear.scales.astype(mx.bfloat16)
-    linear.biases = linear.biases.astype(mx.bfloat16)
-    x = mx.random.normal((1, 3, 512)).astype(mx.bfloat16)
+def test_qwen_target_verify_quantized_single_batch_matches_timewise():
+    for bits in (4, 5, 8):
+        for group_size in (32, 64, 128):
+            mx.random.seed(170 + bits + group_size)
+            linear = nn.QuantizedLinear(
+                512, 16, bias=False, group_size=group_size, bits=bits
+            )
+            linear.scales = linear.scales.astype(mx.bfloat16)
+            linear.biases = linear.biases.astype(mx.bfloat16)
+            x = mx.random.normal((1, 3, 512)).astype(mx.bfloat16)
 
-    ref = linear(x)
-    out = qwen_language._target_verify_quantized_linear(linear, x)
-    mx.eval(ref, out)
+            ref = qwen_language._target_verify_timewise(linear, x)
+            out = qwen_language._target_verify_linear(linear, x, target_verify=True)
+            mx.eval(ref, out)
 
-    assert bool(mx.array_equal(ref, out).item())
+            assert bool(mx.array_equal(ref, out).item())
 
 
 def test_qwen3_5_decode_quantized_linears_fused_matches_separate():
@@ -621,18 +629,70 @@ def test_qwen3_5_decode_quantized_linears_fused_matches_separate():
         assert all(bool(mx.array_equal(a, b).item()) for a, b in zip(ref, out))
 
 
+def test_qwen_target_verify_quantized_linears_fused_matches_separate():
+    for bits in (4, 5, 8):
+        for dtype in (mx.bfloat16, mx.float16):
+            mx.random.seed(178 + bits)
+            linears = [
+                nn.QuantizedLinear(512, out_dim, bias=False, group_size=64, bits=bits)
+                for out_dim in (64, 32, 16)
+            ]
+            for linear in linears:
+                linear.scales = linear.scales.astype(dtype)
+                linear.biases = linear.biases.astype(dtype)
+            x = mx.random.normal((2, 3, 512), dtype=dtype)
+
+            ref = tuple(
+                qwen_language._target_verify_linear(linear, x, target_verify=True)
+                for linear in linears
+            )
+            out = qwen_language._target_verify_quantized_linears_fused(
+                tuple(linears), x
+            )
+
+            assert out is not None
+            mx.eval(*ref, *out)
+            assert all(bool(mx.array_equal(a, b).item()) for a, b in zip(ref, out))
+
+
+def test_qwen_target_verify_quantized_qkv_fused_matches_production_shape():
+    mx.random.seed(179)
+    linears = [
+        nn.QuantizedLinear(2048, out_dim, bias=False, group_size=64, bits=8)
+        for out_dim in (8192, 512, 512)
+    ]
+    for linear in linears:
+        linear.scales = linear.scales.astype(mx.bfloat16)
+        linear.biases = linear.biases.astype(mx.bfloat16)
+    x = mx.random.normal((1, 4, 2048), dtype=mx.bfloat16)
+
+    ref = tuple(
+        qwen_language._target_verify_linear(linear, x, target_verify=True)
+        for linear in linears
+    )
+    out = qwen_language._target_verify_quantized_linears_fused(tuple(linears), x)
+
+    assert out is not None
+    mx.eval(*ref, *out)
+    assert all(bool(mx.array_equal(a, b).item()) for a, b in zip(ref, out))
+
+
 def test_qwen_target_verify_quantized_argmax_matches_singleton_path():
-    mx.random.seed(16)
-    linear = nn.QuantizedLinear(512, 16, bias=False, group_size=32, bits=4)
-    linear.scales = linear.scales.astype(mx.bfloat16)
-    linear.biases = linear.biases.astype(mx.bfloat16)
+    for bits in (4, 5, 8):
+        for group_size in (32, 64, 128):
+            mx.random.seed(160 + bits + group_size)
+            linear = nn.QuantizedLinear(
+                512, 16, bias=False, group_size=group_size, bits=bits
+            )
+            linear.scales = linear.scales.astype(mx.bfloat16)
+            linear.biases = linear.biases.astype(mx.bfloat16)
 
-    x = mx.random.normal((2, 3, 512)).astype(mx.bfloat16)
-    ref = mx.argmax(qwen_language._target_verify_timewise(linear, x), axis=-1)
-    out = qwen_language._target_verify_quantized_argmax(linear, x)
-    mx.eval(ref, out)
+            x = mx.random.normal((2, 3, 512)).astype(mx.bfloat16)
+            ref = mx.argmax(qwen_language._target_verify_singletons(linear, x), axis=-1)
+            out = qwen_language._target_verify_quantized_argmax(linear, x)
+            mx.eval(ref, out)
 
-    assert bool(mx.array_equal(ref, out).item())
+            assert bool(mx.array_equal(ref, out).item())
 
 
 def test_qwen3_5_quantized_argmax_batch_as_time_matches_rowwise():


### PR DESCRIPTION
## Summary

Extend Qwen3.5/Qwen3.6 MTP target verification to support affine 8-bit quantized projections while preserving singleton decode semantics.

This is a follow-up to #1188. The existing exact quantized verifier handles 4- and 5-bit projections, but mixed-precision targets can contain 8-bit attention, GDN, and shared-expert projections. Those layers currently fall back to multi-token `quantized_matmul`, whose reduction order can differ from one-token QMV decoding and eventually change greedy output.

This PR:

- Adds affine 8-bit support to the existing QMV-style Metal verifier and fused argmax.
- Routes supported quantized projections through singleton-exact verification for B=1 and batched inputs.
- Restricts the custom path to MLX-supported group sizes 32, 64, and 128.
- Fuses compatible quantized Q/K/V verification into one Metal launch.
- Reuses cached concatenated packed weights, scales, and biases between decode and verification paths.
- Expands parity coverage across 4-, 5-, and 8-bit quantization.

## Motivation

The issue is visible with dynamically quantized Qwen3.6 models where routed experts are 4-bit but ordinary projections are overridden to affine 8-bit.

For a B=1 speculative block with multiple proposed tokens, the previous path called the 8-bit `QuantizedLinear` over the complete sequence dimension. On MLX 0.32 this can dispatch a QMM kernel rather than the singleton QMV kernel used by autoregressive decode.

The operations are mathematically equivalent, but their floating-point reduction order is not bit-identical. On the tested Qwen3.6-35B-A3B target, that numerical drift changed the greedy token stream.

The new 8-bit branch follows the same packing, affine scale/bias handling, and SIMD reduction structure as singleton QMV.

## Performance

Hardware and protocol:

- Apple M3 Max, 40-core GPU, 128 GB unified memory
- MLX 0.32.0
- Target: `unsloth/Qwen3.6-35B-A3B-UD-MLX-4bit`
- Drafter: `mlx-community/Qwen3.6-35B-A3B-MTP-5bit`
- Greedy decoding, 512 generated tokens
- Six cyclic trial orders with six trials per mode

| Mode | Median tok/s | Speedup | Draft acceptance |
| --- | ---: | ---: | ---: |
| No drafter | 70.50 | 1.00x | n/a |
| MTP block 2 | 77.81 | 1.10x | 79.3% |
| MTP block 3 | 87.13 | 1.24x | 66.7% |
| MTP block 4 | 94.24 | 1.34x | 58.3% |
| MTP block 5 | 90.27 | 1.28x | 50.8% |
| MTP block 6 | 76.75 | 1.09x | 41.1% |

All 36 AR and MTP runs produced the same raw 512-token SHA-256:

```text
847a6bfad5ad1564fae6d6b3c83314a37a00e4c6e936f3cc004e64eccd5965ec
```

The block-4 path peaked at approximately 23.84 GB of MLX memory.

## Validation

```text
python -m pytest mlx_vlm/tests/test_speculative.py
152 passed

python -m pytest mlx_vlm/tests/test_models.py -k qwen3_5
11 passed
```

Added coverage includes:

- Affine 4-, 5-, and 8-bit verifier output against singleton QMV.
- Group sizes 32, 64, and 128.
- BF16 and FP16 inputs.
- B=1 and batched target verification.
- Quantized fused-QKV output against separate exact projections.
- Production Qwen dimensions: `K=2048`, `N=(8192, 512, 512)`.
- Quantized fused argmax against singleton logits.

## Scope

The end-to-end token result covers the recorded greedy prompt and model configuration. The kernel tests provide broader bitwise coverage across supported bit widths, dtypes, group sizes, and batch shapes.

Unsupported quantization modes or shapes continue to use the existing safe fallback path.
