### PR TITLE
Flatten image_grid_thw collation for multi-image SFT

### DIFF
--- a/mlx_vlm/tests/test_trainer.py
+++ b/mlx_vlm/tests/test_trainer.py
@@ -241,6 +241,23 @@ class TestBatchCollation(unittest.TestCase):
             mx.array_equal(batch["image_grid_thw"], mx.array([[1, 1, 2], [1, 1, 3]]))
         )
 
+    def test_iterate_batches_flattens_multi_image_grid_thw(self):
+        dataset = [
+            {
+                "input_ids": mx.array([1, 2, 3]),
+                "attention_mask": mx.array([1, 1, 1]),
+                "pixel_values": mx.zeros((4, 4)),
+                "image_grid_thw": mx.array([[1, 1, 2], [1, 1, 2]]),
+            }
+        ]
+
+        batch = next(iterate_batches(dataset, batch_size=1, max_seq_length=32))
+
+        self.assertEqual(batch["image_grid_thw"].shape, (2, 3))
+        self.assertTrue(
+            mx.array_equal(batch["image_grid_thw"], mx.array([[1, 1, 2], [1, 1, 2]]))
+        )
+
     def test_iterate_batches_pads_completion_mask(self):
         dataset = [
             {

--- a/mlx_vlm/trainer/sft_trainer.py
+++ b/mlx_vlm/trainer/sft_trainer.py
@@ -48,6 +48,13 @@ def _collate_arrays(values):
         raise
 
 
+def _collate_extra_key(key, values):
+    if key == "image_grid_thw":
+        rows = [v.reshape(-1, 3) for v in values]
+        return mx.concatenate(rows, axis=0)
+    return _collate_arrays(values)
+
+
 @dataclass
 class TrainingArgs:
     batch_size: int = field(default=4, metadata={"help": "Minibatch size."})
@@ -288,7 +295,7 @@ def iterate_batches(dataset, batch_size, max_seq_length, train=False):
                 vals = [_squeeze_leading_batch_dim(item[k]) for item in items]
                 if isinstance(vals[0], mx.array):
                     try:
-                        batch[k] = _collate_arrays(vals)
+                        batch[k] = _collate_extra_key(k, vals)
                     except Exception:
                         batch[k] = vals[0]
                 else:


### PR DESCRIPTION
Fixes #1726.\n\n## Summary\n- collate image_grid_thw as a flat row per image\n- add a regression test for batch_size=1 multi-image records\n\n## Tests\n- uv run --with pytest pytest mlx_vlm/tests/test_trainer.py