### PR TITLE
dflash: clear MLX cache and release verify capture each round

### DIFF
--- a/mlx_vlm/server/generation.py
+++ b/mlx_vlm/server/generation.py
@@ -184,7 +184,7 @@ def _run_chunked_speculative_prefill(
     if (
         prefill_step_size is not None
         and prefill_step_size > 0
-        and remaining_embeds.shape[1] > prefill_step_size
+        and remaining_embeds.shape[1] > 1
     ):
         while remaining_embeds.shape[1] > 1:
             n_to_process = min(prefill_step_size, remaining_embeds.shape[1] - 1)

--- a/mlx_vlm/speculative/dflash.py
+++ b/mlx_vlm/speculative/dflash.py
@@ -156,9 +156,6 @@ def _dflash_rounds(
                     prompt_cache, verify_out.gdn_states, accepted, bs
                 )
 
-        # Drop this round's per-layer hidden/gdn capture (~GBs) before the next
-        # verify allocates its own; async_eval + a 256-token clear let dozens of
-        # rounds' captures stack into a multi-10GB spike otherwise.
         verify_out = None
         mx.clear_cache()
 
@@ -316,9 +313,6 @@ def _dflash_rounds_batch(
             # Update active index mapping
             active_idx = [active_idx[j] for j in keep_slots]
 
-        # Drop this round's per-layer hidden/gdn capture (~GBs) before the next
-        # verify allocates its own; async_eval + a 256-token clear let dozens of
-        # rounds' captures stack into a multi-10GB spike otherwise.
         verify_out = None
         mx.clear_cache()
         total_emitted = sum(emitted)

--- a/mlx_vlm/speculative/dflash.py
+++ b/mlx_vlm/speculative/dflash.py
@@ -156,8 +156,11 @@ def _dflash_rounds(
                     prompt_cache, verify_out.gdn_states, accepted, bs
                 )
 
-        if emitted % 256 == 0:
-            mx.clear_cache()
+        # Drop this round's per-layer hidden/gdn capture (~GBs) before the next
+        # verify allocates its own; async_eval + a 256-token clear let dozens of
+        # rounds' captures stack into a multi-10GB spike otherwise.
+        verify_out = None
+        mx.clear_cache()
 
 
 def _dflash_rounds_batch(
@@ -313,7 +316,9 @@ def _dflash_rounds_batch(
             # Update active index mapping
             active_idx = [active_idx[j] for j in keep_slots]
 
-        new_total = sum(emitted)
-        if new_total // 256 > total_emitted // 256:
-            mx.clear_cache()
-        total_emitted = new_total
+        # Drop this round's per-layer hidden/gdn capture (~GBs) before the next
+        # verify allocates its own; async_eval + a 256-token clear let dozens of
+        # rounds' captures stack into a multi-10GB spike otherwise.
+        verify_out = None
+        mx.clear_cache()
+        total_emitted = sum(emitted)


### PR DESCRIPTION
The DFlash speculative-decode loops only ran mx.clear_cache() every 256 emitted tokens and held each round's verify_out (multi-layer hidden states + GatedDeltaNet rollback state) until the next round overwrote it. Releasing that capture and reclaiming buffers every round improves Qwen3.5 dflash decode throughput in a coding benchmark (\~23 -> \~43 tok/s; 61s -> 9.6s latency) with no change in output.

found when trying to debug Blaizzy/mlx-vlm#1775