### PR TITLE
Expose per-request speculative decoding acceptance stats in response timings

### DIFF
--- a/mlx_vlm/server/generation.py
+++ b/mlx_vlm/server/generation.py
@@ -2235,7 +2235,9 @@ class ResponseGenerator:
                                 prompt_tps=prompt_tps_map.get(uid),
                                 token_count=0,
                                 emitted_at=emitted_at,
-                                spec_draft_kind=draft_kind,
+                                spec_draft_kind=(
+                                    draft_kind if rounds is not None else None
+                                ),
                                 spec_rounds=rounds,
                                 spec_accepted_tokens=accepted,
                                 spec_drafted_tokens=drafted,

--- a/mlx_vlm/server/generation.py
+++ b/mlx_vlm/server/generation.py
@@ -41,6 +41,8 @@ from ..speculative.utils import (
     run_speculative_server_rounds,
     speculative_hidden_state,
     speculative_prefill_kwargs,
+    speculative_stats_since,
+    speculative_stats_snapshot,
 )
 from ..structured import ThinkingAwareLogitsProcessor
 from ..tokenizer_utils import _ServerTokenStreamer, make_streaming_detokenizer
@@ -1766,6 +1768,11 @@ class ResponseGenerator:
                         "gen_kwargs": gen_kwargs if has_embeds else None,
                         "prompt_tps": None,
                         "cached_tokens": 0,
+                        "spec_snapshot": (
+                            speculative_stats_snapshot(self.draft_model)
+                            if self.draft_model is not None
+                            else None
+                        ),
                         **log_state,
                     }
 
@@ -2116,21 +2123,10 @@ class ResponseGenerator:
                         return True
                     return False
 
-                # Per-request acceptance stats: slice the drafter's lifetime
-                # accept/draft histories from here. Rounds are batch-wide, so
-                # the split is exact for B=1 and shared across the batch.
-                accept_start = len(getattr(drafter, "accept_lens", None) or [])
-                draft_start = len(getattr(drafter, "draft_lens", None) or [])
+                spec_snapshot = speculative_stats_snapshot(drafter)
 
                 def spec_summary():
-                    accepts = (getattr(drafter, "accept_lens", None) or [])[
-                        accept_start:
-                    ]
-                    if not accepts:
-                        return None, None, None
-                    drafts = (getattr(drafter, "draft_lens", None) or [])[draft_start:]
-                    drafted = int(sum(drafts)) if len(drafts) == len(accepts) else None
-                    return len(accepts), int(sum(accepts)), drafted
+                    return speculative_stats_since(drafter, spec_snapshot)
 
                 rounds_iter = run_speculative_server_rounds(
                     self.model,
@@ -2300,6 +2296,15 @@ class ResponseGenerator:
                 token_count=token_count,
             )
 
