### PR TITLE
generate: reuse a running mlx-vlm server via --base-url

### DIFF
--- a/mlx_vlm/generate/dispatch.py
+++ b/mlx_vlm/generate/dispatch.py
@@ -74,6 +74,20 @@ def parse_arguments():
         help="The path to the local model directory or Hugging Face repo.",
     )
     parser.add_argument(
+        "--base-url",
+        type=str,
+        default=None,
+        help="Reuse a running mlx-vlm server instead of loading the model "
+        "locally. Also read from $MLX_VLM_BASE_URL. With no base URL, "
+        "generation runs locally.",
+    )
+    parser.add_argument(
+        "--api-key",
+        type=str,
+        default=None,
+        help="API key for the server (also read from $MLX_VLM_API_KEY).",
+    )
+    parser.add_argument(
         "--output-modality",
         type=str,
         choices=("text", "image", "video"),
@@ -1243,6 +1257,12 @@ def main():
         args.audio = [args.audio]
     if isinstance(args.video, str):
         args.video = [args.video]
+
+    # Reuse a running server when --base-url is set; otherwise load locally.
+    from .remote import run_on_server
+
+    if run_on_server(args):
+        return
 
     model, processor = load(
         args.model,

--- a/mlx_vlm/generate/remote.py
+++ b/mlx_vlm/generate/remote.py
@@ -1,0 +1,157 @@
+"""Server-aware execution for ``mlx_vlm generate``.
+
+With ``--base-url`` (or ``$MLX_VLM_BASE_URL``) set, forward the request to a
+running mlx-vlm server and stream the reply; otherwise generate locally.
+"""
+
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+
+# Options that change the model itself and cannot be honored over the chat API.
+_LOCAL_ONLY = ("adapter_path", "draft_model", "quantize_activations")
+
+
+def resolve_base_url(args):
+    """--base-url, then $MLX_VLM_BASE_URL, else None. None means run locally."""
+    return getattr(args, "base_url", None) or os.environ.get("MLX_VLM_BASE_URL")
+
+
+def _auth_header(args):
+    key = getattr(args, "api_key", None) or os.environ.get("MLX_VLM_API_KEY")
+    return {"Authorization": f"Bearer {key}"} if key else {}
+
+
+def _prompt_text(args):
+    """--prompt is nargs='+' (a list of words) or the string default."""
+    prompt = args.prompt
+    return " ".join(prompt) if isinstance(prompt, list) else str(prompt)
+
+
+def build_messages(args):
+    """Build chat messages; image paths/URLs pass through for the server to resolve."""
+    messages = []
+    if getattr(args, "system", None):
+        messages.append({"role": "system", "content": args.system})
+
+    text = _prompt_text(args)
+    images = getattr(args, "image", None) or []
+    if isinstance(images, str):
+        images = [images]
+    if images:
+        content = [{"type": "text", "text": text}]
+        content += [
+            {"type": "image_url", "image_url": {"url": os.path.expanduser(path)}}
+            for path in images
+        ]
+        messages.append({"role": "user", "content": content})
+    else:
+        messages.append({"role": "user", "content": text})
+    return messages
+
+
+def sampling_params(args):
+    """Build the request body: OpenAI-spec fields, plus mlx-vlm extras only when
+    engaged, so a default request stays spec-compliant and portable."""
+    params = {}
+    # OpenAI spec fields.
+    for name in (
+        "temperature",
+        "max_tokens",
+        "seed",
+        "frequency_penalty",
+        "presence_penalty",
+    ):
+        value = getattr(args, name, None)
+        if value is not None:
+            params[name] = value
+
+    # mlx-vlm extras — added only when actually engaged, never at their defaults.
+    if getattr(args, "repetition_penalty", None) is not None:
+        params["repetition_penalty"] = args.repetition_penalty
+    for penalty, ctx in (
+        ("repetition_penalty", "repetition_context_size"),
+        ("frequency_penalty", "frequency_context_size"),
+        ("presence_penalty", "presence_context_size"),
+    ):
+        if getattr(args, penalty, None) is not None:
+            value = getattr(args, ctx, None)
+            if value is not None:
+                params[ctx] = value
+    if getattr(args, "enable_thinking", False):
+        params["enable_thinking"] = True
+    if getattr(args, "thinking_budget", None) is not None:
+        params["thinking_budget"] = args.thinking_budget
+        for name in ("thinking_start_token", "thinking_end_token"):
+            value = getattr(args, name, None)
+            if value is not None:
+                params[name] = value
+    return params
+
+
+def stream_chat(base_url, model, messages, params, args=None):
+    """POST a streaming chat completion; yield text deltas from the SSE body."""
+    body = {"model": model, "messages": messages, "stream": True, **params}
+    headers = {"Content-Type": "application/json", **_auth_header(args)}
+    req = urllib.request.Request(
+        base_url.rstrip("/") + "/v1/chat/completions",
+        data=json.dumps(body).encode("utf-8"),
+        headers=headers,
+        method="POST",
+    )
+    with urllib.request.urlopen(req) as response:
+        for raw in response:
+            line = raw.decode("utf-8", "replace").strip()
+            if not line.startswith("data:"):
+                continue
+            payload = line[len("data:") :].strip()
+            if payload == "[DONE]":
+                break
+            try:
+                delta = json.loads(payload)["choices"][0].get("delta", {})
+            except (json.JSONDecodeError, KeyError, IndexError):
+                continue
+            content = delta.get("content")
+            if content:
+                yield content
+
+
+def _local_only_conflict(args):
+    for name in _LOCAL_ONLY:
+        if getattr(args, name, None):
+            return name.replace("_", "-")
+    return None
+
+
+def run_on_server(args):
+    """Serve remotely when a base URL is set: True if handled, False for local."""
+    base_url = resolve_base_url(args)
+    if not base_url:
+        return False
+
+    conflict = _local_only_conflict(args)
+    if conflict:
+        raise SystemExit(f"--{conflict} requires local execution; drop --base-url.")
+
+    messages = build_messages(args)
+    params = sampling_params(args)
+    if getattr(args, "verbose", False):
+        print(f"Using server at {base_url}.", file=sys.stderr)
+    try:
+        for chunk in stream_chat(base_url, args.model, messages, params, args):
+            print(chunk, end="", flush=True)
+        print()
+    except urllib.error.HTTPError as exc:
+        try:
+            detail = exc.read().decode("utf-8", "replace").strip()[:200]
+        except Exception:
+            detail = ""
+        raise SystemExit(f"server at {base_url} returned HTTP {exc.code}: {detail}")
+    except urllib.error.URLError as exc:
+        raise SystemExit(
+            f"server at {base_url} is unreachable ({exc.reason}); "
+            "start it or drop --base-url."
+        )
+    return True

--- a/mlx_vlm/tests/test_cli.py
+++ b/mlx_vlm/tests/test_cli.py
@@ -133,3 +133,224 @@ def test_generate_one_shot_applies_system_prompt():
         and _assigns_prompt(node)
         for node in ast.walk(main)
     ), "one-shot generate must prepend args.system to the prompt"
+
+
+# --- Server-aware generate (--base-url) ----------------------------------------
+
+import importlib.util
+import io
+
+
+def _load_remote():
+    """Load generate/remote.py in isolation (stdlib-only, no mlx import)."""
+    path = SOURCE_ROOT / "mlx_vlm" / "generate" / "remote.py"
+    spec = importlib.util.spec_from_file_location("mlx_vlm_remote_under_test", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _remote_args(**overrides):
+    base = dict(
+        model="mlx-community/Model",
+        prompt="hello",
+        system=None,
+        image=None,
+        base_url=None,
+        api_key=None,
+        verbose=False,
+        temperature=0.0,
+        max_tokens=256,
+        seed=None,
+        repetition_penalty=None,
+        frequency_penalty=None,
+        presence_penalty=None,
+        adapter_path=None,
+        draft_model=None,
+        quantize_activations=False,
+    )
+    base.update(overrides)
+    return argparse.Namespace(**base)
+
+
+class _FakeResponse:
+    def __init__(self, lines):
+        self._lines = lines
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+    def __iter__(self):
+        return iter(self._lines)
+
+
+def test_generate_defines_base_url_and_api_key():
+    module = _load_module("mlx_vlm/generate/dispatch.py")
+    _find_add_argument(module, "--base-url")
+    _find_add_argument(module, "--api-key")
+
+
+def test_generate_main_routes_to_server_before_load():
+    module = _load_module("mlx_vlm/generate/dispatch.py")
+    main = _find_function_def(module, "main")
+    calls = [
+        node.func.id
+        for node in ast.walk(main)
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
+    ]
+    assert "run_on_server" in calls and "load" in calls
+    assert calls.index("run_on_server") < calls.index("load")
+
+
+def test_resolve_base_url_precedence(monkeypatch):
+    remote = _load_remote()
+    monkeypatch.delenv("MLX_VLM_BASE_URL", raising=False)
+    assert remote.resolve_base_url(_remote_args()) is None
+    monkeypatch.setenv("MLX_VLM_BASE_URL", "http://env:1/")
+    assert remote.resolve_base_url(_remote_args()) == "http://env:1/"
+    assert (
+        remote.resolve_base_url(_remote_args(base_url="http://flag:2"))
+        == "http://flag:2"
+    )
+
+
+def test_run_on_server_returns_false_without_base_url(monkeypatch):
+    remote = _load_remote()
+    monkeypatch.delenv("MLX_VLM_BASE_URL", raising=False)
+
+    def _fail(*a, **k):
+        raise AssertionError("must not touch the network without a base URL")
+
+    monkeypatch.setattr(remote.urllib.request, "urlopen", _fail)
+    assert remote.run_on_server(_remote_args()) is False
+
+
+def test_build_messages_passes_images_through_unencoded(tmp_path):
+    remote = _load_remote()
+    img = tmp_path / "pic.png"
+    img.write_bytes(b"not-a-real-png")
+    msgs = remote.build_messages(_remote_args(prompt="what?", image=[str(img)]))
+    content = msgs[0]["content"]
+    assert content[0] == {"type": "text", "text": "what?"}
+    url = content[1]["image_url"]["url"]
+    assert url == str(img)  # passed through, NOT base64-encoded
+    assert not url.startswith("data:")
+
+
+def test_build_messages_system_and_nargs_prompt():
+    remote = _load_remote()
+    msgs = remote.build_messages(
+        _remote_args(system="be terse", prompt=["hi", "there"])
+    )
+    assert msgs[0] == {"role": "system", "content": "be terse"}
+    assert msgs[1] == {"role": "user", "content": "hi there"}
+
+
+def test_sampling_params_default_is_spec_only():
+    remote = _load_remote()
+    # A default request carries only OpenAI-spec fields — no mlx-vlm extras.
+    params = remote.sampling_params(_remote_args(temperature=0.0, max_tokens=256))
+    assert params == {"temperature": 0.0, "max_tokens": 256}
+    assert "enable_thinking" not in params
+    assert "repetition_context_size" not in params
+
+
+def test_sampling_params_adds_extras_only_when_engaged():
+    remote = _load_remote()
+    params = remote.sampling_params(
+        _remote_args(
+            temperature=0.7,
+            repetition_penalty=1.1,
+            repetition_context_size=20,
+            enable_thinking=True,
+            thinking_budget=64,
+            thinking_start_token="<t>",
+            thinking_end_token="</t>",
+        )
+    )
+    assert params["temperature"] == 0.7
+    assert params["repetition_penalty"] == 1.1
+    assert params["repetition_context_size"] == 20  # only because its penalty is set
+    assert params["enable_thinking"] is True
+    assert params["thinking_budget"] == 64
+    assert params["thinking_start_token"] == "<t>"
+
+
+def test_sampling_params_context_size_dropped_without_penalty():
+    remote = _load_remote()
+    # A context size with no matching penalty is a meaningless extra — omit it.
+    params = remote.sampling_params(_remote_args(repetition_context_size=20))
+    assert "repetition_context_size" not in params
+
+
+def test_stream_chat_parses_sse(monkeypatch):
+    remote = _load_remote()
+    lines = [
+        b'data: {"choices":[{"delta":{"role":"assistant"}}]}\n',
+        b'data: {"choices":[{"delta":{"content":"Hel"}}]}\n',
+        b'data: {"choices":[{"delta":{"content":"lo"}}]}\n',
+        b"data: {bad}\n",
+        b"data: [DONE]\n",
+        b'data: {"choices":[{"delta":{"content":"after"}}]}\n',
+    ]
+    monkeypatch.setattr(
+        remote.urllib.request, "urlopen", lambda *a, **k: _FakeResponse(lines)
+    )
+    assert list(remote.stream_chat("http://x", "m", [], {})) == ["Hel", "lo"]
+
+
+def test_run_on_server_streams_and_returns_true(monkeypatch, capsys):
+    remote = _load_remote()
+    lines = [b'data: {"choices":[{"delta":{"content":"Hi!"}}]}\n', b"data: [DONE]\n"]
+    monkeypatch.setattr(
+        remote.urllib.request, "urlopen", lambda *a, **k: _FakeResponse(lines)
+    )
+    assert remote.run_on_server(_remote_args(base_url="http://x")) is True
+    assert "Hi!" in capsys.readouterr().out
+
+
+def test_run_on_server_conflicting_flag_errors(monkeypatch):
+    remote = _load_remote()
+
+    def _fail(*a, **k):
+        raise AssertionError("must not touch the network on a conflict")
+
+    monkeypatch.setattr(remote.urllib.request, "urlopen", _fail)
+    try:
+        remote.run_on_server(_remote_args(base_url="http://x", adapter_path="/a"))
+        raise AssertionError("expected SystemExit")
+    except SystemExit as exc:
+        assert "adapter-path" in str(exc)
+
+
+def test_run_on_server_unreachable_errors(monkeypatch):
+    remote = _load_remote()
+
+    def _refused(*a, **k):
+        raise remote.urllib.error.URLError("connection refused")
+
+    monkeypatch.setattr(remote.urllib.request, "urlopen", _refused)
+    try:
+        remote.run_on_server(_remote_args(base_url="http://x"))
+        raise AssertionError("expected SystemExit")
+    except SystemExit as exc:
+        assert "unreachable" in str(exc)
+
+
+def test_run_on_server_http_error_surfaced(monkeypatch):
+    remote = _load_remote()
+
+    def _boom(*a, **k):
+        raise remote.urllib.error.HTTPError(
+            "http://x", 500, "err", {}, io.BytesIO(b"kaboom")
+        )
+
+    monkeypatch.setattr(remote.urllib.request, "urlopen", _boom)
+    try:
+        remote.run_on_server(_remote_args(base_url="http://x"))
+        raise AssertionError("expected SystemExit")
+    except SystemExit as exc:
+        assert "HTTP 500" in str(exc)


### PR DESCRIPTION
When --base-url (or $MLX_VLM_BASE_URL) is set, mlx_vlm generate forwards the request to a running mlx-vlm server's /v1/chat/completions endpoint and streams the reply, reusing an already-loaded model instead of loading one into this process. With no base URL, generation runs locally exactly as before.

- New flags --base-url and --api-key (also $MLX_VLM_BASE_URL / $MLX_VLM_API_KEY).
- Forwards the request-level controls the server honors (sampling, context sizes, thinking) so remote output matches local generation.
- Options that change the model and can't cross the request API (--adapter-path, --draft-model, --quantize-activations) error clearly.
- An unreachable or erroring server is surfaced, not silently replaced by a local load.
- Standard library only; tests in test_cli.py.