### PR TITLE
Video input for models without a video_processor: frames fallback + Inkling native temporal pairs

### DIFF
--- a/mlx_vlm/generate/dispatch.py
+++ b/mlx_vlm/generate/dispatch.py
@@ -163,6 +163,13 @@ def parse_arguments():
         help="Frames-per-second to sample from --video.",
     )
     parser.add_argument(
+        "--video-max-frames",
+        type=int,
+        default=16,
+        help="Cap on frames sent when video falls back to ordered images "
+        "(long clips are re-sampled evenly to this count).",
+    )
+    parser.add_argument(
         "--resize-shape",
         type=int,
         nargs="+",
@@ -1382,9 +1389,22 @@ def main():
                             _np.transpose(f, (1, 2, 0)).astype("uint8")
                         )
                     )
+            sampled = len(frames)
+            max_frames = max(2, getattr(args, "video_max_frames", 16) or 16)
+            if sampled > max_frames:
+                # Long clips: keep frames evenly spaced across the full clip.
+                # Beyond a couple dozen near-identical frames, models start
+                # describing a static scene mixture instead of the sequence,
+                # so more frames costs tokens and loses the temporal thread.
+                idxs = [
+                    round(i * (sampled - 1) / (max_frames - 1))
+                    for i in range(max_frames)
+                ]
+                frames = [frames[i] for i in idxs]
             print(
                 f"{processor.__class__.__name__} has no native video support; "
-                f"sending {len(frames)} sampled frames as ordered images."
+                f"sending {len(frames)} of {sampled} sampled frames as "
+                f"ordered images."
             )
             args.image = (args.image or []) + frames
             args.video = None

--- a/mlx_vlm/generate/dispatch.py
+++ b/mlx_vlm/generate/dispatch.py
@@ -1362,6 +1362,7 @@ def main():
     # Fall back to sampling the video into frames and sending them as ordered
     # images, which any image-capable model handles.
     gen_kwargs_extra = {}
+    inkling_video_prompt = None
     if args.video:
         import inspect as _inspect
 
@@ -1382,8 +1383,10 @@ def main():
         _has_video_component = getattr(processor, "video_processor", None) is not None
         if "videos" not in _proc_params or not _has_video_component:
             frames = []
+            frame_fps = args.fps or 2.0
             for v in args.video:
