### PR TITLE
Preserve embed_norm when quantizing Muse Glimmer embeddings

### DIFF
--- a/mlx_vlm/models/muse_glimmer/language.py
+++ b/mlx_vlm/models/muse_glimmer/language.py
@@ -36,6 +36,18 @@ class CenteredRMSNorm(nn.Module):
         return normalized * (1.0 + self.weight)
 
 
+class QuantizedNormedEmbedding(nn.QuantizedEmbedding):
+    """Quantized NormedEmbedding that keeps the weightless embedding norm.
+
+    ``nn.Embedding.to_quantized`` returns a plain ``QuantizedEmbedding``, which
+    would silently drop ``embed_norm`` and feed unnormalized embeddings into the
+    residual stream.
+    """
+
+    def __call__(self, inputs: mx.array) -> mx.array:
+        return self.embed_norm(super().__call__(inputs))
+
+
 class NormedEmbedding(nn.Embedding):
     def __init__(self, vocab_size: int, hidden_size: int, eps: float):
         super().__init__(vocab_size, hidden_size)
@@ -43,6 +55,19 @@ class NormedEmbedding(nn.Embedding):
 
     def __call__(self, inputs: mx.array) -> mx.array:
         return self.embed_norm(super().__call__(inputs))
+
+    def to_quantized(
+        self,
+        group_size: int = 64,
+        bits: int = 4,
+        mode: str = "affine",
+        **kwargs,
+    ) -> "QuantizedNormedEmbedding":
+        quantized = QuantizedNormedEmbedding.from_embedding(
+            self, group_size, bits, mode=mode
+        )
+        quantized.embed_norm = self.embed_norm
+        return quantized
 
 
 class MLP(nn.Module):

--- a/mlx_vlm/tests/test_muse_glimmer.py
+++ b/mlx_vlm/tests/test_muse_glimmer.py
@@ -1,10 +1,11 @@
 import mlx.core as mx
+import mlx.nn as nn
 import numpy as np
 from PIL import Image
 
 from mlx_vlm.models.cache import KVCache, RotatingKVCache
 from mlx_vlm.models.muse_glimmer import Model, ModelConfig, TextConfig, VisionConfig
-from mlx_vlm.models.muse_glimmer.language import CenteredRMSNorm
+from mlx_vlm.models.muse_glimmer.language import CenteredRMSNorm, NormedEmbedding
 from mlx_vlm.models.muse_glimmer.processing_muse_glimmer import (
     MuseGlimmerImageProcessor,
     smart_resize,
@@ -139,3 +140,43 @@ def test_checkpoint_prefixes_are_sanitized_to_native_modules():
     assert "language_model.model.layers.0.self_attn.q_proj.weight" in weights
     assert "vision_tower.ln_pre.weight" in weights
     assert "language_model.lm_head.weight" in weights
+
+
+def test_quantization_preserves_embedding_norm():
+    """Quantizing must not drop the weightless norm on the token embedding.
+
+    ``nn.Embedding.to_quantized`` returns a plain ``QuantizedEmbedding``, so
+    without an override the subclass loses ``embed_norm`` and feeds
+    unnormalized embeddings into the residual stream. This regresses silently:
+    the model still runs, but logits collapse onto generic tokens.
+    """
+
+    class Container(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.embed_tokens = NormedEmbedding(64, 64, 1e-5)
+
+        def __call__(self, ids):
+            return self.embed_tokens(ids)
+
+    container = Container()
+    # A deliberately large scale: only the norm can bring this back to unit RMS.
+    container.embed_tokens.weight = mx.random.normal((64, 64)) * 5.0
+
+    ids = mx.array([[1, 2, 3]])
+    reference = container(ids)
+    mx.eval(reference)
+
+    nn.quantize(container, group_size=32, bits=8)
+
+    quantized_embed = container.embed_tokens
+    assert hasattr(quantized_embed, "embed_norm"), (
+        "quantization dropped embed_norm: "
+        f"{type(quantized_embed).__name__} has no weightless embedding norm"
+    )
+
+    quantized = container(ids)
+    mx.eval(quantized)
+
+    assert abs(float(mx.sqrt(mx.mean(reference**2))) - 1.0) < 1e-2
+    assert abs(float(mx.sqrt(mx.mean(quantized**2))) - 1.0) < 1e-2


### PR DESCRIPTION
Targets `pc/muse-glimmer-30b` (the branch behind #1838) rather than `main`, so it can be merged straight into that PR.

## Problem

Quantized conversions of `meta-models/Muse-Glimmer-30B` produce a broken model. `NormedEmbedding` subclasses `nn.Embedding`, so `nn.quantize` calls the inherited `to_quantized()`, which returns a plain `QuantizedEmbedding` and silently drops the weightless `embed_norm`. Unnormalized embeddings then flow into the residual stream.

Two things make this easy to miss:

- **It fails silently.** The model loads, runs at full speed, and emits fluent-looking text. Only the content is wrong.
- **It bites at load time, not just convert time.** `nn.quantize` runs again when loading a quantized checkpoint, so the norm is dropped a second time. Correct weights on disk do not help — anyone downloading a 4-bit conversion gets the broken model.

## Repro

4-bit, `group_size=64`, on the released checkpoint:

```
'The capital of France is' -> [('\n', 11.5), (' ', 11.31), ('\n\n', 11.31)]
```

`--quant-predicate mixed_4_6` fails identically: it protects `lm_head`/`v_proj`/`down_proj`, but not `embed_tokens`.

The same port at bf16 is fine, which is what localized this to quantization rather than the architecture:

```
'The capital of France is' -> [(' Paris', 17.0), (':', 13.5), (' **', 13.44)]
```

Swapping the bf16 embedding table back into the 4-bit model restored it exactly, and a manually re-wrapped *4-bit* embedding also worked — so bit width was never the issue, the missing norm was.

## Fix

Add `QuantizedNormedEmbedding` and a `to_quantized()` override that carries the norm across. This follows the existing precedent in `mlx_lm/models/afm7.py`, where `FusedLinear.to_quantized()` returns a matching quantized subclass; it also threads `mode`/`**kwargs` for current MLX quantization modes.

No checkpoint keys change — `embed_norm` is weightless — so existing conversions keep loading, and they start behaving correctly once this is in.

## Verification

After the fix, 4-bit logits match bf16 exactly:

```
'The capital of France is' -> [(' Paris', 17.0), (':', 13.5), (' **', 13.4)]
```

End-to-end on `meta-models/Muse-Glimmer-30B`, 4-bit `group_size=64` (5.216 bits/weight, 18 GB), M4 Pro 64 GB:

- Text: `Hello` -> `Hello! How can I help you today?` (58 prompt tokens @ 93 tok/s, 16.4 tok/s generation, 19.55 GB peak)
- Vision: correctly identified three shapes, their colours and positions in a synthetic test image

Added `test_quantization_preserves_embedding_norm`, which asserts behaviourally rather than on the class name. Without the fix it fails with `AssertionError: quantization dropped embed_norm: QuantizedEmbedding has no weightless embedding norm`; with it, all 7 tests in the file pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BRUXXJQrVfBDSu8LfzKzt9
