### PR TITLE
Fall back to globbing when the safetensors index is stale

### DIFF
--- a/mlx_vlm/tests/test_utils.py
+++ b/mlx_vlm/tests/test_utils.py
@@ -1,5 +1,6 @@
 import base64
 import json
+import logging
 import struct
 from io import BytesIO
 from pathlib import Path
@@ -16,6 +17,7 @@ from mlx_vlm.models.text_only import TextOnlyModel
 from mlx_vlm.utils import (
     StoppingCriteria,
     _load_safetensors,
+    _resolve_weight_files,
     apply_generation_config_defaults,
     get_model_and_args,
     load,
@@ -927,3 +929,60 @@ class TestLoadImage:
     def test_nonexistent_path_object_raises(self):
         with pytest.raises(ValueError, match="Failed to load image"):
             load_image(Path("/nonexistent/path/image.png"))
+
+
+class TestResolveWeightFiles:
+    def _shard(self, path, name):
+        (path / name).write_bytes(b"stub")
+
+    def _index(self, path, shard_names):
+        index = {
+            "weight_map": {f"layer.{i}": name for i, name in enumerate(shard_names)}
+        }
+        (path / "model.safetensors.index.json").write_text(json.dumps(index))
+
+    def test_complete_index_is_used(self, tmp_path):
+        self._shard(tmp_path, "model-00001-of-00002.safetensors")
+        self._shard(tmp_path, "model-00002-of-00002.safetensors")
+        self._shard(tmp_path, "consolidated.safetensors")
+        self._index(
+            tmp_path,
+            ["model-00001-of-00002.safetensors", "model-00002-of-00002.safetensors"],
+        )
+        files = _resolve_weight_files(tmp_path)
+        assert [Path(f).name for f in files] == [
+            "model-00001-of-00002.safetensors",
+            "model-00002-of-00002.safetensors",
+        ]
+
+    def test_stale_index_falls_back_to_glob_and_warns(self, tmp_path, caplog):
+        # The index names shards from a previous upload; only some (or none)
+        # exist on disk. Trusting it would load a partial weight set.
+        self._shard(tmp_path, "model-00001-of-00002.safetensors")
+        self._shard(tmp_path, "actual.safetensors")
+        self._index(
+            tmp_path,
+            ["model-00001-of-00002.safetensors", "model-00002-of-00002.safetensors"],
+        )
+        with caplog.at_level(logging.WARNING):
+            files = _resolve_weight_files(tmp_path)
+        assert sorted(Path(f).name for f in files) == [
+            "actual.safetensors",
+            "model-00001-of-00002.safetensors",
+        ]
+        assert any("stale" in record.message for record in caplog.records)
+
+    def test_no_index_globs(self, tmp_path):
+        self._shard(tmp_path, "model.safetensors")
+        self._shard(tmp_path, "consolidated.safetensors")
+        files = _resolve_weight_files(tmp_path)
+        assert [Path(f).name for f in files] == ["model.safetensors"]
+
+    def test_corrupt_index_globs(self, tmp_path):
+        self._shard(tmp_path, "model.safetensors")
+        (tmp_path / "model.safetensors.index.json").write_text("{not json")
+        files = _resolve_weight_files(tmp_path)
+        assert [Path(f).name for f in files] == ["model.safetensors"]
+
+    def test_empty_dir_returns_empty(self, tmp_path):
+        assert _resolve_weight_files(tmp_path) == []

--- a/mlx_vlm/utils.py
+++ b/mlx_vlm/utils.py
@@ -606,6 +606,43 @@ def get_model_path(
     return model_path
 
 
+def _resolve_weight_files(model_path: Path) -> List[str]:
+    """Resolve the model's safetensors shards, preferring the index file.
+
+    Falls back to globbing ``*.safetensors`` when the index is absent,
+    unreadable, or stale — i.e. it references shards that are missing on
+    disk. Trusting a stale index would silently load a partial weight set
+    that only fails much later, in ``load_weights``, with a confusing
+    missing-parameter error instead of pointing at the real cause.
+    """
+    index_file = model_path / "model.safetensors.index.json"
+    if index_file.exists():
+        try:
+            with open(index_file) as f:
+                weight_map = json.load(f).get("weight_map", {})
+        except (ValueError, OSError):
+            weight_map = {}
+        shards = sorted(set(weight_map.values()))
+        missing = [shard for shard in shards if not (model_path / shard).exists()]
+        if shards and not missing:
+            return [str(model_path / shard) for shard in shards]
+        if missing:
+            logging.warning(
+                "%s references %d shard(s) not present in %s (e.g. %s); "
+                "treating the index as stale and discovering shards by "
+                "globbing *.safetensors instead.",
+                index_file.name,
+                len(missing),
+                model_path,
+                missing[0],
+            )
+    return [
+        wf
+        for wf in glob.glob(str(model_path / "*.safetensors"))
+        if not wf.endswith("consolidated.safetensors")
+    ]
+
+
 def load_model(model_path: Path, lazy: bool = False, **kwargs) -> nn.Module:
     """
     Load and initialize the model from a given path.
@@ -631,25 +668,7 @@ def load_model(model_path: Path, lazy: bool = False, **kwargs) -> nn.Module:
     strict = kwargs.pop("strict", True)
     config = load_config(model_path, **kwargs)
 
-    index_file = model_path / "model.safetensors.index.json"
-    weight_files = []
-    if index_file.exists():
-        try:
-            with open(index_file) as f:
-                weight_map = json.load(f).get("weight_map", {})
-            weight_files = [
-                str(model_path / shard)
-                for shard in sorted(set(weight_map.values()))
-                if (model_path / shard).exists()
-            ]
-        except (ValueError, OSError):
-            weight_files = []
-    if not weight_files:
-        weight_files = [
-            wf
-            for wf in glob.glob(str(model_path / "*.safetensors"))
-            if not wf.endswith("consolidated.safetensors")
-        ]
+    weight_files = _resolve_weight_files(model_path)
 
     if not weight_files:
         logging.error(f"No safetensors found in {model_path}")


### PR DESCRIPTION
load_model() filters the shards named in model.safetensors.index.json by existence. When the index is stale (checkpoints re-quantized or renamed without regenerating the index, as some hub repos have shipped), the filtered list is non-empty but incomplete, so the *.safetensors glob fallback never fires and loading proceeds with a partial weight set that only fails much later in load_weights with a missing-parameter error that names tensors, not the real cause.

Extract shard resolution into _resolve_weight_files(): use the index only when every shard it names exists; otherwise warn that the index is stale and discover shards by globbing. Behavior is unchanged for complete indexes, absent indexes, and unreadable indexes.