### PR TITLE
Support quantized FLUX.2 models

### DIFF
--- a/mlx_vlm/generate/edit_image.py
+++ b/mlx_vlm/generate/edit_image.py
@@ -132,6 +132,7 @@ def load_image_edit_model(
         not model_path.exists()
         and alias_model_class is not None
         and getattr(alias_model_class, "is_image_edit_model", False)
+        and alias_model_class.supports_model(model)
     ):
         return alias_model_class.from_model_id(
             model,

--- a/mlx_vlm/generate/image.py
+++ b/mlx_vlm/generate/image.py
@@ -42,6 +42,7 @@ IMAGE_METADATA_DOWNLOAD_PATTERNS = (
     "config.json",
     "manifest.json",
     "**/config.json",
+    "**/model.safetensors.index.json",
 )
 
 ImageOutputFormat = Literal["b64_json", "path"]
@@ -233,6 +234,26 @@ def _image_model_type_from_manifest(metadata: dict[str, Any]) -> str | None:
     return None
 
 
+def _image_model_type_from_component_indexes(root: Path) -> str | None:
+    transformer_index = _load_json_file(
+        root / "transformer" / "model.safetensors.index.json"
+    )
+    if transformer_index is None:
+        return None
+    weight_map = transformer_index.get("weight_map")
+    if not isinstance(weight_map, dict):
+        return None
+    keys = set(weight_map)
+    flux2_markers = {
+        "time_guidance_embed.linear_1.weight",
+        "double_stream_modulation_img.linear.weight",
+        "single_transformer_blocks.0.attn.to_qkv_mlp_proj.weight",
+    }
+    if flux2_markers <= keys:
+        return "flux2"
+    return None
+
+
 def _load_json_file(path: Path) -> dict[str, Any] | None:
     if not path.exists():
         return None
@@ -258,6 +279,7 @@ def _local_image_model_types(model: str) -> tuple[str, ...]:
     manifest = _load_json_file(root / "manifest.json")
     if manifest is not None:
         _add_model_type(candidates, _image_model_type_from_manifest(manifest))
+    _add_model_type(candidates, _image_model_type_from_component_indexes(root))
 
     for config_path in sorted(root.glob("*/config.json")):
         metadata = _load_json_file(config_path)

--- a/mlx_vlm/generate/image.py
+++ b/mlx_vlm/generate/image.py
@@ -42,6 +42,9 @@ IMAGE_METADATA_DOWNLOAD_PATTERNS = (
     "config.json",
     "manifest.json",
     "**/config.json",
+)
+IMAGE_COMPONENT_INDEX_DOWNLOAD_PATTERNS = (
+    *IMAGE_METADATA_DOWNLOAD_PATTERNS,
     "**/model.safetensors.index.json",
 )
 
@@ -342,14 +345,36 @@ def _resolve_image_model_path(
     )
 
 
-def _resolve_image_model_metadata_path(model: str) -> Path | None:
+def _resolve_image_model_metadata_path(
+    model: str, *, include_component_indexes: bool = False
+) -> Path | None:
     model_path = Path(model).expanduser()
     if model_path.exists():
         return model_path
+    patterns = (
+        IMAGE_COMPONENT_INDEX_DOWNLOAD_PATTERNS
+        if include_component_indexes
+        else IMAGE_METADATA_DOWNLOAD_PATTERNS
+    )
     return get_model_path(
         model,
-        allow_patterns=list(IMAGE_METADATA_DOWNLOAD_PATTERNS),
+        allow_patterns=list(patterns),
     )
+
+
+def _image_generation_model_class_from_path(
+    model: str, resolved_path: Path | None
+) -> type[Any] | None:
+    local_model_types = (
+        _local_image_model_types(str(resolved_path))
+        if resolved_path is not None
+        else ()
+    )
+    for model_type in (*local_model_types, _model_type_from_id(model)):
+        model_class = _image_model_class_for_type(model_type)
+        if model_class is not None and model_class.is_image_generation_model:
+            return model_class
+    return None
 
 
 def image_generation_model_class(model: str | None) -> type[Any] | None:
@@ -364,20 +389,17 @@ def image_generation_model_class(model: str | None) -> type[Any] | None:
         resolved_path = _resolve_image_model_metadata_path(model)
     except Exception:
         resolved_path = None
-    local_model_types = (
-        _local_image_model_types(str(resolved_path))
-        if resolved_path is not None
-        else ()
-    )
-    for model_type in (
-        *local_model_types,
-        _model_type_from_id(model),
-    ):
-        model_class = _image_model_class_for_type(model_type)
-        if model_class is not None and model_class.is_image_generation_model:
-            return model_class
+    model_class = _image_generation_model_class_from_path(model, resolved_path)
+    if model_class is not None or Path(model).expanduser().exists():
+        return model_class
 
-    return None
+    try:
+        resolved_path = _resolve_image_model_metadata_path(
+            model, include_component_indexes=True
+        )
+    except Exception:
+        return None
+    return _image_generation_model_class_from_path(model, resolved_path)
 
 
 def is_image_generation_model(model: str | None) -> bool:

--- a/mlx_vlm/models/flux2/config.py
+++ b/mlx_vlm/models/flux2/config.py
@@ -144,7 +144,11 @@ def get_variant(name: str | Flux2Variant = "flux2-klein-4b") -> Flux2Variant:
 
 def variant_from_local_path(model_path: str | Path) -> Flux2Variant:
     root = Path(model_path).expanduser()
-    name = str(root).lower()
+    name = root.name.lower()
+    if root.parent.name == "snapshots" and root.parent.parent.name.startswith(
+        "models--"
+    ):
+        name = root.parent.parent.name.removeprefix("models--").replace("--", "/")
     if "kv" in name or (root / "flux-2-klein-9b-kv.safetensors").exists():
         return VARIANTS["flux2-klein-9b-kv"]
     if "base" in name and "9b" in name:

--- a/mlx_vlm/models/flux2/model.py
+++ b/mlx_vlm/models/flux2/model.py
@@ -82,6 +82,7 @@ class Flux2ImageGenerationModel(ImageGenerationModel):
         seed = 0 if request.seed is None else request.seed
         max_sequence_length = request.extra.get("max_sequence_length", None)
         tiled_vae = request.extra.get("tiled_vae", None)
+        quantization_config = getattr(self.pipeline, "quantization_config", None)
         array = self.pipeline.generate_array(
             request.prompt,
             seed=seed,
@@ -92,6 +93,13 @@ class Flux2ImageGenerationModel(ImageGenerationModel):
             max_sequence_length=max_sequence_length,
             tiled_vae=tiled_vae,
         )
+        metadata = {
+            "model_path": str(self.pipeline.model_path),
+            "architecture": "quantized" if quantization_config else "dense",
+            "vae_variant": "full",
+        }
+        if quantization_config is not None:
+            metadata["quantization"] = dict(quantization_config)
         return ImageGenerationResult(
             array=array,
             seed=seed,
@@ -104,11 +112,7 @@ class Flux2ImageGenerationModel(ImageGenerationModel):
             guidance=request.guidance,
             prompt_tokens=self.count_prompt_tokens(request.prompt),
             peak_memory=mx.get_peak_memory() / 1e9,
-            metadata={
-                "model_path": str(self.pipeline.model_path),
-                "architecture": "dense",
-                "vae_variant": "full",
-            },
+            metadata=metadata,
         )
 
     @classmethod
@@ -131,8 +135,9 @@ class Flux2ImageGenerationModel(ImageGenerationModel):
             )
             else model_path_arg
         )
