### PR TITLE
Fix APC exact cache short prompt poisoning

### DIFF
--- a/mlx_vlm/apc.py
+++ b/mlx_vlm/apc.py
@@ -494,8 +494,11 @@ def adjust_prefix_to_text_suffix_boundary(
     )
     if max_len <= 0:
         return 0
-    desired = max(1, int(desired_prefix_len))
-    prefix_len = max(desired, media_safe_prefix_min(token_ids, media_token_ids))
+    desired = int(desired_prefix_len)
+    media_min = media_safe_prefix_min(token_ids, media_token_ids)
+    if desired <= 0 and media_min <= 0:
+        return 0
+    prefix_len = max(desired, media_min)
     if prefix_len > max_len:
         return 0
     return prefix_len

--- a/mlx_vlm/generate/ar.py
+++ b/mlx_vlm/generate/ar.py
@@ -2251,13 +2251,17 @@ class BatchGenerator:
         if not ids_list or len(ids_list) < 2:
             return None
         safe_lookup_min = self._apc_safe_prefix_lookup_min(ids_list)
+        exact_lookup_min = max(
+            safe_lookup_min,
+            self.apc_manager.exact_cache_guard_tokens,
+        )
         extra_hash = self._apc_extra_hash(prompt_kwargs or {})
         apc_mode = getattr(self, "apc_mode", "block")
         if apc_mode == "exact":
             exact_cache, exact_prefix_len = self.apc_manager.lookup_exact_cache(
                 ids_list,
                 extra_hash=extra_hash,
-                min_prefix_tokens=safe_lookup_min,
+                min_prefix_tokens=exact_lookup_min,
             )
             if (
                 exact_cache is not None
@@ -2287,7 +2291,7 @@ class BatchGenerator:
             exact_cache, exact_prefix_len = self.apc_manager.lookup_exact_cache(
                 ids_list,
                 extra_hash=extra_hash,
-                min_prefix_tokens=max(prefix_len, safe_lookup_min),
+                min_prefix_tokens=max(prefix_len, exact_lookup_min),
             )
         warm_cache = None
         disk_prefix_len = 0

--- a/mlx_vlm/generate/dispatch.py
+++ b/mlx_vlm/generate/dispatch.py
@@ -822,6 +822,7 @@ def stream_generate(
         multimodal_token_ids,
     )
     apc_safe_prefix_lookup_min = max(0, apc_safe_prefix_min - 1)
+    apc_exact_lookup_min = apc_safe_prefix_lookup_min
 
     def _apc_suffix_is_text_only(prefix_len: int) -> bool:
         return _apc.prefix_leaves_text_only_suffix(
@@ -841,6 +842,11 @@ def stream_generate(
         apc_mode = _apc.model_apc_mode(model.language_model)
         if apc_mode is None:
             apc_manager = None
+        else:
+            apc_exact_lookup_min = max(
+                apc_exact_lookup_min,
+                apc_manager.exact_cache_guard_tokens,
+            )
 
     if apc_manager is not None:
         image_hash = _apc.hash_image_payload(pixel_values=pixel_values, image_ref=image)
@@ -877,7 +883,7 @@ def stream_generate(
             exact_prompt_cache, exact_prefix_len = apc_manager.lookup_exact_cache(
                 full_input_ids_list,
                 extra_hash=apc_extra_hash,
-                min_prefix_tokens=apc_safe_prefix_lookup_min,
+                min_prefix_tokens=apc_exact_lookup_min,
             )
             if (
                 exact_prompt_cache is not None
@@ -905,7 +911,7 @@ def stream_generate(
                 exact_prompt_cache, exact_prefix_len = apc_manager.lookup_exact_cache(
                     full_input_ids_list,
                     extra_hash=apc_extra_hash,
-                    min_prefix_tokens=max(prefix_len, apc_safe_prefix_lookup_min),
+                    min_prefix_tokens=max(prefix_len, apc_exact_lookup_min),
                 )
             disk_prompt_cache = None
             disk_prefix_len = 0

--- a/mlx_vlm/tests/test_apc.py
+++ b/mlx_vlm/tests/test_apc.py
@@ -897,6 +897,50 @@ def test_adjust_prefix_returns_zero_when_no_text_suffix_remains():
     )
 
 
+def test_adjust_prefix_returns_zero_for_short_text_prompt_below_guard():
+    token_ids = list(range(15))
+
+    assert (
+        apc_module.adjust_prefix_to_text_suffix_boundary(
+            token_ids,
+            desired_prefix_len=len(token_ids) - 16,
+            media_token_ids=set(),
+            max_prefix_tokens=len(token_ids) - 1,
+        )
+        == 0
+    )
+
+
+def test_adjust_prefix_allows_media_floor_when_desired_is_non_positive():
+    token_ids = [1, 42, 42, 2, 3]
+
+    assert (
+        apc_module.adjust_prefix_to_text_suffix_boundary(
+            token_ids,
+            desired_prefix_len=-11,
+            media_token_ids={42},
+            max_prefix_tokens=len(token_ids) - 1,
+        )
+        == 3
+    )
+
+
+def test_exact_lookup_can_reject_entries_at_or_below_guard(monkeypatch):
+    monkeypatch.setenv("APC_EXACT_PREFIX_GUARD_TOKENS", "16")
+    manager = APCManager(num_blocks=1, block_size=16)
+    token_ids = list(range(15))
+    assert manager.store_exact_cache(token_ids, _make_exact_row_cache(len(token_ids)))
+
+    warm, matched = manager.lookup_exact_cache(
+        token_ids + [999],
+        min_prefix_tokens=manager.exact_cache_guard_tokens,
+    )
+
+    assert warm is None
+    assert matched == 0
+    manager.close()
+
+
 def test_exact_disk_hit_is_promoted_to_memory(tmp_path, monkeypatch):
     """After a disk restore, the entry is written to _exact_cache so the next
     identical request is served from memory (disk_hits stays unchanged)."""


### PR DESCRIPTION
## Summary

Fixes #1617.

APC exact-mode checkpoint selection treated short text prompts as reusable one-token prefixes because `adjust_prefix_to_text_suffix_boundary()` clamped non-positive desired prefix lengths up to `1`. That allowed a short first prompt to create a degenerate exact-cache entry, and subsequent prompts could match that one token and skip writing a useful checkpoint.

This changes exact-mode APC to:

- return `0` for text-only guarded checkpoint lengths at or below zero
- keep the media-safe floor behavior for multimodal prompts that need media spans included in the prefix
- require exact-cache lookups during generation to exceed `exact_cache_guard_tokens`, so stale one-token entries already on disk do not keep poisoning tenants
- cover the short-prompt and media-floor cases with focused APC tests

## Validation

- `uv run --with pytest pytest mlx_vlm/tests/test_apc.py -q` -> 40 passed, 2 warnings
- pre-commit during commit: `black`, `isort`, `autoflake` passed
- `python3 -m compileall -q mlx_vlm/apc.py mlx_vlm/generate/dispatch.py mlx_vlm/generate/ar.py` passed using the bundled Python runtime