+            spec_rounds = spec_accepted = spec_drafted = None
+            spec_kind = None
+            if r.finish_reason is not None and info.get("spec_snapshot") is not None:
+                spec_rounds, spec_accepted, spec_drafted = speculative_stats_since(
+                    self.draft_model, info["spec_snapshot"]
+                )
+                if spec_rounds is not None:
+                    spec_kind = self.draft_kind
+
             rqueue.put(
                 StreamingToken(
                     text=text,
@@ -2308,6 +2313,10 @@ class ResponseGenerator:
                     finish_reason=r.finish_reason,
                     peak_memory=mx.get_peak_memory() / 1e9 if r.finish_reason else 0,
                     prompt_tps=info.get("prompt_tps"),
+                    spec_draft_kind=spec_kind,
+                    spec_rounds=spec_rounds,
+                    spec_accepted_tokens=spec_accepted,
+                    spec_drafted_tokens=spec_drafted,
                     top_logprobs=getattr(r, "top_logprobs", None),
                     cached_tokens=info.get("cached_tokens", 0),
                     token_count=token_count,

--- a/mlx_vlm/server/generation.py
+++ b/mlx_vlm/server/generation.py
@@ -832,10 +832,10 @@ class GenerationMetrics:
     last_chunk_rate: Optional[float] = None
     generated_tokens: int = 0
     first_chunk_tokens: int = 0
-    spec_draft_kind: Optional[str] = None
-    spec_rounds: Optional[int] = None
-    spec_accepted_tokens: Optional[int] = None
-    spec_drafted_tokens: Optional[int] = None
+    draft_kind: Optional[str] = None
+    draft_rounds: Optional[int] = None
+    draft_n_accepted: Optional[int] = None
+    draft_n: Optional[int] = None
 
     def record_chunk(self, chunk) -> Optional[float]:
         now = getattr(chunk, "emitted_at", None) or time.perf_counter()
@@ -881,18 +881,18 @@ class GenerationMetrics:
         cached_tokens = getattr(result, "cached_tokens", None)
         if cached_tokens is not None:
             self.cached_tokens = max(self.cached_tokens, int(cached_tokens))
-        spec_draft_kind = getattr(result, "spec_draft_kind", None)
-        if spec_draft_kind is not None:
-            self.spec_draft_kind = spec_draft_kind
-        spec_rounds = getattr(result, "spec_rounds", None)
-        if spec_rounds is not None:
-            self.spec_rounds = int(spec_rounds)
-        spec_accepted_tokens = getattr(result, "spec_accepted_tokens", None)
-        if spec_accepted_tokens is not None:
-            self.spec_accepted_tokens = int(spec_accepted_tokens)
-        spec_drafted_tokens = getattr(result, "spec_drafted_tokens", None)
-        if spec_drafted_tokens is not None:
-            self.spec_drafted_tokens = int(spec_drafted_tokens)
+        draft_kind = getattr(result, "draft_kind", None)
+        if draft_kind is not None:
+            self.draft_kind = draft_kind
+        draft_rounds = getattr(result, "draft_rounds", None)
+        if draft_rounds is not None:
+            self.draft_rounds = int(draft_rounds)
+        draft_n_accepted = getattr(result, "draft_n_accepted", None)
+        if draft_n_accepted is not None:
+            self.draft_n_accepted = int(draft_n_accepted)
+        draft_n = getattr(result, "draft_n", None)
+        if draft_n is not None:
+            self.draft_n = int(draft_n)
 
 
 @dataclass
@@ -910,10 +910,10 @@ class StreamingToken:
     peak_memory: float = 0.0
     prompt_tps: Optional[float] = None
     generation_tps: Optional[float] = None
-    spec_draft_kind: Optional[str] = None
-    spec_rounds: Optional[int] = None
-    spec_accepted_tokens: Optional[int] = None
-    spec_drafted_tokens: Optional[int] = None
+    draft_kind: Optional[str] = None
+    draft_rounds: Optional[int] = None
+    draft_n_accepted: Optional[int] = None
+    draft_n: Optional[int] = None
     top_logprobs: Optional[List[Tuple[int, float]]] = None
     cached_tokens: int = 0
     token_count: int = 1
@@ -2184,10 +2184,10 @@ class ResponseGenerator:
                                 peak_memory=mx.get_peak_memory() / 1e9 if finish else 0,
                                 prompt_tps=prompt_tps_map.get(uid),
                                 emitted_at=emitted_at,
-                                spec_draft_kind=draft_kind if finish else None,
-                                spec_rounds=rounds,
-                                spec_accepted_tokens=accepted,
-                                spec_drafted_tokens=drafted,
+                                draft_kind=draft_kind if finish else None,
+                                draft_rounds=rounds,
+                                draft_n_accepted=accepted,
+                                draft_n=drafted,
                             )
                         )
 
@@ -2235,12 +2235,10 @@ class ResponseGenerator:
                                 prompt_tps=prompt_tps_map.get(uid),
                                 token_count=0,
                                 emitted_at=emitted_at,
-                                spec_draft_kind=(
-                                    draft_kind if rounds is not None else None
-                                ),
-                                spec_rounds=rounds,
-                                spec_accepted_tokens=accepted,
-                                spec_drafted_tokens=drafted,
+                                draft_kind=(draft_kind if rounds is not None else None),
+                                draft_rounds=rounds,
+                                draft_n_accepted=accepted,
+                                draft_n=drafted,
                             )
                         )
                         rqueues[uid].put(None)
@@ -2298,14 +2296,14 @@ class ResponseGenerator:
                 token_count=token_count,
             )
 
-            spec_rounds = spec_accepted = spec_drafted = None
-            spec_kind = None
+            draft_rounds = draft_accepted = draft_total = None
+            request_draft_kind = None
             if r.finish_reason is not None and info.get("spec_snapshot") is not None:
