### PR TITLE
Fix LFM2-VL tokenizer loading without PyTorch

### DIFF
--- a/mlx_vlm/models/lfm2_vl/processing_lfm2_vl.py
+++ b/mlx_vlm/models/lfm2_vl/processing_lfm2_vl.py
@@ -341,9 +341,6 @@ def _patched_from_pretrained(cls, pretrained_model_name_or_path, **kwargs):
 
     tokenizer = AutoTokenizer.from_pretrained(
         str(model_path) if is_local else pretrained_model_name_or_path,
-        # The tokenizer is a standard PreTrainedTokenizerFast. Trusting remote
-        # code here makes AutoConfig import modeling_lfm2_vl.py, which requires
-        # torch even though MLX only needs the tokenizer files.
         trust_remote_code=False,
         local_files_only=is_local,
     )

--- a/mlx_vlm/models/lfm2_vl/processing_lfm2_vl.py
+++ b/mlx_vlm/models/lfm2_vl/processing_lfm2_vl.py
@@ -341,7 +341,10 @@ def _patched_from_pretrained(cls, pretrained_model_name_or_path, **kwargs):
 
     tokenizer = AutoTokenizer.from_pretrained(
         str(model_path) if is_local else pretrained_model_name_or_path,
-        trust_remote_code=True,
+        # The tokenizer is a standard PreTrainedTokenizerFast. Trusting remote
+        # code here makes AutoConfig import modeling_lfm2_vl.py, which requires
+        # torch even though MLX only needs the tokenizer files.
+        trust_remote_code=False,
         local_files_only=is_local,
     )
     if is_local:

--- a/mlx_vlm/tests/test_processors.py
+++ b/mlx_vlm/tests/test_processors.py
@@ -2149,7 +2149,7 @@ class TestLfm2VlProcessorPatch(unittest.TestCase):
                 patch(
                     "transformers.AutoTokenizer.from_pretrained",
                     return_value=_mock_tokenizer(),
-                ),
+                ) as tokenizer_from_pretrained,
                 patch(
                     "mlx_vlm.models.lfm2_vl.processing_lfm2_vl.Siglip2ImageProcessor",
                     DummySiglip2ImageProcessor,
@@ -2169,6 +2169,11 @@ class TestLfm2VlProcessorPatch(unittest.TestCase):
         self.assertIsInstance(processor.image_processor, DummySiglip2ImageProcessor)
         self.assertTrue(processor.image_processor.do_resize)
         self.assertFalse(processor.image_processor.do_image_splitting)
+        tokenizer_from_pretrained.assert_called_once_with(
+            tmpdir,
+            trust_remote_code=False,
+            local_files_only=True,
+        )
 
 
 class TestMolmoPointProcessor(unittest.TestCase):


### PR DESCRIPTION
## Summary

- load the standard LFM2-VL fast tokenizer without trusting remote model code
- avoid importing the upstream PyTorch-dependent modeling module during MLX processor setup
- add a regression assertion for the tokenizer loading arguments

## Root cause

The LFM2-VL processor patch passed `trust_remote_code=True` to `AutoTokenizer.from_pretrained`. The converted checkpoint advertises a remote `AutoConfig`, so Transformers imported `modeling_lfm2_vl.py` and failed when `torch` was absent, even though tokenizer loading and MLX inference do not require PyTorch.

## Impact

`mlx_vlm.generate` can now load `mlx-community/LFM2-VL-1.6B-4bit` in the normal MLX environment without installing PyTorch.

## Validation

- `uv run python -m unittest mlx_vlm.tests.test_processors -q` — 102 passed, 2 skipped
- exact LFM2-VL image generation command completed successfully and generated OCR output
- Black, isort, and autoflake pre-commit hooks passed
- `git diff --check` passed