### PR TITLE
Add Mage-VL (microsoft/Mage-VL) support

### DIFF
--- a/mlx_vlm/models/mage_vl/__init__.py
+++ b/mlx_vlm/models/mage_vl/__init__.py
@@ -1,0 +1,4 @@
+import mlx_vlm.models.mage_vl.processing_mage_vl  # noqa: F401 (installs processor patch)
+
+from .config import ModelConfig, TextConfig, VisionConfig
+from .mage_vl import LanguageModel, Model, VisionModel

--- a/mlx_vlm/models/mage_vl/config.py
+++ b/mlx_vlm/models/mage_vl/config.py
@@ -1,0 +1,86 @@
+import inspect
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional, Union
+
+from ..base import BaseModelConfig
+
+
+def _kw(cls, params):
+    return {k: v for k, v in params.items() if k in inspect.signature(cls).parameters}
+
+
+@dataclass
+class VisionConfig(BaseModelConfig):
+    model_type: str = "mage_vl_vision"
+    hidden_size: int = 1024
+    intermediate_size: int = 4096
+    num_hidden_layers: int = 24
+    num_attention_heads: int = 16
+    num_channels: int = 3
+    image_size: int = 448
+    patch_size: int = 16
+    hidden_act: str = "gelu"
+    layer_norm_eps: float = 1e-6
+    layer_norm_type: str = "layer_norm"
+    rope_theta: float = 10000.0
+    use_head: bool = False
+    out_hidden_size: int = 2560
+    spatial_merge_size: int = 2
+    frame_windows_size: int = 4
+    use_patch_position_encoding: bool = False
+    skip_vision: bool = False
+
+
+@dataclass
+class TextConfig(BaseModelConfig):
+    model_type: str = "qwen3"
+    hidden_size: int = 2560
+    num_hidden_layers: int = 36
+    intermediate_size: int = 9728
+    num_attention_heads: int = 32
+    num_key_value_heads: int = 8
+    head_dim: int = 128
+    rms_norm_eps: float = 1e-6
+    vocab_size: int = 151936
+    rope_theta: float = 5000000.0
+    max_position_embeddings: int = 262144
+    tie_word_embeddings: bool = False
+    rope_scaling: Optional[Dict[str, Union[float, str]]] = None
+
+    def __post_init__(self):
+        if self.num_key_value_heads is None:
+            self.num_key_value_heads = self.num_attention_heads
+
+
+@dataclass
+class ModelConfig(BaseModelConfig):
+    text_config: TextConfig
+    vision_config: VisionConfig
+    model_type: str = "mage_vl"
+    image_token_id: int = 151655
+    video_token_id: int = 151656
+    image_token_index: Optional[int] = None
+    video_token_index: Optional[int] = None
+    vision_start_token_id: int = 151652
+    vision_end_token_id: int = 151653
+    vocab_size: int = 151936
+    eos_token_id: Optional[List[int]] = None
+
+    def __post_init__(self):
+        if self.image_token_index is None:
+            self.image_token_index = self.image_token_id
+        if self.video_token_index is None:
+            self.video_token_index = self.video_token_id
+
+    @classmethod
+    def from_dict(cls, params):
+        params = dict(params)
+        vc = params.get("vision_config") or {}
+        tc = params.get("text_config") or {}
+        params["vision_config"] = (
+            vc if not isinstance(vc, dict) else VisionConfig(**_kw(VisionConfig, vc))
+        )
+        params["text_config"] = (
+            tc if not isinstance(tc, dict) else TextConfig(**_kw(TextConfig, tc))
+        )
+        return cls(**_kw(cls, params))

