### PR TITLE
Fix AutoProcessor.register string-first calls (transformers 5.13 issue)

### DIFF
--- a/mlx_vlm/models/deepseek_vl_v2/__init__.py
+++ b/mlx_vlm/models/deepseek_vl_v2/__init__.py
@@ -1,4 +1,5 @@
 import mlx_vlm.models.deepseek_vl_v2.processing_deepsek_vl_v2  # noqa: F401 (installs processor patch)
 
 from .config import MLPConfig, ModelConfig, ProjectorConfig, TextConfig, VisionConfig
-from .deepseek_vl_v2 import DeepseekVLV2Processor, LanguageModel, Model, VisionModel
+from .deepseek_vl_v2 import LanguageModel, Model, VisionModel
+from .processing_deepsek_vl_v2 import DeepseekVLV2Processor

--- a/mlx_vlm/models/deepseek_vl_v2/deepseek_vl_v2.py
+++ b/mlx_vlm/models/deepseek_vl_v2/deepseek_vl_v2.py
@@ -4,15 +4,11 @@ from typing import Optional
 import mlx.core as mx
 import mlx.nn as nn
 import numpy as np
-from transformers import AutoProcessor
 
 from ..base import InputEmbeddingsFeatures
 from .config import ModelConfig, ProjectorConfig
 from .language import LanguageModel
-from .processing_deepsek_vl_v2 import DeepseekVLV2Processor
 from .vision import VisionModel
-
-AutoProcessor.register("deepseek_vl_v2", DeepseekVLV2Processor)
 
 
 class MlpProjector(nn.Module):

--- a/mlx_vlm/models/deepseekocr/__init__.py
+++ b/mlx_vlm/models/deepseekocr/__init__.py
@@ -1,2 +1,3 @@
 from .config import MLPConfig, ModelConfig, ProjectorConfig, TextConfig, VisionConfig
-from .deepseekocr import DeepseekOCRProcessor, LanguageModel, Model, VisionModel
+from .deepseekocr import LanguageModel, Model, VisionModel
+from .processing_deepseekocr import DeepseekOCRProcessor

--- a/mlx_vlm/models/deepseekocr/deepseekocr.py
+++ b/mlx_vlm/models/deepseekocr/deepseekocr.py
@@ -4,17 +4,13 @@ from typing import Optional
 import mlx.core as mx
 import mlx.nn as nn
 import numpy as np
-from transformers import AutoProcessor
 
 from mlx_vlm.models.base import InputEmbeddingsFeatures
 
 from .config import ModelConfig, ProjectorConfig, SAMViTConfig
 from .language import LanguageModel
-from .processing_deepseekocr import DeepseekOCRProcessor
 from .sam import SAMEncoder
 from .vision import VisionModel
-
-AutoProcessor.register("deepseekocr", DeepseekOCRProcessor)
 
 
 class MlpProjector(nn.Module):

--- a/mlx_vlm/models/deepseekocr_2/__init__.py
+++ b/mlx_vlm/models/deepseekocr_2/__init__.py
@@ -8,5 +8,6 @@ from .config import (
     TextConfig,
     VisionConfig,
 )
-from .deepseekocr_2 import DeepseekOCR2Processor, Model
+from .deepseekocr_2 import Model
+from .processing_deepseekocr import DeepseekOCR2Processor
 from .vision import Qwen2Decoder2Encoder, VisionModel

--- a/mlx_vlm/models/deepseekocr_2/deepseekocr_2.py
+++ b/mlx_vlm/models/deepseekocr_2/deepseekocr_2.py
@@ -3,16 +3,12 @@ from typing import Optional
 import mlx.core as mx
 import mlx.nn as nn
 import numpy as np
-from transformers import AutoProcessor
 
 from ..base import InputEmbeddingsFeatures
 from ..deepseekocr.language import LanguageModel
 from ..deepseekocr.sam import SAMEncoder
 from .config import ModelConfig, SAMViTConfig
-from .processing_deepseekocr import DeepseekOCR2Processor
 from .vision import VisionModel
-
-AutoProcessor.register("deepseekocr_2", DeepseekOCR2Processor)
 
 
 class MlpProjector(nn.Module):

--- a/mlx_vlm/models/glm4v/glm4v.py
+++ b/mlx_vlm/models/glm4v/glm4v.py
@@ -6,17 +6,7 @@ import mlx.nn as nn
 from ..base import InputEmbeddingsFeatures
 from .config import ModelConfig
 from .language import LanguageModel
-from .processing import Glm46VProcessor
 from .vision import VisionModel
