### PR TITLE
Decline prefix-cache reuse for non-trimmable recurrent caches

### DIFF
--- a/mlx_vlm/generate/dispatch.py
+++ b/mlx_vlm/generate/dispatch.py
@@ -669,6 +669,77 @@ def _cache_fully_retained(c: Any) -> bool:
     return True  # KVCache / QuantizedKVCache retain the whole sequence
 
 
+def _cache_supports_trim(c: Any) -> bool:
+    """Whether ``c`` can be rolled back at all, i.e. whether ``trim()`` is usable.
+
+    Complements :func:`_cache_fully_retained`, which asks whether the prefix is
+    still *present*. A recurrent entry has no per-token history to roll back to:
+    ``ArraysCache`` -- used by the linear-attention (GatedDeltaNet) layers of
+    hybrid models such as Qwen3.5/Qwen3.6 MoE -- holds a fixed-size state, reports
+    ``is_trimmable() == False`` and defines no ``trim`` at all. It also exposes
+    none of the attributes ``_cache_fully_retained`` keys off, so it falls through
+    that check as reusable and the caller then dies on ``c.trim(n_drop)`` with
+    ``AttributeError: 'ArraysCache' object has no attribute 'trim'``.
+
+    This mirrors ``mlx_lm.models.cache.can_trim_prompt_cache``.
+    """
+    children = getattr(c, "caches", None)
+    if children is not None:  # CacheList
+        return all(_cache_supports_trim(x) for x in children)
+    if not hasattr(c, "trim"):
+        return False
+    is_trimmable = getattr(c, "is_trimmable", None)
+    if callable(is_trimmable):
+        try:
+            return bool(is_trimmable())
+        except Exception:
+            return False
+    return True
+
+
+def _cache_logical_len(c: Any) -> Optional[int]:
+    """How many tokens ``c`` logically holds, or ``None`` when that is unknowable.
+
+    ``_prefix_cache_trim_amount`` used to read this off a top-level ``offset``.
+    Two shapes have no such attribute and silently collapsed to ``0``:
+
+    * ``CacheList``, which keeps its length in its children -- used per layer by
+      hybrid models (inkling / zaya1_vl / falcon_h1).
+    * ``ArraysCache``, whose fixed-size recurrent state has no token axis at all
+      -- the whole cache for mamba / mamba2 / rwkv7, and the linear-attention
+      layers of Qwen3.5 / Qwen3.6 MoE.
+
+    A ``0`` there makes ``n_drop == 0``, which reports the cache as fully
+    reusable and skips both rollback guards below. For a recurrent cache that is
+    not a conservative answer but a wrong one: the prompt is sliced down to the
+    shared prefix while the state still represents the old full sequence.
+
+    ``offset`` is still preferred wherever it exists, so flat and rotating caches
+    keep their exact current semantics (note ``RotatingKVCache.size()`` clamps to
+    ``max_size`` and is deliberately *not* used here). Otherwise recurse into
+    ``caches``, and fall back to ``0`` only for a provably empty cache. A
+    non-empty cache with no way to state its length returns ``None`` -- fail
+    closed, because the alternative is reusing stale state.
+    """
+    offset = getattr(c, "offset", None)
+    if offset is not None:
+        return int(offset or 0)
+    children = getattr(c, "caches", None)
+    if children is not None:  # CacheList: length lives in the children
+        lens = [_cache_logical_len(x) for x in children]
+        if any(n is None for n in lens):
+            return None
+        return max(lens, default=0)
+    empty = getattr(c, "empty", None)
+    if callable(empty):
+        try:
+            if empty():
+                return 0  # nothing cached yet, so nothing to roll back
+        except Exception:
+            return None
+    return None
+
+
 def _prefix_cache_trim_amount(kv_cache: List[Any], prefix_len: int) -> Optional[int]:
     """Trailing tokens to drop so ``kv_cache`` keeps only its first ``prefix_len``.
 
@@ -678,11 +749,18 @@ def _prefix_cache_trim_amount(kv_cache: List[Any], prefix_len: int) -> Optional[
     taking an arbitrary rotation of the window and leaving the ring index stale:
     silent output corruption, or a broadcast crash once speculative decoding wraps
     the cache in ``BufferedRotatingKVCache``. Returns the number of tokens to drop
-    (``0`` when the whole cache is reusable), or ``None`` when an entry has already
-    evicted part of the prefix and the caller must cold-prefill instead.
+    (``0`` when the whole cache is reusable), or ``None`` when the caller must
+    cold-prefill instead -- because an entry's cached length cannot be
+    established, because it does not support ``trim()`` at all, or because it has
+    already evicted part of the prefix.
     """
-    cached_len = max((int(getattr(c, "offset", 0) or 0) for c in kv_cache), default=0)
+    lens = [_cache_logical_len(c) for c in kv_cache]
+    if any(n is None for n in lens):
+        return None
+    cached_len = max(lens, default=0)
     n_drop = max(0, cached_len - prefix_len)
