### PR TITLE
Fix multi-image SFT grid collation

### DIFF
--- a/mlx_vlm/tests/test_trainer.py
+++ b/mlx_vlm/tests/test_trainer.py
@@ -241,6 +241,49 @@ class TestBatchCollation(unittest.TestCase):
             mx.array_equal(batch["image_grid_thw"], mx.array([[1, 1, 2], [1, 1, 3]]))
         )
 
+    def test_iterate_batches_preserves_multi_image_grid_rows(self):
+        dataset = [
+            {
+                "input_ids": mx.array([1, 2, 3]),
+                "attention_mask": mx.array([1, 1, 1]),
+                "pixel_values": mx.zeros((5, 4)),
+                "image_grid_thw": mx.array([[1, 1, 2], [1, 1, 3]]),
+            }
+        ]
+
+        batch = next(iterate_batches(dataset, batch_size=1, max_seq_length=32))
+
+        self.assertEqual(batch["image_grid_thw"].shape, (2, 3))
+        self.assertTrue(
+            mx.array_equal(batch["image_grid_thw"], mx.array([[1, 1, 2], [1, 1, 3]]))
+        )
+
+    def test_iterate_batches_concatenates_mixed_image_grid_rows(self):
+        dataset = [
+            {
+                "input_ids": mx.array([1, 2, 3]),
+                "attention_mask": mx.array([1, 1, 1]),
+                "pixel_values": mx.zeros((2, 4)),
+                "image_grid_thw": mx.array([[1, 1, 2]]),
+            },
+            {
+                "input_ids": mx.array([4, 5]),
+                "attention_mask": mx.array([1, 1]),
+                "pixel_values": mx.ones((7, 4)),
+                "image_grid_thw": mx.array([[1, 1, 3], [1, 2, 2]]),
+            },
+        ]
+
+        batch = next(iterate_batches(dataset, batch_size=2, max_seq_length=32))
+
+        self.assertEqual(batch["image_grid_thw"].shape, (3, 3))
+        self.assertTrue(
+            mx.array_equal(
+                batch["image_grid_thw"],
+                mx.array([[1, 1, 2], [1, 1, 3], [1, 2, 2]]),
+            )
+        )
+
     def test_iterate_batches_pads_completion_mask(self):
         dataset = [
             {

--- a/mlx_vlm/trainer/sft_trainer.py
+++ b/mlx_vlm/trainer/sft_trainer.py
@@ -48,6 +48,21 @@ def _collate_arrays(values):
         raise
 
 
+def _collate_grid_thw(values):
+    """Pack per-example image/video grids as (total_media, 3)."""
+    rows = []
+    for value in values:
+        value = value if isinstance(value, mx.array) else mx.array(value)
+        if value.ndim == 1:
+            value = value[None, :]
+        if value.ndim != 2 or value.shape[1] != 3:
+            raise ValueError(
+                f"Expected grid_thw values with shape (num_media, 3), got {value.shape}"
+            )
+        rows.append(value)
+    return mx.concatenate(rows, axis=0)
+
+
 @dataclass
 class TrainingArgs:
     batch_size: int = field(default=4, metadata={"help": "Minibatch size."})
@@ -285,6 +300,10 @@ def iterate_batches(dataset, batch_size, max_seq_length, train=False):
                 )
             ]
             for k in extra_keys:
+                if k in ("image_grid_thw", "video_grid_thw"):
+                    batch[k] = _collate_grid_thw([item[k] for item in items])
+                    continue
+
                 vals = [_squeeze_leading_batch_dim(item[k]) for item in items]
                 if isinstance(vals[0], mx.array):
                     try:


### PR DESCRIPTION
## Summary

Fix LoRA/SFT training for records containing multiple images by packing `image_grid_thw` and `video_grid_thw` rows across examples.

## Root cause

The generic extra-key collation removed a leading dimension only when it was `1`, then stacked the remaining values. A multi-image example therefore changed from `(N, 3)` to `(1, N, 3)` at batch size 1, which the Qwen3-VL vision tower could not unpack as `(t, h, w)` rows.

For batches mixing single- and multi-image examples, the incompatible shapes also triggered the fallback that retained only the first example's grid metadata.

## Changes

- Add dedicated grid collation that produces `(total_media, 3)`.
- Apply it to both image and video grid metadata.
- Add regressions for a two-image example at batch size 1.
- Add regressions for batches mixing one- and two-image examples.

## Impact

Multi-image SFT inputs now preserve every media grid row without introducing a spurious batch dimension or silently discarding metadata.

## Validation

- `uv run --frozen --with pytest pytest mlx_vlm/tests/test_trainer.py -q`
- 21 tests passed