### PR TITLE
Fix /v1/responses image reference output

### DIFF
--- a/mlx_vlm/prompt_utils.py
+++ b/mlx_vlm/prompt_utils.py
@@ -174,6 +174,16 @@ def _get_role_content(item: Any) -> Union[tuple[str, Any], None]:
     return None
 
 
+def _content_media_count(content: Any, media_types: tuple[str, ...]) -> int:
+    if not isinstance(content, list):
+        return 0
+    return sum(
+        1
+        for item in content
+        if isinstance(item, dict) and item.get("type") in media_types
+    )
+
+
 def _normalize_tool_call_arguments(message: Dict[str, Any]) -> Dict[str, Any]:
     """Copy a message and convert OpenAI JSON-string tool arguments to dicts."""
     normalized = dict(message)
@@ -894,26 +904,48 @@ def apply_chat_template(
                 )
             )
     elif isinstance(prompt, list):
-        # List of prompts — find the last user message to place image/audio tokens
+        # Preserve explicit media markers on their originating user message.
+        # Any legacy side-channel media without markers remains attached to the
+        # last user message for backward compatibility.
         last_user_idx = -1
+        explicit_image_counts = [0] * len(prompt)
         for i, p in enumerate(prompt):
             if isinstance(p, str):
                 last_user_idx = i
             elif (rc := _get_role_content(p)) is not None:
-                if rc[0] not in ("system", "assistant", "tool"):
+                role, content = rc
+                if role not in ("system", "assistant", "tool"):
                     last_user_idx = i
+                    explicit_image_counts[i] = _content_media_count(
+                        content, ("image", "image_url", "input_image")
+                    )
+
+        def _allocate_media_counts(explicit_counts, total_count):
+            remaining = total_count
+            allocated = []
+            for count in explicit_counts:
+                count = min(count, remaining)
+                allocated.append(count)
+                remaining -= count
+            if remaining and last_user_idx >= 0:
+                allocated[last_user_idx] += remaining
+            return allocated
+
+        image_counts = _allocate_media_counts(explicit_image_counts, num_images)
+        audio_counts = [0] * len(prompt)
+        if last_user_idx >= 0:
+            audio_counts[last_user_idx] = num_audios
 
         for i, p in enumerate(prompt):
             if isinstance(p, str):
-                is_target = i == last_user_idx
                 messages.append(
                     get_message_json(
                         model_type,
                         p,
-                        skip_image_token=not is_target,
-                        skip_audio_token=not is_target,
-                        num_images=num_images,
-                        num_audios=num_audios,
+                        skip_image_token=image_counts[i] == 0,
+                        skip_audio_token=audio_counts[i] == 0,
+                        num_images=image_counts[i],
+                        num_audios=audio_counts[i],
                         **kwargs,
                     )
                 )
@@ -929,18 +961,17 @@ def apply_chat_template(
                 else:
                     # Handle multimodal content: extract only text, skip image/audio URLs
                     content = extract_text_from_content(content)
-                    is_target = i == last_user_idx
                     messages.append(
                         get_message_json(
                             model_type,
                             content,
                             role,
-                            skip_image_token=not is_target
+                            skip_image_token=image_counts[i] == 0
                             or role in ["system", "assistant"],
-                            skip_audio_token=not is_target
+                            skip_audio_token=audio_counts[i] == 0
                             or role in ["system", "assistant"],
-                            num_images=num_images,
-                            num_audios=num_audios,
+                            num_images=image_counts[i],
+                            num_audios=audio_counts[i],
                             **kwargs,
                         )
                     )

--- a/mlx_vlm/server/responses_state.py
+++ b/mlx_vlm/server/responses_state.py
@@ -415,6 +415,68 @@ def _response_call_to_chat_tool_call(item: Dict[str, Any]) -> Dict[str, Any]:
     }
 
 
