### PR TITLE
Honor quantized_kv_start on the batch TurboQuant path

### DIFF
--- a/mlx_vlm/generate/ar.py
+++ b/mlx_vlm/generate/ar.py
@@ -714,6 +714,8 @@ def _make_cache(
     kv_bits=None,
     kv_group_size=64,
     kv_quant_scheme=DEFAULT_KV_QUANT_SCHEME,
+    quantized_kv_start=0,
+    prefill_length=0,
 ):
     """
     Convert a list of regular caches into their corresponding
@@ -729,8 +731,14 @@ def _make_cache(
     """
     use_turbo = kv_bits is not None and turboquant_enabled(kv_bits, kv_quant_scheme)
 
+    defer_turbo = (
+        use_turbo and quantized_kv_start > 0 and prefill_length < quantized_kv_start
+    )
+
     def _make_quant_cache(lp):
         if use_turbo:
+            if defer_turbo:
+                return cache.BatchKVCache(lp)
             return BatchTurboQuantKVCache(lp, bits=kv_bits)
         return cache.BatchQuantizedKVCache(
             lp, group_size=kv_group_size, bits=int(kv_bits)
@@ -1519,6 +1527,7 @@ class PromptProcessingBatch:
         kv_bits=None,
         kv_group_size: int = DEFAULT_KV_GROUP_SIZE,
         kv_quant_scheme: str = DEFAULT_KV_QUANT_SCHEME,
+        quantized_kv_start: int = 0,
         warm_cache: Optional[List[Any]] = None,
         apc_meta: Optional[List[dict]] = None,
         apc_manager: Optional["_apc.APCManager"] = None,
@@ -1617,6 +1626,8 @@ class PromptProcessingBatch:
                     kv_bits=kv_bits,
                     kv_group_size=kv_group_size,
                     kv_quant_scheme=kv_quant_scheme,
+                    quantized_kv_start=quantized_kv_start,
+                    prefill_length=max_length,
                 ),
             )
         elif (
@@ -1633,6 +1644,8 @@ class PromptProcessingBatch:
                 kv_bits=kv_bits,
                 kv_group_size=kv_group_size,
                 kv_quant_scheme=kv_quant_scheme,
+                quantized_kv_start=quantized_kv_start,
+                prefill_length=max_length,
             )
 
         # Declare per-row right-padding on each cache so finalize() can roll
@@ -2462,6 +2475,9 @@ class BatchGenerator:
             kv_bits=self.kv_bits,
             kv_group_size=self.kv_group_size,
             kv_quant_scheme=self.kv_quant_scheme,
+            quantized_kv_start=getattr(
+                self, "quantized_kv_start", DEFAULT_QUANTIZED_KV_START
+            ),
             warm_cache=warm_cache,
             apc_meta=apc_meta,
             apc_manager=self.apc_manager,
@@ -2761,6 +2777,9 @@ class BatchGenerator:
                 kv_bits=self.kv_bits,
                 kv_group_size=self.kv_group_size,
                 kv_quant_scheme=self.kv_quant_scheme,
+                quantized_kv_start=getattr(
+                    self, "quantized_kv_start", DEFAULT_QUANTIZED_KV_START
+                ),
                 apc_meta=apc_meta,
                 apc_manager=self.apc_manager,
                 apc_mode=self.apc_mode,

--- a/mlx_vlm/tests/test_generate.py
+++ b/mlx_vlm/tests/test_generate.py
@@ -2248,5 +2248,36 @@ def test_apc_pick_rejects_image_tokens_and_releases_blocks():
     assert all(block.ref_cnt == 0 for block in stored)
 
 
+class TestBatchTurboQuantizedKVStart:
+    def _cache_kinds(self, **kwargs):
+        from mlx_vlm.generate.ar import _make_cache
+
+        caches = _make_cache(
+            MockModel(),
+            [0],
+            kv_bits=3.5,
+            kv_quant_scheme="turboquant",
+            **kwargs,
+        )
+        return [type(c).__name__ for c in caches]
+
+    def test_defers_to_float_below_threshold(self):
+        kinds = self._cache_kinds(quantized_kv_start=5000, prefill_length=16)
+        assert "BatchTurboQuantKVCache" not in kinds
+        assert set(kinds) == {"BatchKVCache"}
+
+    def test_quantizes_at_or_above_threshold(self):
+        kinds = self._cache_kinds(quantized_kv_start=8, prefill_length=32)
+        assert "BatchTurboQuantKVCache" in kinds
+
+    def test_immediate_when_start_zero(self):
+        kinds = self._cache_kinds(quantized_kv_start=0, prefill_length=16)
+        assert "BatchTurboQuantKVCache" in kinds
+
+    def test_default_preserves_immediate_quantization(self):
+        kinds = self._cache_kinds()
+        assert "BatchTurboQuantKVCache" in kinds
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
Continuous batching built BatchTurboQuantKVCache from token 0, quantizing every prompt and decode token immediately. For short sequences this degraded 3.5-bit KV enough to collapse generation into digit/repetition spam, while stream_generate stayed coherent because maybe_quantize_kv_cache keeps KV in float until the context reaches quantized_kv_start (default 5000).

Thread quantized_kv_start and the prefill length into _make_cache so the batch path defers TurboQuant to a float BatchKVCache below the threshold, matching the stream path. quantized_kv_start=0 preserves immediate quantization. Uniform KV and non-batch paths are unchanged.

Fixes #1569


All tests green