### PR TITLE
Add server-aware generate and chat CLIs

### DIFF
--- a/mlx_vlm/chat.py
+++ b/mlx_vlm/chat.py
@@ -23,6 +23,14 @@ from mlx_vlm.generate import (
     PromptCacheState,
     stream_generate,
 )
+from mlx_vlm.generate.remote import (
+    RemoteServerError,
+    _image_url,
+    resolve_base_url,
+    sampling_params,
+    server_available,
+    stream_chat,
+)
 from mlx_vlm.prompt_utils import apply_chat_template
 from mlx_vlm.utils import load_image
 from mlx_vlm.vision_cache import VisionFeatureCache
@@ -35,9 +43,12 @@ class MLXVisionChat:
         temperature: float = 0.7,
         max_tokens: int = 1000,
         verbose: bool = False,
+        remote_args=None,
         **kwargs,
     ):
         self.console = Console()
+        self.model_path = model_path
+        self.remote_args = remote_args
         self.verbose = verbose
         self.temperature = temperature
         self.max_tokens = max_tokens
@@ -56,10 +67,16 @@ class MLXVisionChat:
             self.chat_template_kwargs["thinking_mode"] = thinking_mode
         self.stream_kwargs = kwargs
 
-        with self.console.status("[bold green]Loading model..."):
-            self.model, self.processor = load(model_path)
-
-        rprint("[bold green]Model loaded successfully![/bold green]")
+        if remote_args is None:
+            with self.console.status("[bold green]Loading model..."):
+                self.model, self.processor = load(model_path)
+            rprint("[bold green]Model loaded successfully![/bold green]")
+        else:
+            self.model = None
+            self.processor = None
+            rprint(
+                f"[bold green]Using server at {resolve_base_url(remote_args)}.[/bold green]"
+            )
         self.print_help()
 
     def print_help(self) -> None:
@@ -96,10 +113,31 @@ class MLXVisionChat:
     def add_to_history(self, role: str, text: str) -> None:
         """Add a message to the conversation history."""
         content = [{"type": "text", "text": text}]
+        if role == "user" and self.remote_args and self.current_image_path:
+            content.append(
+                {
+                    "type": "image_url",
+                    "image_url": {"url": _image_url(self.current_image_path)},
+                }
+            )
         self.history.append({"role": role, "content": content})
 
     def generate_response(self) -> str:
         """Generate a response from the model based on the conversation history."""
+        if self.remote_args is not None:
+            text = ""
+            for chunk in stream_chat(
+                resolve_base_url(self.remote_args),
+                self.model_path,
+                self.history,
+                sampling_params(self.remote_args),
+                self.remote_args,
+            ):
+                text += chunk
+                if self.verbose:
+                    rprint(chunk, end="", flush=True)
+            return text
+
         num_images = 1 if self.current_image_path else 0
         image = [self.current_image_path] if self.current_image_path else None
 
@@ -193,6 +231,28 @@ def main():
         "--model",
         default="mlx-community/idefics2-8b-chatty-4bit",
         help="Path to the model or model identifier",
