### PR TITLE
Wire Muse Glimmer's reasoning channel through the server

### DIFF
--- a/mlx_vlm/server/anthropic.py
+++ b/mlx_vlm/server/anthropic.py
@@ -481,7 +481,10 @@ async def anthropic_messages_endpoint(http_request: Request):
 
         try:
             gen_args = _build_gen_args(
-                request, processor, tenant_id=_read_tenant_id(http_request)
+                request,
+                processor,
+                config=config,
+                tenant_id=_read_tenant_id(http_request),
             )
         except Exception as e:
             return _anthropic_error_response(400, str(e))
@@ -1055,7 +1058,10 @@ async def anthropic_count_tokens_endpoint(http_request: Request):
             _anthropic_messages_to_internal(request)
         )
         gen_args = _build_gen_args(
-            request, processor, tenant_id=_read_tenant_id(http_request)
+            request,
+            processor,
+            config=config,
+            tenant_id=_read_tenant_id(http_request),
         )
         template_kwargs = gen_args.to_template_kwargs()
         if tool_choice is not None:

--- a/mlx_vlm/server/app.py
+++ b/mlx_vlm/server/app.py
@@ -163,12 +163,13 @@ def _server_runtime_snapshot() -> dict:
 
 
 def _build_gen_args(
-    request, processor=None, tenant_id: Optional[str] = None
+    request, processor=None, config=None, tenant_id: Optional[str] = None
 ) -> GenerationArguments:
     """Build GenerationArguments from a compatible API request."""
     return _request_normalization._build_gen_args(
         request,
         processor=processor,
+        config=config,
         tenant_id=tenant_id,
         structured_logits_processor_builder=_build_structured_logits_processors,
     )

--- a/mlx_vlm/server/generation.py
+++ b/mlx_vlm/server/generation.py
@@ -810,6 +810,8 @@ class GenerationArguments:
             kw["reasoning"] = self.reasoning
         if self.reasoning_effort is not None:
             kw["reasoning_effort"] = self.reasoning_effort
+            # Muse Glimmer's chat template reads the reasoning_strength alias.
+            kw["reasoning_strength"] = self.reasoning_effort
         if self.thinking_budget is not None:
             kw["thinking_budget"] = self.thinking_budget
         if self.thinking_start_token is not None:

--- a/mlx_vlm/server/openai.py
+++ b/mlx_vlm/server/openai.py
@@ -820,7 +820,10 @@ async def responses_input_tokens_endpoint(request: Request):
         del model
         chat_tools, _ = _response_tool_registry(openai_request.tools)
         gen_args = _build_gen_args(
-            openai_request, processor, tenant_id=_read_tenant_id(request)
+            openai_request,
+            processor,
+            config=config,
+            tenant_id=_read_tenant_id(request),
         )
         template_kwargs = gen_args.to_template_kwargs()
         if openai_request.tool_choice is not None:
@@ -986,7 +989,10 @@ async def responses_endpoint(request: Request):
 
         try:
             gen_args = _build_gen_args(
-                openai_request, processor, tenant_id=_read_tenant_id(request)
+                openai_request,
+                processor,
+                config=config,
+                tenant_id=_read_tenant_id(request),
             )
         except Exception as e:
             raise HTTPException(status_code=400, detail=str(e))
@@ -1696,7 +1702,10 @@ async def chat_completions_endpoint(request: ChatRequest, http_request: Request)
 
         try:
             gen_args = _build_gen_args(
-                request, processor, tenant_id=_read_tenant_id(http_request)
+                request,
+                processor,
+                config=config,
+                tenant_id=_read_tenant_id(http_request),
             )
         except Exception as e:
             raise HTTPException(status_code=400, detail=str(e))

