### PR TITLE
Add Muse Glimmer ATEM tool parser

### DIFF
--- a/mlx_vlm/models/muse_glimmer/config.py
+++ b/mlx_vlm/models/muse_glimmer/config.py
@@ -105,6 +105,8 @@ class ModelConfig(BaseModelConfig):
     projector_hidden_act: str = "gelu"
     eos_token_id: Optional[Union[int, List[int]]] = None
     vocab_size: int = 202048
+    thinking_start_token: str = "to=self<|message|>"
+    thinking_end_token: str = "<|eom|>"
 
     def __post_init__(self):
         if self.eos_token_id is None:

--- a/mlx_vlm/tests/test_atem_tool_parser.py
+++ b/mlx_vlm/tests/test_atem_tool_parser.py
@@ -1,0 +1,100 @@
+import json
+
+import pytest
+
+from mlx_vlm.models.muse_glimmer import ModelConfig
+from mlx_vlm.server.responses_state import process_tool_calls
+from mlx_vlm.tool_parsers import _infer_tool_parser, atem, load_tool_module
+
+ATEM_TEMPLATE = """
+<atem:function_calls>
+<atem:invoke name="$FUNCTION_NAME">
+<atem:parameter name="$PARAMETER_NAME">$PARAMETER_VALUE</atem:parameter>
+</atem:invoke>
+</atem:function_calls>
+"""
+
+
+def test_infers_atem_parser_from_muse_chat_template():
+    assert _infer_tool_parser(ATEM_TEMPLATE) == "atem"
+    assert load_tool_module("atem") is atem
+
+
+def test_muse_config_exposes_native_reasoning_boundaries():
+    config = ModelConfig()
+
+    assert config.thinking_start_token == "to=self<|message|>"
+    assert config.thinking_end_token == "<|eom|>"
+
+
+def test_parses_json_and_unquoted_atem_parameter_values():
+    result = atem.parse_tool_call(
+        """
+<atem:invoke name="weather.get_weather">
+<atem:parameter name="city">New York</atem:parameter>
+<atem:parameter name="days">3</atem:parameter>
+<atem:parameter name="detailed">true</atem:parameter>
+<atem:parameter name="filters">{"units":"metric"}</atem:parameter>
+<atem:parameter name="labels">["rain", "wind"]</atem:parameter>
+<atem:parameter name="note">  keep surrounding spaces  </atem:parameter>
+</atem:invoke>
+"""
+    )
+
+    assert result == {
+        "name": "weather.get_weather",
+        "arguments": {
+            "city": "New York",
+            "days": 3,
+            "detailed": True,
+            "filters": {"units": "metric"},
+            "labels": ["rain", "wind"],
+            "note": "  keep surrounding spaces  ",
+        },
+    }
+
+
+def test_parses_multiline_parameters_and_multiple_invocations():
+    result = atem.parse_tool_call(
+        """
+<atem:invoke name="files.write">
+<atem:parameter name="content">first line
+second line</atem:parameter>
+</atem:invoke>
+<atem:invoke name="files.read">
+<atem:parameter name="path">notes.txt</atem:parameter>
+</atem:invoke>
+"""
+    )
+
+    assert result == [
+        {
+            "name": "files.write",
+            "arguments": {"content": "first line\nsecond line"},
+        },
+        {"name": "files.read", "arguments": {"path": "notes.txt"}},
+    ]
+
+
+def test_process_tool_calls_converts_atem_to_openai_shape():
+    result = process_tool_calls(
+        """to=self<|message|>I should check the weather.<|eom|><|start|>assistant to=weather.get_weather<|message|><atem:function_calls>
+<atem:invoke name="weather.get_weather">
+<atem:parameter name="city">Warsaw</atem:parameter>
+</atem:invoke>
+</atem:function_calls>""",
+        atem,
+        tools=None,
+    )
+
+    assert result["remaining_text"] == ""
+    assert len(result["calls"]) == 1
+    call = result["calls"][0]
+    assert call["type"] == "function"
+    assert call["function"]["name"] == "weather.get_weather"
+    assert json.loads(call["function"]["arguments"]) == {"city": "Warsaw"}
+
+
+def test_rejects_text_without_an_atem_invocation():
+    with pytest.raises(ValueError, match="No ATEM function invocation"):
+        atem.parse_tool_call("not a tool call")

--- a/mlx_vlm/tests/test_atem_tool_parser.py
+++ b/mlx_vlm/tests/test_atem_tool_parser.py
@@ -28,8 +28,7 @@ def test_muse_config_exposes_native_reasoning_boundaries():
 
 
 def test_parses_json_and_unquoted_atem_parameter_values():
