### PR TITLE
Add and improve MLX-VLM agent skills

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,18 @@
+{
+  "name": "mlx-vlm",
+  "metadata": {
+    "description": "Agent skills for MLX-VLM: command-line and server inference, convert/quantize, adding new models, benchmarking, contributing, cached-model listing, and reproducible GitHub issues.",
+    "version": "0.1.0"
+  },
+  "owner": {
+    "name": "MLX-VLM contributors"
+  },
+  "plugins": [
+    {
+      "name": "mlx-vlm-skills",
+      "description": "Skills for MLX-VLM: command-line and server inference, convert/quantize, adding new models, benchmarking, contributing, cached-model listing, and reproducible GitHub issues.",
+      "version": "0.1.0",
+      "source": "./skills"
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -76,6 +76,42 @@ pip install -U 'mlx-vlm[ui]'
 Quote the package name so that shells which expand square brackets, such as
 `zsh`, do not treat `[ui]` as a glob pattern.
 
+## Agent Skills
+
+This repo ships an agent-skills bundle under `skills/` for common MLX-VLM workflows — usage, conversion, development, and support. Skills load into a coding agent (Claude Code, Codex, Gemini) so it follows the right project conventions instead of guessing.
+
+| Skill | Description |
+|-------|-------------|
+| `cli-inference` | Run and debug command-line inference (`mlx_vlm.generate`) — text/image/audio inputs and image-generation flags. |
+| `server-inference` | Run and debug the local server across the models, chat, responses, messages, audio, image, cache, and metrics endpoints. |
+| `convert-quantize` | Convert and quantize Hugging Face models to MLX (`mlx_vlm.convert`) — bits/group size, quant modes, RTN/AWQ, mixed recipes. |
+| `add-new-model` | Port a new architecture into `mlx_vlm/models` — config, weight-name mapping, reuse a similar model, add a test class. |
+| `benchmarking` | Produce credible, reproducible perf numbers and fork-vs-main A/B tables for PRs. |
+| `contributing` | Shape a change to pass review — code/config/test placement, pre-commit hooks, and PR expectations. |
+| `hf-cache-models` | List MLX-VLM-supported (and, with `--check-arch`, loadable) models in the local Hugging Face cache. |
+| `reproducible-github-issues` | Turn CLI or server failures into concise, reproducible GitHub issues. |
+
+Validate the bundle at any time:
+
+```sh
+python3 skills/scripts/validate_skills.py
+```
+
+Install from a local checkout:
+
+```sh
+# Claude Code
+/plugin marketplace add /path/to/mlx-vlm
+/plugin install mlx-vlm-skills@mlx-vlm
+
+# Codex CLI
+codex plugin marketplace add /path/to/mlx-vlm
+codex plugin add mlx-vlm-skills@mlx-vlm
+
+# Gemini CLI
+gemini extensions install /path/to/mlx-vlm/skills
+```
+
 ## Usage
 
 ### Command Line Interface (CLI)

--- a/skills/.claude-plugin/plugin.json
+++ b/skills/.claude-plugin/plugin.json
@@ -1,0 +1,14 @@
+{
+  "name": "mlx-vlm-skills",
+  "description": "Skills for MLX-VLM: command-line and server inference, convert/quantize, adding new models, benchmarking, contributing, cached-model listing, and reproducible GitHub issues.",
+  "version": "0.1.0",
+  "author": {
+    "name": "MLX-VLM contributors"
+  },
+  "keywords": [
+    "mlx",
+    "mlx-vlm",
+    "vision-language-models",
+    "apple-silicon"
+  ]
+}

--- a/skills/.codex-plugin/plugin.json
+++ b/skills/.codex-plugin/plugin.json
@@ -1,0 +1,27 @@
+{
+  "name": "mlx-vlm-skills",
+  "version": "0.1.0",
+  "description": "Skills for MLX-VLM: command-line and server inference, convert/quantize, adding new models, benchmarking, contributing, cached-model listing, and reproducible GitHub issues.",
+  "author": {
+    "name": "MLX-VLM contributors"
+  },
+  "keywords": [
+    "mlx",
+    "mlx-vlm",
+    "vision-language-models",
+    "apple-silicon"
+  ],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "MLX-VLM skills",
+    "shortDescription": "Run/convert/benchmark and contribute to MLX-VLM",
+    "longDescription": "Skills for MLX-VLM workflows: command-line and local server/API inference, converting and quantizing Hugging Face models to MLX, adding new model architectures, benchmarking changes for PRs, contributing (test placement, pre-commit), listing cached models, and creating reproducible GitHub issues.",
+    "defaultPrompt": "Use the MLX-VLM skills to run CLI or server inference, convert/quantize a model, add a new model, benchmark a change for a PR, contribute, list cached models, or file a reproducible issue.",
+    "developerName": "MLX-VLM contributors",
+    "category": "Coding",
+    "capabilities": [
+      "Read",
+      "Write"
+    ]
+  }
+}

--- a/skills/gemini-extension.json
+++ b/skills/gemini-extension.json
@@ -1,0 +1,14 @@
+{
+  "name": "mlx-vlm-skills",
+  "description": "Skills for MLX-VLM: command-line and server inference, convert/quantize, adding new models, benchmarking, contributing, cached-model listing, and reproducible GitHub issues.",
+  "version": "0.1.0",
+  "author": {
+    "name": "MLX-VLM contributors"
+  },
+  "keywords": [
+    "mlx",
+    "mlx-vlm",
+    "vision-language-models",
+    "apple-silicon"
+  ]
+}

--- a/skills/scripts/validate_skills.py
+++ b/skills/scripts/validate_skills.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""Self-contained validator for the mlx-vlm-skills bundle (stdlib only).
+
+Checks:
+- every skills/skills/<name>/SKILL.md has YAML frontmatter with a `name` (matching its
+  directory) and a non-trivial `description`;
+- cross-skill `Skill("mlx-vlm-skills:<x>")` references point at skills that exist;
+- the plugin metadata files agree on name and version.
+
+Exits non-zero (listing every problem) on failure. Run: `python3 skills/scripts/validate_skills.py`.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]  # the skills/ bundle root
+SKILLS_DIR = ROOT / "skills"
+METADATA = {
+    "claude": ROOT.parent / ".claude-plugin" / "marketplace.json",
+    "plugin": ROOT / ".claude-plugin" / "plugin.json",
+    "codex": ROOT / ".codex-plugin" / "plugin.json",
+    "gemini": ROOT / "gemini-extension.json",
+}
+_FRONTMATTER = re.compile(r"^---\s*\n(.*?)\n---\s*\n", re.DOTALL)
+_REF = re.compile(r'Skill\("mlx-vlm-skills:([a-z0-9-]+)"\)')
+
+
+def _parse_frontmatter(text: str) -> dict:
+    m = _FRONTMATTER.match(text)
+    if not m:
+        return {}
+    out = {}
+    for line in m.group(1).splitlines():
+        if ":" in line and not line.startswith((" ", "\t")):
+            k, v = line.split(":", 1)
+            out[k.strip()] = v.strip()
+    return out
+
+
+def main() -> int:
+    errors: list[str] = []
+    skill_names: set[str] = set()
+
+    if not SKILLS_DIR.is_dir():
+        print(f"FAIL: {SKILLS_DIR} not found")
+        return 1
+
+    skill_dirs = sorted(p for p in SKILLS_DIR.iterdir() if p.is_dir())
+    for d in skill_dirs:
+        skill_names.add(d.name)
+        md = d / "SKILL.md"
+        if not md.is_file():
+            errors.append(f"{d.name}: missing SKILL.md")
+            continue
+        fm = _parse_frontmatter(md.read_text())
+        if fm.get("name") != d.name:
+            errors.append(
+                f"{d.name}: frontmatter name={fm.get('name')!r} != directory name"
+            )
+        if len(fm.get("description", "")) < 40:
+            errors.append(
+                f"{d.name}: description missing or too short (needs a real trigger sentence)"
+            )
+
+    # cross-skill references must resolve
+    for d in skill_dirs:
+        md = d / "SKILL.md"
+        if not md.is_file():
+            continue
+        for ref in _REF.findall(md.read_text()):
+            if ref not in skill_names:
+                errors.append(f"{d.name}: references unknown skill '{ref}'")
+
+    # metadata consistency
+    metas = {}
+    for label, path in METADATA.items():
+        if not path.is_file():
+            errors.append(f"metadata: {label} file missing at {path}")
+            continue
+        try:
+            metas[label] = json.loads(path.read_text())
+        except json.JSONDecodeError as e:
+            errors.append(f"metadata: {label} is not valid JSON ({e})")
+    versions = {lbl: m.get("version") for lbl, m in metas.items() if "version" in m}
+    if len(set(versions.values())) > 1:
+        errors.append(f"metadata: version mismatch across files: {versions}")
+
+    if errors:
+        print(f"FAIL: {len(errors)} problem(s):")
+        for e in errors:
+            print(f"  - {e}")
+        return 1
+
+    print(f"OK: {len(skill_dirs)} skill(s) valid: {', '.join(sorted(skill_names))}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/skills/add-new-model/SKILL.md
+++ b/skills/skills/add-new-model/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: add-new-model
+description: Use this skill when the user wants to add or port a new model architecture to MLX-VLM — mapping a Hugging Face model_type to a new file under mlx_vlm/models, writing the ModelConfig, matching layer/weight names, reusing a similar existing model, adding a test class, and validating the port. Covers vision-language, language, audio, and diffusion model ports.
+---
+
+# Add a New Model
+
+Use this workflow to port a Hugging Face model to MLX-VLM.
+
+## Layout Rules
+
+- New model lives in `mlx_vlm/models/<model_type>/`, and the main file is named after the `config.json` `model_type` (e.g. `model_type: "llava"` → `mlx_vlm/models/llava/llava.py`). The loader resolves the arch by importing `mlx_vlm.models.<model_type>` (see `MODEL_REMAPPING` in `mlx_vlm/utils.py` for aliases).
+- Split by concern like the existing families: `language.py`, `vision.py`, `config.py`, `processing_*.py`. A new kernel/helper goes in **its own file** in the model dir, not inside `language.py`.
+- **Start from a similar existing model** in `mlx_vlm/models/` and adapt — don't write from scratch.
+
+## Steps
+
+1. **Confirm weights are safetensors.** If not, convert them first (HF safetensors converter), then proceed.
+2. **Copy a close relative** as scaffolding (same attention/vision style). Rename to the new `model_type`.
+3. **Write `config.py`.** A `ModelConfig` dataclass; give every new field a **backward-compatible default** (`None`/`0`/`False`) so existing configs still load unchanged. Add inline `# comments`.
+4. **Map layer/weight names.** Determine them by one of:
+   - the Transformers implementation, if you know it;
+   - loading the weights and printing key names;
+   - reading `model.safetensors.index.json` in the HF repo.
+5. **Wire the forward pass** (embeddings → vision/audio encoder → projector → language model), reusing shared helpers (`prompt_utils.py`, processors) where possible.
+6. **Convert to MLX** to get loadable weights — `Skill("mlx-vlm-skills:convert-quantize")`.
+7. **Add a test class** in `mlx_vlm/tests/test_models.py` (e.g. `TestMyModel`) — a tiny random-weight config, a shape/forward check, and (if applicable) an exactness check against a reference path in the degenerate limit. Do not create a standalone test file.
+
+## Determine Layer Names (quick)
+
+```bash
+uv run python - <<'PY'
+from huggingface_hub import hf_hub_download
+import json
+p = hf_hub_download("<repo>", "model.safetensors.index.json")
+print("\n".join(sorted(json.load(open(p))["weight_map"])[:60]))
+PY
+```
+
+## Validation
+
+- Run the model's test class:
+  ```bash
+  cd mlx_vlm && uv run --with pytest python -m pytest tests/test_models.py -q -k "TestMyModel"
+  ```
+- Then a real end-to-end generation via `Skill("mlx-vlm-skills:cli-inference")`. Run on Apple Silicon with enough RAM for the model; isolate a submodule with random-init weights if the full model does not fit (do not run large models on an 8 GB machine).
+- Compare a few greedy outputs against the reference implementation (Transformers) on the same prompt to confirm correctness, not just that it runs.
+- Format with pre-commit and follow PR expectations — `Skill("mlx-vlm-skills:contributing")`.
+
+## Common Failure Routing
+
+- `Model type <x> not supported`: the folder name / `model_type` don't match, or the arch import failed — check `mlx_vlm/models/<model_type>/` exists and imports cleanly.
+- Weight-name mismatches on load: your module attribute names don't match the checkpoint; reconcile against `model.safetensors.index.json`.
+- Processor/chat-template errors: mirror a sibling model's `processing_*.py` and `prompt_utils` usage.
+- If you get stuck and want to file it, use `Skill("mlx-vlm-skills:reproducible-github-issues")`.

--- a/skills/skills/benchmarking/SKILL.md
+++ b/skills/skills/benchmarking/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: benchmarking
+description: Use this skill when the user wants to benchmark an MLX-VLM change and present the numbers in a PR — fork-vs-main A/B comparisons, isolated-module micro-benchmarks, median-of-N timing with warmup, peak-memory reporting, correctness checks, parameter sweeps, and self-contained reproducible bench scripts to paste into a PR description.
+---
+
+# Benchmarking & PR A/B Testing
+
+Use this workflow to produce **credible, reproducible** performance numbers for a PR.
+
+## Rules for a trustworthy benchmark
+
+- **Median of N** (not mean), with a few warmup iterations discarded.
+- Call `mx.eval(...)` / `mx.synchronize()` before stopping the timer (MLX is lazy — untimed work hides otherwise).
+- Report **peak memory** via `mx.get_peak_memory()/1e9` (GB); reset with `mx.reset_peak_memory()` if available.
+- Include an **inline correctness check** — a benchmark that computes the wrong thing is meaningless. Assert the new path matches the baseline (exactly in the degenerate limit, or within tolerance).
+- **Sweep one parameter** (sequence length, batch, tokens, layers) and print a **markdown table** with `flush=True`.
+- Prefer a **random-init synthetic model** (tiny config) so the script needs no checkpoint download and runs on a fresh checkout.
+- State the hardware (Apple-Silicon chip + RAM). A model must fit in RAM; isolate the module under test with random weights if the full model won't fit — don't run large models on an 8 GB machine.
+
+## Fork-vs-main A/B (paste into the PR body)
+
+Clones upstream `main` and your fork, runs the *identical* bench on both, and joins into a speedup table:
+
+```bash
+#!/usr/bin/env bash
+# <feature> perf: upstream main vs fork, random-init tiny <model>, swept over <param>.
+set -euo pipefail
+W=$(mktemp -d)
+git clone -q --depth 1 https://github.com/Blaizzy/mlx-vlm "$W/main"
+git clone -q --depth 1 https://github.com/<you>/mlx-vlm   "$W/fork"
+
+cat > "$W/b.py" <<'PY'
+import time, numpy as np, mlx.core as mx
+from mlx_vlm.models.<model> import Model, ModelConfig
+cfg = ModelConfig(...tiny config...)          # small enough to fit in RAM
+m = Model(cfg); m.eval(); mx.eval(m.parameters())
+def ms(T):
+    c = m.make_cache(); p = 0
+    while p < T:                               # chunked prefill avoids OOM
+        n = min(256, T - p)
+        mx.eval(m(mx.array(np.random.randint(0, cfg.vocab_size, (1, n))), cache=c).logits); p += n
+    for _ in range(4): mx.eval(m(mx.array([[0]]), cache=c).logits)   # warmup
+    t = time.perf_counter()
+    for _ in range(20): mx.eval(m(mx.array([[0]]), cache=c).logits)
+    return (time.perf_counter() - t) / 20 * 1e3
+for T in (16384, 32768, 65536):
+    print(T, round(ms(T), 2), flush=True)
+PY
+
+run() { uv venv -q "$1/.venv"; uv pip install -q -e "$1" --python "$1/.venv/bin/python"; "$1/.venv/bin/python" "$W/b.py"; }
+run "$W/main" > "$W/m.txt"
+run "$W/fork" > "$W/f.txt"
+echo; printf "| param | main | fork | speedup |\n|--:|--:|--:|--:|\n"
+join "$W/m.txt" "$W/f.txt" | awk '{printf "| %d | %.2f ms | %.2f ms | %.2fx |\n", $1, $2, $3, $2/$3}'
+```
+
+## Isolated-module micro-benchmark
+
+For one function/kernel (time + peak mem + correctness), swept over a param:
+
+```python
+import time, statistics, mlx.core as mx
+def bench(fn, it=30, warm=5):
+    for _ in range(warm): mx.eval(fn())
+    mx.synchronize()
+    if hasattr(mx, "reset_peak_memory"): mx.reset_peak_memory()
+    s = []
+    for _ in range(it):
+        t0 = time.perf_counter(); mx.eval(fn()); s.append((time.perf_counter() - t0) * 1e3)
+    return statistics.median(s), mx.get_peak_memory() / 1e9
+# build inputs; assert new == baseline in the degenerate limit; then print a swept markdown table.
+```
+
+## Presenting in the PR
+
+- Paste the **exact script** (self-contained) plus the resulting **markdown table**, and state the chip/RAM and mlx-vlm commit.
+- Report both **latency** and **peak memory** — a speedup that blows the memory budget isn't a win.
+- If comparing against another PR (e.g. an earlier version), link it and use the same script for both.
+- Keep the repro script in scratch (not committed); only the script text + table go in the PR body.

--- a/skills/skills/cli-inference/SKILL.md
+++ b/skills/skills/cli-inference/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: cli-inference
+description: Use this skill when the user wants to run or debug MLX-VLM inference from the command line, including uv run mlx_vlm.generate, image/audio/video inputs, local model paths, Hugging Face model IDs, deterministic repro commands, and CLI errors around processors, prompts, model loading, or missing weights.
+---
+
+# CLI Inference
+
+Use this workflow for `uv run mlx_vlm.generate` and related command-line inference tasks.
+
+## First Checks
+
+1. Identify the model ID or local path, modality, prompt, media files, and expected output.
+2. Prefer an existing local model path or cached Hugging Face model when reproducing. Do not download a large model unless the user asks.
+3. Check model-specific docs first when the family has a README under `mlx_vlm/models/<family>/README.md`.
+4. Use `uv run mlx_vlm.generate --help` to verify current flags before giving a final command.
+
+## Command Patterns
+
+Text:
+
+```bash
+uv run mlx_vlm.generate \
+  --model <model-or-path> \
+  --prompt "Write a short answer." \
+  --max-tokens 128
+```
+
+Image:
+
+```bash
+uv run mlx_vlm.generate \
+  --model <model-or-path> \
+  --image /path/to/image.jpg \
+  --prompt "Describe this image." \
+  --max-tokens 128
+```
+
+Audio or multimodal:
+
+```bash
+uv run mlx_vlm.generate \
+  --model <model-or-path> \
+  --image /path/to/image.jpg \
+  --audio /path/to/audio.wav \
+  --prompt "Describe what you see and hear." \
+  --max-tokens 128
+```
+
+## More Flags & Modalities
+
+`uv run mlx_vlm.generate --help` is the source of truth (the CLI lives in the `mlx_vlm/generate/` package). Beyond `--model/--prompt/--image/--audio/--max-tokens`, common flags:
+
+- `--chat` — interactive multi-turn session.
+- `--adapter-path` — apply a LoRA adapter.
+- `--eos-tokens` and sampling flags — use greedy/low-temp when debugging quality.
+- `--trust-remote-code` — needed for some custom processors.
+- `--kv-bits` / `--kv-quant-scheme` / `--max-kv-size` — quantized/bounded KV cache.
+- `--draft-model` / `--draft-kind` — speculative decoding.
+- **Image generation/editing:** `--output-modality image`, `--output <file>`, and the `--diffusion-*` flags drive diffusion image models — not just text-out VLMs.
+
+## Reproducibility Rules
+
+- Include the exact command, model ID/path, media file type and size, Python version, package version or git commit, and full error.
+- Use low-temperature or greedy settings when debugging quality or regressions.
+- Bound output with `--max-tokens`.
+- Preserve shell quoting exactly, especially prompts with JSON, XML-like thinking tokens, or newlines.
+- If the failure depends on an image/audio/video file, record dimensions, duration, codec, and whether a small synthetic input reproduces it.
+
+## Common Failure Routing
+
+- `model_type` unsupported: inspect `config.json` and current folders under `mlx_vlm/models/`.
+- Missing weights: check for `.safetensors` or `model.safetensors.index.json`.
+- Processor/chat template errors: inspect `processing_*.py`, `prompt_utils.py`, and model-specific README examples.
+- Media shape errors: test one image/audio/video item first, then multi-input cases.
+- If the user needs an issue report rather than a fix, switch to `Skill("mlx-vlm-skills:reproducible-github-issues")`.
+
+## Validation
+
+- Run the smallest command that exercises the requested modality.
+- For code changes touching CLI parsing, run `uv run pytest mlx_vlm/tests/test_cli.py -q`.
+- For generation behavior, prefer focused tests such as `test_generate.py`, `test_processors.py`, or a model-specific test file before broad suites.

--- a/skills/skills/contributing/SKILL.md
+++ b/skills/skills/contributing/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: contributing
+description: Use this skill when the user wants to contribute to MLX-VLM — opening a PR, where model code/config/tests go, backward-compatible config args, running the test suite, code formatting and the pre-commit hooks (black, clang-format), and PR expectations (tests, review, perf evidence). Use it to set up a change so it passes review.
+---
+
+# Contributing to MLX-VLM
+
+Use this workflow to shape a contribution so it lands cleanly. It reflects the current `mlx_vlm/` layout (note: `CONTRIBUTING.md` still points at an older `src/` layout — the real paths are below).
+
+## Setup
+
+```bash
+git clone https://github.com/<you>/mlx-vlm && cd mlx-vlm
+uv pip install -e .            # editable install (or: pip install -e .)
+```
+
+## Where things go
+
+- **Model code:** `mlx_vlm/models/<model_type>/`, and the file name matches the `config.json` `model_type` (e.g. `llava`). A new kernel or helper goes in **its own file in that model directory**, not bolted into `language.py`. To add a whole new model, use `Skill("mlx-vlm-skills:add-new-model")`.
+- **Config args:** add to the model's `ModelConfig` (in `<model>/config.py`) with an inline `# comment`, and keep them **backward-compatible** — a default of `None`/`0`/`False` must reproduce the original behavior so existing checkpoints and configs are unaffected. Gate new features so they are opt-in.
+- **Tests:** add to `mlx_vlm/tests/test_models.py` as a **class per feature** (e.g. `TestMyFeature`). Do not create a standalone `test_<feature>.py` — repo convention keeps model tests in `test_models.py`. Prefer cheap synthetic/random-weight tests (tiny configs) and check exactness against the original path in the degenerate limit (feature disabled == baseline).
+
+## Run the tests
+
+```bash
+cd mlx_vlm && uv run --with pytest python -m pytest tests/test_models.py -q -k "<ClassName>"
+```
+
+## Formatting — install and run pre-commit
+
+**Before opening a PR, install the pre-commit hooks once and run them.** The repo uses `pre-commit` (black for Python, clang-format for C++); PRs are expected to be hook-clean.
+
+```bash
+pip install pre-commit
+pre-commit install                 # install the git hooks (run once per clone)
+
+# run on the files you changed
+pre-commit run --files <file1.py> <file2.py>
+# or check everything
+pre-commit run --all-files
+```
+
+You can also format a single file directly:
+
+```bash
+black <file>.py
+# clang-format -i <file>.cpp   # for C++
+```
+
+Reminder: run `pre-commit run --all-files` (or at least on your changed files) as the **last step before pushing** — an unformatted diff will fail CI/review.
+
+## PR expectations
+
+1. Fork and open the PR against `main`.
+2. New code that should be tested comes with tests (see above).
+3. Every PR needs passing tests and at least one review.
+4. Include **perf evidence** for anything performance-sensitive — a self-contained, reproducible benchmark. Use `Skill("mlx-vlm-skills:benchmarking")` for the fork-vs-main table format.
+5. Keep the change scoped and opt-in; don't regress existing checkpoints.
+
+## Routing
+
+- Adding a model → `Skill("mlx-vlm-skills:add-new-model")`.
+- Converting/quantizing weights → `Skill("mlx-vlm-skills:convert-quantize")`.
+- Perf numbers for the PR → `Skill("mlx-vlm-skills:benchmarking")`.
+- Filing a bug found while contributing → `Skill("mlx-vlm-skills:reproducible-github-issues")`.

--- a/skills/skills/convert-quantize/SKILL.md
+++ b/skills/skills/convert-quantize/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: convert-quantize
+description: Use this skill when the user wants to convert a Hugging Face model to MLX or quantize/dequantize one with mlx_vlm.convert, including bits and group size, quant modes (affine, mxfp4, nvfp4, mxfp8), RTN vs AWQ, mixed-bit recipes, dtype casts, calibration (text or multimodal), local vs Hub paths, revisions, uploading to the Hub, and convert/quant errors.
+---
+
+# Convert & Quantize
+
+Use this workflow for `mlx_vlm.convert` — turning a Hugging Face checkpoint into MLX format, optionally quantizing it.
+
+## First Checks
+
+1. Confirm the source: a Hugging Face repo id or a local path (`--hf-path`, alias `--model`).
+2. Confirm the model family is supported in `mlx_vlm/models/` (a folder named after the `config.json` `model_type`). If not, this is a porting task — switch to `Skill("mlx-vlm-skills:add-new-model")`.
+3. Verify current flags before finalizing: `uv run mlx_vlm.convert --help`.
+4. Entry point is `mlx_vlm.convert`. `python -m mlx_vlm.convert` is deprecated; use `uv run mlx_vlm.convert ...` or `python -m mlx_vlm convert ...`.
+
+## Command Patterns
+
+Plain convert (no quantization), saves to `./mlx_model` by default:
+
+```bash
+uv run mlx_vlm.convert --hf-path <repo-or-path> --mlx-path ./out-mlx
+```
+
+4-bit affine quantization (RTN, the default method):
+
+```bash
+uv run mlx_vlm.convert --hf-path <repo-or-path> --mlx-path ./out-4bit -q --q-bits 4 --q-group-size 64
+```
+
+Other quant modes (`--q-mode` sets its own bit/group defaults):
+
+```bash
+# mxfp4 (group 32, 4 bit), nvfp4 (group 16, 4 bit), mxfp8 (group 32, 8 bit)
+uv run mlx_vlm.convert --hf-path <repo-or-path> --mlx-path ./out-mxfp4 -q --q-mode mxfp4
+```
+
+Mixed-bit recipe (per-layer bit allocation, llama.cpp-style):
+
+```bash
+# recipes: mixed_2_6 mixed_3_4 mixed_3_5 mixed_3_6 mixed_3_8 mixed_4_6 mixed_4_8
+uv run mlx_vlm.convert --hf-path <repo-or-path> --mlx-path ./out-mixed -q --quant-predicate mixed_3_6
+```
+
+AWQ (activation-aware, needs a calibration pass):
+
+```bash
+uv run mlx_vlm.convert --hf-path <repo-or-path> --mlx-path ./out-awq -q --quant-method awq \
+  --calibration multimodal --calibration-data /path/to/media   # or --calibration text (default)
+```
+
+dtype cast only / dequantize:
+
+```bash
+uv run mlx_vlm.convert --hf-path <repo-or-path> --mlx-path ./out-bf16 --dtype bfloat16
+uv run mlx_vlm.convert --hf-path <quantized-repo> --mlx-path ./out-fp -d   # dequantize
+```
+
+Upload the result to the Hub:
+
+```bash
+uv run mlx_vlm.convert --hf-path <repo> --mlx-path ./out -q --upload-repo <user>/<name>-mlx
+```
+
+## Key Facts
+
+- **Multimodal modules are skipped from quantization by default** (`skip_multimodal_module`) — vision/audio towers stay full precision; only the language model is quantized. This is expected, not a bug.
+- `--q-mode` choices: `affine` (default, group 64 / 4 bit), `mxfp4` (32/4), `nvfp4` (16/4), `mxfp8` (32/8). `--q-bits`/`--q-group-size` override the mode defaults.
+- `--quant-method`: `rtn` (default, round-to-nearest) or `awq` (needs calibration; `--calibration text|multimodal`, optional `--calibration-data`).
+- `-q`/`--quantize` and `-d`/`--dequantize` are mutually exclusive.
+- `--dtype` (from `config.json` `torch_dtype` if unset) casts float weights; useful for shrinking fp32 → bf16 without quantizing.
+- The converted folder gets the weights, copied `*.py`/`*.json`, the processor, a regenerated `config.json`, and a model card — it is ready for `mlx_vlm.generate` and the server.
+
+## Validation
+
+- After converting, load and run a tiny generation to prove the checkpoint works — see `Skill("mlx-vlm-skills:cli-inference")`. Run on Apple Silicon with enough RAM for the model; do not attempt a large model on an 8 GB machine.
+- For quality, compare a few greedy outputs between the source and the quantized model; large drops usually mean too-low bits or a wrong `--q-mode` for the model.
+- For code changes touching conversion, run `uv run --with pytest python -m pytest mlx_vlm/tests/test_utils.py -q` and any model-specific test.
+- If the outcome is a bug report, switch to `Skill("mlx-vlm-skills:reproducible-github-issues")`.

--- a/skills/skills/hf-cache-models/SKILL.md
+++ b/skills/skills/hf-cache-models/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: hf-cache-models
+description: Use this skill when the user wants to list, inspect, or report MLX-VLM-supported models available in the local Hugging Face cache directory, including models shown by the server /v1/models endpoint, cache-dir overrides, JSON output, or issue-ready cached model lists.
+---
+
+# HF Cache Models
+
+Use this workflow to list locally cached Hugging Face models that MLX-VLM should treat as server-visible models.
+
+## Supported Model Rule
+
+Match the server `/v1/models` cache filter:
+
+- repo type is `model`
+- `main` revision exists in the cache
+- `config.json` exists
+- `tokenizer_config.json` exists
+- either `model.safetensors.index.json` exists or at least one `*.safetensors` file exists
+
+This is a cache/file-presence check that mirrors the server (`mlx_vlm/server/app.py`). It does not load the model or prove generation works. Pass `--check-arch` to additionally require that mlx-vlm ships an architecture for the `model_type` — this narrows the list from *server-visible* to *probably loadable* (folder-name match; it does not resolve `MODEL_REMAPPING` aliases, so use it as a strong hint, not proof).
+
+## Script
+
+Use the bundled script instead of rewriting cache-scanning logic:
+
+```bash
+uv run python skills/skills/hf-cache-models/scripts/list_supported_hf_cache_models.py
+```
+
+JSON output:
+
+```bash
+uv run python skills/skills/hf-cache-models/scripts/list_supported_hf_cache_models.py --json
+```
+
+Only models mlx-vlm can actually load (architecture present, not just files present):
+
+```bash
+uv run python skills/skills/hf-cache-models/scripts/list_supported_hf_cache_models.py --check-arch
+```
+
+Custom cache directory:
+
+```bash
+uv run python skills/skills/hf-cache-models/scripts/list_supported_hf_cache_models.py \
+  --cache-dir /path/to/huggingface/cache
+```
+
+## Reporting
+
+When reporting the result, include:
+
+- cache directory used, if non-default
+- number of supported models
+- exact model IDs
+- whether the list came from the script or from `curl http://127.0.0.1:8080/v1/models`
+
+For server-visible verification, start the server and compare with:
+
+```bash
+curl http://127.0.0.1:8080/v1/models
+```
+
+If this becomes part of a bug report, switch to `Skill("mlx-vlm-skills:reproducible-github-issues")`.

--- a/skills/skills/hf-cache-models/scripts/list_supported_hf_cache_models.py
+++ b/skills/skills/hf-cache-models/scripts/list_supported_hf_cache_models.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+from pathlib import Path
+
+from huggingface_hub import scan_cache_dir
+from huggingface_hub.constants import HF_HUB_CACHE
+from huggingface_hub.errors import CacheNotFound
+
+# Mirrors the server /v1/models cache filter (mlx_vlm/server/app.py: models_endpoint).
+# Keep in sync with that endpoint; a cached repo is "server-visible" when these hold.
+REQUIRED_FILES = {"config.json", "tokenizer_config.json"}
+
+
+def _main_ref_files(repo) -> dict[str, Path]:
+    """Map filename -> cached path for the repo's `main` revision (empty if not a model repo)."""
+    if repo.repo_type != "model" or "main" not in repo.refs:
+        return {}
+    return {file.file_path.name: file.file_path for file in repo.refs["main"].files}
+
+
+def is_supported_model(files: dict[str, Path]) -> bool:
+    has_weights = "model.safetensors.index.json" in files or any(
+        name.endswith(".safetensors") for name in files
+    )
+    return REQUIRED_FILES.issubset(files) and has_weights
+
+
+def _mlx_vlm_model_types() -> set[str] | None:
+    """Model-type folders shipped in mlx_vlm/models, located WITHOUT importing mlx_vlm
+    (find_spec does not execute the package, so this stays lightweight — no mlx import).
+    """
+    spec = importlib.util.find_spec("mlx_vlm")
+    if spec is None or not spec.submodule_search_locations:
+        return None
+    models_dir = Path(next(iter(spec.submodule_search_locations))) / "models"
+    if not models_dir.is_dir():
+        return None
+    return {
+        p.name
+        for p in models_dir.iterdir()
+        if p.is_dir() and not p.name.startswith("_")
+    }
+
+
+def _config_model_type(files: dict[str, Path]) -> str | None:
+    cfg = files.get("config.json")
+    if cfg is None:
+        return None
+    try:
+        data = json.loads(cfg.read_text())
+    except Exception:
+        return None
+    model_type = data.get("model_type") or data.get("speculators_model_type")
+    return model_type.lower() if isinstance(model_type, str) else None
+
+
+def supported_models(
+    cache_dir: str | None = None, check_arch: bool = False
+) -> list[dict]:
+    resolved_cache_dir = Path(cache_dir or HF_HUB_CACHE).expanduser()
+    try:
+        cache_info = scan_cache_dir(cache_dir=resolved_cache_dir)
+    except CacheNotFound:
+        return []
+
+    arch_types = _mlx_vlm_model_types() if check_arch else None
+
+    models = []
+    for repo in cache_info.repos:
+        files = _main_ref_files(repo)
+        if not is_supported_model(files):
+            continue
+        entry = {
+            "id": repo.repo_id,
+            "repo_type": repo.repo_type,
+            "last_modified": int(repo.last_modified),
+            "cache_dir": str(resolved_cache_dir),
+        }
+        if check_arch:
+            model_type = _config_model_type(files)
+            # Folder-name match; does not resolve MODEL_REMAPPING aliases, so a False
+            # here is "probably not loadable" rather than definitive.
+            entry["model_type"] = model_type
+            if arch_types is None or model_type not in arch_types:
+                continue
+        models.append(entry)
+    return sorted(models, key=lambda model: model["id"].lower())
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description=(
+            "List Hugging Face cache model repos that MLX-VLM can expose through "
+            "the server /v1/models endpoint."
+        )
+    )
+    parser.add_argument(
+        "--cache-dir",
+        help="Hugging Face cache directory. Defaults to huggingface_hub's cache.",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit JSON instead of one model id per line.",
+    )
+    parser.add_argument(
+        "--check-arch",
+        action="store_true",
+        help=(
+            "Also require an mlx_vlm arch for the model_type (folder in mlx_vlm/models). "
+            "Narrows the list from 'server-visible' to 'probably loadable by mlx-vlm'."
+        ),
+    )
+    args = parser.parse_args()
+
+    models = supported_models(args.cache_dir, check_arch=args.check_arch)
+    if args.json:
+        print(json.dumps(models, indent=2))
+        return
+
+    for model in models:
+        print(model["id"])
+    label = "loadable" if args.check_arch else "supported"
+    print(f"\n{len(models)} {label} model(s)")
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/skills/reproducible-github-issues/SKILL.md
+++ b/skills/skills/reproducible-github-issues/SKILL.md
@@ -1,0 +1,115 @@
+---
+name: reproducible-github-issues
+description: Use this skill when the user wants to create, improve, or triage a reproducible GitHub issue for MLX-VLM, including bug reports from CLI inference, server inference, model loading, processors, media inputs, dependency setup, crashes, wrong outputs, or performance regressions.
+---
+
+# Reproducible GitHub Issues
+
+Use this workflow to turn a failure into a concise, actionable MLX-VLM issue. Do not open a GitHub issue unless the user explicitly asks; otherwise produce issue-ready Markdown.
+
+## Required Information
+
+Collect or infer:
+
+- MLX-VLM version or git commit.
+- Install method: PyPI, editable checkout, branch, or wheel.
+- Python version, OS version, machine/chip, and whether MLX Metal or MLX CUDA is in use.
+- Exact model ID or local path.
+- Whether the model is from Hugging Face cache, a local conversion, or a custom checkpoint.
+- Exact `uv run` CLI command or server startup command.
+- Exact request body for server issues.
+- Input media facts: image dimensions, audio duration/sample rate, video duration/frame count, and whether the input can be shared.
+- Expected behavior, actual behavior, and full error/traceback.
+
+## Collect the Environment Automatically
+
+Instead of hand-filling versions, run and paste the output into the Environment section:
+
+```bash
+uv run python - <<'PY'
+import platform, mlx.core as mx
+try:
+    import mlx_vlm
+    v = getattr(mlx_vlm, "__version__", "unknown")
+except Exception as e:
+    v = f"import failed: {e}"
+print("mlx-vlm:", v)
+print("mlx:", mx.__version__, "| default device:", mx.default_device())
+print("python:", platform.python_version(), "| platform:", platform.platform())
+PY
+```
+
+## Repro Minimization
+
+1. Reduce to the smallest command or request that still fails.
+2. Remove private paths, tokens, and unrelated environment variables.
+3. Prefer `curl` over client SDKs for server repros.
+4. Prefer one image/audio/video file before multi-input repros.
+5. Use small public media or synthetic inputs when possible.
+6. State whether the bug reproduces with a public model or only a private/local checkpoint.
+
+## Issue Template
+
+````markdown
+### Summary
+
+<One sentence describing the failure.>
+
+### Environment
+
+- MLX-VLM:
+- Python:
+- OS:
+- Hardware:
+- Install method:
+
+### Model
+
+- Model:
+- Source: <HF cache | local path | converted checkpoint>
+- Trust remote code: <yes/no>
+
+### Reproduction
+
+```bash
+uv run mlx_vlm.generate <args>
+```
+
+For server issues:
+
+```bash
+uv run mlx_vlm.server <args>
+```
+
+```bash
+<curl request>
+```
+
+### Expected Behavior
+
+<What should have happened.>
+
+### Actual Behavior
+
+<What happened instead.>
+
+### Logs / Traceback
+
+```text
+<trimmed traceback or relevant logs>
+```
+
+### Inputs
+
+<Describe attached or shareable inputs. Include dimensions/duration when relevant.>
+````
+
+## Classification
+
+- CLI inference: use `Skill("mlx-vlm-skills:cli-inference")` if a repro command is still missing.
+- Server inference: use `Skill("mlx-vlm-skills:server-inference")` if a minimal request is still missing.
+- Model-specific failures: include `config.json` `model_type`, processor class, and whether the family has a README in `mlx_vlm/models/`.
+
+## Quality Bar
+
+The issue is ready when a maintainer can run one command or one server command plus one request and see the same failure without asking for basic environment or model details.

--- a/skills/skills/server-inference/SKILL.md
+++ b/skills/skills/server-inference/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: server-inference
+description: Use this skill when the user wants to run or debug MLX-VLM server inference, including uv run mlx_vlm.server, /v1/models, /v1/chat/completions, /v1/responses, streaming, OpenAI-compatible clients, health checks, metrics, model unload/reload, adapters, trust-remote-code, and server request/response failures.
+---
+
+# Server Inference
+
+Use this workflow for the FastAPI server and API-compatible inference.
+
+## First Checks
+
+1. Identify the server command, model, port, request endpoint, request body, and expected response.
+2. Start with health/model-list checks before debugging generation.
+3. Separate server startup failures from request-handling failures.
+4. Keep streaming and non-streaming repros separate.
+
+## Startup
+
+```bash
+uv run mlx_vlm.server \
+  --model <model-or-path> \
+  --port 8080
+```
+
+Useful startup flags include `--adapter-path`, `--trust-remote-code`, `--log-level`, `--enable-thinking`, `--thinking-budget`, `--draft-model`, `--draft-kind`, `--kv-bits`, `--kv-quant-scheme`, `--max-kv-size`, and `--vision-cache-size`.
+
+## Minimal Checks
+
+```bash
+curl http://127.0.0.1:8080/health
+curl http://127.0.0.1:8080/v1/models
+curl http://127.0.0.1:8080/metrics
+```
+
+Minimal chat request:
+
+```bash
+curl -s http://127.0.0.1:8080/v1/chat/completions \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "model": "<model-or-path>",
+    "messages": [{"role": "user", "content": "Say hello."}],
+    "max_tokens": 32,
+    "stream": false
+  }'
+```
+
+Minimal Responses API request:
+
+```bash
+curl -s http://127.0.0.1:8080/v1/responses \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "model": "<model-or-path>",
+    "input": "Say hello.",
+    "max_output_tokens": 32
+  }'
+```
+
+## Endpoint Surface (beyond chat/responses)
+
+The server exposes more than chat — cover or route to these as needed:
+
+- **Anthropic Messages API:** `/v1/messages`, plus `/v1/messages/count` for token counting.
+- **Audio:** `/v1/audio/speech` (TTS), `/v1/audio/transcriptions` and `/v1/audio/translations` (STT).
+- **Images:** `/v1/images/generations` and `/v1/images/edits` (diffusion image models).
+- **Cache & metrics:** `/v1/cache/stats`, `/v1/cache/reset`, `/v1/metrics`.
+- **Models:** `/v1/models` lists cached + currently-loaded models — see `Skill("mlx-vlm-skills:hf-cache-models")`.
+
+Match the model kind to the endpoint (an image endpoint needs a diffusion/image model, audio endpoints need an audio model); a mismatch returns a clear 4xx, not a crash.
+
+## Debugging Rules
+
+- Capture the server command, server logs, request body, response status, and response body.
+- Test `/v1/models` after preload/load changes.
+- For OpenAI client issues, reproduce with `curl` before blaming the client SDK.
+- For streaming bugs, save raw event chunks and compare with non-streaming.
+- For structured outputs, isolate the JSON schema and confirm whether the same request works without schema constraints.
+- For tool calls, record the chat template/tool parser inferred by the loaded processor when possible.
+
+## Validation
+
+- For route/schema changes, run `uv run pytest mlx_vlm/tests/test_server.py -q`.
+- For structured output changes, include `uv run pytest mlx_vlm/tests/test_structured.py -q`.
+- For tool parser changes, include the relevant parser tests under `mlx_vlm/tests/test_*tool_parser.py`.
+- If the result is a user-facing bug report, switch to `Skill("mlx-vlm-skills:reproducible-github-issues")`.


### PR DESCRIPTION
Expand the agent-skills bundle to 8 skills: add convert-quantize, add-new-model, benchmarking, and contributing (with a pre-commit reminder); refresh cli-inference, server-inference, hf-cache-models, and reproducible-github-issues for current mlx-vlm.

Add a self-contained validator (skills/scripts/validate_skills.py), update plugin metadata descriptions to cover all 8 skills, and document the bundle in the README. Improved/expanded version of #1343.