### PR TITLE
Vendor standard models

### DIFF
--- a/mlx_vlm/models/activations.py
+++ b/mlx_vlm/models/activations.py
@@ -7,3 +7,34 @@ import mlx.nn as nn
 @partial(mx.compile, shapeless=True)
 def swiglu(gate, x):
     return nn.silu(gate) * x
+
+
+def xielu(x, alpha_p, alpha_n, beta, eps):
+    alpha_p = nn.softplus(alpha_p)
+    alpha_n = beta + nn.softplus(alpha_n)
+    return mx.where(
+        x > 0,
+        alpha_p * mx.square(x) + beta * x,
+        (mx.expm1(mx.minimum(x, eps)) - x) * alpha_n + beta * x,
+    )
+
+
+class XieLU(nn.Module):
+    def __init__(
+        self,
+        alpha_p_init=0.8,
+        alpha_n_init=0.8,
+        beta=0.5,
+        eps=-1e-6,
+    ):
+        super().__init__()
+        alpha_p_tensor = mx.array(alpha_p_init)
+        alpha_n_tensor = mx.array(alpha_n_init - beta)
+        self.alpha_p = mx.log(mx.exp(alpha_p_tensor) - 1)
+        self.alpha_n = mx.log(mx.exp(alpha_n_tensor) - 1)
+
+        self.beta = mx.array(beta)
+        self.eps = mx.array(eps)
+
+    def __call__(self, x: mx.array) -> mx.array:
+        return xielu(x, self.alpha_p, self.alpha_n, self.beta, self.eps)

--- a/mlx_vlm/models/afmoe/__init__.py
+++ b/mlx_vlm/models/afmoe/__init__.py
@@ -1,0 +1,4 @@
+from .afmoe import Model
+from .config import ModelConfig
+
+__all__ = ["Model", "ModelConfig"]

--- a/mlx_vlm/models/afmoe/afmoe.py
+++ b/mlx_vlm/models/afmoe/afmoe.py
@@ -1,0 +1,49 @@
+from typing import Optional
+
+import mlx.core as mx
+import mlx.nn as nn
+
+from ..base import InputEmbeddingsFeatures, LanguageModelOutput
+from .config import ModelConfig
+from .language import LanguageModel
+
+
+class Model(nn.Module):
+    def __init__(self, config: ModelConfig):
+        super().__init__()
+        self.config = config
+        self.model_type = config.model_type
+        self.language_model = LanguageModel(config)
+
+    def get_input_embeddings(
+        self,
+        input_ids: Optional[mx.array] = None,
+        pixel_values: Optional[mx.array] = None,
+        **kwargs,
+    ) -> InputEmbeddingsFeatures:
+        return InputEmbeddingsFeatures(
+            inputs_embeds=self.language_model.model.embed_tokens(input_ids)
+        )
+
+    def __call__(
+        self,
+        input_ids: mx.array,
+        pixel_values: mx.array = None,
+        mask: mx.array = None,
+        cache=None,
+        **kwargs,
+    ) -> LanguageModelOutput:
+        return self.language_model(input_ids, cache=cache, **kwargs)
+
+    def sanitize(self, weights):
+        if any(k.startswith("language_model.") for k in weights):
+            return weights
+        weights = self.language_model.sanitize(weights)
+        return {f"language_model.{k}": v for k, v in weights.items()}
+
+    @property
+    def layers(self):
+        return self.language_model.layers
+
+    def make_cache(self):
+        return self.language_model.make_cache()

--- a/mlx_vlm/models/afmoe/config.py
+++ b/mlx_vlm/models/afmoe/config.py
@@ -1,0 +1,35 @@
+from dataclasses import dataclass
+from typing import Dict, List, Optional, Union
+
+from ..base import BaseModelConfig
+
+
+@dataclass
+class ModelConfig(BaseModelConfig):
+    model_type: str
+    layer_types: List[str]
+    vocab_size: int = 200192
+    hidden_size: int = 2048
+    intermediate_size: int = 6144
+    moe_intermediate_size: int = 1024
+    num_hidden_layers: int = 32
+    num_attention_heads: int = 32
+    num_key_value_heads: int = 4
+    head_dim: int = 64
+    max_position_embeddings: int = 131072
+    rms_norm_eps: float = 1e-5
+    rope_theta: float = 10000
+    rope_scaling: Optional[Dict[str, Union[float, str]]] = None
+    tie_word_embeddings: bool = False
+    # MoE config
+    num_experts: int = 128
+    num_experts_per_tok: int = 8
+    num_shared_experts: int = 1
+    num_dense_layers: int = 2
+    route_norm: bool = True
+    route_scale: float = 2.826
+    score_func: str = "sigmoid"
+    n_group: int = 1
+    topk_group: int = 1
+    sliding_window: int = 2048
+    mup_enabled: bool = True

--- a/mlx_vlm/models/afmoe/language.py
+++ b/mlx_vlm/models/afmoe/language.py
@@ -1,0 +1,375 @@
+import math
+from typing import Any, Optional
+
+import mlx.core as mx
+import mlx.nn as nn
+
+from ..activations import swiglu
+from ..base import (
+    LanguageModelOutput,
+    create_attention_mask,
+    scaled_dot_product_attention,
+)
+from ..cache import KVCache, RotatingKVCache
+from ..rope_utils import initialize_rope
+from ..switch_layers import SwitchGLU
+from .config import ModelConfig
+
+
+class Attention(nn.Module):
+    def __init__(self, args: ModelConfig, is_local_attention: bool = False):
+        super().__init__()
+
+        self.hidden_size = args.hidden_size
+        self.n_heads = args.num_attention_heads
+        self.n_kv_heads = args.num_key_value_heads
+        self.head_dim = args.head_dim
+        self.is_local_attention = is_local_attention
+
+        self.scale = self.head_dim**-0.5
+
+        self.q_proj = nn.Linear(
+            self.hidden_size, self.n_heads * self.head_dim, bias=False
+        )
+        self.k_proj = nn.Linear(
+            self.hidden_size, self.n_kv_heads * self.head_dim, bias=False
+        )
+        self.v_proj = nn.Linear(
+            self.hidden_size, self.n_kv_heads * self.head_dim, bias=False
+        )
+        self.o_proj = nn.Linear(
+            self.n_heads * self.head_dim, self.hidden_size, bias=False
+        )
+
+        self.q_norm = nn.RMSNorm(self.head_dim, eps=args.rms_norm_eps)
+        self.k_norm = nn.RMSNorm(self.head_dim, eps=args.rms_norm_eps)
+
+        self.gate_proj = nn.Linear(
+            self.hidden_size, self.n_heads * self.head_dim, bias=False
+        )
+
+        if is_local_attention:
+            self.rope = initialize_rope(
+                self.head_dim,
+                args.rope_theta,
+                False,  # traditional
+                args.rope_scaling,
+                args.max_position_embeddings,
+            )
+        else:
+            self.rope = None
+
+    def __call__(
+        self,
+        x: mx.array,
+        mask: Optional[mx.array] = None,
+        cache: Optional[Any] = None,
+    ) -> mx.array:
+        B, L, D = x.shape
+
+        queries = self.q_proj(x)
+        keys = self.k_proj(x)
+        values = self.v_proj(x)
+
+        queries = queries.reshape(B, L, self.n_heads, self.head_dim).transpose(
+            0, 2, 1, 3
+        )
+        keys = keys.reshape(B, L, self.n_kv_heads, self.head_dim).transpose(0, 2, 1, 3)
+        values = values.reshape(B, L, self.n_kv_heads, self.head_dim).transpose(
+            0, 2, 1, 3
+        )
+
+        queries = self.q_norm(queries)
+        keys = self.k_norm(keys)
+
+        if self.is_local_attention and self.rope is not None:
+            if cache is not None:
+                queries = self.rope(queries, offset=cache.offset)
+                keys = self.rope(keys, offset=cache.offset)
+            else:
+                queries = self.rope(queries)
+                keys = self.rope(keys)
+
+        if cache is not None:
+            keys, values = cache.update_and_fetch(keys, values)
+
+        output = scaled_dot_product_attention(
+            queries, keys, values, cache=cache, scale=self.scale, mask=mask
+        )
+
+        output = output.transpose(0, 2, 1, 3).reshape(B, L, -1)
+
+        gate = mx.sigmoid(self.gate_proj(x))
+        output = output * gate
+
+        return self.o_proj(output)
+
+
+class MLP(nn.Module):
+    def __init__(self, args: ModelConfig, intermediate_size: Optional[int] = None):
+        super().__init__()
+
+        dim = args.hidden_size
+        hidden_dim = (
+            intermediate_size
+            if intermediate_size is not None
+            else args.intermediate_size
+        )
+
+        self.gate_proj = nn.Linear(dim, hidden_dim, bias=False)
+        self.down_proj = nn.Linear(hidden_dim, dim, bias=False)
+        self.up_proj = nn.Linear(dim, hidden_dim, bias=False)
+
+    def __call__(self, x) -> mx.array:
+        return self.down_proj(swiglu(self.gate_proj(x), self.up_proj(x)))
+
+
+class MoERouter(nn.Module):
+    """Router module that wraps the gate for proper weight naming."""
+
+    def __init__(self, args: ModelConfig):
+        super().__init__()
+        self.gate = nn.Linear(args.hidden_size, args.num_experts, bias=False)
+
+    def __call__(self, x: mx.array) -> mx.array:
+        return self.gate(x)
+
+
+class AfmoeMoE(nn.Module):
+    def __init__(self, args: ModelConfig):
+        super().__init__()
+        self.args = args
+        self.num_experts = args.num_experts
+        self.num_experts_per_tok = args.num_experts_per_tok
+        self.route_norm = args.route_norm
+        self.route_scale = args.route_scale
+        self.score_func = args.score_func
+        self.n_group = args.n_group
+        self.topk_group = args.topk_group
+
+        self.router = MoERouter(args)
+
+        self.expert_bias = mx.zeros((args.num_experts,))
+
+        self.experts = SwitchGLU(
+            args.hidden_size,
+            args.moe_intermediate_size,
+            args.num_experts,
+        )
+
+        if args.num_shared_experts > 0:
+            shared_intermediate_size = (
+                args.moe_intermediate_size * args.num_shared_experts
+            )
+            self.shared_experts = MLP(args, intermediate_size=shared_intermediate_size)
+
+    def __call__(self, x: mx.array) -> mx.array:
+        gates = self.router(x)
+
+        if self.score_func == "sigmoid":
+            scores = mx.sigmoid(gates.astype(mx.float32))
+        else:
+            scores = mx.softmax(gates.astype(mx.float32), axis=-1)
+
+        # Add expert bias for selection
+        selection_scores = scores + self.expert_bias
+
+        # Group-based expert selection if n_group > 1
+        if self.n_group > 1:
+            selection_scores = mx.unflatten(
+                selection_scores, axis=-1, shape=(self.n_group, -1)
+            )
+            group_scores = mx.topk(selection_scores, 2, axis=-1).sum(
+                axis=-1, keepdims=True
+            )
+            k = self.n_group - self.topk_group
+            group_idx = mx.argpartition(group_scores, kth=k - 1, axis=-2)[..., :k, :]
+            selection_scores = mx.put_along_axis(
+                selection_scores, mx.stop_gradient(group_idx), mx.array(0.0), axis=-2
+            )
+            selection_scores = mx.flatten(selection_scores, -2, -1)
+
+        # Select top-k experts
+        k = self.num_experts_per_tok
+        inds = mx.argpartition(-selection_scores, kth=k - 1, axis=-1)[..., :k]
+
+        selected_scores = mx.take_along_axis(scores, inds, axis=-1)
+
+        if self.route_norm and self.num_experts_per_tok > 1:
+            denominator = selected_scores.sum(axis=-1, keepdims=True)
+            selected_scores = selected_scores / denominator
+
+        selected_scores = selected_scores * self.route_scale
+
+        y = self.experts(x, inds)
+        y = (y * selected_scores[..., None]).sum(axis=-2).astype(y.dtype)
+
+        if self.args.num_shared_experts > 0:
+            y = y + self.shared_experts(x)
+
+        return y
+
+
+class DecoderLayer(nn.Module):
+    def __init__(self, args: ModelConfig, layer_idx: int, use_sliding: bool = False):
+        super().__init__()
+        self.hidden_size = args.hidden_size
+        self.use_sliding = use_sliding
+        self.layer_idx = layer_idx
+
+        self.self_attn = Attention(args, is_local_attention=use_sliding)
+
+        if layer_idx < args.num_dense_layers:
+            self.mlp = MLP(args)
+        else:
+            self.mlp = AfmoeMoE(args)
+
+        self.input_layernorm = nn.RMSNorm(args.hidden_size, eps=args.rms_norm_eps)
+        self.post_attention_layernorm = nn.RMSNorm(
+            args.hidden_size, eps=args.rms_norm_eps
+        )
+        self.pre_mlp_layernorm = nn.RMSNorm(args.hidden_size, eps=args.rms_norm_eps)
+        self.post_mlp_layernorm = nn.RMSNorm(args.hidden_size, eps=args.rms_norm_eps)
+
+    def __call__(
+        self,
+        x: mx.array,
+        mask: Optional[mx.array] = None,
+        cache: Optional[Any] = None,
+    ) -> mx.array:
+        r = self.self_attn(self.input_layernorm(x), mask, cache)
+        r = self.post_attention_layernorm(r)
+        h = x + r
+
+        r = self.mlp(self.pre_mlp_layernorm(h))
+        r = self.post_mlp_layernorm(r)
+        return h + r
+
+
+class AfmoeModel(nn.Module):
+    def __init__(self, args: ModelConfig):
+        super().__init__()
+        self.args = args
+        self.vocab_size = args.vocab_size
+        self.num_hidden_layers = args.num_hidden_layers
+        self.layer_types = args.layer_types
+        self.sliding_window = args.sliding_window
+        self.mup_enabled = args.mup_enabled
+        self.hidden_size = args.hidden_size
+
+        self.embed_tokens = nn.Embedding(args.vocab_size, args.hidden_size)
+        self.layers = [
+            DecoderLayer(
+                args=args, layer_idx=idx, use_sliding=layer_type == "sliding_attention"
+            )
+            for idx, layer_type in enumerate(self.layer_types)
+        ]
+        self.norm = nn.RMSNorm(args.hidden_size, eps=args.rms_norm_eps)
+
+        self.fa_idx = self.layer_types.index("full_attention")
+        self.swa_idx = None
+        for idx, layer in enumerate(self.layers):
+            if layer.use_sliding:
+                self.swa_idx = idx
+                break
+
+    def __call__(
+        self,
+        inputs: mx.array,
+        cache=None,
+        inputs_embeds: Optional[mx.array] = None,
+    ):
+        h = self.embed_tokens(inputs) if inputs_embeds is None else inputs_embeds
+
+        if self.mup_enabled:
+            h = h * math.sqrt(self.hidden_size)
+
+        if cache is None:
+            cache = [None] * len(self.layers)
+
+        fa_mask = create_attention_mask(h, cache[self.fa_idx])
+        swa_mask = None
+        if self.swa_idx is not None:
+            swa_mask = create_attention_mask(
+                h, cache[self.swa_idx], window_size=self.sliding_window
+            )
+
+        for layer, c in zip(self.layers, cache):
+            mask = swa_mask if layer.use_sliding else fa_mask
+            h = layer(h, mask, cache=c)
+
+        return self.norm(h)
+
+
+class LanguageModel(nn.Module):
+    def __init__(self, args: ModelConfig):
+        super().__init__()
+        self.args = args
+        self.model_type = args.model_type
+        self.model = AfmoeModel(args)
+
+        if not args.tie_word_embeddings:
+            self.lm_head = nn.Linear(args.hidden_size, args.vocab_size, bias=False)
+
+    def __call__(
+        self, inputs: mx.array, cache=None, inputs_embeds=None, mask=None, **kwargs
+    ):
+        out = self.model(inputs, cache, inputs_embeds=inputs_embeds)
+        if self.args.tie_word_embeddings:
+            out = self.model.embed_tokens.as_linear(out)
+        else:
+            out = self.lm_head(out)
+        return LanguageModelOutput(logits=out)
+
+    def sanitize(self, weights):
+        # Remove unused precomputed rotary freqs
+        weights = {k: v for k, v in weights.items() if "rotary_emb.inv_freq" not in k}
+
+        if self.args.tie_word_embeddings:
+            weights.pop("lm_head.weight", None)
+
+        # Stack experts weights for SwitchGLU
+        for l in range(self.args.num_hidden_layers):
+            if l < self.args.num_dense_layers:
+                continue
+            prefix = f"model.layers.{l}"
+            for n in ["up_proj", "down_proj", "gate_proj"]:
+                for k in ["weight", "scales", "biases"]:
+                    if f"{prefix}.mlp.experts.0.{n}.{k}" in weights:
+                        to_join = [
+                            weights.pop(f"{prefix}.mlp.experts.{e}.{n}.{k}")
+                            for e in range(self.args.num_experts)
+                        ]
+                        weights[f"{prefix}.mlp.experts.{n}.{k}"] = mx.stack(to_join)
+
+        return weights
+
+    @property
+    def layers(self):
+        return self.model.layers
+
+    def make_cache(self):
+        return [
+            (
+                RotatingKVCache(max_size=self.model.sliding_window)
+                if layer.use_sliding
+                else KVCache()
+            )
+            for layer in self.layers
+        ]
+
+    @property
+    def cast_predicate(self):
+        def predicate(k):
+            return "expert_bias" not in k
+
+        return predicate
+
+    @property
+    def quant_predicate(self):
+        def predicate(path, _):
+            if "router.gate" in path:
+                return {"group_size": 64, "bits": 8}
+            return True
+
+        return predicate

--- a/mlx_vlm/models/afmoe/language.py
+++ b/mlx_vlm/models/afmoe/language.py
@@ -4,13 +4,13 @@ from typing import Any, Optional
 import mlx.core as mx
 import mlx.nn as nn
 
-from ..activations import swiglu
 from ..base import (
     LanguageModelOutput,
     create_attention_mask,
     scaled_dot_product_attention,
 )
 from ..cache import KVCache, RotatingKVCache
+from ..mlp import SwiGLUMLP
 from ..rope_utils import initialize_rope
 from ..switch_layers import SwitchGLU
 from .config import ModelConfig
@@ -105,25 +105,6 @@ class Attention(nn.Module):
         return self.o_proj(output)
 
 
-class MLP(nn.Module):
-    def __init__(self, args: ModelConfig, intermediate_size: Optional[int] = None):
-        super().__init__()
-
-        dim = args.hidden_size
-        hidden_dim = (
-            intermediate_size
-            if intermediate_size is not None
-            else args.intermediate_size
-        )
-
-        self.gate_proj = nn.Linear(dim, hidden_dim, bias=False)
-        self.down_proj = nn.Linear(hidden_dim, dim, bias=False)
-        self.up_proj = nn.Linear(dim, hidden_dim, bias=False)
-
-    def __call__(self, x) -> mx.array:
-        return self.down_proj(swiglu(self.gate_proj(x), self.up_proj(x)))
-
-
 class MoERouter(nn.Module):
     """Router module that wraps the gate for proper weight naming."""
 
@@ -161,7 +142,7 @@ class AfmoeMoE(nn.Module):
             shared_intermediate_size = (
                 args.moe_intermediate_size * args.num_shared_experts
             )
-            self.shared_experts = MLP(args, intermediate_size=shared_intermediate_size)
+            self.shared_experts = SwiGLUMLP(args.hidden_size, shared_intermediate_size)
 
     def __call__(self, x: mx.array) -> mx.array:
         gates = self.router(x)
@@ -220,7 +201,7 @@ class DecoderLayer(nn.Module):
         self.self_attn = Attention(args, is_local_attention=use_sliding)
 
         if layer_idx < args.num_dense_layers:
-            self.mlp = MLP(args)
+            self.mlp = SwiGLUMLP(args.hidden_size, args.intermediate_size)
         else:
             self.mlp = AfmoeMoE(args)
 

--- a/mlx_vlm/models/apertus/__init__.py
+++ b/mlx_vlm/models/apertus/__init__.py
@@ -1,0 +1,4 @@
+from .apertus import Model
+from .config import ModelConfig
+
+__all__ = ["Model", "ModelConfig"]

--- a/mlx_vlm/models/apertus/apertus.py
+++ b/mlx_vlm/models/apertus/apertus.py
@@ -1,0 +1,46 @@
+from typing import Optional
+
+import mlx.core as mx
+import mlx.nn as nn
+
+from ..base import InputEmbeddingsFeatures, LanguageModelOutput
+from .config import ModelConfig
+from .language import LanguageModel
+
+
+class Model(nn.Module):
+    def __init__(self, config: ModelConfig):
+        super().__init__()
+        self.config = config
+        self.model_type = config.model_type
+        self.language_model = LanguageModel(config)
+
+    def get_input_embeddings(
+        self,
+        input_ids: Optional[mx.array] = None,
+        pixel_values: Optional[mx.array] = None,
+        **kwargs,
+    ) -> InputEmbeddingsFeatures:
+        return InputEmbeddingsFeatures(
+            inputs_embeds=self.language_model.model.embed_tokens(input_ids)
+        )
+
+    def __call__(
+        self,
+        input_ids: mx.array,
+        pixel_values: mx.array = None,
+        mask: mx.array = None,
+        cache=None,
+        **kwargs,
+    ) -> LanguageModelOutput:
+        return self.language_model(input_ids, cache=cache, **kwargs)
+
+    def sanitize(self, weights):
+        if any(k.startswith("language_model.") for k in weights):
+            return weights
+        weights = self.language_model.sanitize(weights)
+        return {f"language_model.{k}": v for k, v in weights.items()}
+
+    @property
+    def layers(self):
+        return self.language_model.layers

--- a/mlx_vlm/models/apertus/config.py
+++ b/mlx_vlm/models/apertus/config.py
@@ -1,0 +1,25 @@
+from dataclasses import dataclass
+from typing import Dict, Optional, Union
+
+from ..base import BaseModelConfig
+
+
+@dataclass
+class ModelConfig(BaseModelConfig):
+    model_type: str
+    hidden_size: int
+    num_hidden_layers: int
+    intermediate_size: int
+    mlp_bias: bool
+    num_attention_heads: int
+    attention_bias: bool
+    rms_norm_eps: float
+    vocab_size: int
+    num_key_value_heads: int
+    max_position_embeddings: int
+    rope_theta: float
+    post_norm: bool
+    qk_norm: bool
+    tie_word_embeddings: bool
+    rope_traditional: bool = False
+    rope_scaling: Optional[Dict[str, Union[float, str]]] = None

--- a/mlx_vlm/models/apertus/language.py
+++ b/mlx_vlm/models/apertus/language.py
@@ -1,0 +1,195 @@
+from typing import Any, Optional
+
+import mlx.core as mx
+import mlx.nn as nn
+
+from ..activations import XieLU
+from ..base import (
+    LanguageModelOutput,
+    create_attention_mask,
+    scaled_dot_product_attention,
+)
+from ..cache import KVCache
+from ..rope_utils import initialize_rope
+from .config import ModelConfig
+
+
+class ApertusMLP(nn.Module):
+    def __init__(self, args: ModelConfig):
+        super().__init__()
+        self.up_proj = nn.Linear(
+            args.hidden_size, args.intermediate_size, bias=args.mlp_bias
+        )
+        self.down_proj = nn.Linear(
+            args.intermediate_size, args.hidden_size, bias=args.mlp_bias
+        )
+        self.act_fn = XieLU()
+
+    def __call__(self, x: mx.array) -> mx.array:
+        return self.down_proj(self.act_fn(self.up_proj(x)))
+
+
+class ApertusAttention(nn.Module):
+    def __init__(self, args: ModelConfig):
+        super().__init__()
+        self.num_attention_heads = args.num_attention_heads
+        self.num_key_value_heads = args.num_key_value_heads
+
+        self.head_dim = args.hidden_size // args.num_attention_heads
+        self.scale = self.head_dim**-0.5
+
+        self.q_proj = nn.Linear(
+            args.hidden_size, args.num_attention_heads * self.head_dim, bias=False
+        )
+        self.k_proj = nn.Linear(
+            args.hidden_size, args.num_key_value_heads * self.head_dim, bias=False
+        )
+        self.v_proj = nn.Linear(
+            args.hidden_size, args.num_key_value_heads * self.head_dim, bias=False
+        )
+        self.o_proj = nn.Linear(
+            args.num_attention_heads * self.head_dim, args.hidden_size, bias=False
+        )
+
+        self.q_norm = nn.RMSNorm(self.head_dim, eps=args.rms_norm_eps)
+        self.k_norm = nn.RMSNorm(self.head_dim, eps=args.rms_norm_eps)
+
+        self.rope = initialize_rope(
+            self.head_dim,
+            args.rope_theta,
+            args.rope_traditional,
+            args.rope_scaling,
+            args.max_position_embeddings,
+        )
+
+    def __call__(
+        self,
+        x: mx.array,
+        mask: Optional[mx.array] = None,
+        cache: Optional[Any] = None,
+    ) -> mx.array:
+        B, L, D = x.shape
+        queries, keys, values = self.q_proj(x), self.k_proj(x), self.v_proj(x)
+        queries = self.q_norm(
+            queries.reshape(B, L, self.num_attention_heads, -1)
+        ).transpose(0, 2, 1, 3)
+        keys = self.k_norm(keys.reshape(B, L, self.num_key_value_heads, -1)).transpose(
+            0, 2, 1, 3
+        )
+        values = values.reshape(B, L, self.num_key_value_heads, -1).transpose(
+            0, 2, 1, 3
+        )
+
+        if cache is not None:
+            queries = self.rope(queries, offset=cache.offset)
+            keys = self.rope(keys, offset=cache.offset)
+            keys, values = cache.update_and_fetch(keys, values)
+        else:
+            queries = self.rope(queries)
+            keys = self.rope(keys)
+
+        output = scaled_dot_product_attention(
+            queries, keys, values, cache=cache, scale=self.scale, mask=mask
+        )
+        output = output.transpose(0, 2, 1, 3).reshape(B, L, -1)
+        return self.o_proj(output)
+
+
+class ApertusDecoderLayer(nn.Module):
+    def __init__(self, args: ModelConfig):
+        super().__init__()
+        self.self_attn = ApertusAttention(args)
+        self.mlp = ApertusMLP(args)
+
+        self.attention_layernorm = nn.RMSNorm(args.hidden_size, eps=args.rms_norm_eps)
+        self.feedforward_layernorm = nn.RMSNorm(args.hidden_size, eps=args.rms_norm_eps)
+
+    def __call__(
+        self,
+        x: mx.array,
+        mask: Optional[mx.array] = None,
+        cache: Optional[Any] = None,
+    ) -> mx.array:
+        h = x + self.self_attn(self.attention_layernorm(x), mask, cache)
+        out = h + self.mlp(self.feedforward_layernorm(h))
+        return out
+
+
+class ApertusModel(nn.Module):
+    def __init__(self, args: ModelConfig):
+        super().__init__()
+        self.embed_tokens = nn.Embedding(args.vocab_size, args.hidden_size)
+        self.layers = [
+            ApertusDecoderLayer(args=args) for _ in range(args.num_hidden_layers)
+        ]
+        self.norm = nn.RMSNorm(args.hidden_size, eps=args.rms_norm_eps)
+
+    def __call__(self, inputs, cache=None, input_embeddings=None):
+        h = (
+            input_embeddings
+            if input_embeddings is not None
+            else self.embed_tokens(inputs)
+        )
+
+        if cache is None:
+            cache = [None] * len(self.layers)
+
+        mask = create_attention_mask(h, cache[0])
+
+        for layer, c in zip(self.layers, cache):
+            h = layer(h, mask=mask, cache=c)
+
+        return self.norm(h)
+
+
+class LanguageModel(nn.Module):
+    def __init__(self, args: ModelConfig):
+        super().__init__()
+        self.args = args
+        self.config = args
+        self.model_type = args.model_type
+        self.model = ApertusModel(args)
+        if not args.tie_word_embeddings:
+            self.lm_head = nn.Linear(args.hidden_size, args.vocab_size, bias=False)
+
+    def __call__(
+        self,
+        inputs: Optional[mx.array] = None,
+        cache=None,
+        input_embeddings: Optional[mx.array] = None,
+        inputs_embeds: Optional[mx.array] = None,
+        **kwargs,
+    ) -> LanguageModelOutput:
+        if inputs is None:
+            inputs = kwargs.get("input_ids")
+        if inputs_embeds is None:
+            inputs_embeds = input_embeddings
+        out = self.model(inputs, cache, inputs_embeds)
+        if self.args.tie_word_embeddings:
+            out = self.model.embed_tokens.as_linear(out)
+        else:
+            out = self.lm_head(out)
+        return LanguageModelOutput(logits=out)
+
+    def sanitize(self, weights):
+        for k, v in weights.items():
+            if k.endswith("alpha_p") or k.endswith("alpha_n"):
+                weights[k] = v.squeeze()
+        if self.args.tie_word_embeddings:
+            weights.pop("lm_head.weight", None)
+        return weights
+
+    def make_cache(self):
+        return [KVCache() for _ in self.model.layers]
+
+    @property
+    def layers(self):
+        return self.model.layers
+
+    @property
+    def head_dim(self):
+        return self.args.hidden_size // self.args.num_attention_heads
+
+    @property
+    def n_kv_heads(self):
+        return self.args.num_key_value_heads

--- a/mlx_vlm/models/baichuan_m1/__init__.py
+++ b/mlx_vlm/models/baichuan_m1/__init__.py
@@ -1,0 +1,4 @@
+from .baichuan_m1 import Model
+from .config import ModelConfig
+
+__all__ = ["Model", "ModelConfig"]

