### PR TITLE
server: draw a fresh sampling seed when the request omits one

### DIFF
--- a/mlx_vlm/server/generation.py
+++ b/mlx_vlm/server/generation.py
@@ -1,6 +1,7 @@
 import gc
 import logging
 import os
+import random
 import time
 from collections import deque
 from contextlib import nullcontext
@@ -21,7 +22,6 @@ from ..generate import (
     DEFAULT_PREFILL_STEP_SIZE,
     DEFAULT_QUANTIZED_KV_START,
     DEFAULT_REPETITION_CONTEXT_SIZE,
-    DEFAULT_SEED,
     DEFAULT_TEMPERATURE,
     DEFAULT_THINKING_END_TOKEN,
     DEFAULT_THINKING_START_TOKEN,
@@ -253,7 +253,7 @@ class _PositionedTargetSampler:
     def __init__(self, *, temperature: float, top_p: float, seed: Optional[int]):
         self.temperature = float(temperature)
         self.top_p = float(top_p)
-        self.seed = DEFAULT_SEED if seed is None else int(seed)
+        self.seed = random.randrange(2**32) if seed is None else int(seed)
 
     def __call__(self, logprobs: mx.array) -> mx.array:
         if self.top_p > 0 and self.top_p < 1.0:

--- a/mlx_vlm/server/schemas.py
+++ b/mlx_vlm/server/schemas.py
@@ -9,7 +9,6 @@ if TYPE_CHECKING:
 
 from ..generate import (
     DEFAULT_MAX_TOKENS,
-    DEFAULT_SEED,
     DEFAULT_TEMPERATURE,
     DEFAULT_TOP_P,
     normalize_resize_shape,
@@ -744,7 +743,10 @@ class VLMRequest(FlexibleBaseModel):
     typical_p: float = Field(
         1.0, description="Locally typical sampling. 1.0 disables; typical ~0.2-0.95."
     )
-    seed: int = Field(DEFAULT_SEED, description="Seed for random generation.")
+    seed: Optional[int] = Field(
+        None,
+        description="Seed for random generation. Omitted requests draw a fresh seed.",
+    )
     repetition_penalty: Optional[float] = Field(None, description="Repetition penalty.")
     repetition_context_size: Optional[int] = Field(
         None, description="Repetition penalty context size."

--- a/mlx_vlm/tests/test_server.py
+++ b/mlx_vlm/tests/test_server.py
@@ -136,6 +136,14 @@ def test_chat_request_schema_requires_model():
     assert "model" in server.ChatRequest.model_json_schema()["required"]
 
 
+def test_chat_request_schema_leaves_seed_unset_by_default():
+    request = server.ChatRequest(
+        model="model", messages=[{"role": "user", "content": "hi"}]
+    )
+
+    assert request.seed is None
+
+
 def test_chat_request_schema_declares_tool_choice_fields():
     properties = server.ChatRequest.model_json_schema()["properties"]
 
@@ -422,6 +430,50 @@ def test_positioned_target_sampler_is_batch_grouping_invariant():
     mx.eval(batched, single_0, single_1)
 
     assert batched.tolist() == [single_0.item(), single_1.item()]
+
+
+def _uniform_logprobs(rows, vocab):
+    return mx.zeros((rows, vocab)) - float(np.log(vocab))
+
+
+def test_positioned_target_sampler_draws_a_fresh_seed_when_none_is_given():
+    positions = list(range(32))
+    row_ids = [0] * len(positions)
+    logprobs = _uniform_logprobs(len(positions), 8)
+
+    first = server_generation._PositionedTargetSampler(
+        temperature=1.0, top_p=1.0, seed=None
+    )
+    second = server_generation._PositionedTargetSampler(
+        temperature=1.0, top_p=1.0, seed=None
+    )
+
+    assert first.seed != second.seed
+
+    tokens_first = first.sample_target(logprobs, row_ids=row_ids, positions=positions)
+    tokens_second = second.sample_target(logprobs, row_ids=row_ids, positions=positions)
+    mx.eval(tokens_first, tokens_second)
+
+    assert tokens_first.tolist() != tokens_second.tolist()
+
+
+def test_positioned_target_sampler_repeats_draws_for_an_explicit_seed():
+    positions = list(range(32))
+    row_ids = [0] * len(positions)
+    logprobs = _uniform_logprobs(len(positions), 8)
+
+    first = server_generation._PositionedTargetSampler(
+        temperature=1.0, top_p=1.0, seed=1234
+    )
+    second = server_generation._PositionedTargetSampler(
+        temperature=1.0, top_p=1.0, seed=1234
+    )
+
+    tokens_first = first.sample_target(logprobs, row_ids=row_ids, positions=positions)
+    tokens_second = second.sample_target(logprobs, row_ids=row_ids, positions=positions)
+    mx.eval(tokens_first, tokens_second)
+
+    assert tokens_first.tolist() == tokens_second.tolist()
 
 
 def test_speculative_server_dispatches_eagle3_batch_loop():


### PR DESCRIPTION
Fixes #1818.

## Problem

`/v1/chat/completions` returns byte-identical completions for identical prompts at `temperature=0.7`, so k repetitions of one prompt sample the same point k times.

Reproduced on an unmodified checkout at 321514d6 with `mlx-community/SmolVLM-256M-Instruct-bf16`, three identical requests at `temperature=0.7, top_p=0.8` and no `seed` field:

```
--- A) no seed, same prompt x3 ---
  run 1: d340f351d877  'Name: "Nautical Explorer".<end_of_utterance>'
  run 2: d340f351d877  'Name: "Nautical Explorer".<end_of_utterance>'
  run 3: d340f351d877  'Name: "Nautical Explorer".<end_of_utterance>'
  => 1 distinct output(s) in 3 runs
--- C) control: 3 different prompts ---
  => 3 distinct output(s) in 3 runs
```

## Root cause

`VLMRequest.seed` was `int = Field(DEFAULT_SEED)`, so a request that omits `seed` arrives as `seed=0` rather than unset. `_PositionedTargetSampler` keys every draw from `(seed, row_id, position)`, and its own `DEFAULT_SEED if seed is None` fallback closed the remaining gap. Same prompt, same seed and same positions give the same tokens on every request.

`mlx_vlm.generate` already treats an absent seed as not reproducible: `--seed` defaults to `None`, and `ar.py` only selects `_PositionedTargetSampler` when `seed is not None`. The server was the one path pinning it to a constant.

## Fix

Make `seed` `Optional[int]` defaulting to `None`, and draw `random.randrange(2**32)` when the sampler is built without one. This is the idiom already used for an absent seed in `generate/image.py`, `generate/video_generation.py` and `server/openai.py`.

Stateless keying stays, so batch grouping invariance and ragged speculative verification are unchanged within a request.

## Verification

Same script against the patched server:

```
--- A) no seed, same prompt x3 ---
  run 1: e887dd933f12  'Name: Moonflower\nExplanation: Moonflower is a name that is uniqu'
  run 2: 4a8018fa3c38  'Name: Ocean Breeze.<end_of_utterance>'
  run 3: a46a32ff93f8  '"Sailboat" is a name that could be invented and has several adva'
  => 3 distinct output(s) in 3 runs
```

Explicit seeds still reproduce exactly. `seed: 1/2/3` returned the same three hashes before and after the change (`8e7fb204cba4`, `ba66661be662`, `b341d123d944`), and `seed: 7` sent three times gives one hash.

`test_chat_request_schema_leaves_seed_unset_by_default` and `test_positioned_target_sampler_draws_a_fresh_seed_when_none_is_given` fail on main and pass with the change. `test_positioned_target_sampler_repeats_draws_for_an_explicit_seed` guards the other direction. `pytest mlx_vlm/tests/test_server.py` gives 268 passed; the server, server_audio, generate, cli, sample_utils and responses_state modules together give 430 passed.

## Not covered

Concurrent identical prompts that land in the same in-flight batch still match each other. `BatchGenerator` keeps one sampler for its lifetime and `GenerationBatch` passes `row_ids=[0] * n`, so two rows at the same position share a key. Three concurrent identical requests on the patched server gave 2 distinct outputs rather than 3. Fixing that needs a stable per-request row id, which is a larger change in `generate/ar.py` and looked out of scope for this issue.

Diagnosed by @tagisade, who traced it to `_PositionedTargetSampler` and the `DEFAULT_SEED` fallback and offered to take option (1). I picked it up because the issue had been sitting; happy to close this if they would rather open their own.
