### PR TITLE
Stop Idefics3 generation at end of utterance

### DIFF
--- a/mlx_vlm/models/idefics3/processing_idefics3.py
+++ b/mlx_vlm/models/idefics3/processing_idefics3.py
@@ -100,6 +100,12 @@ class Idefics3Processor(ProcessorMixin):
     image_processor_class = "AutoImageProcessor"
     tokenizer_class = "AutoTokenizer"
 
+    @property
+    def additional_eos_token_ids(self):
+        """Return processor-specific turn delimiters that should stop generation."""
+        token_id = self.tokenizer.convert_tokens_to_ids(self.end_of_utterance_token)
+        return [token_id] if token_id is not None else []
+
     def __init__(
         self,
         image_processor,

--- a/mlx_vlm/tests/test_processors.py
+++ b/mlx_vlm/tests/test_processors.py
@@ -1494,6 +1494,56 @@ class TestIdefics3Processor(_ProcessorTestBase, unittest.TestCase):
         self.assertIn("<row_1_col_1>", result)
         self.assertIn("<row_2_col_2>", result)
 
+    def test_end_of_utterance_is_added_to_stopping_criteria(self):
+        from mlx_vlm.models.idefics3.processing_idefics3 import Idefics3Processor
+        from mlx_vlm.utils import load_processor
+
+        processor = Idefics3Processor.__new__(Idefics3Processor)
+        processor.end_of_utterance_token = "<end_of_utterance>"
+        processor.tokenizer = SimpleNamespace(
+            eos_token_ids=[128001, 128008, 128009],
+            convert_tokens_to_ids=lambda token: (
+                128258 if token == "<end_of_utterance>" else None
+            ),
+        )
+        self.assertEqual(processor.additional_eos_token_ids, [128258])
+
+        class _Detokenizer:
+            def __init__(self, tokenizer):
+                self.tokenizer = tokenizer
+
+        with (
+            patch(
+                "mlx_vlm.utils.AutoProcessor.from_pretrained",
+                return_value=processor,
+            ),
+            patch("mlx_vlm.utils.load_tokenizer", return_value=_Detokenizer),
+        ):
+            loaded = load_processor("unused-model-path")
+            self.assertIs(loaded, processor)
+            loaded_eos_token_ids = list(
+                loaded.tokenizer.stopping_criteria.eos_token_ids
+            )
+            loaded.tokenizer.stopping_criteria.reset([128001, 128008, 128009])
+            reset_eos_token_ids = list(loaded.tokenizer.stopping_criteria.eos_token_ids)
+            loaded_with_existing_token = load_processor(
+                "unused-model-path",
+                eos_token_ids=[128001, 128008, 128009, 128258],
+            )
+
+        self.assertEqual(
+            loaded_eos_token_ids,
+            [128001, 128008, 128009, 128258],
+        )
+        self.assertEqual(
+            reset_eos_token_ids,
+            [128001, 128008, 128009, 128258],
+        )
+        self.assertEqual(
+            loaded_with_existing_token.tokenizer.stopping_criteria.eos_token_ids,
+            [128001, 128008, 128009, 128258],
+        )
+
 
 class TestAyaVisionProcessor(_ProcessorTestBase, unittest.TestCase):
     def _make_processor(self):

--- a/mlx_vlm/utils.py
+++ b/mlx_vlm/utils.py
@@ -1121,9 +1121,14 @@ def load_processor(
             or getattr(tokenizer_obj, "eos_token_ids", None)
             or getattr(tokenizer_obj, "eos_token_id", None)
         )
+        additional_eos_token_ids = getattr(processor, "additional_eos_token_ids", ())
 
         # Create and assign the StoppingCriteria
-        criteria = StoppingCriteria(final_eos_token_ids, tokenizer_obj)
+        criteria = StoppingCriteria(
+            final_eos_token_ids,
+            tokenizer_obj,
+            additional_eos_token_ids=additional_eos_token_ids,
+        )
         if hasattr(processor, "tokenizer"):
             processor.tokenizer.stopping_criteria = criteria
         else:
@@ -2005,14 +2010,17 @@ def group_images_by_shape(
 
 
 class StoppingCriteria:
-    def __init__(self, eos_token_ids: List[int], tokenizer=None):
-
-        if isinstance(eos_token_ids, int):
-            self.eos_token_ids = [eos_token_ids]
-        else:
-            self.eos_token_ids = list(eos_token_ids)
-
+    def __init__(
+        self,
+        eos_token_ids: List[int],
+        tokenizer=None,
+        additional_eos_token_ids: List[int] = None,
+    ):
         self.tokenizer = tokenizer
+        self.additional_eos_token_ids = list(
+            dict.fromkeys(additional_eos_token_ids or ())
+        )
+        self.reset(eos_token_ids)
 
     def add_eos_token_ids(self, new_eos_token_ids: Union[int, List[int]] = None):
         """
@@ -2039,7 +2047,9 @@ class StoppingCriteria:
                     resolved.append(
                         self.tokenizer.encode(" " + token, add_special_tokens=False)[-1]
                     )
-            self.eos_token_ids.extend(resolved)
+            self.eos_token_ids.extend(
+                token_id for token_id in resolved if token_id not in self.eos_token_ids
+            )
 
     def reset(self, eos_token_ids: List[int] = None):
         eos_token_ids = (
@@ -2049,8 +2059,14 @@ class StoppingCriteria:
         if isinstance(eos_token_ids, int):
             eos_token_ids = [eos_token_ids]
 
-        if self.eos_token_ids != eos_token_ids:
-            self.eos_token_ids = list(eos_token_ids)
+        resolved = list(eos_token_ids)
+        resolved.extend(
+            token_id
+            for token_id in self.additional_eos_token_ids
+            if token_id not in resolved
+        )
+        if getattr(self, "eos_token_ids", None) != resolved:
+            self.eos_token_ids = resolved
 
     def __call__(self, input_ids: mx.array) -> bool:
         return input_ids in self.eos_token_ids


### PR DESCRIPTION
## Summary

- expose Idefics3's declared `<end_of_utterance>` token as a processor-specific EOS ID
- preserve processor-specific EOS IDs when generation resets stopping criteria from the model config
- preserve order and avoid duplicate EOS IDs

## Root cause

`Idefics3Processor` adds `<end_of_utterance>` as a special token, but it was not part of mlx-vlm's stopping criteria. `generate()` also resets the criteria from `model.config.eos_token_id`, so adding the token only during processor loading would not survive generation startup.

With `mlx-community/Idefics3-8B-Llama3-bf16` at revision `8c2a30c48864f3251701b7bde40f601d25535098`, native generation ended with:

```text
Keywords: the cut, halesworth, suffolk, england, uk, brick building, red brick, windows, white sign, brick wall, gravel, blue sky, clouds.<end_of_utterance>
```

Passing `--eos-tokens '<end_of_utterance>'` removed the delimiter without changing the answer, confirming the missing stop ID.

## Validation

- `python -m pytest mlx_vlm/tests/test_processors.py::TestIdefics3Processor mlx_vlm/tests/test_utils.py -k "Idefics3Processor or stopping_criteria" -q` — 6 passed
- cached native generation with the same model revision and no `eos_tokens` override — `HAS_END_OF_UTTERANCE False`, effective stop IDs `[128001, 128258]`
- Black check passes for the two edited production files; autoflake passes

Environment: mlx-vlm base `f47a3cedbc709f2c1d25eded3cc39405c7a88742`, MLX `0.32.1.dev20260802+fb5133e10`, Transformers `5.14.1`, tokenizers `0.22.2`, Python `3.13.13`, Apple M5 Max.

The repository's combined pre-commit invocation does not currently converge under Python 3.13: Black 26.3.1 and isort rewrite existing imports in `processing_idefics3.py` and `test_processors.py` in opposite directions. Those unrelated rewrites are excluded from this PR.
