### PR TITLE
Quick fix to properly recoginze Bonsai Image models.

### DIFF
--- a/mlx_vlm/generate/image.py
+++ b/mlx_vlm/generate/image.py
@@ -273,15 +273,22 @@ def _local_image_model_types(model: str) -> tuple[str, ...]:
         return ()
 
     candidates: list[str] = []
+    manifest = _load_json_file(root / "manifest.json")
+    if manifest is not None:
+        # Bonsai repos ship FLUX.2 configs (Flux2KleinPipeline /
+        # Flux2Transformer2DModel), so class-name scanning below would
+        # classify them as flux2 before the manifest check. The manifest
+        # layout (transformer-packed-mflux + text_encoder-mlx-4bit +
+        # tokenizer) is the authoritative Bonsai discriminator, so it must
+        # be checked first.
+        _add_model_type(candidates, _image_model_type_from_manifest(manifest))
+
     for filename in ("model_index.json", "config.json"):
         metadata = _load_json_file(root / filename)
         if metadata is not None:
             for model_type in _image_model_types_from_metadata(metadata):
                 _add_model_type(candidates, model_type)
 
-    manifest = _load_json_file(root / "manifest.json")
-    if manifest is not None:
-        _add_model_type(candidates, _image_model_type_from_manifest(manifest))
     _add_model_type(candidates, _image_model_type_from_component_indexes(root))
 
     for config_path in sorted(root.glob("*/config.json")):
@@ -370,7 +377,7 @@ def _image_generation_model_class_from_path(
         if resolved_path is not None
         else ()
     )
-    for model_type in (*local_model_types, _model_type_from_id(model)):
+    for model_type in (_model_type_from_id(model), *local_model_types):
         model_class = _image_model_class_for_type(model_type)
         if model_class is not None and model_class.is_image_generation_model:
             return model_class
@@ -440,7 +447,7 @@ def load_image_generation_model(
         else ()
     )
     model_class = None
-    for model_type in (*local_model_types, _model_type_from_id(model)):
+    for model_type in (_model_type_from_id(model), *local_model_types):
         model_class = _image_model_class_for_type(model_type)
         if model_class is not None and model_class.is_image_generation_model:
             break


### PR DESCRIPTION
Bonsai Image models weren't being recognized as supported image generation models. 

This fix checks the model manifest before model_index.json and config.json, letting the manifest be the first source of truth.

NOTE: This is not my code, it's AI generated, human read and tested.