### PR TITLE
Preserve packed TurboQuant states in exact APC snapshots [New]

### DIFF
--- a/mlx_vlm/apc.py
+++ b/mlx_vlm/apc.py
@@ -815,6 +815,79 @@ def _decode_checkpoint_tree(structure: dict, load_array) -> Any:
     raise ValueError(f"unsupported checkpoint tree node: {kind!r}")
 
 
+def _encode_turboquant_state(
+    value: Any,
+    tensor_prefix: str,
+    arrays: Dict[str, mx.array],
+    counter: List[int],
+) -> Optional[dict]:
+    """Encode a packed TurboQuant state while preserving NamedTuple types."""
+    if isinstance(value, mx.array):
+        name = f"{tensor_prefix}_t{counter[0]}"
+        counter[0] += 1
+        arrays[name] = value
+        return {"kind": "array", "name": name}
+    if value is None:
+        return {"kind": "none"}
+    if isinstance(value, tuple):
+        from . import turboquant as tq
+
+        state_types = {
+            cls.__name__
+            for cls in (
+                tq.TurboQuantMSEState,
+                tq.TurboQuantProdState,
+                tq.TurboQuantPolarState,
+                tq.TurboQuantPolarProdState,
+                tq.TurboQuantSplitState,
+            )
+        }
+        items = [
+            _encode_turboquant_state(item, tensor_prefix, arrays, counter)
+            for item in value
+        ]
+        if any(item is None for item in items):
+            return None
+        type_name = type(value).__name__
+        if type_name not in state_types:
+            return None
+        return {"kind": "state", "type": type_name, "items": items}
+    return None
+
+
+def _decode_turboquant_state(structure: dict, load_array) -> Any:
+    """Decode a packed TurboQuant state produced by its exact-APC schema."""
+    kind = structure.get("kind")
+    if kind == "array":
+        return load_array(structure["name"])
+    if kind == "none":
+        return None
+    if kind != "state":
+        raise ValueError(f"unsupported TurboQuant state node: {kind!r}")
+
+    from . import turboquant as tq
+
+    state_types = {
+        cls.__name__: cls
+        for cls in (
+            tq.TurboQuantMSEState,
+            tq.TurboQuantProdState,
+            tq.TurboQuantPolarState,
+            tq.TurboQuantPolarProdState,
+            tq.TurboQuantSplitState,
+        )
+    }
+    state_type = state_types.get(structure.get("type"))
+    if state_type is None:
+        raise ValueError("unknown TurboQuant state type")
+    return state_type(
+        *(
+            _decode_turboquant_state(item, load_array)
+            for item in structure.get("items", ())
+        )
+    )
+
+
 def _resolve_checkpoint_class(module_name: str, qualname: str) -> Optional[type]:
     """Resolve an importable cache class recorded by the local disk tier."""
     if not module_name.startswith("mlx_vlm.") or "<locals>" in qualname:
@@ -877,7 +950,13 @@ def _mlx_array_from_safetensors_bytes(buf, entry: dict) -> Optional[mx.array]:
         return None
     _, buffer_format, mlx_dtype, bitcast_to = dtype_info
     try:
-        view = memoryview(buf).cast(buffer_format)
+        if str(entry["dtype"]) == "F16":
+            # Python's memoryview does not implement the half-float ``e``
+            # format on every supported runtime. NumPy does, and MLX copies
+            # the resulting host view into its own array.
+            view = np.frombuffer(buf, dtype=np.dtype("<f2"))
+        else:
+            view = memoryview(buf).cast(buffer_format)
         if len(view) != _numel(shape):
             return None
         out = mx.array(view, dtype=mlx_dtype).reshape(shape)
@@ -1526,6 +1605,59 @@ class DiskBlockStore:
         from .models import cache as lm_cache
 
         kind = metadata.get(f"{prefix}_kind")
+        if kind == "turboquant_kv":
+            from .turboquant import TurboQuantKVCache
+
+            try:
+                bits = float(metadata[f"{prefix}_bits"])
+                key_bits = float(metadata[f"{prefix}_key_bits"])
+                value_bits = float(metadata[f"{prefix}_value_bits"])
+                seed = int(metadata.get(f"{prefix}_seed", "0"))
+                offset = int(metadata.get(f"{prefix}_offset", "0"))
+            except (KeyError, TypeError, ValueError):
+                return None
+            cache = TurboQuantKVCache(
+                bits=bits,
+                seed=seed,
+                key_bits=key_bits,
+                value_bits=value_bits,
+            )
+            if metadata.get(f"{prefix}_empty", "0") == "1":
+                return cache
+            try:
+                head_dim = int(metadata[f"{prefix}_head_dim"])
+                key_tree = json.loads(metadata[f"{prefix}_keys"])
+                value_tree = json.loads(metadata[f"{prefix}_values"])
+            except (KeyError, TypeError, ValueError, json.JSONDecodeError):
+                return None
+            if head_dim <= 0:
+                return None
+
+            loaded_arrays: List[mx.array] = []
+
+            def load_array(name: str) -> mx.array:
+                entry = tensor_entries.get(name)
+                if entry is None:
+                    raise KeyError(name)
+                array = _read_safetensors_tensor(path, data_start, entry)
+                if array is None:
+                    raise ValueError(name)
+                loaded_arrays.append(array)
+                return array
+
+            try:
+                keys = _decode_turboquant_state(key_tree, load_array)
+                values = _decode_turboquant_state(value_tree, load_array)
+                dummy = mx.zeros((1, 1, 1, head_dim), dtype=mx.bfloat16)
+                cache._ensure_codecs(dummy, dummy)
+                cache.keys = keys
+                cache.values = values
+                cache.offset = offset
+            except (KeyError, TypeError, ValueError, AttributeError):
+                return None
+            eval_targets.extend(loaded_arrays)
+            return cache
+
         if kind == "ring_kv":
             from .models.unlimited_ocr.language import RingSlidingKVCache
 
@@ -2509,6 +2641,36 @@ class DiskBlockStore:
         metadata: dict[str, str],
     ) -> bool:
         from .models import cache as lm_cache
