### PR TITLE
Add Chat Completions tool choice support

### DIFF
--- a/mlx_vlm/server/openai.py
+++ b/mlx_vlm/server/openai.py
@@ -157,6 +157,110 @@ def _ensure_effective_input(messages, *, images=None, audio=None):
     raise HTTPException(status_code=400, detail=_MISSING_INPUT_DETAIL)
 
 
+def _tool_function_name(tool: Any) -> Optional[str]:
+    if hasattr(tool, "model_dump"):
+        tool = tool.model_dump(exclude_none=True)
+    if not isinstance(tool, dict) or tool.get("type") != "function":
+        return None
+    function = tool.get("function")
+    if hasattr(function, "model_dump"):
+        function = function.model_dump(exclude_none=True)
+    if not isinstance(function, dict):
+        return None
+    name = function.get("name")
+    return name if isinstance(name, str) and name else None
+
+
+def _with_tool_choice_instruction(messages, instruction: str):
+    messages = [dict(message) for message in messages]
+    if messages and messages[0].get("role") == "system":
+        content = messages[0].get("content") or ""
+        messages[0]["content"] = f"{content}\n\n{instruction}".strip()
+    user_instruction_added = False
+    for message in reversed(messages):
+        if message.get("role") == "user" and isinstance(message.get("content"), str):
+            message["content"] = f"{message['content']}\n\n{instruction}".strip()
+            user_instruction_added = True
+            break
+    if not user_instruction_added and not (
+        messages and messages[0].get("role") == "system"
+    ):
+        messages.insert(0, {"role": "system", "content": instruction})
+    return messages
+
+
+def _prepare_chat_tool_choice(messages, tools, tool_choice):
+    """Validate and enforce OpenAI Chat Completions tool_choice semantics."""
+    available_tools = list(tools or [])
+    if tool_choice is None:
+        return messages, available_tools or None, None
+
+    if hasattr(tool_choice, "model_dump"):
+        tool_choice = tool_choice.model_dump(exclude_none=True)
+
+    if isinstance(tool_choice, str):
+        if tool_choice not in ("none", "auto", "required"):
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    "Invalid tool_choice. Expected 'none', 'auto', 'required', "
+                    "or a specific function."
+                ),
+            )
+        if tool_choice == "none":
+            return messages, None, tool_choice
+        if tool_choice == "auto":
+            return messages, available_tools or None, tool_choice
+        if not available_tools:
+            raise HTTPException(
+                status_code=400,
+                detail="tool_choice 'required' requires at least one tool.",
+            )
+        instruction = (
+            "You must call one or more of the available functions to answer the "
+            "user's request. Do not answer directly without calling a function."
+        )
+        return (
+            _with_tool_choice_instruction(messages, instruction),
+            available_tools,
+            tool_choice,
+        )
+
+    if not isinstance(tool_choice, dict):
+        raise HTTPException(status_code=400, detail="Invalid tool_choice.")
+
+    function = tool_choice.get("function")
+    if hasattr(function, "model_dump"):
+        function = function.model_dump(exclude_none=True)
+    name = function.get("name") if isinstance(function, dict) else None
+    if tool_choice.get("type") != "function" or not isinstance(name, str) or not name:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "A specific tool_choice must be "
+                "{'type':'function','function':{'name':'...'}}."
+            ),
+        )
+
+    selected_tools = [
+        tool for tool in available_tools if _tool_function_name(tool) == name
+    ]
+    if not selected_tools:
+        raise HTTPException(
+            status_code=400,
+            detail=f"tool_choice references unknown function {name!r}.",
+        )
+    instruction = (
+        f"You must call the {name!r} function to answer the user's request. "
+        "Do not call any other function and do not answer directly."
+    )
+    return (
+        _with_tool_choice_instruction(messages, instruction),
+        selected_tools,
+        tool_choice,
+    )
+
+
 def _runtime_cache_get(key, default=None, *, kind=None):
     cache = runtime.model_cache
     try:
@@ -1545,12 +1649,19 @@ async def chat_completions_endpoint(request: ChatRequest, http_request: Request)
 
         _ensure_effective_input(processed_messages, images=images, audio=audio)
 
+        processed_messages, tools, tool_choice = _prepare_chat_tool_choice(
+            processed_messages,
+            request.tools,
+            request.tool_choice,
+        )
+
         model, processor, config = get_cached_model(request.model, adapter_path)
 
         # Detect tool parser from chat template
-        tools = getattr(request, "tools", None)
         tool_parser_type = _infer_tool_parser_from_processor(processor)
         tool_module = load_tool_module(tool_parser_type) if tool_parser_type else None
