### PR TITLE
Honor explicit trust_remote_code in processor from_pretrained

### DIFF
--- a/mlx_vlm/models/falcon_ocr/processing_falcon_ocr.py
+++ b/mlx_vlm/models/falcon_ocr/processing_falcon_ocr.py
@@ -147,19 +147,20 @@ class FalconOCRProcessor:
     @classmethod
     def from_pretrained(cls, pretrained_model_name_or_path, **kwargs):
         kwargs.pop("use_fast", None)
+        trust_remote_code = kwargs.pop("trust_remote_code", True)
 
         model_path = Path(pretrained_model_name_or_path)
         is_local = model_path.exists() and model_path.is_dir()
 
         if is_local:
             tokenizer = AutoTokenizer.from_pretrained(
-                str(model_path), trust_remote_code=True
+                str(model_path), trust_remote_code=trust_remote_code
             )
             config_file = model_path / "config.json"
             config = json.loads(config_file.read_text()) if config_file.exists() else {}
         else:
             tokenizer = AutoTokenizer.from_pretrained(
-                pretrained_model_name_or_path, trust_remote_code=True
+                pretrained_model_name_or_path, trust_remote_code=trust_remote_code
             )
             try:
                 from huggingface_hub import hf_hub_download

--- a/mlx_vlm/models/falcon_perception/processing_falcon_perception.py
+++ b/mlx_vlm/models/falcon_perception/processing_falcon_perception.py
@@ -126,19 +126,20 @@ class FalconPerceptionProcessor:
     @classmethod
     def from_pretrained(cls, pretrained_model_name_or_path, **kwargs):
         kwargs.pop("use_fast", None)
+        trust_remote_code = kwargs.pop("trust_remote_code", True)
 
         model_path = Path(pretrained_model_name_or_path)
         is_local = model_path.exists() and model_path.is_dir()
 
         if is_local:
             tokenizer = AutoTokenizer.from_pretrained(
-                str(model_path), trust_remote_code=True
+                str(model_path), trust_remote_code=trust_remote_code
             )
             config_file = model_path / "config.json"
             config = json.loads(config_file.read_text()) if config_file.exists() else {}
         else:
             tokenizer = AutoTokenizer.from_pretrained(
-                pretrained_model_name_or_path, trust_remote_code=True
+                pretrained_model_name_or_path, trust_remote_code=trust_remote_code
             )
             try:
                 from huggingface_hub import hf_hub_download

--- a/mlx_vlm/models/fastvlm/processing.py
+++ b/mlx_vlm/models/fastvlm/processing.py
@@ -438,7 +438,7 @@ class FastVLMProcessor(ProcessorMixin):
         """Load processor from pretrained model path."""
         from huggingface_hub import hf_hub_download
 
-        kwargs.pop("trust_remote_code", None)
+        trust_remote_code = kwargs.pop("trust_remote_code", True)
 
         model_path = Path(pretrained_model_name_or_path)
         is_local = model_path.exists() and model_path.is_dir()
@@ -446,7 +446,7 @@ class FastVLMProcessor(ProcessorMixin):
         # Load tokenizer
         tokenizer = AutoTokenizer.from_pretrained(
             str(model_path) if is_local else pretrained_model_name_or_path,
-            trust_remote_code=True,
+            trust_remote_code=trust_remote_code,
             local_files_only=is_local,
         )
 

--- a/mlx_vlm/models/gemma4/processing_gemma4.py
+++ b/mlx_vlm/models/gemma4/processing_gemma4.py
@@ -900,7 +900,7 @@ class Gemma4Processor(ProcessorMixin):
 
         from transformers import AutoTokenizer
 
-        kwargs.pop("trust_remote_code", None)
+        trust_remote_code = kwargs.pop("trust_remote_code", True)
         kwargs.pop("use_fast", None)
 
         model_path = Path(pretrained_model_name_or_path)
@@ -908,7 +908,7 @@ class Gemma4Processor(ProcessorMixin):
 
         tokenizer = AutoTokenizer.from_pretrained(
             str(model_path) if is_local else pretrained_model_name_or_path,
-            trust_remote_code=True,
+            trust_remote_code=trust_remote_code,
             local_files_only=is_local,
         )
         load_chat_template(tokenizer, pretrained_model_name_or_path)

--- a/mlx_vlm/models/gemma4_unified/processing_gemma4_unified.py
+++ b/mlx_vlm/models/gemma4_unified/processing_gemma4_unified.py
@@ -362,7 +362,7 @@ class Gemma4UnifiedProcessor(Gemma4Processor):
     def from_pretrained(cls, pretrained_model_name_or_path, **kwargs):
         from transformers import AutoTokenizer
 
-        kwargs.pop("trust_remote_code", None)
+        trust_remote_code = kwargs.pop("trust_remote_code", True)
         kwargs.pop("use_fast", None)
 
         model_path = Path(pretrained_model_name_or_path)
