### PR TITLE
Skip full-sequence LM head during Gemma 4 prefill

### DIFF
--- a/mlx_vlm/generate/ar.py
+++ b/mlx_vlm/generate/ar.py
@@ -328,6 +328,8 @@ def generate_step(
         step_kwargs = kwargs
         if speculative_prefill_capture_kwargs:
             step_kwargs = {**kwargs, **speculative_prefill_capture_kwargs}
+        if getattr(model.language_model, "supports_logits_to_keep", False):
+            step_kwargs = {**step_kwargs, "logits_to_keep": 1}
 
         with mx.stream(generation_stream):
             if "decoder_input_ids" in step_kwargs:
@@ -433,12 +435,15 @@ def generate_step(
                         and processed_tokens + n_to_process > checkpoint_len
                     ):
                         n_to_process = checkpoint_len - processed_tokens
+                    chunk_kwargs = kwargs
+                    if getattr(model.language_model, "supports_logits_to_keep", False):
+                        chunk_kwargs = {**kwargs, "logits_to_keep": 1}
                     model.language_model(
                         inputs=input_ids[:, :n_to_process],
                         inputs_embeds=inputs_embeds[:, :n_to_process],
                         cache=prompt_cache,
                         n_to_process=n_to_process,
-                        **kwargs,
+                        **chunk_kwargs,
                     )
                     quantize_cache_fn(prompt_cache)
                     mx.eval([c.state for c in prompt_cache])

--- a/mlx_vlm/models/gemma4/language.py
+++ b/mlx_vlm/models/gemma4/language.py
@@ -650,6 +650,8 @@ class Gemma4TextModel(nn.Module):
 
 
 class LanguageModel(nn.Module):
+    supports_logits_to_keep = True
+
     def __init__(self, config: TextConfig):
         super().__init__()
         self.config = config
@@ -726,6 +728,7 @@ class LanguageModel(nn.Module):
         # Allow callers to pass pre-allocated sinks directly.
         hidden_sink = kwargs.pop("hidden_sink", hidden_sink)
         shared_kv_sink = kwargs.pop("shared_kv_sink", shared_kv_sink)
+        logits_to_keep = kwargs.pop("logits_to_keep", None)
 
         out = self.model(
             inputs,
@@ -738,6 +741,8 @@ class LanguageModel(nn.Module):
             shared_kv_sink=shared_kv_sink,
             **kwargs,
         )
+        if logits_to_keep:
+            out = out[:, -int(logits_to_keep) :, :]
         out = self.logits_from_hidden(out)
         return LanguageModelOutput(
             logits=out,

--- a/mlx_vlm/models/gemma4_text/language.py
+++ b/mlx_vlm/models/gemma4_text/language.py
@@ -496,6 +496,8 @@ class Gemma4TextModel(nn.Module):
 
 
 class LanguageModel(nn.Module):
+    supports_logits_to_keep = True
+
     def __init__(self, args: ModelConfig):
         super().__init__()
         self.args = args
@@ -515,12 +517,15 @@ class LanguageModel(nn.Module):
         mask=None,
         **kwargs,
     ):
+        logits_to_keep = kwargs.pop("logits_to_keep", None)
         out = self.model(
             inputs,
             cache=cache,
             input_embeddings=input_embeddings,
             per_layer_inputs=per_layer_inputs,
         )
+        if logits_to_keep:
+            out = out[:, -int(logits_to_keep) :, :]
         if self.tie_word_embeddings:
             out = self.model.embed_tokens.as_linear(out)
         else:

--- a/mlx_vlm/tests/test_generate.py
+++ b/mlx_vlm/tests/test_generate.py
@@ -2443,6 +2443,53 @@ class TestPrefixCacheReuseTrim:
         assert c.offset == 41
 
 
+class TestGemma4LogitsToKeep:
+    class _FakeTextModel:
+        def __init__(self, hidden):
+            self.hidden = hidden
+
+        def __call__(
+            self, inputs=None, inputs_embeds=None, input_embeddings=None, **kwargs
+        ):
+            seq = next(
+                t for t in (inputs, inputs_embeds, input_embeddings) if t is not None
+            )
+            return mx.zeros((1, seq.shape[1], self.hidden))
+
+    def _gemma4_lm(self, hidden):
+        from mlx_vlm.models.gemma4.language import LanguageModel
+
+        lm = LanguageModel.__new__(LanguageModel)
+        lm.model = self._FakeTextModel(hidden)
+        lm.logits_from_hidden = lambda h: h
+        return LanguageModel, lm
+
+    def _gemma4_text_lm(self, hidden):
+        from mlx_vlm.models.gemma4_text.language import LanguageModel
+
+        lm = LanguageModel.__new__(LanguageModel)
+        lm.model = self._FakeTextModel(hidden)
+        lm.tie_word_embeddings = False
+        lm.lm_head = lambda h: h
+        lm.final_logit_softcapping = None
+        return LanguageModel, lm
+
+    def test_gemma4_slices_before_lm_head(self):
+        cls, lm = self._gemma4_lm(hidden=8)
+        ids = mx.zeros((1, 6), dtype=mx.int32)
+        assert cls.supports_logits_to_keep is True
+        assert lm(ids).logits.shape == (1, 6, 8)
+        assert lm(ids, logits_to_keep=1).logits.shape == (1, 1, 8)
+        assert lm(ids, logits_to_keep=3).logits.shape == (1, 3, 8)
+
+    def test_gemma4_text_slices_before_lm_head(self):
+        cls, lm = self._gemma4_text_lm(hidden=8)
+        ids = mx.zeros((1, 6), dtype=mx.int32)
+        assert cls.supports_logits_to_keep is True
+        assert lm(ids).logits.shape == (1, 6, 8)
+        assert lm(ids, logits_to_keep=1).logits.shape == (1, 1, 8)
+
+
 def test_batch_apc_extra_hash_uses_precomputed_image_hash():
     batch_generator = SimpleNamespace(apc_manager=object())
 


### PR DESCRIPTION
Gemma 4's LanguageModel projected every prompt position through the LM head before [ar.py](<http://ar.py>) sliced the final row, materialising \[1, N, vocab\] logits (\~1 MiB/token at the 262144-token vocab) during prefill.

Add an opt-in logits_to_keep path: LanguageModels expose supports_logits_to_keep, and generation asks for a single row so prefill (and each discarded chunked-prefill step) slices the hidden states before the LM head. Covers gemma4 (incl. gemma4_unified) and gemma4_text. The retained last-row logits are identical, so generation output is unchanged.

Fixes Blaizzy/mlx-vlm#1732.

All tests green!