### PR TITLE
Flush the stream buffer on the last token

### DIFF
--- a/mlx_vlm/server/anthropic.py
+++ b/mlx_vlm/server/anthropic.py
@@ -671,7 +671,9 @@ async def anthropic_messages_endpoint(http_request: Request):
                         for event in start_message_event():
                             yield event
 
-                        thinking_delta = thinking_state.feed(delta)
+                        thinking_delta = thinking_state.feed(
+                            delta, last=bool(getattr(token, "finish_reason", None))
+                        )
                         delta_reasoning = thinking_delta.reasoning
                         delta_content = thinking_delta.content
 

--- a/mlx_vlm/server/openai.py
+++ b/mlx_vlm/server/openai.py
@@ -1136,7 +1136,9 @@ async def responses_endpoint(request: Request):
                             raw_delta = token.text
                             full_text += raw_delta
                             chunk_rate = metrics.record_chunk(token)
-                            thinking_delta = thinking_state.feed(raw_delta)
+                            thinking_delta = thinking_state.feed(
+                                raw_delta, last=bool(token.finish_reason)
+                            )
                             if thinking_delta.reasoning:
                                 streamed_reasoning += thinking_delta.reasoning
                                 yield _response_sse_event(
@@ -1187,7 +1189,10 @@ async def responses_endpoint(request: Request):
                             raw_delta = chunk.text
                             full_text += raw_delta
                             chunk_rate = metrics.record_chunk(chunk)
-                            thinking_delta = thinking_state.feed(raw_delta)
+                            chunk_finish = getattr(chunk, "finish_reason", None)
+                            thinking_delta = thinking_state.feed(
+                                raw_delta, last=bool(chunk_finish)
+                            )
                             if thinking_delta.reasoning:
                                 streamed_reasoning += thinking_delta.reasoning
                                 yield _response_sse_event(
@@ -1206,7 +1211,6 @@ async def responses_endpoint(request: Request):
                             in_tool_call, delta = suppress_tool_call_content(
                                 full_text, in_tool_call, tc_start, delta
                             )
-                            chunk_finish = getattr(chunk, "finish_reason", None)
                             if chunk_finish is not None:
                                 finish_reason = chunk_finish
                             usage_stats = {
@@ -1810,7 +1814,9 @@ async def chat_completions_endpoint(request: ChatRequest, http_request: Request)
                             chunk_rate = metrics.record_chunk(token)
 
                             # Detect thinking boundaries
-                            thinking_delta = thinking_state.feed(token.text)
+                            thinking_delta = thinking_state.feed(
+                                token.text, last=bool(token.finish_reason)
+                            )
                             delta_reasoning = thinking_delta.reasoning
                             delta_content = thinking_delta.content
 
@@ -1951,7 +1957,9 @@ async def chat_completions_endpoint(request: ChatRequest, http_request: Request)
                             if chunk_finish is not None:
                                 finish_reason = chunk_finish
 
-                            thinking_delta = thinking_state.feed(chunk.text)
+                            thinking_delta = thinking_state.feed(
+                                chunk.text, last=bool(chunk_finish)
+                            )
                             if thinking_delta.content or thinking_delta.reasoning:
                                 choices = [
                                     ChatStreamChoice(

--- a/mlx_vlm/server/responses_state.py
+++ b/mlx_vlm/server/responses_state.py
@@ -61,7 +61,7 @@ class ThinkingStreamState:
         self.thinking_done = False
         self.buffer = ""
 
-    def feed(self, text: str) -> ThinkingStreamDelta:
+    def feed(self, text: str, last: bool = False) -> ThinkingStreamDelta:
         self.buffer += text or ""
         reasoning = []
         content = []
@@ -111,6 +111,13 @@ class ThinkingStreamState:
 
             self.buffer = self.buffer[idx + len(marker) :].lstrip("\n")
             self.in_thinking = True
+
+        if last and self.buffer:
+            held, self.buffer = self.buffer, ""
+            if self.in_thinking:
+                reasoning.append(self._strip_open_marker(held))
+            else:
+                content.append(_strip_content_markers(held))
 
         return ThinkingStreamDelta(
             reasoning="".join(reasoning) or None,

--- a/mlx_vlm/tests/test_server.py
+++ b/mlx_vlm/tests/test_server.py
@@ -6548,6 +6548,54 @@ class TestThinkingStreamState:
 
         assert (reasoning, content) == ("why", "answer")
 
+    def test_last_chunk_on_an_empty_buffer_emits_nothing(self):
+        state = server.ThinkingStreamState()
+
+        delta = state.feed("", last=True)
+
+        assert (delta.reasoning, delta.content) == (None, None)
+
+    def test_buffer_is_only_released_once(self):
+        state = server.ThinkingStreamState()
+
+        state.feed("hello <")
+        assert state.feed("", last=True).content == "<"
+        assert state.feed("", last=True).content is None
+
+    def test_last_chunk_releases_to_reasoning_when_thinking_opened_in_the_prompt(self):
+        state = server.ThinkingStreamState(enable_thinking=True)
+
+        delta = state.feed("why </thi", last=True)
+
+        assert (delta.reasoning, delta.content) == ("why </thi", None)
+
+    def test_last_chunk_releases_a_partial_custom_end_token(self):
+        state = server.ThinkingStreamState(
+            thinking_start_token="<BEGIN>", thinking_end_token="<END>"
+        )
+
+        state.feed("<BEGIN>")
+        assert state.feed("work <EN", last=True).reasoning == "work <EN"
+
+    def test_last_chunk_releases_content_held_after_thinking_closed(self):
+        state = server.ThinkingStreamState()
+
+        state.feed("<think>x</think>")
+        assert state.feed("done <|START_TE", last=True).content == "done <|START_TE"
+
+    def test_last_chunk_still_reports_thinking_closed(self):
+        state = server.ThinkingStreamState()
+
+        state.feed("<think>why")
+        delta = state.feed("</think>tail <", last=True)
+
+        assert (delta.content, delta.thinking_closed) == ("tail <", True)
+
+    def test_last_chunk_strips_complete_content_markers(self):
+        state = server.ThinkingStreamState()
+
+        assert state.feed("hi <|END_TEXT|>", last=True).content == "hi "
+
     def test_prompt_must_end_with_open_thinking_marker_to_start_in_thinking(self):
         assert server.prompt_has_open_thinking("prompt", enable_thinking=True) is False
         assert (

--- a/mlx_vlm/tests/test_server.py
+++ b/mlx_vlm/tests/test_server.py
@@ -6396,6 +6396,29 @@ class TestSplitThinking:
 class TestThinkingStreamState:
     """Tests for streaming thinking tag parsing."""
 
+    def test_last_chunk_releases_text_held_for_an_unfinished_marker(self):
+        state = server.ThinkingStreamState()
+
+        assert state.feed("hello <").content == "hello "
+        assert state.feed("", last=True).content == "<"
+
+    def test_last_chunk_releases_reasoning_held_for_an_unfinished_marker(self):
+        state = server.ThinkingStreamState()
+
+        state.feed("<think>")
+        assert state.feed("cut off </thi", last=True).reasoning == "cut off </thi"
+
+    def test_last_chunk_does_not_disturb_a_complete_stream(self):
+        state = server.ThinkingStreamState()
+        reasoning, content = "", ""
+
+        for chunk in ("<think>", "why", "</think>", "answer"):
+            delta = state.feed(chunk, last=chunk == "answer")
+            reasoning += delta.reasoning or ""
+            content += delta.content or ""
+
+        assert (reasoning, content) == ("why", "answer")
+
     def test_prompt_must_end_with_open_thinking_marker_to_start_in_thinking(self):
         assert server.prompt_has_open_thinking("prompt", enable_thinking=True) is False
         assert (


### PR DESCRIPTION
## Summary

```python
s = ThinkingStreamState()
s.feed("hello <").content              # 'hello '        the '<' never arrives

s = ThinkingStreamState()
s.feed("<think>")
s.feed("cut off </thi").reasoning      # 'cut off '      the '</thi' never arrives
```

`_split_partial` keeps those trailing characters back in case `<think>` or `</think>` follows, and nothing sends them once the stream ends. Hits reasoning and content alike.

- `feed()` takes a `last` flag and empties whatever is left when it's set
- wired up at the five streaming call sites in `openai.py` and `anthropic.py`
- no change for callers that don't pass it

## Why

Any response ending in `<`, or a partial like `<thi`, quietly loses those characters. Asking for a response of exactly `<` on main:

```
                            non-streaming   streaming
Qwen2.5-VL-3B-Instruct-4bit      '<'            ''
Qwen2-VL-2B-Instruct-4bit        '<'            ''
gemma-3-4b-it-4bit               '<'            ''
```

## Validation

Three tests in `TestThinkingStreamState` covering content, reasoning and a normal stream. Failure set unchanged from main. `pre-commit run --all` clean.
