### PR TITLE
Assert sanitize() idempotency in tests and document the invariant

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,13 +31,45 @@ To determine the model layer names, we suggest either:
 - Look at the names of the weights by inspecting `model.safetensors.index.json`
   in the Hugging Face repo.
 
-Additionally, add a test for the new model type to the [model
-tests](https://github.com/Blaizzy/mlx-vlm/tree/main/src/tests/test_models.py).
+If the model needs a `sanitize()` to convert weights from the PyTorch layout,
+note that `load_model` calls it on **every** checkpoint, including ones already
+converted to MLX layout. `sanitize()` must therefore be idempotent: running it
+on its own output has to be a no-op.
 
-From the `src/` directory, you can run the tests with:
+For conv weight transposes, `check_array_shape` is the established guard. It
+does not cover the other conversions a `sanitize()` may perform, and each needs
+its own "has this already been done?" check:
+
+| conversion | detect it by |
+|---|---|
+| conv transpose | target layout (`check_array_shape`, or compare against `self.<conv>.weight.shape`) |
+| norm-weight shift (`v + 1.0`) | a marker that only an unconverted checkpoint carries; `v.ndim == 1` is **not** one, since it holds before and after |
+| expert / qkv / gate_up splits and merges | absence of the source key |
+| quantization-scale rewrites | the scale dtype or grouping already being the MLX one |
+| MTP or draft shard filtering | presence of the shard keys |
+
+Prefer an explicit check over relying on an earlier step in the same
+`sanitize()` to have consumed its input key. That works, but it makes
+idempotency a side effect of unrelated code, and reordering silently breaks it.
+
+Getting this wrong fails in two ways. A shape-changing conversion applied twice
+dies loudly at weight-load; a value-changing one (a norm shift, a scale rewrite)
+loads fine and generates garbage.
+
+Additionally, add a test for the new model type to the [model
+tests](https://github.com/Blaizzy/mlx-vlm/tree/main/mlx_vlm/tests/test_models.py),
+and assert the invariant above with the shared helper:
+
+```python
+from mlx_vlm.tests.sanitize_invariants import assert_sanitize_idempotent
+
+sanitized = assert_sanitize_idempotent(model, hf_weights)
+```
+
+From the repository root, you can run the tests with:
 
 ```shell
-python -m unittest discover tests/
+python -m unittest discover mlx_vlm/tests/
 ```
 
 ## Pull Requests

--- a/mlx_vlm/tests/sanitize_invariants.py
+++ b/mlx_vlm/tests/sanitize_invariants.py
@@ -1,0 +1,108 @@
+"""Shared invariant checks for model ``sanitize()`` implementations.
+
+Since #1498 ("Always sanitize loaded weights"), ``load_model`` calls
+``sanitize()`` on every checkpoint it loads, including ones that are already in
+MLX layout. Weight conversion is therefore no longer guarded by the caller, and
+each ``sanitize()`` has to detect for itself whether its input still needs
+converting.
+
+Concretely, every ``sanitize()`` must be **idempotent**: running it on its own
+output must be a no-op. When it is not, an already-converted checkpoint gets
+transposed (or norm-shifted, or split) a second time, and the model either dies
+at weight-load with a shape mismatch or -- worse -- loads and generates garbage.
+
+Most implementations already satisfy this by comparing against the target layout
+before converting; ``check_array_shape`` is the usual helper. This module is the
+assertion side of that convention, so new architectures can state the invariant
+in one line instead of hand-rolling it.
+
+Usage::
+
+    from .sanitize_invariants import assert_sanitize_idempotent
+
+    assert_sanitize_idempotent(model, hf_weights)
+
+For a submodule sanitizer, pass it explicitly::
+
+    assert_sanitize_idempotent(
+        model, hf_weights, sanitize=model.thinker.audio_tower.sanitize
+    )
+"""
+
+import mlx.core as mx
+
+__all__ = ["assert_sanitize_idempotent"]
+
+
+def _describe(value):
+    shape = getattr(value, "shape", None)
+    return f"shape {tuple(shape)}" if shape is not None else repr(value)
+
+
+def _assert_same(first, second, key, context):
+    first_shape = getattr(first, "shape", None)
+    second_shape = getattr(second, "shape", None)
+
+    if first_shape != second_shape:
+        raise AssertionError(
+            f"{context}: sanitize() changed {key!r} on a second pass -- "
+            f"{_describe(first)} became {_describe(second)}. sanitize() must "
+            f"detect already-converted weights and leave them alone."
+        )
+
+    if first_shape is None:
+        if first != second:
+            raise AssertionError(
+                f"{context}: sanitize() changed the value of {key!r} on a "
+                f"second pass ({first!r} -> {second!r})."
+            )
+        return
+
+    if not mx.array_equal(first, second):
+        raise AssertionError(
+            f"{context}: sanitize() left {key!r} at {_describe(first)} but "
+            f"changed its values on a second pass. A layout conversion is "
+            f"probably being applied twice."
+        )
+
+
+def assert_sanitize_idempotent(model, hf_weights, *, sanitize=None, context=None):
+    """Assert that ``sanitize()`` is a no-op on its own output.
+
+    Args:
+        model: the model (or submodule) whose ``sanitize`` is under test.
+        hf_weights: a weights dict in the *source* (usually PyTorch) layout.
+            Only the keys the sanitizer cares about need to be present.
+        sanitize: the callable to exercise. Defaults to ``model.sanitize``.
+        context: label used in failure messages. Defaults to the model's class
+            name.
+
+    Returns:
+        The sanitized weights, so callers can make architecture-specific
+        assertions about them without sanitizing a second time.
+
+    Raises:
+        AssertionError: if a second ``sanitize()`` pass adds keys, drops keys,
+            or changes any value.
+    """
+    if sanitize is None:
+        sanitize = model.sanitize
+    if context is None:
+        context = type(model).__name__
+
+    once = sanitize(dict(hf_weights))
+    twice = sanitize(dict(once))
+
+    added = sorted(set(twice) - set(once))
+    dropped = sorted(set(once) - set(twice))
+    if added or dropped:
+        raise AssertionError(
+            f"{context}: a second sanitize() pass changed the key set "
+            f"(added={added}, dropped={dropped}). sanitize() must be safe to "
+            f"run on an already-converted checkpoint."
+        )
+
+    for key in once:
+        _assert_same(once[key], twice[key], key, context)
+
+    return once

--- a/mlx_vlm/tests/test_models.py
+++ b/mlx_vlm/tests/test_models.py
@@ -9,6 +9,8 @@ import mlx.nn as nn
 import numpy as np
 from mlx.utils import tree_flatten, tree_map
 
+from mlx_vlm.tests.sanitize_invariants import assert_sanitize_idempotent
+
 
 class TestModels(unittest.TestCase):
     def language_test_runner(self, model, model_type, vocab_size, num_layers):
@@ -8454,7 +8456,7 @@ class TestGetInputEmbeddings(unittest.TestCase):
             ),
         }
 
