### PR TITLE
Support mixed-precision compressed-tensors checkpoints (fp8 + NVFP4)

### DIFF
--- a/mlx_vlm/tests/test_models.py
+++ b/mlx_vlm/tests/test_models.py
@@ -10985,3 +10985,189 @@ class TestVendoredDenseModels(unittest.TestCase):
 
     def test_afmoe(self):
         self._run("afmoe")
+
+
+class TestMixedPrecisionCompressedTensors(unittest.TestCase):
+    """``format: mixed-precision`` compressed-tensors (NVFP4 + channel fp8)."""
+
+    OUT = 32
+    IN = 32
+
+    @staticmethod
+    def _config():
+        # Mirrors unsloth/Qwen3.6-27B-NVFP4: fp8 float-quantized attn/lm_head
+        # in group_0, NVFP4-packed MLP in group_1, one top-level format.
+        return {
+            "quant_method": "compressed-tensors",
+            "format": "mixed-precision",
+            "config_groups": {
+                "group_0": {
+                    "format": "float-quantized",
+                    "weights": {
+                        "num_bits": 8,
+                        "type": "float",
+                        "strategy": "channel",
+                    },
+                },
+                "group_1": {
+                    "format": "nvfp4-pack-quantized",
+                    "weights": {"num_bits": 4, "group_size": 16},
+                },
+            },
+        }
+
+    def _weights(self):
+        out, inp = self.OUT, self.IN
+        rng = np.random.default_rng(0)
+        weights = {}
+        # NVFP4-packed MLP projection (group_1).
+        weights["model.layer.mlp.gate_proj.weight_packed"] = mx.array(
+            rng.integers(0, 256, (out, inp // 2), dtype=np.uint8)
+        )
+        weights["model.layer.mlp.gate_proj.weight_scale"] = mx.full(
+            (out, inp // 16), 0x38, dtype=mx.uint8  # E4M3 1.0
+        )
+        weights["model.layer.mlp.gate_proj.weight_global_scale"] = mx.array(
+            [1.0], dtype=mx.float32
+        )
+        # Metadata with no MLX consumer -- must be dropped.
+        weights["model.layer.mlp.gate_proj.input_global_scale"] = mx.array(
+            [1.0], dtype=mx.float32
+        )
+        weights["model.layer.mlp.gate_proj.weight_shape"] = mx.array(
+            [out, inp], dtype=mx.int64
+        )
+        # Channel-wise fp8 float-quantized attention projection (group_0).
+        fp8_bytes = np.array([[0x38, 0x40] * (inp // 2)] * out, dtype=np.uint8)
+        weights["model.layer.self_attn.q_proj.weight"] = mx.array(fp8_bytes)
+        weights["model.layer.self_attn.q_proj.weight_scale"] = mx.full(
+            (out, 1), 2.0, dtype=mx.bfloat16
+        )
+        weights["model.layer.self_attn.k_scale"] = mx.array([1.0], dtype=mx.float32)
+        # Ignored dense layer (e.g. linear_attn / vision) -- passes through.
+        weights["model.layer.linear_attn.in_proj.weight"] = mx.array(
+            rng.standard_normal((out, inp)), dtype=mx.bfloat16
+        )
+        return weights
+
+    def test_routes_nvfp4_fp8_and_dense(self):
+        from mlx_vlm.utils import _transform_compressed_tensors_weights
+
+        weights = self._weights()
+        dense_ref = weights["model.layer.linear_attn.in_proj.weight"]
+        new, quant = _transform_compressed_tensors_weights(weights, self._config())
+
+        # Top-level descriptor drives nn.quantize for the (only) native mode.
+        self.assertEqual(quant, {"group_size": 16, "bits": 4, "mode": "nvfp4"})
+
+        # NVFP4 folded to MLX-native weight/scales.
+        gate = "model.layer.mlp.gate_proj"
+        self.assertEqual(new[f"{gate}.weight"].dtype, mx.uint32)
+        self.assertEqual(new[f"{gate}.weight"].shape, (self.OUT, self.IN // 8))
+        self.assertEqual(new[f"{gate}.scales"].dtype, mx.uint8)
+
+        # fp8 dequantized to a dense weight (no scales -> stays dense at load).
+        qproj = "model.layer.self_attn.q_proj"
+        self.assertEqual(new[f"{qproj}.weight"].shape, (self.OUT, self.IN))
+        self.assertEqual(new[f"{qproj}.weight"].dtype, mx.bfloat16)
+        self.assertNotIn(f"{qproj}.weight_scale", new)
+
+        # Ignored dense layer untouched.
+        self.assertTrue(
+            mx.array_equal(new["model.layer.linear_attn.in_proj.weight"], dense_ref)
+        )
+
+        # All compressed-tensors metadata dropped before strict load.
+        for dropped in (
+            f"{gate}.weight_packed",
+            f"{gate}.weight_global_scale",
+            f"{gate}.input_global_scale",
+            f"{gate}.weight_shape",
+            "model.layer.self_attn.k_scale",
+        ):
+            self.assertNotIn(dropped, new)
+        self.assertFalse(any(k.endswith(".weight_packed") for k in new))
+
+    def test_fp8_dequantized_values(self):
+        from mlx_vlm.utils import _transform_compressed_tensors_weights
+
+        new, _ = _transform_compressed_tensors_weights(self._weights(), self._config())
+        w = new["model.layer.self_attn.q_proj.weight"].astype(mx.float32)
+        # bytes 0x38=E4M3(1.0), 0x40=E4M3(2.0); per-channel scale 2.0.
+        expected = mx.tile(mx.array([2.0, 4.0]), (self.OUT, self.IN // 2))
+        self.assertTrue(mx.allclose(w, expected, atol=1e-3).item())
+
+    def test_strict_load_and_selective_quantize(self):
+        from mlx_vlm.utils import _transform_compressed_tensors_weights
+
+        new, quant = _transform_compressed_tensors_weights(
+            self._weights(), self._config()
+        )
+
+        # Module tree whose leaf paths match the transformed weight keys.
+        model = _tree_from_paths(
+            {
+                "model.layer.mlp.gate_proj": nn.Linear(self.IN, self.OUT, bias=False),
+                "model.layer.self_attn.q_proj": nn.Linear(
+                    self.IN, self.OUT, bias=False
+                ),
+                "model.layer.linear_attn.in_proj": nn.Linear(
+                    self.IN, self.OUT, bias=False
+                ),
+            }
+        )
+
+        nn.quantize(
+            model,
+            group_size=quant["group_size"],
+            bits=quant["bits"],
+            mode=quant["mode"],
+            class_predicate=lambda p, m: f"{p}.scales" in new,
+        )
+        # The line that used to abort with "parameters not in model" (status 3).
+        model.load_weights(list(new.items()), strict=True)
+        mx.eval(model.parameters())
+
+        # Only the NVFP4 layer is quantized; fp8-dense and ignored stay Linear.
+        self.assertEqual(
+            type(model.model.layer.mlp.gate_proj).__name__, "QuantizedLinear"
+        )
+        self.assertEqual(type(model.model.layer.self_attn.q_proj).__name__, "Linear")
+        self.assertEqual(type(model.model.layer.linear_attn.in_proj).__name__, "Linear")
+
+        y = model.model.layer.mlp.gate_proj(mx.zeros((1, self.IN)))
+        mx.eval(y)
+        self.assertEqual(y.shape, (1, self.OUT))
+
+    def test_rejects_multiple_native_quant_modes(self):
+        from mlx_vlm.utils import _transform_compressed_tensors_weights
+
+        weights = self._weights()
+        # Add an INT4 pack-quantized layer -> nvfp4 + affine both need scales.
+        weights["model.layer.extra.weight_packed"] = mx.array(
+            np.zeros((self.OUT, self.IN // 8), dtype=np.int32)
+        )
+        weights["model.layer.extra.weight_scale"] = mx.ones(
+            (self.OUT, self.IN // 32), dtype=mx.bfloat16
+        )
+        config = self._config()
+        config["config_groups"]["group_2"] = {
+            "format": "pack-quantized",
+            "weights": {"num_bits": 4, "group_size": 32, "type": "int"},
+        }
+        with self.assertRaises(NotImplementedError):
+            _transform_compressed_tensors_weights(weights, config)
+
+
+def _tree_from_paths(leaves):
+    """Build a nested nn.Module tree whose leaf paths equal ``leaves`` keys."""
+    root = nn.Module()
+    for path, leaf in leaves.items():
+        node = root
+        parts = path.split(".")
+        for part in parts[:-1]:
+            if part not in node:
+                setattr(node, part, nn.Module())
+            node = getattr(node, part)
+        setattr(node, parts[-1], leaf)
+    return root

--- a/mlx_vlm/utils.py
+++ b/mlx_vlm/utils.py
@@ -255,6 +255,144 @@ def _transform_compressed_tensors_int4_weights(
     return new_weights, {"group_size": group_size, "bits": bits, "mode": "affine"}
 
 
+# Compressed-tensors auxiliary tensors with no MLX consumer. They carry
+# activation / kv-cache / shape metadata; left in place they reach
+# ``model.load_weights(strict=True)`` as unexpected keys and abort startup.
+_COMPRESSED_TENSORS_DROP_SUFFIXES = (
+    ".weight_shape",
+    ".weight_global_scale",  # folded into ``.scales`` alongside ``.weight_packed``
+    ".weight_zero_point",
+    ".input_global_scale",
+    ".input_scale",
+    ".k_scale",
+    ".v_scale",
+)
+
+
+def _compressed_tensors_group_weights(
+    quantization_config: Dict[str, Any], ct_format: str
+) -> Dict[str, Any]:
+    """Return the ``weights`` sub-config of the first group with ``ct_format``."""
+    for group in (quantization_config.get("config_groups") or {}).values():
+        if isinstance(group, dict) and group.get("format") == ct_format:
+            return group.get("weights") or {}
+    return {}
+
+
+def _dequantize_compressed_tensors_fp8_weight(
+    weight: mx.array, scale: mx.array
+) -> mx.array:
+    """Dequantize a channel-wise fp8 ``float-quantized`` weight to dense.
+
+    ``float-quantized`` (``num_bits: 8``, ``strategy: channel``) stores the
+    weight as ``float8_e4m3fn`` -- which ``mx.load`` surfaces as raw ``uint8``
+    E4M3 bytes -- plus a per-output-channel ``weight_scale``. MLX has no
+    per-channel fp8 quantization mode, so we decode the E4M3 codes with the
+    shared LUT and rescale into a dense tensor: ``w = E4M3(byte) * weight_scale``.
+    The dense weight is emitted in ``weight_scale``'s dtype (the checkpoint's
+    compute dtype, typically ``bfloat16``).
+    """
+    out_dtype = scale.dtype if scale.dtype != mx.float32 else mx.bfloat16
+    decoded = _E4M3_DECODE_LUT[weight.astype(mx.uint32)]  # float32 [out, in]
+    scale = scale.astype(mx.float32)
+    if scale.ndim == 1:
+        scale = scale[:, None]
+    return (decoded * scale).astype(out_dtype)
+
+
+def _transform_compressed_tensors_mixed_weights(
+    weights: Dict[str, mx.array],
+    quantization_config: Dict[str, Any],
+) -> Tuple[Dict[str, mx.array], Optional[Dict[str, Any]]]:
+    """Route a compressed-tensors ``mixed-precision`` checkpoint per group.
+
+    A ``mixed-precision`` export keeps a single top-level ``format`` and puts
+    the real formats in per-group ``config_groups``. Rather than match each
+    group's regex ``targets``/``ignore`` against module paths (fragile -- the
+    HF names differ from MLX's), we route every quantized Linear by the tensors
+    it actually carries, which is exactly what the group assignment produced:
+
+    - ``.weight_packed`` + ``.weight_global_scale`` -> NVFP4
+      (folded to MLX-native ``nvfp4``, as ``_transform_..._nvfp4_weights`` does)
+    - ``.weight_packed`` alone -> INT4 ``pack-quantized`` (folded to ``affine``)
+    - ``.weight_scale`` without ``.weight_packed`` -> channel-wise fp8
+      ``float-quantized`` (dequantized to a dense weight)
+
+    Layers under ``ignore`` (vision, ``linear_attn``, ``mtp``) carry a plain
+    ``.weight`` with no scale and pass through untouched, so the later
+    ``nn.quantize`` pass -- which only quantizes modules that have a ``.scales``
+    tensor -- leaves them dense.
+
+    Only one MLX-native quantized mode may coexist with the dense/fp8 layers
+    (``nn.quantize`` applies a single ``group_size``/``bits``/``mode``). The
+    reported models pair NVFP4 with dense fp8, so this holds; a checkpoint that
+    mixes e.g. NVFP4 and INT4 raises rather than silently mis-quantizing.
+    """
+    packed_prefixes = {
+        key[: -len(".weight_packed")]
+        for key in weights
+        if key.endswith(".weight_packed")
+    }
+    # A ``.weight_scale`` with no packed sibling is a float-quantized fp8 layer.
+    fp8_prefixes = {
+        key[: -len(".weight_scale")] for key in weights if key.endswith(".weight_scale")
+    } - packed_prefixes
+
+    int4_cfg = _compressed_tensors_group_weights(quantization_config, "pack-quantized")
+    int4_bits = int4_cfg.get("num_bits", 4)
+    int4_group_size = int4_cfg.get("group_size", 32)
+
+    new_weights: Dict[str, mx.array] = {}
+    native_quant: Dict[str, Dict[str, Any]] = {}
+
+    for key, value in weights.items():
+        if key.endswith(".weight_packed"):
+            prefix = key[: -len(".weight_packed")]
+            scale = weights[f"{prefix}.weight_scale"]
+            global_key = f"{prefix}.weight_global_scale"
+            if global_key in weights:  # NVFP4
+                global_scale = weights[global_key].astype(mx.float32)
+                new_weights[f"{prefix}.weight"] = value.view(mx.uint32)
+                decoded = _E4M3_DECODE_LUT[scale.astype(mx.uint32)]
+                new_weights[f"{prefix}.scales"] = _f32_to_e4m3(decoded / global_scale)
+                native_quant["nvfp4"] = {"group_size": 16, "bits": 4, "mode": "nvfp4"}
+            else:  # INT4 symmetric pack-quantized
+                new_weights[f"{prefix}.weight"] = value.view(mx.uint32)
+                new_weights[f"{prefix}.scales"] = scale
+                new_weights[f"{prefix}.biases"] = -(2 ** (int4_bits - 1)) * scale
+                native_quant["affine"] = {
+                    "group_size": int4_group_size,
+                    "bits": int4_bits,
+                    "mode": "affine",
+                }
+            continue
+        if key.endswith(".weight_scale"):
+            prefix = key[: -len(".weight_scale")]
+            if prefix in fp8_prefixes:
+                new_weights[f"{prefix}.weight"] = (
+                    _dequantize_compressed_tensors_fp8_weight(
+                        weights[f"{prefix}.weight"], value
+                    )
+                )
+            # NVFP4 / INT4 scales are consumed with their ``.weight_packed``.
+            continue
+        if key.endswith(".weight") and key[: -len(".weight")] in fp8_prefixes:
+            continue  # emitted (dequantized to dense) at its ``.weight_scale``
+        if any(key.endswith(suffix) for suffix in _COMPRESSED_TENSORS_DROP_SUFFIXES):
+            continue
+        new_weights[key] = value
+
+    if not native_quant:
+        return new_weights, None
+    if len(native_quant) > 1:
+        raise NotImplementedError(
+            "mixed-precision compressed-tensors checkpoint mixes multiple "
+            f"MLX-native quantized modes {sorted(native_quant)}; only one native "
+            "mode alongside dense/fp8 layers is supported."
+        )
+    return new_weights, next(iter(native_quant.values()))
+
+
 def _transform_compressed_tensors_weights(
     weights: Dict[str, mx.array],
     quantization_config: Optional[Dict[str, Any]],
@@ -268,6 +406,12 @@ def _transform_compressed_tensors_weights(
         return weights, None
     if quantization_config.get("quant_method") != "compressed-tensors":
         return weights, None
+
+    # ``mixed-precision`` puts the real formats in per-group ``config_groups``;
+    # route per group (some groups may be dense fp8 with no ``.weight_packed``).
+    if quantization_config.get("format") == "mixed-precision":
+        return _transform_compressed_tensors_mixed_weights(weights, quantization_config)
+
     if not any(key.endswith(".weight_packed") for key in weights):
         return weights, None
 


### PR DESCRIPTION
Fixes #1706.

A `format: "mixed-precision"` compressed-tensors export keeps the real per-group formats in `config_groups`, so the NVFP4 fold was skipped and the packed tensors reached `model.load_weights(strict=True)`, aborting startup with "parameters not in model".

Route `mixed-precision` to a new transform that dispatches each quantized Linear by the tensors it actually carries (the group assignment already encodes this, so no fragile regex target matching):
- `.weight_packed` + `.weight_global_scale` -> NVFP4 fold
- `.weight_packed` alone -> INT4 pack-quantized fold
- `.weight_scale` without a packed sibling -> channel-wise fp8 `float-quantized`, dequantized to a dense weight (MLX has no per-channel fp8 mode)

Ignored layers (vision, linear_attn, mtp) carry a plain `.weight`, pass through untouched, and stay dense since the later nn.quantize pass only touches modules that have a `.scales` tensor. Compressed-tensors metadata with no MLX consumer (weight_shape, weight_global_scale, weight_zero_point, input_scale/input_global_scale, kv-cache k/v scales) is dropped before the strict load. A checkpoint mixing more than one MLX-native quantized mode raises rather than silently mis-quantizing.

Verification
Added TestMixedPrecisionCompressedTensors covering routing/metadata-drop, exact fp8 dequant values, an end-to-end nn.quantize → load_weights(strict=True) → forward (the line that used to abort), and the multi-mode guard; the full CI suite as well