### PR TITLE
fix(rope): apply declared rope_scaling in models that ignored it (Llama-3.2-Vision and 9 others)

### DIFF
--- a/mlx_vlm/models/glm4_moe/language.py
+++ b/mlx_vlm/models/glm4_moe/language.py
@@ -12,6 +12,7 @@ from ..base import (
 from ..mlp import DeepseekMLP as MLP
 from ..pipeline import PipelineMixin
 from ..switch_layers import SwitchGLU
+from ..rope_utils import initialize_rope
 from .config import ModelConfig
 
 
@@ -36,10 +37,12 @@ class Attention(nn.Module):
             self.q_norm = nn.RMSNorm(head_dim, eps=args.rms_norm_eps)
             self.k_norm = nn.RMSNorm(head_dim, eps=args.rms_norm_eps)
 
-        self.rope = nn.RoPE(
-            int(head_dim * args.partial_rotary_factor),
-            traditional=False,
+        self.rope = initialize_rope(
+            dims=int(head_dim * args.partial_rotary_factor),
             base=args.rope_theta,
+            traditional=False,
+            scaling_config=args.rope_scaling,
+            max_position_embeddings=args.max_position_embeddings,
         )
 
     def __call__(

--- a/mlx_vlm/models/granite4_vision/language.py
+++ b/mlx_vlm/models/granite4_vision/language.py
@@ -8,6 +8,7 @@ from ..base import (
     create_attention_mask,
     scaled_dot_product_attention,
 )
+from ..rope_utils import initialize_rope
 from .config import TextConfig
 
 
@@ -26,10 +27,12 @@ class Attention(nn.Module):
         self.v_proj = nn.Linear(dim, n_kv_heads * head_dim, bias=config.attention_bias)
         self.o_proj = nn.Linear(n_heads * head_dim, dim, bias=config.attention_bias)
 
-        self.rope = nn.RoPE(
-            head_dim,
-            traditional=config.rope_traditional,
+        self.rope = initialize_rope(
+            dims=head_dim,
             base=config.rope_theta,
+            traditional=config.rope_traditional,
+            scaling_config=config.rope_scaling,
+            max_position_embeddings=config.max_position_embeddings,
         )
 
     def __call__(self, x, mask=None, cache=None):

--- a/mlx_vlm/models/granite_vision/language.py
+++ b/mlx_vlm/models/granite_vision/language.py
@@ -9,6 +9,7 @@ from ..base import (
     scaled_dot_product_attention,
 )
 from ..cache import KVCache
+from ..rope_utils import initialize_rope
 from .config import TextConfig
 
 
@@ -30,10 +31,12 @@ class Attention(nn.Module):
         self.v_proj = nn.Linear(dim, n_kv_heads * head_dim, bias=config.attention_bias)
         self.o_proj = nn.Linear(n_heads * head_dim, dim, bias=config.attention_bias)
 
-        self.rope = nn.RoPE(
-            head_dim,
-            traditional=config.rope_traditional,
+        self.rope = initialize_rope(
+            dims=head_dim,
             base=config.rope_theta,
+            traditional=config.rope_traditional,
+            scaling_config=config.rope_scaling,
+            max_position_embeddings=config.max_position_embeddings,
         )
 
     def __call__(

--- a/mlx_vlm/models/locateanything/language.py
+++ b/mlx_vlm/models/locateanything/language.py
@@ -10,6 +10,7 @@ from ..base import (
 )
 from ..cache import KVCache
 from ..mlp import SwiGLUMLP as MLP
+from ..rope_utils import initialize_rope
 from .config import TextConfig
 
 
@@ -68,8 +69,12 @@ class Attention(nn.Module):
         self.v_proj = nn.Linear(dim, n_kv_heads * head_dim, bias=True)
         self.o_proj = nn.Linear(n_heads * head_dim, dim, bias=False)
 
-        self.rope = nn.RoPE(
-            head_dim, traditional=args.rope_traditional, base=args.rope_theta
+        self.rope = initialize_rope(
+            dims=head_dim,
+            base=args.rope_theta,
+            traditional=args.rope_traditional,
+            scaling_config=args.rope_scaling,
+            max_position_embeddings=args.max_position_embeddings,
         )
 
     def __call__(

--- a/mlx_vlm/models/mixtral/language.py
+++ b/mlx_vlm/models/mixtral/language.py
@@ -9,6 +9,7 @@ from ..base import (
     scaled_dot_product_attention,
 )
 from ..switch_layers import SwitchGLU
+from ..rope_utils import initialize_rope
 from .config import ModelConfig
 
 
@@ -36,10 +37,11 @@ class MixtralAttention(nn.Module):
             self.num_heads * self.head_dim, self.hidden_size, bias=False
         )
 
-        self.rope = nn.RoPE(
-            self.head_dim,
-            traditional=args.rope_traditional,
+        self.rope = initialize_rope(
+            dims=self.head_dim,
             base=args.rope_theta,
+            traditional=args.rope_traditional,
+            scaling_config=args.rope_scaling,
         )
 
     def __call__(

--- a/mlx_vlm/models/mllama/language.py
+++ b/mlx_vlm/models/mllama/language.py
@@ -9,6 +9,7 @@ from ..base import (
     scaled_dot_product_attention,
 )
 from ..cache import KVCache
+from ..rope_utils import initialize_rope
 from .config import TextConfig
 
 
@@ -115,11 +116,12 @@ class MllamaTextSelfAttention(nn.Module):
             self.num_heads * self.head_dim, self.hidden_size, bias=False
         )
 
-        self.rope = nn.RoPE(
-            self.head_dim,
-            traditional=config.rope_traditional,
+        self.rope = initialize_rope(
+            dims=self.head_dim,
             base=config.rope_theta,
-            scale=1,
+            traditional=config.rope_traditional,
+            scaling_config=config.rope_scaling,
+            max_position_embeddings=config.max_position_embeddings,
         )
 
     def __call__(

--- a/mlx_vlm/models/molmo2/language.py
+++ b/mlx_vlm/models/molmo2/language.py
@@ -9,6 +9,7 @@ from ..base import (
     scaled_dot_product_attention,
 )
 from ..cache import KVCache
+from ..rope_utils import initialize_rope
 from .config import ModelConfig, TextConfig
 
 
@@ -70,7 +71,13 @@ class Molmo2Attention(nn.Module):
             bias=False,
         )
 
-        self.rotary_emb = nn.RoPE(self.head_dim, base=config.rope_theta)
+        self.rotary_emb = initialize_rope(
+            dims=self.head_dim,
+            base=config.rope_theta,
+            traditional=False,
+            scaling_config=config.rope_scaling,
+            max_position_embeddings=config.max_position_embeddings,
+        )
 
     def __call__(
         self,

--- a/mlx_vlm/models/molmo_point/language.py
+++ b/mlx_vlm/models/molmo_point/language.py
@@ -9,6 +9,7 @@ from ..base import (
     scaled_dot_product_attention,
 )
 from ..cache import KVCache
+from ..rope_utils import initialize_rope
 from .config import ModelConfig, TextConfig
 
 
@@ -65,7 +66,13 @@ class Molmo2Attention(nn.Module):
             bias=False,
         )
 
-        self.rotary_emb = nn.RoPE(self.head_dim, base=config.rope_theta)
+        self.rotary_emb = initialize_rope(
+            dims=self.head_dim,
+            base=config.rope_theta,
+            traditional=False,
+            scaling_config=config.rope_scaling,
+            max_position_embeddings=config.max_position_embeddings,
+        )
 
     def __call__(
         self,

--- a/mlx_vlm/models/phi4mm/language.py
+++ b/mlx_vlm/models/phi4mm/language.py
@@ -5,6 +5,7 @@ import mlx.nn as nn
 
 from ..base import LanguageModelOutput, create_attention_mask
 from ..cache import KVCache
+from ..rope_utils import initialize_rope
 from .config import ModelConfig
 
 
@@ -23,10 +24,12 @@ class Attention(nn.Module):
         self.o_proj = nn.Linear(n_heads * head_dim, dim, bias=False)
 
         rope_dim = int(head_dim * config.partial_rotary_factor)
-        self.rope = nn.RoPE(
-            rope_dim,
-            traditional=config.rope_traditional,
+        self.rope = initialize_rope(
+            dims=rope_dim,
             base=config.rope_theta,
+            traditional=config.rope_traditional,
+            scaling_config=config.rope_scaling,
+            max_position_embeddings=config.max_position_embeddings,
         )
 
     def __call__(

--- a/mlx_vlm/models/qwen3_moe/language.py
+++ b/mlx_vlm/models/qwen3_moe/language.py
@@ -10,6 +10,7 @@ from ..base import (
 )
 from ..mlp import SwiGLUMLP as MLP
 from ..switch_layers import SwitchGLU
+from ..rope_utils import initialize_rope
 from .config import ModelConfig
 
 
@@ -35,10 +36,12 @@ class Attention(nn.Module):
         self.q_norm = nn.RMSNorm(head_dim, eps=args.rms_norm_eps)
         self.k_norm = nn.RMSNorm(head_dim, eps=args.rms_norm_eps)
 
-        self.rope = nn.RoPE(
-            head_dim,
-            traditional=False,
+        self.rope = initialize_rope(
+            dims=head_dim,
             base=args.rope_theta,
+            traditional=False,
+            scaling_config=args.rope_scaling,
+            max_position_embeddings=args.max_position_embeddings,
         )
 
     def __call__(

--- a/mlx_vlm/tests/test_models.py
+++ b/mlx_vlm/tests/test_models.py
@@ -3653,6 +3653,31 @@ class TestModels(unittest.TestCase):
 
         self.assertEqual(output.shape, (1, 1, 1, 4))
 
+    def test_mllama_rope_scaling_is_applied(self):
+        from mlx_vlm.models import mllama
+        from mlx_vlm.models.rope_utils import Llama3RoPE
+
+        config = mllama.TextConfig(
+            rope_scaling={
+                "rope_type": "llama3",
+                "factor": 8.0,
+                "high_freq_factor": 4.0,
+                "low_freq_factor": 1.0,
+                "original_max_position_embeddings": 8192,
+            }
+        )
+
+        attn = mllama.language.MllamaTextSelfAttention(config, layer_idx=0)
+        self.assertIsInstance(attn.rope, Llama3RoPE)
+
+    def test_mllama_without_rope_scaling_is_plain(self):
+        from mlx_vlm.models import mllama
+
+        attn = mllama.language.MllamaTextSelfAttention(
+            mllama.TextConfig(rope_scaling=None), layer_idx=0
+        )
+        self.assertAlmostEqual(attn.rope.scale, 1.0)
+
     def test_mllama(self):
         from mlx_vlm.models import mllama
 


### PR DESCRIPTION
## Problem

Ten models declare `rope_scaling` on their config dataclass and then build a plain `nn.RoPE` without passing it, so any checkpoint that ships scaling runs **unscaled** positions. The error is exactly zero at position 0 and grows with context length, so it does not show up in short-prompt testing.

**Llama-3.2-Vision is affected today.** `meta-llama/Llama-3.2-11B-Vision-Instruct` ships:

```json
"rope_scaling": {"rope_type": "llama3", "factor": 8.0, "high_freq_factor": 4.0,
                 "low_freq_factor": 1.0, "original_max_position_embeddings": 8192}
```

while `mllama/language.py` builds `nn.RoPE(..., scale=1)`. Comparing the required `Llama3RoPE` against that plain RoPE on identical inputs with the real config:

| position | cosine(correct, current) |
|---|---|
| 0 | 1.000000 |
| 1 000 | 0.959 |
| 8 192 | 0.757 |
| 20 000 | 0.619 |
| 60 000 | 0.503 |

`llama3` scaling is frequency-dependent, not a uniform divide, so it cannot be approximated by the unscaled path — the model's long-context behaviour is what suffers.

## Fix

Route each through the existing `rope_utils.initialize_rope`, already the pattern in `gemma4` and `diffusion_gemma`. Where a config declares no `rope_scaling`, `initialize_rope` returns the same unscaled `nn.RoPE`, so behaviour is unchanged for every current checkpoint of the other nine.

Models changed: `mllama`, `glm4_moe`, `qwen3_moe`, `granite_vision`, `granite4_vision`, `mixtral`, `molmo2`, `molmo_point`, `phi4mm`, `locateanything`.

## Deliberately not changed

`internvl_chat` declares `{"type": "dynamic", "factor": 2.0}` (e.g. InternVL2-8B). `initialize_rope` raises on `dynamic`, so routing it there would turn a silent inaccuracy into a load-time failure. It needs dynamic-NTK support first — flagging it here rather than papering over it.

## Tests

- `test_mllama_rope_scaling_is_applied` — asserts a `llama3` config yields `Llama3RoPE`. Fails on `main`.
- `test_mllama_without_rope_scaling_is_plain` — asserts the no-scaling path stays unscaled.

`python -m unittest mlx_vlm.tests.test_models` passes.

Companion to #1709, which fixes the same class in `gemma3`/`gemma3n` (found first, verified end-to-end against a real gemma-3 checkpoint).