-                spec_rounds, spec_accepted, spec_drafted = speculative_stats_since(
+                draft_rounds, draft_accepted, draft_total = speculative_stats_since(
                     self.draft_model, info["spec_snapshot"]
                 )
-                if spec_rounds is not None:
-                    spec_kind = self.draft_kind
+                if draft_rounds is not None:
+                    request_draft_kind = self.draft_kind
 
             rqueue.put(
                 StreamingToken(
@@ -2315,10 +2313,10 @@ class ResponseGenerator:
                     finish_reason=r.finish_reason,
                     peak_memory=mx.get_peak_memory() / 1e9 if r.finish_reason else 0,
                     prompt_tps=info.get("prompt_tps"),
-                    spec_draft_kind=spec_kind,
-                    spec_rounds=spec_rounds,
-                    spec_accepted_tokens=spec_accepted,
-                    spec_drafted_tokens=spec_drafted,
+                    draft_kind=request_draft_kind,
+                    draft_rounds=draft_rounds,
+                    draft_n_accepted=draft_accepted,
+                    draft_n=draft_total,
                     top_logprobs=getattr(r, "top_logprobs", None),
                     cached_tokens=info.get("cached_tokens", 0),
                     token_count=token_count,

--- a/mlx_vlm/server/generation.py
+++ b/mlx_vlm/server/generation.py
@@ -830,6 +830,10 @@ class GenerationMetrics:
     last_chunk_rate: Optional[float] = None
     generated_tokens: int = 0
     first_chunk_tokens: int = 0
+    spec_draft_kind: Optional[str] = None
+    spec_rounds: Optional[int] = None
+    spec_accepted_tokens: Optional[int] = None
+    spec_drafted_tokens: Optional[int] = None
 
     def record_chunk(self, chunk) -> Optional[float]:
         now = getattr(chunk, "emitted_at", None) or time.perf_counter()
@@ -875,6 +879,18 @@ class GenerationMetrics:
         cached_tokens = getattr(result, "cached_tokens", None)
         if cached_tokens is not None:
             self.cached_tokens = max(self.cached_tokens, int(cached_tokens))
+        spec_draft_kind = getattr(result, "spec_draft_kind", None)
+        if spec_draft_kind is not None:
+            self.spec_draft_kind = spec_draft_kind
+        spec_rounds = getattr(result, "spec_rounds", None)
+        if spec_rounds is not None:
+            self.spec_rounds = int(spec_rounds)
+        spec_accepted_tokens = getattr(result, "spec_accepted_tokens", None)
+        if spec_accepted_tokens is not None:
+            self.spec_accepted_tokens = int(spec_accepted_tokens)
+        spec_drafted_tokens = getattr(result, "spec_drafted_tokens", None)
+        if spec_drafted_tokens is not None:
+            self.spec_drafted_tokens = int(spec_drafted_tokens)
 
 
 @dataclass
@@ -892,6 +908,10 @@ class StreamingToken:
     peak_memory: float = 0.0
     prompt_tps: Optional[float] = None
     generation_tps: Optional[float] = None
+    spec_draft_kind: Optional[str] = None
+    spec_rounds: Optional[int] = None
+    spec_accepted_tokens: Optional[int] = None
+    spec_drafted_tokens: Optional[int] = None
     top_logprobs: Optional[List[Tuple[int, float]]] = None
     cached_tokens: int = 0
     token_count: int = 1
@@ -2096,6 +2116,22 @@ class ResponseGenerator:
                         return True
                     return False
 
+                # Per-request acceptance stats: slice the drafter's lifetime
+                # accept/draft histories from here. Rounds are batch-wide, so
+                # the split is exact for B=1 and shared across the batch.
+                accept_start = len(getattr(drafter, "accept_lens", None) or [])
+                draft_start = len(getattr(drafter, "draft_lens", None) or [])
+
+                def spec_summary():
+                    accepts = (getattr(drafter, "accept_lens", None) or [])[
+                        accept_start:
+                    ]
+                    if not accepts:
+                        return None, None, None
+                    drafts = (getattr(drafter, "draft_lens", None) or [])[draft_start:]
+                    drafted = int(sum(drafts)) if len(drafts) == len(accepts) else None
+                    return len(accepts), int(sum(accepts)), drafted
+
                 rounds_iter = run_speculative_server_rounds(
                     self.model,
                     drafter,
@@ -2140,6 +2176,9 @@ class ResponseGenerator:
                             finish_reason=finish,
                         )
 
+                        rounds, accepted, drafted = (
+                            spec_summary() if finish else (None, None, None)
+                        )
                         rqueues[uid].put(
                             StreamingToken(
                                 text=text,
@@ -2149,6 +2188,10 @@ class ResponseGenerator:
                                 peak_memory=mx.get_peak_memory() / 1e9 if finish else 0,
                                 prompt_tps=prompt_tps_map.get(uid),
                                 emitted_at=emitted_at,
+                                spec_draft_kind=draft_kind if finish else None,
+                                spec_rounds=rounds,
+                                spec_accepted_tokens=accepted,
+                                spec_drafted_tokens=drafted,
                             )
                         )
 
@@ -2158,18 +2201,20 @@ class ResponseGenerator:
                     if len(finished_uids) == len(uids):
                         break
 
-                # Log acceptance stats
-                al = drafter.accept_lens
-                if al:
-                    mean_a = (sum(al) + len(al)) / len(al)
+                # Log acceptance stats for this batch only, not the drafter's
+                # lifetime history.
+                rounds, accepted, drafted = spec_summary()
+                if rounds:
+                    mean_a = (accepted + rounds) / rounds
                     logger.info(
                         "Speculative decode: kind=%s batch=%d tokens=%d "
-                        "accept=%.2f rounds=%d",
+                        "accept=%.2f rounds=%d drafted=%s",
                         draft_kind,
                         B,
                         sum(len(token_lists[u]) for u in uids),
                         mean_a,
-                        len(al),
+                        rounds,
+                        drafted,
                     )
 
                 # Finalize any remaining
@@ -2194,6 +2239,10 @@ class ResponseGenerator:
                                 prompt_tps=prompt_tps_map.get(uid),
                                 token_count=0,
                                 emitted_at=emitted_at,
+                                spec_draft_kind=draft_kind,
+                                spec_rounds=rounds,
+                                spec_accepted_tokens=accepted,
+                                spec_drafted_tokens=drafted,
                             )
                         )
                         rqueues[uid].put(None)

--- a/mlx_vlm/server/schemas.py
+++ b/mlx_vlm/server/schemas.py
@@ -448,6 +448,12 @@ class GenerationTimings(BaseModel):
     predicted_per_token_ms: float
     predicted_per_second: float
     peak_memory: float = 0.0
+    # Speculative decoding stats; None unless the request ran with a drafter.
+    draft_kind: Optional[str] = None
+    spec_rounds: Optional[int] = None
+    spec_accepted_tokens: Optional[int] = None
+    spec_drafted_tokens: Optional[int] = None
+    spec_acceptance_rate: Optional[float] = None
 
     @staticmethod
     def _derive_gen_tps(token_times: List[float]) -> Optional[float]:
@@ -488,7 +494,23 @@ class GenerationTimings(BaseModel):
             ),
             predicted_per_second=float(generation_tps or 0.0),
             peak_memory=float(metrics.peak_memory or 0.0),