-                arr, _ = _load_video(str(v), fps=args.fps or 2.0)
+                arr, _sfps = _load_video(str(v), fps=args.fps or 2.0)
+                frame_fps = _sfps or frame_fps
                 for f in arr:
                     frames.append(
                         _PILImage.fromarray(
@@ -1420,10 +1423,53 @@ def main():
                 gen_kwargs_extra["video_temporal_pixels"] = mx.array(
                     _np.asarray(odd_feats)[:, 0]
                 )
+                user_still_count = len(args.image or [])
                 args.image = (args.image or []) + evens
+                # Timestamped single-message prompt. Bare image entities in
+                # separate messages read as a slideshow ("a sequence of still
+                # images"); labeling each pair with its clip time makes the
+                # model ground observations chronologically and track how
+                # positions change. The template renders interleaved
+                # text/image parts natively, so this stays template-faithful.
+                user_text = (
+                    " ".join(args.prompt)
+                    if isinstance(args.prompt, list)
+                    else str(args.prompt)
+                )
+                parts = [{"type": "image"} for _ in range(user_still_count)]
+                parts.append(
+                    {
+                        "type": "text",
+                        "text": "Here is a video as a sequence of frames "
+                        "in chronological order.",
+                    }
+                )
+                for a in anchors:
+                    parts.append(
+                        {
+                            "type": "text",
+                            "text": f"frame at t={a / max(frame_fps, 1e-6):.1f}s:",
+                        }
+                    )
+                    parts.append({"type": "image"})
+                parts.append({"type": "text", "text": user_text})
+                msgs = (
+                    [{"role": "system", "content": args.system}]
+                    if args.system
+                    else []
+                ) + [{"role": "user", "content": parts}]
+                _tok = (
+                    processor.tokenizer
+                    if hasattr(processor, "tokenizer")
+                    else processor
+                )
+                inkling_video_prompt = _tok.apply_chat_template(
+                    msgs, add_generation_prompt=True, tokenize=False
+                )
                 print(
-                    f"inkling native video: {len(evens)} temporal pairs "
-                    f"({odd_feats.shape[0]} patches carry frame 2 of each pair)."
+                    f"inkling native video: {len(evens)} timestamped temporal "
+                    f"pairs ({odd_feats.shape[0]} patches carry frame 2 of "
+                    f"each pair)."
                 )
             else:
                 if sampled > max_frames:
@@ -1455,14 +1501,17 @@ def main():
         chat_template_kwargs["video"] = args.video
         chat_template_kwargs["fps"] = args.fps
 
-    prompt = apply_chat_template(
-        processor,
-        config,
-        prompt,
-        num_images=num_images,
-        num_audios=num_audios,
-        **chat_template_kwargs,
-    )
+    if inkling_video_prompt is not None:
+        prompt = inkling_video_prompt
+    else:
+        prompt = apply_chat_template(
+            processor,
+            config,
+            prompt,
+            num_images=num_images,
+            num_audios=num_audios,
+            **chat_template_kwargs,
+        )
 
     kwargs = {}
 

--- a/mlx_vlm/generate/dispatch.py
+++ b/mlx_vlm/generate/dispatch.py
@@ -1349,6 +1349,46 @@ def main():
             prompt if isinstance(prompt, list) else [prompt]
         )
 
+    # Processors without native video support (no `videos` parameter) used to
+    # drop --video silently: the frames were loaded, the processor ignored the
+    # kwarg, and the model hallucinated an answer with no visual input at all.
+    # Fall back to sampling the video into frames and sending them as ordered
+    # images, which any image-capable model handles.
+    if args.video:
+        import inspect as _inspect
+
+        import numpy as _np
+        from PIL import Image as _PILImage
+
+        from ..utils import load_video as _load_video
+
+        # A `videos` parameter in the signature is not enough: the generic HF
+        # processor skeleton accepts videos but only processes them when a
+        # video_processor component exists, and silently discards them
+        # otherwise. Check for the component, not the parameter.
+        _proc_method = getattr(processor, "process", processor)
+        try:
+            _proc_params = _inspect.signature(_proc_method).parameters
+        except (TypeError, ValueError):
+            _proc_params = {}
+        _has_video_component = getattr(processor, "video_processor", None) is not None
+        if "videos" not in _proc_params or not _has_video_component:
+            frames = []
+            for v in args.video:
+                arr, _ = _load_video(str(v), fps=args.fps or 2.0)
+                for f in arr:
+                    frames.append(
+                        _PILImage.fromarray(
+                            _np.transpose(f, (1, 2, 0)).astype("uint8")
+                        )
+                    )
+            print(
+                f"{processor.__class__.__name__} has no native video support; "
+                f"sending {len(frames)} sampled frames as ordered images."
+            )
+            args.image = (args.image or []) + frames
+            args.video = None
+
     num_images = len(args.image) if args.image is not None else 0
     num_audios = len(args.audio) if args.audio is not None else 0
 

--- a/mlx_vlm/generate/dispatch.py
+++ b/mlx_vlm/generate/dispatch.py
@@ -1361,6 +1361,7 @@ def main():
     # kwarg, and the model hallucinated an answer with no visual input at all.
     # Fall back to sampling the video into frames and sending them as ordered
     # images, which any image-capable model handles.
+    gen_kwargs_extra = {}
     if args.video:
         import inspect as _inspect
 
@@ -1391,22 +1392,57 @@ def main():
                     )
             sampled = len(frames)
             max_frames = max(2, getattr(args, "video_max_frames", 16) or 16)