--- a/mlx_vlm/models/baichuan_m1/baichuan_m1.py
+++ b/mlx_vlm/models/baichuan_m1/baichuan_m1.py
@@ -1,0 +1,46 @@
+from typing import Optional
+
+import mlx.core as mx
+import mlx.nn as nn
+
+from ..base import InputEmbeddingsFeatures, LanguageModelOutput
+from .config import ModelConfig
+from .language import LanguageModel
+
+
+class Model(nn.Module):
+    def __init__(self, config: ModelConfig):
+        super().__init__()
+        self.config = config
+        self.model_type = config.model_type
+        self.language_model = LanguageModel(config)
+
+    def get_input_embeddings(
+        self,
+        input_ids: Optional[mx.array] = None,
+        pixel_values: Optional[mx.array] = None,
+        **kwargs,
+    ) -> InputEmbeddingsFeatures:
+        return InputEmbeddingsFeatures(
+            inputs_embeds=self.language_model.model.embed_tokens(input_ids)
+        )
+
+    def __call__(
+        self,
+        input_ids: mx.array,
+        pixel_values: mx.array = None,
+        mask: mx.array = None,
+        cache=None,
+        **kwargs,
+    ) -> LanguageModelOutput:
+        return self.language_model(input_ids, cache=cache, **kwargs)
+
+    def sanitize(self, weights):
+        if any(k.startswith("language_model.") for k in weights):
+            return weights
+        weights = self.language_model.sanitize(weights)
+        return {f"language_model.{k}": v for k, v in weights.items()}
+
+    @property
+    def layers(self):
+        return self.language_model.layers

--- a/mlx_vlm/models/baichuan_m1/config.py
+++ b/mlx_vlm/models/baichuan_m1/config.py
@@ -1,0 +1,23 @@
+from dataclasses import dataclass
+from typing import List, Optional
+
+from ..base import BaseModelConfig
+
+
+@dataclass
+class ModelConfig(BaseModelConfig):
+    vocab_size: int
+    hidden_size: int
+    intermediate_size: int
+    num_hidden_layers: int
+    num_attention_heads: int
+    num_key_value_heads: int
+    rope_theta: float
+    sliding_window: int
+    sliding_window_layers: List[int]
+    conv_window: int
+    rms_norm_eps: float
+    model_type: str = "baichuan_m1"
+    num_swa_attention_heads: Optional[int] = None
+    num_swa_key_value_heads: Optional[int] = None
+    tie_word_embeddings: bool = False

--- a/mlx_vlm/models/baichuan_m1/language.py
+++ b/mlx_vlm/models/baichuan_m1/language.py
@@ -3,13 +3,13 @@ from typing import Any, List, Optional
 import mlx.core as mx
 import mlx.nn as nn
 
-from ..activations import swiglu
 from ..base import (
     LanguageModelOutput,
     create_attention_mask,
     scaled_dot_product_attention,
 )
 from ..cache import ArraysCache, CacheList, KVCache, RotatingKVCache
+from ..mlp import SwiGLUMLP
 from .config import ModelConfig
 
 
@@ -110,28 +110,11 @@ class Attention(nn.Module):
         return self.o_proj(out)
 
 
-class MLP(nn.Module):
-    def __init__(self, config: ModelConfig):
-        super().__init__()
-        self.gate_proj = nn.Linear(
-            config.hidden_size, config.intermediate_size, bias=False
-        )
-        self.up_proj = nn.Linear(
-            config.hidden_size, config.intermediate_size, bias=False
-        )
-        self.down_proj = nn.Linear(
-            config.intermediate_size, config.hidden_size, bias=False
-        )
-
-    def __call__(self, x: mx.array) -> mx.array:
-        return self.down_proj(swiglu(self.gate_proj(x), self.up_proj(x)))
-
-
 class DecoderLayer(nn.Module):
     def __init__(self, config: ModelConfig, layer_idx: int):
         super().__init__()
         self.self_attn = Attention(config, layer_idx)