+            draft_kind=getattr(metrics, "spec_draft_kind", None),
+            spec_rounds=getattr(metrics, "spec_rounds", None),
+            spec_accepted_tokens=getattr(metrics, "spec_accepted_tokens", None),
+            spec_drafted_tokens=getattr(metrics, "spec_drafted_tokens", None),
+            spec_acceptance_rate=cls._acceptance_rate(
+                getattr(metrics, "spec_accepted_tokens", None),
+                getattr(metrics, "spec_drafted_tokens", None),
+            ),
         )
+
+    @staticmethod
+    def _acceptance_rate(
+        accepted: Optional[int], drafted: Optional[int]
+    ) -> Optional[float]:
+        if accepted is None or not drafted:
+            return None
+        return accepted / drafted
 
 
 class StreamingTimings(BaseModel):

--- a/mlx_vlm/server/schemas.py
+++ b/mlx_vlm/server/schemas.py
@@ -448,12 +448,12 @@ class GenerationTimings(BaseModel):
     predicted_per_token_ms: float
     predicted_per_second: float
     peak_memory: float = 0.0
-    # Speculative decoding stats; None unless the request ran with a drafter.
+    # Speculative decoding stats, following the llama.cpp server timings
+    # field names; None unless the request ran with a drafter.
     draft_kind: Optional[str] = None
