### PR TITLE
Split unterminated reasoning correctly when the prompt opens the thinking block 

### DIFF
--- a/mlx_vlm/server/app.py
+++ b/mlx_vlm/server/app.py
@@ -258,9 +258,12 @@ def _split_thinking(
     text: str,
     thinking_start_token: Optional[str] = None,
     thinking_end_token: Optional[str] = None,
+    starts_in_thinking: bool = False,
 ) -> Tuple[Optional[str], str]:
     """Split thinking tags from content. Returns (reasoning, content)."""
-    return _split_thinking_text(text, thinking_start_token, thinking_end_token)
+    return _split_thinking_text(
+        text, thinking_start_token, thinking_end_token, starts_in_thinking
+    )
 
 
 def _decode_token(tokenizer, token_id: int) -> Tuple[str, Optional[List[int]]]:

--- a/mlx_vlm/server/openai.py
+++ b/mlx_vlm/server/openai.py
@@ -2173,6 +2173,12 @@ async def chat_completions_endpoint(request: ChatRequest, http_request: Request)
                     full_text,
                     gen_args.thinking_start_token,
                     gen_args.thinking_end_token,
+                    prompt_has_open_thinking(
+                        formatted_prompt,
+                        gen_args.enable_thinking,
+                        gen_args.thinking_start_token,
+                        gen_args.thinking_end_token,
+                    ),
                 )
 
                 # Count raw generated tokens minus thinking tag tokens

--- a/mlx_vlm/server/responses_state.py
+++ b/mlx_vlm/server/responses_state.py
@@ -289,6 +289,7 @@ def _split_thinking(
     text: str,
     thinking_start_token: Optional[str] = None,
     thinking_end_token: Optional[str] = None,
+    starts_in_thinking: bool = False,
 ) -> Tuple[Optional[str], str]:
     if not text:
         return None, text
@@ -313,6 +314,10 @@ def _split_thinking(
         if start_marker in text:
             reasoning = _clean_reasoning(text, start_marker)
             return reasoning or None, ""
+
+    if starts_in_thinking:
+        reasoning = _strip_content_markers(text).strip()
+        return reasoning or None, ""
 
     return None, _strip_content_markers(text).strip()
 

--- a/mlx_vlm/tests/test_server.py
+++ b/mlx_vlm/tests/test_server.py
@@ -6285,6 +6285,34 @@ class TestSplitThinking:
         assert reasoning is None
         assert content == "Just plain text."
 
+    def test_prompt_opened_thinking_is_detected(self):
+        assert server.prompt_has_open_thinking("<|im_start|>assistant\n<think>")
+        assert not server.prompt_has_open_thinking("<|im_start|>assistant\n")
+
+    def test_unterminated_thinking_without_markers_is_reasoning(self):
+        text = "The user is asking me to say OK. This is a simple request"
+        reasoning, content = server._split_thinking(text, starts_in_thinking=True)
+        assert reasoning == text
+        assert content == ""
+
+    def test_unterminated_thinking_stays_content_when_not_in_block(self):
+        text = "The user is asking me to say OK. This is a simple request"
+        reasoning, content = server._split_thinking(text, starts_in_thinking=False)
+        assert reasoning is None
+        assert content == text
+
+    def test_starts_in_thinking_still_splits_on_close_marker(self):
+        text = "Reasoning first.</think>The answer."
+        reasoning, content = server._split_thinking(text, starts_in_thinking=True)
+        assert reasoning == "Reasoning first."
+        assert content == "The answer."
+
+    def test_starts_in_thinking_respects_paired_markers(self):
+        text = "<think>Thinking.</think>Answer."
+        reasoning, content = server._split_thinking(text, starts_in_thinking=True)
+        assert reasoning == "Thinking."
+        assert content == "Answer."
+
     def test_empty_content_after_thinking(self):
         text = "<|channel>thought\nOnly thinking.<channel|>"
         reasoning, content = server._split_thinking(text)


### PR DESCRIPTION
`_split_thinking` gains a `starts_in_thinking` parameter, and the OpenAI non-streaming call site now passes the same prompt_has_open_thinking(formatted_prompt, …) signal that streaming already uses. When a model's chat template opens the thinking block in the prompt (so no <think> ever appears in generated text) and the block never closes, the output is now correctly returned as reasoning instead of being mislabeled as the answer.

solves https://github.com/Blaizzy/nativ/issues/223