### PR TITLE
Optimize 1-bit decode and fused greedy routing

### DIFF
--- a/mlx_vlm/generate/ar.py
+++ b/mlx_vlm/generate/ar.py
@@ -958,6 +958,14 @@ class GenerationBatch:
         ):
             return None
 
+        lm_head = getattr(self._language_model, "lm_head", None)
+        if getattr(lm_head, "bits", None) == 1:
+            output = self._language_model(
+                inputs[:, None], cache=self.prompt_cache, **fwd_kwargs
+            )
+            logits = output.logits if hasattr(output, "logits") else output
+            return self.sampler(logits[:, -1, :])
+
         argmax_from_hidden = getattr(
             self._language_model, "speculative_argmax_from_hidden", None
         )

--- a/mlx_vlm/generate/ar.py
+++ b/mlx_vlm/generate/ar.py
@@ -960,11 +960,7 @@ class GenerationBatch:
 
         lm_head = getattr(self._language_model, "lm_head", None)
         if getattr(lm_head, "bits", None) == 1:
-            output = self._language_model(
-                inputs[:, None], cache=self.prompt_cache, **fwd_kwargs
-            )
-            logits = output.logits if hasattr(output, "logits") else output
-            return self.sampler(logits[:, -1, :])
+            return None
 
         argmax_from_hidden = getattr(
             self._language_model, "speculative_argmax_from_hidden", None
@@ -1035,13 +1031,22 @@ class GenerationBatch:
                 processed_logits.append(sample_logits)
             logits = mx.concatenate(processed_logits, axis=0)
 
-        logprobs = logits - mx.logsumexp(logits, axis=-1, keepdims=True)
-        sampled = _sample_with_positions(
-            self.sampler,
-            logprobs,
-            row_ids=[0] * len(self.uids),
-            positions=[n + 1 for n in self._num_tokens],
-        )
+        if (
+            self.greedy_sampling
+            and not self.compute_logprobs
+            and self.top_logprobs_k == 0
+            and not (self.logits_processors and any(self.logits_processors))
+        ):
+            logprobs = None
+            sampled = self.sampler(logits)
+        else:
+            logprobs = logits - mx.logsumexp(logits, axis=-1, keepdims=True)
+            sampled = _sample_with_positions(
+                self.sampler,
+                logprobs,
+                row_ids=[0] * len(self.uids),
+                positions=[n + 1 for n in self._num_tokens],
+            )
 
         self._next_tokens = sampled
         prev_top_idx = self._next_top_idx

--- a/mlx_vlm/generate/ar.py
+++ b/mlx_vlm/generate/ar.py
@@ -949,7 +949,7 @@ class GenerationBatch:
         elif len(self.token_context) > len(self.uids):
             self.token_context = self.token_context[: len(self.uids)]
 
-    def _greedy_argmax_step(self, inputs: mx.array, fwd_kwargs: dict):
+    def _fused_greedy_step(self, inputs: mx.array, fwd_kwargs: dict):
         if (
             not self.greedy_sampling
             or self.compute_logprobs
@@ -958,21 +958,15 @@ class GenerationBatch:
         ):
             return None
 
-        argmax_from_hidden = getattr(
-            self._language_model, "speculative_argmax_from_hidden", None
-        )
-        if not callable(argmax_from_hidden):
+        fused_greedy_decode = getattr(self._language_model, "fused_greedy_decode", None)
+        if not callable(fused_greedy_decode):
             return None
 
-        output = self._language_model(
+        sampled = fused_greedy_decode(
             inputs[:, None],
             cache=self.prompt_cache,
-            return_hidden=True,
-            skip_logits=True,
             **fwd_kwargs,
         )
-        hidden = output.hidden_states[-1]
-        sampled = argmax_from_hidden(hidden)
         if sampled is None:
             return None
         if sampled.ndim == 2 and sampled.shape[1] == 1:
@@ -989,7 +983,7 @@ class GenerationBatch:
         if self._rope_deltas is not None:
             fwd_kwargs["rope_deltas"] = self._rope_deltas
 
-        sampled = self._greedy_argmax_step(inputs, fwd_kwargs)
+        sampled = self._fused_greedy_step(inputs, fwd_kwargs)
         if sampled is not None:
             self._next_tokens = sampled
             self._next_lps = None

--- a/mlx_vlm/generate/ar.py
+++ b/mlx_vlm/generate/ar.py
@@ -958,10 +958,6 @@ class GenerationBatch:
         ):
             return None
 
-        lm_head = getattr(self._language_model, "lm_head", None)
-        if getattr(lm_head, "bits", None) == 1:
-            return None
-
         argmax_from_hidden = getattr(
             self._language_model, "speculative_argmax_from_hidden", None
         )
@@ -1031,22 +1027,13 @@ class GenerationBatch:
                 processed_logits.append(sample_logits)
             logits = mx.concatenate(processed_logits, axis=0)
 
-        if (
-            self.greedy_sampling
-            and not self.compute_logprobs
-            and self.top_logprobs_k == 0
-            and not (self.logits_processors and any(self.logits_processors))
-        ):
-            logprobs = None
-            sampled = self.sampler(logits)
-        else:
-            logprobs = logits - mx.logsumexp(logits, axis=-1, keepdims=True)
-            sampled = _sample_with_positions(
-                self.sampler,
-                logprobs,
-                row_ids=[0] * len(self.uids),
-                positions=[n + 1 for n in self._num_tokens],
-            )
+        logprobs = logits - mx.logsumexp(logits, axis=-1, keepdims=True)
+        sampled = _sample_with_positions(
+            self.sampler,
+            logprobs,
+            row_ids=[0] * len(self.uids),
+            positions=[n + 1 for n in self._num_tokens],
+        )
 
         self._next_tokens = sampled
         prev_top_idx = self._next_top_idx

--- a/mlx_vlm/models/qwen3_5/language.py
+++ b/mlx_vlm/models/qwen3_5/language.py
@@ -468,25 +468,33 @@ def _target_verify_qargmax_kernel(bits, group_size, dtype, verify_t, k_size, n_s
     )
 
 
-def _can_target_verify_quantized(linear, x: mx.array) -> bool:
+def _can_target_verify_quantized_head(linear) -> bool:
     if (
         not isinstance(linear, nn.QuantizedLinear)
-        or x.ndim != 3
-        or x.shape[1] < 1
         or linear.bits not in (4, 5)
         or linear.mode != "affine"
         or linear.biases is None
-        or x.dtype not in (mx.bfloat16, mx.float16)
-        or linear.scales.dtype != x.dtype
-        or linear.biases.dtype != x.dtype
+        or linear.scales.dtype not in (mx.bfloat16, mx.float16)
+        or linear.biases.dtype != linear.scales.dtype
     ):
         return False
 
-    _, _, K = x.shape
+    K = linear.weight.shape[1] * 32 // linear.bits
     N = linear.weight.shape[0]
-    return (
-        K == linear.weight.shape[1] * 32 // linear.bits and K % 512 == 0 and N % 8 == 0
-    )
+    return K % 512 == 0 and N % 8 == 0
+
+
+def _can_target_verify_quantized(linear, x: mx.array) -> bool:
+    if (
+        not _can_target_verify_quantized_head(linear)
+        or x.ndim != 3
+        or x.shape[1] < 1
+        or x.dtype != linear.scales.dtype
+    ):
+        return False
+
+    K = linear.weight.shape[1] * 32 // linear.bits
+    return x.shape[-1] == K
 
 
 def _target_verify_quantized_linear(linear, x: mx.array) -> Optional[mx.array]:
@@ -2645,6 +2653,27 @@ class LanguageModel(nn.Module):
                 return out
         logits = self.speculative_logits_from_hidden(hidden)
         return mx.argmax(logits, axis=-1)
+
+    def fused_greedy_decode(self, inputs: mx.array, cache=None, **kwargs):
+        if (
+            self.args.tie_word_embeddings
+            or not _can_target_verify_quantized_head(self.lm_head)
+            or "bias" in self.lm_head
+        ):
+            return None
+
+        output = self(
+            inputs,
+            cache=cache,
+            return_hidden=True,
+            skip_logits=True,
+            **kwargs,
+        )
+        hidden = output.hidden_states[-1]
+        sampled = _target_verify_quantized_argmax(self.lm_head, hidden)
+        if sampled is not None:
+            return sampled
+        return mx.argmax(self.speculative_logits_from_hidden(hidden), axis=-1)
 
     def speculative_verify_logits(self, inputs: mx.array, cache, sampler):
         out = self(

--- a/mlx_vlm/quantization/one_bit.py
+++ b/mlx_vlm/quantization/one_bit.py
@@ -17,9 +17,10 @@ _ONE_BIT_QMV_SOURCE = r"""
     uint input_dims = x_shape[1];
     uint output_dims = weight_shape[0];
     uint groups = scales_shape[1];
-    uint output_start = threadgroup_position_in_grid.x * 8 + simd_group * 4;
+    uint output_start = threadgroup_position_in_grid.x * OUTPUTS_PER_THREADGROUP +
+        simd_group * OUTPUTS_PER_SIMDGROUP;
 
-    float accumulators[4] = {0.0f, 0.0f, 0.0f, 0.0f};
+    float accumulators[OUTPUTS_PER_SIMDGROUP] = {0.0f};
     constexpr uint VALUES_PER_THREAD = 16;
     constexpr uint BLOCK_SIZE = VALUES_PER_THREAD * 32;
 
@@ -42,7 +43,7 @@ _ONE_BIT_QMV_SOURCE = r"""
         uint group = block_start / GROUP_SIZE;
         uint packed_column = block_start >> 5;
         uint packed_shift = block_start & 31;
-        for (uint row = 0; row < 4; ++row) {
+        for (uint row = 0; row < OUTPUTS_PER_SIMDGROUP; ++row) {
             uint output_row = output_start + row;
             if (ROW_VALID) {
                 ushort packed = ushort(
@@ -64,7 +65,7 @@ _ONE_BIT_QMV_SOURCE = r"""
         }
     }
 
-    for (uint row = 0; row < 4; ++row) {
+    for (uint row = 0; row < OUTPUTS_PER_SIMDGROUP; ++row) {
         accumulators[row] = simd_sum(accumulators[row]);
         uint output_row = output_start + row;
         if (lane == 0 && output_row < output_dims) {
@@ -208,15 +209,23 @@ def _validate_group_size(group_size: int) -> None:
 
 
 @lru_cache(maxsize=None)
-def _one_bit_qmv_kernel(group_size: int, output_aligned: bool):
+def _one_bit_qmv_kernel(
+    group_size: int, output_aligned: bool, outputs_per_simdgroup: int
+):
     _validate_group_size(group_size)
     if not hasattr(mx, "metal") or not mx.metal.is_available():
         return None
-    source = _ONE_BIT_QMV_SOURCE.replace("GROUP_SIZE", str(group_size)).replace(
-        "ROW_VALID", "true" if output_aligned else "output_row < output_dims"
+    source = (
+        _ONE_BIT_QMV_SOURCE.replace("GROUP_SIZE", str(group_size))
+        .replace("OUTPUTS_PER_THREADGROUP", str(outputs_per_simdgroup * 2))
+        .replace("OUTPUTS_PER_SIMDGROUP", str(outputs_per_simdgroup))
+        .replace("ROW_VALID", "true" if output_aligned else "output_row < output_dims")
     )
     return mx.fast.metal_kernel(
-        name=f"mlx_vlm_affine_1bit_qmv_gs_{group_size}_aligned_{int(output_aligned)}",
+        name=(
+            f"mlx_vlm_affine_1bit_qmv_gs_{group_size}_"
+            f"rows_{outputs_per_simdgroup}_aligned_{int(output_aligned)}"
+        ),
         input_names=["x", "weight", "scales", "biases"],
         output_names=["out"],
         source=source,
@@ -319,7 +328,15 @@ def one_bit_quantized_matmul(
             )[0]
             return out.reshape(output_shape)
 
-    kernel = _one_bit_qmv_kernel(group_size, output_dims % 8 == 0)
+    outputs_per_simdgroup = (
+        4 if output_dims <= 64 or input_dims >= 2 * output_dims else 8
+    )
+    outputs_per_threadgroup = outputs_per_simdgroup * 2
+    kernel = _one_bit_qmv_kernel(
+        group_size,
+        output_dims % outputs_per_threadgroup == 0,
+        outputs_per_simdgroup,
+    )
     if kernel is None:
         dense_weight = dequantize_one_bit(weight, scales, biases, group_size).astype(
             x.dtype
@@ -329,7 +346,12 @@ def one_bit_quantized_matmul(
     out = kernel(
         inputs=[x_2d, weight, scales, biases],
         template=[("T", x.dtype)],
-        grid=(((output_dims + 7) // 8) * 64, x_2d.shape[0], 1),
+        grid=(
+            ((output_dims + outputs_per_threadgroup - 1) // outputs_per_threadgroup)
+            * 64,
+            x_2d.shape[0],
+            1,
+        ),
         threadgroup=(64, 1, 1),
         output_shapes=[(x_2d.shape[0] * output_dims,)],
         output_dtypes=[x.dtype],

--- a/mlx_vlm/tests/test_generate.py
+++ b/mlx_vlm/tests/test_generate.py
@@ -744,6 +744,42 @@ class TestBatchGenerator:
         assert batch._next_tokens.tolist() == [7, 7]
         assert model.calls == [{"return_hidden": True, "skip_logits": True}]
 
+    def test_generation_batch_uses_direct_logits_argmax_for_one_bit_head(self):
+        class OneBitModel:
+            def __init__(self):
+                self.lm_head = SimpleNamespace(bits=1)
+                self.calls = []
+
+            def __call__(self, input_ids, cache=None, **kwargs):
+                del cache
+                self.calls.append(kwargs)
+                logits = mx.broadcast_to(
+                    mx.array([0.0, 1.0, 4.0, 2.0]),
+                    (input_ids.shape[0], input_ids.shape[1], 4),
+                )
+                return SimpleNamespace(logits=logits)
+
+            def speculative_argmax_from_hidden(self, hidden):
+                raise AssertionError("1-bit decode should use direct logits")
+
+        model = OneBitModel()
+        batch = GenerationBatch(
+            model=model,
+            uids=[0],
+            inputs=mx.array([5], dtype=mx.int32),
+            prompt_cache=[],
+            sampler=lambda logits: mx.argmax(logits, axis=-1),
+            stop_criteria=lambda token: False,
+            max_tokens=[2],
+            greedy_sampling=True,
+        )
+        batch.compute_logprobs = False
+
+        first = batch.next()
+        assert [r.token for r in first] == [5]
+        assert batch._next_tokens.tolist() == [2]
+        assert model.calls == [{}]
+
     def test_speculative_generation_batch_drains_full_round(self, monkeypatch):
         def fake_rounds(*args, **kwargs):
             del args, kwargs

--- a/mlx_vlm/tests/test_generate.py
+++ b/mlx_vlm/tests/test_generate.py
@@ -744,49 +744,6 @@ class TestBatchGenerator:
         assert batch._next_tokens.tolist() == [7, 7]
         assert model.calls == [{"return_hidden": True, "skip_logits": True}]
 
-    def test_generation_batch_uses_direct_logits_argmax_for_one_bit_head(self):
-        class OneBitModel:
-            def __init__(self):
-                self.lm_head = SimpleNamespace(bits=1)
-                self.calls = []
-
-            def __call__(self, input_ids, cache=None, **kwargs):
-                del cache
-                self.calls.append(kwargs)
-                logits = mx.broadcast_to(
-                    mx.array([0.0, 1.0, 4.0, 2.0]),
-                    (input_ids.shape[0], input_ids.shape[1], 4),
-                )
-                return SimpleNamespace(logits=logits)
-
-            def speculative_argmax_from_hidden(self, hidden):
-                raise AssertionError("1-bit decode should use direct logits")
-
-        model = OneBitModel()
-        sampled_logits = []
-
-        def sample(logits):
-            sampled_logits.append(logits.tolist())
-            return mx.argmax(logits, axis=-1)
-
-        batch = GenerationBatch(
-            model=model,
-            uids=[0],
-            inputs=mx.array([5], dtype=mx.int32),
-            prompt_cache=[],
-            sampler=sample,
-            stop_criteria=lambda token: False,
-            max_tokens=[2],
-            greedy_sampling=True,
-        )
-        batch.compute_logprobs = False
-
-        first = batch.next()
-        assert [r.token for r in first] == [5]
-        assert batch._next_tokens.tolist() == [2]
-        assert model.calls == [{}]
-        assert sampled_logits == [[[0.0, 1.0, 4.0, 2.0]]]
-
     def test_speculative_generation_batch_drains_full_round(self, monkeypatch):
         def fake_rounds(*args, **kwargs):
             del args, kwargs

--- a/mlx_vlm/tests/test_generate.py
+++ b/mlx_vlm/tests/test_generate.py
@@ -710,21 +710,17 @@ class TestBatchGenerator:
         second = batch.next()
         assert [r.token for r in second] == [3]
 
-    def test_generation_batch_uses_greedy_hidden_argmax_without_logprobs(self):
+    def test_generation_batch_uses_fused_greedy_decode_without_logprobs(self):
         class FastArgmaxModel:
             def __init__(self):
                 self.calls = []
 
-            def __call__(self, input_ids, cache=None, **kwargs):
-                del cache
+            def fused_greedy_decode(self, input_ids, cache=None, **kwargs):
                 self.calls.append(kwargs)
-                assert kwargs["return_hidden"] is True
-                assert kwargs["skip_logits"] is True
-                hidden = mx.ones((input_ids.shape[0], input_ids.shape[1], 3))
-                return SimpleNamespace(hidden_states=[hidden])
-
-            def speculative_argmax_from_hidden(self, hidden):
-                return mx.full((hidden.shape[0], hidden.shape[1]), 7, dtype=mx.int32)
+                assert cache == []
+                return mx.full(
+                    (input_ids.shape[0], input_ids.shape[1]), 7, dtype=mx.int32
+                )
 
         model = FastArgmaxModel()
         batch = GenerationBatch(
@@ -742,7 +738,42 @@ class TestBatchGenerator:
         first = batch.next()
         assert [r.token for r in first] == [5, 6]
         assert batch._next_tokens.tolist() == [7, 7]
-        assert model.calls == [{"return_hidden": True, "skip_logits": True}]
+        assert model.calls == [{}]
+
+    def test_generation_batch_ignores_speculative_argmax_without_fused_decode(self):
+        class FallbackArgmaxModel:
+            def __init__(self):
+                self.calls = []
+
+            def __call__(self, input_ids, cache=None, **kwargs):
+                del cache
+                self.calls.append(kwargs)
+                logits = mx.broadcast_to(
+                    mx.array([0.0, 1.0, 4.0, 2.0]),
+                    (input_ids.shape[0], input_ids.shape[1], 4),
+                )
+                return SimpleNamespace(logits=logits)
+
+            def speculative_argmax_from_hidden(self, hidden):
+                raise AssertionError("fallback argmax must not select the fused path")
+
+        model = FallbackArgmaxModel()
+        batch = GenerationBatch(
+            model=model,
+            uids=[0],
+            inputs=mx.array([5], dtype=mx.int32),
+            prompt_cache=[],
+            sampler=lambda logprobs: mx.argmax(logprobs, axis=-1),
+            stop_criteria=lambda token: False,
+            max_tokens=[2],
+            greedy_sampling=True,
+        )
+        batch.compute_logprobs = False
+
+        first = batch.next()
+        assert [r.token for r in first] == [5]
+        assert batch._next_tokens.tolist() == [2]
+        assert model.calls == [{}]
 
     def test_speculative_generation_batch_drains_full_round(self, monkeypatch):
         def fake_rounds(*args, **kwargs):

--- a/mlx_vlm/tests/test_generate.py
+++ b/mlx_vlm/tests/test_generate.py
@@ -763,12 +763,18 @@ class TestBatchGenerator:
                 raise AssertionError("1-bit decode should use direct logits")
 
         model = OneBitModel()
+        sampled_logits = []
+
+        def sample(logits):
+            sampled_logits.append(logits.tolist())
+            return mx.argmax(logits, axis=-1)
+
         batch = GenerationBatch(
             model=model,
             uids=[0],
             inputs=mx.array([5], dtype=mx.int32),
             prompt_cache=[],
-            sampler=lambda logits: mx.argmax(logits, axis=-1),
+            sampler=sample,
             stop_criteria=lambda token: False,
             max_tokens=[2],
             greedy_sampling=True,
@@ -779,6 +785,7 @@ class TestBatchGenerator:
         assert [r.token for r in first] == [5]
         assert batch._next_tokens.tolist() == [2]
         assert model.calls == [{}]
+        assert sampled_logits == [[[0.0, 1.0, 4.0, 2.0]]]
 
     def test_speculative_generation_batch_drains_full_round(self, monkeypatch):
         def fake_rounds(*args, **kwargs):

--- a/mlx_vlm/tests/test_one_bit.py
+++ b/mlx_vlm/tests/test_one_bit.py
@@ -67,6 +67,24 @@ def test_one_bit_prompt_matmul_matches_dense(group_size):
     assert mx.allclose(out, reference, rtol=1e-5, atol=1e-4).item()
 
 
+def test_one_bit_wide_decode_matmul_matches_dense():
+    rng = np.random.default_rng(117)
+    input_dims = 128
+    output_dims = 128
+    bits = rng.integers(0, 2, size=(output_dims, input_dims), dtype=np.uint32)
+    weight = _pack_bits(bits)
+    scales = mx.array(rng.normal(size=(output_dims, 2)).astype(np.float32))
+    biases = mx.array(rng.normal(size=(output_dims, 2)).astype(np.float32))
+    x = mx.array(rng.normal(size=(1, input_dims)).astype(np.float32))
+
+    out = one_bit_quantized_matmul(x, weight, scales, biases, group_size=64)
+    dense = dequantize_one_bit(weight, scales, biases, 64)
+    reference = x @ dense.T
+    mx.eval(out, reference)
+
+    assert mx.allclose(out, reference, rtol=1e-5, atol=1e-4).item()
+
+
 def test_one_bit_linear_applies_output_bias():
     layer = OneBitLinear(64, 3, bias=True, group_size=64)
     layer.weight = _pack_bits(np.ones((3, 64), dtype=np.uint32))

--- a/mlx_vlm/tests/test_speculative.py
+++ b/mlx_vlm/tests/test_speculative.py
@@ -30,6 +30,7 @@ from mlx_vlm.models.cache import (
     PoolingCache,
     RotatingKVCache,
 )
+from mlx_vlm.quantization.one_bit import OneBitLinear
 from mlx_vlm.speculative.common import _SpeculativeSamplerRNG
 from mlx_vlm.speculative.drafters import (
     DEFAULT_DRAFTER_KIND,
@@ -599,6 +600,75 @@ def test_qwen_target_verify_quantized_linear_matches_singleton_batch_path():
     mx.eval(ref, out)
 
     assert bool(mx.array_equal(ref, out).item())
+
+
+def test_qwen_fused_greedy_decode_support_matches_lm_head():
+    linear = nn.QuantizedLinear(512, 16, bias=False, group_size=32, bits=4)
+    linear.scales = linear.scales.astype(mx.bfloat16)
+    linear.biases = linear.biases.astype(mx.bfloat16)
+    model = SimpleNamespace(
+        args=SimpleNamespace(tie_word_embeddings=False),
+        lm_head=linear,
+    )
+    assert qwen_language._can_target_verify_quantized_head(model.lm_head)
+
+    model.lm_head = OneBitLinear(512, 16, bias=False, group_size=32)
+    assert not qwen_language._can_target_verify_quantized_head(model.lm_head)
+    assert (
+        qwen_language.LanguageModel.fused_greedy_decode(
+            model, mx.array([[1]], dtype=mx.int32), cache=[]
+        )
+        is None
+    )
+
+    model.lm_head = linear
+    model.args.tie_word_embeddings = True
+    assert (
+        qwen_language.LanguageModel.fused_greedy_decode(
+            model, mx.array([[1]], dtype=mx.int32), cache=[]
+        )
+        is None
+    )
+
+
+def test_qwen_fused_greedy_decode_uses_quantized_argmax():
+    mx.random.seed(19)
+    hidden = mx.random.normal((1, 1, 512)).astype(mx.bfloat16)
+
+    class Model:
+        args = SimpleNamespace(tie_word_embeddings=False)
+
+        def __init__(self):
+            self.lm_head = nn.QuantizedLinear(
+                512, 16, bias=False, group_size=32, bits=4
+            )
+            self.lm_head.scales = self.lm_head.scales.astype(mx.bfloat16)
+            self.lm_head.biases = self.lm_head.biases.astype(mx.bfloat16)
+            self.calls = []
+
+        def __call__(self, inputs, cache=None, **kwargs):
+            self.calls.append((inputs.tolist(), cache, kwargs))
+            return SimpleNamespace(hidden_states=[hidden])
+
+        def speculative_logits_from_hidden(self, value):
+            return self.lm_head(value)
+
+    model = Model()
+    inputs = mx.array([[1]], dtype=mx.int32)
+    out = qwen_language.LanguageModel.fused_greedy_decode(
+        model, inputs, cache=["cache"]
+    )
+    ref = qwen_language._target_verify_quantized_argmax(model.lm_head, hidden)
+    mx.eval(out, ref)
+
+    assert bool(mx.array_equal(out, ref).item())
+    assert model.calls == [
+        (
+            [[1]],
+            ["cache"],
+            {"return_hidden": True, "skip_logits": True},
+        )
+    ]
 
 
 def test_qwen3_5_decode_quantized_linears_fused_matches_separate():


### PR DESCRIPTION
## Summary

- reuse each activation block across eight output rows in the common 1-bit QMV path
- use a four-row variant for narrow or reduction-heavy projections
- replace the batcher's implicit `speculative_argmax_from_hidden` fast-path detection with an explicit `fused_greedy_decode` model operation
- keep Qwen3.5's fused affine 4/5-bit argmax while routing 1-bit, dense, tied, and unsupported heads through normal logits

## Root cause

Commit `774c69e5` in #1210 introduced the hidden-state greedy shortcut while routing server MTP through `BatchGenerator`. The gate checked only whether `speculative_argmax_from_hidden` was callable. Qwen3.5 exposes that method for speculative verification, but only its stock affine 4/5-bit head has a fused argmax; other heads reconstruct full logits. As a result, ordinary temperature-zero server requests selected `skip_logits=True` even when no fused operation existed.

The refactor makes the fused forward model-owned and optional. Unsupported heads return before a cache-mutating forward, so the batcher safely uses its normal logits path. No quantization-type special case is present in generation code.

## Performance

M3 Max, `prism-ml/Bonsai-27B-mlx-1bit`, 44-token prompt, 500 generated tokens:

- CLI: 37.848 tokens/s
- singleton server run 1: 39.485 tokens/s
- singleton server run 2: 38.422 tokens/s
- previous singleton server path: 30.223 tokens/s
- peak memory: 5.558–5.566 GB

## Validation

```text
1616 passed, 3 skipped, 3 warnings, 60 subtests passed
```

Coverage includes unsupported fallback routing, OneBitLinear rejection before forward, tied-head fallback, and preservation of the stock quantized Qwen fused argmax.

```bash
uv run --with pytest --with psutil pytest -q
```