-        sanitized = model.sanitize(dict(hf_weights))
+        sanitized = assert_sanitize_idempotent(model, hf_weights)
         self.assertIn("language_model.model.embed_tokens.weight", sanitized)
         self.assertIn("language_model.model.layers.0.input_layernorm.weight", sanitized)
         self.assertIn("language_model.lm_head.weight", sanitized)
@@ -8464,8 +8466,6 @@ class TestGetInputEmbeddings(unittest.TestCase):
         self.assertEqual(
             sanitized["visual.layers.0.self_attn.qkv.weight"].shape, (48, 16)
         )
-
-        self.assertIs(model.sanitize(sanitized), sanitized)
 
         for key in sanitized:
             self.assertNotIn("language_language_model", key)
@@ -8855,11 +8855,8 @@ class TestGetInputEmbeddings(unittest.TestCase):
             )
             key = f"thinker.audio_tower.{local_key}"
 
-            sanitized = model.sanitize({key: mx.zeros(source_shape)})
+            sanitized = assert_sanitize_idempotent(model, {key: mx.zeros(source_shape)})
             self.assertEqual(sanitized[key].shape, target_shape)
-
-            resanitized = model.sanitize(dict(sanitized))
-            self.assertEqual(resanitized[key].shape, target_shape)
 
             already_mlx = model.sanitize({key: mx.zeros(target_shape)})
             self.assertEqual(already_mlx[key].shape, target_shape)