+        variant = resolve_variant(model_path if model_path is not None else model)
         pipeline = Flux2Image.from_pretrained(
-            resolve_variant(model),
+            variant,
             model_path=model_path,
             download=kwargs.pop("download", True),
             token=kwargs.pop("token", None),
@@ -169,6 +174,7 @@ class Flux2ImageEditModel(ImageEditModel):
         seed = 0 if request.seed is None else request.seed
         max_sequence_length = request.extra.get("max_sequence_length", None)
         tiled_vae = request.extra.get("tiled_vae", None)
+        quantization_config = getattr(self.pipeline, "quantization_config", None)
         array = self.pipeline.edit_array(
             request.prompt,
             request.image_paths,
@@ -180,6 +186,15 @@ class Flux2ImageEditModel(ImageEditModel):
             max_sequence_length=max_sequence_length,
             tiled_vae=tiled_vae,
         )
+        metadata = {
+            "model_path": str(self.pipeline.model_path),
+            "architecture": "quantized" if quantization_config else "dense",
+            "vae_variant": "full",
+            "reference_count": len(request.image_paths),
+            "uses_reference_kv_cache": self.pipeline.variant.uses_reference_kv_cache,
+        }
+        if quantization_config is not None:
+            metadata["quantization"] = dict(quantization_config)
         return ImageGenerationResult(
             array=array,
             seed=seed,
@@ -192,13 +207,7 @@ class Flux2ImageEditModel(ImageEditModel):
             guidance=request.guidance,
             prompt_tokens=self.count_prompt_tokens(request.prompt),
             peak_memory=mx.get_peak_memory() / 1e9,
-            metadata={
-                "model_path": str(self.pipeline.model_path),
-                "architecture": "dense",
-                "vae_variant": "full",
-                "reference_count": len(request.image_paths),
-                "uses_reference_kv_cache": self.pipeline.variant.uses_reference_kv_cache,
-            },
+            metadata=metadata,
         )
 
     @classmethod
@@ -211,9 +220,6 @@ class Flux2ImageEditModel(ImageEditModel):
         model: str = "flux2-klein-9b-kv",
         **kwargs: Any,
     ) -> "Flux2ImageEditModel":