+        if not tools:
+            tool_module = None
 
         try:
             gen_args = _build_gen_args(
@@ -1561,6 +1672,10 @@ async def chat_completions_endpoint(request: ChatRequest, http_request: Request)
         if tools and tool_module is not None:
             gen_args.skip_special_tokens = False
 
+        template_kwargs = gen_args.to_template_kwargs()
+        if tool_choice is not None:
+            template_kwargs["tool_choice"] = tool_choice
+
         formatted_prompt = apply_chat_template(
             processor,
             config,
@@ -1569,7 +1684,7 @@ async def chat_completions_endpoint(request: ChatRequest, http_request: Request)
             num_audios=len(audio),
             video=videos or None,
             tools=tools,
-            **gen_args.to_template_kwargs(),
+            **template_kwargs,
         )
 
         logger.debug(

--- a/mlx_vlm/server/schemas.py
+++ b/mlx_vlm/server/schemas.py
@@ -795,6 +795,13 @@ class StreamOptions(BaseModel):
 class ChatRequest(GenerationRequest):
     messages: List[ChatMessage]
     stream_options: Optional[StreamOptions] = None
+    tools: Optional[List[Any]] = Field(None, description="Tools the model may call.")
+    tool_choice: Optional[Any] = Field(
+        None,
+        description=(
+            "Controls tool use: none, auto, required, or a specific function."
+        ),
+    )
 
 
 class TopLogprob(BaseModel):

--- a/mlx_vlm/tests/test_server.py
+++ b/mlx_vlm/tests/test_server.py
@@ -135,6 +135,13 @@ def test_chat_request_schema_requires_model():
     assert "model" in server.ChatRequest.model_json_schema()["required"]
 
 
+def test_chat_request_schema_declares_tool_choice_fields():
+    properties = server.ChatRequest.model_json_schema()["properties"]
+
+    assert "tools" in properties
+    assert "tool_choice" in properties
+
+
 def test_chat_request_schema_allows_one_or_two_resize_shape_values():
     resize_shape = server.ChatRequest.model_json_schema()["properties"]["resize_shape"]
     lengths = {
@@ -144,6 +151,174 @@ def test_chat_request_schema_allows_one_or_two_resize_shape_values():
     }
 
     assert lengths == {(1, 1), (2, 2)}
+
+
+def test_chat_completions_tool_choice_none_disables_tools(client, monkeypatch):
+    monkeypatch.setattr(server.runtime, "response_generator", None)
+    model = SimpleNamespace()
+    processor = SimpleNamespace(
+        tokenizer=SimpleNamespace(chat_template="<tool_call>\n<function=")
+    )
+    config = SimpleNamespace(model_type="qwen3_5")
+    result = GenerationResult(
+        text="No tool call.", prompt_tokens=5, generation_tokens=3
+    )
+    tools = [
+        {
+            "type": "function",
+            "function": {"name": "get_weather", "parameters": {"type": "object"}},
+        }
+    ]
+
+    with (
+        patch.object(
+            server, "get_cached_model", return_value=(model, processor, config)
+        ),
+        patch.object(
+            server, "apply_chat_template", return_value="prompt"
+        ) as mock_template,
+        patch.object(server, "generate", return_value=result),
+    ):
+        response = client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "demo",
+                "messages": [{"role": "user", "content": "Use the tool."}],
+                "tools": tools,
+                "tool_choice": "none",
+            },
+        )
+
+    assert response.status_code == 200
+    assert response.json()["choices"][0]["message"]["tool_calls"] is None
+    assert mock_template.call_args.kwargs["tools"] is None
+    assert mock_template.call_args.kwargs["tool_choice"] == "none"
+
+
+def test_chat_completions_required_tool_choice_adds_instruction(client, monkeypatch):
+    monkeypatch.setattr(server.runtime, "response_generator", None)
+    model = SimpleNamespace()
+    processor = SimpleNamespace()
+    config = SimpleNamespace(model_type="qwen2_vl")
+    result = GenerationResult(text="done", prompt_tokens=5, generation_tokens=2)
+    tools = [
+        {
+            "type": "function",
+            "function": {"name": "get_weather", "parameters": {"type": "object"}},
+        }
+    ]
+
+    with (
+        patch.object(
+            server, "get_cached_model", return_value=(model, processor, config)
+        ),
+        patch.object(
+            server, "apply_chat_template", return_value="prompt"
+        ) as mock_template,
+        patch.object(server, "generate", return_value=result),
+    ):
+        response = client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "demo",
+                "messages": [{"role": "user", "content": "Weather?"}],
+                "tools": tools,
+                "tool_choice": "required",
+            },
+        )
+
+    assert response.status_code == 200
+    messages = mock_template.call_args.args[2]
+    assert messages[0]["role"] == "user"
+    assert "must call one or more" in messages[0]["content"]
+    assert mock_template.call_args.kwargs["tools"] == tools
+    assert mock_template.call_args.kwargs["tool_choice"] == "required"
+
+
+def test_chat_completions_forced_tool_choice_filters_tools(client, monkeypatch):
+    monkeypatch.setattr(server.runtime, "response_generator", None)
+    model = SimpleNamespace()
+    processor = SimpleNamespace()
+    config = SimpleNamespace(model_type="qwen2_vl")
+    result = GenerationResult(text="done", prompt_tokens=5, generation_tokens=2)
+    tools = [
+        {
+            "type": "function",
+            "function": {"name": "get_time", "parameters": {"type": "object"}},
+        },
+        {
+            "type": "function",
+            "function": {"name": "get_weather", "parameters": {"type": "object"}},
+        },
+    ]
+    tool_choice = {"type": "function", "function": {"name": "get_weather"}}
+
+    with (
+        patch.object(
+            server, "get_cached_model", return_value=(model, processor, config)
+        ),
+        patch.object(
+            server, "apply_chat_template", return_value="prompt"
+        ) as mock_template,
+        patch.object(server, "generate", return_value=result),
+    ):
+        response = client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "demo",
+                "messages": [
+                    {"role": "system", "content": "Be concise."},
+                    {"role": "user", "content": "Say hello."},
+                ],
+                "tools": tools,
+                "tool_choice": tool_choice,
+            },
+        )
+
+    assert response.status_code == 200
+    messages = mock_template.call_args.args[2]
+    assert messages[0]["content"].startswith("Be concise.")
+    assert "must call the 'get_weather' function" in messages[0]["content"]
+    assert "must call the 'get_weather' function" in messages[-1]["content"]
+    selected_tools = mock_template.call_args.kwargs["tools"]
+    assert [tool["function"]["name"] for tool in selected_tools] == ["get_weather"]
+    assert mock_template.call_args.kwargs["tool_choice"] == tool_choice
+
+
+@pytest.mark.parametrize(
+    ("tools", "tool_choice", "detail"),
+    [
+        ([], "required", "requires at least one tool"),
+        (
+            [
+                {
+                    "type": "function",
+                    "function": {"name": "get_weather"},
+                }
+            ],
+            {"type": "function", "function": {"name": "missing"}},
+            "unknown function 'missing'",
+        ),
+        ([], "sometimes", "Invalid tool_choice"),
+    ],
+)
+def test_chat_completions_rejects_invalid_tool_choice(
+    client, tools, tool_choice, detail
+):
+    with patch.object(server, "get_cached_model") as mock_get_cached_model:
+        response = client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "demo",
+                "messages": [{"role": "user", "content": "Hello"}],
+                "tools": tools,
+                "tool_choice": tool_choice,
+            },
+        )
+
+    assert response.status_code == 400
+    assert detail in response.json()["detail"]
+    mock_get_cached_model.assert_not_called()
 
 
 def test_speculative_server_dispatches_mtp_batch_loop():