+    )
+    parser.add_argument(
+        "--base-url",
+        default=None,
+        help="Base URL of a running mlx-vlm server to reuse (default: "
+        "$MLX_VLM_BASE_URL or http://127.0.0.1:8080).",
+    )
+    parser.add_argument(
+        "--api-key",
+        default=None,
+        help="API key for the server (default: $MLX_VLM_API_KEY).",
+    )
+    server_mode = parser.add_mutually_exclusive_group()
+    server_mode.add_argument(
+        "--server",
+        action="store_true",
+        help="Require a running server instead of loading the model locally.",
+    )
+    server_mode.add_argument(
+        "--local",
+        action="store_true",
+        help="Force local execution even if a server is running.",
     )
     parser.add_argument(
         "--verbose",
@@ -332,6 +392,31 @@ def main():
 
     args = parser.parse_args()
 
+    remote_eligible = (
+        args.eos_tokens is None
+        and not args.skip_special_tokens
+        and args.thinking_mode is None
+        and args.max_kv_size is None
+        and args.kv_bits is None
+        and args.prefill_step_size in (None, DEFAULT_PREFILL_STEP_SIZE)
+    )
+    use_server = False
+    if not args.local and remote_eligible:
+        try:
+            use_server = server_available(resolve_base_url(args), args)
+        except RemoteServerError as exc:
+            print(f"Error: {exc}", file=sys.stderr)
+            sys.exit(1)
+    if args.server and not remote_eligible:
+        print("Error: --server cannot be used with these chat options", file=sys.stderr)
+        sys.exit(1)
+    if args.server and not use_server:
+        print(
+            f"Error: No mlx-vlm server is available at {resolve_base_url(args)}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
     # Build stream_generate kwargs matching generate.py's main()
     kwargs = {}
 
@@ -382,6 +467,7 @@ def main():
             temperature=args.temperature,
             max_tokens=args.max_tokens,
             verbose=args.verbose,
+            remote_args=args if use_server else None,
             **kwargs,
         )
         chat.chat_loop()

--- a/mlx_vlm/generate/dispatch.py
+++ b/mlx_vlm/generate/dispatch.py
@@ -74,6 +74,32 @@ def parse_arguments():
         help="The path to the local model directory or Hugging Face repo.",
     )
     parser.add_argument(
+        "--base-url",
+        type=str,
+        default=None,
+        help="Base URL of a running mlx-vlm server to reuse (default: "
+        "$MLX_VLM_BASE_URL or http://127.0.0.1:8080). Used only for plain "
+        "text/vision generation; other flags always run locally.",
+    )
+    parser.add_argument(
+        "--api-key",
+        type=str,
+        default=None,
+        help="API key for the server (default: $MLX_VLM_API_KEY).",
+    )
+    server_mode = parser.add_mutually_exclusive_group()
+    server_mode.add_argument(
+        "--server",
+        action="store_true",
+        help="Require the server: send the request over HTTP instead of loading "
+        "the model locally (errors if the server is unreachable).",
+    )
+    server_mode.add_argument(
+        "--local",
+        action="store_true",
+        help="Force local execution even if a server is running.",
+    )
+    parser.add_argument(
         "--output-modality",
         type=str,
         choices=("text", "image", "video"),
@@ -1243,6 +1269,11 @@ def main():
         args.audio = [args.audio]
     if isinstance(args.video, str):
         args.video = [args.video]
+
+    from .remote import run_on_server
+
+    if run_on_server(args):
+        return
 
     model, processor = load(
         args.model,

--- a/mlx_vlm/generate/remote.py
+++ b/mlx_vlm/generate/remote.py
@@ -1,0 +1,259 @@
+"""Optional server-aware execution for the generate CLI.
+
+When an mlx-vlm server is already running, the CLI can send a plain text or
+vision request to it instead of cold-loading the model into this process. The
+local path remains authoritative for every option the OpenAI-compatible server
+does not expose.
+"""
+
+import base64
+import json
+import mimetypes
+import os
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+
+DEFAULT_BASE_URL = "http://127.0.0.1:8080"
+DEFAULT_PREFILL_STEP_SIZE = 2048
+
+
+class RemoteServerError(RuntimeError):
+    """A reachable server could not satisfy a CLI request."""
+
+
+def resolve_base_url(args):
+    """Resolve --base-url, then $MLX_VLM_BASE_URL, then the local default."""
+    return (
+        getattr(args, "base_url", None)
+        or os.environ.get("MLX_VLM_BASE_URL")
+        or DEFAULT_BASE_URL
+    )
+
+
+def _auth_header(args):
+    key = getattr(args, "api_key", None) or os.environ.get("MLX_VLM_API_KEY")
+    return {"Authorization": f"Bearer {key}"} if key else {}
+
+
+def _http_error_message(exc):
+    try:
+        detail = exc.read().decode("utf-8", "replace").strip()
+    except OSError:
+        detail = ""
+    suffix = f": {detail}" if detail else ""
+    return f"mlx-vlm server returned HTTP {exc.code}{suffix}"
+
+
+def server_available(base_url, args=None, timeout=1.5):
+    """Return whether an mlx-vlm server answers its models endpoint.
+
+    A connection failure permits automatic local fallback. A reachable server
+    that returns an authentication or other HTTP error is surfaced instead of
+    being silently bypassed by a separate local model load.
+    """
+    req = urllib.request.Request(
+        base_url.rstrip("/") + "/v1/models",
+        headers=_auth_header(args) if args is not None else {},
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=timeout):
+            return True
+    except urllib.error.HTTPError as exc:
+        if exc.code == 404:
+            return False
+        raise RemoteServerError(_http_error_message(exc)) from exc
+    except OSError:
+        return False
+
+
+def eligible_for_server(args):
+    """Whether every requested generate feature maps to the server API."""
+    if getattr(args, "local", False):
+        return False
+    if getattr(args, "output_modality", "text") != "text":
+        return False
+    if not getattr(args, "model", None) or getattr(args, "prompt", None) is None:
+        return False
+
+    # --prompt is nargs="+" (a list of words) or the string default. A list
+    # of message dicts is an internal representation, not a plain CLI prompt.
+    prompt = args.prompt
+    if isinstance(prompt, list) and not all(isinstance(part, str) for part in prompt):
+        return False
+
+    # Keep this conservative. These options either require local state or are
+    # server-start configuration rather than request-level API fields.
+    disqualifying = (
+        getattr(args, "adapter_path", None),
+        getattr(args, "draft_model", None),
+        getattr(args, "quantize_activations", False),
+        getattr(args, "chat", False),
+        getattr(args, "audio", None),
+        getattr(args, "video", None),
+        getattr(args, "eos_tokens", None),
+        getattr(args, "processor_kwargs", None),
+        getattr(args, "gen_kwargs", None),
+        getattr(args, "thinking_mode", None),
+        getattr(args, "force_download", False),
+        getattr(args, "trust_remote_code", False),
+        getattr(args, "max_kv_size", None),
+        getattr(args, "kv_bits", None),
+        getattr(args, "kv_key_bits", None),
+        getattr(args, "kv_value_bits", None),
+        getattr(args, "kv_key_scheme", None),
+        getattr(args, "kv_value_scheme", None),
+    )
+    if any(disqualifying):
+        return False
+    if getattr(args, "revision", "main") != "main":
+        return False
+    prefill_step_size = getattr(args, "prefill_step_size", None)
+    return prefill_step_size in (None, DEFAULT_PREFILL_STEP_SIZE)
+
+
+def _image_url(path):
+    """Return an HTTP(S) image URL unchanged or encode a local path as data."""
+    parsed = urllib.parse.urlparse(path)
+    if parsed.scheme in {"http", "https", "data"}:
+        return path
+    mime = mimetypes.guess_type(path)[0] or "image/jpeg"
+    with open(os.path.expanduser(path), "rb") as image_file:
+        data = base64.b64encode(image_file.read()).decode("ascii")
+    return f"data:{mime};base64,{data}"
+
+
+def _prompt_text(args):
+    """Join argparse's nargs prompt representation into one text message."""
+    prompt = args.prompt
+    return " ".join(prompt) if isinstance(prompt, list) else str(prompt)
+
+
+def build_messages(args):
+    """Map the CLI prompt, system message, and images to chat messages."""
+    messages = []
+    if getattr(args, "system", None):
+        messages.append({"role": "system", "content": args.system})
+
+    text = _prompt_text(args)
+    images = getattr(args, "image", None) or []
+    if isinstance(images, str):
+        images = [images]
+    if images:
+        content = [{"type": "text", "text": text}]
+        content.extend(
+            {"type": "image_url", "image_url": {"url": _image_url(path)}}
+            for path in images
+        )
+        messages.append({"role": "user", "content": content})
+    else:
+        messages.append({"role": "user", "content": text})
+    return messages
+
+
+def sampling_params(args):
+    """Map request-level CLI controls to the server schema."""
+    params = {}
+    for cli_name, api_name in (
+        ("temperature", "temperature"),
+        ("max_tokens", "max_tokens"),
+        ("repetition_penalty", "repetition_penalty"),
+        ("repetition_context_size", "repetition_context_size"),
+        ("frequency_penalty", "frequency_penalty"),
+        ("frequency_context_size", "frequency_context_size"),
+        ("presence_penalty", "presence_penalty"),
+        ("presence_context_size", "presence_context_size"),
+        ("seed", "seed"),
+        ("resize_shape", "resize_shape"),
+        ("thinking_budget", "thinking_budget"),
+    ):
+        value = getattr(args, cli_name, None)
+        if value is not None:
+            params[api_name] = value
+    # The local CLI always passes this boolean into its chat template, including
+    # its false default. Do the same remotely rather than inheriting a server
+    # process's unrelated default.
+    params["enable_thinking"] = getattr(args, "enable_thinking", False)
+    if getattr(args, "thinking_budget", None) is not None:
+        for cli_name in ("thinking_start_token", "thinking_end_token"):
+            value = getattr(args, cli_name, None)
+            if value is not None:
+                params[cli_name] = value
+    return params
+
+
+def stream_chat(base_url, model, messages, params, args=None):
+    """POST a streaming chat request and yield text deltas from its SSE body."""
+    body = {"model": model, "messages": messages, "stream": True, **params}
+    headers = {"Content-Type": "application/json", **_auth_header(args)}
+    req = urllib.request.Request(
+        base_url.rstrip("/") + "/v1/chat/completions",
+        data=json.dumps(body).encode("utf-8"),
+        headers=headers,
+        method="POST",
+    )
+    with urllib.request.urlopen(req) as response:
+        for raw in response:
+            line = raw.decode("utf-8", "replace").strip()
+            if not line.startswith("data:"):
+                continue
+            payload = line[len("data:") :].strip()
+            if payload == "[DONE]":
+                break
+            try:
+                delta = json.loads(payload)["choices"][0].get("delta", {})
+            except (IndexError, json.JSONDecodeError, KeyError, TypeError):
+                continue
+            content = delta.get("content")
+            if content:
+                yield content
+
+
+def run_on_server(args):
+    """Run one eligible request remotely, else return ``False`` for local use."""
+    forced = getattr(args, "server", False)
+    if not eligible_for_server(args):
+        if forced:
+            raise RemoteServerError(
+                "--server cannot be used with this combination of generate options"
+            )
+        return False
+
+    base_url = resolve_base_url(args)
+    if not server_available(base_url, args):
+        if forced:
+            raise RemoteServerError(f"No mlx-vlm server is available at {base_url}")
+        return False
+
+    verbose = getattr(args, "verbose", False)
+    if verbose:
+        print(f"Using server at {base_url} (model: {args.model}).", file=sys.stderr)
+
+    received = False
+    chunks = []
+    try:
+        for chunk in stream_chat(
+            base_url, args.model, build_messages(args), sampling_params(args), args
+        ):
+            received = True
+            if verbose:
+                print(chunk, end="", flush=True)
+            else:
+                chunks.append(chunk)
+        if verbose:
+            if received:
+                print()
+        else:
+            print("".join(chunks))
+        return True
+    except urllib.error.HTTPError as exc:
+        raise RemoteServerError(_http_error_message(exc)) from exc
+    except urllib.error.URLError as exc:
+        # A request that never produced output may race a just-stopped server;
+        # retrying locally is safe only in that case.
+        if forced or received:
+            raise RemoteServerError(f"mlx-vlm server request failed: {exc}") from exc
+        if verbose:
+            print(f"Server request failed ({exc}); loading locally.", file=sys.stderr)
+        return False

--- a/mlx_vlm/tests/test_cli.py
+++ b/mlx_vlm/tests/test_cli.py
@@ -1,6 +1,12 @@
 import argparse
 import ast
+import importlib.util
+import io
+import json
 from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
 
 SOURCE_ROOT = Path(__file__).resolve().parents[2]
 
@@ -133,3 +139,255 @@ def test_generate_one_shot_applies_system_prompt():
         and _assigns_prompt(node)
         for node in ast.walk(main)
     ), "one-shot generate must prepend args.system to the prompt"
+
+
+def _load_remote():
+    path = SOURCE_ROOT / "mlx_vlm/generate/remote.py"
+    spec = importlib.util.spec_from_file_location("remote_for_tests", path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def _remote_args(**overrides):
+    values = {
+        "adapter_path": None,
+        "api_key": None,
+        "audio": None,
+        "base_url": None,
+        "chat": False,
+        "enable_thinking": False,
+        "eos_tokens": None,
+        "force_download": False,
+        "frequency_context_size": 20,
+        "frequency_penalty": None,
+        "gen_kwargs": {},
+        "image": None,
+        "kv_bits": None,
+        "kv_key_bits": None,
+        "kv_key_scheme": None,
+        "kv_value_bits": None,
+        "kv_value_scheme": None,
+        "local": False,
+        "max_kv_size": None,
+        "max_tokens": 32,
+        "model": "demo/model",
+        "output_modality": "text",
+        "prefill_step_size": 2048,
+        "presence_context_size": 20,
+        "presence_penalty": None,
+        "processor_kwargs": {},
+        "prompt": ["hello", "there"],
+        "quantize_activations": False,
+        "repetition_context_size": 20,
+        "repetition_penalty": None,
+        "resize_shape": None,
+        "revision": "main",
+        "seed": None,
+        "server": False,
+        "system": None,
+        "temperature": 0.0,
+        "thinking_budget": None,
+        "thinking_end_token": "</think>",
+        "thinking_mode": None,
+        "thinking_start_token": "<think>",
+        "trust_remote_code": False,
+        "verbose": False,
+        "video": None,
+    }
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+def test_generate_server_flags_are_mutually_exclusive_and_routed_before_load():
+    source = (SOURCE_ROOT / "mlx_vlm/generate/dispatch.py").read_text()
+    assert "server_mode = parser.add_mutually_exclusive_group()" in source
+    assert 'server_mode.add_argument(\n        "--server"' in source
+    assert 'server_mode.add_argument(\n        "--local"' in source
+    assert source.index("if run_on_server(args):") < source.index(
+        "model, processor = load("
+    )
+
+
+def test_chat_exposes_the_same_server_controls():
+    source = (SOURCE_ROOT / "mlx_vlm/chat.py").read_text()
+    assert '"--base-url"' in source
+    assert '"--api-key"' in source
+    assert "server_mode = parser.add_mutually_exclusive_group()" in source
+    assert "remote_args=args if use_server else None" in source
+    assert "for chunk in stream_chat(" in source
+
+
+def test_remote_eligibility_accepts_plain_generate_and_rejects_local_features():
+    remote = _load_remote()
+
+    assert remote.eligible_for_server(_remote_args())
+    assert not remote.eligible_for_server(_remote_args(local=True))
+    assert not remote.eligible_for_server(_remote_args(audio=["speech.wav"]))
+    assert not remote.eligible_for_server(_remote_args(chat=True))
+    assert not remote.eligible_for_server(_remote_args(kv_bits=4))
+    assert not remote.eligible_for_server(_remote_args(revision="abc123"))
+    assert not remote.eligible_for_server(_remote_args(prefill_step_size=512))
+    assert not remote.eligible_for_server(_remote_args(prompt=[{"role": "user"}]))
+
+
+def test_remote_build_messages_joins_prompt_and_preserves_image_urls(tmp_path):
+    remote = _load_remote()
+    image = tmp_path / "example.png"
+    image.write_bytes(b"png")
+
+    messages = remote.build_messages(
+        _remote_args(
+            system="be concise",
+            image=[str(image), "https://example.test/remote.png"],
+        )
+    )
+
+    assert messages[0] == {"role": "system", "content": "be concise"}
+    content = messages[1]["content"]
+    assert content[0] == {"type": "text", "text": "hello there"}
+    assert content[1]["image_url"]["url"].startswith("data:image/png;base64,")
+    assert content[2]["image_url"]["url"] == "https://example.test/remote.png"
+
+
+def test_remote_sampling_params_preserve_supported_cli_values():
+    remote = _load_remote()
+    params = remote.sampling_params(
+        _remote_args(
+            enable_thinking=True,
+            frequency_penalty=0.2,
+            presence_penalty=0.3,
+            repetition_penalty=1.1,
+            resize_shape=[512, 768],
+            seed=7,
+            thinking_budget=64,
+        )
+    )
+
+    assert params == {
+        "enable_thinking": True,
+        "frequency_context_size": 20,
+        "frequency_penalty": 0.2,
+        "max_tokens": 32,
+        "presence_context_size": 20,
+        "presence_penalty": 0.3,
+        "repetition_context_size": 20,
+        "repetition_penalty": 1.1,
+        "resize_shape": [512, 768],
+        "seed": 7,
+        "temperature": 0.0,
+        "thinking_budget": 64,
+        "thinking_end_token": "</think>",
+        "thinking_start_token": "<think>",
+    }
+
+
+def test_remote_stream_parses_sse_and_posts_expected_request(monkeypatch):
+    remote = _load_remote()
+    seen = {}
+
+    class Response:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return False
+
+        def __iter__(self):
+            return iter(
+                [
+                    b"event: message" + bytes([10]),
+                    b'data: {"choices":[{"delta":{"content":"hello"}}]}' + bytes([10]),
+                    b'data: {"choices":[{"delta":{"content":" world"}}]}' + bytes([10]),
+                    b"data: [DONE]" + bytes([10]),
+                ]
+            )
+
+    def urlopen(request):
+        seen["url"] = request.full_url
+        seen["body"] = json.loads(request.data)
+        return Response()
+
+    monkeypatch.setattr(remote.urllib.request, "urlopen", urlopen)
+    assert list(
+        remote.stream_chat(
+            "http://127.0.0.1:8080",
+            "demo/model",
+            [{"role": "user", "content": "hello"}],
+            {"max_tokens": 32},
+        )
+    ) == ["hello", " world"]
+    assert seen["url"] == "http://127.0.0.1:8080/v1/chat/completions"
+    assert seen["body"]["stream"] is True
+    assert seen["body"]["model"] == "demo/model"
+
+
+def test_remote_server_probe_returns_false_for_missing_endpoint(monkeypatch):
+    remote = _load_remote()
+
+    def missing(*args, **kwargs):
+        raise remote.urllib.error.HTTPError(
+            "http://127.0.0.1:8080/v1/models", 404, "missing", {}, io.BytesIO()
+        )
+
+    monkeypatch.setattr(remote.urllib.request, "urlopen", missing)
+    assert not remote.server_available("http://127.0.0.1:8080")
+
+
+def test_remote_server_probe_surfaces_auth_errors(monkeypatch):
+    remote = _load_remote()
+
+    def unauthorized(*args, **kwargs):
+        raise remote.urllib.error.HTTPError(
+            "http://127.0.0.1:8080/v1/models",
+            401,
+            "unauthorized",
+            {},
+            io.BytesIO(b'{"detail":"bad key"}'),
+        )
+
+    monkeypatch.setattr(remote.urllib.request, "urlopen", unauthorized)
+    with pytest.raises(remote.RemoteServerError, match="HTTP 401"):
+        remote.server_available("http://127.0.0.1:8080")
+
+
+def test_remote_run_streams_when_available(monkeypatch, capsys):
+    remote = _load_remote()
+    seen = {}
+    monkeypatch.setattr(remote, "server_available", lambda *args: True)
+
+    def stream(base_url, model, messages, params, args):
+        seen.update(base_url=base_url, model=model, messages=messages, params=params)
+        yield "answer"
+
+    monkeypatch.setattr(remote, "stream_chat", stream)
+    assert remote.run_on_server(_remote_args())
+    assert capsys.readouterr().out == "answer" + chr(10)
+    assert seen["messages"] == [{"role": "user", "content": "hello there"}]
+    assert seen["params"]["enable_thinking"] is False
+
+
+def test_remote_run_forced_rejects_unsupported_features():
+    remote = _load_remote()
+    with pytest.raises(remote.RemoteServerError, match="--server cannot"):
+        remote.run_on_server(_remote_args(server=True, chat=True))
+
+
+def test_remote_run_forced_errors_when_server_is_unavailable(monkeypatch):
+    remote = _load_remote()
+    monkeypatch.setattr(remote, "server_available", lambda *args: False)
+    with pytest.raises(remote.RemoteServerError, match="No mlx-vlm server"):
+        remote.run_on_server(_remote_args(server=True))
+
+
+def test_remote_run_falls_back_only_before_any_output(monkeypatch):
+    remote = _load_remote()
+    monkeypatch.setattr(remote, "server_available", lambda *args: True)
+
+    def disconnected(*args):
+        raise remote.urllib.error.URLError("connection reset")
+        yield
+
+    monkeypatch.setattr(remote, "stream_chat", disconnected)
+    assert not remote.run_on_server(_remote_args())


### PR DESCRIPTION
## Summary

  - Add optional server reuse to `mlx_vlm generate` and `mlx_vlm chat`.
  - Reuse a running mlx-vlm server through its OpenAI-compatible
    `/v1/chat/completions` API instead of cold-loading the model again.
  - Add `--base-url`, `--api-key`, `--server`, and `--local`.
  - Preserve the existing local path for unsupported or local-only options.

  ## Behavior

  For plain text and vision generation, the CLI probes a running server and
  streams its response when available. `--server` requires remote execution;
  `--local` explicitly bypasses the server.

  Options that cannot be represented faithfully by the request API remain local.
  A reachable server that returns an authentication or HTTP error is surfaced,
  rather than silently falling back to a separate local model load.

  ## Validation

  - `uv run --with pytest python -m pytest mlx_vlm/tests/test_cli.py mlx_vlm/tests/test_server.py -q`
    - 283 passed
  - Formatted with Black; pre-commit Black, isort, and autoflake passed.
  - End-to-end verified on an M4 Mac mini against a real mlx-vlm server using
    `mlx-community/Qwen3-1.7B-4bit`.

  ## Related

  This provides the engine-side server-aware CLI behavior needed by the Nativ CLI:
  https://github.com/Blaizzy/nativ/pull/228