### PR TITLE
Fix double transpose of Nemotron Omni audio conv weights on MLX checkpoints

### DIFF
--- a/mlx_vlm/models/nemotron_h_nano_omni/audio.py
+++ b/mlx_vlm/models/nemotron_h_nano_omni/audio.py
@@ -545,38 +545,25 @@ class SoundFeatureExtractor:
         )
 
 
-def _conv1d_needs_transpose(shape, conv_kernel_size):
-    # PyTorch conv1d weights are (out, in/groups, K); MLX expects (out, K, in/groups).
-    # Guard so already-converted MLX checkpoints are not transposed twice:
-    # torch depthwise ends with the kernel size, torch pointwise carries the
-    # (large) channel count in dim 1; MLX layouts match neither pattern.
-    _, d1, d2 = shape
-    if d2 == conv_kernel_size and d1 != conv_kernel_size:
-        return True
-    if d2 == 1 and d1 > conv_kernel_size:
-        return True
-    return False
-
-
-def sanitize_audio_weights(weights, conv_kernel_size=9):
+def sanitize_audio_weights(weights):
+    # The PyTorch checkpoint ships feature_extractor buffers that are dropped
+    # below, so their presence distinguishes the PyTorch layout from an
+    # already-converted MLX checkpoint. load_model re-runs sanitize on every
+    # load; without this check the conv weights of MLX checkpoints would be
+    # transposed a second time and fail with a shape mismatch.
+    is_torch_layout = any(
+        key.startswith("sound_encoder.encoder.feature_extractor.") for key in weights
+    )
     sanitized = {}
     for key, value in weights.items():
         if key.startswith("sound_encoder.encoder.feature_extractor."):
             continue
         if key.endswith(".num_batches_tracked"):
             continue
-        if key.startswith("sound_encoder.encoder."):
-            if (
-                key.endswith(".weight")
-                and value.ndim == 3
-                and _conv1d_needs_transpose(value.shape, conv_kernel_size)
-            ):
+        if is_torch_layout and key.startswith("sound_encoder.encoder."):
+            if key.endswith(".weight") and value.ndim == 3:
                 value = value.transpose(0, 2, 1)
             elif key.endswith(".weight") and value.ndim == 4:
-                # PyTorch conv2d weights are (out, in, kH, kW); MLX expects
-                # (out, kH, kW, in). Square kernel dims sit in the middle for
-                # NCHW input, so only transpose when they are at the end.
-                if value.shape[2] == value.shape[3]:
-                    value = value.transpose(0, 2, 3, 1)
+                value = value.transpose(0, 2, 3, 1)
         sanitized[key] = value
     return sanitized

--- a/mlx_vlm/models/nemotron_h_nano_omni/audio.py
+++ b/mlx_vlm/models/nemotron_h_nano_omni/audio.py
@@ -545,7 +545,20 @@ class SoundFeatureExtractor:
         )
 
 
-def sanitize_audio_weights(weights):
+def _conv1d_needs_transpose(shape, conv_kernel_size):
+    # PyTorch conv1d weights are (out, in/groups, K); MLX expects (out, K, in/groups).
+    # Guard so already-converted MLX checkpoints are not transposed twice:
+    # torch depthwise ends with the kernel size, torch pointwise carries the
+    # (large) channel count in dim 1; MLX layouts match neither pattern.
+    _, d1, d2 = shape
+    if d2 == conv_kernel_size and d1 != conv_kernel_size:
+        return True
+    if d2 == 1 and d1 > conv_kernel_size:
+        return True
+    return False
+
+
+def sanitize_audio_weights(weights, conv_kernel_size=9):
     sanitized = {}
     for key, value in weights.items():
         if key.startswith("sound_encoder.encoder.feature_extractor."):
@@ -553,9 +566,17 @@ def sanitize_audio_weights(weights):
         if key.endswith(".num_batches_tracked"):
             continue
         if key.startswith("sound_encoder.encoder."):
