### PR TITLE
Add APC default tenant fallback

### DIFF
--- a/mlx_vlm/server/app.py
+++ b/mlx_vlm/server/app.py
@@ -272,14 +272,17 @@ def _model_config_field_or_default(processor, field_name: str, default):
 
 
 def _read_tenant_id(http_request) -> Optional[str]:
-    """Pull a per-tenant APC salt from the request headers.
+    """Pull a per-tenant APC salt from request headers or environment.
 
-    Honoured headers (in order): ``X-APC-Tenant``, ``X-Tenant-Id``.
+    Honoured sources (in order): ``X-APC-Tenant``, ``X-Tenant-Id``,
+    ``APC_DEFAULT_TENANT``, then ``"default"``.
     """
-    if http_request is None or not hasattr(http_request, "headers"):
-        return None
-    h = http_request.headers
-    return h.get("x-apc-tenant") or h.get("x-tenant-id") or None
+    if http_request is not None and hasattr(http_request, "headers"):
+        h = http_request.headers
+        tenant = h.get("x-apc-tenant") or h.get("x-tenant-id")
+        if tenant:
+            return tenant
+    return os.environ.get("APC_DEFAULT_TENANT") or "default"
 
 
 async def _preflight_stream_context_budget(

--- a/mlx_vlm/tests/test_server.py
+++ b/mlx_vlm/tests/test_server.py
@@ -4902,6 +4902,35 @@ class TestResponseGenerator:
         assert args.logit_bias == {5: -1.0}  # string keys converted to int
         assert args.to_generate_kwargs()["apc_tenant"] == "tenant-a"
 
+    def test_read_tenant_id_prefers_apc_header(self, monkeypatch):
+        monkeypatch.setenv("APC_DEFAULT_TENANT", "env-tenant")
+        req = SimpleNamespace(
+            headers={
+                "x-apc-tenant": "header-tenant",
+                "x-tenant-id": "legacy-tenant",
+            }
+        )
+
+        assert server._read_tenant_id(req) == "header-tenant"
+
+    def test_read_tenant_id_uses_legacy_header_before_env(self, monkeypatch):
+        monkeypatch.setenv("APC_DEFAULT_TENANT", "env-tenant")
+        req = SimpleNamespace(headers={"x-tenant-id": "legacy-tenant"})
+
+        assert server._read_tenant_id(req) == "legacy-tenant"
+
+    def test_read_tenant_id_uses_env_default(self, monkeypatch):
+        monkeypatch.setenv("APC_DEFAULT_TENANT", "env-tenant")
+        req = SimpleNamespace(headers={})
+
+        assert server._read_tenant_id(req) == "env-tenant"
+
+    def test_read_tenant_id_falls_back_to_default(self, monkeypatch):
+        monkeypatch.delenv("APC_DEFAULT_TENANT", raising=False)
+        req = SimpleNamespace(headers={})
+
+        assert server._read_tenant_id(req) == "default"
+
     def test_build_gen_args_from_chat_request(self):
         req = SimpleNamespace(
             max_tokens=256,


### PR DESCRIPTION
## Summary

- resolve APC tenant IDs from `X-APC-Tenant`, then `X-Tenant-Id`, then `APC_DEFAULT_TENANT`, then `"default"`
- keep the existing generation argument wiring unchanged so OpenAI, Anthropic, and shared server routes use the same helper
- add regression tests for the full precedence order

Fixes #1632

## Validation

- `uv run --with pytest python -m pytest mlx_vlm/tests/test_server.py -k "tenant_id or build_gen_args"`
- `uv run --with pytest python -m pytest mlx_vlm/tests/test_server.py`
- pre-commit hooks during commit: `black`, `isort`, `autoflake`
- GitHub Actions: `Test PRs / test` passed in 2m19s