### PR TITLE
Avoid thinking budget decode synchronization

### DIFF
--- a/mlx_vlm/generate/ar.py
+++ b/mlx_vlm/generate/ar.py
@@ -1238,7 +1238,8 @@ class GenerationBatch:
 
         keep = []
         responses = []
-        forced_next_tokens = None
+        forced_next_tokens = [None] * len(self.uids)
+        fallback_next_tokens = {}
         for i in range(len(self.uids)):
             finish_reason = None
             self._num_tokens[i] += 1
@@ -1249,15 +1250,15 @@ class GenerationBatch:
             ):
                 criteria = self.thinking_budget_criteria[i]
                 criteria(tok)
-                if forced_next_tokens is None:
-                    mx.eval(self._next_tokens)
-                    forced_next_tokens = self._next_tokens.tolist()
-                next_y = criteria.apply_forced_token(
-                    mx.array([forced_next_tokens[i]], dtype=mx.int32)
-                )
-                next_token = int(next_y.item())
-                if next_token != forced_next_tokens[i]:
-                    forced_next_tokens[i] = next_token
+                pop_forced_token_id = getattr(criteria, "pop_forced_token_id", None)
+                if callable(pop_forced_token_id):
+                    forced_next_tokens[i] = pop_forced_token_id()
+                else:
+                    # Keep compatibility with custom criteria without
+                    # materializing the asynchronously generated token.
+                    fallback_next_tokens[i] = criteria.apply_forced_token(
+                        self._next_tokens[i : i + 1]
+                    )
 
             if self.stop_criteria(tok):
                 finish_reason = "stop"
@@ -1281,8 +1282,26 @@ class GenerationBatch:
                 )
             )
 
-        if forced_next_tokens is not None:
-            self._next_tokens = mx.array(forced_next_tokens, dtype=mx.int32)
+        has_forced_next_tokens = any(token is not None for token in forced_next_tokens)
+        if has_forced_next_tokens:
+            force_mask = mx.array(
+                [token is not None for token in forced_next_tokens], dtype=mx.bool_
+            )
+            replacements = mx.array(
+                [token if token is not None else 0 for token in forced_next_tokens],
+                dtype=self._next_tokens.dtype,
+            )
+            self._next_tokens = mx.where(force_mask, replacements, self._next_tokens)
+
+        if fallback_next_tokens:
+            self._next_tokens = mx.concatenate(
+                [
+                    fallback_next_tokens.get(i, self._next_tokens[i : i + 1])
+                    for i in range(len(self.uids))
+                ]
+            )
+
+        if has_forced_next_tokens or fallback_next_tokens:
             mx.async_eval(self._next_tokens)
 
         if len(keep) < len(self.uids):

--- a/mlx_vlm/tests/test_generate.py
+++ b/mlx_vlm/tests/test_generate.py
@@ -710,6 +710,51 @@ class TestBatchGenerator:
         second = batch.next()
         assert [r.token for r in second] == [3]
 
+    def test_generation_batch_thinking_budget_does_not_sync_next_token(self):
+        class FixedLogitModel:
+            def __call__(self, input_ids, cache=None, **kwargs):
+                token_scores = mx.array([0.0, 10.0, 0.0, 0.0])
+                logits = mx.broadcast_to(
+                    token_scores, (input_ids.shape[0], input_ids.shape[1], 4)
+                )
+                return MagicMock(logits=logits)
+
+        class ForceAfterFirst:
+            def __init__(self):
+                self.forced_token_id = None
+
+            def __call__(self, token):
+                self.forced_token_id = 3 if token == 5 else None
+
+            def pop_forced_token_id(self):
+                forced_token_id = self.forced_token_id
+                self.forced_token_id = None
+                return forced_token_id
+
+            def apply_forced_token(self, next_y):
+                return next_y
+
+        batch = GenerationBatch(
+            model=FixedLogitModel(),
+            uids=[0],
+            inputs=mx.array([5], dtype=mx.int32),
+            prompt_cache=[],
+            sampler=lambda logprobs: mx.argmax(logprobs, axis=-1),
+            stop_criteria=lambda token: False,
+            max_tokens=[2],
+            thinking_budget_criteria=[ForceAfterFirst()],
+        )
+
+        original_eval = mx.eval
+        with patch.object(generate_module.mx, "eval", wraps=original_eval) as mock_eval:
+            first = batch.next()
+
+        assert [r.token for r in first] == [5]
+        # GenerationBatch._step synchronizes the current token once. Budget
+        # handling must not add a second synchronization for the next token.
+        assert mock_eval.call_count == 1
+        assert [r.token for r in batch.next()] == [3]
+
     def test_generation_batch_uses_greedy_hidden_argmax_without_logprobs(self):
         class FastArgmaxModel:
             def __init__(self):
