### PR TITLE
fix(utils): resolve model module before AutoProcessor in load_processor

### DIFF
--- a/mlx_vlm/tests/test_utils.py
+++ b/mlx_vlm/tests/test_utils.py
@@ -781,6 +781,48 @@ def test_load_processor_propagates_auto_processor_errors():
             load_processor(Path("/tmp/model"), eos_token_ids=2)
 
 
+def test_load_processor_registers_model_module_before_auto_processor(tmp_path):
+    """Standalone load_processor must import the model module first so
+    import-time AutoProcessor registrations (install_auto_processor_patch)
+    are visible — load() got this implicitly via load_model."""
+    (tmp_path / "config.json").write_text(json.dumps({"model_type": "qwen3_5"}))
+    call_order = []
+
+    with (
+        patch(
+            "mlx_vlm.utils.get_model_and_args",
+            side_effect=lambda cfg: call_order.append(("register", cfg["model_type"])),
+        ),
+        patch(
+            "mlx_vlm.utils.AutoProcessor.from_pretrained",
+            side_effect=lambda *a, **k: call_order.append(("auto_processor",))
+            or MagicMock(),
+        ),
+    ):
+        load_processor(tmp_path, add_detokenizer=False)
+
+    assert call_order[0] == ("register", "qwen3_5")
+    assert call_order[1] == ("auto_processor",)
+
+
+def test_load_processor_module_resolution_is_best_effort(tmp_path):
+    """No local config.json and the hub fetch failing must not break
+    load_processor — AutoProcessor proceeds exactly as before."""
+    processor_mock = MagicMock()
+    with (
+        patch("huggingface_hub.hf_hub_download", side_effect=OSError("offline")),
+        patch("mlx_vlm.utils.get_model_and_args") as mock_get_model_and_args,
+        patch(
+            "mlx_vlm.utils.AutoProcessor.from_pretrained",
+            return_value=processor_mock,
+        ),
+    ):
+        processor = load_processor(tmp_path / "missing", add_detokenizer=False)
+
+    assert processor is processor_mock
+    mock_get_model_and_args.assert_not_called()
+
+
 def test_text_only_model_provides_input_embeddings_and_wraps_logits():
     class TinyInner(nn.Module):
         def __init__(self):

--- a/mlx_vlm/utils.py
+++ b/mlx_vlm/utils.py
@@ -932,10 +932,42 @@ def load_image_processor(model_path: Union[str, Path], **kwargs) -> BaseImagePro
     return image_processor
 
 
+def _ensure_model_module_registered(model_path) -> None:
+    """Best-effort import of the model's mlx-vlm module before AutoProcessor
+    resolution.
+
+    Many model modules register their own processor classes with
+    ``AutoProcessor`` at import time (``install_auto_processor_patch``), which
+    ``load_model()`` triggers via ``get_model_and_args`` but a standalone
+    ``load_processor()`` call does not — so processors that transformers
+    cannot resolve on its own (e.g. a qwen3_5 quant written by
+    ``mlx_vlm.convert``) fail to load. Only ``config.json`` is read: local
+    directories directly, hub repos via ``hf_hub_download`` (never weights).
+
+    Failures are deliberately swallowed: this is a pre-registration pass, and
+    on any error ``AutoProcessor.from_pretrained`` proceeds exactly as before.
+    """
+    try:
+        config_file = Path(model_path) / "config.json"
+        if not config_file.exists():
+            from huggingface_hub import hf_hub_download
+
+            config_file = Path(
+                hf_hub_download(repo_id=str(model_path), filename="config.json")
+            )
+        with open(config_file, encoding="utf-8") as f:
+            get_model_and_args(json.load(f))
+    except Exception:
+        pass
+
+
 def load_processor(
     model_path, add_detokenizer=True, eos_token_ids=None, **kwargs
 ) -> ProcessorMixin:
 
+    if isinstance(model_path, str) and Path(model_path).exists():
+        model_path = Path(model_path)  # load_tokenizer below needs a Path
+    _ensure_model_module_registered(model_path)
     processor = AutoProcessor.from_pretrained(model_path, **kwargs)
     if add_detokenizer:
         detokenizer_class = load_tokenizer(model_path, return_tokenizer=False)


### PR DESCRIPTION
## Problem

A standalone `load_processor()` call fails for models whose processor classes are registered by mlx-vlm itself, while `load()` on the same path works:

```python
from mlx_vlm.utils import load_processor
load_processor("<local qwen3_5 quant written by mlx_vlm.convert>")
# ValueError: Unrecognized image processor in ...
```

Reproduced on current `main` (torch-free venv, transformers 5.14.1, macOS/Apple Silicon) with a Qwen3.5-based quant produced by `mlx_vlm.convert` (microsoft/Fara1.5-9B → 4-bit). `mlx_vlm.load()` on the identical path returns `Qwen3VLProcessor` fine.

## Root cause

30+ model modules install their `AutoProcessor` registrations as an **import side-effect** (`install_auto_processor_patch` in `qwen3_5`, `gemma3`/`gemma4`, `kimi_k25`, `molmo`, `phi3_v`, `deepseekocr`, …). `load()` triggers those imports via `load_model()` → `get_model_and_args`, but `load_processor()` calls `AutoProcessor.from_pretrained` directly — so whether it works depends on whether the caller happened to load weights first in the same process. Anyone using `load_processor` standalone (chat-template rendering, request validation in a server, tokenizer-only tooling) hits the raw transformers error.

## Fix

`_ensure_model_module_registered(model_path)`: best-effort resolution of the model module before the `AutoProcessor` call, mirroring what `load_image_processor` already does — but reading **only `config.json`** (local dirs directly; hub repos via `hf_hub_download`, never a weights snapshot). Every failure mode falls through to the previous behavior, so this can only widen the set of models that load.

Also normalizes an existing-local-dir `str` to `Path` at the top of `load_processor`: the `add_detokenizer` branch does `model_path / "tokenizer.json"`, which previously crashed with `TypeError` for plain-string local paths (second latent bug on the same standalone path).

## Verification

- Before: `load_processor(<qwen3_5 quant>)` raises `ValueError: Unrecognized image processor`; after: returns `Qwen3VLProcessor` with detokenizer + stopping criteria attached (str and `Path` args both).
- `load()` on the same model unregressed.
- `pytest mlx_vlm/tests/test_utils.py` — 36/36 pass (34 existing + 2 new regression tests: registration ordering, and best-effort fall-through when no config is reachable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)