### PR TITLE
Guard APC media token lookup for text-only models

### DIFF
--- a/mlx_vlm/generate/ar.py
+++ b/mlx_vlm/generate/ar.py
@@ -2233,7 +2233,10 @@ class BatchGenerator:
         )
 
     def _apc_media_token_ids(self) -> set[int]:
-        return _apc.multimodal_token_ids_from_config(self.model.config)
+        config = getattr(self.model, "config", None)
+        if config is None:
+            return set()
+        return _apc.multimodal_token_ids_from_config(config)
 
     def _apc_safe_prefix_lookup_min(self, ids_list: List[int]) -> int:
         safe_min = _apc.media_safe_prefix_min(ids_list, self._apc_media_token_ids())

--- a/mlx_vlm/tests/test_generate.py
+++ b/mlx_vlm/tests/test_generate.py
@@ -166,6 +166,20 @@ def mock_processor():
     return MockProcessor()
 
 
+def test_batch_generator_apc_media_token_ids_handles_text_only_model(mock_processor):
+    model = SimpleNamespace(
+        language_model=MockLanguageModel(),
+        make_cache=lambda: [KVCache()],
+    )
+    generator = ar_module.BatchGenerator(
+        model,
+        mock_processor,
+        apc_manager=apc_module.APCManager(num_blocks=1),
+    )
+
+    assert generator._apc_media_token_ids() == set()
+
+
 # ============================================================================
 # Tests for Dataclasses
 # ============================================================================


### PR DESCRIPTION
Fixes #1725.\n\n## Summary\n- return an empty APC media-token set when a model has no config\n- add a BatchGenerator regression test for text-only models\n\n## Tests\n- uv run --with pytest pytest mlx_vlm/tests/test_generate.py mlx_vlm/tests/test_apc.py