### PR TITLE
Fix Responses instructions for Qwen chat templates

### DIFF
--- a/mlx_vlm/server/openai.py
+++ b/mlx_vlm/server/openai.py
@@ -284,6 +284,31 @@ def _adapter_path_or_inherit(request):
     )
 
 
+def _normalize_response_instruction_messages(
+    chat_messages: List[dict],
+    instructions: Optional[str],
+) -> Optional[str]:
+    instruction_parts = [instructions] if instructions else []
+    conversation = []
+
+    for message in chat_messages:
+        if message.get("role") in ("system", "developer"):
+            content = message.get("content")
+            if content:
+                instruction_parts.append(str(content))
+        else:
+            conversation.append(message)
+
+    normalized_instructions = "\n\n".join(instruction_parts) or None
+    if normalized_instructions:
+        conversation.insert(
+            0,
+            {"role": "system", "content": normalized_instructions},
+        )
+    chat_messages[:] = conversation
+    return normalized_instructions
+
+
 def _decode_input_audio_data(input_audio: InputAudio):
     data = input_audio["data"]
     if not isinstance(data, str):
@@ -783,10 +808,10 @@ async def responses_input_tokens_endpoint(request: Request):
             + current_input_items
         )
         chat_messages, images = _response_items_to_chat(prompt_items)
-        if openai_request.instructions:
-            chat_messages.insert(
-                0, {"role": "system", "content": openai_request.instructions}
-            )
+        _normalize_response_instruction_messages(
+            chat_messages,
+            openai_request.instructions,
+        )
         _ensure_effective_input(chat_messages, images=images)
 
         model, processor, config = get_cached_model(
@@ -944,11 +969,10 @@ async def responses_endpoint(request: Request):
             + current_input_items
         )
         chat_messages, images = _response_items_to_chat(prompt_items)
-        instructions = openai_request.instructions
-        if instructions:
-            chat_messages.insert(0, {"role": "system", "content": instructions})
-        elif chat_messages and chat_messages[0].get("role") in ("system", "developer"):
-            instructions = chat_messages[0].get("content")
+        instructions = _normalize_response_instruction_messages(
+            chat_messages,
+            openai_request.instructions,
+        )
         _ensure_effective_input(chat_messages, images=images)
 
         # Get model, processor, config - loading if necessary

--- a/mlx_vlm/tests/test_server.py
+++ b/mlx_vlm/tests/test_server.py
@@ -1698,6 +1698,61 @@ def test_responses_endpoint_forwards_new_sampling_args(client):
     assert mock_generate.call_args.kwargs["thinking_end_token"] == "</think>"
 
 
+def test_responses_endpoint_merges_developer_message_with_instructions(client):
+    model = SimpleNamespace()
+    processor = SimpleNamespace()
+    config = SimpleNamespace(model_type="qwen2_vl")
+    result = GenerationResult(
+        text="done",
+        prompt_tokens=8,
+        generation_tokens=4,
+        total_tokens=12,
+    )
+
+    with (
+        patch.object(
+            server, "get_cached_model", return_value=(model, processor, config)
+        ),
+        patch.object(
+            server, "apply_chat_template", return_value="prompt"
+        ) as mock_template,
+        patch.object(server, "generate", return_value=result),
+    ):
+        response = client.post(
+            "/responses",
+            json={
+                "model": "demo",
+                "instructions": "Top-level instructions.",
+                "input": [
+                    {
+                        "type": "message",
+                        "role": "developer",
+                        "content": [
+                            {
+                                "type": "input_text",
+                                "text": "Developer instructions.",
+                            }
+                        ],
+                    },
+                    {
+                        "type": "message",
+                        "role": "user",
+                        "content": [{"type": "input_text", "text": "Hello"}],
+                    },
+                ],
+            },
+        )
+
+    assert response.status_code == 200
+    assert mock_template.call_args.args[2] == [
+        {
+            "role": "system",
+            "content": "Top-level instructions.\n\nDeveloper instructions.",
+        },
+        {"role": "user", "content": "Hello"},
+    ]
+
+
 @pytest.mark.parametrize(
     ("include_adapter", "adapter_path", "expected_adapter"),
     [


### PR DESCRIPTION
## What

Normalize Responses API instruction messages before applying a model chat template:

- Merge top-level `instructions` with `system` and `developer` input messages.
- Emit one leading `system` message followed by the conversation.
- Apply the same normalization to `/responses` and `/responses/input_tokens`.
- Add a regression test covering the payload shape produced by Codex CLI.

## Why

Codex CLI can send both top-level `instructions` and a leading `developer` message. The server previously inserted a `system` message while leaving the `developer` message in place. Qwen chat templates reject that sequence with `Unexpected message role`, so the request failed before reaching inference even though other model templates accepted it.

## Impact

Qwen models can handle Codex-style Responses requests without changing the client payload. Existing user conversation messages and API-key authentication behavior are preserved.

## Checks

- `uv run --with pytest pytest mlx_vlm/tests/test_server.py -q -k 'merges_developer_message_with_instructions or inference_endpoint_accepts_configured_api_key'` — 2 passed
- Real Codex CLI smoke test with `mlx-community/Qwen3.5-0.8B-MLX-4bit` — completed successfully with one server request and no failed requests