### PR TITLE
Fix chunked MRoPE positions across Qwen VL models

### DIFF
--- a/mlx_vlm/models/qwen2_5_vl/language.py
+++ b/mlx_vlm/models/qwen2_5_vl/language.py
@@ -441,6 +441,13 @@ class LanguageModel(nn.Module):
             ):
                 cache_offsets = mx.maximum(c0.offset, 0)
 
+        if position_ids is not None and cache_offsets is None:
+            seq_length = inputs.shape[-1]
+            if position_ids.shape[-1] > seq_length:
+                position_ids = position_ids[
+                    ..., cache_offset : cache_offset + seq_length
+                ]
+
         # Check if mask shape matches input shape (for chunked prefill compatibility)
         rope_mask = mask
         if mask is not None and mask.shape[-1] != inputs.shape[-1]:

--- a/mlx_vlm/models/qwen2_vl/language.py
+++ b/mlx_vlm/models/qwen2_vl/language.py
@@ -434,6 +434,13 @@ class LanguageModel(nn.Module):
             ):
                 cache_offsets = mx.maximum(c0.offset, 0)
 
+        if position_ids is not None and cache_offsets is None:
+            seq_length = inputs.shape[-1]
+            if position_ids.shape[-1] > seq_length:
+                position_ids = position_ids[
+                    ..., cache_offset : cache_offset + seq_length
+                ]
+
         # Check if mask shape matches input shape (for chunked prefill compatibility)
         rope_mask = mask
         if mask is not None and mask.shape[-1] != inputs.shape[-1]:

--- a/mlx_vlm/models/qwen3_5/language.py
+++ b/mlx_vlm/models/qwen3_5/language.py
@@ -2548,6 +2548,13 @@ class LanguageModel(nn.Module):
             ):
                 cache_offsets = mx.maximum(c0.offset, 0)
 
+        if position_ids is not None and cache_offsets is None:
+            seq_length = inputs.shape[-1]
+            if position_ids.shape[-1] > seq_length:
+                position_ids = position_ids[
+                    ..., cache_offset : cache_offset + seq_length
+                ]
+
         if (
             mask is None
             and c0 is not None

--- a/mlx_vlm/models/qwen3_vl/language.py
+++ b/mlx_vlm/models/qwen3_vl/language.py
@@ -501,6 +501,13 @@ class LanguageModel(nn.Module):
             if isinstance(c0.offset, mx.array) and c0.offset.ndim > 0:
                 cache_offset_array = c0.offset
 
+        if position_ids is not None and cache_offset_array is None:
+            seq_length = inputs.shape[-1]
+            if position_ids.shape[-1] > seq_length:
+                position_ids = position_ids[
+                    ..., cache_offset : cache_offset + seq_length
+                ]
+
         if (
             visual_pos_masks is not None
             and visual_pos_masks.shape[-1] != inputs.shape[-1]

--- a/mlx_vlm/models/qwen3_vl_moe/language.py
+++ b/mlx_vlm/models/qwen3_vl_moe/language.py
@@ -545,6 +545,13 @@ class LanguageModel(nn.Module):
             ):
                 cache_offsets = c0.offset
 
+        if position_ids is not None and cache_offsets is None:
+            seq_length = inputs.shape[-1]
+            if position_ids.shape[-1] > seq_length:
+                position_ids = position_ids[
+                    ..., cache_offset : cache_offset + seq_length
+                ]
+
         if (
             visual_pos_masks is not None
             and visual_pos_masks.shape[-1] != inputs.shape[-1]

--- a/mlx_vlm/tests/test_models.py
+++ b/mlx_vlm/tests/test_models.py
@@ -6736,9 +6736,12 @@ class TestGetInputEmbeddings(unittest.TestCase):
 
     def _assert_qwen_chunked_prefill_slices_mrope_position_ids(self, model):
         language_model = model.language_model
+        hidden_size = language_model.args.hidden_size
         captured = {}
 
         class _CapturingModel:
+            fa_idx = 0
+
             class _Embed:
                 @staticmethod
                 def as_linear(x):
@@ -6752,7 +6755,7 @@ class TestGetInputEmbeddings(unittest.TestCase):
                     (
                         inputs.shape[0],
                         inputs.shape[1],
-                        model.config.text_config.hidden_size,
+                        hidden_size,
                     )
                 )
 
@@ -6766,9 +6769,7 @@ class TestGetInputEmbeddings(unittest.TestCase):
         full_position_ids = mx.arange(15, dtype=mx.int32).reshape(3, 1, 5)
         language_model(
             mx.array([[7, 8]], dtype=mx.int32),
-            inputs_embeds=mx.zeros(
-                (1, 2, model.config.text_config.hidden_size), dtype=mx.float32
-            ),
+            inputs_embeds=mx.zeros((1, 2, hidden_size), dtype=mx.float32),
             cache=[_StubCache()],
             position_ids=full_position_ids,
         )
@@ -6916,6 +6917,7 @@ class TestGetInputEmbeddings(unittest.TestCase):
         )
         self._check_returns_input_embeddings_features(model, "qwen2_vl")
         self._assert_qwen_request_owned_mrope_kwargs(model)