-    spec_rounds: Optional[int] = None
-    spec_accepted_tokens: Optional[int] = None
-    spec_drafted_tokens: Optional[int] = None
-    spec_acceptance_rate: Optional[float] = None
+    draft_rounds: Optional[int] = None
+    draft_n: Optional[int] = None
+    draft_n_accepted: Optional[int] = None
 
     @staticmethod
     def _derive_gen_tps(token_times: List[float]) -> Optional[float]:
@@ -494,23 +494,11 @@ class GenerationTimings(BaseModel):
             ),
             predicted_per_second=float(generation_tps or 0.0),
             peak_memory=float(metrics.peak_memory or 0.0),
-            draft_kind=getattr(metrics, "spec_draft_kind", None),
-            spec_rounds=getattr(metrics, "spec_rounds", None),
-            spec_accepted_tokens=getattr(metrics, "spec_accepted_tokens", None),
-            spec_drafted_tokens=getattr(metrics, "spec_drafted_tokens", None),
-            spec_acceptance_rate=cls._acceptance_rate(
-                getattr(metrics, "spec_accepted_tokens", None),
-                getattr(metrics, "spec_drafted_tokens", None),
-            ),
+            draft_kind=getattr(metrics, "draft_kind", None),
+            draft_rounds=getattr(metrics, "draft_rounds", None),
+            draft_n=getattr(metrics, "draft_n", None),
+            draft_n_accepted=getattr(metrics, "draft_n_accepted", None),
         )
-
-    @staticmethod
-    def _acceptance_rate(
-        accepted: Optional[int], drafted: Optional[int]
-    ) -> Optional[float]:
-        if accepted is None or not drafted:
-            return None
-        return accepted / drafted
 
 
 class StreamingTimings(BaseModel):