@@ -370,7 +370,7 @@ class Gemma4UnifiedProcessor(Gemma4Processor):
 
         tokenizer = AutoTokenizer.from_pretrained(
             str(model_path) if is_local else pretrained_model_name_or_path,
-            trust_remote_code=True,
+            trust_remote_code=trust_remote_code,
             local_files_only=is_local,
         )
         load_chat_template(tokenizer, pretrained_model_name_or_path)

--- a/mlx_vlm/models/kimi_k25/processing_kimi_k25.py
+++ b/mlx_vlm/models/kimi_k25/processing_kimi_k25.py
@@ -243,11 +243,13 @@ class KimiK25Processor(ProcessorMixin):
     def from_pretrained(cls, pretrained_model_name_or_path, **kwargs):
         from huggingface_hub import hf_hub_download
 
+        trust_remote_code = kwargs.pop("trust_remote_code", True)
+
         model_path = Path(pretrained_model_name_or_path)
         is_local = model_path.exists() and model_path.is_dir()
         tokenizer = AutoTokenizer.from_pretrained(
             str(model_path) if is_local else pretrained_model_name_or_path,
-            trust_remote_code=True,
+            trust_remote_code=trust_remote_code,
             local_files_only=is_local,
         )
 

--- a/mlx_vlm/models/kimi_vl/processing_kimi_vl.py
+++ b/mlx_vlm/models/kimi_vl/processing_kimi_vl.py
@@ -497,14 +497,14 @@ class KimiVLProcessor(ProcessorMixin):
         """Load the processor from a pretrained model path."""
         from huggingface_hub import hf_hub_download
 
-        kwargs.pop("trust_remote_code", None)
+        trust_remote_code = kwargs.pop("trust_remote_code", True)
         _ensure_gpt2_bytes_to_unicode()
 
         model_path = Path(pretrained_model_name_or_path)
         is_local = model_path.exists() and model_path.is_dir()
         tokenizer = AutoTokenizer.from_pretrained(
             str(model_path) if is_local else pretrained_model_name_or_path,
-            trust_remote_code=True,
+            trust_remote_code=trust_remote_code,
             local_files_only=is_local,
         )
 

--- a/mlx_vlm/models/locateanything/processing_locateanything.py
+++ b/mlx_vlm/models/locateanything/processing_locateanything.py
@@ -264,13 +264,13 @@ class LocateAnythingProcessor(ProcessorMixin):
     def from_pretrained(cls, pretrained_model_name_or_path, **kwargs):
         from huggingface_hub import hf_hub_download
 
-        kwargs.pop("trust_remote_code", None)
+        trust_remote_code = kwargs.pop("trust_remote_code", True)
 
         model_path = Path(pretrained_model_name_or_path)
         is_local = model_path.exists() and model_path.is_dir()
         tokenizer = AutoTokenizer.from_pretrained(
             str(model_path) if is_local else pretrained_model_name_or_path,
-            trust_remote_code=True,
+            trust_remote_code=trust_remote_code,
             local_files_only=is_local,
         )
 

--- a/mlx_vlm/models/molmo/processing_molmo.py
+++ b/mlx_vlm/models/molmo/processing_molmo.py
@@ -646,7 +646,7 @@ class MolmoProcessor(ProcessorMixin):
         """Load processor from pretrained model."""
         from huggingface_hub import hf_hub_download
 
-        kwargs.pop("trust_remote_code", None)
+        trust_remote_code = kwargs.pop("trust_remote_code", True)
 
         model_path = Path(pretrained_model_name_or_path)
         is_local = model_path.exists() and model_path.is_dir()
@@ -654,7 +654,7 @@ class MolmoProcessor(ProcessorMixin):
         # Load tokenizer
         tokenizer = AutoTokenizer.from_pretrained(
             str(model_path) if is_local else pretrained_model_name_or_path,
-            trust_remote_code=True,
+            trust_remote_code=trust_remote_code,
             local_files_only=is_local,
         )
 

--- a/mlx_vlm/models/molmo2/processing.py
+++ b/mlx_vlm/models/molmo2/processing.py
@@ -677,7 +677,7 @@ class Molmo2Processor(ProcessorMixin):
         from huggingface_hub import hf_hub_download
         from transformers import AutoTokenizer
 
-        kwargs.pop("trust_remote_code", None)
+        trust_remote_code = kwargs.pop("trust_remote_code", True)
 
         model_path = Path(pretrained_model_name_or_path)
         is_local = model_path.exists() and model_path.is_dir()
@@ -685,7 +685,7 @@ class Molmo2Processor(ProcessorMixin):
         # Load tokenizer
         tokenizer = AutoTokenizer.from_pretrained(
             str(model_path) if is_local else pretrained_model_name_or_path,
-            trust_remote_code=True,
+            trust_remote_code=trust_remote_code,
             local_files_only=is_local,
         )
 