+        self._assert_qwen_chunked_prefill_slices_mrope_position_ids(model)
 
     def test_qwen2_5_vl_input_embeddings(self):
         from mlx_vlm.models import qwen2_5_vl
@@ -6991,6 +6993,7 @@ class TestGetInputEmbeddings(unittest.TestCase):
         )
         self._check_returns_input_embeddings_features(model, "qwen3_vl")
         self._assert_qwen_request_owned_mrope_kwargs(model)
+        self._assert_qwen_chunked_prefill_slices_mrope_position_ids(model)
 
     def test_paligemma_input_embeddings(self):
         from mlx_vlm.models import paligemma
@@ -8352,6 +8355,7 @@ class TestGetInputEmbeddings(unittest.TestCase):
         )
         self._check_returns_input_embeddings_features(model, "qwen3_vl_moe")
         self._assert_qwen_request_owned_mrope_kwargs(model)
+        self._assert_qwen_chunked_prefill_slices_mrope_position_ids(model)
 
     def test_qwen3_5_input_embeddings_owns_mrope_kwargs(self):
         from mlx_vlm.models import qwen3_5
@@ -8387,6 +8391,45 @@ class TestGetInputEmbeddings(unittest.TestCase):
             )
         )
         self._assert_qwen_request_owned_mrope_kwargs(model)
+        self._assert_qwen_chunked_prefill_slices_mrope_position_ids(model)
+
+    def test_qwen3_5_moe_chunked_prefill_slices_mrope_position_ids(self):
+        from mlx_vlm.models import qwen3_5_moe
+
+        model = qwen3_5_moe.Model(
+            qwen3_5_moe.ModelConfig(
+                text_config=qwen3_5_moe.TextConfig(
+                    model_type="qwen3_5_moe",
+                    hidden_size=16,
+                    linear_num_value_heads=2,
+                    linear_num_key_heads=2,
+                    linear_key_head_dim=8,
+                    linear_value_head_dim=8,
+                    linear_conv_kernel_dim=3,
+                    num_hidden_layers=1,
+                    num_attention_heads=2,
+                    num_experts=2,
+                    num_experts_per_tok=1,
+                    shared_expert_intermediate_size=32,
+                    moe_intermediate_size=16,
+                    rms_norm_eps=1e-5,
+                    vocab_size=32,
+                    num_key_value_heads=2,
+                    max_position_embeddings=128,
+                    head_dim=8,
+                ),
+                vision_config=qwen3_5_moe.VisionConfig(
+                    model_type="qwen3_5_moe",
+                    depth=1,
+                    hidden_size=16,
+                    intermediate_size=32,
+                    out_hidden_size=16,
+                    num_heads=2,
+                ),
+                model_type="qwen3_5_moe",
+            )
+        )
+        self._assert_qwen_chunked_prefill_slices_mrope_position_ids(model)
 
     def test_qwen3_omni_moe_input_embeddings(self):
         from mlx_vlm.models import qwen3_omni_moe
@@ -8448,6 +8491,7 @@ class TestGetInputEmbeddings(unittest.TestCase):
         )
         self._check_returns_input_embeddings_features(model, "qwen3_omni_moe")
         self._assert_qwen_request_owned_mrope_kwargs(model)
