### PR TITLE
Allow image editing with FLUX.2-klein-4b

### DIFF
--- a/mlx_vlm/models/flux2/README.md
+++ b/mlx_vlm/models/flux2/README.md
@@ -6,7 +6,7 @@ token generation path.
 
 Capabilities:
 - **Text-to-image generation** with FLUX.2 Klein and FLUX.2 Klein Base models
-- **Image editing** with FLUX.2 Klein 9B and the 9B KV reference-cache variant
+- **Image editing** with FLUX.2 Klein and FLUX.2 Klein Base models
 - **CLI output** to PNG files
 - **Python API output** as an evaluated `mx.array`
 - **OpenAI-compatible API** through `/v1/images/generations` and `/v1/images/edits`
@@ -15,10 +15,10 @@ Capabilities:
 
 | Model | Alias | Generation | Editing | Notes |
 |-------|-------|------------|---------|-------|
-| `black-forest-labs/FLUX.2-klein-4B` | `flux2-klein-4b`, `flux2-klein`, `klein-4b` | Yes | No | Dense 4B text-to-image model |
+| `black-forest-labs/FLUX.2-klein-4B` | `flux2-klein-4b`, `flux2-klein`, `klein-4b` | Yes | Yes | Dense 4B text-to-image and image-edit model |
 | `black-forest-labs/FLUX.2-klein-9B` | `flux2-klein-9b`, `klein-9b` | Yes | Yes | Dense 9B text-to-image and image-edit model |
-| `black-forest-labs/FLUX.2-klein-base-4B` | `flux2-klein-base-4b`, `flux2-base-4b`, `klein-base-4b` | Yes | No | Base 4B text-to-image model |
-| `black-forest-labs/FLUX.2-klein-base-9B` | `flux2-klein-base-9b`, `flux2-base-9b`, `klein-base-9b` | Yes | No | Base 9B text-to-image model |
+| `black-forest-labs/FLUX.2-klein-base-4B` | `flux2-klein-base-4b`, `flux2-base-4b`, `klein-base-4b` | Yes | Yes | Base 4B text-to-image and image-edit model |
+| `black-forest-labs/FLUX.2-klein-base-9B` | `flux2-klein-base-9b`, `flux2-base-9b`, `klein-base-9b` | Yes | Yes | Base 9B text-to-image and image-edit model |
 | `black-forest-labs/FLUX.2-klein-9b-kv` | `flux2-klein-9b-kv`, `klein-9b-kv` | Yes | Yes | 9B image-edit model with per-call reference-image KV caching |
 
 Models are downloaded with `huggingface_hub.snapshot_download` when they are not

--- a/mlx_vlm/models/flux2/config.py
+++ b/mlx_vlm/models/flux2/config.py
@@ -55,6 +55,7 @@ VARIANTS: dict[str, Flux2Variant] = {
         local_dir_name="FLUX.2-klein-4B",
         transformer_overrides=FLUX2_KLEIN_4B_TRANSFORMER,
         text_encoder_overrides=FLUX2_KLEIN_4B_TEXT_ENCODER,
+        supports_edit=True,
     ),
     "flux2-klein-9b": Flux2Variant(
         name="flux2-klein-9b",
@@ -86,6 +87,7 @@ VARIANTS: dict[str, Flux2Variant] = {
         local_dir_name="FLUX.2-klein-base-4B",
         transformer_overrides=FLUX2_KLEIN_4B_TRANSFORMER,
         text_encoder_overrides=FLUX2_KLEIN_4B_TEXT_ENCODER,
+        supports_edit=True,
     ),
     "flux2-klein-base-9b": Flux2Variant(
         name="flux2-klein-base-9b",
@@ -102,6 +104,7 @@ VARIANTS: dict[str, Flux2Variant] = {
         local_dir_name="FLUX.2-klein-base-9B",
         transformer_overrides=FLUX2_KLEIN_9B_TRANSFORMER,
         text_encoder_overrides=FLUX2_KLEIN_9B_TEXT_ENCODER,
+        supports_edit=True,
     ),
     "flux2-klein-9b-kv": Flux2Variant(
         name="flux2-klein-9b-kv",

--- a/mlx_vlm/tests/test_flux2.py
+++ b/mlx_vlm/tests/test_flux2.py
@@ -146,8 +146,15 @@ def test_flux2_declares_image_edit_model_type(
         is Flux2ImageEditModel
     )
     assert image_edit_model_class(tmp_path.as_posix()) is Flux2ImageEditModel
-    assert is_image_edit_model("black-forest-labs/FLUX.2-klein-9b-kv")
-    assert is_image_edit_model("black-forest-labs/FLUX.2-klein-9B")
+    for model_id in (
+        "black-forest-labs/FLUX.2-klein-4B",
+        "black-forest-labs/FLUX.2-klein-9B",
+        "black-forest-labs/FLUX.2-klein-base-4B",
+        "black-forest-labs/FLUX.2-klein-base-9B",
+        "black-forest-labs/FLUX.2-klein-9b-kv",
+    ):
+        assert image_edit_model_class(model_id) is Flux2ImageEditModel
+        assert is_image_edit_model(model_id)
 
 
 def test_flux2_image_model_class_uses_remote_model_index(


### PR DESCRIPTION
This was an oversight in the original implementations, but it's fully supported.