--- a/mlx_vlm/models/molmo_point/processing_molmo_point.py
+++ b/mlx_vlm/models/molmo_point/processing_molmo_point.py
@@ -93,9 +93,11 @@ class MolmoPointProcessor:
     def from_pretrained(cls, pretrained_model_name_or_path, **kwargs):
         from transformers import AutoTokenizer
 
+        trust_remote_code = kwargs.pop("trust_remote_code", True)
+
         tokenizer = AutoTokenizer.from_pretrained(
             pretrained_model_name_or_path,
-            trust_remote_code=True,
+            trust_remote_code=trust_remote_code,
             padding_side="left",
         )
         load_chat_template(tokenizer, pretrained_model_name_or_path)

--- a/mlx_vlm/models/phi3_v/processing_phi3_v.py
+++ b/mlx_vlm/models/phi3_v/processing_phi3_v.py
@@ -590,14 +590,14 @@ class Phi3VProcessor(ProcessorMixin):
         """Load the processor from a pretrained model path."""
         from huggingface_hub import hf_hub_download
 
-        kwargs.pop("trust_remote_code", None)
+        trust_remote_code = kwargs.pop("trust_remote_code", True)
 
         model_path = Path(pretrained_model_name_or_path)
         is_local = model_path.exists() and model_path.is_dir()
 
         tokenizer = AutoTokenizer.from_pretrained(
             str(model_path) if is_local else pretrained_model_name_or_path,
-            trust_remote_code=True,
+            trust_remote_code=trust_remote_code,
             local_files_only=is_local,
         )
 

--- a/mlx_vlm/models/phi4mm/processing_phi4mm.py
+++ b/mlx_vlm/models/phi4mm/processing_phi4mm.py
@@ -634,14 +634,14 @@ class Phi4MMProcessor(ProcessorMixin):
 
     @classmethod
     def from_pretrained(cls, pretrained_model_name_or_path, **kwargs):
-        kwargs.pop("trust_remote_code", None)
+        trust_remote_code = kwargs.pop("trust_remote_code", True)
 
         model_path = Path(pretrained_model_name_or_path)
         is_local = model_path.exists() and model_path.is_dir()
 
         tokenizer = AutoTokenizer.from_pretrained(
             str(model_path) if is_local else pretrained_model_name_or_path,
-            trust_remote_code=True,
+            trust_remote_code=trust_remote_code,
             local_files_only=is_local,
         )
 

--- a/mlx_vlm/tests/test_processors.py
+++ b/mlx_vlm/tests/test_processors.py
@@ -2907,5 +2907,23 @@ class TestProcessorRegistration(unittest.TestCase):
                 importlib.import_module(module)
 
 
+class TestTrustRemoteCodePassthrough(unittest.TestCase):
+    """Regression test for #1724 — an explicit trust_remote_code must not be overridden."""
+
+    def test_molmo_point_honors_explicit_false(self):
+        from mlx_vlm.models.molmo_point import processing_molmo_point
+
+        with (
+            patch("transformers.AutoTokenizer.from_pretrained") as from_pretrained,
+            patch.object(processing_molmo_point, "load_chat_template"),
+        ):
+            processing_molmo_point.MolmoPointProcessor.from_pretrained(
+                "/tmp/model", trust_remote_code=False
+            )
+
+        _, kwargs = from_pretrained.call_args
+        self.assertFalse(kwargs["trust_remote_code"])
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Fixes Blaizzy/mlx-vlm#1724

13 processors ignored an explicitly-passed `trust_remote_code` — nine popped the caller's value and hardcoded `True`, four never read it at all. Passing `trust_remote_code=False` did not prevent remote code execution.

```python
# before
kwargs.pop("trust_remote_code", None)
...
    trust_remote_code=True,

# after
trust_remote_code = kwargs.pop("trust_remote_code", True)
...
    trust_remote_code=trust_remote_code,
```

This is the pattern `glm4v`, `glm4v_moe`, `glm_ocr`, `paddleocr_vl`, and `hunyuan_vl` already use — the PR brings 13 processors in line with 5 that were already correct.

Adds `TestTrustRemoteCodePassthrough` covering the `False` case on `molmo_point`. Verified on my fork that it fails without the fix and passes with it.

`internvl_chat`, `lfm2_vl`, and `phi4_siglip` also discard the argument, but in ways that differ from this issue — left out of scope, happy to file separately.

**On the default:** it stays `True`, so callers that don't pass the flag see no change in behavior. I deliberately didn't switch it to `False` — safer, but a breaking change for every existing caller, and a separate discussion from<br>  fixing the flag being ignored. Glad to open an issue for it if you'd want that.