+
+        try:
+            from .turboquant import TurboQuantKVCache, _slice_state
+        except ImportError:
+            TurboQuantKVCache = ()
+
+        if isinstance(c, TurboQuantKVCache):
+            offset = int(getattr(c, "offset", 0) or 0)
+            metadata[f"{prefix}_kind"] = "turboquant_kv"
+            metadata[f"{prefix}_offset"] = str(offset)
+            metadata[f"{prefix}_bits"] = str(float(c.bits))
+            metadata[f"{prefix}_key_bits"] = str(float(c.key_bits))
+            metadata[f"{prefix}_value_bits"] = str(float(c.value_bits))
+            metadata[f"{prefix}_seed"] = str(int(c.seed))
+            if c.keys is None or c.values is None or offset <= 0:
+                metadata[f"{prefix}_empty"] = "1"
+                return True
+            head_dim = getattr(getattr(c, "key_codec", None), "dim", 0)
+            if not head_dim:
+                return False
+            keys = _slice_state(c.keys, offset)
+            values = _slice_state(c.values, offset)
+            key_tree = _encode_turboquant_state(keys, f"{prefix}_k", arrays, [0])
+            value_tree = _encode_turboquant_state(values, f"{prefix}_v", arrays, [0])
+            if key_tree is None or value_tree is None:
+                return False
+            metadata[f"{prefix}_head_dim"] = str(int(head_dim))
+            metadata[f"{prefix}_keys"] = json.dumps(key_tree, separators=(",", ":"))
+            metadata[f"{prefix}_values"] = json.dumps(value_tree, separators=(",", ":"))
+            return True
 
         if (
             type(c).__name__ == "RingSlidingKVCache"
@@ -3951,10 +4113,10 @@ def make_warm_batch_exact_cache_multi(
 ) -> Tuple[Optional[List[Any]], int]:
     """Merge single-row exact-cache snapshots into batch-aware caches.
 
-    When *kv_quant_config* is provided, full-attention ``BatchKVCache`` layers
-    are re-quantized to match live ``_make_cache`` via
+    When *kv_quant_config* is provided, float full-attention ``BatchKVCache``
+    layers are re-quantized to match live ``_make_cache`` via
     ``should_quantize_kv_layer`` (last layer stays float when n > 2). Hybrid
-    non-KV entries are unchanged. On-disk exact snapshots remain float. When
+    non-KV entries and already-packed TurboQuant entries are unchanged. When
     *consume_sources* is true, each row must be a list; its entries are cleared
     as their materialized batch layers take ownership of the restored state.
     """
@@ -4053,8 +4215,9 @@ def snapshot_prompt_cache_row(
     """Row-normalize a prompt cache for APC store/lookup.
 
     Batch-shaped layouts (every entry has ``extract``) are extracted first.
-    Single-row caches are cloned in place. Quantized layers are dequantized
-    into float ``KVCache`` entries.
+    Single-row caches are cloned in place. TurboQuant layers retain their
+    packed representation; other quantized cache implementations continue to
+    use their existing APC adapter behavior.
     """
     if not caches:
         return []

--- a/mlx_vlm/apc.py
+++ b/mlx_vlm/apc.py
@@ -3136,14 +3136,24 @@ class APCManager:
         prompt_cache: Sequence[Any],
         *,
         extra_hash: int = 0,
+        take_ownership: bool = False,
     ) -> bool:
-        """Store a full prompt-cache snapshot for exact-prefix reuse."""
+        """Store a full prompt-cache snapshot for exact-prefix reuse.
+
+        By default the manager defensively clones the supplied cache. Callers
+        may set *take_ownership* only when every entry is already a detached
+        snapshot that they will not access or mutate after this call.
+        """
         if len(token_ids) < self.exact_cache_min_tokens:
             return False
         if (self._exact_cache_max <= 0 and self.disk is None) or not token_ids:
             return False
         token_tuple = tuple(int(t) for t in token_ids)
-        copied = _clone_prompt_cache_for_apc(prompt_cache)
+        copied = (
+            list(prompt_cache)
+            if take_ownership
+            else _clone_prompt_cache_for_apc(prompt_cache)
+        )
         if copied is None:
             types = [type(c).__name__ for c in prompt_cache]
             logger.warning(
@@ -3847,11 +3857,17 @@ def _collect_mx_arrays(x: Any, out: List[mx.array]) -> None:
 def _merge_exact_cache_entries(
     entries: Sequence[Any],
     prefix_lens: Sequence[int],
+    *,
+    consume_sources: bool = False,
 ) -> Any:
     """Merge single-row exact snapshots via the registered cache adapter."""
     from .apc_adapters import merge_cache_entries
 
-    return merge_cache_entries(entries, prefix_lens)
+    return merge_cache_entries(
+        entries,
+        prefix_lens,
+        consume_sources=consume_sources,
+    )
 
 
 def _empty_quant_batch_cache(left_padding: List[int], kv_quant_config: dict) -> Any:
@@ -3876,6 +3892,33 @@ def _empty_quant_batch_cache(left_padding: List[int], kv_quant_config: dict) -> 
     )
 
 
+def _align_exact_batch_cache_to_kv_policy(
+    cache: Any,
+    kv_quant_config: dict,
+    *,
+    layer_idx: int,
+    num_layers: int,
+) -> Any:
+    """Align one exact-restored layer with the live KV policy."""
+    from .models.cache import BatchKVCache, should_quantize_kv_layer
+
+    if not should_quantize_kv_layer(layer_idx, num_layers) or not isinstance(
+        cache, BatchKVCache
+    ):
+        return cache
+    left_padding = [int(x) for x in cache.left_padding.tolist()]
+    if cache.keys is None or int(cache._idx) == 0:
+        return _empty_quant_batch_cache(left_padding, kv_quant_config)
+    return _fill_batch_layer_cache(
+        cache.keys[..., : int(cache._idx), :],
+        cache.values[..., : int(cache._idx), :],
+        left_padding=left_padding,
+        offset=[int(x) for x in cache.offset.tolist()],
+        quantize=True,
+        kv_quant_config=kv_quant_config,
+    )
+
+
 def _align_exact_batch_caches_to_kv_policy(
     caches: List[Any],
     kv_quant_config: dict,
@@ -3888,46 +3931,32 @@ def _align_exact_batch_caches_to_kv_policy(
     marks, float last layer when n > 2). Hybrid non-KV types
     (``ArraysCache``, ``BatchRotatingKVCache``, …) are left unchanged.
     """
-    from .models.cache import BatchKVCache, should_quantize_kv_layer
-
-    n = len(caches)
-    out: List[Any] = []
-    for layer_idx, c in enumerate(caches):
-        quantize = should_quantize_kv_layer(layer_idx, n)
-        if not quantize or not isinstance(c, BatchKVCache):
-            out.append(c)
-            continue
-        left_padding = [int(x) for x in c.left_padding.tolist()]
-        if c.keys is None or int(c._idx) == 0:
-            out.append(_empty_quant_batch_cache(left_padding, kv_quant_config))
-            continue
-        merged_k = c.keys[..., : int(c._idx), :]
-        merged_v = c.values[..., : int(c._idx), :]
-        offset = [int(x) for x in c.offset.tolist()]
-        out.append(
-            _fill_batch_layer_cache(
-                merged_k,
-                merged_v,
-                left_padding=left_padding,
-                offset=offset,
-                quantize=True,
-                kv_quant_config=kv_quant_config,
-            )
+    return [
+        _align_exact_batch_cache_to_kv_policy(
+            cache,
+            kv_quant_config,
+            layer_idx=layer_idx,
+            num_layers=len(caches),
         )
-    return out
+        for layer_idx, cache in enumerate(caches)
+    ]
 
 
 def make_warm_batch_exact_cache_multi(
     row_caches: Sequence[Sequence[Any]],
     prefix_lens: Sequence[int],
     kv_quant_config: Optional[dict] = None,
+    *,
+    consume_sources: bool = False,
 ) -> Tuple[Optional[List[Any]], int]:
     """Merge single-row exact-cache snapshots into batch-aware caches.
 
     When *kv_quant_config* is provided, full-attention ``BatchKVCache`` layers
     are re-quantized to match live ``_make_cache`` via
     ``should_quantize_kv_layer`` (last layer stays float when n > 2). Hybrid
-    non-KV entries are unchanged. On-disk exact snapshots remain float.
+    non-KV entries are unchanged. On-disk exact snapshots remain float. When
+    *consume_sources* is true, each row must be a list; its entries are cleared
+    as their materialized batch layers take ownership of the restored state.
     """
 
     if not row_caches:
@@ -3937,25 +3966,45 @@ def make_warm_batch_exact_cache_multi(
     num_entries = len(row_caches[0])
     if any(len(row) != num_entries for row in row_caches):
         return None, 0
+    if consume_sources and any(not isinstance(row, list) for row in row_caches):
+        raise TypeError("consume_sources requires mutable cache-row lists")
 
     out: List[Any] = []
     for entry_idx in range(num_entries):
         merged = _merge_exact_cache_entries(
             [row[entry_idx] for row in row_caches],
             prefix_lens,
+            consume_sources=consume_sources,
         )
         if merged is None:
             return None, 0
+        if consume_sources and kv_quant_config is not None:
+            merged = _align_exact_batch_cache_to_kv_policy(
+                merged,
+                kv_quant_config,
+                layer_idx=entry_idx,
+                num_layers=num_entries,
+            )
         out.append(merged)
+        if consume_sources:
+            eval_targets: List[mx.array] = []
+            _collect_mx_arrays(merged.state, eval_targets)
+            if eval_targets:
+                mx.eval(eval_targets)
+            for row in row_caches:
+                if not isinstance(row, list):  # Guarded above; narrows the type.
+                    raise TypeError("consume_sources requires mutable cache-row lists")
+                row[entry_idx] = None
+            mx.clear_cache()
 
-    if kv_quant_config is not None:
-        out = _align_exact_batch_caches_to_kv_policy(out, kv_quant_config)
-
-    eval_targets: List[mx.array] = []
-    for c in out:
-        _collect_mx_arrays(c.state, eval_targets)
-    if eval_targets:
-        mx.eval(eval_targets)
+    if not consume_sources:
+        if kv_quant_config is not None:
+            out = _align_exact_batch_caches_to_kv_policy(out, kv_quant_config)
+        eval_targets: List[mx.array] = []
+        for cache in out:
+            _collect_mx_arrays(cache.state, eval_targets)
+        if eval_targets:
+            mx.eval(eval_targets)
     return out, max(prefix_lens) if prefix_lens else 0
 
 

--- a/mlx_vlm/apc_adapters.py
+++ b/mlx_vlm/apc_adapters.py
@@ -513,6 +513,90 @@ class PoolingCacheCloneAdapter:
         return type(caches[0]).merge(caches)
 
 
+class TurboQuantKVCacheCloneAdapter:
+    capability = Capability.PAGEABLE
+
+    @staticmethod
+    def _copy_state(state, eval_targets):
+        from .apc import _copy_mlx_array
+        from .turboquant import _map_state
+
+        def copy_leaf(value, ndim):
+            copied = _copy_mlx_array(value)
+            eval_targets.append(copied)
+            return copied
+
+        return _map_state(state, copy_leaf)
+
+    def clone(self, c, *, min_capacity_tokens, eval_targets):
+        from .turboquant import TurboQuantKVCache, _slice_state
+
+        out = TurboQuantKVCache(
+            bits=c.bits,
+            seed=c.seed,
+            key_bits=c.key_bits,
+            value_bits=c.value_bits,
+        )
+        out.key_codec = c.key_codec
+        out.value_codec = c.value_codec
+        out.offset = int(c.offset)
+        if c.keys is not None and out.offset > 0:
+            out.keys = self._copy_state(_slice_state(c.keys, out.offset), eval_targets)
+            out.values = self._copy_state(
+                _slice_state(c.values, out.offset), eval_targets
+            )
+        return out
+
+    @staticmethod
+    def _validate_rows(caches):
+        first = caches[0]
+        policy = (first.bits, first.key_bits, first.value_bits, first.seed)
+        return not any(
+            (cache.bits, cache.key_bits, cache.value_bits, cache.seed) != policy
+            for cache in caches[1:]
+        )
+
+    def _merge_rows(self, caches, *, borrow_single):
+        from .apc import _copy_mlx_array
+        from .turboquant import BatchTurboQuantKVCache, _map_state, _slice_state
+
+        if not self._validate_rows(caches):
+            return None
+        merged = None
+        for cache in caches:
+            row = BatchTurboQuantKVCache(
+                [0],
+                bits=cache.bits,
+                seed=cache.seed,
+                key_bits=cache.key_bits,
+                value_bits=cache.value_bits,
+            )
+            row.key_codec = cache.key_codec
+            row.value_codec = cache.value_codec
+            row._idx = int(cache.offset)
+            row.offset = mx.array([int(cache.offset)])
+            if cache.keys is not None and row._idx > 0:
+                keys = _slice_state(cache.keys, row._idx)
+                values = _slice_state(cache.values, row._idx)
+                if len(caches) == 1 and not borrow_single:
+                    keys = _map_state(keys, lambda value, ndim: _copy_mlx_array(value))
+                    values = _map_state(
+                        values, lambda value, ndim: _copy_mlx_array(value)
+                    )
+                row.keys, row.values = keys, values
+            if merged is None:
+                merged = row
+            else:
+                merged.extend(row)
+        return merged
+
+    def merge_rows(self, caches, prefix_lens):
+        return self._merge_rows(caches, borrow_single=False)
+
+    def merge_rows_consuming(self, caches, prefix_lens):
+        return self._merge_rows(caches, borrow_single=True)
+
+
 _CLONE_RULES: Optional[list] = None
 
 
@@ -528,6 +612,12 @@ def _clone_rules():
             (lm.ArraysCache, ArraysCacheCloneAdapter()),
             (lm.PoolingCache, PoolingCacheCloneAdapter()),
         ]
+        try:
+            from .turboquant import TurboQuantKVCache
+
+            _CLONE_RULES.append((TurboQuantKVCache, TurboQuantKVCacheCloneAdapter()))
+        except ImportError:
+            pass
     return _CLONE_RULES
 
 
@@ -650,8 +740,9 @@ def merge_cache_entries(entries, prefix_lens, *, consume_sources=False):
         else:
             ok = all(isinstance(c, typ) for c in entries)
         if ok:
-            if consume_sources and typ is lm.KVCache:
-                return adapter.merge_rows_consuming(entries, prefix_lens)
+            merge_consuming = getattr(adapter, "merge_rows_consuming", None)
+            if consume_sources and callable(merge_consuming):
+                return merge_consuming(entries, prefix_lens)
             return adapter.merge_rows(entries, prefix_lens)
     if all(isinstance(c, lm.CacheList) for c in entries):
         merged = [

--- a/mlx_vlm/apc_adapters.py
+++ b/mlx_vlm/apc_adapters.py
@@ -391,6 +391,21 @@ class KVCacheCloneAdapter:
 
         return lm.BatchKVCache.merge(caches)
 
+    def merge_rows_consuming(self, caches, prefix_lens):
+        """Transfer a single detached row into its batch cache without copying."""
+        from .models import cache as lm
+
+        if len(caches) == 1:
+            source = caches[0]
+            offset = int(getattr(source, "offset", 0) or 0)
+            out = lm.BatchKVCache([0])
+            out.keys = source.keys
+            out.values = source.values
+            out.offset = mx.array([offset])
+            out._idx = offset
+            return out
+        return self.merge_rows(caches, prefix_lens)
+
 
 class RotatingKVCacheCloneAdapter:
     capability = Capability.WINDOWED
@@ -622,7 +637,8 @@ def clone_cache_entry(c, *, min_capacity_tokens, eval_targets):
     return None
 
 
-def merge_cache_entries(entries, prefix_lens):
+def merge_cache_entries(entries, prefix_lens, *, consume_sources=False):
+    """Merge exact-cache rows, optionally transferring detached KV storage."""
     from .models import cache as lm
 
     if not entries:
@@ -634,16 +650,26 @@ def merge_cache_entries(entries, prefix_lens):
         else:
             ok = all(isinstance(c, typ) for c in entries)
         if ok:
+            if consume_sources and typ is lm.KVCache:
+                return adapter.merge_rows_consuming(entries, prefix_lens)
             return adapter.merge_rows(entries, prefix_lens)
     if all(isinstance(c, lm.CacheList) for c in entries):
         merged = [
-            merge_cache_entries([e.caches[i] for e in entries], prefix_lens)
+            merge_cache_entries(
+                [e.caches[i] for e in entries],
+                prefix_lens,
+                consume_sources=consume_sources,
+            )
             for i in range(len(first.caches))
         ]
         return None if any(m is None for m in merged) else lm.CacheList(*merged)
     if all(isinstance(c, tuple) for c in entries):
         merged = [
-            merge_cache_entries([e[i] for e in entries], prefix_lens)
+            merge_cache_entries(
+                [e[i] for e in entries],
+                prefix_lens,
+                consume_sources=consume_sources,
+            )
             for i in range(len(first))
         ]
         return None if any(m is None for m in merged) else lm.CacheList(*merged)

--- a/mlx_vlm/apc_coordinator.py
+++ b/mlx_vlm/apc_coordinator.py
@@ -109,13 +109,18 @@ class APCCoordinator:
 
         if self.is_checkpoint:
             row_caches = [
-                pick["warm_cache"] if pick is not None else self.fresh_cache()
+                (
+                    list(pick.pop("warm_cache"))
+                    if pick is not None
+                    else self.fresh_cache()
+                )
                 for pick in picks
             ]
             return make_warm_batch_exact_cache_multi(
                 row_caches,
                 prefix_lens,
                 kv_quant_config=kv_quant_config,
+                consume_sources=True,
             )
         return make_warm_batch_kv_cache_multi(
             list(picks),
@@ -157,7 +162,10 @@ class APCCoordinator:
         if snapshot is None:
             return False
         return self.manager.store_exact_cache(
-            token_ids, snapshot, extra_hash=extra_hash
+            token_ids,
+            snapshot,
+            extra_hash=extra_hash,
+            take_ownership=True,
         )
 
     def commit(

--- a/mlx_vlm/generate/ar.py
+++ b/mlx_vlm/generate/ar.py
@@ -1922,21 +1922,23 @@ class PromptProcessingBatch:
                 continue
             if self._row_real_tokens_processed(batch_idx) != checkpoint_len:
                 continue
-            prompt_cache = self._apc_prompt_cache_for_store(batch_idx)
-            if prompt_cache is None:
-                continue
             coordinator = getattr(self, "_apc_coordinator", None)
             if coordinator is not None:
                 coordinator.store_checkpoint(
                     meta["full_input_ids"][:checkpoint_len],
-                    prompt_cache,
+                    self.prompt_cache,
                     extra_hash=meta.get("extra_hash", 0),
+                    batch_idx=batch_idx,
                 )
             else:
+                prompt_cache = self._apc_prompt_cache_for_store(batch_idx)
+                if prompt_cache is None:
+                    continue
                 self._apc_manager.store_exact_cache(
                     meta["full_input_ids"][:checkpoint_len],
                     prompt_cache,
                     extra_hash=meta.get("extra_hash", 0),
+                    take_ownership=True,
                 )
             meta["checkpoint_done"] = True
 
@@ -2184,6 +2186,7 @@ class PromptProcessingBatch:
                                 meta["full_input_ids"],
                                 prompt_cache,
                                 extra_hash=meta.get("extra_hash", 0),
+                                take_ownership=True,
                             )
                         self._apc_manager.release(meta.get("apc_blocks", []))
                     else:
@@ -2574,13 +2577,18 @@ class BatchGenerator:
             )
         elif apc_mode == "exact":
             row_caches = [
-                p["warm_cache"] if p is not None else self.model.make_cache()
+                (
+                    list(p.pop("warm_cache"))
+                    if p is not None
+                    else list(self.model.make_cache())
+                )
                 for p in picks
             ]
             warm_cache, _ = _apc.make_warm_batch_exact_cache_multi(
                 row_caches,
                 prefix_lens,
                 kv_quant_config=_quant_cfg,
+                consume_sources=True,
             )
         else:
             num_layers = (

--- a/mlx_vlm/tests/test_apc.py
+++ b/mlx_vlm/tests/test_apc.py
@@ -930,6 +930,179 @@ def test_exact_cache_disk_restore_rebuilds_index(tmp_path, monkeypatch):
     manager.close()
 
 
+def test_exact_cache_snapshot_keeps_turboquant_state_packed():
+    from mlx_vlm.apc import snapshot_prompt_cache_row
+    from mlx_vlm.turboquant import BatchTurboQuantKVCache, TurboQuantKVCache
+
+    cache = BatchTurboQuantKVCache([0], bits=3.5)
+    keys = mx.arange(1 * 2 * 12 * 32, dtype=mx.float32).reshape(1, 2, 12, 32)
+    values = keys + 1000
+    cache.update_and_fetch(keys, values)
+    mx.eval(cache.state)
+
+    snapshot = snapshot_prompt_cache_row([cache])
+
+    assert snapshot is not None
+    restored = snapshot[0]
+    assert isinstance(restored, TurboQuantKVCache)
+    assert (restored.bits, restored.key_bits, restored.value_bits) == (3.5, 3.0, 4.0)
+    assert restored.offset == 12
+    assert restored.keys is not cache.keys
+    assert restored.values is not cache.values
+    assert restored.keys.indices.dtype == mx.uint32
+    assert restored.values.indices.dtype == mx.uint32
+
+
+def test_exact_disk_roundtrip_preserves_q4_and_q3_5_turboquant(tmp_path, monkeypatch):
+    from mlx_vlm.apc import snapshot_prompt_cache_row
+    from mlx_vlm.turboquant import BatchTurboQuantKVCache, TurboQuantKVCache
+
+    monkeypatch.setenv("APC_EXACT_CACHE_ENTRIES", "0")
+    monkeypatch.setenv("APC_EXACT_MIN_TOKENS", "1")
+    token_ids = list(range(12))
+    for bits, expected_widths in ((4.0, (4.0, 4.0)), (3.5, (3.0, 4.0))):
+        cache = BatchTurboQuantKVCache([0], bits=bits, seed=23)
+        keys = mx.arange(1 * 2 * 12 * 32, dtype=mx.float32).reshape(1, 2, 12, 32)
+        cache.update_and_fetch(keys, keys + 1000)
+        snapshot = snapshot_prompt_cache_row([cache])
+        assert snapshot is not None
+
+        namespace = f"packed-turboquant-{bits}"
+        disk = DiskBlockStore(tmp_path, namespace=namespace)
+        manager = APCManager(num_blocks=1, block_size=4, disk=disk)
+        assert manager.store_exact_cache(token_ids, snapshot, take_ownership=True)
+        disk._q.join()
+        manager.close()
+
+        disk = DiskBlockStore(tmp_path, namespace=namespace)
+        manager = APCManager(num_blocks=1, block_size=4, disk=disk)
+        warm, matched_tokens = manager.lookup_exact_cache(token_ids + [999])
+
+        assert matched_tokens == len(token_ids)
+        assert warm is not None
+        restored = warm[0]
+        assert isinstance(restored, TurboQuantKVCache)
+        assert restored.bits == bits
+        assert (restored.key_bits, restored.value_bits) == expected_widths
+        assert restored.seed == 23
+        _assert_allclose(
+            restored.key_codec.dequantize(restored.keys),
+            cache.key_codec.dequantize(cache.keys),
+        )
+        manager.close()
+
+
+def test_exact_merge_preserves_two_packed_turboquant_rows():
+    from mlx_vlm.apc import snapshot_prompt_cache_row
+    from mlx_vlm.turboquant import BatchTurboQuantKVCache
+
+    rows = []
+    for length, value in ((12, 1), (8, 2)):
+        cache = BatchTurboQuantKVCache([0], bits=3.5)
+        keys = mx.full((1, 2, length, 32), value, dtype=mx.float32)
+        cache.update_and_fetch(keys, keys + 10)
+        snapshot = snapshot_prompt_cache_row([cache])
+        assert snapshot is not None
+        rows.append(snapshot)
+
+    batch, max_prefix = make_warm_batch_exact_cache_multi(
+        rows,
+        [12, 8],
+        kv_quant_config={
+            "bits": 3.5,
+            "scheme": "turboquant",
+            "group_size": 64,
+        },
+        consume_sources=True,
+    )
+
+    assert max_prefix == 12
+    assert batch is not None
+    assert isinstance(batch[0], BatchTurboQuantKVCache)
+    assert batch[0]._idx == 12
+    assert batch[0].offset.tolist() == [12, 8]
+    assert batch[0].left_padding.tolist() == [0, 4]
+    assert all(row[0] is None for row in rows)
+
+    next_keys = mx.full((2, 2, 1, 32), 3, dtype=mx.float32)
+    batch[0].update_and_fetch(next_keys, next_keys + 10)
+    mx.eval(batch[0].state)
+    assert batch[0]._idx == 13
+    assert batch[0].offset.tolist() == [13, 9]
+
+
+def test_exact_disk_roundtrip_preserves_packed_turboquant_widths(tmp_path, monkeypatch):
+    from mlx_vlm.apc import snapshot_prompt_cache_row
+    from mlx_vlm.turboquant import BatchTurboQuantKVCache, TurboQuantKVCache
+
+    monkeypatch.setenv("APC_EXACT_CACHE_ENTRIES", "0")
+    monkeypatch.setenv("APC_EXACT_MIN_TOKENS", "1")
+    token_ids = list(range(12))
+    cache = BatchTurboQuantKVCache([0], bits=5.5, key_bits=3, value_bits=8, seed=17)
+    keys = mx.arange(1 * 2 * 12 * 32, dtype=mx.float32).reshape(1, 2, 12, 32)
+    values = keys + 1000
+    cache.update_and_fetch(keys, values)
+    snapshot = snapshot_prompt_cache_row([cache])
+    assert snapshot is not None
+
+    disk = DiskBlockStore(tmp_path, namespace="packed-turboquant")
+    manager = APCManager(num_blocks=1, block_size=4, disk=disk)
+    assert manager.store_exact_cache(token_ids, snapshot, take_ownership=True)
+    disk._q.join()
+    snapshot_path = next(iter(disk._exact_index.values()))
+    _, metadata, _ = disk._open_shard_header(snapshot_path)
+    assert metadata["c0_kind"] == "turboquant_kv"
+    assert metadata["c0_key_bits"] == "3.0"
+    assert metadata["c0_value_bits"] == "8.0"
+    manager.close()
+
+    disk = DiskBlockStore(tmp_path, namespace="packed-turboquant")
+    manager = APCManager(num_blocks=1, block_size=4, disk=disk)
+    warm, matched_tokens = manager.lookup_exact_cache(token_ids + [999])
+
+    assert matched_tokens == len(token_ids)
+    assert warm is not None
+    restored = warm[0]
+    assert isinstance(restored, TurboQuantKVCache)
+    assert (restored.bits, restored.key_bits, restored.value_bits) == (5.5, 3.0, 8.0)
+    assert restored.seed == 17
+    assert restored.offset == len(token_ids)
+    assert restored.keys.indices.dtype == mx.uint32
+    assert restored.values.indices.dtype == mx.uint32
+    _assert_allclose(
+        restored.key_codec.dequantize(restored.keys),
+        cache.key_codec.dequantize(cache.keys),
+    )
+    _assert_allclose(
+        restored.value_codec.dequantize(restored.values),
+        cache.value_codec.dequantize(cache.values),
+    )
+
+    rows = [list(warm)]
+    batch, max_prefix = make_warm_batch_exact_cache_multi(
+        rows,
+        [len(token_ids)],
+        kv_quant_config={
+            "bits": 5.5,
+            "scheme": "turboquant",
+            "key_bits": 3,
+            "value_bits": 8,
+            "group_size": 64,
+        },
+        consume_sources=True,
+    )
+    assert max_prefix == len(token_ids)
+    assert batch is not None
+    assert isinstance(batch[0], BatchTurboQuantKVCache)
+    assert (batch[0].bits, batch[0].key_bits, batch[0].value_bits) == (
+        5.5,
+        3.0,
+        8.0,
+    )
+    assert rows[0][0] is None
+    manager.close()
+
+
 def test_exact_disk_restore_keeps_the_first_decode_growth_boundary(
     tmp_path, monkeypatch
 ):

--- a/mlx_vlm/tests/test_apc.py
+++ b/mlx_vlm/tests/test_apc.py
@@ -305,6 +305,95 @@ def test_exact_batch_cache_merge_and_extract_supports_arrays_and_kv():
     assert extracted[1].offset == 12
 
 
+def test_single_row_exact_merge_consumes_source_and_preserves_capacity():
+    from mlx_vlm.models.cache import BatchKVCache, KVCache
+
+    prefix_len = 40
+    reserved_capacity = 1024
+    cache = KVCache()
+    cache.keys = mx.zeros((1, 1, reserved_capacity, 2), dtype=mx.float16)
+    cache.values = mx.ones((1, 1, reserved_capacity, 2), dtype=mx.float16)
+    cache.offset = prefix_len
+    original_keys = cache.keys
+    original_values = cache.values
+
+    rows = [[cache]]
+    warm, matched = make_warm_batch_exact_cache_multi(
+        rows,
+        [prefix_len],
+        consume_sources=True,
+    )
+
+    assert matched == prefix_len
+    assert warm is not None
+    assert isinstance(warm[0], BatchKVCache)
+    assert warm[0]._idx == prefix_len
+    assert int(warm[0].offset[0].item()) == prefix_len
+    assert warm[0].keys is original_keys
+    assert warm[0].values is original_values
+    assert warm[0].keys.shape[2] == reserved_capacity
+    assert warm[0].state[0].shape[2] == prefix_len
+    assert rows[0][0] is None
+
+    warm[0].update_and_fetch(
+        mx.full((1, 1, 8, 2), 2, dtype=mx.float16),
+        mx.full((1, 1, 8, 2), 3, dtype=mx.float16),
+    )
+    assert warm[0].keys is original_keys
+    assert warm[0].values is original_values
+    assert warm[0]._idx == prefix_len + 8
+
+
+def test_single_row_exact_merge_without_consuming_keeps_copy_semantics():
+    from mlx_vlm.models.cache import BatchKVCache, KVCache
+
+    prefix_len = 40
+    cache = KVCache()
+    cache.keys = mx.zeros((1, 1, 64, 2), dtype=mx.float16)
+    cache.values = mx.ones((1, 1, 64, 2), dtype=mx.float16)
+    cache.offset = prefix_len
+    original_keys = cache.keys
+    original_values = cache.values
+
+    rows = [[cache]]
+    warm, matched = make_warm_batch_exact_cache_multi(rows, [prefix_len])
+
+    assert matched == prefix_len
+    assert warm is not None
+    assert isinstance(warm[0], BatchKVCache)
+    assert warm[0].keys is not original_keys
+    assert warm[0].values is not original_values
+    assert rows[0][0] is cache
+
+
+def test_exact_merge_releases_each_source_layer_before_clearing(monkeypatch):
+    from mlx_vlm.models.cache import KVCache
+
+    row = []
+    for value in (1, 2):
+        cache = KVCache()
+        cache.keys = mx.full((1, 1, 4, 2), value, dtype=mx.float16)
+        cache.values = mx.full((1, 1, 4, 2), value + 1, dtype=mx.float16)
+        cache.offset = 4
+        row.append(cache)
+    rows = [row]
+    released_at_clear = []
+    clear_cache = lambda: released_at_clear.append(
+        tuple(cache is None for cache in rows[0])
+    )
+    monkeypatch.setattr(mx, "clear_cache", clear_cache)
+
+    warm, matched = make_warm_batch_exact_cache_multi(
+        rows,
+        [4],
+        consume_sources=True,
+    )
+
+    assert warm is not None
+    assert matched == 4
+    assert released_at_clear == [(True, False), (True, True)]
+
+
 def test_single_row_prompt_batch_exact_checkpoint_stores_without_extract():
     from mlx_vlm.generate.ar import PromptProcessingBatch
     from mlx_vlm.models.cache import ArraysCache, KVCache, RotatingKVCache
@@ -346,6 +435,43 @@ def test_single_row_prompt_batch_exact_checkpoint_stores_without_extract():
 
     assert batch._apc_meta[0]["checkpoint_done"] is True
     assert batch._apc_manager.stats_snapshot()["exact_stores"] == 1
+
+
+def test_exact_checkpoint_with_coordinator_stores_live_cache_once(monkeypatch):
+    from unittest.mock import MagicMock
+
+    from mlx_vlm.generate.ar import PromptProcessingBatch
+
+    batch = PromptProcessingBatch.__new__(PromptProcessingBatch)
+    batch.prompt_cache = [object()]
+    batch._apc_manager = object()
+    batch._apc_coordinator = MagicMock()
+    batch._apc_meta = [
+        {
+            "full_input_ids": list(range(32)),
+            "prefix_len": 0,
+            "checkpoint_len": 32,
+            "extra_hash": 9,
+        }
+    ]
+    monkeypatch.setattr(batch, "_row_real_tokens_processed", lambda index: 32)
+    monkeypatch.setattr(
+        batch,
+        "_apc_prompt_cache_for_store",
+        lambda index: (_ for _ in ()).throw(
+            AssertionError("the coordinator must create the only snapshot")
+        ),
+    )
+
+    batch._store_apc_exact_checkpoints()
+
+    batch._apc_coordinator.store_checkpoint.assert_called_once_with(
+        list(range(32)),
+        batch.prompt_cache,
+        extra_hash=9,
+        batch_idx=0,
+    )
+    assert batch._apc_meta[0]["checkpoint_done"] is True
 
 
 def test_apc_max_pool_tensors_keeps_disk_persistence(tmp_path, monkeypatch):
@@ -721,6 +847,47 @@ def test_exact_cache_supports_rotating_and_chunked_kv_cache():
     assert warm[2].start_position == chunked.start_position
     _assert_allclose(warm[2].keys, chunked.keys)
     _assert_allclose(warm[2].values, chunked.values)
+
+
+def test_exact_cache_store_can_take_ownership_without_cloning(monkeypatch):
+    from mlx_vlm.models.cache import KVCache
+
+    token_ids = list(range(32))
+    kv = KVCache()
+    kv.keys = mx.ones((1, 1, len(token_ids), 2))
+    kv.values = mx.ones((1, 1, len(token_ids), 2)) * 2
+    kv.offset = len(token_ids)
+    manager = APCManager(num_blocks=1, block_size=16)
+
+    def fail_clone(*args, **kwargs):
+        raise AssertionError("an owned snapshot must not be cloned again")
+
+    monkeypatch.setattr(apc_module, "_clone_prompt_cache_for_apc", fail_clone)
+
+    assert manager.store_exact_cache(
+        token_ids,
+        [kv],
+        take_ownership=True,
+    )
+    stored = next(iter(manager._exact_cache.values())).prompt_cache
+    assert stored[0] is kv
+
+
+def test_exact_cache_store_clones_by_default():
+    from mlx_vlm.models.cache import KVCache
+
+    token_ids = list(range(32))
+    kv = KVCache()
+    kv.keys = mx.ones((1, 1, len(token_ids), 2))
+    kv.values = mx.ones((1, 1, len(token_ids), 2)) * 2
+    kv.offset = len(token_ids)
+    manager = APCManager(num_blocks=1, block_size=16)
+
+    assert manager.store_exact_cache(token_ids, [kv])
+    stored = next(iter(manager._exact_cache.values())).prompt_cache
+    assert stored[0] is not kv
+    assert stored[0].keys is not kv.keys
+    assert stored[0].values is not kv.values
 
 
 def test_exact_cache_disk_restore_rebuilds_index(tmp_path, monkeypatch):

--- a/mlx_vlm/tests/test_apc_adapters.py
+++ b/mlx_vlm/tests/test_apc_adapters.py
@@ -738,7 +738,10 @@ class TestBatchTurboQuantParity:
         assert isinstance(row[0], TurboQuantKVCache)
         cloned = _clone_prompt_cache_for_apc(row)
         assert cloned is not None
-        assert isinstance(cloned[0], KVCache)
+        assert isinstance(cloned[0], TurboQuantKVCache)
+        assert cloned[0].keys is not row[0].keys
+        assert cloned[0].values is not row[0].values
+        assert cloned[0].meta_state == row[0].meta_state
 
     def test_layer_kv_for_apc_batch_turbo(self):
         from mlx_vlm.apc import layer_kv_for_apc

--- a/mlx_vlm/tests/test_apc_component_adapters.py
+++ b/mlx_vlm/tests/test_apc_component_adapters.py
@@ -156,6 +156,70 @@ def test_coordinator_hides_dense_vs_hybrid_storage_strategy():
     assert hybrid.enabled and hybrid.strategy == "checkpoint"
 
 
+def test_checkpoint_coordinator_consumes_restored_rows(monkeypatch):
+    from mlx_vlm import apc
+    from mlx_vlm.apc import APCManager
+    from mlx_vlm.apc_coordinator import APCCoordinator
+
+    class Hybrid:
+        def make_cache(self):
+            return [C.KVCache(), C.ArraysCache(2)]
+
+    coordinator = APCCoordinator(APCManager(num_blocks=4, block_size=4), Hybrid())
+    source = [C.KVCache(), C.ArraysCache(2)]
+    pick = {"warm_cache": source}
+    captured = {}
+
+    def merge(row_caches, prefix_lens, **kwargs):
+        captured["rows"] = row_caches
+        captured["prefix_lens"] = prefix_lens
+        captured["kwargs"] = kwargs
+        return [object()], 4
+
+    monkeypatch.setattr(apc, "make_warm_batch_exact_cache_multi", merge)
+
+    merged, matched = coordinator.merge_rows([pick], [4])
+
+    assert merged is not None and matched == 4
+    assert "warm_cache" not in pick
+    assert captured["rows"][0] is not source
+    assert captured["rows"][0][0] is source[0]
+    assert captured["kwargs"]["consume_sources"] is True
+
+
+def test_checkpoint_coordinator_transfers_detached_snapshot(monkeypatch):
+    from types import SimpleNamespace
+
+    from mlx_vlm import apc
+    from mlx_vlm.apc_coordinator import APCCoordinator
+
+    class Hybrid:
+        def make_cache(self):
+            return [C.KVCache(), C.ArraysCache(2)]
+
+    calls = []
+    manager = SimpleNamespace(
+        store_exact_cache=lambda *args, **kwargs: calls.append((args, kwargs)) or True
+    )
+    snapshot = [object()]
+    monkeypatch.setattr(apc, "snapshot_prompt_cache_row", lambda *args: snapshot)
+    coordinator = APCCoordinator(manager, Hybrid())
+
+    assert coordinator.store_checkpoint(
+        list(range(32)),
+        [object()],
+        extra_hash=7,
+        batch_idx=1,
+    )
+
+    assert calls == [
+        (
+            (list(range(32)), snapshot),
+            {"extra_hash": 7, "take_ownership": True},
+        )
+    ]
+
+
 def test_registry_eligibility_helpers():
     from mlx_vlm.models.unlimited_ocr.language import RingSlidingKVCache
 


### PR DESCRIPTION
Stacked on #2072. Until that PR lands, the GitHub diff also includes its exact-APC ownership-transfer changes; the intended delta here is the packed TurboQuant snapshot support.

## Summary

- keep exact-APC TurboQuant snapshots in their packed representation in memory and on disk
- preserve the exact TurboQuant state type, key/value bit widths, seed, offset, and codec configuration
- restore packed rows directly into `BatchTurboQuantKVCache` without a BF16 round trip
- keep non-consuming merge semantics defensive: only the explicit consuming path borrows a single restored row

## Why

After #2072, exact APC releases restored sources layer by layer and avoids redundant ownership copies. TurboQuant snapshots still took an avoidable representation round trip, however:

```text
packed live TQ KV -> BF16 exact snapshot -> disk -> BF16 restore -> packed batch TQ KV
```

That expanded both the shard and the restore working set, then spent time requantizing data that was already quantized. This PR adds a distinct `turboquant_kv` exact-snapshot schema and keeps the state packed end to end.

Existing float exact snapshots remain readable through the existing `kv` schema. Other cache adapters keep their current behavior.

## Isolated results

I compared current #2072 with this PR in fresh processes on a 24 GB M-series machine. The synthetic cache has the 16 accumulating full-attention layers of Qwen3.8-27B (4 KV heads, head dimension 256) and TQ4 KV. The 16K results are medians of two runs in ABBA order.

| 16K exact snapshot metric | #2072 | This PR | Change |
|---|---:|---:|---:|
| On-disk shard | 2,048.1 MiB | 260.1 MiB | -87.3% |
| Snapshot MLX peak | 3,597.5 MiB | 780.5 MiB | -78.3% |
| Snapshot construction | 184.7 ms | 14.0 ms | -92.4% |
| Restore lookup MLX peak | 3,510.0 MiB | 260.5 MiB | -92.6% |
| Restore lookup | 261.9 ms | 82.2 ms | -68.6% |
| Merge into batch TQ cache | 265.8 ms | 0.44 ms | -99.8% |

A 64K capacity point showed the same scaling:

| 64K exact snapshot metric | #2072 | This PR |
|---|---:|---:|
| On-disk shard | 8,192.4 MiB | 1,040.4 MiB |
| Restore lookup MLX peak | 11,051.0 MiB | 1,040.5 MiB |
| Restore lookup | 2.135 s | 0.171 s |
| Merge into batch TQ cache | 0.836 s | 0.00052 s |

These are cache-transformation measurements, not full-server process-footprint claims.

## Real-model canary

I also ran a cold/warm server canary with Qwen3.8-27B MXFP4, its Q8 vision tower, and TQ4 KV. The cold request had 5,012 prompt tokens. A second identical request restored 5,011 tokens from the packed exact snapshot, returned HTTP 200, and reduced wall time from 40.32 s to 0.351 s. The restored cache continued as `BatchTurboQuantKVCache`; no traceback or watchdog trip occurred.

## Tests

- Q4, Q3.5, and asymmetric K3/V8 packed disk round trips
- detached snapshot ownership and consuming/non-consuming merge behavior
- single-row and padded two-row merge, followed by cache growth
- full suite on MLX 0.32.2: `2916 passed, 7 skipped, 75 subtests passed`
- Black, isort, autoflake, Python compilation, and `git diff --check` pass