### PR TITLE
Keep family-specific STT defaults out of Whisper decode options

### DIFF
--- a/mlx_vlm/server/audio.py
+++ b/mlx_vlm/server/audio.py
@@ -393,23 +393,34 @@ async def _parse_transcription_request(
     if not timestamp_granularities:
         timestamp_granularities = _form_list(form, "timestamp_granularities[]")
 
-    payload = AudioTranscriptionRequest(
-        model=model,
-        language=_clean_form_value(form.get("language")),
-        prompt=_clean_form_value(form.get("prompt")),
-        temperature=_form_float(form.get("temperature")),
-        response_format=_clean_form_value(form.get("response_format")) or "json",
-        verbose=_form_bool(form.get("verbose"), default=False),
-        max_tokens=_form_int(form.get("max_tokens"), default=1024),
-        chunk_duration=_form_float(form.get("chunk_duration"), default=30.0),
-        frame_threshold=_form_int(form.get("frame_threshold"), default=25),
-        stream=_form_bool(form.get("stream"), default=False),
-        context=_clean_form_value(form.get("context")),
-        prefill_step_size=_form_int(form.get("prefill_step_size"), default=2048),
-        text=_clean_form_value(form.get("text")),
-        word_timestamps=_form_bool(form.get("word_timestamps"), default=False),
-        timestamp_granularities=timestamp_granularities or None,
-    )
+    # Only materialize fields the form actually carried so that
+    # ``model_fields_set`` distinguishes client-provided values from request
+    # defaults; downstream kwarg filtering relies on that distinction.
+    values: Dict[str, Any] = {
+        "model": model,
+        "response_format": _clean_form_value(form.get("response_format")) or "json",
+    }
+    form_parsers: Dict[str, Any] = {
+        "language": _clean_form_value,
+        "prompt": _clean_form_value,
+        "context": _clean_form_value,
+        "text": _clean_form_value,
+        "temperature": _form_float,
+        "chunk_duration": _form_float,
+        "max_tokens": lambda value: _form_int(value, default=1024),
+        "frame_threshold": lambda value: _form_int(value, default=25),
+        "prefill_step_size": lambda value: _form_int(value, default=2048),
+        "verbose": lambda value: _form_bool(value, default=False),
+        "stream": lambda value: _form_bool(value, default=False),
+        "word_timestamps": lambda value: _form_bool(value, default=False),
+    }
+    for key, parse in form_parsers.items():
+        if _clean_form_value(form.get(key)) is not None:
+            values[key] = parse(form.get(key))
+    if timestamp_granularities:
+        values["timestamp_granularities"] = timestamp_granularities
+
+    payload = AudioTranscriptionRequest(**values)
     if translate and payload.response_format == "verbose_json":
         # Matches OpenAI's accepted response formats, while still allowing verbose
         # output for models that return segments.
@@ -562,6 +573,20 @@ def _build_stt_generate_kwargs(
     )
     prompt = request.prompt
     accepted = _callable_parameters(model.generate)
+
+    # Family-specific request defaults (e.g. Parakeet's ``frame_threshold``)
+    # must not leak through a ``**kwargs`` catch-all into another family's
+    # decoder — Whisper forwards unknown keys into ``DecodingOptions`` and
+    # raises. Defaults only apply when the model declares the parameter;
+    # values the client explicitly sent always pass through.
+    if accepted is not None and accepted.get("**kwargs"):
+        declared = accepted.get("params", set())
+        provided = request.model_fields_set
+        kwargs = {
+            key: value
+            for key, value in kwargs.items()
+            if key in declared or key in provided
+        }
 
     if prompt:
         if _accepts_parameter(accepted, "context"):

--- a/mlx_vlm/tests/test_server_audio.py
+++ b/mlx_vlm/tests/test_server_audio.py
@@ -352,3 +352,107 @@ def _drain(handle, timeout=2.0):
         elif chunk.kind == "done":
             return chunks
     raise TimeoutError("timed out waiting for audio queue results")
+
+
+class FakeWhisperSTTModel:
+    model_type = "whisper"
+
+    def __init__(self, result):
+        self.result = result
+        self.calls = []
+
+    def generate(
+        self,
+        path,
+        *,
+        language=None,
+        task="transcribe",
+        chunk_duration=1.0,
+        word_timestamps=False,
+        **decode_options,
+    ):
+        allowed = {"temperature", "verbose", "stream", "context", "text"}
+        unexpected = set(decode_options) - allowed
+        if unexpected:
+            raise TypeError(
+                "DecodingOptions.__init__() got an unexpected keyword argument "
+                f"{sorted(unexpected)[0]!r}"
+            )
+        self.calls.append(
+            {
+                "path": path,
+                "language": language,
+                "chunk_duration": chunk_duration,
+                **decode_options,
+            }
+        )
+        return self.result
+
+
+def test_audio_transcriptions_defaults_not_forwarded_to_whisper(client, monkeypatch):
+    fake_model = FakeWhisperSTTModel({"text": "ok"})
+    monkeypatch.setattr(
+        server,
+        "get_cached_model",
+        lambda model, **kwargs: (fake_model, None, SimpleNamespace(model_type="audio")),
+    )
+    monkeypatch.setattr(
+        server_audio,
+        "audio_read",
+        lambda buffer, always_2d=False: (np.zeros(160, dtype=np.float32), 16000),
+    )
+    monkeypatch.setattr(server_audio, "audio_write", _fake_audio_write)
+
+    response = client.post(
+        "/v1/audio/transcriptions",
+        files={"file": ("test.wav", b"audio-bytes", "audio/wav")},
+        data={"model": "fake-whisper", "language": "en"},
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {"text": "ok"}
+    call = fake_model.calls[0]
+    assert call["language"] == "en"
+    assert call["chunk_duration"] == pytest.approx(30.0)
+    assert "frame_threshold" not in call
+    assert "max_tokens" not in call
+    assert "prefill_step_size" not in call
+
+
+def test_audio_transcriptions_explicit_values_reach_var_kwargs(client, monkeypatch):
+    fake_model = FakeSTTModel({"text": "ok"})
+    monkeypatch.setattr(
+        server,
+        "get_cached_model",
+        lambda model, **kwargs: (fake_model, None, SimpleNamespace(model_type="audio")),
+    )
+    monkeypatch.setattr(
+        server_audio,
+        "audio_read",
+        lambda buffer, always_2d=False: (np.zeros(160, dtype=np.float32), 16000),
+    )
+    monkeypatch.setattr(server_audio, "audio_write", _fake_audio_write)
+
+    response = client.post(
+        "/v1/audio/transcriptions",
+        files={"file": ("test.wav", b"audio-bytes", "audio/wav")},
+        data={"model": "fake-stt", "frame_threshold": "30"},
+    )
+
+    assert response.status_code == 200
+    assert fake_model.calls[0]["frame_threshold"] == 30
+
+
+def test_build_stt_kwargs_keeps_defaults_for_declared_parameters():
+    class FakeParakeetModel:
+        def generate(self, path, *, frame_threshold=10, chunk_duration=1.0):
+            raise AssertionError("not called")
+
+    request = server_audio.AudioTranscriptionRequest(model="fake-parakeet")
+    kwargs = server_audio._build_stt_generate_kwargs(
+        FakeParakeetModel(), request, translate=False
+    )
+
+    assert kwargs["frame_threshold"] == 25
+    assert kwargs["chunk_duration"] == pytest.approx(30.0)
+    assert "max_tokens" not in kwargs


### PR DESCRIPTION
The transcription endpoint always injected Parakeet-family request defaults (`frame_threshold`, `max_tokens`, `prefill_step_size`) into every STT call, and Whisper's `**decode_options` catch-all bypasses the signature filter, so every Whisper transcription crashed constructing `DecodingOptions`. Defaults now apply only when the model declares the parameter (client-provided values still pass through), fixing Blaizzy/nativ#212 — verified live with `openai/whisper-large-v3-turbo`: the reported `TypeError` on current main, a successful transcription with this change.