### PR TITLE
Fix streaming reasoning classification

### DIFF
--- a/mlx_vlm/server/__init__.py
+++ b/mlx_vlm/server/__init__.py
@@ -114,6 +114,7 @@ from .responses_state import _sse_event as _response_sse_event
 from .responses_state import (
     _store_response,
     process_tool_calls,
+    prompt_has_open_thinking,
     response_store,
     response_store_lock,
     response_store_order,

--- a/mlx_vlm/server/anthropic.py
+++ b/mlx_vlm/server/anthropic.py
@@ -24,6 +24,7 @@ from .generation import (
 from .responses_state import (
     ThinkingStreamState,
     process_tool_calls,
+    prompt_has_open_thinking,
     suppress_tool_call_content,
 )
 from .runtime import runtime
@@ -540,7 +541,12 @@ async def anthropic_messages_endpoint(http_request: Request):
                 full_output = ""
                 text_output = ""
                 thinking_state = ThinkingStreamState(
-                    gen_args.enable_thinking,
+                    prompt_has_open_thinking(
+                        formatted_prompt,
+                        gen_args.enable_thinking,
+                        gen_args.thinking_start_token,
+                        gen_args.thinking_end_token,
+                    ),
                     gen_args.thinking_start_token,
                     gen_args.thinking_end_token,
                 )

--- a/mlx_vlm/server/openai.py
+++ b/mlx_vlm/server/openai.py
@@ -43,6 +43,7 @@ from .responses_state import _sse_event as _response_sse_event
 from .responses_state import (
     _store_response,
     process_tool_calls,
+    prompt_has_open_thinking,
     response_store,
     response_store_lock,
     suppress_tool_call_content,
@@ -1071,7 +1072,12 @@ async def responses_endpoint(request: Request):
                         else None
                     )
                     thinking_state = ThinkingStreamState(
-                        gen_args.enable_thinking,
+                        prompt_has_open_thinking(
+                            formatted_prompt,
+                            gen_args.enable_thinking,
+                            gen_args.thinking_start_token,
+                            gen_args.thinking_end_token,
+                        ),
                         gen_args.thinking_start_token,
                         gen_args.thinking_end_token,
                     )
@@ -1750,7 +1756,12 @@ async def chat_completions_endpoint(request: ChatRequest, http_request: Request)
                         output_tokens = 0
                         request_id = f"chatcmpl-{uuid.uuid4()}"
                         thinking_state = ThinkingStreamState(
-                            gen_args.enable_thinking,
+                            prompt_has_open_thinking(
+                                formatted_prompt,
+                                gen_args.enable_thinking,
+                                gen_args.thinking_start_token,
+                                gen_args.thinking_end_token,
+                            ),
                             gen_args.thinking_start_token,
                             gen_args.thinking_end_token,
                         )
@@ -1895,7 +1906,12 @@ async def chat_completions_endpoint(request: ChatRequest, http_request: Request)
                         request_id = f"chatcmpl-{uuid.uuid4()}"
                         output_text = ""
                         thinking_state = ThinkingStreamState(
-                            gen_args.enable_thinking,
+                            prompt_has_open_thinking(
+                                formatted_prompt,
+                                gen_args.enable_thinking,
+                                gen_args.thinking_start_token,
+                                gen_args.thinking_end_token,
+                            ),
                             gen_args.thinking_start_token,
                             gen_args.thinking_end_token,
                         )

--- a/mlx_vlm/server/responses_state.py
+++ b/mlx_vlm/server/responses_state.py
@@ -164,6 +164,25 @@ class ThinkingStreamState:
         return text
 
 
+def prompt_has_open_thinking(
+    prompt: Any,
+    enable_thinking: bool = False,
+    thinking_start_token: Optional[str] = None,
+    thinking_end_token: Optional[str] = None,
+) -> bool:
+    """Return whether generation starts inside a prompt-opened thinking block."""
+    if not enable_thinking or not isinstance(prompt, str):
+        return False
+
+    stripped_prompt = prompt.rstrip()
+    for start_marker, _ in ThinkingStreamState._build_open_close_markers(
+        thinking_start_token, thinking_end_token
+    ):
+        if stripped_prompt.endswith(start_marker):
+            return True
+    return False
+
+
 response_store: Dict[str, StoredResponse] = {}
 response_store_order: deque = deque()
 response_store_lock = Lock()

--- a/mlx_vlm/tests/test_server.py
+++ b/mlx_vlm/tests/test_server.py
@@ -2460,6 +2460,66 @@ def test_chat_completions_streaming_uses_custom_thinking_markers(client, monkeyp
     assert "".join(delta.get("content") or "" for delta in deltas) == ("Custom answer.")
 
 
+def test_chat_completions_streaming_keeps_plain_output_as_content_when_thinking_enabled(
+    client, monkeypatch
+):
+    model = SimpleNamespace()
+    processor = SimpleNamespace()
+    config = SimpleNamespace(model_type="lfm2_vl")
+
+    class FakeResponseGenerator:
+        tokenizer = SimpleNamespace(decode=lambda tokens: "")
+
+        def validate_context_budget(self, prompt, images=None, audio=None, args=None):
+            return None
+
+        def generate(self, prompt, images=None, audio=None, args=None):
+            return server.GenerationContext(uid=1, prompt_tokens=8), iter(
+                [
+                    server.StreamingToken(
+                        text="Hello", token=1, logprobs=0.0, finish_reason=None
+                    ),
+                    server.StreamingToken(
+                        text="!", token=2, logprobs=0.0, finish_reason="stop"
+                    ),
+                ]
+            )
+
+    monkeypatch.setattr(server.runtime, "response_generator", FakeResponseGenerator())
+
+    with (
+        patch.object(
+            server, "get_cached_model", return_value=(model, processor, config)
+        ),
+        patch.object(server, "apply_chat_template", return_value="prompt"),
+    ):
+        response = client.post(
+            "/chat/completions",
+            json={
+                "model": "liquidai/LFM2.5-VL-1.6B",
+                "messages": [{"role": "user", "content": "Hello"}],
+                "stream": True,
+                "enable_thinking": True,
+            },
+        )
+
+    assert response.status_code == 200
+    chunks = [
+        json.loads(line[len("data: ") :])
+        for line in response.text.splitlines()
+        if line.startswith("data: ") and line != "data: [DONE]"
+    ]
+    deltas = [
+        chunk["choices"][0]["delta"]
+        for chunk in chunks
+        if chunk.get("choices") and chunk["choices"][0].get("delta")
+    ]
+
+    assert "".join(delta.get("content") or "" for delta in deltas) == "Hello!"
+    assert "".join(delta.get("reasoning_content") or "" for delta in deltas) == ""
+    assert "".join(delta.get("reasoning") or "" for delta in deltas) == ""
+
+
 def test_chat_completions_response_uses_reasoning_content(client):
     model = SimpleNamespace()
     processor = SimpleNamespace()
@@ -5706,6 +5766,28 @@ class TestSplitThinking:
 
 class TestThinkingStreamState:
     """Tests for streaming thinking tag parsing."""
+
+    def test_prompt_must_end_with_open_thinking_marker_to_start_in_thinking(self):
+        assert server.prompt_has_open_thinking("prompt", enable_thinking=True) is False
+        assert (
+            server.prompt_has_open_thinking("prompt<think>\n", enable_thinking=True)
+            is True
+        )
+        assert (
+            server.prompt_has_open_thinking(
+                "User: Say <think> literally\nAssistant:", enable_thinking=True
+            )
+            is False
+        )
+        assert (
+            server.prompt_has_open_thinking(
+                "prompt<analysis>",
+                enable_thinking=True,
+                thinking_start_token="<analysis>",
+                thinking_end_token="</analysis>",
+            )
+            is True
+        )
 
     @pytest.mark.parametrize("enable_thinking", [False, True])
     def test_gemma_channel_markers_and_content_in_same_delta(self, enable_thinking):


### PR DESCRIPTION
## Summary

- initialize the streaming thinking parser from the formatted prompt instead of the request flag alone
- keep ordinary model output in `content` when `enable_thinking: true` but no thinking block is active
- apply the behavior consistently to Chat Completions, Responses API, and Anthropic streaming
- add an LFM2.5-VL regression test and prompt-marker edge-case coverage

## Root cause

`ThinkingStreamState` previously entered thinking mode whenever `enable_thinking` was true. For models such as `liquidai/LFM2.5-VL-1.6B` that do not emit thinking tokens, this moved normal streamed output into `reasoning_content` and `reasoning`, even though the equivalent non-streaming response correctly returned it as `content`.

The state now starts in thinking mode only when the formatted prompt actually ends with an opening thinking marker. Models that emit their own opening marker continue to be detected by the existing streaming parser.

## Impact

OpenAI-compatible clients now receive normal streamed text under `delta.content` even if they accidentally enable thinking for a non-thinking model. Prompt-opened reasoning flows continue to stream through the reasoning fields.

## Validation

- `uv run --with pytest pytest mlx_vlm/tests/test_server.py -q` — 210 passed
- pre-commit hooks: Black, isort, and autoflake passed
- `git diff --check` passed