-        self.mlp = MLP(config)
+        self.mlp = SwiGLUMLP(config.hidden_size, config.intermediate_size)
         self.input_layernorm = nn.RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
         self.post_attention_layernorm = nn.RMSNorm(
             config.hidden_size, eps=config.rms_norm_eps

--- a/mlx_vlm/models/baichuan_m1/language.py
+++ b/mlx_vlm/models/baichuan_m1/language.py
@@ -1,0 +1,259 @@
+from typing import Any, List, Optional
+
+import mlx.core as mx
+import mlx.nn as nn
+
+from ..activations import swiglu
+from ..base import (
+    LanguageModelOutput,
+    create_attention_mask,
+    scaled_dot_product_attention,
+)
+from ..cache import ArraysCache, CacheList, KVCache, RotatingKVCache
+from .config import ModelConfig
+
+
+class Attention(nn.Module):
+    def __init__(self, config: ModelConfig, layer_idx: Optional[int] = None):
+        super().__init__()
+        self.config = config
+        self.layer_idx = layer_idx
+        if layer_idx is None:
+            raise ValueError("Layer index must be provided to Attention module.")
+
+        self.is_swa = layer_idx in config.sliding_window_layers
+        self.num_heads = (
+            config.num_swa_attention_heads
+            if self.is_swa and config.num_swa_attention_heads
+            else config.num_attention_heads
+        )
+        self.num_kv_heads = (
+            config.num_swa_key_value_heads
+            if self.is_swa and config.num_swa_key_value_heads
+            else config.num_key_value_heads
+        )
+
+        self.hidden_size = config.hidden_size
+        self.head_dim = self.hidden_size // self.num_heads
+        assert self.head_dim * self.num_heads == self.hidden_size
+
+        self.scale = self.head_dim**-0.5
+
+        self.W_pack = nn.Linear(
+            config.hidden_size,
+            self.hidden_size + 2 * self.num_kv_heads * self.head_dim,
+            bias=False,
+        )
+        self.o_proj = nn.Linear(
+            self.num_heads * self.head_dim, config.hidden_size, bias=False
+        )
+
+        self.rope = nn.RoPE(self.head_dim, traditional=False, base=config.rope_theta)
+
+        self.conv_window = config.conv_window
+        assert self.conv_window == 2
+        self.conv_k = mx.zeros((1, 1, self.num_kv_heads, 1, self.conv_window))
+        self.conv_v = mx.zeros((1, 1, self.num_kv_heads, 1, self.conv_window))
+
+    def _custom_convolution(self, u, weights, state=None):
+        B, H, L, D = u.shape
+        weights = weights.reshape((1, H, self.conv_window, 1, 1))
+        w0 = weights[:, :, 0]
+        w1 = weights[:, :, 1]
+        if state is None:
+            state = mx.zeros((B, H, 1, D), u.dtype)
+        if L > 1:
+            u_prev = mx.concatenate([state, u[:, :, :-1]], axis=2)
+        else:
+            u_prev = state
+        return u_prev * w0 + u * w1
+
+    def __call__(
+        self, x: mx.array, mask: mx.array = None, cache: Any = None
+    ) -> mx.array:
+        B, L, D = x.shape
+
+        proj = self.W_pack(x)
+        q, k, v = mx.split(proj, (D, D + self.num_kv_heads * self.head_dim), axis=-1)
+
+        q = q.reshape(B, L, self.num_heads, self.head_dim).transpose(0, 2, 1, 3)
+        k = k.reshape(B, L, self.num_kv_heads, self.head_dim).transpose(0, 2, 1, 3)
+        v = v.reshape(B, L, self.num_kv_heads, self.head_dim).transpose(0, 2, 1, 3)
+
+        if cache is None:
+            cache = (None, None)
+
+        if cache[0] is not None:
+            offset = cache[1].offset
+            last_k, last_v = cache[0][0], cache[0][1]
+        else:
+            offset = 0
+            last_k, last_v = None, None
+
+        k_init = k
+        v_init = v
+        k = self._custom_convolution(k, self.conv_k, state=last_k)
+        v = self._custom_convolution(v, self.conv_v, state=last_v)
+        q = self.rope(q, offset=offset)
+        k = self.rope(k, offset=offset)
+
+        if cache[0] is not None:
+            k, v = cache[1].update_and_fetch(k, v)
+            if L > 0:
+                cache[0][0] = k_init[:, :, -1:, :]
+                cache[0][1] = v_init[:, :, -1:, :]
+
+        out = scaled_dot_product_attention(
+            q, k, v, cache=cache[1], scale=self.scale, mask=mask
+        )
+        out = out.transpose(0, 2, 1, 3).reshape(B, L, -1)
+        return self.o_proj(out)
+
+
+class MLP(nn.Module):
+    def __init__(self, config: ModelConfig):
+        super().__init__()
+        self.gate_proj = nn.Linear(
+            config.hidden_size, config.intermediate_size, bias=False
+        )
+        self.up_proj = nn.Linear(
+            config.hidden_size, config.intermediate_size, bias=False
+        )
+        self.down_proj = nn.Linear(
+            config.intermediate_size, config.hidden_size, bias=False
+        )
+
+    def __call__(self, x: mx.array) -> mx.array:
+        return self.down_proj(swiglu(self.gate_proj(x), self.up_proj(x)))
+
+
+class DecoderLayer(nn.Module):
+    def __init__(self, config: ModelConfig, layer_idx: int):
+        super().__init__()
+        self.self_attn = Attention(config, layer_idx)
+        self.mlp = MLP(config)
+        self.input_layernorm = nn.RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.post_attention_layernorm = nn.RMSNorm(
+            config.hidden_size, eps=config.rms_norm_eps
+        )
+
+    def __call__(
+        self, x: mx.array, mask: mx.array = None, cache: Any = None
+    ) -> mx.array:
+        r = self.self_attn(self.input_layernorm(x), mask, cache)
+        x = x + r
+        r = self.mlp(self.post_attention_layernorm(x))
+        return x + r
+
+
+class BaichuanModel(nn.Module):
+    def __init__(self, config: ModelConfig):
+        super().__init__()
+        self.args = config
+        self.embed_tokens = nn.Embedding(config.vocab_size, config.hidden_size)
+        self.layers = [DecoderLayer(config, i) for i in range(config.num_hidden_layers)]
+        self.norm = nn.RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+
+        self.sliding_window = config.sliding_window
+        self.first_swa_idx = None
+        if config.sliding_window_layers:
+            self.first_swa_idx = config.sliding_window_layers[0]
+
+        self.first_global_idx = None
+        self.swa_layers = set(config.sliding_window_layers)
+        for i in range(config.num_hidden_layers):
+            if i in self.swa_layers:
+                continue
+            self.first_global_idx = i
+            break
+
+    def __call__(self, inputs, cache=None, input_embeddings=None):
+        x = (
+            input_embeddings
+            if input_embeddings is not None
+            else self.embed_tokens(inputs)
+        )
+
+        if cache is None:
+            cache = [(None, None)] * len(self.layers)
+
+        if self.first_global_idx is None:
+            c_global = None
+        else:
+            c_global = cache[self.first_global_idx][1]
+
+        if self.first_swa_idx is None:
+            c_swa = None
+        else:
+            c_swa = cache[self.first_swa_idx][1]
+
+        global_mask = create_attention_mask(x, c_global)
+        swa_mask = create_attention_mask(x, c_swa, window_size=self.sliding_window)
+
+        for l, (layer, c) in enumerate(zip(self.layers, cache)):
+            mask = swa_mask if l in self.swa_layers else global_mask
+            x = layer(x, mask, c)
+        return self.norm(x)
+
+
+class LanguageModel(nn.Module):
+    def __init__(self, config: ModelConfig):
+        super().__init__()
+        self.args = config
+        self.config = config
+        self.model_type = config.model_type
+        self.model = BaichuanModel(config)
+        self.tie_word_embeddings = config.tie_word_embeddings
+        if not config.tie_word_embeddings:
+            self.lm_head = nn.Linear(config.hidden_size, config.vocab_size, bias=False)
+
+    def __call__(
+        self,
+        inputs: Optional[mx.array] = None,
+        cache=None,
+        input_embeddings: Optional[mx.array] = None,
+        inputs_embeds: Optional[mx.array] = None,
+        **kwargs,
+    ) -> LanguageModelOutput:
+        if inputs is None:
+            inputs = kwargs.get("input_ids")
+        if inputs_embeds is None:
+            inputs_embeds = input_embeddings
+        out = self.model(inputs, cache, inputs_embeds)
+        out = self.lm_head(out)
+        return LanguageModelOutput(logits=out)
+
+    def make_cache(self) -> List[Any]:
+        caches = []
+        for i, layer in enumerate(self.model.layers):
+            is_swa = i in self.config.sliding_window_layers
+            conv_cache = ArraysCache(size=2)
+            if is_swa:
+                kv_cache = RotatingKVCache(max_size=self.config.sliding_window)
+            else:
+                kv_cache = KVCache()
+            caches.append(CacheList(conv_cache, kv_cache))
+        return caches
+
+    def sanitize(self, weights: dict) -> dict:
+        is_quantized = "lm_head.scales" in weights
+        if not is_quantized and "lm_head.weight" in weights:
+            w = weights["lm_head.weight"]
+            dtype = w.dtype
+            w = w.astype(mx.float32)
+            norm = mx.linalg.norm(w, axis=-1, keepdims=True)
+            w = (w / (norm + 1e-7)).astype(dtype)
+            weights["lm_head.weight"] = w
+        return weights
+
+    @property
+    def layers(self) -> List[nn.Module]:
+        return self.model.layers
+
+    @property
+    def head_dim(self):
+        return self.args.hidden_size // self.args.num_attention_heads
+
+    @property
+    def n_kv_heads(self):
+        return self.args.num_key_value_heads

--- a/mlx_vlm/models/bailing_moe/__init__.py
+++ b/mlx_vlm/models/bailing_moe/__init__.py
@@ -1,0 +1,4 @@
+from .bailing_moe import Model
+from .config import ModelConfig
+
+__all__ = ["Model", "ModelConfig"]

--- a/mlx_vlm/models/bailing_moe/bailing_moe.py
+++ b/mlx_vlm/models/bailing_moe/bailing_moe.py
@@ -1,0 +1,49 @@
+from typing import Optional
+
+import mlx.core as mx
+import mlx.nn as nn
+
+from ..base import InputEmbeddingsFeatures, LanguageModelOutput
+from .config import ModelConfig
+from .language import LanguageModel
+
+
+class Model(nn.Module):
+    def __init__(self, config: ModelConfig):
+        super().__init__()
+        self.config = config
+        self.model_type = config.model_type
+        self.language_model = LanguageModel(config)
+
+    def get_input_embeddings(
+        self,
+        input_ids: Optional[mx.array] = None,
+        pixel_values: Optional[mx.array] = None,
+        **kwargs,
+    ) -> InputEmbeddingsFeatures:
+        return InputEmbeddingsFeatures(
+            inputs_embeds=self.language_model.model.word_embeddings(input_ids)
+        )
+
+    def __call__(
+        self,
+        input_ids: mx.array,
+        pixel_values: mx.array = None,
+        mask: mx.array = None,
+        cache=None,
+        **kwargs,
+    ) -> LanguageModelOutput:
+        return self.language_model(input_ids, cache=cache, **kwargs)
+
+    def sanitize(self, weights):
+        if any(k.startswith("language_model.") for k in weights):
+            return weights
+        weights = self.language_model.sanitize(weights)
+        return {f"language_model.{k}": v for k, v in weights.items()}
+
+    @property
+    def layers(self):
+        return self.language_model.layers
+
+    def make_cache(self):
+        return self.language_model.make_cache()

--- a/mlx_vlm/models/bailing_moe/config.py
+++ b/mlx_vlm/models/bailing_moe/config.py
@@ -1,0 +1,41 @@
+from dataclasses import dataclass
+from typing import Dict, Optional, Union
+
+from ..base import BaseModelConfig
+
+
+@dataclass
+class ModelConfig(BaseModelConfig):
+    model_type: str
+    hidden_size: int
+    intermediate_size: int
+    max_position_embeddings: int
+    moe_intermediate_size: int
+    num_experts: int
+    num_shared_experts: int
+    norm_topk_prob: bool
+    num_attention_heads: int
+    num_experts_per_tok: int
+    num_hidden_layers: int
+    num_key_value_heads: int
+    rms_norm_eps: float
+    rope_theta: float
+    vocab_size: int
+    first_k_dense_replace: int
+    rope_scaling: Optional[Dict[str, Union[float, str]]] = None
+    use_bias: bool = False
+    use_qkv_bias: bool = False
+    norm_head: bool = False
+    norm_softmax: bool = False
+    use_qk_norm: bool = False
+    tie_word_embeddings: bool = False
+    partial_rotary_factor: float = 1.0
+    rotary_dim: Optional[int] = None
+    moe_router_enable_expert_bias: bool = False
+    moe_router_enable_routed_scaling: bool = True
+    routed_scaling_factor: float = 1.0
+    score_function: str = "softmax"
+    n_group: int = 1
+    topk_group: int = 4
+    moe_shared_expert_intermediate_size: Optional[int] = None
+    moe_router_enable_shared_expert: bool = True

--- a/mlx_vlm/models/bailing_moe/language.py
+++ b/mlx_vlm/models/bailing_moe/language.py
@@ -1,0 +1,369 @@
+from functools import partial
+from typing import Any, Optional
+
+import mlx.core as mx
+import mlx.nn as nn
+
+from ..activations import swiglu
+from ..base import (
+    LanguageModelOutput,
+    create_attention_mask,
+    scaled_dot_product_attention,
+)
+from ..cache import KVCache
+from ..rope_utils import initialize_rope
+from ..switch_layers import SwitchGLU
+from .config import ModelConfig
+
+
+@partial(mx.compile, shapeless=True)
+def aggregate_expert_outputs(expert_outputs, scores):
+    return (
+        (expert_outputs * scores[..., None]).sum(axis=-2).astype(expert_outputs.dtype)
+    )
+
+
+class BailingMoeMLP(nn.Module):
+    def __init__(self, args: ModelConfig, intermediate_size: Optional[int] = None):
+        super().__init__()
+        self.intermediate_size = (
+            intermediate_size
+            if intermediate_size is not None
+            else args.intermediate_size
+        )
+
+        self.gate_proj = nn.Linear(
+            args.hidden_size, self.intermediate_size, bias=args.use_bias
+        )
+        self.down_proj = nn.Linear(
+            self.intermediate_size, args.hidden_size, bias=args.use_bias
+        )
+        self.up_proj = nn.Linear(
+            args.hidden_size, self.intermediate_size, bias=args.use_bias
+        )
+
+    def __call__(self, x) -> mx.array:
+        return self.down_proj(swiglu(self.gate_proj(x), self.up_proj(x)))
+
+
+class BailingMoeAttention(nn.Module):
+    def __init__(self, args: ModelConfig):
+        super().__init__()
+        self.use_qk_norm = args.use_qk_norm
+        self.num_attention_heads = args.num_attention_heads
+        self.num_key_value_heads = args.num_key_value_heads
+        self.head_dim = args.hidden_size // self.num_attention_heads
+        self.scale = self.head_dim**-0.5
+
+        self.query_key_value = nn.Linear(
+            args.hidden_size,
+            (self.num_attention_heads + 2 * self.num_key_value_heads) * self.head_dim,
+            bias=args.use_qkv_bias,
+        )
+        self.dense = nn.Linear(
+            self.num_attention_heads * self.head_dim,
+            args.hidden_size,
+            bias=args.use_bias,
+        )
+
+        if args.use_qk_norm:
+            self.key_layernorm = nn.RMSNorm(self.head_dim, eps=args.rms_norm_eps)
+            self.query_layernorm = nn.RMSNorm(self.head_dim, eps=args.rms_norm_eps)
+
+        if (rope_dim := args.rotary_dim) is None:
+            rope_dim = int(self.head_dim * args.partial_rotary_factor)
+        self.rope = initialize_rope(
+            rope_dim,
+            args.rope_theta,
+            traditional=False,
+            scaling_config=args.rope_scaling,
+            max_position_embeddings=args.max_position_embeddings,
+        )
+
+    def __call__(
+        self,
+        x: mx.array,
+        mask: Optional[mx.array] = None,
+        cache: Optional[Any] = None,
+    ) -> mx.array:
+        B, L, D = x.shape
+
+        qkv = self.query_key_value(x)
+
+        q_size = self.num_attention_heads * self.head_dim
+        kv_size = self.num_key_value_heads * self.head_dim
+        q, k, v = mx.split(qkv, [q_size, q_size + kv_size], axis=-1)
+
+        queries = q.reshape(B, L, self.num_attention_heads, self.head_dim).transpose(
+            0, 2, 1, 3
+        )
+        keys = k.reshape(B, L, self.num_key_value_heads, self.head_dim).transpose(
+            0, 2, 1, 3
+        )
+        values = v.reshape(B, L, self.num_key_value_heads, self.head_dim).transpose(
+            0, 2, 1, 3
+        )
+
+        if self.use_qk_norm:
+            queries = self.query_layernorm(queries)
+            keys = self.key_layernorm(keys)
+
+        if cache is not None:
+            queries = self.rope(queries, offset=cache.offset)
+            keys = self.rope(keys, offset=cache.offset)
+            keys, values = cache.update_and_fetch(keys, values)
+        else:
+            queries = self.rope(queries)
+            keys = self.rope(keys)
+
+        output = scaled_dot_product_attention(
+            queries, keys, values, cache=cache, scale=self.scale, mask=mask
+        )
+
+        output = output.transpose(0, 2, 1, 3).reshape(B, L, -1)
+        return self.dense(output)
+
+
+@mx.compile
+def group_expert_select(
+    gates,
+    e_score_correction_bias,
+    top_k,
+    n_group,
+    topk_group,
+    routed_scaling_factor,
+    norm_topk_prob,
+    score_function,
+):
+
+    in_type = gates.dtype
+    if score_function == "sigmoid":
+        scores = mx.sigmoid(gates.astype(mx.float32))
+    else:
+        scores = mx.softmax(gates.astype(mx.float32), axis=-1)
+    orig_scores = scores
+    if e_score_correction_bias is not None:
+        scores = scores + e_score_correction_bias
+    if n_group > 1:
+        scores = mx.unflatten(scores, axis=-1, shape=(n_group, -1))
+        group_scores = mx.topk(scores, 2, axis=-1).sum(axis=-1, keepdims=True)
+        k = n_group - topk_group
+        group_idx = mx.argpartition(group_scores, kth=k - 1, axis=-2)[..., :k, :]
+        scores = mx.put_along_axis(
+            scores, mx.stop_gradient(group_idx), mx.array(0.0, scores.dtype), axis=-2
+        )
+        scores = mx.flatten(scores, -2, -1)
+
+    k = top_k
+    inds = mx.argpartition(scores, kth=-k, axis=-1)[..., -k:]
+    scores = mx.take_along_axis(orig_scores, inds, axis=-1)
+    if top_k > 1 and norm_topk_prob:
+        denominator = scores.sum(axis=-1, keepdims=True) + 1e-20
+        scores = scores / denominator
+    scores = scores * routed_scaling_factor
+
+    return inds, scores.astype(in_type)
+
+
+class BailingMoeGate(nn.Module):
+    def __init__(self, args: ModelConfig):
+        super().__init__()
+        self.norm_topk_prob = args.norm_topk_prob
+
+        self.top_k = args.num_experts_per_tok
+        self.n_group = args.n_group
+        self.topk_group = args.topk_group
+        self.routed_scaling_factor = args.routed_scaling_factor
+        self.enable_routed_scaling = args.moe_router_enable_routed_scaling
+
+        self.gate_proj = nn.Linear(args.hidden_size, args.num_experts, bias=False)
+        self.expert_bias = (
+            mx.zeros((args.num_experts,))
+            if args.moe_router_enable_expert_bias
+            else None
+        )
+        self.score_function = args.score_function
+
+    def __call__(self, x):
+        return group_expert_select(
+            self.gate_proj(x),
+            self.expert_bias,
+            self.top_k,
+            self.n_group,
+            self.topk_group,
+            self.routed_scaling_factor,
+            self.norm_topk_prob,
+            self.score_function,
+        )
+
+
+class BailingMoeSparseMoeBlock(nn.Module):
+    def __init__(self, args: ModelConfig):
+        super().__init__()
+        self.args = args
+        self.num_experts_per_tok = args.num_experts_per_tok
+        self.switch_mlp = SwitchGLU(
+            args.hidden_size,
+            args.moe_intermediate_size,
+            args.num_experts,
+            bias=args.use_bias,
+        )
+        self.gate = BailingMoeGate(args)
+        shared_dim = (
+            args.moe_shared_expert_intermediate_size or args.moe_intermediate_size
+        )
+        self.shared_experts = (
+            BailingMoeMLP(
+                args=args,
+                intermediate_size=shared_dim * args.num_shared_experts,
+            )
+            if args.num_shared_experts > 0 and args.moe_router_enable_shared_expert
+            else None
+        )
+
+    def __call__(self, x):
+        topk_idx, topk_weight = self.gate(x)
+        out = self.switch_mlp(x, topk_idx)
+        out = aggregate_expert_outputs(out, topk_weight)
+        if self.shared_experts is not None:
+            out = out + self.shared_experts(x)
+        return out
+
+
+class BailingMoeDecoderLayer(nn.Module):
+    def __init__(self, args: ModelConfig, layer_idx: int):
+        super().__init__()
+        self.attention = BailingMoeAttention(args)
+
+        self.mlp = (
+            BailingMoeSparseMoeBlock(args)
+            if (
+                args.num_experts is not None and layer_idx >= args.first_k_dense_replace
+            )
+            else BailingMoeMLP(args)
+        )
+        self.input_layernorm = nn.RMSNorm(args.hidden_size, eps=args.rms_norm_eps)
+        self.post_attention_layernorm = nn.RMSNorm(
+            args.hidden_size, eps=args.rms_norm_eps
+        )
+
+    def __call__(
+        self,
+        x: mx.array,
+        mask: Optional[mx.array] = None,
+        cache: Optional[Any] = None,
+    ) -> mx.array:
+        r = self.attention(self.input_layernorm(x), mask, cache)
+        h = x + r
+        r = self.mlp(self.post_attention_layernorm(h))
+        return h + r
+
+
+class BailingMoeModel(nn.Module):
+    def __init__(self, args: ModelConfig):
+        super().__init__()
+        self.word_embeddings = nn.Embedding(args.vocab_size, args.hidden_size)
+        self.layers = [
+            BailingMoeDecoderLayer(args, layer_idx=i)
+            for i in range(args.num_hidden_layers)
+        ]
+        self.norm = nn.RMSNorm(args.hidden_size, eps=args.rms_norm_eps)
+
+    def __call__(
+        self,
+        inputs: mx.array,
+        cache: Optional[Any] = None,
+        inputs_embeds: Optional[mx.array] = None,
+    ):
+        h = self.word_embeddings(inputs) if inputs_embeds is None else inputs_embeds
+
+        if cache is None:
+            cache = [None] * len(self.layers)
+
+        mask = create_attention_mask(h, cache[0])
+
+        for layer, c in zip(self.layers, cache):
+            h = layer(h, mask, c)
+
+        return self.norm(h)
+
+
+class LanguageModel(nn.Module):
+    def __init__(self, args: ModelConfig):
+        super().__init__()
+        self.args = args
+        self.norm_head = args.norm_head
+        self.model_type = args.model_type
+        self.model = BailingMoeModel(args)
+        if not args.tie_word_embeddings:
+            self.lm_head = nn.Linear(args.hidden_size, args.vocab_size, bias=False)
+
+    def __call__(
+        self, inputs: mx.array, cache=None, inputs_embeds=None, mask=None, **kwargs
+    ):
+        out = self.model(inputs, cache, inputs_embeds=inputs_embeds)
+        if self.args.tie_word_embeddings:
+            out = self.model.word_embeddings.as_linear(out)
+        else:
+            out = self.lm_head(out)
+        return LanguageModelOutput(logits=out)
+
+    def sanitize(self, weights):
+        if self.args.tie_word_embeddings:
+            weights.pop("lm_head.weight", None)
+
+        if self.norm_head:
+            w = weights["lm_head.weight"]
+            dtype = w.dtype
+            weight_norm = (
+                mx.linalg.norm(w.astype(mx.float32), axis=0, keepdims=True) + 1e-7
+            )
+            weights["lm_head.weight"] = (w / weight_norm).astype(dtype)
+
+        for l in range(self.args.num_hidden_layers):
+            prefix = f"model.layers.{l}"
+
+            if l >= self.args.first_k_dense_replace:
+                for m in ["gate_proj", "down_proj", "up_proj"]:
+                    for k in ["weight", "scales", "biases"]:
+                        if f"{prefix}.mlp.experts.0.{m}.{k}" in weights:
+                            to_join = [
+                                weights.pop(f"{prefix}.mlp.experts.{e}.{m}.{k}")
+                                for e in range(self.args.num_experts)
+                            ]
+                            weights[f"{prefix}.mlp.switch_mlp.{m}.{k}"] = mx.stack(
+                                to_join
+                            )
+
+                if f"{prefix}.mlp.gate.weight" in weights:
+                    gate_weight = weights.pop(f"{prefix}.mlp.gate.weight")
+                    weights[f"{prefix}.mlp.gate.gate_proj.weight"] = gate_weight
+
+                if f"{prefix}.mlp.gate.bias" in weights:
+                    gate_bias = weights.pop(f"{prefix}.mlp.gate.bias")
+                    weights[f"{prefix}.mlp.gate.gate_proj.bias"] = gate_bias
+
+        return weights
+
+    @property
+    def quant_predicate(self):
+        def predicate(path, _):
+            if path.endswith("mlp.gate.gate_proj"):
+                return {"group_size": 64, "bits": 8}
+            return True
+
+        return predicate
+
+    @property
+    def cast_predicate(self):
+        def predicate(k):
+            return "expert_bias" not in k
+
+        return predicate
+
+    @property
+    def layers(self):
+        return self.model.layers
+
+    def make_cache(self):
+        return [KVCache() for _ in self.model.layers]

--- a/mlx_vlm/models/bailing_moe/language.py
+++ b/mlx_vlm/models/bailing_moe/language.py
@@ -4,13 +4,13 @@ from typing import Any, Optional
 import mlx.core as mx
 import mlx.nn as nn
 
-from ..activations import swiglu
 from ..base import (
     LanguageModelOutput,
     create_attention_mask,
     scaled_dot_product_attention,
 )
 from ..cache import KVCache
+from ..mlp import SwiGLUMLP
 from ..rope_utils import initialize_rope
 from ..switch_layers import SwitchGLU
 from .config import ModelConfig
@@ -21,29 +21,6 @@ def aggregate_expert_outputs(expert_outputs, scores):
     return (
         (expert_outputs * scores[..., None]).sum(axis=-2).astype(expert_outputs.dtype)
     )
-
-
-class BailingMoeMLP(nn.Module):
-    def __init__(self, args: ModelConfig, intermediate_size: Optional[int] = None):
-        super().__init__()
-        self.intermediate_size = (
-            intermediate_size
-            if intermediate_size is not None
-            else args.intermediate_size
-        )
-
-        self.gate_proj = nn.Linear(
-            args.hidden_size, self.intermediate_size, bias=args.use_bias
-        )
-        self.down_proj = nn.Linear(
-            self.intermediate_size, args.hidden_size, bias=args.use_bias
-        )
-        self.up_proj = nn.Linear(
-            args.hidden_size, self.intermediate_size, bias=args.use_bias
-        )
-
-    def __call__(self, x) -> mx.array:
-        return self.down_proj(swiglu(self.gate_proj(x), self.up_proj(x)))
 
 
 class BailingMoeAttention(nn.Module):
@@ -213,9 +190,10 @@ class BailingMoeSparseMoeBlock(nn.Module):
             args.moe_shared_expert_intermediate_size or args.moe_intermediate_size
         )
         self.shared_experts = (
-            BailingMoeMLP(
-                args=args,
-                intermediate_size=shared_dim * args.num_shared_experts,
+            SwiGLUMLP(
+                args.hidden_size,
+                shared_dim * args.num_shared_experts,
+                bias=args.use_bias,
             )
             if args.num_shared_experts > 0 and args.moe_router_enable_shared_expert
             else None
@@ -240,7 +218,7 @@ class BailingMoeDecoderLayer(nn.Module):
             if (
                 args.num_experts is not None and layer_idx >= args.first_k_dense_replace
             )
-            else BailingMoeMLP(args)
+            else SwiGLUMLP(args.hidden_size, args.intermediate_size, bias=args.use_bias)
         )
         self.input_layernorm = nn.RMSNorm(args.hidden_size, eps=args.rms_norm_eps)
         self.post_attention_layernorm = nn.RMSNorm(

--- a/mlx_vlm/models/dots1/__init__.py
+++ b/mlx_vlm/models/dots1/__init__.py
@@ -1,0 +1,4 @@
+from .config import ModelConfig
+from .dots1 import Model
+
+__all__ = ["Model", "ModelConfig"]

--- a/mlx_vlm/models/dots1/config.py
+++ b/mlx_vlm/models/dots1/config.py
@@ -1,0 +1,33 @@
+from dataclasses import dataclass
+from typing import Dict, Optional, Union
+
+from ..base import BaseModelConfig
+
+
+@dataclass
+class ModelConfig(BaseModelConfig):
+    model_type: str
+    hidden_size: int
+    num_hidden_layers: int
+    intermediate_size: int
+    num_attention_heads: int
+    rms_norm_eps: float
+    vocab_size: int
+    max_position_embeddings: Optional[int]
+    num_key_value_heads: int
+    first_k_dense_replace: int
+    moe_intermediate_size: int
+    n_routed_experts: int
+    n_shared_experts: int
+    norm_topk_prob: bool
+    num_experts_per_tok: int
+    rope_theta: float
+    routed_scaling_factor: float
+    head_dim: Optional[int] = None
+    scoring_func: str = "noaux_tc"
+    n_group: Optional[int] = 1
+    topk_group: Optional[int] = 1
+    attention_bias: bool = False
+    mlp_bias: bool = False
+    rope_scaling: Optional[Dict[str, Union[float, str]]] = None
+    tie_word_embeddings: bool = False

--- a/mlx_vlm/models/dots1/dots1.py
+++ b/mlx_vlm/models/dots1/dots1.py
@@ -1,0 +1,49 @@
+from typing import Optional
+
+import mlx.core as mx
+import mlx.nn as nn
+
+from ..base import InputEmbeddingsFeatures, LanguageModelOutput
+from .config import ModelConfig
+from .language import LanguageModel
+
+
+class Model(nn.Module):
+    def __init__(self, config: ModelConfig):
+        super().__init__()
+        self.config = config
+        self.model_type = config.model_type
+        self.language_model = LanguageModel(config)
+
+    def get_input_embeddings(
+        self,
+        input_ids: Optional[mx.array] = None,
+        pixel_values: Optional[mx.array] = None,
+        **kwargs,
+    ) -> InputEmbeddingsFeatures:
+        return InputEmbeddingsFeatures(
+            inputs_embeds=self.language_model.model.embed_tokens(input_ids)
+        )
+
+    def __call__(
+        self,
+        input_ids: mx.array,
+        pixel_values: mx.array = None,
+        mask: mx.array = None,
+        cache=None,
+        **kwargs,
+    ) -> LanguageModelOutput:
+        return self.language_model(input_ids, cache=cache, **kwargs)
+
+    def sanitize(self, weights):
+        if any(k.startswith("language_model.") for k in weights):
+            return weights
+        weights = self.language_model.sanitize(weights)
+        return {f"language_model.{k}": v for k, v in weights.items()}
+
+    @property
+    def layers(self):
+        return self.language_model.layers
+
+    def make_cache(self):
+        return self.language_model.make_cache()

--- a/mlx_vlm/models/dots1/language.py
+++ b/mlx_vlm/models/dots1/language.py
@@ -3,13 +3,13 @@ from typing import Any, Optional
 import mlx.core as mx
 import mlx.nn as nn
 
-from ..activations import swiglu
 from ..base import (
     LanguageModelOutput,
     create_attention_mask,
     scaled_dot_product_attention,
 )
 from ..cache import KVCache
+from ..mlp import SwiGLUMLP
 from ..rope_utils import initialize_rope
 from ..switch_layers import SwitchGLU
 from .config import ModelConfig
@@ -131,31 +131,6 @@ class Dots1TopkRouter(nn.Module):
         )
 
 
-class Dots1MLP(nn.Module):
-    def __init__(
-        self, args: ModelConfig, hidden_size: int = None, intermediate_size: int = None
-    ):
-        super().__init__()
-
-        self.hidden_size = args.hidden_size if hidden_size is None else hidden_size
-        self.intermediate_size = (
-            args.intermediate_size if intermediate_size is None else intermediate_size
-        )
-
-        self.gate_proj = nn.Linear(
-            self.hidden_size, self.intermediate_size, bias=args.mlp_bias
-        )
-        self.up_proj = nn.Linear(
-            self.hidden_size, self.intermediate_size, bias=args.mlp_bias
-        )
-        self.down_proj = nn.Linear(
-            self.intermediate_size, self.hidden_size, bias=args.mlp_bias
-        )
-
-    def __call__(self, x) -> mx.array:
-        return self.down_proj(swiglu(self.gate_proj(x), self.up_proj(x)))
-
-
 class Dots1MoE(nn.Module):
     def __init__(self, args: ModelConfig):
         super().__init__()
@@ -170,9 +145,10 @@ class Dots1MoE(nn.Module):
 
         self.gate = Dots1TopkRouter(args)
 
-        self.shared_experts = Dots1MLP(
-            args=args,
-            intermediate_size=args.moe_intermediate_size * args.n_shared_experts,
+        self.shared_experts = SwiGLUMLP(
+            args.hidden_size,
+            args.moe_intermediate_size * args.n_shared_experts,
+            bias=args.mlp_bias,
         )
 
     def __call__(self, x):
@@ -193,7 +169,9 @@ class Dots1DecoderLayer(nn.Module):
         if layer_idx >= args.first_k_dense_replace:
             self.mlp = Dots1MoE(args)
         else:
-            self.mlp = Dots1MLP(args)
+            self.mlp = SwiGLUMLP(
+                args.hidden_size, args.intermediate_size, bias=args.mlp_bias
+            )
 
         self.input_layernorm = nn.RMSNorm(args.hidden_size, eps=args.rms_norm_eps)
         self.post_attention_layernorm = nn.RMSNorm(

--- a/mlx_vlm/models/dots1/language.py
+++ b/mlx_vlm/models/dots1/language.py
@@ -1,0 +1,281 @@
+from typing import Any, Optional
+
+import mlx.core as mx
+import mlx.nn as nn
+
+from ..activations import swiglu
+from ..base import (
+    LanguageModelOutput,
+    create_attention_mask,
+    scaled_dot_product_attention,
+)
+from ..cache import KVCache
+from ..rope_utils import initialize_rope
+from ..switch_layers import SwitchGLU
+from .config import ModelConfig
+
+
+class Dots1Attention(nn.Module):
+    def __init__(self, args: ModelConfig):
+        super().__init__()
+
+        dim = args.hidden_size
+        self.n_heads = n_heads = args.num_attention_heads
+        self.n_kv_heads = n_kv_heads = args.num_key_value_heads
+
+        head_dim = args.head_dim or args.hidden_size // n_heads
+        self.scale = head_dim**-0.5
+
+        self.q_proj = nn.Linear(dim, n_heads * head_dim, bias=False)
+        self.k_proj = nn.Linear(dim, n_kv_heads * head_dim, bias=False)
+        self.v_proj = nn.Linear(dim, n_kv_heads * head_dim, bias=False)
+        self.o_proj = nn.Linear(n_heads * head_dim, dim, bias=False)
+
+        self.q_norm = nn.RMSNorm(head_dim, eps=args.rms_norm_eps)
+        self.k_norm = nn.RMSNorm(head_dim, eps=args.rms_norm_eps)
+        self.rope = initialize_rope(
+            head_dim,
+            base=args.rope_theta,
+            traditional=False,
+            scaling_config=args.rope_scaling,
+            max_position_embeddings=args.max_position_embeddings,
+        )
+
+    def __call__(
+        self,
+        x: mx.array,
+        mask: Optional[mx.array] = None,
+        cache: Optional[Any] = None,
+    ) -> mx.array:
+        B, L, D = x.shape
+
+        queries, keys, values = self.q_proj(x), self.k_proj(x), self.v_proj(x)
+
+        queries = self.q_norm(queries.reshape(B, L, self.n_heads, -1)).transpose(
+            0, 2, 1, 3
+        )
+        keys = self.k_norm(keys.reshape(B, L, self.n_kv_heads, -1)).transpose(
+            0, 2, 1, 3
+        )
+        values = values.reshape(B, L, self.n_kv_heads, -1).transpose(0, 2, 1, 3)
+
+        if cache is not None:
+            queries = self.rope(queries, offset=cache.offset)
+            keys = self.rope(keys, offset=cache.offset)
+            keys, values = cache.update_and_fetch(keys, values)
+        else:
+            queries = self.rope(queries)
+            keys = self.rope(keys)
+
+        output = scaled_dot_product_attention(
+            queries, keys, values, cache=cache, scale=self.scale, mask=mask
+        )
+        output = output.transpose(0, 2, 1, 3).reshape(B, L, -1)
+        return self.o_proj(output)
+
+
+@mx.compile
+def group_expert_select(
+    gates,
+    e_score_correction_bias,
+    top_k,
+    n_group,
+    topk_group,
+    routed_scaling_factor,
+    norm_topk_prob,
+):
+    k = top_k
+    scores = mx.sigmoid(gates.astype(mx.float32))
+    orig_scores = scores
+    scores = scores + e_score_correction_bias
+    k = n_group - topk_group
+    if k != 0:
+        scores = mx.unflatten(scores, axis=-1, shape=(n_group, -1))
+        group_scores = mx.topk(scores, 2, axis=-1).sum(axis=-1, keepdims=True)
+        group_idx = mx.argpartition(group_scores, kth=k - 1, axis=-2)[..., :k, :]
+        scores = mx.put_along_axis(scores, group_idx, mx.array(0.0), axis=-2)
+        scores = mx.flatten(scores, -2, -1)
+
+    k = top_k
+    inds = mx.argpartition(-scores, kth=k - 1, axis=-1)[..., :k]
+    scores = mx.take_along_axis(orig_scores, inds, axis=-1)
+    if top_k > 1 and norm_topk_prob:
+        denominator = scores.sum(axis=-1, keepdims=True)
+        scores = scores / denominator
+    scores = scores * routed_scaling_factor
+
+    return inds, scores
+
+
+class Dots1TopkRouter(nn.Module):
+    def __init__(self, args: ModelConfig):
+        super().__init__()
+        self.top_k = args.num_experts_per_tok
+        self.norm_topk_prob = args.norm_topk_prob
+        self.n_routed_experts = args.n_routed_experts
+        self.routed_scaling_factor = args.routed_scaling_factor
+        self.n_group = args.n_group
+        self.topk_group = args.topk_group
+        self.weight = mx.zeros((self.n_routed_experts, args.hidden_size))
+        self.e_score_correction_bias = mx.zeros((self.n_routed_experts,))
+
+    def __call__(self, x):
+        return group_expert_select(
+            x @ self.weight.T,
+            self.e_score_correction_bias,
+            self.top_k,
+            self.n_group,
+            self.topk_group,
+            self.routed_scaling_factor,
+            self.norm_topk_prob,
+        )
+
+
+class Dots1MLP(nn.Module):
+    def __init__(
+        self, args: ModelConfig, hidden_size: int = None, intermediate_size: int = None
+    ):
+        super().__init__()
+
+        self.hidden_size = args.hidden_size if hidden_size is None else hidden_size
+        self.intermediate_size = (
+            args.intermediate_size if intermediate_size is None else intermediate_size
+        )
+
+        self.gate_proj = nn.Linear(
+            self.hidden_size, self.intermediate_size, bias=args.mlp_bias
+        )
+        self.up_proj = nn.Linear(
+            self.hidden_size, self.intermediate_size, bias=args.mlp_bias
+        )
+        self.down_proj = nn.Linear(
+            self.intermediate_size, self.hidden_size, bias=args.mlp_bias
+        )
+
+    def __call__(self, x) -> mx.array:
+        return self.down_proj(swiglu(self.gate_proj(x), self.up_proj(x)))
+
+
+class Dots1MoE(nn.Module):
+    def __init__(self, args: ModelConfig):
+        super().__init__()
+        self.num_experts_per_tok = args.num_experts_per_tok
+        self.n_shared_experts = args.n_shared_experts
+
+        self.experts = SwitchGLU(
+            args.hidden_size,
+            args.moe_intermediate_size,
+            args.n_routed_experts,
+        )
+
+        self.gate = Dots1TopkRouter(args)
+
+        self.shared_experts = Dots1MLP(
+            args=args,
+            intermediate_size=args.moe_intermediate_size * args.n_shared_experts,
+        )
+
+    def __call__(self, x):
+        inds, scores = self.gate(x)
+        y = self.experts(x, inds)
+        y = (y * scores[..., None]).sum(axis=-2).astype(y.dtype)
+        if self.n_shared_experts is not None:
+            y = y + self.shared_experts(x)
+
+        return y
+
+
+class Dots1DecoderLayer(nn.Module):
+    def __init__(self, args: ModelConfig, layer_idx: int):
+        super().__init__()
+        self.self_attn = Dots1Attention(args)
+
+        if layer_idx >= args.first_k_dense_replace:
+            self.mlp = Dots1MoE(args)
+        else:
+            self.mlp = Dots1MLP(args)
+
+        self.input_layernorm = nn.RMSNorm(args.hidden_size, eps=args.rms_norm_eps)
+        self.post_attention_layernorm = nn.RMSNorm(
+            args.hidden_size, eps=args.rms_norm_eps
+        )
+
+    def __call__(
+        self,
+        x: mx.array,
+        mask: Optional[mx.array] = None,
+        cache: Optional[Any] = None,
+    ) -> mx.array:
+        r = self.self_attn(self.input_layernorm(x), mask, cache)
+        h = x + r
+        r = self.mlp(self.post_attention_layernorm(h))
+        return h + r
+
+
+class Dots1Model(nn.Module):
+    def __init__(self, args: ModelConfig):
+        super().__init__()
+        self.embed_tokens = nn.Embedding(args.vocab_size, args.hidden_size)
+        self.layers = [
+            Dots1DecoderLayer(args, layer_idx)
+            for layer_idx in range(args.num_hidden_layers)
+        ]
+        self.norm = nn.RMSNorm(args.hidden_size, eps=args.rms_norm_eps)
+
+    def __call__(self, inputs: mx.array, cache=None, inputs_embeds=None) -> mx.array:
+        h = self.embed_tokens(inputs) if inputs_embeds is None else inputs_embeds
+
+        if cache is None:
+            cache = [None] * len(self.layers)
+
+        mask = create_attention_mask(h, cache[0])
+
+        for layer, c in zip(self.layers, cache):
+            h = layer(h, mask, c)
+
+        return self.norm(h)
+
+
+class LanguageModel(nn.Module):
+    def __init__(self, args: ModelConfig):
+        super().__init__()
+        self.args = args
+        self.model_type = args.model_type
+        self.model = Dots1Model(args)
+        if not args.tie_word_embeddings:
+            self.lm_head = nn.Linear(args.hidden_size, args.vocab_size, bias=False)
+
+    def __call__(
+        self, inputs: mx.array, cache=None, inputs_embeds=None, mask=None, **kwargs
+    ):
+        out = self.model(inputs, cache, inputs_embeds=inputs_embeds)
+        if self.args.tie_word_embeddings:
+            out = self.model.embed_tokens.as_linear(out)
+        else:
+            out = self.lm_head(out)
+        return LanguageModelOutput(logits=out)
+
+    def sanitize(self, weights):
+        if self.args.tie_word_embeddings:
+            weights.pop("lm_head.weight", None)
+
+        for l in range(self.args.num_hidden_layers):
+            prefix = f"model.layers.{l}"
+            if l >= self.args.first_k_dense_replace:
+                for m in ("gate_proj", "down_proj", "up_proj"):
+                    for k in ("weight", "scales", "biases"):
+                        if f"{prefix}.mlp.experts.0.{m}.{k}" in weights:
+                            to_join = [
+                                weights.pop(f"{prefix}.mlp.experts.{e}.{m}.{k}")
+                                for e in range(self.args.n_routed_experts)
+                            ]
+                            weights[f"{prefix}.mlp.experts.{m}.{k}"] = mx.stack(to_join)
+
+        return {k: v for k, v in weights.items() if "rotary_emb.inv_freq" not in k}
+
+    def make_cache(self):
+        return [KVCache() for _ in self.model.layers]
+
+    @property
+    def layers(self):
+        return self.model.layers

--- a/mlx_vlm/models/ernie4_5/__init__.py
+++ b/mlx_vlm/models/ernie4_5/__init__.py
@@ -1,0 +1,4 @@
+from .config import ModelConfig
+from .ernie4_5 import Model
+
+__all__ = ["Model", "ModelConfig"]

--- a/mlx_vlm/models/ernie4_5/config.py
+++ b/mlx_vlm/models/ernie4_5/config.py
@@ -1,0 +1,21 @@
+from dataclasses import dataclass
+from typing import Optional
+
+from ..base import BaseModelConfig
+
+
+@dataclass
+class ModelConfig(BaseModelConfig):
+    hidden_size: int
+    intermediate_size: int
+    model_type: str
+    max_position_embeddings: int
+    num_attention_heads: int
+    num_key_value_heads: int
+    head_dim: Optional[int]
+    num_hidden_layers: int
+    rms_norm_eps: float
+    vocab_size: int
+    rope_theta: float
+    use_bias: bool
+    tie_word_embeddings: bool

--- a/mlx_vlm/models/ernie4_5/ernie4_5.py
+++ b/mlx_vlm/models/ernie4_5/ernie4_5.py
@@ -1,0 +1,46 @@
+from typing import Optional
+
+import mlx.core as mx
+import mlx.nn as nn
+
+from ..base import InputEmbeddingsFeatures, LanguageModelOutput
+from .config import ModelConfig
+from .language import LanguageModel
+
+
+class Model(nn.Module):
+    def __init__(self, config: ModelConfig):
+        super().__init__()
+        self.config = config
+        self.model_type = config.model_type
+        self.language_model = LanguageModel(config)
+
+    def get_input_embeddings(
+        self,
+        input_ids: Optional[mx.array] = None,
+        pixel_values: Optional[mx.array] = None,
+        **kwargs,
+    ) -> InputEmbeddingsFeatures:
+        return InputEmbeddingsFeatures(
+            inputs_embeds=self.language_model.model.embed_tokens(input_ids)
+        )
+
+    def __call__(
+        self,
+        input_ids: mx.array,
+        pixel_values: mx.array = None,
+        mask: mx.array = None,
+        cache=None,
+        **kwargs,
+    ) -> LanguageModelOutput:
+        return self.language_model(input_ids, cache=cache, **kwargs)
+
+    def sanitize(self, weights):
+        if any(k.startswith("language_model.") for k in weights):
+            return weights
+        weights = self.language_model.sanitize(weights)
+        return {f"language_model.{k}": v for k, v in weights.items()}
+
+    @property
+    def layers(self):
+        return self.language_model.layers

--- a/mlx_vlm/models/ernie4_5/language.py
+++ b/mlx_vlm/models/ernie4_5/language.py
@@ -1,0 +1,168 @@
+from typing import Any, Optional
+
+import mlx.core as mx
+import mlx.nn as nn
+
+from ..activations import swiglu
+from ..base import (
+    LanguageModelOutput,
+    create_attention_mask,
+    scaled_dot_product_attention,
+)
+from ..cache import KVCache
+from ..rope_utils import initialize_rope
+from .config import ModelConfig
+
+
+class Attention(nn.Module):
+    def __init__(self, args: ModelConfig):
+        super().__init__()
+        dim = args.hidden_size
+        self.n_heads = n_heads = args.num_attention_heads
+        self.n_kv_heads = n_kv_heads = args.num_key_value_heads
+        self.head_dim = head_dim = args.head_dim or dim // n_heads
+        self.scale = head_dim**-0.5
+
+        self.q_proj = nn.Linear(dim, n_heads * head_dim, bias=args.use_bias)
+        self.k_proj = nn.Linear(dim, n_kv_heads * head_dim, bias=args.use_bias)
+        self.v_proj = nn.Linear(dim, n_kv_heads * head_dim, bias=args.use_bias)
+        self.o_proj = nn.Linear(n_heads * head_dim, dim, bias=args.use_bias)
+
+        self.rope = initialize_rope(
+            head_dim,
+            base=args.rope_theta,
+            traditional=True,
+            max_position_embeddings=args.max_position_embeddings,
+        )
+
+    def __call__(
+        self,
+        x: mx.array,
+        mask: Optional[mx.array] = None,
+        cache: Optional[Any] = None,
+    ) -> mx.array:
+        B, L, D = x.shape
+        queries, keys, values = self.q_proj(x), self.k_proj(x), self.v_proj(x)
+        queries = queries.reshape(B, L, self.n_heads, -1).transpose(0, 2, 1, 3)
+        keys = keys.reshape(B, L, self.n_kv_heads, -1).transpose(0, 2, 1, 3)
+        values = values.reshape(B, L, self.n_kv_heads, -1).transpose(0, 2, 1, 3)
+
+        if cache is not None:
+            queries = self.rope(queries, offset=cache.offset)
+            keys = self.rope(keys, offset=cache.offset)
+            keys, values = cache.update_and_fetch(keys, values)
+        else:
+            queries = self.rope(queries)
+            keys = self.rope(keys)
+
+        output = scaled_dot_product_attention(
+            queries, keys, values, cache=cache, scale=self.scale, mask=mask
+        )
+        output = output.transpose(0, 2, 1, 3).reshape(B, L, -1)
+        return self.o_proj(output)
+
+
+class MLP(nn.Module):
+    def __init__(self, dim, hidden_dim, use_bias=False):
+        super().__init__()
+        self.gate_proj = nn.Linear(dim, hidden_dim, bias=use_bias)
+        self.down_proj = nn.Linear(hidden_dim, dim, bias=use_bias)
+        self.up_proj = nn.Linear(dim, hidden_dim, bias=use_bias)
+
+    def __call__(self, x) -> mx.array:
+        return self.down_proj(swiglu(self.gate_proj(x), self.up_proj(x)))
+
+
+class DecoderLayer(nn.Module):
+    def __init__(self, args: ModelConfig):
+        super().__init__()
+        self.self_attn = Attention(args)
+        self.mlp = MLP(args.hidden_size, args.intermediate_size, args.use_bias)
+        self.input_layernorm = nn.RMSNorm(args.hidden_size, eps=args.rms_norm_eps)
+        self.post_attention_layernorm = nn.RMSNorm(
+            args.hidden_size, eps=args.rms_norm_eps
+        )
+
+    def __call__(
+        self,
+        x: mx.array,
+        mask: Optional[mx.array] = None,
+        cache: Optional[Any] = None,
+    ) -> mx.array:
+        r = self.self_attn(self.input_layernorm(x), mask, cache)
+        h = x + r
+        r = self.mlp(self.post_attention_layernorm(h))
+        return h + r
+
+
+class Ernie45Model(nn.Module):
+    def __init__(self, args: ModelConfig):
+        super().__init__()
+        self.embed_tokens = nn.Embedding(args.vocab_size, args.hidden_size)
+        self.layers = [DecoderLayer(args) for _ in range(args.num_hidden_layers)]
+        self.norm = nn.RMSNorm(args.hidden_size, eps=args.rms_norm_eps)
+
+    def __call__(self, inputs, cache=None, input_embeddings=None):
+        h = (
+            input_embeddings
+            if input_embeddings is not None
+            else self.embed_tokens(inputs)
+        )
+        if cache is None:
+            cache = [None] * len(self.layers)
+        mask = create_attention_mask(h, cache[0])
+        for layer, c in zip(self.layers, cache):
+            h = layer(h, mask, c)
+        return self.norm(h)
+
+
+class LanguageModel(nn.Module):
+    def __init__(self, args: ModelConfig):
+        super().__init__()
+        self.args = args
+        self.config = args
+        self.model_type = args.model_type
+        self.model = Ernie45Model(args)
+        if not args.tie_word_embeddings:
+            self.lm_head = nn.Linear(args.hidden_size, args.vocab_size, bias=False)
+
+    def __call__(
+        self,
+        inputs: Optional[mx.array] = None,
+        cache=None,
+        input_embeddings: Optional[mx.array] = None,
+        inputs_embeds: Optional[mx.array] = None,
+        **kwargs,
+    ) -> LanguageModelOutput:
+        if inputs is None:
+            inputs = kwargs.get("input_ids")
+        if inputs_embeds is None:
+            inputs_embeds = input_embeddings
+        out = self.model(inputs, cache, inputs_embeds)
+        if self.args.tie_word_embeddings:
+            out = self.model.embed_tokens.as_linear(out)
+        else:
+            out = self.lm_head(out)
+        return LanguageModelOutput(logits=out)
+
+    def sanitize(self, weights):
+        if self.args.tie_word_embeddings:
+            weights.pop("lm_head.weight", None)
+        return weights
+
+    def make_cache(self):
+        return [KVCache() for _ in self.model.layers]
+
+    @property
+    def layers(self):
+        return self.model.layers
+
+    @property
+    def head_dim(self):
+        return (
+            self.args.head_dim or self.args.hidden_size // self.args.num_attention_heads
+        )
+
+    @property
+    def n_kv_heads(self):
+        return self.args.num_key_value_heads

--- a/mlx_vlm/models/ernie4_5/language.py
+++ b/mlx_vlm/models/ernie4_5/language.py
@@ -3,13 +3,13 @@ from typing import Any, Optional
 import mlx.core as mx
 import mlx.nn as nn
 
-from ..activations import swiglu
 from ..base import (
     LanguageModelOutput,
     create_attention_mask,
     scaled_dot_product_attention,
 )
 from ..cache import KVCache
+from ..mlp import SwiGLUMLP
 from ..rope_utils import initialize_rope
 from .config import ModelConfig
 
@@ -62,22 +62,11 @@ class Attention(nn.Module):
         return self.o_proj(output)
 
 
-class MLP(nn.Module):
-    def __init__(self, dim, hidden_dim, use_bias=False):
-        super().__init__()
-        self.gate_proj = nn.Linear(dim, hidden_dim, bias=use_bias)
-        self.down_proj = nn.Linear(hidden_dim, dim, bias=use_bias)
-        self.up_proj = nn.Linear(dim, hidden_dim, bias=use_bias)
-
-    def __call__(self, x) -> mx.array:
-        return self.down_proj(swiglu(self.gate_proj(x), self.up_proj(x)))
-
-
 class DecoderLayer(nn.Module):
     def __init__(self, args: ModelConfig):
         super().__init__()
         self.self_attn = Attention(args)
-        self.mlp = MLP(args.hidden_size, args.intermediate_size, args.use_bias)
+        self.mlp = SwiGLUMLP(args.hidden_size, args.intermediate_size, args.use_bias)
         self.input_layernorm = nn.RMSNorm(args.hidden_size, eps=args.rms_norm_eps)
         self.post_attention_layernorm = nn.RMSNorm(
             args.hidden_size, eps=args.rms_norm_eps

--- a/mlx_vlm/models/ernie4_5_moe/__init__.py
+++ b/mlx_vlm/models/ernie4_5_moe/__init__.py
@@ -1,0 +1,4 @@
+from .config import ModelConfig
+from .ernie4_5_moe import Model
+
+__all__ = ["Model", "ModelConfig"]

--- a/mlx_vlm/models/ernie4_5_moe/config.py
+++ b/mlx_vlm/models/ernie4_5_moe/config.py
@@ -1,0 +1,31 @@
+from dataclasses import dataclass, field
+from typing import List, Optional
+
+from ..base import BaseModelConfig
+
+
+@dataclass
+class ModelConfig(BaseModelConfig):
+    hidden_size: int
+    intermediate_size: int
+    model_type: str
+    max_position_embeddings: int
+    num_attention_heads: int
+    num_key_value_heads: int
+    num_hidden_layers: int
+    rms_norm_eps: float
+    vocab_size: int
+    rope_theta: float
+    use_bias: bool
+    tie_word_embeddings: bool
+    moe_num_experts: int
+    moe_layer_start_index: int = 0
+    moe_intermediate_size: int = 0
+    moe_capacity: List[int] = field(default_factory=list)
+    moe_k: int = 1
+    moe_layer_interval: int = 1
+    moe_use_aux_free: bool = False
+    moe_num_shared_experts: int = 0
+    moe_layer_end_index: Optional[int] = None
+    head_dim: Optional[int] = None
+    moe_gate_act: str = "softmax"

--- a/mlx_vlm/models/ernie4_5_moe/ernie4_5_moe.py
+++ b/mlx_vlm/models/ernie4_5_moe/ernie4_5_moe.py
@@ -1,0 +1,49 @@
+from typing import Optional
+
+import mlx.core as mx
+import mlx.nn as nn
+
+from ..base import InputEmbeddingsFeatures, LanguageModelOutput
+from .config import ModelConfig
+from .language import LanguageModel
+
+
+class Model(nn.Module):
+    def __init__(self, config: ModelConfig):
+        super().__init__()
+        self.config = config
+        self.model_type = config.model_type
+        self.language_model = LanguageModel(config)
+
+    def get_input_embeddings(
+        self,
+        input_ids: Optional[mx.array] = None,
+        pixel_values: Optional[mx.array] = None,
+        **kwargs,
+    ) -> InputEmbeddingsFeatures:
+        return InputEmbeddingsFeatures(
+            inputs_embeds=self.language_model.model.embed_tokens(input_ids)
+        )
+
+    def __call__(
+        self,
+        input_ids: mx.array,
+        pixel_values: mx.array = None,
+        mask: mx.array = None,
+        cache=None,
+        **kwargs,
+    ) -> LanguageModelOutput:
+        return self.language_model(input_ids, cache=cache, **kwargs)
+
+    def sanitize(self, weights):
+        if any(k.startswith("language_model.") for k in weights):
+            return weights
+        weights = self.language_model.sanitize(weights)
+        return {f"language_model.{k}": v for k, v in weights.items()}
+
+    @property
+    def layers(self):
+        return self.language_model.layers
+
+    def make_cache(self):
+        return self.language_model.make_cache()

--- a/mlx_vlm/models/ernie4_5_moe/language.py
+++ b/mlx_vlm/models/ernie4_5_moe/language.py
@@ -3,13 +3,13 @@ from typing import Any, Optional
 import mlx.core as mx
 import mlx.nn as nn
 
-from ..activations import swiglu
 from ..base import (
     LanguageModelOutput,
     create_attention_mask,
     scaled_dot_product_attention,
 )
 from ..cache import KVCache
+from ..mlp import SwiGLUMLP
 from ..rope_utils import initialize_rope
 from ..switch_layers import SwitchGLU
 from .config import ModelConfig
@@ -67,17 +67,6 @@ class Attention(nn.Module):
         return self.o_proj(output)
 
 
-class Ernie4_5_MLP(nn.Module):
-    def __init__(self, dim, hidden_dim, use_bias=False):
-        super().__init__()
-        self.gate_proj = nn.Linear(dim, hidden_dim, bias=use_bias)
-        self.down_proj = nn.Linear(hidden_dim, dim, bias=use_bias)
-        self.up_proj = nn.Linear(dim, hidden_dim, bias=use_bias)
-
-    def __call__(self, x) -> mx.array:
-        return self.down_proj(swiglu(self.gate_proj(x), self.up_proj(x)))
-
-
 class Ernie4_5_MoeMLP(nn.Module):
     def __init__(self, args: ModelConfig):
         super().__init__()
@@ -104,7 +93,7 @@ class Ernie4_5_MoeMLP(nn.Module):
                 if getattr(args, "moe_intermediate_size", None)
                 else args.intermediate_size * args.moe_num_shared_experts
             )
-            self.shared_experts = Ernie4_5_MLP(
+            self.shared_experts = SwiGLUMLP(
                 args.hidden_size, shared_intermediate_size, args.use_bias
             )
         else:
@@ -163,7 +152,7 @@ class Ernie4_5_DecoderLayer(nn.Module):
         ):
             self.mlp = Ernie4_5_MoeMLP(args)
         else:
-            self.mlp = Ernie4_5_MLP(
+            self.mlp = SwiGLUMLP(
                 args.hidden_size, args.intermediate_size, args.use_bias
             )
 

--- a/mlx_vlm/models/ernie4_5_moe/language.py
+++ b/mlx_vlm/models/ernie4_5_moe/language.py
@@ -1,0 +1,260 @@
+from typing import Any, Optional
+
+import mlx.core as mx
+import mlx.nn as nn
+
+from ..activations import swiglu
+from ..base import (
+    LanguageModelOutput,
+    create_attention_mask,
+    scaled_dot_product_attention,
+)
+from ..cache import KVCache
+from ..rope_utils import initialize_rope
+from ..switch_layers import SwitchGLU
+from .config import ModelConfig
+
+
+class Attention(nn.Module):
+    def __init__(self, args: ModelConfig):
+        super().__init__()
+
+        dim = args.hidden_size
+        self.n_heads = n_heads = args.num_attention_heads
+        self.n_kv_heads = n_kv_heads = args.num_key_value_heads
+
+        self.head_dim = head_dim = args.head_dim or dim // n_heads
+        self.scale = head_dim**-0.5
+
+        self.q_proj = nn.Linear(dim, n_heads * head_dim, bias=args.use_bias)
+        self.k_proj = nn.Linear(dim, n_kv_heads * head_dim, bias=args.use_bias)
+        self.v_proj = nn.Linear(dim, n_kv_heads * head_dim, bias=args.use_bias)
+        self.o_proj = nn.Linear(n_heads * head_dim, dim, bias=args.use_bias)
+
+        self.rope = initialize_rope(
+            head_dim,
+            base=args.rope_theta,
+            traditional=True,
+            max_position_embeddings=args.max_position_embeddings,
+        )
+
+    def __call__(
+        self,
+        x: mx.array,
+        mask: Optional[mx.array] = None,
+        cache: Optional[Any] = None,
+    ) -> mx.array:
+        B, L, D = x.shape
+
+        queries, keys, values = self.q_proj(x), self.k_proj(x), self.v_proj(x)
+
+        queries = queries.reshape(B, L, self.n_heads, -1).transpose(0, 2, 1, 3)
+        keys = keys.reshape(B, L, self.n_kv_heads, -1).transpose(0, 2, 1, 3)
+        values = values.reshape(B, L, self.n_kv_heads, -1).transpose(0, 2, 1, 3)
+
+        if cache is not None:
+            queries = self.rope(queries, offset=cache.offset)
+            keys = self.rope(keys, offset=cache.offset)
+            keys, values = cache.update_and_fetch(keys, values)
+        else:
+            queries = self.rope(queries)
+            keys = self.rope(keys)
+
+        output = scaled_dot_product_attention(
+            queries, keys, values, cache=cache, scale=self.scale, mask=mask
+        )
+        output = output.transpose(0, 2, 1, 3).reshape(B, L, -1)
+        return self.o_proj(output)
+
+
+class Ernie4_5_MLP(nn.Module):
+    def __init__(self, dim, hidden_dim, use_bias=False):
+        super().__init__()
+        self.gate_proj = nn.Linear(dim, hidden_dim, bias=use_bias)
+        self.down_proj = nn.Linear(hidden_dim, dim, bias=use_bias)
+        self.up_proj = nn.Linear(dim, hidden_dim, bias=use_bias)
+
+    def __call__(self, x) -> mx.array:
+        return self.down_proj(swiglu(self.gate_proj(x), self.up_proj(x)))
+
+
+class Ernie4_5_MoeMLP(nn.Module):
+    def __init__(self, args: ModelConfig):
+        super().__init__()
+        self.args = args
+        self.k = args.moe_k
+        self.moe_intermediate_size = (
+            args.moe_intermediate_size
+            if args.moe_intermediate_size
+            else args.intermediate_size
+        )
+
+        self.gate = nn.Linear(args.hidden_size, args.moe_num_experts, bias=False)
+
+        self.switch_mlp = SwitchGLU(
+            args.hidden_size,
+            self.moe_intermediate_size,
+            args.moe_num_experts,
+            bias=args.use_bias,
+        )
+
+        if getattr(args, "moe_num_shared_experts", 0) > 0:
+            shared_intermediate_size = (
+                args.moe_intermediate_size * args.moe_num_shared_experts
+                if getattr(args, "moe_intermediate_size", None)
+                else args.intermediate_size * args.moe_num_shared_experts
+            )
+            self.shared_experts = Ernie4_5_MLP(
+                args.hidden_size, shared_intermediate_size, args.use_bias
+            )
+        else:
+            self.shared_experts = None
+
+        if args.moe_gate_act == "softmax":
+            self.gate_act = nn.Softmax()
+        elif args.moe_gate_act == "sigmoid":
+            self.gate_act = nn.Sigmoid()
+        else:
+            raise ValueError(f"{args.moe_gate_act} is not supported.")
+
+    def __call__(self, x: mx.array) -> mx.array:
+        gates = self.gate(x)
+        gates = self.gate_act(gates.astype(mx.float32))
+
+        k = self.k
+        inds = mx.stop_gradient(mx.argpartition(-gates, kth=k - 1, axis=-1)[..., :k])
+        scores = mx.take_along_axis(gates, inds, axis=-1)
+
+        scores = scores / mx.maximum(scores.sum(axis=-1, keepdims=True), 1e-12)
+
+        y = self.switch_mlp(x, inds)
+        y = (y * scores[..., None]).sum(axis=-2).astype(y.dtype)
+
+        if self.shared_experts is not None:
+            y = y + self.shared_experts(x)
+
+        return y
+
+
+class Ernie4_5_DecoderLayer(nn.Module):
+    def __init__(self, args: ModelConfig, layer_idx: int):
+        super().__init__()
+        self.self_attn = Attention(args)
+
+        moe_layer_start_index = (
+            min(args.moe_layer_start_index)
+            if isinstance(args.moe_layer_start_index, (tuple, list))
+            else args.moe_layer_start_index
+        )
+
+        if args.moe_layer_end_index is None:
+            moe_layer_end_index = args.num_hidden_layers - 1
+        else:
+            moe_layer_end_index = (
+                max(args.moe_layer_end_index)
+                if isinstance(args.moe_layer_end_index, (tuple, list))
+                else args.moe_layer_end_index
+            )
+
+        if (
+            ((layer_idx + 1) % args.moe_layer_interval == 0)
+            and layer_idx >= moe_layer_start_index
+            and layer_idx <= moe_layer_end_index
+        ):
+            self.mlp = Ernie4_5_MoeMLP(args)
+        else:
+            self.mlp = Ernie4_5_MLP(
+                args.hidden_size, args.intermediate_size, args.use_bias
+            )
+
+        self.input_layernorm = nn.RMSNorm(args.hidden_size, eps=args.rms_norm_eps)
+        self.post_attention_layernorm = nn.RMSNorm(
+            args.hidden_size, eps=args.rms_norm_eps
+        )
+
+    def __call__(
+        self,
+        x: mx.array,
+        mask: Optional[mx.array] = None,
+        cache: Optional[Any] = None,
+    ) -> mx.array:
+        r = self.self_attn(self.input_layernorm(x), mask, cache)
+        h = x + r
+        r = self.mlp(self.post_attention_layernorm(h))
+        return h + r
+
+
+class Ernie45Model(nn.Module):
+    def __init__(self, args: ModelConfig):
+        super().__init__()
+        self.embed_tokens = nn.Embedding(args.vocab_size, args.hidden_size)
+        self.layers = [
+            Ernie4_5_DecoderLayer(args, i) for i in range(args.num_hidden_layers)
+        ]
+        self.norm = nn.RMSNorm(args.hidden_size, eps=args.rms_norm_eps)
+
+    def __call__(self, inputs: mx.array, cache=None, inputs_embeds=None):
+        h = self.embed_tokens(inputs) if inputs_embeds is None else inputs_embeds
+
+        if cache is None:
+            cache = [None] * len(self.layers)
+
+        mask = create_attention_mask(h, cache[0])
+
+        for layer, c in zip(self.layers, cache):
+            h = layer(h, mask, c)
+
+        return self.norm(h)
+
+
+class LanguageModel(nn.Module):
+    def __init__(self, args: ModelConfig):
+        super().__init__()
+        self.args = args
+        self.model_type = args.model_type
+        self.model = Ernie45Model(args)
+        if not args.tie_word_embeddings:
+            self.lm_head = nn.Linear(args.hidden_size, args.vocab_size, bias=False)
+
+    def __call__(
+        self, inputs: mx.array, cache=None, inputs_embeds=None, mask=None, **kwargs
+    ):
+        out = self.model(inputs, cache, inputs_embeds=inputs_embeds)
+        if self.args.tie_word_embeddings:
+            out = self.model.embed_tokens.as_linear(out)
+        else:
+            out = self.lm_head(out)
+        return LanguageModelOutput(logits=out)
+
+    def sanitize(self, weights):
+        remove_patterns = [
+            "mtp_block.",
+            "mtp_linear_proj.",
+            "mtp_hidden_norm.",
+            "mtp_emb_norm.",
+            "e_score_correction_bias",
+        ]
+        weights = {
+            key: value
+            for key, value in weights.items()
+            if not any(pattern in key for pattern in remove_patterns)
+        }
+
+        for l in range(self.args.num_hidden_layers):
+            prefix = f"model.layers.{l}"
+            for m in ["gate_proj", "down_proj", "up_proj"]:
+                if f"{prefix}.mlp.experts.0.{m}.weight" in weights:
+                    to_join = [
+                        weights.pop(f"{prefix}.mlp.experts.{e}.{m}.weight")
+                        for e in range(self.args.moe_num_experts)
+                    ]
+                    weights[f"{prefix}.mlp.switch_mlp.{m}.weight"] = mx.stack(to_join)
+
+        return weights
+
+    @property
+    def layers(self):
+        return self.model.layers
+
+    def make_cache(self):
+        return [KVCache() for _ in self.layers]

--- a/mlx_vlm/models/exaone_moe/__init__.py
+++ b/mlx_vlm/models/exaone_moe/__init__.py
@@ -1,0 +1,4 @@
+from .config import ModelConfig
+from .exaone_moe import Model
+
+__all__ = ["Model", "ModelConfig"]

--- a/mlx_vlm/models/exaone_moe/config.py
+++ b/mlx_vlm/models/exaone_moe/config.py
@@ -1,0 +1,39 @@
+from dataclasses import dataclass
+from typing import Dict, List, Optional, Union
+
+from ..base import BaseModelConfig
+
+
+@dataclass
+class ModelConfig(BaseModelConfig):
+    model_type: str
+    vocab_size: int
+    hidden_size: int
+    intermediate_size: int
+    moe_intermediate_size: int
+    num_hidden_layers: int
+    num_attention_heads: int
+    num_key_value_heads: int
+    head_dim: int
+    num_experts: int
+    num_experts_per_tok: int
+    num_shared_experts: int
+    rms_norm_eps: float
+    max_position_embeddings: int
+    sliding_window: int
+    layer_types: List[str]
+    is_moe_layer: List[bool]
+    n_group: int = 1
+    topk_group: int = 1
+    routed_scaling_factor: float = 2.5
+    norm_topk_prob: bool = True
+    scoring_func: str = "sigmoid"
+    topk_method: str = "noaux_tc"
+    rope_theta: float = 1000000.0
+    rope_scaling: Optional[Dict[str, Union[float, str]]] = None
+    rope_parameters: Optional[dict] = None
+    tie_word_embeddings: bool = False
+
+    def __post_init__(self):
+        if self.rope_parameters is not None and "rope_theta" in self.rope_parameters:
+            self.rope_theta = self.rope_parameters["rope_theta"]

--- a/mlx_vlm/models/exaone_moe/exaone_moe.py
+++ b/mlx_vlm/models/exaone_moe/exaone_moe.py
@@ -1,0 +1,49 @@
+from typing import Optional
+
+import mlx.core as mx
+import mlx.nn as nn
+
+from ..base import InputEmbeddingsFeatures, LanguageModelOutput
+from .config import ModelConfig
+from .language import LanguageModel
+
+
+class Model(nn.Module):
+    def __init__(self, config: ModelConfig):
+        super().__init__()
+        self.config = config
+        self.model_type = config.model_type
+        self.language_model = LanguageModel(config)
+
+    def get_input_embeddings(
+        self,
+        input_ids: Optional[mx.array] = None,
+        pixel_values: Optional[mx.array] = None,
+        **kwargs,
+    ) -> InputEmbeddingsFeatures:
+        return InputEmbeddingsFeatures(
+            inputs_embeds=self.language_model.model.embed_tokens(input_ids)
+        )
+
+    def __call__(
+        self,
+        input_ids: mx.array,
+        pixel_values: mx.array = None,
+        mask: mx.array = None,
+        cache=None,
+        **kwargs,
+    ) -> LanguageModelOutput:
+        return self.language_model(input_ids, cache=cache, **kwargs)
+
+    def sanitize(self, weights):
+        if any(k.startswith("language_model.") for k in weights):
+            return weights
+        weights = self.language_model.sanitize(weights)
+        return {f"language_model.{k}": v for k, v in weights.items()}
+
+    @property
+    def layers(self):
+        return self.language_model.layers
+
+    def make_cache(self):
+        return self.language_model.make_cache()

--- a/mlx_vlm/models/exaone_moe/language.py
+++ b/mlx_vlm/models/exaone_moe/language.py
@@ -3,13 +3,13 @@ from typing import Any, Optional
 import mlx.core as mx
 import mlx.nn as nn
 
-from ..activations import swiglu
 from ..base import (
     LanguageModelOutput,
     create_attention_mask,
     scaled_dot_product_attention,
 )
 from ..cache import KVCache, RotatingKVCache
+from ..mlp import SwiGLUMLP
 from ..rope_utils import initialize_rope
 from ..switch_layers import SwitchGLU
 from .config import ModelConfig
@@ -76,19 +76,6 @@ class MoEGate(nn.Module):
         )
 
 
-class MLP(nn.Module):
-    def __init__(self, args: ModelConfig, intermediate_size: Optional[int] = None):
-        super().__init__()
-        hidden_size = args.hidden_size
-        intermediate_size = intermediate_size or args.intermediate_size
-        self.gate_proj = nn.Linear(hidden_size, intermediate_size, bias=False)
-        self.up_proj = nn.Linear(hidden_size, intermediate_size, bias=False)
-        self.down_proj = nn.Linear(intermediate_size, hidden_size, bias=False)
-
-    def __call__(self, x):
-        return self.down_proj(swiglu(self.gate_proj(x), self.up_proj(x)))
-
-
 class MoE(nn.Module):
     def __init__(self, args: ModelConfig):
         super().__init__()
@@ -101,9 +88,9 @@ class MoE(nn.Module):
         self.gate = MoEGate(args)
 
         self.shared_experts = (
-            MLP(
-                args,
-                intermediate_size=args.moe_intermediate_size * args.num_shared_experts,
+            SwiGLUMLP(
+                args.hidden_size,
+                args.moe_intermediate_size * args.num_shared_experts,
             )
             if args.num_shared_experts is not None and args.num_shared_experts > 0
             else None
@@ -197,7 +184,11 @@ class DecoderLayer(nn.Module):
         super().__init__()
 
         self.self_attn = Attention(args, layer_idx)
-        self.mlp = MoE(args) if args.is_moe_layer[layer_idx] else MLP(args)
+        self.mlp = (
+            MoE(args)
+            if args.is_moe_layer[layer_idx]
+            else SwiGLUMLP(args.hidden_size, args.intermediate_size)
+        )
         self.is_sliding_window = self.self_attn.is_sliding_window
 
         self.input_layernorm = nn.RMSNorm(args.hidden_size, eps=args.rms_norm_eps)

--- a/mlx_vlm/models/exaone_moe/language.py
+++ b/mlx_vlm/models/exaone_moe/language.py
@@ -1,0 +1,340 @@
+from typing import Any, Optional
+
+import mlx.core as mx
+import mlx.nn as nn
+
+from ..activations import swiglu
+from ..base import (
+    LanguageModelOutput,
+    create_attention_mask,
+    scaled_dot_product_attention,
+)
+from ..cache import KVCache, RotatingKVCache
+from ..rope_utils import initialize_rope
+from ..switch_layers import SwitchGLU
+from .config import ModelConfig
+
+
+@mx.compile
+def group_expert_select(
+    gates,
+    e_score_correction_bias,
+    top_k,
+    n_group,
+    topk_group,
+    routed_scaling_factor,
+    norm_topk_prob,
+):
+    scores = mx.sigmoid(gates.astype(mx.float32))
+    orig_scores = scores
+    scores = scores + e_score_correction_bias
+
+    if n_group > 1:
+        scores = mx.unflatten(scores, axis=-1, shape=(n_group, -1))
+        group_scores = mx.topk(scores, 2, axis=-1).sum(axis=-1, keepdims=True)
+        k = n_group - topk_group
+        group_idx = mx.argpartition(group_scores, kth=k - 1, axis=-2)[..., :k, :]
+        scores = mx.put_along_axis(
+            scores, mx.stop_gradient(group_idx), mx.array(0.0), axis=-2
+        )
+        scores = mx.flatten(scores, -2, -1)
+
+    k = top_k
+    inds = mx.argpartition(-scores, kth=k - 1, axis=-1)[..., :k]
+    scores = mx.take_along_axis(orig_scores, inds, axis=-1)
+
+    if top_k > 1 and norm_topk_prob:
+        denominator = scores.sum(axis=-1, keepdims=True)
+        scores = scores / (denominator + 1e-20)
+
+    scores = scores * routed_scaling_factor
+    return inds, scores
+
+
+class MoEGate(nn.Module):
+    def __init__(self, args: ModelConfig):
+        super().__init__()
+        self.top_k = args.num_experts_per_tok
+        self.norm_topk_prob = args.norm_topk_prob
+        self.n_routed_experts = args.num_experts
+        self.routed_scaling_factor = args.routed_scaling_factor
+        self.n_group = args.n_group
+        self.topk_group = args.topk_group
+        self.weight = mx.zeros((self.n_routed_experts, args.hidden_size))
+        self.e_score_correction_bias = mx.zeros((self.n_routed_experts,))
+        assert args.topk_method == "noaux_tc", "Unsupported topk method."
+
+    def __call__(self, x):
+        return group_expert_select(
+            x @ self.weight.T,
+            self.e_score_correction_bias,
+            self.top_k,
+            self.n_group,
+            self.topk_group,
+            self.routed_scaling_factor,
+            self.norm_topk_prob,
+        )
+
+
+class MLP(nn.Module):
+    def __init__(self, args: ModelConfig, intermediate_size: Optional[int] = None):
+        super().__init__()
+        hidden_size = args.hidden_size
+        intermediate_size = intermediate_size or args.intermediate_size
+        self.gate_proj = nn.Linear(hidden_size, intermediate_size, bias=False)
+        self.up_proj = nn.Linear(hidden_size, intermediate_size, bias=False)
+        self.down_proj = nn.Linear(intermediate_size, hidden_size, bias=False)
+
+    def __call__(self, x):
+        return self.down_proj(swiglu(self.gate_proj(x), self.up_proj(x)))
+
+
+class MoE(nn.Module):
+    def __init__(self, args: ModelConfig):
+        super().__init__()
+        self.switch_mlp = SwitchGLU(
+            args.hidden_size,
+            args.moe_intermediate_size,
+            args.num_experts,
+        )
+
+        self.gate = MoEGate(args)
+
+        self.shared_experts = (
+            MLP(
+                args,
+                intermediate_size=args.moe_intermediate_size * args.num_shared_experts,
+            )
+            if args.num_shared_experts is not None and args.num_shared_experts > 0
+            else None
+        )
+
+    def __call__(self, x):
+        inds, scores = self.gate(x)
+        y = self.switch_mlp(x, inds)
+        y = (y * scores[..., None]).sum(axis=-2).astype(y.dtype)
+        if self.shared_experts is not None:
+            y = y + self.shared_experts(x)
+
+        return y
+
+
+class Attention(nn.Module):
+    def __init__(self, args: ModelConfig, layer_idx: int):
+        super().__init__()
+
+        self.hidden_size = args.hidden_size
+        self.n_heads = args.num_attention_heads
+        self.n_kv_heads = args.num_key_value_heads
+        self.head_dim = args.head_dim
+        self.scale = self.head_dim**-0.5
+
+        self.q_proj = nn.Linear(
+            self.hidden_size, self.n_heads * self.head_dim, bias=False
+        )
+        self.k_proj = nn.Linear(
+            self.hidden_size, self.n_kv_heads * self.head_dim, bias=False
+        )
+        self.v_proj = nn.Linear(
+            self.hidden_size, self.n_kv_heads * self.head_dim, bias=False
+        )
+        self.o_proj = nn.Linear(
+            self.n_heads * self.head_dim, self.hidden_size, bias=False
+        )
+
+        self.q_norm = nn.RMSNorm(self.head_dim, eps=args.rms_norm_eps)
+        self.k_norm = nn.RMSNorm(self.head_dim, eps=args.rms_norm_eps)
+
+        self.is_sliding_window = args.layer_types[layer_idx] == "sliding_attention"
+        self.apply_rope_all_layers = "sliding_attention" not in args.layer_types
+        self.use_rope = self.is_sliding_window or self.apply_rope_all_layers
+
+        if self.use_rope:
+            self.rope = initialize_rope(
+                self.head_dim,
+                base=args.rope_theta,
+                traditional=False,
+                scaling_config=args.rope_scaling,
+                max_position_embeddings=args.max_position_embeddings,
+            )
+
+    def __call__(
+        self,
+        x: mx.array,
+        mask: Optional[mx.array] = None,
+        cache: Optional[Any] = None,
+    ) -> mx.array:
+        B, L, D = x.shape
+
+        queries, keys, values = self.q_proj(x), self.k_proj(x), self.v_proj(x)
+
+        queries = self.q_norm(queries.reshape(B, L, self.n_heads, -1)).transpose(
+            0, 2, 1, 3
+        )
+        keys = self.k_norm(keys.reshape(B, L, self.n_kv_heads, -1)).transpose(
+            0, 2, 1, 3
+        )
+        values = values.reshape(B, L, self.n_kv_heads, -1).transpose(0, 2, 1, 3)
+
+        if cache is not None:
+            if self.use_rope:
+                queries = self.rope(queries, offset=cache.offset)
+                keys = self.rope(keys, offset=cache.offset)
+            keys, values = cache.update_and_fetch(keys, values)
+        elif self.use_rope:
+            queries = self.rope(queries)
+            keys = self.rope(keys)
+
+        output = scaled_dot_product_attention(
+            queries, keys, values, cache=cache, scale=self.scale, mask=mask
+        )
+        output = output.transpose(0, 2, 1, 3).reshape(B, L, -1)
+        return self.o_proj(output)
+
+
+class DecoderLayer(nn.Module):
+    def __init__(self, args: ModelConfig, layer_idx: int):
+        super().__init__()
+
+        self.self_attn = Attention(args, layer_idx)
+        self.mlp = MoE(args) if args.is_moe_layer[layer_idx] else MLP(args)
+        self.is_sliding_window = self.self_attn.is_sliding_window
+
+        self.input_layernorm = nn.RMSNorm(args.hidden_size, eps=args.rms_norm_eps)
+        self.post_attention_layernorm = nn.RMSNorm(
+            args.hidden_size, eps=args.rms_norm_eps
+        )
+
+    def __call__(
+        self,
+        x: mx.array,
+        mask: Optional[mx.array] = None,
+        cache: Optional[Any] = None,
+    ) -> mx.array:
+        r = self.self_attn(self.input_layernorm(x), mask, cache)
+        h = x + r
+        r = self.mlp(self.post_attention_layernorm(h))
+        return h + r
+
+
+class ExaoneMoEModel(nn.Module):
+    def __init__(self, args: ModelConfig):
+        super().__init__()
+        self.args = args
+        self.vocab_size = args.vocab_size
+        self.embed_tokens = nn.Embedding(args.vocab_size, args.hidden_size)
+        self.layers = [DecoderLayer(args, idx) for idx in range(args.num_hidden_layers)]
+        self.norm = nn.RMSNorm(args.hidden_size, eps=args.rms_norm_eps)
+
+        self.swa_idx = None
+        self.ga_idx = None
+        for i, layer in enumerate(self.layers):
+            if layer.is_sliding_window and self.swa_idx is None:
+                self.swa_idx = i
+            if not layer.is_sliding_window and self.ga_idx is None:
+                self.ga_idx = i
+
+        self.window_size = args.sliding_window
+
+    def __call__(
+        self,
+        inputs: mx.array,
+        cache: Optional[Any] = None,
+        inputs_embeds: Optional[mx.array] = None,
+    ) -> mx.array:
+        h = self.embed_tokens(inputs) if inputs_embeds is None else inputs_embeds
+
+        if cache is None:
+            cache = [None] * len(self.layers)
+
+        global_mask = create_attention_mask(
+            h, cache[self.ga_idx] if self.ga_idx is not None else cache[0]
+        )
+        swa_mask = create_attention_mask(
+            h,
+            cache[self.swa_idx] if self.swa_idx is not None else cache[0],
+            window_size=self.window_size,
+        )
+
+        for layer, c in zip(self.layers, cache):
+            mask = swa_mask if layer.is_sliding_window else global_mask
+            h = layer(h, mask, c)
+
+        return self.norm(h)
+
+
+class LanguageModel(nn.Module):
+    def __init__(self, args: ModelConfig):
+        super().__init__()
+        self.args = args
+        self.model_type = args.model_type
+        self.model = ExaoneMoEModel(args)
+
+        if not args.tie_word_embeddings:
+            self.lm_head = nn.Linear(args.hidden_size, args.vocab_size, bias=False)
+
+    def __call__(
+        self, inputs: mx.array, cache=None, inputs_embeds=None, mask=None, **kwargs
+    ):
+        out = self.model(inputs, cache, inputs_embeds=inputs_embeds)
+        if self.args.tie_word_embeddings:
+            out = self.model.embed_tokens.as_linear(out)
+        else:
+            out = self.lm_head(out)
+        return LanguageModelOutput(logits=out)
+
+    def sanitize(self, weights):
+        new_weights = {k: v for k, v in weights.items() if not k.startswith("mtp.")}
+        weights = new_weights
+
+        for l in range(self.args.num_hidden_layers):
+            if not self.args.is_moe_layer[l]:
+                continue
+
+            prefix = f"model.layers.{l}"
+
+            bias_key = f"{prefix}.mlp.e_score_correction_bias"
+            if bias_key in weights:
+                weights[f"{prefix}.mlp.gate.e_score_correction_bias"] = weights.pop(
+                    bias_key
+                )
+
+            for m in ["gate_proj", "down_proj", "up_proj"]:
+                for k in ["weight", "scales", "biases"]:
+                    first_key = f"{prefix}.mlp.experts.0.{m}.{k}"
+                    last_key = (
+                        f"{prefix}.mlp.experts.{self.args.num_experts - 1}.{m}.{k}"
+                    )
+                    if first_key in weights and last_key in weights:
+                        to_join = [
+                            weights.pop(f"{prefix}.mlp.experts.{e}.{m}.{k}")
+                            for e in range(self.args.num_experts)
+                        ]
+                        weights[f"{prefix}.mlp.switch_mlp.{m}.{k}"] = mx.stack(to_join)
+
+        if self.args.tie_word_embeddings:
+            weights.pop("lm_head.weight", None)
+
+        return weights
+
+    @property
+    def layers(self):
+        return self.model.layers
+
+    @property
+    def cast_predicate(self):
+        def predicate(k):
+            return "e_score_correction_bias" not in k
+
+        return predicate
+
+    def make_cache(self):
+        caches = []
+        for layer in self.layers:
+            if layer.is_sliding_window:
+                caches.append(
+                    RotatingKVCache(max_size=self.args.sliding_window, keep=0)
+                )
+            else:
+                caches.append(KVCache())
+        return caches

--- a/mlx_vlm/models/hunyuan_v1_dense/__init__.py
+++ b/mlx_vlm/models/hunyuan_v1_dense/__init__.py
@@ -1,0 +1,4 @@
+from .config import ModelConfig
+from .hunyuan_v1_dense import Model
+
+__all__ = ["Model", "ModelConfig"]

--- a/mlx_vlm/models/hunyuan_v1_dense/config.py
+++ b/mlx_vlm/models/hunyuan_v1_dense/config.py
@@ -1,0 +1,29 @@
+from dataclasses import dataclass
+from typing import Dict, Optional, Union
+
+from ..base import BaseModelConfig
+
+
+@dataclass
+class ModelConfig(BaseModelConfig):
+    model_type: str
+    vocab_size: int
+    hidden_size: int
+    num_hidden_layers: int
+    intermediate_size: int
+    num_attention_heads: int
+    num_key_value_heads: int
+    rms_norm_eps: float
+    rope_theta: float = 10000
+    max_position_embeddings: int = 32768
+    attention_bias: bool = False
+    use_qk_norm: bool = True
+    rope_scaling: Optional[Dict[str, Union[float, str]]] = None
+    tie_word_embeddings: bool = False
+    head_dim: Optional[int] = None
+
+    def __post_init__(self):
+        if self.rope_scaling:
+            required_keys = {"alpha", "factor", "type"}
+            if not all(key in self.rope_scaling for key in required_keys):
+                raise ValueError(f"rope_scaling must contain keys {required_keys}")

--- a/mlx_vlm/models/hunyuan_v1_dense/hunyuan_v1_dense.py
+++ b/mlx_vlm/models/hunyuan_v1_dense/hunyuan_v1_dense.py
@@ -1,0 +1,46 @@
+from typing import Optional
+
+import mlx.core as mx
+import mlx.nn as nn
+
+from ..base import InputEmbeddingsFeatures, LanguageModelOutput
+from .config import ModelConfig
+from .language import LanguageModel
+
+
+class Model(nn.Module):
+    def __init__(self, config: ModelConfig):
+        super().__init__()
+        self.config = config
+        self.model_type = config.model_type
+        self.language_model = LanguageModel(config)
+
+    def get_input_embeddings(
+        self,
+        input_ids: Optional[mx.array] = None,
+        pixel_values: Optional[mx.array] = None,
+        **kwargs,
+    ) -> InputEmbeddingsFeatures:
+        return InputEmbeddingsFeatures(
+            inputs_embeds=self.language_model.model.embed_tokens(input_ids)
+        )
+
+    def __call__(
+        self,
+        input_ids: mx.array,
+        pixel_values: mx.array = None,
+        mask: mx.array = None,
+        cache=None,
+        **kwargs,
+    ) -> LanguageModelOutput:
+        return self.language_model(input_ids, cache=cache, **kwargs)
+
+    def sanitize(self, weights):
+        if any(k.startswith("language_model.") for k in weights):
+            return weights
+        weights = self.language_model.sanitize(weights)
+        return {f"language_model.{k}": v for k, v in weights.items()}
+
+    @property
+    def layers(self):
+        return self.language_model.layers

--- a/mlx_vlm/models/hunyuan_v1_dense/language.py
+++ b/mlx_vlm/models/hunyuan_v1_dense/language.py
@@ -1,0 +1,231 @@
+from typing import Any, Optional
+
+import mlx.core as mx
+import mlx.nn as nn
+
+from ..activations import swiglu
+from ..base import (
+    LanguageModelOutput,
+    create_attention_mask,
+    scaled_dot_product_attention,
+)
+from ..cache import KVCache
+from .config import ModelConfig
+
+
+class DynamicNTKAlphaRoPE(nn.Module):
+    def __init__(
+        self,
+        dims: int,
+        base: float = 10000,
+        scaling_alpha: float = 1.0,
+    ):
+        super().__init__()
+        self.dims = dims
+        base = base * scaling_alpha ** (dims / (dims - 2))
+        self._freqs = base ** (mx.arange(0, self.dims, 2) / self.dims)
+
+    def __call__(self, x, offset: int = 0):
+        return mx.fast.rope(
+            x,
+            self.dims,
+            traditional=False,
+            base=None,
+            scale=1.0,
+            offset=offset,
+            freqs=self._freqs,
+        )
+
+
+class Attention(nn.Module):
+    def __init__(self, args: ModelConfig):
+        super().__init__()
+
+        dim = args.hidden_size
+        self.n_heads = n_heads = args.num_attention_heads
+        self.n_kv_heads = n_kv_heads = args.num_key_value_heads
+
+        head_dim = (
+            args.head_dim if args.head_dim is not None else args.hidden_size // n_heads
+        )
+        self.head_dim = head_dim
+        self.scale = head_dim**-0.5
+
+        self.q_proj = nn.Linear(dim, n_heads * head_dim, bias=args.attention_bias)
+        self.k_proj = nn.Linear(dim, n_kv_heads * head_dim, bias=args.attention_bias)
+        self.v_proj = nn.Linear(dim, n_kv_heads * head_dim, bias=args.attention_bias)
+        self.o_proj = nn.Linear(n_heads * head_dim, dim, bias=args.attention_bias)
+
+        self.use_qk_norm = args.use_qk_norm
+        if self.use_qk_norm:
+            self.query_layernorm = nn.RMSNorm(head_dim, args.rms_norm_eps)
+            self.key_layernorm = nn.RMSNorm(head_dim, args.rms_norm_eps)
+
+        scaling_alpha = 1.0
+        if args.rope_scaling and "alpha" in args.rope_scaling:
+            scaling_alpha = args.rope_scaling["alpha"]
+
+        self.rope = DynamicNTKAlphaRoPE(
+            head_dim,
+            base=args.rope_theta,
+            scaling_alpha=scaling_alpha,
+        )
+
+    def __call__(
+        self,
+        x: mx.array,
+        mask: Optional[mx.array] = None,
+        cache: Optional[Any] = None,
+    ) -> mx.array:
+        B, L, D = x.shape
+
+        queries, keys, values = self.q_proj(x), self.k_proj(x), self.v_proj(x)
+
+        queries = queries.reshape(B, L, self.n_heads, self.head_dim).transpose(
+            0, 2, 1, 3
+        )
+        keys = keys.reshape(B, L, self.n_kv_heads, self.head_dim).transpose(0, 2, 1, 3)
+        values = values.reshape(B, L, self.n_kv_heads, self.head_dim).transpose(
+            0, 2, 1, 3
+        )
+
+        if cache is not None:
+            queries = self.rope(queries, offset=cache.offset)
+            keys = self.rope(keys, offset=cache.offset)
+        else:
+            queries = self.rope(queries)
+            keys = self.rope(keys)
+
+        if self.use_qk_norm:
+            queries = self.query_layernorm(queries)
+            keys = self.key_layernorm(keys)
+
+        if cache is not None:
+            keys, values = cache.update_and_fetch(keys, values)
+
+        output = scaled_dot_product_attention(
+            queries, keys, values, cache=cache, scale=self.scale, mask=mask
+        )
+
+        output = output.transpose(0, 2, 1, 3).reshape(B, L, -1)
+        return self.o_proj(output)
+
+
+class MLP(nn.Module):
+    def __init__(self, args: ModelConfig):
+        super().__init__()
+
+        dim = args.hidden_size
+        hidden_dim = args.intermediate_size
+
+        self.gate_proj = nn.Linear(dim, hidden_dim, bias=False)
+        self.down_proj = nn.Linear(hidden_dim, dim, bias=False)
+        self.up_proj = nn.Linear(dim, hidden_dim, bias=False)
+
+    def __call__(self, x) -> mx.array:
+        return self.down_proj(swiglu(self.gate_proj(x), self.up_proj(x)))
+
+
+class TransformerBlock(nn.Module):
+    def __init__(self, args: ModelConfig):
+        super().__init__()
+        self.num_attention_heads = args.num_attention_heads
+        self.hidden_size = args.hidden_size
+        self.self_attn = Attention(args)
+        self.mlp = MLP(args)
+        self.input_layernorm = nn.RMSNorm(args.hidden_size, eps=args.rms_norm_eps)
+        self.post_attention_layernorm = nn.RMSNorm(
+            args.hidden_size, eps=args.rms_norm_eps
+        )
+        self.args = args
+
+    def __call__(
+        self,
+        x: mx.array,
+        mask: Optional[mx.array] = None,
+        cache: Optional[Any] = None,
+    ) -> mx.array:
+        r = self.self_attn(self.input_layernorm(x), mask, cache)
+        h = x + r
+        r = self.mlp(self.post_attention_layernorm(h))
+        out = h + r
+        return out
+
+
+class HunyuanV1DenseModel(nn.Module):
+    def __init__(self, args: ModelConfig):
+        super().__init__()
+        self.args = args
+        self.vocab_size = args.vocab_size
+        self.num_hidden_layers = args.num_hidden_layers
+        self.embed_tokens = nn.Embedding(args.vocab_size, args.hidden_size)
+        self.layers = [TransformerBlock(args) for _ in range(args.num_hidden_layers)]
+        self.norm = nn.RMSNorm(args.hidden_size, eps=args.rms_norm_eps)
+
+    def __call__(self, inputs, cache=None, input_embeddings=None):
+        h = (
+            input_embeddings
+            if input_embeddings is not None
+            else self.embed_tokens(inputs)
+        )
+
+        if cache is None:
+            cache = [None] * len(self.layers)
+
+        mask = create_attention_mask(h, cache[0])
+        for layer, c in zip(self.layers, cache):
+            h = layer(h, mask, c)
+
+        return self.norm(h)
+
+
+class LanguageModel(nn.Module):
+    def __init__(self, args: ModelConfig):
+        super().__init__()
+        self.args = args
+        self.config = args
+        self.model_type = args.model_type
+        self.model = HunyuanV1DenseModel(args)
+        if not args.tie_word_embeddings:
+            self.lm_head = nn.Linear(args.hidden_size, args.vocab_size, bias=False)
+
+    def __call__(
+        self,
+        inputs: Optional[mx.array] = None,
+        cache=None,
+        input_embeddings: Optional[mx.array] = None,
+        inputs_embeds: Optional[mx.array] = None,
+        **kwargs,
+    ) -> LanguageModelOutput:
+        if inputs is None:
+            inputs = kwargs.get("input_ids")
+        if inputs_embeds is None:
+            inputs_embeds = input_embeddings
+        out = self.model(inputs, cache, inputs_embeds)
+        if self.args.tie_word_embeddings:
+            out = self.model.embed_tokens.as_linear(out)
+        else:
+            out = self.lm_head(out)
+        return LanguageModelOutput(logits=out)
+
+    def sanitize(self, weights):
+        if self.args.tie_word_embeddings:
+            weights.pop("lm_head.weight", None)
+        return weights
+
+    def make_cache(self):
+        return [KVCache() for _ in self.model.layers]
+
+    @property
+    def layers(self):
+        return self.model.layers
+
+    @property
+    def head_dim(self):
+        return (
+            self.args.head_dim or self.args.hidden_size // self.args.num_attention_heads
+        )
+
+    @property
+    def n_kv_heads(self):
+        return self.args.num_key_value_heads

--- a/mlx_vlm/models/hunyuan_v1_dense/language.py
+++ b/mlx_vlm/models/hunyuan_v1_dense/language.py
@@ -3,13 +3,13 @@ from typing import Any, Optional
 import mlx.core as mx
 import mlx.nn as nn
 
-from ..activations import swiglu
 from ..base import (
     LanguageModelOutput,
     create_attention_mask,
     scaled_dot_product_attention,
 )
 from ..cache import KVCache
+from ..mlp import SwiGLUMLP
 from .config import ModelConfig
 
 
@@ -111,28 +111,13 @@ class Attention(nn.Module):
         return self.o_proj(output)
 
 
-class MLP(nn.Module):
-    def __init__(self, args: ModelConfig):
-        super().__init__()
-
-        dim = args.hidden_size
-        hidden_dim = args.intermediate_size
-
-        self.gate_proj = nn.Linear(dim, hidden_dim, bias=False)
-        self.down_proj = nn.Linear(hidden_dim, dim, bias=False)
-        self.up_proj = nn.Linear(dim, hidden_dim, bias=False)
-
-    def __call__(self, x) -> mx.array:
-        return self.down_proj(swiglu(self.gate_proj(x), self.up_proj(x)))
-
-
 class TransformerBlock(nn.Module):
     def __init__(self, args: ModelConfig):
         super().__init__()
         self.num_attention_heads = args.num_attention_heads
         self.hidden_size = args.hidden_size
         self.self_attn = Attention(args)
-        self.mlp = MLP(args)
+        self.mlp = SwiGLUMLP(args.hidden_size, args.intermediate_size)
         self.input_layernorm = nn.RMSNorm(args.hidden_size, eps=args.rms_norm_eps)
         self.post_attention_layernorm = nn.RMSNorm(
             args.hidden_size, eps=args.rms_norm_eps

--- a/mlx_vlm/models/mimo/__init__.py
+++ b/mlx_vlm/models/mimo/__init__.py
@@ -1,0 +1,4 @@
+from .config import ModelConfig
+from .mimo import Model
+
+__all__ = ["Model", "ModelConfig"]

--- a/mlx_vlm/models/mimo/config.py
+++ b/mlx_vlm/models/mimo/config.py
@@ -1,0 +1,22 @@
+from dataclasses import dataclass
+from typing import Dict, Optional, Union
+
+from ..base import BaseModelConfig
+
+
+@dataclass
+class ModelConfig(BaseModelConfig):
+    model_type: str
+    hidden_size: int
+    num_hidden_layers: int
+    intermediate_size: int
+    num_attention_heads: int
+    rms_norm_eps: float
+    vocab_size: int
+    num_key_value_heads: int
+    max_position_embeddings: int = 32768
+    rope_theta: float = 10000.0
+    rope_traditional: bool = False
+    rope_scaling: Optional[Dict[str, Union[float, str]]] = None
+    tie_word_embeddings: bool = False
+    num_nextn_predict_layers: int = 2

--- a/mlx_vlm/models/mimo/language.py
+++ b/mlx_vlm/models/mimo/language.py
@@ -3,13 +3,13 @@ from typing import Any, Optional
 import mlx.core as mx
 import mlx.nn as nn
 
-from ..activations import swiglu
 from ..base import (
     LanguageModelOutput,
     create_attention_mask,
     scaled_dot_product_attention,
 )
 from ..cache import KVCache
+from ..mlp import SwiGLUMLP
 from ..rope_utils import initialize_rope
 from .config import ModelConfig
 
@@ -63,22 +63,11 @@ class Attention(nn.Module):
         return self.o_proj(output)
 
 
-class MLP(nn.Module):
-    def __init__(self, dim, hidden_dim):
-        super().__init__()
-        self.gate_proj = nn.Linear(dim, hidden_dim, bias=False)
-        self.down_proj = nn.Linear(hidden_dim, dim, bias=False)
-        self.up_proj = nn.Linear(dim, hidden_dim, bias=False)
-
-    def __call__(self, x) -> mx.array:
-        return self.down_proj(swiglu(self.gate_proj(x), self.up_proj(x)))
-
-
 class TransformerBlock(nn.Module):
     def __init__(self, args: ModelConfig):
         super().__init__()
         self.self_attn = Attention(args)
-        self.mlp = MLP(args.hidden_size, args.intermediate_size)
+        self.mlp = SwiGLUMLP(args.hidden_size, args.intermediate_size)
         self.input_layernorm = nn.RMSNorm(args.hidden_size, eps=args.rms_norm_eps)
         self.post_attention_layernorm = nn.RMSNorm(
             args.hidden_size, eps=args.rms_norm_eps

--- a/mlx_vlm/models/mimo/language.py
+++ b/mlx_vlm/models/mimo/language.py
@@ -1,0 +1,172 @@
+from typing import Any, Optional
+
+import mlx.core as mx
+import mlx.nn as nn
+
+from ..activations import swiglu
+from ..base import (
+    LanguageModelOutput,
+    create_attention_mask,
+    scaled_dot_product_attention,
+)
+from ..cache import KVCache
+from ..rope_utils import initialize_rope
+from .config import ModelConfig
+
+
+class Attention(nn.Module):
+    def __init__(self, args: ModelConfig):
+        super().__init__()
+        dim = args.hidden_size
+        self.n_heads = n_heads = args.num_attention_heads
+        self.n_kv_heads = n_kv_heads = args.num_key_value_heads
+        head_dim = args.hidden_size // n_heads
+        self.scale = head_dim**-0.5
+
+        self.q_proj = nn.Linear(dim, n_heads * head_dim, bias=True)
+        self.k_proj = nn.Linear(dim, n_kv_heads * head_dim, bias=True)
+        self.v_proj = nn.Linear(dim, n_kv_heads * head_dim, bias=True)
+        self.o_proj = nn.Linear(n_heads * head_dim, dim, bias=False)
+
+        self.rope = initialize_rope(
+            head_dim,
+            base=args.rope_theta,
+            traditional=args.rope_traditional,
+            scaling_config=args.rope_scaling,
+            max_position_embeddings=args.max_position_embeddings,
+        )
+
+    def __call__(
+        self,
+        x: mx.array,
+        mask: Optional[mx.array] = None,
+        cache: Optional[Any] = None,
+    ) -> mx.array:
+        B, L, D = x.shape
+        queries, keys, values = self.q_proj(x), self.k_proj(x), self.v_proj(x)
+        queries = queries.reshape(B, L, self.n_heads, -1).transpose(0, 2, 1, 3)
+        keys = keys.reshape(B, L, self.n_kv_heads, -1).transpose(0, 2, 1, 3)
+        values = values.reshape(B, L, self.n_kv_heads, -1).transpose(0, 2, 1, 3)
+
+        if cache is not None:
+            queries = self.rope(queries, offset=cache.offset)
+            keys = self.rope(keys, offset=cache.offset)
+            keys, values = cache.update_and_fetch(keys, values)
+        else:
+            queries = self.rope(queries)
+            keys = self.rope(keys)
+
+        output = scaled_dot_product_attention(
+            queries, keys, values, cache=cache, scale=self.scale, mask=mask
+        )
+        output = output.transpose(0, 2, 1, 3).reshape(B, L, -1)
+        return self.o_proj(output)
+
+
+class MLP(nn.Module):
+    def __init__(self, dim, hidden_dim):
+        super().__init__()
+        self.gate_proj = nn.Linear(dim, hidden_dim, bias=False)
+        self.down_proj = nn.Linear(hidden_dim, dim, bias=False)
+        self.up_proj = nn.Linear(dim, hidden_dim, bias=False)
+
+    def __call__(self, x) -> mx.array:
+        return self.down_proj(swiglu(self.gate_proj(x), self.up_proj(x)))
+
+
+class TransformerBlock(nn.Module):
+    def __init__(self, args: ModelConfig):
+        super().__init__()
+        self.self_attn = Attention(args)
+        self.mlp = MLP(args.hidden_size, args.intermediate_size)
+        self.input_layernorm = nn.RMSNorm(args.hidden_size, eps=args.rms_norm_eps)
+        self.post_attention_layernorm = nn.RMSNorm(
+            args.hidden_size, eps=args.rms_norm_eps
+        )
+
+    def __call__(
+        self,
+        x: mx.array,
+        mask: Optional[mx.array] = None,
+        cache: Optional[Any] = None,
+    ) -> mx.array:
+        r = self.self_attn(self.input_layernorm(x), mask, cache)
+        h = x + r
+        r = self.mlp(self.post_attention_layernorm(h))
+        return h + r
+
+
+class MiMoModel(nn.Module):
+    def __init__(self, args: ModelConfig):
+        super().__init__()
+        self.embed_tokens = nn.Embedding(args.vocab_size, args.hidden_size)
+        self.layers = [TransformerBlock(args) for _ in range(args.num_hidden_layers)]
+        self.norm = nn.RMSNorm(args.hidden_size, eps=args.rms_norm_eps)
+
+    def __call__(self, inputs, cache=None, input_embeddings=None):
+        h = (
+            input_embeddings
+            if input_embeddings is not None
+            else self.embed_tokens(inputs)
+        )
+        if cache is None:
+            cache = [None] * len(self.layers)
+        mask = create_attention_mask(h, cache[0])
+        for layer, c in zip(self.layers, cache):
+            h = layer(h, mask, c)
+        return self.norm(h)
+
+
+class LanguageModel(nn.Module):
+    def __init__(self, args: ModelConfig):
+        super().__init__()
+        self.args = args
+        self.config = args
+        self.model_type = args.model_type
+        self.model = MiMoModel(args)
+        if not args.tie_word_embeddings:
+            self.lm_head = nn.Linear(args.hidden_size, args.vocab_size, bias=False)
+
+    def __call__(
+        self,
+        inputs: Optional[mx.array] = None,
+        cache=None,
+        input_embeddings: Optional[mx.array] = None,
+        inputs_embeds: Optional[mx.array] = None,
+        **kwargs,
+    ) -> LanguageModelOutput:
+        if inputs is None:
+            inputs = kwargs.get("input_ids")
+        if inputs_embeds is None:
+            inputs_embeds = input_embeddings
+        out = self.model(inputs, cache, inputs_embeds)
+        if self.args.tie_word_embeddings:
+            out = self.model.embed_tokens.as_linear(out)
+        else:
+            out = self.lm_head(out)
+        return LanguageModelOutput(logits=out)
+
+    def sanitize(self, weights):
+        if self.args.tie_word_embeddings:
+            weights.pop("lm_head.weight", None)
+        return {
+            k: v
+            for k, v in weights.items()
+            if "self_attn.rotary_emb.inv_freq" not in k
+            and not k.startswith("model.mtp_layers.")
+        }
+
+    def make_cache(self):
+        return [KVCache() for _ in self.model.layers]
+
+    @property
+    def layers(self):
+        return self.model.layers
+
+    @property
+    def head_dim(self):
+        return self.args.hidden_size // self.args.num_attention_heads
+
+    @property
+    def n_kv_heads(self):
+        return self.args.num_key_value_heads

--- a/mlx_vlm/models/mimo/mimo.py
+++ b/mlx_vlm/models/mimo/mimo.py
@@ -1,0 +1,46 @@
+from typing import Optional
+
+import mlx.core as mx
+import mlx.nn as nn
+
+from ..base import InputEmbeddingsFeatures, LanguageModelOutput
+from .config import ModelConfig
+from .language import LanguageModel
+
+
+class Model(nn.Module):
+    def __init__(self, config: ModelConfig):
+        super().__init__()
+        self.config = config
+        self.model_type = config.model_type
+        self.language_model = LanguageModel(config)
+
+    def get_input_embeddings(
+        self,
+        input_ids: Optional[mx.array] = None,
+        pixel_values: Optional[mx.array] = None,
+        **kwargs,
+    ) -> InputEmbeddingsFeatures:
+        return InputEmbeddingsFeatures(
+            inputs_embeds=self.language_model.model.embed_tokens(input_ids)
+        )
+
+    def __call__(
+        self,
+        input_ids: mx.array,
+        pixel_values: mx.array = None,
+        mask: mx.array = None,
+        cache=None,
+        **kwargs,
+    ) -> LanguageModelOutput:
+        return self.language_model(input_ids, cache=cache, **kwargs)
+
+    def sanitize(self, weights):
+        if any(k.startswith("language_model.") for k in weights):
+            return weights
+        weights = self.language_model.sanitize(weights)
+        return {f"language_model.{k}": v for k, v in weights.items()}
+
+    @property
+    def layers(self):
+        return self.language_model.layers

--- a/mlx_vlm/models/mimo_v2_flash/__init__.py
+++ b/mlx_vlm/models/mimo_v2_flash/__init__.py
@@ -1,0 +1,4 @@
+from .config import ModelConfig
+from .mimo_v2_flash import Model
+
+__all__ = ["Model", "ModelConfig"]

--- a/mlx_vlm/models/mimo_v2_flash/config.py
+++ b/mlx_vlm/models/mimo_v2_flash/config.py
@@ -1,0 +1,41 @@
+from dataclasses import dataclass
+from typing import List, Optional
+
+from ..base import BaseModelConfig
+
+
+@dataclass
+class ModelConfig(BaseModelConfig):
+    model_type: str
+    num_experts_per_tok: int
+    hybrid_layer_pattern: List[int]
+    moe_layer_freq: List[int]
+    add_swa_attention_sink_bias: bool
+    add_full_attention_sink_bias: bool
+    sliding_window_size: int
+    vocab_size: int
+    hidden_size: int
+    intermediate_size: int
+    moe_intermediate_size: int
+    num_hidden_layers: int
+    num_attention_heads: int
+    num_key_value_heads: int
+    n_shared_experts: Optional[int]
+    n_routed_experts: Optional[int]
+    routed_scaling_factor: Optional[float]
+    topk_method: str
+    scoring_func: str
+    norm_topk_prob: bool
+    n_group: int
+    topk_group: int
+    max_position_embeddings: int
+    layernorm_epsilon: float
+    rope_theta: float
+    swa_rope_theta: float
+    swa_num_attention_heads: int
+    swa_num_key_value_heads: int
+    head_dim: int
+    v_head_dim: int
+    swa_head_dim: int
+    swa_v_head_dim: int
+    partial_rotary_factor: float

--- a/mlx_vlm/models/mimo_v2_flash/language.py
+++ b/mlx_vlm/models/mimo_v2_flash/language.py
@@ -3,13 +3,13 @@ from typing import Any, Optional
 import mlx.core as mx
 import mlx.nn as nn
 
-from ..activations import swiglu
 from ..base import (
     LanguageModelOutput,
     create_attention_mask,
     scaled_dot_product_attention,
 )
 from ..cache import KVCache, RotatingKVCache
+from ..mlp import SwiGLUMLP
 from ..switch_layers import SwitchGLU
 from .config import ModelConfig
 
@@ -85,29 +85,6 @@ class Attention(nn.Module):
         )
         output = output.transpose(0, 2, 1, 3).reshape(B, L, -1)
         return self.o_proj(output)
-
-
-class MLP(nn.Module):
-    def __init__(
-        self,
-        config: ModelConfig,
-        hidden_size: int = None,
-        intermediate_size: int = None,
-    ):
-        super().__init__()
-        self.config = config
-        self.hidden_size = config.hidden_size if hidden_size is None else hidden_size
-        self.intermediate_size = (
-            config.intermediate_size if intermediate_size is None else intermediate_size
-        )
-
-        self.gate_proj = nn.Linear(self.hidden_size, self.intermediate_size, bias=False)
-        self.up_proj = nn.Linear(self.hidden_size, self.intermediate_size, bias=False)
-        self.down_proj = nn.Linear(self.intermediate_size, self.hidden_size, bias=False)
-
-    def __call__(self, x):
-        down_proj = self.down_proj(swiglu(self.gate_proj(x), self.up_proj(x)))
-        return down_proj
 
 
 @mx.compile
@@ -189,9 +166,7 @@ class MoE(nn.Module):
         self.gate = MoEGate(config)
         if config.n_shared_experts is not None:
             intermediate_size = config.moe_intermediate_size * config.n_shared_experts
-            self.shared_experts = MLP(
-                config=config, intermediate_size=intermediate_size
-            )
+            self.shared_experts = SwiGLUMLP(config.hidden_size, intermediate_size)
 
     def __call__(self, x):
         inds, scores = self.gate(x)
@@ -207,7 +182,11 @@ class DecoderLayer(nn.Module):
     def __init__(self, config: ModelConfig, is_moe, is_sliding_window):
         super().__init__()
         self.self_attn = Attention(config, is_sliding_window)
-        self.mlp = MoE(config) if is_moe else MLP(config)
+        self.mlp = (
+            MoE(config)
+            if is_moe
+            else SwiGLUMLP(config.hidden_size, config.intermediate_size)
+        )
         self.is_sliding_window = is_sliding_window
         self.input_layernorm = nn.RMSNorm(
             config.hidden_size, eps=config.layernorm_epsilon

--- a/mlx_vlm/models/mimo_v2_flash/language.py
+++ b/mlx_vlm/models/mimo_v2_flash/language.py
@@ -1,0 +1,350 @@
+from typing import Any, Optional
+
+import mlx.core as mx
+import mlx.nn as nn
+
+from ..activations import swiglu
+from ..base import (
+    LanguageModelOutput,
+    create_attention_mask,
+    scaled_dot_product_attention,
+)
+from ..cache import KVCache, RotatingKVCache
+from ..switch_layers import SwitchGLU
+from .config import ModelConfig
+
+
+class Attention(nn.Module):
+    def __init__(self, args: ModelConfig, is_sliding_window: bool):
+        super().__init__()
+
+        dim = args.hidden_size
+        self.is_sliding_window = is_sliding_window
+        if self.is_sliding_window:
+            self.n_heads = n_heads = args.swa_num_attention_heads
+            self.n_kv_heads = n_kv_heads = args.swa_num_key_value_heads
+            self.has_sinks = args.add_swa_attention_sink_bias
+            head_dim = args.swa_head_dim
+            v_head_dim = args.swa_v_head_dim
+            rope_theta = args.swa_rope_theta
+        else:
+            self.n_heads = n_heads = args.num_attention_heads
+            self.n_kv_heads = n_kv_heads = args.num_key_value_heads
+            self.has_sinks = args.add_full_attention_sink_bias
+            head_dim = args.head_dim
+            v_head_dim = args.v_head_dim
+            rope_theta = args.rope_theta
+
+        self.scale = head_dim**-0.5
+
+        self.q_proj = nn.Linear(dim, n_heads * head_dim, bias=False)
+        self.k_proj = nn.Linear(dim, n_kv_heads * head_dim, bias=False)
+        self.v_proj = nn.Linear(dim, n_kv_heads * v_head_dim, bias=False)
+        self.o_proj = nn.Linear(n_heads * v_head_dim, dim, bias=False)
+        if self.has_sinks:
+            self.attention_sink_bias = mx.ones((self.n_heads,))
+        else:
+            self.attention_sink_bias = None
+
+        self.rope = nn.RoPE(
+            int(args.partial_rotary_factor * head_dim),
+            traditional=False,
+            base=rope_theta,
+        )
+
+    def __call__(
+        self,
+        x: mx.array,
+        mask: Optional[mx.array] = None,
+        cache: Optional[Any] = None,
+    ) -> mx.array:
+        B, L, D = x.shape
+
+        queries, keys, values = self.q_proj(x), self.k_proj(x), self.v_proj(x)
+
+        queries = queries.reshape(B, L, self.n_heads, -1).transpose(0, 2, 1, 3)
+        keys = keys.reshape(B, L, self.n_kv_heads, -1).transpose(0, 2, 1, 3)
+        values = values.reshape(B, L, self.n_kv_heads, -1).transpose(0, 2, 1, 3)
+
+        if cache is not None:
+            queries = self.rope(queries, offset=cache.offset)
+            keys = self.rope(keys, offset=cache.offset)
+            keys, values = cache.update_and_fetch(keys, values)
+        else:
+            queries = self.rope(queries)
+            keys = self.rope(keys)
+
+        output = scaled_dot_product_attention(
+            queries,
+            keys,
+            values,
+            cache=cache,
+            scale=self.scale,
+            mask=mask,
+            sinks=self.attention_sink_bias,
+        )
+        output = output.transpose(0, 2, 1, 3).reshape(B, L, -1)
+        return self.o_proj(output)
+
+
+class MLP(nn.Module):
+    def __init__(
+        self,
+        config: ModelConfig,
+        hidden_size: int = None,
+        intermediate_size: int = None,
+    ):
+        super().__init__()
+        self.config = config
+        self.hidden_size = config.hidden_size if hidden_size is None else hidden_size
+        self.intermediate_size = (
+            config.intermediate_size if intermediate_size is None else intermediate_size
+        )
+
+        self.gate_proj = nn.Linear(self.hidden_size, self.intermediate_size, bias=False)
+        self.up_proj = nn.Linear(self.hidden_size, self.intermediate_size, bias=False)
+        self.down_proj = nn.Linear(self.intermediate_size, self.hidden_size, bias=False)
+
+    def __call__(self, x):
+        down_proj = self.down_proj(swiglu(self.gate_proj(x), self.up_proj(x)))
+        return down_proj
+
+
+@mx.compile
+def group_expert_select(
+    gates,
+    e_score_correction_bias,
+    top_k,
+    n_group,
+    topk_group,
+    routed_scaling_factor,
+    norm_topk_prob,
+):
+
+    scores = mx.sigmoid(gates.astype(mx.float32))
+    orig_scores = scores
+    scores = scores + e_score_correction_bias
+    if n_group > 1:
+        scores = mx.unflatten(scores, axis=-1, shape=(n_group, -1))
+        group_scores = mx.topk(scores, 2, axis=-1).sum(axis=-1, keepdims=True)
+        k = n_group - topk_group
+        group_idx = mx.argpartition(group_scores, kth=k - 1, axis=-2)[..., :k, :]
+        scores = mx.put_along_axis(
+            scores, mx.stop_gradient(group_idx), mx.array(0.0), axis=-2
+        )
+        scores = mx.flatten(scores, -2, -1)
+
+    k = top_k
+    inds = mx.argpartition(-scores, kth=k - 1, axis=-1)[..., :k]
+    scores = mx.take_along_axis(orig_scores, inds, axis=-1)
+    if top_k > 1 and norm_topk_prob:
+        denominator = scores.sum(axis=-1, keepdims=True)
+        scores = scores / (denominator + 1e-20)
+    scores = scores * routed_scaling_factor
+
+    return inds, scores
+
+
+class MoEGate(nn.Module):
+    def __init__(self, config: ModelConfig):
+        super().__init__()
+        self.config = config
+        self.top_k = config.num_experts_per_tok
+        self.norm_topk_prob = config.norm_topk_prob
+        self.n_routed_experts = config.n_routed_experts
+        self.routed_scaling_factor = (
+            config.routed_scaling_factor
+            if config.routed_scaling_factor is not None
+            else 1.0
+        )
+        self.n_group = config.n_group
+        self.topk_group = config.topk_group
+        self.weight = mx.zeros((self.n_routed_experts, config.hidden_size))
+        self.e_score_correction_bias = mx.zeros((self.n_routed_experts,))
+        assert config.topk_method == "noaux_tc", "Unsupported topk method."
+
+    def __call__(self, x):
+        return group_expert_select(
+            x @ self.weight.T,
+            self.e_score_correction_bias,
+            self.top_k,
+            self.n_group,
+            self.topk_group,
+            self.routed_scaling_factor,
+            self.norm_topk_prob,
+        )
+
+
+class MoE(nn.Module):
+    def __init__(self, config: ModelConfig):
+        super().__init__()
+        self.config = config
+        self.num_experts_per_tok = config.num_experts_per_tok
+        self.switch_mlp = SwitchGLU(
+            config.hidden_size,
+            config.moe_intermediate_size,
+            config.n_routed_experts,
+        )
+
+        self.gate = MoEGate(config)
+        if config.n_shared_experts is not None:
+            intermediate_size = config.moe_intermediate_size * config.n_shared_experts
+            self.shared_experts = MLP(
+                config=config, intermediate_size=intermediate_size
+            )
+
+    def __call__(self, x):
+        inds, scores = self.gate(x)
+        y = self.switch_mlp(x, inds)
+        y = (y * scores[..., None]).sum(axis=-2).astype(y.dtype)
+        if self.config.n_shared_experts is not None:
+            y = y + self.shared_experts(x)
+
+        return y
+
+
+class DecoderLayer(nn.Module):
+    def __init__(self, config: ModelConfig, is_moe, is_sliding_window):
+        super().__init__()
+        self.self_attn = Attention(config, is_sliding_window)
+        self.mlp = MoE(config) if is_moe else MLP(config)
+        self.is_sliding_window = is_sliding_window
+        self.input_layernorm = nn.RMSNorm(
+            config.hidden_size, eps=config.layernorm_epsilon
+        )
+        self.post_attention_layernorm = nn.RMSNorm(
+            config.hidden_size, eps=config.layernorm_epsilon
+        )
+
+    def __call__(
+        self,
+        x: mx.array,
+        mask: Optional[mx.array] = None,
+        cache: Optional[Any] = None,
+    ) -> mx.array:
+        r = self.self_attn(self.input_layernorm(x), mask, cache)
+        h = x + r
+        r = self.mlp(self.post_attention_layernorm(h))
+        return h + r
+
+
+class MimoModel(nn.Module):
+    def __init__(self, config: ModelConfig):
+        super().__init__()
+        self.vocab_size = config.vocab_size
+        self.embed_tokens = nn.Embedding(config.vocab_size, config.hidden_size)
+        self.layers = [
+            DecoderLayer(
+                config,
+                is_moe=config.moe_layer_freq[idx] == 1,
+                is_sliding_window=config.hybrid_layer_pattern[idx] == 1,
+            )
+            for idx in range(config.num_hidden_layers)
+        ]
+        self.norm = nn.RMSNorm(config.hidden_size, eps=config.layernorm_epsilon)
+        self.swa_idx = config.hybrid_layer_pattern.index(1)
+        self.ga_idx = config.hybrid_layer_pattern.index(0)
+        self.sliding_window_size = config.sliding_window_size
+
+    def __call__(
+        self,
+        x: mx.array,
+        cache: Optional[Any] = None,
+        inputs_embeds: Optional[mx.array] = None,
+    ) -> mx.array:
+        h = self.embed_tokens(x) if inputs_embeds is None else inputs_embeds
+
+        if cache is None:
+            cache = [None] * len(self.layers)
+
+        full_mask = create_attention_mask(h, cache[self.ga_idx])
+        swa_mask = create_attention_mask(
+            h, cache[self.swa_idx], window_size=self.sliding_window_size
+        )
+
+        for l, c in zip(self.layers, cache):
+            mask = swa_mask if l.is_sliding_window else full_mask
+            h = l(h, mask, cache=c)
+
+        return self.norm(h)
+
+
+class LanguageModel(nn.Module):
+    def __init__(self, config: ModelConfig):
+        super().__init__()
+        self.args = config
+        self.model_type = config.model_type
+        self.model = MimoModel(config)
+        self.lm_head = nn.Linear(config.hidden_size, config.vocab_size, bias=False)
+
+    def __call__(
+        self, inputs: mx.array, cache=None, inputs_embeds=None, mask=None, **kwargs
+    ):
+        out = self.model(inputs, cache, inputs_embeds=inputs_embeds)
+        out = self.lm_head(out)
+        return LanguageModelOutput(logits=out)
+
+    def sanitize(self, weights):
+        def dequant(weight, scale_inv):
+            dtype = mx.bfloat16
+            weight = mx.from_fp8(weight, dtype=mx.bfloat16)
+            bs = 128  # block size
+            m, n = weight.shape
+            pad_bottom = bs * scale_inv.shape[0] - m
+            pad_side = bs * scale_inv.shape[1] - n
+            weight = mx.pad(weight, ((0, pad_bottom), (0, pad_side)))
+            weight = weight.reshape(
+                ((m + pad_bottom) // bs, bs, (n + pad_side) // bs, bs)
+            )
+            weight = (weight * scale_inv[:, None, :, None]).reshape(
+                m + pad_bottom, n + pad_side
+            )
+            return weight[:m, :n].astype(dtype)
+
+        # Dequantize fp8
+        new_weights = {}
+        for k, v in weights.items():
+            if "weight_scale_inv" in k:
+                scale_inv = v
+                wk = k.replace("_scale_inv", "")
+                weight = weights[wk]
+                weight = dequant(weight, scale_inv)
+                new_weights[wk] = weight
+            elif k not in new_weights:
+                new_weights[k] = v
+        weights = new_weights
+
+        # Stack experts
+        for l in range(self.args.num_hidden_layers):
+            prefix = f"model.layers.{l}"
+            for n, m in [("w1", "gate_proj"), ("w2", "down_proj"), ("w3", "up_proj")]:
+                for k in ["weight", "scales", "biases"]:
+                    if f"{prefix}.mlp.experts.0.{m}.{k}" in weights:
+                        to_join = [
+                            weights.pop(f"{prefix}.mlp.experts.{e}.{m}.{k}")
+                            for e in range(self.args.n_routed_experts)
+                        ]
+                        weights[f"{prefix}.mlp.switch_mlp.{m}.{k}"] = mx.stack(to_join)
+
+        # Remove multi-token prediction layer
+        return {k: v for k, v in weights.items() if not k.startswith("model.mtp")}
+
+    @property
+    def layers(self):
+        return self.model.layers
+
+    @property
+    def cast_predicate(self):
+        def predicate(k):
+            return "e_score_correction_bias" not in k
+
+        return predicate
+
+    def make_cache(self):
+        caches = []
+        for l in self.layers:
+            if l.is_sliding_window:
+                caches.append(RotatingKVCache(max_size=self.args.sliding_window_size))
+            else:
+                caches.append(KVCache())
+        return caches

--- a/mlx_vlm/models/mimo_v2_flash/mimo_v2_flash.py
+++ b/mlx_vlm/models/mimo_v2_flash/mimo_v2_flash.py
@@ -1,0 +1,49 @@
+from typing import Optional
+
+import mlx.core as mx
+import mlx.nn as nn
+
+from ..base import InputEmbeddingsFeatures, LanguageModelOutput
+from .config import ModelConfig
+from .language import LanguageModel
+
+
+class Model(nn.Module):
+    def __init__(self, config: ModelConfig):
+        super().__init__()
+        self.config = config
+        self.model_type = config.model_type
+        self.language_model = LanguageModel(config)
+
+    def get_input_embeddings(
+        self,
+        input_ids: Optional[mx.array] = None,
+        pixel_values: Optional[mx.array] = None,
+        **kwargs,
+    ) -> InputEmbeddingsFeatures:
+        return InputEmbeddingsFeatures(
+            inputs_embeds=self.language_model.model.embed_tokens(input_ids)
+        )
+
+    def __call__(
+        self,
+        input_ids: mx.array,
+        pixel_values: mx.array = None,
+        mask: mx.array = None,
+        cache=None,
+        **kwargs,
+    ) -> LanguageModelOutput:
+        return self.language_model(input_ids, cache=cache, **kwargs)
+
+    def sanitize(self, weights):
+        if any(k.startswith("language_model.") for k in weights):
+            return weights
+        weights = self.language_model.sanitize(weights)
+        return {f"language_model.{k}": v for k, v in weights.items()}
+
+    @property
+    def layers(self):
+        return self.language_model.layers
+
+    def make_cache(self):
+        return self.language_model.make_cache()

--- a/mlx_vlm/models/nemotron_nas/__init__.py
+++ b/mlx_vlm/models/nemotron_nas/__init__.py
@@ -1,0 +1,4 @@
+from .config import ModelConfig
+from .nemotron_nas import Model
+
+__all__ = ["Model", "ModelConfig"]

--- a/mlx_vlm/models/nemotron_nas/config.py
+++ b/mlx_vlm/models/nemotron_nas/config.py
@@ -1,0 +1,106 @@
+from dataclasses import dataclass, field
+from typing import Dict, Optional, Union
+
+from ..base import BaseModelConfig
+
+
+@dataclass(frozen=True)
+class AttentionConfig:
+    no_op: bool = False
+    replace_with_linear: bool = False
+    sparsify: Optional[list] = None
+    n_heads_in_group: Optional[int] = None
+    window_length: Optional[int] = None
+    num_sink_tokens: Optional[int] = None
+    use_prefill_window_in_sink_attention: bool = False
+    unshifted_sink: bool = False
+
+    def __post_init__(self):
+        if self.no_op or self.replace_with_linear:
+            object.__setattr__(self, "n_heads_in_group", None)
+            object.__setattr__(self, "window_length", None)
+            object.__setattr__(self, "num_sink_tokens", None)
+        elif not self.no_op:
+            if self.n_heads_in_group is None:
+                raise ValueError(
+                    "n_heads_in_group must be specified for active attention blocks"
+                )
+            if self.n_heads_in_group <= 0:
+                raise ValueError(
+                    f"n_heads_in_group must be positive, got {self.n_heads_in_group}"
+                )
+
+
+@dataclass(frozen=True)
+class FFNConfig:
+    no_op: bool = False
+    replace_with_linear: bool = False
+    sparsify: Optional[list] = None
+    ffn_mult: Optional[float] = None
+
+    def __post_init__(self):
+        if self.no_op or self.replace_with_linear:
+            object.__setattr__(self, "ffn_mult", None)
+        elif not self.no_op:
+            if self.ffn_mult is None:
+                raise ValueError("ffn_mult must be specified for active FFN blocks")
+            object.__setattr__(self, "ffn_mult", round(self.ffn_mult, 6))
+
+
+@dataclass(frozen=True)
+class BlockConfig:
+    attention: AttentionConfig
+    ffn: FFNConfig
+
+    @classmethod
+    def from_dict(cls, data: dict):
+        attn_conf = AttentionConfig(**data.get("attention", {}))
+        ffn_conf = FFNConfig(**data.get("ffn", {}))
+        return cls(attention=attn_conf, ffn=ffn_conf)
+
+
+@dataclass
+class ModelConfig(BaseModelConfig):
+    model_type: str = "nemotron-nas"
+    hidden_size: int = 8192
+    num_hidden_layers: int = 80
+    num_attention_heads: int = 64
+    rms_norm_eps: float = 1e-5
+    vocab_size: int = 128256
+    block_configs: list = field(default_factory=list)
+    hidden_act: str = "silu"
+    attention_bias: bool = False
+    mlp_bias: bool = False
+    rope_theta: float = 500000.0
+    rope_scaling: Optional[Dict[str, Union[float, str]]] = None
+    max_position_embeddings: int = 131072
+    tie_word_embeddings: bool = False
+
+    def __post_init__(self):
+        if self.block_configs and isinstance(self.block_configs[0], dict):
+            self.block_configs = [
+                BlockConfig.from_dict(conf) for conf in self.block_configs
+            ]
+
+        if len(self.block_configs) != self.num_hidden_layers:
+            raise ValueError(
+                f"Number of block_configs ({len(self.block_configs)}) must match "
+                f"num_hidden_layers ({self.num_hidden_layers})"
+            )
+
+        if self.rope_scaling:
+            if "factor" not in self.rope_scaling:
+                raise ValueError("rope_scaling must contain 'factor'")
+            rope_type = self.rope_scaling.get("rope_type")
+            if rope_type is None:
+                raise ValueError("rope_scaling must contain 'rope_type'")
+
+        for i, block_conf in enumerate(self.block_configs):
+            attn_conf = block_conf.attention
+            if not attn_conf.no_op and not attn_conf.replace_with_linear:
+                if self.num_attention_heads % attn_conf.n_heads_in_group != 0:
+                    raise ValueError(
+                        f"Layer {i}: num_attention_heads ({self.num_attention_heads}) "
+                        f"must be divisible by n_heads_in_group "
+                        f"({attn_conf.n_heads_in_group})"
+                    )

--- a/mlx_vlm/models/nemotron_nas/language.py
+++ b/mlx_vlm/models/nemotron_nas/language.py
@@ -1,0 +1,274 @@
+from typing import Any, List, Optional
+
+import mlx.core as mx
+import mlx.nn as nn
+
+from ..base import (
+    LanguageModelOutput,
+    create_attention_mask,
+    scaled_dot_product_attention,
+)
+from ..cache import KVCache
+from ..rope_utils import initialize_rope
+from .config import AttentionConfig, FFNConfig, ModelConfig
+
+
+def _find_multiple(n: int, k: int) -> int:
+    if n % k == 0:
+        return n
+    return n + k - (n % k)
+
+
+def _ffn_mult_to_intermediate_size(ffn_mult: float, n_embd: int) -> int:
+    intermediate_size = int(2 * ffn_mult * n_embd / 3)
+    return _find_multiple(intermediate_size, 256)
+
+
+_ACT2FN = {
+    "silu": nn.silu,
+    "relu": nn.relu,
+    "gelu": nn.gelu,
+    "gelu_new": nn.gelu_approx,
+    "gelu_fast": nn.gelu_approx,
+}
+
+
+class Attention(nn.Module):
+    def __init__(self, args: ModelConfig, attention_config: AttentionConfig):
+        super().__init__()
+
+        dim = args.hidden_size
+        self.n_heads = n_heads = args.num_attention_heads
+        self.n_kv_heads = n_kv_heads = n_heads // attention_config.n_heads_in_group
+
+        self.head_dim = head_dim = args.hidden_size // n_heads
+        if (self.head_dim * n_heads) != dim:
+            raise ValueError(
+                f"hidden_size ({dim}) must be divisible by "
+                f"num_attention_heads ({n_heads})"
+            )
+
+        self.scale = head_dim**-0.5
+
+        self.q_proj = nn.Linear(dim, n_heads * head_dim, bias=args.attention_bias)
+        self.k_proj = nn.Linear(dim, n_kv_heads * head_dim, bias=args.attention_bias)
+        self.v_proj = nn.Linear(dim, n_kv_heads * head_dim, bias=args.attention_bias)
+        self.o_proj = nn.Linear(n_heads * head_dim, dim, bias=args.attention_bias)
+
+        self.rope = initialize_rope(
+            self.head_dim,
+            args.rope_theta,
+            False,
+            args.rope_scaling,
+            args.max_position_embeddings,
+        )
+
+    def __call__(
+        self,
+        x: mx.array,
+        mask: Optional[mx.array] = None,
+        cache: Optional[Any] = None,
+    ) -> mx.array:
+        B, L, D = x.shape
+
+        queries, keys, values = self.q_proj(x), self.k_proj(x), self.v_proj(x)
+
+        queries = queries.reshape(B, L, self.n_heads, self.head_dim).transpose(
+            0, 2, 1, 3
+        )
+        keys = keys.reshape(B, L, self.n_kv_heads, self.head_dim).transpose(0, 2, 1, 3)
+        values = values.reshape(B, L, self.n_kv_heads, self.head_dim).transpose(
+            0, 2, 1, 3
+        )
+
+        if cache is not None:
+            queries = self.rope(queries, offset=cache.offset)
+            keys = self.rope(keys, offset=cache.offset)
+            keys, values = cache.update_and_fetch(keys, values)
+        else:
+            queries = self.rope(queries)
+            keys = self.rope(keys)
+
+        output = scaled_dot_product_attention(
+            queries, keys, values, cache=cache, scale=self.scale, mask=mask
+        )
+        output = output.transpose(0, 2, 1, 3).reshape(B, L, -1)
+        return self.o_proj(output)
+
+
+class MLP(nn.Module):
+    def __init__(self, args: ModelConfig, ffn_config: FFNConfig):
+        super().__init__()
+
+        dim = args.hidden_size
+        hidden_dim = _ffn_mult_to_intermediate_size(ffn_config.ffn_mult, dim)
+
+        self.gate_proj = nn.Linear(dim, hidden_dim, bias=args.mlp_bias)
+        self.down_proj = nn.Linear(hidden_dim, dim, bias=args.mlp_bias)
+        self.up_proj = nn.Linear(dim, hidden_dim, bias=args.mlp_bias)
+
+        self.act_fn = args.hidden_act
+        if self.act_fn not in _ACT2FN:
+            raise ValueError(f"Unknown activation function: {args.hidden_act}")
+
+    def __call__(self, x) -> mx.array:
+        act_fn = _ACT2FN[self.act_fn]
+        return self.down_proj(act_fn(self.gate_proj(x)) * self.up_proj(x))
+
+
+class LinearSubblockReplacement(nn.Module):
+    def __init__(self, hidden_size: int, bias: bool):
+        super().__init__()
+        self.linear = nn.Linear(hidden_size, hidden_size, bias=bias)
+
+    def __call__(self, x: mx.array, *args, **kwargs) -> mx.array:
+        return self.linear(x)
+
+
+class TransformerBlock(nn.Module):
+    def __init__(self, args: ModelConfig, layer_idx: int):
+        super().__init__()
+        self.hidden_size = args.hidden_size
+        block_config = args.block_configs[layer_idx]
+        self.attention_config = block_config.attention
+        self.ffn_config = block_config.ffn
+
+        if not self.attention_config.no_op:
+            self.input_layernorm = nn.RMSNorm(args.hidden_size, eps=args.rms_norm_eps)
+        else:
+            self.input_layernorm = None
+
+        if self.attention_config.no_op:
+            self.self_attn = None
+        elif self.attention_config.replace_with_linear:
+            self.self_attn = LinearSubblockReplacement(
+                args.hidden_size, args.attention_bias
+            )
+        else:
+            self.self_attn = Attention(args, self.attention_config)
+
+        if not self.ffn_config.no_op:
+            self.post_attention_layernorm = nn.RMSNorm(
+                args.hidden_size, eps=args.rms_norm_eps
+            )
+        else:
+            self.post_attention_layernorm = None
+
+        if self.ffn_config.no_op:
+            self.mlp = None
+        elif self.ffn_config.replace_with_linear:
+            self.mlp = LinearSubblockReplacement(args.hidden_size, args.mlp_bias)
+        else:
+            self.mlp = MLP(args, self.ffn_config)
+
+    def __call__(
+        self,
+        x: mx.array,
+        mask: Optional[mx.array] = None,
+        cache: Optional[Any] = None,
+    ) -> mx.array:
+        if self.self_attn is not None:
+            residual = x
+            h = self.input_layernorm(x)
+            attn_out = self.self_attn(h, mask=mask, cache=cache)
+            x = residual + attn_out
+
+        if self.mlp is not None:
+            residual = x
+            h = self.post_attention_layernorm(x)
+            mlp_out = self.mlp(h)
+            x = residual + mlp_out
+
+        return x
+
+
+class NemotronNASModel(nn.Module):
+    def __init__(self, args: ModelConfig):
+        super().__init__()
+        self.args = args
+        self.vocab_size = args.vocab_size
+        self.num_hidden_layers = args.num_hidden_layers
+        self.embed_tokens = nn.Embedding(args.vocab_size, args.hidden_size)
+        self.layers = [
+            TransformerBlock(args=args, layer_idx=i)
+            for i in range(args.num_hidden_layers)
+        ]
+        self.norm = nn.RMSNorm(args.hidden_size, eps=args.rms_norm_eps)
+        self.num_attn_layers = sum(
+            1 for layer in self.layers if layer.self_attn is not None
+        )
+
+    def __call__(self, inputs, cache=None, input_embeddings=None):
+        h = (
+            input_embeddings
+            if input_embeddings is not None
+            else self.embed_tokens(inputs)
+        )
+
+        if cache is None:
+            cache = [None] * self.num_attn_layers
+
+        mask = create_attention_mask(h, cache[0])
+
+        cache_idx = 0
+        for layer in self.layers:
+            if layer.self_attn is not None:
+                c = cache[cache_idx]
+                cache_idx += 1
+            else:
+                c = None
+            h = layer(h, mask, cache=c)
+
+        return self.norm(h)
+
+
+class LanguageModel(nn.Module):
+    def __init__(self, args: ModelConfig):
+        super().__init__()
+        self.args = args
+        self.config = args
+        self.model_type = args.model_type
+        self.model = NemotronNASModel(args)
+        if not args.tie_word_embeddings:
+            self.lm_head = nn.Linear(args.hidden_size, args.vocab_size, bias=False)
+        else:
+            self.lm_head = None
+
+    def __call__(
+        self,
+        inputs: Optional[mx.array] = None,
+        cache=None,
+        input_embeddings: Optional[mx.array] = None,
+        inputs_embeds: Optional[mx.array] = None,
+        **kwargs,
+    ) -> LanguageModelOutput:
+        if inputs is None:
+            inputs = kwargs.get("input_ids")
+        if inputs_embeds is None:
+            inputs_embeds = input_embeddings
+        out = self.model(inputs, cache=cache, input_embeddings=inputs_embeds)
+        if self.args.tie_word_embeddings:
+            out = self.model.embed_tokens.as_linear(out)
+        else:
+            out = self.lm_head(out)
+        return LanguageModelOutput(logits=out)
+
+    def sanitize(self, weights):
+        if self.args.tie_word_embeddings:
+            weights.pop("lm_head.weight", None)
+        return weights
+
+    def make_cache(self):
+        return [KVCache() for layer in self.layers if layer.self_attn is not None]
+
+    @property
+    def layers(self) -> List[nn.Module]:
+        return self.model.layers
+
+    @property
+    def head_dim(self):
+        return self.args.hidden_size // self.args.num_attention_heads
+
+    @property
+    def n_kv_heads(self):
+        return self.args.num_attention_heads

--- a/mlx_vlm/models/nemotron_nas/nemotron_nas.py
+++ b/mlx_vlm/models/nemotron_nas/nemotron_nas.py
@@ -1,0 +1,46 @@
+from typing import Optional
+
+import mlx.core as mx
+import mlx.nn as nn
+
+from ..base import InputEmbeddingsFeatures, LanguageModelOutput
+from .config import ModelConfig
+from .language import LanguageModel
+
+
+class Model(nn.Module):
+    def __init__(self, config: ModelConfig):
+        super().__init__()
+        self.config = config
+        self.model_type = config.model_type
+        self.language_model = LanguageModel(config)
+
+    def get_input_embeddings(
+        self,
+        input_ids: Optional[mx.array] = None,
+        pixel_values: Optional[mx.array] = None,
+        **kwargs,
+    ) -> InputEmbeddingsFeatures:
+        return InputEmbeddingsFeatures(
+            inputs_embeds=self.language_model.model.embed_tokens(input_ids)
+        )
+
+    def __call__(
+        self,
+        input_ids: mx.array,
+        pixel_values: mx.array = None,
+        mask: mx.array = None,
+        cache=None,
+        **kwargs,
+    ) -> LanguageModelOutput:
+        return self.language_model(input_ids, cache=cache, **kwargs)
+
+    def sanitize(self, weights):
+        if any(k.startswith("language_model.") for k in weights):
+            return weights
+        weights = self.language_model.sanitize(weights)
+        return {f"language_model.{k}": v for k, v in weights.items()}
+
+    @property
+    def layers(self):
+        return self.language_model.layers

--- a/mlx_vlm/models/olmo3/__init__.py
+++ b/mlx_vlm/models/olmo3/__init__.py
@@ -1,0 +1,4 @@
+from .config import ModelConfig
+from .olmo3 import Model
+
+__all__ = ["Model", "ModelConfig"]

--- a/mlx_vlm/models/olmo3/config.py
+++ b/mlx_vlm/models/olmo3/config.py
@@ -1,0 +1,33 @@
+from dataclasses import dataclass
+from typing import Dict, List, Optional, Union
+
+from ..base import BaseModelConfig
+
+
+@dataclass
+class ModelConfig(BaseModelConfig):
+    model_type: str
+    hidden_size: int
+    num_hidden_layers: int
+    intermediate_size: int
+    num_attention_heads: int
+    rms_norm_eps: float
+    vocab_size: int
+    max_position_embeddings: int
+    sliding_window: int
+    rope_theta: float
+    attention_bias: bool = False
+    layer_types: Optional[List[str]] = None
+    num_key_value_heads: Optional[int] = None
+    head_dim: Optional[int] = None
+    rope_scaling: Optional[Dict[str, Union[float, str]]] = None
+    tie_word_embeddings: bool = False
+
+    def __post_init__(self):
+        if self.num_key_value_heads is None:
+            self.num_key_value_heads = self.num_attention_heads
+        if self.layer_types is None:
+            self.layer_types = [
+                "full_attention" if (i + 1) % 4 == 0 else "sliding_attention"
+                for i in range(self.num_hidden_layers)
+            ]

--- a/mlx_vlm/models/olmo3/language.py
+++ b/mlx_vlm/models/olmo3/language.py
@@ -1,0 +1,232 @@
+from typing import Any, Optional
+
+import mlx.core as mx
+import mlx.nn as nn
+
+from ..activations import swiglu
+from ..base import (
+    LanguageModelOutput,
+    create_attention_mask,
+    scaled_dot_product_attention,
+)
+from ..cache import KVCache, RotatingKVCache
+from ..rope_utils import initialize_rope
+from .config import ModelConfig
+
+
+class Olmo3Attention(nn.Module):
+    def __init__(self, args: ModelConfig, layer_idx: int):
+        super().__init__()
+        self.num_attention_heads = args.num_attention_heads
+        self.num_key_value_heads = args.num_key_value_heads
+        self.layer_idx = layer_idx
+
+        self.head_dim = args.head_dim or args.hidden_size // args.num_attention_heads
+        self.scale = self.head_dim**-0.5
+
+        self.q_proj = nn.Linear(
+            args.hidden_size,
+            args.num_attention_heads * self.head_dim,
+            bias=args.attention_bias,
+        )
+        self.k_proj = nn.Linear(
+            args.hidden_size,
+            args.num_key_value_heads * self.head_dim,
+            bias=args.attention_bias,
+        )
+        self.v_proj = nn.Linear(
+            args.hidden_size,
+            args.num_key_value_heads * self.head_dim,
+            bias=args.attention_bias,
+        )
+        self.o_proj = nn.Linear(
+            args.num_attention_heads * self.head_dim,
+            args.hidden_size,
+            bias=args.attention_bias,
+        )
+
+        self.q_norm = nn.RMSNorm(
+            args.num_attention_heads * self.head_dim, eps=args.rms_norm_eps
+        )
+        self.k_norm = nn.RMSNorm(
+            args.num_key_value_heads * self.head_dim, eps=args.rms_norm_eps
+        )
+
+        if args.layer_types[layer_idx] != "full_attention":
+            self.rope = nn.RoPE(self.head_dim, traditional=False, base=args.rope_theta)
+        else:
+            self.rope = initialize_rope(
+                self.head_dim,
+                traditional=False,
+                base=args.rope_theta,
+                scaling_config=args.rope_scaling,
+                max_position_embeddings=args.max_position_embeddings,
+            )
+
+    def __call__(
+        self,
+        x: mx.array,
+        mask: Optional[mx.array] = None,
+        cache: Optional[Any] = None,
+    ) -> mx.array:
+        B, L, _ = x.shape
+        queries = self.q_norm(self.q_proj(x))
+        keys = self.k_norm(self.k_proj(x))
+        values = self.v_proj(x)
+
+        queries = queries.reshape(B, L, self.num_attention_heads, -1).transpose(
+            0, 2, 1, 3
+        )
+        keys = keys.reshape(B, L, self.num_key_value_heads, -1).transpose(0, 2, 1, 3)
+        values = values.reshape(B, L, self.num_key_value_heads, -1).transpose(
+            0, 2, 1, 3
+        )
+
+        if cache is not None:
+            queries = self.rope(queries, offset=cache.offset)
+            keys = self.rope(keys, offset=cache.offset)
+            keys, values = cache.update_and_fetch(keys, values)
+        else:
+            queries = self.rope(queries)
+            keys = self.rope(keys)
+
+        output = scaled_dot_product_attention(
+            queries, keys, values, cache=cache, scale=self.scale, mask=mask
+        )
+        output = output.transpose(0, 2, 1, 3).reshape(B, L, -1)
+        return self.o_proj(output)
+
+
+class Olmo3MLP(nn.Module):
+    def __init__(self, args: ModelConfig):
+        super().__init__()
+        self.gate_proj = nn.Linear(args.hidden_size, args.intermediate_size, bias=False)
+        self.down_proj = nn.Linear(args.intermediate_size, args.hidden_size, bias=False)
+        self.up_proj = nn.Linear(args.hidden_size, args.intermediate_size, bias=False)
+
+    def __call__(self, x: mx.array) -> mx.array:
+        return self.down_proj(swiglu(self.gate_proj(x), self.up_proj(x)))
+
+
+class Olmo3DecoderLayer(nn.Module):
+    def __init__(self, args: ModelConfig, layer_idx: int):
+        super().__init__()
+        self.num_attention_heads = args.num_attention_heads
+        self.hidden_size = args.hidden_size
+        self.self_attn = Olmo3Attention(args, layer_idx=layer_idx)
+        self.mlp = Olmo3MLP(args)
+        self.post_attention_layernorm = nn.RMSNorm(
+            args.hidden_size, eps=args.rms_norm_eps
+        )
+        self.post_feedforward_layernorm = nn.RMSNorm(
+            args.hidden_size, eps=args.rms_norm_eps
+        )
+        self.args = args
+
+    def __call__(
+        self,
+        x: mx.array,
+        mask: Optional[mx.array] = None,
+        cache: Optional[Any] = None,
+    ) -> mx.array:
+        r = self.post_attention_layernorm(self.self_attn(x, mask, cache))
+        h = x + r
+        r = self.post_feedforward_layernorm(self.mlp(h))
+        out = h + r
+        return out
+
+
+class Olmo3Model(nn.Module):
+    def __init__(self, args: ModelConfig):
+        super().__init__()
+        self.sliding_window = args.sliding_window
+
+        self.embed_tokens = nn.Embedding(args.vocab_size, args.hidden_size)
+        self.layers = [
+            Olmo3DecoderLayer(args=args, layer_idx=i)
+            for i in range(args.num_hidden_layers)
+        ]
+        self.norm = nn.RMSNorm(args.hidden_size, eps=args.rms_norm_eps)
+
+        self.swa_idx = args.layer_types.index("sliding_attention")
+        self.ga_idx = args.layer_types.index("full_attention")
+        self.layer_types = args.layer_types
+
+    def __call__(self, inputs, cache=None, input_embeddings=None):
+        h = (
+            input_embeddings
+            if input_embeddings is not None
+            else self.embed_tokens(inputs)
+        )
+
+        if cache is None:
+            cache = [None] * len(self.layers)
+
+        full_mask = create_attention_mask(h, cache[self.ga_idx])
+        sliding_window_mask = create_attention_mask(
+            h, cache[self.swa_idx], window_size=self.sliding_window
+        )
+
+        for layer, c, layer_type in zip(self.layers, cache, self.layer_types):
+            mask = full_mask if layer_type == "full_attention" else sliding_window_mask
+            h = layer(h, mask, cache=c)
+
+        return self.norm(h)
+
+
+class LanguageModel(nn.Module):
+    def __init__(self, args: ModelConfig):
+        super().__init__()
+        self.args = args
+        self.config = args
+        self.model_type = args.model_type
+        self.model = Olmo3Model(args)
+        if not args.tie_word_embeddings:
+            self.lm_head = nn.Linear(args.hidden_size, args.vocab_size, bias=False)
+
+    def __call__(
+        self,
+        inputs: Optional[mx.array] = None,
+        cache=None,
+        input_embeddings: Optional[mx.array] = None,
+        inputs_embeds: Optional[mx.array] = None,
+        **kwargs,
+    ) -> LanguageModelOutput:
+        if inputs is None:
+            inputs = kwargs.get("input_ids")
+        if inputs_embeds is None:
+            inputs_embeds = input_embeddings
+        out = self.model(inputs, cache, inputs_embeds)
+        if self.args.tie_word_embeddings:
+            out = self.model.embed_tokens.as_linear(out)
+        else:
+            out = self.lm_head(out)
+        return LanguageModelOutput(logits=out)
+
+    def sanitize(self, weights):
+        if self.args.tie_word_embeddings:
+            weights.pop("lm_head.weight", None)
+        return weights
+
+    def make_cache(self):
+        caches = []
+        for lt in self.model.layer_types:
+            if lt == "full_attention":
+                caches.append(KVCache())
+            else:
+                caches.append(RotatingKVCache(max_size=self.args.sliding_window))
+        return caches
+
+    @property
+    def layers(self):
+        return self.model.layers
+
+    @property
+    def head_dim(self):
+        return self.args.head_dim or (
+            self.args.hidden_size // self.args.num_attention_heads
+        )
+
+    @property
+    def n_kv_heads(self):
+        return self.args.num_key_value_heads

--- a/mlx_vlm/models/olmo3/language.py
+++ b/mlx_vlm/models/olmo3/language.py
@@ -3,13 +3,13 @@ from typing import Any, Optional
 import mlx.core as mx
 import mlx.nn as nn
 
-from ..activations import swiglu
 from ..base import (
     LanguageModelOutput,
     create_attention_mask,
     scaled_dot_product_attention,
 )
 from ..cache import KVCache, RotatingKVCache
+from ..mlp import SwiGLUMLP
 from ..rope_utils import initialize_rope
 from .config import ModelConfig
 
@@ -97,24 +97,13 @@ class Olmo3Attention(nn.Module):
         return self.o_proj(output)
 
 
-class Olmo3MLP(nn.Module):
-    def __init__(self, args: ModelConfig):
-        super().__init__()
-        self.gate_proj = nn.Linear(args.hidden_size, args.intermediate_size, bias=False)
-        self.down_proj = nn.Linear(args.intermediate_size, args.hidden_size, bias=False)
-        self.up_proj = nn.Linear(args.hidden_size, args.intermediate_size, bias=False)
-
-    def __call__(self, x: mx.array) -> mx.array:
-        return self.down_proj(swiglu(self.gate_proj(x), self.up_proj(x)))
-
-
 class Olmo3DecoderLayer(nn.Module):
     def __init__(self, args: ModelConfig, layer_idx: int):
         super().__init__()
         self.num_attention_heads = args.num_attention_heads
         self.hidden_size = args.hidden_size
         self.self_attn = Olmo3Attention(args, layer_idx=layer_idx)
-        self.mlp = Olmo3MLP(args)
+        self.mlp = SwiGLUMLP(args.hidden_size, args.intermediate_size)
         self.post_attention_layernorm = nn.RMSNorm(
             args.hidden_size, eps=args.rms_norm_eps
         )

--- a/mlx_vlm/models/olmo3/olmo3.py
+++ b/mlx_vlm/models/olmo3/olmo3.py
@@ -1,0 +1,46 @@
+from typing import Optional
+
+import mlx.core as mx
+import mlx.nn as nn
+
+from ..base import InputEmbeddingsFeatures, LanguageModelOutput
+from .config import ModelConfig
+from .language import LanguageModel
+
+
+class Model(nn.Module):
+    def __init__(self, config: ModelConfig):
+        super().__init__()
+        self.config = config
+        self.model_type = config.model_type
+        self.language_model = LanguageModel(config)
+
+    def get_input_embeddings(
+        self,
+        input_ids: Optional[mx.array] = None,
+        pixel_values: Optional[mx.array] = None,
+        **kwargs,
+    ) -> InputEmbeddingsFeatures:
+        return InputEmbeddingsFeatures(
+            inputs_embeds=self.language_model.model.embed_tokens(input_ids)
+        )
+
+    def __call__(
+        self,
+        input_ids: mx.array,
+        pixel_values: mx.array = None,
+        mask: mx.array = None,
+        cache=None,
+        **kwargs,
+    ) -> LanguageModelOutput:
+        return self.language_model(input_ids, cache=cache, **kwargs)
+
+    def sanitize(self, weights):
+        if any(k.startswith("language_model.") for k in weights):
+            return weights
+        weights = self.language_model.sanitize(weights)
+        return {f"language_model.{k}": v for k, v in weights.items()}
+
+    @property
+    def layers(self):
+        return self.language_model.layers

--- a/mlx_vlm/models/openelm/__init__.py
+++ b/mlx_vlm/models/openelm/__init__.py
@@ -1,0 +1,4 @@
+from .config import ModelConfig
+from .openelm import Model
+
+__all__ = ["Model", "ModelConfig"]

--- a/mlx_vlm/models/openelm/config.py
+++ b/mlx_vlm/models/openelm/config.py
@@ -1,0 +1,22 @@
+from dataclasses import dataclass
+from typing import List
+
+from ..base import BaseModelConfig
+
+
+@dataclass
+class ModelConfig(BaseModelConfig):
+    model_type: str
+    head_dim: int
+    num_transformer_layers: int
+    model_dim: int
+    vocab_size: int
+    ffn_dim_divisor: int
+    num_query_heads: List
+    num_kv_heads: List
+    ffn_multipliers: List
+    ffn_with_glu: bool = True
+    normalize_qk_projections: bool = True
+    share_input_output_layers: bool = True
+    rms_norm_eps: float = 1e-6
+    rope_freq_constant: float = 10000

--- a/mlx_vlm/models/openelm/language.py
+++ b/mlx_vlm/models/openelm/language.py
@@ -1,0 +1,210 @@
+from typing import Any, Optional, Union
+
+import mlx.core as mx
+import mlx.nn as nn
+
+from ..activations import swiglu
+from ..base import (
+    LanguageModelOutput,
+    create_attention_mask,
+    scaled_dot_product_attention,
+)
+from ..cache import KVCache
+from .config import ModelConfig
+
+
+def make_divisible(
+    v: Union[float, int],
+    divisor: Optional[int] = 8,
+    min_value: Optional[Union[float, int]] = None,
+) -> Union[float, int]:
+    if min_value is None:
+        min_value = divisor
+    new_v = max(min_value, int(v + divisor / 2) // divisor * divisor)
+    if new_v < 0.9 * v:
+        new_v += divisor
+    return new_v
+
+
+class Attention(nn.Module):
+    def __init__(self, args: ModelConfig, layer_id: int):
+        super().__init__()
+        self.head_dim = head_dim = args.head_dim
+        self.layer_id = layer_id
+        self.model_dim = model_dim = args.model_dim
+
+        self.n_heads = n_heads = args.num_query_heads[layer_id]
+        self.n_kv_heads = n_kv_heads = args.num_kv_heads[layer_id]
+        self.scale = head_dim**-0.5
+
+        op_size = (n_heads + (n_kv_heads * 2)) * head_dim
+        self.qkv_proj = nn.Linear(model_dim, op_size, bias=False)
+        self.out_proj = nn.Linear(n_heads * head_dim, model_dim, bias=False)
+
+        self.normalize_qk_projections = args.normalize_qk_projections
+
+        if self.normalize_qk_projections:
+            self.q_norm = nn.RMSNorm(head_dim, eps=args.rms_norm_eps)
+            self.k_norm = nn.RMSNorm(head_dim, eps=args.rms_norm_eps)
+
+        self.rope = nn.RoPE(head_dim, traditional=False, base=args.rope_freq_constant)
+
+    def __call__(
+        self,
+        x: mx.array,
+        mask: Optional[mx.array] = None,
+        cache: Optional[Any] = None,
+    ) -> mx.array:
+        B, L, D = x.shape
+
+        qkv = self.qkv_proj(x)
+
+        qkv = qkv.reshape(
+            B, L, self.n_heads + (self.n_kv_heads * 2), self.head_dim
+        ).transpose(0, 2, 1, 3)
+
+        queries, keys, values = mx.split(
+            qkv, [self.n_heads, self.n_heads + self.n_kv_heads], axis=1
+        )
+
+        if self.normalize_qk_projections:
+            queries = self.q_norm(queries)
+            keys = self.k_norm(keys)
+
+        if cache is not None:
+            queries = self.rope(queries, offset=cache.offset)
+            keys = self.rope(keys, offset=cache.offset)
+            keys, values = cache.update_and_fetch(keys, values)
+        else:
+            queries = self.rope(queries)
+            keys = self.rope(keys)
+
+        output = scaled_dot_product_attention(
+            queries, keys, values, cache=cache, scale=self.scale, mask=mask
+        )
+
+        output = output.transpose(0, 2, 1, 3).reshape(B, L, -1)
+
+        return self.out_proj(output)
+
+
+class MLP(nn.Module):
+    def __init__(self, args: ModelConfig, layer_id: int):
+        super().__init__()
+        self.args = args
+        dim = args.model_dim
+        ffn_multiplier = args.ffn_multipliers[layer_id]
+
+        intermediate_dim = int(
+            make_divisible(
+                ffn_multiplier * args.model_dim,
+                divisor=args.ffn_dim_divisor,
+            )
+        )
+
+        self.proj_1 = nn.Linear(dim, 2 * intermediate_dim, bias=False)
+        self.proj_2 = nn.Linear(intermediate_dim, dim, bias=False)
+
+    def __call__(self, x) -> mx.array:
+        x = self.proj_1(x)
+        gate, x = mx.split(x, 2, axis=-1)
+        return self.proj_2(swiglu(gate, x))
+
+
+class TransformerBlock(nn.Module):
+    def __init__(self, args: ModelConfig, layer_id: int):
+        super().__init__()
+        dim = args.model_dim
+        self.attn = Attention(args, layer_id=layer_id)
+        self.ffn = MLP(args, layer_id=layer_id)
+        self.ffn_norm = nn.RMSNorm(dim, eps=args.rms_norm_eps)
+        self.attn_norm = nn.RMSNorm(dim, eps=args.rms_norm_eps)
+
+    def __call__(
+        self,
+        x: mx.array,
+        mask: Optional[mx.array] = None,
+        cache: Optional[Any] = None,
+    ) -> mx.array:
+        r = self.attn(self.attn_norm(x), mask, cache)
+        h = x + r
+        r = self.ffn(self.ffn_norm(h))
+        out = h + r
+        return out
+
+
+class OpenELMModel(nn.Module):
+    def __init__(self, args: ModelConfig):
+        super().__init__()
+        self.args = args
+        self.vocab_size = args.vocab_size
+        self.num_transformer_layers = args.num_transformer_layers
+        assert self.vocab_size > 0
+        self.token_embeddings = nn.Embedding(args.vocab_size, args.model_dim)
+        self.layers = [
+            TransformerBlock(args, layer_id=layer_id)
+            for layer_id in range(self.num_transformer_layers)
+        ]
+        self.norm = nn.RMSNorm(args.model_dim, eps=args.rms_norm_eps)
+
+    def __call__(self, inputs, cache=None, input_embeddings=None):
+        h = (
+            input_embeddings
+            if input_embeddings is not None
+            else self.token_embeddings(inputs)
+        )
+
+        if cache is None:
+            cache = [None] * len(self.layers)
+
+        mask = create_attention_mask(h, cache[0])
+        for layer, c in zip(self.layers, cache):
+            h = layer(h, mask, cache=c)
+
+        return self.norm(h)
+
+
+class LanguageModel(nn.Module):
+    def __init__(self, args: ModelConfig):
+        super().__init__()
+        self.args = args
+        self.config = args
+        self.model_type = args.model_type
+        self.transformer = OpenELMModel(args)
+        if not args.share_input_output_layers:
+            self.lm_head = nn.Linear(args.model_dim, args.vocab_size, bias=False)
+
+    def __call__(
+        self,
+        inputs: Optional[mx.array] = None,
+        cache=None,
+        input_embeddings: Optional[mx.array] = None,
+        inputs_embeds: Optional[mx.array] = None,
+        **kwargs,
+    ) -> LanguageModelOutput:
+        if inputs is None:
+            inputs = kwargs.get("input_ids")
+        if inputs_embeds is None:
+            inputs_embeds = input_embeddings
+        out = self.transformer(inputs, cache, inputs_embeds)
+        if self.args.share_input_output_layers:
+            out = self.transformer.token_embeddings.as_linear(out)
+        else:
+            out = self.lm_head(out)
+        return LanguageModelOutput(logits=out)
+
+    def sanitize(self, weights):
+        if self.args.share_input_output_layers:
+            weights.pop("lm_head.weight", None)
+        return weights
+
+    def make_cache(self):
+        return [KVCache() for _ in self.transformer.layers]
+
+    @property
+    def layers(self):
+        return self.transformer.layers
+
+    @property
+    def head_dim(self):
+        return self.args.head_dim

--- a/mlx_vlm/models/openelm/openelm.py
+++ b/mlx_vlm/models/openelm/openelm.py
@@ -1,0 +1,46 @@
+from typing import Optional
+
+import mlx.core as mx
+import mlx.nn as nn
+
+from ..base import InputEmbeddingsFeatures, LanguageModelOutput
+from .config import ModelConfig
+from .language import LanguageModel
+
+
+class Model(nn.Module):
+    def __init__(self, config: ModelConfig):
+        super().__init__()
+        self.config = config
+        self.model_type = config.model_type
+        self.language_model = LanguageModel(config)
+
+    def get_input_embeddings(
+        self,
+        input_ids: Optional[mx.array] = None,
+        pixel_values: Optional[mx.array] = None,
+        **kwargs,
+    ) -> InputEmbeddingsFeatures:
+        return InputEmbeddingsFeatures(
+            inputs_embeds=self.language_model.transformer.token_embeddings(input_ids)
+        )
+
+    def __call__(
+        self,
+        input_ids: mx.array,
+        pixel_values: mx.array = None,
+        mask: mx.array = None,
+        cache=None,
+        **kwargs,
+    ) -> LanguageModelOutput:
+        return self.language_model(input_ids, cache=cache, **kwargs)
+
+    def sanitize(self, weights):
+        if any(k.startswith("language_model.") for k in weights):
+            return weights
+        weights = self.language_model.sanitize(weights)
+        return {f"language_model.{k}": v for k, v in weights.items()}
+
+    @property
+    def layers(self):
+        return self.language_model.layers

--- a/mlx_vlm/models/seed_oss/__init__.py
+++ b/mlx_vlm/models/seed_oss/__init__.py
@@ -1,0 +1,4 @@
+from .config import ModelConfig
+from .seed_oss import Model
+
+__all__ = ["Model", "ModelConfig"]

--- a/mlx_vlm/models/seed_oss/config.py
+++ b/mlx_vlm/models/seed_oss/config.py
@@ -1,0 +1,25 @@
+from dataclasses import dataclass
+from typing import Dict, Optional, Union
+
+from ..base import BaseModelConfig
+
+
+@dataclass
+class ModelConfig(BaseModelConfig):
+    model_type: str
+    hidden_size: int
+    num_hidden_layers: int
+    intermediate_size: int
+    num_attention_heads: int
+    rms_norm_eps: float
+    vocab_size: int
+    num_key_value_heads: int
+    head_dim: int
+    max_position_embeddings: Optional[int] = None
+    attention_bias: bool = False
+    attention_out_bias: bool = False
+    mlp_bias: bool = False
+    rope_theta: float = 10000
+    rope_traditional: bool = False
+    rope_scaling: Optional[Dict[str, Union[float, str]]] = None
+    tie_word_embeddings: bool = True

--- a/mlx_vlm/models/seed_oss/language.py
+++ b/mlx_vlm/models/seed_oss/language.py
@@ -1,0 +1,171 @@
+from typing import Any, Optional
+
+import mlx.core as mx
+import mlx.nn as nn
+
+from ..activations import swiglu
+from ..base import (
+    LanguageModelOutput,
+    create_attention_mask,
+    scaled_dot_product_attention,
+)
+from ..cache import KVCache
+from ..rope_utils import initialize_rope
+from .config import ModelConfig
+
+
+class Attention(nn.Module):
+    def __init__(self, args: ModelConfig):
+        super().__init__()
+        dim = args.hidden_size
+        self.n_heads = n_heads = args.num_attention_heads
+        self.n_kv_heads = n_kv_heads = args.num_key_value_heads
+        self.head_dim = head_dim = args.head_dim
+        self.scale = head_dim**-0.5
+
+        input_bias = args.attention_bias
+        output_bias = args.attention_out_bias
+
+        self.q_proj = nn.Linear(dim, n_heads * head_dim, bias=input_bias)
+        self.k_proj = nn.Linear(dim, n_kv_heads * head_dim, bias=input_bias)
+        self.v_proj = nn.Linear(dim, n_kv_heads * head_dim, bias=input_bias)
+        self.o_proj = nn.Linear(n_heads * head_dim, dim, bias=output_bias)
+
+        self.rope = initialize_rope(
+            self.head_dim,
+            args.rope_theta,
+            args.rope_traditional,
+            args.rope_scaling,
+            args.max_position_embeddings,
+        )
+
+    def __call__(
+        self,
+        x: mx.array,
+        mask: Optional[mx.array] = None,
+        cache: Optional[Any] = None,
+    ) -> mx.array:
+        B, L, D = x.shape
+        queries, keys, values = self.q_proj(x), self.k_proj(x), self.v_proj(x)
+        queries = queries.reshape(B, L, self.n_heads, -1).transpose(0, 2, 1, 3)
+        keys = keys.reshape(B, L, self.n_kv_heads, -1).transpose(0, 2, 1, 3)
+        values = values.reshape(B, L, self.n_kv_heads, -1).transpose(0, 2, 1, 3)
+
+        if cache is not None:
+            queries = self.rope(queries, offset=cache.offset)
+            keys = self.rope(keys, offset=cache.offset)
+            keys, values = cache.update_and_fetch(keys, values)
+        else:
+            queries = self.rope(queries)
+            keys = self.rope(keys)
+
+        output = scaled_dot_product_attention(
+            queries, keys, values, cache=cache, scale=self.scale, mask=mask
+        )
+        output = output.transpose(0, 2, 1, 3).reshape(B, L, -1)
+        return self.o_proj(output)
+
+
+class MLP(nn.Module):
+    def __init__(self, dim, hidden_dim, bias=False):
+        super().__init__()
+        self.gate_proj = nn.Linear(dim, hidden_dim, bias=bias)
+        self.down_proj = nn.Linear(hidden_dim, dim, bias=bias)
+        self.up_proj = nn.Linear(dim, hidden_dim, bias=bias)
+
+    def __call__(self, x) -> mx.array:
+        return self.down_proj(swiglu(self.gate_proj(x), self.up_proj(x)))
+
+
+class TransformerBlock(nn.Module):
+    def __init__(self, args: ModelConfig):
+        super().__init__()
+        self.self_attn = Attention(args)
+        self.mlp = MLP(args.hidden_size, args.intermediate_size, args.mlp_bias)
+        self.input_layernorm = nn.RMSNorm(args.hidden_size, eps=args.rms_norm_eps)
+        self.post_attention_layernorm = nn.RMSNorm(
+            args.hidden_size, eps=args.rms_norm_eps
+        )
+
+    def __call__(
+        self,
+        x: mx.array,
+        mask: Optional[mx.array] = None,
+        cache: Optional[Any] = None,
+    ) -> mx.array:
+        r = self.self_attn(self.input_layernorm(x), mask, cache)
+        h = x + r
+        r = self.mlp(self.post_attention_layernorm(h))
+        return h + r
+
+
+class SeedModel(nn.Module):
+    def __init__(self, args: ModelConfig):
+        super().__init__()
+        self.embed_tokens = nn.Embedding(args.vocab_size, args.hidden_size)
+        self.layers = [TransformerBlock(args) for _ in range(args.num_hidden_layers)]
+        self.norm = nn.RMSNorm(args.hidden_size, eps=args.rms_norm_eps)
+
+    def __call__(self, inputs, cache=None, input_embeddings=None):
+        h = (
+            input_embeddings
+            if input_embeddings is not None
+            else self.embed_tokens(inputs)
+        )
+        if cache is None:
+            cache = [None] * len(self.layers)
+        mask = create_attention_mask(h, cache[0])
+        for layer, c in zip(self.layers, cache):
+            h = layer(h, mask, cache=c)
+        return self.norm(h)
+
+
+class LanguageModel(nn.Module):
+    def __init__(self, args: ModelConfig):
+        super().__init__()
+        self.args = args
+        self.config = args
+        self.model_type = args.model_type
+        self.model = SeedModel(args)
+        self.tie_word_embeddings = args.tie_word_embeddings
+        if not args.tie_word_embeddings:
+            self.lm_head = nn.Linear(args.hidden_size, args.vocab_size, bias=False)
+
+    def __call__(
+        self,
+        inputs: Optional[mx.array] = None,
+        cache=None,
+        input_embeddings: Optional[mx.array] = None,
+        inputs_embeds: Optional[mx.array] = None,
+        **kwargs,
+    ) -> LanguageModelOutput:
+        if inputs is None:
+            inputs = kwargs.get("input_ids")
+        if inputs_embeds is None:
+            inputs_embeds = input_embeddings
+        h = self.model(inputs, cache, inputs_embeds)
+        if self.tie_word_embeddings:
+            out = self.model.embed_tokens.as_linear(h)
+        else:
+            out = self.lm_head(h)
+        return LanguageModelOutput(logits=out)
+
+    def sanitize(self, weights):
+        if self.tie_word_embeddings:
+            weights.pop("lm_head.weight", None)
+        return weights
+
+    def make_cache(self):
+        return [KVCache() for _ in self.model.layers]
+
+    @property
+    def layers(self):
+        return self.model.layers
+
+    @property
+    def head_dim(self):
+        return self.args.head_dim
+
+    @property
+    def n_kv_heads(self):
+        return self.args.num_key_value_heads

--- a/mlx_vlm/models/seed_oss/language.py
+++ b/mlx_vlm/models/seed_oss/language.py
@@ -3,13 +3,13 @@ from typing import Any, Optional
 import mlx.core as mx
 import mlx.nn as nn
 
-from ..activations import swiglu
 from ..base import (
     LanguageModelOutput,
     create_attention_mask,
     scaled_dot_product_attention,
 )
 from ..cache import KVCache
+from ..mlp import SwiGLUMLP
 from ..rope_utils import initialize_rope
 from .config import ModelConfig
 
@@ -66,22 +66,11 @@ class Attention(nn.Module):
         return self.o_proj(output)
 
 
-class MLP(nn.Module):
-    def __init__(self, dim, hidden_dim, bias=False):
-        super().__init__()
-        self.gate_proj = nn.Linear(dim, hidden_dim, bias=bias)
-        self.down_proj = nn.Linear(hidden_dim, dim, bias=bias)
-        self.up_proj = nn.Linear(dim, hidden_dim, bias=bias)
-
-    def __call__(self, x) -> mx.array:
-        return self.down_proj(swiglu(self.gate_proj(x), self.up_proj(x)))
-
-
 class TransformerBlock(nn.Module):
     def __init__(self, args: ModelConfig):
         super().__init__()
         self.self_attn = Attention(args)
-        self.mlp = MLP(args.hidden_size, args.intermediate_size, args.mlp_bias)
+        self.mlp = SwiGLUMLP(args.hidden_size, args.intermediate_size, args.mlp_bias)
         self.input_layernorm = nn.RMSNorm(args.hidden_size, eps=args.rms_norm_eps)
         self.post_attention_layernorm = nn.RMSNorm(
             args.hidden_size, eps=args.rms_norm_eps

--- a/mlx_vlm/models/seed_oss/seed_oss.py
+++ b/mlx_vlm/models/seed_oss/seed_oss.py
@@ -1,0 +1,46 @@
+from typing import Optional
+
+import mlx.core as mx
+import mlx.nn as nn
+
+from ..base import InputEmbeddingsFeatures, LanguageModelOutput
+from .config import ModelConfig
+from .language import LanguageModel
+
+
+class Model(nn.Module):
+    def __init__(self, config: ModelConfig):
+        super().__init__()
+        self.config = config
+        self.model_type = config.model_type
+        self.language_model = LanguageModel(config)
+
+    def get_input_embeddings(
+        self,
+        input_ids: Optional[mx.array] = None,
+        pixel_values: Optional[mx.array] = None,
+        **kwargs,
+    ) -> InputEmbeddingsFeatures:
+        return InputEmbeddingsFeatures(
+            inputs_embeds=self.language_model.model.embed_tokens(input_ids)
+        )
+
+    def __call__(
+        self,
+        input_ids: mx.array,
+        pixel_values: mx.array = None,
+        mask: mx.array = None,
+        cache=None,
+        **kwargs,
+    ) -> LanguageModelOutput:
+        return self.language_model(input_ids, cache=cache, **kwargs)
+
+    def sanitize(self, weights):
+        if any(k.startswith("language_model.") for k in weights):
+            return weights
+        weights = self.language_model.sanitize(weights)
+        return {f"language_model.{k}": v for k, v in weights.items()}
+
+    @property
+    def layers(self):
+        return self.language_model.layers

--- a/mlx_vlm/models/solar_open/__init__.py
+++ b/mlx_vlm/models/solar_open/__init__.py
@@ -1,0 +1,4 @@
+from .config import ModelConfig
+from .solar_open import Model
+
+__all__ = ["Model", "ModelConfig"]

--- a/mlx_vlm/models/solar_open/config.py
+++ b/mlx_vlm/models/solar_open/config.py
@@ -1,0 +1,35 @@
+from dataclasses import dataclass
+from typing import Dict, Optional
+
+from ..base import BaseModelConfig
+
+
+@dataclass
+class ModelConfig(BaseModelConfig):
+    model_type: str
+    vocab_size: int
+    hidden_size: int
+    intermediate_size: int
+    moe_intermediate_size: int
+    num_hidden_layers: int
+    num_attention_heads: int
+    num_key_value_heads: int
+    head_dim: int
+    n_shared_experts: int
+    n_routed_experts: int
+    routed_scaling_factor: float
+    num_experts_per_tok: int
+    first_k_dense_replace: int
+    norm_topk_prob: bool
+    max_position_embeddings: int
+    rms_norm_eps: float
+    rope_theta: float
+    tie_word_embeddings: bool
+    partial_rotary_factor: float
+    rope_scaling: Optional[Dict] = None
+    attention_bias: bool = False
+    use_qk_norm: bool = False
+    n_group: int = 1
+    topk_group: int = 1
+    scoring_func: str = "sigmoid"
+    topk_method: str = "noaux_tc"

--- a/mlx_vlm/models/solar_open/solar_open.py
+++ b/mlx_vlm/models/solar_open/solar_open.py
@@ -1,0 +1,5 @@
+"""SOLAR-open reuses the GLM-4 MoE model implementation."""
+
+from ..glm4_moe.glm4_moe import Model
+
+__all__ = ["Model"]

--- a/mlx_vlm/models/telechat3/__init__.py
+++ b/mlx_vlm/models/telechat3/__init__.py
@@ -1,0 +1,4 @@
+from .config import ModelConfig
+from .telechat3 import Model
+
+__all__ = ["Model", "ModelConfig"]

--- a/mlx_vlm/models/telechat3/config.py
+++ b/mlx_vlm/models/telechat3/config.py
@@ -1,0 +1,23 @@
+from dataclasses import dataclass
+from typing import Dict, Optional, Union
+
+from ..base import BaseModelConfig
+
+
+@dataclass
+class ModelConfig(BaseModelConfig):
+    model_type: str
+    hidden_size: int
+    intermediate_size: int
+    max_position_embeddings: int
+    num_attention_heads: int
+    num_hidden_layers: int
+    num_key_value_heads: int
+    rms_norm_eps: float
+    vocab_size: int
+    rope_theta: float
+    mlp_bias: bool = False
+    attention_bias: bool = False
+    head_dim: Optional[int] = None
+    rope_scaling: Optional[Dict[str, Union[float, str]]] = None
+    tie_word_embeddings: bool = False

--- a/mlx_vlm/models/telechat3/language.py
+++ b/mlx_vlm/models/telechat3/language.py
@@ -1,0 +1,169 @@
+from typing import Any, Optional
+
+import mlx.core as mx
+import mlx.nn as nn
+
+from ..activations import swiglu
+from ..base import (
+    LanguageModelOutput,
+    create_attention_mask,
+    scaled_dot_product_attention,
+)
+from ..cache import KVCache
+from ..rope_utils import initialize_rope
+from .config import ModelConfig
+
+
+class Attention(nn.Module):
+    def __init__(self, args: ModelConfig):
+        super().__init__()
+        dim = args.hidden_size
+        self.n_heads = n_heads = args.num_attention_heads
+        self.n_kv_heads = n_kv_heads = args.num_key_value_heads
+        self.head_dim = head_dim = args.head_dim or dim // n_heads
+        self.scale = head_dim**-0.5
+
+        self.q_proj = nn.Linear(dim, n_heads * head_dim, bias=args.attention_bias)
+        self.k_proj = nn.Linear(dim, n_kv_heads * head_dim, bias=args.attention_bias)
+        self.v_proj = nn.Linear(dim, n_kv_heads * head_dim, bias=args.attention_bias)
+        self.o_proj = nn.Linear(n_heads * head_dim, dim, bias=args.attention_bias)
+
+        self.rope = initialize_rope(
+            head_dim,
+            base=args.rope_theta,
+            traditional=False,
+            scaling_config=args.rope_scaling,
+            max_position_embeddings=args.max_position_embeddings,
+        )
+
+    def __call__(
+        self,
+        x: mx.array,
+        mask: Optional[mx.array] = None,
+        cache: Optional[Any] = None,
+    ) -> mx.array:
+        B, L, D = x.shape
+        queries, keys, values = self.q_proj(x), self.k_proj(x), self.v_proj(x)
+        queries = queries.reshape(B, L, self.n_heads, -1).transpose(0, 2, 1, 3)
+        keys = keys.reshape(B, L, self.n_kv_heads, -1).transpose(0, 2, 1, 3)
+        values = values.reshape(B, L, self.n_kv_heads, -1).transpose(0, 2, 1, 3)
+
+        if cache is not None:
+            queries = self.rope(queries, offset=cache.offset)
+            keys = self.rope(keys, offset=cache.offset)
+            keys, values = cache.update_and_fetch(keys, values)
+        else:
+            queries = self.rope(queries)
+            keys = self.rope(keys)
+
+        output = scaled_dot_product_attention(
+            queries, keys, values, cache=cache, scale=self.scale, mask=mask
+        )
+        output = output.transpose(0, 2, 1, 3).reshape(B, L, -1)
+        return self.o_proj(output)
+
+
+class MLP(nn.Module):
+    def __init__(self, dim, hidden_dim, mlp_bias=False):
+        super().__init__()
+        self.gate_proj = nn.Linear(dim, hidden_dim, bias=mlp_bias)
+        self.down_proj = nn.Linear(hidden_dim, dim, bias=mlp_bias)
+        self.up_proj = nn.Linear(dim, hidden_dim, bias=mlp_bias)
+
+    def __call__(self, x) -> mx.array:
+        return self.down_proj(swiglu(self.gate_proj(x), self.up_proj(x)))
+
+
+class DecoderLayer(nn.Module):
+    def __init__(self, args: ModelConfig):
+        super().__init__()
+        self.self_attn = Attention(args)
+        self.mlp = MLP(args.hidden_size, args.intermediate_size, args.mlp_bias)
+        self.input_layernorm = nn.RMSNorm(args.hidden_size, eps=args.rms_norm_eps)
+        self.post_attention_layernorm = nn.RMSNorm(
+            args.hidden_size, eps=args.rms_norm_eps
+        )
+
+    def __call__(
+        self,
+        x: mx.array,
+        mask: Optional[mx.array] = None,
+        cache: Optional[Any] = None,
+    ) -> mx.array:
+        r = self.self_attn(self.input_layernorm(x), mask, cache)
+        h = x + r
+        r = self.mlp(self.post_attention_layernorm(h))
+        return h + r
+
+
+class Telechat3Model(nn.Module):
+    def __init__(self, args: ModelConfig):
+        super().__init__()
+        self.embed_tokens = nn.Embedding(args.vocab_size, args.hidden_size)
+        self.layers = [DecoderLayer(args) for _ in range(args.num_hidden_layers)]
+        self.norm = nn.RMSNorm(args.hidden_size, eps=args.rms_norm_eps)
+
+    def __call__(self, inputs, cache=None, input_embeddings=None):
+        h = (
+            input_embeddings
+            if input_embeddings is not None
+            else self.embed_tokens(inputs)
+        )
+        if cache is None:
+            cache = [None] * len(self.layers)
+        mask = create_attention_mask(h, cache[0])
+        for layer, c in zip(self.layers, cache):
+            h = layer(h, mask, c)
+        return self.norm(h)
+
+
+class LanguageModel(nn.Module):
+    def __init__(self, args: ModelConfig):
+        super().__init__()
+        self.args = args
+        self.config = args
+        self.model_type = args.model_type
+        self.model = Telechat3Model(args)
+        if not args.tie_word_embeddings:
+            self.lm_head = nn.Linear(args.hidden_size, args.vocab_size, bias=False)
+
+    def __call__(
+        self,
+        inputs: Optional[mx.array] = None,
+        cache=None,
+        input_embeddings: Optional[mx.array] = None,
+        inputs_embeds: Optional[mx.array] = None,
+        **kwargs,
+    ) -> LanguageModelOutput:
+        if inputs is None:
+            inputs = kwargs.get("input_ids")
+        if inputs_embeds is None:
+            inputs_embeds = input_embeddings
+        out = self.model(inputs, cache, inputs_embeds)
+        if self.args.tie_word_embeddings:
+            out = self.model.embed_tokens.as_linear(out)
+        else:
+            out = self.lm_head(out)
+        return LanguageModelOutput(logits=out)
+
+    def sanitize(self, weights):
+        if self.args.tie_word_embeddings:
+            weights.pop("lm_head.weight", None)
+        return weights
+
+    def make_cache(self):
+        return [KVCache() for _ in self.model.layers]
+
+    @property
+    def layers(self):
+        return self.model.layers
+
+    @property
+    def head_dim(self):
+        return (
+            self.args.head_dim or self.args.hidden_size // self.args.num_attention_heads
+        )
+
+    @property
+    def n_kv_heads(self):
+        return self.args.num_key_value_heads

--- a/mlx_vlm/models/telechat3/language.py
+++ b/mlx_vlm/models/telechat3/language.py
@@ -3,13 +3,13 @@ from typing import Any, Optional
 import mlx.core as mx
 import mlx.nn as nn
 
-from ..activations import swiglu
 from ..base import (
     LanguageModelOutput,
     create_attention_mask,
     scaled_dot_product_attention,
 )
 from ..cache import KVCache
+from ..mlp import SwiGLUMLP
 from ..rope_utils import initialize_rope
 from .config import ModelConfig
 
@@ -63,22 +63,11 @@ class Attention(nn.Module):
         return self.o_proj(output)
 
 
-class MLP(nn.Module):
-    def __init__(self, dim, hidden_dim, mlp_bias=False):
-        super().__init__()
-        self.gate_proj = nn.Linear(dim, hidden_dim, bias=mlp_bias)
-        self.down_proj = nn.Linear(hidden_dim, dim, bias=mlp_bias)
-        self.up_proj = nn.Linear(dim, hidden_dim, bias=mlp_bias)
-
-    def __call__(self, x) -> mx.array:
-        return self.down_proj(swiglu(self.gate_proj(x), self.up_proj(x)))
-
-
 class DecoderLayer(nn.Module):
     def __init__(self, args: ModelConfig):
         super().__init__()
         self.self_attn = Attention(args)
-        self.mlp = MLP(args.hidden_size, args.intermediate_size, args.mlp_bias)
+        self.mlp = SwiGLUMLP(args.hidden_size, args.intermediate_size, args.mlp_bias)
         self.input_layernorm = nn.RMSNorm(args.hidden_size, eps=args.rms_norm_eps)
         self.post_attention_layernorm = nn.RMSNorm(
             args.hidden_size, eps=args.rms_norm_eps

--- a/mlx_vlm/models/telechat3/telechat3.py
+++ b/mlx_vlm/models/telechat3/telechat3.py
@@ -1,0 +1,46 @@
+from typing import Optional
+
+import mlx.core as mx
+import mlx.nn as nn
+
+from ..base import InputEmbeddingsFeatures, LanguageModelOutput
+from .config import ModelConfig
+from .language import LanguageModel
+
+
+class Model(nn.Module):
+    def __init__(self, config: ModelConfig):
+        super().__init__()
+        self.config = config
+        self.model_type = config.model_type
+        self.language_model = LanguageModel(config)
+
+    def get_input_embeddings(
+        self,
+        input_ids: Optional[mx.array] = None,
+        pixel_values: Optional[mx.array] = None,
+        **kwargs,
+    ) -> InputEmbeddingsFeatures:
+        return InputEmbeddingsFeatures(
+            inputs_embeds=self.language_model.model.embed_tokens(input_ids)
+        )
+
+    def __call__(
+        self,
+        input_ids: mx.array,
+        pixel_values: mx.array = None,
+        mask: mx.array = None,
+        cache=None,
+        **kwargs,
+    ) -> LanguageModelOutput:
+        return self.language_model(input_ids, cache=cache, **kwargs)
+
+    def sanitize(self, weights):
+        if any(k.startswith("language_model.") for k in weights):
+            return weights
+        weights = self.language_model.sanitize(weights)
+        return {f"language_model.{k}": v for k, v in weights.items()}
+
+    @property
+    def layers(self):
+        return self.language_model.layers

--- a/mlx_vlm/tests/test_models.py
+++ b/mlx_vlm/tests/test_models.py
@@ -10618,6 +10618,27 @@ class TestVendoredDenseModels(unittest.TestCase):
                 {"attention": {"no_op": True}, "ffn": {"ffn_mult": 2.0}},
             ],
         ),
+        "ernie4_5_moe": dict(
+            model_type="ernie4_5_moe",
+            hidden_size=64,
+            intermediate_size=128,
+            max_position_embeddings=512,
+            num_attention_heads=4,
+            num_key_value_heads=2,
+            num_hidden_layers=2,
+            rms_norm_eps=1e-5,
+            vocab_size=128,
+            rope_theta=10000.0,
+            use_bias=False,
+            tie_word_embeddings=False,
+            moe_num_experts=8,
+            moe_k=2,
+            moe_intermediate_size=32,
+            moe_num_shared_experts=1,
+            moe_layer_start_index=0,
+            moe_layer_interval=1,
+            head_dim=None,
+        ),
     }
 
     def _run(self, name):
@@ -10663,3 +10684,6 @@ class TestVendoredDenseModels(unittest.TestCase):
 
     def test_nemotron_nas(self):
         self._run("nemotron_nas")
+
+    def test_ernie4_5_moe(self):
+        self._run("ernie4_5_moe")

--- a/mlx_vlm/tests/test_models.py
+++ b/mlx_vlm/tests/test_models.py
@@ -10461,3 +10461,72 @@ class TestInklingMTP(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TestVendoredDenseModels(unittest.TestCase):
+    CFGS = {
+        "ernie4_5": dict(
+            model_type="ernie4_5",
+            hidden_size=64,
+            intermediate_size=128,
+            max_position_embeddings=512,
+            num_attention_heads=4,
+            num_key_value_heads=2,
+            head_dim=16,
+            num_hidden_layers=2,
+            rms_norm_eps=1e-5,
+            vocab_size=128,
+            rope_theta=10000.0,
+            use_bias=True,
+            tie_word_embeddings=False,
+        ),
+        "seed_oss": dict(
+            model_type="seed_oss",
+            hidden_size=64,
+            num_hidden_layers=2,
+            intermediate_size=128,
+            num_attention_heads=4,
+            rms_norm_eps=1e-5,
+            vocab_size=128,
+            num_key_value_heads=2,
+            head_dim=16,
+            max_position_embeddings=512,
+            attention_out_bias=True,
+            tie_word_embeddings=False,
+        ),
+        "mimo": dict(
+            model_type="mimo",
+            hidden_size=64,
+            num_hidden_layers=2,
+            intermediate_size=128,
+            num_attention_heads=4,
+            rms_norm_eps=1e-5,
+            vocab_size=128,
+            num_key_value_heads=2,
+            max_position_embeddings=512,
+            tie_word_embeddings=False,
+        ),
+    }
+
+    def _run(self, name):
+        import importlib
+
+        pkg = importlib.import_module(f"mlx_vlm.models.{name}")
+        model = pkg.Model(pkg.ModelConfig.from_dict(dict(self.CFGS[name])))
+        model.eval()
+        mx.eval(model.parameters())
+        ids = mx.array([[1, 5, 9, 13, 2, 7, 11, 3]])
+        vocab = self.CFGS[name]["vocab_size"]
+        self.assertEqual(model(ids).logits.shape, (1, 8, vocab))
+        cache = model.language_model.make_cache()
+        model(ids[:, :-1], cache=cache)
+        self.assertEqual(model(ids[:, -1:], cache=cache).logits.shape, (1, 1, vocab))
+
+    def test_ernie4_5(self):
+        self._run("ernie4_5")
+
+    def test_seed_oss(self):
+        self._run("seed_oss")
+
+    def test_mimo(self):
+        self._run("mimo")

--- a/mlx_vlm/tests/test_models.py
+++ b/mlx_vlm/tests/test_models.py
@@ -10506,6 +10506,118 @@ class TestVendoredDenseModels(unittest.TestCase):
             max_position_embeddings=512,
             tie_word_embeddings=False,
         ),
+        "openelm": dict(
+            model_type="openelm",
+            model_dim=64,
+            num_transformer_layers=2,
+            head_dim=16,
+            vocab_size=128,
+            ffn_dim_divisor=16,
+            num_query_heads=[4, 4],
+            num_kv_heads=[2, 2],
+            ffn_multipliers=[2.0, 2.0],
+            normalize_qk_projections=True,
+            share_input_output_layers=True,
+            rope_freq_constant=10000.0,
+            rms_norm_eps=1e-6,
+        ),
+        "olmo3": dict(
+            model_type="olmo3",
+            hidden_size=64,
+            num_hidden_layers=2,
+            intermediate_size=128,
+            num_attention_heads=4,
+            num_key_value_heads=2,
+            head_dim=16,
+            rms_norm_eps=1e-5,
+            vocab_size=128,
+            max_position_embeddings=512,
+            sliding_window=32,
+            rope_theta=10000.0,
+            layer_types=["sliding_attention", "full_attention"],
+            tie_word_embeddings=False,
+        ),
+        "apertus": dict(
+            model_type="apertus",
+            hidden_size=64,
+            num_hidden_layers=2,
+            intermediate_size=128,
+            mlp_bias=False,
+            num_attention_heads=4,
+            attention_bias=False,
+            rms_norm_eps=1e-5,
+            vocab_size=128,
+            num_key_value_heads=2,
+            max_position_embeddings=512,
+            rope_theta=10000.0,
+            post_norm=True,
+            qk_norm=True,
+            tie_word_embeddings=False,
+        ),
+        "baichuan_m1": dict(
+            model_type="baichuan_m1",
+            vocab_size=128,
+            hidden_size=64,
+            intermediate_size=128,
+            num_hidden_layers=2,
+            num_attention_heads=4,
+            num_key_value_heads=2,
+            rope_theta=10000.0,
+            sliding_window=32,
+            sliding_window_layers=[0],
+            conv_window=2,
+            rms_norm_eps=1e-5,
+            num_swa_attention_heads=4,
+            num_swa_key_value_heads=2,
+            tie_word_embeddings=False,
+        ),
+        "hunyuan_v1_dense": dict(
+            model_type="hunyuan_v1_dense",
+            vocab_size=128,
+            hidden_size=64,
+            num_hidden_layers=2,
+            intermediate_size=128,
+            num_attention_heads=4,
+            num_key_value_heads=2,
+            rms_norm_eps=1e-5,
+            rope_theta=10000.0,
+            max_position_embeddings=512,
+            attention_bias=False,
+            use_qk_norm=True,
+            head_dim=16,
+            tie_word_embeddings=False,
+        ),
+        "telechat3": dict(
+            model_type="telechat3",
+            hidden_size=64,
+            intermediate_size=128,
+            max_position_embeddings=512,
+            num_attention_heads=4,
+            num_hidden_layers=2,
+            num_key_value_heads=2,
+            rms_norm_eps=1e-5,
+            vocab_size=128,
+            rope_theta=10000.0,
+            mlp_bias=False,
+            attention_bias=False,
+            head_dim=16,
+            tie_word_embeddings=False,
+        ),
+        "nemotron_nas": dict(
+            model_type="nemotron-nas",
+            hidden_size=64,
+            num_hidden_layers=2,
+            num_attention_heads=4,
+            rms_norm_eps=1e-5,
+            vocab_size=128,
+            rope_theta=500000.0,
+            max_position_embeddings=512,
+            tie_word_embeddings=False,
+            block_configs=[
+                {"attention": {"n_heads_in_group": 2}, "ffn": {"ffn_mult": 2.0}},
+                {"attention": {"no_op": True}, "ffn": {"ffn_mult": 2.0}},
+            ],
+        ),
     }
 
     def _run(self, name):
@@ -10530,3 +10642,24 @@ class TestVendoredDenseModels(unittest.TestCase):
 
     def test_mimo(self):
         self._run("mimo")
+
+    def test_openelm(self):
+        self._run("openelm")
+
+    def test_olmo3(self):
+        self._run("olmo3")
+
+    def test_apertus(self):
+        self._run("apertus")
+
+    def test_baichuan_m1(self):
+        self._run("baichuan_m1")
+
+    def test_hunyuan_v1_dense(self):
+        self._run("hunyuan_v1_dense")
+
+    def test_telechat3(self):
+        self._run("telechat3")
+
+    def test_nemotron_nas(self):
+        self._run("nemotron_nas")

--- a/mlx_vlm/tests/test_models.py
+++ b/mlx_vlm/tests/test_models.py
@@ -10711,6 +10711,30 @@ class TestVendoredDenseModels(unittest.TestCase):
             routed_scaling_factor=2.5,
             norm_topk_prob=True,
         ),
+        "bailing_moe": dict(
+            model_type="bailing_moe",
+            hidden_size=64,
+            intermediate_size=128,
+            max_position_embeddings=512,
+            moe_intermediate_size=32,
+            num_experts=8,
+            num_shared_experts=1,
+            norm_topk_prob=True,
+            num_attention_heads=8,
+            num_experts_per_tok=2,
+            num_hidden_layers=3,
+            num_key_value_heads=4,
+            rms_norm_eps=1e-5,
+            rope_theta=10000.0,
+            vocab_size=128,
+            first_k_dense_replace=1,
+            use_qk_norm=True,
+            moe_router_enable_expert_bias=True,
+            n_group=2,
+            topk_group=1,
+            score_function="sigmoid",
+            routed_scaling_factor=2.5,
+        ),
     }
 
     def _run(self, name):
@@ -10768,3 +10792,6 @@ class TestVendoredDenseModels(unittest.TestCase):
 
     def test_exaone_moe(self):
         self._run("exaone_moe")
+
+    def test_bailing_moe(self):
+        self._run("bailing_moe")

--- a/mlx_vlm/tests/test_models.py
+++ b/mlx_vlm/tests/test_models.py
@@ -10661,6 +10661,28 @@ class TestVendoredDenseModels(unittest.TestCase):
             tie_word_embeddings=False,
             partial_rotary_factor=0.5,
         ),
+        "dots1": dict(
+            model_type="dots1",
+            hidden_size=64,
+            num_hidden_layers=3,
+            intermediate_size=128,
+            num_attention_heads=8,
+            rms_norm_eps=1e-5,
+            vocab_size=128,
+            max_position_embeddings=512,
+            num_key_value_heads=4,
+            first_k_dense_replace=1,
+            moe_intermediate_size=32,
+            n_routed_experts=8,
+            n_shared_experts=1,
+            norm_topk_prob=True,
+            num_experts_per_tok=2,
+            rope_theta=10000.0,
+            routed_scaling_factor=2.5,
+            head_dim=8,
+            n_group=1,
+            topk_group=1,
+        ),
     }
 
     def _run(self, name):
@@ -10712,3 +10734,6 @@ class TestVendoredDenseModels(unittest.TestCase):
 
     def test_solar_open(self):
         self._run("solar_open")
+
+    def test_dots1(self):
+        self._run("dots1")

--- a/mlx_vlm/tests/test_models.py
+++ b/mlx_vlm/tests/test_models.py
@@ -10639,6 +10639,28 @@ class TestVendoredDenseModels(unittest.TestCase):
             moe_layer_interval=1,
             head_dim=None,
         ),
+        "solar_open": dict(
+            model_type="solar_open",
+            vocab_size=128,
+            hidden_size=64,
+            intermediate_size=128,
+            moe_intermediate_size=32,
+            num_hidden_layers=2,
+            num_attention_heads=4,
+            num_key_value_heads=2,
+            head_dim=16,
+            n_shared_experts=1,
+            n_routed_experts=8,
+            routed_scaling_factor=2.5,
+            num_experts_per_tok=2,
+            first_k_dense_replace=1,
+            norm_topk_prob=True,
+            max_position_embeddings=512,
+            rms_norm_eps=1e-6,
+            rope_theta=10000.0,
+            tie_word_embeddings=False,
+            partial_rotary_factor=0.5,
+        ),
     }
 
     def _run(self, name):
@@ -10687,3 +10709,6 @@ class TestVendoredDenseModels(unittest.TestCase):
 
     def test_ernie4_5_moe(self):
         self._run("ernie4_5_moe")
+
+    def test_solar_open(self):
+        self._run("solar_open")

--- a/mlx_vlm/tests/test_models.py
+++ b/mlx_vlm/tests/test_models.py
@@ -10735,6 +10735,41 @@ class TestVendoredDenseModels(unittest.TestCase):
             score_function="sigmoid",
             routed_scaling_factor=2.5,
         ),