@@ -8913,11 +8910,8 @@ class TestGetInputEmbeddings(unittest.TestCase):
                 continue
 
             key = f"code2wav.{local_key}"
-            sanitized = model.sanitize({key: mx.zeros(source_shape)})
+            sanitized = assert_sanitize_idempotent(model, {key: mx.zeros(source_shape)})
             self.assertEqual(sanitized[key].shape, target_shape)
-
-            resanitized = model.sanitize(dict(sanitized))
-            self.assertEqual(resanitized[key].shape, target_shape)
 
             already_mlx = model.sanitize({key: mx.zeros(target_shape)})
             self.assertEqual(already_mlx[key].shape, target_shape)


### PR DESCRIPTION
Follow-up to #1718 ([comment](https://github.com/Blaizzy/mlx-vlm/issues/1718#issuecomment-5232128770)).

Since #1498, `load_model` calls `sanitize()` on every checkpoint, including ones already converted to MLX layout. So every `sanitize()` now has to detect for itself whether its input still needs converting. That requirement isn't written down anywhere and isn't tested, and the bugs it produces have been fixed one architecture at a time — #1521, then the sanitize fixes in 0.6.7–0.6.9.

This doesn't touch library code. It just makes the invariant explicit and checkable.

### What's here

- **`mlx_vlm/tests/sanitize_invariants.py`** (new) — `assert_sanitize_idempotent(model, hf_weights)`. Runs `sanitize()`, runs it again on its own output, and asserts nothing moved. Reports shape *and* value changes, since the value-changing case (a norm shift, a scale rewrite) is the one that loads fine and generates garbage.
- **`mlx_vlm/tests/test_models.py`** — three tests already assert this per-architecture (`:8415`, `:8832`, `:8867`); refactored onto the helper. No new fixtures, no new model configs.
- **`CONTRIBUTING.md`** — states the invariant next to the existing "add a model test" instruction, with a table of the conversion classes `check_array_shape` doesn't cover (norm-weight shifts, expert/qkv/gate_up splits, quant-scale rewrites, MTP shard filtering) and how to detect each. Also corrects the test paths in that section, which still pointed at `src/tests/`.

### Why the helper rather than per-architecture fixes

I couldn't find a currently-broken `sanitize()` at HEAD. What I did find is that several are idempotent only incidentally — an earlier step consumes the key a later guard tests:

- `qwen3_next/language.py:410` — early return keys on `model.layers.0.mlp.experts.0.up_proj.weight`, which line 422 `pop`s while stacking experts. That's what stops the unguarded `v + 1.0` norm shift at line 439 being applied twice.
- `gpt2/language.py` — transposes keyed on unprefixed `h.{i}.…`, and the `model.` prefixing runs afterwards.
- `hunyuan/language.py` — gated on `gate_and_up_proj`, which the first pass consumes.

All correct today, but correct as a side effect of unrelated restructuring rather than by assertion — so reordering breaks them, and in the norm-shift case it breaks them silently.

### Verification

Tests pass under both runners. Mutation-tested to confirm the helper has teeth — removing the `qwen3_omni_moe` audio guard reproduces the 0.6.9 failure signature:

```
AudioModel: sanitize() changed 'thinker.audio_tower.conv2d1.weight' on a second
pass -- shape (4, 3, 3, 1) became shape (4, 3, 1, 3). sanitize() must detect
already-converted weights and leave them alone.
```

Guard restored, green again. `black` clean.

Unrelated: `TestAWQ::test_fold_into_linear_is_identity` and `test_fold_into_norm_is_identity` fail for me on a clean checkout of `main` too, so they're not from this branch.

A parametrised sweep over every architecture would be better than three call sites, but each one needs a hand-built config and a plausible torch-layout weight dict, so I haven't attempted it. Happy to extend the helper to more architectures if you'd like it in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
