### PR TITLE
Fix image-valued Responses function output handling

### DIFF
--- a/mlx_vlm/server/responses_state.py
+++ b/mlx_vlm/server/responses_state.py
@@ -415,6 +415,44 @@ def _response_call_to_chat_tool_call(item: Dict[str, Any]) -> Dict[str, Any]:
     }
 
 
+def _response_tool_output_to_text(output: Any, images: List[Any]) -> str:
+    if isinstance(output, str):
+        return output
+    if not isinstance(output, list):
+        return json.dumps(output, ensure_ascii=False)
+
+    text_parts = []
+    remaining_parts = []
+    image_count = 0
+    for part in output:
+        part = _as_plain_dict(part)
+        if not isinstance(part, dict):
+            remaining_parts.append(part)
+            continue
+        part_type = part.get("type")
+        if part_type in ("input_text", "output_text", "text"):
+            text_parts.append(str(part.get("text", "")))
+        elif part_type == "input_image":
+            image = part.get("image_url") or part.get("file_id")
+            if image:
+                images.append(image)
+                image_count += 1
+        elif part_type == "image_url":
+            image_url = part.get("image_url")
+            image = image_url.get("url") if isinstance(image_url, dict) else image_url
+            if image:
+                images.append(image)
+                image_count += 1
+        else:
+            remaining_parts.append(part)
+
+    if remaining_parts:
+        text_parts.append(json.dumps(remaining_parts, ensure_ascii=False))
+    if image_count and not any(part.strip() for part in text_parts):
+        text_parts.append("[Image output attached]")
+    return "\n".join(part for part in text_parts if part)
+
+
 def _append_response_item_to_prompt(
     item: Dict[str, Any],
     chat_messages: List[Dict[str, Any]],
@@ -465,8 +503,7 @@ def _append_response_item_to_prompt(
         "tool_result",
     ):
         output = item.get("output", item.get("content", ""))
-        if not isinstance(output, str):
-            output = json.dumps(output, ensure_ascii=False)
+        output = _response_tool_output_to_text(output, images)
         chat_messages.append(
             {
                 "role": "tool",

--- a/mlx_vlm/tests/test_responses_state.py
+++ b/mlx_vlm/tests/test_responses_state.py
@@ -1,0 +1,59 @@
+from mlx_vlm.server.responses_state import _response_items_to_chat
+
+
+def test_function_output_image_becomes_visual_input():
+    image_url = "data:image/png;base64,ZmFrZS1pbWFnZQ=="
+    items = [
+        {
+            "type": "function_call",
+            "name": "view_image",
+            "arguments": "{}",
+            "call_id": "call_view_image",
+        },
+        {
+            "type": "function_call_output",
+            "call_id": "call_view_image",
+            "output": [
+                {
+                    "type": "input_image",
+                    "image_url": image_url,
+                    "detail": "high",
+                }
+            ],
+        },
+    ]
+
+    messages, images = _response_items_to_chat(items)
+
+    assert images == [image_url]
+    assert messages[-1] == {
+        "role": "tool",
+        "tool_call_id": "call_view_image",
+        "content": "[Image output attached]",
+    }
+    assert image_url not in messages[-1]["content"]
+
+
+def test_function_output_preserves_text_alongside_visual_input():
+    image_url = "https://example.com/result.png"
+    items = [
+        {
+            "type": "function_call_output",
+            "call_id": "call_analyze_image",
+            "output": [
+                {"type": "input_text", "text": "Rendered result"},
+                {"type": "image_url", "image_url": {"url": image_url}},
+            ],
+        }
+    ]
+
+    messages, images = _response_items_to_chat(items)
+
+    assert images == [image_url]
+    assert messages == [
+        {
+            "role": "tool",
+            "tool_call_id": "call_analyze_image",
+            "content": "Rendered result",
+        }
+    ]

--- a/mlx_vlm/tests/test_server.py
+++ b/mlx_vlm/tests/test_server.py
@@ -1803,6 +1803,62 @@ def test_responses_endpoint_merges_developer_message_with_instructions(client):
     ]
 
 
+def test_responses_endpoint_passes_function_output_image_as_visual_input(client):
+    image_url = "data:image/png;base64,ZmFrZS1pbWFnZQ=="
+    model = SimpleNamespace()
+    processor = SimpleNamespace()
+    config = SimpleNamespace(model_type="qwen2_vl")
+    result = GenerationResult(
+        text="done",
+        prompt_tokens=8,
+        generation_tokens=4,
+        total_tokens=12,
+    )
+
+    with (
+        patch.object(
+            server, "get_cached_model", return_value=(model, processor, config)
+        ),
+        patch.object(
+            server, "apply_chat_template", return_value="prompt"
+        ) as mock_template,
+        patch.object(server, "generate", return_value=result) as mock_generate,
+    ):
+        response = client.post(
+            "/responses",
+            json={
+                "model": "demo",
+                "input": [
+                    {
+                        "type": "function_call",
+                        "name": "view_image",
+                        "arguments": "{}",
+                        "call_id": "call_view_image",
+                    },
+                    {
+                        "type": "function_call_output",
+                        "call_id": "call_view_image",
+                        "output": [
+                            {
+                                "type": "input_image",
+                                "image_url": image_url,
+                                "detail": "high",
+                            }
+                        ],
+                    },
+                ],
+            },
+        )
+
+    assert response.status_code == 200
+    assert mock_template.call_args.args[2][-1] == {
+        "role": "tool",
+        "tool_call_id": "call_view_image",
+        "content": "[Image output attached]",
+    }
+    assert mock_generate.call_args.kwargs["image"] == [image_url]
+
+
 @pytest.mark.parametrize(
     ("include_adapter", "adapter_path", "expected_adapter"),
     [


### PR DESCRIPTION
## Disclosure

This pull request was prepared and submitted by **OpenAI Codex** at Rajeev-SG's direction.

## Summary

Preserve image-valued function output as visual input in the Responses API adapter instead of serializing the image data as tool-message text.

Closes #1760.

## API contract

The official OpenAI Responses API reference defines `function_call_output.output` as either a string or an array of `ResponseInputText`, `ResponseInputImage`, or `ResponseInputFile` items. The image-valued tool output sent by Codex is therefore valid Responses API input; the adapter must preserve the image as visual input rather than stringify it.

Reference: https://developers.openai.com/api/reference/resources/responses/methods/create

## Root cause

`_append_response_item_to_prompt()` converted every non-string function output with `json.dumps()`. When a tool such as `view_image` returned an `input_image` content block, the complete base64 data URL became ordinary text in the next prompt.

The change now:

- extracts `input_image` and `image_url` blocks into the visual input list;
- preserves accompanying text blocks in the tool message;
- keeps unknown content blocks as JSON for backward compatibility;
- uses `[Image output attached]` when an output contains only images.

## Failure evidence

This was reproduced in a real Codex + Qwen3.6 + MLX-VLM conversation:

- Codex-side conversation count before the follow-up: **56,861 tokens**
- image data URL returned by the tool: **391,202 characters**
- MLX-VLM prompt count after JSON serialization: **305,961 tokens**
- request including output allowance: **310,057 tokens**
- configured KV limit: **163,840 tokens**
- result before the fix: HTTP 400

The initial image request succeeded. The failure occurred on the automatic follow-up after the image-valued function output was appended.

## Verification

### Regression coverage

- Added converter tests for image-only and mixed text/image function outputs.
- Added a public `/responses` endpoint test proving the image reaches the generation call as visual input and the tool message does not contain base64 data.
- Full server suite: **253 passed**
- Responses-state tests: **2 passed**
- Pre-commit checks: **black, isort, and autoflake passed**

### Real user-flow proof

An equivalent local routing fix was exercised against the installed, otherwise unmodified MLX-VLM service:

1. Started a fresh Codex task using local Qwen3.6.
2. Attached the original failure screenshot.
3. Required the model to call `view_image`.
4. Confirmed the returned image was converted to visual input.
5. Confirmed the follow-up `/v1/responses` request returned HTTP 200.
6. Confirmed the model completed with `IMAGE_TOOL_LOOP_OK`.

Successful run usage: **39,157 input tokens**, **100 output tokens**.

No image data or private conversation content is included in this PR.

### Direct local boundary proof

A second proof sent the screenshot **only** inside `function_call_output`; there was no ordinary image attachment.

- Installed backend: MLX-VLM **0.6.5**, intentionally left unpatched
- original JSON tool output: **374,586 text characters**
- normalized tool text: **23 characters**
- complete image URL preserved as `input_image`: **374,526 characters**
- base64 present in tool text: **false**
- live endpoint result: **HTTP 200**
- model response: `LOCAL_IMAGE_OUTPUT_OK310057`
- input usage: **2,383 tokens**

The model correctly read `310057` from the function-returned screenshot. This proves the local transformation preserves image semantics while preventing the base64 payload from entering the language-token prompt.
