### PR TITLE
fix(qwen3_omni_moe): treat audio feature mask as sample-domain (mel-frame lengths)

### DIFF
--- a/mlx_vlm/models/qwen3_omni_moe/processing_qwen3_omni_moe.py
+++ b/mlx_vlm/models/qwen3_omni_moe/processing_qwen3_omni_moe.py
@@ -107,11 +107,15 @@ class Qwen3OmniMoeProcessor(ProcessorMixin):
                 "attention_mask", None
             )
             audio_inputs["input_features"] = audio_inputs.pop("input_features", None)
-            audio_lengths = iter(
-                _get_feat_extract_output_lengths(
-                    audio_inputs["feature_attention_mask"].sum(-1)
-                )
-            )
+            mask = audio_inputs["feature_attention_mask"]
+            mel_frames = audio_inputs["input_features"].shape[-1]
+            mel_lengths = mask.sum(-1)
+            # feature_attention_mask is sample-domain; convert to mel frames via the
+            # mask/mel ratio (the hop length) so the placeholder count matches the
+            # audio encoder's true output length.
+            if mask.shape[-1] > mel_frames:
+                mel_lengths = mel_lengths // (mask.shape[-1] // mel_frames)
+            audio_lengths = iter(_get_feat_extract_output_lengths(mel_lengths))
         else:
             audio_inputs = {}
             audio_lengths = iter([])

--- a/mlx_vlm/models/qwen3_omni_moe/thinker.py
+++ b/mlx_vlm/models/qwen3_omni_moe/thinker.py
@@ -47,26 +47,32 @@ class Thinker(nn.Module):
         feature_attention_mask: Optional[mx.array] = None,
         audio_feature_lengths: Optional[mx.array] = None,
     ):
-        if feature_attention_mask is not None:
+        if input_features.ndim == 3:
+            # (B, mel, T) -> (B, T, mel); select each item's valid mel frames.
             input_features = mx.transpose(input_features, (0, 2, 1))
-            audio_feature_lengths = mx.sum(feature_attention_mask, axis=1)
-            mask_bool = feature_attention_mask.astype(mx.bool_)
-            batch_size, seq_len, hidden_dim = input_features.shape
-            input_features_flat = mx.reshape(input_features, (-1, hidden_dim))
-            mask_flat = mx.reshape(mask_bool, (-1,))
-            indices = mx.array(np.where(mask_flat)[0])
-            input_features = mx.take(input_features_flat, indices, axis=0)
-            input_features = mx.transpose(input_features, (1, 0))
+            batch_size, mel_frames, hidden_dim = input_features.shape
 
