### PR TITLE
Pin MLX_ENABLE_TF32=0 for the tests

### DIFF
--- a/mlx_vlm/tests/conftest.py
+++ b/mlx_vlm/tests/conftest.py
@@ -1,0 +1,6 @@
+import os
+
+# float32 matmul runs at TF32 precision on hardware with matrix units, which is
+# looser than the float32 references these tests compare against. Set rather than
+# setdefault, so an inherited MLX_ENABLE_TF32=1 doesn't leak into the test run.
+os.environ["MLX_ENABLE_TF32"] = "0"


### PR DESCRIPTION
27 failures on a clean main on an M5 Max, across `test_turboquant_rht_value_kernels`, `test_one_bit`, `test_models`, `test_minimax_m3`, `test_qwen3_omni_moe` and `test_speculative`. CI is green on your runners so it probably doesn't show up there.

It's `MLX_ENABLE_TF32`, which defaults to 1, so float32 matmul runs at TF32 precision on hardware with matrix units:

```python
np.abs(a @ b - ref).max() / np.abs(ref).max()                       # 7.5e-07
np.abs(np.array(mx.matmul(A, B)) - ref).max() / np.abs(ref).max()   # 7.8e-04
```

The kernels here accumulate in real float32, the references go through `mx.matmul`, and cause a mismatch on my mac. [ml-explore/mlx#3860](https://github.com/ml-explore/mlx/issues/3860), and [ml-explore/mlx#3883](https://github.com/ml-explore/mlx/pull/3883) mentions the M5 NAX route.

`MLX_ENABLE_TF32=0` takes it from 27 to 1. mlx pins the same flag in [its own harness](https://github.com/ml-explore/mlx/blob/main/python/tests/mlx_tests.py) 

The failing test is `test_qwen_target_verify_quantized_linear_matches_singleton_batch_path` probably unrelated.

macOS 26.6.1, M5 Max, Python 3.12, mlx 0.32.0.
