### PR TITLE
Fix Qwen3.5 gated delta training async eval

### DIFF
--- a/mlx_vlm/models/qwen3_5/gated_delta.py
+++ b/mlx_vlm/models/qwen3_5/gated_delta.py
@@ -119,7 +119,11 @@ def gated_delta_chunked(q, k, v, g, beta, state, mask=None, C: int = 64):
     # this boundary without blocking the Python thread, letting graph-building
     # for the next layer overlap with GPU compute. Decode (T==1) never calls
     # this path, so its CUDA graphs stay intact.
-    mx.async_eval(Y, S)
+    try:
+        mx.async_eval(Y, S)
+    except ValueError as exc:
+        if "Not allowed inside a graph transformation" not in str(exc):
+            raise
     return Y, S
 
 

--- a/mlx_vlm/tests/test_models.py
+++ b/mlx_vlm/tests/test_models.py
@@ -8554,6 +8554,31 @@ class TestMultiImageMRoPE(unittest.TestCase):
                 )
 
 
+class TestQwen35GatedDeltaTraining(unittest.TestCase):
+    def test_chunked_update_allows_value_and_grad(self):
+        from mlx_vlm.models.qwen3_5.gated_delta import gated_delta_chunked
+
+        mx.random.seed(0)
+        batch, seq, heads, dim = 1, 4, 1, 4
+        q = mx.random.normal((batch, seq, heads, dim))
+        k = mx.random.normal((batch, seq, heads, dim))
+        v = mx.random.normal((batch, seq, heads, dim))
+        g = mx.full((batch, seq, heads), 0.9)
+        beta = mx.full((batch, seq, heads), 0.5)
+        state = mx.zeros((batch, heads, dim, dim))
+
+        def loss(q):
+            y, next_state = gated_delta_chunked(q, k, v, g, beta, state, C=2)
+            return y.astype(mx.float32).sum() + next_state.astype(mx.float32).sum()
+
+        value, grad = mx.value_and_grad(loss)(q)
+        mx.eval(value, grad)
+
+        self.assertTrue(bool(mx.isfinite(value)))
+        self.assertEqual(grad.shape, q.shape)
+        self.assertTrue(bool(mx.all(mx.isfinite(grad))))
+
+
 class TestMRoPETrainingVJP(unittest.TestCase):
     """Regression tests for issue #1474: LoRA/fine-tuning any M-RoPE VL model
     crashed on the first backward with ``[Primitive::vjp] Not implemented for


### PR DESCRIPTION
## Summary
- guard the Qwen 3.5 chunked gated-delta `mx.async_eval` scheduling hint when MLX is tracing a graph transformation
- keep unrelated `ValueError`s from `async_eval` visible
- add a regression test that runs `gated_delta_chunked` through `mx.value_and_grad`

## Tests
- `python3 -m py_compile mlx_vlm/models/qwen3_5/gated_delta.py mlx_vlm/tests/test_models.py`
- `uv run --with pytest pytest mlx_vlm/tests/test_models.py::TestQwen35GatedDeltaTraining::test_chunked_update_allows_value_and_grad`

Fixes #1584