### PR TITLE
fix(prompt_utils): render tool-call turns that carry no text (#1785)

### DIFF
--- a/mlx_vlm/prompt_utils.py
+++ b/mlx_vlm/prompt_utils.py
@@ -582,6 +582,39 @@ def get_message_json(
     )
 
 
+def _normalize_tool_call_content(
+    messages: List[Dict[str, Any]],
+) -> List[Dict[str, Any]]:
+    """Coerce ``content: None`` to ``""`` on assistant tool-call turns.
+
+    A tool-call turn carrying no accompanying text is an ordinary shape in an
+    agentic loop, and both the OpenAI and Anthropic compatibility layers
+    forward it as ``{"content": None, "tool_calls": [...]}``. Chat templates
+    commonly branch on ``message.content is string`` and otherwise iterate the
+    value, so ``None`` raises ``'NoneType' object is not iterable`` during
+    rendering. An empty string takes the string branch and renders identically
+    to a turn whose text really is empty.
+
+    The input list is left untouched; a shallow copy is made only when a
+    message actually needs patching.
+    """
+    normalized = None
+
+    for index, message in enumerate(messages):
+        if (
+            isinstance(message, dict)
+            and message.get("content") is None
+            and message.get("tool_calls")
+        ):
+            if normalized is None:
+                normalized = list(messages)
+            patched = dict(message)
+            patched["content"] = ""
+            normalized[index] = patched
+
+    return messages if normalized is None else normalized
+
+
 def get_chat_template(
     processor,
     messages: List[Dict[str, Any]],
@@ -590,6 +623,8 @@ def get_chat_template(
     **kwargs,
 ) -> Any:
     """Apply chat template using processor's tokenizer."""
+
+    messages = _normalize_tool_call_content(messages)
 
     def _get_image_token() -> str:
         if processor is None:

--- a/mlx_vlm/tests/test_prompt_utils.py
+++ b/mlx_vlm/tests/test_prompt_utils.py
@@ -762,3 +762,126 @@ class TestModelSpecificPromptContracts:
             "text",
         ]
         assert result[0]["content"][-1]["text"] == "OCR:"
+
+
+class TestToolCallOnlyAssistantTurn:
+    """A tool-call turn carrying no text must still render (#1785, #1034)."""
+
+    # Faithful reduction of the Qwen3-VL assistant branch: it checks whether
+    # content is a string and otherwise assumes the value is iterable.
+    ASSISTANT_BRANCH_TEMPLATE = (
+        "{%- for message in messages %}"
+        '{%- if message.role == "assistant" %}'
+        "{{- '<|im_start|>assistant\n' }}"
+        "{%- if message.content is string %}{{- message.content }}"
+        "{%- else %}"
+        "{%- for content_item in message.content %}"
+        "{%- if 'text' in content_item %}{{- content_item.text }}{%- endif %}"
+        "{%- endfor %}"
+        "{%- endif %}"
+        "{%- if message.tool_calls %}"
+        "{%- for tc in message.tool_calls %}"
+        "{{- '<tool_call>' + tc.function.name + '</tool_call>' }}"
+        "{%- endfor %}"
+        "{%- endif %}"
+        "{{- '<|im_end|>\n' }}"
+        "{%- else %}"
+        "{{- '<|im_start|>' + message.role + '\n'"
+        " + (message.content or '') + '<|im_end|>\n' }}"
+        "{%- endif %}"
+        "{%- endfor %}"
+        "{%- if add_generation_prompt %}"
+        "{{- '<|im_start|>assistant\n' }}{%- endif %}"
+    )
+
+    @staticmethod
+    def _processor(template):
+        from jinja2 import Environment
+
+        class _Processor:
+            chat_template = template
+
+            def apply_chat_template(
+                self,
+                messages,
+                tokenize=False,
+                add_generation_prompt=False,
+                **kwargs,
+            ):
+                compiled = Environment().from_string(template)
+                return compiled.render(
+                    messages=messages,
+                    add_generation_prompt=add_generation_prompt,
+                    **kwargs,
+                )
+
+        return _Processor()
+
+    @staticmethod
+    def _messages(content):
+        return [
+            {"role": "user", "content": "Open the docs page."},
+            {
+                "role": "assistant",
+                "content": content,
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {
+                            "name": "navigate",
+                            "arguments": {"url": "/docs"},
+                        },
+                    }
+                ],
+            },
+            {"role": "tool", "tool_call_id": "call_1", "content": "ok"},
+        ]
+
+    def test_null_content_tool_call_turn_renders(self):
+        """content=None must not blow up the template with a TypeError."""
+        from mlx_vlm.prompt_utils import get_chat_template
+
+        rendered = get_chat_template(
+            self._processor(self.ASSISTANT_BRANCH_TEMPLATE),
+            self._messages(None),
+            add_generation_prompt=True,
+        )
+
+        assert "<tool_call>navigate</tool_call>" in rendered
+        assert rendered.endswith("<|im_start|>assistant\n")
+
+    def test_null_content_renders_like_empty_string(self):
+        """content=None and content="" must produce identical prompts."""
+        from mlx_vlm.prompt_utils import get_chat_template
+
+        processor = self._processor(self.ASSISTANT_BRANCH_TEMPLATE)
+        from_null = get_chat_template(
+            processor, self._messages(None), add_generation_prompt=True
+        )
+        from_empty = get_chat_template(
+            processor, self._messages(""), add_generation_prompt=True
+        )
+
+        assert from_null == from_empty
+
+    def test_caller_messages_are_not_mutated(self):
+        """Normalization must not write back into the caller's list."""
+        from mlx_vlm.prompt_utils import get_chat_template
+
+        messages = self._messages(None)
+        get_chat_template(
+            self._processor(self.ASSISTANT_BRANCH_TEMPLATE),
+            messages,
+            add_generation_prompt=True,
+        )
+
+        assert messages[1]["content"] is None
+
+    def test_null_content_without_tool_calls_is_left_alone(self):
+        """Only tool-call turns are normalized; other None content is untouched."""
+        from mlx_vlm.prompt_utils import _normalize_tool_call_content
+
+        messages = [{"role": "assistant", "content": None}]
+
+        assert _normalize_tool_call_content(messages) is messages


