### PR TITLE
Inkling: restore audio input in the bundled processor

### DIFF
--- a/mlx_vlm/models/inkling/processing_inkling.py
+++ b/mlx_vlm/models/inkling/processing_inkling.py
@@ -10,6 +10,7 @@ from typing import List, Optional, Union
 
 import mlx.core as mx
 import numpy as np
+import transformers
 from PIL import Image
 from transformers import AutoTokenizer
 from transformers.feature_extraction_utils import BatchFeature
@@ -24,6 +25,38 @@ OPENAI_CLIP_STD = [0.26862954, 0.26130258, 0.27577711]
 
 IMAGE_TOKEN = "<|unused_200054|>"
 IMAGE_BOS_TOKEN = "<|content_image|>"
+AUDIO_TOKEN = "<|unused_200053|>"
+
+# dMel quantization defaults (match processor_config.json).
+NUM_DMEL_BINS = 16
+DMEL_MIN_VALUE = -7.0
+DMEL_MAX_VALUE = 2.0
+
+
+def dmel_bin_centers(
+    num_bins: int = NUM_DMEL_BINS,
+    min_value: float = DMEL_MIN_VALUE,
+    max_value: float = DMEL_MAX_VALUE,
+) -> np.ndarray:
+    return np.linspace(min_value, max_value, num_bins, dtype=np.float64)
+
+
+def extract_dmel_bins(
+    features,
+    bin_centers: np.ndarray,
+    min_value: float = DMEL_MIN_VALUE,
+    max_value: float = DMEL_MAX_VALUE,
+) -> np.ndarray:
+    """Quantize log-mel features to nearest-bin dMel token ids.
+
+    Same arithmetic as the reference processor (clamp then nearest bin center,
+    computed in float64), but in numpy so audio input does not require torch.
+    numpy and torch linspace centers can differ in their last ulp, which could
+    only matter for a feature value exactly midway between two centers; real
+    log-mel features never sit on that measure-zero set.
+    """
+    mel = np.clip(np.asarray(features, dtype=np.float64), min_value, max_value)
+    return np.abs(mel[..., None] - bin_centers).argmin(axis=-1).astype(np.int32)
 
 
 def divide_to_patches(image: np.ndarray, patch_size: int) -> List[np.ndarray]:
@@ -124,12 +157,13 @@ class InklingImageProcessor(BaseImageProcessor):
 
 
 class InklingProcessor(ProcessorMixin):
-    """Wraps the Inkling image processor and tokenizer.
+    """Wraps the Inkling image processor, audio feature extractor and tokenizer.
 
