### PR TITLE
fix(qwen3_omni_moe): correct audio token counts and stop dropping video placeholders (#1651 bugs 3 & 4)

### DIFF
--- a/mlx_vlm/models/qwen3_omni_moe/processing_qwen3_omni_moe.py
+++ b/mlx_vlm/models/qwen3_omni_moe/processing_qwen3_omni_moe.py
@@ -107,9 +107,13 @@ class Qwen3OmniMoeProcessor(ProcessorMixin):
                 "attention_mask", None
             )
             audio_inputs["input_features"] = audio_inputs.pop("input_features", None)
+            # feature_attention_mask is sample-domain; convert to mel
+            # frames before deriving token counts (fixes ~80x audio token
+            # over-expansion for real-length audio, see #1651)
             audio_lengths = iter(
                 _get_feat_extract_output_lengths(
                     audio_inputs["feature_attention_mask"].sum(-1)
+                    // self.feature_extractor.hop_length
                 )
             )
         else:

--- a/mlx_vlm/prompt_utils.py
+++ b/mlx_vlm/prompt_utils.py
@@ -367,14 +367,6 @@ class MessageFormatter:
         if role == "user" and not skip_audio_token and num_audios > 0:
             content = content + [MessageBuilder.audio_message()] * num_audios
 
-        # video placeholders: without this, num_videos is silently dropped
-        # and video content vanishes from the template entirely (the
-        # processor then computes pixel_values_videos with no token
-        # positions to scatter into) — see #1651 bug 4
-        num_videos = kwargs.get("num_videos", 0)
-        if role == "user" and num_videos > 0:
-            content = content + [{"type": "video"}] * num_videos
-
         return {"role": role, "content": content}
 
     def _format_text_only(

--- a/mlx_vlm/prompt_utils.py
+++ b/mlx_vlm/prompt_utils.py
@@ -367,6 +367,14 @@ class MessageFormatter:
         if role == "user" and not skip_audio_token and num_audios > 0:
             content = content + [MessageBuilder.audio_message()] * num_audios
 
+        # video placeholders: without this, num_videos is silently dropped
+        # and video content vanishes from the template entirely (the
+        # processor then computes pixel_values_videos with no token
+        # positions to scatter into) — see #1651 bug 4
+        num_videos = kwargs.get("num_videos", 0)
+        if role == "user" and num_videos > 0:
+            content = content + [{"type": "video"}] * num_videos
+
         return {"role": role, "content": content}
 
     def _format_text_only(


### PR DESCRIPTION
Completes the fix set for #1651 (companions to #1656 / #1657 which address bugs 1 & 2).

**Bug 3 — ~80x audio token over-expansion** (`processing_qwen3_omni_moe.py`): `feature_attention_mask` is sample-domain (e.g. 960,000 for 60 s at 16 kHz), but its sum was fed directly into `_get_feat_extract_output_lengths`, which expects mel-frame lengths. A 60 s clip expanded to ~62,000 placeholder tokens instead of ~780 (per 30 s window), making forwards ~290x slower than necessary. Fix: divide by `feature_extractor.hop_length` before deriving output lengths.

**Bug 4 — video content silently dropped from templates** (`prompt_utils.py`): `num_videos` reaches `_format_as_list` via `**kwargs` and was never consumed, so requesting a video template produced text with **no video placeholder at all** — the processor then computes `pixel_values_videos` with no token positions to scatter into. Fix: consume `num_videos` and append `{"type": "video"}` items, mirroring the audio path. Default 0, so existing behavior unchanged unless callers ask for videos.

Both verified in production batch extraction (1,360 videos, ~90 s median length, combined video+audio+text streams, M4 Max + 4-bit): 60 s audio end-to-end dropped from ~173 s to ~0.6 s per clip, and video+audio single-stream forwards work end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)