### PR TITLE
Fix wrapped mixed-quantization path matching

### DIFF
--- a/mlx_vlm/models/deepseek_v4/language.py
+++ b/mlx_vlm/models/deepseek_v4/language.py
@@ -16,6 +16,7 @@ from ..cache import CacheList, PoolingCache, RotatingKVCache
 from ..mla import MultiLinear
 from ..pipeline import PipelineMixin
 from ..switch_layers import SwitchGLU
+from ...quantization.one_bit import _quantization_entry_for_path
 from .config import ModelConfig
 from .hisa_kernel import hisa_select
 from .hyper_connection import HyperConnection, HyperHead, hc_expand
@@ -1405,8 +1406,10 @@ class LanguageModel(nn.Module):
         quantization_config = make_quantization_config(self)
 
         def predicate(path, _):
-            path = path.removeprefix("language_model.")
-            return quantization_config.get(path, True)
+            has_per_layer, per_layer = _quantization_entry_for_path(
+                quantization_config, path
+            )
+            return per_layer if has_per_layer else True
 
         return predicate
 

--- a/mlx_vlm/quantization/one_bit.py
+++ b/mlx_vlm/quantization/one_bit.py
@@ -1,7 +1,7 @@
 """Python-hosted 1-bit affine inference kernels."""
 
 from functools import lru_cache
-from typing import Dict, Optional
+from typing import Any, Dict, Optional, Tuple
 
 import mlx.core as mx
 import mlx.nn as nn
@@ -456,14 +456,29 @@ class OneBitEmbedding(nn.Module):
         )
 
 
+def _quantization_entry_for_path(
+    quantization: Dict[str, Any], path: str
+) -> Tuple[bool, Any]:
+    """Resolve a per-module entry with the known language-model wrapper removed."""
+    if path in quantization:
+        per_layer = quantization[path]
+    else:
+        unwrapped_path = path.removeprefix("language_model.")
+        if unwrapped_path == path or unwrapped_path not in quantization:
+            return False, None
+        per_layer = quantization[unwrapped_path]
+
+    return True, per_layer.copy() if isinstance(per_layer, dict) else per_layer
+
+
 def _quantization_for_path(quantization: dict, path: str) -> dict:
     base = {
         key: quantization[key]
         for key in ("group_size", "bits", "mode")
         if key in quantization
     }
-    per_layer = quantization.get(path)
-    if isinstance(per_layer, dict):
+    has_per_layer, per_layer = _quantization_entry_for_path(quantization, path)
+    if has_per_layer and isinstance(per_layer, dict):
         base.update(per_layer)
     return base
 

--- a/mlx_vlm/speculative/drafters/deepseek_v4_mtp/deepseek_v4_mtp.py
+++ b/mlx_vlm/speculative/drafters/deepseek_v4_mtp/deepseek_v4_mtp.py
@@ -9,6 +9,7 @@ from ....models.base import create_attention_mask
 from ....models.cache import RotatingKVCache
 from ....models.deepseek_v4.hyper_connection import HyperHead
 from ....models.deepseek_v4.language import DeepseekV4Block
+from ....quantization.one_bit import _quantization_entry_for_path
 from .config import DeepseekV4MTPConfig
 
 
@@ -86,7 +87,10 @@ class DeepseekV4MTPDraftModel(nn.Module):
         quantization_config = make_quantization_config(self)
 
         def predicate(path, _):
-            return quantization_config.get(path, True)
+            has_per_layer, per_layer = _quantization_entry_for_path(
+                quantization_config, path
+            )
+            return per_layer if has_per_layer else True
 
         return predicate
 

