### PR TITLE
Fix Laguna NVFP4 sanitize

### DIFF
--- a/mlx_vlm/models/laguna/laguna.py
+++ b/mlx_vlm/models/laguna/laguna.py
@@ -42,6 +42,10 @@ class Model(nn.Module):
         )
 
     def sanitize(self, weights):
+        weights = {
+            k[len("language_model.") :] if k.startswith("language_model.") else k: v
+            for k, v in weights.items()
+        }
         weights = self.language_model.sanitize(weights)
 
         def transform_key(key):

--- a/mlx_vlm/models/laguna/language.py
+++ b/mlx_vlm/models/laguna/language.py
@@ -336,6 +336,7 @@ class LanguageModel(nn.Module):
         weights = self._unpack_compressed_tensors(weights)
         weights = self._remap_router_weights(weights)
         weights = self._stack_experts(weights)
+        weights = self._fuse_split_switch_gate_up(weights)
         return {
             k: v
             for k, v in weights.items()
@@ -470,6 +471,23 @@ class LanguageModel(nn.Module):
                             weights.pop(f"{prefix}.experts.{e}.{proj}.{suffix}")
                             for e in range(self.args.num_experts)
                         ]
+                    )
+        return weights
+
+    def _fuse_split_switch_gate_up(self, weights):
+        for layer_idx in range(self.args.num_hidden_layers):
+            prefix = f"model.layers.{layer_idx}.mlp.switch_mlp"
+            for suffix in ["weight", "scales", "biases"]:
+                gate_key = f"{prefix}.gate_proj.{suffix}"
+                up_key = f"{prefix}.up_proj.{suffix}"
+                fused_key = f"{prefix}.gate_up_proj.{suffix}"
+
+                if fused_key in weights:
+                    weights.pop(gate_key, None)
+                    weights.pop(up_key, None)
+                elif gate_key in weights and up_key in weights:
+                    weights[fused_key] = mx.concatenate(
+                        [weights.pop(gate_key), weights.pop(up_key)], axis=1
                     )
         return weights
 

--- a/mlx_vlm/tests/test_models.py
+++ b/mlx_vlm/tests/test_models.py
@@ -312,6 +312,54 @@ class TestModels(unittest.TestCase):
             sanitized,
         )
 
+    def test_laguna_sanitize_fuses_prefixed_split_switch_gate_up(self):
+        from mlx_vlm.models import laguna
+
+        config = laguna.ModelConfig(
+            model_type="laguna",
+            vocab_size=128,
+            hidden_size=16,
+            intermediate_size=32,
+            num_hidden_layers=2,
+            num_attention_heads=2,
+            num_key_value_heads=1,
+            head_dim=8,
+            max_position_embeddings=128,
+            mlp_layer_types=["dense", "sparse"],
+            num_attention_heads_per_layer=[2, 2],
+            num_experts=2,
+            num_experts_per_tok=1,
+            moe_intermediate_size=16,
+            shared_expert_intermediate_size=16,
+            quantization={"group_size": 16, "bits": 4, "mode": "nvfp4"},
+        )
+        model = laguna.Model(config)
+        prefix = "language_model.model.layers.1.mlp.switch_mlp"
+
+        sanitized = model.sanitize(
+            {
+                f"{prefix}.gate_proj.weight": mx.full((2, 16, 2), 1, dtype=mx.uint32),
+                f"{prefix}.up_proj.weight": mx.full((2, 16, 2), 2, dtype=mx.uint32),
+                f"{prefix}.gate_proj.scales": mx.full((2, 16, 1), 0x38, dtype=mx.uint8),
+                f"{prefix}.up_proj.scales": mx.full((2, 16, 1), 0x40, dtype=mx.uint8),
+                f"{prefix}.down_proj.weight": mx.zeros((2, 16, 2), dtype=mx.uint32),
+                f"{prefix}.down_proj.scales": mx.zeros((2, 16, 1), dtype=mx.uint8),
+            }
+        )
+
+        fused_weight = sanitized[f"{prefix}.gate_up_proj.weight"]
+        fused_scales = sanitized[f"{prefix}.gate_up_proj.scales"]
+        mx.eval(fused_weight, fused_scales)
+
+        self.assertEqual(fused_weight.shape, (2, 32, 2))
+        self.assertEqual(fused_scales.shape, (2, 32, 1))
+        self.assertTrue(np.all(np.array(fused_weight[:, :16]) == 1))
+        self.assertTrue(np.all(np.array(fused_weight[:, 16:]) == 2))
+        self.assertTrue(np.all(np.array(fused_scales[:, :16]) == 0x38))
+        self.assertTrue(np.all(np.array(fused_scales[:, 16:]) == 0x40))
+        self.assertNotIn(f"{prefix}.gate_proj.weight", sanitized)
+        self.assertNotIn(f"{prefix}.up_proj.weight", sanitized)
+
     def test_hrm_text_language_model(self):
         from mlx_vlm.models import hrm_text
 


### PR DESCRIPTION
## Summary

Fix Laguna checkpoint sanitization for NVFP4 models that already contain `language_model.`-prefixed split `switch_mlp.gate_proj` and `switch_mlp.up_proj` tensors.

The Laguna runtime uses a packed `gate_up_proj`, so these split tensors need to be fused during sanitize. The wrapper sanitizer now normalizes `language_model.` prefixes before invoking the inner language sanitizer, then reapplies the expected top-level prefix.

## Impact

This allows `poolside/Laguna-S-2.1-NVFP4-mlx` to load without strict-loading failures from extra split switch MLP parameters.

## Validation

- `uv run black mlx_vlm/models/laguna/laguna.py mlx_vlm/models/laguna/language.py mlx_vlm/tests/test_models.py`
- `uv run python -m unittest mlx_vlm.tests.test_models.TestModels.test_laguna_nvfp4_compressed_tensors_config mlx_vlm.tests.test_models.TestModels.test_laguna_stacks_nvfp4_experts_before_scale_folding mlx_vlm.tests.test_models.TestModels.test_laguna_sanitize_drops_input_global_scale mlx_vlm.tests.test_models.TestModels.test_laguna_sanitize_fuses_prefixed_split_switch_gate_up`
- `uv run mlx_vlm.generate --model poolside/Laguna-S-2.1-NVFP4-mlx --prompt "Make a prompt to calculate the pi" --max-tokens 1 --temperature 0`