### PR TITLE
Evaluate weights incrementally when saving to avoid Metal GPU timeout

### DIFF
--- a/mlx_vlm/convert.py
+++ b/mlx_vlm/convert.py
@@ -9,6 +9,8 @@ import mlx.nn as nn
 from mlx.utils import tree_map_with_path
 
 from .utils import (
+    DEFAULT_EVAL_EVERY,
+    MAX_FILE_SIZE_GB,
     MODEL_CONVERSION_DTYPES,
     create_model_card,
     fetch_from_hub,
@@ -295,6 +297,8 @@ def convert(
     dequantize: bool = False,
     trust_remote_code: bool = True,
     quant_predicate: Optional[str] = None,
+    shard_gb: int = MAX_FILE_SIZE_GB,
+    eval_every: Optional[int] = DEFAULT_EVAL_EVERY,
 ):
     print("[INFO] Loading")
     model_path = get_model_path(hf_path, revision=revision)
@@ -388,7 +392,13 @@ def convert(
     if isinstance(mlx_path, str):
         mlx_path = Path(mlx_path)
 
-    save_weights(mlx_path, target, donate_weights=True)
+    save_weights(
+        mlx_path,
+        target,
+        donate_weights=True,
+        shard_gb=shard_gb,
+        eval_every=eval_every,
+    )
 
     # Copy Python and JSON files from the model path to the MLX path
     for pattern in ["*.py", "*.json"]:
@@ -534,6 +544,19 @@ def configure_parser() -> argparse.ArgumentParser:
         help="Trust remote code.",
         action="store_true",
         default=False,
+    )
+    parser.add_argument(
+        "--shard-gb",
+        help="Maximum size of each safetensors shard, in gigabytes.",
+        type=int,
+        default=MAX_FILE_SIZE_GB,
+    )
+    parser.add_argument(
+        "--eval-every",
+        help="Tensors to evaluate per batch while writing shards. Lower this if"
+        " saving a large model hits a Metal GPU timeout.",
+        type=int,
+        default=DEFAULT_EVAL_EVERY,
     )
     return parser
 

--- a/mlx_vlm/tests/test_utils.py
+++ b/mlx_vlm/tests/test_utils.py
@@ -10,10 +10,12 @@ from unittest.mock import MagicMock, patch
 import mlx.core as mx
 import mlx.nn as nn
 import pytest
+from mlx.utils import tree_flatten
 
 from mlx_vlm.convert import _preserve_existing_deepseek_v4_quantization
 from mlx_vlm.models.text_only import TextOnlyModel
 from mlx_vlm.utils import (
+    MAX_FILE_SIZE_GB,
     StoppingCriteria,
     _load_safetensors,
     apply_generation_config_defaults,
@@ -23,9 +25,11 @@ from mlx_vlm.utils import (
     load_image,
     load_model,
     load_processor,
+    make_shards,
     prepare_inputs,
     process_inputs_with_fallback,
     sanitize_weights,
+    save_weights,
     update_module_configs,
 )
 
@@ -927,3 +931,126 @@ class TestLoadImage:
     def test_nonexistent_path_object_raises(self):
         with pytest.raises(ValueError, match="Failed to load image"):
             load_image(Path("/nonexistent/path/image.png"))
+
+
+class TestSaveWeights:
+    """Covers shard sizing and the incremental evaluation that keeps Metal
+    command buffers inside the IOGPU watchdog window (see #1448)."""
+
+    @staticmethod
+    def _model(n_layers=5, dims=64):
+        class Stack(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.layers = [nn.Linear(dims, dims) for _ in range(n_layers)]
+
+        return Stack()
+
+    def test_make_shards_respects_max_file_size(self):
+        gb = 1 << 30
+        weights = {f"w{i}": SimpleNamespace(nbytes=gb // 2) for i in range(6)}
+
+        assert len(make_shards(weights, max_file_size_gb=1)) == 3
+        assert len(make_shards(weights, max_file_size_gb=3)) == 1
+
+    def test_shard_gb_is_forwarded_to_make_shards(self, tmp_path):
+        model = self._model()
+
+        with patch("mlx_vlm.utils.make_shards", side_effect=make_shards) as mock_shards:
+            save_weights(tmp_path, model, shard_gb=2)
+
+        assert mock_shards.call_args.kwargs["max_file_size_gb"] == 2
+
+    def test_shard_gb_defaults_to_max_file_size_gb(self, tmp_path):
+        model = self._model()
+
+        with patch("mlx_vlm.utils.make_shards", side_effect=make_shards) as mock_shards:
+            save_weights(tmp_path, model)
+
+        assert mock_shards.call_args.kwargs["max_file_size_gb"] == MAX_FILE_SIZE_GB
+
+    def test_tensors_are_evaluated_in_batches(self, tmp_path):
+        # 5 Linear layers -> 10 tensors (weight + bias each).
+        model = self._model(n_layers=5)
+
+        with patch("mlx_vlm.utils.mx.eval", side_effect=mx.eval) as mock_eval:
+            save_weights(tmp_path, model, eval_every=4)
+
+        batch_sizes = [len(call.args[0]) for call in mock_eval.call_args_list]
+        assert batch_sizes == [4, 4, 2]
+
+    def test_eval_every_none_skips_incremental_eval(self, tmp_path):
+        model = self._model()
+
+        with patch("mlx_vlm.utils.mx.eval", side_effect=mx.eval) as mock_eval:
+            save_weights(tmp_path, model, eval_every=None)
+
+        mock_eval.assert_not_called()
+        assert (tmp_path / "model.safetensors").exists()
+
+    @pytest.mark.parametrize("eval_every", [0, -1])
+    def test_invalid_eval_every_raises(self, tmp_path, eval_every):
+        with pytest.raises(ValueError, match="eval_every must be >= 1"):
+            save_weights(tmp_path, self._model(), eval_every=eval_every)
+
+    @pytest.mark.parametrize("shard_gb", [0, -1])
+    def test_invalid_shard_gb_raises(self, tmp_path, shard_gb):
+        # make_shards would otherwise emit a leading empty shard.
+        with pytest.raises(ValueError, match="shard_gb must be >= 1"):
+            save_weights(tmp_path, self._model(), shard_gb=shard_gb)
+
+    def test_written_weights_do_not_depend_on_eval_every(self, tmp_path):
+        model = self._model()
+        expected = dict(tree_flatten(model.parameters()))
+
+        for eval_every in (None, 1, 3, 1000):
+            out = tmp_path / f"eval_{eval_every}"
+            save_weights(out, model, eval_every=eval_every)
+
+            written = mx.load(str(out / "model.safetensors"))
+            assert written.keys() == expected.keys()
+            for key, value in expected.items():
+                assert mx.array_equal(written[key], value), key
+
+    def test_index_and_metadata_are_written(self, tmp_path):
+        model = self._model()
+        weights = dict(tree_flatten(model.parameters()))
+
+        save_weights(tmp_path, model)
+
+        with open(tmp_path / "model.safetensors.index.json") as f:
+            index = json.load(f)
+
+        assert index["metadata"]["total_size"] == sum(
+            v.nbytes for v in weights.values()
+        )
+        assert set(index["weight_map"]) == set(weights)
+        assert set(index["weight_map"].values()) == {"model.safetensors"}
+        assert list(index["weight_map"]) == sorted(index["weight_map"])
+
+    def test_incremental_eval_works_with_donated_weights(self, tmp_path):
+        """convert() saves with donate_weights=True; the shard references must
+        still be evaluable after the model drops its own parameters."""
+        model = self._model()
+        expected = dict(tree_flatten(model.parameters()))
+
+        save_weights(tmp_path, model, donate_weights=True, eval_every=1)
+
+        written = mx.load(str(tmp_path / "model.safetensors"))
+        for key, value in expected.items():
+            assert mx.array_equal(written[key], value), key
+
+    def test_quantized_weights_survive_incremental_eval(self, tmp_path):
+        """The failing path in #1448: lazily quantized tensors are what
+        mx.save_safetensors would otherwise evaluate in one command buffer."""
+        model = self._model(n_layers=3)
+        nn.quantize(model, group_size=64, bits=4)
+        expected = dict(tree_flatten(model.parameters()))
+
+        save_weights(tmp_path, model, eval_every=2)
+
+        written = mx.load(str(tmp_path / "model.safetensors"))
+        assert any(k.endswith("scales") for k in written)
+        assert written.keys() == expected.keys()
+        for key, value in expected.items():
+            assert mx.array_equal(written[key], value), key

--- a/mlx_vlm/utils.py
+++ b/mlx_vlm/utils.py
@@ -54,6 +54,10 @@ MODEL_REMAPPING = {
 
 MAX_FILE_SIZE_GB = 5
 
+# Tensors evaluated per mx.eval call while writing shards. Keeps each Metal
+# command buffer small enough to stay inside the IOGPU watchdog window.
+DEFAULT_EVAL_EVERY = 16
+
 MODEL_CONVERSION_DTYPES = ["float16", "bfloat16", "float32"]
 
 SAFETENSORS_DTYPE_FALLBACKS = {"F8_E8M0": "U8"}
@@ -1274,16 +1278,38 @@ def save_weights(
     model: nn.Module,
     *,
     donate_weights: bool = False,
+    shard_gb: int = MAX_FILE_SIZE_GB,
+    eval_every: Optional[int] = DEFAULT_EVAL_EVERY,
 ) -> None:
-    """Save model weights into specified directory."""
+    """Save model weights into specified directory.
+
+    Args:
+        save_path: Directory to write the shards and index into.
+        model: Module whose parameters are saved.
+        donate_weights: Drop the model's references to its parameters so memory
+            can be reclaimed while shards are written.
+        shard_gb: Maximum size of each safetensors shard, in gigabytes.
+        eval_every: Number of tensors to force-evaluate per ``mx.eval`` call
+            before a shard is handed to ``mx.save_safetensors``. Lazily
+            quantized weights are otherwise all evaluated by the save itself,
+            as a single Metal command buffer that can exceed the IOGPU
+            watchdog window on large models. Pass ``None`` to skip the
+            incremental evaluation.
+    """
     if isinstance(save_path, str):
         save_path = Path(save_path)
+
+    if shard_gb < 1:
+        raise ValueError(f"shard_gb must be >= 1, got {shard_gb}")
+
+    if eval_every is not None and eval_every < 1:
+        raise ValueError(f"eval_every must be >= 1, got {eval_every}")
 
     weights = dict(tree_flatten(model.parameters()))
 
     save_path.mkdir(parents=True, exist_ok=True)
 
-    shards = make_shards(weights)
+    shards = make_shards(weights, max_file_size_gb=shard_gb)
     shards_count = len(shards)
     shard_file_format = (
         "model-{:05d}-of-{:05d}.safetensors"
@@ -1307,6 +1333,17 @@ def save_weights(
         shards[i] = None
         shard_name = shard_file_format.format(i + 1, shards_count)
         shard_path = save_path / shard_name
+
+        # Evaluate the shard's tensors in small batches so that no single Metal
+        # command buffer is large enough to trip the GPU watchdog. Without this,
+        # mx.save_safetensors evaluates every lazily quantized tensor in the
+        # shard at once, which fails on large models with:
+        #   [METAL] Command buffer execution failed: Caused GPU Timeout
+        if eval_every is not None:
+            shard_arrays = list(shard.values())
+            for start in range(0, len(shard_arrays), eval_every):
+                mx.eval(shard_arrays[start : start + eval_every])
+            del shard_arrays
 
         mx.save_safetensors(str(shard_path), shard, metadata={"format": "mlx"})
 


### PR DESCRIPTION
Addresses #1448, which was closed without a fix.

## Summary

`mlx_vlm.convert` quantizes a large model fine and then dies while writing the
weights:

```
[INFO] Quantized model with 4.402 bits per weight.
RuntimeError: [METAL] Command buffer execution failed: Caused GPU Timeout Error
  (00000002:kIOGPUCommandBufferCallbackErrorTimeout)
```

`save_weights()` builds shards of up to `MAX_FILE_SIZE_GB` (5 GB) and hands each
one straight to `mx.save_safetensors`. That call forces evaluation of every lazy
tensor in the shard as a single Metal command buffer, and on a big model the
buffer runs long enough for the IOGPU watchdog to kill it. The quantization step
has already finished by then; only the write fails.

The fix evaluates each shard in small batches before saving, so no single command
buffer is big enough to trip the watchdog. Same approach used in mlx-lm for the
same class of failure (ml-explore/mlx-lm#1572).

## Changes

- `mlx_vlm/utils.py`: `save_weights()` takes `shard_gb` and `eval_every`. Before
  each `mx.save_safetensors`, the shard's tensors are evaluated in batches of
  `eval_every`. Added `DEFAULT_EVAL_EVERY = 16` and validation on both params.
- `mlx_vlm/convert.py`: both are threaded through `convert()` and exposed as
  `--shard-gb` and `--eval-every`.
- `mlx_vlm/tests/test_utils.py`: new `TestSaveWeights`, 13 tests.

Defaults preserve today's on-disk layout; `shard_gb` stays at `MAX_FILE_SIZE_GB`
and the batched eval is behaviour-preserving. Pass `eval_every=None` to get the
exact previous code path.

## Evidence

Controlled pair on the model from #1448, `huihui-ai/Huihui-Qwen3.6-35B-A3B-abliterated`
with `-q --q-mode mxfp4`, same machine, minutes apart. `eval_every=None` is the
current behaviour:

| Run | Settings | Result |
|---|---|---|
| stock | `eval_every=None`, `shard_gb=5` | crash after 138s, `kIOGPUCommandBufferCallbackErrorSubmissionsIgnored`, shard 1 at 5.35 GB and shard 2 at 0 bytes |
| fixed | `eval_every=16`, `shard_gb=1` | ok after 57s, 19 shards written |

Both runs report `4.402 bits per weight`, which matches the number in #1448
exactly, so this is the same failure the issue describes. The crash happened with
37.9 GB of disk free, and the fixed run then completed the same conversion with
25 GB free, so it is not a disk problem.

Two more data points from a 36B MoE (`qwen3_5_moe`, 102 GB bf16 source): the stock
converter died the same way while writing shard 3, and a chunked writer got
through 20 of 22 shards with no GPU error at all.

Correctness of the output:

- With default settings the emitted `model.safetensors` and
  `model.safetensors.index.json` are byte-identical to the pre-change code path,
  verified by SHA-256 against a run with `eval_every=None`.
- Multi-shard round-trip is bit-exact: 2.64 GB across 1120 quantized tensors into
  3 shards, every tensor compared with `mx.array_equal` after reload, and every
  `weight_map` entry checked to resolve to the shard that actually holds it.

## Risks

The watchdog is a timeout, so the failure is load sensitive rather than a hard
threshold. On a smaller model I could not get it to fire at all across repeated
stock runs, so shard byte size alone is not sufficient; it depends on how much
work the buffer ends up doing and what else is using the GPU. Treat the 35B
result above as the case this addresses.

The batched eval now runs on every convert, not just large models. It is
behaviour-preserving and the byte-identical check above covers that, but it is a
change to a path every conversion goes through, hence `eval_every=None` as an
escape hatch.

`eval_every=16` is a conservative default. Very wide tensors could in principle
still make one batch large; lowering `--eval-every` handles that without a code
change.

## Pre-merge

- `pytest mlx_vlm/tests/test_utils.py`, 47 passed, 13 of them new.
- `pytest mlx_vlm/tests/test_models.py -k "quant or gemma4_unified or save"`, 14
  passed. These cover the existing save then reload round-trips with quantized
  weights, which is the path being changed.
- `black` and `isort --profile=black` clean.

## Post-merge

- Worth reopening #1448 so the original reporter can confirm on their model, it
  was closed without a fix.
- Anyone hitting this on a very large model can drop `--shard-gb` to 1 as well;
  smaller shards reduce peak memory during the write.

## Note

`convert()` defaults `q_group_size=64` in its Python signature, which is invalid
for `mxfp4` and raises `[quantize] mxfp4 quantization requires group size 32 but
got 64` when the function is called directly. The CLI avoids it by passing `None`.
Unrelated to this change so I left it alone, but it looks like a real API vs CLI
inconsistency.