@@ -1583,6 +1628,15 @@ class TestThinkingBudgetCriteria:
         forced = criteria(60)  # \n forced
         assert forced == 10
         assert criteria.apply_forced_token(mx.array([0])).tolist() == [10]
+
+    def test_pop_forced_token_id_consumes_pending_token(self):
+        criteria = self._make_criteria()
+        for i in range(5):
+            assert criteria(50 + i) is None
+
+        assert criteria(60) == 10
+        assert criteria.pop_forced_token_id() == 10
+        assert criteria.pop_forced_token_id() is None
 
 
 class TestSamplerArgs:

--- a/mlx_vlm/utils.py
+++ b/mlx_vlm/utils.py
@@ -1956,11 +1956,20 @@ class ThinkingBudgetCriteria:
         return None
 
     def apply_forced_token(self, next_y: mx.array) -> Optional[mx.array]:
-        if self.forced_token_id is not None and self.enable_thinking:
-            next_y = mx.array([self.forced_token_id])
-            self.forced_token_id = None
+        forced_token_id = self.pop_forced_token_id()
+        if forced_token_id is not None:
+            next_y = mx.array([forced_token_id])
             return next_y
         return next_y
+
+    def pop_forced_token_id(self) -> Optional[int]:
+        """Return and clear the pending forced token, if any."""
+        if self.forced_token_id is None or not self.enable_thinking:
+            return None
+
+        forced_token_id = self.forced_token_id
+        self.forced_token_id = None
+        return forced_token_id
 
 
 def print_array_report(t: mx.array, label: Optional[str]) -> dict:


### PR DESCRIPTION
## Summary

- remove the per-token `mx.eval()` and GPU-to-CPU `.tolist()` conversion from continuous-batch thinking budget handling
- consume forced token IDs from CPU-side criterion state and apply overrides with an asynchronous MLX `where` operation only when needed
- preserve compatibility with custom thinking budget criteria
- add regression coverage for forced-token behavior and the absence of an extra synchronization

## Root cause

`GenerationBatch.next()` materialized the asynchronously generated next-token array on every token whenever a thinking budget criterion was active. That synchronization broke the decode-ahead pipeline even before the budget was reached and caused a repeatable ~20% decode slowdown.

## Impact

Using `prism-ml/Bonsai-27B-mlx-1bit`, 500 generated tokens, batch size 1, and the server's built-in `/v1/metrics` endpoint:

| Mode | Before | After samples | After mean |
| --- | ---: | --- | ---: |
| No budget | 34.89 / 34.78 tok/s | 35.18 / 34.30 / 33.48 tok/s | 34.32 tok/s |
| Budget 512 | 27.84 tok/s | 34.59 / 32.58 tok/s | 33.59 tok/s |

The deterministic ~20% regression is removed. Post-fix means differ by ~2.1%, with overlapping run-to-run and thermal variation.

## Validation

- `uv run --with pytest pytest -q mlx_vlm/tests/test_generate.py mlx_vlm/tests/test_server.py` — 286 passed
- commit hooks: Black, isort, and autoflake passed
- `git diff --check` passed