--- a/mlx_vlm/models/mage_vl/language.py
+++ b/mlx_vlm/models/mage_vl/language.py
@@ -1,0 +1,115 @@
+"""Mage-VL language backbone = plain Qwen3-4B (1D RoPE, GQA, q/k-norm).
+Mage-VL uses simple 1D position ids for the LLM, so no multimodal RoPE."""
+from typing import Any, Optional
+
+import mlx.core as mx
+import mlx.nn as nn
+
+from ..base import LanguageModelOutput, create_attention_mask, scaled_dot_product_attention
+from ..cache import KVCache
+from .config import ModelConfig, TextConfig
+
+
+class Attention(nn.Module):
+    def __init__(self, args: TextConfig):
+        super().__init__()
+        dim = args.hidden_size
+        self.n_heads = args.num_attention_heads
+        self.n_kv_heads = args.num_key_value_heads
+        self.head_dim = args.head_dim
+        self.scale = self.head_dim**-0.5
+
+        self.q_proj = nn.Linear(dim, self.n_heads * self.head_dim, bias=False)
+        self.k_proj = nn.Linear(dim, self.n_kv_heads * self.head_dim, bias=False)
+        self.v_proj = nn.Linear(dim, self.n_kv_heads * self.head_dim, bias=False)
+        self.o_proj = nn.Linear(self.n_heads * self.head_dim, dim, bias=False)
+        self.q_norm = nn.RMSNorm(self.head_dim, eps=args.rms_norm_eps)
+        self.k_norm = nn.RMSNorm(self.head_dim, eps=args.rms_norm_eps)
+        self.rope = nn.RoPE(self.head_dim, traditional=False, base=args.rope_theta)
+
+    def __call__(self, x, mask=None, cache=None):
+        B, L, _ = x.shape
+        q, k, v = self.q_proj(x), self.k_proj(x), self.v_proj(x)
+        q = self.q_norm(q.reshape(B, L, self.n_heads, -1)).transpose(0, 2, 1, 3)
+        k = self.k_norm(k.reshape(B, L, self.n_kv_heads, -1)).transpose(0, 2, 1, 3)
+        v = v.reshape(B, L, self.n_kv_heads, -1).transpose(0, 2, 1, 3)
+
+        if cache is not None:
+            q = self.rope(q, offset=cache.offset)
+            k = self.rope(k, offset=cache.offset)
+            k, v = cache.update_and_fetch(k, v)
+        else:
+            q = self.rope(q)
+            k = self.rope(k)
+
+        out = scaled_dot_product_attention(q, k, v, cache=cache, scale=self.scale, mask=mask)
+        out = out.transpose(0, 2, 1, 3).reshape(B, L, -1)
+        return self.o_proj(out)
+
+
+class MLP(nn.Module):
+    def __init__(self, dim, hidden):
+        super().__init__()
+        self.gate_proj = nn.Linear(dim, hidden, bias=False)
+        self.down_proj = nn.Linear(hidden, dim, bias=False)
+        self.up_proj = nn.Linear(dim, hidden, bias=False)
+
+    def __call__(self, x):
+        return self.down_proj(nn.silu(self.gate_proj(x)) * self.up_proj(x))
+
+
+class TransformerBlock(nn.Module):
+    def __init__(self, args: TextConfig):
+        super().__init__()
+        self.self_attn = Attention(args)
+        self.mlp = MLP(args.hidden_size, args.intermediate_size)
+        self.input_layernorm = nn.RMSNorm(args.hidden_size, eps=args.rms_norm_eps)
+        self.post_attention_layernorm = nn.RMSNorm(args.hidden_size, eps=args.rms_norm_eps)
+
+    def __call__(self, x, mask=None, cache=None):
+        h = x + self.self_attn(self.input_layernorm(x), mask, cache)
+        return h + self.mlp(self.post_attention_layernorm(h))
+
+
+class Qwen3Model(nn.Module):
+    def __init__(self, args: TextConfig):
+        super().__init__()
+        self.embed_tokens = nn.Embedding(args.vocab_size, args.hidden_size)
+        self.layers = [TransformerBlock(args) for _ in range(args.num_hidden_layers)]
+        self.norm = nn.RMSNorm(args.hidden_size, eps=args.rms_norm_eps)
+
+    def __call__(self, inputs, inputs_embeds=None, mask=None, cache=None, **kwargs):
+        h = inputs_embeds if inputs_embeds is not None else self.embed_tokens(inputs)
+        if cache is None:
+            cache = [None] * len(self.layers)
+        if mask is None:
+            mask = create_attention_mask(h, cache[0] if cache else None)
+        for layer, c in zip(self.layers, cache):
+            h = layer(h, mask, c)
+        return self.norm(h)
+
+
+class LanguageModel(nn.Module):
+    def __init__(self, args: TextConfig, config: ModelConfig = None):
+        super().__init__()
+        self.args = args
+        self.config = config
+        self.model_type = args.model_type
+        self.model = Qwen3Model(args)
+        if not args.tie_word_embeddings:
+            self.lm_head = nn.Linear(args.hidden_size, args.vocab_size, bias=False)
+
+    def __call__(self, inputs, inputs_embeds=None, mask=None, cache=None, **kwargs):
+        out = self.model(inputs, inputs_embeds=inputs_embeds, mask=mask, cache=cache)
+        if self.args.tie_word_embeddings:
+            out = self.model.embed_tokens.as_linear(out)
+        else:
+            out = self.lm_head(out)
+        return LanguageModelOutput(logits=out)
+
+    @property
+    def layers(self):
+        return self.model.layers
+
+    def make_cache(self):
+        return [KVCache() for _ in self.model.layers]

