### PR TITLE
Add qwen3 text backbone support to llmjpvl (Jagle-VL)

### DIFF
--- a/mlx_vlm/models/llmjpvl/config.py
+++ b/mlx_vlm/models/llmjpvl/config.py
@@ -28,6 +28,7 @@ class TextConfig(BaseModelConfig):
     rms_norm_eps: float = 1e-6
     vocab_size: int = 196608
     num_key_value_heads: Optional[int] = None
+    head_dim: Optional[int] = None
     rope_theta: float = 500000.0
     rope_traditional: bool = False
     rope_scaling: Optional[Dict[str, Union[float, str]]] = None

--- a/mlx_vlm/models/llmjpvl/language.py
+++ b/mlx_vlm/models/llmjpvl/language.py
@@ -23,13 +23,19 @@ class Attention(nn.Module):
 
         self.repeats = n_heads // n_kv_heads
 
-        head_dim = config.hidden_size // n_heads
+        head_dim = getattr(config, "head_dim", None) or config.hidden_size // n_heads
         self.scale = head_dim**-0.5
 
         if config.model_type == "qwen2":
             attention_bias = True
         else:
             attention_bias = False
+
+        # qwen3 applies per-head RMSNorm to q/k (e.g. Jagle-VL's Qwen3-1.7B backbone)
+        self.use_qk_norm = config.model_type == "qwen3"
+        if self.use_qk_norm:
+            self.q_norm = nn.RMSNorm(head_dim, eps=config.rms_norm_eps)
+            self.k_norm = nn.RMSNorm(head_dim, eps=config.rms_norm_eps)
 
         self.q_proj = nn.Linear(dim, n_heads * head_dim, bias=attention_bias)
         self.k_proj = nn.Linear(dim, n_kv_heads * head_dim, bias=attention_bias)
@@ -63,6 +69,10 @@ class Attention(nn.Module):
         queries = queries.reshape(B, L, self.n_heads, -1).transpose(0, 2, 1, 3)
         keys = keys.reshape(B, L, self.n_kv_heads, -1).transpose(0, 2, 1, 3)
         values = values.reshape(B, L, self.n_kv_heads, -1).transpose(0, 2, 1, 3)
+
+        if self.use_qk_norm:
+            queries = self.q_norm(queries)
+            keys = self.k_norm(keys)
 
         if cache is not None:
             queries = self.rope(queries, offset=cache.offset)
@@ -148,9 +158,9 @@ class LanguageModel(nn.Module):
         super().__init__()
         self.config = config
         self.model_type = config.model_type
-        if self.model_type not in ["llama", "qwen2"]:
+        if self.model_type not in ["llama", "qwen2", "qwen3"]:
             raise ValueError(
-                f"Model type {self.model_type} not supported. Supported types: 'llama', 'qwen2'"
+                f"Model type {self.model_type} not supported. Supported types: 'llama', 'qwen2', 'qwen3'"
             )
         self.model = Llama(config)
         if not config.tie_word_embeddings:


### PR DESCRIPTION
## Motivation

llm-jp released the Jagle-VL series ([llm-jp/Jagle-VL-2.2B-Jagle-FineVision](https://huggingface.co/llm-jp/Jagle-VL-2.2B-Jagle-FineVision) etc.), which uses the llmjpvl architecture with a **Qwen3-1.7B** language backbone. The current llmjpvl `LanguageModel` only accepts `llama`/`qwen2` model types, so these models fail to load:

```
ValueError: Model type qwen3 not supported. Supported types: 'llama', 'qwen2'
```

## Changes

- `llmjpvl/language.py`: qwen3 applies per-head RMSNorm to queries/keys before RoPE (`q_norm`/`k_norm`, eps = `rms_norm_eps`), gated on `model_type == "qwen3"`. Attention bias stays off for qwen3 (existing qwen2-only branch already handles this). `head_dim` now honors an explicit config value when present.
- `llmjpvl/config.py`: add optional `head_dim` to `TextConfig`.
- Add `qwen3` to the supported model type list.

Existing llama/qwen2 paths are untouched (the new norm layers are only created for qwen3, so weight sanitization for other backbones is unaffected).

## Verification

Converted `llm-jp/Jagle-VL-2.2B-Jagle-FineVision` with `mlx_vlm.convert` (8bit) and ran deterministic (temp 0) Japanese document QA with known answers: 6/6 content-correct (invoice total, staffing change, contract clause, checklist item, report metric). Published the verified conversion at [tokimoa/Jagle-VL-2.2B-Jagle-FineVision-MLX-8bit](https://huggingface.co/tokimoa/Jagle-VL-2.2B-Jagle-FineVision-MLX-8bit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)