### PR TITLE
fix(tokenizer): keep incomplete UTF-8 tail buffered at streaming flush boundary (#1771)

### DIFF
--- a/mlx_vlm/tests/test_streaming_detokenizer_utf8.py
+++ b/mlx_vlm/tests/test_streaming_detokenizer_utf8.py
@@ -1,0 +1,47 @@
+"""Regression test for issue #1771: an incomplete multi-byte UTF-8
+sequence at the streaming flush boundary must neither raise nor mangle
+the already-decodable head of the buffer."""
+
+import unittest
+
+
+class FakeTokenizer:
+    """Minimal stand-in exposing what BPEStreamingDetokenizer uses."""
+
+    def __init__(self, vocab):
+        self.vocab = vocab
+
+    def get_vocab(self):
+        return self.vocab
+
+
+class TestBPEStreamingUTF8(unittest.TestCase):
+    def test_incomplete_tail_at_flush_boundary(self):
+        from mlx_vlm.tokenizer_utils import BPEStreamingDetokenizer
+
+        BPEStreamingDetokenizer.make_byte_decoder()
+        byte_decoder = BPEStreamingDetokenizer._byte_decoder  # char -> byte
+        byte_encoder = {b: c for c, b in byte_decoder.items()}
+
+        def surface(bs: bytes) -> str:
+            return "".join(byte_encoder[b] for b in bs)
+
+        # A buffer ending mid-character ("ni" complete + first byte of
+        # "hao"), then a space-led token forcing a flush: the old strict
+        # decode raised UnicodeDecodeError here; a blanket errors="replace"
+        # mangles the head. The fix flushes the clean head and buffers the
+        # incomplete tail.
+        nihao = "你好".encode("utf-8")                    # 3 + 3 bytes
+        vocab = {surface(nihao[:4]): 0, surface(b" ok"): 1}
+        detok = BPEStreamingDetokenizer(FakeTokenizer(vocab))
+        detok.reset()
+        detok.add_token(0)
+        detok.add_token(1)   # space-led -> flush with incomplete tail
+        detok.finalize()
+        self.assertIn("你", detok.text)   # the clean head survived intact
+        self.assertIn("ok", detok.text)
+        self.assertNotIn("\ufffd", detok.text)  # nothing was mangled
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/mlx_vlm/tokenizer_utils.py
+++ b/mlx_vlm/tokenizer_utils.py
@@ -232,14 +232,27 @@ class BPEStreamingDetokenizer(StreamingDetokenizer):
         v = self.tokenmap[token]
         # if the token starts with space
         if self._byte_decoder[v[0]] == 32:
-            current_text = bytearray(
-                self._byte_decoder[c] for c in self._unflushed
-            ).decode("utf-8", errors="replace")
+            raw = bytearray(self._byte_decoder[c] for c in self._unflushed)
+            try:
+                current_text = raw.decode("utf-8")
+                kept = ""
+            except UnicodeDecodeError as e:
+                if e.end == len(raw):
+                    # An incomplete multi-byte sequence at the buffer edge:
+                    # flush the clean head and keep the trailing bytes
+                    # buffered so they can complete with the next token,
+                    # instead of mangling them into replacement chars.
+                    current_text = raw[: e.start].decode("utf-8", errors="replace")
+                    kept = self._unflushed[e.start :]
+                else:
+                    # Genuinely invalid bytes mid-buffer: replace and move on.
+                    current_text = raw.decode("utf-8", errors="replace")
+                    kept = ""
             if self.text or not self.trim_space:
                 self.text += current_text
             else:
                 self.text += _remove_space(current_text)
-            self._unflushed = v
+            self._unflushed = kept + v
         else:
             self._unflushed += v
 


### PR DESCRIPTION
Fixes #1771.

The BPE streaming detokenizer flushes its byte buffer whenever a token starts with a space. If the buffer ends in the middle of a multi-byte UTF-8 sequence at that moment, the current `errors="replace"` decode turns the pending bytes into replacement characters — corrupting text (CJK, Hebrew, emoji) that would have decoded cleanly once the next token's bytes arrived. The previous strict decode raised `UnicodeDecodeError` at the same spot, which is what #1771 reports.

This change decodes strictly first; on failure it distinguishes the two cases:
- **truncated sequence at the buffer edge** (`e.end == len(raw)`): flush the clean head, keep the undecoded tail buffered so it completes with the next token — lossless;
- **genuinely invalid bytes mid-buffer**: fall back to replacement, as today.

Includes a regression test that fails on current main (the head gets a replacement char appended) and passes with the fix. Verified against the reproduction in #1771 on an M-series machine.