### PR TITLE
Speed up llguidance structured decoding on Qwen 3.5

### DIFF
--- a/mlx_vlm/generate/ar.py
+++ b/mlx_vlm/generate/ar.py
@@ -951,22 +951,27 @@ class GenerationBatch:
             self.token_context = self.token_context[: len(self.uids)]
 
     def _fused_greedy_step(self, inputs: mx.array, fwd_kwargs: dict):
-        if (
-            not self.greedy_sampling
-            or self.compute_logprobs
-            or self.top_logprobs_k > 0
-            or (self.logits_processors and any(self.logits_processors))
-        ):
+        if not self.greedy_sampling or self.compute_logprobs or self.top_logprobs_k > 0:
             return None
 
         fused_greedy_decode = getattr(self._language_model, "fused_greedy_decode", None)
         if not callable(fused_greedy_decode):
             return None
 
+        decode_kwargs = dict(fwd_kwargs)
+        if self.logits_processors and any(self.logits_processors):
+            supports_processors = getattr(
+                self._language_model, "supports_fused_greedy_logits_processors", None
+            )
+            if not callable(supports_processors) or not supports_processors(
+                self.logits_processors
+            ):
+                return None
+            decode_kwargs["logits_processors"] = self.logits_processors
         sampled = fused_greedy_decode(
             inputs[:, None],
             cache=self.prompt_cache,
-            **fwd_kwargs,
+            **decode_kwargs,
         )
         if sampled is None:
             return None
@@ -2670,6 +2675,11 @@ class BatchGenerator:
         prompt_responses = []
 
         # Decode-first: always emit a generation step before touching prefill.
+        yield_after_decode = any(
+            getattr(processor, "requires_immediate_decode_yield", False)
+            for processors in getattr(self._generation_batch, "logits_processors", [])
+            for processor in processors or []
+        )
         if len(self._generation_batch) > 0:
             generation_responses = self._generation_batch.next()
             self._gen_tokens_counter += len(generation_responses)
@@ -2684,6 +2694,8 @@ class BatchGenerator:
                 else:
                     mx.eval([c.state for c in self._generation_batch.prompt_cache])
                 mx.clear_cache()
