### PR TITLE
Add PLaMo 2.1 VL (plamo2vl) model support

### DIFF
--- a/mlx_vlm/models/plamo2vl/__init__.py
+++ b/mlx_vlm/models/plamo2vl/__init__.py
@@ -1,0 +1,4 @@
+from .config import ModelConfig, TextConfig, VisionConfig
+from .language import LanguageModel
+from .plamo2vl import Model
+from .vision import VisionModel

--- a/mlx_vlm/models/plamo2vl/config.py
+++ b/mlx_vlm/models/plamo2vl/config.py
@@ -1,0 +1,78 @@
+import inspect
+from dataclasses import dataclass
+from typing import List, Optional
+
+from ..base import BaseModelConfig
+
+
+@dataclass
+class VisionConfig(BaseModelConfig):
+    model_type: str = "siglip_vision_model"
+    hidden_size: int = 1152
+    num_hidden_layers: int = 27
+    intermediate_size: int = 4304
+    num_attention_heads: int = 16
+    patch_size: int = 14
+    image_size: int = 384
+    num_channels: int = 3
+    layer_norm_eps: float = 1e-6
+    hidden_act: str = "gelu_pytorch_tanh"
+    image_token_id: int = 100002
+    image_feature_size: int = 1152
+    image_proj_hidden_size: int = 2048
+
+    @classmethod
+    def from_dict(cls, params):
+        # Upstream flattens the SigLIP encoder config as vision_encoder_* keys
+        mapped = {}
+        for k, v in dict(params).items():
+            if k.startswith("vision_encoder_"):
+                mapped[k[len("vision_encoder_") :]] = v
+            else:
+                mapped[k] = v
+        # Upstream config carries an empty model_type; keep our default
+        if not mapped.get("model_type"):
+            mapped.pop("model_type", None)
+        return cls(
+            **{
+                k: v
+                for k, v in mapped.items()
+                if k in inspect.signature(cls).parameters
+            }
+        )
+
+
+@dataclass
+class TextConfig(BaseModelConfig):
+    model_type: str = "plamo2"
+    hidden_size: int = 2048
+    num_hidden_layers: int = 32
+    rms_norm_eps: float = 1e-6
+    # Upstream Plamo2Config defaults to tied embeddings when absent from config.json
+    tie_word_embeddings: bool = True
+    num_attention_heads: int = 32
+    num_key_value_heads: int = 4
+    hidden_size_per_head: int = 128
+    max_position_embeddings: int = 10485760
+    attention_window_size: int = 32768
+    full_attention_idx: Optional[List[int]] = None
+    rope_theta: float = 1000000.0
+    rope_local_theta: float = 1000000.0
+    mamba_d_state: int = 64
+    mamba_d_conv: int = 4
+    mamba_num_heads: int = 64
+    mamba_step: int = 2
+    mamba_chunk_size: int = 256
+    mamba_enabled: bool = True
+    intermediate_size: int = 5632
+    vocab_size: int = 100032
+
+
+@dataclass
+class ModelConfig(BaseModelConfig):
+    model_type: str = "plamo2vl"
+    text_config: Optional[TextConfig] = None
+    vision_config: Optional[VisionConfig] = None
+    image_token_index: Optional[int] = None
+    ignore_index: int = -100
+    eos_token_id: Optional[List[int]] = None

