### PR TITLE
Make Nemotron Omni audio sanitize idempotent for converted MLX checkpoints

### DIFF
--- a/mlx_vlm/models/nemotron_h_nano_omni/audio.py
+++ b/mlx_vlm/models/nemotron_h_nano_omni/audio.py
@@ -5,6 +5,7 @@ import mlx.core as mx
 import mlx.nn as nn
 import numpy as np
 
+from ..base import check_array_shape
 from .config import AudioConfig
 
 
@@ -545,6 +546,18 @@ class SoundFeatureExtractor:
         )
 
 
+def _is_mlx_conv1d_layout(key, shape):
+    """Conv1d: PyTorch [out, in // groups, kW] -> MLX [out, kW, in // groups].
+
+    ``depthwise_conv`` is grouped per channel, so ``in // groups`` is 1 and only
+    the MLX layout puts that 1 last. The pointwise convolutions have ``kW == 1``,
+    so only the MLX layout puts that 1 in the middle.
+    """
+    if key.endswith(".depthwise_conv.weight"):
+        return shape[2] == 1
+    return shape[1] == 1
+
+
 def sanitize_audio_weights(weights):
     sanitized = {}
     for key, value in weights.items():
@@ -552,10 +565,15 @@ def sanitize_audio_weights(weights):
             continue
         if key.endswith(".num_batches_tracked"):
             continue
-        if key.startswith("sound_encoder.encoder."):
-            if key.endswith(".weight") and value.ndim == 3:
+        # Converted checkpoints already store the MLX layout, and sanitize runs
+        # on those too, so the conv transposes below have to be idempotent.
+        if key.startswith("sound_encoder.encoder.") and key.endswith(".weight"):
+            if value.ndim == 3 and not _is_mlx_conv1d_layout(key, value.shape):
                 value = value.transpose(0, 2, 1)
-            elif key.endswith(".weight") and value.ndim == 4:
+            # Conv2d: PyTorch [out, in // groups, kH, kW] -> MLX
+            # [out, kH, kW, in // groups]. Every kernel in the subsampling stack
+            # is square, which is what check_array_shape keys off.
+            elif value.ndim == 4 and not check_array_shape(value):
                 value = value.transpose(0, 2, 3, 1)
         sanitized[key] = value
     return sanitized

--- a/mlx_vlm/tests/test_nemotron_h_nano_omni.py
+++ b/mlx_vlm/tests/test_nemotron_h_nano_omni.py
@@ -1,6 +1,7 @@
 import mlx.core as mx
 import numpy as np
 import pytest
