### PR TITLE
Fix prompt-cache prefix reuse corrupting rotating KV caches

### DIFF
--- a/mlx_vlm/generate/dispatch.py
+++ b/mlx_vlm/generate/dispatch.py
@@ -694,6 +694,45 @@ def _prime_cached_prefix_rope_state(
     return True
 
 
+def _cache_fully_retained(c: Any) -> bool:
+    """Whether ``c`` still holds its whole sequence from position 0.
+
+    Only such a cache can be rolled back to an earlier prefix. Note this is not
+    ``is_trimmable()``: ``BufferedRotatingKVCache`` reports itself trimmable even
+    after it has evicted early tokens, and trimming it then would only clamp to
+    its retained window and desync ``offset`` from the flat layers.
+    """
+    children = getattr(c, "caches", None)
+    if children is not None:  # CacheList
+        return all(_cache_fully_retained(x) for x in children)
+    start_position = getattr(c, "start_position", None)
+    if start_position is not None:  # Buffered/Chunked: evicts by advancing start
+        return int(start_position) == 0
+    max_size = getattr(c, "max_size", None)
+    if max_size is not None:  # RotatingKVCache: reusable until the window wraps
+        return int(getattr(c, "offset", 0) or 0) <= int(max_size)
+    return True  # KVCache / QuantizedKVCache retain the whole sequence
+
+
+def _prefix_cache_trim_amount(kv_cache: List[Any], prefix_len: int) -> Optional[int]:
+    """Trailing tokens to drop so ``kv_cache`` keeps only its first ``prefix_len``.
+
+    The old reuse path sliced key/value arrays directly --
+    ``keys[..., :prefix_len, :]`` -- which is only valid for a flat cache. On a
+    rotating (sliding-window) cache it slices a ring buffer by a logical length,
+    taking an arbitrary rotation of the window and leaving the ring index stale:
+    silent output corruption, or a broadcast crash once speculative decoding wraps
+    the cache in ``BufferedRotatingKVCache``. Returns the number of tokens to drop
+    (``0`` when the whole cache is reusable), or ``None`` when an entry has already
+    evicted part of the prefix and the caller must cold-prefill instead.
+    """
+    cached_len = max((int(getattr(c, "offset", 0) or 0) for c in kv_cache), default=0)
+    n_drop = max(0, cached_len - prefix_len)
+    if n_drop and not all(_cache_fully_retained(c) for c in kv_cache):
+        return None
+    return n_drop
+
+
 from .ar import generate_step
 
 
@@ -864,27 +903,26 @@ def stream_generate(
 
     if prompt_cache_state is not None and prompt_cache_state.cache is not None:
         prefix_len = prompt_cache_state.find_prefix_length(full_input_ids_list)
-        if prefix_len > 0 and prefix_len < input_ids.shape[1]:
-            if _apc_suffix_is_text_only(prefix_len) and _prime_cached_prefix_rope_state(
-                model, input_ids, mask, kwargs
-            ):
-                reused_prefix_len = prefix_len
-                # Trim to only new tokens
-                input_ids = input_ids[:, prefix_len:]
-                pixel_values = None
-                kwargs.pop("cached_image_features", None)
-                # Reuse the saved KV cache (trimmed to prefix length)
-                kv_cache = prompt_cache_state.cache
-                # Trim cache to prefix_len in case it includes generated tokens
-                for c in kv_cache:
-                    if hasattr(c, "keys") and c.keys is not None:
-                        cached_len = c.keys.shape[2]
-                        if cached_len > prefix_len:
-                            c.keys = c.keys[:, :, :prefix_len, :]
-                            c.values = c.values[:, :, :prefix_len, :]
-                            if hasattr(c, "offset"):
-                                c.offset = prefix_len
-                kwargs["prompt_cache"] = kv_cache
+        kv_cache = prompt_cache_state.cache
+        # None => a cache can't be trimmed back to the shared prefix (wrapped
+        # rotating window); reusing it would corrupt state, so cold-prefill instead.
+        n_drop = _prefix_cache_trim_amount(kv_cache, prefix_len)
+        if (
+            0 < prefix_len < input_ids.shape[1]
+            and n_drop is not None
+            and _apc_suffix_is_text_only(prefix_len)
+            and _prime_cached_prefix_rope_state(model, input_ids, mask, kwargs)
+        ):
+            # Drop cached tokens past the shared prefix via each cache's own trim().
+            for c in kv_cache:
+                if n_drop:
+                    c.trim(n_drop)
+            reused_prefix_len = prefix_len
+            # Trim to only new tokens
+            input_ids = input_ids[:, prefix_len:]
+            pixel_values = None
+            kwargs.pop("cached_image_features", None)
+            kwargs["prompt_cache"] = kv_cache
 
     # APC: cross-request, hash-based prefix lookup. Only consulted if a per-turn
     # PromptCacheState didn't already produce a hit.

--- a/mlx_vlm/tests/test_generate.py
+++ b/mlx_vlm/tests/test_generate.py
@@ -26,7 +26,12 @@ from mlx_vlm.generate import (
 from mlx_vlm.generate import ar as ar_module
 from mlx_vlm.generate import dispatch as dispatch_module
 from mlx_vlm.generate import normalize_resize_shape
-from mlx_vlm.models.cache import BatchKVCache, KVCache
+from mlx_vlm.models.cache import (
+    BatchKVCache,
+    BufferedRotatingKVCache,
+    KVCache,
+    RotatingKVCache,
+)
 from mlx_vlm.utils import ThinkingBudgetCriteria
 
 generate_module = sys.modules["mlx_vlm.generate"]
@@ -2258,6 +2263,82 @@ def test_cached_prefix_rope_failure_falls_back_to_cold(caplog):
     assert bool(mx.array_equal(language_model._rope_deltas, rope_deltas_before))
     assert bool(mx.array_equal(language_model._position_ids, position_ids_before))
     assert "falling back to cold prefill" in caplog.text
+
+
+class TestPrefixCacheReuseTrim:
+    """Prompt-cache prefix reuse must trim each cache through its own trim()
+    contract. A raw ``keys[..., :prefix_len, :]`` slice corrupts rotating
+    (sliding-window) ring buffers -- silent wrong output, or a shape crash once
+    speculative decoding wraps them (mlx-vlm issue #1715)."""
+
+    @staticmethod
+    def _fill(cache, n, marker=False, heads=1, dim=4):
+        for i in range(n):
+            v = (
+                mx.full((1, heads, 1, dim), float(i))
+                if marker
+                else mx.zeros((1, heads, 1, dim))
+            )
+            cache.update_and_fetch(v, v)
+        return cache
+
+    def test_flat_cache_trims_to_prefix(self):
+        c = self._fill(KVCache(), 20, marker=True)
+        n_drop = dispatch_module._prefix_cache_trim_amount([c], 8)
+        assert n_drop == 12
+        c.trim(n_drop)
+        keys, _ = c.state
+        assert c.offset == 8 and keys.shape[2] == 8
+        assert bool(mx.array_equal(keys[0, 0, :, 0], mx.arange(8, dtype=keys.dtype)))
+
+    def test_full_prefix_needs_no_trim(self):
+        c = self._fill(KVCache(), 12)
+        assert dispatch_module._prefix_cache_trim_amount([c], 12) == 0
+
+    def test_empty_cache_is_reusable(self):
+        assert dispatch_module._prefix_cache_trim_amount([], 0) == 0
+
+    def test_unwrapped_rotating_trims_and_stays_usable(self):
+        c = self._fill(RotatingKVCache(max_size=512), 100)
+        assert c.offset == 100  # window has not wrapped
+        n_drop = dispatch_module._prefix_cache_trim_amount([c], 40)
+        assert n_drop == 60
+        c.trim(n_drop)
+        assert c.offset == 40 and c._idx == 40
+        c.update_and_fetch(mx.zeros((1, 1, 1, 4)), mx.zeros((1, 1, 1, 4)))
+        assert c.offset == 41
+
+    def test_wrapped_rotating_is_not_reusable(self):
+        c = self._fill(RotatingKVCache(max_size=8), 20)  # ring has wrapped
+        assert c.offset > c.max_size
+        assert dispatch_module._prefix_cache_trim_amount([c], 3) is None
+
+    def test_mixed_flat_and_wrapped_rotating_is_not_reusable(self):
+        flat = self._fill(KVCache(), 20)
+        wrapped = self._fill(RotatingKVCache(max_size=8), 20)
+        assert dispatch_module._prefix_cache_trim_amount([flat, wrapped], 3) is None
+
+    def test_wrapped_buffered_rotating_declined_and_survives_next_step(self):
+        # BufferedRotatingKVCache is what speculative decoding installs; the old
+        # raw slice desynced its ring index and crashed on the next update. When
+        # reuse is declined the cache stays intact, so generation continues.
+        c = BufferedRotatingKVCache.from_cache(
+            self._fill(RotatingKVCache(max_size=8), 20), buffer_size=16
+        )
+        assert dispatch_module._prefix_cache_trim_amount([c], 2) is None
+        c.update_and_fetch(mx.zeros((1, 1, 2, 4)), mx.zeros((1, 1, 2, 4)))
+
+    def test_unwrapped_buffered_rotating_trims(self):
+        # A buffered cache that has not evicted anything (start_position == 0) is
+        # still rollback-able even though is_trimmable() is unconditionally True.
+        c = BufferedRotatingKVCache(max_size=512, buffer_size=16)
+        self._fill(c, 100)
+        assert c.start_position == 0
+        assert dispatch_module._prefix_cache_trim_amount([c], 40) == 60
+        c.trim(60)
+        assert c.offset == 40
+        c.update_and_fetch(mx.zeros((1, 1, 1, 4)), mx.zeros((1, 1, 1, 4)))
+        assert c.offset == 41
 
 
 def test_batch_apc_extra_hash_uses_precomputed_image_hash():


### PR DESCRIPTION
The per-turn prompt-cache reuse in generate/dispatch.py trimmed the KV cache with a raw array slice (keys[..., :prefix_len, :]) that is only valid for a flat KVCache. On a rotating (sliding-window) cache it slices the ring buffer by a logical length, taking an arbitrary rotation of the window and leaving the ring index stale causing silent wrong output, and a broadcast crash once speculative decoding wraps the cache in BufferedRotatingKVCache.

Fix: Reuse the prefix only when every cache still retains its whole sequence from position 0 (start_position == 0 for buffered/chunked caches, not-yet-wrapped for rotating), trimming through each cache's own trim(); otherwise fall back to a cold prefill. Decide reuse before priming RoPE state so the fallback applies no partial state.

Fixes #1715.