-    result = atem.parse_tool_call(
-        """
+    result = atem.parse_tool_call("""
 <atem:invoke name="weather.get_weather">
 <atem:parameter name="city">New York</atem:parameter>
 <atem:parameter name="days">3</atem:parameter>
@@ -38,8 +37,7 @@ def test_parses_json_and_unquoted_atem_parameter_values():
 <atem:parameter name="labels">["rain", "wind"]</atem:parameter>
 <atem:parameter name="note">  keep surrounding spaces  </atem:parameter>
 </atem:invoke>
-"""
-    )
+""")
 
     assert result == {
         "name": "weather.get_weather",
@@ -55,8 +53,7 @@ def test_parses_json_and_unquoted_atem_parameter_values():
 
 
 def test_parses_multiline_parameters_and_multiple_invocations():
-    result = atem.parse_tool_call(
-        """
+    result = atem.parse_tool_call("""
 <atem:invoke name="files.write">
 <atem:parameter name="content">first line
 second line</atem:parameter>
@@ -64,8 +61,7 @@ second line</atem:parameter>
 <atem:invoke name="files.read">
 <atem:parameter name="path">notes.txt</atem:parameter>
 </atem:invoke>
-"""
-    )
+""")
 
     assert result == [
         {

--- a/mlx_vlm/tool_parsers/__init__.py
+++ b/mlx_vlm/tool_parsers/__init__.py
@@ -8,6 +8,7 @@ matching parser module from ``mlx_vlm.tool_parsers``.
 import importlib
 
 _TEMPLATE_MARKERS = [
+    (("<atem:function_calls>", "<atem:invoke"), "atem"),
     (("<|tool_call>",), "gemma4"),
     (("<|START_ACTION|>",), "cohere2_moe"),
     (("]<]minimax[>[<tool_call>",), "minimax_m3"),

--- a/mlx_vlm/tool_parsers/atem.py
+++ b/mlx_vlm/tool_parsers/atem.py
@@ -10,8 +10,7 @@ tool_call_start = "to=self<|message|>"
 tool_call_end = "</atem:function_calls>"
 
 _INVOKE_PATTERN = re.compile(
-    r'<atem:invoke\b[^>]*?\bname="(?P<name>[^"]+)">(?P<body>.*?)'
-    r"</atem:invoke>",
+    r'<atem:invoke\b[^>]*?\bname="(?P<name>[^"]+)">(?P<body>.*?)' r"</atem:invoke>",
     re.DOTALL,
 )
 _PARAMETER_PATTERN = re.compile(

--- a/mlx_vlm/tool_parsers/atem.py
+++ b/mlx_vlm/tool_parsers/atem.py
@@ -1,0 +1,44 @@
+"""Parse ATEM tool calls emitted by Muse models."""
+
+import json
+import re
+
+# Muse emits a self-reasoning turn before routing an ATEM call. Starting at the
+# reasoning envelope lets the shared server remove the complete protocol block
+# from assistant content after parsing the invocation.
+tool_call_start = "to=self<|message|>"
+tool_call_end = "</atem:function_calls>"
+
+_INVOKE_PATTERN = re.compile(
+    r'<atem:invoke\b[^>]*?\bname="(?P<name>[^"]+)">(?P<body>.*?)'
+    r"</atem:invoke>",
+    re.DOTALL,
+)
+_PARAMETER_PATTERN = re.compile(
+    r'<atem:parameter\b[^>]*?\bname="(?P<name>[^"]+)"[^>]*?>'
+    r"(?P<value>.*?)</atem:parameter>",
+    re.DOTALL,
+)
+
+
+def _parse_value(value: str):
+    """Parse JSON values while preserving ATEM's unquoted string form."""
+    try:
+        return json.loads(value)
+    except (json.JSONDecodeError, TypeError):
+        return value
+
+
+def parse_tool_call(text: str, tools=None):
+    """Return one or more ATEM invocations in the common parser shape."""
+    calls = []
+    for invoke in _INVOKE_PATTERN.finditer(text):
+        arguments = {
+            parameter.group("name"): _parse_value(parameter.group("value"))
+            for parameter in _PARAMETER_PATTERN.finditer(invoke.group("body"))
+        }
+        calls.append({"name": invoke.group("name"), "arguments": arguments})
+
+    if not calls:
+        raise ValueError("No ATEM function invocation found.")
+    return calls[0] if len(calls) == 1 else calls


### PR DESCRIPTION
## Summary

- add a dedicated ATEM parser for Muse Glimmer tool calls
- infer it from the native `<atem:function_calls>` and `<atem:invoke>` chat-template markers
- parse repeated invocations, multiline values, JSON scalars/objects/arrays, and unquoted strings
- consume Muse's complete self-reasoning/tool envelope so routing text is removed from assistant content
- expose Muse Glimmer's native reasoning start/end boundaries in its model config
- add focused tests for inference, value parsing, multiple calls, OpenAI-compatible conversion, invalid input, and model-config boundaries

This PR does not modify server request normalization, OpenAI/Anthropic endpoint handling, or response state.

## Why

Muse Glimmer's chat template advertises ATEM tools, but the parser registry had no matching implementation. The inner ATEM payload could not be converted into server tool calls, and parsing only that inner block left Muse's surrounding routing text in assistant content.

## Validation

- `35 passed`: Muse Glimmer plus all tool-parser test suites
- Ruff check passes for the new parser and tests
- real 4-bit server test:
  - non-streaming returns `finish_reason: "tool_calls"`, null content, and valid function arguments
  - streaming emits an empty content stream followed by the correct structured tool call
- no server files changed