-            if key.endswith(".weight") and value.ndim == 3:
+            if (
+                key.endswith(".weight")
+                and value.ndim == 3
+                and _conv1d_needs_transpose(value.shape, conv_kernel_size)
+            ):
                 value = value.transpose(0, 2, 1)
             elif key.endswith(".weight") and value.ndim == 4:
-                value = value.transpose(0, 2, 3, 1)
+                # PyTorch conv2d weights are (out, in, kH, kW); MLX expects
+                # (out, kH, kW, in). Square kernel dims sit in the middle for
+                # NCHW input, so only transpose when they are at the end.
+                if value.shape[2] == value.shape[3]:
+                    value = value.transpose(0, 2, 3, 1)
         sanitized[key] = value
     return sanitized

--- a/mlx_vlm/models/nemotron_h_nano_omni/nemotron_h_nano_omni.py
+++ b/mlx_vlm/models/nemotron_h_nano_omni/nemotron_h_nano_omni.py
@@ -318,14 +318,7 @@ class Model(nn.Module):
 
     def sanitize(self, weights):
         sanitized = {}
-        conv_kernel_size = (
-            self.config.sound_config.conv_kernel_size
-            if self.config.sound_config is not None
-            else 9
-        )
-        for key, value in sanitize_audio_weights(
-            weights, conv_kernel_size=conv_kernel_size
-        ).items():
+        for key, value in sanitize_audio_weights(weights).items():
             if key.startswith("mlp1."):
                 key = key.replace("mlp1.0.", "mlp1.layers.0.")
                 key = key.replace("mlp1.1.", "mlp1.layers.1.")

--- a/mlx_vlm/models/nemotron_h_nano_omni/nemotron_h_nano_omni.py
+++ b/mlx_vlm/models/nemotron_h_nano_omni/nemotron_h_nano_omni.py
@@ -318,7 +318,14 @@ class Model(nn.Module):
 
     def sanitize(self, weights):
         sanitized = {}
-        for key, value in sanitize_audio_weights(weights).items():
+        conv_kernel_size = (
+            self.config.sound_config.conv_kernel_size
+            if self.config.sound_config is not None
+            else 9
+        )
+        for key, value in sanitize_audio_weights(
+            weights, conv_kernel_size=conv_kernel_size
+        ).items():
             if key.startswith("mlp1."):
                 key = key.replace("mlp1.0.", "mlp1.layers.0.")
                 key = key.replace("mlp1.1.", "mlp1.layers.1.")


### PR DESCRIPTION
## Description

`sanitize_audio_weights` in `nemotron_h_nano_omni` unconditionally transposes `sound_encoder` conv weights. That is correct when converting from the PyTorch checkpoint, but `load_model` runs sanitize on every load — so loading an **already-converted MLX checkpoint** transposes the weights a second time and fails:

```
ValueError: Expected shape (256, 3, 3, 1) but received shape (256, 3, 1, 3)
for parameter sound_encoder.encoder.subsampling.layers.0.weight
```

This currently affects every published MLX conversion of this architecture I tried (e.g. `mlx-community/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-4bit`).

## Fix

Add idempotence guards (same spirit as `check_array_shape` in the vision towers):

- conv2d: transpose only when the square kernel dims are in NCHW position (`shape[2] == shape[3]`)
- conv1d: transpose only when the shape matches a PyTorch layout for the configured kernel size (depthwise ends with the kernel size; pointwise carries the channel count in dim 1). The kernel size is taken from `sound_config.conv_kernel_size`.

## Verification

- Before: `mlx_vlm generate` with `mlx-community/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-4bit` fails with the shape error above.
- After: loads and answers an invoice-reading probe correctly (「880,000円」, 97 tok/s generation on M4 Max).
- Converting from the original PyTorch checkpoint still transposes as before (guards match the PyTorch layouts).

The code was written in collaboration with Claude (AI assistant); verification was run on real hardware as described above.