### PR TITLE
Inkling: decode fast path (fused sconv and MoE kernels, stacked qkvr, window-bounded attention)

### DIFF
--- a/mlx_vlm/models/inkling/config.py
+++ b/mlx_vlm/models/inkling/config.py
@@ -1,7 +1,25 @@
 from dataclasses import dataclass
-from typing import List, Optional, Union
+from typing import Dict, List, Optional, Union
 
 from ..base import BaseModelConfig
+
+
+def sanitize_quantization_config(quantization):
+    """Alias per-layer quantization entries onto the load-time fused ``qkvr_proj``.
+
+    Checkpoints quantized before the fusion existed key their per-layer
+    overrides by the constituent paths (``...self_attn.q_proj`` and friends).
+    The stacked projection inherits the ``q_proj`` entry: row-concat keeps each
+    output row's own quantization groups (see ``fuse_qkvr``), so the
+    constituents' settings apply unchanged to the fused matrix.
+    """
+    if not isinstance(quantization, dict):
+        return quantization
+    out = dict(quantization)
+    for key, value in quantization.items():
+        if key.endswith(".self_attn.q_proj"):
+            out.setdefault(key[: -len("q_proj")] + "qkvr_proj", value)
+    return out
 
 
 @dataclass
@@ -86,6 +104,8 @@ class ModelConfig(BaseModelConfig):
     audio_token_id: int = 200053
     vocab_size: int = 201024
     eos_token_id: Optional[List[int]] = None
+    quantization: Optional[Dict] = None
+    quantization_config: Optional[Dict] = None
 
     def __post_init__(self):
         # Coerce dict sub-configs (from config.json) into typed dataclasses, and wire the
@@ -104,3 +124,11 @@ class ModelConfig(BaseModelConfig):
             self.audio_config = AudioConfig.from_dict(self.audio_config)
         self.vision_config.text_hidden_size = self.text_config.hidden_size
         self.audio_config.text_hidden_size = self.text_config.hidden_size
+        quantization = self.quantization
+        self.quantization = sanitize_quantization_config(quantization)
+        if self.quantization_config == quantization:
+            self.quantization_config = self.quantization
+        else:
+            self.quantization_config = sanitize_quantization_config(
+                self.quantization_config
+            )

--- a/mlx_vlm/models/inkling/inkling.py
+++ b/mlx_vlm/models/inkling/inkling.py
@@ -7,7 +7,7 @@ import numpy as np
 from ..base import InputEmbeddingsFeatures
 from .audio import AudioModel
 from .config import ModelConfig
-from .language import LanguageModel, shared_experts_to_dense
+from .language import LanguageModel, fuse_qkvr, shared_experts_to_dense
 from .vision import VisionModel
 
 
@@ -248,7 +248,7 @@ class Model(nn.Module):
                 out[k] = v
         for i, buf in experts.items():
             out.update(self._map_experts(i, buf))
-        return shared_experts_to_dense(out)
+        return fuse_qkvr(shared_experts_to_dense(out))
 
     def make_cache(self):
         return self.language_model.make_cache()

--- a/mlx_vlm/models/inkling/inkling.py
+++ b/mlx_vlm/models/inkling/inkling.py
@@ -7,7 +7,7 @@ import numpy as np
 from ..base import InputEmbeddingsFeatures
 from .audio import AudioModel
 from .config import ModelConfig
-from .language import LanguageModel
+from .language import LanguageModel, shared_experts_to_dense
 from .vision import VisionModel
 
 
@@ -248,7 +248,7 @@ class Model(nn.Module):
                 out[k] = v
         for i, buf in experts.items():
             out.update(self._map_experts(i, buf))
-        return out
+        return shared_experts_to_dense(out)
 
     def make_cache(self):
         return self.language_model.make_cache()

--- a/mlx_vlm/models/inkling/language.py
+++ b/mlx_vlm/models/inkling/language.py
@@ -403,9 +403,7 @@ class InklingAttention(nn.Module):
             self.n_kv * self.head_dim,
             self.n_heads * self.d_rel,
         )
-        self.qkvr_proj = nn.Linear(
-            config.hidden_size, sum(self.qkvr_dims), bias=False
-        )
+        self.qkvr_proj = nn.Linear(config.hidden_size, sum(self.qkvr_dims), bias=False)
         self.o_proj = nn.Linear(
             self.n_heads * self.head_dim, config.hidden_size, bias=False
         )
@@ -427,9 +425,7 @@ class InklingAttention(nn.Module):
         qkvr = self.qkvr_proj(x)
         dq, dk, dv, _ = self.qkvr_dims
         k = self.k_sconv(qkvr[..., dq : dq + dk], cache=conv, mask=conv_mask)
-        v = self.v_sconv(
-            qkvr[..., dq + dk : dq + dk + dv], cache=conv, mask=conv_mask
-        )
+        v = self.v_sconv(qkvr[..., dq + dk : dq + dk + dv], cache=conv, mask=conv_mask)
 
         k = self.k_norm(k.reshape(B, L, self.n_kv, self.head_dim)).transpose(0, 2, 1, 3)
         v = v.reshape(B, L, self.n_kv, self.head_dim).transpose(0, 2, 1, 3)

--- a/mlx_vlm/models/inkling/language.py
+++ b/mlx_vlm/models/inkling/language.py
@@ -1,3 +1,4 @@
+from functools import partial
 from typing import Optional
 
 import mlx.core as mx
@@ -411,12 +412,25 @@ class InklingSwitchGLU(SwitchGLU):
         super().__init__(input_dims, hidden_dims, num_experts, **kwargs)
         self.gate_scale = mx.ones((num_experts,))  # s13 (fused gate/up scale2)
         self.out_scale = mx.ones((num_experts,))  # s13 * s2
