### PR TITLE
Fix ResponseGenerator cross-thread preprocessing arrays

### DIFF
--- a/mlx_vlm/server/generation.py
+++ b/mlx_vlm/server/generation.py
@@ -335,6 +335,25 @@ def _count_prompt_tokens(raw_inputs: dict) -> int:
     return input_ids.size if hasattr(input_ids, "size") else len(input_ids)
 
 
+def _materialize_mx_arrays(value):
+    arrays = []
+
+    def collect(item):
+        if isinstance(item, mx.array):
+            arrays.append(item)
+        elif isinstance(item, dict):
+            for child in item.values():
+                collect(child)
+        elif isinstance(item, (list, tuple)):
+            for child in item:
+                collect(child)
+
+    collect(value)
+    if arrays:
+        mx.eval(*arrays)
+    return value
+
+
 def _check_configured_context_budget(prompt_tokens: int, max_tokens: int):
     context_limit = get_configured_context_limit()
     requested_tokens = prompt_tokens + max(0, int(max_tokens or 0))
@@ -1058,6 +1077,7 @@ class ResponseGenerator:
         # CPU preprocessing (tokenize, load images) on caller thread.
         # GPU work (vision encoder) deferred to GPU thread.
         raw_inputs = self._preprocess_request(prompt, images, audio, videos)
+        _materialize_mx_arrays(raw_inputs)
         prompt_tokens = _count_prompt_tokens(raw_inputs)
         _check_configured_context_budget(prompt_tokens, args.max_tokens)
 
@@ -1372,27 +1392,27 @@ class ResponseGenerator:
                             prefill_step_size=get_prefill_step_size(),
                         )
 
-                    # Vision encoder runs on the GPU thread; text tokenization
-                    # already happened on the caller thread.
-                    input_ids, gen_kwargs = self._gpu_embed(raw_inputs, images)
-                    has_embeds = bool(gen_kwargs.get("inputs_embeds") is not None)
-                    # Per-tenant APC salt: keep this out of the model forward
-                    # by namespacing under "_apc_tenant"; BatchGenerator strips
-                    # it before merging kwargs for the language model.
-                    if getattr(args, "tenant_id", None):
-                        gen_kwargs["_apc_tenant"] = args.tenant_id
-
-                    # Drain pending text-only prompts before inserting an
-                    # embed-bearing request — multi-row PromptProcessingBatch
-                    # admission expects all rows to carry inputs_embeds (the
-                    # mixed APC path concatenates them per-row).
-                    if has_embeds and any(
-                        not (s[3] and s[3].get("inputs_embeds") is not None)
-                        for s in batch_gen.unprocessed_prompts
-                    ):
-                        self._flush(batch_gen, active)
-
                     try:
+                        # Vision encoder runs on the GPU thread; text tokenization
+                        # already happened on the caller thread.
+                        input_ids, gen_kwargs = self._gpu_embed(raw_inputs, images)
+                        has_embeds = bool(gen_kwargs.get("inputs_embeds") is not None)
+                        # Per-tenant APC salt: keep this out of the model forward
+                        # by namespacing under "_apc_tenant"; BatchGenerator strips
+                        # it before merging kwargs for the language model.
+                        if getattr(args, "tenant_id", None):
+                            gen_kwargs["_apc_tenant"] = args.tenant_id
+
+                        # Drain pending text-only prompts before inserting an
+                        # embed-bearing request — multi-row PromptProcessingBatch
+                        # admission expects all rows to carry inputs_embeds (the
+                        # mixed APC path concatenates them per-row).
+                        if has_embeds and any(
+                            not (s[3] and s[3].get("inputs_embeds") is not None)
+                            for s in batch_gen.unprocessed_prompts
+                        ):
+                            self._flush(batch_gen, active)
+
                         thinking_budget_criteria = self._make_thinking_budget_criteria(
                             args, input_ids
                         )

--- a/mlx_vlm/tests/test_server.py
+++ b/mlx_vlm/tests/test_server.py
@@ -214,6 +214,28 @@ def test_speculative_server_samples_first_bonus_with_positioned_sampler():
     assert tokens.tolist() == [2, 0]
 
 
