### PR TITLE
fix: isolate Qwen MTP shards during sanitization

### DIFF
--- a/mlx_vlm/models/qwen3_5/qwen3_5.py
+++ b/mlx_vlm/models/qwen3_5/qwen3_5.py
@@ -142,10 +142,10 @@ class Model(Qwen3VLModel):
         return inputs_embeds, special_image_mask
 
     def sanitize(self, weights):
-        shift_norm_weights = should_shift_norm_weights(weights)
-
-        # ignore mtp weights
+        # The MTP draft shard is separate from the base model. Its presence
+        # must not select the base model's RMSNorm loading convention.
         weights = {key: value for key, value in weights.items() if "mtp." not in key}
+        shift_norm_weights = should_shift_norm_weights(weights)
 
         if self.config.text_config.tie_word_embeddings:
             weights.pop("lm_head.weight", None)

--- a/mlx_vlm/models/qwen3_5_moe/qwen3_5_moe.py
+++ b/mlx_vlm/models/qwen3_5_moe/qwen3_5_moe.py
@@ -23,10 +23,10 @@ class Model(Qwen3_5Model):
         self.language_model = LanguageModel(config.text_config, config)
 
     def sanitize(self, weights):
-        shift_norm_weights = should_shift_norm_weights(weights)
-
-        # ignore mtp weights
+        # The MTP draft shard is separate from the base model. Its presence
+        # must not select the base model's RMSNorm loading convention.
         weights = {key: value for key, value in weights.items() if "mtp." not in key}
+        shift_norm_weights = should_shift_norm_weights(weights)
 
         if self.config.text_config.tie_word_embeddings:
             weights.pop("lm_head.weight", None)

--- a/mlx_vlm/tests/test_qwen3_5_mtp_sanitize.py
+++ b/mlx_vlm/tests/test_qwen3_5_mtp_sanitize.py
@@ -1,0 +1,39 @@
+from types import SimpleNamespace
+
+import mlx.core as mx
+
+from mlx_vlm.models.qwen3_5.qwen3_5 import Model as DenseModel
+from mlx_vlm.models.qwen3_5_moe.qwen3_5_moe import Model as MoEModel
+
+
+def _model_for_sanitize(model_class):
+    model = model_class.__new__(model_class)
+    model.config = SimpleNamespace(
+        text_config=SimpleNamespace(tie_word_embeddings=False, num_hidden_layers=0)
+    )
+    return model
+
+
+def _weights_with_draft_shard():
+    return {
+        "language_model.model.layers.0.input_layernorm.weight": mx.array([2.0]),
+        "language_model.mtp.layers.0.input_layernorm.weight": mx.array([1.0]),
+    }
+
+
+def test_dense_qwen_mtp_shard_does_not_shift_base_norm_weights():
+    weights = _model_for_sanitize(DenseModel).sanitize(_weights_with_draft_shard())
+
+    assert weights["language_model.model.layers.0.input_layernorm.weight"].tolist() == [
+        2.0
+    ]
+    assert not any("mtp." in key for key in weights)
+
+
+def test_moe_qwen_mtp_shard_does_not_shift_base_norm_weights():
+    weights = _model_for_sanitize(MoEModel).sanitize(_weights_with_draft_shard())
+
+    assert weights["language_model.model.layers.0.input_layernorm.weight"].tolist() == [
+        2.0
+    ]
+    assert not any("mtp." in key for key in weights)


### PR DESCRIPTION
## Summary

Prevent Qwen 3.5 VLM sanitization from letting MTP draft-shard keys select the base model RMSNorm loading convention.

The sanitizers already discard `mtp.*` tensors. They computed `shift_norm_weights` before that discard, so an attached `language_model.mtp.*` shard caused base RMSNorm values to receive the MTP offset. This moves the decision after draft keys are filtered for both dense and MoE Qwen 3.5 VLM implementations.

## Regression coverage

Adds focused dense and MoE tests using a base norm plus an MTP-shard norm. The base value remains unchanged and no MTP key reaches the sanitized result.

## Reproduction boundary

Validated locally with standalone Qwen MTP composite artifacts whose index maps `language_model.mtp.*` tensors to `model-mtp.safetensors`:

- Qwen 3.6 35B-A3B VLM MTP
- Qwen 3.5 122B-A10B VLM MTP

Before the change, the text route emitted corrupted output even with MTP disabled. With the change, the same artifacts returned normal final text. This PR does not claim speculative-throughput improvement or change MTP decoding behavior; it fixes base-weight sanitization when a draft shard is present.