-        variant = resolve_variant(model)
-        if not variant.supports_edit:
-            raise ValueError(f"{variant.repo_id} does not support image editing")
         model_path_arg = kwargs.pop("model_path", None)
         model_path = (
             Path(model).expanduser()
@@ -224,6 +230,9 @@ class Flux2ImageEditModel(ImageEditModel):
             )
             else model_path_arg
         )
+        variant = resolve_variant(model_path if model_path is not None else model)
+        if not variant.supports_edit:
+            raise ValueError(f"{variant.repo_id} does not support image editing")
         pipeline = Flux2ImageEdit.from_pretrained(
             variant,
             model_path=model_path,

--- a/mlx_vlm/models/flux2/pipeline.py
+++ b/mlx_vlm/models/flux2/pipeline.py
@@ -52,6 +52,9 @@ class Flux2Image:
         self.runtime_config = runtime_config or Flux2RuntimeConfig()
         self.tokenizer = Flux2Tokenizer(self.model_path)
         self.text_encoder = load_text_encoder(self.model_path, self.variant)
+        self.quantization_config = getattr(
+            self.text_encoder, "quantization_config", None
+        )
         self.transformer = None
         self.vae = None
         self.prompt_cache: dict[tuple[str, int, bool], tuple[mx.array, mx.array]] = {}

--- a/mlx_vlm/models/flux2/weights.py
+++ b/mlx_vlm/models/flux2/weights.py
@@ -1,9 +1,13 @@
 from __future__ import annotations
 
+import json
+from dataclasses import dataclass
 from pathlib import Path
+from typing import Any
 
 import mlx.core as mx
-from mlx.utils import tree_unflatten
+from mlx import nn
+from mlx.utils import tree_flatten, tree_unflatten
 
 from mlx_vlm.models.flux2.config import Flux2Variant
 from mlx_vlm.models.flux2.constants import ModelConfig
@@ -14,24 +18,36 @@ from mlx_vlm.models.flux2.vae import Flux2VAE
 FULL_DECODER_CHANNELS = (128, 256, 512, 512)
 
 
+@dataclass(frozen=True, slots=True)
+class QuantizationConfig:
+    bits: int
+    group_size: int
+    mode: str = "affine"
+
+    def as_dict(self) -> dict[str, int | str]:
+        return {
+            "bits": self.bits,
+            "group_size": self.group_size,
+            "mode": self.mode,
+        }
+
+
 def load_text_encoder(
     model_path: str | Path, variant: Flux2Variant
 ) -> Qwen3TextEncoder:
-    raw = _load_safetensors(Path(model_path).expanduser() / "text_encoder")
+    raw, metadata = _load_safetensors(Path(model_path).expanduser() / "text_encoder")
     weights = {}
     for key, value in raw.items():
-        if not key.startswith("model."):
+        mapped = key.removeprefix("model.")
+        if not mapped.startswith(("embed_tokens.", "layers.", "norm.")):
             continue
-        stripped = key[len("model.") :]
-        if stripped.startswith(("embed_tokens.", "layers.", "norm.")):
-            weights[stripped] = value.astype(ModelConfig.precision)
+        weights[mapped] = _cast_float(value)
     text_encoder = Qwen3TextEncoder(**variant.text_encoder_overrides)
-    text_encoder.update(tree_unflatten(list(weights.items())))
-    return text_encoder
+    return _apply_weights(text_encoder, weights, metadata)
 
 
 def load_transformer(model_path: str | Path, variant: Flux2Variant) -> Flux2Transformer:
-    raw = _load_safetensors(Path(model_path).expanduser() / "transformer")
+    raw, metadata = _load_safetensors(Path(model_path).expanduser() / "transformer")
     weights = {}
     for key, value in raw.items():
         mapped = key
@@ -39,49 +55,225 @@ def load_transformer(model_path: str | Path, variant: Flux2Variant) -> Flux2Tran
             "time_guidance_embed.timestep_embedder.", "time_guidance_embed."
         )
         mapped = mapped.replace(".to_out.0.", ".to_out.")