-    ``__call__`` expands the single image placeholder emitted by the chat
-    template into one ``image_token`` per patch, and tokenizes via ``encode``
-    (+ manual left/right padding) so it does not depend on the tokenizer having a
-    pad token configured.
+    ``__call__`` expands the single image (audio) placeholder emitted by the
+    chat template into one ``image_token`` per patch (``audio_token`` per dMel
+    frame), and tokenizes via ``encode`` (+ manual left/right padding) so it
+    does not depend on the tokenizer having a pad token configured. Audio is
+    quantized to dMel token ids in numpy; torch is not required.
     """
 
     attributes = ["image_processor", "tokenizer"]
@@ -138,17 +172,44 @@ class InklingProcessor(ProcessorMixin):
     tokenizer_class = "AutoTokenizer"
 
     def __init__(
-        self, image_processor=None, tokenizer=None, chat_template=None, **kwargs
+        self,
+        image_processor=None,
+        tokenizer=None,
+        chat_template=None,
+        audio_extractor=None,
+        num_dmel_bins: int = NUM_DMEL_BINS,
+        dmel_min_value: float = DMEL_MIN_VALUE,
+        dmel_max_value: float = DMEL_MAX_VALUE,
+        **kwargs,
     ):
         self.image_token = IMAGE_TOKEN
+        self.audio_token = AUDIO_TOKEN
+        self.num_dmel_bins = num_dmel_bins
+        self.dmel_min_value = dmel_min_value
+        self.dmel_max_value = dmel_max_value
+        self.bin_centers = dmel_bin_centers(
+            num_dmel_bins, dmel_min_value, dmel_max_value
+        )
         if image_processor is None:
             image_processor = InklingImageProcessor()
         super().__init__(image_processor, tokenizer, chat_template=chat_template)
+        # Stored under the conventional name (callers probe
+        # `processor.feature_extractor` for the sampling rate), but the
+        # parameter must not be called that: ProcessorMixin derives its
+        # required arguments from modality keywords in the __init__ signature,
+        # and would demand a feature extractor for every checkpoint.
+        self.feature_extractor = audio_extractor
+
+    def _extract_dmel_bins(self, input_features) -> np.ndarray:
+        return extract_dmel_bins(
+            input_features, self.bin_centers, self.dmel_min_value, self.dmel_max_value
+        )
 
     def __call__(
         self,
         images: ImageInput = None,
         text: Union[TextInput, PreTokenizedInput, List[TextInput]] = None,
+        audio=None,
         padding_side: str = "left",
         **kwargs,
     ) -> BatchFeature:
@@ -161,6 +222,34 @@ class InklingProcessor(ProcessorMixin):
         if images is not None:
             image_inputs = self.image_processor(images)
             num_patches = image_inputs.pop("num_patches")
+
+        audio_inputs = {}
+        num_audio_tokens = None
+        if audio is not None:
+            if self.feature_extractor is None:
+                raise ValueError(
+                    "This processor has no audio feature extractor (the "
+                    "checkpoint ships none, or the installed transformers "
+                    "predates Inkling); audio input is unavailable."
+                )
+            if not isinstance(audio, list):
+                audio = [audio]
+            fe_out = self.feature_extractor(
+                audio,
+                sampling_rate=getattr(self.feature_extractor, "sampling_rate", None),
+                return_tensors="np",
+            )
+            bins = self._extract_dmel_bins(fe_out["input_features"])
+            mask = fe_out.get("input_features_mask", fe_out.get("attention_mask"))
+            audio_inputs = {"audio_input_ids": mx.array(bins)}
+            if mask is not None:
+                mask = np.asarray(mask)
+                audio_inputs["audio_input_ids_mask"] = mx.array(mask)
+            # One audio soft token per valid dMel frame.
+            num_audio_tokens = [
+                int(mask[i].sum()) if mask is not None else int(bins[i].shape[-2])
+                for i in range(bins.shape[0])
+            ]
 
         if isinstance(text, str):
             text = [text]
@@ -181,6 +270,19 @@ class InklingProcessor(ProcessorMixin):
                     idx += 1
                 text[i] = text[i].replace("<|placeholder|>", self.image_token)
 
+        # Audio placeholders expand the same way, one token per dMel frame.
+        if num_audio_tokens is not None and text is not None:
+            idx = 0
+            for i in range(len(text)):
+                while self.audio_token in text[i]:
+                    text[i] = text[i].replace(
+                        self.audio_token,
+                        "<|placeholder|>" * num_audio_tokens[idx],
+                        1,
+                    )
+                    idx += 1
+                text[i] = text[i].replace("<|placeholder|>", self.audio_token)
+
         text_inputs = {}
         if text is not None:
             all_ids = [self.tokenizer.encode(t) for t in text]
@@ -200,7 +302,7 @@ class InklingProcessor(ProcessorMixin):
                 "attention_mask": mx.array(attention),
             }
 
-        return BatchFeature(data={**text_inputs, **image_inputs})
+        return BatchFeature(data={**text_inputs, **image_inputs, **audio_inputs})
 
     def batch_decode(self, *args, **kwargs):
         return self.tokenizer.batch_decode(*args, **kwargs)
@@ -249,10 +351,35 @@ class InklingProcessor(ProcessorMixin):
                 chat_template = jinja_path.read_text(encoding="utf-8")
                 tokenizer.chat_template = chat_template
 
+        # Audio: the checkpoint nests the feature-extractor config inside
+        # processor_config.json. Resolve the class from transformers by name;
+        # when it is missing (transformers predating Inkling) the processor
+        # still loads and raises a clear error only if audio arrives.
+        feature_extractor = None
+        dmel_kwargs = {}
+        proc_cfg_path = model_path / "processor_config.json"
+        if proc_cfg_path.exists():
+            proc_cfg = json.loads(proc_cfg_path.read_text())
+            dmel_kwargs = {
+                key: proc_cfg[key]
+                for key in ("num_dmel_bins", "dmel_min_value", "dmel_max_value")
+                if key in proc_cfg
+            }
+            fe_cfg = proc_cfg.get("feature_extractor")
+            if isinstance(fe_cfg, dict):
+                fe_cfg = dict(fe_cfg)
+                fe_cls = getattr(
+                    transformers, fe_cfg.pop("feature_extractor_type", ""), None
+                )
+                if fe_cls is not None:
+                    feature_extractor = fe_cls(**fe_cfg)
+
         return cls(
             image_processor=InklingImageProcessor(),
             tokenizer=tokenizer,
             chat_template=chat_template,
+            audio_extractor=feature_extractor,
+            **dmel_kwargs,
         )
 
 

--- a/mlx_vlm/tests/test_inkling.py
+++ b/mlx_vlm/tests/test_inkling.py
@@ -1,4 +1,5 @@
 import mlx.core as mx
+import pytest
 
 from mlx_vlm.generate.ar import _make_cache
 from mlx_vlm.models.cache import ArraysCache, BatchKVCache, CacheList
@@ -167,3 +168,62 @@ def test_mtp_eval_state_skips_empty_kv_caches():
     state = drafter.draft_eval_state()
 
     assert len(state) == 4
+
+
+def test_dmel_bins_match_reference():
+    torch = pytest.importorskip("torch")
+    try:
+        from transformers.models.inkling.processing_inkling import (
+            InklingProcessor as HFInklingProcessor,
+        )
+    except Exception:
+        pytest.skip("transformers without inkling")
+    import numpy as np
+
+    from mlx_vlm.models.inkling.processing_inkling import (
+        DMEL_MAX_VALUE,
+        DMEL_MIN_VALUE,
+        NUM_DMEL_BINS,
+        dmel_bin_centers,
+        extract_dmel_bins,
+    )
+
+    centers = dmel_bin_centers()
+
+    class Reference:
+        bin_centers = torch.linspace(
+            DMEL_MIN_VALUE, DMEL_MAX_VALUE, NUM_DMEL_BINS, dtype=torch.float64
+        )
+        dmel_min_value = DMEL_MIN_VALUE
+        dmel_max_value = DMEL_MAX_VALUE
+
+    rng = np.random.default_rng(0)
+    random_mel = rng.normal(-2.0, 3.0, size=(2, 40, 80)).astype(np.float32)
+    # exact bin centers, values a hair off the midpoints, and out-of-range
+    # values that exercise the clamp (exact midpoints are excluded: numpy and
+    # torch linspace centers differ in the last ulp, and no clamped log-mel
+    # feature can land on a midpoint)
+    edges = np.concatenate(
+        [
+            centers,
+            (centers[:-1] + centers[1:]) / 2 + 1e-3,
+            (centers[:-1] + centers[1:]) / 2 - 1e-3,
+            [DMEL_MIN_VALUE - 5.0, DMEL_MAX_VALUE + 5.0],
+        ]
+    ).astype(np.float32)
+    for mel in (random_mel, edges.reshape(1, 1, -1)):
+        ours = extract_dmel_bins(mel, centers)
+        theirs = HFInklingProcessor._extract_dmel_bins(
+            Reference(), torch.from_numpy(mel)
+        )
+        assert ours.dtype == np.int32
+        assert np.array_equal(ours, theirs.numpy())
+
+
+def test_processor_audio_requires_feature_extractor():
+    from mlx_vlm.models.inkling.processing_inkling import InklingProcessor
+
+    proc = InklingProcessor.__new__(InklingProcessor)
+    proc.feature_extractor = None
+    with pytest.raises(ValueError, match="audio input is unavailable"):
+        InklingProcessor.__call__(proc, text="hi", audio=[[0.0] * 16000])


### PR DESCRIPTION
## Summary

Audio input for Inkling is broken on main: any `--audio` request raises `Processor InklingProcessor does not support audio parameter`. This restores it inside the bundled processor, torch-free, with dMel quantization verified bit-equal to the reference implementation and end-to-end greedy output token-identical to the last known-good state.

## What broke

The bundled `InklingProcessor` from #1756 installs itself over `AutoProcessor` for every Inkling checkpoint, and it only implements the image and text paths. `process_inputs` inspects the processor signature for an `audio` parameter, finds none, and raises before any audio touches the model. The transformers processor is not a fallback either: its `_extract_dmel_bins` calls `.to(...)` on its input, and this pipeline runs feature extractors with numpy return types, so routing audio there dies with `'numpy.ndarray' object has no attribute 'to'`.

## The fix

Audio becomes a first-class path in the bundled processor:

- `from_pretrained` resolves the feature extractor from the config nested in `processor_config.json`, by class name through the transformers namespace. An older transformers without Inkling still loads the processor for image and text work; only an actual audio input raises, with a message saying why.
- dMel quantization is implemented in plain numpy: clamp to the dMel range, then nearest bin center, computed in float64 like the reference. No torch import anywhere in the path.
- The audio placeholder emitted by the chat template expands into one audio token per valid dMel frame (mask-aware), mirroring how image placeholders expand per patch, and the processor returns `audio_input_ids` and `audio_input_ids_mask` in the shapes the model's audio tower consumes.

One deliberate oddity, commented in the code: the constructor parameter is `audio_extractor`, stored as `self.feature_extractor`. `ProcessorMixin.get_attributes` scrapes the `__init__` signature for modality keywords, and a parameter named `feature_extractor` silently becomes a required constructor argument for every checkpoint, image-only conversions included.

## Verification

- New test compares the numpy dMel binning against the transformers torch implementation on random features, exact bin centers, values just off the bin midpoints, and out-of-range values that exercise the clamp: bit-equal bin ids everywhere. Exact midpoints are excluded on purpose: numpy and torch `linspace` disagree in the last ulp of the centers, and only a feature sitting exactly on a midpoint could observe it; the clamp keeps real log-mel values off that measure-zero set. The tests skip cleanly when torch or an Inkling-aware transformers is absent.
- A second test pins the error behavior when no feature extractor is available.
- End to end on Inkling-Small (q4, M-series): greedy `--audio` generation over a 440 Hz sine fixture produces exactly the same tokens as the pre-regression transformers path did ("A brief, high-pitched electronic beep."), and the full `test_inkling.py` suite passes.
