### PR TITLE
Add Apertus 1.5 (image + audio + text)

### DIFF
--- a/mlx_vlm/models/apertus1p5/__init__.py
+++ b/mlx_vlm/models/apertus1p5/__init__.py
@@ -1,0 +1,16 @@
+from . import processing_apertus1p5  # noqa: F401 (installs processor patch)
+from .apertus1p5 import Model
+from .config import ModelConfig, TextConfig, VisionTokenizerConfig
+from .language import LanguageModel
+from .processing_apertus1p5 import Apertus1p5Processor as Processor
+from .vision import VisionTokenizer
+
+__all__ = [
+    "Model",
+    "ModelConfig",
+    "TextConfig",
+    "VisionTokenizerConfig",
+    "LanguageModel",
+    "VisionTokenizer",
+    "Processor",
+]

--- a/mlx_vlm/models/apertus1p5/apertus1p5.py
+++ b/mlx_vlm/models/apertus1p5/apertus1p5.py
@@ -1,0 +1,393 @@
+import re
+from typing import Optional
+
+import mlx.core as mx
+import mlx.nn as nn
+
+from ..base import InputEmbeddingsFeatures, LanguageModelOutput
+from .audio import AudioTokenizer
+from .config import ModelConfig
+from .language import LanguageModel
+from .vision import VisionTokenizer, ensure_channels_last
+
+_AUDIO_LSTM_KEY = re.compile(r"^(.*\.lstm)\.(weight|bias)_(ih|hh)_l(\d+)$")
+
+
+def masked_scatter(input_tensor: mx.array, mask: mx.array, source: mx.array):
+    mask_flat = mask.flatten().astype(mx.int32)
+    indices = mx.cumsum(mask_flat) - 1
+    aligned = source.flatten()[indices % source.size]
+    return mx.where(mask_flat, aligned, input_tensor.flatten()).reshape(
+        input_tensor.shape
+    )
+
+
+class Model(nn.Module):
+    """Image/audio/text Apertus 1.5 inference.
+
+    The initial port intentionally supports one prompt at a time. Custom
+    attention masks are accepted for API compatibility but ignored; the
+    Apertus backbone builds its own causal mask.
+    """
+
+    def __init__(self, config: ModelConfig):
+        super().__init__()
+        self.config = config
+        self.model_type = config.model_type
+        if config.tie_word_embeddings and not config.text_config.tie_word_embeddings:
+            # utils.load_model rebuilds text_config from the raw nested dict
+            # after ModelConfig.from_dict, discarding the hoisted top-level
+            # flag; reapply it before the language model reads it.
+            config.text_config.tie_word_embeddings = True
+        self.language_model = LanguageModel(config.text_config)
+        self.vision_tokenizer = VisionTokenizer(config.vision_tokenizer_config)
+        self.audio_tokenizer = (
+            AudioTokenizer(config.audio_tokenizer_config)
+            if config.audio_tokenizer_config is not None
+            else None
+        )
+
+    def get_image_tokens(
+        self, pixel_values: mx.array, image_sizes: Optional[mx.array] = None
+    ) -> mx.array:
+        if pixel_values.ndim != 4 or pixel_values.shape[0] == 0:
+            raise ValueError("pixel_values must contain at least one rank-4 image")
+        pixel_values = ensure_channels_last(
+            pixel_values, self.config.vision_tokenizer_config.in_channels
+        )
+        padded_height, padded_width = pixel_values.shape[1:3]
+        if image_sizes is None:
+            image_sizes = mx.array(
+                [[padded_height, padded_width]] * pixel_values.shape[0]
+            )
+        elif image_sizes.shape[0] != pixel_values.shape[0]:
+            raise ValueError(
+                "The number of image sizes must match the number of images."
+            )
+
+        vocab_ids = []
+        factor = self.config.vision_tokenizer_config.spatial_scale_factor
+        for image_index in range(pixel_values.shape[0]):
+            height, width = [int(value) for value in image_sizes[image_index].tolist()]
+            if (
+                height <= 0
+                or width <= 0
+                or height > padded_height
+                or width > padded_width
+                or height % factor
+                or width % factor
+            ):
+                raise ValueError(
+                    "Each image size must be positive, within the padded tensor, "
+                    f"and divisible by spatial factor {factor}; got {height}x{width} "
+                    f"inside {padded_height}x{padded_width}."
+                )
+            image = pixel_values[image_index : image_index + 1, :height, :width, :]
+            codes = self.vision_tokenizer.encode(image)[0]
+            vocab_ids.append(codes.flatten() + self.config.image_token_offset)
+        return mx.concatenate(vocab_ids)
+
+    def get_image_features(
+        self, pixel_values: mx.array, image_sizes: Optional[mx.array] = None
+    ) -> mx.array:
+        vocab_ids = self.get_image_tokens(pixel_values, image_sizes)
+        return self.language_model.model.embed_tokens(vocab_ids)
+
+    def get_audio_tokens(
+        self,
+        input_features: mx.array,
+        feature_attention_mask: Optional[mx.array] = None,
+    ) -> mx.array:
+        if self.audio_tokenizer is None:
+            raise ValueError(
+                "This checkpoint has no audio tokenizer configuration; audio "
+                "inputs are not supported."
+            )
+        if input_features.ndim != 3 or input_features.shape[0] == 0:
+            raise ValueError(
+                "input_features must be a rank-3 (num_clips, 1, num_samples) "
+                "array with at least one clip."
+            )
+        num_clips, _, padded_length = input_features.shape
+        if feature_attention_mask is None:
+            lengths = [padded_length] * num_clips
+        else:
+            if feature_attention_mask.shape[0] != num_clips:
+                raise ValueError(
+                    "The number of audio clips in input_features must match "
+                    "the number of rows in feature_attention_mask."
+                )
+            # Clips are right-padded, so the valid length is the mask sum.
+            lengths = [
+                int(value)
+                for value in mx.sum(
+                    feature_attention_mask.astype(mx.int32), axis=-1
+                ).tolist()
+            ]
+            if any(length == 0 for length in lengths):
+                raise ValueError(
+                    "feature_attention_mask marks an audio clip with zero "
+                    "valid samples."
+                )
+            # Slicing ``[:length]`` below is only correct for right padding;
+            # reject left-padded or gapped masks instead of mis-encoding.
+            expected = mx.arange(padded_length)[None, :] < mx.array(lengths)[:, None]
+            if not mx.array_equal(feature_attention_mask != 0, expected):
+                raise ValueError(
+                    "feature_attention_mask must be right-padded: each row "
+                    "must be ones followed by zeros."
+                )
+
+        # Encode clip by clip so batch zero-padding never reaches the codec.
+        vocab_ids = []
+        for clip_index, length in enumerate(lengths):
+            clip = input_features[clip_index : clip_index + 1, :, :length]
+            codes = self.audio_tokenizer.encode(clip)[0]
+            vocab_ids.append(codes.flatten() + self.config.audio_token_offset)
+        return mx.concatenate(vocab_ids)
+
+    def get_audio_features(
+        self,
+        input_features: mx.array,
+        feature_attention_mask: Optional[mx.array] = None,
+    ) -> mx.array:
+        vocab_ids = self.get_audio_tokens(input_features, feature_attention_mask)
+        return self.language_model.model.embed_tokens(vocab_ids)
+
+    def _scatter_features(
+        self,
+        inputs_embeds: mx.array,
+        input_ids: mx.array,
+        features: mx.array,
+        token_id: int,
+        modality: str,
+    ) -> mx.array:
+        placeholder_mask = input_ids == token_id
+        num_placeholders = int(mx.sum(placeholder_mask).item())
+        if num_placeholders != features.shape[0]:
+            raise ValueError(
+                f"{modality} features and {modality} placeholders do not match: "
+                f"{features.shape[0]} features for {num_placeholders} placeholders."
+            )
+        expanded_mask = mx.broadcast_to(
+            mx.expand_dims(placeholder_mask, -1), inputs_embeds.shape
+        )
+        return masked_scatter(inputs_embeds, expanded_mask, features)
+
+    def get_input_embeddings(
+        self,
+        input_ids: mx.array,
+        pixel_values: Optional[mx.array] = None,
+        image_sizes: Optional[mx.array] = None,
+        input_features: Optional[mx.array] = None,
+        feature_attention_mask: Optional[mx.array] = None,
+        **kwargs,
+    ) -> InputEmbeddingsFeatures:
+        inputs_embeds = self.language_model.model.embed_tokens(input_ids)
+        if pixel_values is not None:
+            image_features = self.get_image_features(pixel_values, image_sizes)
+            inputs_embeds = self._scatter_features(
+                inputs_embeds,
+                input_ids,
+                image_features,
+                self.config.image_token_id,
+                "Image",
+            )
+        if input_features is not None:
+            audio_features = self.get_audio_features(
+                input_features, feature_attention_mask
+            )
+            inputs_embeds = self._scatter_features(
+                inputs_embeds,
+                input_ids,
+                audio_features,
+                self.config.audio_token_id,
+                "Audio",
+            )
+        return InputEmbeddingsFeatures(inputs_embeds=inputs_embeds)
+
+    def __call__(
+        self,
+        input_ids: Optional[mx.array] = None,
+        pixel_values: Optional[mx.array] = None,
+        # Trainers pass the attention mask as the third positional argument
+        # (see sft_trainer/orpo_trainer), so keep mask/cache in the shared
+        # slots and the model-specific parameters keyword-friendly after.
+        mask: Optional[mx.array] = None,
+        cache=None,
+        image_sizes: Optional[mx.array] = None,
+        input_features: Optional[mx.array] = None,
+        feature_attention_mask: Optional[mx.array] = None,
+        inputs_embeds: Optional[mx.array] = None,
+        **kwargs,
+    ) -> LanguageModelOutput:
+        if input_ids is not None and input_ids.ndim != 2:
+            raise ValueError("input_ids must be a rank-2 array.")
+        if inputs_embeds is not None and inputs_embeds.ndim != 3:
+            raise ValueError("inputs_embeds must be a rank-3 array.")
+        if input_ids is not None and inputs_embeds is not None:
+            if input_ids.shape != inputs_embeds.shape[:2]:
+                raise ValueError(
+                    "input_ids and inputs_embeds must have matching batch and "
+                    "sequence dimensions."
+                )
+        batch_size = (
+            inputs_embeds.shape[0]
+            if inputs_embeds is not None
+            else input_ids.shape[0] if input_ids is not None else None
+        )
+        if batch_size != 1:
+            raise ValueError(
+                "The initial Apertus 1.5 implementation supports batch size 1 only."
+            )
+        if inputs_embeds is None:
+            features = self.get_input_embeddings(
+                input_ids=input_ids,
+                pixel_values=pixel_values,
+                image_sizes=image_sizes,
+                input_features=input_features,
+                feature_attention_mask=feature_attention_mask,
+            )
+            inputs_embeds = features.inputs_embeds
+        elif pixel_values is not None or input_features is not None:
+            raise ValueError(
+                "Media inputs cannot be combined with precomputed inputs_embeds."
+            )
+
+        # The reused ApertusModel constructs its own causal mask from the cache.
+        # Keep mask and extra generator kwargs in the public signature for API
+        # compatibility, but do not forward unsupported arguments into the LM.
+        return self.language_model(
+            inputs=None,
+            cache=cache,
+            inputs_embeds=inputs_embeds,
+        )
+
+    def _sanitize_audio(self, weights):
+        """Convert reference WavTokenizer weights to this port's layout.
+
+        Keeps the encoder and quantizer codebook only, fuses torch
+        weight-normalization parametrizations into plain conv weights,
+        transposes convs to MLX layout, and folds the two torch LSTM bias
+        vectors into MLX's single one.
+        """
+        sanitized = {}
+        norm_pairs = {}
+        lstm_biases = {}
+        for key, value in weights.items():
+            if key.startswith("model.audio_tokenizer."):
+                key = key[len("model.") :]
+            elif not key.startswith("audio_tokenizer."):
+                sanitized[key] = value
+                continue
+            if self.audio_tokenizer is None:
+                continue
+            rest = key[len("audio_tokenizer.") :]
+            # The Vocos-style decoder is never used for understanding audio.
+            if rest.startswith(("backbone.", "head.")):
+                continue
+            # EMA training buffers of the codebook; only `embed` is used.
+            if rest.startswith("quantizer.codebook.") and not rest.endswith(".embed"):
+                continue
+
+            if key.endswith(".parametrizations.weight.original0"):
+                base = key[: -len(".parametrizations.weight.original0")]
+                norm_pairs.setdefault(base, {})["g"] = value
+                continue
+            if key.endswith(".parametrizations.weight.original1"):
+                base = key[: -len(".parametrizations.weight.original1")]
+                norm_pairs.setdefault(base, {})["v"] = value
+                continue
+
+            lstm_match = _AUDIO_LSTM_KEY.match(key)
+            if lstm_match:
+                prefix, kind, gate_input, layer = lstm_match.groups()
+                target = f"{prefix}.{layer}"
+                if kind == "weight":
+                    name = "Wx" if gate_input == "ih" else "Wh"
+                    sanitized[f"{target}.{name}"] = value
+                else:
+                    pending = lstm_biases.setdefault(target, {})
+                    pending[gate_input] = value
+                continue
+
+            sanitized[key] = value
+
+        for base, pair in norm_pairs.items():
+            if "g" not in pair or "v" not in pair:
+                raise ValueError(
+                    f"Incomplete weight normalization pair for {base}.weight."
+                )
+            magnitude = pair["g"].astype(mx.float32)
+            direction = pair["v"].astype(mx.float32)
+            norm = mx.sqrt(mx.sum(direction * direction, axis=(1, 2), keepdims=True))
+            fused = magnitude * direction / norm
+            # torch (out, in, kernel) -> MLX (out, kernel, in)
+            sanitized[f"{base}.weight"] = fused.transpose(0, 2, 1)
+
+        for target, pending in lstm_biases.items():
+            if "ih" not in pending or "hh" not in pending:
+                raise ValueError(f"Incomplete LSTM bias pair for {target}.bias.")
+            sanitized[f"{target}.bias"] = pending["ih"].astype(mx.float32) + pending[
+                "hh"
+            ].astype(mx.float32)
+
+        return sanitized
+
+    def sanitize(self, weights):
+        sanitized = {}
+        for key, value in self._sanitize_audio(weights).items():
+            is_hf_vision_weight = key.startswith("model.vision_tokenizer.")
+            if key.startswith("model.language_model."):
+                suffix = key[len("model.language_model.") :]
+                key = f"language_model.model.{suffix}"
+            elif key.startswith("model."):
+                key = key[len("model.") :]
+            elif key.startswith("language_model.") and not key.startswith(
+                ("language_model.model.", "language_model.lm_head.")
+            ):
+                # Also accept checkpoints where the outer ``model.`` prefix
+                # was removed but the decoder has not yet gained its MLX
+                # wrapper prefix. Already-converted keys are left untouched.
+                suffix = key[len("language_model.") :]
+                key = f"language_model.model.{suffix}"
+            elif key == "lm_head.weight":
+                key = "language_model.lm_head.weight"
+
+            if is_hf_vision_weight and value.ndim == 4:
+                value = value.transpose(0, 2, 3, 1)
+            if any(
+                key.endswith(suffix)
+                for suffix in ("alpha_p", "alpha_n", ".beta", ".eps")
+            ):
+                value = value.squeeze()
+            if (
+                self.config.text_config.tie_word_embeddings
+                and key == "language_model.lm_head.weight"
+            ):
+                continue
+            sanitized[key] = value
+        return sanitized
+
+    def make_cache(self):
+        return self.language_model.make_cache()
+
+    @property
+    def cast_predicate(self):
+        # Code assignment is an argmax over the codebooks. Casting the
+        # tokenizer weights can flip otherwise deterministic code IDs.
+        return lambda path: not path.startswith(
+            ("vision_tokenizer.", "audio_tokenizer.")
+        )
+
+    @property
+    def quant_predicate(self):
+        # Keep the discrete tokenizers, especially their codebooks,
+        # unquantized even when quantize_model() is called outside convert.py.
+        return lambda path, module: not path.startswith(
+            ("vision_tokenizer.", "audio_tokenizer.")
+        )
+
+    @property
+    def layers(self):
+        return self.language_model.layers

