### PR TITLE
chore(deps): make training-only datasets an optional [train] extra

### DIFF
--- a/README.md
+++ b/README.md
@@ -1422,7 +1422,12 @@ See [docs/usage.md](https://github.com/Blaizzy/mlx-vlm/blob/main/docs/usage.md#d
 
 # Fine-tuning
 
-MLX-VLM supports fine-tuning models with LoRA and QLoRA.
+MLX-VLM supports fine-tuning models with LoRA and QLoRA. Fine-tuning (and the
+eval scripts) need the training extra, which is not installed by default:
+
+```bash
+pip install "mlx-vlm[train]"
+```
 
 ## LoRA & QLoRA
 

--- a/mlx_vlm/LORA.MD
+++ b/mlx_vlm/LORA.MD
@@ -7,7 +7,11 @@
 ## Requirements
 
 - Python 3.7+
-- Required Python packages: `mlx-vlm`, `mlx`, `numpy`, `transformers`, `datasets`, `PIL`
+- Install the training extra (adds `datasets` on top of the inference dependencies):
+
+  ```bash
+  pip install "mlx-vlm[train]"
+  ```
 
 ## Trainer Backend
 

--- a/mlx_vlm/evals/math_vista.py
+++ b/mlx_vlm/evals/math_vista.py
@@ -8,7 +8,12 @@ import re
 from pathlib import Path
 from typing import Optional
 
-from datasets import load_dataset
+try:
+    from datasets import load_dataset
+except ModuleNotFoundError as e:  # optional 'train' extra
+    raise ImportError(
+        "Evaluation requires the 'train' extra: pip install 'mlx-vlm[train]'"
+    ) from e
 from PIL import Image
 from tqdm import tqdm
 

--- a/mlx_vlm/evals/mmmu.py
+++ b/mlx_vlm/evals/mmmu.py
@@ -6,7 +6,12 @@ import random
 import re
 from json import dump
 
-from datasets import load_dataset
+try:
+    from datasets import load_dataset
+except ModuleNotFoundError as e:  # optional 'train' extra
+    raise ImportError(
+        "Evaluation requires the 'train' extra: pip install 'mlx-vlm[train]'"
+    ) from e
 from tqdm import tqdm
 
 from mlx_vlm import load

--- a/mlx_vlm/evals/mmstar.py
+++ b/mlx_vlm/evals/mmstar.py
@@ -7,7 +7,12 @@ import re
 from copy import deepcopy
 from json import dump
 
-from datasets import load_dataset
+try:
+    from datasets import load_dataset
+except ModuleNotFoundError as e:  # optional 'train' extra
+    raise ImportError(
+        "Evaluation requires the 'train' extra: pip install 'mlx-vlm[train]'"
+    ) from e
 from tqdm import tqdm
 
 from mlx_vlm import load

--- a/mlx_vlm/evals/ocrbench.py
+++ b/mlx_vlm/evals/ocrbench.py
@@ -8,7 +8,13 @@ from pathlib import Path
 from typing import Optional
 
 import mlx.core as mx
-from datasets import load_dataset
+
+try:
+    from datasets import load_dataset
+except ModuleNotFoundError as e:  # optional 'train' extra
+    raise ImportError(
+        "Evaluation requires the 'train' extra: pip install 'mlx-vlm[train]'"
+    ) from e
 from tqdm import tqdm
 
 from mlx_vlm import load

--- a/mlx_vlm/lora.py
+++ b/mlx_vlm/lora.py
@@ -3,7 +3,13 @@ import json
 import logging
 
 import mlx.optimizers as optim
-from datasets import load_dataset
+
+try:
+    from datasets import load_dataset
+except ModuleNotFoundError as e:  # optional 'train' extra
+    raise ImportError(
+        "Fine-tuning requires the 'train' extra: pip install 'mlx-vlm[train]'"
+    ) from e
 
 from .trainer.datasets import PreferenceVisionDataset, VisionDataset
 from .trainer.orpo_trainer import ORPOTrainingArgs, train_orpo

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,3 +46,4 @@ dependencies = {file = ["requirements.txt"]}
 ui = ["gradio>=5.19.0"]
 cuda = ["mlx-cuda"]
 cpu = ["mlx-cpu"]
+train = ["datasets>=2.19.1"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 mlx>=0.32.0
 transformers>=5.14.0
-datasets>=2.19.1
 miniaudio>=1.59
 tqdm>=4.66.2
 Pillow>=10.3.0


### PR DESCRIPTION
configures it so that mlx-vlm for lora is when other libraries are downloaded, inference-only regime therefore stays lean

verified the full inference surface imports without datasets; lora/evals raise the friendly error when not downloaded properly.

docs updated as well