### PR TITLE
Inkling: batch-cache position fix, depth-8 MTP empty-cache fixes, numpy dMel input

### DIFF
--- a/mlx_vlm/models/inkling/__init__.py
+++ b/mlx_vlm/models/inkling/__init__.py
@@ -3,3 +3,37 @@ from .inkling import Model
 from .language import LanguageModel
 
 __all__ = ["Model", "ModelConfig", "LanguageModel"]
+
+
+def _patch_hf_processor_dmel_numpy():
+    """Let InklingProcessor._extract_dmel_bins accept numpy input.
+
+    The HF processor assumes torch tensors, but this pipeline runs the
+    feature extractor with numpy return types, which crashes the dMel bin
+    extraction with `'numpy.ndarray' object has no attribute 'to'`. Coerce
+    numpy -> torch for the call and hand back numpy when numpy came in, so
+    the surrounding BatchFeature conversion stays type-consistent.
+    """
+    try:
+        import numpy as np
+        from transformers.models.inkling.processing_inkling import InklingProcessor
+    except Exception:  # transformers without inkling — nothing to patch
+        return
+    orig = InklingProcessor._extract_dmel_bins
+    if getattr(orig, "_mlx_vlm_numpy_ok", False):
+        return
+
+    def _extract_dmel_bins(self, input_features):
+        import torch
+
+        was_numpy = isinstance(input_features, np.ndarray)
+        if was_numpy:
+            input_features = torch.from_numpy(input_features)
+        out = orig(self, input_features)
+        return out.numpy() if was_numpy else out
+
+    _extract_dmel_bins._mlx_vlm_numpy_ok = True
+    InklingProcessor._extract_dmel_bins = _extract_dmel_bins
+
+
+_patch_hf_processor_dmel_numpy()

--- a/mlx_vlm/models/inkling/language.py
+++ b/mlx_vlm/models/inkling/language.py
@@ -109,6 +109,14 @@ def banded_additive_mask(rel, proj, q_offset, S, sliding, rel_extent):
     """rel: [B, LQ, H, d_rel]; proj: [d_rel, rel_extent] -> additive mask [B, H, LQ, S]."""
     B, LQ, H, d_rel = rel.shape
     dtype = rel.dtype