+        "mimo_v2_flash": dict(
+            model_type="mimo_v2_flash",
+            num_experts_per_tok=2,
+            hybrid_layer_pattern=[1, 0, 1, 0],
+            moe_layer_freq=[0, 1, 1, 1],
+            add_swa_attention_sink_bias=True,
+            add_full_attention_sink_bias=True,
+            sliding_window_size=4,
+            vocab_size=128,
+            hidden_size=64,
+            intermediate_size=128,
+            moe_intermediate_size=32,
+            num_hidden_layers=4,
+            num_attention_heads=8,
+            num_key_value_heads=4,
+            n_shared_experts=1,
+            n_routed_experts=8,
+            routed_scaling_factor=2.5,
+            topk_method="noaux_tc",
+            scoring_func="sigmoid",
+            norm_topk_prob=True,
+            n_group=2,
+            topk_group=1,
+            max_position_embeddings=512,
+            layernorm_epsilon=1e-5,
+            rope_theta=10000.0,
+            swa_rope_theta=10000.0,
+            swa_num_attention_heads=8,
+            swa_num_key_value_heads=4,
+            head_dim=8,
+            v_head_dim=8,
+            swa_head_dim=8,
+            swa_v_head_dim=8,
+            partial_rotary_factor=1.0,
+        ),
     }
 
     def _run(self, name):