--- a/mlx_vlm/tests/test_quantization_path_matching.py
+++ b/mlx_vlm/tests/test_quantization_path_matching.py
@@ -1,0 +1,113 @@
+from copy import deepcopy
+
+from mlx_vlm.quantization.one_bit import _quantization_for_path
+from mlx_vlm.utils import get_class_predicate
+
+
+class _QuantizableModule:
+    class _Weight:
+        size = 64
+
+    weight = _Weight()
+
+    def to_quantized(self):
+        pass
+
+
+def _predicate(quantization):
+    return get_class_predicate(quantization_config=quantization)
+
+
+def test_exact_path_uses_matching_override():
+    path = "model.layers.0.attn.wkv"
+    exact = {"group_size": 16, "bits": 2, "mode": "affine"}
+    quantization = {
+        "group_size": 64,
+        "bits": 4,
+        "mode": "affine",
+        path: exact,
+    }
+
+    assert _quantization_for_path(quantization, path) == exact
+    resolved = _predicate(quantization)(path, _QuantizableModule())
+    assert resolved == exact
+    assert resolved is not exact
+    resolved["bits"] = 8
+    assert quantization[path] == exact
+
+
+def test_wrapped_model_layers_use_unwrapped_override():
+    path = "language_model.model.layers.1.attn.wkv"
+    override = {"group_size": 32, "bits": 8, "mode": "mxfp8"}
+    quantization = {
+        "group_size": 64,
+        "bits": 4,
+        "mode": "affine",
+        "model.layers.1.attn.wkv": override,
+    }
+
+    assert _quantization_for_path(quantization, path) == override
+    assert _predicate(quantization)(path, _QuantizableModule()) == override
+
+
+def test_wrapped_lm_head_uses_unwrapped_override():
+    path = "language_model.lm_head"
+    override = {"group_size": 32, "bits": 8, "mode": "mxfp8"}
+    quantization = {
+        "group_size": 64,
+        "bits": 2,
+        "mode": "affine",
+        "lm_head": override,
+    }
+
+    assert _quantization_for_path(quantization, path) == override
+    assert _predicate(quantization)(path, _QuantizableModule()) == override
+
+
+def test_missing_override_uses_global_fallback():
+    quantization = {"group_size": 64, "bits": 2, "mode": "affine"}
+    path = "language_model.model.layers.7.attn.wkv"
+
+    assert _quantization_for_path(quantization, path) == quantization
+    assert _predicate(quantization)(path, _QuantizableModule()) is True
+
+
+def test_exact_prefixed_override_wins_over_unwrapped_override():
+    path = "language_model.model.layers.2.attn.wkv"
+    exact = {"group_size": 16, "bits": 2, "mode": "affine"}
+    fallback = {"group_size": 32, "bits": 8, "mode": "mxfp8"}
+    quantization = {
+        "group_size": 64,
+        "bits": 4,
+        "mode": "affine",
+        path: exact,
+        "model.layers.2.attn.wkv": fallback,
+    }
+
+    assert _quantization_for_path(quantization, path) == exact
+    assert _predicate(quantization)(path, _QuantizableModule()) == exact
+
+
+def test_mixed_attention_shared_and_routed_expert_modes():
+    attention_path = "language_model.model.layers.3.attn.wkv"
+    shared_path = "language_model.model.layers.3.ffn.shared_experts.up_proj"
+    routed_path = "language_model.model.layers.3.ffn.switch_mlp.0.up_proj"
+    mxfp8 = {"group_size": 32, "bits": 8, "mode": "mxfp8"}
+    affine = {"group_size": 64, "bits": 2, "mode": "affine"}
+    quantization = {
+        **affine,
+        "model.layers.3.attn.wkv": mxfp8,
+        "model.layers.3.ffn.shared_experts.up_proj": mxfp8,
+        "model.layers.3.ffn.switch_mlp.0.up_proj": affine,
+    }
+    original = deepcopy(quantization)
+
+    for path, expected in (
+        (attention_path, mxfp8),
+        (shared_path, mxfp8),
+        (routed_path, affine),
+    ):
+        assert _quantization_for_path(quantization, path) == expected
+        assert _predicate(quantization)(path, _QuantizableModule()) == expected
+
+    assert quantization == original

--- a/mlx_vlm/utils.py
+++ b/mlx_vlm/utils.py
@@ -21,7 +21,11 @@ from transformers import AutoProcessor
 from transformers.processing_utils import ProcessorMixin
 
 from .models.base import BaseImageProcessor
-from .quantization.one_bit import _quantization_for_path, replace_one_bit_modules
+from .quantization.one_bit import (
+    _quantization_entry_for_path,
+    _quantization_for_path,
+    replace_one_bit_modules,
+)
 from .tokenizer_utils import load_tokenizer
 from .trainer.utils import apply_lora_layers
 
@@ -501,8 +505,12 @@ def get_class_predicate(skip_vision=False, weights=None, quantization_config=Non
             and not _has_quantized_weights(p, weights)
         ):
             return False
-        if quantization_config is not None and p in quantization_config:
-            return quantization_config[p]
+        if quantization_config is not None:
+            has_per_layer, per_layer = _quantization_entry_for_path(
+                quantization_config, p
+            )
+            if has_per_layer:
+                return per_layer
         if not hasattr(m, "to_quantized"):
             return False
         if hasattr(m, "weight") and m.weight.size % 64 != 0:
