### PR TITLE
Add APC default tenant environment variable

### DIFF
--- a/mlx_vlm/server/app.py
+++ b/mlx_vlm/server/app.py
@@ -274,12 +274,14 @@ def _model_config_field_or_default(processor, field_name: str, default):
 def _read_tenant_id(http_request) -> Optional[str]:
     """Pull a per-tenant APC salt from the request headers.
 
-    Honoured headers (in order): ``X-APC-Tenant``, ``X-Tenant-Id``.
+    Honoured sources, in order: ``X-APC-Tenant``, ``X-Tenant-Id``,
+    ``APC_DEFAULT_TENANT``, then ``default``.
     """
+    default_tenant = os.environ.get("APC_DEFAULT_TENANT") or "default"
     if http_request is None or not hasattr(http_request, "headers"):
-        return None
+        return default_tenant
     h = http_request.headers
-    return h.get("x-apc-tenant") or h.get("x-tenant-id") or None
+    return h.get("x-apc-tenant") or h.get("x-tenant-id") or default_tenant
 
 
 async def _preflight_stream_context_budget(

--- a/mlx_vlm/tests/test_server.py
+++ b/mlx_vlm/tests/test_server.py
@@ -1581,6 +1581,35 @@ def test_speculative_server_prefill_threads_qwen_dflash_prompt_kwargs(monkeypatc
     assert "_apc_tenant" not in call
 
 
+def test_read_tenant_id_prefers_apc_header(monkeypatch):
+    monkeypatch.setenv("APC_DEFAULT_TENANT", "env-tenant")
+    request = SimpleNamespace(
+        headers={"x-apc-tenant": "header-tenant", "x-tenant-id": "legacy-tenant"}
+    )
+
+    assert server._read_tenant_id(request) == "header-tenant"
+
+
+def test_read_tenant_id_uses_legacy_header_before_env(monkeypatch):
+    monkeypatch.setenv("APC_DEFAULT_TENANT", "env-tenant")
+    request = SimpleNamespace(headers={"x-tenant-id": "legacy-tenant"})
+
+    assert server._read_tenant_id(request) == "legacy-tenant"
+
+
+def test_read_tenant_id_uses_env_default(monkeypatch):
+    monkeypatch.setenv("APC_DEFAULT_TENANT", "env-tenant")
+
+    assert server._read_tenant_id(SimpleNamespace(headers={})) == "env-tenant"
+    assert server._read_tenant_id(None) == "env-tenant"
+
+
+def test_read_tenant_id_falls_back_to_default(monkeypatch):
+    monkeypatch.delenv("APC_DEFAULT_TENANT", raising=False)
+
+    assert server._read_tenant_id(SimpleNamespace(headers={})) == "default"
+
+
 def test_responses_endpoint_forwards_new_sampling_args(client):
     model = SimpleNamespace()
     processor = SimpleNamespace()


### PR DESCRIPTION
## Summary

Fixes #1632.

- Add `APC_DEFAULT_TENANT` as the fallback APC tenant for server requests without tenant headers.
- Preserve request header priority: `X-APC-Tenant`, then `X-Tenant-Id`, then `APC_DEFAULT_TENANT`, then `default`.
- Add focused server tests for header precedence, env fallback, and the final `default` fallback.

## Impact

Single-tenant deployments can configure one process-wide APC tenant without requiring every client to send `X-APC-Tenant`, while explicit request headers still override the default.

## Validation

- `uv run --with pytest pytest mlx_vlm/tests/test_server.py::test_read_tenant_id_prefers_apc_header mlx_vlm/tests/test_server.py::test_read_tenant_id_uses_legacy_header_before_env mlx_vlm/tests/test_server.py::test_read_tenant_id_uses_env_default mlx_vlm/tests/test_server.py::test_read_tenant_id_falls_back_to_default -q`
- `uv run python -m py_compile mlx_vlm/server/app.py`
- `git diff --check`