### PR TITLE
Authenticate inference API routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -410,6 +410,9 @@ mlx_vlm.server --model Qwen/Qwen3.5-4B \
   --thinking-budget 512 \
   --thinking-start-token "<think>" \
   --thinking-end-token "</think>"
+
+# Require bearer authentication for API endpoints
+mlx_vlm.server --api-key <secret-token>
 ```
 
 #### Server Options
@@ -435,6 +438,7 @@ mlx_vlm.server --model Qwen/Qwen3.5-4B \
 - `--max-kv-size`: Maximum KV cache size in tokens
 - `--vision-cache-size`: Max number of cached vision features (default: `20`)
 - `--log-progress-interval`: Decoded tokens between progress log messages; `0` disables periodic decode progress (default: `10`)
+- `--api-key`: Bearer token required for inference, model discovery, and management endpoints
 - `--log-level`: Logging level — `DEBUG`, `INFO`, `WARNING`, `ERROR`, `CRITICAL` (default: `INFO`)
 
 At `INFO`, the server logs request start/completion, chunked-prefill progress,

--- a/mlx_vlm/server/app.py
+++ b/mlx_vlm/server/app.py
@@ -11,7 +11,7 @@ from types import SimpleNamespace
 from typing import List, Optional, Tuple
 
 import mlx.core as mx
-from fastapi import FastAPI, HTTPException, Request
+from fastapi import APIRouter, Depends, FastAPI, HTTPException, Request
 from fastapi.middleware.cors import CORSMiddleware
 from huggingface_hub import scan_cache_dir
 from huggingface_hub.errors import CacheNotFound, RepositoryNotFoundError
@@ -383,6 +383,9 @@ app = FastAPI(
     version=__version__,
     lifespan=lifespan,
 )
+inference_router = APIRouter(
+    dependencies=[Depends(_require_management_api_key)],
+)
 
 app.add_middleware(
     CORSMiddleware,
@@ -728,13 +731,17 @@ _protocol_deps = SimpleNamespace(
     make_logprob_content=_make_logprob_content,
     build_metrics_envelope=_build_metrics_envelope,
 )
-register_anthropic_routes(app, _protocol_deps)
-register_openai_routes(app, _protocol_deps)
-register_audio_routes(app, _protocol_deps)
+register_anthropic_routes(inference_router, _protocol_deps)
+register_openai_routes(inference_router, _protocol_deps)
+register_audio_routes(inference_router, _protocol_deps)
 
 
-@app.get("/models", response_model=ModelsResponse)
-@app.get("/v1/models", response_model=ModelsResponse, include_in_schema=False)
+@inference_router.get("/models", response_model=ModelsResponse)
+@inference_router.get(
+    "/v1/models",
+    response_model=ModelsResponse,
+    include_in_schema=False,
+)
 def models_endpoint():
     """
     Return list of locally downloaded MLX models.
@@ -784,6 +791,9 @@ def models_endpoint():
     response = {"object": "list", "data": models}
 
     return response
+
+
+app.include_router(inference_router)
 
 
 # MLX_VLM API endpoints

--- a/mlx_vlm/server/cli.py
+++ b/mlx_vlm/server/cli.py
@@ -207,8 +207,8 @@ def main():
         type=str,
         default=None,
         help=(
-            "Optional bearer token required for management endpoints such as "
-            "/health, /metrics, /cache/stats, /cache/reset, and /unload. "
+            "Optional bearer token required for inference, model discovery, and "
+            "management endpoints. "
             "Maps to the MLX_VLM_SERVER_API_KEY env var."
         ),
     )

--- a/mlx_vlm/tests/test_server.py
+++ b/mlx_vlm/tests/test_server.py
@@ -1149,6 +1149,70 @@ def test_management_endpoints_require_configured_api_key(
     assert valid.status_code == 200
 
 
+@pytest.mark.parametrize(
+    ("method", "path"),
+    [
+        ("post", "/messages"),
+        ("post", "/messages/count_tokens"),
+        ("post", "/responses/input_tokens"),
+        ("get", "/responses/missing"),
+        ("delete", "/responses/missing"),
+        ("post", "/responses/missing/cancel"),
+        ("get", "/responses/missing/input_items"),
+        ("post", "/responses"),
+        ("post", "/chat/completions"),
+        ("post", "/images/generations"),
+        ("post", "/images/edits"),
+        ("post", "/audio/speech"),
+        ("post", "/audio/transcriptions"),
+        ("post", "/audio/translations"),
+        ("get", "/models"),
+        ("post", "/v1/messages"),
+        ("post", "/v1/messages/count_tokens"),
+        ("post", "/v1/responses/input_tokens"),
+        ("get", "/v1/responses/missing"),
+        ("delete", "/v1/responses/missing"),
+        ("post", "/v1/responses/missing/cancel"),
+        ("get", "/v1/responses/missing/input_items"),
+        ("post", "/v1/responses"),
+        ("post", "/v1/chat/completions"),
+        ("post", "/v1/images/generations"),
+        ("post", "/v1/images/edits"),
+        ("post", "/v1/audio/speech"),
+        ("post", "/v1/audio/transcriptions"),
+        ("post", "/v1/audio/translations"),
+        ("get", "/v1/models"),
+    ],
+)
+def test_inference_endpoints_require_configured_api_key(
+    client, monkeypatch, method, path
+):
+    monkeypatch.setenv("MLX_VLM_SERVER_API_KEY", "secret-token")
+
+    missing = getattr(client, method)(path)
+    invalid = getattr(client, method)(
+        path,
+        headers={"Authorization": "Bearer wrong-token"},
+    )
+
+    assert missing.status_code == 401
+    assert invalid.status_code == 401
+    assert missing.headers["WWW-Authenticate"] == "Bearer"
+    assert invalid.headers["WWW-Authenticate"] == "Bearer"
+
+
+def test_inference_endpoint_accepts_configured_api_key(client, monkeypatch):
+    monkeypatch.setenv("MLX_VLM_SERVER_API_KEY", "secret-token")
+
+    response = client.post(
+        "/v1/chat/completions",
+        headers={"Authorization": "Bearer secret-token"},
+        json={},
+    )
+
+    assert response.status_code == 422
+
+
 def _fake_image_result(*, seed: int, output_path=None) -> ImageGenerationResult:
     image = Image.new("RGB", (16, 16), (seed % 255, 8, 16))
     data = ImageGenerationResult(


### PR DESCRIPTION
## Summary

- keep the existing API-key protection for health, metrics, cache, and unload endpoints unchanged
- protect the previously unprotected inference, response-lifecycle, and model-discovery routes
- cover both `/v1/*` endpoints and their unversioned aliases to prevent authentication bypass
- document the expanded `--api-key` scope

## Root cause

`_require_management_api_key` was called only from management handlers. OpenAI, Anthropic, image, audio, response-lifecycle, and model-listing routes were registered directly on the application without an authentication dependency.

The confirmed-unprotected routes now register on a dedicated inference router with the existing API-key check as a shared dependency. No request-path inspection or management-handler refactor is involved.

## Live verification

Started the unmodified server with:

```sh
mlx_vlm.server --host 127.0.0.1 --port 18080 --api-key probe-secret
```

Before the fix, management routes returned `401` without the token, while every inference/model route returned its normal handler status regardless of credentials. After the fix, all 38 API routes tested return:

- `401` with no token
- `401` with an invalid token
- the route's normal response with the valid token

## Automated validation

- `uv run --frozen --with pytest pytest mlx_vlm/tests/test_server.py mlx_vlm/tests/test_server_audio.py -q` — 257 passed
- Black, isort, and autoflake pre-commit hooks passed
- `git diff --check` passed