@@ -10795,3 +10830,6 @@ class TestVendoredDenseModels(unittest.TestCase):
 
     def test_bailing_moe(self):
         self._run("bailing_moe")
+
+    def test_mimo_v2_flash(self):
+        self._run("mimo_v2_flash")

--- a/mlx_vlm/tests/test_models.py
+++ b/mlx_vlm/tests/test_models.py
@@ -10770,6 +10770,37 @@ class TestVendoredDenseModels(unittest.TestCase):
             swa_v_head_dim=8,
             partial_rotary_factor=1.0,
         ),
+        "afmoe": dict(
+            model_type="afmoe",
+            layer_types=[
+                "full_attention",
+                "sliding_attention",
+                "full_attention",
+                "sliding_attention",
+            ],
+            vocab_size=128,
+            hidden_size=64,
+            intermediate_size=128,
+            moe_intermediate_size=32,
+            num_hidden_layers=4,
+            num_attention_heads=8,
+            num_key_value_heads=4,
+            head_dim=8,
+            max_position_embeddings=512,
+            rms_norm_eps=1e-5,
+            rope_theta=10000,
+            num_experts=8,
+            num_experts_per_tok=2,
+            num_shared_experts=1,
+            num_dense_layers=1,
+            route_norm=True,
+            route_scale=2.826,
+            score_func="sigmoid",
+            n_group=2,
+            topk_group=1,
+            sliding_window=4,
+            mup_enabled=True,
+        ),
     }
 
     def _run(self, name):
