### PR TITLE
trainer: load text-model LoRA adapters via mlx-vlm's own loader

### DIFF
--- a/mlx_vlm/tests/test_trainer_utils.py
+++ b/mlx_vlm/tests/test_trainer_utils.py
@@ -78,21 +78,32 @@ class TestTrainerUtils(unittest.TestCase):
         result = find_all_linear_names(model)
         self.assertEqual(set(result), {"layer1", "layer2"})
 
-    @patch("mlx_lm.utils.load_adapters")
-    def test_apply_lora_layers_dispatches_text_model_adapters(self, mock_load_adapters):
-        inner_model = MagicMock()
-        loaded_inner_model = MagicMock()
-        mock_load_adapters.return_value = loaded_inner_model
+    @patch("mlx_vlm.trainer.utils._apply_lora_layers")
+    def test_apply_lora_layers_dispatches_text_model_adapters(self, mock_apply):
+        with TemporaryDirectory() as tmpdir:
+            adapter_dir = Path(tmpdir) / "adapter"
+            adapter_dir.mkdir()
+            (adapter_dir / "adapter_config.json").write_text(
+                '{"lora_parameters": {"rank": 4, "scale": 2.0, "dropout": 0.0}}'
+            )
+            (adapter_dir / "adapters.safetensors").touch()
 
-        model = MagicMock()
-        model._is_text_model = True
-        model.language_model._model = inner_model
+            inner_model = MagicMock()
+            loaded_inner_model = MagicMock()
+            mock_apply.return_value = loaded_inner_model
 
-        result = apply_lora_layers(model, "adapter-dir")
+            model = MagicMock()
+            model._is_text_model = True
+            model.language_model._model = inner_model
 
-        self.assertIs(result, model)
-        mock_load_adapters.assert_called_once_with(inner_model, "adapter-dir")
-        self.assertIs(model.language_model._model, loaded_inner_model)
+            result = apply_lora_layers(model, str(adapter_dir))
+
+            self.assertIs(result, model)
+            self.assertIs(mock_apply.call_args[0][0], inner_model)
+            loaded_inner_model.load_weights.assert_called_once_with(
+                str(adapter_dir / "adapters.safetensors"), strict=False
+            )
+            self.assertIs(model.language_model._model, loaded_inner_model)
 
     @patch("mlx_vlm.trainer.utils.get_peft_model")
     def test_apply_lora_layers_keeps_vlm_adapter_schema(self, mock_get_peft):

--- a/mlx_vlm/trainer/utils.py
+++ b/mlx_vlm/trainer/utils.py
@@ -322,7 +322,7 @@ def apply_lora_layers(model: nn.Module, adapter_path: str) -> nn.Module:
     """
     is_text_model = getattr(model, "_is_text_model", False)
     # Text-only fallback models wrap the inner LM as language_model._model;
-    # apply LoRA to that inner module with mlx-vlm's own loader 
+    # apply LoRA to that inner module with mlx-vlm's own loader
     target = model.language_model._model if is_text_model else model
 
     adapter_path = Path(adapter_path)

--- a/mlx_vlm/trainer/utils.py
+++ b/mlx_vlm/trainer/utils.py
@@ -322,8 +322,7 @@ def apply_lora_layers(model: nn.Module, adapter_path: str) -> nn.Module:
     """
     is_text_model = getattr(model, "_is_text_model", False)
     # Text-only fallback models wrap the inner LM as language_model._model;
-    # apply LoRA to that inner module with mlx-vlm's own loader (previously this
-    # delegated to mlx_lm.utils.load_adapters).
+    # apply LoRA to that inner module with mlx-vlm's own loader 
     target = model.language_model._model if is_text_model else model
 
     adapter_path = Path(adapter_path)

--- a/mlx_vlm/trainer/utils.py
+++ b/mlx_vlm/trainer/utils.py
@@ -320,13 +320,11 @@ def apply_lora_layers(model: nn.Module, adapter_path: str) -> nn.Module:
     Returns:
         nn.Module: The updated model with LoRA layers applied.
     """
-    if getattr(model, "_is_text_model", False):
-        from mlx_lm.utils import load_adapters
-
-        model.language_model._model = load_adapters(
-            model.language_model._model, adapter_path
-        )
-        return model
+    is_text_model = getattr(model, "_is_text_model", False)
+    # Text-only fallback models wrap the inner LM as language_model._model;
+    # apply LoRA to that inner module with mlx-vlm's own loader (previously this
+    # delegated to mlx_lm.utils.load_adapters).
+    target = model.language_model._model if is_text_model else model
 
     adapter_path = Path(adapter_path)
 
@@ -339,13 +337,16 @@ def apply_lora_layers(model: nn.Module, adapter_path: str) -> nn.Module:
             raise ValueError("The adapter does not have lora params in the config")
 
     if "lora_parameters" in config:
-        model = _apply_lora_layers(model, config)
+        target = _apply_lora_layers(target, config)
     else:
-        model = _apply_legacy_lora_layers(model, config)
+        target = _apply_legacy_lora_layers(target, config)
 
-    model.load_weights(str(adapter_path / "adapters.safetensors"), strict=False)
+    target.load_weights(str(adapter_path / "adapters.safetensors"), strict=False)
 
-    return model
+    if is_text_model:
+        model.language_model._model = target
+        return model
+    return target
 
 
 def unfreeze_modules(model: nn.Module, module_names):


### PR DESCRIPTION
apply_lora_layers delegated the _is_text_model branch to mlx_lm.utils.load_adapters. Route it through mlx-vlm's own _apply_lora_layers/_apply_legacy_lora_layers on the wrapped inner model instead, removing trainer/utils.py's mlx_lm import. Part of the mlx-lm removal series 


verified on phi-3.5 adapter loads with round-trip fidelity and full test_trainer.py passes!

