### PR TITLE
Fix APC extra_hash to use prefix-invariant semantic inputs

### DIFF
--- a/mlx_vlm/apc.py
+++ b/mlx_vlm/apc.py
@@ -190,6 +190,123 @@ def model_key_dependencies(model: Any = None, processor: Any = None) -> Tuple[in
     return tuple(deps)
 
 
+def resolve_apc_image_hash(
+    prompt_kwargs: Optional[dict],
+    *,
+    image_ref: Any = None,
+) -> int:
+    """Image salt from precomputed hash, ``pixel_values``, or image path ref."""
+    kw = prompt_kwargs or {}
+    img = kw.get("_apc_image_hash")
+    if img is not None:
+        return int(img)
+    pixel_values = kw.get("pixel_values")
+    return hash_image_payload(pixel_values=pixel_values, image_ref=image_ref)
+
+
+def apc_prefix_invariant_media(
+    prompt_kwargs: Optional[dict],
+    *,
+    audio_ref: Any = None,
+    video_ref: Any = None,
+) -> Dict[str, Any]:
+    """Source multimodal inputs for APC identity — not derived full-sequence tensors."""
+    kw = prompt_kwargs or {}
+    audio = kw.get("input_features")
+    if audio is None:
+        audio = audio_ref
+    video = kw.get("pixel_values_videos")
+    if video is None:
+        video = video_ref
+    return {
+        "audio": audio,
+        "video": video,
+    }
+
+
+def apc_legacy_media(
+    prompt_kwargs: Optional[dict],
+    *,
+    audio_ref: Any = None,
+    video_ref: Any = None,
+    attention_mask: Any = None,
+) -> Dict[str, Any]:
+    """Pre-fix media dict including full-sequence embeds/masks (0.6.8–)."""
+    media = apc_prefix_invariant_media(
+        prompt_kwargs, audio_ref=audio_ref, video_ref=video_ref
+    )
+    kw = prompt_kwargs or {}
+    media["embeddings"] = kw.get("inputs_embeds")
+    mask = kw.get("attention_mask")
+    if mask is None:
+        mask = attention_mask
+    media["masks"] = mask
+    return media
+
+
+def compute_apc_extra_hash(
+    prompt_kwargs: Optional[dict],
+    *,
+    tenant: Optional[str] = None,
+    model: Any = None,
+    processor: Any = None,
+    legacy: bool = False,
+    audio_ref: Any = None,
+    video_ref: Any = None,
+    attention_mask: Any = None,
+    image_ref: Any = None,
+) -> int:
+    """APC ``extra_hash`` from prefix-invariant (default) or legacy media inputs."""
+    kw = prompt_kwargs or {}
+    if tenant is None:
+        tenant = kw.get("_apc_tenant")
+    image_hash = resolve_apc_image_hash(kw, image_ref=image_ref)
+    if legacy:
+        media = apc_legacy_media(
+            kw,
+            audio_ref=audio_ref,
+            video_ref=video_ref,
+            attention_mask=attention_mask,
+        )
+    else:
+        media = apc_prefix_invariant_media(kw, audio_ref=audio_ref, video_ref=video_ref)
+    return semantic_extra_hash(
+        tenant=tenant,
+        image_hash=image_hash,
+        media=media,
+        model=model,
+        processor=processor,
+    )
+
+
+def apc_extra_hash_candidates(
+    prompt_kwargs: Optional[dict],
+    *,
+    tenant: Optional[str] = None,
+    model: Any = None,
+    processor: Any = None,
+    audio_ref: Any = None,
+    video_ref: Any = None,
+    attention_mask: Any = None,
+    image_ref: Any = None,
+) -> Tuple[int, ...]:
+    """Stable hash first, then legacy when they differ (lookup fallback)."""
+    common = {
+        "tenant": tenant,
+        "model": model,
+        "processor": processor,
+        "audio_ref": audio_ref,
+        "video_ref": video_ref,
+        "attention_mask": attention_mask,
+        "image_ref": image_ref,
+    }
+    stable = compute_apc_extra_hash(prompt_kwargs, legacy=False, **common)
+    legacy = compute_apc_extra_hash(prompt_kwargs, legacy=True, **common)
+    if stable == legacy:
+        return (stable,)
+    return (stable, legacy)
+
+
 def semantic_extra_hash(
     *,
     tenant: Optional[str] = None,
@@ -200,10 +317,12 @@ def semantic_extra_hash(
 ) -> int:
     """Complete APC salt: tenant + image + non-token media inputs + model/processor deps.
 
-    ``media`` maps a semantic-input name (audio/video/embeddings/masks/
-    rope_deltas/...) to its payload; entries fold in sorted-key order so the
-    result is order-independent. Reduces exactly to
-    ``tenant_scoped_hash(tenant, image_hash)`` when no extra inputs are present.
+    ``media`` maps source semantic-input names (audio/video/...) to payloads;
+    entries fold in sorted-key order so the result is order-independent. Do not
+    pass derived full-sequence ``inputs_embeds`` or ``attention_mask`` here —
+    use :func:`compute_apc_extra_hash` for the supported APC identity contract.
+    Reduces exactly to ``tenant_scoped_hash(tenant, image_hash)`` when no extra
+    inputs are present.
     """
     folded = int(image_hash)
     if media:
@@ -4124,13 +4243,48 @@ def apc_lookup_plan(
     manager: "APCManager",
     ids_list: Sequence[int],
     *,
-    extra_hash: int,
+    extra_hash: int = 0,
+    extra_hashes: Optional[Sequence[int]] = None,
     apc_mode: str,
     safe_lookup_min: int,
     suffix_is_text_only,
     prefix_has_media,
 ) -> Optional[dict]:
     """Pick the best APC prefix (disk > exact > block); shared by both generate paths, releases losers, callers apply."""
+    hashes: Tuple[int, ...]
+    if extra_hashes is not None:
+        hashes = tuple(int(h) for h in extra_hashes)
+    else:
+        hashes = (int(extra_hash),)
+    if not hashes:
+        hashes = (0,)
+
+    for eh in hashes:
+        plan = _apc_lookup_plan_for_extra_hash(
+            manager,
+            ids_list,
+            extra_hash=eh,
+            apc_mode=apc_mode,
+            safe_lookup_min=safe_lookup_min,
+            suffix_is_text_only=suffix_is_text_only,
+            prefix_has_media=prefix_has_media,
+        )
+        if plan is not None:
+            return plan
+    return None
+
+
+def _apc_lookup_plan_for_extra_hash(
+    manager: "APCManager",
+    ids_list: Sequence[int],
+    *,
+    extra_hash: int,
+    apc_mode: str,
+    safe_lookup_min: int,
+    suffix_is_text_only,
+    prefix_has_media,
+) -> Optional[dict]:
+    """Single-extra_hash APC lookup (internal helper for :func:`apc_lookup_plan`)."""
     n = len(ids_list)
     if not ids_list or n < 2:
         return None

--- a/mlx_vlm/generate/ar.py
+++ b/mlx_vlm/generate/ar.py
@@ -2209,25 +2209,21 @@ class BatchGenerator:
     _APC_PRIVATE_KEYS = APC_PRIVATE_PROMPT_KEYS
 
     def _apc_extra_hash(self, prompt_kwargs: dict) -> int:
-        """Salt for the APC hash chain."""
+        """Salt for the APC hash chain (stable prefix-invariant media)."""
         if self.apc_manager is None:
             return 0
-        if prompt_kwargs is None:
-            prompt_kwargs = {}
-        img = prompt_kwargs.get("_apc_image_hash")
-        if img is None:
-            pixel_values = prompt_kwargs.get("pixel_values")
-            img = _apc.hash_image_payload(pixel_values=pixel_values, image_ref=None)
-        tenant = prompt_kwargs.get("_apc_tenant")
-        return _apc.semantic_extra_hash(
-            tenant=tenant,
-            image_hash=img,
-            media={
-                "audio": prompt_kwargs.get("input_features"),
-                "video": prompt_kwargs.get("pixel_values_videos"),
-                "embeddings": prompt_kwargs.get("inputs_embeds"),
-                "masks": prompt_kwargs.get("attention_mask"),
-            },
+        return _apc.compute_apc_extra_hash(
+            prompt_kwargs,
+            model=getattr(self, "model", None),
+            processor=getattr(self, "processor", None),
+            legacy=False,
+        )
+
+    def _apc_extra_hash_candidates(self, prompt_kwargs: dict) -> Tuple[int, ...]:
+        if self.apc_manager is None:
+            return (0,)
+        return _apc.apc_extra_hash_candidates(
+            prompt_kwargs,
             model=getattr(self, "model", None),
             processor=getattr(self, "processor", None),
         )
@@ -2280,7 +2276,7 @@ class BatchGenerator:
         return _apc.apc_lookup_plan(
             self.apc_manager,
             ids_list,
-            extra_hash=self._apc_extra_hash(prompt_kwargs or {}),
+            extra_hashes=self._apc_extra_hash_candidates(prompt_kwargs or {}),
             apc_mode=getattr(self, "apc_mode", "block"),
             safe_lookup_min=self._apc_safe_prefix_lookup_min(ids_list),
             suffix_is_text_only=lambda pl: self._apc_suffix_is_text_only(ids_list, pl),

--- a/mlx_vlm/generate/dispatch.py
+++ b/mlx_vlm/generate/dispatch.py
@@ -864,7 +864,6 @@ def stream_generate(
     reused_prefix_len = 0
     full_input_ids_list = input_ids.flatten().tolist()
     apc_blocks_in_use: List[_apc.APCBlock] = []
-    apc_extra_hash = 0
     apc_mode: Optional[str] = None
 
     multimodal_token_ids = _apc.multimodal_token_ids_from_config(model.config)
@@ -893,21 +892,34 @@ def stream_generate(
         if apc_mode is None:
             apc_manager = None
 
+    apc_extra_hash = 0
+    apc_extra_hashes: Tuple[int, ...] = (0,)
     if apc_manager is not None:
-        image_hash = _apc.hash_image_payload(pixel_values=pixel_values, image_ref=image)
-        audio_features = kwargs.get("input_features")
-        video_features = kwargs.get("pixel_values_videos")
-        apc_extra_hash = _apc.semantic_extra_hash(
+        prompt_kwargs_for_apc = dict(kwargs)
+        if mask is not None:
+            prompt_kwargs_for_apc.setdefault("attention_mask", mask)
+        if pixel_values is not None:
+            prompt_kwargs_for_apc.setdefault("pixel_values", pixel_values)
+        apc_extra_hash = _apc.compute_apc_extra_hash(
+            prompt_kwargs_for_apc,
             tenant=apc_tenant,
-            image_hash=image_hash,
-            media={
-                "audio": audio_features if audio_features is not None else audio,
-                "video": video_features if video_features is not None else video,
-                "embeddings": kwargs.get("inputs_embeds"),
-                "masks": mask,
-            },
             model=model,
             processor=processor,
+            legacy=False,
+            audio_ref=audio,
+            video_ref=video,
+            attention_mask=mask,
+            image_ref=image,
+        )
+        apc_extra_hashes = _apc.apc_extra_hash_candidates(
+            prompt_kwargs_for_apc,
+            tenant=apc_tenant,
+            model=model,
+            processor=processor,
+            audio_ref=audio,
+            video_ref=video,
+            attention_mask=mask,
+            image_ref=image,
         )
 
     if prompt_cache_state is not None and prompt_cache_state.cache is not None:
@@ -939,7 +951,7 @@ def stream_generate(
         plan = _apc.apc_lookup_plan(
             apc_manager,
             full_input_ids_list,
-            extra_hash=apc_extra_hash,
+            extra_hashes=apc_extra_hashes,
             apc_mode=apc_mode,
             safe_lookup_min=apc_safe_prefix_lookup_min,
             suffix_is_text_only=_apc_suffix_is_text_only,

--- a/mlx_vlm/tests/test_apc.py
+++ b/mlx_vlm/tests/test_apc.py
@@ -15,6 +15,8 @@ from mlx_vlm.apc import (
     DiskBlockStore,
     _copy_mlx_array,
     _hash_tokens,
+    apc_lookup_plan,
+    compute_apc_extra_hash,
     extract_prompt_cache_from_batch,
     from_env,
     harvest_blocks_from_batch_cache,
@@ -24,6 +26,7 @@ from mlx_vlm.apc import (
     make_warm_batch_kv_cache_multi,
     make_warm_kv_cache,
     model_apc_mode,
+    semantic_extra_hash,
     tenant_scoped_hash,
 )
 
@@ -1168,3 +1171,98 @@ def test_exact_disk_hit_promotion_with_nonzero_extra_hash(tmp_path, monkeypatch)
     assert warm_wrong is None
 
     manager.close()
+
+
+def test_apc_extra_hash_stable_when_prompt_grows():
+    short_embeds = mx.zeros((1, 128, 64))
+    long_embeds = mx.zeros((1, 2048, 64))
+    kw_short = {
+        "inputs_embeds": short_embeds,
+        "attention_mask": mx.ones((1, 128)),
+        "_apc_tenant": "tenant-a",
+    }
+    kw_long = {
+        "inputs_embeds": long_embeds,
+        "attention_mask": mx.ones((1, 2048)),
+        "_apc_tenant": "tenant-a",
+    }
+    assert compute_apc_extra_hash(kw_short, legacy=False) == compute_apc_extra_hash(
+        kw_long, legacy=False
+    )
+
+    zeros = mx.zeros((1, 3, 8, 8))
+    ones = mx.ones((1, 3, 8, 8))
+    assert compute_apc_extra_hash(
+        {"pixel_values": zeros, "_apc_tenant": "tenant-a"}, legacy=False
+    ) != compute_apc_extra_hash(
+        {"pixel_values": ones, "_apc_tenant": "tenant-a"}, legacy=False
+    )
+
+
+def test_apc_legacy_extra_hash_matches_full_sequence_media():
+    embeds = mx.zeros((1, 64, 32))
+    mask = mx.ones((1, 64))
+    kw = {"inputs_embeds": embeds, "attention_mask": mask}
+    legacy = compute_apc_extra_hash(kw, legacy=True)
+    manual = semantic_extra_hash(
+        image_hash=0,
+        media={
+            "audio": None,
+            "video": None,
+            "embeddings": embeds,
+            "masks": mask,
+        },
+    )
+    assert legacy == manual
+
+    kw_longer = {
+        "inputs_embeds": mx.zeros((1, 128, 32)),
+        "attention_mask": mx.ones((1, 128)),
+    }
+    assert compute_apc_extra_hash(kw, legacy=True) != compute_apc_extra_hash(
+        kw_longer, legacy=True
+    )
+
+
+def test_apc_lookup_plan_falls_back_to_legacy_extra_hash():
+    from mlx_vlm.models.cache import KVCache
+
+    token_ids = list(range(32))
+    kv = KVCache()
+    kv.keys = mx.ones((1, 1, len(token_ids), 4))
+    kv.values = mx.ones((1, 1, len(token_ids), 4)) * 2
+    kv.offset = len(token_ids)
+
+    embeds = mx.zeros((1, 64, 16))
+    mask = mx.ones((1, 64))
+    kw = {"inputs_embeds": embeds, "attention_mask": mask}
+    stable = compute_apc_extra_hash(kw, legacy=False)
+    legacy = compute_apc_extra_hash(kw, legacy=True)
+    assert stable != legacy
+
+    manager = APCManager(num_blocks=4, block_size=16)
+    assert manager.store_exact_cache(token_ids, [kv], extra_hash=legacy)
+
+    plan_stable_only = apc_lookup_plan(
+        manager,
+        token_ids + [999],
+        extra_hash=stable,
+        apc_mode="exact",
+        safe_lookup_min=0,
+        suffix_is_text_only=lambda pl: True,
+        prefix_has_media=lambda pl: False,
+    )
+    assert plan_stable_only is None
+
+    plan_candidates = apc_lookup_plan(
+        manager,
+        token_ids + [999],
+        extra_hashes=(stable, legacy),
+        apc_mode="exact",
+        safe_lookup_min=0,
+        suffix_is_text_only=lambda pl: True,
+        prefix_has_media=lambda pl: False,
+    )
+    assert plan_candidates is not None
+    assert plan_candidates["prefix_len"] == len(token_ids)
+    assert plan_candidates["extra_hash"] == legacy


### PR DESCRIPTION
## Summary
- Centralize APC identity in `apc.py`: hash **source** multimodal inputs (image/audio/video/tenant), not full-sequence `inputs_embeds` / `attention_mask`.
- **Store** with stable `extra_hash`; **lookup** tries stable first, then legacy (pre-fix full-tensor hash) for backward compatibility.
- Fixes cross-turn exact-cache misses on the continuous-batching server path (`exact_hits: 0` with growing context).

Fixes #999

## Test plan
- [x] `pytest mlx_vlm/tests/test_apc.py -k "extra_hash or legacy"`
- [x] `pytest mlx_vlm/tests/test_apc.py mlx_vlm/tests/test_apc_semantic_key.py`
- [x] Two-turn chat with `APC_ENABLED=1` → `/v1/cache/stats` shows `exact_hits > 0`

## Operator note
For long multi-turn sessions, set `APC_EXACT_CACHE_ENTRIES` above the default LRU of 2 (e.g. `32`).