--- a/mlx_vlm/models/mage_vl/mage_vl.py
+++ b/mlx_vlm/models/mage_vl/mage_vl.py
@@ -1,0 +1,86 @@
+"""Mage-VL (microsoft/Mage-VL) for MLX / mlx-vlm.
+
+Mage-ViT vision tower (codec-native, 3D-RoPE, 2x2 merger) + Qwen3-4B text
+backbone. The LLM uses plain 1D position ids; image features are spliced at
+`image_token_id` via masked_scatter (Qwen2-VL style)."""
+from typing import Optional
+
+import mlx.core as mx
+import mlx.nn as nn
+import numpy as np
+
+from ..base import InputEmbeddingsFeatures
+from .config import ModelConfig
+from .language import LanguageModel
+from .vision import VisionModel
+
+
+def masked_scatter(final_embedding, mask_expanded, features):
+    shape = final_embedding.shape
+    feats = mx.flatten(features)
+    flat = mx.flatten(final_embedding)
+    pos = mx.array(np.where(mx.flatten(mask_expanded))[0], mx.uint32)
+    flat[pos] = feats.astype(flat.dtype)
+    return mx.reshape(flat, shape)
+
+
+class Model(nn.Module):
+    def __init__(self, config: ModelConfig):
+        super().__init__()
+        self.config = config
+        self.model_type = config.model_type
+        self.vision_tower = VisionModel(config.vision_config)
+        self.language_model = LanguageModel(config.text_config, config)
+
+    def get_input_embeddings(self, input_ids=None, pixel_values=None, **kwargs):
+        grid_thw = kwargs.get("image_grid_thw", kwargs.get("video_grid_thw", None))
+        if pixel_values is None:
+            pixel_values = kwargs.get("pixel_values_videos", None)
+
+        inputs_embeds = self.language_model.model.embed_tokens(input_ids)
+        if pixel_values is None:
+            return InputEmbeddingsFeatures(inputs_embeds=inputs_embeds)
+
+        dtype = self.vision_tower.embeddings.patch_embedding.weight.dtype
+        if hasattr(pixel_values, "astype"):
+            pixel_values = pixel_values.astype(dtype)
+        image_features = self.vision_tower(pixel_values, grid_thw)
+
+        tok = self.config.image_token_id
+        vtok = self.config.video_token_id
+        mask = (input_ids == tok) | (input_ids == vtok)
+        mask = mx.broadcast_to(mask[..., None], inputs_embeds.shape)
+        if int(mask.sum()) != image_features.size:
+            raise ValueError(
+                f"image tokens != features: mask={int(mask.sum())} feat={image_features.size}"
+            )
+        inputs_embeds = masked_scatter(inputs_embeds, mask, image_features)
+        return InputEmbeddingsFeatures(inputs_embeds=inputs_embeds)
+
+    @property
+    def layers(self):
+        return self.language_model.model.layers
+
+    def __call__(self, input_ids, pixel_values=None, mask=None, cache=None, **kwargs):
+        feats = self.get_input_embeddings(input_ids, pixel_values, **kwargs)
+        return self.language_model(
+            input_ids, inputs_embeds=feats.inputs_embeds, mask=mask, cache=cache
+        )
+
+    def sanitize(self, weights):
+        w = {}
+        for k, v in weights.items():
+            if k.startswith("model.language_model"):
+                k = k.replace("model.language_model", "language_model.model")
+            elif k.startswith("model.visual"):
+                k = k.replace("model.visual", "vision_tower")
+            elif k.startswith("lm_head"):
+                k = k.replace("lm_head", "language_model.lm_head")
+            w[k] = v
+        # vision-specific fixups (patch_embedding reshape, merger rename)
+        vt = {k[len("vision_tower.") :]: v for k, v in w.items() if k.startswith("vision_tower.")}
+        vt = self.vision_tower.sanitize(vt)
+        w = {k: v for k, v in w.items() if not k.startswith("vision_tower.")}
+        for k, v in vt.items():
+            w["vision_tower." + k] = v
+        return w