+    if n_drop and not all(_cache_supports_trim(c) for c in kv_cache):
+        return None
     if n_drop and not all(_cache_fully_retained(c) for c in kv_cache):
         return None
     return n_drop

--- a/mlx_vlm/tests/test_generate.py
+++ b/mlx_vlm/tests/test_generate.py
@@ -28,6 +28,7 @@ from mlx_vlm.generate import ar as ar_module
 from mlx_vlm.generate import dispatch as dispatch_module
 from mlx_vlm.generate import normalize_resize_shape
 from mlx_vlm.models.cache import (
+    ArraysCache,
     BatchKVCache,
     BatchPoolingCache,
     BatchRotatingKVCache,
@@ -2720,6 +2721,96 @@ class TestPrefixCacheReuseTrim:
         assert c.offset == 40
         c.update_and_fetch(mx.zeros((1, 1, 1, 4)), mx.zeros((1, 1, 1, 4)))
         assert c.offset == 41
+
+    @staticmethod
+    def _recurrent(n_states=1):
+        # A production-shaped ArraysCache: state written, no synthetic .offset.
+        c = ArraysCache(n_states)
+        for i in range(n_states):
+            c[i] = mx.zeros((1, 4))
+        return c
+
+    def test_mixed_flat_and_recurrent_is_not_reusable(self):
+        # A hybrid model interleaves both: 3 linear-attention layers per full
+        # attention layer for Qwen3.5/3.6. One non-trimmable entry must decline
+        # reuse for the whole cache, otherwise the flat layers get rolled back
+        # while the recurrent ones do not and the two desync.
+        flat = self._fill(KVCache(), 100)
+        assert (
+            dispatch_module._prefix_cache_trim_amount([flat, self._recurrent()], 60)
+            is None
+        )
+
+    def test_mixed_flat_and_untouched_recurrent_is_not_reusable(self):
+        # Same shape, but the recurrent entry is still empty, so its length *is*
+        # known (0) and the sibling KVCache sets cached_len. This is the case that
+        # reaches _cache_supports_trim rather than the unknown-length guard:
+        # ArraysCache defines no trim() at all.
+        flat = self._fill(KVCache(), 100)
+        empty_recurrent = ArraysCache(1)
+        assert not hasattr(empty_recurrent, "trim")
+        assert (
+            dispatch_module._prefix_cache_trim_amount([flat, empty_recurrent], 60)
+            is None
+        )
+
+    def test_pure_recurrent_stack_is_not_reusable(self):
+        # mamba/mamba2/rwkv7 have no full-attention layer at all, so no sibling
+        # contributes an offset and cached_len used to collapse to 0 -- reporting
+        # the cache fully reusable and skipping every rollback guard. The failure
+        # there was never the AttributeError, it was silent stale-state reuse.
+        cache = [self._recurrent() for _ in range(4)]
+        assert dispatch_module._prefix_cache_trim_amount(cache, 60) is None
+
+    def test_per_layer_cachelist_hybrid_is_not_reusable(self):
+        # inkling/zaya1_vl/falcon_h1 wrap attention + recurrent state in one
+        # CacheList per layer. CacheList has no top-level offset either, so this
+        # shape hit the same collapse-to-0 path.
+        cache = [
+            CacheList(self._fill(KVCache(), 20), self._recurrent()) for _ in range(4)
+        ]
+        assert dispatch_module._prefix_cache_trim_amount(cache, 8) is None
+
+    def test_nested_non_trimmable_cache_is_not_reusable(self):
+        # Hybrid recurrent models can wrap an attention cache and recurrent state
+        # in a CacheList. CacheList has no top-level offset, so the cached length
+        # must be obtained from its children before deciding whether trimming is
+        # required.
+        c = CacheList(self._fill(KVCache(), 20), ArraysCache(2))
+        assert c.size() == 20
+        assert dispatch_module._prefix_cache_trim_amount([c], 8) is None
+
+    def test_nonempty_recurrent_cache_without_length_is_not_reusable(self):
+        # ArraysCache state does not expose a logical token length or offset.
+        # Assigning a synthetic offset in a test hides that production behavior;
+        # without a trustworthy length, divergent-prefix reuse must be declined.
+        c = ArraysCache(1)
+        c[0] = mx.zeros((1, 4))
+        assert not c.empty()
+        assert c.size() == 0
+        assert dispatch_module._prefix_cache_trim_amount([c], 8) is None
+
+    def test_nested_trimmable_cache_uses_child_length(self):
+        # A composite made entirely from trimmable caches should still reuse the
+        # shared prefix; this guards against conservatively rejecting every
+        # CacheList while fixing the recurrent-cache case above.
+        c = CacheList(self._fill(KVCache(), 20), self._fill(KVCache(), 20))
+        assert c.size() == 20
+        assert dispatch_module._prefix_cache_trim_amount([c], 8) == 12
+
+    def test_nested_trimmable_cache_with_exact_prefix_stays_warm(self):
+        # n_drop == 0 needs no rollback, so an all-trimmable CacheList keeps the
+        # append-only follow-up turn on the warm path.
+        c = CacheList(self._fill(KVCache(), 20), self._fill(KVCache(), 20))
+        assert dispatch_module._prefix_cache_trim_amount([c], 20) == 0
+
+    def test_rotating_cache_length_still_read_from_offset(self):
+        # RotatingKVCache.size() clamps to max_size, so cached_len must keep
+        # coming from offset -- otherwise a wrapped window would under-report its
+        # length and n_drop would silently shrink.
+        c = self._fill(RotatingKVCache(max_size=32), 100)
+        assert c.size() == 32
+        assert dispatch_module._cache_logical_len(c) == 100
 
 
 class TestGemma4LogitsToKeep:


### PR DESCRIPTION
## Problem

Multi-turn generation crashes from the **second turn onward** on hybrid linear-attention models (Qwen3.5 / Qwen3.6 MoE):

```
File "mlx_vlm/generate/dispatch.py", line 928, in stream_generate
    c.trim(n_drop)
AttributeError: 'ArraysCache' object has no attribute 'trim'
```

Reproduced on `mlx-vlm==0.6.10` (also present on `main` @ ffd7aef) with `Qwen3.6-35B-A3B-MLX-4bit` (`model_type: qwen3_5_moe`) via `mlx_vlm.chat_ui`, and by any caller that passes a `prompt_cache_state`.

## Cause

`_prefix_cache_trim_amount` decides whether a prompt cache can be rolled back to a shared prefix. Its only guard is `_cache_fully_retained`, which answers a *different* question — "has this cache already evicted part of the prefix?" — and deliberately does not use `is_trimmable()` (see its docstring re: `BufferedRotatingKVCache`).

Nothing checks whether the cache supports `trim()` **at all**.

`ArraysCache` backs the linear-attention (GatedDeltaNet) layers of hybrid models. It holds a fixed-size recurrent state with no per-token history, so:

- `is_trimmable()` → `False`
- it defines no `trim` method
- it exposes none of `caches` / `start_position` / `max_size`

That last point is what makes it silent: it falls straight through `_cache_fully_retained` to the final `return True`, reuse is accepted, and `stream_generate` then calls `c.trim(n_drop)` on it.

Qwen3.5/3.6 interleave 3 linear-attention layers per full-attention layer (40 layers, `full_attention_interval=4`), so the cache list always contains `ArraysCache` entries and every conversation with a shared prefix hits this.

The `is_trimmable()` + `trim()` pairing was what #1715 originally recommended (mirroring `mlx_lm.models.cache.trim_prompt_cache`); the merged fix replaced it with the retention check and the trimmability half was dropped.

## Fix

Add `_cache_supports_trim`, mirroring `mlx_lm.models.cache.can_trim_prompt_cache`:

```python
def can_trim_prompt_cache(cache: List[Any]) -> bool:
    return all(c.is_trimmable() for c in cache)
```

with two additions over the mlx-lm version: recursion into `CacheList.caches`, and treating a raising/absent `is_trimmable` as not trimmable. It is consulted before `_cache_fully_retained`, so reuse is declined and the caller cold-prefills — the fallback the docstring already documents for `None`.

`n_drop == 0` still takes the warm path: the cache already *is* the shared prefix, so a recurrent state carries over as-is with no rollback. Append-only follow-up turns keep their cache hit.

## Cost

When a hybrid model has a partially-matching prefix, the turn now re-prefills instead of crashing. This does not make prefix reuse work for these architectures — recurrent state genuinely cannot be rolled back to an arbitrary token boundary (see ml-explore/mlx-lm#980; lmstudio-ai/mlx-engine#287 disables cross-turn caching outright for the same reason). This PR only makes the existing "decline and cold-prefill" path handle them instead of raising.

## Tests

Three cases added to `TestPrefixCacheReuseTrim`:

- `test_recurrent_cache_is_not_reusable` — bare `ArraysCache` declines
- `test_mixed_flat_and_recurrent_is_not_reusable` — one non-trimmable entry declines the whole cache, so flat layers can't roll back while recurrent ones don't and desync
- `test_recurrent_cache_with_exact_prefix_still_reusable` — `n_drop == 0` stays on the warm path

The first two fail on `main` (`assert 40 is None`) and pass with the fix.

```
$ pytest mlx_vlm/tests/test_generate.py -k TestPrefixCacheReuseTrim
11 passed
```

`test_generate.py`, `test_apc.py`, `test_speculative.py` → 304 passed. One unrelated pre-existing failure, `test_qwen_target_verify_quantized_linear_matches_singleton_batch_path` (bfloat16 exact-equality on a quantized matmul), which fails identically on unmodified `main`.

Also verified end-to-end: a 3-turn conversation on `Qwen3.6-35B-A3B-MLX-4bit` through `chat_ui` crashes on turn 2 before the fix and completes with correct cross-turn context after.

Related: #1715 (introduced the guard), ml-explore/mlx-lm#980, ml-explore/mlx-swift-lm#157.
