### PR TITLE
Vendor GLM DSA DeepSeek V3.2 layers

### DIFF
--- a/mlx_vlm/models/glm_moe_dsa/language.py
+++ b/mlx_vlm/models/glm_moe_dsa/language.py
@@ -1,21 +1,446 @@
+import math
 from typing import Any, Dict, Optional
 
 import mlx.core as mx
 import mlx.nn as nn
-from mlx_lm.models.deepseek_v32 import (
-    DeepseekV32Attention,
-    DeepseekV32DecoderLayer,
-    DeepseekV32Model,
-)
-from mlx_lm.models.deepseek_v32 import Model as DSV32Model
+from mlx.nn.layers.distributed import shard_inplace, shard_linear, sum_gradients
+from mlx_lm.models.mla import MultiLinear
 
+from ..activations import swiglu
 from ..base import (
     LanguageModelOutput,
     create_attention_mask,
     scaled_dot_product_attention,
 )
 from ..cache import CacheList, KVCache
+from ..rope_utils import initialize_rope
+from ..switch_layers import SwitchGLU
 from .config import ModelConfig
+
+
+class Indexer(nn.Module):
+    def __init__(self, args: ModelConfig):
+        super().__init__()
+        self.dim = args.hidden_size
+        self.n_heads = args.index_n_heads
+        self.head_dim = args.index_head_dim
+        self.rope_head_dim = args.qk_rope_head_dim
+        self.index_topk = args.index_topk
+        self.q_lora_rank = args.q_lora_rank
+        self.wq_b = nn.Linear(
+            self.q_lora_rank, self.n_heads * self.head_dim, bias=False
+        )
+        self.wk = nn.Linear(self.dim, self.head_dim, bias=False)
+        self.k_norm = nn.LayerNorm(self.head_dim)
+        self.weights_proj = nn.Linear(self.dim, self.n_heads, bias=False)
+        self.softmax_scale = self.head_dim**-0.5
+        self.rope = initialize_rope(
+            dims=args.qk_rope_head_dim,
+            base=args.rope_theta,
+            traditional=True,
+            max_position_embeddings=args.max_position_embeddings,
+            scaling_config=args.rope_scaling,
+        )
+
+    def __call__(
+        self,
+        x: mx.array,
+        qr: mx.array,
+        mask: Optional[mx.array],
+        cache: Optional[Any] = None,
+    ):
+        b, s, _ = x.shape
+        q = self.wq_b(qr)
+        q = q.reshape(b, s, self.n_heads, self.head_dim).swapaxes(1, 2)
+        k = self.wk(x)
+        k = self.k_norm(k)
+        k = mx.reshape(k, (b, 1, s, self.head_dim))
+
+        offset = cache.offset if cache is not None else 0
+
+        q = self.rope(q, offset=offset)
+        k = self.rope(k, offset=offset)
+
+        if cache is not None:
+            k, _ = cache.update_and_fetch(k, mx.zeros([b, 1, s, 0]))
+        if k.shape[2] <= self.index_topk:
+            return None
+        scores = q @ k.swapaxes(-1, -2)
+        scores = mx.maximum(scores, 0)
+        weights = self.weights_proj(x) * (self.n_heads**-0.5 * self.softmax_scale)
+        weights = weights.swapaxes(-1, -2)[..., None]
+        scores = scores * weights
+        scores = scores.sum(axis=1, keepdims=True)
+        if mask is not None:
+            scores = mx.where(mask, scores, -float("inf"))
+        return mx.argpartition(scores, kth=-self.index_topk, axis=-1)[
+            ..., -self.index_topk :
+        ]
+
+
+class DeepseekV32Attention(nn.Module):
+    def __init__(self, config: ModelConfig):
+        super().__init__()
+        self.config = config
+        self.hidden_size = config.hidden_size
+        self.num_heads = config.num_attention_heads
+        self.max_position_embeddings = config.max_position_embeddings
+        self.rope_theta = config.rope_theta
+        self.q_lora_rank = config.q_lora_rank
+        self.qk_rope_head_dim = config.qk_rope_head_dim
+        self.kv_lora_rank = config.kv_lora_rank
+        self.v_head_dim = config.v_head_dim
+        self.qk_nope_head_dim = config.qk_nope_head_dim
+        self.q_head_dim = config.qk_nope_head_dim + config.qk_rope_head_dim
+
+        self.scale = self.q_head_dim**-0.5
+
+        self.q_a_proj = nn.Linear(
+            self.hidden_size, self.q_lora_rank, bias=config.attention_bias
+        )
+        self.q_a_layernorm = nn.RMSNorm(self.q_lora_rank, eps=1e-6)
+        self.q_b_proj = nn.Linear(
+            self.q_lora_rank, self.num_heads * self.q_head_dim, bias=False
+        )
+
+        self.kv_a_proj_with_mqa = nn.Linear(
+            self.hidden_size,
+            self.kv_lora_rank + self.qk_rope_head_dim,
+            bias=config.attention_bias,
+        )
+        self.kv_a_layernorm = nn.RMSNorm(self.kv_lora_rank, eps=1e-6)
+        self.embed_q = MultiLinear(
+            self.qk_nope_head_dim, self.kv_lora_rank, self.num_heads
+        )
+        self.unembed_out = MultiLinear(
+            self.kv_lora_rank, self.v_head_dim, self.num_heads
+        )
+
+        self.o_proj = nn.Linear(
+            self.num_heads * self.v_head_dim,
+            self.hidden_size,
+            bias=config.attention_bias,
+        )
+
+        if self.config.rope_scaling is not None:
+            mscale_all_dim = self.config.rope_scaling.get("mscale_all_dim", 0)
+            if mscale_all_dim:
+                scaling_factor = self.config.rope_scaling["factor"]
+                if scaling_factor > 1:
+                    s = 0.1 * mscale_all_dim * math.log(scaling_factor) + 1.0
+                    self.scale = self.scale * s * s
+
+        self.indexer = Indexer(config)
+        self.rope = initialize_rope(
+            dims=self.qk_rope_head_dim,
+            base=self.rope_theta,
+            traditional=True,
+            max_position_embeddings=self.max_position_embeddings,
+            scaling_config=self.config.rope_scaling,
+        )
+
+
+class DeepseekV32MLP(nn.Module):
+    def __init__(
+        self, config: ModelConfig, hidden_size: int = None, intermediate_size: int = None
+    ):
+        super().__init__()
+        self.config = config
+        self.hidden_size = config.hidden_size if hidden_size is None else hidden_size
+        self.intermediate_size = (
+            config.intermediate_size if intermediate_size is None else intermediate_size
+        )
+
+        self.gate_proj = nn.Linear(self.hidden_size, self.intermediate_size, bias=False)
+        self.up_proj = nn.Linear(self.hidden_size, self.intermediate_size, bias=False)
+        self.down_proj = nn.Linear(self.intermediate_size, self.hidden_size, bias=False)
+
+    def __call__(self, x):
+        return self.down_proj(swiglu(self.gate_proj(x), self.up_proj(x)))
+
+
+@mx.compile
+def group_expert_select(
+    gates,
+    e_score_correction_bias,
+    top_k,
+    n_group,
+    topk_group,
+    routed_scaling_factor,
+    norm_topk_prob,
+):
+    scores = mx.sigmoid(gates.astype(mx.float32))
+    orig_scores = scores
+    scores = scores + e_score_correction_bias
+    if n_group > 1:
+        scores = mx.unflatten(scores, axis=-1, shape=(n_group, -1))
+        group_scores = mx.topk(scores, 2, axis=-1).sum(axis=-1, keepdims=True)
+        k = n_group - topk_group
+        group_idx = mx.argpartition(group_scores, kth=k - 1, axis=-2)[..., :k, :]
+        scores = mx.put_along_axis(
+            scores, mx.stop_gradient(group_idx), mx.array(0.0), axis=-2
+        )
+        scores = mx.flatten(scores, -2, -1)
+
+    inds = mx.argpartition(-scores, kth=top_k - 1, axis=-1)[..., :top_k]
+    scores = mx.take_along_axis(orig_scores, inds, axis=-1)
+    if top_k > 1 and norm_topk_prob:
+        denominator = scores.sum(axis=-1, keepdims=True)
+        scores = scores / denominator
+    scores = scores * routed_scaling_factor
+
+    return inds, scores
+
+
+class MoEGate(nn.Module):
+    def __init__(self, config: ModelConfig):
+        super().__init__()
+        self.config = config
+        self.top_k = config.num_experts_per_tok
+        self.norm_topk_prob = config.norm_topk_prob
+        self.n_routed_experts = config.n_routed_experts
+        self.routed_scaling_factor = config.routed_scaling_factor
+        self.n_group = config.n_group
+        self.topk_group = config.topk_group
+        self.weight = mx.zeros((self.n_routed_experts, config.hidden_size))
+        self.e_score_correction_bias = mx.zeros((self.n_routed_experts,))
+        assert config.topk_method == "noaux_tc", "Unsupported topk method."
+
+    def __call__(self, x):
+        return group_expert_select(
+            x @ self.weight.T,
+            self.e_score_correction_bias,
+            self.top_k,
+            self.n_group,
+            self.topk_group,
+            self.routed_scaling_factor,
+            self.norm_topk_prob,
+        )
+
+
+class DeepseekV32MoE(nn.Module):
+    def __init__(self, config: ModelConfig):
+        super().__init__()
+        self.config = config
+        self.num_experts_per_tok = config.num_experts_per_tok
+        self.switch_mlp = SwitchGLU(
+            config.hidden_size,
+            config.moe_intermediate_size,
+            config.n_routed_experts,
+        )
+
+        self.gate = MoEGate(config)
+        if config.n_shared_experts is not None:
+            intermediate_size = config.moe_intermediate_size * config.n_shared_experts
+            self.shared_experts = DeepseekV32MLP(
+                config=config, intermediate_size=intermediate_size
+            )
+
+        self.sharding_group = None
+
+    def __call__(self, x):
+        if self.sharding_group is not None:
+            x = sum_gradients(self.sharding_group)(x)
+
+        inds, scores = self.gate(x)
+        y = self.switch_mlp(x, inds)
+        y = (y * scores[..., None]).sum(axis=-2).astype(y.dtype)
+        if self.config.n_shared_experts is not None:
+            y = y + self.shared_experts(x)
+
+        if self.sharding_group is not None:
+            y = mx.distributed.all_sum(y, group=self.sharding_group)
+
+        return y
+
+
+class DeepseekV32DecoderLayer(nn.Module):
+    def __init__(self, config: ModelConfig, layer_idx: int):
+        super().__init__()
+        self.self_attn = DeepseekV32Attention(config)
+        self.mlp = (
+            DeepseekV32MoE(config)
+            if (
+                config.n_routed_experts is not None
+                and layer_idx >= config.first_k_dense_replace
+                and layer_idx % config.moe_layer_freq == 0
+            )
+            else DeepseekV32MLP(config)
+        )
+        self.input_layernorm = nn.RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.post_attention_layernorm = nn.RMSNorm(
+            config.hidden_size, eps=config.rms_norm_eps
+        )
+
+
+class DeepseekV32Model(nn.Module):
+    def __init__(self, config: ModelConfig):
+        super().__init__()
+        self.vocab_size = config.vocab_size
+        self.embed_tokens = nn.Embedding(config.vocab_size, config.hidden_size)
+        self.layers = [
+            DeepseekV32DecoderLayer(config, idx)
+            for idx in range(config.num_hidden_layers)
+        ]
+        self.start_idx = 0
+        self.end_idx = len(self.layers)
+        self.num_layers = self.end_idx
+
+        self.norm = nn.RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.pipeline_rank = 0
+        self.pipeline_size = 1
+
+    def pipeline(self, group):
+        self.pipeline_rank = group.rank()
+        self.pipeline_size = group.size()
+        layers_per_rank = len(self.layers) // self.pipeline_size
+        extra = len(self.layers) - layers_per_rank * self.pipeline_size
+        if self.pipeline_rank < extra:
+            layers_per_rank += 1
+        self.start_idx = (self.pipeline_size - self.pipeline_rank - 1) * layers_per_rank
+        self.end_idx = self.start_idx + layers_per_rank
+        self.layers = self.layers[: self.end_idx]
+        self.layers[: self.start_idx] = [None] * self.start_idx
+        self.num_layers = len(self.layers) - self.start_idx
+
+
+def _sanitize_deepseek_v32(self, weights):
+    mpt_layer = self.args.num_hidden_layers
+    new_weights = {}
+    for k, v in weights.items():
+        parts = k.split(".")
+        if len(parts) >= 3 and parts[1] == "layers" and int(parts[2]) >= mpt_layer:
+            continue
+        new_weights[k] = v
+    weights = new_weights
+
+    def dequant(weight, scale_inv):
+        dtype = mx.bfloat16
+        weight = mx.from_fp8(weight, dtype=mx.bfloat16)
+        bs = 128
+        m, n = weight.shape
+        pad_bottom = (-m) % bs
+        pad_side = (-n) % bs
+        weight = mx.pad(weight, ((0, pad_bottom), (0, pad_side)))
+        weight = weight.reshape(
+            ((m + pad_bottom) // bs, bs, (n + pad_side) // bs, bs)
+        )
+        weight = (weight * scale_inv[:, None, :, None]).reshape(
+            m + pad_bottom, n + pad_side
+        )
+        return weight[:m, :n].astype(dtype)
+
+    new_weights = {}
+    for k, v in weights.items():
+        if "weight_scale_inv" in k:
+            scale_inv = v
+            wk = k.replace("_scale_inv", "")
+            weight = weights[wk]
+            weight = dequant(weight, scale_inv)
+            new_weights[wk] = weight
+        elif k not in new_weights:
+            new_weights[k] = v
+    weights = new_weights
+
+    for layer_idx in range(self.args.num_hidden_layers):
+        prefix = f"model.layers.{layer_idx}"
+        for _, m in [("w1", "gate_proj"), ("w2", "down_proj"), ("w3", "up_proj")]:
+            for k in ["weight", "scales", "biases"]:
+                if f"{prefix}.mlp.experts.0.{m}.{k}" in weights:
+                    to_join = [
+                        weights.pop(f"{prefix}.mlp.experts.{e}.{m}.{k}")
+                        for e in range(self.args.n_routed_experts)
+                    ]
+                    weights[f"{prefix}.mlp.switch_mlp.{m}.{k}"] = mx.stack(to_join)
+        prefix = f"model.layers.{layer_idx}.self_attn"
+        if f"{prefix}.kv_b_proj.weight" in weights:
+            quantized = f"{prefix}.kv_b_proj.scales" in weights
+            v = weights.pop(f"{prefix}.kv_b_proj.weight")
+            head_dim = self.args.qk_nope_head_dim + self.args.v_head_dim
+
+            if quantized:
+                dims = self.args.kv_lora_rank
+                scales = weights.pop(f"{prefix}.kv_b_proj.scales")
+                biases = weights.pop(f"{prefix}.kv_b_proj.biases")
+                bits = (v.shape[-1] * 32) // dims
+                group_size = dims // scales.shape[-1]
+                v = mx.dequantize(
+                    v, scales, biases, bits=bits, group_size=group_size
+                )
+            num_heads = self.args.num_attention_heads
+            v = v.reshape(num_heads, head_dim, -1)
+            wk = mx.contiguous(
+                v[:, : self.args.qk_nope_head_dim, :].swapaxes(-1, -2)
+            )
+            wv = mx.contiguous(v[:, self.args.qk_nope_head_dim :, :])
+            if quantized:
+                wk, wk_scales, wk_biases = mx.quantize(
+                    wk, bits=bits, group_size=group_size
+                )
+                wv, wv_scales, wv_biases = mx.quantize(
+                    wv, bits=bits, group_size=group_size
+                )
+                weights[f"{prefix}.embed_q.scales"] = wk_scales
+                weights[f"{prefix}.unembed_out.scales"] = wv_scales
+                weights[f"{prefix}.embed_q.biases"] = wk_biases
+                weights[f"{prefix}.unembed_out.biases"] = wv_biases
+            weights[f"{prefix}.embed_q.weight"] = wk
+            weights[f"{prefix}.unembed_out.weight"] = wv
+
+    return weights
+
+
+def _shard_deepseek_v32(self, group: Optional[mx.distributed.Group] = None):
+    group = group or mx.distributed.init()
+    n_ranks = group.size()
+    rank = group.rank()
+    for layer in self.model.layers:
+        layer.self_attn.q_b_proj = shard_linear(
+            layer.self_attn.q_b_proj, "all-to-sharded", group=group
+        )
+
+        layer.self_attn.o_proj = shard_linear(
+            layer.self_attn.o_proj, "sharded-to-all", group=group
+        )
+        layer.self_attn.num_heads //= n_ranks
+        num_heads = layer.self_attn.num_heads
+        sh = rank * num_heads
+        eh = sh + num_heads
+
+        def shard_heads(w):
+            return w[sh:eh]
+
+        layer.self_attn.embed_q.apply(shard_heads)
+        layer.self_attn.unembed_out.apply(shard_heads)
+
+        if isinstance(layer.mlp, DeepseekV32MLP):
+            layer.mlp.gate_proj = shard_linear(
+                layer.mlp.gate_proj, "all-to-sharded", group=group
+            )
+            layer.mlp.down_proj = shard_linear(
+                layer.mlp.down_proj, "sharded-to-all", group=group
+            )
+            layer.mlp.up_proj = shard_linear(
+                layer.mlp.up_proj, "all-to-sharded", group=group
+            )
+        else:
+            layer.mlp.sharding_group = group
+            shard_inplace(
+                layer.mlp.shared_experts.gate_proj, "all-to-sharded", group=group
+            )
+            shard_inplace(
+                layer.mlp.shared_experts.down_proj, "sharded-to-all", group=group
+            )
+            shard_inplace(
+                layer.mlp.shared_experts.up_proj, "all-to-sharded", group=group
+            )
+            shard_inplace(
+                layer.mlp.switch_mlp.gate_proj, "all-to-sharded", group=group
+            )
+            shard_inplace(
+                layer.mlp.switch_mlp.down_proj, "sharded-to-all", group=group
+            )
+            shard_inplace(layer.mlp.switch_mlp.up_proj, "all-to-sharded", group=group)
 
 
 class GlmMoeDsaAttention(DeepseekV32Attention):
@@ -203,10 +628,10 @@ class LanguageModel(nn.Module):
         return LanguageModelOutput(logits=logits)
 
     def sanitize(self, weights: Dict[str, mx.array]) -> Dict[str, mx.array]:
-        return DSV32Model.sanitize(self, weights)
+        return _sanitize_deepseek_v32(self, weights)
 
     def shard(self, group: Optional[mx.distributed.Group] = None):
-        return DSV32Model.shard(self, group)
+        return _shard_deepseek_v32(self, group)
 
     @property
     def layers(self):
@@ -214,7 +639,10 @@ class LanguageModel(nn.Module):
 
     @property
     def cast_predicate(self):
-        return DSV32Model.cast_predicate(self)
+        def predicate(k):
+            return "e_score_correction_bias" not in k
+
+        return predicate
 
     @property
     def quant_predicate(self):


### PR DESCRIPTION
## Summary

Vendor the DeepSeek V3.2-style support code needed by `glm_moe_dsa` directly into its language module on top of `pc/port-glm-moe-dsa-indexer-sharing`.

This removes the direct dependency on `mlx_lm.models.deepseek_v32` for that branch while preserving the GLM DSA shared-indexer behavior.

## Impact

- Keeps the GLM DSA branch usable when the installed `mlx-lm` does not expose the newer `deepseek_v32` module.
- Leaves the alternating full/shared DSA layer behavior and cache layout intact.

## Validation

- `python -m py_compile mlx_vlm/models/glm_moe_dsa/language.py mlx_vlm/models/glm_moe_dsa/config.py mlx_vlm/models/glm_moe_dsa/glm_moe_dsa.py`
- `uvx ruff check mlx_vlm/models/glm_moe_dsa/language.py mlx_vlm/tests/test_models.py`
- `git diff --check`
- `uv run --with pytest python -m pytest mlx_vlm/tests/test_models.py -k glm_moe_dsa -q`

Note: the same targeted pytest under the base Conda Python failed before collection because `mlx.core` could not load the default metallib. The project `uv` environment passed.