--- a/mlx_vlm/models/mage_vl/processing_mage_vl.py
+++ b/mlx_vlm/models/mage_vl/processing_mage_vl.py
@@ -1,0 +1,102 @@
+"""mlx-vlm processor for Mage-VL (image path).
+
+Reuses HuggingFace's *slow* ``Qwen2VLImageProcessor`` (numpy, no torch) for
+pixel preprocessing, expands ``<|image_pad|>`` placeholders to the merged token
+count, and returns mlx arrays. Registered on ``AutoProcessor`` for the
+``mage_vl`` model type so ``mlx_vlm`` picks it up without ``trust_remote_code``.
+
+Video (the DCVC neural codec) is out of scope here — image inference only.
+The model recomputes vision ``patch_positions`` internally from ``image_grid_thw``,
+so the processor only needs to emit ``input_ids`` / ``pixel_values`` /
+``image_grid_thw``.
+"""
+from typing import List, Optional, Union
+
+import numpy as np
+from transformers.feature_extraction_utils import BatchFeature
+from transformers.processing_utils import ProcessorMixin
+
+from ..base import install_auto_processor_patch, load_chat_template, to_mlx
+
+
+class MageVLProcessor(ProcessorMixin):
+    attributes = ["image_processor", "tokenizer"]
+    valid_kwargs = ["chat_template"]
+    image_processor_class = "AutoImageProcessor"
+    tokenizer_class = "AutoTokenizer"
+
+    # torch-free envs: skip HF's isinstance validation (our numpy processors are
+    # duck-typed to the call sites).
+    def check_argument_for_proper_class(self, argument_name, argument):
+        return type(argument)
+
+    def __init__(self, image_processor=None, tokenizer=None, chat_template=None, **kwargs):
+        self.image_token = "<|image_pad|>"
+        self.video_token = "<|video_pad|>"
+        self.image_token_id = tokenizer.convert_tokens_to_ids(self.image_token)
+        super().__init__(image_processor, tokenizer, chat_template=chat_template)
+
+    def __call__(self, images=None, text=None, videos=None, **kwargs) -> BatchFeature:
+        image_inputs = {}
+        image_grid_thw = None
+        if images is not None:
+            image_inputs = self.image_processor(images=images, return_tensors="np")
+            image_grid_thw = image_inputs["image_grid_thw"]
+
+        if not isinstance(text, list):
+            text = [text]
+        text = list(text)
+
+        if image_grid_thw is not None:
+            merge = self.image_processor.merge_size**2
+            idx = 0
+            for i in range(len(text)):
+                while self.image_token in text[i]:
+                    n = int(np.prod(image_grid_thw[idx]) // merge)
+                    text[i] = text[i].replace(self.image_token, "<|ph|>" * n, 1)
+                    idx += 1
+                text[i] = text[i].replace("<|ph|>", self.image_token)
+
+        kwargs.pop("return_tensors", None)
+        kwargs.pop("return_mm_token_type_ids", None)
+        text_inputs = self.tokenizer(text, **kwargs)
+        return BatchFeature(data=to_mlx({**text_inputs, **image_inputs}))
+
+    def batch_decode(self, *args, **kwargs):
+        return self.tokenizer.batch_decode(*args, **kwargs)
+
+    def decode(self, *args, **kwargs):
+        return self.tokenizer.decode(*args, **kwargs)
+
+    @property
+    def model_input_names(self):
+        return list(
+            dict.fromkeys(
+                self.tokenizer.model_input_names
+                + self.image_processor.model_input_names
+            )
+        )
+
+    @classmethod
+    def from_pretrained(cls, pretrained_model_name_or_path, **kwargs):
+        from transformers import AutoTokenizer, Qwen2VLImageProcessor
+
+        kwargs.pop("use_fast", None)
+        kwargs.pop("trust_remote_code", None)
+        kwargs.pop("_from_auto", None)
+        tokenizer = AutoTokenizer.from_pretrained(pretrained_model_name_or_path, **kwargs)
+        load_chat_template(tokenizer, pretrained_model_name_or_path)
+        # SLOW image processor: the Fast variant changes pixel_values bit-for-bit.
+        image_processor = Qwen2VLImageProcessor.from_pretrained(
+            pretrained_model_name_or_path, **kwargs
+        )
+        return cls(
+            image_processor=image_processor,
+            tokenizer=tokenizer,
+            chat_template=getattr(tokenizer, "chat_template", None),
+        )
+
+
+__all__ = ["MageVLProcessor"]
+
+install_auto_processor_patch("mage_vl", MageVLProcessor)

--- a/mlx_vlm/models/mage_vl/vision.py
+++ b/mlx_vlm/models/mage_vl/vision.py
@@ -1,0 +1,188 @@
+"""Mage-VL vision tower (Mage-ViT): SigLIP-style encoder with 3D (T:H:W = 4:6:6)
+rotary embeddings and a 2x2 patch merger. Verified numerically against the
+reference torch implementation (cosine 0.99992 fp32-vs-fp32)."""
+from typing import Optional
+
+import mlx.core as mx
+import mlx.nn as nn
+import numpy as np
+
+from .config import VisionConfig
+
+
+def _convert_to_block_layout(pp, t, h, w, sms):
+    total = t * h * w
+    idx = np.arange(total).reshape(t, h, w)
+    hm, wm = h // sms, w // sms
+    idx = idx.reshape(t, hm, sms, wm, sms).transpose(0, 1, 3, 2, 4).reshape(total)
+    return pp[idx]
+
+
+def build_patch_positions(grid_thw, sms=2):
+    """Deterministic [sum(t*h*w), 3] (t,h,w) positions in 2x2 block layout,
+    matching video_processing_mage_vl.build_patch_positions for images."""
+    out = []
+    for row in grid_thw:
+        t, h, w = int(row[0]), int(row[1]), int(row[2])
+        h_coords = np.tile(np.repeat(np.arange(h), w), t)
+        w_coords = np.tile(np.tile(np.arange(w), h), t)
+        t_coords = np.repeat(np.arange(t), h * w)
+        pp = np.stack([t_coords, h_coords, w_coords], axis=1)
+        out.append(_convert_to_block_layout(pp, t, h, w, sms))
+    return np.concatenate(out, axis=0).astype(np.float32)
+
+
+def rotate_half(x):
+    x1 = x[..., 0::2]
+    x2 = x[..., 1::2]
+    return mx.stack([-x2, x1], axis=-1).reshape(x.shape)
+
+
+class Attention(nn.Module):
+    def __init__(self, config: VisionConfig):
+        super().__init__()
+        self.num_heads = config.num_attention_heads
+        self.head_dim = config.hidden_size // config.num_attention_heads
+        self.scale = self.head_dim**-0.5
+        self.qkv = nn.Linear(config.hidden_size, config.hidden_size * 3, bias=True)
+        self.proj = nn.Linear(config.hidden_size, config.hidden_size, bias=True)
+
+    def __call__(self, x, cos, sin, mask):
+        L, _ = x.shape
+        qkv = self.qkv(x).reshape(L, 3, self.num_heads, self.head_dim)
+        qkv = qkv.transpose(1, 2, 0, 3)  # (3, NH, L, HD)
+        q, k, v = qkv[0], qkv[1], qkv[2]
+        # RoPE in float32
+        qf, kf = q.astype(mx.float32), k.astype(mx.float32)
+        q = (qf * cos + rotate_half(qf) * sin).astype(x.dtype)
+        k = (kf * cos + rotate_half(kf) * sin).astype(x.dtype)
+        out = mx.fast.scaled_dot_product_attention(
+            q[None], k[None], v[None], scale=self.scale, mask=mask
+        )[0]
+        out = out.transpose(1, 0, 2).reshape(L, self.num_heads * self.head_dim)
+        return self.proj(out)
+
+
+class MLP(nn.Module):
+    def __init__(self, config: VisionConfig):
+        super().__init__()
+        self.fc1 = nn.Linear(config.hidden_size, config.intermediate_size)
+        self.fc2 = nn.Linear(config.intermediate_size, config.hidden_size)
+
+    def __call__(self, x):
+        return self.fc2(nn.gelu(self.fc1(x)))
+
+
+class EncoderLayer(nn.Module):
+    def __init__(self, config: VisionConfig):
+        super().__init__()
+        self.self_attn = Attention(config)
+        self.layer_norm1 = nn.LayerNorm(config.hidden_size, eps=config.layer_norm_eps)
+        self.layer_norm2 = nn.LayerNorm(config.hidden_size, eps=config.layer_norm_eps)
+        self.mlp = MLP(config)
+
+    def __call__(self, x, cos, sin, mask):
+        x = x + self.self_attn(self.layer_norm1(x), cos, sin, mask)
+        x = x + self.mlp(self.layer_norm2(x))
+        return x
+
+
+class Encoder(nn.Module):
+    def __init__(self, config: VisionConfig):
+        super().__init__()
+        self.layers = [EncoderLayer(config) for _ in range(config.num_hidden_layers)]
+
+
+class Embeddings(nn.Module):
+    def __init__(self, config: VisionConfig):
+        super().__init__()
+        # Conv2d(k=stride=patch, no bias) == Linear over flattened patch.
+        pdim = config.num_channels * config.patch_size * config.patch_size
+        self.patch_embedding = nn.Linear(pdim, config.hidden_size, bias=False)
+
+    def __call__(self, x):
+        return self.patch_embedding(x)
+
+
+class Merger(nn.Module):
+    def __init__(self, config: VisionConfig):
+        super().__init__()
+        ctx = config.hidden_size * (config.spatial_merge_size**2)
+        self.ln_q = nn.LayerNorm(config.hidden_size, eps=config.layer_norm_eps)
+        self.fc1 = nn.Linear(ctx, ctx)
+        self.fc2 = nn.Linear(ctx, config.out_hidden_size)
+
+    def __call__(self, x, merge_dim):
+        x = self.ln_q(x).reshape(-1, merge_dim)
+        return self.fc2(nn.gelu(self.fc1(x)))
+
+
+class VisionModel(nn.Module):
+    def __init__(self, config: VisionConfig):
+        super().__init__()
+        self.config = config
+        self.model_type = config.model_type
+        self.sms = config.spatial_merge_size
+        nh = config.num_attention_heads
+        self.head_dim = config.hidden_size // nh
+        self.half = self.head_dim // 2
+        unit = self.half // 16
+        self.t_size, self.h_size, self.w_size = 4 * unit, 6 * unit, 6 * unit
+        self.base = config.rope_theta
+
+        self.embeddings = Embeddings(config)
+        self.layernorm_pre = nn.LayerNorm(config.hidden_size, eps=config.layer_norm_eps)
+        self.encoder = Encoder(config)
+        self.merger = Merger(config)
+
+    def _rope(self, grid_thw):
+        pp = build_patch_positions(grid_thw, self.sms)  # (L,3) np
+
+        def inv(n):
+            return 1.0 / (self.base ** (np.arange(n, dtype=np.float32) / n))
+
+        ft = np.outer(pp[:, 0], inv(self.t_size))
+        fh = np.outer(pp[:, 1], inv(self.h_size))
+        fw = np.outer(pp[:, 2], inv(self.w_size))
+        freqs = np.concatenate([ft, fh, fw], axis=-1)
+        freqs = np.concatenate([freqs, freqs], axis=-1)  # (L, head_dim)
+        cos = mx.array(np.cos(freqs))[None]  # (1,L,HD)
+        sin = mx.array(np.sin(freqs))[None]
+        return cos, sin
+
+    def _block_mask(self, grid_thw, L, dtype):
+        # Block-diagonal (bidirectional within each image/frame). t is always 1
+        # for image rows and expanded video frames, so blocks are h*w each.
+        blocks = [int(r[0]) * int(r[1]) * int(r[2]) for r in grid_thw]
+        if len(blocks) == 1:
+            return None  # single image: full attention
+        m = np.full((L, L), -np.inf, dtype=np.float32)
+        s = 0
+        for b in blocks:
+            m[s : s + b, s : s + b] = 0.0
+            s += b
+        return mx.array(m).astype(dtype)
+
+    def __call__(self, pixel_values, grid_thw):
+        grid_thw = np.array(grid_thw)
+        cos, sin = self._rope(grid_thw)
+        h = self.embeddings(pixel_values)
+        h = self.layernorm_pre(h)
+        L = h.shape[0]
+        mask = self._block_mask(grid_thw, L, h.dtype)
+        for layer in self.encoder.layers:
+            h = layer(h, cos, sin, mask)
+        return self.merger(h, self.config.hidden_size * (self.sms**2))
+
+    def sanitize(self, weights):
+        out = {}
+        for k, v in weights.items():
+            # Conv2d (O,C,ph,pw) -> Linear (O, C*ph*pw)
+            if k.endswith("embeddings.patch_embedding.weight") and v.ndim == 4:
+                v = v.reshape(v.shape[0], -1)
+            # merger.mlp.0 -> merger.fc1 ; merger.mlp.2 -> merger.fc2
+            k = k.replace("merger.mlp.0.", "merger.fc1.").replace(
+                "merger.mlp.2.", "merger.fc2."
+            )
+            out[k] = v
+        return out

--- a/mlx_vlm/prompt_utils.py
+++ b/mlx_vlm/prompt_utils.py
@@ -46,6 +46,7 @@ MODEL_CONFIG = {
     "zaya1_vl": MessageFormat.LIST_WITH_IMAGE_FIRST,
     "qwen3_vl": MessageFormat.LIST_WITH_IMAGE_FIRST,
     "qwen3_vl_moe": MessageFormat.LIST_WITH_IMAGE_FIRST,
+    "mage_vl": MessageFormat.LIST_WITH_IMAGE_FIRST,
     "qwen3_5": MessageFormat.LIST_WITH_IMAGE_FIRST,
     "qwen3_5_moe": MessageFormat.LIST_WITH_IMAGE_FIRST,
     "qwen3_omni_moe": MessageFormat.LIST_WITH_IMAGE_FIRST,


### PR DESCRIPTION
## Summary

Adds support for **Mage-VL** ([`microsoft/Mage-VL`](https://huggingface.co/microsoft/Mage-VL)), a ~5B vision-language model: a **Mage-ViT** codec-native visual encoder (SigLIP-style encoder with 3D `T:H:W = 4:6:6` rotary embeddings + a 2×2 patch merger) paired with a **Qwen3-4B-Instruct** text backbone. Image features are spliced at `image_token_id` via `masked_scatter` (Qwen2-VL style); the LLM uses plain 1D position ids (no multimodal RoPE).

## Changes

- `mlx_vlm/models/mage_vl/`:
  - `config.py` — `ModelConfig` / `TextConfig` (qwen3) / `VisionConfig` (mage_vl_vision)
  - `language.py` — plain Qwen3 backbone (GQA, q/k-norm, 1D RoPE)
  - `vision.py` — Mage-ViT tower (patch embed, 3D-RoPE attention, SigLIP MLP, 2×2 merger); recomputes `patch_positions` from `image_grid_thw`
  - `mage_vl.py` — top-level `Model` + `sanitize`
  - `processing_mage_vl.py` — numpy processor (reuses the slow `Qwen2VLImageProcessor`, no torch) registered via `install_auto_processor_patch`
- `mlx_vlm/prompt_utils.py` — register `mage_vl` as `LIST_WITH_IMAGE_FIRST`

## Verification

Validated against the original torch model (bf16, CPU) on image inputs:
- MLX vision features match the reference at **cosine 0.99992** (fp32-vs-fp32).
- `mlx_vlm generate` reproduces the reference caption **exactly** on a test image; verified on both a bf16 build and MXFP4/MXFP8 MLX quants ([sahilchachra/mage-vl-mxfp8-mlx](https://huggingface.co/sahilchachra/mage-vl-mxfp8-mlx), [mxfp4](https://huggingface.co/sahilchachra/mage-vl-mxfp4-mlx)).

## Scope / notes

- **Image path only.** Video (the DCVC neural codec) and the `streammind_gate` streaming component are out of scope for this PR.
- Vision tower is kept in bf16 by the existing `skip_multimodal_module` default when quantizing.