@@ -10833,3 +10864,6 @@ class TestVendoredDenseModels(unittest.TestCase):
 
     def test_mimo_v2_flash(self):
         self._run("mimo_v2_flash")
+
+    def test_afmoe(self):
+        self._run("afmoe")

--- a/mlx_vlm/tests/test_models.py
+++ b/mlx_vlm/tests/test_models.py
@@ -10683,6 +10683,34 @@ class TestVendoredDenseModels(unittest.TestCase):
             n_group=1,
             topk_group=1,
         ),
+        "exaone_moe": dict(
+            model_type="exaone_moe",
+            vocab_size=128,
+            hidden_size=64,
+            intermediate_size=128,
+            moe_intermediate_size=32,
+            num_hidden_layers=4,
+            num_attention_heads=8,
+            num_key_value_heads=4,
+            head_dim=8,
+            num_experts=8,
+            num_experts_per_tok=2,
+            num_shared_experts=1,
+            rms_norm_eps=1e-5,
+            max_position_embeddings=512,
+            sliding_window=4,
+            layer_types=[
+                "sliding_attention",
+                "full_attention",
+                "sliding_attention",
+                "full_attention",
+            ],
+            is_moe_layer=[False, True, True, True],
+            n_group=2,
+            topk_group=1,
+            routed_scaling_factor=2.5,
+            norm_topk_prob=True,
+        ),
     }
 
     def _run(self, name):
@@ -10737,3 +10765,6 @@ class TestVendoredDenseModels(unittest.TestCase):
 
     def test_dots1(self):
         self._run("dots1")
+
+    def test_exaone_moe(self):
+        self._run("exaone_moe")

--- a/mlx_vlm/utils.py
+++ b/mlx_vlm/utils.py
@@ -48,6 +48,7 @@ MODEL_REMAPPING = {
     "cohere2moe": "cohere2_moe",
     "unlimited-ocr": "unlimited_ocr",
     "mistral": "llama",
+    "nemotron-nas": "nemotron_nas",
 }
 
 MAX_FILE_SIZE_GB = 5


### PR DESCRIPTION
 Continues the mlx-lm removal series (after #1606/#1616/#1625): 17 models vendored (10 dense + 7 MoE), each bit-exact Δ=0.0 vs mlx-lm 0.31.3, all recovered by test_models.py
 


 