### PR TITLE
Add audio feature extractor for Inkling

### DIFF
--- a/mlx_vlm/models/inkling/__init__.py
+++ b/mlx_vlm/models/inkling/__init__.py
@@ -1,3 +1,4 @@
+from .audio_feature_extractor import InklingAudioFeatureExtractor
 from .config import AudioConfig, ModelConfig, TextConfig, VisionConfig
 from .inkling import Model
 from .language import LanguageModel
@@ -9,6 +10,7 @@ __all__ = [
     "TextConfig",
     "VisionConfig",
     "AudioConfig",
+    "InklingAudioFeatureExtractor",
     "LanguageModel",
     "InklingProcessor",
     "InklingImageProcessor",

--- a/mlx_vlm/models/inkling/audio.py
+++ b/mlx_vlm/models/inkling/audio.py
@@ -14,14 +14,31 @@ class AudioModel(nn.Module):
         self.model_type = config.model_type
         self.n_mel_bins = config.n_mel_bins
         self.mel_vocab_size = config.mel_vocab_size
+        self.hidden_size = config.text_hidden_size
+        self.max_frames_per_chunk = config.max_frames_per_chunk
+        if self.max_frames_per_chunk <= 0:
+            raise ValueError("max_frames_per_chunk must be positive")
         self.embed_audio_tokens = nn.Embedding(
             config.n_mel_bins * config.mel_vocab_size, config.text_hidden_size
         )
         self.norm = nn.RMSNorm(config.text_hidden_size, eps=config.rms_norm_eps)
 
-    def __call__(self, audio_input_ids):
-        """audio_input_ids: [..., frames, n_mel_bins] of bucket indices -> [..., frames, hidden]."""
+    def _embed(self, audio_input_ids):
         offsets = mx.arange(self.n_mel_bins) * self.mel_vocab_size
         embeds = self.embed_audio_tokens(audio_input_ids + offsets)
         embeds = embeds.sum(axis=-2)
         return self.norm(embeds)
+
+    def __call__(self, audio_input_ids):
+        """audio_input_ids: [..., frames, n_mel_bins] of bucket indices -> [..., frames, hidden]."""
+        output_shape = (*audio_input_ids.shape[:-1], self.hidden_size)
+        frames = audio_input_ids.reshape(-1, self.n_mel_bins)
+        if frames.shape[0] <= self.max_frames_per_chunk:
+            return self._embed(frames).reshape(output_shape)
+
+        chunks = []
+        for start in range(0, frames.shape[0], self.max_frames_per_chunk):
+            features = self._embed(frames[start : start + self.max_frames_per_chunk])
+            mx.eval(features)
+            chunks.append(features)
+        return mx.concatenate(chunks, axis=0).reshape(output_shape)

--- a/mlx_vlm/models/inkling/audio_feature_extractor.py
+++ b/mlx_vlm/models/inkling/audio_feature_extractor.py
@@ -1,0 +1,228 @@
+from collections.abc import Sequence
+from typing import Optional, Union
+
+import mlx.core as mx
+import numpy as np
+from mlx_audio.dsp import hanning, mel_filters, stft
+
+
+def _exact_sample_count(value: float, name: str) -> int:
+    rounded = round(value)
+    if abs(value - rounded) > 1e-6:
+        raise ValueError(f"{name} must resolve to an integer sample count, got {value}")
+    return int(rounded)
+
+
+class InklingAudioFeatureExtractor:
+    """Convert waveforms to the log-mel frames consumed by Inkling's dMel tokenizer."""
+
+    model_input_names = ["input_features", "input_features_mask"]
+
+    def __init__(
+        self,
+        feature_size: int = 80,
+        sampling_rate: int = 16_000,
+        padding_value: float = 0.0,
+        audio_token_duration_s: float = 0.05,
+        window_size_multiplier: float = 2.0,
+        n_fft: Optional[int] = None,
+        hop_length: Optional[int] = None,
+        window_size: Optional[int] = None,
+        max_frames_per_chunk: int = 1024,
+        return_attention_mask: bool = True,
+        **kwargs,
+    ):
+        computed_hop = _exact_sample_count(
+            audio_token_duration_s * sampling_rate,
+            "audio_token_duration_s * sampling_rate",
+        )
+        computed_window = _exact_sample_count(
+            audio_token_duration_s * window_size_multiplier * sampling_rate,
+            "audio_token_duration_s * window_size_multiplier * sampling_rate",
+        )
+
+        self.feature_size = feature_size
+        self.sampling_rate = sampling_rate
+        self.padding_value = padding_value
+        self.audio_token_duration_s = audio_token_duration_s
+        self.window_size_multiplier = window_size_multiplier
+        self.hop_length = computed_hop if hop_length is None else hop_length
+        self.window_size = computed_window if window_size is None else window_size
+        self.n_fft = self.window_size if n_fft is None else n_fft
+        self.max_frames_per_chunk = max_frames_per_chunk
+        self.return_attention_mask = return_attention_mask
+
+        if min(self.hop_length, self.window_size, self.n_fft) <= 0:
+            raise ValueError("hop_length, window_size, and n_fft must be positive")
+        if self.window_size > self.n_fft:
+            raise ValueError("window_size cannot be larger than n_fft")
+        if self.max_frames_per_chunk <= 0:
+            raise ValueError("max_frames_per_chunk must be positive")
+
+        window = hanning(self.window_size, periodic=True).astype(mx.float32)
+        if self.window_size < self.n_fft:
+            left = (self.n_fft - self.window_size) // 2
+            right = self.n_fft - self.window_size - left
+            window = mx.pad(window, [(left, right)])
+        self.window = window
+        self.mel_filters = mel_filters(
+            sampling_rate,
+            self.n_fft,
+            feature_size,
+            norm="slaney",
+            mel_scale="slaney",
+            precise=True,
+        )
+
+    @staticmethod
+    def _as_clips(raw_speech) -> list:
+        if isinstance(raw_speech, (np.ndarray, mx.array)):
+            if raw_speech.ndim > 2:
+                raise ValueError(
+                    "A single audio array must be 1-D or 2-D; pass a list of "
+                    "arrays for a batch."
+                )
+            return [raw_speech]
+
+        if not isinstance(raw_speech, (list, tuple)):
+            raise TypeError(f"Unsupported audio input type: {type(raw_speech)}")
+        if not raw_speech:
+            raise ValueError("Received an empty audio input.")
+        if np.isscalar(raw_speech[0]):
+            return [raw_speech]
+        return list(raw_speech)
+
+    @staticmethod
+    def _to_mono(clip) -> mx.array:
+        if isinstance(clip, mx.array):
+            waveform = clip.astype(mx.float32)
+        else:
+            waveform = mx.array(np.asarray(clip, dtype=np.float32))
+
+        if waveform.ndim == 2:
+            waveform = mx.mean(waveform, axis=-1)
+        elif waveform.ndim != 1:
+            raise ValueError(
+                f"Each audio clip must be 1-D or 2-D, got shape {waveform.shape}."
+            )
+        if waveform.size == 0:
+            raise ValueError("Audio clips must contain at least one sample.")
+        return waveform
+
+    def _extract_log_mel(self, waveform: mx.array, padded_length: int) -> mx.array:
+        right_pad = (-padded_length) % self.hop_length
+        left_pad = max(self.n_fft - self.hop_length, 0)
+        total_length = left_pad + padded_length + right_pad
+        num_frames = 1 + (total_length - self.n_fft) // self.hop_length
+
+        chunks = []
+        for frame_start in range(0, num_frames, self.max_frames_per_chunk):
+            frame_count = min(self.max_frames_per_chunk, num_frames - frame_start)
+            segment_start = frame_start * self.hop_length - left_pad
+            segment_length = (frame_count - 1) * self.hop_length + self.n_fft
+            segment_end = segment_start + segment_length
+
+            data_start = min(max(segment_start, 0), waveform.shape[0])
+            data_end = min(max(segment_end, data_start), waveform.shape[0])
+            segment = waveform[data_start:data_end]
+            pad_left = max(-segment_start, 0)
+            pad_right = segment_length - pad_left - segment.shape[0]
+
+            if pad_left or pad_right:
+                segment = mx.pad(segment, [(pad_left, pad_right)])
+            spectrum = stft(
+                segment,
+                n_fft=self.n_fft,
+                hop_length=self.hop_length,
+                win_length=self.n_fft,
+                window=self.window,
+                center=False,
+            )
+            magnitudes = mx.maximum(mx.abs(spectrum), 1e-10)
+            # vmap uses accurate GEMV reductions; Metal GEMM can move values
+            # across nearby dMel bin boundaries.
+            mel = mx.vmap(lambda mel_filter: magnitudes @ mel_filter)(
+                self.mel_filters
+            ).T
+            log_mel = mx.log10(mx.maximum(mel, 1e-10))
+
+            # Bound the lazy graph and release FFT temporaries before the next chunk.
+            mx.eval(log_mel)
+            chunks.append(log_mel)
+
+        return chunks[0] if len(chunks) == 1 else mx.concatenate(chunks, axis=0)
+
+    def __call__(
+        self,
+        raw_speech: Union[
+            np.ndarray,
+            mx.array,
+            Sequence[float],
+            Sequence[np.ndarray],
+        ],
+        sampling_rate: Optional[int] = None,
+        padding: Union[bool, str] = True,
+        max_length: Optional[int] = None,
+        truncation: bool = False,
+        pad_to_multiple_of: Optional[int] = None,
+        return_attention_mask: Optional[bool] = None,
+        return_tensors: Optional[str] = None,
+        **kwargs,
+    ) -> dict:
+        if sampling_rate is not None and sampling_rate != self.sampling_rate:
+            raise ValueError(
+                f"Inkling expects {self.sampling_rate} Hz audio, got {sampling_rate} Hz."
+            )
+
+        waveforms = [self._to_mono(clip) for clip in self._as_clips(raw_speech)]
+        if truncation and max_length is not None:
+            waveforms = [waveform[:max_length] for waveform in waveforms]
+            if any(waveform.size == 0 for waveform in waveforms):
+                raise ValueError("max_length must retain at least one audio sample.")
+
+        lengths = [waveform.shape[0] for waveform in waveforms]
+        if padding in (True, "longest"):
+            padded_length = max(lengths)
+        elif padding == "max_length":
+            if max_length is None:
+                raise ValueError("padding='max_length' requires max_length")
+            padded_length = max_length
+        elif padding in (False, None, "do_not_pad"):
+            if len(set(lengths)) != 1:
+                raise ValueError(
+                    "Batched audio with different lengths requires padding"
+                )
+            padded_length = lengths[0]
+        else:
+            raise ValueError(f"Unsupported padding strategy: {padding}")
+
+        if any(length > padded_length for length in lengths):
+            raise ValueError("Audio longer than max_length requires truncation=True")
+
+        if pad_to_multiple_of:
+            padded_length = (
+                (padded_length + pad_to_multiple_of - 1) // pad_to_multiple_of
+            ) * pad_to_multiple_of
+
+        features = []
+        masks = []
+        for waveform, length in zip(waveforms, lengths):
+            mel = self._extract_log_mel(waveform, padded_length)
+            valid_frames = (length + self.hop_length - 1) // self.hop_length
+            mask = mx.arange(mel.shape[0]) < valid_frames
+            mel = mx.where(mask[:, None], mel, self.padding_value)
+            features.append(mel.astype(mx.float32))
+            masks.append(mask)
+
+        result = {"input_features": mx.stack(features)}
+        include_mask = (
+            self.return_attention_mask
+            if return_attention_mask is None
+            else return_attention_mask
+        )
+        if include_mask:
+            result["input_features_mask"] = mx.stack(masks)
+        return result
+
+
+__all__ = ["InklingAudioFeatureExtractor"]

--- a/mlx_vlm/models/inkling/config.py
+++ b/mlx_vlm/models/inkling/config.py
@@ -74,6 +74,7 @@ class AudioConfig(BaseModelConfig):
     mel_vocab_size: int = 16
     text_hidden_size: int = 6144
     rms_norm_eps: float = 1e-6
+    max_frames_per_chunk: int = 256
 
 
 @dataclass

--- a/mlx_vlm/models/inkling/processing_inkling.py
+++ b/mlx_vlm/models/inkling/processing_inkling.py
@@ -24,6 +24,75 @@ OPENAI_CLIP_STD = [0.26862954, 0.26130258, 0.27577711]
 
 IMAGE_TOKEN = "<|unused_200054|>"
 IMAGE_BOS_TOKEN = "<|content_image|>"
+AUDIO_TOKEN = "<|unused_200053|>"
+AUDIO_BOS_TOKEN = "<|content_audio_input|>"
+
+NUM_DMEL_BINS = 16
+DMEL_MIN_VALUE = -7.0
+DMEL_MAX_VALUE = 2.0
+
+
+def dmel_bin_centers(
+    num_bins: int = NUM_DMEL_BINS,
+    min_value: float = DMEL_MIN_VALUE,
+    max_value: float = DMEL_MAX_VALUE,
+) -> np.ndarray:
+    return np.linspace(min_value, max_value, num_bins, dtype=np.float64)
+
+
+def dmel_bin_boundaries(
+    num_bins: int = NUM_DMEL_BINS,
+    min_value: float = DMEL_MIN_VALUE,
+    max_value: float = DMEL_MAX_VALUE,
+) -> mx.array:
+    centers = dmel_bin_centers(num_bins, min_value, max_value)
+    midpoints = (centers[:-1] + centers[1:]) / 2
+    boundaries = midpoints.astype(np.float32)
+
+    # Metal has no float64. Use the largest float32 value at or below each
+    # midpoint so a strict comparison preserves the reference's lower-bin ties.
+    rounded_up = boundaries.astype(np.float64) > midpoints
+    boundaries[rounded_up] = np.nextafter(boundaries[rounded_up], np.float32(-np.inf))
+    return mx.array(boundaries)
+
+
+def extract_dmel_bins(
+    input_features,
+    bin_boundaries: Optional[mx.array] = None,
+    min_value: float = DMEL_MIN_VALUE,
+    max_value: float = DMEL_MAX_VALUE,
+    max_frames_per_chunk: int = 1024,
+) -> mx.array:
+    if max_frames_per_chunk <= 0:
+        raise ValueError("max_frames_per_chunk must be positive")
+
+    boundaries = (
+        dmel_bin_boundaries(min_value=min_value, max_value=max_value)
+        if bin_boundaries is None
+        else bin_boundaries
+    )
+    mel = (
+        input_features
+        if isinstance(input_features, mx.array)
+        else mx.array(input_features)
+    )
+    mel = mx.clip(mel.astype(mx.float32), min_value, max_value)
+
+    def quantize(chunk):
+        bins = mx.zeros(chunk.shape, dtype=mx.int32)
+        for boundary in boundaries:
+            bins = bins + (chunk > boundary)
+        return bins
+
+    if mel.ndim < 2 or mel.shape[-2] <= max_frames_per_chunk:
+        return quantize(mel)
+
+    chunks = []
+    for start in range(0, mel.shape[-2], max_frames_per_chunk):
+        bins = quantize(mel[..., start : start + max_frames_per_chunk, :])
+        mx.eval(bins)
+        chunks.append(bins)
+    return mx.concatenate(chunks, axis=-2)
 
 
 def divide_to_patches(image: np.ndarray, patch_size: int) -> List[np.ndarray]:
@@ -124,12 +193,11 @@ class InklingImageProcessor(BaseImageProcessor):
 
 
 class InklingProcessor(ProcessorMixin):
-    """Wraps the Inkling image processor and tokenizer.
+    """Wraps Inkling audio/image preprocessing and tokenization.
 
-    ``__call__`` expands the single image placeholder emitted by the chat
-    template into one ``image_token`` per patch, and tokenizes via ``encode``
-    (+ manual left/right padding) so it does not depend on the tokenizer having a
-    pad token configured.
+    ``__call__`` expands media placeholders to match their image patches or
+    audio frames. Text is tokenized via ``encode`` with manual padding so no
+    tokenizer pad token is required.
     """
 
     attributes = ["image_processor", "tokenizer"]
@@ -138,22 +206,51 @@ class InklingProcessor(ProcessorMixin):
     tokenizer_class = "AutoTokenizer"
 
     def __init__(
-        self, image_processor=None, tokenizer=None, chat_template=None, **kwargs
+        self,
+        image_processor=None,
+        tokenizer=None,
+        chat_template=None,
+        image_token: str = IMAGE_TOKEN,
+        audio_token: str = AUDIO_TOKEN,
+        image_bos_token: str = IMAGE_BOS_TOKEN,
+        audio_bos_token: str = AUDIO_BOS_TOKEN,
+        num_dmel_bins: int = NUM_DMEL_BINS,
+        dmel_min_value: float = DMEL_MIN_VALUE,
+        dmel_max_value: float = DMEL_MAX_VALUE,
+        **kwargs,
     ):
-        self.image_token = IMAGE_TOKEN
+        from .audio_feature_extractor import InklingAudioFeatureExtractor
+
+        feature_extractor = kwargs.pop("feature_extractor", None)
+        self.image_token = image_token
+        self.audio_token = audio_token
+        self.image_bos_token = image_bos_token
+        self.audio_bos_token = audio_bos_token
+        self.num_dmel_bins = num_dmel_bins
+        self.dmel_min_value = dmel_min_value
+        self.dmel_max_value = dmel_max_value
+        self.bin_boundaries = dmel_bin_boundaries(
+            num_dmel_bins, dmel_min_value, dmel_max_value
+        )
         if image_processor is None:
             image_processor = InklingImageProcessor()
+        if feature_extractor is None:
+            feature_extractor = InklingAudioFeatureExtractor()
         super().__init__(image_processor, tokenizer, chat_template=chat_template)
+        self.feature_extractor = feature_extractor
 
     def __call__(
         self,
         images: ImageInput = None,
         text: Union[TextInput, PreTokenizedInput, List[TextInput]] = None,
+        audio=None,
         padding_side: str = "left",
         **kwargs,
     ) -> BatchFeature:
-        if images is None and text is None:
-            raise ValueError("You have to specify at least one of `images` or `text`.")
+        if images is None and text is None and audio is None:
+            raise ValueError(
+                "You have to specify at least one of `images`, `text`, or `audio`."
+            )
         kwargs.pop("return_tensors", None)
 
         image_inputs = {}
@@ -161,6 +258,38 @@ class InklingProcessor(ProcessorMixin):
         if images is not None:
             image_inputs = self.image_processor(images)
             num_patches = image_inputs.pop("num_patches")
+
+        audio_inputs = {}
+        num_audio_tokens = None
+        if audio is not None:
+            audio_kwargs = {
+                key: kwargs[key]
+                for key in (
+                    "sampling_rate",
+                    "padding",
+                    "max_length",
+                    "truncation",
+                    "pad_to_multiple_of",
+                )
+                if key in kwargs
+            }
+            extracted = self.feature_extractor(audio, **audio_kwargs)
+            audio_mask = extracted.get("input_features_mask")
+            audio_inputs = {
+                "audio_input_ids": extract_dmel_bins(
+                    extracted["input_features"],
+                    self.bin_boundaries,
+                    self.dmel_min_value,
+                    self.dmel_max_value,
+                ),
+                "audio_input_ids_mask": audio_mask,
+            }
+            if audio_mask is not None:
+                num_audio_tokens = audio_mask.sum(axis=1).tolist()
+            else:
+                num_audio_tokens = [
+                    audio_inputs["audio_input_ids"].shape[-2]
+                ] * audio_inputs["audio_input_ids"].shape[0]
 
         if isinstance(text, str):
             text = [text]
@@ -181,6 +310,18 @@ class InklingProcessor(ProcessorMixin):
                     idx += 1
                 text[i] = text[i].replace("<|placeholder|>", self.image_token)
 
+        if num_audio_tokens is not None and text is not None:
+            idx = 0
+            for i in range(len(text)):
+                while self.audio_token in text[i]:
+                    text[i] = text[i].replace(
+                        self.audio_token,
+                        "<|audio_placeholder|>" * int(num_audio_tokens[idx]),
+                        1,
+                    )
+                    idx += 1
+                text[i] = text[i].replace("<|audio_placeholder|>", self.audio_token)
+
         text_inputs = {}
         if text is not None:
             all_ids = [self.tokenizer.encode(t) for t in text]
@@ -200,7 +341,7 @@ class InklingProcessor(ProcessorMixin):
                 "attention_mask": mx.array(attention),
             }
 
-        return BatchFeature(data={**text_inputs, **image_inputs})
+        return BatchFeature(data={**text_inputs, **image_inputs, **audio_inputs})
 
     def batch_decode(self, *args, **kwargs):
         return self.tokenizer.batch_decode(*args, **kwargs)
@@ -210,13 +351,18 @@ class InklingProcessor(ProcessorMixin):
 
     @property
     def model_input_names(self):
-        names = (
-            self.tokenizer.model_input_names + self.image_processor.model_input_names
-        )
+        names = [
+            "audio_input_ids",
+            "audio_input_ids_mask",
+            *self.tokenizer.model_input_names,
+            *self.image_processor.model_input_names,
+        ]
         return list(dict.fromkeys(names))
 
     @classmethod
     def from_pretrained(cls, pretrained_model_name_or_path, **kwargs):
+        from .audio_feature_extractor import InklingAudioFeatureExtractor
+
         kwargs.pop("trust_remote_code", None)
         model_path = Path(pretrained_model_name_or_path)
         is_local = model_path.exists() and model_path.is_dir()
@@ -249,10 +395,38 @@ class InklingProcessor(ProcessorMixin):
                 chat_template = jinja_path.read_text(encoding="utf-8")
                 tokenizer.chat_template = chat_template
 
+        processor_config = {}
+        processor_config_path = model_path / "processor_config.json"
+        if processor_config_path.exists():
+            processor_config = json.loads(processor_config_path.read_text())
+        elif not is_local:
+            try:
+                from huggingface_hub import hf_hub_download
+
+                processor_config_path = Path(
+                    hf_hub_download(
+                        pretrained_model_name_or_path, "processor_config.json"
+                    )
+                )
+                processor_config = json.loads(processor_config_path.read_text())
+            except Exception:
+                pass
+
+        feature_config = dict(processor_config.get("feature_extractor", {}))
+        feature_config.pop("feature_extractor_type", None)
+
         return cls(
             image_processor=InklingImageProcessor(),
             tokenizer=tokenizer,
             chat_template=chat_template,
+            feature_extractor=InklingAudioFeatureExtractor(**feature_config),
+            image_token=processor_config.get("image_token", IMAGE_TOKEN),
+            audio_token=processor_config.get("audio_token", AUDIO_TOKEN),
+            image_bos_token=processor_config.get("image_bos_token", IMAGE_BOS_TOKEN),
+            audio_bos_token=processor_config.get("audio_bos_token", AUDIO_BOS_TOKEN),
+            num_dmel_bins=processor_config.get("num_dmel_bins", NUM_DMEL_BINS),
+            dmel_min_value=processor_config.get("dmel_min_value", DMEL_MIN_VALUE),
+            dmel_max_value=processor_config.get("dmel_max_value", DMEL_MAX_VALUE),
         )
 
 

--- a/mlx_vlm/tests/test_inkling.py
+++ b/mlx_vlm/tests/test_inkling.py
@@ -1,4 +1,5 @@
 import mlx.core as mx
+import numpy as np
 
 from mlx_vlm.generate.ar import _make_cache
 from mlx_vlm.models.cache import ArraysCache, BatchKVCache, CacheList
@@ -167,3 +168,239 @@ def test_mtp_eval_state_skips_empty_kv_caches():
     state = drafter.draft_eval_state()
 
     assert len(state) == 4
+
+
+def test_audio_features_match_numpy_stft():
+    from mlx_vlm.models.inkling.audio_feature_extractor import (
+        InklingAudioFeatureExtractor,
+    )
+
+    extractor = InklingAudioFeatureExtractor()
+    rng = np.random.default_rng(5)
+    waveform = rng.normal(0.0, 0.1, 2401).astype(np.float32)
+    actual = np.asarray(extractor(waveform)["input_features"])[0]
+
+    right_pad = (-len(waveform)) % extractor.hop_length
+    padded = np.pad(
+        waveform,
+        (extractor.n_fft - extractor.hop_length, right_pad),
+    )
+    frames = np.lib.stride_tricks.sliding_window_view(padded, extractor.n_fft)[
+        :: extractor.hop_length
+    ]
+    spectrum = np.fft.rfft(frames * np.asarray(extractor.window), axis=-1)
+    magnitudes = np.maximum(np.abs(spectrum), 1e-10)
+    mel = magnitudes @ np.asarray(extractor.mel_filters).T
+    expected = np.log10(np.maximum(mel, 1e-10)).astype(np.float32)
+
+    assert actual.shape == (4, 80)
+    assert np.allclose(actual, expected, atol=2e-6)
+
+
+def test_audio_features_pad_frames_and_mask():
+    from mlx_vlm.models.inkling.audio_feature_extractor import (
+        InklingAudioFeatureExtractor,
+    )
+
+    extractor = InklingAudioFeatureExtractor()
+    result = extractor(
+        [np.ones(799, dtype=np.float32), np.ones(1600, dtype=np.float32)]
+    )
+
+    assert result["input_features"].shape == (2, 2, 80)
+    assert result["input_features_mask"].tolist() == [
+        [True, False],
+        [True, True],
+    ]
+    assert mx.all(result["input_features"][0, 1] == 0).item()
+
+
+def test_audio_feature_chunks_preserve_stft_frames(monkeypatch):
+    from mlx_vlm.models.inkling import audio_feature_extractor as audio_module
+    from mlx_vlm.models.inkling.processing_inkling import extract_dmel_bins
+
+    rng = np.random.default_rng(19)
+    waveform = rng.normal(0.0, 0.1, 8000).astype(np.float32)
+    unchunked = audio_module.InklingAudioFeatureExtractor(max_frames_per_chunk=1024)(
+        waveform
+    )["input_features"]
+
+    calls = []
+    native_stft = audio_module.stft
+
+    def recording_stft(segment, *args, **kwargs):
+        calls.append(segment.shape[0])
+        return native_stft(segment, *args, **kwargs)
+
+    monkeypatch.setattr(audio_module, "stft", recording_stft)
+    chunked = audio_module.InklingAudioFeatureExtractor(max_frames_per_chunk=3)(
+        waveform
+    )["input_features"]
+
+    assert calls == [3200, 3200, 3200, 1600]
+    assert mx.allclose(chunked, unchunked, atol=3e-7).item()
+    assert mx.array_equal(
+        extract_dmel_bins(chunked, max_frames_per_chunk=3),
+        extract_dmel_bins(unchunked),
+    ).item()
+
+
+def test_audio_tower_chunks_embedding_gather():
+    from mlx_vlm.models.inkling.audio import AudioModel
+    from mlx_vlm.models.inkling.config import AudioConfig
+
+    model = AudioModel(
+        AudioConfig(
+            n_mel_bins=8,
+            mel_vocab_size=4,
+            text_hidden_size=32,
+            max_frames_per_chunk=2,
+        )
+    )
+    mx.eval(model.parameters())
+    audio_input_ids = mx.arange(64).reshape(2, 4, 8) % 4
+
+    model.max_frames_per_chunk = 1024
+    unchunked = model(audio_input_ids)
+    mx.eval(unchunked)
+    model.max_frames_per_chunk = 2
+    chunked = model(audio_input_ids)
+    mx.eval(chunked)
+
+    assert chunked.shape == (2, 4, 32)
+    assert mx.allclose(chunked, unchunked, atol=1e-6).item()
+
+
+def test_dmel_quantization_boundaries():
+    from mlx_vlm.models.inkling.processing_inkling import (
+        DMEL_MAX_VALUE,
+        DMEL_MIN_VALUE,
+        dmel_bin_boundaries,
+        dmel_bin_centers,
+        extract_dmel_bins,
+    )
+
+    centers = dmel_bin_centers()
+    midpoints = (centers[:-1] + centers[1:]) / 2
+    rounded_midpoints = midpoints.astype(np.float32)
+    values = np.concatenate(
+        [
+            [DMEL_MIN_VALUE - 1],
+            centers.astype(np.float32),
+            np.nextafter(rounded_midpoints, np.float32(-np.inf)),
+            rounded_midpoints,
+            np.nextafter(rounded_midpoints, np.float32(np.inf)),
+            [DMEL_MAX_VALUE + 1],
+        ]
+    ).astype(np.float32)
+    clipped = np.clip(values, DMEL_MIN_VALUE, DMEL_MAX_VALUE)
+    expected = np.abs(clipped.astype(np.float64)[:, None] - centers).argmin(axis=1)
+    actual = np.asarray(extract_dmel_bins(mx.array(values), dmel_bin_boundaries()))
+
+    assert actual.dtype == np.int32
+    assert np.array_equal(actual, expected)
+
+
+def test_processor_expands_audio_tokens_from_frame_mask():
+    from mlx_vlm.models.inkling.audio_feature_extractor import (
+        InklingAudioFeatureExtractor,
+    )
+    from mlx_vlm.models.inkling.processing_inkling import (
+        AUDIO_TOKEN,
+        DMEL_MAX_VALUE,
+        DMEL_MIN_VALUE,
+        InklingProcessor,
+        dmel_bin_boundaries,
+    )
+
+    class Tokenizer:
+        pad_token_id = 0
+        model_input_names = ["input_ids", "attention_mask"]
+
+        def __init__(self):
+            self.encoded = []
+
+        def encode(self, text):
+            self.encoded.append(text)
+            return [1] * (text.count(AUDIO_TOKEN) + 1)
+
+    class ImageProcessor:
+        model_input_names = ["pixel_values"]
+
+    processor = InklingProcessor.__new__(InklingProcessor)
+    processor.feature_extractor = InklingAudioFeatureExtractor()
+    processor.tokenizer = Tokenizer()
+    processor.image_processor = ImageProcessor()
+    processor.image_token = "<image>"
+    processor.audio_token = AUDIO_TOKEN
+    processor.dmel_min_value = DMEL_MIN_VALUE
+    processor.dmel_max_value = DMEL_MAX_VALUE
+    processor.bin_boundaries = dmel_bin_boundaries()
+
+    result = InklingProcessor.__call__(
+        processor,
+        text=[f"first {AUDIO_TOKEN}", f"second {AUDIO_TOKEN}"],
+        audio=[
+            np.zeros(799, dtype=np.float32),
+            np.zeros(1600, dtype=np.float32),
+        ],
+    )
+
+    assert [text.count(AUDIO_TOKEN) for text in processor.tokenizer.encoded] == [1, 2]
+    assert result["audio_input_ids"].shape == (2, 2, 80)
+    assert result["audio_input_ids"].dtype == mx.int32
+    assert result["audio_input_ids_mask"].tolist() == [
+        [True, False],
+        [True, True],
+    ]
+    assert result["attention_mask"].tolist() == [[0, 1, 1], [1, 1, 1]]
+
+
+def test_from_pretrained_builds_native_audio_extractor(tmp_path, monkeypatch):
+    import json
+
+    from mlx_vlm.models.inkling import processing_inkling
+    from mlx_vlm.models.inkling.audio_feature_extractor import (
+        InklingAudioFeatureExtractor,
+    )
+
+    (tmp_path / "processor_config.json").write_text(
+        json.dumps(
+            {
+                "feature_extractor": {
+                    "feature_extractor_type": "InklingFeatureExtractor",
+                    "feature_size": 12,
+                    "sampling_rate": 8000,
+                    "audio_token_duration_s": 0.05,
+                    "window_size_multiplier": 2.0,
+                    "hop_length": 400,
+                    "window_size": 800,
+                    "n_fft": 800,
+                }
+            }
+        )
+    )
+
+    class Tokenizer:
+        pad_token = "<pad>"
+        eos_token = "<eos>"
+        chat_template = None
+        model_input_names = ["input_ids", "attention_mask"]
+
+    monkeypatch.setattr(
+        processing_inkling.AutoTokenizer,
+        "from_pretrained",
+        lambda *args, **kwargs: Tokenizer(),
+    )
+    monkeypatch.setattr(
+        processing_inkling.InklingProcessor,
+        "check_argument_for_proper_class",
+        lambda self, name, value: type(value),
+    )
+
+    processor = processing_inkling.InklingProcessor.from_pretrained(tmp_path)
+
+    assert isinstance(processor.feature_extractor, InklingAudioFeatureExtractor)
+    assert processor.feature_extractor.feature_size == 12
+    assert processor.feature_extractor.sampling_rate == 8000
+    assert processor.feature_extractor.hop_length == 400


### PR DESCRIPTION
Based on https://github.com/Blaizzy/mlx-vlm/pull/1764.

This uses an MLX-native implementation of dMel that's bit-compatible with the transformers processor which has bin centers and boundaries in fp64. It also chunks the input so max memory usage stays low (~144mb for 30 mins of audio).