--- a/mlx_vlm/server/request_normalization.py
+++ b/mlx_vlm/server/request_normalization.py
@@ -134,6 +134,7 @@ def _build_structured_logits_processors(
 def _build_gen_args(
     request,
     processor=None,
+    config=None,
     tenant_id: Optional[str] = None,
     structured_logits_processor_builder=_build_structured_logits_processors,
 ) -> GenerationArguments:
@@ -166,6 +167,12 @@ def _build_gen_args(
     )
     default_top_p = _model_config_field_or_default(processor, "top_p", DEFAULT_TOP_P)
     default_top_k = _model_config_field_or_default(processor, "top_k", 0)
+    thinking_start_token = get_server_thinking_start_token()
+    if thinking_start_token is None:
+        thinking_start_token = getattr(config, "thinking_start_token", None)
+    thinking_end_token = get_server_thinking_end_token()
+    if thinking_end_token is None:
+        thinking_end_token = getattr(config, "thinking_end_token", None)
     if _model_config_field_or_default(processor, "do_sample", None) is False:
         default_temperature = 0.0
     args = GenerationArguments(
@@ -230,10 +237,10 @@ def _build_gen_args(
             request, "thinking_budget", get_server_thinking_budget()
         ),
         thinking_start_token=_request_field_or_default(
-            request, "thinking_start_token", get_server_thinking_start_token()
+            request, "thinking_start_token", thinking_start_token
         ),
         thinking_end_token=_request_field_or_default(
-            request, "thinking_end_token", get_server_thinking_end_token()
+            request, "thinking_end_token", thinking_end_token
         ),
         tenant_id=tenant_id,
     )

--- a/mlx_vlm/server/responses_state.py
+++ b/mlx_vlm/server/responses_state.py
@@ -14,12 +14,16 @@ logger = logging.getLogger("mlx_vlm.server")
 
 RESPONSE_STORE_LIMIT = int(os.environ.get("MLX_VLM_RESPONSE_STORE_LIMIT", "1024"))
 _CONTENT_MARKERS = ("<|START_TEXT|>", "<|END_TEXT|>")
+_HARMONY_START_MARKER = "<|start|>"
+_HARMONY_MESSAGE_MARKER = "<|message|>"
+_HARMONY_CHANNEL_HEADER = re.compile(r"<\|start\|>[^<]*?<\|message\|>")
+_CONTENT_END_MARKERS = ("<|eom|>", "<|eot|>")
 
 
 def _strip_content_markers(text: str) -> str:
-    for marker in _CONTENT_MARKERS:
+    for marker in _CONTENT_MARKERS + _CONTENT_END_MARKERS:
         text = text.replace(marker, "")
-    return text
+    return _HARMONY_CHANNEL_HEADER.sub("", text)
 
 
 @dataclass
@@ -90,7 +94,7 @@ class ThinkingStreamState:
                 continue
 
             if self.thinking_done:
-                emit, self.buffer = self._split_partial(self.buffer, _CONTENT_MARKERS)
+                emit, self.buffer = self._split_content_partial(self.buffer)
                 emit = _strip_content_markers(emit)
                 if emit:
                     content.append(emit)
@@ -155,6 +159,24 @@ class ThinkingStreamState:
         if hold:
             return text[:-hold], text[-hold:]
         return text, ""
+
+    @staticmethod
+    def _split_content_partial(text: str) -> Tuple[str, str]:
+        emit, partial = ThinkingStreamState._split_partial(
+            text, _CONTENT_MARKERS + _CONTENT_END_MARKERS + (_HARMONY_START_MARKER,)
+        )
+        start = text.rfind(_HARMONY_START_MARKER)
+        if start >= 0:
+            header_tail = text[start + len(_HARMONY_START_MARKER) :]
+            message_start = header_tail.find("<")
+            is_partial_header = _HARMONY_MESSAGE_MARKER not in header_tail and (
+                message_start < 0
+                or _HARMONY_MESSAGE_MARKER.startswith(header_tail[message_start:])
+            )
+            partial_start = len(text) - len(partial) if partial else len(text)
+            if is_partial_header and start < partial_start:
+                return text[:start], text[start:]
+        return emit, partial
 
     def _strip_open_marker(self, text: str) -> str:
         for marker in self.open_markers:

--- a/mlx_vlm/server/responses_state.py
+++ b/mlx_vlm/server/responses_state.py
@@ -17,13 +17,19 @@ _CONTENT_MARKERS = ("<|START_TEXT|>", "<|END_TEXT|>")
 _HARMONY_START_MARKER = "<|start|>"
 _HARMONY_MESSAGE_MARKER = "<|message|>"
 _HARMONY_CHANNEL_HEADER = re.compile(r"<\|start\|>[^<]*?<\|message\|>")
+# When the model answers without reasoning first, add_generation_prompt has
+# already emitted "<|start|>assistant", so the header it writes has no prefix.
+_HARMONY_BARE_HEADER = re.compile(r"^to=[^<]*?<\|message\|>")
 _CONTENT_END_MARKERS = ("<|eom|>", "<|eot|>")
 
 
-def _strip_content_markers(text: str) -> str:
+def _strip_content_markers(text: str, strip_bare_header: bool = True) -> str:
     for marker in _CONTENT_MARKERS + _CONTENT_END_MARKERS:
         text = text.replace(marker, "")
-    return _HARMONY_CHANNEL_HEADER.sub("", text)
+    text = _HARMONY_CHANNEL_HEADER.sub("", text)
+    if strip_bare_header:
+        text = _HARMONY_BARE_HEADER.sub("", text, count=1)
+    return text
 
 
 @dataclass
@@ -63,6 +69,7 @@ class ThinkingStreamState:
         self.close_markers = tuple(marker for _, marker in self.open_close_markers)
         self.in_thinking = bool(enable_thinking)
         self.thinking_done = False
+        self.content_started = False
         self.buffer = ""
 
     def feed(self, text: str) -> ThinkingStreamDelta:
@@ -93,9 +100,20 @@ class ThinkingStreamState:
                 thinking_closed = True
                 continue
 
+            if not self.content_started and not self._starts_like_open_marker(
+                self.buffer
+            ):
+                header = _HARMONY_BARE_HEADER.match(self.buffer)
+                if header:
+                    self.buffer = self.buffer[header.end() :]
+                    if not self.buffer:
+                        break
+                elif self._is_partial_bare_header(self.buffer):
+                    break
+
             if self.thinking_done:
                 emit, self.buffer = self._split_content_partial(self.buffer)
-                emit = _strip_content_markers(emit)
+                emit = _strip_content_markers(emit, strip_bare_header=False)
                 if emit:
                     content.append(emit)
                 break
@@ -103,22 +121,28 @@ class ThinkingStreamState:
             idx, marker = self._find_first(self.buffer, self.open_markers)
             if idx < 0:
                 emit, self.buffer = self._split_partial(self.buffer, self.open_markers)
-                emit = _strip_content_markers(emit)
+                emit = _strip_content_markers(emit, strip_bare_header=False)
                 if emit:
                     content.append(emit)
                 break
 
             if idx:
-                emit = _strip_content_markers(self.buffer[:idx])
+                emit = _strip_content_markers(
+                    self.buffer[:idx], strip_bare_header=False
+                )
                 if emit:
                     content.append(emit)
 
             self.buffer = self.buffer[idx + len(marker) :].lstrip("\n")
             self.in_thinking = True
 
+        emitted_content = "".join(content)
+        if emitted_content:
+            self.content_started = True
+
         return ThinkingStreamDelta(
             reasoning="".join(reasoning) or None,
-            content="".join(content) or None,
+            content=emitted_content or None,
             thinking_closed=thinking_closed,
         )
 
@@ -177,6 +201,27 @@ class ThinkingStreamState:
             if is_partial_header and start < partial_start:
                 return text[:start], text[start:]
         return emit, partial
+
+    def _starts_like_open_marker(self, text: str) -> bool:
+        """Whether text is, or could still become, a thinking open marker."""
+        return any(
+            text.startswith(marker) or marker.startswith(text)
+            for marker in self.open_markers
+        )
+
+    @staticmethod
+    def _is_partial_bare_header(text: str) -> bool:
+        """Whether text could still grow into a bare to=...<|message|> header."""
+        prefix = "to="
+        if len(text) < len(prefix):
+            return prefix.startswith(text)
+        if not text.startswith(prefix):
+            return False
+        recipient = text[len(prefix) :]
+        marker_start = recipient.find("<")
+        if marker_start < 0:
+            return True
+        return _HARMONY_MESSAGE_MARKER.startswith(recipient[marker_start:])
 
     def _strip_open_marker(self, text: str) -> str:
         for marker in self.open_markers:

--- a/mlx_vlm/tests/test_muse_glimmer_reasoning.py
+++ b/mlx_vlm/tests/test_muse_glimmer_reasoning.py
@@ -1,0 +1,103 @@
+from types import SimpleNamespace
+
+from mlx_vlm.server.generation import GenerationArguments
+from mlx_vlm.server.request_normalization import _build_gen_args
+from mlx_vlm.server.responses_state import (
+    ThinkingStreamState,
+    _split_thinking,
+    _strip_content_markers,
+)
+
+
+def test_splits_muse_glimmer_reasoning_and_channel_header():
+    reasoning, content = _split_thinking(
+        "to=self<|message|>Say exactly: hello world ... No extra."
+        "<|eom|><|start|>assistant to=user<|message|>hello world",
+        "to=self<|message|>",
+        "<|eom|>",
+    )
+
+    assert (reasoning, content) == (
+        "Say exactly: hello world ... No extra.",
+        "hello world",
+    )
+
+
+def test_streaming_thinking_strips_split_harmony_channel_header():
+    state = ThinkingStreamState(
+        thinking_start_token="to=self<|message|>", thinking_end_token="<|eom|>"
+    )
+    reasoning = []
+    content = []
+
+    for chunk in [
+        "to=self<|message|>REASONING<|eom|><|start|>",
+        "assistant to=user",
+        "<|message|>hello world",
+    ]:
+        delta = state.feed(chunk)
+        if delta.reasoning:
+            reasoning.append(delta.reasoning)
+        if delta.content:
+            content.append(delta.content)
+
+    assert "".join(reasoning) == "REASONING"
+    assert "".join(content) == "hello world"
+
+
+def test_strips_harmony_channel_headers_without_changing_ordinary_text():
+    assert (
+        _strip_content_markers("<|start|>assistant to=user<|message|>hello world")
+        == "hello world"
+    )
+    assert (
+        _strip_content_markers(
+            "<|start|>assistant to=user<|message|>hello"
+            "<|eom|><|start|>assistant to=user<|message|> world<|eot|>"
+        )
+        == "hello world"
+    )
+    assert _strip_content_markers("ordinary text") == "ordinary text"
+
+
+def test_build_gen_args_prefers_request_and_environment_to_config(monkeypatch):
+    monkeypatch.delenv("MLX_VLM_THINKING_START_TOKEN", raising=False)
+    monkeypatch.delenv("MLX_VLM_THINKING_END_TOKEN", raising=False)
+    config = SimpleNamespace(
+        thinking_start_token="config-start",
+        thinking_end_token="config-end",
+    )
+
+    config_args = _build_gen_args(SimpleNamespace(), config=config)
+    assert config_args.thinking_start_token == "config-start"
+    assert config_args.thinking_end_token == "config-end"
+
+    no_marker_config_args = _build_gen_args(SimpleNamespace(), config=SimpleNamespace())
+    assert no_marker_config_args.thinking_start_token is None
+    assert no_marker_config_args.thinking_end_token is None
+
+    monkeypatch.setenv("MLX_VLM_THINKING_START_TOKEN", "env-start")
+    monkeypatch.setenv("MLX_VLM_THINKING_END_TOKEN", "env-end")
+    env_args = _build_gen_args(SimpleNamespace(), config=config)
+    assert env_args.thinking_start_token == "env-start"
+    assert env_args.thinking_end_token == "env-end"
+
+    request = SimpleNamespace(
+        thinking_start_token="request-start",
+        thinking_end_token="request-end",
+    )
+    request_args = _build_gen_args(request, config=config)
+    assert request_args.thinking_start_token == "request-start"
+    assert request_args.thinking_end_token == "request-end"
+
+
+def test_template_kwargs_aliases_reasoning_effort_to_reasoning_strength():
+    args = GenerationArguments(reasoning_effort="medium")
+    kwargs = args.to_template_kwargs()
+
+    assert kwargs["reasoning_effort"] == "medium"
+    assert kwargs["reasoning_strength"] == "medium"
+
+    kwargs_without_effort = GenerationArguments().to_template_kwargs()
+    assert "reasoning_effort" not in kwargs_without_effort
+    assert "reasoning_strength" not in kwargs_without_effort

--- a/mlx_vlm/tests/test_muse_glimmer_reasoning.py
+++ b/mlx_vlm/tests/test_muse_glimmer_reasoning.py
@@ -101,3 +101,72 @@ def test_template_kwargs_aliases_reasoning_effort_to_reasoning_strength():
     kwargs_without_effort = GenerationArguments().to_template_kwargs()
     assert "reasoning_effort" not in kwargs_without_effort
     assert "reasoning_strength" not in kwargs_without_effort
+
+
+# Captured from a live Muse Glimmer server: when the model answers without
+# reasoning first, add_generation_prompt has already emitted "<|start|>assistant",
+# so the header the model produces has no "<|start|>" prefix.
+BARE_HEADER_OUTPUT = "to=user<|message|>391"
+FULL_HEADER_OUTPUT = (
+    "to=self<|message|>Reasoning here.<|eom|><|start|>assistant to=user<|message|>391"
+)
+
+
+def _drive_stream(chunks):
+    state = ThinkingStreamState(
+        thinking_start_token="to=self<|message|>", thinking_end_token="<|eom|>"
+    )
+    reasoning = []
+    content = []
+    for chunk in chunks:
+        delta = state.feed(chunk)
+        if delta.reasoning:
+            reasoning.append(delta.reasoning)
+        if delta.content:
+            content.append(delta.content)
+    return "".join(reasoning), "".join(content)
+
+
+def test_strips_bare_harmony_channel_header():
+    assert _strip_content_markers("to=user<|message|>391") == "391"
+
+
+def test_streaming_strips_bare_header_at_every_split_point():
+    for index in range(len(BARE_HEADER_OUTPUT) + 1):
+        _, content = _drive_stream(
+            [BARE_HEADER_OUTPUT[:index], BARE_HEADER_OUTPUT[index:]]
+        )
+        assert content == "391", f"split at {index}"
+
+
+def test_streaming_strips_bare_header_one_character_at_a_time():
+    _, content = _drive_stream(list(BARE_HEADER_OUTPUT))
+    assert content == "391"
+
+
+def test_streaming_splits_full_header_at_every_split_point():
+    for index in range(len(FULL_HEADER_OUTPUT) + 1):
+        reasoning, content = _drive_stream(
+            [FULL_HEADER_OUTPUT[:index], FULL_HEADER_OUTPUT[index:]]
+        )
+        assert content == "391", f"split at {index}"
+        assert reasoning == "Reasoning here.", f"split at {index}"
+
+
+def test_keeps_harmony_like_text_once_content_has_started():
+    text = "391 and the literal to=user<|message|> marker"
+    assert _strip_content_markers(text) == text
+    _, content = _drive_stream([text])
+    assert content == text
+
+
+def test_streaming_keeps_harmony_like_chunk_after_content_started():
+    state = ThinkingStreamState(
+        thinking_start_token="to=self<|message|>", thinking_end_token="<|eom|>"
+    )
+
+    first = state.feed("The answer is 391. ")
+    second = state.feed("to=user<|message|> is the literal marker")
+
+    assert first.content == "The answer is 391. "
+    assert second.content == "to=user<|message|> is the literal marker"


### PR DESCRIPTION
## Problem

#1841 added Muse Glimmer's harmony markers to the model config:

```python
# mlx_vlm/models/muse_glimmer/config.py
thinking_start_token: str = "to=self<|message|>"
thinking_end_token: str = "<|eom|>"
```

but nothing in the server ever reads them. `_build_gen_args()` resolves the tokens as
request field → `MLX_VLM_THINKING_*_TOKEN` env → `None`, so on a default server run the
model's whole chain of thought comes back inside `message.content`:

```
to=self<|message|>Say exactly: hello world

We need to say exactly: hello world ...

No extra.<|eom|><|start|>assistant to=user<|message|>hello world
```

with `message.reasoning` / `message.reasoning_content` both `null`.

Because the reasoning sits inside `content` *and* inside the token budget, any answer
longer than a sentence tends to exhaust `max_tokens` before the final channel is reached,
so `content` ends up being pure chain of thought with no answer in it at all.

Two smaller things fall out of the same area:

* Even after the thinking split, the final `<|start|>assistant to=user<|message|>` header
  is left in `content` for every consumer to strip.
* `to_template_kwargs()` forwards `reasoning_effort` to the chat template, but Muse
  Glimmer's template does not read that name — it renders `Reasoning strength: <value>.`
  from a `reasoning_strength` variable (unconditionally, defaulting to `high`). So the
  OpenAI-style `reasoning_effort` field silently does nothing for this model.

## Changes

1. **`request_normalization.py`** — `_build_gen_args()` takes an optional `config` and falls
   back to the model config's `thinking_start_token` / `thinking_end_token` when neither the
   request nor the env var supplies them. Resolution order is unchanged otherwise
   (request → env/CLI → model config → `None`). `config` is threaded from the existing call
   sites in `app.py`, `openai.py` (3) and `anthropic.py` (2); all of them already have it in
   scope from `get_cached_model(...)`.

2. **`generation.py`** — `to_template_kwargs()` emits `reasoning_strength` alongside
   `reasoning_effort` with the same value. Templates that don't reference it ignore the extra
   kwarg, so this is a no-op for every other model.

3. **`responses_state.py`** — `_strip_content_markers()` also removes harmony channel headers
   (`<|start|>…<|message|>`) and stray `<|eom|>` / `<|eot|>` markers. The streaming path holds
   back a partially-received header so a header split across chunks isn't emitted as content.

## Result

Default run, no flags:

```bash
python -m mlx_vlm.server --model /path/to/Muse-Glimmer-30B-4bit --port 8088
```

| | before | after |
|---|---|---|
| `content` | `to=self<\|message\|>…<\|eom\|><\|start\|>assistant to=user<\|message\|>hello world` | `hello world` |
| `reasoning` | `null` | the chain of thought |

`reasoning_effort` now actually steers the model (same prompt, `mlx-community/Muse-Glimmer-30B-4bit`):

| `reasoning_effort` | reasoning length | completion tokens |
|---|---|---|
| `low` | 186 chars | 60 |
| `xhigh` | 523 chars | 168 |

## Testing

New `mlx_vlm/tests/test_muse_glimmer_reasoning.py` (5 tests, no weights/network/server):
non-streaming split, streaming split with the channel header broken across chunks, marker
stripping, config/env/request precedence in `_build_gen_args`, and the
`reasoning_strength` alias.

```
mlx_vlm/tests/test_muse_glimmer_reasoning.py    5 passed
mlx_vlm/tests/test_server.py + test_atem_tool_parser.py + test_gemma4_tool_parser.py
                                              285 passed
```

Manually verified on an M1 Max (32 GB) against `mlx-community/Muse-Glimmer-30B-4bit`:
non-streaming and streaming both return clean `content`, ATEM tool calls from #1841 still
parse correctly, and `lmstudio-community/Qwen3-VL-8B-Instruct-MLX-4bit` (non-harmony) is
unaffected.

## Notes

* Two behaviours I deliberately left alone, happy to fold either in if you'd prefer:
  * Streamed `content` keeps a leading space (`" hello world"`) where the non-streaming path
    `.strip()`s it. That difference predates this change.
  * `reasoning_effort: "none"` is passed through to `reasoning_strength` as-is. Muse Glimmer
    documents only `low / medium / high / xhigh`, so `none` lands as a value it wasn't trained
    on and yields minimal-but-nonzero reasoning rather than none. Mapping disabling efforts to
    `low` would be a judgement call I didn't want to make unilaterally.