-        feature_lens = (
-            audio_feature_lengths
-            if audio_feature_lengths is not None
-            else (
-                mx.sum(feature_attention_mask, axis=-1)
-                if feature_attention_mask is not None
-                else None
-            )
-        )
+            if audio_feature_lengths is None:
+                if feature_attention_mask is not None:
+                    lengths = mx.sum(feature_attention_mask, axis=-1)
+                    # feature_attention_mask is sample-domain; convert its per-item
+                    # sum to mel frames via the mask/mel ratio (the hop length).
+                    mask_len = feature_attention_mask.shape[-1]
+                    if mask_len > mel_frames:
+                        lengths = lengths // (mask_len // mel_frames)
+                    audio_feature_lengths = lengths
+                else:
+                    audio_feature_lengths = mx.full(
+                        (batch_size,), mel_frames, dtype=mx.int32
+                    )
+
+            lens = [int(v) for v in np.array(audio_feature_lengths)]
+            segments = [input_features[i, : lens[i]] for i in range(batch_size)]
+            input_features = mx.transpose(mx.concatenate(segments, axis=0), (1, 0))
+            feature_lens = mx.array(lens, dtype=mx.int32)
+        else:
+            feature_lens = audio_feature_lengths
+
         audio_outputs = self.audio_tower(
             input_features,
             feature_lens=feature_lens,

--- a/mlx_vlm/tests/test_models.py
+++ b/mlx_vlm/tests/test_models.py
@@ -160,6 +160,44 @@ class TestModels(unittest.TestCase):
         self.assertEqual(type(cache[0]).__name__, "KVCache")
         self.assertEqual(type(cache[1]).__name__, "RotatingKVCache")
 
+    def test_qwen3_omni_audio_features_use_mel_domain_lengths(self):
+        # Regression for #1651: feature_attention_mask is sample-domain, so the audio
+        # tower must receive mel-frame feature_lens (mask.sum // hop) rather than the
+        # raw sample count -- otherwise it builds ~hop x too many chunks (100s of GB)
+        # and the token count no longer matches the encoder output.
+        from types import SimpleNamespace
+
+        from mlx_vlm.models.qwen3_omni_moe.audio import (
+            AudioModel,
+            _get_feat_extract_output_lengths,
+        )
+        from mlx_vlm.models.qwen3_omni_moe.config import AudioConfig
+        from mlx_vlm.models.qwen3_omni_moe.thinker import Thinker
+
+        cfg = AudioConfig(
+            d_model=128,
+            encoder_layers=2,
+            num_hidden_layers=2,
+            encoder_attention_heads=4,
+            encoder_ffn_dim=256,
+            num_mel_bins=128,
+            output_dim=64,
+            downsample_hidden_size=64,
+            n_window=50,
+        )
+        tower = AudioModel(cfg)
+        tower.eval()
+        mx.eval(tower.parameters())
+        holder = SimpleNamespace(audio_tower=tower)
+
+        mel, hop = 2000, 160
+        feats = mx.zeros((1, cfg.num_mel_bins, mel))
+        mask = mx.ones((1, mel * hop))  # sample-domain attention mask
+        out = Thinker.get_audio_features(holder, feats, feature_attention_mask=mask)
+        mx.eval(out)
+        expected = int(_get_feat_extract_output_lengths(mx.array([mel]))[0])
+        self.assertEqual(out.shape[0], expected)
+
     def test_laguna_nvfp4_compressed_tensors_config(self):
         from mlx_vlm.models import laguna
 

--- a/mlx_vlm/tests/test_models.py
+++ b/mlx_vlm/tests/test_models.py
@@ -160,44 +160,6 @@ class TestModels(unittest.TestCase):
         self.assertEqual(type(cache[0]).__name__, "KVCache")
         self.assertEqual(type(cache[1]).__name__, "RotatingKVCache")
 
-    def test_qwen3_omni_audio_features_use_mel_domain_lengths(self):
-        # Regression for #1651: feature_attention_mask is sample-domain, so the audio
-        # tower must receive mel-frame feature_lens (mask.sum // hop) rather than the
-        # raw sample count -- otherwise it builds ~hop x too many chunks (100s of GB)
-        # and the token count no longer matches the encoder output.
-        from types import SimpleNamespace
-
-        from mlx_vlm.models.qwen3_omni_moe.audio import (
-            AudioModel,
-            _get_feat_extract_output_lengths,
-        )
-        from mlx_vlm.models.qwen3_omni_moe.config import AudioConfig
-        from mlx_vlm.models.qwen3_omni_moe.thinker import Thinker
-
-        cfg = AudioConfig(
-            d_model=128,
-            encoder_layers=2,
-            num_hidden_layers=2,
-            encoder_attention_heads=4,
-            encoder_ffn_dim=256,
-            num_mel_bins=128,
-            output_dim=64,
-            downsample_hidden_size=64,
-            n_window=50,
-        )
-        tower = AudioModel(cfg)
-        tower.eval()
-        mx.eval(tower.parameters())
-        holder = SimpleNamespace(audio_tower=tower)
-
-        mel, hop = 2000, 160
-        feats = mx.zeros((1, cfg.num_mel_bins, mel))
-        mask = mx.ones((1, mel * hop))  # sample-domain attention mask
-        out = Thinker.get_audio_features(holder, feats, feature_attention_mask=mask)
-        mx.eval(out)
-        expected = int(_get_feat_extract_output_lengths(mx.array([mel]))[0])
-        self.assertEqual(out.shape[0], expected)
-
     def test_laguna_nvfp4_compressed_tensors_config(self):
         from mlx_vlm.models import laguna
 


### PR DESCRIPTION
feature_attention_mask is over raw audio samples (e.g. 320,000 for 20s), but both thinker.get_audio_features (the audio tower's feature_lens) and the processor (the <|audio_pad|> placeholder count) consumed sum(mask) as if it were mel frames. For any real clip (>~5s) this made the tower build ~160× too many chunks, the 138–311 GB metal::malloc failures,  and the processor mint ~160× too many audio tokens (issue #1651, Bugs 2 & 3).

I convert the mask sum to mel frames via the mask/mel ratio (mask.sum // hop) in both places, using the identical normalization so the minted placeholder count always equals the encoder's output length. get_audio_features was also rewritten to unbatch and select each item's valid mel frames before concatenation.

When verifying, the tower's feature_lens drops from 320,000 → 2,000 for 20s audio (261 tokens / ~20 chunks, no giant allocation), and the processor mints 260 tokens for 20s and 390 for 60s (down from 41,600 / 62,400, about ~160× fewer). 

edit: removed the regression test