-        weights[mapped] = value.astype(ModelConfig.precision)
+        weights[mapped] = _cast_float(value)
     transformer = Flux2Transformer(**variant.transformer_overrides)
-    transformer.update(tree_unflatten(list(weights.items())))
-    return transformer
+    return _apply_weights(transformer, weights, metadata)
 
 
 def load_vae(model_path: str | Path, *, include_encoder: bool = False) -> Flux2VAE:
-    raw = _load_safetensors(Path(model_path).expanduser() / "vae")
-    weights = {}
-    for key, value in raw.items():
-        if key.endswith(".num_batches_tracked"):
-            continue
-        if not (
-            key.startswith("decoder.")
-            or key.startswith("post_quant_conv.")
-            or key.startswith("bn.")
-            or (include_encoder and key.startswith("encoder."))
-            or (include_encoder and key.startswith("quant_conv."))
-        ):
-            continue
-        mapped = key.replace(".to_out.0.", ".to_out.")
-        tensor = value.astype(ModelConfig.precision)
-        if tensor.ndim == 4:
-            tensor = tensor.transpose(0, 2, 3, 1)
-        weights[mapped] = tensor
+    raw, metadata = _load_safetensors(Path(model_path).expanduser() / "vae")
     vae = Flux2VAE(
         decoder_block_out_channels=FULL_DECODER_CHANNELS,
         include_encoder=include_encoder,
         encoder_block_out_channels=FULL_DECODER_CHANNELS,
     )