-
-# Register the processor with the name expected by the model config
-try:
-    from transformers import AutoProcessor
-
-    # The model's preprocessor_config.json specifies "processor_class": "Glm46VProcessor"
-    AutoProcessor.register("Glm46VProcessor", Glm46VProcessor)
-except Exception as e:
-    print(f"Error registering glm4v processor: {e}")
 
 
 class Model(nn.Module):

--- a/mlx_vlm/models/glm4v_moe/glm4v_moe.py
+++ b/mlx_vlm/models/glm4v_moe/glm4v_moe.py
@@ -6,17 +6,7 @@ import mlx.nn as nn
 from ..base import InputEmbeddingsFeatures
 from .config import ModelConfig
 from .language import LanguageModel
-from .processing import Glm46VMoEProcessor
 from .vision import VisionModel
-
-# Register the processor with the name expected by the model config
-try:
-    from transformers import AutoProcessor
-
-    # Register for both possible processor class names
-    AutoProcessor.register("Glm46VMoEProcessor", Glm46VMoEProcessor)
-except Exception as e:
-    print(f"Error registering glm4v_moe processor: {e}")
 
 
 class Model(nn.Module):

--- a/mlx_vlm/models/jina_vlm/jina_vlm.py
+++ b/mlx_vlm/models/jina_vlm/jina_vlm.py
@@ -4,15 +4,14 @@ from typing import Optional
 
 import mlx.core as mx
 import mlx.nn as nn
-from transformers import AutoProcessor
 
-from ..base import InputEmbeddingsFeatures
+from ..base import InputEmbeddingsFeatures, install_auto_processor_patch
 from .config import ModelConfig, VisionConfig
 from .language import LanguageModel
 from .processing_jinavlm import JinaVLMProcessor
 from .vision import VisionModel
 
-AutoProcessor.register("jvlm", JinaVLMProcessor)
+install_auto_processor_patch("jvlm", JinaVLMProcessor)
 
 
 class CrossAttention(nn.Module):

--- a/mlx_vlm/models/unlimited_ocr/unlimitedocr.py
+++ b/mlx_vlm/models/unlimited_ocr/unlimitedocr.py
@@ -2,7 +2,6 @@ from typing import Optional
 
 import mlx.core as mx
 import numpy as np
-from transformers import AutoProcessor
 
 from mlx_vlm.models.base import InputEmbeddingsFeatures
 
@@ -13,8 +12,6 @@ from ..deepseekocr.vision import VisionModel
 from .config import ModelConfig
 from .language import LanguageModel
 from .processing_unlimitedocr import UnlimitedOCRHFProcessor, UnlimitedOCRProcessor
-
-AutoProcessor.register("unlimited-ocr", UnlimitedOCRProcessor)
 
 
 class Model(DeepseekOCRModel):

--- a/mlx_vlm/tests/test_processors.py
+++ b/mlx_vlm/tests/test_processors.py
@@ -2738,5 +2738,39 @@ class TestLocateAnythingProcessor(unittest.TestCase):
             self.assertEqual(reloaded.tokenizer.chat_template, chat_template)
 
 
+class TestProcessorRegistration(unittest.TestCase):
+    _AFFECTED_MODULES = (
+        "mlx_vlm.models.glm4v.glm4v",
+        "mlx_vlm.models.glm4v_moe.glm4v_moe",
+        "mlx_vlm.models.deepseek_vl_v2.deepseek_vl_v2",
+        "mlx_vlm.models.deepseekocr.deepseekocr",
+        "mlx_vlm.models.deepseekocr_2.deepseekocr_2",
+        "mlx_vlm.models.unlimited_ocr.unlimitedocr",
+        "mlx_vlm.models.jina_vlm.jina_vlm",
+    )
+
+    def test_no_string_first_autoprocessor_register(self):
+        import re
+        from pathlib import Path
+
+        import mlx_vlm
+
+        models_dir = Path(mlx_vlm.__file__).parent / "models"
+        pattern = re.compile(r"""AutoProcessor\.register\(\s*['"]""")
+        offenders = [
+            str(path.relative_to(models_dir))
+            for path in models_dir.rglob("*.py")
+            if pattern.search(path.read_text())
+        ]
+        self.assertEqual(offenders, [], f"string-first register calls: {offenders}")
+
+    def test_affected_modules_import_cleanly(self):
+        import importlib
+
+        for module in self._AFFECTED_MODULES:
+            with self.subTest(module=module):
+                importlib.import_module(module)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION

During debugging #1564, realized seven other model modules experience the same AutoProcessor.register with a processor-class name strings as first arg. 

This pr delete sthe broken string-first AutoProcessor.register("Name", cls) calls from 7 model files. 

Verified on Apple Silicon across both transformers versions: transformers==5.13.0, all seven modules import cleanly, all seven processor re-exports work, and GLM-4.6V-nvfp4 dispatches to Glm46VMoEProcessor.

This fixes #1564 