### PR TITLE
Prevent cross-thread MLX stream errors in multimodal generation

### DIFF
--- a/mlx_vlm/array_utils.py
+++ b/mlx_vlm/array_utils.py
@@ -1,0 +1,11 @@
+from typing import Any
+
+import mlx.core as mx
+from mlx.utils import tree_flatten
+
+
+def materialize_mx_arrays(tree: Any) -> Any:
+    arrays = [value for _, value in tree_flatten(tree) if isinstance(value, mx.array)]
+    if arrays:
+        mx.eval(*arrays)
+    return tree

--- a/mlx_vlm/models/diffusion_gemma/processing_diffusion_gemma.py
+++ b/mlx_vlm/models/diffusion_gemma/processing_diffusion_gemma.py
@@ -10,10 +10,10 @@ from typing import List, Optional, Union
 
 import mlx.core as mx
 import numpy as np
-from mlx.utils import tree_flatten
 from transformers.feature_extraction_utils import BatchFeature
 from transformers.tokenization_utils_base import PreTokenizedInput, TextInput
 
+from ...array_utils import materialize_mx_arrays
 from ..gemma4.processing_gemma4 import Gemma4Processor
 
 _TOOL_PARSER_TOKENS = {
@@ -53,15 +53,6 @@ def _make_tool_parser_tokens_non_special(tokenizer):
         for token in additional_tokens
         if _token_text(token) not in _TOOL_PARSER_TOKENS
     ]
-
-
-def _materialize_mx_arrays(inputs: BatchFeature) -> BatchFeature:
-    arrays = [
-        value for _, value in tree_flatten(inputs.data) if isinstance(value, mx.array)
-    ]
-    if arrays:
-        mx.eval(*arrays)
-    return inputs
 
 
 class DiffusionGemma4Processor(Gemma4Processor):
@@ -171,7 +162,9 @@ class DiffusionGemma4Processor(Gemma4Processor):
                 "Provide `text`, `images`, and/or `videos` for DiffusionGemma4Processor."
             )
         inputs = super().__call__(images=images, text=text, videos=videos, **kwargs)
-        return _materialize_mx_arrays(self._merge_video_pixel_values(inputs))
+        inputs = self._merge_video_pixel_values(inputs)
+        materialize_mx_arrays(inputs.data)
+        return inputs
 
     @classmethod
     def from_pretrained(cls, pretrained_model_name_or_path, **kwargs):

--- a/mlx_vlm/server/generation.py
+++ b/mlx_vlm/server/generation.py
@@ -15,6 +15,7 @@ import mlx.core as mx
 from fastapi import HTTPException
 
 from .. import apc as _apc
+from ..array_utils import materialize_mx_arrays
 from ..generate import (
     DEFAULT_KV_GROUP_SIZE,
     DEFAULT_KV_QUANT_SCHEME,
@@ -1069,6 +1070,9 @@ class ResponseGenerator:
             )
         prompt_tokens = _count_prompt_tokens(raw_inputs)
         _check_configured_context_budget(prompt_tokens, args.max_tokens)
+
+        # Inputs cross from the caller thread to the GPU generation thread here.
+        materialize_mx_arrays(raw_inputs)
 
         self.requests.put(
             QueuedGenerationRequest(

--- a/mlx_vlm/tests/test_server.py
+++ b/mlx_vlm/tests/test_server.py
@@ -3602,6 +3602,37 @@ class TestResponseGenerator:
         assert len(queued) == 4
         assert all(request.thinking_budget_criteria is not None for request in queued)
 
+    def test_generate_materializes_inputs_before_generation_thread_handoff(self):
+        gen = server.ResponseGenerator.__new__(server.ResponseGenerator)
+        gen.wait_until_ready = lambda: None
+        gen.draft_model = None
+        gen._cancel = lambda uid: None
+        gen._preprocess_request = lambda prompt, images, audio, videos: {
+            "input_ids": mx.array([[1, 2, 3]], dtype=mx.int32),
+            "attention_mask": mx.arange(3) * 2,
+        }
+        errors = []
+
+        class Requests:
+            def put(self, item):
+                def consume():
+                    try:
+                        item.raw_inputs["attention_mask"].tolist()
+                    except Exception as exc:
+                        errors.append(exc)
+
+                thread = Thread(target=consume)
+                thread.start()
+                thread.join(timeout=1.0)
+                assert not thread.is_alive()
+                item.rqueue.put(SimpleNamespace(uid="req-1"))
+
+        gen.requests = Requests()
+
+        gen.generate("hello")
+
+        assert errors == []
+
     def test_server_runtime_snapshot_reports_effective_context_limit(self, monkeypatch):
         monkeypatch.setenv("MAX_KV_SIZE", "8")
         monkeypatch.setattr(


### PR DESCRIPTION
## Summary

Fixes #1591 

Multimodal preprocessing can produce lazy MLX arrays associated with the request caller's stream.

`ResponseGenerator` queues these arrays for consumption by its dedicated generation thread. When that thread evaluates an array associated with the caller's stream, MLX raises:

```text
RuntimeError: There is no Stream(gpu, N) in current thread.
```

This was reproduced with `Qwen3.5-9B-MLX-4bit` and a mixed text/image request.

## Changes

- Recursively collect MLX arrays from preprocessed request inputs using `mlx.utils.tree_flatten`
- Materialize the collected arrays with a single `mx.eval()` call
- Perform materialization after context validation and immediately before inserting the request into the generation queue
- Add a regression test that consumes a lazy preprocessing array from another thread through `ResponseGenerator.generate()`

## Why Materialize at the Queue Boundary

`ResponseGenerator.generate()` performs preprocessing on the caller thread, while `BatchGenerator` and model execution run on a dedicated generation thread.

The request queue is therefore the ownership boundary between those threads.

Materializing the arrays immediately before that boundary ensures that no lazy MLX graph carrying caller-thread stream state is transferred to the generation thread.

Materialization happens after context-budget validation, so rejected requests do not perform unnecessary MLX evaluation.

## Reproduction Before the Fix

A normal multimodal request fails in the generation thread:

```text
File "mlx_vlm/models/qwen3_5/language.py", line 2306, in get_rope_index
    row_mask = attention_mask[i].tolist()
RuntimeError: There is no Stream(gpu, 2) in current thread.
```

The caller then remains blocked waiting for the generation context.

## Result After the Fix

The same Qwen3.5 mixed-image request completes normally:

```text
This image is completely blank, showing only a solid white background with no visible content or details.
```

## Testing

The tests were run using the same VLM runtime environment used for the model reproduction.

```text
mlx_vlm/tests/test_server.py::TestResponseGenerator
52 passed
```

The end-to-end reproduction was also run with:

```text
Model: lmstudio-community/Qwen3.5-9B-MLX-4bit
Input: mixed text and generated PNG image
Prompt tokens: 614
Result: generation completed successfully
```