### PR TITLE
Limit Gemma 4 prefill logits to final row

### DIFF
--- a/mlx_vlm/generate/ar.py
+++ b/mlx_vlm/generate/ar.py
@@ -328,6 +328,8 @@ def generate_step(
         step_kwargs = kwargs
         if speculative_prefill_capture_kwargs:
             step_kwargs = {**kwargs, **speculative_prefill_capture_kwargs}
+        if getattr(model.language_model, "supports_logits_to_keep", False):
+            step_kwargs = {**step_kwargs, "logits_to_keep": 1}
 
         with mx.stream(generation_stream):
             if "decoder_input_ids" in step_kwargs:

--- a/mlx_vlm/models/gemma4/language.py
+++ b/mlx_vlm/models/gemma4/language.py
@@ -655,6 +655,8 @@ class Gemma4TextModel(nn.Module):
 
 
 class LanguageModel(nn.Module):
+    supports_logits_to_keep = True
+
     def __init__(self, config: TextConfig):
         super().__init__()
         self.config = config
@@ -731,6 +733,7 @@ class LanguageModel(nn.Module):
         # Allow callers to pass pre-allocated sinks directly.
         hidden_sink = kwargs.pop("hidden_sink", hidden_sink)
         shared_kv_sink = kwargs.pop("shared_kv_sink", shared_kv_sink)
+        logits_to_keep = kwargs.pop("logits_to_keep", None)
 
         out = self.model(
             inputs,
@@ -743,6 +746,10 @@ class LanguageModel(nn.Module):
             shared_kv_sink=shared_kv_sink,
             **kwargs,
         )
+        if logits_to_keep is not None:
+            logits_to_keep = int(logits_to_keep)
+            if logits_to_keep > 0:
+                out = out[:, -logits_to_keep:, :]
         out = self.logits_from_hidden(out)
         return LanguageModelOutput(
             logits=out,

--- a/mlx_vlm/tests/test_gemma4_language.py
+++ b/mlx_vlm/tests/test_gemma4_language.py
@@ -1,0 +1,20 @@
+import mlx.core as mx
+
+from mlx_vlm.models.gemma4.language import LanguageModel
+
+
+class FakeGemma4TextModel:
+    def __call__(self, *args, **kwargs):
+        return mx.arange(24).reshape(1, 4, 6)
+
+
+def test_gemma4_language_model_slices_hidden_before_logits():
+    language_model = LanguageModel.__new__(LanguageModel)
+    language_model.model = FakeGemma4TextModel()
+    language_model.logits_from_hidden = lambda hidden: hidden
+
+    output = language_model(mx.array([[1, 2, 3, 4]]), logits_to_keep=1)
+
+    assert LanguageModel.supports_logits_to_keep is True
+    assert output.logits.shape == (1, 1, 6)
+    assert mx.array_equal(output.logits, mx.array([[[18, 19, 20, 21, 22, 23]]]))


### PR DESCRIPTION
Fixes #1732.\n\n## Summary\n- let generation request a single logits row from models that opt in\n- add Gemma 4 logits_to_keep support by slicing hidden states before the LM head\n- cover the slice with a lightweight regression test\n\n## Tests\n- uv run --with pytest pytest mlx_vlm/tests/test_gemma4_language.py mlx_vlm/tests/test_generate.py\n- python3 -m py_compile mlx_vlm/generate/ar.py mlx_vlm/models/gemma4/language.py mlx_vlm/tests/test_gemma4_language.py