--- a/mlx_vlm/models/apertus1p5/audio.py
+++ b/mlx_vlm/models/apertus1p5/audio.py
@@ -1,0 +1,276 @@
+"""WavTokenizer audio tokenizer (encode path) for Apertus 1.5.
+
+Ports the SEANet encoder and single Euclidean VQ codebook of the WavTokenizer
+neural codec bundled with the Apertus 1.5 checkpoints. Only encoding (waveform
+to discrete codes) is implemented: the language model consumes audio as input
+tokens and never emits them, so the Vocos-style decoder is not needed and its
+weights are dropped in the model's ``sanitize``.
+
+Weight normalization is fused into plain convolution weights at load time, so
+the modules here hold ordinary ``nn.Conv1d`` layers. All arrays use the MLX
+channel-last convention ``(batch, length, channels)`` internally.
+"""
+
+from typing import List
+
+import mlx.core as mx
+import mlx.nn as nn
+
+from .config import AudioTokenizerConfig
+
+
+def _pad1d(
+    hidden_states: mx.array, padding_left: int, padding_right: int, mode: str
+) -> mx.array:
+    """Pad along the length axis, replicating the reference semantics.
+
+    Reflect padding on inputs shorter than the pad width first zero-extends
+    the signal so the reflection has enough context, then trims the extra.
+    """
+    if mode != "reflect":
+        return mx.pad(hidden_states, [(0, 0), (padding_left, padding_right), (0, 0)])
+
+    length = hidden_states.shape[1]
+    max_pad = max(padding_left, padding_right)
+    extra_pad = 0
+    if length <= max_pad:
+        extra_pad = max_pad - length + 1
+        hidden_states = mx.pad(hidden_states, [(0, 0), (0, extra_pad), (0, 0)])
+        length = hidden_states.shape[1]
+
+    parts = []
+    if padding_left:
+        indices = mx.arange(padding_left, 0, -1)
+        parts.append(mx.take(hidden_states, indices, axis=1))
+    parts.append(hidden_states)
+    if padding_right:
+        indices = mx.arange(length - 2, length - 2 - padding_right, -1)
+        parts.append(mx.take(hidden_states, indices, axis=1))
+    padded = mx.concatenate(parts, axis=1) if len(parts) > 1 else hidden_states
+    end = padded.shape[1] - extra_pad
+    return padded[:, :end]
+
+
+class AudioConv1d(nn.Module):
+    """Conv1d with EnCodec-style asymmetric (or causal) padding."""
+
+    def __init__(
+        self,
+        config: AudioTokenizerConfig,
+        in_channels: int,
+        out_channels: int,
+        kernel_size: int,
+        stride: int = 1,
+        dilation: int = 1,
+    ):
+        super().__init__()
+        self.conv = nn.Conv1d(
+            in_channels, out_channels, kernel_size, stride=stride, dilation=dilation
+        )
+        self.causal = config.use_causal_conv
+        self.pad_mode = "constant" if config.pad_mode == "zero" else config.pad_mode
+        self.conv_stride = stride
+        self.effective_kernel_size = (kernel_size - 1) * dilation + 1
+        self.padding_total = self.effective_kernel_size - stride
+
+    def _extra_padding(self, length: int) -> int:
+        # ceil((length - kernel + padding_total) / stride + 1) - 1 frames,
+        # padded back up to the ideal input length for the final frame.
+        numerator = length - self.effective_kernel_size + self.padding_total
+        n_frames = -(-numerator // self.conv_stride)
+        ideal_length = (
+            n_frames * self.conv_stride
+            + self.effective_kernel_size
+            - self.padding_total
+        )
+        return ideal_length - length
+
+    def __call__(self, hidden_states: mx.array) -> mx.array:
+        extra_padding = self._extra_padding(hidden_states.shape[1])
+        if self.causal:
+            hidden_states = _pad1d(
+                hidden_states, self.padding_total, extra_padding, self.pad_mode
+            )
+        else:
+            padding_right = self.padding_total // 2
+            padding_left = self.padding_total - padding_right
+            hidden_states = _pad1d(
+                hidden_states,
+                padding_left,
+                padding_right + extra_padding,
+                self.pad_mode,
+            )
+        return self.conv(hidden_states)
+
+
+class AudioResnetBlock(nn.Module):
+    """SEANet residual block: ELU + conv (bottleneck), with a conv shortcut."""
+
+    def __init__(self, config: AudioTokenizerConfig, dim: int, dilations: List[int]):
+        super().__init__()
+        kernel_sizes = (config.residual_kernel_size, 1)
+        if len(kernel_sizes) != len(dilations):
+            raise ValueError("Number of kernel sizes should match number of dilations")
+
+        hidden = dim // config.compress
+        block = []
+        for index, (kernel_size, dilation) in enumerate(zip(kernel_sizes, dilations)):
+            in_channels = dim if index == 0 else hidden
+            out_channels = dim if index == len(kernel_sizes) - 1 else hidden
+            block.append(nn.ELU())
+            block.append(
+                AudioConv1d(
+                    config, in_channels, out_channels, kernel_size, dilation=dilation
+                )
+            )
+        self.block = block
+        if config.use_conv_shortcut:
+            self.shortcut = AudioConv1d(config, dim, dim, kernel_size=1)
+        else:
+            self.shortcut = nn.Identity()
+
+    def __call__(self, hidden_states: mx.array) -> mx.array:
+        residual = hidden_states
+        for layer in self.block:
+            hidden_states = layer(hidden_states)
+        return self.shortcut(residual) + hidden_states
+
+
+class AudioLSTM(nn.Module):
+    """Stacked LSTM with a residual connection, in convolutional layout."""
+
+    def __init__(self, config: AudioTokenizerConfig, dimension: int):
+        super().__init__()
+        self.lstm = [
+            nn.LSTM(dimension, dimension) for _ in range(config.num_lstm_layers)
+        ]
+
+    def __call__(self, hidden_states: mx.array) -> mx.array:
+        # (batch, length, channels) already matches the MLX LSTM NLD layout.
+        outputs = hidden_states
+        for layer in self.lstm:
+            outputs = layer(outputs)[0]
+        return outputs + hidden_states
+
+
+class AudioEncoder(nn.Module):
+    """SEANet encoder as used by WavTokenizer.
+
+    Layer indices (initial conv, residual blocks, ELUs, strided downsampling
+    convs, LSTM, final conv) intentionally mirror the reference ModuleList so
+    checkpoint weight names map one-to-one.
+    """
+
+    def __init__(self, config: AudioTokenizerConfig):
+        super().__init__()
+        layers = [
+            AudioConv1d(
+                config, config.audio_channels, config.num_filters, config.kernel_size
+            )
+        ]
+        scaling = 1
+        for ratio in reversed(config.upsampling_ratios):
+            current_scale = scaling * config.num_filters
+            for j in range(config.num_residual_layers):
+                layers.append(
+                    AudioResnetBlock(
+                        config, current_scale, [config.dilation_growth_rate**j, 1]
+                    )
+                )
+            layers.append(nn.ELU())
+            layers.append(
+                AudioConv1d(
+                    config,
+                    current_scale,
+                    current_scale * 2,
+                    kernel_size=ratio * 2,
+                    stride=ratio,
+                )
+            )
+            scaling *= 2
+        layers.append(AudioLSTM(config, scaling * config.num_filters))
+        layers.append(nn.ELU())
+        layers.append(
+            AudioConv1d(
+                config,
+                scaling * config.num_filters,
+                config.hidden_size,
+                config.last_kernel_size,
+            )
+        )
+        self.layers = layers
+
+    def __call__(self, hidden_states: mx.array) -> mx.array:
+        for layer in self.layers:
+            hidden_states = layer(hidden_states)
+        return hidden_states
+
+
+class AudioEuclideanCodebook(nn.Module):
+    """Codebook with Euclidean distance."""
+
+    def __init__(self, config: AudioTokenizerConfig):
+        super().__init__()
+        self.embed = mx.zeros((config.codebook_size, config.codebook_dim))
+
+    def encode(self, hidden_states: mx.array) -> mx.array:
+        shape = hidden_states.shape
+        flat = hidden_states.reshape(-1, shape[-1])
+        # Same formula and axis order as the reference; the squared-input term
+        # is constant across codes but kept so near-ties resolve identically.
+        scaled_states = mx.sum(flat * flat, axis=1, keepdims=True)
+        embed = self.embed.T
+        distances = -(
+            scaled_states
+            - 2 * flat @ embed
+            + mx.sum(embed * embed, axis=0, keepdims=True)
+        )
+        codes = mx.argmax(distances, axis=-1)
+        return codes.reshape(shape[:-1])
+
+
+class AudioVectorQuantization(nn.Module):
+    def __init__(self, config: AudioTokenizerConfig):
+        super().__init__()
+        self.codebook = AudioEuclideanCodebook(config)
+
+    def encode(self, hidden_states: mx.array) -> mx.array:
+        return self.codebook.encode(hidden_states)
+
+
+class AudioTokenizer(nn.Module):
+    """WavTokenizer encode path: mono waveform to discrete codebook indices."""
+
+    def __init__(self, config: AudioTokenizerConfig):
+        super().__init__()
+        self.config = config
+        self.model_type = config.model_type
+        self.encoder = AudioEncoder(config)
+        self.quantizer = AudioVectorQuantization(config)
+        self.hop_length = config.hop_length
+
+    def encode(self, input_values: mx.array) -> mx.array:
+        """Encode waveforms of shape ``(batch, 1, num_samples)`` into codes.
+
+        Returns an integer array of shape ``(batch, ceil(num_samples / hop))``.
+        """
+        if input_values.ndim != 3 or input_values.shape[1] != 1:
+            raise ValueError(
+                "input_values must have shape (batch, 1, num_samples), got "
+                f"{input_values.shape}."
+            )
+        if input_values.shape[-1] == 0:
+            raise ValueError("input_values must contain at least one sample.")
+        first_conv = self.encoder.layers[0]
+        if (
+            first_conv.conv.weight.dtype != mx.float32
+            or self.quantizer.codebook.embed.dtype != mx.float32
+        ):
+            raise ValueError(
+                "The Apertus 1.5 audio tokenizer weights must remain in float32."
+            )
+
+        # (batch, 1, length) -> channel-last (batch, length, 1)
+        hidden_states = input_values.astype(mx.float32).transpose(0, 2, 1)
+        embeddings = self.encoder(hidden_states)
+        return self.quantizer.encode(embeddings)

--- a/mlx_vlm/models/apertus1p5/config.py
+++ b/mlx_vlm/models/apertus1p5/config.py
@@ -1,0 +1,245 @@
+import inspect
+from dataclasses import dataclass, field
+from typing import Dict, Optional, Union
+
+from ..base import BaseModelConfig
+
+
+@dataclass
+class TextConfig(BaseModelConfig):
+    model_type: str = "apertus1p5_text"
+    hidden_size: int = 4096
+    num_hidden_layers: int = 32
+    intermediate_size: int = 21504
+    mlp_bias: bool = False
+    num_attention_heads: int = 32
+    attention_bias: bool = False
+    rms_norm_eps: float = 1e-5
+    vocab_size: int = 266752
+    output_vocab_size: Optional[int] = 131072
+    num_key_value_heads: int = 8
+    max_position_embeddings: int = 262144
+    post_norm: bool = False
+    qk_norm: bool = True
+    tie_word_embeddings: bool = False
+    rope_traditional: bool = False
+    rope_parameters: Optional[Dict[str, Union[float, str]]] = field(
+        default_factory=lambda: {
+            "factor": 32.0,
+            "high_freq_factor": 4.0,
+            "low_freq_factor": 1.0,
+            "original_max_position_embeddings": 8192,
+            "rope_theta": 4000000,
+            "rope_type": "llama3",
+        }
+    )
+    rope_theta: float = 4000000.0
+    rope_scaling: Optional[Dict[str, Union[float, str]]] = None
+
+    def __post_init__(self):
+        if not self.qk_norm:
+            raise ValueError("Apertus 1.5 requires qk_norm=True.")
+        if self.post_norm:
+            raise ValueError("Apertus 1.5 requires post_norm=False.")
+        if self.attention_bias:
+            raise ValueError("Apertus 1.5 requires attention_bias=False.")
+
+        if self.output_vocab_size is not None:
+            if not 1 <= self.output_vocab_size <= self.vocab_size:
+                raise ValueError(
+                    "output_vocab_size must be in [1, vocab_size], got "
+                    f"{self.output_vocab_size} for vocab_size={self.vocab_size}"
+                )
+            if self.output_vocab_size == self.vocab_size:
+                self.output_vocab_size = None
+            elif self.tie_word_embeddings:
+                raise ValueError(
+                    "A pruned output vocabulary cannot be tied to the extended "
+                    "input embeddings."
+                )
+
+        if self.rope_parameters is not None:
+            self.rope_theta = float(
+                self.rope_parameters.get("rope_theta", self.rope_theta)
+            )
+            scaling = {
+                key: value
+                for key, value in self.rope_parameters.items()
+                if key != "rope_theta"
+            }
+            if "rope_type" not in scaling:
+                scaling["rope_type"] = scaling.pop("type", "llama3")
+            self.rope_scaling = scaling
+
+
+@dataclass
+class VisionTokenizerConfig(BaseModelConfig):
+    model_type: str = "apertus1p5_vision_tokenizer"
+    codebook_size: int = 131072
+    embed_dim: int = 256
+    latent_channels: int = 256
+    in_channels: int = 3
+    base_channels: int = 256
+    channel_multiplier: tuple[int, ...] = (1, 1, 2, 2, 4)
+    num_res_blocks: int = 4
+    attn_resolutions: tuple[int, ...] = (16,)
+    resolution: int = 256
+    dropout: float = 0.0
+
+    @classmethod
+    def from_dict(cls, params):
+        params = dict(params or {})
+        for name in ("channel_multiplier", "attn_resolutions"):
+            if name in params:
+                params[name] = tuple(params[name])
+        return super().from_dict(params)
+
+    @property
+    def spatial_scale_factor(self) -> int:
+        return 2 ** (len(self.channel_multiplier) - 1)
+
+
+@dataclass
+class AudioTokenizerConfig(BaseModelConfig):
+    model_type: str = "wavtokenizer"
+    audio_channels: int = 1
+    num_filters: int = 32
+    upsampling_ratios: tuple[int, ...] = (6, 5, 5, 4)
+    num_residual_layers: int = 1
+    dilation_growth_rate: int = 2
+    compress: int = 2
+    use_conv_shortcut: bool = True
+    use_causal_conv: bool = False
+    pad_mode: str = "reflect"
+    norm_type: str = "weight_norm"
+    kernel_size: int = 7
+    last_kernel_size: int = 7
+    residual_kernel_size: int = 3
+    num_lstm_layers: int = 2
+    hidden_size: int = 512
+    codebook_size: int = 4096
+    codebook_dim: int = 512
+    sampling_rate: int = 24000
+
+    def __post_init__(self):
+        # Weight normalization is fused into plain conv weights in sanitize;
+        # time_group_norm checkpoints carry norm modules this port does not
+        # instantiate, so their weights would silently go unused.
+        if self.norm_type != "weight_norm":
+            raise ValueError(
+                "The Apertus 1.5 audio tokenizer port supports "
+                f'norm_type="weight_norm" only, got {self.norm_type!r}.'
+            )
+        if self.pad_mode not in ("reflect", "constant", "zero"):
+            raise ValueError(
+                'The audio tokenizer pad_mode must be "reflect", "constant" '
+                f'or "zero", got {self.pad_mode!r}.'
+            )
+        if self.codebook_dim != self.hidden_size:
+            raise ValueError(
+                "WavTokenizer uses no projections around the quantizer, so "
+                f"codebook_dim ({self.codebook_dim}) must equal hidden_size "
+                f"({self.hidden_size})."
+            )
+
+    @classmethod
+    def from_dict(cls, params):
+        params = dict(params or {})
+        if "upsampling_ratios" in params:
+            params["upsampling_ratios"] = tuple(params["upsampling_ratios"])
+        return super().from_dict(params)
+
+    @property
+    def hop_length(self) -> int:
+        hop = 1
+        for ratio in self.upsampling_ratios:
+            hop *= ratio
+        return hop
+
+
+@dataclass
+class ModelConfig(BaseModelConfig):
+    text_config: TextConfig = field(default_factory=TextConfig)
+    vision_tokenizer_config: VisionTokenizerConfig = field(
+        default_factory=VisionTokenizerConfig
+    )
+    audio_tokenizer_config: Optional[AudioTokenizerConfig] = None
+    model_type: str = "apertus1p5"
+    image_token_id: int = 131079
+    audio_token_id: int = 131085
+    image_token_offset: int = 131272
+    audio_token_offset: int = 262344
+    tie_word_embeddings: bool = False
+    eos_token_id: Optional[list[int]] = None
+
+    def __post_init__(self):
+        self._validate_token_ranges()
+
+    @classmethod
+    def from_dict(cls, params):
+        params = dict(params or {})
+        top_level_tie = bool(params.get("tie_word_embeddings", False))
+        text_params = params.pop("text_config", {})
+        if isinstance(text_params, TextConfig):
+            if top_level_tie and not text_params.tie_word_embeddings:
+                text_params = TextConfig.from_dict(
+                    {**text_params.to_dict(), "tie_word_embeddings": True}
+                )
+            text_config = text_params
+        else:
+            text_params = dict(text_params or {})
+            text_params["tie_word_embeddings"] = bool(
+                text_params.get("tie_word_embeddings", False) or top_level_tie
+            )
+            # The released checkpoints store eos_token_id inside text_config,
+            # but the shared stopping criteria read it from the top-level
+            # config (see utils.load), so hoist it when only nested.
+            if params.get("eos_token_id") is None:
+                params["eos_token_id"] = text_params.get("eos_token_id")
+            text_config = TextConfig.from_dict(text_params)
+
+        # Transformers treats either the top-level or nested flag as enabling
+        # tying. Keep both views synchronized because the language model reads
+        # the nested text configuration.
+        params["tie_word_embeddings"] = text_config.tie_word_embeddings
+        if isinstance(params.get("eos_token_id"), int):
+            params["eos_token_id"] = [params["eos_token_id"]]
+        vision_params = params.pop("vision_tokenizer_config", {})
+        vision_tokenizer_config = (
+            vision_params
+            if isinstance(vision_params, VisionTokenizerConfig)
+            else VisionTokenizerConfig.from_dict(vision_params)
+        )
+        audio_params = params.pop("audio_tokenizer_config", None)
+        if audio_params is None or isinstance(audio_params, AudioTokenizerConfig):
+            audio_tokenizer_config = audio_params
+        else:
+            audio_tokenizer_config = AudioTokenizerConfig.from_dict(audio_params)
+
+        config = cls(
+            text_config=text_config,
+            vision_tokenizer_config=vision_tokenizer_config,
+            audio_tokenizer_config=audio_tokenizer_config,
+            **{
+                key: value
+                for key, value in params.items()
+                if key in inspect.signature(cls).parameters
+            },
+        )
+        return config
+
+    def _validate_token_ranges(self):
+        visual_end = (
+            self.image_token_offset + self.vision_tokenizer_config.codebook_size
+        )
+        if visual_end != self.audio_token_offset:
+            raise ValueError(
+                "The visual token range must end at audio_token_offset, got "
+                f"{visual_end} and {self.audio_token_offset}."
+            )
+
+        audio_codebook_size = 4096
+        if self.audio_tokenizer_config is not None:
+            audio_codebook_size = self.audio_tokenizer_config.codebook_size
+        if self.audio_token_offset + audio_codebook_size > self.text_config.vocab_size:
+            raise ValueError("The audio token range exceeds the input vocabulary.")

--- a/mlx_vlm/models/apertus1p5/language.py
+++ b/mlx_vlm/models/apertus1p5/language.py
@@ -1,0 +1,63 @@
+from typing import Optional
+
+import mlx.core as mx
+import mlx.nn as nn
+
+from ..apertus.language import ApertusModel
+from ..base import LanguageModelOutput
+from ..cache import KVCache
+from .config import TextConfig
+
+
+class LanguageModel(nn.Module):
+    def __init__(self, config: TextConfig):
+        super().__init__()
+        self.args = config
+        self.config = config
+        self.model_type = config.model_type
+        self.model = ApertusModel(config)
+
+        output_vocab_size = config.output_vocab_size or config.vocab_size
+        if config.tie_word_embeddings:
+            if output_vocab_size != config.vocab_size:
+                raise ValueError(
+                    "tie_word_embeddings requires output_vocab_size to equal "
+                    f"vocab_size, got {output_vocab_size} and {config.vocab_size}."
+                )
+        else:
+            self.lm_head = nn.Linear(config.hidden_size, output_vocab_size, bias=False)
+
+    def __call__(
+        self,
+        inputs: Optional[mx.array] = None,
+        cache=None,
+        input_embeddings: Optional[mx.array] = None,
+        inputs_embeds: Optional[mx.array] = None,
+        **kwargs,
+    ) -> LanguageModelOutput:
+        if inputs is None:
+            inputs = kwargs.get("input_ids")
+        if inputs_embeds is None:
+            inputs_embeds = input_embeddings
+
+        hidden_states = self.model(inputs, cache, inputs_embeds)
+        if self.args.tie_word_embeddings:
+            logits = self.model.embed_tokens.as_linear(hidden_states)
+        else:
+            logits = self.lm_head(hidden_states)
+        return LanguageModelOutput(logits=logits)
+
+    def make_cache(self):
+        return [KVCache() for _ in self.model.layers]
+
+    @property
+    def layers(self):
+        return self.model.layers
+
+    @property
+    def head_dim(self):
+        return self.args.hidden_size // self.args.num_attention_heads
+
+    @property
+    def n_kv_heads(self):
+        return self.args.num_key_value_heads

--- a/mlx_vlm/models/apertus1p5/processing_apertus1p5.py
+++ b/mlx_vlm/models/apertus1p5/processing_apertus1p5.py
@@ -1,0 +1,777 @@
+import json
+import math
+from pathlib import Path
+from typing import Optional
+
+import numpy as np
+from PIL import Image
+from transformers import AutoTokenizer
+from transformers.feature_extraction_utils import BatchFeature, FeatureExtractionMixin
+from transformers.image_processing_utils import BaseImageProcessor
+from transformers.image_utils import make_flat_list_of_images
+from transformers.processing_utils import ProcessorMixin
+
+from ..base import install_auto_processor_patch, load_chat_template, to_mlx
+
+_HUB_DOWNLOAD_KWARGS = {
+    "cache_dir",
+    "endpoint",
+    "etag_timeout",
+    "force_download",
+    "headers",
+    "library_name",
+    "library_version",
+    "local_files_only",
+    "repo_type",
+    "revision",
+    "subfolder",
+    "token",
+    "user_agent",
+}
+
+
+# Resizing must be bit-exact with Torchvision's uint8 CPU bicubic path, not
+# merely close: the vision tokenizer maps pixels to discrete codes via a hard
+# argmax over a 131k-entry codebook, so sub-pixel differences from PIL's
+# bicubic filter can flip codes and change the tokens the model sees.
+def _cubic_filter(value: float) -> float:
+    """Keys' cubic filter used by Torchvision for antialiased bicubic resize."""
+    value = abs(value)
+    if value < 1.0:
+        return ((1.5 * value - 2.5) * value * value) + 1.0
+    if value < 2.0:
+        return (((-0.5 * value + 2.5) * value - 4.0) * value) + 2.0
+    return 0.0
+
+
+def _uint8_bicubic_coefficients(
+    input_size: int, output_size: int
+) -> tuple[list[int], list[np.ndarray], int]:
+    """Build the integer coefficients used by Torchvision's uint8 CPU path."""
+    scale = input_size / output_size
+    support = 2.0 * scale if scale >= 1.0 else 2.0
+    max_interp_size = math.ceil(support) * 2 + 1
+    starts = []
+    weights = []
+    max_weight = 0.0
+
+    for output_index in range(output_size):
+        center = scale * (output_index + 0.5)
+        inverse_scale = 1.0 / scale if scale >= 1.0 else 1.0
+        start = max(int(center - support + 0.5), 0)
+        count = min(int(center + support + 0.5), input_size) - start
+        count = max(0, min(count, max_interp_size))
+        coefficients = [
+            _cubic_filter((index + start - center + 0.5) * inverse_scale)
+            for index in range(count)
+        ]
+        total = sum(coefficients)
+        if total:
+            coefficients = [coefficient / total for coefficient in coefficients]
+        max_weight = max(max_weight, max(coefficients, default=0.0))
+        starts.append(start)
+        weights.append(np.asarray(coefficients, dtype=np.float64))
+
+    precision = 0
+    for precision in range(22):
+        next_value = int(0.5 + max_weight * (1 << (precision + 1)))
+        if next_value >= 1 << 15:
+            break
+
+    integer_weights = []
+    multiplier = 1 << precision
+    for coefficients in weights:
+        integer_weights.append(
+            np.asarray(
+                [
+                    (
+                        int(-0.5 + coefficient * multiplier)
+                        if coefficient < 0
+                        else int(0.5 + coefficient * multiplier)
+                    )
+                    for coefficient in coefficients
+                ],
+                dtype=np.int64,
+            )
+        )
+    return starts, integer_weights, precision
+
+
+def _resize_uint8_axis(image: np.ndarray, output_size: int, axis: int) -> np.ndarray:
+    starts, weights, precision = _uint8_bicubic_coefficients(
+        image.shape[axis], output_size
+    )
+    output_shape = list(image.shape)
+    output_shape[axis] = output_size
+    output = np.empty(output_shape, dtype=np.uint8)
+    rounding = 1 << (precision - 1)
+
+    for output_index, (start, coefficients) in enumerate(zip(starts, weights)):
+        indices = np.arange(start, start + len(coefficients))
+        values = np.take(image, indices, axis=axis).astype(np.int64)
+        weight_shape = [1] * image.ndim
+        weight_shape[axis] = len(coefficients)
+        values = (values * coefficients.reshape(weight_shape)).sum(axis=axis)
+        values = (values + rounding) >> precision
+        output_slice = [slice(None)] * image.ndim
+        output_slice[axis] = output_index
+        output[tuple(output_slice)] = np.clip(values, 0, 255).astype(np.uint8)
+    return output
+
+
+def _resize_uint8_bicubic(image: np.ndarray, height: int, width: int) -> np.ndarray:
+    """Resize a CHW uint8 image exactly like Torchvision's bicubic CPU path."""
+    if image.shape[-1] != width:
+        image = _resize_uint8_axis(image, width, axis=2)
+    if image.shape[-2] != height:
+        image = _resize_uint8_axis(image, height, axis=1)
+    return image
+
+
+def smart_resize(
+    height: int,
+    width: int,
+    factor: int = 16,
+    min_pixels: int = 256 * 256,
+    max_pixels: int = 1400 * 1400,
+) -> tuple[int, int]:
+    target_area = max(min(max_pixels, height * width), min_pixels)
+    aspect_ratio = width / height
+    new_height = int((target_area / aspect_ratio) ** 0.5)
+    new_width = int(new_height * aspect_ratio)
+    new_height = ((new_height + factor // 2) // factor) * factor
+    new_width = ((new_width + factor // 2) // factor) * factor
+    return max(new_height, factor), max(new_width, factor)
+
+
+def _is_nested_images(images) -> bool:
+    return (
+        isinstance(images, (list, tuple))
+        and bool(images)
+        and all(isinstance(sample, (list, tuple)) for sample in images)
+    )
+
+
+def _is_nested_audio(audio) -> bool:
+    # One sub-list of clips per text sample. A bare list of numbers is a
+    # single audio clip, not a nesting; a list of arrays is a flat clip list.
+    if not isinstance(audio, (list, tuple)) or not audio:
+        return False
+
+    def _is_clip_container(item):
+        return isinstance(item, (list, tuple)) and (
+            len(item) == 0 or not np.isscalar(item[0])
+        )
+
+    return all(_is_clip_container(item) for item in audio)
+
+
+class Apertus1p5FeatureExtractor(FeatureExtractionMixin):
+    """Numpy port of the WavTokenizer feature extractor.
+
+    Audio is not resampled or downmixed here; clips must already be mono at
+    ``sampling_rate``. Batches are right-padded with ``padding_value`` to the
+    longest clip and a padding mask marks the valid samples. The codec model
+    pads internally, so each clip produces ``ceil(num_samples / hop_length)``
+    codes regardless of batch padding (the model re-slices clips by mask
+    before encoding).
+    """
+
+    model_input_names = ["input_values", "padding_mask"]
+
+    def __init__(
+        self,
+        feature_size: int = 1,
+        sampling_rate: int = 24000,
+        padding_value: float = 0.0,
+        hop_length: int = 600,
+        **kwargs,
+    ):
+        if feature_size != 1:
+            raise ValueError(
+                "The Apertus 1.5 audio feature extractor supports mono audio "
+                f"only (feature_size=1), got feature_size={feature_size}."
+            )
+        super().__init__(**kwargs)
+        self.feature_size = feature_size
+        self.sampling_rate = sampling_rate
+        self.padding_value = padding_value
+        self.hop_length = hop_length
+
+    def get_num_audio_codes(self, num_samples: int) -> int:
+        return -(-num_samples // self.hop_length)
+
+    def __call__(self, audio, sampling_rate=None) -> dict:
+        if sampling_rate is not None and sampling_rate != self.sampling_rate:
+            raise ValueError(
+                "Apertus 1.5 audio must be sampled at "
+                f"{self.sampling_rate} Hz, got {sampling_rate} Hz."
+            )
+        if isinstance(audio, np.ndarray) and audio.ndim == 1:
+            audio = [audio]
+        elif not isinstance(audio, (list, tuple)):
+            audio = [audio]
+        elif audio and np.isscalar(audio[0]):
+            # A bare list of numbers is one clip.
+            audio = [audio]
+
+        clips = []
+        for index, clip in enumerate(audio):
+            clip = np.asarray(clip, dtype=np.float32)
+            if clip.ndim != 1:
+                raise ValueError(
+                    "Expected mono audio of shape (num_samples,) but got "
+                    f"shape {clip.shape} at index {index}."
+                )
+            if clip.size == 0:
+                raise ValueError(f"Input audio at index {index} is empty.")
+            clips.append(clip)
+
+        max_length = max(clip.size for clip in clips)
+        input_values = np.full(
+            (len(clips), 1, max_length), self.padding_value, dtype=np.float32
+        )
+        padding_mask = np.zeros((len(clips), max_length), dtype=np.int64)
+        for index, clip in enumerate(clips):
+            input_values[index, 0, : clip.size] = clip
+            padding_mask[index, : clip.size] = 1
+        return {"input_values": input_values, "padding_mask": padding_mask}
+
+
+class Apertus1p5ImageProcessor(BaseImageProcessor):
+    model_input_names = ["pixel_values", "image_sizes"]
+
+    def __init__(
+        self,
+        do_resize: bool = True,
+        do_rescale: bool = True,
+        do_normalize: bool = True,
+        do_convert_rgb: bool = True,
+        do_pad: bool = True,
+        rescale_factor: float = 1 / 255,
+        image_mean=(0.5, 0.5, 0.5),
+        image_std=(0.5, 0.5, 0.5),
+        min_pixels: int = 256 * 256,
+        max_pixels: int = 1400 * 1400,
+        spatial_factor: int = 16,
+        **kwargs,
+    ):
+        super().__init__(**kwargs)
+        self.do_resize = do_resize
+        self.do_rescale = do_rescale
+        self.do_normalize = do_normalize
+        self.do_convert_rgb = do_convert_rgb
+        self.do_pad = do_pad
+        self.rescale_factor = rescale_factor
+        self.image_mean = tuple(image_mean)
+        self.image_std = tuple(image_std)
+        self.min_pixels = min_pixels
+        self.max_pixels = max_pixels
+        self.spatial_factor = spatial_factor
+
+    @staticmethod
+    def _to_pil(image) -> Image.Image:
+        if isinstance(image, Image.Image):
+            return image
+        array = np.asarray(image)
+        # Transpose CHW to HWC only when unambiguous: a short HWC image such
+        # as (4, W, 3) must not be mistaken for channel-first.
+        if (
+            array.ndim == 3
+            and array.shape[0] in (1, 3, 4)
+            and array.shape[-1] not in (1, 3, 4)
+        ):
+            array = np.moveaxis(array, 0, -1)
+        if array.ndim == 3 and array.shape[-1] == 1:
+            array = array[..., 0]
+        if np.issubdtype(array.dtype, np.floating):
+            raise TypeError(
+                "Apertus 1.5 image arrays must contain unscaled uint8 pixels; "
+                "pass a PIL image or a uint8 NumPy array."
+            )
+        if array.dtype != np.uint8:
+            raise TypeError(
+                f"Apertus 1.5 image arrays must have dtype uint8, got {array.dtype}."
+            )
+        return Image.fromarray(array)
+
+    def preprocess(self, images, **kwargs) -> BatchFeature:
+        # Accept the standard transformers image-input forms (single image,
+        # flat/nested lists, 4-D batched arrays), like the upstream processor.
+        images = make_flat_list_of_images(images)
+        if not images:
+            raise ValueError(
+                "`images` contains no images; pass `images=None` when there "
+                "are no images."
+            )
+
+        do_resize = kwargs.pop("do_resize", self.do_resize)
+        do_rescale = kwargs.pop("do_rescale", self.do_rescale)
+        do_normalize = kwargs.pop("do_normalize", self.do_normalize)
+        do_convert_rgb = kwargs.pop("do_convert_rgb", self.do_convert_rgb)
+        do_pad = kwargs.pop("do_pad", self.do_pad)
+        min_pixels = kwargs.pop("min_pixels", self.min_pixels)
+        max_pixels = kwargs.pop("max_pixels", self.max_pixels)
+        spatial_factor = kwargs.pop("spatial_factor", self.spatial_factor)
+
+        processed = []
+        image_sizes = []
+        image_grids = []
+        for image in images:
+            image = self._to_pil(image)
+            if do_convert_rgb:
+                image = image.convert("RGB")
+            array = np.ascontiguousarray(
+                np.moveaxis(np.asarray(image, dtype=np.uint8), -1, 0)
+            )
+            if do_resize:
+                height, width = image.height, image.width
+                resized_height, resized_width = smart_resize(
+                    height,
+                    width,
+                    factor=spatial_factor,
+                    min_pixels=min_pixels,
+                    max_pixels=max_pixels,
+                )
+                array = _resize_uint8_bicubic(array, resized_height, resized_width)
+
+            array = array.astype(np.float32)
+            if do_rescale:
+                array *= self.rescale_factor
+            if do_normalize:
+                mean = np.asarray(self.image_mean, dtype=np.float32)
+                std = np.asarray(self.image_std, dtype=np.float32)
+                array = (array - mean[:, None, None]) / std[:, None, None]
+            processed.append(array)
+            height, width = array.shape[-2:]
+            image_sizes.append((height, width))
+            image_grids.append((height // spatial_factor, width // spatial_factor))
+
+        if do_pad:
+            max_height = max(image.shape[-2] for image in processed)
+            max_width = max(image.shape[-1] for image in processed)
+            padded = np.zeros(
+                (len(processed), 3, max_height, max_width), dtype=np.float32
+            )
+            for index, image in enumerate(processed):
+                padded[index, :, : image.shape[-2], : image.shape[-1]] = image
+            pixel_values = padded
+        else:
+            first_shape = processed[0].shape
+            if any(image.shape != first_shape for image in processed):
+                raise ValueError(
+                    "do_pad=False requires images with identical processed "
+                    "sizes; the model consumes a single stacked pixel array."
+                )
+            pixel_values = np.stack(processed).astype(np.float32)
+
+        data = {
+            "pixel_values": pixel_values,
+            "image_sizes": np.asarray(image_sizes, dtype=np.int64),
+            "image_grids": np.asarray(image_grids, dtype=np.int64),
+        }
+        return BatchFeature(data=to_mlx(data))
+
+    __call__ = preprocess
+
+    def get_number_of_image_patches(
+        self, height: int, width: int, images_kwargs=None
+    ) -> int:
+        images_kwargs = images_kwargs or {}
+        factor = images_kwargs.get("spatial_factor", self.spatial_factor)
+        resized_height, resized_width = smart_resize(
+            height,
+            width,
+            factor=factor,
+            min_pixels=images_kwargs.get("min_pixels", self.min_pixels),
+            max_pixels=images_kwargs.get("max_pixels", self.max_pixels),
+        )
+        return (resized_height // factor) * (resized_width // factor)
+
+
+class Apertus1p5Processor(ProcessorMixin):
+    attributes = ["image_processor", "tokenizer", "feature_extractor"]
+    image_processor_class = "AutoImageProcessor"
+    tokenizer_class = "AutoTokenizer"
+    feature_extractor_class = "AutoFeatureExtractor"
+
+    def __init__(
+        self,
+        image_processor=None,
+        tokenizer=None,
+        feature_extractor=None,
+        chat_template: Optional[str] = None,
+        **kwargs,
+    ):
+        self.image_token = getattr(tokenizer, "image_token", None) or "<|image|>"
+        self.audio_token = getattr(tokenizer, "audio_token", None) or "<|audio|>"
+        self.boi_token = getattr(tokenizer, "boi_token", None) or "<|img_start|>"
+        self.eoi_token = getattr(tokenizer, "eoi_token", None) or "<|img_end|>"
+        self.image_wrapper_token = (
+            getattr(tokenizer, "image_wrapper_token", None) or "<|img_token_start|>"
+        )
+        self.eol_token = getattr(tokenizer, "eol_token", None) or "<|img_end_of_row|>"
+        self.boa_token = getattr(tokenizer, "boa_token", None) or "<|audio_start|>"
+        self.eoa_token = getattr(tokenizer, "eoa_token", None) or "<|audio_end|>"
+        super().__init__(
+            image_processor,
+            tokenizer,
+            feature_extractor or Apertus1p5FeatureExtractor(),
+            chat_template=chat_template or getattr(tokenizer, "chat_template", None),
+        )
+
+    @classmethod
+    def from_pretrained(cls, pretrained_model_name_or_path, **kwargs):
+        kwargs.pop("quantize_activations", None)
+        kwargs.pop("eos_token_ids", None)
+        kwargs.pop("trust_remote_code", None)
+        hub_kwargs = {
+            key: value for key, value in kwargs.items() if key in _HUB_DOWNLOAD_KWARGS
+        }
+        if "token" not in hub_kwargs and "use_auth_token" in kwargs:
+            hub_kwargs["token"] = kwargs["use_auth_token"]
+        tokenizer = AutoTokenizer.from_pretrained(
+            pretrained_model_name_or_path, trust_remote_code=False, **kwargs
+        )
+
+        processor_config = {}
+        model_config = {}
+        path = Path(pretrained_model_name_or_path)
+        config_root = path
+        if path.is_dir() and kwargs.get("subfolder"):
+            config_root = path / kwargs["subfolder"]
+        load_chat_template(tokenizer, config_root if path.is_dir() else path)
+
+        if config_root.is_dir() and (config_root / "processor_config.json").exists():
+            processor_config = json.loads(
+                (config_root / "processor_config.json").read_text()
+            )
+            config_path = config_root / "config.json"
+            if config_path.exists():
+                model_config = json.loads(config_path.read_text())
+        elif not path.exists():
+            from huggingface_hub import hf_hub_download
+
+            config_path = hf_hub_download(
+                pretrained_model_name_or_path,
+                "processor_config.json",
+                **hub_kwargs,
+            )
+            processor_config = json.loads(Path(config_path).read_text())
+            model_config_path = hf_hub_download(
+                pretrained_model_name_or_path,
+                "config.json",
+                **hub_kwargs,
+            )
+            model_config = json.loads(Path(model_config_path).read_text())
+
+        image_config = processor_config.get("image_processor", processor_config)
+        image_config = {
+            key: value
+            for key, value in image_config.items()
+            if key
+            not in {
+                "image_processor_type",
+                "resample",
+                "size",
+                "crop_size",
+            }
+        }
+        image_processor = Apertus1p5ImageProcessor(**image_config)
+        channel_multiplier = model_config.get("vision_tokenizer_config", {}).get(
+            "channel_multiplier"
+        )
+        if channel_multiplier:
+            vision_spatial_factor = 2 ** (len(channel_multiplier) - 1)
+            if image_processor.spatial_factor != vision_spatial_factor:
+                raise ValueError(
+                    "Processor and vision tokenizer spatial factors do not match: "
+                    f"{image_processor.spatial_factor} and {vision_spatial_factor}."
+                )
+
+        audio_config = {
+            key: value
+            for key, value in processor_config.get("feature_extractor", {}).items()
+            if key
+            not in {
+                "feature_extractor_type",
+                "padding_side",
+                "return_attention_mask",
+            }
+        }
+        feature_extractor = Apertus1p5FeatureExtractor(**audio_config)
+        upsampling_ratios = model_config.get("audio_tokenizer_config", {}).get(
+            "upsampling_ratios"
+        )
+        if upsampling_ratios:
+            codec_hop = 1
+            for ratio in upsampling_ratios:
+                codec_hop *= ratio
+            if feature_extractor.hop_length != codec_hop:
+                raise ValueError(
+                    "Processor and audio tokenizer hop lengths do not match: "
+                    f"{feature_extractor.hop_length} and {codec_hop}."
+                )
+        return cls(
+            image_processor=image_processor,
+            tokenizer=tokenizer,
+            feature_extractor=feature_extractor,
+        )
+
+    def replace_image_token(self, grid_height: int, grid_width: int) -> str:
+        rows = self.eol_token.join([self.image_token * grid_width] * grid_height)
+        return (
+            f"{self.boi_token}{grid_height}*{grid_width}"
+            f"{self.image_wrapper_token}{rows}{self.eoi_token}"
+        )
+
+    def replace_audio_token(self, num_codes: int) -> str:
+        return f"{self.boa_token}{self.audio_token * num_codes}{self.eoa_token}"
+
+    def _process_audio(self, audio, sampling_rate=None):
+        """Peak-normalize clips to -3 dBFS and extract padded features.
+
+        Returns the model inputs (``input_features``/``feature_attention_mask``)
+        and the per-clip placeholder expansions. The normalization matches the
+        reference Apertus 1.5 pipeline; the feature extractor itself performs
+        none. Code counts come from the extractor output masks so they can
+        never desync from the features the model will encode.
+        """
+        target_peak = 10.0 ** (-3.0 / 20.0)
+        clips = []
+        for clip in audio:
+            clip = np.asarray(clip, dtype=np.float32)
+            if clip.size > 0:
+                clip = clip * (target_peak / max(float(np.abs(clip).max()), 1e-10))
+            clips.append(clip)  # empty clips get the extractor's clear error
+
+        extracted = self.feature_extractor(clips, sampling_rate=sampling_rate)
+        audio_inputs = {
+            "input_features": extracted["input_values"],
+            "feature_attention_mask": extracted["padding_mask"],
+        }
+        replacements = [
+            self.replace_audio_token(
+                self.feature_extractor.get_num_audio_codes(int(mask.sum()))
+            )
+            for mask in extracted["padding_mask"]
+        ]
+        return audio_inputs, replacements
+
+    # These must stay named parameters: utils.process_inputs only forwards
+    # generate() kwargs whose names appear in this signature.
+    def __call__(
+        self,
+        text=None,
+        images=None,
+        audio=None,
+        add_special_tokens=True,
+        sampling_rate=None,
+        do_resize=None,
+        do_rescale=None,
+        do_normalize=None,
+        do_convert_rgb=None,
+        do_pad=None,
+        min_pixels=None,
+        max_pixels=None,
+        spatial_factor=None,
+        **kwargs,
+    ):
+        if text is None:
+            raise ValueError("text must be provided")
+        if isinstance(text, str):
+            text = [text]
+        if not isinstance(text, (list, tuple)) or not all(
+            isinstance(sample, str) for sample in text
+        ):
+            raise TypeError("text must be a string or a sequence of strings")
+        if len(text) != 1:
+            raise ValueError(
+                "The initial Apertus 1.5 implementation supports batch size 1 only."
+            )
+
+        nested_images = _is_nested_images(images)
+        if nested_images:
+            if len(images) != len(text):
+                raise ValueError(
+                    "Nested image inputs must provide one image list per text sample."
+                )
+            placeholder_counts = [sample.count(self.image_token) for sample in text]
+            image_counts = [len(sample) for sample in images]
+            if placeholder_counts != image_counts:
+                raise ValueError(
+                    "Per-sample image placeholder counts must match the nested "
+                    "image inputs."
+                )
+            images = [image for sample in images for image in sample]
+            if not images:
+                images = None
+        elif images is not None:
+            images = make_flat_list_of_images(images)
+            if not images:
+                images = None
+
+        if audio is not None:
+            if isinstance(audio, np.ndarray) and audio.ndim == 1:
+                audio = [audio]
+            elif not isinstance(audio, (list, tuple)):
+                # Non-1D arrays become a single clip; the feature extractor
+                # rejects them with a clear mono-audio error.
+                audio = [audio]
+            elif audio and np.isscalar(audio[0]):
+                audio = [np.asarray(audio, dtype=np.float32)]
+            if _is_nested_audio(audio):
+                if len(audio) != len(text):
+                    raise ValueError(
+                        "Nested audio inputs must provide one clip list per "
+                        "text sample."
+                    )
+                audio_placeholder_counts = [
+                    sample.count(self.audio_token) for sample in text
+                ]
+                clip_counts = [len(sample) for sample in audio]
+                if audio_placeholder_counts != clip_counts:
+                    raise ValueError(
+                        "Per-sample audio placeholder counts must match the "
+                        "nested audio inputs."
+                    )
+                audio = [clip for sample in audio for clip in sample]
+            if not len(audio):
+                audio = None
+
+        image_kwargs = {
+            key: value
+            for key, value in (
+                ("do_resize", do_resize),
+                ("do_rescale", do_rescale),
+                ("do_normalize", do_normalize),
+                ("do_convert_rgb", do_convert_rgb),
+                ("do_pad", do_pad),
+                ("min_pixels", min_pixels),
+                ("max_pixels", max_pixels),
+                ("spatial_factor", spatial_factor),
+            )
+            if value is not None
+        }
+
+        if images is not None:
+            image_inputs = self.image_processor(images, **image_kwargs)
+            image_grids = image_inputs.pop("image_grids")
+            grids = iter(image_grids.tolist())
+            image_count = image_grids.shape[0]
+        else:
+            image_inputs = {}
+            grids = iter(())
+            image_count = 0
+
+        if sum(sample.count(self.image_token) for sample in text) != image_count:
+            raise ValueError(
+                "The number of image placeholders must match the number of images."
+            )
+
+        if audio is not None:
+            audio_inputs, audio_replacements = self._process_audio(
+                audio, sampling_rate=sampling_rate
+            )
+        else:
+            audio_inputs, audio_replacements = {}, []
+        if sum(sample.count(self.audio_token) for sample in text) != len(
+            audio_replacements
+        ):
+            raise ValueError(
+                "The number of audio placeholders must match the number of "
+                "audio clips."
+            )
+
+        expanded = []
+        for sample in text:
+            pieces = sample.split(self.image_token)
+            rebuilt = [pieces[0]]
+            for piece in pieces[1:]:
+                grid_height, grid_width = next(grids)
+                rebuilt.extend(
+                    (
+                        self.replace_image_token(int(grid_height), int(grid_width)),
+                        piece,
+                    )
+                )
+            expanded.append("".join(rebuilt))
+
+        # Expand audio after images: image expansions introduce no audio
+        # placeholders, so per-clip order is preserved.
+        replacements = iter(audio_replacements)
+        audio_expanded = []
+        for sample in expanded:
+            pieces = sample.split(self.audio_token)
+            rebuilt = [pieces[0]]
+            for piece in pieces[1:]:
+                rebuilt.extend((next(replacements), piece))
+            audio_expanded.append("".join(rebuilt))
+        expanded = audio_expanded
+
+        kwargs.pop("return_tensors", None)
+        text_inputs = self.tokenizer(
+            expanded, add_special_tokens=add_special_tokens, **kwargs
+        )
+        return BatchFeature(
+            data=to_mlx({**text_inputs, **image_inputs, **audio_inputs})
+        )
+
+    @property
+    def model_input_names(self):
+        # __call__ renames the feature extractor's input_values/padding_mask
+        # to the names the model consumes, so advertise those.
+        return [
+            "input_ids",
+            "attention_mask",
+            "pixel_values",
+            "image_sizes",
+            "input_features",
+            "feature_attention_mask",
+        ]
+
+    @staticmethod
+    def _with_plain_non_user_roles(conversation):
+        # The published chat template accepts content-part lists only for
+        # user messages; other roles' lists must collapse to plain strings
+        # or the template raises jinja2.TemplateError.
+        if not isinstance(conversation, list):
+            return conversation
+        normalized = []
+        for message in conversation:
+            content = message.get("content") if isinstance(message, dict) else None
+            if (
+                isinstance(content, list)
+                and message.get("role") != "user"
+                and message.get("role") != "tool"
+            ):
+                text = "".join(
+                    part.get("text", "")
+                    for part in content
+                    if isinstance(part, dict) and part.get("type") == "text"
+                )
+                message = {**message, "content": text}
+            normalized.append(message)
+        return normalized
+
+    def apply_chat_template(self, conversation, *args, **kwargs):
+        return self.tokenizer.apply_chat_template(
+            self._with_plain_non_user_roles(conversation), *args, **kwargs
+        )
+
+    def decode(self, *args, **kwargs):
+        return self.tokenizer.decode(*args, **kwargs)
+
+    def batch_decode(self, *args, **kwargs):
+        return self.tokenizer.batch_decode(*args, **kwargs)
+
+
+install_auto_processor_patch("apertus1p5", Apertus1p5Processor)
+
+
+__all__ = [
+    "Apertus1p5FeatureExtractor",
+    "Apertus1p5ImageProcessor",
+    "Apertus1p5Processor",
+    "smart_resize",
+]

--- a/mlx_vlm/models/apertus1p5/vision.py
+++ b/mlx_vlm/models/apertus1p5/vision.py
@@ -1,0 +1,241 @@
+import mlx.core as mx
+import mlx.nn as nn
+
+from .config import VisionTokenizerConfig
+
+
+class ResnetBlock(nn.Module):
+    def __init__(
+        self, in_channels: int, out_channels: int | None = None, dropout: float = 0.0
+    ):
+        super().__init__()
+        self.in_channels = in_channels
+        self.out_channels = out_channels or in_channels
+        self.norm1 = nn.GroupNorm(32, in_channels, eps=1e-6, pytorch_compatible=True)
+        self.conv1 = nn.Conv2d(
+            in_channels, self.out_channels, kernel_size=3, stride=1, padding=1
+        )
+        self.norm2 = nn.GroupNorm(
+            32, self.out_channels, eps=1e-6, pytorch_compatible=True
+        )
+        self.dropout = nn.Dropout(dropout)
+        self.conv2 = nn.Conv2d(
+            self.out_channels,
+            self.out_channels,
+            kernel_size=3,
+            stride=1,
+            padding=1,
+        )
+        if in_channels != self.out_channels:
+            self.nin_shortcut = nn.Conv2d(in_channels, self.out_channels, kernel_size=1)
+
+    @staticmethod
+    def _silu(hidden_states: mx.array) -> mx.array:
+        return hidden_states * mx.sigmoid(hidden_states)
+
+    def __call__(self, hidden_states: mx.array) -> mx.array:
+        residual = hidden_states
+        hidden_states = self.conv1(self._silu(self.norm1(hidden_states)))
+        hidden_states = self.norm2(hidden_states)
+        hidden_states = self.dropout(self._silu(hidden_states))
+        hidden_states = self.conv2(hidden_states)
+        if self.in_channels != self.out_channels:
+            residual = self.nin_shortcut(residual)
+        return residual + hidden_states
+
+
+class AttentionBlock(nn.Module):
+    def __init__(self, channels: int):
+        super().__init__()
+        self.channels = channels
+        self.norm = nn.GroupNorm(32, channels, eps=1e-6, pytorch_compatible=True)
+        self.q = nn.Conv2d(channels, channels, kernel_size=1)
+        self.k = nn.Conv2d(channels, channels, kernel_size=1)
+        self.v = nn.Conv2d(channels, channels, kernel_size=1)
+        self.proj_out = nn.Conv2d(channels, channels, kernel_size=1)
+
+    def __call__(self, hidden_states: mx.array) -> mx.array:
+        residual = hidden_states
+        hidden_states = self.norm(hidden_states)
+        query = self.q(hidden_states)
+        key = self.k(hidden_states)
+        value = self.v(hidden_states)
+
+        batch, height, width, channels = query.shape
+        query = query.reshape(batch, height * width, channels)
+        key = key.reshape(batch, height * width, channels).transpose(0, 2, 1)
+        attention = mx.softmax((query @ key) * channels**-0.5, axis=-1)
+        value = value.reshape(batch, height * width, channels)
+        hidden_states = (attention @ value).reshape(batch, height, width, channels)
+        return residual + self.proj_out(hidden_states)
+
+
+class Downsample(nn.Module):
+    def __init__(self, channels: int):
+        super().__init__()
+        self.conv = nn.Conv2d(channels, channels, kernel_size=3, stride=2)
+
+    def __call__(self, hidden_states: mx.array) -> mx.array:
+        hidden_states = mx.pad(hidden_states, ((0, 0), (0, 1), (0, 1), (0, 0)))
+        return self.conv(hidden_states)
+
+
+class DownBlock(nn.Module):
+    def __init__(self, block, attn, downsample=None):
+        super().__init__()
+        self.block = block
+        self.attn = attn
+        if downsample is not None:
+            self.downsample = downsample
+
+
+class MidBlock(nn.Module):
+    def __init__(self, channels: int, dropout: float):
+        super().__init__()
+        self.block_1 = ResnetBlock(channels, channels, dropout)
+        self.attn_1 = AttentionBlock(channels)
+        self.block_2 = ResnetBlock(channels, channels, dropout)
+
+
+class Encoder(nn.Module):
+    def __init__(self, config: VisionTokenizerConfig):
+        super().__init__()
+        self.num_resolutions = len(config.channel_multiplier)
+        self.num_res_blocks = config.num_res_blocks
+        self.conv_in = nn.Conv2d(
+            config.in_channels, config.base_channels, kernel_size=3, padding=1
+        )
+
+        current_resolution = config.resolution
+        input_multipliers = (1,) + tuple(config.channel_multiplier)
+        self.down = []
+        block_out = config.base_channels
+        for level in range(self.num_resolutions):
+            block_in = config.base_channels * input_multipliers[level]
+            block_out = config.base_channels * config.channel_multiplier[level]
+            blocks = []
+            attention = []
+            for _ in range(config.num_res_blocks):
+                blocks.append(ResnetBlock(block_in, block_out, config.dropout))
+                block_in = block_out
+                if current_resolution in config.attn_resolutions:
+                    attention.append(AttentionBlock(block_in))
+
+            downsample = None
+            if level != self.num_resolutions - 1:
+                downsample = Downsample(block_in)
+                current_resolution //= 2
+            self.down.append(DownBlock(blocks, attention, downsample))
+
+        self.mid = MidBlock(block_out, config.dropout)
+        self.norm_out = nn.GroupNorm(32, block_out, eps=1e-6, pytorch_compatible=True)
+        self.conv_out = nn.Conv2d(
+            block_out, config.latent_channels, kernel_size=3, padding=1
+        )
+
+    def __call__(self, pixel_values: mx.array) -> mx.array:
+        hidden_states = self.conv_in(pixel_values)
+        for level, down in enumerate(self.down):
+            for block_index, block in enumerate(down.block):
+                hidden_states = block(hidden_states)
+                if down.attn:
+                    hidden_states = down.attn[block_index](hidden_states)
+            if level != self.num_resolutions - 1:
+                hidden_states = down.downsample(hidden_states)
+
+        hidden_states = self.mid.block_1(hidden_states)
+        hidden_states = self.mid.attn_1(hidden_states)
+        hidden_states = self.mid.block_2(hidden_states)
+        hidden_states = self.norm_out(hidden_states)
+        hidden_states = hidden_states * mx.sigmoid(hidden_states)
+        return self.conv_out(hidden_states)
+
+
+class VectorQuantizer(nn.Module):
+    def __init__(
+        self,
+        config: VisionTokenizerConfig,
+        max_positions_per_chunk: int = 512,
+    ):
+        super().__init__()
+        if max_positions_per_chunk <= 0:
+            raise ValueError("max_positions_per_chunk must be positive")
+        self.embedding = nn.Embedding(config.codebook_size, config.embed_dim)
+        self.max_positions_per_chunk = max_positions_per_chunk
+
+    def __call__(self, hidden_states: mx.array) -> mx.array:
+        batch_size, height, width, _ = hidden_states.shape
+        column_chunk_size = min(width, self.max_positions_per_chunk)
+        rows_per_chunk = max(1, self.max_positions_per_chunk // column_chunk_size)
+        num_chunks = (
+            batch_size
+            * ((height + rows_per_chunk - 1) // rows_per_chunk)
+            * ((width + column_chunk_size - 1) // column_chunk_size)
+        )
+        batch_codes = []
+
+        # Preserve the reference einsum and argmax axes while bounding the
+        # temporary score tensor. Spatial chunks are independent, so no
+        # cross-chunk maximum or tie bookkeeping is needed.
+        for batch_index in range(batch_size):
+            row_codes = []
+            sample = hidden_states[batch_index : batch_index + 1]
+            for row_start in range(0, height, rows_per_chunk):
+                column_codes = []
+                row_end = min(row_start + rows_per_chunk, height)
+                for column_start in range(0, width, column_chunk_size):
+                    column_end = min(column_start + column_chunk_size, width)
+                    block = sample[:, row_start:row_end, column_start:column_end, :]
+                    logits = mx.einsum("bhwd,nd->bnhw", block, self.embedding.weight)
+                    codes = mx.argmax(logits, axis=1)
+                    if num_chunks > 1:
+                        mx.eval(codes)  # Release score storage before the next chunk.
+                    column_codes.append(codes)
+                row_codes.append(mx.concatenate(column_codes, axis=2))
+            batch_codes.append(mx.concatenate(row_codes, axis=1))
+        return mx.concatenate(batch_codes, axis=0)
+
+
+def ensure_channels_last(pixel_values: mx.array, in_channels: int) -> mx.array:
+    if pixel_values.shape[-1] == in_channels:
+        return pixel_values
+    if pixel_values.shape[1] == in_channels:
+        return pixel_values.transpose(0, 2, 3, 1)
+    raise ValueError(f"pixel_values must have {in_channels} channels")
+
+
+class VisionTokenizer(nn.Module):
+    def __init__(self, config: VisionTokenizerConfig):
+        super().__init__()
+        self.config = config
+        self.model_type = config.model_type
+        self.encoder = Encoder(config)
+        self.quantize = VectorQuantizer(config)
+        self.quant_conv = nn.Conv2d(
+            config.latent_channels, config.embed_dim, kernel_size=1
+        )
+        self.vision_spatial_factor = config.spatial_scale_factor
+
+    def encode(self, pixel_values: mx.array) -> mx.array:
+        if pixel_values.ndim != 4:
+            raise ValueError("pixel_values must be a rank-4 NCHW or NHWC array")
+        channel_last = ensure_channels_last(pixel_values, self.config.in_channels)
+
+        height, width = channel_last.shape[1:3]
+        factor = self.vision_spatial_factor
+        if height <= 0 or width <= 0 or height % factor or width % factor:
+            raise ValueError(
+                "Image height and width must be positive multiples of the vision "
+                f"tokenizer's spatial factor ({factor}), got {height}x{width}."
+            )
+        if (
+            self.encoder.conv_in.weight.dtype != mx.float32
+            or self.quantize.embedding.weight.dtype != mx.float32
+        ):
+            raise ValueError(
+                "The Apertus 1.5 vision tokenizer weights must remain in float32."
+            )
+
+        hidden_states = self.encoder(channel_last.astype(mx.float32))
+        hidden_states = self.quant_conv(hidden_states)
+        return self.quantize(hidden_states)

--- a/mlx_vlm/prompt_utils.py
+++ b/mlx_vlm/prompt_utils.py
@@ -50,6 +50,7 @@ MODEL_CONFIG = {
     "qwen3_5": MessageFormat.LIST_WITH_IMAGE_FIRST,
     "qwen3_5_moe": MessageFormat.LIST_WITH_IMAGE_FIRST,
     "qwen3_omni_moe": MessageFormat.LIST_WITH_IMAGE_FIRST,
+    "apertus1p5": MessageFormat.LIST_WITH_IMAGE_FIRST,
     "minicpmo": MessageFormat.IMAGE_TOKEN,
     "minicpmv4_6": MessageFormat.IMAGE_TOKEN_WRAPPED,
     "mistral3": MessageFormat.LIST_WITH_IMAGE_FIRST,

--- a/mlx_vlm/server/generation.py
+++ b/mlx_vlm/server/generation.py
@@ -46,7 +46,12 @@ from ..speculative.utils import (
 )
 from ..structured import ThinkingAwareLogitsProcessor
 from ..tokenizer_utils import _ServerTokenStreamer, make_streaming_detokenizer
-from ..utils import ThinkingBudgetCriteria, load, prepare_inputs
+from ..utils import (
+    ThinkingBudgetCriteria,
+    load,
+    prepare_inputs,
+    should_add_special_tokens,
+)
 from .runtime import runtime
 
 logger = logging.getLogger("mlx_vlm.server")
@@ -1261,11 +1266,8 @@ class ResponseGenerator:
 
     def _cpu_preprocess(self, prompt, images=None, audio=None, videos=None) -> dict:
         """CPU-only: tokenize text, load/resize images. Thread-safe."""
-        add_special_tokens = (
-            getattr(self.processor, "chat_template", None) is None
-            if self.model.config.model_type
-            in ["gemma3", "gemma3n", "gemma4", "gemma4_unified"]
-            else True
+        add_special_tokens = should_add_special_tokens(
+            self.model.config.model_type, self.processor
         )
         image_token_index = getattr(self.model.config, "image_token_index", None)
         return prepare_inputs(

--- a/mlx_vlm/tests/test_models.py
+++ b/mlx_vlm/tests/test_models.py
@@ -8,6 +8,7 @@ import mlx.core as mx
 import mlx.nn as nn
 import numpy as np
 from mlx.utils import tree_flatten, tree_map
+from transformers.tokenization_utils_base import PreTrainedTokenizerBase
 
 
 class TestModels(unittest.TestCase):
@@ -12201,3 +12202,1038 @@ class TestLfm2Embedding(unittest.TestCase):
         self.assertEqual(out.text_embeds.shape, (batch, config.hidden_size))
         norms = mx.linalg.norm(out.text_embeds, axis=-1)
         self.assertTrue(mx.allclose(norms, mx.ones(batch), atol=1e-4).item())
+
+
+def _apertus1p5_tiny_config():
+    from mlx_vlm.models import apertus1p5
+
+    return apertus1p5.ModelConfig.from_dict(_apertus1p5_tiny_config_dict())
+
+
+def _apertus1p5_tiny_config_dict():
+    return {
+        "model_type": "apertus1p5",
+        "image_token_id": 9,
+        "audio_token_id": 10,
+        "image_token_offset": 96,
+        "audio_token_offset": 160,
+        "text_config": {
+            "hidden_size": 32,
+            "num_hidden_layers": 1,
+            "intermediate_size": 64,
+            "num_attention_heads": 4,
+            "num_key_value_heads": 2,
+            "vocab_size": 192,
+            "output_vocab_size": 64,
+            "max_position_embeddings": 128,
+            "rope_parameters": {
+                "rope_theta": 4000000,
+                "rope_type": "llama3",
+                "factor": 2.0,
+                "high_freq_factor": 4.0,
+                "low_freq_factor": 1.0,
+                "original_max_position_embeddings": 64,
+            },
+        },
+        "vision_tokenizer_config": {
+            "codebook_size": 64,
+            "embed_dim": 32,
+            "latent_channels": 8,
+            "base_channels": 32,
+            "channel_multiplier": [1, 2],
+            "num_res_blocks": 1,
+            "attn_resolutions": [8],
+            "resolution": 16,
+        },
+        "audio_tokenizer_config": {
+            "codebook_size": 32,
+            "codebook_dim": 8,
+            "hidden_size": 8,
+            "num_filters": 2,
+            "upsampling_ratios": [2, 2],
+            "num_lstm_layers": 1,
+            "kernel_size": 3,
+            "last_kernel_size": 3,
+        },
+    }
+
+
+class _Apertus1p5FakeTokenizer(PreTrainedTokenizerBase):
+    image_token = "<|image|>"
+    audio_token = "<|audio|>"
+    model_input_names = ["input_ids", "attention_mask"]
+
+    def __init__(self):
+        super().__init__(chat_template=None)
+
+    def __call__(self, text, **kwargs):
+        self.last_text = text
+        self.last_kwargs = kwargs
+        return {
+            "input_ids": np.ones((len(text), 1), dtype=np.int64),
+            "attention_mask": np.ones((len(text), 1), dtype=np.int64),
+        }
+
+    def save_pretrained(self, save_directory, **kwargs):
+        from pathlib import Path
+
+        path = Path(save_directory, "tokenizer_config.json")
+        path.write_text("{}")
+        return (str(path),)
+
+
+class TestApertus1p5(unittest.TestCase):
+    def setUp(self):
+        from mlx_vlm.models import apertus1p5
+
+        self.apertus1p5 = apertus1p5
+
+    def test_split_vocabulary_and_image_placeholders(self):
+        config = _apertus1p5_tiny_config()
+        model = self.apertus1p5.Model(config)
+        pixels = mx.random.uniform(shape=(1, 3, 16, 16), low=-1, high=1)
+
+        codes = model.vision_tokenizer.encode(pixels)
+        mx.eval(codes)
+        self.assertEqual(codes.shape, (1, 8, 8))
+        self.assertGreaterEqual(int(mx.min(codes).item()), 0)
+        self.assertLess(int(mx.max(codes).item()), 64)
+
+        input_ids = mx.array([[1] + [config.image_token_id] * 64 + [2]])
+        outputs = model(
+            input_ids,
+            pixel_values=pixels,
+            image_sizes=mx.array([[16, 16]]),
+        )
+        mx.eval(outputs.logits)
+        self.assertEqual(outputs.logits.shape, (1, 66, 64))
+
+    def test_extended_ids_work_without_media(self):
+        model = self.apertus1p5.Model(_apertus1p5_tiny_config())
+        outputs = model(mx.array([[0, 63, 191]]))
+        mx.eval(outputs.logits)
+        self.assertEqual(outputs.logits.shape, (1, 3, 64))
+
+    def test_precomputed_inputs_embeds_follow_generator_path(self):
+        model = self.apertus1p5.Model(_apertus1p5_tiny_config())
+        input_ids = mx.array([[1, 2, 3]])
+        inputs_embeds = model.get_input_embeddings(input_ids).inputs_embeds
+
+        expected = model(input_ids).logits
+        actual = model(
+            input_ids,
+            inputs_embeds=inputs_embeds,
+            n_to_process=input_ids.shape[1],
+        ).logits
+        mx.eval(expected, actual)
+        self.assertTrue(mx.array_equal(expected, actual).item())
+
+        with self.assertRaisesRegex(ValueError, "cannot be combined"):
+            model(
+                input_ids,
+                inputs_embeds=inputs_embeds,
+                pixel_values=mx.zeros((1, 3, 16, 16)),
+            )
+        with self.assertRaisesRegex(ValueError, "matching batch and sequence"):
+            model(input_ids[:, :2], inputs_embeds=inputs_embeds)
+
+    def test_config_derives_rope_and_validates_ranges(self):
+        config = _apertus1p5_tiny_config()
+        self.assertEqual(config.text_config.rope_theta, 4000000)
+        self.assertEqual(config.text_config.rope_scaling["rope_type"], "llama3")
+        self.assertEqual(config.vision_tokenizer_config.spatial_scale_factor, 2)
+
+        raw = _apertus1p5_tiny_config().to_dict()
+        raw["audio_token_offset"] = 159
+        with self.assertRaisesRegex(ValueError, "visual token range"):
+            self.apertus1p5.ModelConfig.from_dict(raw)
+
+        raw = _apertus1p5_tiny_config().to_dict()
+        raw["text_config"] = raw["text_config"].to_dict()
+        raw["text_config"]["qk_norm"] = False
+        with self.assertRaisesRegex(ValueError, "qk_norm"):
+            self.apertus1p5.ModelConfig.from_dict(raw)
+
+        raw = _apertus1p5_tiny_config().to_dict()
+        raw["text_config"] = raw["text_config"].to_dict()
+        raw["text_config"]["post_norm"] = True
+        with self.assertRaisesRegex(ValueError, "post_norm"):
+            self.apertus1p5.ModelConfig.from_dict(raw)
+
+        raw = _apertus1p5_tiny_config().to_dict()
+        raw["tie_word_embeddings"] = True
+        with self.assertRaisesRegex(ValueError, "pruned output vocabulary"):
+            self.apertus1p5.ModelConfig.from_dict(raw)
+
+        raw["text_config"] = raw["text_config"].to_dict()
+        raw["text_config"]["output_vocab_size"] = None
+        tied_config = self.apertus1p5.ModelConfig.from_dict(raw)
+        self.assertTrue(tied_config.tie_word_embeddings)
+        self.assertTrue(tied_config.text_config.tie_word_embeddings)
+        tied_model = self.apertus1p5.Model(tied_config)
+        self.assertFalse(hasattr(tied_model.language_model, "lm_head"))
+        logits = tied_model(mx.array([[1, 2]])).logits
+        mx.eval(logits)
+        self.assertEqual(logits.shape, (1, 2, 192))
+
+        sanitized = tied_model.sanitize(
+            {
+                "model.language_model.embed_tokens.weight": mx.zeros((192, 32)),
+                "lm_head.weight": mx.zeros((192, 32)),
+            }
+        )
+        self.assertIn("language_model.model.embed_tokens.weight", sanitized)
+        self.assertNotIn("language_model.lm_head.weight", sanitized)
+
+    def test_config_parses_published_checkpoint_config(self):
+        from mlx_vlm.models import apertus1p5
+
+        # Vendored verbatim from swiss-ai/Apertus-v1.5-8B config.json so the
+        # parser is validated against the real checkpoint layout instead of
+        # hand-written fixtures (e.g. eos_token_id lives inside text_config).
+        published = {
+            "architectures": ["Apertus1p5ForConditionalGeneration"],
+            "audio_token_id": 131085,
+            "audio_token_offset": 262344,
+            "audio_tokenizer_config": {
+                "adanorm_num_embeddings": 4,
+                "architectures": ["WavTokenizerModel"],
+                "audio_channels": 1,
+                "codebook_dim": 512,
+                "codebook_size": 4096,
+                "compress": 2,
+                "decoder_attention_num_groups": 32,
+                "decoder_hidden_size": 768,
+                "decoder_intermediate_size": 2304,
+                "decoder_num_layers": 12,
+                "dilation_growth_rate": 2,
+                "dtype": "float32",
+                "hidden_size": 512,
+                "kernel_size": 7,
+                "last_kernel_size": 7,
+                "model_type": "wavtokenizer",
+                "norm_eps": 1e-06,
+                "norm_type": "weight_norm",
+                "num_filters": 32,
+                "num_lstm_layers": 2,
+                "num_residual_layers": 1,
+                "pad_mode": "reflect",
+                "residual_kernel_size": 3,
+                "sampling_rate": 24000,
+                "upsampling_ratios": [6, 5, 5, 4],
+                "use_causal_conv": False,
+                "use_conv_shortcut": True,
+            },
+            "image_token_id": 131079,
+            "image_token_offset": 131272,
+            "model_type": "apertus1p5",
+            "text_config": {
+                "attention_bias": False,
+                "attention_dropout": 0.0,
+                "bos_token_id": 1,
+                "dtype": "bfloat16",
+                "eos_token_id": [2, 68, 72],
+                "hidden_act": "xielu",
+                "hidden_dropout": 0.0,
+                "hidden_size": 4096,
+                "initializer_range": 0.02,
+                "intermediate_size": 21504,
+                "max_position_embeddings": 262144,
+                "mlp_bias": False,
+                "model_type": "apertus1p5_text",
+                "num_attention_heads": 32,
+                "num_hidden_layers": 32,
+                "num_key_value_heads": 8,
+                "output_vocab_size": 131072,
+                "pad_token_id": 3,
+                "post_norm": False,
+                "qk_norm": True,
+                "rms_norm_eps": 1e-05,
+                "rope_parameters": {
+                    "factor": 32.0,
+                    "high_freq_factor": 4.0,
+                    "low_freq_factor": 1.0,
+                    "original_max_position_embeddings": 8192,
+                    "rope_theta": 4000000,
+                    "rope_type": "llama3",
+                },
+                "tie_word_embeddings": False,
+                "use_cache": True,
+                "vocab_size": 266752,
+            },
+            "tie_word_embeddings": False,
+            "transformers_version": "5.14.0.dev0",
+            "vision_tokenizer_config": {
+                "architectures": ["Apertus1p5VisionTokenizerModel"],
+                "attn_resolutions": [16],
+                "base_channels": 256,
+                "channel_multiplier": [1, 1, 2, 2, 4],
+                "codebook_size": 131072,
+                "dropout": 0.0,
+                "dtype": "float32",
+                "embed_dim": 256,
+                "in_channels": 3,
+                "latent_channels": 256,
+                "model_type": "apertus1p5_vision_tokenizer",
+                "num_res_blocks": 4,
+                "resolution": 256,
+            },
+        }
+
+        config = apertus1p5.ModelConfig.from_dict(published)
+
+        self.assertEqual(config.eos_token_id, [2, 68, 72])
+        self.assertFalse(config.tie_word_embeddings)
+        self.assertFalse(config.text_config.tie_word_embeddings)
+        self.assertEqual(config.image_token_id, 131079)
+        self.assertEqual(config.image_token_offset, 131272)
+        self.assertEqual(config.audio_token_offset, 262344)
+        self.assertEqual(config.text_config.vocab_size, 266752)
+        self.assertEqual(config.text_config.output_vocab_size, 131072)
+        self.assertEqual(config.vision_tokenizer_config.codebook_size, 131072)
+        self.assertEqual(config.vision_tokenizer_config.spatial_scale_factor, 16)
+
+    def test_call_accepts_trainer_positional_convention(self):
+        config = _apertus1p5_tiny_config()
+        model = self.apertus1p5.Model(config)
+
+        # sft/orpo trainers call model(input_ids, pixel_values, attention_mask,
+        # **batch), so mask must occupy the third positional slot even when the
+        # batch also carries image_sizes as a keyword.
+        input_ids = mx.array([[1, 2, 3]])
+        outputs = model(input_ids, None, mx.ones_like(input_ids))
+        self.assertEqual(outputs.logits.shape, (1, 3, 64))
+
+        pixels = mx.random.uniform(shape=(1, 3, 16, 16), low=-1, high=1)
+        image_ids = mx.array([[1] + [config.image_token_id] * 64 + [2]])
+        outputs = model(
+            image_ids,
+            pixels,
+            mx.ones_like(image_ids),
+            image_sizes=mx.array([[16, 16]]),
+        )
+        self.assertEqual(outputs.logits.shape, (1, 66, 64))
+
+    def test_image_array_channel_inference(self):
+        from mlx_vlm.models.apertus1p5.processing_apertus1p5 import (
+            Apertus1p5ImageProcessor,
+        )
+
+        # PIL size is (width, height).
+        chw = Apertus1p5ImageProcessor._to_pil(np.zeros((3, 5, 8), dtype=np.uint8))
+        self.assertEqual(chw.size, (8, 5))
+        grayscale_chw = Apertus1p5ImageProcessor._to_pil(
+            np.zeros((1, 5, 8), dtype=np.uint8)
+        )
+        self.assertEqual(grayscale_chw.size, (8, 5))
+        # A short HWC image must not be mistaken for channel-first.
+        short_hwc = Apertus1p5ImageProcessor._to_pil(
+            np.zeros((4, 8, 3), dtype=np.uint8)
+        )
+        self.assertEqual(short_hwc.size, (8, 4))
+
+    def test_top_level_tie_flag_survives_module_config_rebuild(self):
+        from mlx_vlm.utils import update_module_configs
+
+        raw = _apertus1p5_tiny_config_dict()
+        raw["tie_word_embeddings"] = True
+        raw["text_config"]["output_vocab_size"] = raw["text_config"]["vocab_size"]
+
+        config = self.apertus1p5.ModelConfig.from_dict(raw)
+        self.assertTrue(config.text_config.tie_word_embeddings)
+
+        # load_model reparses text_config from the raw nested dict after
+        # from_dict, which discards the hoisted flag (the nested dict does
+        # not carry it).
+        config = update_module_configs(
+            config,
+            self.apertus1p5,
+            raw,
+            ["text", "vision", "perceiver", "projector", "audio"],
+        )
+        self.assertFalse(config.text_config.tie_word_embeddings)
+
+        model = self.apertus1p5.Model(config)
+        self.assertTrue(config.text_config.tie_word_embeddings)
+        self.assertFalse(hasattr(model.language_model, "lm_head"))
+
+        logits = model(mx.array([[1, 2, 3]])).logits
+        self.assertEqual(logits.shape[-1], raw["text_config"]["vocab_size"])
+
+        # Tying is structurally impossible with the pruned output head: the
+        # config guard catches it at parse time...
+        pruned = _apertus1p5_tiny_config_dict()
+        pruned["tie_word_embeddings"] = True
+        with self.assertRaisesRegex(ValueError, "cannot be tied"):
+            self.apertus1p5.ModelConfig.from_dict(pruned)
+
+        # ...and the language model re-checks after the load-path re-hoist,
+        # which runs after __post_init__ validation already happened.
+        config = _apertus1p5_tiny_config()
+        config.tie_word_embeddings = True
+        with self.assertRaisesRegex(ValueError, "output_vocab_size"):
+            self.apertus1p5.Model(config)
+
+    def test_sanitize_and_conversion_predicates(self):
+        model = self.apertus1p5.Model(_apertus1p5_tiny_config())
+        conv = mx.zeros((4, 3, 3, 2))
+        weights = {
+            "model.language_model.embed_tokens.weight": mx.zeros((192, 32)),
+            "model.vision_tokenizer.encoder.conv_in.weight": conv,
+            "model.audio_tokenizer.backbone.embed.weight": mx.zeros((1,)),
+            "model.audio_tokenizer.head.linear.weight": mx.zeros((1,)),
+            "model.audio_tokenizer.quantizer.codebook.inited": mx.zeros((1,)),
+            "model.audio_tokenizer.quantizer.codebook.cluster_size": mx.zeros((32,)),
+            "model.audio_tokenizer.quantizer.codebook.embed_avg": mx.zeros((32, 8)),
+            "model.audio_tokenizer.quantizer.codebook.embed": mx.zeros((32, 8)),
+            "lm_head.weight": mx.zeros((64, 32)),
+        }
+        sanitized = model.sanitize(weights)
+        self.assertIn("language_model.model.embed_tokens.weight", sanitized)
+        self.assertIn("language_model.lm_head.weight", sanitized)
+        self.assertEqual(
+            sanitized["vision_tokenizer.encoder.conv_in.weight"].shape,
+            (4, 3, 2, 3),
+        )
+        # Decoder weights and codebook EMA buffers are dropped; the codebook
+        # itself is kept.
+        self.assertEqual(
+            [key for key in sanitized if "audio_tokenizer" in key],
+            ["audio_tokenizer.quantizer.codebook.embed"],
+        )
+        vision_path = "vision_tokenizer.quantize.embedding"
+        self.assertFalse(model.cast_predicate(vision_path))
+        self.assertFalse(model.quant_predicate(vision_path, model.vision_tokenizer))
+        audio_path = "audio_tokenizer.quantizer.codebook.embed"
+        self.assertFalse(model.cast_predicate(audio_path))
+        self.assertFalse(model.quant_predicate(audio_path, model.audio_tokenizer))
+        self.assertTrue(
+            model.cast_predicate("language_model.model.embed_tokens.weight")
+        )
+        self.assertTrue(
+            model.quant_predicate(
+                "language_model.model.embed_tokens", model.language_model
+            )
+        )
+
+        sanitized_again = model.sanitize(sanitized)
+        self.assertEqual(sanitized.keys(), sanitized_again.keys())
+        for key in sanitized:
+            self.assertEqual(sanitized[key].shape, sanitized_again[key].shape)
+            self.assertTrue(mx.array_equal(sanitized[key], sanitized_again[key]).item())
+
+    def test_audio_sanitize_fuses_weight_norm_and_lstm(self):
+        model = self.apertus1p5.Model(_apertus1p5_tiny_config())
+        direction = mx.array(
+            [[[3.0, 0.0, 4.0]], [[0.0, 5.0, 12.0]]]
+        )  # (out=2, in=1, k=3)
+        magnitude = mx.array([[[10.0]], [[26.0]]])  # (out=2, 1, 1)
+        weights = {
+            "model.audio_tokenizer.encoder.layers.0.conv.parametrizations"
+            ".weight.original0": magnitude,
+            "model.audio_tokenizer.encoder.layers.0.conv.parametrizations"
+            ".weight.original1": direction,
+            "model.audio_tokenizer.encoder.layers.0.conv.bias": mx.zeros((2,)),
+            "model.audio_tokenizer.encoder.layers.3.lstm.weight_ih_l0": mx.ones(
+                (32, 8)
+            ),
+            "model.audio_tokenizer.encoder.layers.3.lstm.weight_hh_l0": mx.ones(
+                (32, 8)
+            ),
+            "model.audio_tokenizer.encoder.layers.3.lstm.bias_ih_l0": mx.ones((32,)),
+            "model.audio_tokenizer.encoder.layers.3.lstm.bias_hh_l0": 2
+            * mx.ones((32,)),
+        }
+        sanitized = model.sanitize(weights)
+
+        fused = sanitized["audio_tokenizer.encoder.layers.0.conv.weight"]
+        # torch (out, in, k) -> MLX (out, k, in); rows scaled to g * v / |v|.
+        self.assertEqual(fused.shape, (2, 3, 1))
+        expected = mx.array([[[6.0], [0.0], [8.0]], [[0.0], [10.0], [24.0]]])
+        self.assertTrue(mx.allclose(fused, expected).item())
+        self.assertIn("audio_tokenizer.encoder.layers.0.conv.bias", sanitized)
+        self.assertEqual(
+            sanitized["audio_tokenizer.encoder.layers.3.lstm.0.Wx"].shape, (32, 8)
+        )
+        self.assertEqual(
+            sanitized["audio_tokenizer.encoder.layers.3.lstm.0.Wh"].shape, (32, 8)
+        )
+        bias = sanitized["audio_tokenizer.encoder.layers.3.lstm.0.bias"]
+        self.assertTrue(mx.allclose(bias, 3 * mx.ones((32,))).item())
+
+        with self.assertRaisesRegex(ValueError, "Incomplete weight normalization"):
+            model.sanitize(
+                {
+                    "model.audio_tokenizer.encoder.layers.0.conv"
+                    ".parametrizations.weight.original0": magnitude
+                }
+            )
+
+    def test_audio_feature_extractor_pads_and_counts_codes(self):
+        from mlx_vlm.models.apertus1p5.processing_apertus1p5 import (
+            Apertus1p5FeatureExtractor,
+        )
+
+        extractor = Apertus1p5FeatureExtractor(hop_length=4)
+        self.assertEqual(extractor.get_num_audio_codes(1), 1)
+        self.assertEqual(extractor.get_num_audio_codes(4), 1)
+        self.assertEqual(extractor.get_num_audio_codes(5), 2)
+
+        clips = [np.ones(6, dtype=np.float32), np.ones(3, dtype=np.float32)]
+        outputs = extractor(clips)
+        self.assertEqual(outputs["input_values"].shape, (2, 1, 6))
+        self.assertTrue((outputs["padding_mask"][0] == 1).all())
+        self.assertEqual(outputs["padding_mask"][1].tolist(), [1, 1, 1, 0, 0, 0])
+        self.assertEqual(float(outputs["input_values"][1, 0, 3:].sum()), 0.0)
+
+        with self.assertRaisesRegex(ValueError, "sampled at"):
+            extractor(clips, sampling_rate=16000)
+        with self.assertRaisesRegex(ValueError, "mono audio"):
+            extractor([np.ones((2, 6), dtype=np.float32)])
+        with self.assertRaisesRegex(ValueError, "is empty"):
+            extractor([np.ones(0, dtype=np.float32)])
+
+    def test_processor_expands_audio_placeholders(self):
+        from mlx_vlm.models.apertus1p5.processing_apertus1p5 import (
+            Apertus1p5FeatureExtractor,
+            Apertus1p5ImageProcessor,
+            Apertus1p5Processor,
+        )
+
+        tokenizer = _Apertus1p5FakeTokenizer()
+        processor = Apertus1p5Processor(
+            image_processor=Apertus1p5ImageProcessor(),
+            tokenizer=tokenizer,
+            feature_extractor=Apertus1p5FeatureExtractor(hop_length=4),
+        )
+        clip_a = np.ones(8, dtype=np.float32)
+        clip_b = np.ones(5, dtype=np.float32)
+        outputs = processor(
+            text="Hear <|audio|> then <|audio|> end",
+            audio=[clip_a, clip_b],
+        )
+        expected = (
+            "Hear <|audio_start|><|audio|><|audio|><|audio_end|> then "
+            "<|audio_start|><|audio|><|audio|><|audio_end|> end"
+        )
+        self.assertEqual(tokenizer.last_text, [expected])
+        self.assertEqual(outputs["input_features"].shape, (2, 1, 8))
+        self.assertEqual(
+            np.asarray(outputs["feature_attention_mask"]).tolist(),
+            [[1] * 8, [1] * 5 + [0] * 3],
+        )
+        # Clips are peak-normalized to -3 dBFS before feature extraction.
+        peak = float(np.abs(np.asarray(outputs["input_features"])).max())
+        self.assertAlmostEqual(peak, 10.0 ** (-3.0 / 20.0), places=5)
+
+        # Nested audio must provide one clip list per text sample.
+        processor(text="One <|audio|> two <|audio|>", audio=[[clip_a, clip_b]])
+        with self.assertRaisesRegex(ValueError, "Per-sample audio"):
+            processor(text="One <|audio|>", audio=[[clip_a, clip_b]])
+
+    def test_audio_tokenizer_encode_and_model_merge(self):
+        config = _apertus1p5_tiny_config()
+        model = self.apertus1p5.Model(config)
+        hop = config.audio_tokenizer_config.hop_length
+        self.assertEqual(hop, 4)
+
+        rng = np.random.default_rng(0)
+        for num_samples, expected_codes in ((1, 1), (4, 1), (5, 2), (11, 3)):
+            clip = mx.array(rng.standard_normal((1, 1, num_samples)).astype(np.float32))
+            codes = model.audio_tokenizer.encode(clip)
+            self.assertEqual(codes.shape, (1, expected_codes))
+
+        features = mx.array(rng.standard_normal((2, 1, 8)).astype(np.float32))
+        mask = mx.array([[1] * 8, [1] * 4 + [0] * 4])
+        vocab_ids = model.get_audio_tokens(features, mask)
+        self.assertEqual(vocab_ids.shape, (3,))  # 2 codes + 1 code
+        self.assertTrue(
+            (np.asarray(vocab_ids) >= config.audio_token_offset).all()
+            and (
+                np.asarray(vocab_ids)
+                < config.audio_token_offset
+                + config.audio_tokenizer_config.codebook_size
+            ).all()
+        )
+
+        audio_id = config.audio_token_id
+        input_ids = mx.array([[1, audio_id, audio_id, audio_id, 2]])
+        embeds = model.get_input_embeddings(
+            input_ids, input_features=features, feature_attention_mask=mask
+        ).inputs_embeds
+        expected = model.language_model.model.embed_tokens(vocab_ids)
+        self.assertTrue(mx.allclose(embeds[0, 1:4], expected).item())
+
+        with self.assertRaisesRegex(ValueError, "do not match"):
+            model.get_input_embeddings(
+                mx.array([[1, audio_id, 2]]),
+                input_features=features,
+                feature_attention_mask=mask,
+            )
+        with self.assertRaisesRegex(ValueError, "zero"):
+            model.get_audio_tokens(features, mx.zeros((2, 8)))
+        with self.assertRaisesRegex(ValueError, "right-padded"):
+            model.get_audio_tokens(features, mx.array([[1] * 8, [0] * 4 + [1] * 4]))
+        with self.assertRaisesRegex(ValueError, "right-padded"):
+            model.get_audio_tokens(
+                features, mx.array([[1] * 8, [1, 1, 0, 1, 0, 0, 0, 0]])
+            )
+
+        model.audio_tokenizer.set_dtype(mx.bfloat16)
+        with self.assertRaisesRegex(ValueError, "float32"):
+            model.audio_tokenizer.encode(mx.ones((1, 1, 4)))
+
+    def test_converted_checkpoint_strictly_reloads(self):
+        import json
+        from pathlib import Path
+        from tempfile import TemporaryDirectory
+
+        from mlx_vlm.utils import load_model, save_weights
+
+        config = _apertus1p5_tiny_config()
+        model = self.apertus1p5.Model(config)
+        input_ids = mx.array([[1, 2, 3]])
+        expected = model(input_ids).logits
+        mx.eval(expected)
+
+        config_dict = config.to_dict()
+        config_dict["text_config"] = config.text_config.to_dict()
+        config_dict["vision_tokenizer_config"] = (
+            config.vision_tokenizer_config.to_dict()
+        )
+        config_dict["audio_tokenizer_config"] = config.audio_tokenizer_config.to_dict()
+        with TemporaryDirectory() as directory:
+            model_path = Path(directory)
+            save_weights(model_path, model)
+            Path(model_path, "config.json").write_text(json.dumps(config_dict))
+            reloaded = load_model(model_path, lazy=False, strict=True)
+            actual = reloaded(input_ids).logits
+            mx.eval(actual)
+
+        self.assertTrue(mx.array_equal(expected, actual).item())
+
+    def test_quantization_keeps_discrete_tokenizer_in_float32(self):
+        from mlx_vlm.quant_utils import quantize_model
+
+        config = _apertus1p5_tiny_config()
+        model = self.apertus1p5.Model(config)
+        model, _ = quantize_model(
+            model,
+            config.to_dict(),
+            group_size=32,
+            bits=4,
+        )
+        self.assertIsInstance(model.vision_tokenizer.quantize.embedding, nn.Embedding)
+        self.assertEqual(
+            model.vision_tokenizer.quantize.embedding.weight.dtype, mx.float32
+        )
+        self.assertIsInstance(model.language_model.lm_head, nn.QuantizedLinear)
+
+    def test_chunked_quantizer_matches_full_reference(self):
+        from mlx_vlm.models.apertus1p5.vision import VectorQuantizer
+
+        config = _apertus1p5_tiny_config().vision_tokenizer_config
+        quantizer = VectorQuantizer(config, max_positions_per_chunk=5)
+        hidden_states = mx.random.normal((2, 3, 7, config.embed_dim))
+        expected = mx.argmax(
+            mx.einsum("bhwd,nd->bnhw", hidden_states, quantizer.embedding.weight),
+            axis=1,
+        )
+        actual = quantizer(hidden_states)
+        mx.eval(expected, actual)
+        self.assertTrue(mx.array_equal(expected, actual).item())
+
+    def test_image_processor_resize_normalize_and_pad(self):
+        from PIL import Image
+
+        from mlx_vlm.models.apertus1p5.processing_apertus1p5 import (
+            Apertus1p5ImageProcessor,
+            smart_resize,
+        )
+
+        self.assertEqual(smart_resize(100, 200, 16, 65536, 1960000), (176, 368))
+        processor = Apertus1p5ImageProcessor(
+            min_pixels=16 * 16,
+            max_pixels=32 * 32,
+            spatial_factor=16,
+        )
+        black = Image.fromarray(np.zeros((16, 32, 3), dtype=np.uint8))
+        white = Image.fromarray(np.full((32, 16, 3), 255, dtype=np.uint8))
+        outputs = processor([black, white])
+        self.assertEqual(outputs["pixel_values"].shape, (2, 3, 32, 32))
+        self.assertEqual(outputs["image_sizes"].tolist(), [[16, 32], [32, 16]])
+        self.assertEqual(outputs["image_grids"].tolist(), [[1, 2], [2, 1]])
+        self.assertEqual(float(outputs["pixel_values"][0, 0, 0, 0].item()), -1.0)
+        self.assertEqual(float(outputs["pixel_values"][1, 0, 0, 0].item()), 1.0)
+
+        grayscale = np.arange(16 * 16, dtype=np.uint8).reshape(16, 16)
+        chw_grayscale = processor(grayscale[None, :, :])["pixel_values"]
+        hwc_grayscale = processor(grayscale[:, :, None])["pixel_values"]
+        mx.eval(chw_grayscale, hwc_grayscale)
+        self.assertTrue(mx.array_equal(chw_grayscale, hwc_grayscale).item())
+        self.assertEqual(chw_grayscale.shape, (1, 3, 16, 16))
+        with self.assertRaisesRegex(TypeError, "unscaled uint8"):
+            processor(np.zeros((16, 16, 3), dtype=np.float32))
+
+    def test_uint8_bicubic_matches_torchvision_reference(self):
+        from mlx_vlm.models.apertus1p5.processing_apertus1p5 import (
+            _resize_uint8_bicubic,
+        )
+
+        image = np.arange(18, dtype=np.uint8).reshape(3, 2, 3) * 13
+        expected = np.asarray(
+            [
+                [
+                    [0, 1, 10, 19, 24],
+                    [8, 12, 21, 30, 35],
+                    [30, 35, 44, 53, 58],
+                    [41, 46, 55, 64, 69],
+                ],
+                [
+                    [74, 79, 88, 97, 102],
+                    [85, 90, 99, 108, 113],
+                    [108, 113, 122, 131, 136],
+                    [119, 124, 133, 142, 147],
+                ],
+                [
+                    [152, 157, 166, 175, 180],
+                    [163, 168, 177, 186, 191],
+                    [186, 191, 200, 209, 214],
+                    [197, 202, 211, 220, 225],
+                ],
+            ],
+            dtype=np.uint8,
+        )
+        np.testing.assert_array_equal(
+            _resize_uint8_bicubic(image, height=4, width=5), expected
+        )
+
+    def test_processor_normalizes_batched_and_empty_image_inputs(self):
+        from mlx_vlm.models.apertus1p5.processing_apertus1p5 import (
+            Apertus1p5ImageProcessor,
+            Apertus1p5Processor,
+        )
+
+        image_processor = Apertus1p5ImageProcessor(
+            min_pixels=16 * 16,
+            max_pixels=32 * 48,
+            spatial_factor=16,
+        )
+        batch = np.arange(2 * 32 * 48 * 3, dtype=np.uint8).reshape(2, 32, 48, 3)
+        batched = image_processor.preprocess(batch)
+        listed = image_processor.preprocess([batch[0], batch[1]])
+        self.assertTrue(np.array_equal(batched["pixel_values"], listed["pixel_values"]))
+        with self.assertRaises(ValueError):
+            image_processor.preprocess([])
+
+        processor = Apertus1p5Processor(
+            image_processor=image_processor,
+            tokenizer=_Apertus1p5FakeTokenizer(),
+        )
+        outputs = processor(text="no images here", images=[])
+        self.assertNotIn("pixel_values", outputs)
+
+    def test_processor_expands_nontrivial_grids_and_validates_inputs(self):
+        from PIL import Image
+
+        from mlx_vlm.models.apertus1p5.processing_apertus1p5 import (
+            Apertus1p5ImageProcessor,
+            Apertus1p5Processor,
+        )
+
+        tokenizer = _Apertus1p5FakeTokenizer()
+        processor = Apertus1p5Processor(
+            image_processor=Apertus1p5ImageProcessor(
+                min_pixels=16 * 16,
+                max_pixels=32 * 48,
+                spatial_factor=16,
+            ),
+            tokenizer=tokenizer,
+        )
+        small = Image.fromarray(np.zeros((16, 16, 3), dtype=np.uint8))
+        large = Image.fromarray(np.zeros((32, 48, 3), dtype=np.uint8))
+        outputs = processor(
+            text="A <|image|> B <|image|>",
+            images=[[small, large]],
+        )
+
+        self.assertNotIn("image_grids", outputs)
+        self.assertEqual(outputs["pixel_values"].shape, (2, 3, 32, 48))
+        expected = (
+            "A <|img_start|>1*1<|img_token_start|><|image|><|img_end|> B "
+            "<|img_start|>2*3<|img_token_start|>"
+            "<|image|><|image|><|image|><|img_end_of_row|>"
+            "<|image|><|image|><|image|><|img_end|>"
+        )
+        self.assertEqual(tokenizer.last_text, [expected])
+
+        processor(
+            text="A <|image|> B <|image|>",
+            images=[small, large],
+        )
+        self.assertEqual(tokenizer.last_text, [expected])
+
+        with self.assertRaisesRegex(ValueError, "number of image placeholders"):
+            processor(text="A <|image|>", images=[small, large])
+        with self.assertRaisesRegex(ValueError, "Per-sample"):
+            processor(
+                text="A <|image|>",
+                images=[[small, large]],
+            )
+        with self.assertRaisesRegex(ValueError, "batch size 1"):
+            processor(text=["A", "B"])
+        with self.assertRaisesRegex(ValueError, "audio placeholders"):
+            processor(text="Listen: <|audio|>")
+        with self.assertRaisesRegex(ValueError, "audio placeholders"):
+            processor(text="no audio", audio=[np.zeros(8, dtype=np.float32)])
+
+    def test_processor_collapses_non_user_roles_for_template(self):
+        from mlx_vlm.models.apertus1p5.processing_apertus1p5 import (
+            Apertus1p5ImageProcessor,
+            Apertus1p5Processor,
+        )
+        from mlx_vlm.prompt_utils import get_message_json
+
+        def message(prompt, role, num_images=0):
+            return get_message_json(
+                "apertus1p5",
+                prompt,
+                role=role,
+                skip_image_token=role != "user",
+                skip_audio_token=True,
+                num_images=num_images,
+                num_audios=0,
+            )
+
+        messages = [
+            message("Be terse.", "system"),
+            message("Describe this.", "user", num_images=2),
+            message("It is a cat.", "assistant"),
+        ]
+        # The shared formatter emits content-part lists for every role...
+        self.assertIsInstance(messages[0]["content"], list)
+        self.assertEqual(
+            [part["type"] for part in messages[1]["content"]],
+            ["image", "image", "text"],
+        )
+
+        # ...but the published chat template accepts part lists only for user
+        # messages (non-string system/assistant content raises TemplateError),
+        # so the processor collapses other roles before delegating.
+        processor = Apertus1p5Processor(
+            image_processor=Apertus1p5ImageProcessor(),
+            tokenizer=_Apertus1p5FakeTokenizer(),
+        )
+        rendered = processor.apply_chat_template(
+            messages,
+            tokenize=False,
+            chat_template=(
+                "{% for m in messages %}"
+                "{% if m.content is string %}[{{ m.role }}:{{ m.content }}]"
+                "{% else %}[{{ m.role }}:"
+                "{% for p in m.content %}({{ p.type }}){% endfor %}]"
+                "{% endif %}"
+                "{% endfor %}"
+            ),
+        )
+        self.assertEqual(
+            rendered,
+            "[system:Be terse.][user:(image)(image)(text)][assistant:It is a cat.]",
+        )
+
+    def test_processor_forwards_tokenizer_and_image_overrides(self):
+        from PIL import Image
+
+        from mlx_vlm.models.apertus1p5.processing_apertus1p5 import (
+            Apertus1p5ImageProcessor,
+            Apertus1p5Processor,
+        )
+        from mlx_vlm.utils import process_inputs, should_add_special_tokens
+
+        tokenizer = _Apertus1p5FakeTokenizer()
+        processor = Apertus1p5Processor(
+            image_processor=Apertus1p5ImageProcessor(
+                min_pixels=16 * 16,
+                max_pixels=32 * 48,
+                spatial_factor=16,
+            ),
+            tokenizer=tokenizer,
+            chat_template="{{ messages }}",
+        )
+
+        # The chat template emits <s> itself, so generate() must not ask the
+        # tokenizer for another one.
+        self.assertFalse(should_add_special_tokens("apertus1p5", processor))
+        self.assertTrue(
+            should_add_special_tokens(
+                "apertus1p5",
+                Apertus1p5Processor(
+                    image_processor=processor.image_processor,
+                    tokenizer=tokenizer,
+                ),
+            )
+        )
+
+        image = Image.fromarray(np.zeros((32, 48, 3), dtype=np.uint8))
+        inputs = process_inputs(
+            processor,
+            prompts=["<|image|> hi"],
+            images=[image],
+            audio=None,
+            add_special_tokens=False,
+            max_pixels=16 * 16,
+        )
+        self.assertIs(tokenizer.last_kwargs["add_special_tokens"], False)
+        self.assertEqual(inputs["pixel_values"].shape, (1, 3, 16, 16))
+        # The processor renames the feature extractor's outputs, so its
+        # advertised model input names must be the renamed keys.
+        self.assertIn("input_features", processor.model_input_names)
+        self.assertIn("feature_attention_mask", processor.model_input_names)
+
+    def test_processor_forwards_hub_download_options(self):
+        import json
+        from pathlib import Path
+        from tempfile import TemporaryDirectory
+        from unittest.mock import call, patch
+
+        from mlx_vlm.models.apertus1p5.processing_apertus1p5 import Apertus1p5Processor
+
+        with TemporaryDirectory() as directory:
+            processor_config = Path(directory, "processor_config.json")
+            processor_config.write_text(
+                json.dumps({"image_processor": {"min_pixels": 1024}})
+            )
+            model_config = Path(directory, "config.json")
+            model_config.write_text(
+                json.dumps(
+                    {"vision_tokenizer_config": {"channel_multiplier": [1, 1, 2, 2, 4]}}
+                )
+            )
+            cache_dir = Path(directory, "cache")
+            hub_options = {
+                "revision": "test-revision",
+                "token": "test-token",
+                "cache_dir": cache_dir,
+                "local_files_only": True,
+            }
+            with (
+                patch(
+                    "mlx_vlm.models.apertus1p5.processing_apertus1p5."
+                    "AutoTokenizer.from_pretrained",
+                    return_value=_Apertus1p5FakeTokenizer(),
+                ) as load_tokenizer,
+                patch(
+                    "huggingface_hub.hf_hub_download",
+                    side_effect=[str(processor_config), str(model_config)],
+                ) as download,
+            ):
+                processor = Apertus1p5Processor.from_pretrained(
+                    "test-owner/test-apertus", trust_remote_code=True, **hub_options
+                )
+
+        load_tokenizer.assert_called_once_with(
+            "test-owner/test-apertus",
+            trust_remote_code=False,
+            **hub_options,
+        )
+        self.assertEqual(
+            download.call_args_list,
+            [
+                call(
+                    "test-owner/test-apertus",
+                    "processor_config.json",
+                    **hub_options,
+                ),
+                call("test-owner/test-apertus", "config.json", **hub_options),
+            ],
+        )
+        self.assertEqual(processor.image_processor.min_pixels, 1024)
+
+    def test_processor_save_and_reload_preserves_image_configuration(self):
+        import json
+        from pathlib import Path
+        from tempfile import TemporaryDirectory
+        from unittest.mock import patch
+
+        from mlx_vlm.models.apertus1p5.processing_apertus1p5 import (
+            Apertus1p5ImageProcessor,
+            Apertus1p5Processor,
+        )
+        from mlx_vlm.utils import load_image_processor
+
+        processor = Apertus1p5Processor(
+            image_processor=Apertus1p5ImageProcessor(
+                min_pixels=32 * 32,
+                max_pixels=64 * 64,
+                spatial_factor=16,
+            ),
+            tokenizer=_Apertus1p5FakeTokenizer(),
+        )
+        with TemporaryDirectory() as directory:
+            processor.save_pretrained(directory)
+            Path(directory, "config.json").write_text(
+                json.dumps({"model_type": "apertus1p5"})
+            )
+            config_path = Path(directory, "processor_config.json")
+            self.assertTrue(config_path.exists())
+            saved_config = json.loads(config_path.read_text())
+            self.assertEqual(saved_config["image_processor"]["min_pixels"], 1024)
+            self.assertEqual(saved_config["image_processor"]["max_pixels"], 4096)
+
+            with patch(
+                "mlx_vlm.models.apertus1p5.processing_apertus1p5."
+                "AutoTokenizer.from_pretrained",
+                return_value=_Apertus1p5FakeTokenizer(),
+            ):
+                reloaded = Apertus1p5Processor.from_pretrained(
+                    directory, local_files_only=True
+                )
+
+            self.assertIsNone(load_image_processor(Path(directory)))
+
+        self.assertEqual(reloaded.image_processor.min_pixels, 1024)
+        self.assertEqual(reloaded.image_processor.max_pixels, 4096)
+        self.assertEqual(reloaded.image_processor.spatial_factor, 16)
+
+    def test_model_rejects_unsupported_batch_and_invalid_image_sizes(self):
+        model = self.apertus1p5.Model(_apertus1p5_tiny_config())
+        with self.assertRaisesRegex(ValueError, "batch size 1"):
+            model(mx.array([[1], [2]]))
+        with self.assertRaisesRegex(ValueError, "batch size 1"):
+            model(inputs_embeds=mx.zeros((2, 1, 32)))
+        with self.assertRaisesRegex(ValueError, "rank-3"):
+            model.get_input_embeddings(
+                mx.array([[1]]), input_features=mx.zeros((1, 10))
+            )
+
+        invalid_pixels = mx.zeros((1, 3, 15, 16))
+        with self.assertRaisesRegex(ValueError, "positive multiples"):
+            model.vision_tokenizer.encode(invalid_pixels)
+
+        pixels = mx.zeros((1, 3, 16, 16))
+        with self.assertRaisesRegex(ValueError, "within the padded tensor"):
+            model.get_image_tokens(pixels, mx.array([[16, 32]]))
+
+    def test_model_config_validates_on_direct_construction(self):
+        with self.assertRaisesRegex(ValueError, "audio_token_offset"):
+            self.apertus1p5.ModelConfig(audio_token_offset=1)
+
+    def test_do_pad_false_rejects_mixed_image_sizes(self):
+        from PIL import Image
+
+        from mlx_vlm.models.apertus1p5.processing_apertus1p5 import (
+            Apertus1p5ImageProcessor,
+        )
+
+        processor = Apertus1p5ImageProcessor(
+            min_pixels=16 * 16,
+            max_pixels=32 * 32,
+            spatial_factor=16,
+        )
+        small = Image.fromarray(np.zeros((16, 16, 3), dtype=np.uint8))
+        wide = Image.fromarray(np.zeros((16, 32, 3), dtype=np.uint8))
+        with self.assertRaisesRegex(ValueError, "do_pad=False"):
+            processor([small, wide], do_pad=False)
+
+        uniform = processor([small, small], do_pad=False)["pixel_values"]
+        self.assertEqual(uniform.shape, (2, 3, 16, 16))

--- a/mlx_vlm/tests/test_trainer.py
+++ b/mlx_vlm/tests/test_trainer.py
@@ -510,6 +510,38 @@ class TestTrainer(unittest.TestCase):
 
         self.assertAlmostEqual(actual.item(), expected.item(), places=6)
 
+    def test_out_of_vocab_labels_are_excluded_from_loss(self):
+        class DummyOutput:
+            def __init__(self, logits):
+                self.logits = logits
+
+        vocab_size = 131072
+        row = (mx.arange(vocab_size) % 7).astype(mx.float32) * 0.1
+
+        class PrunedHeadModel:
+            model_type = "apertus1p5"
+
+            def __call__(self, input_ids, pixel_values, mask, **kwargs):
+                return DummyOutput(mx.broadcast_to(row, (*input_ids.shape, vocab_size)))
+
+        # Released apertus1p5 ids: the media placeholder (131079) and the
+        # image/audio codes (131272+, 262344+) all exceed the pruned
+        # 131072-logit output head, so only the final label may contribute.
+        batch = {
+            "input_ids": mx.array([[5, 131079, 131272, 262344, 3]]),
+            "attention_mask": mx.array([[1, 1, 1, 1, 1]]),
+            "pixel_values": None,
+        }
+        expected = (mx.logsumexp(row) - row[3]).item()
+
+        loss = vision_language_loss_fn(PrunedHeadModel(), batch)
+        self.assertAlmostEqual(loss.item(), expected, places=4)
+
+        from mlx_vlm.trainer.orpo_trainer import get_logps
+
+        logps, _ = get_logps(PrunedHeadModel(), batch)
+        self.assertAlmostEqual(logps[0].item(), -expected, places=4)
+
 
 class TestLoRaScaling(unittest.TestCase):
     """Verify LoRaLayer uses alpha/rank scaling (standard LoRA convention)."""

--- a/mlx_vlm/trainer/orpo_trainer.py
+++ b/mlx_vlm/trainer/orpo_trainer.py
@@ -83,6 +83,13 @@ def get_logps(model, batch, train_on_completions=False, assistant_id=77091):
     else:
         mask = base_mask
 
+    # MLX cross-entropy does not bounds-check targets, and models with a
+    # pruned output head (split input/output vocabulary, e.g. apertus1p5)
+    # have media token ids beyond the logit range.
+    in_vocab = targets < logits.shape[-1]
+    mask = mask * in_vocab
+    targets = mx.where(in_vocab, targets, 0)
+
     log_probs = -nn.losses.cross_entropy(logits, targets, reduction="none")
     mask_f = mask.astype(log_probs.dtype)
     token_counts = mx.maximum(mask_f.sum(-1), 1)

--- a/mlx_vlm/trainer/sft_trainer.py
+++ b/mlx_vlm/trainer/sft_trainer.py
@@ -213,6 +213,13 @@ def vision_language_loss_fn(
             )
             loss_mask = loss_mask * completion_mask[:, 1:]
 
+    # MLX cross-entropy does not bounds-check targets, and models with a
+    # pruned output head (split input/output vocabulary, e.g. apertus1p5)
+    # have media token ids beyond the logit range.
+    in_vocab = labels < logits.shape[-1]
+    loss_mask = loss_mask * in_vocab
+    labels = mx.where(in_vocab, labels, 0)
+
     ce = nn.losses.cross_entropy(logits, labels)
     return (ce * loss_mask).sum() / mx.maximum(loss_mask.sum(), 1)
 

--- a/mlx_vlm/utils.py
+++ b/mlx_vlm/utils.py
@@ -476,10 +476,12 @@ def skip_multimodal_module(path: str) -> bool:
     """
     multimodal_modules = (
         "vision_model",
+        "vision_tokenizer",
         "vision_tower",
         "vl_connector",
         "sam_model",
         "audio_model",
+        "audio_tokenizer",
         "audio_tower",
         "code_predictor",
         "img_projector",
@@ -2180,6 +2182,7 @@ def print_array_report(t: mx.array, label: Optional[str]) -> dict:
 def should_add_special_tokens(model_type: str, processor) -> bool:
     """Return whether tokenization should add markers outside the chat template."""
     template_owns_markers = {
+        "apertus1p5",
         "gemma3",
         "gemma3n",
         "gemma4",


### PR DESCRIPTION
Adds [swiss-ai/Apertus-v1.5-8B](https://huggingface.co/swiss-ai/Apertus-v1.5-8B) and [-70B](https://huggingface.co/swiss-ai/Apertus-v1.5-70B).

Apertus 1.5 turns media into discrete tokens in the text vocabulary instead
of projected embeddings. Images go through a VQGAN-style tokenizer (131k
codes, 16×16 px per code), audio through a WavTokenizer codec (4k codes,
40 codes/s at 24 kHz). The decoder reuses the existing `ApertusModel`
(xIELU, QK-norm, llama3 rope) with a split vocabulary: 266,752 input
tokens, 131,072-logit output head. First slice is single prompt (batch
size 1).

Port notes:

- Both codec towers stay fp32 end to end, also under `convert -q`: code
  assignment is an argmax over the codebook and half precision flips codes.
  These are the same modules the reference pins via
  `_keep_in_fp32_modules_strict`.
- The processor is torch-free (numpy/PIL). The uint8 bicubic resize is
  bit-exact with torchvision's integer CPU path, since resize drift also
  flips codes.
- Only the audio encode path is ported (the Vocos decoder weights are
  dropped); weight-norm and torch-LSTM parametrizations are fused into
  plain MLX weights at load. The tokenizer loads with
  `trust_remote_code=False`, like kimi_k3 and mage_vl.
- The chat template emits `<s>` itself, so apertus1p5 joins the
  template-owns-markers set in `should_add_special_tokens`. The server had
  a stale gemma-only copy of that check; it now calls the shared helper.
- The SFT/ORPO losses now mask labels beyond the output head. MLX
  cross-entropy accepts out-of-range targets silently, so with a split
  vocabulary any media position in a training batch was contributing a
  corrupt gradient. The regression test uses the released id ranges.

## Parity with the reference

Real 8B checkpoint vs the transformers fork the model card prescribes,
same inputs:

- Tokenized prompts, pixel values (1e-7) and all discrete codes match
  exactly: 744/744 vision codes, 418/418 audio codes, plus 8 synthetic
  clips down to sub-hop lengths.
- Logits: same argmax, KL ≤ 3e-4. Teacher-forced argmax agreement over 24
  tokens: 24/24 on audio, 23/24 on image (the miss is a bf16 near-tie).
- On the real model: correct image descriptions, correct full speech
  transcription, system prompts and multi-turn honored, 73% on an MMLU
  sample.

## Performance

M2 Max 96 GB, bf16, greedy, 64 new tokens, warm:

| Scenario | Prompt tokens | Prefill tok/s | Decode tok/s | Peak mem |
|---|---|---|---|---|
| Text | 76 | 305 | 22.6 | 18.4 GB |
| Image (586×640) | 1,597 | 467 | 22.1 | 24.8 GB |
| Audio (10.4 s) | 492 | 509 | 23.1 | 18.8 GB |

Decode sits at the bf16 bandwidth ceiling for an 8B, so the multimodal
wrapper costs nothing there — after encoding, media are just tokens.
Qwen2.5-VL-7B decodes at 25 tok/s on the same machine; the torch reference
on MPS gets 11–16 tok/s, and in my runs its MPS output was wrong (the
fork's xIELU targets CUDA; on CPU it is correct at ~1 tok/s). The real
cost of the discrete-token design is the image budget, ~3× the prompt
tokens of ViT-patch models.

## Limitations

- Real-checkpoint validation covered the 8B. The 70B config parses into
  the expected shape but I have not run it.
- Audio must be mono 24 kHz; anything else errors instead of downmixing.
- The head returns the physical 131,072 logits; the reference pads
  inference logits to the logical 266,752 vocab with dtype-min. Argmax and
  sampling are unaffected.
- Shared-framework behavior applies: media positions are fixed by the
  message formatter, one audio clip per prompt.

## Tests

`TestApertus1p5` (27 tests) covers config parsing against the vendored
real `config.json` (which caught `eos_token_id = [2, 68, 72]` hiding
inside `text_config`), sanitize/conversion including the weight-norm and
LSTM fusions, fp32 codebook preservation under quantization, the
torchvision-reference resize, placeholder expansion and scatter for both
modalities, and a save/reload round trip. `test_trainer.py` adds the
out-of-vocab label-masking regression test.