+from mlx.utils import tree_flatten
 
 from mlx_vlm.models.nemotron_h_nano_omni.audio import (
     SoundEncoder,
@@ -251,3 +252,46 @@ def test_sanitize_audio_and_projection_weights():
     assert "mlp1.layers.0.weight" in model_sanitized
     assert "mlp1.layers.1.weight" in model_sanitized
     assert "mlp1.layers.3.weight" in model_sanitized
+
+
+def _encoder_conv_shapes(config):
+    """Shapes the encoder's conv weights must have, keyed like a checkpoint."""
+    encoder = SoundEncoder(config)
+    shapes = {
+        f"sound_encoder.encoder.{name}": param.shape
+        for name, param in tree_flatten(encoder.parameters())
+        if name.endswith(".weight") and param.ndim in (3, 4)
+    }
+    assert shapes, "expected the sound encoder to expose conv weights"
+    return shapes
+
+
+@pytest.mark.parametrize("hidden_size", [16, 32])
+def test_sanitize_audio_weights_is_idempotent_for_conv_layouts(hidden_size):
+    """Conv transposes must be no-ops on already-converted MLX checkpoints.
+
+    ``load_model`` sanitizes every checkpoint, including ones mlx-vlm converted
+    itself, which already store the MLX layout. Transposing those a second time
+    produced e.g. ``(256, 3, 1, 3)`` for a subsampling kernel the model expects
+    as ``(256, 3, 3, 1)``.
+    """
+    config = tiny_sound_config(hidden_size=hidden_size)
+    expected = _encoder_conv_shapes(config)
+
+    mlx_layout = {key: mx.zeros(shape) for key, shape in expected.items()}
+    # Invert the sanitizer to synthesize the upstream PyTorch layout.
+    upstream_layout = {
+        key: (
+            value.transpose(0, 2, 1) if value.ndim == 3 else value.transpose(0, 3, 1, 2)
+        )
+        for key, value in mlx_layout.items()
+    }
+
+    from_upstream = sanitize_audio_weights(upstream_layout)
+    from_mlx = sanitize_audio_weights(mlx_layout)
+    twice = sanitize_audio_weights(from_upstream)
+
+    for key, shape in expected.items():
+        assert from_upstream[key].shape == shape, key
+        assert from_mlx[key].shape == shape, key
+        assert twice[key].shape == shape, key


### PR DESCRIPTION
## Summary

Fixes #1718. `mlx-community/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-{8bit,mxfp4}` fail to load on 0.6.4–0.6.7 with:

```
ValueError: Expected shape (256, 3, 3, 1) but received shape (256, 3, 1, 3)
for parameter sound_encoder.encoder.subsampling.layers.0.weight
```

`sanitize_audio_weights` transposes every 3-D and 4-D `sound_encoder.encoder.*` weight unconditionally. Since #1498 made `load_model` sanitize every checkpoint — including ones mlx-vlm converted itself, which already store the MLX layout — those weights get transposed a second time. This guards both transposes on the layout actually present.

## Why this shape rather than restoring the `is_mlx_format` gate

The issue suggests restoring the `is_mlx_format` guard that #1498 removed. I went the other way, because #1498 removed it deliberately: "The previous sanitizer gate could bypass model-specific cleanup for checkpoints that still need remapping." Bringing the gate back would re-break that, and it would also skip genuinely-needed remapping — e.g. this model's own `mlp1.0.` → `mlp1.layers.0.` rename in `Model.sanitize`.

Idempotent sanitize is already the convention here: `check_array_shape` guards conv transposes in ~40 model files, and the gemma4 audio tower carries the same comment for the same reason ("Converted checkpoints may already use the MLX layout", `gemma4.py:252`). `sanitize_audio_weights` was the outlier, not the rule. This keeps `should_shift_norm_weights` and friends consistent with one policy instead of two.

## The layout checks

- **Conv2d** (subsampling stack): PyTorch `[out, in // groups, kH, kW]` → MLX `[out, kH, kW, in // groups]`. Every kernel here is square, so `check_array_shape` distinguishes them: `(256, 3, 3, 1)` and `(256, 1, 1, 256)` are already MLX; `(256, 1, 3, 3)` and `(256, 256, 1, 1)` are not.
- **Conv1d** (conformer conv module): PyTorch `[out, in // groups, kW]` → MLX `[out, kW, in // groups]`. `check_array_shape`'s 3-D branch doesn't apply — it assumes `kW >= out_channels`, which is false for all three convs here. `depthwise_conv` is grouped per channel so `in // groups == 1` and only the MLX layout puts that 1 last; `pointwise_conv1`/`pointwise_conv2` have `kW == 1` so only the MLX layout puts that 1 in the middle.

## Validation against the real checkpoints

Both affected checkpoints were available locally, so this is checked end-to-end, not just by unit test.

**Before/after on `mlx-community/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-mxfp4`:** `mlx_vlm.load` raises the exact traceback above on `main` at bd6cb12, and loads cleanly on this branch.

**All 77 conv weights, both checkpoints.** Compared on-disk shapes against an instantiated `SoundEncoder` (24 conformer layers × 3 Conv1d, plus 5 subsampling Conv2d). Every one is already in MLX layout, and sanitize is now a strict no-op on all of them — no permutation applied at all:

```
safetensors metadata format: 'mlx'
sound_encoder.encoder.layers.0.conv.depthwise_conv.weight:  disk=(1024, 9, 1)     sanitized=(1024, 9, 1)     model_wants=(1024, 9, 1)
sound_encoder.encoder.layers.0.conv.pointwise_conv1.weight: disk=(2048, 1, 1024)  sanitized=(2048, 1, 1024)  model_wants=(2048, 1, 1024)
sound_encoder.encoder.subsampling.layers.0.weight:          disk=(256, 3, 3, 1)   sanitized=(256, 3, 3, 1)   model_wants=(256, 3, 3, 1)
sound_encoder.encoder.subsampling.layers.3.weight:          disk=(256, 1, 1, 256) sanitized=(256, 1, 1, 256) model_wants=(256, 1, 1, 256)
...
--> 77 conv weights checked, 0 wrong   (8bit and mxfp4 both)
```

**The audio tower produces correct output, not just correct shapes.** Encoding a 5 s clip gives 65 finite embeddings (mean 0.0083, std 0.3120), and transcription is exact:

```
prompt: "Transcribe this audio exactly."
output: "The quick brown fox jumps over the lazy dog. Today the weather in
         Melbourne is cold and rainy."
```

which is the input clip word for word.

## Unit test

New test derives ground truth from an instantiated `SoundEncoder` rather than hardcoding shapes, then checks all three directions — upstream → MLX, MLX → MLX (idempotency), and double-sanitize. It covers all 8 conv weight kinds the encoder exposes, and fails on `main`:

```
FAILED test_sanitize_audio_weights_is_idempotent_for_conv_layouts[16]
FAILED test_sanitize_audio_weights_is_idempotent_for_conv_layouts[32]
```

- `python -m pytest mlx_vlm/tests/test_nemotron_h_nano_omni.py` → 8 passed
- `python -m pytest mlx_vlm/tests/test_models.py mlx_vlm/tests/test_utils.py mlx_vlm/tests/test_processors.py` → 372 passed, 2 failed
  - The 2 failures are `TestAWQ::test_fold_into_{linear,norm}_is_identity`, a numerical tolerance issue that reproduces unchanged on `main` at bd6cb12.
- Hooks: `black`, `isort`

## Scope, and one thing found along the way

This fixes the weight-loading bug in the issue's repro. Two adjacent things I did **not** change:

1. Other architectures may have non-idempotent sanitizers too; happy to follow up with a sweep if you'd like.
2. `mlx_vlm.generate --audio` never reaches the audio tower for this model, independently of this fix: `nemotron_h_nano_omni` maps to `MessageFormat.LIST_WITH_IMAGE_TYPE`, whose handler ignores `num_audios`, so no `<so_embedding>` is emitted and the run dies with `Sound token count (0) does not match feature count (65)`. Passing the token by hand works (that is how the transcription above was produced). Say the word and I will open a separate issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)