### PR TITLE
Add llm-jp-4-vl (llmjpvl) model support

### DIFF
--- a/mlx_vlm/models/llmjpvl/__init__.py
+++ b/mlx_vlm/models/llmjpvl/__init__.py
@@ -1,0 +1,4 @@
+from .config import ModelConfig, TextConfig, VisionConfig
+from .language import LanguageModel
+from .llmjpvl import Model
+from .vision import VisionModel

--- a/mlx_vlm/models/llmjpvl/config.py
+++ b/mlx_vlm/models/llmjpvl/config.py
@@ -1,0 +1,72 @@
+from dataclasses import dataclass
+from typing import Dict, List, Optional, Union
+
+from ..base import BaseModelConfig
+
+
+@dataclass
+class VisionConfig(BaseModelConfig):
+    model_type: str = "siglip_vision_model"
+    hidden_size: int = 1152
+    num_attention_heads: int = 16
+    num_hidden_layers: int = 27
+    intermediate_size: int = 4304
+    patch_size: int = 16
+    image_size: int = 512
+    num_channels: int = 3
+    layer_norm_eps: float = 1e-6
+    hidden_act: str = "gelu_pytorch_tanh"
+
+
+@dataclass
+class TextConfig(BaseModelConfig):
+    model_type: str = "llama"
+    hidden_size: int = 4096
+    num_hidden_layers: int = 32
+    intermediate_size: int = 14336
+    num_attention_heads: int = 32
+    rms_norm_eps: float = 1e-6
+    vocab_size: int = 196608
+    num_key_value_heads: Optional[int] = None
+    rope_theta: float = 500000.0
+    rope_traditional: bool = False
+    rope_scaling: Optional[Dict[str, Union[float, str]]] = None
+    max_position_embeddings: int = 65536
+    tie_word_embeddings: bool = False
+
+    def __post_init__(self):
+        if self.num_key_value_heads is None:
+            self.num_key_value_heads = self.num_attention_heads
+
+
+@dataclass
+class ModelConfig(BaseModelConfig):
+    model_type: str = "llmjpvl"
+    text_config: Optional[TextConfig] = None
+    vision_config: Optional[VisionConfig] = None
+    image_token_index: int = 14
+    video_token_index: int = -1
+    downsample_ratio: float = 0.5
+    select_layer: int = -1
+    vocab_size: int = 196608
+    ignore_index: int = -100
+    eos_token_id: Optional[List[int]] = None
+
+    @classmethod
+    def from_dict(cls, params):
+        params = dict(params)
+        # Map upstream config's img_context_token_id to image_token_index
+        if (
+            "img_context_token_id" in params
+            and params["img_context_token_id"] is not None
+        ):
+            params["image_token_index"] = params["img_context_token_id"]
+        import inspect as _inspect
+
+        return cls(
+            **{
+                k: v
+                for k, v in params.items()
+                if k in _inspect.signature(cls).parameters
+            }
+        )

