### PR TITLE
Fix streaming reasoning protocol compatibility

### DIFF
--- a/mlx_vlm/server/app.py
+++ b/mlx_vlm/server/app.py
@@ -163,6 +163,52 @@ def _server_runtime_snapshot() -> dict:
     }
 
 
+_DISABLED_REASONING_EFFORTS = {"none", "off", "disabled", "false", "0"}
+
+
+def _request_field_is_set(request, field_name: str) -> bool:
+    fields_set = getattr(request, "model_fields_set", None)
+    if fields_set is not None:
+        return field_name in fields_set
+    return getattr(request, field_name, None) is not None
+
+
+def _reasoning_effort_enabled(effort) -> Tuple[Optional[bool], Optional[str]]:
+    if effort is None:
+        return None, None
+    normalized = str(effort).strip().lower()
+    if not normalized:
+        return None, None
+    return normalized not in _DISABLED_REASONING_EFFORTS, normalized
+
+
+def _standard_reasoning_control(
+    request,
+) -> Tuple[Optional[bool], Optional[str], bool]:
+    """Normalize OpenAI reasoning fields into a thinking-mode decision."""
+    if _request_field_is_set(request, "reasoning"):
+        reasoning = getattr(request, "reasoning", None)
+        if hasattr(reasoning, "model_dump"):
+            reasoning = reasoning.model_dump(exclude_none=True)
+        if isinstance(reasoning, dict):
+            enabled, effort = _reasoning_effort_enabled(reasoning.get("effort"))
+            return (True if enabled is None else enabled), effort, True
+        if isinstance(reasoning, bool):
+            return reasoning, None, True
+        enabled, effort = _reasoning_effort_enabled(reasoning)
+        if enabled is not None:
+            return enabled, effort, True
+
+    if _request_field_is_set(request, "reasoning_effort"):
+        enabled, effort = _reasoning_effort_enabled(
+            getattr(request, "reasoning_effort", None)
+        )
+        if enabled is not None:
+            return enabled, effort, True
+
+    return None, None, False
+
+
 def _build_gen_args(
     request, processor=None, tenant_id: Optional[str] = None
 ) -> GenerationArguments:
@@ -175,11 +221,21 @@ def _build_gen_args(
     logit_bias = getattr(request, "logit_bias", None)
     if logit_bias is not None and isinstance(logit_bias, dict):
         logit_bias = {int(k): v for k, v in logit_bias.items()}
-    enable_thinking = _request_field_or_default(
-        request,
-        "enable_thinking",
-        get_server_enable_thinking(),
+    standard_reasoning, reasoning_effort, has_standard_reasoning = (
+        _standard_reasoning_control(request)
     )
+    server_enable_thinking = get_server_enable_thinking()
+    if _request_field_is_set(request, "enable_thinking"):
+        enable_thinking = bool(getattr(request, "enable_thinking", False))
+        template_reasoning = enable_thinking
+    elif has_standard_reasoning:
+        enable_thinking = bool(standard_reasoning)
+        template_reasoning = enable_thinking
+    else:
+        enable_thinking = server_enable_thinking
+        # Preserve a model template's native default when the server default is
+        # off and the request did not express a reasoning preference.
+        template_reasoning = True if server_enable_thinking else None
     default_temperature = _model_config_field_or_default(
         processor, "temperature", DEFAULT_TEMPERATURE
     )
@@ -240,6 +296,8 @@ def _build_gen_args(
         min_threshold=_request_field_or_default(request, "min_threshold", None),
         logit_bias=logit_bias,
         enable_thinking=enable_thinking,
+        reasoning=template_reasoning,
+        reasoning_effort=reasoning_effort,
         thinking_budget=_request_field_or_default(
             request, "thinking_budget", get_server_thinking_budget()
         ),

--- a/mlx_vlm/server/app.py
+++ b/mlx_vlm/server/app.py
@@ -8,7 +8,7 @@ import time
 from contextlib import asynccontextmanager
 from threading import Lock
 from types import SimpleNamespace
-from typing import List, Optional, Tuple, Union
+from typing import List, Optional, Tuple
 
 import mlx.core as mx
 from fastapi import FastAPI, HTTPException, Request
@@ -17,17 +17,13 @@ from huggingface_hub import scan_cache_dir
 from huggingface_hub.errors import CacheNotFound, RepositoryNotFoundError
 
 from .. import apc as _apc
-from ..generate import (
-    DEFAULT_REPETITION_CONTEXT_SIZE,
-    DEFAULT_TEMPERATURE,
-    DEFAULT_TOP_P,
-)
 from ..generate.edit_image import load_image_edit_model
 from ..generate.image import is_image_generation_model, load_image_generation_model
 from ..structured import build_json_schema_logits_processor
 from ..tool_parsers import _infer_tool_parser_from_processor
 from ..version import __version__
 from ..vision_cache import VisionFeatureCache
+from . import request_normalization as _request_normalization
 from .anthropic import register_routes as register_anthropic_routes
 from .audio import register_routes as register_audio_routes
 from .generation import (
@@ -41,11 +37,6 @@ from .generation import (
     get_kv_quant_scheme,
     get_quantized_kv_bits,
     get_quantized_kv_start,
-    get_server_enable_thinking,
-    get_server_max_tokens,
-    get_server_thinking_budget,
-    get_server_thinking_end_token,
-    get_server_thinking_start_token,
     get_top_logprobs_k,
 )
 from .openai import register_routes as register_openai_routes
@@ -58,6 +49,8 @@ DEFAULT_SERVER_PORT = 8080
 SERVER_API_KEY_ENV = "MLX_VLM_SERVER_API_KEY"
 
 logger = logging.getLogger("mlx_vlm.server")
+
+_as_plain_dict = _request_normalization._as_plain_dict
 
 
 def _server_api_key() -> Optional[str]:
@@ -163,170 +156,16 @@ def _server_runtime_snapshot() -> dict:
     }
 
 
-_DISABLED_REASONING_EFFORTS = {"none", "off", "disabled", "false", "0"}
-
-
-def _request_field_is_set(request, field_name: str) -> bool:
-    fields_set = getattr(request, "model_fields_set", None)
-    if fields_set is not None:
-        return field_name in fields_set
-    return getattr(request, field_name, None) is not None
-
-
-def _reasoning_effort_enabled(effort) -> Tuple[Optional[bool], Optional[str]]:
-    if effort is None:
-        return None, None
-    normalized = str(effort).strip().lower()
-    if not normalized:
-        return None, None
-    return normalized not in _DISABLED_REASONING_EFFORTS, normalized
-
-
-def _standard_reasoning_control(
-    request,
-) -> Tuple[Optional[bool], Optional[str], bool]:
-    """Normalize OpenAI reasoning fields into a thinking-mode decision."""
-    if _request_field_is_set(request, "reasoning"):
-        reasoning = getattr(request, "reasoning", None)
-        if hasattr(reasoning, "model_dump"):
-            reasoning = reasoning.model_dump(exclude_none=True)
-        if isinstance(reasoning, dict):
-            enabled, effort = _reasoning_effort_enabled(reasoning.get("effort"))
-            return (True if enabled is None else enabled), effort, True
-        if isinstance(reasoning, bool):
-            return reasoning, None, True
-        enabled, effort = _reasoning_effort_enabled(reasoning)
-        if enabled is not None:
-            return enabled, effort, True
-
-    if _request_field_is_set(request, "reasoning_effort"):
-        enabled, effort = _reasoning_effort_enabled(
-            getattr(request, "reasoning_effort", None)
-        )
-        if enabled is not None:
-            return enabled, effort, True
-
-    return None, None, False
-
-
 def _build_gen_args(
     request, processor=None, tenant_id: Optional[str] = None
 ) -> GenerationArguments:
-    """Build GenerationArguments from an OpenAIRequest or ChatRequest."""
-    max_tokens = getattr(request, "max_tokens", None)
-    if max_tokens is None:
-        max_tokens = getattr(request, "max_output_tokens", None)
-    if max_tokens is None:
-        max_tokens = get_server_max_tokens()
-    logit_bias = getattr(request, "logit_bias", None)
-    if logit_bias is not None and isinstance(logit_bias, dict):
-        logit_bias = {int(k): v for k, v in logit_bias.items()}
-    standard_reasoning, reasoning_effort, has_standard_reasoning = (
-        _standard_reasoning_control(request)
-    )
-    server_enable_thinking = get_server_enable_thinking()
-    if _request_field_is_set(request, "enable_thinking"):
-        enable_thinking = bool(getattr(request, "enable_thinking", False))
-        template_reasoning = enable_thinking
-    elif has_standard_reasoning:
-        enable_thinking = bool(standard_reasoning)
-        template_reasoning = enable_thinking
-    else:
-        enable_thinking = server_enable_thinking
-        # Preserve a model template's native default when the server default is
-        # off and the request did not express a reasoning preference.
-        template_reasoning = True if server_enable_thinking else None
-    default_temperature = _model_config_field_or_default(
-        processor, "temperature", DEFAULT_TEMPERATURE
-    )
-    default_top_p = _model_config_field_or_default(processor, "top_p", DEFAULT_TOP_P)
-    default_top_k = _model_config_field_or_default(processor, "top_k", 0)
-    if _model_config_field_or_default(processor, "do_sample", None) is False:
-        default_temperature = 0.0
-    args = GenerationArguments(
-        max_tokens=max_tokens,
-        temperature=_request_field_or_default(
-            request, "temperature", default_temperature
-        ),
-        top_p=_request_field_or_default(request, "top_p", default_top_p),
-        top_k=_request_field_or_default(request, "top_k", default_top_k),
-        min_p=getattr(request, "min_p", 0.0),
-        seed=getattr(request, "seed", None),
-        logprobs=bool(getattr(request, "logprobs", False)),
-        repetition_penalty=getattr(request, "repetition_penalty", None),
-        repetition_context_size=_request_field_or_default(
-            request,
-            "repetition_context_size",
-            DEFAULT_REPETITION_CONTEXT_SIZE,
-        ),
-        presence_penalty=getattr(request, "presence_penalty", None),
-        presence_context_size=_request_field_or_default(
-            request,
-            "presence_context_size",
-            DEFAULT_REPETITION_CONTEXT_SIZE,
-        ),
-        frequency_penalty=getattr(request, "frequency_penalty", None),
-        frequency_context_size=_request_field_or_default(
-            request,
-            "frequency_context_size",
-            DEFAULT_REPETITION_CONTEXT_SIZE,
-        ),
-        max_denoising_steps=_request_field_or_default(
-            request, "max_denoising_steps", None
-        ),
-        block_length=_request_field_or_default(request, "block_length", None),
-        num_to_transfer=_request_field_or_default(request, "num_to_transfer", None),
-        max_transfer_per_step=_request_field_or_default(
-            request, "max_transfer_per_step", None
-        ),
-        editing_threshold=_request_field_or_default(request, "editing_threshold", None),
-        max_post_steps=_request_field_or_default(request, "max_post_steps", None),
-        stability_steps=_request_field_or_default(request, "stability_steps", None),
-        diffusion_full_canvas=_request_field_or_default(
-            request, "diffusion_full_canvas", None
-        ),
-        diffusion_min_canvas_length=_request_field_or_default(
-            request, "diffusion_min_canvas_length", None
-        ),
-        diffusion_max_canvas_length=_request_field_or_default(
-            request, "diffusion_max_canvas_length", None
-        ),
-        diffusion_sampler=_request_field_or_default(request, "diffusion_sampler", None),
-        threshold=_request_field_or_default(request, "threshold", None),
-        min_threshold=_request_field_or_default(request, "min_threshold", None),
-        logit_bias=logit_bias,
-        enable_thinking=enable_thinking,
-        reasoning=template_reasoning,
-        reasoning_effort=reasoning_effort,
-        thinking_budget=_request_field_or_default(
-            request, "thinking_budget", get_server_thinking_budget()
-        ),
-        thinking_start_token=_request_field_or_default(
-            request, "thinking_start_token", get_server_thinking_start_token()
-        ),
-        thinking_end_token=_request_field_or_default(
-            request, "thinking_end_token", get_server_thinking_end_token()
-        ),
+    """Build GenerationArguments from a compatible API request."""
+    return _request_normalization._build_gen_args(
+        request,
+        processor=processor,
         tenant_id=tenant_id,
+        structured_logits_processor_builder=_build_structured_logits_processors,
     )
-    if processor is not None:
-        args.logits_processors = _build_structured_logits_processors(request, processor)
-    return args
-
-
-def _request_field_or_default(request, field_name: str, default):
-    fields_set = getattr(request, "model_fields_set", None)
-    if fields_set is not None and field_name not in fields_set:
-        return default
-    value = getattr(request, field_name, default)
-    return default if value is None else value
-
-
-def _model_config_field_or_default(processor, field_name: str, default):
-    config = runtime.model_cache.get("config")
-    if config is None and processor is not None:
-        config = getattr(processor, "config", None)
-    return getattr(config, field_name, default)
 
 
 def _read_tenant_id(http_request) -> Optional[str]:
@@ -374,56 +213,20 @@ async def _preflight_stream_context_budget(
         raise HTTPException(status_code=400, detail=str(e))
 
 
-def _as_plain_dict(value):
-    if value is None:
-        return None
-    if isinstance(value, dict):
-        return value
-    if hasattr(value, "model_dump"):
-        return value.model_dump(exclude_none=True)
-    return value
-
-
-def _extract_response_format_schema(request) -> Optional[Union[str, dict]]:
-    response_format = _as_plain_dict(getattr(request, "response_format", None))
-
-    text_config = _as_plain_dict(getattr(request, "text", None))
-    if response_format is None and isinstance(text_config, dict):
-        response_format = _as_plain_dict(text_config.get("format"))
-
-    if response_format is None:
-        return None
-
-    format_type = response_format.get("type")
-    if format_type in (None, "text"):
-        return None
-    if format_type in ("json_object", "object"):
-        return {"type": "object"}
-    if format_type != "json_schema":
-        raise ValueError(f"Unsupported response_format type: {format_type!r}")
-
-    json_schema = _as_plain_dict(response_format.get("json_schema"))
-    if json_schema is None:
-        # Responses API text.format places schema directly on the format object.
-        json_schema = response_format
-
-    schema = json_schema.get("schema") if isinstance(json_schema, dict) else None
-    if schema is None:
-        raise ValueError("response_format json_schema must include a schema field")
-    return schema
-
-
 def _build_structured_logits_processors(request, processor):
-    schema = _extract_response_format_schema(request)
-    if schema is None:
-        return None
+    return _request_normalization._build_structured_logits_processors(
+        request,
+        processor,
+        logits_processor_factory=_server_package_attr(
+            "build_json_schema_logits_processor",
+            build_json_schema_logits_processor,
+        ),
+    )
 
-    tokenizer = processor.tokenizer if hasattr(processor, "tokenizer") else processor
-    logits_processor = _server_package_attr(
-        "build_json_schema_logits_processor",
-        build_json_schema_logits_processor,
-    )(tokenizer, schema)
-    return [logits_processor]
+
+def _extract_response_format_schema(request):
+    """Retain the package-level compatibility alias for schema extraction."""
+    return _request_normalization._extract_response_format_schema(request)
 
 
 def _count_thinking_tag_tokens(

--- a/mlx_vlm/server/generation.py
+++ b/mlx_vlm/server/generation.py
@@ -697,6 +697,8 @@ class GenerationArguments:
     min_threshold: Optional[float] = None
     logit_bias: Optional[dict] = None
     enable_thinking: bool = DEFAULT_ENABLE_THINKING
+    reasoning: Optional[bool] = None
+    reasoning_effort: Optional[str] = None
     thinking_budget: Optional[int] = None
     thinking_start_token: Optional[str] = None
     thinking_end_token: Optional[str] = None
@@ -772,6 +774,10 @@ class GenerationArguments:
     def to_template_kwargs(self) -> dict:
         """Convert to kwargs for apply_chat_template()."""
         kw = {"enable_thinking": self.enable_thinking}
+        if self.reasoning is not None:
+            kw["reasoning"] = self.reasoning
+        if self.reasoning_effort is not None:
+            kw["reasoning_effort"] = self.reasoning_effort
         if self.thinking_budget is not None:
             kw["thinking_budget"] = self.thinking_budget
         if self.thinking_start_token is not None:

--- a/mlx_vlm/server/request_normalization.py
+++ b/mlx_vlm/server/request_normalization.py
@@ -1,0 +1,239 @@
+"""Normalize compatible API requests into server generation arguments."""
+
+from typing import Optional, Tuple, Union
+
+from ..generate import (
+    DEFAULT_REPETITION_CONTEXT_SIZE,
+    DEFAULT_TEMPERATURE,
+    DEFAULT_TOP_P,
+)
+from ..structured import build_json_schema_logits_processor
+from .generation import (
+    GenerationArguments,
+    get_server_enable_thinking,
+    get_server_max_tokens,
+    get_server_thinking_budget,
+    get_server_thinking_end_token,
+    get_server_thinking_start_token,
+)
+from .runtime import runtime
+
+_DISABLED_REASONING_EFFORTS = {"none", "off", "disabled", "false", "0"}
+
+
+def _request_field_is_set(request, field_name: str) -> bool:
+    fields_set = getattr(request, "model_fields_set", None)
+    if fields_set is not None:
+        return field_name in fields_set
+    return getattr(request, field_name, None) is not None
+
+
+def _request_field_or_default(request, field_name: str, default):
+    fields_set = getattr(request, "model_fields_set", None)
+    if fields_set is not None and field_name not in fields_set:
+        return default
+    value = getattr(request, field_name, default)
+    return default if value is None else value
+
+
+def _reasoning_effort_enabled(effort) -> Tuple[Optional[bool], Optional[str]]:
+    if effort is None:
+        return None, None
+    normalized = str(effort).strip().lower()
+    if not normalized:
+        return None, None
+    return normalized not in _DISABLED_REASONING_EFFORTS, normalized
+
+
+def _standard_reasoning_control(
+    request,
+) -> Tuple[Optional[bool], Optional[str], bool]:
+    """Normalize OpenAI reasoning fields into a thinking-mode decision."""
+    if _request_field_is_set(request, "reasoning"):
+        reasoning = getattr(request, "reasoning", None)
+        if hasattr(reasoning, "model_dump"):
+            reasoning = reasoning.model_dump(exclude_none=True)
+        if isinstance(reasoning, dict):
+            enabled, effort = _reasoning_effort_enabled(reasoning.get("effort"))
+            return (True if enabled is None else enabled), effort, True
+        if isinstance(reasoning, bool):
+            return reasoning, None, True
+        enabled, effort = _reasoning_effort_enabled(reasoning)
+        if enabled is not None:
+            return enabled, effort, True
+
+    if _request_field_is_set(request, "reasoning_effort"):
+        enabled, effort = _reasoning_effort_enabled(
+            getattr(request, "reasoning_effort", None)
+        )
+        if enabled is not None:
+            return enabled, effort, True
+
+    return None, None, False
+
+
+def _model_config_field_or_default(processor, field_name: str, default):
+    config = runtime.model_cache.get("config")
+    if config is None and processor is not None:
+        config = getattr(processor, "config", None)
+    return getattr(config, field_name, default)
+
+
+def _as_plain_dict(value):
+    if value is None:
+        return None
+    if isinstance(value, dict):
+        return value
+    if hasattr(value, "model_dump"):
+        return value.model_dump(exclude_none=True)
+    return value
+
+
+def _extract_response_format_schema(request) -> Optional[Union[str, dict]]:
+    response_format = _as_plain_dict(getattr(request, "response_format", None))
+
+    text_config = _as_plain_dict(getattr(request, "text", None))
+    if response_format is None and isinstance(text_config, dict):
+        response_format = _as_plain_dict(text_config.get("format"))
+
+    if response_format is None:
+        return None
+
+    format_type = response_format.get("type")
+    if format_type in (None, "text"):
+        return None
+    if format_type in ("json_object", "object"):
+        return {"type": "object"}
+    if format_type != "json_schema":
+        raise ValueError(f"Unsupported response_format type: {format_type!r}")
+
+    json_schema = _as_plain_dict(response_format.get("json_schema"))
+    if json_schema is None:
+        # Responses API text.format places schema directly on the format object.
+        json_schema = response_format
+
+    schema = json_schema.get("schema") if isinstance(json_schema, dict) else None
+    if schema is None:
+        raise ValueError("response_format json_schema must include a schema field")
+    return schema
+
+
+def _build_structured_logits_processors(
+    request,
+    processor,
+    logits_processor_factory=build_json_schema_logits_processor,
+):
+    schema = _extract_response_format_schema(request)
+    if schema is None:
+        return None
+
+    tokenizer = processor.tokenizer if hasattr(processor, "tokenizer") else processor
+    return [logits_processor_factory(tokenizer, schema)]
+
+
+def _build_gen_args(
+    request,
+    processor=None,
+    tenant_id: Optional[str] = None,
+    structured_logits_processor_builder=_build_structured_logits_processors,
+) -> GenerationArguments:
+    """Build generation arguments from a compatible API request."""
+    max_tokens = getattr(request, "max_tokens", None)
+    if max_tokens is None:
+        max_tokens = getattr(request, "max_output_tokens", None)
+    if max_tokens is None:
+        max_tokens = get_server_max_tokens()
+    logit_bias = getattr(request, "logit_bias", None)
+    if logit_bias is not None and isinstance(logit_bias, dict):
+        logit_bias = {int(k): v for k, v in logit_bias.items()}
+    standard_reasoning, reasoning_effort, has_standard_reasoning = (
+        _standard_reasoning_control(request)
+    )
+    server_enable_thinking = get_server_enable_thinking()
+    if _request_field_is_set(request, "enable_thinking"):
+        enable_thinking = bool(getattr(request, "enable_thinking", False))
+        template_reasoning = enable_thinking
+    elif has_standard_reasoning:
+        enable_thinking = bool(standard_reasoning)
+        template_reasoning = enable_thinking
+    else:
+        enable_thinking = server_enable_thinking
+        # Preserve a model template's native default when the server default is
+        # off and the request did not express a reasoning preference.
+        template_reasoning = True if server_enable_thinking else None
+    default_temperature = _model_config_field_or_default(
+        processor, "temperature", DEFAULT_TEMPERATURE
+    )
+    default_top_p = _model_config_field_or_default(processor, "top_p", DEFAULT_TOP_P)
+    default_top_k = _model_config_field_or_default(processor, "top_k", 0)
+    if _model_config_field_or_default(processor, "do_sample", None) is False:
+        default_temperature = 0.0
+    args = GenerationArguments(
+        max_tokens=max_tokens,
+        temperature=_request_field_or_default(
+            request, "temperature", default_temperature
+        ),
+        top_p=_request_field_or_default(request, "top_p", default_top_p),
+        top_k=_request_field_or_default(request, "top_k", default_top_k),
+        min_p=getattr(request, "min_p", 0.0),
+        seed=getattr(request, "seed", None),
+        logprobs=bool(getattr(request, "logprobs", False)),
+        repetition_penalty=getattr(request, "repetition_penalty", None),
+        repetition_context_size=_request_field_or_default(
+            request,
+            "repetition_context_size",
+            DEFAULT_REPETITION_CONTEXT_SIZE,
+        ),
+        presence_penalty=getattr(request, "presence_penalty", None),
+        presence_context_size=_request_field_or_default(
+            request,
+            "presence_context_size",
+            DEFAULT_REPETITION_CONTEXT_SIZE,
+        ),
+        frequency_penalty=getattr(request, "frequency_penalty", None),
+        frequency_context_size=_request_field_or_default(
+            request,
+            "frequency_context_size",
+            DEFAULT_REPETITION_CONTEXT_SIZE,
+        ),
+        max_denoising_steps=_request_field_or_default(
+            request, "max_denoising_steps", None
+        ),
+        block_length=_request_field_or_default(request, "block_length", None),
+        num_to_transfer=_request_field_or_default(request, "num_to_transfer", None),
+        max_transfer_per_step=_request_field_or_default(
+            request, "max_transfer_per_step", None
+        ),
+        editing_threshold=_request_field_or_default(request, "editing_threshold", None),
+        max_post_steps=_request_field_or_default(request, "max_post_steps", None),
+        stability_steps=_request_field_or_default(request, "stability_steps", None),
+        diffusion_full_canvas=_request_field_or_default(
+            request, "diffusion_full_canvas", None
+        ),
+        diffusion_min_canvas_length=_request_field_or_default(
+            request, "diffusion_min_canvas_length", None
+        ),
+        diffusion_max_canvas_length=_request_field_or_default(
+            request, "diffusion_max_canvas_length", None
+        ),
+        diffusion_sampler=_request_field_or_default(request, "diffusion_sampler", None),
+        threshold=_request_field_or_default(request, "threshold", None),
+        min_threshold=_request_field_or_default(request, "min_threshold", None),
+        logit_bias=logit_bias,
+        enable_thinking=enable_thinking,
+        reasoning=template_reasoning,
+        reasoning_effort=reasoning_effort,
+        thinking_budget=_request_field_or_default(
+            request, "thinking_budget", get_server_thinking_budget()
+        ),
+        thinking_start_token=_request_field_or_default(
+            request, "thinking_start_token", get_server_thinking_start_token()
+        ),
+        thinking_end_token=_request_field_or_default(
+            request, "thinking_end_token", get_server_thinking_end_token()
+        ),
+        tenant_id=tenant_id,
+    )
+    if processor is not None:
+        args.logits_processors = structured_logits_processor_builder(request, processor)
+    return args

--- a/mlx_vlm/server/responses_state.py
+++ b/mlx_vlm/server/responses_state.py
@@ -171,7 +171,7 @@ def prompt_has_open_thinking(
     thinking_end_token: Optional[str] = None,
 ) -> bool:
     """Return whether generation starts inside a prompt-opened thinking block."""
-    if not enable_thinking or not isinstance(prompt, str):
+    if not isinstance(prompt, str):
         return False
 
     stripped_prompt = prompt.rstrip()

--- a/mlx_vlm/server/schemas.py
+++ b/mlx_vlm/server/schemas.py
@@ -358,6 +358,14 @@ class OpenAIRequest(FlexibleBaseModel):
             "server default set by --enable-thinking is used."
         ),
     )
+    reasoning: Optional[Any] = Field(
+        None,
+        description="OpenAI Responses API reasoning configuration.",
+    )
+    reasoning_effort: Optional[str] = Field(
+        None,
+        description="OpenAI-compatible reasoning effort.",
+    )
     thinking_budget: Optional[int] = Field(None, description="Max thinking tokens.")
     thinking_start_token: Optional[str] = Field(
         None, description="Thinking start token."
@@ -730,6 +738,14 @@ class VLMRequest(FlexibleBaseModel):
             "Override server thinking mode for this request. If omitted, the "
             "server default set by --enable-thinking is used."
         ),
+    )
+    reasoning: Optional[Any] = Field(
+        None,
+        description="OpenAI-compatible reasoning configuration.",
+    )
+    reasoning_effort: Optional[str] = Field(
+        None,
+        description="OpenAI-compatible reasoning effort.",
     )
     thinking_budget: Optional[int] = Field(None, description="Max thinking tokens.")
     thinking_start_token: Optional[str] = Field(

--- a/mlx_vlm/tests/test_server.py
+++ b/mlx_vlm/tests/test_server.py
@@ -2000,6 +2000,72 @@ def test_responses_streaming_emits_reasoning_events(client):
     assert completed["output_text"] == "Done."
 
 
+def test_responses_streaming_uses_prompt_opened_thinking_without_flag(client):
+    server.response_store.clear()
+    server.response_store_order.clear()
+    model = SimpleNamespace()
+    processor = SimpleNamespace()
+    config = SimpleNamespace(model_type="cohere2_moe")
+    chunks = [
+        GenerationResult(text="North reasoning.", prompt_tokens=8, generation_tokens=1),
+        GenerationResult(
+            text="<|END_THINKING|><|START_TEXT|>North answer.<|END_TEXT|>",
+            prompt_tokens=8,
+            generation_tokens=4,
+            finish_reason="stop",
+        ),
+    ]
+    template_kwargs = {}
+
+    def fake_apply_chat_template(*args, **kwargs):
+        template_kwargs.update(kwargs)
+        return "prompt<|START_THINKING|>"
+
+    with (
+        patch.object(
+            server, "get_cached_model", return_value=(model, processor, config)
+        ),
+        patch.object(
+            server,
+            "apply_chat_template",
+            side_effect=fake_apply_chat_template,
+        ),
+        patch.object(server, "stream_generate", return_value=iter(chunks)),
+        patch.object(server.runtime, "response_generator", None),
+    ):
+        response = client.post(
+            "/v1/responses",
+            json={
+                "model": "CohereLabs/North-Mini-Code-1.0-w4a16",
+                "input": "hello",
+                "reasoning": {"effort": "high", "summary": "auto"},
+                "stream": True,
+            },
+        )
+
+    assert response.status_code == 200
+    events = _sse_events(response.text)
+    reasoning = "".join(
+        data["delta"]
+        for event_type, data in events
+        if event_type == "response.reasoning_text.delta"
+    )
+    content = "".join(
+        data["delta"]
+        for event_type, data in events
+        if event_type == "response.output_text.delta"
+    )
+
+    assert reasoning == "North reasoning."
+    assert content == "North answer."
+    assert template_kwargs["enable_thinking"] is True
+    assert template_kwargs["reasoning"] is True
+    assert template_kwargs["reasoning_effort"] == "high"
+    assert "<|END_THINKING|>" not in response.text
+    assert "<|START_TEXT|>" not in response.text
+    assert "<|END_TEXT|>" not in response.text
+
+
 def test_responses_streaming_emits_function_call_arguments_done(client):
     server.response_store.clear()
     server.response_store_order.clear()
@@ -2458,6 +2524,88 @@ def test_chat_completions_streaming_uses_custom_thinking_markers(client, monkeyp
         "Custom reasoning."
     )
     assert "".join(delta.get("content") or "" for delta in deltas) == ("Custom answer.")
+
+
+def test_chat_completions_streaming_uses_prompt_opened_thinking_without_flag(
+    client, monkeypatch
+):
+    model = SimpleNamespace()
+    processor = SimpleNamespace()
+    config = SimpleNamespace(model_type="cohere2_moe")
+
+    class FakeResponseGenerator:
+        tokenizer = SimpleNamespace(decode=lambda tokens: "")
+
+        def validate_context_budget(self, prompt, images=None, audio=None, args=None):
+            return None
+
+        def generate(self, prompt, images=None, audio=None, args=None):
+            return server.GenerationContext(uid=1, prompt_tokens=8), iter(
+                [
+                    server.StreamingToken(
+                        text="North reasoning.",
+                        token=1,
+                        logprobs=0.0,
+                        finish_reason=None,
+                    ),
+                    server.StreamingToken(
+                        text="<|END_THINK",
+                        token=2,
+                        logprobs=0.0,
+                        finish_reason=None,
+                    ),
+                    server.StreamingToken(
+                        text="ING|><|START_TEXT|>North answer.<|END_TEXT|>",
+                        token=3,
+                        logprobs=0.0,
+                        finish_reason="stop",
+                    ),
+                ]
+            )
+
+    monkeypatch.setattr(server.runtime, "response_generator", FakeResponseGenerator())
+
+    with (
+        patch.object(
+            server, "get_cached_model", return_value=(model, processor, config)
+        ),
+        patch.object(
+            server,
+            "apply_chat_template",
+            return_value="prompt<|START_THINKING|>",
+        ),
+    ):
+        response = client.post(
+            "/chat/completions",
+            json={
+                "model": "CohereLabs/North-Mini-Code-1.0-w4a16",
+                "messages": [{"role": "user", "content": "Hello"}],
+                "stream": True,
+            },
+        )
+
+    assert response.status_code == 200
+    chunks = [
+        json.loads(line[len("data: ") :])
+        for line in response.text.splitlines()
+        if line.startswith("data: ") and line != "data: [DONE]"
+    ]
+    deltas = [
+        chunk["choices"][0]["delta"]
+        for chunk in chunks
+        if chunk.get("choices") and chunk["choices"][0].get("delta")
+    ]
+
+    assert "".join(delta.get("reasoning_content") or "" for delta in deltas) == (
+        "North reasoning."
+    )
+    assert "".join(delta.get("reasoning") or "" for delta in deltas) == (
+        "North reasoning."
+    )
+    assert "".join(delta.get("content") or "" for delta in deltas) == "North answer."
+    assert "<|END_THINKING|>" not in response.text
+    assert "<|START_TEXT|>" not in response.text
+    assert "<|END_TEXT|>" not in response.text
 
 
 def test_chat_completions_streaming_keeps_plain_output_as_content_when_thinking_enabled(
@@ -4987,11 +5135,15 @@ class TestResponseGenerator:
     def test_generate_arguments_to_template_kwargs(self):
         args = server.GenerationArguments(
             enable_thinking=False,
+            reasoning=True,
+            reasoning_effort="high",
             thinking_budget=50,
             thinking_end_token="</think>",
         )
         kw = args.to_template_kwargs()
         assert kw["enable_thinking"] is False
+        assert kw["reasoning"] is True
+        assert kw["reasoning_effort"] == "high"
         assert kw["thinking_budget"] == 50
         assert kw["thinking_end_token"] == "</think>"
 
@@ -5180,6 +5332,61 @@ class TestResponseGenerator:
         args = server._build_gen_args(req)
         assert args.max_tokens == 256
         assert args.enable_thinking is True
+
+    def test_build_gen_args_maps_responses_reasoning_configuration(self):
+        req = server.OpenAIRequest(
+            model="demo",
+            input="hi",
+            reasoning={"effort": "high", "summary": "auto"},
+        )
+
+        args = server._build_gen_args(req)
+
+        assert args.enable_thinking is True
+        assert args.reasoning is True
+        assert args.reasoning_effort == "high"
+        assert args.to_template_kwargs()["reasoning"] is True
+        assert args.to_template_kwargs()["reasoning_effort"] == "high"
+
+    def test_build_gen_args_maps_chat_reasoning_effort(self):
+        req = server.ChatRequest(
+            model="demo",
+            messages=[server.ChatMessage(role="user", content="hi")],
+            reasoning_effort="low",
+        )
+
+        args = server._build_gen_args(req)
+
+        assert args.enable_thinking is True
+        assert args.reasoning is True
+        assert args.reasoning_effort == "low"
+
+    def test_build_gen_args_maps_none_reasoning_effort_to_disabled(self):
+        req = server.OpenAIRequest(
+            model="demo",
+            input="hi",
+            reasoning={"effort": "none"},
+        )
+
+        args = server._build_gen_args(req)
+
+        assert args.enable_thinking is False
+        assert args.reasoning is False
+        assert args.reasoning_effort == "none"
+
+    def test_build_gen_args_explicit_thinking_overrides_standard_reasoning(self):
+        req = server.ChatRequest(
+            model="demo",
+            messages=[server.ChatMessage(role="user", content="hi")],
+            enable_thinking=False,
+            reasoning_effort="high",
+        )
+
+        args = server._build_gen_args(req)
+
+        assert args.enable_thinking is False
+        assert args.reasoning is False
+        assert args.reasoning_effort == "high"
 
     def test_build_gen_args_preserves_diffusion_options(self):
         req = server.ChatRequest(
@@ -5785,6 +5992,14 @@ class TestThinkingStreamState:
                 enable_thinking=True,
                 thinking_start_token="<analysis>",
                 thinking_end_token="</analysis>",
+            )
+            is True
+        )
+
+    def test_prompt_open_marker_is_authoritative_when_flag_is_disabled(self):
+        assert (
+            server.prompt_has_open_thinking(
+                "prompt<|START_THINKING|>", enable_thinking=False
             )
             is True
         )


### PR DESCRIPTION
## Summary

- normalize standard Responses API `reasoning.effort` and Chat Completions `reasoning_effort` into mlx-vlm thinking controls
- forward normalized `reasoning` and `reasoning_effort` values to chat templates while preserving explicit `enable_thinking` precedence
- detect prompt-opened thinking blocks during streaming even when the request omits mlx-vlm's custom thinking fields
- keep reasoning and Cohere text delimiters out of normal answer content for both Chat Completions and Responses API streams

## Root cause

Some chat templates, including Cohere North, place the thinking opener in the rendered prompt. Generation therefore begins directly with reasoning and later emits only the closing delimiter. The streaming parser previously started in content mode whenever `enable_thinking` was absent, so it never observed the opener and leaked reasoning plus the closing marker through normal content. Non-streaming responses were unaffected because they split the completed output afterward.

## Impact

Standard OpenAI-compatible clients can now request reasoning without mlx-vlm-specific fields. Templates receive the reasoning controls they expect, and streaming classification follows the actual rendered prompt rather than depending solely on request metadata. No model ID is hardcoded.

## Validation

- `217 passed` in `mlx_vlm/tests/test_server.py`
- Black, isort, autoflake, and `git diff --check` pass
- live North server verification for default, explicit mlx-vlm, and standard reasoning requests: reasoning separated, final content `Hi`, no delimiter leakage
- live Responses API verification: reasoning delta/done events and `response.completed` emitted successfully