### PR TITLE
Fix Gemma 4 dtype leak

### DIFF
--- a/mlx_vlm/models/gemma4/gemma4.py
+++ b/mlx_vlm/models/gemma4/gemma4.py
@@ -291,30 +291,12 @@ class Model(nn.Module):
                 mid_dim = v.shape[-1] // 2
                 gate_value = v[..., :mid_dim].swapaxes(-1, -2)
                 up_value = v[..., mid_dim:].swapaxes(-1, -2)
-                if self._needs_float32_language_weight(gate_key, gate_value):
-                    gate_value = gate_value.astype(mx.float32)
-                if self._needs_float32_language_weight(up_key, up_value):
-                    up_value = up_value.astype(mx.float32)
                 sanitized[gate_key] = gate_value
                 sanitized[up_key] = up_value
                 continue
 
-            if self._needs_float32_language_weight(new_key, v):
-                v = v.astype(mx.float32)
-
             sanitized[new_key] = v
         return sanitized
-
-    def _needs_float32_language_weight(self, key: str, value: mx.array) -> bool:
-        if not key.startswith("language_model."):
-            return False
-        if value.dtype not in (mx.bfloat16, mx.float16):
-            return False
-        # Quantized MLX checkpoints keep scale/bias tensors alongside packed
-        # weights. Leave those in their checkpoint dtype.
-        if key.endswith((".scales", ".biases")):
-            return False
-        return True
 
     @property
     def quant_predicate(self):

--- a/mlx_vlm/tests/test_models.py
+++ b/mlx_vlm/tests/test_models.py
@@ -3776,7 +3776,7 @@ class TestModels(unittest.TestCase):
         )
         self.assertEqual(
             sanitized["language_model.model.layers.0.self_attn.q_proj.weight"].dtype,
-            mx.float32,
+            mx.bfloat16,
         )
         self.assertEqual(
             sanitized["language_model.model.layers.0.self_attn.q_proj.scales"].dtype,


### PR DESCRIPTION
## Summary

- preserve the checkpoint dtype when sanitizing Gemma 4 language weights
- preserve dtype for split MoE gate/up projection weights
- update the sanitizer regression test to expect bf16 weights to remain bf16

## Root cause

The Gemma 4 sanitizer converted every unquantized bf16/fp16 language weight to float32. For `google/gemma-4-e4b-it`, this expanded 7.518B language parameters from about 14.0 GiB to 28.0 GiB. Because MLX promotes `bf16 @ fp32` to fp32, the cast also promoted downstream computation.

## Impact

In the reported generation workload, removing the conversion reduced peak memory from 32.97 GB to 15.97 GB and improved decode throughput from 14.04 to 25.77 tokens/sec.

## Validation

- `uv run python -m unittest mlx_vlm.tests.test_models.TestModels.test_gemma4`
- pre-commit hooks: black, isort, autoflake
- runtime generation benchmark with `google/gemma-4-e4b-it`