### PR TITLE
Fix generation batch logits processor alignment

### DIFF
--- a/mlx_vlm/generate/ar.py
+++ b/mlx_vlm/generate/ar.py
@@ -921,6 +921,15 @@ class GenerationBatch:
     def cache_states(self):
         return [c.state for c in self.prompt_cache if hasattr(c, "state")]
 
+    def _ensure_logits_processor_slots(self, *, force: bool = False):
+        if not (force or (self.logits_processors and any(self.logits_processors))):
+            return
+        if len(self.logits_processors) < len(self.uids):
+            missing = len(self.uids) - len(self.logits_processors)
+            self.logits_processors.extend([None] * missing)
+        elif len(self.logits_processors) > len(self.uids):
+            self.logits_processors = self.logits_processors[: len(self.uids)]
+
     def _ensure_token_context(self, *, force: bool = False):
         if not (force or (self.logits_processors and any(self.logits_processors))):
             if not self.logits_processors:
@@ -1102,6 +1111,8 @@ class GenerationBatch:
         self_has_processors = self.logits_processors and any(self.logits_processors)
         other_has_processors = other.logits_processors and any(other.logits_processors)
         if self_has_processors or other_has_processors:
+            self._ensure_logits_processor_slots(force=bool(other_has_processors))
+            other._ensure_logits_processor_slots(force=bool(self_has_processors))
             self._ensure_token_context(force=bool(other_has_processors))
             other._ensure_token_context(force=bool(self_has_processors))
         else:
@@ -1117,6 +1128,7 @@ class GenerationBatch:
         self.token_context.extend(other.token_context)
         self.logits_processors.extend(other.logits_processors)
         self.thinking_budget_criteria.extend(other.thinking_budget_criteria)
+        self._ensure_logits_processor_slots()
         self._ensure_token_context()
 
         if self._current_tokens is None:

--- a/mlx_vlm/tests/test_generate.py
+++ b/mlx_vlm/tests/test_generate.py
@@ -826,6 +826,41 @@ class TestBatchGenerator:
         assert [r.token for r in first] == [5, 6, 7]
         assert seen_contexts == [[30, 7]]
 
+    def test_generation_batch_extend_expands_compact_processor_state(self):
+        sampler = lambda logprobs: mx.argmax(logprobs, axis=-1)
+        stop_criteria = lambda token: False
+
+        def make_batch(uid, processor=None):
+            return GenerationBatch(
+                model=object(),
+                uids=[uid],
+                inputs=mx.array([uid + 1], dtype=mx.int32),
+                prompt_cache=[],
+                sampler=sampler,
+                stop_criteria=stop_criteria,
+                max_tokens=[2],
+                token_context=[[30]] if processor is not None else None,
+                logits_processors=[[processor]] if processor is not None else None,
+            )
+
+        first_plain = make_batch(0)
+        second_plain = make_batch(1)
+        structured_processor = lambda tokens, logits: logits
+        structured = make_batch(2, structured_processor)
+
+        first_plain.extend(second_plain)
+        assert first_plain.logits_processors == []
+
+        first_plain.extend(structured)
+
+        assert first_plain.uids == [0, 1, 2]
+        assert first_plain.token_context == [[], [], [30]]
+        assert first_plain.logits_processors == [
+            None,
+            None,
+            [structured_processor],
+        ]
+
     def test_generation_batch_extend_discards_inactive_stale_processor_state(self):
         sampler = lambda logprobs: mx.argmax(logprobs, axis=-1)
         stop_criteria = lambda token: False


### PR DESCRIPTION
## Summary

normalize compact logits processor state to one slot per UID before merging batches with active processors\n- preserve empty compact state for all-plain batches\n- add a regression test for plain + plain followed by structured admission

Fixes #1574.

## Tests

- `uv run --with pytest python -m pytest mlx_vlm/tests/test_generate.py`
- `uv run --with pytest python -m pytest mlx_vlm/tests/test_processors.py::TestGemma4UnifiedProcessor::test_processor_init_declares_video_processor_attribute`