### PR TITLE
Fix Qwen3.5 ragged decode on GPUs that reject a 1024-thread threadgroup

### DIFF
--- a/mlx_vlm/models/qwen3_5/language.py
+++ b/mlx_vlm/models/qwen3_5/language.py
@@ -1265,6 +1265,55 @@ def _qwen3_5_cached_sdpa_scalars(scale: float, k_size: int):
     )
 
 
+# Threads per threadgroup the one-pass kernel and the second pass of the
+# two-pass plan are written for. Both assume exactly 32 SIMD groups of 32 lanes
+# (BN == BD == 32): the block reduction and the threadgroup transpose index off
+# simd_gid over [0, 32), so this cannot simply be lowered without reworking them.
+_QWEN3_5_SDPA_THREADS = 1024
+
+# Metal caps threads-per-threadgroup per compiled *pipeline*, not per device --
+# a kernel holding more registers live gets a lower ceiling than the device
+# maximum. At D_SIZE == 256 the two-pass reduction keeps elem_per_thread == 8
+# floats per thread, and on applegpu_g14d (M2 Ultra) that compiles to a ceiling
+# of 896 threads, so requesting 1024 raises:
+#
+#   ValueError: Thread group size (1024) is greater than the maximum allowed
+#   threads per threadgroup (896).
+#
+# D_SIZE is what moves it: 64/96/128 launch fine on the same GPU, and the same
+# 256 launches fine on applegpu_g16s (M4 Max). Nothing in the shapes predicts
+# which parts are affected, and the error is raised lazily
+# when the command buffer is built rather than when the kernel is called, so it
+# cannot be caught around the call site. Probe each kernel signature once with a
+# forced eval, cache the verdict, and route around whichever launches this GPU
+# rejects: two-pass degrades to one-pass, one-pass degrades to the caller's
+# portable per-pad-group fallback. No-op wherever 1024 threads are legal.
+_QWEN3_5_SDPA_LAUNCHABLE = {}
+
+
+def _qwen3_5_try_launch(key, launch):
+    """Run ``launch()``, or return None if this GPU rejects that launch.
+
+    ``key`` must capture everything that determines the compiled pipeline (the
+    kernel and its template arguments), so the verdict is cached per pipeline
+    rather than per call.
+    """
+    verdict = _QWEN3_5_SDPA_LAUNCHABLE.get(key)
+    if verdict is False:
+        return None
+    try:
+        outputs = launch()
+        if verdict is None:
+            # First use of this pipeline: force it now so an illegal
+            # threadgroup surfaces here instead of at the caller's next eval.
+            mx.eval(outputs)
+            _QWEN3_5_SDPA_LAUNCHABLE[key] = True
+        return outputs
+    except ValueError:
+        _QWEN3_5_SDPA_LAUNCHABLE[key] = False
+        return None
+
+
 def _qwen3_5_ragged_decode_attention(
     queries: mx.array,
     keys: mx.array,
@@ -1321,45 +1370,66 @@ def _qwen3_5_ragged_decode_attention(
         ("GQA_FACTOR", int(q_heads // kv_heads)),
     ]
 
-    if mode == "one_pass":
-        kernel = _qwen3_5_ragged_sdpa_one_pass_kernel(queries.dtype, d_size, v_size)
-        return kernel(
+    signature = (queries.dtype, int(d_size), int(v_size), int(q_heads), int(kv_heads))
+
+    if mode == "two_pass":
+        kernel_1 = _qwen3_5_ragged_sdpa_two_pass_1_kernel(
+            queries.dtype, d_size, v_size, blocks
+        )
+        pass_1 = _qwen3_5_try_launch(
+            ("two_pass_1", *signature, int(blocks)),
+            lambda: kernel_1(
+                inputs=[queries, keys, values, pads_array, scale_array, k_size_array],
+                template=[*template, ("BLOCKS", int(blocks))],
+                grid=(32 * kv_heads, (q_heads // kv_heads) * batch, blocks),
+                threadgroup=(32, q_heads // kv_heads, 1),
+                output_shapes=[
+                    (batch, q_heads, 1, blocks, v_size),
+                    (batch, q_heads, 1, blocks),
+                    (batch, q_heads, 1, blocks),
+                ],
+                output_dtypes=[queries.dtype, mx.float32, mx.float32],
+            ),
+        )
+        if pass_1 is not None:
+            partials, sums, maxs = pass_1
+            kernel_2 = _qwen3_5_ragged_sdpa_two_pass_2_kernel(
+                queries.dtype, v_size, blocks
+            )
+            pass_2 = _qwen3_5_try_launch(
+                ("two_pass_2", queries.dtype, int(v_size), int(blocks)),
+                lambda: kernel_2(
+                    inputs=[partials, sums, maxs],
+                    template=[
+                        ("T", queries.dtype),
+                        ("D_SIZE", int(v_size)),
+                        ("BLOCKS", int(blocks)),
+                    ],
+                    grid=(_QWEN3_5_SDPA_THREADS, batch * q_heads, 1),
+                    threadgroup=(_QWEN3_5_SDPA_THREADS, 1, 1),
+                    output_shapes=[(batch, q_heads, 1, v_size)],
+                    output_dtypes=[queries.dtype],
+                ),
+            )
+            if pass_2 is not None:
+                return pass_2[0]
+        # This GPU will not launch the two-pass kernels at this size. The
+        # one-pass kernel computes the same attention in a single dispatch, so
+        # prefer it over dropping out of the fast path entirely.
+
+    kernel = _qwen3_5_ragged_sdpa_one_pass_kernel(queries.dtype, d_size, v_size)
+    one_pass = _qwen3_5_try_launch(
+        ("one_pass", *signature),
+        lambda: kernel(
             inputs=[queries, keys, values, pads_array, scale_array, k_size_array],
             template=template,
-            grid=(1024, batch * q_heads, 1),
-            threadgroup=(1024, 1, 1),
+            grid=(_QWEN3_5_SDPA_THREADS, batch * q_heads, 1),
+            threadgroup=(_QWEN3_5_SDPA_THREADS, 1, 1),
             output_shapes=[(batch, q_heads, 1, v_size)],
             output_dtypes=[queries.dtype],
-        )[0]
-
-    kernel_1 = _qwen3_5_ragged_sdpa_two_pass_1_kernel(
-        queries.dtype, d_size, v_size, blocks
+        ),
     )
-    partials, sums, maxs = kernel_1(
-        inputs=[queries, keys, values, pads_array, scale_array, k_size_array],
-        template=[*template, ("BLOCKS", int(blocks))],
-        grid=(32 * kv_heads, (q_heads // kv_heads) * batch, blocks),
-        threadgroup=(32, q_heads // kv_heads, 1),
-        output_shapes=[
-            (batch, q_heads, 1, blocks, v_size),
-            (batch, q_heads, 1, blocks),
-            (batch, q_heads, 1, blocks),
-        ],
-        output_dtypes=[queries.dtype, mx.float32, mx.float32],
-    )
-    kernel_2 = _qwen3_5_ragged_sdpa_two_pass_2_kernel(queries.dtype, v_size, blocks)
-    return kernel_2(
-        inputs=[partials, sums, maxs],
-        template=[
-            ("T", queries.dtype),
-            ("D_SIZE", int(v_size)),
-            ("BLOCKS", int(blocks)),
-        ],
-        grid=(1024, batch * q_heads, 1),
-        threadgroup=(1024, 1, 1),
-        output_shapes=[(batch, q_heads, 1, v_size)],
-        output_dtypes=[queries.dtype],
-    )[0]
+    return None if one_pass is None else one_pass[0]
 
 
 def _target_verify_left_padded_attention(


### PR DESCRIPTION
# Fix Qwen3.5 ragged decode crashing on GPUs that reject a 1024-thread threadgroup

## Summary

`_qwen3_5_ragged_decode_attention` dispatches two of its custom Metal kernels with a
hardcoded `threadgroup=(1024, 1, 1)`. On an M2 Ultra (`applegpu_g14d`) the second pass of
the two-pass plan does not compile to a 1024-thread pipeline when `D_SIZE == 256`, so the
launch raises and batched decode dies mid-generation:

```
ValueError: Thread group size (1024) is greater than  the maximum allowed threads per
threadgroup (896).
```

Any `head_dim=256` Qwen3.5 checkpoint hits this — `mlx-community/Qwen3.5-4B-mxfp4` is what
surfaced it here. It is not a load-time failure: it needs a ragged batch where every row has
passed 1024 KV tokens, so it presents as intermittent inference errors under continuous
batching once conversations get long enough.

Present in every release from 0.6.5 through 0.6.10 (the function is byte-identical across
them) and on current `main`.

## Environment

| | Reproduces | Does not reproduce |
|---|---|---|
| Machine | Mac Studio, Apple M2 Ultra, 64 GB | Mac Studio, Apple M4 Max, 128 GB |
| GPU architecture | `applegpu_g14d` | `applegpu_g16s` |
| macOS | 26.5 | 26.6 |
| mlx / mlx-vlm | 0.32.0 / 0.6.5, 0.6.10, `main` | 0.32.0 / 0.6.5, 0.6.10, `main` |
| Python | 3.10.20 | 3.10.20 |
| Model | `mlx-community/Qwen3.5-4B-mxfp4` (16 q heads, 4 kv heads, `head_dim=256`) | same |

## Reproducing

No weights and no download — the geometry alone is enough:

```python
"""Minimal repro for the Qwen3.5 ragged-decode threadgroup failure."""

import mlx.core as mx

import mlx_vlm
from mlx_vlm.models.qwen3_5.language import (
    _qwen3_5_ragged_decode_attention,
    _qwen3_5_sdpa_vector_plan,
)

Q_HEADS, KV_HEADS = 16, 4      # Qwen3.5-4B text config
PADS = [0, 8]                  # two rows, different left padding -> a ragged batch
DTYPE = mx.bfloat16


def reference(queries, keys, values, pads, scale):
    """What the caller falls back to when the fast path returns None."""
    rows = [
        mx.fast.scaled_dot_product_attention(
            queries[i : i + 1], keys[i : i + 1, :, p:], values[i : i + 1, :, p:], scale=scale
        )
        for i, p in enumerate(pads)
    ]
    return mx.concatenate(rows, axis=0)


def run(head_dim, kv_len):
    mx.random.seed(0)
    batch = len(PADS)
    queries = mx.random.normal((batch, Q_HEADS, 1, head_dim)).astype(DTYPE)
    keys = mx.random.normal((batch, KV_HEADS, kv_len, head_dim)).astype(DTYPE)
    values = mx.random.normal((batch, KV_HEADS, kv_len, head_dim)).astype(DTYPE)
    scale = head_dim**-0.5

    plan = _qwen3_5_sdpa_vector_plan(kv_len - max(PADS), Q_HEADS, KV_HEADS)
    label = f"  head_dim={head_dim:3d} kv_len={kv_len:5d} plan={str(plan):22s} -> "
    try:
        out = _qwen3_5_ragged_decode_attention(queries, keys, values, PADS, scale)
        if out is None:
            print(label + "None (caller uses the portable fallback)")
            return
        ref = reference(queries, keys, values, PADS, scale)
        mx.eval(out, ref)
        delta = float(mx.max(mx.abs(out.astype(mx.float32) - ref.astype(mx.float32))))
        print(label + f"ok, max|kernel - reference| = {delta:.2e}")
    except Exception as exc:
        print(label + f"{type(exc).__name__}: {exc}")


info = mx.device_info()
print(f"mlx-vlm {mlx_vlm.__version__}, mlx {mx.__version__}")
print(f"{info['device_name']} ({info['architecture']})\n")
for head_dim in (64, 96, 128, 256):
    for kv_len in (512, 2048):   # <1024 takes one_pass, >=1024 takes two_pass
        run(head_dim, kv_len)
```

On the M2 Ultra, before this change:

```
mlx-vlm 0.6.10, mlx 0.32.0
Apple M2 Ultra (applegpu_g14d)

  head_dim= 64 kv_len=  512 plan=('one_pass', 0)        -> ok, max|kernel - reference| = 0.00e+00
  head_dim= 64 kv_len= 2048 plan=('two_pass', 128)      -> ok, max|kernel - reference| = 0.00e+00
  head_dim= 96 kv_len=  512 plan=('one_pass', 0)        -> ok, max|kernel - reference| = 0.00e+00
  head_dim= 96 kv_len= 2048 plan=('two_pass', 128)      -> ok, max|kernel - reference| = 0.00e+00
  head_dim=128 kv_len=  512 plan=('one_pass', 0)        -> ok, max|kernel - reference| = 0.00e+00
  head_dim=128 kv_len= 2048 plan=('two_pass', 128)      -> ok, max|kernel - reference| = 0.00e+00
  head_dim=256 kv_len=  512 plan=('one_pass', 0)        -> ok, max|kernel - reference| = 0.00e+00
  head_dim=256 kv_len= 2048 plan=('two_pass', 128)      -> ValueError: Thread group size (1024) is greater than  the maximum allowed threads per threadgroup (896).
```

Exactly one configuration fails, and `head_dim` is what moves it: 64/96/128 launch fine on
the same GPU with the same plan and the same block count.

## Root cause

Metal caps threads-per-threadgroup per *compiled pipeline*, not per device. A kernel that
keeps more registers live gets a lower ceiling than the device maximum, and nothing in the
launch shapes predicts it.

`_QWEN3_5_RAGGED_SDPA_TWO_PASS_2_SOURCE` scales its per-thread register footprint with
`D_SIZE`:

```metal
constexpr int BN = 32;
constexpr int BD = 32;
constexpr int elem_per_thread = D_SIZE / BD;

typedef float U;
thread U o[elem_per_thread] = {0};
threadgroup U outputs[BN * BD];
```

At `D_SIZE == 256` that is `elem_per_thread == 8` floats held per thread, and on
`applegpu_g14d` the pipeline compiles to a 896-thread ceiling. The launch asks for 1024 and
is rejected. The same 1024 is legal for this kernel at `D_SIZE <= 128`, and legal at 256 on
`applegpu_g16s`.

## Why not simply lower the thread count

The kernel is written for exactly `BN * BD == 1024` threads: 32 SIMD groups of 32 lanes.
`simd_gid` is used as an index over `[0, 32)` both for the per-block reduction and for the
threadgroup transpose:

```metal
outputs[simd_lid * BD + simd_gid] = o[i];
threadgroup_barrier(mem_flags::mem_threadgroup);
o[i] = simd_sum(outputs[simd_gid * BD + simd_lid]);
```

Dispatching fewer threads would silently drop lanes from that reduction, so the thread count
cannot be lowered without reworking the kernel.

## Why not catch the exception at the call site

The `ValueError` is raised lazily, when the command buffer is built, not when the kernel
object is called. The kernel call only records a graph node, so a `try`/`except` around it
never fires — the error surfaces much later, inside whatever `mx.eval` / `mx.async_eval` the
caller reaches next. In practice it lands in the generation loop, several frames away from
the kernel that caused it.

## The fix

Probe each pipeline once, cache the verdict, and route around whatever this GPU rejects.

`_qwen3_5_try_launch(key, launch)` runs the launch and, the first time it sees a given
`key`, forces `mx.eval` so an illegal threadgroup surfaces there instead of at the caller's
next eval. `key` captures the kernel and its template arguments — everything that determines
the compiled pipeline — so the cost is one forced eval per pipeline per process, not per
call. On rejection it records `False` and returns `None`.

The dispatch then degrades in one step rather than falling out of the fast path entirely:

- two-pass rejected -> **one-pass**, which computes the same attention in a single dispatch
  and compiles fine at `D_SIZE == 256` on the affected GPU;
- one-pass also rejected -> `None`, the existing contract that sends the caller to the
  portable per-pad-group `scaled_dot_product_attention`.

Where 1024 threads are legal the guard is a no-op: the first launch per pipeline is forced,
every launch after that goes through untouched, and the same kernels run as before.

## Tests

`mlx_vlm/tests/test_qwen3_5_ragged_sdpa_fallback.py`. Whether a launch is rejected is a
property of the GPU, so the tests inject the rejection instead of depending on the hardware
and cover the same paths on any machine:

- a rejected two-pass reduction falls back to the one-pass kernel and still matches
  per-pad-group `scaled_dot_product_attention`;
- with no launchable kernel the dispatch returns `None` so the caller takes the portable path;
- a rejected pipeline is probed once and remembered, not retried per call;
- where every launch succeeds the result still matches the reference.

They pass on both an M4 Max (where nothing is rejected) and an M2 Ultra (where the two-pass
reduction genuinely is). The KV length that selects the two-pass plan is probed from
`_qwen3_5_sdpa_vector_plan` rather than hardcoded, since the threshold is
architecture-dependent.

## Verification

**Affected GPU (M2 Ultra, `applegpu_g14d`)** — same box, same script, only the package
changes:

```
                                   stock 0.6.10        with this change
head_dim=256 kv_len= 512   ok, Δ = 0.00e+00      ok, Δ = 0.00e+00
head_dim=256 kv_len=1200   -                     ok, Δ = 9.77e-04
head_dim=256 kv_len=2048   ValueError            ok, Δ = 4.88e-04
head_dim=256 kv_len=4096   -                     ok, Δ = 4.88e-04
```

`Δ` is `max|kernel - reference|` against per-pad-group `mx.fast.scaled_dot_product_attention`.
The non-zero values are bf16 rounding from the different accumulation order of the one-pass
kernel, not a change in behaviour: at `kv_len=512`, where both stock and patched take the
one-pass path, the result is bit-identical to the reference.

The launchability cache ends up rejecting exactly one pipeline, leaving the rest on the fast
path:

```
('one_pass',   bfloat16, 256, 256, 16, 4)      -> True
('two_pass_1', bfloat16, 256, 256, 16, 4, 128) -> True
('two_pass_2', bfloat16, 256, 128)             -> False
```

**Unaffected GPU (M4 Max, `applegpu_g16s`)** — stock and patched produce identical output
across the whole sweep, every row `ok, Δ = 0.00e+00`, confirming the guard does not change
behaviour where the launch is legal.

**End to end**, on both machines: a FastAPI server running Qwen3.5-4B-mxfp4 under continuous
batching, three concurrent requests with prompts over 1500 tokens and different lengths (so
every row is past 1024 KV tokens in a ragged batch). Before the change the M2 Ultra logged
201 of these errors across the day; after it, three coherent completions and no threadgroup
errors.