+        self._assert_qwen_chunked_prefill_slices_mrope_position_ids(model)
 
     def test_qwen3_omni_audio_sanitize_is_idempotent_for_conv2d_weights(self):
         from mlx_vlm.models import qwen3_omni_moe

--- a/mlx_vlm/tests/test_models.py
+++ b/mlx_vlm/tests/test_models.py
@@ -6734,6 +6734,51 @@ class TestGetInputEmbeddings(unittest.TestCase):
             mx.array_equal(model.language_model._rope_deltas, stale_rope_deltas).item()
         )
 
+    def _assert_qwen_chunked_prefill_slices_mrope_position_ids(self, model):
+        language_model = model.language_model
+        captured = {}
+
+        class _CapturingModel:
+            class _Embed:
+                @staticmethod
+                def as_linear(x):
+                    return x
+
+            embed_tokens = _Embed()
+
+            def __call__(self, inputs, position_ids=None, **kwargs):
+                captured["position_ids"] = position_ids
+                return mx.zeros(
+                    (
+                        inputs.shape[0],
+                        inputs.shape[1],
+                        model.config.text_config.hidden_size,
+                    )
+                )
+
+        class _StubCache:
+            _idx = 2
+            offset = mx.array(2)
+
+        language_model.model = _CapturingModel()
+        language_model.lm_head = lambda x: x
+
+        full_position_ids = mx.arange(15, dtype=mx.int32).reshape(3, 1, 5)
+        language_model(
+            mx.array([[7, 8]], dtype=mx.int32),
+            inputs_embeds=mx.zeros(
+                (1, 2, model.config.text_config.hidden_size), dtype=mx.float32
+            ),
+            cache=[_StubCache()],
+            position_ids=full_position_ids,
+        )
+
+        self.assertEqual(captured["position_ids"].shape, (3, 1, 2))
+        self.assertEqual(
+            captured["position_ids"].tolist(),
+            full_position_ids[:, :, 2:4].tolist(),
+        )
+
     def test_llava_input_embeddings(self):
         from mlx_vlm.models import llava
 
@@ -6907,6 +6952,7 @@ class TestGetInputEmbeddings(unittest.TestCase):
         )
         self._check_returns_input_embeddings_features(model, "qwen2_5_vl")
         self._assert_qwen_request_owned_mrope_kwargs(model)
+        self._assert_qwen_chunked_prefill_slices_mrope_position_ids(model)
 
     def test_qwen3_vl_input_embeddings(self):
         from mlx_vlm.models import qwen3_vl


### PR DESCRIPTION
## Summary

- slice full-prompt MRoPE position IDs to each model's current prefill window
- cover Qwen2-VL, Qwen2.5-VL, Qwen3-VL, Qwen3-VL-MoE, Qwen3.5, and Qwen3.5-MoE
- retain Qwen3-Omni-MoE's existing equivalent safeguard and test it with the shared regression

## Root cause

After MRoPE state became request-owned, plain generation passed full-prompt `position_ids` to every chunked-prefill call. Affected Qwen multimodal language models applied the prompt's initial positions to later chunks, which caused immediate EOS or chat-template echo for image prompts longer than the prefill chunk size.

The fix stays at the model level and leaves divergent continuous-batching offsets untouched because that path already receives aligned per-request positions. Text-only Qwen models do not use request-owned multimodal MRoPE positions and are unaffected.

Fixes #1737.

## Validation

- `uv run --with pytest pytest -q mlx_vlm/tests/test_generate.py` — 99 passed
- `uv run --with pytest pytest -q mlx_vlm/tests/test_models.py -k 'qwen'` — 32 passed, 12 subtests passed
- shared chunk-position regression passes for every multimodal Qwen implementation, including Qwen3.5-MoE's inherited path and Qwen3-Omni-MoE's existing safeguard
- real-model regression with `mlx-community/Qwen2.5-VL-3B-Instruct-4bit`: a 2,308-token image prompt crossing the default 2,048-token prefill boundary now produces the same coherent document description as unchunked prefill
- Black and `git diff --check` pass