### PR DESCRIPTION
## Problem

A multi-turn tool-use conversation dies with a 500 as soon as the model emits a tool call with no accompanying text — an ordinary shape in any agentic loop, not an edge case:

```
File ".../mlx_vlm/prompt_utils.py", line 782, in get_chat_template
    return template_processor.apply_chat_template(...)
  ...
  File "<template>", line 64, in top-level template code
TypeError: 'NoneType' object is not iterable
```

## Root cause

Both compatibility layers build a text-free tool-call turn as `content: None`, which is the spec-compliant OpenAI shape:

- `mlx_vlm/server/anthropic.py:358-363` sets `msg["content"] = None` when `tool_calls` are present and `content_text` is empty.
- `mlx_vlm/server/openai.py:1650` forwards `message.content` verbatim, so a client sending `"content": null` lands the same way.

Chat templates commonly branch on *"is this a string"* and otherwise assume the value is iterable — Qwen3-VL's `chat_template.jinja` is representative:

```jinja
{%- if message.content is string %}
    {{- message.content }}
{%- else %}
    {%- for content_item in message.content %}   {# <- None reaches here #}
```

There is no `None` branch, so rendering raises `TypeError: 'NoneType' object is not iterable`.

## Fix

Normalize `content: None` to `""` on assistant turns that carry `tool_calls`, immediately before the template is rendered.

`get_chat_template` is the single choke point shared by `/v1/chat/completions`, `/v1/messages`, `/v1/responses` and the library `generate()` path, so one normalization covers all of them and stays template-agnostic rather than patching each endpoint separately. An empty string takes the `is string` branch and renders identically to a turn whose text genuinely is empty, so no template that already handles this shape changes behaviour. The caller's message list is never mutated — a shallow copy is made only when a message actually needs patching.

## Verification

Reproduced against a Jinja template reduced from Qwen3-VL's assistant branch, on this commit's parent vs. this commit:

| | before | after |
|---|---|---|
| `content: None` + `tool_calls` | `TypeError: 'NoneType' object is not iterable` | renders, tool call preserved, turn closed, generation prompt emitted |

Four regression tests added to `mlx_vlm/tests/test_prompt_utils.py`:

- `test_null_content_tool_call_turn_renders` — the crash case
- `test_null_content_renders_like_empty_string` — `None` and `""` produce byte-identical prompts
- `test_caller_messages_are_not_mutated` — no write-back into the caller's list
- `test_null_content_without_tool_calls_is_left_alone` — only tool-call turns are touched

`mlx_vlm/tests/test_prompt_utils.py` passes in full (40 tests). `black` 26.3.1 and `isort --profile=black` 5.13.2 (the pinned pre-commit versions) leave both files unchanged.

## Scope

Closes #1785.

Partially addresses #1034: that report covers both `content: null` **and** `content: ""` for Gemma 4. The `null` half is fixed here. The `""` half is not — Gemma 4's template gates turn closure on `not message.get('content')`, which is already true for an empty string, so it needs the template-side fix (option 1 in that issue) or a non-empty placeholder. Substituting a non-empty placeholder globally would inject stray text into every other model's prompt, so I have deliberately left it out of this change rather than trade a crash for a silent prompt regression.

Credit to @agent-smith-ddp for the precise server-side traceback in #1785 and to @reza-yousefi for identifying the empty-content/tool-call class in #1034. @agent-smith-ddp offered a PR on the `anthropic.py` one-liner — happy to close this in favour of that if preferred; I went to the shared choke point because the same shape reaches the template from three endpoints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