+        self._scales_trivial = None
 
     def _per_expert(self, scale, idx, like):
         s = scale[idx].astype(like.dtype)
         return s.reshape(s.shape + (1,) * (like.ndim - s.ndim))
 
+    def scales_trivial(self):
+        # Non-NVFP4 checkpoints carry all-ones expert scales; checked once,
+        # after load.
+        if self._scales_trivial is None:
+            self._scales_trivial = bool(
+                (mx.all(self.gate_scale == 1) & mx.all(self.out_scale == 1)).item()
+            )
+        return self._scales_trivial
+
     def __call__(self, x, indices) -> mx.array:
+        # All-ones expert scales: skip the two gather+mul chains entirely.
+        if self.scales_trivial():
+            return super().__call__(x, indices)
         x = mx.expand_dims(x, (-2, -3))
         do_sort = indices.size >= 64
         idx = indices
@@ -433,6 +447,173 @@ class InklingSwitchGLU(SwitchGLU):
         return x.squeeze(-2)
 
 
+_ROUTE_SRC = r"""
+    // One simdgroup (32 lanes) per token; each lane owns ceil(R/32) experts
+    // (strided by 32 so logit reads coalesce). Top-K via K rounds of
+    // simd_max; ties resolved to the lowest lane (deterministic).
+    uint lane = thread_position_in_grid.x;   // 0..31, simd lane
+    uint n = thread_position_in_grid.y;      // token
+    if (n >= N) return;
+    const device T* lg = logits + (size_t)n * (R + SH);
+    float ws = wscale[0];
+    constexpr int PER = (R + 31) / 32;
+    float sc[PER];
+    float tl_[PER];
+    bool taken[PER];
+    for (int t = 0; t < PER; ++t) {
+        uint j = lane + (uint)t * 32u;
+        taken[t] = false;
+        if (j < R) {
+            float l = (float)lg[j];
+            tl_[t] = l;
+            sc[t] = 1.0f / (1.0f + metal::exp(-l)) + (float)corr[j];
+        } else {
+            sc[t] = -INFINITY;
+        }
+    }
+    uint bidx[K];
+    float btl[K];
+    for (uint kk = 0; kk < K; ++kk) {
+        float lb = -INFINITY; int lt = -1;
+        for (int t = 0; t < PER; ++t)
+            if (!taken[t] && sc[t] > lb) { lb = sc[t]; lt = t; }
+        float gb = simd_max(lb);
+        ushort wl = (ushort)simd_min(lb == gb ? lane : 32u);
+        uint wj = simd_shuffle(lt >= 0 ? lane + (uint)lt * 32u : 0u, wl);
+        float wtl = simd_shuffle(lt >= 0 ? tl_[lt] : 0.0f, wl);
+        if (lane == (uint)wl && lt >= 0 && sc[lt] == gb) taken[lt] = true;
+        bidx[kk] = wj; btl[kk] = wtl;
+    }
+    // Routing weights: softmax over logsigmoid of the K routed + SH shared
+    // logits, times route_scale * global_scale (folded into ws). Computed
+    // redundantly on every lane (cheap; K + SH values).
+    float lp[K + SH];
+    float m = -INFINITY;
+    for (uint t = 0; t < K + SH; ++t) {
+        float tv = (t < K) ? btl[t] : (float)lg[R + (t - K)];
+        float a = -tv;
+        float lad = metal::max(a, 0.0f)
+                  + metal::log(1.0f + metal::exp(-metal::fabs(a)));
+        lp[t] = -lad;
+        m = metal::max(m, lp[t]);
+    }
+    float se = 0.0f;
+    for (uint t = 0; t < K + SH; ++t) se += metal::exp(lp[t] - m);
+    float lse = m + metal::log(se);
+    if (lane < K) {
+        idx[(size_t)n * K + lane] = bidx[lane];
+        wk[(size_t)n * K + lane] = (T)(metal::exp(lp[lane] - lse) * ws);
+    }
+    T gv[SH];
+    for (uint s = 0; s < SH; ++s) gv[s] = (T)(metal::exp(lp[K + s] - lse) * ws);
+    device T* gp = gamma + (size_t)n * SH * I;
+    for (uint t = lane; t < SH * I; t += 32u) gp[t] = gv[t / I];
+"""
+_route_kernel = mx.fast.metal_kernel(
+    name="inkling_moe_route",
+    input_names=["logits", "corr", "wscale"],
+    output_names=["idx", "wk", "gamma"],
+    source=_ROUTE_SRC,
+)
+
+
+# Escape hatch: use gather_qmm for the routed down projection at decode.
+_DOWN_COMBINE = True
+
+_DOWN_COMBINE_SRC = r"""
+    // Weighted routed-expert down-projection for decode: gather_qmm's
+    // vector-per-expert mode runs at ~200 GB/s on the [2048 -> 4096] down
+    // shape (vs ~750 broadcast), so this kernel dequantizes q4/g64 rows
+    // directly: one threadgroup per output row, one simdgroup per selected
+    // expert, one quant group per lane; the top-k weighted sum over experts
+    // is folded in, so the [N, K, out] intermediate never exists.
+    uint lane = thread_index_in_simdgroup;
+    uint sg   = simdgroup_index_in_threadgroup;   // expert slot (8 sgs, K used)
+    uint row  = threadgroup_position_in_grid.y;   // output row [0, OUT)
+    uint n    = threadgroup_position_in_grid.z;   // token
+    threadgroup float partial[8];
+    if (sg < K) {
+        uint e = idx[(size_t)n * K + sg];
+        const device uint* wr = wq + ((size_t)e * OUT + row) * (IN / 8u);
+        const device T* sr = sc + ((size_t)e * OUT + row) * GROUPS;
+        const device T* br = bi + ((size_t)e * OUT + row) * GROUPS;
+        const device T* xr = xin + ((size_t)n * K + sg) * IN;
+        float s = (float)sr[lane];
+        float b = (float)br[lane];
+        float accq = 0.0f, accx = 0.0f;
+        uint base = lane * 8u;      // 8 uint32 = 64 packed q4 values
+        uint xbase = lane * 64u;
+        for (uint u = 0; u < 8u; ++u) {
+            uint w8 = wr[base + u];
+            for (uint t = 0; t < 8u; ++t) {
+                float xv = (float)xr[xbase + u * 8u + t];
+                accq += (float)((w8 >> (4u * t)) & 0xFu) * xv;
+                accx += xv;
+            }
+        }
+        float dot = simd_sum(s * accq + b * accx);
+        if (lane == 0) {
+            // match the unfused chain: down output rounds to T, then the
+            // per-expert weight multiply rounds again before the sum
+            float dv = (float)((T)dot);
+            partial[sg] = (float)((T)(dv * (float)wk[(size_t)n * K + sg]));
+        }
+    } else if (lane == 0) {
+        partial[sg] = 0.0f;
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    if (sg == 0 && lane == 0) {
+        float tot = 0.0f;
+        for (uint t = 0; t < 8u; ++t) tot += partial[t];
+        out[(size_t)n * OUT + row] = (T)tot;
+    }
+"""
+_down_combine_kernel = mx.fast.metal_kernel(
+    name="inkling_moe_down_combine",
+    input_names=["xin", "wq", "sc", "bi", "idx", "wk"],
+    output_names=["out"],
+    source=_DOWN_COMBINE_SRC,
+)
+
+
+@partial(mx.compile, shapeless=True)
+def _swiglu_scaled(gate, up, s):
+    return nn.silu(gate) * up * s
+
+
+class InklingSharedExpertsDense(nn.Module):
+    """The ``n_shared`` always-on experts as one dense SwiGLU: expert weights are
+    concatenated at load (see ``shared_experts_to_dense``) so the fixed-index
+    gather_qmm path becomes three plain matmuls. Per-token expert weights arrive
+    pre-broadcast over the expert-major intermediate (``gamma``) and are applied
+    before down_proj, which distributes over the concatenated experts exactly."""
+
+    def __init__(self, input_dims: int, hidden_dims: int, num_experts: int):
+        super().__init__()
+        self.gate_proj = nn.Linear(input_dims, num_experts * hidden_dims, bias=False)
+        self.up_proj = nn.Linear(input_dims, num_experts * hidden_dims, bias=False)
+        self.down_proj = nn.Linear(num_experts * hidden_dims, input_dims, bias=False)
+
+    def __call__(self, x, gamma):
+        return self.down_proj(_swiglu_scaled(self.gate_proj(x), self.up_proj(x), gamma))
+
+
+def shared_experts_to_dense(weights):
+    """Remap SwitchGLU-shaped shared-expert tensors ``[E, out, in]`` (bf16 or
+    quantized triplets) to the dense concatenated layout of
+    ``InklingSharedExpertsDense``. Expert-major on the intermediate axis, so
+    gate/up stack experts along rows and down stacks along input columns."""
+    out = {}
+    for k, v in weights.items():
+        if ".shared_experts." in k and isinstance(v, mx.array) and v.ndim == 3:
+            if ".down_proj." in k:
+                v = v.transpose(1, 0, 2).reshape(v.shape[1], -1)
+            else:
+                v = v.reshape(-1, v.shape[2])
+        out[k] = v
+    return out
+
+
 class InklingSparseMoE(nn.Module):
     """Sigmoid-gated fine-grained MoE: top-k routed experts (+ correction-bias selection)
     plus always-on shared experts, weighted by a logsigmoid/logsumexp softmax."""