-            if sampled > max_frames:
-                # Long clips: keep frames evenly spaced across the full clip.
-                # Beyond a couple dozen near-identical frames, models start
-                # describing a static scene mixture instead of the sequence,
-                # so more frames costs tokens and loses the temporal thread.
-                idxs = [
-                    round(i * (sampled - 1) / (max_frames - 1))
-                    for i in range(max_frames)
+            if getattr(model.config, "model_type", "") == "inkling_mm_model":
+                # Inkling's patches are temporal pairs [P, T=2, H, W, C] and
+                # the image processor duplicates a still into both slots.
+                # Feed the video natively instead: consecutive frame pairs
+                # become one image entity each (even frame goes through the
+                # standard still path; the odd frame's patches are spliced
+                # into temporal slot 1 by the model). Halves the token cost
+                # of the plain fallback and gives the encoder real motion.
+                # Pair ADJACENT sampled frames (small displacement between
+                # the two temporal slots, matching how consecutive video
+                # frames relate) at evenly spaced anchor points across the
+                # FULL sampled sequence. Pairing temporally distant frames
+                # into one patch reads as a double exposure instead of motion.
+                if len(frames) % 2:
+                    frames.append(frames[-1])
+                n_pairs = max(2, min(max_frames, len(frames) // 2))
+                anchors = [
+                    min(round(i * (len(frames) - 2) / max(n_pairs - 1, 1)), len(frames) - 2)
+                    for i in range(n_pairs)
                 ]
-                frames = [frames[i] for i in idxs]
-            print(
-                f"{processor.__class__.__name__} has no native video support; "
-                f"sending {len(frames)} of {sampled} sampled frames as "
-                f"ordered images."
-            )
-            args.image = (args.image or []) + frames
+                evens = [frames[a] for a in anchors]
+                odds = [frames[a + 1] for a in anchors]
+                odd_feats = processor.image_processor.preprocess(
+                    images=odds, return_tensors="np"
+                )["pixel_values"]
+                gen_kwargs_extra["video_temporal_pixels"] = mx.array(
+                    _np.asarray(odd_feats)[:, 0]
+                )
+                args.image = (args.image or []) + evens
+                print(
+                    f"inkling native video: {len(evens)} temporal pairs "
+                    f"({odd_feats.shape[0]} patches carry frame 2 of each pair)."
+                )
+            else:
+                if sampled > max_frames:
+                    # Long clips: keep frames evenly spaced across the clip.
+                    # Beyond a couple dozen near-identical frames, models
+                    # start describing a static scene mixture instead of the
+                    # sequence, so more frames costs tokens and loses the
+                    # temporal thread.
+                    idxs = [
+                        round(i * (sampled - 1) / (max_frames - 1))
+                        for i in range(max_frames)
+                    ]
+                    frames = [frames[i] for i in idxs]
+                print(
+                    f"{processor.__class__.__name__} has no native video "
+                    f"support; sending {len(frames)} of {sampled} sampled "
+                    f"frames as ordered images."
+                )
+                args.image = (args.image or []) + frames
             args.video = None
 
     num_images = len(args.image) if args.image is not None else 0
@@ -1519,6 +1555,7 @@ def main():
 
     else:
         gen_kwargs = {
+            **gen_kwargs_extra,
             "image": args.image,
             "audio": args.audio,
             "video": args.video,

--- a/mlx_vlm/generate/dispatch.py
+++ b/mlx_vlm/generate/dispatch.py
@@ -1356,133 +1356,54 @@ def main():
             prompt if isinstance(prompt, list) else [prompt]
         )
 
-    # Processors without native video support (no `videos` parameter) used to
-    # drop --video silently: the frames were loaded, the processor ignored the
-    # kwarg, and the model hallucinated an answer with no visual input at all.
-    # Fall back to sampling the video into frames and sending them as ordered
-    # images, which any image-capable model handles.
+    # Processors without native video support used to drop --video silently:
+    # the frames were loaded, the processor ignored the kwarg, and the model
+    # hallucinated an answer with no visual input at all. Fall back to sending
+    # sampled frames as ordered images (see generate/video.py).
     gen_kwargs_extra = {}
-    inkling_video_prompt = None
+    video_prompt = None
     if args.video:
-        import inspect as _inspect
+        from .video import (
+            pair_adjacent_frames,
+            processor_handles_video,
+            sample_video_frames,
+            subsample_evenly,
+            timestamped_frame_messages,
+        )
 
-        import numpy as _np
-        from PIL import Image as _PILImage
-
-        from ..utils import load_video as _load_video
-
-        # A `videos` parameter in the signature is not enough: the generic HF
-        # processor skeleton accepts videos but only processes them when a
-        # video_processor component exists, and silently discards them
-        # otherwise. Check for the component, not the parameter.
-        _proc_method = getattr(processor, "process", processor)
-        try:
-            _proc_params = _inspect.signature(_proc_method).parameters
-        except (TypeError, ValueError):
-            _proc_params = {}
-        _has_video_component = getattr(processor, "video_processor", None) is not None
-        if "videos" not in _proc_params or not _has_video_component:
-            frames = []
-            frame_fps = args.fps or 2.0
-            for v in args.video:
-                arr, _sfps = _load_video(str(v), fps=args.fps or 2.0)
-                frame_fps = _sfps or frame_fps
-                for f in arr:
-                    frames.append(
-                        _PILImage.fromarray(
-                            _np.transpose(f, (1, 2, 0)).astype("uint8")
-                        )
-                    )
+        if not processor_handles_video(processor):
+            frames, frame_fps = sample_video_frames(args.video, args.fps or 2.0)
             sampled = len(frames)
             max_frames = max(2, getattr(args, "video_max_frames", 16) or 16)
-            if getattr(model.config, "model_type", "") == "inkling_mm_model":
-                # Inkling's patches are temporal pairs [P, T=2, H, W, C] and
-                # the image processor duplicates a still into both slots.
-                # Feed the video natively instead: consecutive frame pairs
-                # become one image entity each (even frame goes through the
-                # standard still path; the odd frame's patches are spliced
-                # into temporal slot 1 by the model). Halves the token cost
-                # of the plain fallback and gives the encoder real motion.
-                # Pair ADJACENT sampled frames (small displacement between
-                # the two temporal slots, matching how consecutive video
-                # frames relate) at evenly spaced anchor points across the
-                # FULL sampled sequence. Pairing temporally distant frames
-                # into one patch reads as a double exposure instead of motion.
-                if len(frames) % 2:
-                    frames.append(frames[-1])
-                n_pairs = max(2, min(max_frames, len(frames) // 2))
-                anchors = [
-                    min(round(i * (len(frames) - 2) / max(n_pairs - 1, 1)), len(frames) - 2)
-                    for i in range(n_pairs)
-                ]
-                evens = [frames[a] for a in anchors]
-                odds = [frames[a + 1] for a in anchors]
-                odd_feats = processor.image_processor.preprocess(
-                    images=odds, return_tensors="np"
-                )["pixel_values"]
-                gen_kwargs_extra["video_temporal_pixels"] = mx.array(
-                    _np.asarray(odd_feats)[:, 0]
+            pair_hook = getattr(model, "prepare_video_frame_pairs", None)
+            if pair_hook is not None:
+                anchors, first_frames, second_frames = pair_adjacent_frames(
+                    frames, max_frames
                 )
-                user_still_count = len(args.image or [])
-                args.image = (args.image or []) + evens
-                # Timestamped single-message prompt. Bare image entities in
-                # separate messages read as a slideshow ("a sequence of still
-                # images"); labeling each pair with its clip time makes the
-                # model ground observations chronologically and track how
-                # positions change. The template renders interleaved
-                # text/image parts natively, so this stays template-faithful.
+                gen_kwargs_extra.update(pair_hook(processor, second_frames))
+                still_count = len(args.image or [])
+                args.image = (args.image or []) + first_frames
                 user_text = (
                     " ".join(args.prompt)
                     if isinstance(args.prompt, list)
                     else str(args.prompt)
                 )
-                parts = [{"type": "image"} for _ in range(user_still_count)]
-                parts.append(
-                    {
-                        "type": "text",
-                        "text": "Here is a video as a sequence of frames "
-                        "in chronological order.",
-                    }
+                msgs = timestamped_frame_messages(
+                    user_text,
+                    args.system,
+                    still_count,
+                    [a / max(frame_fps, 1e-6) for a in anchors],
                 )
-                for a in anchors:
-                    parts.append(
-                        {
-                            "type": "text",
-                            "text": f"frame at t={a / max(frame_fps, 1e-6):.1f}s:",
-                        }
-                    )
-                    parts.append({"type": "image"})
-                parts.append({"type": "text", "text": user_text})
-                msgs = (
-                    [{"role": "system", "content": args.system}]
-                    if args.system
-                    else []
-                ) + [{"role": "user", "content": parts}]
                 _tok = (
                     processor.tokenizer
                     if hasattr(processor, "tokenizer")
                     else processor
                 )
-                inkling_video_prompt = _tok.apply_chat_template(
+                video_prompt = _tok.apply_chat_template(
                     msgs, add_generation_prompt=True, tokenize=False
                 )
-                print(
-                    f"inkling native video: {len(evens)} timestamped temporal "
-                    f"pairs ({odd_feats.shape[0]} patches carry frame 2 of "
-                    f"each pair)."
-                )
             else:
-                if sampled > max_frames:
-                    # Long clips: keep frames evenly spaced across the clip.
-                    # Beyond a couple dozen near-identical frames, models
-                    # start describing a static scene mixture instead of the
-                    # sequence, so more frames costs tokens and loses the
-                    # temporal thread.
-                    idxs = [
-                        round(i * (sampled - 1) / (max_frames - 1))
-                        for i in range(max_frames)
-                    ]
-                    frames = [frames[i] for i in idxs]
+                frames = subsample_evenly(frames, max_frames)
                 print(
                     f"{processor.__class__.__name__} has no native video "
                     f"support; sending {len(frames)} of {sampled} sampled "
@@ -1501,8 +1422,8 @@ def main():
         chat_template_kwargs["video"] = args.video
         chat_template_kwargs["fps"] = args.fps
 
-    if inkling_video_prompt is not None:
-        prompt = inkling_video_prompt
+    if video_prompt is not None:
+        prompt = video_prompt
     else:
         prompt = apply_chat_template(
             processor,

--- a/mlx_vlm/generate/video.py
+++ b/mlx_vlm/generate/video.py
@@ -1,0 +1,101 @@
+"""Frames fallback for processors without native video support.
+
+A ``videos`` parameter in a processor signature is not enough to know video is
+actually processed: the generic HF processor skeleton accepts ``videos`` but
+only processes them when a ``video_processor`` component exists, and silently
+discards them otherwise; the model then hallucinates an answer with no visual
+input at all. When that would happen, the caller samples the video into frames
+and sends them as ordered images, which any image-capable model handles.
+
+Models whose vision patches carry two temporal slots can opt into a richer
+fallback by defining a ``prepare_video_frame_pairs(processor, second_frames)``
+method (the capability flag): the caller then feeds adjacent-frame pairs from
+``pair_adjacent_frames`` instead of independent stills, and merges the hook's
+returned generation kwargs.
+"""
+
+import inspect
+
+import numpy as np
+from PIL import Image
+
+
+def processor_handles_video(processor) -> bool:
+    """True when the processor genuinely consumes a ``videos`` kwarg: the
+    parameter is declared and a ``video_processor`` component exists (check
+    the component, not just the parameter, see module docstring)."""
+    method = getattr(processor, "process", processor)
+    try:
+        params = inspect.signature(method).parameters
+    except (TypeError, ValueError):
+        params = {}
+    has_component = getattr(processor, "video_processor", None) is not None
+    return "videos" in params and has_component
+
+
+def sample_video_frames(videos, fps=2.0):
+    """Decode ``videos`` at ``fps`` into one chronological list of PIL frames,
+    returned alongside the sampling fps actually used."""
+    from ..utils import load_video
+
+    frames = []
+    frame_fps = fps
+    for video in videos:
+        arr, sampled_fps = load_video(str(video), fps=fps)
+        frame_fps = sampled_fps or frame_fps
+        for frame in arr:
+            frames.append(Image.fromarray(np.transpose(frame, (1, 2, 0))))
+    return frames, frame_fps
+
+
+def subsample_evenly(frames, max_frames):
+    """Keep at most ``max_frames``, evenly spaced across the clip. Beyond a
+    couple dozen near-identical frames, models start describing a static scene
+    mixture instead of the sequence, so more frames costs tokens and loses the
+    temporal thread."""
+    if len(frames) <= max_frames:
+        return frames
+    idxs = [
+        round(i * (len(frames) - 1) / (max_frames - 1)) for i in range(max_frames)
+    ]
+    return [frames[i] for i in idxs]
+
+
+def pair_adjacent_frames(frames, max_pairs):
+    """Anchor up to ``max_pairs`` adjacent-frame pairs, evenly spaced across
+    the full sampled sequence. Pairs must be ADJACENT sampled frames: small
+    displacement between the two temporal slots matches how consecutive video
+    frames relate, while temporally distant frames in one patch read as a
+    double exposure instead of motion. Returns
+    ``(anchor_indices, first_frames, second_frames)``."""
+    frames = list(frames)
+    if len(frames) % 2:
+        frames.append(frames[-1])
+    n_pairs = max(2, min(max_pairs, len(frames) // 2))
+    anchors = [
+        min(round(i * (len(frames) - 2) / max(n_pairs - 1, 1)), len(frames) - 2)
+        for i in range(n_pairs)
+    ]
+    return anchors, [frames[a] for a in anchors], [frames[a + 1] for a in anchors]
+
+
+def timestamped_frame_messages(user_text, system, still_count, timestamps):
+    """Chat messages placing every frame in ONE user message, each labeled with
+    its clip time. Bare image entities in separate messages read as a slideshow
+    ("a sequence of still images"); timestamp labels make the model ground
+    observations chronologically and track how positions change. The chat
+    template renders interleaved text/image parts natively, so this stays
+    template-faithful."""
+    parts = [{"type": "image"} for _ in range(still_count)]
+    parts.append(
+        {
+            "type": "text",
+            "text": "Here is a video as a sequence of frames in chronological order.",
+        }
+    )
+    for t in timestamps:
+        parts.append({"type": "text", "text": f"frame at t={t:.1f}s:"})
+        parts.append({"type": "image"})
+    parts.append({"type": "text", "text": user_text})
+    messages = [{"role": "system", "content": system}] if system else []
+    return messages + [{"role": "user", "content": parts}]

--- a/mlx_vlm/generate/video.py
+++ b/mlx_vlm/generate/video.py
@@ -55,9 +55,7 @@ def subsample_evenly(frames, max_frames):
     temporal thread."""
     if len(frames) <= max_frames:
         return frames
-    idxs = [
-        round(i * (len(frames) - 1) / (max_frames - 1)) for i in range(max_frames)
-    ]
+    idxs = [round(i * (len(frames) - 1) / (max_frames - 1)) for i in range(max_frames)]
     return [frames[i] for i in idxs]
 
 

--- a/mlx_vlm/models/inkling/inkling.py
+++ b/mlx_vlm/models/inkling/inkling.py
@@ -63,6 +63,24 @@ class Model(nn.Module):
         h = self.language_model.model.embed(input_ids)
 
         if pixel_values is not None:
+            # Native video: pixel_values rows carry a temporal pair per patch
+            # [P, T=2, H, W, C], and the image processor duplicates the frame
+            # into both slots for stills. A caller that patchified the SECOND
+            # frame of each consecutive pair can pass those patches here to
+            # overwrite slot 1 of the LAST N rows (video entities are appended
+            # after still images), turning duplicated stills into true
+            # temporal pairs with no other bookkeeping changes.
+            video_slot1 = kwargs.get("video_temporal_pixels", None)
+            if video_slot1 is not None:
+                n = video_slot1.shape[0]
+                head = pixel_values[:-n] if n < pixel_values.shape[0] else None
+                tail = pixel_values[-n:]
+                tail = mx.stack(
+                    [tail[:, 0], video_slot1.astype(tail.dtype)], axis=1
+                )
+                pixel_values = (
+                    tail if head is None else mx.concatenate([head, tail], axis=0)
+                )
             feats = self.get_image_features(pixel_values).astype(h.dtype)
             mask = mx.broadcast_to(
                 (input_ids == self.config.image_token_id)[..., None], h.shape

--- a/mlx_vlm/models/inkling/inkling.py
+++ b/mlx_vlm/models/inkling/inkling.py
@@ -50,6 +50,19 @@ class Model(nn.Module):
     def get_image_features(self, pixel_values):
         return self.vision_tower(pixel_values)
 
+    def prepare_video_frame_pairs(self, processor, second_frames):
+        """Capability hook for the frames fallback (see generate/video.py):
+        inkling patches are temporal pairs [P, T=2, H, W, C] and the image
+        processor duplicates a still into both slots. The first frame of each
+        pair goes through the standard still path; these second frames'
+        patches are spliced into temporal slot 1 by ``get_input_embeddings``,
+        halving the token cost of independent stills and giving the encoder
+        real motion."""
+        pixels = processor.image_processor.preprocess(images=second_frames)[
+            "pixel_values"
+        ]
+        return {"video_temporal_pixels": pixels[:, 0]}
+
     def get_audio_features(self, audio_input_ids, audio_input_ids_mask=None):
         if audio_input_ids_mask is not None:
             flat = audio_input_ids.reshape(-1, audio_input_ids.shape[-1])
@@ -75,9 +88,7 @@ class Model(nn.Module):
                 n = video_slot1.shape[0]
                 head = pixel_values[:-n] if n < pixel_values.shape[0] else None
                 tail = pixel_values[-n:]
-                tail = mx.stack(
-                    [tail[:, 0], video_slot1.astype(tail.dtype)], axis=1
-                )
+                tail = mx.stack([tail[:, 0], video_slot1.astype(tail.dtype)], axis=1)
                 pixel_values = (
                     tail if head is None else mx.concatenate([head, tail], axis=0)
                 )

--- a/mlx_vlm/tests/test_generate.py
+++ b/mlx_vlm/tests/test_generate.py
@@ -2153,7 +2153,13 @@ def test_generate_cli_forwards_video_to_template_and_generate(capsys):
         draft_block_size=None,
     )
     model = SimpleNamespace(config=SimpleNamespace(model_type="gemma4"))
-    processor = SimpleNamespace()
+    # A processor with native video support (a declared ``videos`` kwarg plus a
+    # video_processor component) forwards --video untouched; anything less
+    # diverts into the frames fallback.
+    processor = SimpleNamespace(
+        video_processor=SimpleNamespace(),
+        process=lambda text=None, images=None, videos=None, **kwargs: None,
+    )
 
     with (
         patch.object(dispatch_module, "parse_arguments", return_value=args),
@@ -2174,6 +2180,88 @@ def test_generate_cli_forwards_video_to_template_and_generate(capsys):
     assert mock_generate.call_args.kwargs["video"] == ["clip.mp4"]
     assert mock_generate.call_args.kwargs["fps"] == pytest.approx(1.0)
     assert capsys.readouterr().out.strip() == "done"
+
+
+def test_generate_cli_video_frames_fallback_without_video_processor(capsys):
+    video_module = __import__("mlx_vlm.generate.video", fromlist=[""])
+
+    args = Namespace(
+        model="demo",
+        output_modality="text",
+        output=None,
+        size="512x512",
+        steps=4,
+        seed=None,
+        guidance=1.0,
+        adapter_path=None,
+        image=None,
+        audio=None,
+        video=["clip.mp4"],
+        fps=1.0,
+        resize_shape=None,
+        prompt=["Describe this video."],
+        system=None,
+        max_tokens=8,
+        temperature=0.0,
+        repetition_penalty=None,
+        repetition_context_size=20,
+        presence_penalty=None,
+        presence_context_size=20,
+        frequency_penalty=None,
+        frequency_context_size=20,
+        chat=False,
+        verbose=False,
+        eos_tokens=None,
+        max_kv_size=None,
+        kv_bits=None,
+        kv_group_size=64,
+        kv_quant_scheme="uniform",
+        quantized_kv_start=512,
+        skip_special_tokens=False,
+        force_download=False,
+        revision=None,
+        trust_remote_code=False,
+        quantize_activations=False,
+        processor_kwargs={},
+        gen_kwargs={},
+        prefill_step_size=None,
+        enable_thinking=False,
+        thinking_mode=None,
+        thinking_budget=None,
+        thinking_start_token="<think>",
+        thinking_end_token="</think>",
+        draft_model=None,
+        draft_kind=None,
+        draft_block_size=None,
+        video_max_frames=4,
+    )
+    model = SimpleNamespace(config=SimpleNamespace(model_type="gemma4"))
+    processor = SimpleNamespace()
+    frames = [object() for _ in range(6)]
+
+    with (
+        patch.object(dispatch_module, "parse_arguments", return_value=args),
+        patch.object(dispatch_module, "load", return_value=(model, processor)),
+        patch.object(video_module, "sample_video_frames", return_value=(frames, 2.0)),
+        patch.object(
+            dispatch_module, "apply_chat_template", return_value="prompt"
+        ) as mock_apply_chat_template,
+        patch.object(
+            dispatch_module,
+            "generate",
+            return_value=SimpleNamespace(text="done"),
+        ) as mock_generate,
+    ):
+        dispatch_module.main()
+
+    # 6 sampled frames capped to 4, sent as ordered images; --video is spent.
+    assert mock_apply_chat_template.call_args.kwargs["num_images"] == 4
+    assert "video" not in mock_apply_chat_template.call_args.kwargs
+    assert len(mock_generate.call_args.kwargs["image"]) == 4
+    assert mock_generate.call_args.kwargs["video"] is None
+    out = capsys.readouterr().out
+    assert "no native video support" in out
+    assert "4 of 6 sampled frames" in out
 
 
 def test_generate_image_cli_routes_before_vlm_load():


### PR DESCRIPTION
## Summary

`--video` is dropped silently for models whose processor has no `video_processor` component. The frames load, the generic HF processor skeleton accepts the `videos` kwarg and discards it (it only processes video when the component exists), and the model then answers the question with no visual input at all. With Inkling-Small this produced a confident hallucinated description of a video it never saw.

Three commits:

## 1. Frames-as-images fallback

When `processor.video_processor` is missing, sample the video at the requested fps and append the frames to the image list before the prompt is formatted, so the image placeholder count matches. A signature check is not enough because the skeleton always declares a `videos` parameter, so this checks for the component itself. A notice is printed so the substitution is visible instead of silent.

## 2. Frame cap (--video-max-frames, default 16)

More frames hurt past a couple dozen: at 48 near-identical frames the tested model stopped tracking the event sequence and described a static scene mixture, while 8 to 16 evenly spaced frames preserved event order at a fifth of the token cost. Long clips re-sample evenly to the cap.

## 3. Inkling native temporal pairs

Inkling's vision patches are temporal pairs `[P, T=2, H, W, C]` and the image processor duplicates a still into both slots, so the second slot can carry a different frame. For `inkling_mm_model`, video is fed that way instead: each evenly spaced anchor frame goes through the standard still pipeline as one image entity, and the adjacent frame's patches are spliced into temporal slot 1 inside `get_input_embeddings` via a `video_temporal_pixels` kwarg. Token bookkeeping stays entirely on the standard image path, and each pair carries two frames of temporal signal for the token cost of one still.

Pairing has to use adjacent frames: putting temporally distant frames in one patch reads as a double exposure (the model described one moving ball as two overlapping circles). With adjacent pairing the same clip reads correctly.

## Testing

Synthetic multi-phase 480p clips (moving shape, direction change, object appearance) on Inkling-Small at temperature 0. Before: no media segments in the prompt, hallucinated answer. Fallback: frames arrive as ordered image segments and the model describes the actual events. Native pairs: same quality as the fallback at half the token cost per unit of temporal coverage, with still images unaffected (verified against the single-image baseline). Models with a real video_processor are untouched.