### PR TITLE
feat(speculative): validate Laguna DFlash contract

### DIFF
--- a/mlx_vlm/speculative/drafters/__init__.py
+++ b/mlx_vlm/speculative/drafters/__init__.py
@@ -2,6 +2,7 @@ import json
 import logging
 from typing import Any, Optional, Tuple
 
+from .laguna_dflash import LagunaDFlashDraftModel
 from .qwen3_dflash import DFlashDraftModel
 
 KNOWN_DRAFTER_KINDS = {"dflash", "mtp", "eagle3"}
@@ -16,6 +17,7 @@ DRAFTER_KIND_BY_MODEL_TYPE = {
     "glm4_moe_lite_mtp": "mtp",
     "inkling_mtp": "mtp",
     "qwen3_5_mtp": "mtp",
+    "laguna": "dflash",
 }
 
 DEFAULT_DRAFTER_KIND = "dflash"
@@ -31,6 +33,19 @@ def _cfg_get(config: Any, key: str, default: Any = None) -> Any:
 
 def _hidden_size(config: Any) -> Any:
     return _cfg_get(_cfg_get(config, "text_config", config), "hidden_size")
+
+
+def _noop_target_compatibility(target_model: Any) -> None:
+    del target_model
+
+
+def _validate_model_specific_compatibility(target_model: Any, draft_model: Any) -> None:
+    validator = getattr(
+        draft_model,
+        "validate_target_compatibility",
+        _noop_target_compatibility,
+    )
+    validator(target_model)
 
 
 def validate_drafter_compatibility(
@@ -56,6 +71,8 @@ def validate_drafter_compatibility(
             f"Drafter model_type={model_type!r} requires draft_kind={expected_kind!r}. "
             f"Got draft_kind={draft_kind!r}."
         )
+
+    _validate_model_specific_compatibility(target_model, draft_model)
 
     if draft_kind != "mtp":
         return
@@ -154,6 +171,7 @@ def load_drafter(
 
 __all__ = [
     "DFlashDraftModel",
+    "LagunaDFlashDraftModel",
     "KNOWN_DRAFTER_KINDS",
     "DRAFTER_KIND_BY_MODEL_TYPE",
     "DEFAULT_DRAFTER_KIND",

--- a/mlx_vlm/speculative/drafters/laguna_dflash/__init__.py
+++ b/mlx_vlm/speculative/drafters/laguna_dflash/__init__.py
@@ -4,9 +4,12 @@ from .config import (
     validate_laguna_dflash_target,
     validate_laguna_dflash_weights,
 )
+from .dflash import LagunaDFlashDraftModel, Model
 
 __all__ = [
     "ModelConfig",
+    "LagunaDFlashDraftModel",
+    "Model",
     "expected_laguna_dflash_weight_shapes",
     "validate_laguna_dflash_target",
     "validate_laguna_dflash_weights",

--- a/mlx_vlm/speculative/drafters/laguna_dflash/__init__.py
+++ b/mlx_vlm/speculative/drafters/laguna_dflash/__init__.py
@@ -1,0 +1,13 @@
+from .config import DFlashConfig as ModelConfig
+from .config import (
+    expected_laguna_dflash_weight_shapes,
+    validate_laguna_dflash_target,
+    validate_laguna_dflash_weights,
+)
+
+__all__ = [
+    "ModelConfig",
+    "expected_laguna_dflash_weight_shapes",
+    "validate_laguna_dflash_target",
+    "validate_laguna_dflash_weights",
+]

--- a/mlx_vlm/speculative/drafters/laguna_dflash/config.py
+++ b/mlx_vlm/speculative/drafters/laguna_dflash/config.py
@@ -1,0 +1,292 @@
+import inspect
+from dataclasses import dataclass, field
+from typing import Any, Mapping, Optional
+
+from ....models.base import BaseModelConfig
+
+LAGUNA_DFLASH_HIDDEN_SIZE = 3072
+LAGUNA_DFLASH_INTERMEDIATE_SIZE = 12288
+LAGUNA_DFLASH_NUM_LAYERS = 6
+LAGUNA_DFLASH_NUM_ATTENTION_HEADS = 72
+LAGUNA_DFLASH_NUM_KV_HEADS = 8
+LAGUNA_DFLASH_HEAD_DIM = 128
+LAGUNA_DFLASH_SLIDING_WINDOW = 512
+LAGUNA_DFLASH_VOCAB_SIZE = 100352
+LAGUNA_DFLASH_BLOCK_SIZE = 16
+LAGUNA_DFLASH_MASK_TOKEN_ID = 12
+LAGUNA_DFLASH_TARGET_LAYERS = [1, 10, 19, 29, 38, 47]
+LAGUNA_DFLASH_TARGET_LAYER_COUNT = 48
+LAGUNA_DFLASH_AUX_LAYER_IDS = [2, 11, 20, 30, 39, 48]
+
+
+def _value(source: Any, key: str, default: Any = None) -> Any:
+    if isinstance(source, Mapping):
+        return source.get(key, default)
+    return getattr(source, key, default)
+
+
+def _target_layer_count(config: Any) -> Optional[int]:
+    for key in ("num_hidden_layers", "num_layers", "n_layers"):
+        value = _value(config, key)
+        if value is not None:
+            return int(value)
+    return None
+
+
+def _target_vocab_size(config: Any) -> Optional[int]:
+    for key in ("vocab_size", "padded_vocab_size"):
+        value = _value(config, key)
+        if value is not None:
+            return int(value)
+    return None
+
+
+def validate_laguna_dflash_target(
+    config: "DFlashConfig",
+    *,
+    target_model_config: Any = None,
+    target_model_layer_count: Optional[int] = None,
+    target_tokenizer_length: Optional[int] = None,
+) -> None:
+    """Validate target-model identity before binding shared target tensors."""
+    if target_model_layer_count is None and target_model_config is not None:
+        target_model_layer_count = _target_layer_count(target_model_config)
+    if target_model_layer_count is None:
+        raise ValueError("Laguna DFlash binding requires the target model layer count.")
+    if target_model_layer_count != config.num_target_layers:
+        raise ValueError(
+            "Laguna DFlash target layer count mismatch: "
+            f"draft expects {config.num_target_layers}, target has "
+            f"{target_model_layer_count}."
+        )
+
+    if target_tokenizer_length is None and target_model_config is not None:
+        target_tokenizer_length = _target_vocab_size(target_model_config)
+    if target_tokenizer_length is None:
+        raise ValueError("Laguna DFlash binding requires the target tokenizer length.")
+    if target_tokenizer_length != config.vocab_size:
+        raise ValueError(
+            "Laguna DFlash tokenizer vocabulary mismatch: "
+            f"draft has {config.vocab_size}, target tokenizer has "
+            f"{target_tokenizer_length}."
+        )
+
+
+@dataclass
+class DFlashConfig(BaseModelConfig):
+    """Exact configuration contract for Poolside Laguna S 2.1 DFlash."""
+
+    model_type: str = "laguna"
+    hidden_size: int = LAGUNA_DFLASH_HIDDEN_SIZE
+    intermediate_size: int = LAGUNA_DFLASH_INTERMEDIATE_SIZE
+    num_hidden_layers: int = LAGUNA_DFLASH_NUM_LAYERS
+    num_attention_heads: int = LAGUNA_DFLASH_NUM_ATTENTION_HEADS
+    num_key_value_heads: int = LAGUNA_DFLASH_NUM_KV_HEADS
+    head_dim: int = LAGUNA_DFLASH_HEAD_DIM
+    rms_norm_eps: float = 1e-6
+    vocab_size: int = LAGUNA_DFLASH_VOCAB_SIZE
+    draft_vocab_size: int = LAGUNA_DFLASH_VOCAB_SIZE
+    max_position_embeddings: int = 1048576
+    rope_theta: float = 500000.0
+    rope_parameters: Optional[dict[str, Any]] = None
+    layer_types: list[str] = field(
+        default_factory=lambda: ["sliding_attention"] * LAGUNA_DFLASH_NUM_LAYERS
+    )
+    sliding_windows: list[int] = field(
+        default_factory=lambda: [LAGUNA_DFLASH_SLIDING_WINDOW]
+        * LAGUNA_DFLASH_NUM_LAYERS
+    )
+    sliding_window: int = LAGUNA_DFLASH_SLIDING_WINDOW
+    gating: str = "per-head"
+    block_size: int = LAGUNA_DFLASH_BLOCK_SIZE
+    mask_token_id: int = LAGUNA_DFLASH_MASK_TOKEN_ID
+    target_layer_ids: list[int] = field(
+        default_factory=lambda: list(LAGUNA_DFLASH_TARGET_LAYERS)
+    )
+    num_target_layers: int = LAGUNA_DFLASH_TARGET_LAYER_COUNT
+    aux_hidden_state_layer_ids: list[int] = field(
+        default_factory=lambda: list(LAGUNA_DFLASH_AUX_LAYER_IDS)
+    )
+    causal: bool = True
+    attention_bias: bool = False
+    qkv_bias: bool = False
+    tie_word_embeddings: bool = True
+
+    def validate(self) -> None:
+        expected = {
+            "hidden_size": LAGUNA_DFLASH_HIDDEN_SIZE,
+            "intermediate_size": LAGUNA_DFLASH_INTERMEDIATE_SIZE,
+            "num_hidden_layers": LAGUNA_DFLASH_NUM_LAYERS,
+            "num_attention_heads": LAGUNA_DFLASH_NUM_ATTENTION_HEADS,
+            "num_key_value_heads": LAGUNA_DFLASH_NUM_KV_HEADS,
+            "head_dim": LAGUNA_DFLASH_HEAD_DIM,
+            "sliding_window": LAGUNA_DFLASH_SLIDING_WINDOW,
+            "gating": "per-head",
+            "block_size": LAGUNA_DFLASH_BLOCK_SIZE,
+            "mask_token_id": LAGUNA_DFLASH_MASK_TOKEN_ID,
+            "num_target_layers": LAGUNA_DFLASH_TARGET_LAYER_COUNT,
+            "vocab_size": LAGUNA_DFLASH_VOCAB_SIZE,
+            "draft_vocab_size": LAGUNA_DFLASH_VOCAB_SIZE,
+        }
+        for key, expected_value in expected.items():
+            actual = getattr(self, key)
+            if actual != expected_value:
+                raise ValueError(
+                    f"Laguna S 2.1 DFlash {key} mismatch: expected "
+                    f"{expected_value!r}, got {actual!r}."
+                )
+
+        if self.model_type != "laguna":
+            raise ValueError(
+                f"Laguna S 2.1 DFlash requires model_type='laguna', got {self.model_type!r}."
+            )
+        if self.layer_types != ["sliding_attention"] * LAGUNA_DFLASH_NUM_LAYERS:
+            raise ValueError(
+                "Laguna S 2.1 DFlash requires all six draft layers to use "
+                "sliding_attention."
+            )
+        if (
+            self.sliding_windows
+            != [LAGUNA_DFLASH_SLIDING_WINDOW] * LAGUNA_DFLASH_NUM_LAYERS
+        ):
+            raise ValueError(
+                "Laguna S 2.1 DFlash requires a 512 sliding window for every draft layer."
+            )
+        if self.target_layer_ids != LAGUNA_DFLASH_TARGET_LAYERS:
+            raise ValueError(
+                "Laguna S 2.1 DFlash target_layer_ids mismatch: expected "
+                f"{LAGUNA_DFLASH_TARGET_LAYERS}, got {self.target_layer_ids}."
+            )
+        if self.aux_hidden_state_layer_ids != LAGUNA_DFLASH_AUX_LAYER_IDS:
+            raise ValueError(
+                "Laguna S 2.1 DFlash auxiliary layer IDs mismatch: expected "
+                f"{LAGUNA_DFLASH_AUX_LAYER_IDS}, got {self.aux_hidden_state_layer_ids}."
+            )
+        if not self.causal:
+            raise ValueError("Laguna S 2.1 DFlash requires causal block attention.")
+        if self.draft_vocab_size != self.vocab_size:
+            raise ValueError(
+                "Laguna DFlash requires draft_vocab_size == vocab_size because "
+                "the target tokenizer is shared."
+            )
+
+    @classmethod
+    def from_dict(cls, params: dict) -> "DFlashConfig":
+        raw = dict(params)
+        dflash = raw.pop("dflash_config", None)
+        if not isinstance(dflash, Mapping):
+            raise ValueError("Laguna DFlash config requires a dflash_config object.")
+
+        merged = dict(raw)
+        for key in (
+            "block_size",
+            "mask_token_id",
+            "target_layer_ids",
+            "num_target_layers",
+            "causal",
+        ):
+            if key in dflash:
+                merged[key] = dflash[key]
+        if "eagle_aux_hidden_state_layer_ids" in raw:
+            merged["aux_hidden_state_layer_ids"] = raw[
+                "eagle_aux_hidden_state_layer_ids"
+            ]
+
+        signature = inspect.signature(cls).parameters
+        config = cls(**{k: v for k, v in merged.items() if k in signature})
+        config.validate()
+        return config
+
+
+def expected_laguna_dflash_weight_shapes(
+    config: DFlashConfig,
+) -> dict[str, tuple[int, ...]]:
+    config.validate()
+    qkv_size = (
+        config.num_attention_heads + 2 * config.num_key_value_heads
+    ) * config.head_dim
+    shapes: dict[str, tuple[int, ...]] = {
+        "fc.weight": (
+            config.hidden_size,
+            len(config.target_layer_ids) * config.hidden_size,
+        ),
+        "hidden_norm.weight": (config.hidden_size,),
+        "norm.weight": (config.hidden_size,),
+    }
+    for index in range(config.num_hidden_layers):
+        prefix = f"layers.{index}"
+        shapes.update(
+            {
+                f"aux_hidden_norms.{index}.weight": (config.hidden_size,),
+                f"{prefix}.input_layernorm.weight": (config.hidden_size,),
+                f"{prefix}.post_attention_layernorm.weight": (config.hidden_size,),
+                f"{prefix}.self_attn.qkv_proj.weight": (qkv_size, config.hidden_size),
+                f"{prefix}.self_attn.o_proj.weight": (
+                    config.hidden_size,
+                    config.num_attention_heads * config.head_dim,
+                ),
+                f"{prefix}.self_attn.g_proj.weight": (
+                    config.num_attention_heads,
+                    config.hidden_size,
+                ),
+                f"{prefix}.self_attn.q_norm.weight": (config.head_dim,),
+                f"{prefix}.self_attn.k_norm.weight": (config.head_dim,),
+                f"{prefix}.mlp.gate_proj.weight": (
+                    config.intermediate_size,
+                    config.hidden_size,
+                ),
+                f"{prefix}.mlp.up_proj.weight": (
+                    config.intermediate_size,
+                    config.hidden_size,
+                ),
+                f"{prefix}.mlp.down_proj.weight": (
+                    config.hidden_size,
+                    config.intermediate_size,
+                ),
+            }
+        )
+    return shapes
+
+
+def validate_laguna_dflash_weights(
+    weights: Mapping[str, Any], config: DFlashConfig
+) -> None:
+    expected = expected_laguna_dflash_weight_shapes(config)
+    actual_keys = set(weights)
+    expected_keys = set(expected)
+    quantized_weight_keys = {
+        key
+        for key in expected_keys
+        if key.endswith(".weight")
+        and key.removesuffix(".weight") + ".scales" in actual_keys
+    }
+    quantized_aux_keys = {
+        key.removesuffix(".weight") + suffix
+        for key in quantized_weight_keys
+        for suffix in (".scales", ".biases")
+    }
+    missing = sorted(expected_keys - actual_keys)
+    unexpected = sorted(actual_keys - expected_keys - quantized_aux_keys)
+    if missing or unexpected:
+        raise ValueError(
+            "Laguna DFlash weight keys do not match the published checkpoint: "
+            f"missing={missing}, unexpected={unexpected}."
+        )
+    bad_shapes = {
+        key: (tuple(weights[key].shape), shape)
+        for key, shape in expected.items()
+        if key not in quantized_weight_keys and tuple(weights[key].shape) != shape
+    }
+    if bad_shapes:
+        raise ValueError(
+            "Laguna DFlash weight shapes do not match the published checkpoint: "
+            f"{bad_shapes}."
+        )
+
+
+__all__ = [
+    "DFlashConfig",
+    "expected_laguna_dflash_weight_shapes",
+    "validate_laguna_dflash_target",
+    "validate_laguna_dflash_weights",
+]

--- a/mlx_vlm/speculative/drafters/laguna_dflash/config.py
+++ b/mlx_vlm/speculative/drafters/laguna_dflash/config.py
@@ -4,19 +4,31 @@ from typing import Any, Mapping, Optional
 
 from ....models.base import BaseModelConfig
 
-LAGUNA_DFLASH_HIDDEN_SIZE = 3072
-LAGUNA_DFLASH_INTERMEDIATE_SIZE = 12288
-LAGUNA_DFLASH_NUM_LAYERS = 6
-LAGUNA_DFLASH_NUM_ATTENTION_HEADS = 72
-LAGUNA_DFLASH_NUM_KV_HEADS = 8
-LAGUNA_DFLASH_HEAD_DIM = 128
-LAGUNA_DFLASH_SLIDING_WINDOW = 512
-LAGUNA_DFLASH_VOCAB_SIZE = 100352
-LAGUNA_DFLASH_BLOCK_SIZE = 16
-LAGUNA_DFLASH_MASK_TOKEN_ID = 12
-LAGUNA_DFLASH_TARGET_LAYERS = [1, 10, 19, 29, 38, 47]
-LAGUNA_DFLASH_TARGET_LAYER_COUNT = 48
-LAGUNA_DFLASH_AUX_LAYER_IDS = [2, 11, 20, 30, 39, 48]
+_REQUIRED_CHECKPOINT_FIELDS = {
+    "model_type",
+    "hidden_size",
+    "intermediate_size",
+    "num_hidden_layers",
+    "num_attention_heads",
+    "num_key_value_heads",
+    "head_dim",
+    "vocab_size",
+    "draft_vocab_size",
+    "max_position_embeddings",
+    "rope_theta",
+    "layer_types",
+    "sliding_windows",
+    "sliding_window",
+    "gating",
+    "eagle_aux_hidden_state_layer_ids",
+}
+_REQUIRED_DFLASH_FIELDS = {
+    "block_size",
+    "mask_token_id",
+    "target_layer_ids",
+    "num_target_layers",
+    "causal",
+}
 
 
 def _value(source: Any, key: str, default: Any = None) -> Any:
@@ -39,6 +51,12 @@ def _target_vocab_size(config: Any) -> Optional[int]:
         if value is not None:
             return int(value)
     return None
+
+
+def _is_strictly_increasing_ints(values: list[int]) -> bool:
+    return all(isinstance(value, int) for value in values) and values == sorted(
+        set(values)
+    )
 
 
 def validate_laguna_dflash_target(
@@ -74,93 +92,102 @@ def validate_laguna_dflash_target(
 
 @dataclass
 class DFlashConfig(BaseModelConfig):
-    """Exact configuration contract for Poolside Laguna S 2.1 DFlash."""
+    """Validated DFlash checkpoint metadata for a Laguna target."""
 
-    model_type: str = "laguna"
-    hidden_size: int = LAGUNA_DFLASH_HIDDEN_SIZE
-    intermediate_size: int = LAGUNA_DFLASH_INTERMEDIATE_SIZE
-    num_hidden_layers: int = LAGUNA_DFLASH_NUM_LAYERS
-    num_attention_heads: int = LAGUNA_DFLASH_NUM_ATTENTION_HEADS
-    num_key_value_heads: int = LAGUNA_DFLASH_NUM_KV_HEADS
-    head_dim: int = LAGUNA_DFLASH_HEAD_DIM
+    model_type: str = ""
+    hidden_size: int = 0
+    intermediate_size: int = 0
+    num_hidden_layers: int = 0
+    num_attention_heads: int = 0
+    num_key_value_heads: int = 0
+    head_dim: int = 0
     rms_norm_eps: float = 1e-6
-    vocab_size: int = LAGUNA_DFLASH_VOCAB_SIZE
-    draft_vocab_size: int = LAGUNA_DFLASH_VOCAB_SIZE
-    max_position_embeddings: int = 1048576
-    rope_theta: float = 500000.0
+    vocab_size: int = 0
+    draft_vocab_size: int = 0
+    max_position_embeddings: int = 0
+    rope_theta: float = 0.0
     rope_parameters: Optional[dict[str, Any]] = None
-    layer_types: list[str] = field(
-        default_factory=lambda: ["sliding_attention"] * LAGUNA_DFLASH_NUM_LAYERS
-    )
-    sliding_windows: list[int] = field(
-        default_factory=lambda: [LAGUNA_DFLASH_SLIDING_WINDOW]
-        * LAGUNA_DFLASH_NUM_LAYERS
-    )
-    sliding_window: int = LAGUNA_DFLASH_SLIDING_WINDOW
-    gating: str = "per-head"
-    block_size: int = LAGUNA_DFLASH_BLOCK_SIZE
-    mask_token_id: int = LAGUNA_DFLASH_MASK_TOKEN_ID
-    target_layer_ids: list[int] = field(
-        default_factory=lambda: list(LAGUNA_DFLASH_TARGET_LAYERS)
-    )
-    num_target_layers: int = LAGUNA_DFLASH_TARGET_LAYER_COUNT
-    aux_hidden_state_layer_ids: list[int] = field(
-        default_factory=lambda: list(LAGUNA_DFLASH_AUX_LAYER_IDS)
-    )
-    causal: bool = True
+    layer_types: list[str] = field(default_factory=list)
+    sliding_windows: list[int] = field(default_factory=list)
+    sliding_window: int = 0
+    gating: str = ""
+    block_size: int = 0
+    mask_token_id: int = -1
+    target_layer_ids: list[int] = field(default_factory=list)
+    num_target_layers: int = 0
+    aux_hidden_state_layer_ids: list[int] = field(default_factory=list)
+    causal: bool = False
     attention_bias: bool = False
     qkv_bias: bool = False
     tie_word_embeddings: bool = True
 
     def validate(self) -> None:
-        expected = {
-            "hidden_size": LAGUNA_DFLASH_HIDDEN_SIZE,
-            "intermediate_size": LAGUNA_DFLASH_INTERMEDIATE_SIZE,
-            "num_hidden_layers": LAGUNA_DFLASH_NUM_LAYERS,
-            "num_attention_heads": LAGUNA_DFLASH_NUM_ATTENTION_HEADS,
-            "num_key_value_heads": LAGUNA_DFLASH_NUM_KV_HEADS,
-            "head_dim": LAGUNA_DFLASH_HEAD_DIM,
-            "sliding_window": LAGUNA_DFLASH_SLIDING_WINDOW,
-            "gating": "per-head",
-            "block_size": LAGUNA_DFLASH_BLOCK_SIZE,
-            "mask_token_id": LAGUNA_DFLASH_MASK_TOKEN_ID,
-            "num_target_layers": LAGUNA_DFLASH_TARGET_LAYER_COUNT,
-            "vocab_size": LAGUNA_DFLASH_VOCAB_SIZE,
-            "draft_vocab_size": LAGUNA_DFLASH_VOCAB_SIZE,
-        }
-        for key, expected_value in expected.items():
-            actual = getattr(self, key)
-            if actual != expected_value:
-                raise ValueError(
-                    f"Laguna S 2.1 DFlash {key} mismatch: expected "
-                    f"{expected_value!r}, got {actual!r}."
-                )
-
         if self.model_type != "laguna":
             raise ValueError(
-                f"Laguna S 2.1 DFlash requires model_type='laguna', got {self.model_type!r}."
+                f"Laguna DFlash requires model_type='laguna', got {self.model_type!r}."
             )
-        if self.layer_types != ["sliding_attention"] * LAGUNA_DFLASH_NUM_LAYERS:
+        positive_fields = (
+            "hidden_size",
+            "intermediate_size",
+            "num_hidden_layers",
+            "num_attention_heads",
+            "num_key_value_heads",
+            "head_dim",
+            "vocab_size",
+            "draft_vocab_size",
+            "max_position_embeddings",
+            "sliding_window",
+            "block_size",
+            "num_target_layers",
+        )
+        for key in positive_fields:
+            if not isinstance(getattr(self, key), int) or getattr(self, key) <= 0:
+                raise ValueError(f"Laguna DFlash requires a positive integer {key}.")
+        if not 0 <= self.mask_token_id < self.vocab_size:
             raise ValueError(
-                "Laguna S 2.1 DFlash requires all six draft layers to use "
-                "sliding_attention."
+                "Laguna DFlash mask_token_id must be inside the draft vocabulary."
             )
-        if (
-            self.sliding_windows
-            != [LAGUNA_DFLASH_SLIDING_WINDOW] * LAGUNA_DFLASH_NUM_LAYERS
+        if self.num_key_value_heads > self.num_attention_heads:
+            raise ValueError(
+                "Laguna DFlash num_key_value_heads cannot exceed num_attention_heads."
+            )
+        if self.gating != "per-head":
+            raise ValueError("Laguna DFlash currently supports per-head gating only.")
+        if len(self.layer_types) != self.num_hidden_layers or any(
+            layer_type != "sliding_attention" for layer_type in self.layer_types
         ):
             raise ValueError(
-                "Laguna S 2.1 DFlash requires a 512 sliding window for every draft layer."
+                "Laguna DFlash requires one sliding_attention layer type per draft layer."
             )
-        if self.target_layer_ids != LAGUNA_DFLASH_TARGET_LAYERS:
+        if len(self.sliding_windows) != self.num_hidden_layers or any(
+            window != self.sliding_window for window in self.sliding_windows
+        ):
             raise ValueError(
-                "Laguna S 2.1 DFlash target_layer_ids mismatch: expected "
-                f"{LAGUNA_DFLASH_TARGET_LAYERS}, got {self.target_layer_ids}."
+                "Laguna DFlash requires one matching sliding window per draft layer."
             )
-        if self.aux_hidden_state_layer_ids != LAGUNA_DFLASH_AUX_LAYER_IDS:
+        if (
+            len(self.target_layer_ids) != self.num_hidden_layers
+            or not _is_strictly_increasing_ints(self.target_layer_ids)
+            or any(
+                layer_id < 0 or layer_id >= self.num_target_layers
+                for layer_id in self.target_layer_ids
+            )
+        ):
             raise ValueError(
-                "Laguna S 2.1 DFlash auxiliary layer IDs mismatch: expected "
-                f"{LAGUNA_DFLASH_AUX_LAYER_IDS}, got {self.aux_hidden_state_layer_ids}."
+                "Laguna DFlash target_layer_ids must be unique, increasing target-layer "
+                "indices with one capture per draft layer."
+            )
+        if (
+            len(self.aux_hidden_state_layer_ids) != self.num_hidden_layers
+            or not _is_strictly_increasing_ints(self.aux_hidden_state_layer_ids)
+            or any(
+                layer_id < 0 or layer_id > self.num_target_layers
+                for layer_id in self.aux_hidden_state_layer_ids
+            )
+        ):
+            raise ValueError(
+                "Laguna DFlash auxiliary layer IDs must be unique, increasing, and "
+                "compatible with the target-layer count."
             )
         if not self.causal:
             raise ValueError("Laguna S 2.1 DFlash requires causal block attention.")
@@ -176,6 +203,18 @@ class DFlashConfig(BaseModelConfig):
         dflash = raw.pop("dflash_config", None)
         if not isinstance(dflash, Mapping):
             raise ValueError("Laguna DFlash config requires a dflash_config object.")
+        missing = sorted(_REQUIRED_CHECKPOINT_FIELDS - set(raw))
+        if missing:
+            raise ValueError(
+                "Laguna DFlash config is missing checkpoint fields: "
+                f"{', '.join(missing)}."
+            )
+        missing = sorted(_REQUIRED_DFLASH_FIELDS - set(dflash))
+        if missing:
+            raise ValueError(
+                "Laguna DFlash config is missing dflash_config fields: "
+                f"{', '.join(missing)}."
+            )
 
         merged = dict(raw)
         for key in (

--- a/mlx_vlm/speculative/drafters/laguna_dflash/dflash.py
+++ b/mlx_vlm/speculative/drafters/laguna_dflash/dflash.py
@@ -1,0 +1,385 @@
+from typing import Callable, List, Mapping
+
+import mlx.core as mx
+import mlx.nn as nn
+
+from ....models.activations import swiglu
+from ....models.base import scaled_dot_product_attention
+from ....models.cache import KVCache, RotatingKVCache
+from ....models.rope_utils import initialize_rope
+from .config import (
+    DFlashConfig,
+    validate_laguna_dflash_target,
+    validate_laguna_dflash_weights,
+)
+
+
+def _build_rope(config: DFlashConfig):
+    return initialize_rope(
+        dims=config.head_dim,
+        base=config.rope_theta,
+        traditional=False,
+        scaling_config=config.rope_parameters,
+        max_position_embeddings=config.max_position_embeddings,
+    )
+
+
+def _causal_block_mask(query_length: int, context_length: int) -> mx.array:
+    context = mx.ones((query_length, context_length), dtype=mx.bool_)
+    proposal = mx.tril(mx.ones((query_length, query_length), dtype=mx.bool_))
+    return mx.concatenate([context, proposal], axis=-1)
+
+
+def _trim_dflash_context(context, cache, sliding_window):
+    context_length = context.shape[1]
+    if context_length >= sliding_window:
+        skip = context_length - (sliding_window - 1)
+        context = context[:, skip:]
+        context_length = context.shape[1]
+        cache.offset += skip
+    return context, context_length
+
+
+def _project_dflash_qkv(
+    qkv,
+    context_qkv,
+    batch,
+    length,
+    context_length,
+    num_attention_heads,
+    num_key_value_heads,
+    head_dim,
+):
+    q_size = num_attention_heads * head_dim
+    kv_size = num_key_value_heads * head_dim
+    queries = qkv[..., :q_size]
+    proposal_keys = qkv[..., q_size : q_size + kv_size]
+    proposal_values = qkv[..., q_size + kv_size :]
+    context_keys = context_qkv[..., q_size : q_size + kv_size]
+    context_values = context_qkv[..., q_size + kv_size :]
+
+    queries = queries.reshape(batch, length, num_attention_heads, head_dim).transpose(
+        0, 2, 1, 3
+    )
+    context_keys = context_keys.reshape(
+        batch, context_length, num_key_value_heads, head_dim
+    ).transpose(0, 2, 1, 3)
+    proposal_keys = proposal_keys.reshape(
+        batch, length, num_key_value_heads, head_dim
+    ).transpose(0, 2, 1, 3)
+    context_values = context_values.reshape(
+        batch, context_length, num_key_value_heads, head_dim
+    ).transpose(0, 2, 1, 3)
+    proposal_values = proposal_values.reshape(
+        batch, length, num_key_value_heads, head_dim
+    ).transpose(0, 2, 1, 3)
+    return queries, context_keys, proposal_keys, context_values, proposal_values
+
+
+def _normalize_dflash_qkv(projected, q_norm, k_norm):
+    queries, context_keys, proposal_keys, context_values, proposal_values = projected
+    return (
+        q_norm(queries.transpose(0, 2, 1, 3)).transpose(0, 2, 1, 3),
+        k_norm(context_keys.transpose(0, 2, 1, 3)).transpose(0, 2, 1, 3),
+        k_norm(proposal_keys.transpose(0, 2, 1, 3)).transpose(0, 2, 1, 3),
+        context_values,
+        proposal_values,
+    )
+
+
+def _apply_dflash_attention(attention, x, projected, rope, cache):
+    queries, context_keys, proposal_keys, context_values, proposal_values = projected
+    queries = rope(queries, offset=cache.offset + context_keys.shape[2])
+    context_keys = rope(context_keys, offset=cache.offset)
+    proposal_keys = rope(proposal_keys, offset=cache.offset + context_keys.shape[2])
+    cached_keys, cached_values = cache.update_and_fetch(context_keys, context_values)
+    keys = mx.concatenate([cached_keys, proposal_keys], axis=2)
+    values = mx.concatenate([cached_values, proposal_values], axis=2)
+    mask = (
+        _causal_block_mask(queries.shape[2], cached_keys.shape[2])
+        if attention.causal
+        else None
+    )
+    output = scaled_dot_product_attention(
+        queries, keys, values, cache=None, scale=attention.scale, mask=mask
+    )
+    batch, length, _ = x.shape
+    output = output.transpose(0, 2, 1, 3).reshape(batch, length, -1)
+    gate = nn.softplus(attention.g_proj(x).astype(mx.float32)).astype(output.dtype)
+    output = (
+        output.reshape(batch, length, attention.n_heads, attention.head_dim)
+        * gate[..., None]
+    ).reshape(batch, length, -1)
+    return attention.o_proj(output)
+
+
+class LagunaDFlashAttention(nn.Module):
+    def __init__(self, config: DFlashConfig, layer_idx: int):
+        super().__init__()
+        self.n_heads = config.num_attention_heads
+        self.n_kv_heads = config.num_key_value_heads
+        self.head_dim = config.head_dim
+        self.scale = self.head_dim**-0.5
+        self.sliding_window = config.sliding_window
+        self.causal = config.causal
+        dim = config.hidden_size
+        qkv_size = (self.n_heads + 2 * self.n_kv_heads) * self.head_dim
+        self.qkv_proj = nn.Linear(dim, qkv_size, bias=config.qkv_bias)
+        self.o_proj = nn.Linear(self.n_heads * self.head_dim, dim, bias=False)
+        self.g_proj = nn.Linear(dim, self.n_heads, bias=False)
+        self.q_norm = nn.RMSNorm(self.head_dim, eps=config.rms_norm_eps)
+        self.k_norm = nn.RMSNorm(self.head_dim, eps=config.rms_norm_eps)
+        self.layer_idx = layer_idx
+
+    def __call__(
+        self,
+        x: mx.array,
+        context: mx.array,
+        rope,
+        cache: RotatingKVCache,
+    ) -> mx.array:
+        batch, length, _ = x.shape
+        context, context_length = _trim_dflash_context(
+            context, cache, self.sliding_window
+        )
+        qkv = self.qkv_proj(x)
+        context_qkv = self.qkv_proj(context)
+        projected = _project_dflash_qkv(
+            qkv,
+            context_qkv,
+            batch,
+            length,
+            context_length,
+            self.n_heads,
+            self.n_kv_heads,
+            self.head_dim,
+        )
+        projected = _normalize_dflash_qkv(
+            projected,
+            self.q_norm,
+            self.k_norm,
+        )
+        return _apply_dflash_attention(self, x, projected, rope, cache)
+
+
+class LagunaDFlashDecoderLayer(nn.Module):
+    def __init__(self, config: DFlashConfig, layer_idx: int):
+        super().__init__()
+        self.self_attn = LagunaDFlashAttention(config, layer_idx)
+        self.mlp = LagunaDFlashMLP(config.hidden_size, config.intermediate_size)
+        self.input_layernorm = nn.RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.post_attention_layernorm = nn.RMSNorm(
+            config.hidden_size, eps=config.rms_norm_eps
+        )
+
+    def __call__(self, x, context, rope, cache):
+        h = x + self.self_attn(self.input_layernorm(x), context, rope, cache)
+        return h + self.mlp(self.post_attention_layernorm(h))
+
+
+class LagunaDFlashMLP(nn.Module):
+    def __init__(self, dim: int, hidden_dim: int):
+        super().__init__()
+        self.gate_proj = nn.Linear(dim, hidden_dim, bias=False)
+        self.down_proj = nn.Linear(hidden_dim, dim, bias=False)
+        self.up_proj = nn.Linear(dim, hidden_dim, bias=False)
+
+    def __call__(self, x: mx.array) -> mx.array:
+        return self.down_proj(swiglu(self.gate_proj(x), self.up_proj(x)))
+
+
+def sanitize_laguna_dflash_weights(
+    weights: Mapping[str, mx.array], config: DFlashConfig
+) -> dict[str, mx.array]:
+    """Normalize published or HF-prefixed keys and fuse split QKV weights."""
+    normalized = {}
+    split_qkv: dict[int, dict[str, mx.array]] = {}
+    for key, value in weights.items():
+        key = key.removeprefix("model.")
+        parts = key.split(".")
+        if len(parts) >= 5 and parts[0] == "layers" and parts[2] == "self_attn":
+            layer = int(parts[1])
+            projection = parts[3]
+            if projection in {"q_proj", "k_proj", "v_proj"}:
+                split_qkv.setdefault(layer, {})[projection] = value
+                continue
+        if key in normalized:
+            raise ValueError(
+                f"Duplicate Laguna DFlash weight key after sanitization: {key}"
+            )
+        normalized[key] = value
+
+    for layer, projections in split_qkv.items():
+        missing = {"q_proj", "k_proj", "v_proj"} - set(projections)
+        if missing:
+            raise ValueError(
+                f"Laguna DFlash layer {layer} has incomplete split QKV weights: "
+                f"missing={sorted(missing)}."
+            )
+        key = f"layers.{layer}.self_attn.qkv_proj.weight"
+        if key in normalized:
+            raise ValueError(
+                f"Laguna DFlash has both fused and split QKV weights for layer {layer}."
+            )
+        normalized[key] = mx.concatenate(
+            [projections["q_proj"], projections["k_proj"], projections["v_proj"]],
+            axis=0,
+        )
+
+    validate_laguna_dflash_weights(normalized, config)
+    return normalized
+
+
+class LagunaDFlashDraftModel(nn.Module):
+    def __init__(self, config: DFlashConfig):
+        super().__init__()
+        config.validate()
+        self.config = config
+        self.layers = [
+            LagunaDFlashDecoderLayer(config, index)
+            for index in range(config.num_hidden_layers)
+        ]
+        self.aux_hidden_norms = [
+            nn.RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+            for _ in config.target_layer_ids
+        ]
+        self.fc = nn.Linear(
+            len(config.target_layer_ids) * config.hidden_size,
+            config.hidden_size,
+            bias=False,
+        )
+        self.hidden_norm = nn.RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.norm = nn.RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.rope = _build_rope(config)
+        self.embed_tokens = None
+        self.lm_head = None
+        self.embed_scale = 1.0
+        self.accept_lens: List[int] = []
+        self.draft_lens: List[int] = []
+
+    def bind(self, target_model, tokenizer=None) -> "LagunaDFlashDraftModel":
+        inner = getattr(target_model, "model", target_model)
+        language_model = getattr(target_model, "language_model", None)
+        if language_model is not None:
+            inner = getattr(language_model, "model", language_model)
+        if not hasattr(inner, "embed_tokens"):
+            raise AttributeError(
+                f"Cannot find target embed_tokens in {type(target_model).__name__}."
+            )
+
+        target_config = getattr(language_model, "config", None)
+        if target_config is None:
+            target_config = getattr(target_model, "config", None)
+        target_layers = getattr(inner, "layers", None)
+        target_layer_count = len(target_layers) if target_layers is not None else None
+        tokenizer_length = len(tokenizer) if tokenizer is not None else None
+        if tokenizer_length is None and target_config is not None:
+            tokenizer_length = getattr(target_config, "vocab_size", None)
+        validate_laguna_dflash_target(
+            self.config,
+            target_model_config=target_config,
+            target_model_layer_count=target_layer_count,
+            target_tokenizer_length=tokenizer_length,
+        )
+        self.embed_tokens = inner.embed_tokens
+        self.embed_scale = getattr(self.embed_tokens, "embed_scale", 1.0)
+        lm = getattr(target_model, "language_model", target_model)
+        self.lm_head = getattr(lm, "lm_head", None) or self.embed_tokens.as_linear
+        return self
+
+    def validate_target_compatibility(self, target_model) -> None:
+        target = getattr(target_model, "language_model", target_model)
+        target_inner = getattr(target, "model", target)
+        target_layers = getattr(target_inner, "layers", None)
+        validate_laguna_dflash_target(
+            self.config,
+            target_model_config=getattr(target, "config", None),
+            target_model_layer_count=(
+                len(target_layers) if target_layers is not None else None
+            ),
+        )
+
+    def make_cache(self) -> List[KVCache]:
+        return [
+            RotatingKVCache(max_size=self.config.sliding_window - 1, keep=0)
+            for _ in self.layers
+        ]
+
+    def reset(self, target_model, tokenizer=None) -> List[KVCache]:
+        self.bind(target_model, tokenizer=tokenizer)
+        self.accept_lens = []
+        self.draft_lens = []
+        return self.make_cache()
+
+    def _embed_input_tokens(self, inputs: mx.array) -> mx.array:
+        if self.embed_tokens is None:
+            raise RuntimeError("bind(target_model) must run before DFlash generation.")
+        return self.embed_tokens(inputs) * self.embed_scale
+
+    def _combine_hidden(self, target_hidden: mx.array) -> mx.array:
+        expected = len(self.config.target_layer_ids) * self.config.hidden_size
+        if target_hidden.shape[-1] != expected:
+            raise ValueError(
+                "Laguna DFlash target hidden state shape mismatch: expected last "
+                f"dimension {expected}, got {target_hidden.shape[-1]}."
+            )
+        slices = mx.split(target_hidden, len(self.aux_hidden_norms), axis=-1)
+        normalized = [norm(value) for norm, value in zip(self.aux_hidden_norms, slices)]
+        return self.hidden_norm(self.fc(mx.concatenate(normalized, axis=-1)))
+
+    def _hidden(self, inputs, target_hidden, cache):
+        h = self._embed_input_tokens(inputs)
+        context = self._combine_hidden(target_hidden)
+        for layer, layer_cache in zip(self.layers, cache):
+            h = layer(h, context, self.rope, layer_cache)
+        return self.norm(h)
+
+    def _logits(self, hidden):
+        if self.lm_head is None:
+            raise RuntimeError("bind(target_model) must run before DFlash generation.")
+        return self.lm_head(hidden)
+
+    def __call__(self, inputs, target_hidden, cache):
+        return self._logits(self._hidden(inputs, target_hidden, cache))
+
+    def draft_block(
+        self,
+        last_bonus,
+        hidden: mx.array,
+        cache: List[KVCache],
+        block_size: int,
+        sampler: Callable[[mx.array], mx.array],
+        token_dtype: mx.Dtype = mx.int32,
+    ) -> mx.array:
+        mask_id = self.config.mask_token_id
+        if isinstance(last_bonus, int):
+            block = mx.array(
+                [[last_bonus] + [mask_id] * (block_size - 1)], dtype=token_dtype
+            )
+        else:
+            batch = last_bonus.shape[0]
+            masks = mx.full((batch, block_size - 1), mask_id, dtype=token_dtype)
+            block = mx.concatenate(
+                [last_bonus[:, None].astype(token_dtype), masks], axis=1
+            )
+        return sampler(self._logits(self._hidden(block, hidden, cache)[:, 1:]))
+
+    def sanitize(self, weights: Mapping[str, mx.array]) -> dict[str, mx.array]:
+        return sanitize_laguna_dflash_weights(weights, self.config)
+
+    def load_weights(self, weights, strict=True):
+        normalized = sanitize_laguna_dflash_weights(dict(weights), self.config)
+        return super().load_weights(list(normalized.items()), strict=strict)
+
+
+DFlashKVCache = KVCache
+Model = LagunaDFlashDraftModel
+
+
+__all__ = [
+    "DFlashKVCache",
+    "LagunaDFlashDraftModel",
+    "LagunaDFlashAttention",
+    "sanitize_laguna_dflash_weights",
+    "Model",
+]

--- a/mlx_vlm/tests/test_laguna_dflash_drafter.py
+++ b/mlx_vlm/tests/test_laguna_dflash_drafter.py
@@ -1,0 +1,151 @@
+from types import SimpleNamespace
+
+import pytest
+
+from mlx_vlm.speculative.drafters.laguna_dflash import ModelConfig
+from mlx_vlm.speculative.drafters.laguna_dflash.config import (
+    LAGUNA_DFLASH_AUX_LAYER_IDS,
+    LAGUNA_DFLASH_TARGET_LAYERS,
+    expected_laguna_dflash_weight_shapes,
+    validate_laguna_dflash_target,
+    validate_laguna_dflash_weights,
+)
+
+
+def _config_dict():
+    return {
+        "model_type": "laguna",
+        "hidden_size": 3072,
+        "intermediate_size": 12288,
+        "num_hidden_layers": 6,
+        "num_attention_heads": 72,
+        "num_key_value_heads": 8,
+        "head_dim": 128,
+        "rms_norm_eps": 1e-6,
+        "max_position_embeddings": 1048576,
+        "rope_theta": 500000.0,
+        "vocab_size": 100352,
+        "draft_vocab_size": 100352,
+        "layer_types": ["sliding_attention"] * 6,
+        "sliding_windows": [512] * 6,
+        "sliding_window": 512,
+        "gating": "per-head",
+        "eagle_aux_hidden_state_layer_ids": LAGUNA_DFLASH_AUX_LAYER_IDS,
+        "dflash_config": {
+            "block_size": 16,
+            "mask_token_id": 12,
+            "num_target_layers": 48,
+            "target_layer_ids": LAGUNA_DFLASH_TARGET_LAYERS,
+            "causal": True,
+        },
+    }
+
+
+def test_poolside_config_is_exact_and_has_six_aux_norms():
+    config = ModelConfig.from_dict(_config_dict())
+
+    assert config.hidden_size == 3072
+    assert config.num_hidden_layers == 6
+    assert config.num_attention_heads == 72
+    assert config.num_key_value_heads == 8
+    assert config.head_dim == 128
+    assert config.layer_types == ["sliding_attention"] * 6
+    assert config.sliding_window == 512
+    assert config.target_layer_ids == [1, 10, 19, 29, 38, 47]
+    assert config.num_target_layers == 48
+    assert config.mask_token_id == 12
+    assert config.vocab_size == config.draft_vocab_size == 100352
+    assert config.block_size == 16
+    assert len(config.aux_hidden_state_layer_ids) == 6
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("hidden_size", 3076),
+        ("num_hidden_layers", 5),
+        ("num_attention_heads", 64),
+        ("num_key_value_heads", 4),
+        ("head_dim", 64),
+        ("sliding_window", 256),
+        ("gating", "per-element"),
+        ("block_size", 8),
+        ("mask_token_id", 0),
+        ("num_target_layers", 47),
+        ("vocab_size", 100351),
+        ("draft_vocab_size", 100350),
+        ("layer_types", ["full_attention"] * 6),
+        ("target_layer_ids", [1, 10, 19, 29, 38, 46]),
+    ],
+)
+def test_config_mismatch_is_rejected(field, value):
+    params = _config_dict()
+    if field in {
+        "block_size",
+        "mask_token_id",
+        "num_target_layers",
+        "target_layer_ids",
+    }:
+        params["dflash_config"][field] = value
+    else:
+        params[field] = value
+
+    with pytest.raises(ValueError, match="Laguna S 2.1 DFlash"):
+        ModelConfig.from_dict(params)
+
+
+def test_target_layer_count_and_tokenizer_length_are_checked():
+    config = ModelConfig.from_dict(_config_dict())
+    target = SimpleNamespace(num_hidden_layers=48, vocab_size=100352)
+
+    validate_laguna_dflash_target(
+        config,
+        target_model_config=target,
+        target_tokenizer_length=100352,
+    )
+    with pytest.raises(ValueError, match="layer count"):
+        validate_laguna_dflash_target(
+            config,
+            target_model_config=SimpleNamespace(num_hidden_layers=47),
+            target_tokenizer_length=100352,
+        )
+    with pytest.raises(ValueError, match="vocabulary"):
+        validate_laguna_dflash_target(
+            config,
+            target_model_config=target,
+            target_tokenizer_length=100351,
+        )
+
+
+def test_published_weight_keys_and_shapes_are_explicit():
+    config = ModelConfig.from_dict(_config_dict())
+    expected = expected_laguna_dflash_weight_shapes(config)
+    assert expected["layers.0.self_attn.o_proj.weight"] == (3072, 9216)
+    weights = {key: SimpleNamespace(shape=shape) for key, shape in expected.items()}
+
+    validate_laguna_dflash_weights(weights, config)
+    bad = dict(weights)
+    bad["layers.0.self_attn.g_proj.weight"] = SimpleNamespace(shape=(71, 3072))
+    with pytest.raises(ValueError, match="weight shapes"):
+        validate_laguna_dflash_weights(bad, config)
+
+
+def test_quantized_weight_auxiliaries_are_accepted():
+    config = ModelConfig.from_dict(_config_dict())
+    expected = expected_laguna_dflash_weight_shapes(config)
+    weights = {key: SimpleNamespace(shape=shape) for key, shape in expected.items()}
+    weights["fc.weight"] = SimpleNamespace(shape=(3072, 9216))
+    weights["fc.scales"] = SimpleNamespace(shape=(3072, 288))
+    weights["fc.biases"] = SimpleNamespace(shape=(3072, 288))
+
+    validate_laguna_dflash_weights(weights, config)
+
+
+def test_weight_key_drift_is_rejected():
+    config = ModelConfig.from_dict(_config_dict())
+    expected = expected_laguna_dflash_weight_shapes(config)
+    weights = {key: SimpleNamespace(shape=shape) for key, shape in expected.items()}
+    weights["layers.0.self_attn.extra.weight"] = SimpleNamespace(shape=(1,))
+
+    with pytest.raises(ValueError, match="weight keys"):
+        validate_laguna_dflash_weights(weights, config)

--- a/mlx_vlm/tests/test_laguna_dflash_drafter.py
+++ b/mlx_vlm/tests/test_laguna_dflash_drafter.py
@@ -4,8 +4,6 @@ import pytest
 
 from mlx_vlm.speculative.drafters.laguna_dflash import ModelConfig
 from mlx_vlm.speculative.drafters.laguna_dflash.config import (
-    LAGUNA_DFLASH_AUX_LAYER_IDS,
-    LAGUNA_DFLASH_TARGET_LAYERS,
     expected_laguna_dflash_weight_shapes,
     validate_laguna_dflash_target,
     validate_laguna_dflash_weights,
@@ -30,12 +28,12 @@ def _config_dict():
         "sliding_windows": [512] * 6,
         "sliding_window": 512,
         "gating": "per-head",
-        "eagle_aux_hidden_state_layer_ids": LAGUNA_DFLASH_AUX_LAYER_IDS,
+        "eagle_aux_hidden_state_layer_ids": [2, 11, 20, 30, 39, 48],
         "dflash_config": {
             "block_size": 16,
             "mask_token_id": 12,
             "num_target_layers": 48,
-            "target_layer_ids": LAGUNA_DFLASH_TARGET_LAYERS,
+            "target_layer_ids": [1, 10, 19, 29, 38, 47],
             "causal": True,
         },
     }
@@ -59,38 +57,69 @@ def test_poolside_config_is_exact_and_has_six_aux_norms():
     assert len(config.aux_hidden_state_layer_ids) == 6
 
 
+def test_checkpoint_values_drive_the_contract_and_weight_shapes():
+    params = _config_dict()
+    params.update(
+        {
+            "hidden_size": 4096,
+            "intermediate_size": 16384,
+            "num_hidden_layers": 4,
+            "num_attention_heads": 32,
+            "num_key_value_heads": 4,
+            "head_dim": 128,
+            "vocab_size": 100480,
+            "draft_vocab_size": 100480,
+            "layer_types": ["sliding_attention"] * 4,
+            "sliding_windows": [1024] * 4,
+            "sliding_window": 1024,
+            "eagle_aux_hidden_state_layer_ids": [2, 18, 34, 50],
+        }
+    )
+    params["dflash_config"].update(
+        {
+            "block_size": 8,
+            "mask_token_id": 17,
+            "num_target_layers": 64,
+            "target_layer_ids": [1, 17, 33, 49],
+        }
+    )
+
+    config = ModelConfig.from_dict(params)
+
+    assert config.hidden_size == 4096
+    assert config.num_hidden_layers == 4
+    assert config.target_layer_ids == [1, 17, 33, 49]
+    assert expected_laguna_dflash_weight_shapes(config)["fc.weight"] == (4096, 16384)
+
+
 @pytest.mark.parametrize(
-    ("field", "value"),
+    ("mutate", "message"),
     [
-        ("hidden_size", 3076),
-        ("num_hidden_layers", 5),
-        ("num_attention_heads", 64),
-        ("num_key_value_heads", 4),
-        ("head_dim", 64),
-        ("sliding_window", 256),
-        ("gating", "per-element"),
-        ("block_size", 8),
-        ("mask_token_id", 0),
-        ("num_target_layers", 47),
-        ("vocab_size", 100351),
-        ("draft_vocab_size", 100350),
-        ("layer_types", ["full_attention"] * 6),
-        ("target_layer_ids", [1, 10, 19, 29, 38, 46]),
+        (
+            lambda params: params.pop("hidden_size"),
+            "missing checkpoint fields: hidden_size",
+        ),
+        (
+            lambda params: params["dflash_config"].pop("target_layer_ids"),
+            "missing dflash_config fields: target_layer_ids",
+        ),
+        (
+            lambda params: params.update({"layer_types": ["full_attention"] * 6}),
+            "sliding_attention",
+        ),
+        (
+            lambda params: params["dflash_config"].update(
+                {"target_layer_ids": [1, 10, 19, 29, 38, 48]}
+            ),
+            "target_layer_ids",
+        ),
     ],
 )
-def test_config_mismatch_is_rejected(field, value):
+def test_malformed_checkpoint_contract_is_rejected(mutate, message):
     params = _config_dict()
-    if field in {
-        "block_size",
-        "mask_token_id",
-        "num_target_layers",
-        "target_layer_ids",
-    }:
-        params["dflash_config"][field] = value
-    else:
-        params[field] = value
+    mutate(params)
 
-    with pytest.raises(ValueError, match="Laguna S 2.1 DFlash"):
+    with pytest.raises(ValueError, match=message):
         ModelConfig.from_dict(params)
 
 

--- a/mlx_vlm/tests/test_laguna_dflash_drafter.py
+++ b/mlx_vlm/tests/test_laguna_dflash_drafter.py
@@ -2,6 +2,7 @@ from types import SimpleNamespace
 
 import pytest
 
+from mlx_vlm.speculative.drafters import validate_drafter_compatibility
 from mlx_vlm.speculative.drafters.laguna_dflash import ModelConfig
 from mlx_vlm.speculative.drafters.laguna_dflash.config import (
     expected_laguna_dflash_weight_shapes,
@@ -144,6 +145,30 @@ def test_target_layer_count_and_tokenizer_length_are_checked():
             target_model_config=target,
             target_tokenizer_length=100351,
         )
+
+
+def test_generic_drafter_gate_invokes_laguna_target_validation():
+    from mlx_vlm.speculative.drafters.laguna_dflash import LagunaDFlashDraftModel
+
+    draft = LagunaDFlashDraftModel(ModelConfig.from_dict(_config_dict()))
+    target = SimpleNamespace(
+        config=SimpleNamespace(num_hidden_layers=48, vocab_size=100352),
+        model=SimpleNamespace(layers=[object()] * 48),
+    )
+
+    validate_drafter_compatibility(target, draft, "dflash")
+    target.model.layers.pop()
+    with pytest.raises(ValueError, match="layer count"):
+        validate_drafter_compatibility(target, draft, "dflash")
+
+
+def test_generic_model_loader_selects_laguna_dflash_backend():
+    from mlx_vlm.utils import get_model_and_args
+
+    architecture, model_type = get_model_and_args(_config_dict())
+
+    assert model_type == "laguna_dflash"
+    assert architecture.Model.__name__ == "LagunaDFlashDraftModel"
 
 
 def test_published_weight_keys_and_shapes_are_explicit():


### PR DESCRIPTION
## Summary

Adds a pure Laguna S 2.1 DFlash checkpoint contract:

- parse and validate the published DFlash configuration;
- reject target-layer-count or tokenizer-vocabulary mismatches before target binding;
- validate the expected checkpoint weight keys and tensor shapes, including quantized weight auxiliaries.

## Scope

The published DFlash checkpoint has a fixed six-layer draft architecture and
requires a 48-layer Laguna target with the shared 100352-token vocabulary.
This slice makes those compatibility requirements executable before later
loader or speculative-generation wiring consumes the checkpoint.

## Tests

- `python -m pytest mlx_vlm/tests/test_laguna_dflash_drafter.py -q` (`19 passed`)
- `python -m pytest mlx_vlm/tests/test_models.py -k laguna -q` (`7 passed`)
- `pre-commit run --files ...` (Black, isort, autoflake)

## Excluded

No model loading, conversion, generation, cache handling, server wiring,
runtime configuration, or performance claim is included. Subsequent DFlash
implementation slices will build on this validation boundary.