--- a/mlx_vlm/speculative/common.py
+++ b/mlx_vlm/speculative/common.py
@@ -215,6 +215,42 @@ def _record_speculative_round(
     draft_model.accept_lens.append(accepted)
     if hasattr(draft_model, "draft_lens"):
         draft_model.draft_lens.append(int(draft_count))
+    # Monotonic lifetime counters for per-request attribution. Unlike the
+    # ``accept_lens`` history, these survive ``reset()`` between requests,
+    # so callers can snapshot-and-diff across a request's lifetime.
+    draft_model.spec_total_rounds = getattr(draft_model, "spec_total_rounds", 0) + 1
+    draft_model.spec_total_accepted = getattr(
+        draft_model, "spec_total_accepted", 0.0
+    ) + float(accepted)
+    draft_model.spec_total_drafted = getattr(
+        draft_model, "spec_total_drafted", 0
+    ) + int(draft_count)
+
+
+def speculative_stats_snapshot(draft_model: nn.Module) -> Tuple[int, float, int]:
+    """Capture the drafter's lifetime round counters for later diffing."""
+    return (
+        getattr(draft_model, "spec_total_rounds", 0),
+        getattr(draft_model, "spec_total_accepted", 0.0),
+        getattr(draft_model, "spec_total_drafted", 0),
+    )
+
+
+def speculative_stats_since(
+    draft_model: nn.Module, snapshot: Tuple[int, float, int]
+) -> Tuple[Optional[int], Optional[int], Optional[int]]:
+    """Return (rounds, accepted, drafted) recorded since ``snapshot``.
+
+    Rounds are batch-wide, so the attribution is exact for batch size 1 and
+    shared across concurrent requests otherwise.
+    """
+    rounds0, accepted0, drafted0 = snapshot
+    rounds = getattr(draft_model, "spec_total_rounds", 0) - rounds0
+    if rounds <= 0:
+        return None, None, None
+    accepted = getattr(draft_model, "spec_total_accepted", 0.0) - accepted0
+    drafted = getattr(draft_model, "spec_total_drafted", 0) - drafted0
+    return rounds, int(round(accepted)), int(drafted)
 
 
 def _dflash_block_total(draft_model: nn.Module, draft_block_size: Optional[int]) -> int:

--- a/mlx_vlm/speculative/common.py
+++ b/mlx_vlm/speculative/common.py
@@ -218,21 +218,23 @@ def _record_speculative_round(
     # Monotonic lifetime counters for per-request attribution. Unlike the
     # ``accept_lens`` history, these survive ``reset()`` between requests,
     # so callers can snapshot-and-diff across a request's lifetime.
-    draft_model.spec_total_rounds = getattr(draft_model, "spec_total_rounds", 0) + 1
-    draft_model.spec_total_accepted = getattr(
-        draft_model, "spec_total_accepted", 0.0
+    draft_model.speculative_total_rounds = (
+        getattr(draft_model, "speculative_total_rounds", 0) + 1
+    )
+    draft_model.speculative_total_accepted = getattr(
+        draft_model, "speculative_total_accepted", 0.0
     ) + float(accepted)
-    draft_model.spec_total_drafted = getattr(
-        draft_model, "spec_total_drafted", 0
+    draft_model.speculative_total_drafted = getattr(
+        draft_model, "speculative_total_drafted", 0
     ) + int(draft_count)
 
 
 def speculative_stats_snapshot(draft_model: nn.Module) -> Tuple[int, float, int]:
     """Capture the drafter's lifetime round counters for later diffing."""
     return (
-        getattr(draft_model, "spec_total_rounds", 0),
-        getattr(draft_model, "spec_total_accepted", 0.0),
-        getattr(draft_model, "spec_total_drafted", 0),
+        getattr(draft_model, "speculative_total_rounds", 0),
+        getattr(draft_model, "speculative_total_accepted", 0.0),
+        getattr(draft_model, "speculative_total_drafted", 0),
     )
 
 
@@ -245,11 +247,11 @@ def speculative_stats_since(
     shared across concurrent requests otherwise.
     """
     rounds0, accepted0, drafted0 = snapshot
-    rounds = getattr(draft_model, "spec_total_rounds", 0) - rounds0
+    rounds = getattr(draft_model, "speculative_total_rounds", 0) - rounds0
     if rounds <= 0:
         return None, None, None
-    accepted = getattr(draft_model, "spec_total_accepted", 0.0) - accepted0
-    drafted = getattr(draft_model, "spec_total_drafted", 0) - drafted0
+    accepted = getattr(draft_model, "speculative_total_accepted", 0.0) - accepted0
+    drafted = getattr(draft_model, "speculative_total_drafted", 0) - drafted0
     return rounds, int(round(accepted)), int(drafted)
 
 

--- a/mlx_vlm/speculative/utils.py
+++ b/mlx_vlm/speculative/utils.py
@@ -10,6 +10,8 @@ from .common import (
     _speculative_walk,
     _speculative_walk_batch,
     _speculative_walk_batch_uniform_acceptance,
+    speculative_stats_since,
+    speculative_stats_snapshot,
 )
 from .dflash import (
     _dflash_committed_hidden_segments,
@@ -61,6 +63,8 @@ __all__ = [
     "run_speculative_server_rounds",
     "speculative_hidden_state",
     "speculative_prefill_kwargs",
+    "speculative_stats_since",
+    "speculative_stats_snapshot",
 ]
 
 

--- a/mlx_vlm/tests/test_server.py
+++ b/mlx_vlm/tests/test_server.py
@@ -3046,18 +3046,18 @@ def test_generation_timings_include_speculative_stats():
         generation_tps=8.0,
         token_times=[],
         peak_memory=0.0,
-        spec_draft_kind="mtp",
-        spec_rounds=5,
-        spec_accepted_tokens=12,
-        spec_drafted_tokens=20,
+        draft_kind="mtp",
+        draft_rounds=5,
+        draft_n_accepted=12,
+        draft_n=20,
     )
     timings = server.GenerationTimings.from_metrics(metrics, 10, 17)
 
     assert timings.draft_kind == "mtp"
-    assert timings.spec_rounds == 5
-    assert timings.spec_accepted_tokens == 12
-    assert timings.spec_drafted_tokens == 20
-    assert timings.spec_acceptance_rate == pytest.approx(0.6)
+    assert timings.draft_rounds == 5
+    assert timings.draft_n_accepted == 12
+    assert timings.draft_n == 20
+    assert timings.draft_n_accepted / timings.draft_n == pytest.approx(0.6)
 
 
 def test_generation_timings_speculative_stats_default_to_none():
@@ -3071,10 +3071,9 @@ def test_generation_timings_speculative_stats_default_to_none():
     timings = server.GenerationTimings.from_metrics(metrics, 10, 4)
 
     assert timings.draft_kind is None
-    assert timings.spec_rounds is None
-    assert timings.spec_accepted_tokens is None
-    assert timings.spec_drafted_tokens is None
-    assert timings.spec_acceptance_rate is None
+    assert timings.draft_rounds is None
+    assert timings.draft_n_accepted is None
+    assert timings.draft_n is None
 
 
 def test_generation_metrics_record_speculative_stats():
@@ -3085,17 +3084,17 @@ def test_generation_metrics_record_speculative_stats():
         SimpleNamespace(
             generation_tokens=6,
             emitted_at=10.5,
-            spec_draft_kind="dflash",
-            spec_rounds=3,
-            spec_accepted_tokens=4,
-            spec_drafted_tokens=9,
+            draft_kind="dflash",
+            draft_rounds=3,
+            draft_n_accepted=4,
+            draft_n=9,
         )
     )
 
-    assert metrics.spec_draft_kind == "dflash"
-    assert metrics.spec_rounds == 3
-    assert metrics.spec_accepted_tokens == 4
-    assert metrics.spec_drafted_tokens == 9
+    assert metrics.draft_kind == "dflash"
+    assert metrics.draft_rounds == 3
+    assert metrics.draft_n_accepted == 4
+    assert metrics.draft_n == 9
 
 
 def test_speculative_lifetime_counters_survive_reset():

--- a/mlx_vlm/tests/test_server.py
+++ b/mlx_vlm/tests/test_server.py
@@ -3039,6 +3039,65 @@ def test_generation_metrics_reports_chunk_and_aggregate_rates():
     assert metrics.rate == pytest.approx(12.0)
 
 
+def test_generation_timings_include_speculative_stats():
+    metrics = SimpleNamespace(
+        cached_tokens=0,
+        prompt_tps=20.0,
+        generation_tps=8.0,
+        token_times=[],
+        peak_memory=0.0,
+        spec_draft_kind="mtp",
+        spec_rounds=5,
+        spec_accepted_tokens=12,
+        spec_drafted_tokens=20,
+    )
+    timings = server.GenerationTimings.from_metrics(metrics, 10, 17)
+
+    assert timings.draft_kind == "mtp"
+    assert timings.spec_rounds == 5
+    assert timings.spec_accepted_tokens == 12
+    assert timings.spec_drafted_tokens == 20
+    assert timings.spec_acceptance_rate == pytest.approx(0.6)
+
+
+def test_generation_timings_speculative_stats_default_to_none():
+    metrics = SimpleNamespace(
+        cached_tokens=0,
+        prompt_tps=20.0,
+        generation_tps=8.0,
+        token_times=[],
+        peak_memory=0.0,
+    )
+    timings = server.GenerationTimings.from_metrics(metrics, 10, 4)
+
+    assert timings.draft_kind is None
+    assert timings.spec_rounds is None
+    assert timings.spec_accepted_tokens is None
+    assert timings.spec_drafted_tokens is None
+    assert timings.spec_acceptance_rate is None
+
+
+def test_generation_metrics_record_speculative_stats():
+    metrics = server_generation.GenerationMetrics()
+
+    metrics.record_chunk(SimpleNamespace(generation_tokens=1, emitted_at=10.0))
+    metrics.record_chunk(
+        SimpleNamespace(
+            generation_tokens=6,
+            emitted_at=10.5,
+            spec_draft_kind="dflash",
+            spec_rounds=3,
+            spec_accepted_tokens=4,
+            spec_drafted_tokens=9,
+        )
+    )
+
+    assert metrics.spec_draft_kind == "dflash"
+    assert metrics.spec_rounds == 3
+    assert metrics.spec_accepted_tokens == 4
+    assert metrics.spec_drafted_tokens == 9
+
+
 def test_chat_completions_returns_timings(client, monkeypatch):
     monkeypatch.setattr(server.runtime, "response_generator", None)
     model = SimpleNamespace()

--- a/mlx_vlm/tests/test_server.py
+++ b/mlx_vlm/tests/test_server.py
@@ -3098,6 +3098,37 @@ def test_generation_metrics_record_speculative_stats():
     assert metrics.spec_drafted_tokens == 9
 
 
+def test_speculative_lifetime_counters_survive_reset():
+    from mlx_vlm.speculative.common import (
+        _record_speculative_round,
+        speculative_stats_since,
+        speculative_stats_snapshot,
+    )
+
+    drafter = SimpleNamespace(accept_lens=[], draft_lens=[])
+
+    assert speculative_stats_since(drafter, speculative_stats_snapshot(drafter)) == (
+        None,
+        None,
+        None,
+    )
+
+    snapshot = speculative_stats_snapshot(drafter)
+    _record_speculative_round(drafter, 3, 7)
+    _record_speculative_round(drafter, 2.5, 7)
+    drafter.accept_lens = []
+    drafter.draft_lens = []
+    _record_speculative_round(drafter, 1.5, 7)
+
+    rounds, accepted, drafted = speculative_stats_since(drafter, snapshot)
+    assert (rounds, accepted, drafted) == (3, 7, 21)
+
+    later_snapshot = speculative_stats_snapshot(drafter)
+    _record_speculative_round(drafter, 2, 7)
+    rounds, accepted, drafted = speculative_stats_since(drafter, later_snapshot)
+    assert (rounds, accepted, drafted) == (1, 2, 7)
+
+
 def test_chat_completions_returns_timings(client, monkeypatch):
     monkeypatch.setattr(server.runtime, "response_generator", None)
     model = SimpleNamespace()


### PR DESCRIPTION
Speculative decoding tracks draft-token acceptance internally but never exposes it, so clients can't tell whether a drafter pairing is actually helping. This PR records per-request acceptance via monotonic lifetime counters (covering both the dedicated speculative loop and the batched MTP path, where the drafter's `reset()` clears its round history) and adds optional `draft_kind`, `draft_rounds`, `draft_n`, and `draft_n_accepted` fields to response `timings` — following the llama.cpp server timings naming that this struct already mirrors, and absent unless a drafter ran, so existing clients are unaffected. Nativ consumes these in Blaizzy/nativ#198 to show a per-response draft-acceptance metric, complementing the speculative-decoding fixes in Blaizzy/nativ#195 and Blaizzy/nativ#196 (all part of Blaizzy/nativ#194).

Validated live on a 16 GB M4 with `mlx-community/Qwen3.5-4B-MLX-4bit` + `mlx-community/Qwen3.5-4B-MTP-4bit`: streaming and non-streaming responses both report `draft_kind="mtp", draft_rounds=30, draft_n=90, draft_n_accepted=81` (90% acceptance), self-consistent with the 111 generated tokens (81 accepted + 30 bonus); a control run without `--draft-model` keeps every field null. Unit tests added in `tests/test_server.py` (counter survival across drafter resets, timings propagation, null defaults); full server suite passes (256 tests).

<details>
<summary>Repro script (self-contained, Apple Silicon ≥16 GB)</summary>

```bash
#!/usr/bin/env bash
set -euo pipefail
D=$(mktemp -d)
git clone -q --depth 1 -b feature/spec-decode-accept-stats https://github.com/Lazarus-931/mlx-vlm "$D/repo"
uv venv -q "$D/venv" --python 3.12
uv pip install -q -e "$D/repo" --python "$D/venv/bin/python3"
PY="$D/venv/bin/python3"

run_case() {
  local mode="$1" port="$2"; shift 2
  PYTHONPATH="$D/repo" $PY -m mlx_vlm.server --model mlx-community/Qwen3.5-4B-MLX-4bit --port "$port" "$@" > "$D/server-$mode.log" 2>&1 &
  local spid=$!
  until curl -s -o /dev/null "http://127.0.0.1:$port/v1/models"; do sleep 5; done
  curl -s "http://127.0.0.1:$port/v1/chat/completions" -H "Content-Type: application/json" \
    -d '{"model":"mlx-community/Qwen3.5-4B-MLX-4bit","messages":[{"role":"user","content":"Count from 1 to 30."}],"max_tokens":120,"temperature":0}' \
    | $PY -c "import json,sys; t=json.load(sys.stdin)[\"timings\"]; print(\"$mode:\", {k:t[k] for k in (\"draft_kind\",\"draft_rounds\",\"draft_n\",\"draft_n_accepted\",\"predicted_per_second\")})"
  kill "$spid"; wait "$spid" 2>/dev/null || true
}

run_case draft 18913 --draft-model mlx-community/Qwen3.5-4B-MTP-4bit
run_case plain 18914
```

</details>