--- a/mlx_vlm/models/llmjpvl/language.py
+++ b/mlx_vlm/models/llmjpvl/language.py
@@ -1,0 +1,191 @@
+from typing import Optional
+
+import mlx.core as mx
+import mlx.nn as nn
+
+from ..base import (
+    LanguageModelOutput,
+    create_attention_mask,
+    scaled_dot_product_attention,
+)
+from ..cache import KVCache
+from ..mlp import SwiGLUMLP as MLP
+from .config import TextConfig
+
+
+class Attention(nn.Module):
+    def __init__(self, config: TextConfig):
+        super().__init__()
+
+        dim = config.hidden_size
+        self.n_heads = n_heads = config.num_attention_heads
+        self.n_kv_heads = n_kv_heads = config.num_key_value_heads
+
+        self.repeats = n_heads // n_kv_heads
+
+        head_dim = config.hidden_size // n_heads
+        self.scale = head_dim**-0.5
+
+        if config.model_type == "qwen2":
+            attention_bias = True
+        else:
+            attention_bias = False
+
+        self.q_proj = nn.Linear(dim, n_heads * head_dim, bias=attention_bias)
+        self.k_proj = nn.Linear(dim, n_kv_heads * head_dim, bias=attention_bias)
+        self.v_proj = nn.Linear(dim, n_kv_heads * head_dim, bias=attention_bias)
+        self.o_proj = nn.Linear(n_heads * head_dim, dim, bias=False)
+
+        rope_scale = (
+            1 / config.rope_scaling["factor"]
+            if config.rope_scaling is not None
+            and config.rope_scaling["type"] == "linear"
+            else 1
+        )
+        self.rope = nn.RoPE(
+            head_dim,
+            traditional=config.rope_traditional,
+            base=config.rope_theta,
+            scale=rope_scale,
+        )
+
+    def __call__(
+        self,
+        x: mx.array,
+        mask: Optional[mx.array] = None,
+        cache: Optional[KVCache] = None,
+    ) -> mx.array:
+        B, L, D = x.shape
+
+        queries, keys, values = self.q_proj(x), self.k_proj(x), self.v_proj(x)
+
+        # Prepare the queries, keys and values for the attention computation
+        queries = queries.reshape(B, L, self.n_heads, -1).transpose(0, 2, 1, 3)
+        keys = keys.reshape(B, L, self.n_kv_heads, -1).transpose(0, 2, 1, 3)
+        values = values.reshape(B, L, self.n_kv_heads, -1).transpose(0, 2, 1, 3)
+
+        if cache is not None:
+            queries = self.rope(queries, offset=cache.offset)
+            keys = self.rope(keys, offset=cache.offset)
+            keys, values = cache.update_and_fetch(keys, values)
+        else:
+            queries = self.rope(queries)
+            keys = self.rope(keys)
+
+        output = scaled_dot_product_attention(
+            queries, keys, values, cache, scale=self.scale, mask=mask
+        )
+        output = output.transpose(0, 2, 1, 3).reshape(B, L, -1)
+        return self.o_proj(output)
+
+
+class TransformerBlock(nn.Module):
+    def __init__(self, config: TextConfig):
+        super().__init__()
+        self.num_attention_heads = config.num_attention_heads
+        self.hidden_size = config.hidden_size
+        self.self_attn = Attention(config)
+        self.mlp = MLP(config.hidden_size, config.intermediate_size)
+        self.input_layernorm = nn.RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.post_attention_layernorm = nn.RMSNorm(
+            config.hidden_size, eps=config.rms_norm_eps
+        )
+        self.config = config
+
+    def __call__(
+        self,
+        x: mx.array,
+        mask: Optional[mx.array] = None,
+        cache: Optional[KVCache] = None,
+    ) -> mx.array:
+        r = self.self_attn(self.input_layernorm(x), mask, cache)
+        h = x + r
+        r = self.mlp(self.post_attention_layernorm(h))
+        out = h + r
+        return out
+
+
+class Llama(nn.Module):
+    def __init__(self, config: TextConfig):
+        super().__init__()
+        self.config = config
+        self.vocab_size = config.vocab_size
+        self.num_hidden_layers = config.num_hidden_layers
+        assert self.vocab_size > 0
+        self.embed_tokens = nn.Embedding(config.vocab_size, config.hidden_size)
+        self.layers = [
+            TransformerBlock(config=config) for _ in range(config.num_hidden_layers)
+        ]
+        self.norm = nn.RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+
+    def __call__(
+        self,
+        inputs: mx.array,
+        inputs_embeds: Optional[mx.array] = None,
+        mask: Optional[mx.array] = None,
+        cache=None,
+    ):
+        # for passing merged input embeddings
+        if inputs_embeds is None:
+            h = self.embed_tokens(inputs)
+        else:
+            h = inputs_embeds
+
+        if cache is None:
+            cache = [None] * len(self.layers)
+
+        # if mask is None:
+        mask = create_attention_mask(h, cache)
+
+        for layer, c in zip(self.layers, cache):
+            h = layer(h, mask, c)
+
+        return self.norm(h)
+
+
+class LanguageModel(nn.Module):
+    def __init__(self, config: TextConfig):
+        super().__init__()
+        self.config = config
+        self.model_type = config.model_type
+        if self.model_type not in ["llama", "qwen2"]:
+            raise ValueError(
+                f"Model type {self.model_type} not supported. Supported types: 'llama', 'qwen2'"
+            )
+        self.model = Llama(config)
+        if not config.tie_word_embeddings:
+            self.lm_head = nn.Linear(config.hidden_size, config.vocab_size, bias=False)
+
+    def __call__(
+        self,
+        inputs: mx.array,
+        inputs_embeds: Optional[mx.array] = None,
+        mask: Optional[mx.array] = None,
+        cache=None,
+        **kwargs,
+    ):
+        out = self.model(inputs, mask=mask, cache=cache, inputs_embeds=inputs_embeds)
+        if self.config.tie_word_embeddings:
+            out = self.model.embed_tokens.as_linear(out)
+        else:
+            out = self.lm_head(out)
+        return LanguageModelOutput(logits=out)
+
+    @staticmethod
+    def sanitize(weights):
+        # Remove unused precomputed rotary freqs
+        return {
+            k: v for k, v in weights.items() if "self_attn.rotary_emb.inv_freq" not in k
+        }
+
+    @property
+    def layers(self):
+        return self.model.layers
+
+    @property
+    def head_dim(self):
+        return self.config.hidden_size // self.config.num_attention_heads
+
+    @property
+    def n_kv_heads(self):
+        return self.config.num_key_value_heads