+    # Metal template args must be Python int/bool/Dtype. Batch engines (e.g.
+    # omlx) hand cache offsets over as numpy/mx scalars; coerce or the kernel
+    # rejects the template. Scalar Q_OFF also means a batch must share one
+    # offset — true today (per-request rows are padded to a common offset).
+    q_offset = int(q_offset)
+    S = int(S)
+    sliding = int(sliding)
+    rel_extent = int(rel_extent)
     if mx.default_device() == mx.gpu:
         return _mask_kernel(
             inputs=[rel, proj],
@@ -238,10 +246,16 @@ class InklingAttention(nn.Module):
         k = self.k_norm(k.reshape(B, L, self.n_kv, self.head_dim)).transpose(0, 2, 1, 3)
         v = v.reshape(B, L, self.n_kv, self.head_dim).transpose(0, 2, 1, 3)
 
-        offset = kv.offset if kv is not None else 0
         if kv is not None:
             k, v = kv.update_and_fetch(k, v)
         S = k.shape[2]
+        # Query positions derive from the post-update key length: the queries
+        # are always the last L of the S cached positions. Do NOT trust
+        # kv.offset here — batch cache implementations (e.g. an engine's
+        # BatchKVCache) disagree with plain KVCache by one on whether the
+        # in-flight token is counted, which shifts the whole relative-position
+        # band during decode and derails generation.
+        offset = S - L
 
         mask = banded_additive_mask(
             r, self.rel_proj.astype(x.dtype), offset, S, self.sliding, self.rel_extent

--- a/mlx_vlm/models/inkling/language.py
+++ b/mlx_vlm/models/inkling/language.py
@@ -23,11 +23,33 @@ def _clone_cache_tree(value):
     return value
 
 
+# Sentinel marking a KVCache that was empty (keys is None) at snapshot time.
+# KVCache.state raises on empty caches, and the deep-8 MTP drafter legitimately
+# snapshots blocks whose caches have never been written (only block 0 is fed
+# during prefill), so empties must round-trip through snapshot/restore.
+_EMPTY_KV = object()
+
+
+def _subcaches(c):
+    return getattr(c, "caches", None) or [c]
+
+
 def _snapshot_cache_state(caches):
     """Deep-copy the full state of every cache so a speculative block can be
     rolled back by replay. Inkling's short-conv slots keep only the last K-1
     inputs and cannot be trimmed, so we restore-and-replay instead."""
-    snapshot = [None if c is None else _clone_cache_tree(c.state) for c in caches]
+    snapshot = []
+    for c in caches:
+        if c is None:
+            snapshot.append(None)
+            continue
+        subs = []
+        for sc in _subcaches(c):
+            if getattr(sc, "keys", False) is None:
+                subs.append(_EMPTY_KV)
+            else:
+                subs.append(_clone_cache_tree(sc.state))
+        snapshot.append(subs)
     arrays = [v for _, v in tree_flatten(snapshot) if isinstance(v, mx.array)]
     if arrays:
         mx.eval(arrays)
@@ -36,8 +58,15 @@ def _snapshot_cache_state(caches):
 
 def _restore_cache_state(caches, snapshot):
     for c, s in zip(caches, snapshot):
-        if c is not None and s is not None:
-            c.state = _clone_cache_tree(s)
+        if c is None or s is None:
+            continue
+        for sc, ss in zip(_subcaches(c), s):
+            if ss is _EMPTY_KV:
+                sc.keys = None
+                sc.values = None
+                sc.offset = 0
+            else:
+                sc.state = _clone_cache_tree(ss)
 
 
 _MASK_SRC = r"""

--- a/mlx_vlm/speculative/drafters/inkling_mtp/inkling_mtp.py
+++ b/mlx_vlm/speculative/drafters/inkling_mtp/inkling_mtp.py
@@ -176,7 +176,13 @@ class InklingMTPDraftModel(nn.Module):
     def draft_eval_state(self):
         state = [self._seed_token, self._seed_hidden]
         for cache in self._cache:
-            state.append(cache.state)
+            for c in cache.caches:
+                # KVCache.state raises on an empty cache (keys is None), and
+                # the first draft round runs before anything is appended —
+                # skip empties; there is nothing to synchronize on yet.
+                if getattr(c, "keys", False) is None:
+                    continue
+                state.append(c.state)
         return state
 
     def set_shared_kv(


### PR DESCRIPTION
## Summary

Four fixes for the Inkling family, found while serving Inkling-Small (converted per #1756) behind a batch-cache engine and exercising the depth-8 MTP drafter.

## Decode positions (language.py)

The attention read `kv.offset` before `update_and_fetch` to place its relative-position band. Batch cache implementations can disagree with the plain `KVCache` by one on whether the in-flight token is counted in `.offset`, which shifts the band by one position on every decode step and derails generation within a few tokens (it shows up as immediate token loops). Deriving the query position as `S - L` after `update_and_fetch` is correct for any contiguous cache, and is exactly equal to the old value for a plain `KVCache`.

The same function now coerces the Metal kernel template args to Python ints. Engines hand offsets over as numpy or mx scalars, and `mx.fast.metal_kernel` rejects those with "Invalid template argument".

## Empty-cache handling in the MTP chain (language.py, inkling_mtp.py)

With the depth-8 Inkling-Small MTP chain, only block 0 is fed during prefill, so the later blocks are legitimately snapshotted while still empty, and `KVCache.state` raises when `keys` is None. `_snapshot_cache_state` now records empty caches with a sentinel and `_restore_cache_state` restores them to empty. `draft_eval_state` skips empty caches for the same reason on the first draft round.

## numpy input for dMel extraction (models/inkling/__init__.py)

`InklingProcessor._extract_dmel_bins` assumes torch tensors, but this pipeline runs feature extractors with numpy return types, so audio input crashes with "'numpy.ndarray' object has no attribute 'to'". The patch converts numpy to torch for the call and hands numpy back when numpy came in.

## Testing

Verified end to end on Inkling-Small: text, vision, and audio generation, plus greedy MTP speculative decode with token-identity checks against non-speculative baselines at draft block sizes 2, 3, and 4.