### PR TITLE
make mlx-lm optional for text-only fallback + text-model LoRA

### DIFF
--- a/mlx_vlm/models/text_only.py
+++ b/mlx_vlm/models/text_only.py
@@ -34,7 +34,14 @@ class ModelConfig(AttributeConfig):
     @classmethod
     def from_dict(cls, params):
         params = dict(params or {})
-        from mlx_lm.utils import _get_classes
+        try:
+            from mlx_lm.utils import _get_classes
+        except ImportError as e:
+            raise ImportError(
+                f"Loading text-only model_type '{params.get('model_type')}' relies "
+                "on mlx-lm's model registry (no native mlx-vlm implementation). "
+                "Install it with `pip install mlx-lm`."
+            ) from e
 
         model_class, model_args_class = _get_classes(params)
         return cls(params, model_class, model_args_class)

--- a/mlx_vlm/tests/test_trainer_utils.py
+++ b/mlx_vlm/tests/test_trainer_utils.py
@@ -78,21 +78,32 @@ class TestTrainerUtils(unittest.TestCase):
         result = find_all_linear_names(model)
         self.assertEqual(set(result), {"layer1", "layer2"})
 
-    @patch("mlx_lm.utils.load_adapters")
-    def test_apply_lora_layers_dispatches_text_model_adapters(self, mock_load_adapters):
-        inner_model = MagicMock()
-        loaded_inner_model = MagicMock()
-        mock_load_adapters.return_value = loaded_inner_model
+    @patch("mlx_vlm.trainer.utils._apply_lora_layers")
+    def test_apply_lora_layers_dispatches_text_model_adapters(self, mock_apply):
+        with TemporaryDirectory() as tmpdir:
+            adapter_dir = Path(tmpdir) / "adapter"
+            adapter_dir.mkdir()
+            (adapter_dir / "adapter_config.json").write_text(
+                '{"lora_parameters": {"rank": 4, "scale": 2.0, "dropout": 0.0}}'
+            )
+            (adapter_dir / "adapters.safetensors").touch()
 
-        model = MagicMock()
-        model._is_text_model = True
-        model.language_model._model = inner_model
+            inner_model = MagicMock()
+            loaded_inner_model = MagicMock()
+            mock_apply.return_value = loaded_inner_model
 
-        result = apply_lora_layers(model, "adapter-dir")
+            model = MagicMock()
+            model._is_text_model = True
+            model.language_model._model = inner_model
 
-        self.assertIs(result, model)
-        mock_load_adapters.assert_called_once_with(inner_model, "adapter-dir")
-        self.assertIs(model.language_model._model, loaded_inner_model)
+            result = apply_lora_layers(model, str(adapter_dir))
+
+            self.assertIs(result, model)
+            self.assertIs(mock_apply.call_args[0][0], inner_model)
+            loaded_inner_model.load_weights.assert_called_once_with(
+                str(adapter_dir / "adapters.safetensors"), strict=False
+            )
+            self.assertIs(model.language_model._model, loaded_inner_model)
 
     @patch("mlx_vlm.trainer.utils.get_peft_model")
     def test_apply_lora_layers_keeps_vlm_adapter_schema(self, mock_get_peft):

--- a/mlx_vlm/trainer/utils.py
+++ b/mlx_vlm/trainer/utils.py
@@ -321,7 +321,13 @@ def apply_lora_layers(model: nn.Module, adapter_path: str) -> nn.Module:
         nn.Module: The updated model with LoRA layers applied.
     """
     if getattr(model, "_is_text_model", False):
-        from mlx_lm.utils import load_adapters
+        try:
+            from mlx_lm.utils import load_adapters
+        except ImportError as e:
+            raise ImportError(
+                "Loading LoRA adapters for a text-only fallback model relies on "
+                "mlx-lm. Install it with `pip install mlx-lm`."
+            ) from e
 
         model.language_model._model = load_adapters(
             model.language_model._model, adapter_path

--- a/mlx_vlm/trainer/utils.py
+++ b/mlx_vlm/trainer/utils.py
@@ -320,19 +320,8 @@ def apply_lora_layers(model: nn.Module, adapter_path: str) -> nn.Module:
     Returns:
         nn.Module: The updated model with LoRA layers applied.
     """
-    if getattr(model, "_is_text_model", False):
-        try:
-            from mlx_lm.utils import load_adapters
-        except ImportError as e:
-            raise ImportError(
-                "Loading LoRA adapters for a text-only fallback model relies on "
-                "mlx-lm. Install it with `pip install mlx-lm`."
-            ) from e
-
-        model.language_model._model = load_adapters(
-            model.language_model._model, adapter_path
-        )
-        return model
+    is_text_model = getattr(model, "_is_text_model", False)
+    target = model.language_model._model if is_text_model else model
 
     adapter_path = Path(adapter_path)
 
@@ -345,13 +334,16 @@ def apply_lora_layers(model: nn.Module, adapter_path: str) -> nn.Module:
             raise ValueError("The adapter does not have lora params in the config")
 
     if "lora_parameters" in config:
-        model = _apply_lora_layers(model, config)
+        target = _apply_lora_layers(target, config)
     else:
-        model = _apply_legacy_lora_layers(model, config)
+        target = _apply_legacy_lora_layers(target, config)
 
-    model.load_weights(str(adapter_path / "adapters.safetensors"), strict=False)
+    target.load_weights(str(adapter_path / "adapters.safetensors"), strict=False)
 
-    return model
+    if is_text_model:
+        model.language_model._model = target
+        return model
+    return target
 
 
 def unfreeze_modules(model: nn.Module, module_names):


### PR DESCRIPTION
The last two mlx_lm touchpoints (text_only._get_classes, trainer.load_adapters) are the fallback for text architectures mlx-vlm has not vendored natively; they inherently use mlx-lm's model/tuner registries. 

Part of the mlx-lm removal series (#1509, #1516, etc).

Verified: works with mlx-lm present; clear error (not raw ImportError) when absent.