+            if yield_after_decode:
+                return prompt_responses, generation_responses
 
         if (
             getattr(self._generation_batch, "is_speculative", False)

--- a/mlx_vlm/models/qwen3_5/language.py
+++ b/mlx_vlm/models/qwen3_5/language.py
@@ -437,6 +437,15 @@ _TARGET_VERIFY_QARGMAX_SOURCE = r"""
     }
 """
 
+_TARGET_VERIFY_MASKED_QARGMAX_SOURCE = _TARGET_VERIFY_QARGMAX_SOURCE.replace(
+    "if (n < N_SIZE) {",
+    """if (
+          n < N_SIZE &&
+          ((as_type<uint>(mask[
+                (int(b_idx) * VERIFY_T + t) * mask_shape[1] + (n >> 5)]) >>
+            (n & 31)) & 1u) != 0u) {""",
+)
+
 
 @lru_cache(maxsize=None)
 def _target_verify_qmv_kernel(bits, group_size, dtype, verify_t, k_size, n_size):
@@ -465,6 +474,23 @@ def _target_verify_qargmax_kernel(bits, group_size, dtype, verify_t, k_size, n_s
         output_names=["tile_values", "tile_indices"],
         header=_target_verify_qlinear_header(bits, group_size),
         source=_TARGET_VERIFY_QARGMAX_SOURCE,
+    )
+
+
+@lru_cache(maxsize=None)
+def _target_verify_masked_qargmax_kernel(
+    bits, group_size, dtype, verify_t, k_size, n_size
+):
+    dtype_name = {mx.bfloat16: "bf16", mx.float16: "fp16"}.get(dtype, "unk")
+    return mx.fast.metal_kernel(
+        name=(
+            "qwen3_5_target_verify_masked_qargmax_"
+            f"b{bits}_gs{group_size}_t{verify_t}_k{k_size}_n{n_size}_{dtype_name}"
+        ),
+        input_names=["x", "w", "scales", "biases", "mask"],
+        output_names=["tile_values", "tile_indices"],
+        header=_target_verify_qlinear_header(bits, group_size),
+        source=_TARGET_VERIFY_MASKED_QARGMAX_SOURCE,
     )
 
 
@@ -577,13 +603,17 @@ def _decode_quantized_linears_fused(linears, x: mx.array):
     return tuple(mx.split(output, split_indices, axis=-1))
 
 
-def _target_verify_quantized_argmax(linear, x: mx.array) -> Optional[mx.array]:
+def _target_verify_quantized_argmax(
+    linear, x: mx.array, token_mask: Optional[mx.array] = None
+) -> Optional[mx.array]:
     if not _can_target_verify_quantized(linear, x) or "bias" in linear:
         return None
 
     B, T, K = x.shape
     if T == 1 and 1 < B <= 4:
-        out = _target_verify_quantized_argmax(linear, x.transpose(1, 0, 2))
+        out = _target_verify_quantized_argmax(
+            linear, x.transpose(1, 0, 2), token_mask=token_mask
+        )
         if out is not None:
             return out.transpose(1, 0)
 
@@ -591,11 +621,27 @@ def _target_verify_quantized_argmax(linear, x: mx.array) -> Optional[mx.array]:
     num_tiles = N // 8
 
     x = mx.contiguous(x)
-    kernel = _target_verify_qargmax_kernel(
-        linear.bits, linear.group_size, x.dtype, T, K, N
+    kernel_factory = (
+        _target_verify_masked_qargmax_kernel
+        if token_mask is not None
+        else _target_verify_qargmax_kernel
     )
+    kernel = kernel_factory(linear.bits, linear.group_size, x.dtype, T, K, N)
+    inputs = [x, linear.weight, linear.scales, linear.biases]
+    if token_mask is not None:
+        if token_mask.ndim == 1:
+            token_mask = token_mask[None, :]
+        if (
+            token_mask.dtype != mx.int32
+            or token_mask.shape[0] != B * T
+            or token_mask.shape[1] < (N + 31) // 32
+        ):
+            raise ValueError(
+                "packed token mask must be int32 with one complete row per token"
+            )
+        inputs.append(token_mask)
     tile_values, tile_indices = kernel(
-        inputs=[x, linear.weight, linear.scales, linear.biases],
+        inputs=inputs,
         template=[
             ("T", x.dtype),
             ("VERIFY_T", int(T)),
@@ -2654,13 +2700,47 @@ class LanguageModel(nn.Module):
         logits = self.speculative_logits_from_hidden(hidden)
         return mx.argmax(logits, axis=-1)
 
-    def fused_greedy_decode(self, inputs: mx.array, cache=None, **kwargs):
+    def supports_fused_greedy_logits_processors(self, logits_processors) -> bool:
+        return (
+            len(logits_processors) <= 4
+            and all(
+                processors
+                and len(processors) == 1
+                and callable(getattr(processors[0], "prepare_next_token_mask", None))
+                for processors in logits_processors
+            )
+            and not self.args.tie_word_embeddings
+            and _can_target_verify_quantized_head(self.lm_head)
+            and "bias" not in self.lm_head
+        )
+
+    def fused_greedy_decode(
+        self,
+        inputs: mx.array,
+        cache=None,
+        logits_processors=None,
+        **kwargs,
+    ):
         if (
             self.args.tie_word_embeddings
             or not _can_target_verify_quantized_head(self.lm_head)
             or "bias" in self.lm_head
         ):
             return None
+
+        token_mask = None
+        if logits_processors:
+            if not self.supports_fused_greedy_logits_processors(logits_processors):
+                return None
+            token_mask = mx.concatenate(
+                [
+                    processors[0].prepare_next_token_mask(token)
+                    for processors, token in zip(
+                        logits_processors, inputs[:, -1].tolist()
+                    )
+                ],
+                axis=0,
+            )
 
         output = self(
             inputs,
@@ -2670,9 +2750,13 @@ class LanguageModel(nn.Module):
             **kwargs,
         )
         hidden = output.hidden_states[-1]
-        sampled = _target_verify_quantized_argmax(self.lm_head, hidden)
+        sampled = _target_verify_quantized_argmax(
+            self.lm_head, hidden, token_mask=token_mask
+        )
         if sampled is not None:
             return sampled
+        if token_mask is not None:
+            raise RuntimeError("masked fused greedy decode became unsupported")
         return mx.argmax(self.speculative_logits_from_hidden(hidden), axis=-1)
 
     def speculative_verify_logits(self, inputs: mx.array, cache, sampler):

--- a/mlx_vlm/structured.py
+++ b/mlx_vlm/structured.py
@@ -2,6 +2,52 @@ import json
 from typing import Any
 
 import mlx.core as mx
+import numpy as np
+
+_LLGUIDANCE_MASK_KERNEL = mx.fast.metal_kernel(
+    name="mlx_vlm_llguidance_mask",
+    input_names=["logits", "mask"],
+    output_names=["out"],
+    source="""
+        uint batch = thread_position_in_grid.y;
+        uint token = thread_position_in_grid.x;
+        uint word = token >> 5;
+        uint bit = token & 31;
+        bool allowed = word < mask_shape[1] &&
+            ((as_type<uint>(mask[batch * mask_shape[1] + word]) >> bit) & 1u);
+        uint offset = batch * logits_shape[1] + token;
+        out[offset] = allowed ? logits[offset] : -metal::numeric_limits<T>::infinity();
+    """,
+)
+
+
+def _apply_llguidance_mask(logits: mx.array, mask: mx.array) -> mx.array:
+    if logits.ndim == 1:
+        logits = logits[None, :]
+    if mask.ndim == 1:
+        mask = mask[None, :]
+    return _LLGUIDANCE_MASK_KERNEL(
+        inputs=[logits, mask],
+        template=[("T", logits.dtype)],
+        grid=(logits.shape[1], logits.shape[0], 1),
+        threadgroup=(256, 1, 1),
+        output_shapes=[logits.shape],
+        output_dtypes=[logits.dtype],
+    )[0]
+
+
+def _allocate_shared_bitmask(batch_size: int, vocab_size: int):
+    """Allocate a CPU-writable mask backed by MLX shared memory."""
+    mask = mx.full(
+        (batch_size, (vocab_size + 31) // 32),
+        -1,
+        dtype=mx.int32,
+    )
+    mx.eval(mask)
+    view = np.array(mask, copy=False)
+    if not view.flags["C_CONTIGUOUS"] or not view.flags["WRITEABLE"]:
+        raise RuntimeError("MLX bitmask must expose writable contiguous memory")
+    return mask, view
 
 
 class LLGuidanceLogitsProcessor:
@@ -12,10 +58,15 @@ class LLGuidanceLogitsProcessor:
     (batch, vocab).
     """
 
+    # Do not hold a latency-sensitive constrained token behind unrelated
+    # prompt-prefill work after it has been decoded.
+    requires_immediate_decode_yield = True
+
     def __init__(self, grammar: str, llg_tokenizer) -> None:
         self.grammar = grammar
         self.llg_tokenizer = llg_tokenizer
         self.is_first_token = True
+        self._mask_cursor = -1
 
     def clone(self) -> "LLGuidanceLogitsProcessor":
         return LLGuidanceLogitsProcessor(self.grammar, self.llg_tokenizer)
@@ -24,18 +75,21 @@ class LLGuidanceLogitsProcessor:
         self.is_first_token = True
         self.ll_matchers = None
         self.bitmask = None
+        self.bitmask_mx = None
+        self._mask_buffers = None
+        self._mask_cursor = -1
 
     def _setup(self, batch_size: int) -> None:
-        import llguidance
-        import llguidance.numpy
         from llguidance import LLMatcher
 
         self.ll_matchers = [
             LLMatcher(self.llg_tokenizer, self.grammar) for _ in range(batch_size)
         ]
-        self.bitmask = llguidance.numpy.allocate_token_bitmask(
-            batch_size, self.llg_tokenizer.vocab_size
-        )
+        self._mask_buffers = [
+            _allocate_shared_bitmask(batch_size, self.llg_tokenizer.vocab_size)
+            for _ in range(2)
+        ]
+        self._mask_cursor = -1
 
     def _consume_tokens(self, last_tokens: list[int]) -> None:
         for i, last_token in enumerate(last_tokens):
@@ -44,24 +98,26 @@ class LLGuidanceLogitsProcessor:
             if error:
                 raise ValueError(f"LLGuidance matcher error: {error}")
 
-    def _apply_bitmask(self, logits: mx.array) -> mx.array:
-        import llguidance.mlx
+    def _fill_next_token_mask(self) -> mx.array:
         import llguidance.numpy
 
-        biased_logits = []
-        for i in range(logits.shape[0]):
-            llguidance.numpy.fill_next_token_bitmask(
-                self.ll_matchers[i], self.bitmask, i
-            )
-            row = mx.array(
-                llguidance.mlx.apply_token_bitmask(logits[i], self.bitmask[i])
-            )
-            if row.ndim == 2 and row.shape[0] == 1:
-                row = row[0]
-            biased_logits.append(row)
-        return mx.concatenate(
-            [mx.array(logit)[None, :] for logit in biased_logits], axis=0
-        )
+        self._mask_cursor = (self._mask_cursor + 1) % len(self._mask_buffers)
+        self.bitmask_mx, self.bitmask = self._mask_buffers[self._mask_cursor]
+        for i, matcher in enumerate(self.ll_matchers):
+            llguidance.numpy.fill_next_token_bitmask(matcher, self.bitmask, i)
+        return self.bitmask_mx
+
+    def _apply_bitmask(self, logits: mx.array) -> mx.array:
+        return _apply_llguidance_mask(logits, self._fill_next_token_mask())
+
+    def prepare_next_token_mask(self, last_token: int) -> mx.array:
+        """Advance one matcher and return its packed MLX token mask."""
+        if self.is_first_token:
+            self._setup(1)
+            self.is_first_token = False
+        else:
+            self._consume_tokens([last_token])
+        return self._fill_next_token_mask()
 
     def process_last_token(self, last_token: int, logits: mx.array) -> mx.array:
         if logits.ndim == 1:


### PR DESCRIPTION
## Summary

- keep llguidance grammar matching on CPU while exposing its packed token mask through MLX shared memory
- apply the packed mask with Metal and avoid materializing full-vocabulary logits in Qwen 3.5's quantized greedy decode
- keep AR model-agnostic by forwarding logits processors only through an advertised fused-decoding capability
- yield latency-sensitive constrained decode responses before unrelated prompt-prefill work
- support constrained fused decoding for batches up to 4

## Root cause

Claude Code 2.1.205 sends a short background structured-output request for internal utilities while its foreground request is also being processed. The previous path copied the llguidance NumPy mask back into MLX, materialized full logits, and could hold each completed structured token behind unrelated prompt prefill. The reproduced 400-token/10-token request therefore reported 0.055 decode tok/s and 180.6 seconds of decode time.

## Performance

Exact Claude Code structured-output request using `prism-ml/Bonsai-27B-mlx-1bit`:

| Run | Prefill tok/s | Decode tok/s | Decode time |
| --- | ---: | ---: | ---: |
| Original pathological run | 119.8 | 0.055 | 180.6s |
| Refactored clean run 1 | 122.75 | 41.97 | 0.238s |
| Refactored clean run 2 | 122.28 | 42.76 | 0.234s |

The two clean runs average 122.52 prefill tok/s and 42.36 decode tok/s.

## Validation

- `453 passed` across generate, structured-output, server, and speculative tests
- actual Metal masked-argmax validation at batch size 4
- exact Claude Code request completed its 400-input/10-output structured utility response normally
- Black, isort, autoflake, and `git diff --check` pass
- one pre-existing bfloat16 exact-equality test remains failing and was confirmed to fail identically on untouched commit `9aacec1a`