### PR TITLE
Preserve MLX attention masks during preprocessing

### DIFF
--- a/mlx_vlm/tests/test_utils.py
+++ b/mlx_vlm/tests/test_utils.py
@@ -3,6 +3,7 @@ import json
 import struct
 from io import BytesIO
 from pathlib import Path
+from threading import Thread
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
@@ -404,6 +405,37 @@ def test_prepare_inputs():
     )
     assert "input_ids" in inputs
     assert mx.array_equal(inputs["input_ids"], mx.array([[1, 2, 3]]))
+
+
+def test_prepare_inputs_preserves_mlx_attention_mask_for_thread_handoff():
+    attention_mask = mx.array([[1, 1]], dtype=mx.int32)
+
+    class Processor:
+        tokenizer = SimpleNamespace(pad_token="[PAD]", eos_token="[EOS]")
+
+        def __call__(self, text=None, images=None, padding=None, return_tensors="mlx"):
+            return {
+                "input_ids": mx.array([[1, 2]], dtype=mx.int32),
+                "attention_mask": attention_mask,
+                "pixel_values": mx.zeros((1, 2), dtype=mx.float32),
+            }
+
+    inputs = prepare_inputs(
+        Processor(),
+        prompts="test <image>",
+        images=mx.zeros((3, 8, 8)),
+    )
+    consumed = []
+
+    def consume_attention_mask():
+        consumed.append(inputs["attention_mask"].tolist())
+
+    worker = Thread(target=consume_attention_mask)
+    worker.start()
+    worker.join(timeout=1)
+
+    assert inputs["attention_mask"] is attention_mask
+    assert consumed == [[[1, 1]]]
 
 
 def test_process_inputs_with_fallback():

--- a/mlx_vlm/utils.py
+++ b/mlx_vlm/utils.py
@@ -1760,8 +1760,11 @@ def prepare_inputs(
             inputs["pixel_values"] = inputs["images"]
             inputs.pop("images")
 
+        attention_mask = inputs.get("attention_mask")
         model_inputs["attention_mask"] = (
-            mx.array(inputs["attention_mask"]) if "attention_mask" in inputs else None
+            attention_mask
+            if attention_mask is None or isinstance(attention_mask, mx.array)
+            else mx.array(attention_mask)
         )
 
         # Convert inputs to model_inputs with mx.array if present


### PR DESCRIPTION
## Summary

Closes #1591.

- Preserve an `attention_mask` that a model processor already returned as an MLX array instead of wrapping it in another `mx.array()` operation.
- Add a regression test that consumes the processed attention mask from a different thread.

## Root cause

Qwen3.5 uses the custom `Qwen3VLProcessor`, whose direct `input_ids`, `attention_mask`, `pixel_values`, and `image_grid_thw` outputs are materialized and safe to consume across threads.

The generic `prepare_inputs()` path subsequently called `mx.array(inputs["attention_mask"])` even when the value was already an MLX array. That redundant conversion created a lazy graph associated with the request caller's MLX stream. When `ResponseGenerator` handed the result to its dedicated generation thread, Qwen3.5 evaluated the mask in `get_rope_index()` and raised `RuntimeError: There is no Stream(gpu, N) in current thread`.

Preserving existing MLX arrays removes the lazy re-wrap at its source without forcing eager evaluation of every preprocessed request input.

## Impact

Mixed text/image requests using Qwen3.5 through `ResponseGenerator` now complete instead of failing in the generation thread and leaving the caller blocked waiting for a generation context.

This supersedes #1592 with a narrower fix based on tracing the custom processor's direct outputs.

## Validation

- Reproduced the failure with `Qwen/Qwen3.5-0.8B` before the fix.
- Confirmed the same multimodal request completes after applying only this `prepare_inputs()` change.
- `230 passed`: utility tests, `TestQwen3VLProcessor`, and the full server test module.
- Black, isort, autoflake, and `git diff --check` pass.