+def _response_image_source(part: Dict[str, Any]) -> Optional[Any]:
+    part_type = part.get("type")
+    if part_type == "image_url":
+        image_url = part.get("image_url")
+        return image_url.get("url") if isinstance(image_url, dict) else image_url
+    if part_type != "input_image":
+        return None
+
+    if part.get("file_id") is not None:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "input_image.file_id is not supported by this server. "
+                "Provide image_url instead."
+            ),
+        )
+    image_url = part.get("image_url")
+    return image_url or None
+
+
+def _response_tool_output_to_text_and_images(
+    output: Any,
+) -> Tuple[str, List[Any]]:
+    if isinstance(output, str):
+        return output, []
+    if not isinstance(output, list):
+        return json.dumps(output, ensure_ascii=False), []
+
+    text_parts = []
+    remaining_parts = []
+    output_images = []
+    for part in output:
+        part = _as_plain_dict(part)
+        if not isinstance(part, dict):
+            remaining_parts.append(part)
+            continue
+        part_type = part.get("type")
+        if part_type in ("input_text", "output_text", "text"):
+            text_parts.append(str(part.get("text", "")))
+        elif part_type in ("input_image", "image_url"):
+            image = _response_image_source(part)
+            if image:
+                output_images.append(image)
+            else:
+                remaining_parts.append(part)
+        else:
+            remaining_parts.append(part)
+
+    if remaining_parts:
+        text_parts.append(json.dumps(remaining_parts, ensure_ascii=False))
+    if output_images:
+        text_parts.append("[Image output attached in the next message]")
+    return "\n".join(part for part in text_parts if part), output_images
+
+
+def _response_image_message(image_count: int) -> Dict[str, Any]:
+    return {
+        "role": "user",
+        "content": [{"type": "image"} for _ in range(image_count)],
+    }
+
+
 def _append_response_item_to_prompt(
     item: Dict[str, Any],
     chat_messages: List[Dict[str, Any]],
@@ -425,26 +487,36 @@ def _append_response_item_to_prompt(
         role = item.get("role") or "user"
         content = item.get("content")
         if isinstance(content, list):
-            text_parts = []
+            content_parts = []
+            item_images = []
             for part in content:
                 part = _as_plain_dict(part)
                 if not isinstance(part, dict):
                     continue
                 part_type = part.get("type")
                 if part_type in ("input_text", "output_text", "text"):
-                    text_parts.append(str(part.get("text", "")))
-                elif part_type == "input_image":
-                    image = part.get("image_url") or part.get("file_id")
+                    text = str(part.get("text", ""))
+                    if text:
+                        content_parts.append({"type": "text", "text": text})
+                elif part_type in ("input_image", "image_url"):
+                    image = _response_image_source(part)
                     if image:
-                        images.append(image)
-                elif part_type == "image_url":
-                    image_url = part.get("image_url")
-                    images.append(
-                        image_url.get("url")
-                        if isinstance(image_url, dict)
-                        else image_url
-                    )
-            content = "\n".join(p for p in text_parts if p)
+                        item_images.append(image)
+                        content_parts.append({"type": "image"})
+            images.extend(item_images)
+            if item_images and role not in ("user",):
+                text = "\n".join(
+                    part["text"] for part in content_parts if part.get("type") == "text"
+                )
+                chat_messages.append({"role": role, "content": text})
+                chat_messages.append(_response_image_message(len(item_images)))
+                return
+            if item_images:
+                content = content_parts
+            else:
+                content = "\n".join(
+                    part["text"] for part in content_parts if part.get("type") == "text"
+                )
         chat_messages.append({"role": role, "content": content or ""})
         return
 
@@ -465,8 +537,7 @@ def _append_response_item_to_prompt(
         "tool_result",
     ):
         output = item.get("output", item.get("content", ""))
-        if not isinstance(output, str):
-            output = json.dumps(output, ensure_ascii=False)
+        output, output_images = _response_tool_output_to_text_and_images(output)
         chat_messages.append(
             {
                 "role": "tool",
@@ -474,6 +545,9 @@ def _append_response_item_to_prompt(
                 "content": output,
             }
         )
+        if output_images:
+            images.extend(output_images)
+            chat_messages.append(_response_image_message(len(output_images)))
 
 
 def _response_chain_items(previous_response_id: Optional[str]) -> List[Dict[str, Any]]:

--- a/mlx_vlm/server/schemas.py
+++ b/mlx_vlm/server/schemas.py
@@ -202,11 +202,9 @@ class ResponseInputImageParam(TypedDict, total=False):
     type: Required[
         Literal["input_image"]
     ]  # The type of the input item. Always `input_image`.
-    image_url: Required[str]
+    image_url: Optional[str]
     file_id: Optional[str]
-    """The ID of the file to be sent to the model.
-     NOTE : wouldn't this help the model if we passed the file_id as well to the vlm models
-    """
+    """A file reference. This server currently rejects file IDs."""
 
 
 class InputAudio(TypedDict, total=False):

--- a/mlx_vlm/tests/test_responses_state.py
+++ b/mlx_vlm/tests/test_responses_state.py
@@ -1,0 +1,158 @@
+import json
+
+import pytest
+from fastapi import HTTPException
+
+from mlx_vlm.prompt_utils import apply_chat_template
+from mlx_vlm.server.responses_state import _response_items_to_chat
+
+
+def test_function_output_image_stays_after_tool_result():
+    image_url = "data:image/png;base64,ZmFrZS1pbWFnZQ=="
+    items = [
+        {
+            "type": "function_call",
+            "name": "view_image",
+            "arguments": "{}",
+            "call_id": "call_view_image",
+        },
+        {
+            "type": "function_call_output",
+            "call_id": "call_view_image",
+            "output": [
+                {
+                    "type": "input_image",
+                    "image_url": image_url,
+                    "detail": "high",
+                }
+            ],
+        },
+    ]
+
+    messages, images = _response_items_to_chat(items)
+
+    assert images == [image_url]
+    assert messages[-2:] == [
+        {
+            "role": "tool",
+            "tool_call_id": "call_view_image",
+            "content": "[Image output attached in the next message]",
+        },
+        {"role": "user", "content": [{"type": "image"}]},
+    ]
+
+    prompt = apply_chat_template(
+        None,
+        {"model_type": "qwen2_vl"},
+        messages,
+        num_images=len(images),
+    )
+    assert prompt.index("Tool:") < prompt.index("<image>")
+    assert image_url not in prompt
+
+
+def test_function_output_preserves_text_alongside_visual_input():
+    image_url = "https://example.com/result.png"
+    items = [
+        {
+            "type": "function_call_output",
+            "call_id": "call_analyze_image",
+            "output": [
+                {"type": "input_text", "text": "Rendered result"},
+                {"type": "image_url", "image_url": {"url": image_url}},
+            ],
+        }
+    ]
+
+    messages, images = _response_items_to_chat(items)
+
+    assert images == [image_url]
+    assert messages == [
+        {
+            "role": "tool",
+            "tool_call_id": "call_analyze_image",
+            "content": "Rendered result\n[Image output attached in the next message]",
+        },
+        {"role": "user", "content": [{"type": "image"}]},
+    ]
+
+
+def test_message_image_stays_on_its_original_user_turn():
+    image_url = "https://example.com/first-turn.png"
+    items = [
+        {
+            "type": "message",
+            "role": "user",
+            "content": [
+                {"type": "input_text", "text": "First turn"},
+                {"type": "input_image", "image_url": image_url},
+            ],
+        },
+        {
+            "type": "message",
+            "role": "assistant",
+            "content": [{"type": "output_text", "text": "I see it."}],
+        },
+        {
+            "type": "message",
+            "role": "user",
+            "content": [{"type": "input_text", "text": "Second turn"}],
+        },
+    ]
+
+    messages, images = _response_items_to_chat(items)
+    normalized = apply_chat_template(
+        None,
+        {"model_type": "qwen2_vl"},
+        messages,
+        num_images=len(images),
+        return_messages=True,
+    )
+
+    assert images == [image_url]
+    assert any(part["type"] == "image" for part in normalized[0]["content"])
+    assert normalized[-1]["content"] == [
+        {"type": "text", "text": "Second turn", "content": "Second turn"}
+    ]
+
+
+@pytest.mark.parametrize(
+    "item",
+    [
+        {
+            "type": "message",
+            "role": "user",
+            "content": [{"type": "input_image", "file_id": "file-image"}],
+        },
+        {
+            "type": "function_call_output",
+            "call_id": "call_view_image",
+            "output": [
+                {
+                    "type": "input_image",
+                    "file_id": "file-image",
+                    "image_url": "data:image/png;base64,ZmFrZQ==",
+                }
+            ],
+        },
+    ],
+)
+def test_response_input_rejects_image_file_id(item):
+    with pytest.raises(HTTPException, match=r"input_image\.file_id is not supported"):
+        _response_items_to_chat([item])
+
+
+def test_unknown_function_output_blocks_remain_text():
+    unknown = {"type": "custom_output", "value": {"answer": 42}}
+    messages, images = _response_items_to_chat(
+        [
+            {
+                "type": "function_call_output",
+                "call_id": "call_custom",
+                "output": [unknown],
+            }
+        ]
+    )
+
+    assert images == []
+    assert json.loads(messages[0]["content"]) == [unknown]

--- a/mlx_vlm/tests/test_server.py
+++ b/mlx_vlm/tests/test_server.py
@@ -1803,6 +1803,82 @@ def test_responses_endpoint_merges_developer_message_with_instructions(client):
     ]
 
 
+def test_responses_endpoint_places_function_output_image_after_tool_result(
+    client, monkeypatch
+):
+    monkeypatch.setattr(server.runtime, "response_generator", None)
+    image_url = "data:image/png;base64,ZmFrZS1pbWFnZQ=="
+    model = SimpleNamespace()
+    processor = SimpleNamespace()
+    config = SimpleNamespace(model_type="qwen2_vl")
+    result = GenerationResult(
+        text="done",
+        prompt_tokens=8,
+        generation_tokens=4,
+        total_tokens=12,
+    )
+
+    with (
+        patch.object(
+            server, "get_cached_model", return_value=(model, processor, config)
+        ),
+        patch.object(server, "generate", return_value=result) as mock_generate,
+    ):
+        response = client.post(
+            "/responses",
+            json={
+                "model": "demo",
+                "input": [
+                    {
+                        "type": "function_call",
+                        "name": "view_image",
+                        "arguments": "{}",
+                        "call_id": "call_view_image",
+                    },
+                    {
+                        "type": "function_call_output",
+                        "call_id": "call_view_image",
+                        "output": [
+                            {
+                                "type": "input_image",
+                                "image_url": image_url,
+                                "detail": "high",
+                            }
+                        ],
+                    },
+                ],
+            },
+        )
+
+    assert response.status_code == 200
+    prompt = mock_generate.call_args.kwargs["prompt"]
+    assert prompt.index("Tool:") < prompt.index("<image>")
+    assert image_url not in prompt
+    assert mock_generate.call_args.kwargs["image"] == [image_url]
+
+
+def test_responses_endpoint_rejects_image_file_id(client):
+    response = client.post(
+        "/v1/responses",
+        json={
+            "model": "demo",
+            "input": [
+                {
+                    "type": "function_call_output",
+                    "call_id": "call_view_image",
+                    "output": [{"type": "input_image", "file_id": "file-image"}],
+                }
+            ],
+        },
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == (
+        "input_image.file_id is not supported by this server. "
+        "Provide image_url instead."
+    )
+
+
 @pytest.mark.parametrize(
     ("include_adapter", "adapter_path", "expected_adapter"),
     [


### PR DESCRIPTION
Based on https://github.com/Blaizzy/mlx-vlm/pull/1761, but expanded to cover properly inserting outputs associated with specific turns.