--- a/mlx_vlm/models/plamo2vl/language.py
+++ b/mlx_vlm/models/plamo2vl/language.py
@@ -1,0 +1,477 @@
+from typing import Any, Optional
+
+import mlx.core as mx
+import mlx.nn as nn
+
+from ..activations import swiglu
+from ..base import LanguageModelOutput, create_attention_mask, create_ssm_mask
+from ..cache import ArraysCache, KVCache
+from ..ssm import ssm_update
+from .config import TextConfig
+
+
+class RMSNorm(nn.Module):
+    def __init__(
+        self,
+        hidden_size: int,
+        eps: float = 1e-6,
+        offset: float = 1.0,
+    ) -> None:
+        super().__init__()
+        self.weight = mx.zeros(hidden_size)
+        self.variance_epsilon = eps
+        self.offset = offset
+
+    def __call__(self, hidden_states: mx.array) -> mx.array:
+        return mx.fast.rms_norm(
+            hidden_states, self.weight + self.offset, self.variance_epsilon
+        )
+
+
+class Mamba(nn.Module):
+    def __init__(self, config: TextConfig) -> None:
+        super().__init__()
+        self.config = config
+        self.hidden_size = config.hidden_size
+        self.d_state = config.mamba_d_state
+        self.conv_kernel_size = config.mamba_d_conv
+        self.chunk_size = config.mamba_chunk_size
+        self.num_heads = config.mamba_num_heads
+        self.hidden_size_per_head = config.hidden_size_per_head
+
+        self.intermediate_size = self.num_heads * self.hidden_size_per_head
+
+        self.in_proj = nn.Linear(
+            self.hidden_size, 2 * self.intermediate_size, bias=False
+        )
+        self.conv1d = nn.Conv1d(
+            in_channels=self.intermediate_size,
+            out_channels=self.intermediate_size,
+            bias=False,
+            kernel_size=self.conv_kernel_size,
+            groups=self.intermediate_size,
+            padding=0,
+        )
+        self.dt_dim = max(64, self.hidden_size // 16)
+        self.bcdt_proj = nn.Linear(
+            self.intermediate_size,
+            self.dt_dim + 2 * self.d_state,
+            bias=False,
+        )
+        self.dt_proj = nn.Linear(self.dt_dim, self.num_heads, bias=False)
+
+        self.dt_bias = mx.zeros(shape=(self.num_heads,))
+        self.A_log = mx.log(mx.arange(1, self.num_heads + 1, dtype=mx.float32))
+
+        self.D = mx.ones(self.num_heads)
+
+        self.dt_norm_weight = mx.ones(self.dt_dim)
+        self.B_norm_weight = mx.ones(self.d_state)
+        self.C_norm_weight = mx.ones(self.d_state)
+
+        self.out_proj = nn.Linear(self.intermediate_size, self.hidden_size, bias=False)
+
+    def _conv(
+        self,
+        conv_input: mx.array,
+        cache: Optional[ArraysCache],
+        mask: Optional[mx.array],
+    ) -> mx.array:
+        if mask is not None:
+            conv_input = mx.where(mask[..., None], conv_input, 0)
+
+        if cache is not None:
+            if cache[0] is None:
+                conv_state = mx.zeros(
+                    (
+                        conv_input.shape[0],
+                        self.conv_kernel_size - 1,
+                        self.intermediate_size,
+                    ),
+                    dtype=conv_input.dtype,
+                )
+            else:
+                conv_state = cache[0]
+            padded_input = mx.concatenate([conv_state, conv_input], axis=1)
+            n_keep = self.conv_kernel_size - 1
+            if cache.lengths is not None:
+                t = padded_input.shape[1]
+                ends = mx.clip(cache.lengths, 0, t - n_keep)
+                positions = (ends[:, None] + mx.arange(n_keep))[..., None]
+                cache[0] = mx.take_along_axis(padded_input, positions, axis=1)
+            else:
+                cache[0] = padded_input[:, -n_keep:, :]
+        else:
+            padded_input = mx.pad(
+                conv_input, [(0, 0), (self.conv_kernel_size - 1, 0), (0, 0)]
+            )
+
+        conv_output = self.conv1d(padded_input)
+        return nn.silu(conv_output)
+
+    def _ssm(
+        self,
+        x: mx.array,
+        B: mx.array,
+        C: mx.array,
+        dt: mx.array,
+        cache: Optional[Any],
+        mask: Optional[mx.array],
+    ) -> mx.array:
+        batch_size, seq_len, _ = x.shape
+
+        x = x.reshape(batch_size, seq_len, self.num_heads, self.hidden_size_per_head)
+        B = B.reshape(batch_size, seq_len, 1, self.d_state)
+        C = C.reshape(batch_size, seq_len, 1, self.d_state)
+        if cache:
+            state = cache[1]
+            lengths = cache.lengths
+        else:
+            state, lengths = None, None
+
+        y, state = ssm_update(
+            x,
+            self.A_log,
+            B,
+            C,
+            self.D,
+            dt,
+            self.dt_bias,
+            state,
+            mask=mask,
+            lengths=lengths,
+        )
+        if cache:
+            cache[1] = state
+        return y.reshape(batch_size, seq_len, self.intermediate_size)
+
+    def __call__(
+        self,
+        hidden_states: mx.array,
+        mask: Optional[mx.array] = None,
+        cache=None,
+    ):
+        bsize, length, _ = hidden_states.shape
+
+        zx = self.in_proj(hidden_states)
+        zx = zx.reshape(bsize, length, self.num_heads, -1)
+        # z: (bsize, length, num_heads, hidden_size_per_head)
+        # x: (bsize, length, num_heads, hidden_size_per_head)
+        z, x = mx.split(
+            zx,
+            [
+                self.hidden_size_per_head,
+            ],
+            axis=-1,
+        )
+
+        x = x.reshape(bsize, -1, self.num_heads * self.hidden_size_per_head)
+        x = self._conv(x, cache, mask)
+
+        BCdt = self.bcdt_proj(x)
+        B, C, dt = mx.split(BCdt, [self.d_state, self.d_state * 2], axis=-1)
+
+        dt = mx.fast.rms_norm(dt, self.dt_norm_weight, self.config.rms_norm_eps)
+        B = mx.fast.rms_norm(B, self.B_norm_weight, self.config.rms_norm_eps)
+        C = mx.fast.rms_norm(C, self.C_norm_weight, self.config.rms_norm_eps)
+
+        # (bsize, length, num_heads)
+        dt = self.dt_proj(dt)
+        out = self._ssm(
+            x,
+            B,
+            C,
+            dt,
+            cache,
+            mask,
+        )
+        if cache:
+            cache.advance(out.shape[1])
+
+        out = swiglu(z.flatten(-2), out)
+        return self.out_proj(out)
+
+
+class Attention(nn.Module):
+    def __init__(self, config: TextConfig, layer_idx: int) -> None:
+        super().__init__()
+        self.config = config
+        self.hidden_size = config.hidden_size
+        head_dim = config.hidden_size_per_head
+        self.max_position_embeddings = config.max_position_embeddings
+        self.scale = head_dim**-0.5
+
+        self.q_num_heads = config.num_attention_heads
+        self.qk_dim = self.v_dim = head_dim
+        self.k_num_heads = self.v_num_heads = config.num_key_value_heads
+        assert self.q_num_heads % self.k_num_heads == 0
+        self.n_group = self.q_num_heads // self.k_num_heads
+
+        self.q_proj_dim = self.q_num_heads * self.qk_dim
+        self.k_proj_dim = self.k_num_heads * self.qk_dim
+        self.v_proj_dim = self.k_num_heads * self.v_dim
+        self.qkv_proj = nn.Linear(
+            self.hidden_size,
+            self.q_proj_dim + self.k_proj_dim + self.v_proj_dim,
+            bias=False,
+        )
+        self.o_proj = nn.Linear(
+            self.q_num_heads * self.v_dim, self.hidden_size, bias=False
+        )
+
+        self.q_weight = mx.ones((self.q_num_heads, self.qk_dim))
+        self.k_weight = mx.ones((self.k_num_heads, self.qk_dim))
+
+        # Upstream selects the RoPE base per layer: rope_theta for layers in
+        # full_attention_idx, rope_local_theta for sliding-window layers
+        full_attention_idx = config.full_attention_idx or []
+        base = (
+            config.rope_theta
+            if layer_idx in full_attention_idx
+            else config.rope_local_theta
+        )
+        self.rope = nn.RoPE(self.qk_dim, base=base)
+
+    def __call__(
+        self,
+        hidden_states: mx.array,
+        mask: Optional[mx.array] = None,
+        cache=None,
+    ):
+        B, T, _ = hidden_states.shape
+
+        qkv = self.qkv_proj(hidden_states)
+        q, k, v = mx.split(
+            qkv, [self.q_proj_dim, self.q_proj_dim + self.k_proj_dim], axis=-1
+        )
+        q = q.reshape(B, T, self.q_num_heads, self.qk_dim).transpose(0, 2, 1, 3)
+        k = k.reshape(B, T, self.k_num_heads, self.qk_dim).transpose(0, 2, 1, 3)
+        v = v.reshape(B, T, self.v_num_heads, self.v_dim).transpose(0, 2, 1, 3)
+
+        q = mx.fast.rms_norm(q, weight=None, eps=1e-6) * self.q_weight[:, None]
+        k = mx.fast.rms_norm(k, weight=None, eps=1e-6) * self.k_weight[:, None]
+
+        if cache is not None:
+            q = self.rope(q, offset=cache.offset)
+            k = self.rope(k, offset=cache.offset)
+            k, v = cache.update_and_fetch(k, v)
+        else:
+            q = self.rope(q)
+            k = self.rope(k)
+
+        output = mx.fast.scaled_dot_product_attention(
+            q,
+            k,
+            v,
+            scale=self.scale,
+            mask=mask,
+        )
+        output = output.transpose(0, 2, 1, 3).reshape(
+            B, T, self.q_num_heads * self.v_dim
+        )
+        return self.o_proj(output)
+
+
+class MLP(nn.Module):
+    def __init__(self, config: TextConfig) -> None:
+        super().__init__()
+        self.config = config
+        self.hidden_size = config.hidden_size
+        self.intermediate_size = config.intermediate_size
+        self.gate_up_proj = nn.Linear(
+            self.hidden_size, self.intermediate_size * 2, bias=False
+        )
+        self.down_proj = nn.Linear(self.intermediate_size, self.hidden_size, bias=False)
+
+    def __call__(self, x: mx.array) -> mx.array:
+        h = self.gate_up_proj(x)
+        hs = mx.split(h, 2, axis=-1)
+        return self.down_proj(swiglu(hs[0], hs[1]))
+
+
+class PlamoDecoderLayer(nn.Module):
+    def __init__(self, config: TextConfig, is_mamba: bool, layer_idx: int) -> None:
+        super().__init__()
+        self.config = config
+        self.hidden_size = config.hidden_size
+        self.is_mamba = is_mamba
+        self.mixer: nn.Module
+        if is_mamba:
+            self.mixer = Mamba(config)
+        else:
+            self.mixer = Attention(config, layer_idx)
+        self.mlp = MLP(config)
+        self.pre_mixer_norm = RMSNorm(
+            config.hidden_size, eps=config.rms_norm_eps, offset=1.0
+        )
+        self.post_mixer_norm = RMSNorm(
+            config.hidden_size, eps=config.rms_norm_eps, offset=1.0 / 5
+        )
+        self.pre_mlp_norm = RMSNorm(
+            config.hidden_size, eps=config.rms_norm_eps, offset=1.0
+        )
+        self.post_mlp_norm = RMSNorm(
+            config.hidden_size, eps=config.rms_norm_eps, offset=1.0 / (5**1.5)
+        )
+
+    def __call__(
+        self,
+        hidden_states: mx.array,
+        mask: Optional[mx.array] = None,
+        cache=None,
+    ):
+        residual = hidden_states
+        hidden_states = self.pre_mixer_norm(hidden_states)
+
+        hidden_states_sa = self.mixer(
+            hidden_states=hidden_states,
+            mask=mask,
+            cache=cache,
+        )
+
+        hidden_states_sa = self.post_mixer_norm(hidden_states_sa)
+        hidden_states = residual + hidden_states_sa
+
+        residual = hidden_states
+        hidden_states = self.pre_mlp_norm(hidden_states)
+
+        # Fully Connected
+        hidden_states_mlp = self.mlp(hidden_states)
+
+        # Residual
+        hidden_states_mlp = self.post_mlp_norm(hidden_states_mlp)
+        return residual + hidden_states_mlp
+
+
+def is_mamba(config: TextConfig, i: int) -> bool:
+    if not config.mamba_enabled:
+        return False
+    assert config.mamba_step > 1
+    assert i < config.num_hidden_layers
+
+    if config.num_hidden_layers <= (config.mamba_step // 2):
+        # use attention in last layer
+        return i != config.num_hidden_layers - 1
+    return (i % config.mamba_step) != (config.mamba_step // 2)
+
+
+class PlamoDecoder(nn.Module):
+    def __init__(self, config: TextConfig) -> None:
+        super().__init__()
+
+        self.layers = [
+            PlamoDecoderLayer(config, is_mamba=is_mamba(config, i), layer_idx=i)
+            for i in range(config.num_hidden_layers)
+        ]
+        self.ssm_idx = 0 if config.mamba_enabled else None
+        self.fa_idx = config.mamba_step // 2
+
+    def __call__(self, x: mx.array, cache):
+        if cache is None:
+            cache = [None] * len(self.layers)
+
+        attn_mask = create_attention_mask(x, cache[self.fa_idx])
+        if self.ssm_idx is not None:
+            mamba_mask = create_ssm_mask(x, cache[self.ssm_idx])
+        else:
+            mamba_mask = None
+
+        for (
+            l,
+            c,
+        ) in zip(self.layers, cache):
+            x = l(
+                x,
+                mask=mamba_mask if l.is_mamba else attn_mask,
+                cache=c,
+            )
+        return x
+
+
+class PlamoModel(nn.Module):
+    def __init__(self, config: TextConfig):
+        super().__init__()
+
+        self.config = config
+        self.vocab_size = config.vocab_size
+
+        self.embed_tokens = nn.Embedding(config.vocab_size, config.hidden_size)
+        self.layers = PlamoDecoder(config)
+        self.norm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+
+    def __call__(
+        self,
+        inputs: mx.array,
+        inputs_embeds: Optional[mx.array] = None,
+        cache=None,
+    ):
+        if inputs_embeds is None:
+            h = self.embed_tokens(inputs)
+        else:
+            h = inputs_embeds
+
+        out = self.layers(
+            h,
+            cache,
+        )
+
+        return self.norm(out)
+
+
+class LanguageModel(nn.Module):
+    def __init__(self, config: TextConfig) -> None:
+        super().__init__()
+        self.config = config
+        self.model_type = config.model_type
+        if self.model_type != "plamo2":
+            raise ValueError(
+                f"Model type {self.model_type} not supported. Supported type: 'plamo2'"
+            )
+        self.model = PlamoModel(config)
+
+        self.vocab_size = config.vocab_size
+
+        if not config.tie_word_embeddings:
+            self.lm_head: nn.Module = nn.Linear(
+                config.hidden_size, self.vocab_size, bias=False
+            )
+
+    def __call__(
+        self,
+        inputs: mx.array,
+        inputs_embeds: Optional[mx.array] = None,
+        mask: Optional[mx.array] = None,
+        cache=None,
+        **kwargs,
+    ):
+        out = self.model(inputs, inputs_embeds=inputs_embeds, cache=cache)
+        if self.config.tie_word_embeddings:
+            logits = self.model.embed_tokens.as_linear(out)
+        else:
+            logits = self.lm_head(out)
+        return LanguageModelOutput(logits=logits)
+
+    def make_cache(self):
+        return [
+            ArraysCache(size=2) if l.is_mamba else KVCache()
+            for l in self.model.layers.layers
+        ]
+
+    @staticmethod
+    def sanitize(weights):
+        for k, v in weights.items():
+            if "conv1d.weight" in k and v.shape[-1] != 1:
+                weights[k] = v.moveaxis(2, 1)
+        return weights
+
+    @property
+    def layers(self):
+        return self.model.layers.layers
+
+    @property
+    def head_dim(self):
+        return self.config.hidden_size_per_head
+
+    @property
+    def n_kv_heads(self):
+        return self.config.num_key_value_heads

--- a/mlx_vlm/models/plamo2vl/plamo2vl.py
+++ b/mlx_vlm/models/plamo2vl/plamo2vl.py
@@ -1,0 +1,178 @@
+from typing import Optional
+
+import mlx.core as mx
+import mlx.nn as nn
+import numpy as np
+
+from ..base import InputEmbeddingsFeatures
+from .config import ModelConfig
+from .language import LanguageModel, RMSNorm
+from .vision import VisionModel, check_array_shape
+
+
+class Bias(nn.Module):
+    """Upstream stores the parameter as `_bias`; MLX treats leading-underscore
+    attributes as private, so it is renamed to `bias` in sanitize."""
+
+    def __init__(self, num_features: int):
+        super().__init__()
+        self.bias = mx.zeros((num_features,))
+
+    def __call__(self, x: mx.array) -> mx.array:
+        return x + self.bias
+
+
+class MLPImageProjector(nn.Module):
+    def __init__(self, config: ModelConfig):
+        super().__init__()
+        vision_config = config.vision_config
+        text_config = config.text_config
+        hidden_size = vision_config.image_proj_hidden_size
+
+        self.norm0 = RMSNorm(
+            vision_config.image_feature_size, eps=text_config.rms_norm_eps
+        )
+        self.bias0 = Bias(vision_config.image_feature_size)
+
+        self.linear1 = nn.Linear(
+            vision_config.image_feature_size, hidden_size, bias=False
+        )
+        self.bias1 = Bias(hidden_size)
+        # torch nn.GELU() default is the exact (erf) form
+        self.act1 = nn.GELU()
+
+        self.linear2 = nn.Linear(hidden_size, text_config.hidden_size, bias=False)
+        self.bias2 = Bias(text_config.hidden_size)
+
+    def __call__(self, x: mx.array) -> mx.array:
+        x = self.norm0(x)
+        x = self.bias0(x)
+
+        x = self.linear1(x)
+        x = self.bias1(x)
+        x = self.act1(x)
+
+        x = self.linear2(x)
+        x = self.bias2(x)
+        return x
+
+
+class Model(nn.Module):
+    def __init__(self, config: ModelConfig):
+        super().__init__()
+        self.config = config
+        self.vision_model = VisionModel(config.vision_config)
+        self.language_model = LanguageModel(config.text_config)
+        self.image_proj = MLPImageProjector(config)
+
+        if config.image_token_index is None:
+            config.image_token_index = config.vision_config.image_token_id
+
+    def get_input_embeddings(
+        self,
+        input_ids: Optional[mx.array] = None,
+        pixel_values: Optional[mx.array] = None,
+        **kwargs,
+    ):
+        if pixel_values is None:
+            return InputEmbeddingsFeatures(
+                inputs_embeds=self.language_model.model.embed_tokens(input_ids)
+            )
+
+        dtype = (
+            self.vision_model.vision_encoder.model.embeddings.patch_embedding.weight.dtype
+        )
+        pixel_values = pixel_values.astype(dtype)
+
+        if pixel_values.ndim == 5:
+            # (1, total_num_tiles, 3, H, W) -> (total_num_tiles, 3, H, W)
+            pixel_values = pixel_values[0]
+
+        inputs_embeds = self.language_model.model.embed_tokens(input_ids)
+
+        cached = kwargs.get("cached_image_features", None)
+        if cached is not None:
+            image_features = cached
+        else:
+            # SigLIP: NCHW -> NHWC. No CLS token, nothing stripped from the front
+            hidden_states, _, _ = self.vision_model(
+                pixel_values.transpose(0, 2, 3, 1), output_hidden_states=False
+            )
+            # (num_tiles, 729, 1152) -> (num_tiles * 729, 1152)
+            image_features = self.image_proj(
+                hidden_states.reshape(-1, hidden_states.shape[-1])
+            )
+
+        image_token_index = kwargs.get(
+            "image_token_index", self.config.image_token_index
+        )
+
+        final_inputs_embeds = self._merge_input_ids_with_image_features(
+            image_features, inputs_embeds, input_ids, image_token_index
+        )
+        return InputEmbeddingsFeatures(inputs_embeds=final_inputs_embeds)
+
+    def _merge_input_ids_with_image_features(
+        self, image_features, inputs_embeds, input_ids, image_token_index=None
+    ):
+        B, N, C = inputs_embeds.shape
+        if image_token_index is None:
+            image_token_index = self.config.image_token_index
+
+        image_positions = input_ids == image_token_index
+        n_img = int(mx.sum(image_positions))
+        image_features = image_features.reshape(-1, image_features.shape[-1])
+        if n_img != image_features.shape[0]:
+            raise ValueError(
+                f"image token count ({n_img}) != vision feature count "
+                f"({image_features.shape[0]})"
+            )
+
+        image_indices = np.where(image_positions)[1].tolist()
+        inputs_embeds[:, image_indices, :] = image_features
+        return inputs_embeds.reshape(B, N, C)
+
+    @property
+    def layers(self):
+        return self.language_model.model.layers.layers
+
+    def make_cache(self):
+        return self.language_model.make_cache()
+
+    def sanitize(self, weights):
+        sanitized = {}
+        for k, v in weights.items():
+            # SigLIP attention pooling head is unused when only
+            # last_hidden_state is consumed
+            if ".vision_encoder.model.head." in k:
+                continue
+            # Checkpoint stores the language model at the top level; nest it
+            # under language_model to follow the mlx-vlm layout
+            if k.startswith("model."):
+                k = "language_model." + k
+            elif k.startswith("lm_head."):
+                if self.config.text_config.tie_word_embeddings:
+                    continue
+                k = "language_model." + k
+            # MLX cannot register leading-underscore parameters
+            if k.endswith("._bias"):
+                k = k[: -len("._bias")] + ".bias"
+            if "patch_embedding.weight" in k:
+                sanitized[k] = v if check_array_shape(v) else v.transpose(0, 2, 3, 1)
+            else:
+                sanitized[k] = v
+        return sanitized
+
+    def __call__(
+        self,
+        input_ids: mx.array,
+        pixel_values: mx.array,
+        mask: mx.array,
+        cache=None,
+        **kwargs,
+    ):
+        input_embeddings_features = self.get_input_embeddings(input_ids, pixel_values)
+        logits = self.language_model(
+            None, cache=cache, inputs_embeds=input_embeddings_features.inputs_embeds
+        )
+        return logits

--- a/mlx_vlm/models/plamo2vl/vision.py
+++ b/mlx_vlm/models/plamo2vl/vision.py
@@ -1,0 +1,157 @@
+from typing import Optional
+
+import mlx.core as mx
+import mlx.nn as nn
+import numpy as np
+
+from ..attention import VisionAttention as Attention
+from ..mlp import GELUMLP as MLP
+from .config import VisionConfig
+
+
+def check_array_shape(arr):
+    shape = arr.shape
+
+    # Check if the shape has 4 dimensions
+    if len(shape) != 4:
+        return False
+
+    out_channels, kH, KW, _ = shape
+
+    # Check if out_channels is the largest, and kH and KW are the same
+    if (out_channels >= kH) and (out_channels >= KW) and (kH == KW):
+        return True
+    else:
+        return False
+
+
+class EncoderLayer(nn.Module):
+    def __init__(self, config: VisionConfig):
+        super().__init__()
+        self.embed_dim = config.hidden_size
+        self.self_attn = Attention(
+            config.hidden_size, config.num_attention_heads, bias=True
+        )
+        self.layer_norm1 = nn.LayerNorm(self.embed_dim, eps=config.layer_norm_eps)
+        self.mlp = MLP(config)
+        self.layer_norm2 = nn.LayerNorm(self.embed_dim, eps=config.layer_norm_eps)
+
+    def __call__(self, x: mx.array, mask: Optional[mx.array] = None) -> mx.array:
+        r = self.self_attn(self.layer_norm1(x), mask)
+        h = x + r
+        r = self.mlp(self.layer_norm2(h))
+        return h + r
+
+
+class Encoder(nn.Module):
+    def __init__(self, config: VisionConfig):
+        super().__init__()
+        self.layers = [EncoderLayer(config) for _ in range(config.num_hidden_layers)]
+
+    def __call__(
+        self,
+        x: mx.array,
+        output_hidden_states: Optional[bool] = None,
+        mask: Optional[mx.array] = None,
+    ) -> mx.array:
+        encoder_states = (x,) if output_hidden_states else None
+        h = x
+        for l in self.layers:
+            x = l(x, mask=mask)
+            if output_hidden_states:
+                encoder_states = encoder_states + (x,)
+
+            h = x
+
+        return (h, encoder_states)
+
+
+class VisionEmbeddings(nn.Module):
+    def __init__(self, config: VisionConfig):
+        super().__init__()
+        self.config = config
+        self.embed_dim = config.hidden_size
+        self.image_size = config.image_size
+        self.patch_size = config.patch_size
+
+        self.patch_embedding = nn.Conv2d(
+            in_channels=config.num_channels,
+            out_channels=self.embed_dim,
+            kernel_size=self.patch_size,
+            stride=self.patch_size,
+        )
+
+        self.num_patches = (self.image_size // self.patch_size) ** 2
+        self.num_positions = self.num_patches
+        self.position_embedding = nn.Embedding(self.num_positions, self.embed_dim)
+
+    def __call__(self, x: mx.array) -> mx.array:
+        patch_embeddings = self.patch_embedding(x)
+        patch_embeddings = mx.flatten(patch_embeddings, start_axis=1, end_axis=2)
+        position_ids = mx.array(np.arange(self.num_positions)[None, :])
+        embeddings = patch_embeddings
+        embeddings += self.position_embedding(position_ids)
+        return embeddings
+
+
+class SigLipVisionModel(nn.Module):
+    def __init__(self, config: VisionConfig):
+        super().__init__()
+        self.embeddings = VisionEmbeddings(config)
+        self.encoder = Encoder(config)
+        self.post_layernorm = nn.LayerNorm(config.hidden_size)
+
+    def __call__(
+        self,
+        x: mx.array,
+        output_hidden_states: Optional[bool] = None,
+    ) -> mx.array:
+        x = self.embeddings(x)
+
+        encoder_outputs = self.encoder(
+            x=x, output_hidden_states=output_hidden_states, mask=None
+        )
+
+        pooler_output = self.post_layernorm(encoder_outputs[0])
+
+        return pooler_output, x, encoder_outputs[-1]
+
+
+class VisionEncoderWrapper(nn.Module):
+    """Matches the checkpoint nesting vision_model.vision_encoder.model.*"""
+
+    def __init__(self, config: VisionConfig):
+        super().__init__()
+        self.model = SigLipVisionModel(config)
+
+
+class VisionModel(nn.Module):
+    def __init__(self, config: VisionConfig):
+        super().__init__()
+        self.model_type = config.model_type
+        if self.model_type not in ["siglip_vision_model"]:
+            raise ValueError(f"Unsupported model type: {self.model_type}")
+
+        self.vision_encoder = VisionEncoderWrapper(config)
+
+    def __call__(
+        self, x: mx.array, output_hidden_states: Optional[bool] = None
+    ) -> mx.array:
+        return self.vision_encoder.model(x, output_hidden_states)
+
+    def sanitize(self, weights):
+        sanitized_weights = {}
+        for k, v in weights.items():
+            if "patch_embedding.weight" in k:
+                # PyTorch conv2d weight tensors have shape:
+                #   [out_channels, in_channels, kH, KW]
+                # MLX conv2d expects the weight be of shape:
+                #   [out_channels, kH, KW, in_channels]
+                if check_array_shape(v):
+                    sanitized_weights[k] = v
+                else:
+                    sanitized_weights[k] = v.transpose(0, 2, 3, 1)
+            else:
+                sanitized_weights[k] = v
+
+        return sanitized_weights

--- a/mlx_vlm/prompt_utils.py
+++ b/mlx_vlm/prompt_utils.py
@@ -96,6 +96,7 @@ MODEL_CONFIG = {
     "youtu_vl": MessageFormat.LIST_WITH_IMAGE_FIRST,
     # Prompt-only models
     "florence2": MessageFormat.PROMPT_ONLY,
+    "plamo2vl": MessageFormat.PROMPT_ONLY,
     "molmo": MessageFormat.PROMPT_ONLY,
     "moondream2": MessageFormat.PROMPT_ONLY,
     "moondream3": MessageFormat.PROMPT_ONLY,

--- a/mlx_vlm/tests/test_models.py
+++ b/mlx_vlm/tests/test_models.py
@@ -1912,6 +1912,68 @@ class TestModels(unittest.TestCase):
             (config.vision_config.image_size, config.vision_config.image_size),
         )
 
+    def test_plamo2vl(self):
+        from mlx_vlm.models import plamo2vl
+
+        text_config = plamo2vl.TextConfig(
+            model_type="plamo2",
+            hidden_size=64,
+            num_hidden_layers=4,
+            num_attention_heads=4,
+            num_key_value_heads=2,
+            hidden_size_per_head=16,
+            intermediate_size=128,
+            mamba_num_heads=4,
+            mamba_d_state=16,
+            mamba_d_conv=4,
+            mamba_step=2,
+            rms_norm_eps=1e-6,
+            vocab_size=512,
+            rope_theta=1000000.0,
+            rope_local_theta=1000000.0,
+        )
+
+        vision_config = plamo2vl.VisionConfig(
+            model_type="siglip_vision_model",
+            hidden_size=64,
+            num_hidden_layers=2,
+            intermediate_size=128,
+            num_attention_heads=4,
+            patch_size=16,
+            image_size=64,
+            num_channels=3,
+            layer_norm_eps=1e-6,
+            image_token_id=7,
+            image_feature_size=64,
+            image_proj_hidden_size=32,
+        )
+
+        config = plamo2vl.ModelConfig(
+            model_type="plamo2vl",
+            text_config=text_config,
+            vision_config=vision_config,
+        )
+
+        model = plamo2vl.Model(config)
+
+        self.assertEqual(len(model.layers), text_config.num_hidden_layers)
+        self.assertEqual(sum(1 for l in model.layers if l.is_mamba), 2)
+
+        self.language_test_runner(
+            model.language_model,
+            config.text_config.model_type,
+            config.text_config.vocab_size,
+            config.text_config.num_hidden_layers,
+        )
+
+        self.vision_test_runner(
+            model.vision_model,
+            config.vision_config.model_type,
+            config.vision_config.hidden_size,
+            config.vision_config.num_channels,
+            (config.vision_config.image_size, config.vision_config.image_size),
+        )
+
     def test_paligemma(self):
         from mlx_vlm.models import paligemma
 


### PR DESCRIPTION
## Description

Adds support for Preferred Networks' PLaMo 2.1 VL models (`model_type: plamo2vl`) — [pfnet/plamo-2.1-2b-vl](https://huggingface.co/pfnet/plamo-2.1-2b-vl) and [pfnet/plamo-2.1-8b-vl](https://huggingface.co/pfnet/plamo-2.1-8b-vl), Japanese/English VLMs. To my knowledge this is the first MLX support for these models.

The architecture:

- **Language**: `plamo2` — a Mamba2/Attention interleaved hybrid (even layers Mamba, odd layers GQA). Adapted from mlx-lm's `plamo2` implementation using this repo's shared components (`ssm_update`, `ArraysCache`, `create_ssm_mask`, `swiglu`), with two additions: `inputs_embeds` support for the VL path, and **per-layer RoPE base selection** (`rope_theta` for layers in `full_attention_idx`, `rope_local_theta` otherwise — PLaMo 2.1 uses base 1e6, so mlx-lm's fixed default of 10000 does not carry over).
- **Vision**: SigLIP so400m (384px / patch 14 / 729 tokens per tile, Eagle2-style dynamic tiling handled by the upstream processor).
- **Projector**: RMSNorm (weight+offset form) → Bias → Linear → Bias → GELU → Linear → Bias, matching the checkpoint's `image_proj.*` keys. The upstream parameter name `_bias` cannot be registered in MLX (leading underscore), so it is renamed to `bias` in `sanitize`.
- The checkpoint stores the LM at the top level (`model.*` / `lm_head.*`); `sanitize` nests it under `language_model.` to follow the mlx-vlm layout. Both released checkpoints are tied-embedding models.

The upstream HF repos ship their processor via `trust_remote_code` (note: it applies a Japanese-Alpaca-style instruction template internally — no chat template — hence the `PROMPT_ONLY` entry in prompt_utils, and its tokenizer requires `numba`).

## Verification

- **Prefill-logit parity with the upstream transformers implementation** (bf16, MPS) on byte-identical inputs: **top-1 token match 6/6** for both 2B and 8B (cosine similarity 0.9986–0.9996, top-10 overlap 8–10/10) on a Japanese document-QA input set (~2.2k tokens each, 3 tiles per image).
- Greedy photo-description outputs match the transformers implementation string-for-string (2B and 8B).
- Deterministic across repeated runs; quantized 8bit/4bit variants verified against bf16.
- CLI verified on this branch: `mlx_vlm generate --model <plamo2vl-4bit> --image fruit.png --prompt "この画像に写っているものを説明してください。" --temperature 0.0 --trust-remote-code` → correct description at 168 tok/s generation.
- Converted weights published (bundling this model file until merged): [2B bf16](https://huggingface.co/tokimoa/plamo-2.1-2b-vl-mlx-bf16) / [2B 8bit](https://huggingface.co/tokimoa/plamo-2.1-2b-vl-mlx-8bit) / [2B 4bit](https://huggingface.co/tokimoa/plamo-2.1-2b-vl-mlx-4bit) / [8B bf16](https://huggingface.co/tokimoa/plamo-2.1-8b-vl-mlx-bf16) / [8B 8bit](https://huggingface.co/tokimoa/plamo-2.1-8b-vl-mlx-8bit) / [8B 4bit](https://huggingface.co/tokimoa/plamo-2.1-8b-vl-mlx-4bit) (weights under the PLaMo Community License).

## Changes

- `mlx_vlm/models/plamo2vl/` — new model package (config / vision / language / model)
- `mlx_vlm/prompt_utils.py` — `plamo2vl` registered as `PROMPT_ONLY` (the upstream processor builds the full instruction prompt itself)
- `mlx_vlm/tests/test_models.py` — `test_plamo2vl` added (passes)

Formatting: `black` / `isort --profile=black` / `autoflake` applied per pre-commit config.

The code was written in collaboration with Claude (AI assistant); all verification was run on real hardware as described above.