--- a/mlx_vlm/models/llmjpvl/llmjpvl.py
+++ b/mlx_vlm/models/llmjpvl/llmjpvl.py
@@ -1,0 +1,135 @@
+from typing import Optional
+
+import mlx.core as mx
+import mlx.nn as nn
+import numpy as np
+
+from ..base import InputEmbeddingsFeatures, pixel_shuffle
+from .config import ModelConfig
+from .language import LanguageModel
+from .vision import VisionModel, check_array_shape
+
+
+class Model(nn.Module):
+    def __init__(self, config: ModelConfig):
+        super().__init__()
+        self.config = config
+        # Attribute names match the HF checkpoint keys (vision_backbone / language_model / mlp1)
+        self.vision_backbone = VisionModel(config.vision_config)
+        self.language_model = LanguageModel(config.text_config)
+
+        self.downsample_ratio = config.downsample_ratio
+        if config.select_layer != -1:
+            raise ValueError(
+                f"select_layer={config.select_layer} is not supported (only -1)"
+            )
+
+        vit_hidden_size = config.vision_config.hidden_size
+        llm_hidden_size = config.text_config.hidden_size
+
+        self.mlp1 = [
+            nn.LayerNorm(vit_hidden_size * int(1 / self.downsample_ratio) ** 2),
+            nn.Linear(
+                vit_hidden_size * int(1 / self.downsample_ratio) ** 2, llm_hidden_size
+            ),
+            nn.GELU(),
+            nn.Linear(llm_hidden_size, llm_hidden_size),
+        ]
+
+    def get_input_embeddings(
+        self,
+        input_ids: Optional[mx.array] = None,
+        pixel_values: Optional[mx.array] = None,
+        **kwargs,
+    ):
+        if pixel_values is None:
+            return InputEmbeddingsFeatures(
+                inputs_embeds=self.language_model.model.embed_tokens(input_ids)
+            )
+
+        dtype = (
+            self.vision_backbone.vision_model.embeddings.patch_embedding.weight.dtype
+        )
+        pixel_values = pixel_values.astype(dtype)
+
+        if pixel_values.ndim == 5:
+            pixel_values = pixel_values[0]
+
+        inputs_embeds = self.language_model.model.embed_tokens(input_ids)
+
+        cached = kwargs.get("cached_image_features", None)
+        if cached is not None:
+            hidden_states = cached
+        else:
+            # SigLIP: NCHW -> NHWC. No CLS token, so nothing is stripped from the front
+            hidden_states, _, _ = self.vision_backbone(
+                pixel_values.transpose(0, 2, 3, 1), output_hidden_states=False
+            )
+
+            hidden_states = pixel_shuffle(
+                hidden_states, shuffle_ratio=self.downsample_ratio
+            )
+
+            for layer in self.mlp1:
+                hidden_states = layer(hidden_states)
+
+        image_token_index = kwargs.get(
+            "image_token_index", self.config.image_token_index
+        )
+
+        final_inputs_embeds = self._merge_input_ids_with_image_features(
+            hidden_states, inputs_embeds, input_ids, image_token_index
+        )
+        return InputEmbeddingsFeatures(inputs_embeds=final_inputs_embeds)
+
+    def _merge_input_ids_with_image_features(
+        self, image_features, inputs_embeds, input_ids, image_token_index=None
+    ):
+        B, N, C = inputs_embeds.shape
+        if image_token_index is None:
+            image_token_index = self.config.image_token_index
+
+        image_positions = input_ids == image_token_index
+        n_img = int(mx.sum(image_positions))
+        image_features = image_features.reshape(-1, image_features.shape[-1])
+        if n_img != image_features.shape[0]:
+            raise ValueError(
+                f"image token count ({n_img}) != vision feature count "
+                f"({image_features.shape[0]})"
+            )
+
+        image_indices = np.where(image_positions)[1].tolist()
+        inputs_embeds[:, image_indices, :] = image_features
+        return inputs_embeds.reshape(B, N, C)
+
+    @property
+    def layers(self):
+        return self.language_model.model.layers
+
+    def sanitize(self, weights):
+        sanitized = {}
+        for k, v in weights.items():
+            if "rotary_emb.inv_freq" in k:
+                continue
+            # SigLIP's attention pooling head is unused when only last_hidden_state is consumed
+            if ".vision_model.head." in k:
+                continue
+            if "patch_embedding.weight" in k:
+                sanitized[k] = v if check_array_shape(v) else v.transpose(0, 2, 3, 1)
+            else:
+                sanitized[k] = v
+        return sanitized
+
+    def __call__(
+        self,
+        input_ids: mx.array,
+        pixel_values: mx.array,
+        mask: mx.array,
+        cache=None,
+        **kwargs,
+    ):
+        input_embeddings_features = self.get_input_embeddings(input_ids, pixel_values)
+        logits = self.language_model(
+            None, cache=cache, inputs_embeds=input_embeddings_features.inputs_embeds
+        )
+        return logits

