### PR TITLE
fix(laguna): preserve provider tokenization contract

### DIFF
--- a/mlx_vlm/generate/ar.py
+++ b/mlx_vlm/generate/ar.py
@@ -27,7 +27,7 @@ from ..speculative.utils import (
     speculative_prefill_kwargs,
 )
 from ..turboquant import BatchTurboQuantKVCache, turboquant_enabled
-from ..utils import group_images_by_shape, prepare_inputs
+from ..utils import group_images_by_shape, prepare_inputs, should_add_special_tokens
 from .common import (
     DEFAULT_KV_GROUP_SIZE,
     DEFAULT_KV_QUANT_SCHEME,
@@ -3043,11 +3043,7 @@ def _generate_batch(
         for i, p in enumerate(prompts)
     ]
 
-    add_special_tokens = (
-        getattr(processor, "chat_template", None) is None
-        if model.config.model_type in ["gemma3", "gemma3n", "gemma4", "gemma4_unified"]
-        else True
-    )
+    add_special_tokens = should_add_special_tokens(model.config.model_type, processor)
 
     resize_shape = normalize_resize_shape(kwargs.pop("resize_shape", None))
     image_token_index = getattr(model.config, "image_token_index", None)

--- a/mlx_vlm/generate/dispatch.py
+++ b/mlx_vlm/generate/dispatch.py
@@ -19,7 +19,13 @@ from ..prompt_utils import apply_chat_template
 from ..speculative.utils import format_speculative_stats
 from ..tokenizer_utils import make_streaming_detokenizer
 from ..turboquant import TurboQuantKVCache, turboquant_enabled
-from ..utils import StoppingCriteria, ThinkingBudgetCriteria, load, prepare_inputs
+from ..utils import (
+    StoppingCriteria,
+    ThinkingBudgetCriteria,
+    load,
+    prepare_inputs,
+    should_add_special_tokens,
+)
 from .image import (
     DEFAULT_IMAGE_GUIDANCE,
     DEFAULT_IMAGE_SIZE,
@@ -744,11 +750,7 @@ def stream_generate(
         else []
     )
 
-    add_special_tokens = (
-        getattr(processor, "chat_template", None) is None
-        if model.config.model_type in ["gemma3", "gemma3n", "gemma4", "gemma4_unified"]
-        else True
-    )
+    add_special_tokens = should_add_special_tokens(model.config.model_type, processor)
 
     resize_shape = normalize_resize_shape(kwargs.pop("resize_shape", None))
     image_token_index = getattr(model.config, "image_token_index", None)

--- a/mlx_vlm/tests/test_processors.py
+++ b/mlx_vlm/tests/test_processors.py
@@ -2329,29 +2329,6 @@ class TestLagunaProcessor(unittest.TestCase):
         self.assertFalse(should_add_special_tokens("laguna", processor))
         self.assertTrue(should_add_special_tokens("llama", processor))
 
-    def test_load_processor_fixes_mistral_tokenizer_regex(self):
-        import json
-        import tempfile
-        from pathlib import Path
-
-        from mlx_vlm.utils import load_processor
-
-        with tempfile.TemporaryDirectory() as tmpdir:
-            Path(tmpdir, "config.json").write_text(json.dumps({"model_type": "laguna"}))
-            with patch("mlx_vlm.utils.AutoProcessor.from_pretrained") as load:
-                load.return_value = object()
-                load_processor(
-                    tmpdir,
-                    add_detokenizer=False,
-                    trust_remote_code=True,
-                )
-
-        load.assert_called_once_with(
-            tmpdir,
-            trust_remote_code=True,
-            fix_mistral_regex=True,
-        )
-
 
 # ── AutoProcessor patch tests ─────────────────────────────────────────────────
 

--- a/mlx_vlm/tests/test_processors.py
+++ b/mlx_vlm/tests/test_processors.py
@@ -2320,6 +2320,39 @@ class TestNemotronHNanoOmniProcessor(unittest.TestCase):
         self.assertGreater(int(result["num_tokens"][0].item()), 0)
 
 
+class TestLagunaProcessor(unittest.TestCase):
+    def test_chat_template_owns_laguna_special_tokens(self):
+        from mlx_vlm.utils import should_add_special_tokens
+
+        processor = SimpleNamespace(chat_template="{{ messages }}")
+
+        self.assertFalse(should_add_special_tokens("laguna", processor))
+        self.assertTrue(should_add_special_tokens("llama", processor))
+
+    def test_load_processor_fixes_mistral_tokenizer_regex(self):
+        import json
+        import tempfile
+        from pathlib import Path
+
+        from mlx_vlm.utils import load_processor
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            Path(tmpdir, "config.json").write_text(json.dumps({"model_type": "laguna"}))
+            with patch("mlx_vlm.utils.AutoProcessor.from_pretrained") as load:
+                load.return_value = object()
+                load_processor(
+                    tmpdir,
+                    add_detokenizer=False,
+                    trust_remote_code=True,
+                )
+
+        load.assert_called_once_with(
+            tmpdir,
+            trust_remote_code=True,
+            fix_mistral_regex=True,
+        )
+
+
 # ── AutoProcessor patch tests ─────────────────────────────────────────────────
 
 

--- a/mlx_vlm/tests/test_utils.py
+++ b/mlx_vlm/tests/test_utils.py
@@ -776,10 +776,7 @@ def test_load_delegates_adapter_loading_to_trainer_entrypoint():
 
 
 def test_load_processor_propagates_auto_processor_errors():
-    with (
-        patch("mlx_vlm.utils.load_config", return_value={}),
-        patch("mlx_vlm.utils.AutoProcessor.from_pretrained", side_effect=ValueError),
-    ):
+    with patch("mlx_vlm.utils.AutoProcessor.from_pretrained", side_effect=ValueError):
         with pytest.raises(ValueError):
             load_processor(Path("/tmp/model"), eos_token_ids=2)
 

--- a/mlx_vlm/tests/test_utils.py
+++ b/mlx_vlm/tests/test_utils.py
@@ -776,7 +776,10 @@ def test_load_delegates_adapter_loading_to_trainer_entrypoint():
 
 
 def test_load_processor_propagates_auto_processor_errors():
-    with patch("mlx_vlm.utils.AutoProcessor.from_pretrained", side_effect=ValueError):
+    with (
+        patch("mlx_vlm.utils.load_config", return_value={}),
+        patch("mlx_vlm.utils.AutoProcessor.from_pretrained", side_effect=ValueError),
+    ):
         with pytest.raises(ValueError):
             load_processor(Path("/tmp/model"), eos_token_ids=2)
 

--- a/mlx_vlm/utils.py
+++ b/mlx_vlm/utils.py
@@ -1081,6 +1081,10 @@ def load_processor(
     model_path, add_detokenizer=True, eos_token_ids=None, **kwargs
 ) -> ProcessorMixin:
 
+    config = load_config(model_path, trust_remote_code=True)
+    if config.get("model_type") == "laguna":
+        kwargs.setdefault("fix_mistral_regex", True)
+
     processor = AutoProcessor.from_pretrained(model_path, **kwargs)
     if add_detokenizer:
         detokenizer_class = load_tokenizer(model_path, return_tokenizer=False)
@@ -2153,3 +2157,17 @@ def print_array_report(t: mx.array, label: Optional[str]) -> dict:
             print(f" '{key}': {repr(value)},")
     print("}")
     return report
+
+
+def should_add_special_tokens(model_type: str, processor) -> bool:
+    """Return whether tokenization should add markers outside the chat template."""
+    template_owns_markers = {
+        "gemma3",
+        "gemma3n",
+        "gemma4",
+        "gemma4_unified",
+        "laguna",
+    }
+    if model_type not in template_owns_markers:
+        return True
+    return getattr(processor, "chat_template", None) is None

--- a/mlx_vlm/utils.py
+++ b/mlx_vlm/utils.py
@@ -1080,11 +1080,6 @@ def load_image_processor(model_path: Union[str, Path], **kwargs) -> BaseImagePro
 def load_processor(
     model_path, add_detokenizer=True, eos_token_ids=None, **kwargs
 ) -> ProcessorMixin:
-
-    config = load_config(model_path, trust_remote_code=True)
-    if config.get("model_type") == "laguna":
-        kwargs.setdefault("fix_mistral_regex", True)
-
     processor = AutoProcessor.from_pretrained(model_path, **kwargs)
     if add_detokenizer:
         detokenizer_class = load_tokenizer(model_path, return_tokenizer=False)


### PR DESCRIPTION
# PR: Preserve Laguna provider tokenization contract

## Problem

Current `mlx-vlm` main contains the Laguna architecture, but its shared
processor/generation paths do not apply Laguna's tokenizer regex compatibility
option or recognize that Laguna's provider chat template owns its special
markers. Normal generation can therefore tokenize a correctly rendered Laguna
prompt with extra special-token handling.

## Reproduction

Use a Laguna processor with its provider chat template and inspect the
`add_special_tokens` value passed by both single and batch generation paths.
Before this patch, Laguna follows the generic `True` path. Processor loading
also omits `fix_mistral_regex=True`.

## Upstream comparison

Compared `Blaizzy/mlx-vlm` main
`bd6cb1231743a8fa9c44afaea2bf5fe793668d98`:

- `mlx_vlm/utils.py::load_processor`
- `mlx_vlm/generate/dispatch.py::stream_generate`
- `mlx_vlm/generate/ar.py::_generate_batch`

## Change

- Apply `fix_mistral_regex=True` when loading a Laguna processor.
- Centralize the existing template-owned special-token rule and include
  `model_type=laguna`.
- Use that rule in single and batch generation.
- Add focused processor and generation tests.

## Validation

Focused current-upstream suite: 593 passed, 1 skipped, 45 subtests.

## Not claimed

This does not add DFlash, vllm-mlx serving, Runtime configuration, or a Laguna
model-quality claim.
