### PR TITLE
Support current LFM2 feed-forward configs

### DIFF
--- a/mlx_vlm/models/lfm2/config.py
+++ b/mlx_vlm/models/lfm2/config.py
@@ -31,6 +31,12 @@ class ModelConfig(BaseModelConfig):
     eos_token_id: Optional[Union[int, List[int]]] = None
     pad_token_id: Optional[int] = None
 
+    @classmethod
+    def from_dict(cls, params):
+        if params and "block_ff_dim" not in params and "intermediate_size" in params:
+            params = {**params, "block_ff_dim": params["intermediate_size"]}
+        return super().from_dict(params)
+
     def __post_init__(self):
         if self.rope_parameters is not None and "rope_theta" in self.rope_parameters:
             self.rope_theta = self.rope_parameters["rope_theta"]

--- a/mlx_vlm/tests/test_models.py
+++ b/mlx_vlm/tests/test_models.py
@@ -578,6 +578,10 @@ class TestModels(unittest.TestCase):
         )
 
         model = lfm2.Model(config)
+        self.assertEqual(
+            model.language_model.model.layers[0].feed_forward.w1.weight.shape,
+            (96, 64),
+        )
 
         self.language_test_runner(
             model.language_model,
@@ -593,6 +597,51 @@ class TestModels(unittest.TestCase):
         cache = model.make_cache()
         self.assertEqual(type(cache[0]).__name__, "ArraysCache")
         self.assertEqual(type(cache[1]).__name__, "KVCache")
+
+    def test_lfm2_config_feed_forward_dim_compatibility(self):
+        from mlx_vlm.models import lfm2
+
+        base_config = {
+            "model_type": "lfm2",
+            "vocab_size": 128,
+            "hidden_size": 64,
+            "num_hidden_layers": 1,
+            "num_attention_heads": 4,
+            "num_key_value_heads": 2,
+            "max_position_embeddings": 128,
+            "norm_eps": 1e-5,
+            "conv_bias": False,
+            "conv_L_cache": 3,
+            "block_dim": 64,
+            "block_multiple_of": 16,
+            "block_ffn_dim_multiplier": 1.0,
+            "block_auto_adjust_ff_dim": False,
+            "layer_types": ["full_attention"],
+        }
+
+        current_config = lfm2.ModelConfig.from_dict(
+            {**base_config, "intermediate_size": 192}
+        )
+        self.assertEqual(current_config.block_ff_dim, 192)
+        current_model = lfm2.Model(current_config)
+        self.assertEqual(
+            current_model.language_model.model.layers[0].feed_forward.w1.weight.shape,
+            (192, 64),
+        )
+
+        legacy_config = lfm2.ModelConfig.from_dict(
+            {
+                **base_config,
+                "intermediate_size": 192,
+                "block_ff_dim": 128,
+            }
+        )
+        self.assertEqual(legacy_config.block_ff_dim, 128)
+        legacy_model = lfm2.Model(legacy_config)
+        self.assertEqual(
+            legacy_model.language_model.model.layers[0].feed_forward.w1.weight.shape,
+            (128, 64),
+        )
 
     def test_lfm2_moe_language_model(self):
         from mlx_vlm.models import lfm2_moe


### PR DESCRIPTION
## Summary

- accept current LFM2 checkpoints that expose `intermediate_size` without the legacy `block_ff_dim` field
- preserve `block_ff_dim` precedence when both fields are present
- add regression coverage for current and legacy feed-forward dimensions, including the legacy auto-adjusted MLP shape

## Root cause

Current LFM2.5 checkpoints use `intermediate_size` for the feed-forward dimension, while the MLX-VLM LFM2 config still required `block_ff_dim`. This caused model loading to fail during config construction before weights were loaded.

The compatibility mapping mirrors Transformers behavior: `block_ff_dim` wins when supplied; otherwise `intermediate_size` is used.

## Validation

- `11 passed` — LFM2 model tests
- `5 passed` — LFM2-VL processor tests
- Black and isort checks passed
- `git diff --check` passed
- server `/health` returned HTTP 200 and `/v1/chat/completions` returned `4` with `finish_reason: stop`