+def test_materialize_mx_arrays_evaluates_nested_preprocess_outputs(monkeypatch):
+    input_ids = mx.array([[1, 2, 3]])
+    attention_mask = mx.array([[1, 1, 1]])
+    grid = mx.array([[1, 2, 3]])
+    raw_inputs = {
+        "input_ids": input_ids,
+        "attention_mask": attention_mask,
+        "metadata": [{"image_grid_thw": grid}, "keep"],
+    }
+    evaluated = []
+
+    def fake_eval(*arrays):
+        evaluated.extend(arrays)
+
+    monkeypatch.setattr(server_generation.mx, "eval", fake_eval)
+
+    result = server_generation._materialize_mx_arrays(raw_inputs)
+
+    assert result is raw_inputs
+    assert evaluated == [input_ids, attention_mask, grid]
+
+
 def test_positioned_target_sampler_is_batch_grouping_invariant():
     sampler = server_generation._PositionedTargetSampler(
         temperature=0.7, top_p=1.0, seed=42
@@ -682,6 +704,50 @@ def test_speculative_thread_exception_clears_runtime_cache(monkeypatch):
     gen._run_speculative()
 
     assert calls == {"clear_cache": 1, "collect": 1}
+
+
+def test_ar_thread_gpu_embed_exception_reaches_client_queue(monkeypatch):
+    gen = _unstarted_response_generator()
+
+    def fake_initialize_model():
+        gen.model = SimpleNamespace(language_model=object())
+        gen.processor = SimpleNamespace()
+        gen.config = SimpleNamespace()
+        gen.stop_tokens = set()
+        gen.draft_model = None
+        gen.draft_kind = None
+        gen.tokenizer = SimpleNamespace()
+
+    class FakeBatchGenerator:
+        def __init__(self, *args, **kwargs):
+            del args, kwargs
+
+    rqueue = Queue()
+    pending = [
+        server_generation.QueuedGenerationRequest(
+            rqueue=rqueue,
+            raw_inputs={"input_ids": mx.array([[1]], dtype=mx.int32)},
+            prompt_tokens=1,
+            args=server.GenerationArguments(max_tokens=2),
+        )
+    ]
+    calls = {"count": 0}
+    error = RuntimeError("gpu embed failed")
+
+    def collect_pending_requests(**_kwargs):
+        calls["count"] += 1
+        if calls["count"] == 1:
+            return pending, False
+        return [], True
+
+    gen._initialize_model = fake_initialize_model
+    gen._collect_pending_requests = collect_pending_requests
+    gen._gpu_embed = MagicMock(side_effect=error)
+    monkeypatch.setattr(server_generation, "BatchGenerator", FakeBatchGenerator)
+
+    gen._run()
+
+    assert rqueue.get(timeout=1) is error
 
 
 def test_models_endpoint_lists_single_file_safetensors_models(client, monkeypatch):


### PR DESCRIPTION
## Summary

Fixes #1591.

- materialize MLX arrays produced during caller-thread preprocessing before queuing a `ResponseGenerator` request
- keep vision embedding work on the generation thread while avoiding lazy caller-thread stream references crossing the queue boundary
- return `_gpu_embed()` failures to the request queue so `generate()` callers receive the exception instead of blocking indefinitely

## Root Cause

Multimodal preprocessing can produce lazy `mx.array` values such as `attention_mask`. Those arrays were passed directly from the caller thread into the dedicated generation thread, where later evaluation could reference an MLX stream that does not exist in the generation thread.

## Validation

- `uv run --with pytest pytest mlx_vlm/tests/test_server.py::test_materialize_mx_arrays_evaluates_nested_preprocess_outputs mlx_vlm/tests/test_server.py::test_ar_thread_gpu_embed_exception_reaches_client_queue`
- `uv run --with pytest pytest mlx_vlm/tests/test_server.py::TestResponseGenerator`
- `uv run --with pytest pytest mlx_vlm/tests/test_server.py`
- `git diff --check`

Note: local test runs used `uv` with injected `pytest` because the repo does not include pytest in its project dependencies.