### PR TITLE
Return model loading failures as bad requests

### DIFF
--- a/mlx_vlm/server/generation.py
+++ b/mlx_vlm/server/generation.py
@@ -655,15 +655,9 @@ def load_model_resources(model_path: str, adapter_path: Optional[str]):
         config = model.config
         logger.info("Model and processor loaded successfully.")
         return model, processor, config
-    except ValueError as e:
-        logger.warning("Unsupported model %s: %s", model_path, e)
-        raise HTTPException(
-            status_code=400,
-            detail=f"Unsupported model {model_path!r}: {e}",
-        ) from e
     except Exception as e:
         logger.exception("Error loading model %s: %s", model_path, e)
-        raise HTTPException(status_code=500, detail=f"Failed to load model: {e}")
+        raise HTTPException(status_code=400, detail=f"Failed to load model: {e}")
 
 
 # =============================================================================

--- a/mlx_vlm/server/generation.py
+++ b/mlx_vlm/server/generation.py
@@ -655,6 +655,12 @@ def load_model_resources(model_path: str, adapter_path: Optional[str]):
         config = model.config
         logger.info("Model and processor loaded successfully.")
         return model, processor, config
+    except ValueError as e:
+        logger.warning("Unsupported model %s: %s", model_path, e)
+        raise HTTPException(
+            status_code=400,
+            detail=f"Unsupported model {model_path!r}: {e}",
+        ) from e
     except Exception as e:
         logger.exception("Error loading model %s: %s", model_path, e)
         raise HTTPException(status_code=500, detail=f"Failed to load model: {e}")

--- a/mlx_vlm/tests/test_server.py
+++ b/mlx_vlm/tests/test_server.py
@@ -571,9 +571,18 @@ def test_get_cached_model_omitted_adapter_inherits_loaded_adapter(monkeypatch):
     assert server.runtime.model_cache["adapter_path"] == "adapter-a"
 
 
-def test_load_model_resources_returns_unsupported_model_error(monkeypatch):
+@pytest.mark.parametrize(
+    "load_error",
+    [
+        ValueError("Model type bert not supported."),
+        RuntimeError("Unable to initialize model."),
+    ],
+)
+def test_load_model_resources_returns_load_failure_as_bad_request(
+    monkeypatch, load_error
+):
     def reject_model(*_args, **_kwargs):
-        raise ValueError("Model type bert not supported.")
+        raise load_error
 
     monkeypatch.setattr(server_generation, "load", reject_model)
 
@@ -584,10 +593,7 @@ def test_load_model_resources_returns_unsupported_model_error(monkeypatch):
         )
 
     assert exc_info.value.status_code == 400
-    assert exc_info.value.detail == (
-        "Unsupported model 'google-bert/bert-base-multilingual-cased': "
-        "Model type bert not supported."
-    )
+    assert exc_info.value.detail == f"Failed to load model: {load_error}"
 
 
 def test_unsupported_model_request_does_not_crash_server(client, monkeypatch):
@@ -610,8 +616,7 @@ def test_unsupported_model_request_does_not_crash_server(client, monkeypatch):
 
     assert response.status_code == 400
     assert response.json()["detail"] == (
-        "Unsupported model 'google-bert/bert-base-multilingual-cased': "
-        "Model type bert not supported."
+        "Failed to load model: Model type bert not supported."
     )
     assert client.get("/health").status_code == 200
 

--- a/mlx_vlm/tests/test_server.py
+++ b/mlx_vlm/tests/test_server.py
@@ -571,6 +571,51 @@ def test_get_cached_model_omitted_adapter_inherits_loaded_adapter(monkeypatch):
     assert server.runtime.model_cache["adapter_path"] == "adapter-a"
 
 
+def test_load_model_resources_returns_unsupported_model_error(monkeypatch):
+    def reject_model(*_args, **_kwargs):
+        raise ValueError("Model type bert not supported.")
+
+    monkeypatch.setattr(server_generation, "load", reject_model)
+
+    with pytest.raises(server.HTTPException) as exc_info:
+        server_generation.load_model_resources(
+            "google-bert/bert-base-multilingual-cased",
+            None,
+        )
+
+    assert exc_info.value.status_code == 400
+    assert exc_info.value.detail == (
+        "Unsupported model 'google-bert/bert-base-multilingual-cased': "
+        "Model type bert not supported."
+    )
+
+
+def test_unsupported_model_request_does_not_crash_server(client, monkeypatch):
+    def reject_model(*_args, **_kwargs):
+        raise ValueError("Model type bert not supported.")
+
+    monkeypatch.setattr(server_generation, "load", reject_model)
+    monkeypatch.setattr(server._app_module._apc, "from_env", lambda *_, **__: None)
+    monkeypatch.setattr(server.runtime, "model_cache", {})
+    monkeypatch.setattr(server.runtime, "response_generator", None)
+    monkeypatch.setattr(server.runtime, "apc_manager", None)
+
+    response = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "google-bert/bert-base-multilingual-cased",
+            "messages": [{"role": "user", "content": "Hello"}],
+        },
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == (
+        "Unsupported model 'google-bert/bert-base-multilingual-cased': "
+        "Model type bert not supported."
+    )
+    assert client.get("/health").status_code == 200
+
+
 def _unstarted_response_generator():
     gen = server.ResponseGenerator.__new__(server.ResponseGenerator)
     gen.model_path = "demo"


### PR DESCRIPTION
## Summary

- reuse the server's existing model-loading failure handler
- return HTTP 400 instead of HTTP 500 when a requested model cannot be loaded
- verify unsupported and other loading failures use the same response path
- verify the server remains healthy after rejecting an unsupported model

## Root cause

Failures raised while loading a requested model were handled as internal server errors. Unsupported architectures such as `google-bert/bert-base-multilingual-cased` therefore returned HTTP 500 even though the request selected a model the server could not load.

## Impact

All exceptions raised during requested model loading now return the existing `Failed to load model: ...` detail with HTTP 400. Core model-loading behavior is unchanged.

## Validation

- `uv run --with pytest pytest -q mlx_vlm/tests/test_server.py` (220 passed)
- Black and isort checks passed
- repository pre-commit hooks passed