-    vae.update(tree_unflatten(list(weights.items())))
-    return vae
+    target_shapes = {
+        key: tuple(value.shape) for key, value in tree_flatten(vae.parameters())
+    }
+    prefixes = ("decoder.", "post_quant_conv.", "bn.")
+    if include_encoder:
+        prefixes += ("encoder.", "quant_conv.")
+    weights = {}
+    for key, value in raw.items():
+        if key.endswith(".num_batches_tracked"):
+            continue
+        if not key.startswith(prefixes):
+            continue
+        mapped = key.replace(".to_out.0.", ".to_out.")
+        tensor = _cast_float(value)
+        if tensor.ndim == 4:
+            tensor = _match_conv_layout(
+                tensor,
+                target_shape=target_shapes.get(mapped),
+                key=mapped,
+            )
+        weights[mapped] = tensor
+    return _apply_weights(vae, weights, metadata)
 
 
-def _load_safetensors(directory: Path) -> dict[str, mx.array]:
+def _cast_float(value: mx.array) -> mx.array:
+    if mx.issubdtype(value.dtype, mx.floating):
+        return value.astype(ModelConfig.precision)
+    return value
+
+
+def _match_conv_layout(
+    value: mx.array,
+    *,
+    target_shape: tuple[int, ...] | None,
+    key: str,
+) -> mx.array:
+    if target_shape is None or tuple(value.shape) == target_shape:
+        return value
+    transposed = value.transpose(0, 2, 3, 1)
+    if tuple(transposed.shape) == target_shape:
+        return transposed
+    raise ValueError(
+        f"Unsupported convolution weight shape for {key}: "
+        f"checkpoint={tuple(value.shape)}, expected={target_shape}"
+    )
+
+
+def _apply_weights(
+    model: nn.Module,
+    weights: dict[str, mx.array],
+    metadata: dict[str, Any],
+):
+    quantization = _quantization_config(model, weights, metadata)
+    if quantization is not None:
+        quantized_paths = {
+            key[: -len(".scales")] for key in weights if key.endswith(".scales")
+        }
+        nn.quantize(
+            model,
+            group_size=quantization.group_size,
+            bits=quantization.bits,
+            mode=quantization.mode,
+            class_predicate=lambda path, module: path in quantized_paths,
+        )
+        model.quantization_config = quantization.as_dict()
+    else:
+        model.quantization_config = None
+    model.update(tree_unflatten(list(weights.items())), strict=True)
+    return model
+
+
+def _quantization_config(
+    model: nn.Module,
+    weights: dict[str, mx.array],
+    metadata: dict[str, Any],
+) -> QuantizationConfig | None:
+    quantized_paths = sorted(
+        key[: -len(".scales")] for key in weights if key.endswith(".scales")
+    )
+    if not quantized_paths:
+        return None
+
+    modules = dict(model.named_modules())
+    inferred_bits = set()
+    inferred_group_sizes = set()
+    for path in quantized_paths:
+        module = modules.get(path)
+        packed = weights.get(f"{path}.weight")
+        scales = weights.get(f"{path}.scales")
+        if module is None or not hasattr(module, "to_quantized"):
+            raise ValueError(
+                f"Quantized checkpoint path has no matching module: {path}"
+            )
+        if packed is None or scales is None:
+            raise ValueError(f"Incomplete quantized weights for module: {path}")
+        if packed.dtype != mx.uint32:
+            raise ValueError(
+                f"Expected packed uint32 weights for {path}, got {packed.dtype}"
+            )
+        if not hasattr(module, "weight") or module.weight.ndim != 2:
+            raise ValueError(f"Unsupported quantized module shape for: {path}")
+
+        output_dims, input_dims = module.weight.shape
+        if packed.shape[0] != output_dims or scales.shape[0] != output_dims:
+            raise ValueError(
+                f"Quantized output shape mismatch for {path}: "
+                f"weight={tuple(packed.shape)}, scales={tuple(scales.shape)}, "
+                f"expected output={output_dims}"
+            )
+        packed_bits = packed.shape[-1] * 32
+        if packed_bits % input_dims:
+            raise ValueError(f"Could not infer quantization bits for {path}")
+        if input_dims % scales.shape[-1]:
+            raise ValueError(f"Could not infer quantization group size for {path}")
+        inferred_bits.add(packed_bits // input_dims)
+        inferred_group_sizes.add(input_dims // scales.shape[-1])
+
+        if f"{path}.biases" not in weights:
+            raise ValueError(f"Quantized module {path} is missing affine bias tensors")
+
+    if len(inferred_bits) != 1 or len(inferred_group_sizes) != 1:
+        raise ValueError(
+            "FLUX.2 checkpoints with mixed quantization parameters are not supported"
+        )
+    inferred_bits_value = inferred_bits.pop()
+    inferred_group_size = inferred_group_sizes.pop()
+    configured_bits = _metadata_int(
+        metadata,
+        "bits",
+        "num_bits",
+        "quantization_level",
+    )
+    configured_group_size = _metadata_int(
+        metadata,
+        "group_size",
+        "quantization_group_size",
+    )
+    if configured_bits is not None and configured_bits != inferred_bits_value:
+        raise ValueError(
+            "Quantization bits disagree with checkpoint tensor shapes: "
+            f"configured={configured_bits}, inferred={inferred_bits_value}"
+        )
+    if (
+        configured_group_size is not None
+        and configured_group_size != inferred_group_size
+    ):
+        raise ValueError(
+            "Quantization group size disagrees with checkpoint tensor shapes: "
+            f"configured={configured_group_size}, inferred={inferred_group_size}"
+        )
+    mode = str(_metadata_value(metadata, "mode") or "affine")
+    if mode != "affine":
+        raise ValueError(f"Unsupported FLUX.2 quantization mode: {mode}")
+    return QuantizationConfig(
+        bits=configured_bits or inferred_bits_value,
+        group_size=configured_group_size or inferred_group_size,
+        mode=mode,
+    )
+
+
+def _metadata_int(metadata: dict[str, Any], *keys: str) -> int | None:
+    value = _metadata_value(metadata, *keys)
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"Invalid quantization metadata value: {value!r}") from exc
+
+
+def _metadata_value(metadata: dict[str, Any], *keys: str) -> Any:
+    candidates = [metadata]
+    for container_key in ("quantization", "quantization_config"):
+        value = metadata.get(container_key)
+        if isinstance(value, dict):
+            candidates.append(value)
+    for candidate in candidates:
+        for key in keys:
+            if key in candidate:
+                return candidate[key]
+    return None
+
+
+def _load_safetensors(
+    directory: Path,
+) -> tuple[dict[str, mx.array], dict[str, Any]]:
     if not directory.exists():
         raise FileNotFoundError(f"Missing weight directory: {directory}")
     weights: dict[str, mx.array] = {}
+    metadata: dict[str, Any] = {}
+    index_path = directory / "model.safetensors.index.json"
+    if index_path.exists():
+        try:
+            index = json.loads(index_path.read_text())
+            index_metadata = index.get("metadata", {})
+            if isinstance(index_metadata, dict):
+                metadata.update(index_metadata)
+        except (OSError, json.JSONDecodeError) as exc:
+            raise ValueError(f"Invalid safetensor index: {index_path}") from exc
     files = sorted(
         p for p in directory.glob("*.safetensors") if not p.name.startswith("._")
     )
     if not files:
         raise FileNotFoundError(f"No safetensors files found under {directory}")
     for file in files:
-        weights.update(mx.load(str(file)))
-    return weights
+        shard, shard_metadata = mx.load(str(file), return_metadata=True)
+        weights.update(shard)
+        if isinstance(shard_metadata, dict):
+            metadata.update(shard_metadata)
+    return weights, metadata

--- a/mlx_vlm/tests/test_flux2.py
+++ b/mlx_vlm/tests/test_flux2.py
@@ -6,13 +6,16 @@ from pathlib import Path
 import mlx.core as mx
 import numpy as np
 import pytest
+from mlx import nn
 from PIL import Image
 
 import mlx_vlm.models.flux2.download as download_module
+import mlx_vlm.models.flux2.weights as weights_module
 from mlx_vlm.generate.edit_image import (
     ImageEditRequest,
     image_edit_model_class,
     is_image_edit_model,
+    load_image_edit_model,
 )
 from mlx_vlm.generate.image import (
     image_generation_model_class,
@@ -175,6 +178,23 @@ def test_flux2_image_model_class_uses_remote_model_index(
     )
 
 
+def test_flux2_image_model_class_uses_component_weight_index(tmp_path: Path) -> None:
+    _write_layout(tmp_path)
+    index = tmp_path / "transformer" / "model.safetensors.index.json"
+    index.write_text("""{
+          "weight_map": {
+            "time_guidance_embed.linear_1.weight": "model.safetensors",
+            "double_stream_modulation_img.linear.weight": "model.safetensors",
+            "single_transformer_blocks.0.attn.to_qkv_mlp_proj.weight":
+              "model.safetensors"
+          }
+        }""")
+
+    assert (
+        image_generation_model_class(tmp_path.as_posix()) is Flux2ImageGenerationModel
+    )
+
+
 def test_is_image_generation_model_does_not_probe_remote_metadata(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -315,6 +335,127 @@ def test_flux2_edit_model_defaults_to_untiled_vae_decode(
     assert calls[0]["bucketed_seq_len"] is False
     assert calls[1]["tiled_vae"] == "auto"
     assert calls[1]["bucketed_seq_len"] is True
+
+
+@pytest.mark.parametrize("bits", [4, 8])
+def test_flux2_quantization_is_inferred_from_tensor_shapes(bits: int) -> None:
+    class TinyModel(nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.proj = nn.Linear(64, 32, bias=False)
+
+    dense = mx.arange(32 * 64, dtype=mx.float32).reshape(32, 64)
+    packed, scales, biases = mx.quantize(dense, group_size=32, bits=bits)
+    model = weights_module._apply_weights(
+        TinyModel(),
+        {
+            "proj.weight": packed,
+            "proj.scales": scales,
+            "proj.biases": biases,
+        },
+        {},
+    )
+
+    assert isinstance(model.proj, nn.QuantizedLinear)
+    assert model.quantization_config == {
+        "bits": bits,
+        "group_size": 32,
+        "mode": "affine",
+    }
+
+
+def test_flux2_text_encoder_accepts_native_quantized_keys(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    class TinyTextEncoder(nn.Module):
+        def __init__(self, **kwargs) -> None:  # noqa: ARG002
+            super().__init__()
+            self.embed_tokens = nn.Embedding(4, 64)
+
+    dense = mx.arange(4 * 64, dtype=mx.float32).reshape(4, 64)
+    packed, scales, biases = mx.quantize(dense, group_size=32, bits=8)
+    monkeypatch.setattr(weights_module, "Qwen3TextEncoder", TinyTextEncoder)
+    monkeypatch.setattr(
+        weights_module,
+        "_load_safetensors",
+        lambda directory: (  # noqa: ARG005
+            {
+                "embed_tokens.weight": packed,
+                "embed_tokens.scales": scales,
+                "embed_tokens.biases": biases,
+            },
+            {},
+        ),
+    )
+
+    model = weights_module.load_text_encoder(tmp_path, get_variant("flux2-klein-4b"))
+
+    assert isinstance(model.embed_tokens, nn.QuantizedEmbedding)
+    assert model.quantization_config["bits"] == 8
+
+
+def test_flux2_vae_conv_layout_accepts_source_and_native_shapes() -> None:
+    source = mx.arange(8 * 4 * 3 * 3).reshape(8, 4, 3, 3)
+    native = source.transpose(0, 2, 3, 1)
+
+    converted = weights_module._match_conv_layout(
+        source,
+        target_shape=tuple(native.shape),
+        key="decoder.conv.weight",
+    )
+    unchanged = weights_module._match_conv_layout(
+        native,
+        target_shape=tuple(native.shape),
+        key="decoder.conv.weight",
+    )
+
+    assert np.array_equal(np.array(converted), np.array(native))
+    assert np.array_equal(np.array(unchanged), np.array(native))
+
+
+def test_flux2_quantized_repo_routes_through_resolved_layout(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    model_path = (
+        tmp_path
+        / "models--mlx-community--flux2-klein-4b-8bit"
+        / "snapshots"
+        / "9beac1a3ad296d9e5e3f8845674e6577fa8654ec"
+    )
+    _write_layout(model_path)
+    index = model_path / "transformer" / "model.safetensors.index.json"
+    index.write_text("""{
+          "weight_map": {
+            "time_guidance_embed.linear_1.weight": "model.safetensors",
+            "double_stream_modulation_img.linear.weight": "model.safetensors",
+            "single_transformer_blocks.0.attn.to_qkv_mlp_proj.weight":
+              "model.safetensors"
+          }
+        }""")
+    calls = {}
+
+    def fake_get_model_path(repo_id: str, **kwargs):  # noqa: ARG001
+        calls["repo_id"] = repo_id
+        return model_path
+
+    def fake_from_pretrained(cls, variant, **kwargs):  # noqa: ARG001
+        calls["variant"] = variant.name
+        calls["model_path"] = kwargs["model_path"]
+        return _fake_edit_pipeline("flux2-klein-4b")
+
+    monkeypatch.setattr(image_module, "get_model_path", fake_get_model_path)
+    monkeypatch.setattr(
+        Flux2ImageEdit, "from_pretrained", classmethod(fake_from_pretrained)
+    )
+
+    model = load_image_edit_model("mlx-community/flux2-klein-4b-8bit")
+
+    assert model.variant == "flux2-klein-4b"
+    assert calls == {
+        "repo_id": "mlx-community/flux2-klein-4b-8bit",
+        "variant": "flux2-klein-4b",
+        "model_path": model_path,
+    }
 
 
 def test_flux2_reference_image_array_keeps_float32_input() -> None:

--- a/mlx_vlm/tests/test_flux2.py
+++ b/mlx_vlm/tests/test_flux2.py
@@ -195,6 +195,52 @@ def test_flux2_image_model_class_uses_component_weight_index(tmp_path: Path) -> 
     )
 
 
+def test_flux2_remote_component_index_is_a_metadata_fallback(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    metadata_path = tmp_path / "metadata"
+    metadata_path.mkdir()
+    component_index_path = tmp_path / "component-index"
+    _write_layout(component_index_path)
+    index = component_index_path / "transformer" / "model.safetensors.index.json"
+    index.write_text("""{
+          "weight_map": {
+            "time_guidance_embed.linear_1.weight": "model.safetensors",
+            "double_stream_modulation_img.linear.weight": "model.safetensors",
+            "single_transformer_blocks.0.attn.to_qkv_mlp_proj.weight":
+              "model.safetensors"
+          }
+        }""")
+    calls = []
+
+    def fake_get_model_path(repo_id: str, **kwargs):
+        assert repo_id == "example/custom-quantized-model"
+        calls.append(kwargs["allow_patterns"])
+        return metadata_path if len(calls) == 1 else component_index_path
+
+    monkeypatch.setattr(image_module, "get_model_path", fake_get_model_path)
+
+    assert (
+        image_generation_model_class("example/custom-quantized-model")
+        is Flux2ImageGenerationModel
+    )
+    assert calls == [
+        [
+            "model_index.json",
+            "config.json",
+            "manifest.json",
+            "**/config.json",
+        ],
+        [
+            "model_index.json",
+            "config.json",
+            "manifest.json",
+            "**/config.json",
+            "**/model.safetensors.index.json",
+        ],
+    ]
+
+
 def test_is_image_generation_model_does_not_probe_remote_metadata(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
Some of the existing quantized checkpoints for FLUX.2 in `mlx-community` have conversions with custom/unique metadata, so this adds support to the image model loader to handle those converted models. 