--- a/mlx_vlm/models/llmjpvl/vision.py
+++ b/mlx_vlm/models/llmjpvl/vision.py
@@ -1,0 +1,149 @@
+from typing import Optional
+
+import mlx.core as mx
+import mlx.nn as nn
+import numpy as np
+
+from ..attention import VisionAttention as Attention
+from ..mlp import GELUMLP as MLP
+from .config import VisionConfig
+
+
+def check_array_shape(arr):
+    shape = arr.shape
+
+    # Check if the shape has 4 dimensions
+    if len(shape) != 4:
+        return False
+
+    out_channels, kH, KW, _ = shape
+
+    # Check if out_channels is the largest, and kH and KW are the same
+    if (out_channels >= kH) and (out_channels >= KW) and (kH == KW):
+        return True
+    else:
+        return False
+
+
+class EncoderLayer(nn.Module):
+    def __init__(self, config: VisionConfig):
+        super().__init__()
+        self.embed_dim = config.hidden_size
+        self.self_attn = Attention(
+            config.hidden_size, config.num_attention_heads, bias=True
+        )
+        self.layer_norm1 = nn.LayerNorm(self.embed_dim, eps=config.layer_norm_eps)
+        self.mlp = MLP(config)
+        self.layer_norm2 = nn.LayerNorm(self.embed_dim, eps=config.layer_norm_eps)
+
+    def __call__(self, x: mx.array, mask: Optional[mx.array] = None) -> mx.array:
+        r = self.self_attn(self.layer_norm1(x), mask)
+        h = x + r
+        r = self.mlp(self.layer_norm2(h))
+        return h + r
+
+
+class Encoder(nn.Module):
+    def __init__(self, config: VisionConfig):
+        super().__init__()
+        self.layers = [EncoderLayer(config) for _ in range(config.num_hidden_layers)]
+
+    def __call__(
+        self,
+        x: mx.array,
+        output_hidden_states: Optional[bool] = None,
+        mask: Optional[mx.array] = None,
+    ) -> mx.array:
+        encoder_states = (x,) if output_hidden_states else None
+        h = x
+        for l in self.layers:
+            x = l(x, mask=mask)
+            if output_hidden_states:
+                encoder_states = encoder_states + (x,)
+
+            h = x
+
+        return (h, encoder_states)
+
+
+class VisionEmbeddings(nn.Module):
+    def __init__(self, config: VisionConfig):
+        super().__init__()
+        self.config = config
+        self.embed_dim = config.hidden_size
+        self.image_size = config.image_size
+        self.patch_size = config.patch_size
+
+        self.patch_embedding = nn.Conv2d(
+            in_channels=config.num_channels,
+            out_channels=self.embed_dim,
+            kernel_size=self.patch_size,
+            stride=self.patch_size,
+        )
+
+        self.num_patches = (self.image_size // self.patch_size) ** 2
+        self.num_positions = self.num_patches
+        self.position_embedding = nn.Embedding(self.num_positions, self.embed_dim)
+
+    def __call__(self, x: mx.array) -> mx.array:
+        patch_embeddings = self.patch_embedding(x)
+        patch_embeddings = mx.flatten(patch_embeddings, start_axis=1, end_axis=2)
+        position_ids = mx.array(np.arange(self.num_positions)[None, :])
+        embeddings = patch_embeddings
+        embeddings += self.position_embedding(position_ids)
+        return embeddings
+
+
+class SigLipVisionModel(nn.Module):
+    def __init__(self, config: VisionConfig):
+        super().__init__()
+        self.embeddings = VisionEmbeddings(config)
+        self.encoder = Encoder(config)
+        self.post_layernorm = nn.LayerNorm(config.hidden_size)
+
+    def __call__(
+        self,
+        x: mx.array,
+        output_hidden_states: Optional[bool] = None,
+    ) -> mx.array:
+        x = self.embeddings(x)
+
+        encoder_outputs = self.encoder(
+            x=x, output_hidden_states=output_hidden_states, mask=None
+        )
+
+        pooler_output = self.post_layernorm(encoder_outputs[0])
+
+        return pooler_output, x, encoder_outputs[-1]
+
+
+class VisionModel(nn.Module):
+    def __init__(self, config: VisionConfig):
+        super().__init__()
+        self.model_type = config.model_type
+        if self.model_type not in ["siglip_vision_model"]:
+            raise ValueError(f"Unsupported model type: {self.model_type}")
+
+        self.vision_model = SigLipVisionModel(config)
+
+    def __call__(
+        self, x: mx.array, output_hidden_states: Optional[bool] = None
+    ) -> mx.array:
+        return self.vision_model(x, output_hidden_states)
+
+    def sanitize(self, weights):
+        sanitized_weights = {}
+        for k, v in weights.items():
+            if "patch_embedding.weight" in k:
+                # PyTorch conv2d weight tensors have shape:
+                #   [out_channels, in_channels, kH, KW]
+                # MLX conv2d expects the weight be of shape:
+                #   [out_channels, kH, KW, in_channels]
+                if check_array_shape(v):
+                    sanitized_weights[k] = v
+                else:
+                    sanitized_weights[k] = v.transpose(0, 2, 3, 1)
+            else:
+                sanitized_weights[k] = v
+
+        return sanitized_weights

--- a/mlx_vlm/prompt_utils.py
+++ b/mlx_vlm/prompt_utils.py
@@ -58,6 +58,7 @@ MODEL_CONFIG = {
     "dots_ocr": MessageFormat.LIST_WITH_IMAGE_FIRST,
     "ernie4_5_moe_vl": MessageFormat.LIST_WITH_IMAGE_URL_FIRST,
     "internvl_chat": MessageFormat.LIST_WITH_IMAGE_TYPE,
+    "llmjpvl": MessageFormat.IMAGE_TOKEN,
     "nemotron_h_nano_omni": MessageFormat.LIST_WITH_IMAGE_TYPE,
     "nemotronh_nano_omni_reasoning_v3": MessageFormat.LIST_WITH_IMAGE_TYPE,
     "kimi_vl": MessageFormat.LIST_WITH_IMAGE,

--- a/mlx_vlm/tests/test_models.py
+++ b/mlx_vlm/tests/test_models.py
@@ -1912,6 +1912,59 @@ class TestModels(unittest.TestCase):
             (config.vision_config.image_size, config.vision_config.image_size),
         )
 
+    def test_llmjpvl(self):
+        from mlx_vlm.models import llmjpvl
+
+        text_config = llmjpvl.TextConfig(
+            model_type="llama",
+            hidden_size=64,
+            num_hidden_layers=4,
+            intermediate_size=128,
+            num_attention_heads=4,
+            num_key_value_heads=2,
+            rms_norm_eps=1e-6,
+            vocab_size=1024,
+            rope_theta=500000.0,
+            max_position_embeddings=4096,
+        )
+
+        vision_config = llmjpvl.VisionConfig(
+            model_type="siglip_vision_model",
+            hidden_size=64,
+            num_hidden_layers=3,
+            intermediate_size=128,
+            num_attention_heads=4,
+            patch_size=16,
+            image_size=64,
+            num_channels=3,
+            layer_norm_eps=1e-6,
+        )
+
+        config = llmjpvl.ModelConfig(
+            model_type="llmjpvl",
+            text_config=text_config,
+            vision_config=vision_config,
+            image_token_index=14,
+            downsample_ratio=0.5,
+        )
+
+        model = llmjpvl.Model(config)
+
+        self.language_test_runner(
+            model.language_model,
+            config.text_config.model_type,
+            config.text_config.vocab_size,
+            config.text_config.num_hidden_layers,
+        )
+
+        self.vision_test_runner(
+            model.vision_backbone,
+            config.vision_config.model_type,
+            config.vision_config.hidden_size,
+            config.vision_config.num_channels,
+            (config.vision_config.image_size, config.vision_config.image_size),
+        )
+
     def test_paligemma(self):
         from mlx_vlm.models import paligemma
 


### PR DESCRIPTION
## Description

Adds support for [llm-jp/llm-jp-4-vl-9B-beta](https://huggingface.co/llm-jp/llm-jp-4-vl-9b-beta) (`model_type: llmjpvl`), a 9B Japanese/English VLM released by LLM-jp (the Japanese LLM research consortium). To my knowledge this is the first MLX support for this model.

The architecture is an InternVL-style composition:

- **Vision**: SigLIP encoder (1152 dim / 27 layers, no CLS token, attention-pooling head unused)
- **Glue**: dynamic tiling + `pixel_shuffle` (ratio 0.5) + `mlp1` projector (LayerNorm → Linear 4608→4096 → GELU → Linear)
- **Language**: Llama (llm-jp-4-8b, vocab 196,608, GQA 32/8)

The implementation reuses the shared components in `mlx_vlm.models` (`VisionAttention`, `GELUMLP` / `SwiGLUMLP`, `pixel_shuffle`, `KVCache`); attribute names follow the HF checkpoint keys (`vision_backbone` / `language_model` / `mlp1`) so no weight remapping is needed. The upstream HF repo ships its processor via `trust_remote_code`, so `load(model_path, trust_remote_code=True)` works end to end with this model file.

## Verification

- **Greedy parity with the upstream transformers implementation** (bf16, MPS): 6/6 exact string matches on a Japanese business-document QA set (invoice / meeting minutes / contract clause / checklist / technical-doc images; dynamic tiling up to 12 tiles + thumbnail, ~3.4k image tokens per prompt), with pre/post-processing held identical on both sides.
- Deterministic across repeated runs and two independently written eval scripts.
- Quantization via `mlx_vlm.convert -q`: **8bit output is string-identical to bf16** on the same set; 4bit answers 6/6 correctly (5/6 string-identical, one phrasing-only difference).
- Measured on M4 Max 36GB: bf16 17.9 tok/s (peak 20.6GB) / 8bit 38.7 tok/s (12.5GB) / 4bit 61.7 tok/s (8.2GB); prompt processing ~430–500 tok/s.
- Verification re-run on this branch (bf16 and 4bit): outputs identical to the port developed against 0.6.7.
- Converted weights published (currently bundling this model file until merged): [bf16](https://huggingface.co/tokimoa/llm-jp-4-vl-9b-beta-mlx-bf16) / [8bit](https://huggingface.co/tokimoa/llm-jp-4-vl-9b-beta-mlx-8bit) / [4bit](https://huggingface.co/tokimoa/llm-jp-4-vl-9b-beta-mlx-4bit)

## Changes

- `mlx_vlm/models/llmjpvl/` — new model package (config / vision / language / model, ~500 lines)
- `mlx_vlm/tests/test_models.py` — `test_llmjpvl` added (passes)

Formatting: `black` / `isort --profile=black` / `autoflake` applied per pre-commit config.

The code was written in collaboration with Claude (AI assistant); all verification was run on real hardware as described above.