@@ -804,9 +812,12 @@ python -m mlx_vlm.convert --hf-path <local_dir> --mlx-path <mlx_dir>
             # Skip 1-bit layers already replaced above.
             if _quantization_for_path(config["quantization"], p).get("bits") == 1:
                 return False
-            # Handle custom per layer quantizations
-            if p in config["quantization"]:
-                return config["quantization"][p]
+            # Handle custom per layer quantizations.
+            has_per_layer, per_layer = _quantization_entry_for_path(
+                config["quantization"], p
+            )
+            if has_per_layer:
+                return per_layer
             if not hasattr(m, "to_quantized"):
                 return False
             # Skip layers not divisible by 64


### PR DESCRIPTION
## Summary

Fix mixed per-module quantization for language models wrapped under the `language_model.` module path.

## Root cause

Some MLX-VLM checkpoints store per-module entries under the inner language-model paths, for example:

- `model.layers.0.attn.wkv`
- `lm_head`

When the text model is wrapped by MLX-VLM, MLX walks paths such as:

- `language_model.model.layers.0.attn.wkv`
- `language_model.lm_head`

The existing exact lookup missed those entries and fell back to the global quantization settings. For the DeepSeek V4 mixed checkpoint, that selected affine quantization for MXFP8 modules, causing MLX to request 345 nonexistent `.biases` tensors.

## Implementation

- Add one shared per-module lookup helper.
- Preserve exact path lookup as the first operation.
- If exact lookup misses, remove only the known `language_model.` wrapper prefix and retry once.
- Return a shallow copy of dictionary entries so lookup does not mutate configuration data.
- Use the helper in:
  - one-bit replacement quantization lookup;
  - the general class predicate and load-time quantization predicate;
  - DeepSeek V4 language-model quantization;
  - DeepSeek V4 MTP draft-model quantization.
- Keep global settings as the fallback when no per-module entry matches.
- Do not modify `config.json`, safetensors names, model weights, or loading strictness.

Exact prefixed entries continue to win over an unwrapped fallback entry.

## Regression coverage

The added focused tests cover:

1. Exact path matching.
2. Wrapped attention-module matching.
3. Wrapped LM-head matching.
4. Global fallback for missing per-module entries.
5. Exact-prefixed precedence.
6. Mixed MXFP8 attention/shared-expert and affine routed-expert modes, including configuration immutability.

## Verification

- Six focused regression tests: passed.
- Python bytecode compilation for all changed Python files: passed.
- `git diff --check`: passed.
- Original cached Hugging Face snapshot inspected: all 388 relevant entries are unprefixed in both `quantization` and `quantization_config`.
- DeepSeek V4 reproduction against the original unmodified snapshot: loaded and generated successfully; 13 tokens generated, 31.424 tokens/sec generation speed, 106.806 GB peak memory.
- Full pytest/pre-commit checks were not available in the existing environment, so no packages were installed.

## Complete patch

The exact committed unified diff follows:

```diff
diff --git a/mlx_vlm/models/deepseek_v4/language.py b/mlx_vlm/models/deepseek_v4/language.py
index 2c63ae61..5b29e5de 100644
--- a/mlx_vlm/models/deepseek_v4/language.py
+++ b/mlx_vlm/models/deepseek_v4/language.py
@@ -16,6 +16,7 @@ from ..cache import CacheList, PoolingCache, RotatingKVCache
 from ..mla import MultiLinear
 from ..pipeline import PipelineMixin
 from ..switch_layers import SwitchGLU
+from ...quantization.one_bit import _quantization_entry_for_path
 from .config import ModelConfig
 from .hisa_kernel import hisa_select
 from .hyper_connection import HyperConnection, HyperHead, hc_expand
@@ -1405,8 +1406,10 @@ class LanguageModel(nn.Module):
         quantization_config = make_quantization_config(self)
 
         def predicate(path, _):
-            path = path.removeprefix("language_model.")
-            return quantization_config.get(path, True)
+            has_per_layer, per_layer = _quantization_entry_for_path(
+                quantization_config, path
+            )
+            return per_layer if has_per_layer else True
 
         return predicate
 
diff --git a/mlx_vlm/quantization/one_bit.py b/mlx_vlm/quantization/one_bit.py
index 316645a8..ea809388 100644
--- a/mlx_vlm/quantization/one_bit.py
+++ b/mlx_vlm/quantization/one_bit.py
@@ -1,7 +1,7 @@
 """Python-hosted 1-bit affine inference kernels."""
 
 from functools import lru_cache
-from typing import Dict, Optional
+from typing import Any, Dict, Optional, Tuple
 
 import mlx.core as mx
 import mlx.nn as nn
@@ -456,14 +456,29 @@ class OneBitEmbedding(nn.Module):
         )
 
 
+def _quantization_entry_for_path(
+    quantization: Dict[str, Any], path: str
+) -> Tuple[bool, Any]:
+    """Resolve a per-module entry with the known language-model wrapper removed."""
+    if path in quantization:
+        per_layer = quantization[path]
+    else:
+        unwrapped_path = path.removeprefix("language_model.")
+        if unwrapped_path == path or unwrapped_path not in quantization:
+            return False, None
+        per_layer = quantization[unwrapped_path]
+
+    return True, per_layer.copy() if isinstance(per_layer, dict) else per_layer
+
+
 def _quantization_for_path(quantization: dict, path: str) -> dict:
     base = {
         key: quantization[key]
         for key in ("group_size", "bits", "mode")
         if key in quantization
     }
-    per_layer = quantization.get(path)
-    if isinstance(per_layer, dict):
+    has_per_layer, per_layer = _quantization_entry_for_path(quantization, path)
+    if has_per_layer and isinstance(per_layer, dict):
         base.update(per_layer)
     return base
 
diff --git a/mlx_vlm/speculative/drafters/deepseek_v4_mtp/deepseek_v4_mtp.py b/mlx_vlm/speculative/drafters/deepseek_v4_mtp/deepseek_v4_mtp.py
index a4942c95..61af5ce6 100644
--- a/mlx_vlm/speculative/drafters/deepseek_v4_mtp/deepseek_v4_mtp.py
+++ b/mlx_vlm/speculative/drafters/deepseek_v4_mtp/deepseek_v4_mtp.py
@@ -9,6 +9,7 @@ from ....models.base import create_attention_mask
 from ....models.cache import RotatingKVCache
 from ....models.deepseek_v4.hyper_connection import HyperHead
 from ....models.deepseek_v4.language import DeepseekV4Block
+from ....quantization.one_bit import _quantization_entry_for_path
 from .config import DeepseekV4MTPConfig
 
 
@@ -86,7 +87,10 @@ class DeepseekV4MTPDraftModel(nn.Module):
         quantization_config = make_quantization_config(self)
 
         def predicate(path, _):
-            return quantization_config.get(path, True)
+            has_per_layer, per_layer = _quantization_entry_for_path(
+                quantization_config, path
+            )
+            return per_layer if has_per_layer else True
 
         return predicate
 
diff --git a/mlx_vlm/tests/test_quantization_path_matching.py b/mlx_vlm/tests/test_quantization_path_matching.py
new file mode 100644
index 00000000..82172a03
--- /dev/null
+++ b/mlx_vlm/tests/test_quantization_path_matching.py
@@ -0,0 +1,113 @@
+from copy import deepcopy
+
+from mlx_vlm.quantization.one_bit import _quantization_for_path
+from mlx_vlm.utils import get_class_predicate
+
+
+class _QuantizableModule:
+    class _Weight:
+        size = 64
+
+    weight = _Weight()
+
+    def to_quantized(self):
+        pass
+
+
+def _predicate(quantization):
+    return get_class_predicate(quantization_config=quantization)
+
+
+def test_exact_path_uses_matching_override():
+    path = "model.layers.0.attn.wkv"
+    exact = {"group_size": 16, "bits": 2, "mode": "affine"}
+    quantization = {
+        "group_size": 64,
+        "bits": 4,
+        "mode": "affine",
+        path: exact,
+    }
+
+    assert _quantization_for_path(quantization, path) == exact
+    resolved = _predicate(quantization)(path, _QuantizableModule())
+    assert resolved == exact
+    assert resolved is not exact
+    resolved["bits"] = 8
+    assert quantization[path] == exact
+
+
+def test_wrapped_model_layers_use_unwrapped_override():
+    path = "language_model.model.layers.1.attn.wkv"
+    override = {"group_size": 32, "bits": 8, "mode": "mxfp8"}
+    quantization = {
+        "group_size": 64,
+        "bits": 4,
+        "mode": "affine",
+        "model.layers.1.attn.wkv": override,
+    }
+
+    assert _quantization_for_path(quantization, path) == override
+    assert _predicate(quantization)(path, _QuantizableModule()) == override
+
+
+def test_wrapped_lm_head_uses_unwrapped_override():
+    path = "language_model.lm_head"
+    override = {"group_size": 32, "bits": 8, "mode": "mxfp8"}
+    quantization = {
+        "group_size": 64,
+        "bits": 2,
+        "mode": "affine",
+        "lm_head": override,
+    }
+
+    assert _quantization_for_path(quantization, path) == override
+    assert _predicate(quantization)(path, _QuantizableModule()) == override
+
+
+def test_missing_override_uses_global_fallback():
+    quantization = {"group_size": 64, "bits": 2, "mode": "affine"}
+    path = "language_model.model.layers.7.attn.wkv"
+
+    assert _quantization_for_path(quantization, path) == quantization
+    assert _predicate(quantization)(path, _QuantizableModule()) is True
+
+
+def test_exact_prefixed_override_wins_over_unwrapped_override():
+    path = "language_model.model.layers.2.attn.wkv"
+    exact = {"group_size": 16, "bits": 2, "mode": "affine"}
+    fallback = {"group_size": 32, "bits": 8, "mode": "mxfp8"}
+    quantization = {
+        "group_size": 64,
+        "bits": 4,
+        "mode": "affine",
+        path: exact,
+        "model.layers.2.attn.wkv": fallback,
+    }
+
+    assert _quantization_for_path(quantization, path) == exact
+    assert _predicate(quantization)(path, _QuantizableModule()) == exact
+
+
+def test_mixed_attention_shared_and_routed_expert_modes():
+    attention_path = "language_model.model.layers.3.attn.wkv"
+    shared_path = "language_model.model.layers.3.ffn.shared_experts.up_proj"
+    routed_path = "language_model.model.layers.3.ffn.switch_mlp.0.up_proj"
+    mxfp8 = {"group_size": 32, "bits": 8, "mode": "mxfp8"}
+    affine = {"group_size": 64, "bits": 2, "mode": "affine"}
+    quantization = {
+        **affine,
+        "model.layers.3.attn.wkv": mxfp8,
+        "model.layers.3.ffn.shared_experts.up_proj": mxfp8,
+        "model.layers.3.ffn.switch_mlp.0.up_proj": affine,
+    }
+    original = deepcopy(quantization)
+
+    for path, expected in (
+        (attention_path, mxfp8),
+        (shared_path, mxfp8),
+        (routed_path, affine),
+    ):
+        assert _quantization_for_path(quantization, path) == expected
+        assert _predicate(quantization)(path, _QuantizableModule()) == expected
+
+    assert quantization == original
diff --git a/mlx_vlm/utils.py b/mlx_vlm/utils.py
index cc484827..b4e02962 100644
--- a/mlx_vlm/utils.py
+++ b/mlx_vlm/utils.py
@@ -21,7 +21,11 @@ from transformers import AutoProcessor
 from transformers.processing_utils import ProcessorMixin
 
 from .models.base import BaseImageProcessor
-from .quantization.one_bit import _quantization_for_path, replace_one_bit_modules
+from .quantization.one_bit import (
+    _quantization_entry_for_path,
+    _quantization_for_path,
+    replace_one_bit_modules,
+)
 from .tokenizer_utils import load_tokenizer
 from .trainer.utils import apply_lora_layers
 
@@ -501,8 +505,12 @@ def get_class_predicate(skip_vision=False, weights=None, quantization_config=Non
             and not _has_quantized_weights(p, weights)
         ):
             return False
-        if quantization_config is not None and p in quantization_config:
-            return quantization_config[p]
+        if quantization_config is not None:
+            has_per_layer, per_layer = _quantization_entry_for_path(
+                quantization_config, p
+            )
+            if has_per_layer:
+                return per_layer
         if not hasattr(m, "to_quantized"):
             return False
         if hasattr(m, "weight") and m.weight.size % 64 != 0:
@@ -804,9 +812,12 @@ python -m mlx_vlm.convert --hf-path <local_dir> --mlx-path <mlx_dir>
             # Skip 1-bit layers already replaced above.
             if _quantization_for_path(config["quantization"], p).get("bits") == 1:
                 return False
-            # Handle custom per layer quantizations
-            if p in config["quantization"]:
-                return config["quantization"][p]
+            # Handle custom per layer quantizations.
+            has_per_layer, per_layer = _quantization_entry_for_path(
+                config["quantization"], p
+            )
+            if has_per_layer:
+                return per_layer
             if not hasattr(m, "to_quantized"):
                 return False
             # Skip layers not divisible by 64

```