@@ -443,24 +624,51 @@ class InklingSparseMoE(nn.Module):
         self.n_shared = config.n_shared_experts
         self.top_k = config.num_experts_per_tok
         self.route_scale = config.route_scale
+        self.intermediate_size = config.intermediate_size
         self.gate_weight = mx.zeros((self.n_routed + self.n_shared, config.hidden_size))
         self.e_score_correction_bias = mx.zeros((self.n_routed,))
         self.global_scale = mx.ones((1,))
         self.switch_mlp = InklingSwitchGLU(
             config.hidden_size, config.intermediate_size, self.n_routed
         )
-        self.shared_experts = SwitchGLU(
+        self.shared_experts = InklingSharedExpertsDense(
             config.hidden_size, config.intermediate_size, self.n_shared
         )
+        self._wscale = None
 
-    def __call__(self, x):
-        B, L, D = x.shape
-        xf = x.reshape(-1, D)
-        logits = xf @ self.gate_weight.astype(x.dtype).T
+    def _route(self, logits):
+        """Expert selection + routing weights. On GPU the whole post-matmul
+        chain (sigmoid + bias + top-k + logsigmoid softmax + scaling) is one
+        kernel; it also emits the shared-expert weights pre-broadcast over the
+        expert-major dense intermediate."""
+        N = logits.shape[0]
+        if self._wscale is None:
+            self._wscale = mx.array(
+                [self.route_scale], dtype=mx.float32
+            ) * self.global_scale.astype(mx.float32)
+        if mx.default_device() == mx.gpu:
+            return _route_kernel(
+                inputs=[logits, self.e_score_correction_bias, self._wscale],
+                template=[
+                    ("T", logits.dtype),
+                    ("N", N),
+                    ("R", self.n_routed),
+                    ("SH", self.n_shared),
+                    ("K", self.top_k),
+                    ("I", self.intermediate_size),
+                ],
+                grid=(32, N, 1),
+                threadgroup=(32, 1, 1),
+                output_shapes=[
+                    (N, self.top_k),
+                    (N, self.top_k),
+                    (N, self.n_shared * self.intermediate_size),
+                ],
+                output_dtypes=[mx.uint32, logits.dtype, logits.dtype],
+            )
         scores = mx.sigmoid(logits.astype(mx.float32))
         sfc = scores[:, : self.n_routed] + self.e_score_correction_bias
         idx = mx.argpartition(-sfc, self.top_k - 1, axis=-1)[:, : self.top_k]
-
         routed_logits = logits[:, : self.n_routed]
         shared_logits = logits[:, -self.n_shared :]
         tl = mx.concatenate(
@@ -472,16 +680,58 @@ class InklingSparseMoE(nn.Module):
             * self.route_scale
             * self.global_scale
         )
-        shared_gammas = w[:, -self.n_shared :]
-        topk_w = w[:, : self.top_k]
-
-        yr = (self.switch_mlp(xf, idx) * topk_w[..., None].astype(x.dtype)).sum(axis=-2)
-        sh_idx = mx.broadcast_to(
-            mx.arange(self.n_shared)[None], (xf.shape[0], self.n_shared)
+        topk_w = w[:, : self.top_k].astype(logits.dtype)
+        gamma = mx.repeat(
+            w[:, -self.n_shared :].astype(logits.dtype),
+            self.intermediate_size,
+            axis=-1,
         )
-        ys = (
-            self.shared_experts(xf, sh_idx) * shared_gammas[..., None].astype(x.dtype)
-        ).sum(axis=-2)
+        return idx.astype(mx.uint32), topk_w, gamma
+
+    def __call__(self, x):
+        B, L, D = x.shape
+        xf = x.reshape(-1, D)
+        gw = self.gate_weight
+        if gw.dtype != x.dtype:
+            gw = gw.astype(x.dtype)
+        logits = xf @ gw.T
+        idx, topk_w, gamma = self._route(logits)
+        sm = self.switch_mlp
+        dp = sm.down_proj
+        if (
+            _DOWN_COMBINE
+            and xf.shape[0] <= 8
+            and mx.default_device() == mx.gpu
+            and getattr(dp, "bits", None) == 4
+            and getattr(dp, "group_size", None) == 64
+            and getattr(dp, "mode", "affine") == "affine"
+            and getattr(dp, "biases", None) is not None
+            and dp.input_dims == 2048  # kernel maps one 64-wide group per lane
+            and dp.scales.dtype == x.dtype
+            and sm.scales_trivial()
+        ):
+            # decode: gather_qmm's vector-per-expert mode is ~3.5x off peak on
+            # the down shape; dequantize rows directly and fold the weighted
+            # expert sum in.
+            xe = mx.expand_dims(xf, (-2, -3))
+            act = sm.activation(sm.up_proj(xe, idx), sm.gate_proj(xe, idx))
+            yr = _down_combine_kernel(
+                inputs=[act, dp.weight, dp.scales, dp.biases, idx, topk_w],
+                template=[
+                    ("T", x.dtype),
+                    ("OUT", dp.output_dims),
+                    ("IN", dp.input_dims),
+                    ("GROUPS", dp.input_dims // 64),
+                    ("K", self.top_k),
+                ],
+                grid=(256, dp.output_dims, xf.shape[0]),
+                threadgroup=(256, 1, 1),
+                output_shapes=[(xf.shape[0], dp.output_dims)],
+                output_dtypes=[x.dtype],
+            )[0]
+        else:
+            yr = (sm(xf, idx) * topk_w[..., None]).sum(axis=-2)
+        ys = self.shared_experts(xf, gamma)
         return (yr + ys).reshape(B, L, D).astype(x.dtype)
 
 

--- a/mlx_vlm/models/inkling/language.py
+++ b/mlx_vlm/models/inkling/language.py
@@ -184,6 +184,52 @@ def _next_conv_state(state, inputs, mask):
     return mx.take_along_axis(combined, indices, axis=1)
 
 
+_SCONV_SRC = r"""
+    uint c = thread_position_in_grid.x;   // channel
+    uint b = thread_position_in_grid.y;   // batch row
+    if (c >= C || b >= B) return;
+    float w0 = (float)w[c * K + 0];
+    float w1 = (float)w[c * K + 1];
+    float w2 = (float)w[c * K + 2];
+    float w3 = (float)w[c * K + 3];
+    // Virtual padded input xp = [state (K-1 rows, fp32); x (L rows, T)].
+    for (uint i = 0; i < L; ++i) {
+        float acc = 0.0f;
+        for (uint k = 0; k < K; ++k) {
+            int r = (int)(i + k) - (int)(K - 1);  // row into x; negative -> state
+            float v = (r < 0)
+                ? state[(b * (K - 1) + (uint)(r + (int)(K - 1))) * C + c]
+                : (float)x[(b * L + (uint)r) * C + c];
+            float wk = (k == 0) ? w0 : (k == 1) ? w1 : (k == 2) ? w2 : w3;
+            acc += wk * v;
+        }
+        // Match the unfused path's rounding: the conv emits bf16 (rounded)
+        // before the fp32 residual add; the layer residual is a second bf16
+        // add on top (as the decoder layer's x + sconv(r) was).
+        float conv_r = (float)((T)acc);
+        T inner = (T)(conv_r + (float)x[(b * L + i) * C + c]);
+        if (HAS_RES) {
+            out[(b * L + i) * C + c] =
+                (T)((float)inner + (float)res[(b * L + i) * C + c]);
+        } else {
+            out[(b * L + i) * C + c] = inner;
+        }
+    }
+    for (uint s = 0; s < K - 1; ++s) {
+        int r = (int)(L + s) - (int)(K - 1);
+        nstate[(b * (K - 1) + s) * C + c] = (r < 0)
+            ? state[(b * (K - 1) + (uint)(r + (int)(K - 1))) * C + c]
+            : (float)x[(b * L + (uint)r) * C + c];
+    }
+"""
+_sconv_kernel = mx.fast.metal_kernel(
+    name="inkling_sconv_decode",
+    input_names=["x", "state", "w", "res"],
+    output_names=["out", "nstate"],
+    source=_SCONV_SRC,
+)
+
+
 class InklingShortConvolution(nn.Module):
     """Depthwise causal 1-D conv over the previous ``kernel_size - 1`` states, plus a
     residual add. Kept in fp32 for stability (matches the reference). ``conv_idx`` selects
@@ -197,13 +243,52 @@ class InklingShortConvolution(nn.Module):
             channels, channels, kernel_size, groups=channels, bias=False
         )
 
-    def __call__(self, x: mx.array, cache=None, mask: Optional[mx.array] = None):
+    def __call__(
+        self,
+        x: mx.array,
+        cache=None,
+        mask: Optional[mx.array] = None,
+        residual: Optional[mx.array] = None,
+    ):
         dt = x.dtype
+        K = self.kernel_size
+        if (
+            cache is not None
+            and mask is None
+            and K == 4
+            and x.shape[1] <= 8
+            and mx.default_device() == mx.gpu
+        ):
+            B, L, C = x.shape
+            state = cache[self.conv_idx]
+            if state is None:
+                state = mx.zeros((B, K - 1, C), dtype=mx.float32)
+            out, nstate = _sconv_kernel(
+                inputs=[
+                    x,
+                    state,
+                    self.conv.weight.reshape(-1),
+                    residual if residual is not None else x,
+                ],
+                template=[
+                    ("T", dt),
+                    ("B", B),
+                    ("L", L),
+                    ("C", C),
+                    ("K", K),
+                    ("HAS_RES", residual is not None),
+                ],
+                grid=(_rup(C, 32), B, 1),
+                threadgroup=(32, 1, 1),
+                output_shapes=[(B, L, C), (B, K - 1, C)],
+                output_dtypes=[dt, mx.float32],
+            )
+            cache[self.conv_idx] = nstate
+            return out
         xf = x.astype(mx.float32)
         res = xf
         if mask is not None:
             xf = mx.where(mask[..., None], xf, 0)
-        K = self.kernel_size
         if cache is not None:
             state = cache[self.conv_idx]
             if state is None:
@@ -213,7 +298,8 @@ class InklingShortConvolution(nn.Module):
         else:
             xp = mx.pad(xf, [(0, 0), (K - 1, 0), (0, 0)])
         out = self.conv(xp.astype(self.conv.weight.dtype)).astype(mx.float32)
-        return (out + res).astype(dt)
+        out = (out + res).astype(dt)
+        return out if residual is None else residual + out
 
 
 class InklingAttention(nn.Module):
@@ -424,9 +510,9 @@ class InklingDecoderLayer(nn.Module):
         if conv_mask is None:
             conv_mask = _cache_padding_mask(conv, x.shape[1])
         r = self.self_attn(self.input_layernorm(x), cache=cache, conv_mask=conv_mask)
-        h = x + self.attn_sconv(r, cache=conv, mask=conv_mask)
+        h = self.attn_sconv(r, cache=conv, mask=conv_mask, residual=x)
         r = self.mlp(self.post_attention_layernorm(h))
-        out = h + self.mlp_sconv(r, cache=conv, mask=conv_mask)
+        out = self.mlp_sconv(r, cache=conv, mask=conv_mask, residual=h)
         if conv is not None:
             conv.advance(x.shape[1])
         return out

--- a/mlx_vlm/models/inkling/language.py
+++ b/mlx_vlm/models/inkling/language.py
@@ -98,12 +98,56 @@ _mask_kernel = mx.fast.metal_kernel(
 )
 
 
+_MASK_V2_SRC = r"""
+    // Shape-generic variant of the banded mask: every runtime dimension comes
+    // from injected shapes (B/LQ/H from rel, S from the unread shape-carrier
+    // input), and the query offset is S - LQ. Only the per-layer constants
+    // (dtype, band geometry) are template args, so exactly one pipeline is
+    // compiled per layer kind instead of one per (LQ, S) pair.
+    const int B  = rel_shape[0];
+    const int LQ = rel_shape[1];
+    const int H  = rel_shape[2];
+    const int S  = kshape_shape[2];
+    uint j  = thread_position_in_grid.x;   // key   position [0, S)
+    uint i  = thread_position_in_grid.y;   // query position [0, LQ)
+    uint bh = thread_position_in_grid.z;   // b * H + h
+    if ((int)i >= LQ || (int)j >= S || (int)bh >= B * H) return;
+    uint b = bh / H, h = bh % H;
+    int dist = ((int)i + (S - LQ)) - (int)j;     // backward distance
+    T val;
+    if (dist < 0) {
+        val = (T)(-1e30f);                                   // causal
+    } else if (SLIDING > 0 && dist >= (int)SLIDING) {
+        val = (T)(-1e30f);                                   // sliding-window cap
+    } else if (dist < (int)REL_EXTENT) {
+        float acc = 0.0f;
+        const size_t rbase = (size_t)b * rel_strides[0]
+            + (size_t)i * rel_strides[1] + (size_t)h * rel_strides[2];
+        for (uint d = 0; d < D_REL; ++d)
+            acc += (float)rel[rbase + (size_t)d * rel_strides[3]]
+                 * (float)proj[(size_t)d * proj_strides[0]
+                               + (size_t)dist * proj_strides[1]];
+        val = (T)acc;
+    } else {
+        val = (T)0;                                          // in-context, outside band
+    }
+    out[(((size_t)b * H + h) * LQ + i) * S + j] = val;
+"""
+_mask_v2_kernel = mx.fast.metal_kernel(
+    name="inkling_banded_mask_v2",
+    input_names=["rel", "proj", "kshape"],
+    output_names=["out"],
+    source=_MASK_V2_SRC,
+    ensure_row_contiguous=False,
+)
+
+
 def _rup(a, m):
     return ((a + m - 1) // m) * m
 
 
 def banded_additive_mask(
-    rel, proj, q_offset, S, sliding, rel_extent, left_padding=None
+    rel, proj, q_offset, S, sliding, rel_extent, left_padding=None, shape_ref=None
 ):
     """rel: [B, LQ, H, d_rel]; proj: [d_rel, rel_extent] -> additive mask [B, H, LQ, S]."""
     B, LQ, H, d_rel = rel.shape
@@ -112,7 +156,27 @@ def banded_additive_mask(
     S = int(S)
     sliding = int(sliding)
     rel_extent = int(rel_extent)
-    if mx.default_device() == mx.gpu:
+    if (
+        shape_ref is not None
+        and shape_ref.ndim >= 3
+        and shape_ref.shape[2] == S
+        and q_offset == S - LQ
+        and mx.default_device() == mx.gpu
+    ):
+        mask = _mask_v2_kernel(
+            inputs=[rel, proj, shape_ref],
+            template=[
+                ("T", dtype),
+                ("D_REL", d_rel),
+                ("REL_EXTENT", rel_extent),
+                ("SLIDING", sliding),
+            ],
+            grid=(_rup(S, 8), _rup(LQ, 8), B * H),
+            threadgroup=(8, 8, 1),
+            output_shapes=[(B, H, LQ, S)],
+            output_dtypes=[dtype],
+        )[0]
+    elif mx.default_device() == mx.gpu:
         mask = _mask_kernel(
             inputs=[rel, proj],
             template=[
@@ -303,6 +367,10 @@ class InklingShortConvolution(nn.Module):
         return out if residual is None else residual + out
 
 
+# Escape hatch: skip the sliding-layer out-of-window K/V slicing.
+_SLIDING_KV_SLICE = True
+
+
 class InklingAttention(nn.Module):
     def __init__(self, config: ModelConfig, layer_idx: int):
         super().__init__()
@@ -375,6 +443,18 @@ class InklingAttention(nn.Module):
         q = self.q_norm(q.reshape(B, L, self.n_heads, self.head_dim)).transpose(
             0, 2, 1, 3
         )
+        left_padding = getattr(kv, "left_padding", None)
+        if _SLIDING_KV_SLICE and self.sliding > 0 and S > L + self.sliding - 1:
+            # No query row can reach keys older than its window; slice them
+            # off before the mask and SDPA (they were -1e30 masked anyway).
+            # The mask keeps the right positions: its offset is S_eff - L,
+            # and any left padding shifts with the slice.
+            j0 = S - L - (self.sliding - 1)
+            k = k[:, :, j0:, :]
+            v = v[:, :, j0:, :]
+            S = k.shape[2]
+            if left_padding is not None:
+                left_padding = mx.maximum(left_padding - j0, 0)
         offset = S - L
 
         mask = banded_additive_mask(
@@ -384,7 +464,8 @@ class InklingAttention(nn.Module):
             S,
             self.sliding,
             self.rel_extent,
-            left_padding=getattr(kv, "left_padding", None),
+            left_padding=left_padding,
+            shape_ref=k,
         )
         if self.log_floor is not None:
             qpos = (mx.arange(L) + offset + 1).astype(mx.float32)

--- a/mlx_vlm/models/inkling/language.py
+++ b/mlx_vlm/models/inkling/language.py
@@ -327,17 +327,16 @@ class InklingAttention(nn.Module):
         self.log_floor = None if self.is_sliding else config.log_scaling_n_floor
         self.log_alpha = config.log_scaling_alpha
 
-        self.q_proj = nn.Linear(
-            config.hidden_size, self.n_heads * self.head_dim, bias=False
+        # q/k/v/r share the input row; their weights are stacked at load
+        # (see fuse_qkvr) so decode does one matmul instead of four.
+        self.qkvr_dims = (
+            self.n_heads * self.head_dim,
+            self.n_kv * self.head_dim,
+            self.n_kv * self.head_dim,
+            self.n_heads * self.d_rel,
         )
-        self.k_proj = nn.Linear(
-            config.hidden_size, self.n_kv * self.head_dim, bias=False
-        )
-        self.v_proj = nn.Linear(
-            config.hidden_size, self.n_kv * self.head_dim, bias=False
-        )
-        self.r_proj = nn.Linear(
-            config.hidden_size, self.n_heads * self.d_rel, bias=False
+        self.qkvr_proj = nn.Linear(
+            config.hidden_size, sum(self.qkvr_dims), bias=False
         )
         self.o_proj = nn.Linear(
             self.n_heads * self.head_dim, config.hidden_size, bias=False
@@ -357,20 +356,25 @@ class InklingAttention(nn.Module):
         kv = cache[0] if cache is not None else None
         conv = cache[1] if cache is not None else None
 
-        q = self.q_proj(x)
-        k = self.k_sconv(self.k_proj(x), cache=conv, mask=conv_mask)
-        v = self.v_sconv(self.v_proj(x), cache=conv, mask=conv_mask)
-        r = self.r_proj(x).reshape(B, L, self.n_heads, self.d_rel)
-
-        q = self.q_norm(q.reshape(B, L, self.n_heads, self.head_dim)).transpose(
-            0, 2, 1, 3
+        qkvr = self.qkvr_proj(x)
+        dq, dk, dv, _ = self.qkvr_dims
+        k = self.k_sconv(qkvr[..., dq : dq + dk], cache=conv, mask=conv_mask)
+        v = self.v_sconv(
+            qkvr[..., dq + dk : dq + dk + dv], cache=conv, mask=conv_mask
         )
+
         k = self.k_norm(k.reshape(B, L, self.n_kv, self.head_dim)).transpose(0, 2, 1, 3)
         v = v.reshape(B, L, self.n_kv, self.head_dim).transpose(0, 2, 1, 3)
 
         if kv is not None:
             k, v = kv.update_and_fetch(k, v)
         S = k.shape[2]
+
+        q = qkvr[..., :dq]
+        r = qkvr[..., dq + dk + dv :].reshape(B, L, self.n_heads, self.d_rel)
+        q = self.q_norm(q.reshape(B, L, self.n_heads, self.head_dim)).transpose(
+            0, 2, 1, 3
+        )
         offset = S - L
 
         mask = banded_additive_mask(
@@ -596,6 +600,26 @@ class InklingSharedExpertsDense(nn.Module):
 
     def __call__(self, x, gamma):
         return self.down_proj(_swiglu_scaled(self.gate_proj(x), self.up_proj(x), gamma))
+
+
+def fuse_qkvr(weights):
+    """Stack per-layer q/k/v/r projection tensors (rows, plus scales/biases for
+    quantized checkpoints) into the single ``qkvr_proj``. Row-concat of
+    quantized matrices is exact: each output row keeps its own groups."""
+    out = dict(weights)
+    prefixes = {
+        k[: -len("q_proj.weight")]
+        for k in weights
+        if k.endswith(".self_attn.q_proj.weight")
+    }
+    for p in prefixes:
+        for leaf in ("weight", "scales", "biases"):
+            parts = [out.pop(f"{p}{n}_proj.{leaf}", None) for n in "qkvr"]
+            if all(v is not None for v in parts):
+                out[f"{p}qkvr_proj.{leaf}"] = mx.concatenate(parts, axis=0)
+            elif any(v is not None for v in parts):
+                raise ValueError(f"partial q/k/v/r {leaf} set under {p}")
+    return out
 
 
 def shared_experts_to_dense(weights):

--- a/mlx_vlm/speculative/drafters/inkling_mtp/inkling_mtp.py
+++ b/mlx_vlm/speculative/drafters/inkling_mtp/inkling_mtp.py
@@ -10,6 +10,7 @@ from ....models.inkling.language import (
     InklingDecoderLayer,
     _restore_cache_state,
     _snapshot_cache_state,
+    fuse_qkvr,
     shared_experts_to_dense,
 )
 from .config import InklingMTPConfig
@@ -381,4 +382,4 @@ class InklingMTPDraftModel(nn.Module):
                     out[base + sub] = v
             else:
                 out[key] = v
-        return shared_experts_to_dense(out)
+        return fuse_qkvr(shared_experts_to_dense(out))

--- a/mlx_vlm/speculative/drafters/inkling_mtp/inkling_mtp.py
+++ b/mlx_vlm/speculative/drafters/inkling_mtp/inkling_mtp.py
@@ -10,6 +10,7 @@ from ....models.inkling.language import (
     InklingDecoderLayer,
     _restore_cache_state,
     _snapshot_cache_state,
+    shared_experts_to_dense,
 )
 from .config import InklingMTPConfig
 
@@ -380,4 +381,4 @@ class InklingMTPDraftModel(nn.Module):
                     out[base + sub] = v
             else:
                 out[key] = v
-        return out
+        return shared_experts_to_dense(out)

--- a/mlx_vlm/utils.py
+++ b/mlx_vlm/utils.py
@@ -807,6 +807,13 @@ python -m mlx_vlm.convert --hf-path <local_dir> --mlx-path <mlx_dir>
             # Handle custom per layer quantizations
             if p in config["quantization"]:
                 return config["quantization"][p]
+            # Projections fused at load (e.g. inkling qkvr_proj) inherit the
+            # per-path entry of their first constituent from checkpoints saved
+            # before the fusion existed.
+            if p.endswith(".qkvr_proj"):
+                alias = p[: -len("qkvr_proj")] + "q_proj"
+                if alias in config["quantization"]:
+                    return config["quantization"][alias]
             if not hasattr(m, "to_quantized"):
                 return False
             # Skip layers not divisible by 64

--- a/mlx_vlm/utils.py
+++ b/mlx_vlm/utils.py
@@ -807,13 +807,6 @@ python -m mlx_vlm.convert --hf-path <local_dir> --mlx-path <mlx_dir>
             # Handle custom per layer quantizations
             if p in config["quantization"]:
                 return config["quantization"][p]
-            # Projections fused at load (e.g. inkling qkvr_proj) inherit the
-            # per-path entry of their first constituent from checkpoints saved
-            # before the fusion existed.
-            if p.endswith(".qkvr_proj"):
-                alias = p[: -len("qkvr_proj")] + "q_proj"
-                if alias in config["quantization"]:
-                    return config["quantization"][alias]
             if not hasattr(m, "to_quantized"):
                 return False
             # Skip layers not divisible by 64


### PR DESCRIPTION
## Summary

Decode-speed work for the Inkling family, measured on Inkling-Small (q4/g64 with q8 attention and shared experts, M-series, 256 GB). Single-stream decode goes from 26.1 to 21.2 ms/step at short context, and from 70.6 to 22.0 ms/step at 4k context, so decode is now nearly flat in context length instead of collapsing as the cache grows. Prefill picks up about 5% at 8k. Everything loads existing checkpoints unchanged.

Rebased onto main after #1756 and #1763 landed; no dependencies remain and the four commits here are the whole change. The sliding-window slice and the mask variant integrate with the left-padding batch masking from #1763 (padding is re-based when keys are sliced, and applied identically by both mask kernels), and the fused sconv path defers to the masked batching path whenever a cache carries padding information.

## Where the time went

An ablation probe against the bandwidth roofline (about 9 ms/step for this model) showed the gap was spread across launch count and a few specific bad shapes rather than any one heavy op: the MoE block accounted for roughly 16 ms/step, attention 8, and the short convolutions 3.4, with each of them dominated by chains of small kernels around modest amounts of real work. Each commit takes one of those apart.

## Short convolutions (commit 1)

Each of the four sconv sites per layer ran about eight ops at decode (fp32 casts, state concat, cache slice, the 4-tap depthwise conv, residual add), 168 sites across the model. One kernel now does the conv plus residual in fp32 and writes the shifted conv state, and the decoder layer's own residual add is folded in behind the same launch. The output is numerically identical to the unfused path, including its bf16 rounding of the conv result before the residual add; the prefill and masked multimodal paths are untouched.

## MoE (commit 2)

Three changes, one per bottleneck:

- The post-gate routing chain (sigmoid, correction bias, top-k, logsigmoid softmax, route and global scaling) was a dozen small kernels per layer. It is now one simdgroup kernel, one token per simdgroup, top-k by simd_max rounds with ties resolved to the lowest lane. A first version did the selection on a single thread and was dramatically slower than the mx op chain it replaced; the lane-parallel version is what shipped.
- The two always-on shared experts went through gather_qmm with constant indices. Their weights are concatenated at load (a shape-driven remap in sanitize that handles both bf16 and quantized triplets) into plain linear layers, and the per-token expert weight is applied on the expert-major intermediate, where it distributes exactly over the concatenated down projection.
- The routed down projection was the one gather that ran far off peak: gather_qmm's vector-per-expert mode reaches about 200 GB/s on the [2048 to 4096] down shape, versus about 750 GB/s for the broadcast mode the gate/up projections use. For affine q4/g64 checkpoints a small kernel dequantizes the selected rows directly (threadgroup per output row, simdgroup per expert, one quant group per lane) and folds the top-k weighted sum over experts in, so the [N, K, out] intermediate and its mul and sum kernels disappear too. It sustains about 550 GB/s; other quantizations keep the gather path.

NVFP4 expert scales that are all ones (any non-NVFP4 checkpoint) are detected once after load and their gather+mul chains skipped.

## Stacked q/k/v/r projection (commit 3)

The four attention projections share the same input row, so their weights are stacked at load into a single `qkvr_proj`; a row concat of quantized matrices is exact since every output row keeps its own groups. Decode runs one matmul instead of four. Checkpoints from before the fusion record per-path quantization entries under the old names, so the loader predicate lets `qkvr_proj` inherit the `q_proj` entry; without that, a checkpoint with q8 attention over a q4 default would requantize the stacked tensor at the default width and fail shape checks on load.

## Banded mask and sliding-window work bounds (commit 4)

The banded-mask kernel carried S and the query offset as Metal template arguments, so every decode step and every prefill chunk shape compiled a fresh pipeline variant. The added variant reads its runtime dimensions from injected shapes and derives the offset as S minus LQ, leaving only per-layer band geometry in the template: one pipeline per layer kind, ever. Bit-identical output; callers passing any other offset keep the old kernel.

Sliding-window layers also no longer hand SDPA the full cached history. A query row can never reach keys older than window minus one positions before it, yet decode and prefill computed O(L times S) masked scores and materialized an [H, L, S] mask per layer regardless of context length. Slicing the cache views to the reachable range bounds both at window plus L for the sliding layers (35 of 42 in Inkling-Small). The dropped keys carried exactly zero softmax weight, so outputs move only at the bf16 reassociation level, and decode is exact. This change is what flattens decode in context length.

## Numbers

Bare greedy decode loop, warm, Inkling-Small q4:

| | before | after |
|---|---|---|
| decode, 100-token context | 26.1 ms/step (38.3 tok/s) | 21.2 ms/step (47.3 tok/s) |
| decode, 4k context | 70.6 ms/step (14.2 tok/s) | 22.0 ms/step (45.6 tok/s) |
| chunked prefill, 8k | 631 tok/s | 670 tok/s |

Through an OpenAI-compatible server on the same box, warm single-stream decode went from 40 to 51 tok/s.

## Numerics and testing

The kernels reproduce the unfused paths' bf16 rounding points (the conv result before the residual add, routing weights, the down projection output before the expert-weight multiply), so differences sit at the reassociation level: greedy decode over 200-token continuations flips 1 to 7 tokens per prompt, always at top-2 logit gaps of one or two bf16 ulps, and teacher-forced logits match within the same margin.

Verified: per-kernel equivalence tests against the unfused implementations (the sconv kernel is bit-exact; MoE selects identical expert sets with weights within one bf16 ulp; the mask variant is bit-identical including strided views); the tiny-model tests in test_models.py; end-to-end text, vision, and audio generation on Inkling-Small plus greedy MTP speculative decode through the depth-8 drafter, whose sanitize gets the same stacked-projection and dense-shared remaps; long-context generation at 4k compared against the unsliced path. The gate matmul into the routing kernel and a tiled prefill attention kernel were both tried and measured slower or not worth it, in case anyone is tempted.

