### PR TITLE
Improve generation API type hints

### DIFF
--- a/mlx_vlm/generate/__init__.py
+++ b/mlx_vlm/generate/__init__.py
@@ -38,11 +38,13 @@ from .image import (
     load_image_generation_model,
     load_image_model,
 )
+from .types import GenerateKwargs, ProcessorLike
 
 __all__ = [
     "BatchGenerator",
     "BatchResponse",
     "BatchStats",
+    "GenerateKwargs",
     "GenerationResult",
     "ImageEditModel",
     "ImageEditRequest",
@@ -52,6 +54,7 @@ __all__ = [
     "ImageTask",
     "PromptCacheState",
     "PromptProcessingBatch",
+    "ProcessorLike",
     "batch_generate",
     "edit_image",
     "generate",

--- a/mlx_vlm/generate/ar.py
+++ b/mlx_vlm/generate/ar.py
@@ -37,6 +37,7 @@ from .common import (
     maybe_quantize_kv_cache,
     wired_limit,
 )
+from .types import GenerateKwargs, ProcessorLike, Unpack
 
 logger = logging.getLogger("mlx_vlm.generate")
 
@@ -2803,17 +2804,17 @@ class BatchGenerator:
 
 
 def batch_generate(
-    model,
-    processor,
-    images: Union[str, List[str]] = None,
-    audios: Union[str, List[str]] = None,
-    prompts: List[str] = None,
+    model: nn.Module,
+    processor: ProcessorLike,
+    images: Union[str, List[str], None] = None,
+    audios: Union[str, List[str], None] = None,
+    prompts: Optional[List[str]] = None,
     max_tokens: Union[int, List[int]] = 128,
     verbose: bool = False,
     group_by_shape: bool = True,
     track_image_sizes: bool = True,
-    **kwargs,
-):
+    **kwargs: Unpack[GenerateKwargs],
+) -> BatchResponse:
     """
     Generate responses for the given batch of prompts with variable-sized images.
 

--- a/mlx_vlm/generate/dispatch.py
+++ b/mlx_vlm/generate/dispatch.py
@@ -649,6 +649,7 @@ from .diffusion import (
     is_diffusion_model,
     stream_diffusion_generate_from_kwargs,
 )
+from .types import GenerateKwargs, ProcessorLike, Unpack
 
 
 def _prime_cached_prefix_rope_state(
@@ -696,13 +697,13 @@ from .ar import generate_step
 
 def stream_generate(
     model: nn.Module,
-    processor: PreTrainedTokenizer,
+    processor: ProcessorLike | PreTrainedTokenizer,
     prompt: str,
-    image: Union[str, List[str]] = None,
-    audio: Union[str, List[str]] = None,
-    video: Union[str, List[str]] = None,
-    **kwargs,
-) -> Union[str, Generator[str, None, None]]:
+    image: Union[str, List[str], None] = None,
+    audio: Union[str, List[str], None] = None,
+    video: Union[str, List[str], None] = None,
+    **kwargs: Unpack[GenerateKwargs],
+) -> Generator[GenerationResult, None, None]:
     """
     A generator producing text based on the given prompt from the model.
 
@@ -1171,13 +1172,13 @@ def stream_generate(
 
 def generate(
     model: nn.Module,
-    processor: PreTrainedTokenizer,
+    processor: ProcessorLike | PreTrainedTokenizer,
     prompt: str,
-    image: Union[str, List[str]] = None,
-    audio: Union[str, List[str]] = None,
-    video: Union[str, List[str]] = None,
+    image: Union[str, List[str], None] = None,
+    audio: Union[str, List[str], None] = None,
+    video: Union[str, List[str], None] = None,
     verbose: bool = False,
-    **kwargs,
+    **kwargs: Unpack[GenerateKwargs],
 ) -> GenerationResult:
     """
     Generate text from the model.

--- a/mlx_vlm/generate/types.py
+++ b/mlx_vlm/generate/types.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from typing import Any, Callable, Protocol, TypedDict
+
+import mlx.core as mx
+
+try:
+    from typing import Unpack as Unpack
+except ImportError:  # pragma: no cover - Python 3.10 compatibility
+    from typing_extensions import Unpack as Unpack
+
+__all__ = ["GenerateKwargs", "ProcessorLike", "Unpack"]
+
+
+class ProcessorLike(Protocol):
+    tokenizer: Any
+    detokenizer: Any
+
+
+class GenerateKwargs(TypedDict, total=False):
+    max_tokens: int
+    temperature: float
+    repetition_penalty: float | None
+    repetition_context_size: int | None
+    presence_penalty: float | None
+    presence_context_size: int | None
+    frequency_penalty: float | None
+    frequency_context_size: int | None
+    top_p: float
+    min_p: float
+    top_k: int
+    logit_bias: dict[int, float] | None
+    prompt_cache: list[Any] | None
+    max_kv_size: int | None
+    kv_bits: float | None
+    kv_group_size: int
+    kv_quant_scheme: str
+    quantized_kv_start: int
+    sampler: Callable[[mx.array], mx.array] | None
+    logits_processors: list[Callable[[mx.array, mx.array], mx.array]] | None
+    prefill_step_size: int | None
+    input_ids: mx.array
+    pixel_values: Any
+    mask: Any
+    resize_shape: tuple[int, int] | None
+    eos_tokens: list[int] | list[str] | None
+    stopping_criteria: Any
+    thinking_budget: int | None
+    thinking_end_token: str
+    thinking_start_token: str | None
+    enable_thinking: bool
+    skip_special_tokens: bool
+    vision_cache: Any
+    prompt_cache_state: Any
+    apc_manager: Any
+    apc_tenant: str | None
+    seed: int | None
+    verbose: bool
+    video: str | list[str] | None

--- a/mlx_vlm/tests/test_generate.py
+++ b/mlx_vlm/tests/test_generate.py
@@ -2,6 +2,7 @@
 
 import logging
 import sys
+import typing
 from argparse import Namespace
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
@@ -1761,6 +1762,24 @@ def test_stream_generate_forwards_verbose_to_generate_step():
         )
 
     assert captured["verbose"] is True
+
+
+def test_public_generation_annotations_match_runtime_results():
+    hints = typing.get_type_hints(dispatch_module.stream_generate)
+
+    assert hints["return"] == typing.Generator[GenerationResult, None, None]
+    assert type(None) in typing.get_args(hints["image"])
+    assert type(None) in typing.get_args(hints["audio"])
+    assert type(None) in typing.get_args(hints["video"])
+
+
+def test_batch_generate_optional_input_annotations_match_defaults():
+    hints = typing.get_type_hints(ar_module.batch_generate)
+
+    assert type(None) in typing.get_args(hints["images"])
+    assert type(None) in typing.get_args(hints["audios"])
+    assert type(None) in typing.get_args(hints["prompts"])
+    assert hints["return"] is BatchResponse
 
 
 def test_normalize_resize_shape_expands_single_value():


### PR DESCRIPTION
## Summary

* Add exported `ProcessorLike` and `GenerateKwargs` helper types for the public generation API.
* Tighten `generate()` and `stream_generate()` annotations so streaming yields `GenerationResult` objects.
* Fix optional defaults for `batch_generate()` inputs and cover the annotations in tests.

Closes Blaizzy/mlx-vlm#825

## Validation

* `uv run --with pytest pytest mlx_vlm/tests/test_generate.py -q`