### PR TITLE
Add typical-p (locally typical) sampler

### DIFF
--- a/mlx_vlm/generate/ar.py
+++ b/mlx_vlm/generate/ar.py
@@ -166,6 +166,7 @@ def generate_step(
     top_k: int = DEFAULT_TOP_K,
     top_n_sigma: float = DEFAULT_TOP_N_SIGMA,
     p_less: bool = False,
+    typical_p: float = 1.0,
     logit_bias: Optional[Dict[int, float]] = None,
     prompt_cache: Optional[List[Any]] = None,
     max_kv_size: Optional[int] = None,
@@ -259,6 +260,7 @@ def generate_step(
             and top_k == DEFAULT_TOP_K
             and top_n_sigma == DEFAULT_TOP_N_SIGMA
             and not p_less
+            and typical_p == 1.0
         ):
             sampler = _PositionedTargetSampler(
                 temperature=temperature,
@@ -273,6 +275,7 @@ def generate_step(
                 top_k=top_k,
                 top_n_sigma=top_n_sigma,
                 p_less=p_less,
+                typical_p=typical_p,
             )
 
     processors = _generate_module_override(

--- a/mlx_vlm/sample_utils.py
+++ b/mlx_vlm/sample_utils.py
@@ -15,6 +15,7 @@ def make_sampler(
     top_k: int = 0,
     top_n_sigma: float = 0.0,
     p_less: bool = False,
+    typical_p: float = 1.0,
     xtc_probability: float = 0.0,
     xtc_threshold: float = 0.0,
     xtc_special_tokens: Optional[List[int]] = None,
@@ -41,6 +42,9 @@ def make_sampler(
           tokens whose probability is at least the collision probability
           (sum of squared probabilities) of the temperature-scaled
           distribution. Default: ``False``.
+        typical_p (float, optional): Locally typical sampling. Keeps the most
+          typical tokens (surprisal closest to the distribution entropy) until
+          their cumulative probability reaches ``typical_p``. ``1.0`` disables.
         xtc_probability (float, optional): The probability of applying XTC
             sampling.
         xtc_threshold (float, optional): The threshold the probs need to reach
@@ -64,6 +68,8 @@ def make_sampler(
         sampling_methods.append(lambda x: apply_top_n_sigma(x, top_n_sigma))
     if p_less:
         sampling_methods.append(lambda x: apply_p_less(x, temp))
+    if typical_p > 0.0 and typical_p < 1.0:
+        sampling_methods.append(lambda x: apply_typical_p(x, typical_p))
     if top_p > 0 and top_p < 1.0:
         sampling_methods.append(lambda x: apply_top_p(x, top_p))
     if min_p != 0.0:
@@ -310,6 +316,33 @@ def apply_top_p(logprobs: mx.array, top_p: float) -> mx.array:
         logprobs,
         -float("inf"),
     )
+
+
+def apply_typical_p(logprobs: mx.array, typical_p: float) -> mx.array:
+    """Locally typical sampling (https://arxiv.org/abs/2202.00666)."""
+    if not (0.0 < typical_p <= 1.0):
+        raise ValueError(
+            f"`typical_p` has to be a float in the (0, 1] interval, but is {typical_p}"
+        )
+    return _typical_p(logprobs, typical_p)
+
+
+@partial(mx.compile, inputs=mx.random.state, outputs=mx.random.state)
+def _typical_p(logprobs: mx.array, typical_p: float) -> mx.array:
+    p = mx.exp(logprobs)
+    ent = -mx.sum(p * logprobs, axis=-1, keepdims=True)
+    shifted = mx.abs(-logprobs - ent)
+    sorted_indices = mx.argsort(shifted, axis=-1)
+    sorted_probs = mx.take_along_axis(p, sorted_indices, axis=-1)
+    cumulative_probs = mx.cumsum(sorted_probs, axis=-1)
+    inverse_indices = mx.put_along_axis(
+        mx.zeros_like(sorted_indices),
+        sorted_indices,
+        mx.arange(sorted_indices.shape[-1], dtype=sorted_indices.dtype),
+        axis=-1,
+    )
+    cumulative_probs = mx.take_along_axis(cumulative_probs, inverse_indices, axis=-1)
+    return mx.where(cumulative_probs - p < typical_p, logprobs, -float("inf"))
 
 
 @partial(mx.compile, inputs=mx.random.state, outputs=mx.random.state)

--- a/mlx_vlm/server/generation.py
+++ b/mlx_vlm/server/generation.py
@@ -676,6 +676,7 @@ class GenerationArguments:
     min_p: float = 0.0
     top_n_sigma: float = 0.0
     p_less: bool = False
+    typical_p: float = 1.0
     seed: Optional[int] = None
     logprobs: bool = False
     repetition_penalty: Optional[float] = None
@@ -744,6 +745,7 @@ class GenerationArguments:
             "min_p": self.min_p,
             "top_n_sigma": self.top_n_sigma,
             "p_less": self.p_less,
+            "typical_p": self.typical_p,
             "enable_thinking": self.enable_thinking,
         }
         if self.seed is not None:
@@ -1423,6 +1425,12 @@ class ResponseGenerator:
                 temp=args.temperature,
                 top_p=args.top_p,
                 p_less=True,
+            )
+        if args.typical_p < 1.0:
+            return make_sampler(
+                temp=args.temperature,
+                top_p=args.top_p,
+                typical_p=args.typical_p,
             )
         return _PositionedTargetSampler(
             temperature=args.temperature,

--- a/mlx_vlm/server/request_normalization.py
+++ b/mlx_vlm/server/request_normalization.py
@@ -178,6 +178,7 @@ def _build_gen_args(
         min_p=getattr(request, "min_p", 0.0),
         top_n_sigma=getattr(request, "top_n_sigma", 0.0),
         p_less=getattr(request, "p_less", False),
+        typical_p=getattr(request, "typical_p", 1.0),
         seed=getattr(request, "seed", None),
         logprobs=bool(getattr(request, "logprobs", False)),
         repetition_penalty=getattr(request, "repetition_penalty", None),

--- a/mlx_vlm/server/schemas.py
+++ b/mlx_vlm/server/schemas.py
@@ -344,6 +344,9 @@ class OpenAIRequest(FlexibleBaseModel):
     p_less: bool = Field(
         False, description="Hyperparameter-free p-less sampling (on/off)."
     )
+    typical_p: float = Field(
+        1.0, description="Locally typical sampling. 1.0 disables; typical ~0.2-0.95."
+    )
     repetition_penalty: Optional[float] = Field(None, description="Repetition penalty.")
     repetition_context_size: Optional[int] = Field(
         None, description="Repetition penalty context size."
@@ -729,6 +732,9 @@ class VLMRequest(FlexibleBaseModel):
     )
     p_less: bool = Field(
         False, description="Hyperparameter-free p-less sampling (on/off)."
+    )
+    typical_p: float = Field(
+        1.0, description="Locally typical sampling. 1.0 disables; typical ~0.2-0.95."
     )
     seed: int = Field(DEFAULT_SEED, description="Seed for random generation.")
     repetition_penalty: Optional[float] = Field(None, description="Repetition penalty.")

--- a/mlx_vlm/tests/test_generate.py
+++ b/mlx_vlm/tests/test_generate.py
@@ -1768,6 +1768,7 @@ class TestSamplerArgs:
             top_k=32,
             top_n_sigma=0.0,
             p_less=False,
+            typical_p=1.0,
         )
         mock_make_logits_processors.assert_called_once_with(
             {3: -0.75}, 1.15, 512, 0.2, 256, 0.3, 128

--- a/mlx_vlm/tests/test_sample_utils.py
+++ b/mlx_vlm/tests/test_sample_utils.py
@@ -8,6 +8,7 @@ from mlx_vlm.sample_utils import (
     apply_p_less,
     apply_top_k,
     apply_top_n_sigma,
+    apply_typical_p,
     make_sampler,
     top_p_sampling,
 )
@@ -246,6 +247,81 @@ class TestPLess(unittest.TestCase):
         toks = sampler(mx.array([[1.0, 2.0, 3.0, 4.0, 5.0]] * 16))
         mx.eval(toks)
         self.assertEqual(toks.shape, (16,))
+
+
+def _np_typical_keep(logits, typical_p):
+    logp = np.asarray(logits, dtype=np.float64)
+    logp = logp - logp.max()
+    logp = logp - np.log(np.exp(logp).sum())
+    p = np.exp(logp)
+    ent = -(p * logp).sum()
+    shifted = np.abs(-logp - ent)
+    order = np.argsort(shifted, kind="stable")
+    cum_before_sorted = np.cumsum(p[order]) - p[order]
+    keep = np.zeros(len(p), dtype=bool)
+    cum_before = np.zeros(len(p))
+    keep[order] = cum_before_sorted < typical_p
+    cum_before[order] = cum_before_sorted
+    return keep, cum_before
+
+
+class TestTypicalP(unittest.TestCase):
+    def _apply(self, logits, typical_p):
+        lp = logits - mx.logsumexp(logits, axis=-1, keepdims=True)
+        out = apply_typical_p(lp, typical_p)
+        mx.eval(out)
+        return np.asarray(out.tolist(), dtype=np.float64)
+
+    def test_matches_numpy_reference(self):
+        """Mask equals the locally-typical set from an independent numpy
+        implementation, away from the single boundary token."""
+        rng = np.random.default_rng(0)
+        for _ in range(40):
+            V = int(rng.integers(8, 200))
+            typical_p = float(rng.choice([0.2, 0.5, 0.9, 0.95]))
+            logits = rng.normal(0, 3, size=V).astype(np.float32)
+            keep_ref, cum_before = _np_typical_keep(logits, typical_p)
+            keep_mlx = np.isfinite(self._apply(mx.array(logits), typical_p))
+            far = np.abs(cum_before - typical_p) > 1e-4
+            self.assertTrue(np.array_equal(keep_ref[far], keep_mlx[far]))
+
+    def test_disabled_keeps_all(self):
+        """typical_p=1.0 masks nothing."""
+        logits = mx.array([[0.0, 1.0, 2.0, 3.0, 4.0]])
+        lp = logits - mx.logsumexp(logits, axis=-1, keepdims=True)
+        out = apply_typical_p(lp, 1.0)
+        mx.eval(out)
+        self.assertTrue(bool(mx.all(mx.isfinite(out)).item()))
+
+    def test_smaller_keeps_fewer(self):
+        """Lowering typical_p never grows the kept set."""
+        rng = np.random.default_rng(2)
+        logits = mx.array(rng.normal(0, 2, size=64).astype(np.float32))
+        counts = [
+            int(np.isfinite(self._apply(logits, tp)).sum())
+            for tp in (0.2, 0.5, 0.9, 0.99)
+        ]
+        self.assertEqual(counts, sorted(counts))
+
+    def test_make_sampler_selects_survivor(self):
+        """A sharply peaked distribution collapses to the argmax."""
+        sampler = make_sampler(temp=1.0, typical_p=0.3)
+        toks = sampler(mx.array([[10.0, 0.0, 0.0, 0.0, 0.0]] * 64))
+        mx.eval(toks)
+        self.assertTrue(all(t == 0 for t in toks.tolist()))
+
+    def test_disabled_by_default(self):
+        """typical_p=1.0 (default) leaves the sampler unfiltered."""
+        sampler = make_sampler(temp=1.0)
+        toks = sampler(mx.array([[1.0, 2.0, 3.0, 4.0, 5.0]] * 16))
+        mx.eval(toks)
+        self.assertEqual(toks.shape, (16,))
+
+    def test_invalid_raises(self):
+        x = mx.array([0.0, 1.0, 2.0])
+        for bad in (0.0, -0.1, 1.5):
+            with self.assertRaises(ValueError):
+                mx.eval(apply_typical_p(x, bad))
 
 
 class TestValidationDoesNotCorruptCompile(unittest.TestCase):


### PR DESCRIPTION
Adds locally typical sampling (arXiv 2202.00666): keeps the most typical tokens (surprisal closest to the distribution entropy) until their cumulative probability reaches typical_p. Wired through make_sampler, generate_step, and the server (schemas/generation/request), with a numpy-reference test and validation coverage.

Sampler series from #1648