### PR DESCRIPTION
## Summary

Add OpenAI-compatible `tool_choice` handling to `/v1/chat/completions`.

- declare `tools` and `tool_choice` on the chat request schema
- support `auto`, `none`, `required`, and forced named functions
- disable tool exposure and parsing when `tool_choice` is `none`
- restrict forced choices to the selected function
- validate invalid choices, missing tools, and unknown function names
- forward `tool_choice` to model chat templates
- add fallback prompt guidance for templates that do not consume `tool_choice`

This addresses the missing `tool_choice` portion of #1604.

## Root cause

The Chat Completions endpoint forwarded `tools` into the model chat template but did not declare, validate, forward, or enforce `tool_choice`. Some templates, including Qwen3.5/Bonsai, expose tools but do not consume a `tool_choice` template argument.

## Behavior

- `none` is enforced server-side by omitting tools and disabling tool-call parsing.
- forced named choices expose only the selected function.
- `required` and forced choices receive explicit prompt guidance when the model template lacks native enforcement.

Prompt-guided enforcement remains model-dependent for small models under directly conflicting user instructions; native constrained decoding is outside this change.

## Validation

- `301 passed`: server, Gemma 4 tool parser, and MiniMax M3 tests
- live non-streaming and streaming checks with:
  - `prism-ml/Ternary-Bonsai-27B-mlx-2bit`
  - `Qwen/Qwen3.5-0.8B`
  - `google/gemma-4-E4B-it`
- pre-commit hooks: Black, isort, and autoflake
