### PR TITLE
Add a Muse-Glimmer DFlash drafter (muse_glimmer_assistant)

### DIFF
--- a/mlx_vlm/models/muse_glimmer/language.py
+++ b/mlx_vlm/models/muse_glimmer/language.py
@@ -189,7 +189,8 @@ class TextModel(nn.Module):
         inputs: Optional[mx.array],
         cache=None,
         inputs_embeds: Optional[mx.array] = None,
-    ) -> mx.array:
+        capture_layer_ids: Optional[list] = None,
+    ):
         hidden_states = inputs_embeds
         if hidden_states is None:
             hidden_states = self.embed_norm(self.embed_tokens(inputs))
@@ -205,10 +206,17 @@ class TextModel(nn.Module):
                 window_size=self.sliding_window,
             )
 
-        for layer, layer_cache in zip(self.layers, cache):
+        # DFlash drafters consume the target's aux hidden states at
+        # ``capture_layer_ids`` (post-layer, pre-final-norm). ``captured`` stays
+        # None on the normal decode path, so capture costs nothing there.
+        captured = [] if capture_layer_ids is not None else None
+        capture_set = set(capture_layer_ids) if capture_layer_ids is not None else set()
+        for i, (layer, layer_cache) in enumerate(zip(self.layers, cache)):
             mask = sliding_mask if layer.is_sliding else full_mask
             hidden_states = layer(hidden_states, mask=mask, cache=layer_cache)
-        return self.norm(hidden_states)
+            if captured is not None and i in capture_set:
+                captured.append(hidden_states)
+        return self.norm(hidden_states), captured
 
 
 class LanguageModel(nn.Module):
@@ -231,11 +239,62 @@ class LanguageModel(nn.Module):
     ) -> LanguageModelOutput:
         if inputs is None:
             inputs = kwargs.get("input_ids")
-        hidden_states = self.model(inputs, cache=cache, inputs_embeds=inputs_embeds)
+        capture_layer_ids = kwargs.get("capture_layer_ids", None)
+        hidden_states, captured = self.model(
+            inputs,
+            cache=cache,
+            inputs_embeds=inputs_embeds,
+            capture_layer_ids=capture_layer_ids,
+        )
         logits = self.lm_head(hidden_states) * self.output_multiplier
         softcap = self.final_logit_softcapping
         logits = mx.tanh(logits / softcap) * softcap
-        return LanguageModelOutput(logits=logits)
+        output = LanguageModelOutput(logits=logits)
+        if capture_layer_ids is not None:
+            output.hidden_states = captured if captured is not None else []
+        return output
+
+    def rollback_speculative_cache(self, prompt_cache, gdn_states, accepted, bs):
+        """Rewind the target KV caches after a DFlash verify round, trimming the
+        freshly-verified block back to the committed prefix.
+
+        Both Muse cache types (RotatingKVCache / KVCache) fetch by their logical
+        offset, so a scalar offset trim is exact — no per-round KV snapshots or
+        replay forwards. ``gdn_states`` is accepted (and ignored) for API parity
+        with the other DFlash targets; Muse has no SSM / gated-delta state.
+
+        Muse runs the single-stream (B=1) DFlash loop, where ``accepted`` is a
+        scalar. A ragged per-row accept array (batched DFlash) cannot be rolled
+        back losslessly on a concat/rotating cache — zeroing a rejected
+        position's K/V does NOT drop it (a zero key still scores q·0 = 0 and
+        keeps softmax weight e^0/Z) — so we raise rather than silently corrupt.
+        Returns the committed accept count.
+        """
+        del gdn_states
+        if isinstance(accepted, mx.array):
+            accepted_list = [int(x) for x in accepted.reshape(-1).tolist()]
+        elif isinstance(accepted, (list, tuple)):
+            accepted_list = [int(x) for x in accepted]
+        else:
+            accepted_list = [int(accepted)]
+
+        if len(set(accepted_list)) > 1:
+            raise NotImplementedError(
+                "Muse-Glimmer DFlash supports single-stream (B=1) decoding only; "
+                f"got a ragged batch accept array {accepted_list}. Per-row "
+                "rollback of Muse's rotating/full KV caches is not lossless."
+            )
+
+        max_a = max(accepted_list)
+        trim_n = bs - (max_a + 1)
+        for c in prompt_cache:
+            if c is None:
+                continue
+            if trim_n > 0:
+                trim = getattr(c, "trim", None)
+                if trim is not None:
+                    trim(trim_n)
+        return max_a
 
     @property
     def layers(self):

--- a/mlx_vlm/speculative/drafters/__init__.py
+++ b/mlx_vlm/speculative/drafters/__init__.py
@@ -3,6 +3,7 @@ import logging
 from typing import Any, Optional, Tuple
 
 from .laguna_dflash import LagunaDFlashDraftModel
+from .muse_glimmer_assistant import MuseGlimmerAssistantDraftModel
 from .qwen3_dflash import DFlashDraftModel
 
 KNOWN_DRAFTER_KINDS = {"dflash", "mtp", "eagle3"}
@@ -18,6 +19,7 @@ DRAFTER_KIND_BY_MODEL_TYPE = {
     "inkling_mtp": "mtp",
     "qwen3_5_mtp": "mtp",
     "laguna": "dflash",
+    "muse_glimmer_assistant": "dflash",
 }
 
 DEFAULT_DRAFTER_KIND = "dflash"
@@ -172,6 +174,7 @@ def load_drafter(
 __all__ = [
     "DFlashDraftModel",
     "LagunaDFlashDraftModel",
+    "MuseGlimmerAssistantDraftModel",
     "KNOWN_DRAFTER_KINDS",
     "DRAFTER_KIND_BY_MODEL_TYPE",
     "DEFAULT_DRAFTER_KIND",

--- a/mlx_vlm/speculative/drafters/muse_glimmer_assistant/__init__.py
+++ b/mlx_vlm/speculative/drafters/muse_glimmer_assistant/__init__.py
@@ -1,0 +1,10 @@
+from .config import MuseGlimmerAssistantConfig
+from .config import MuseGlimmerAssistantConfig as ModelConfig
+from .muse_glimmer_assistant import Model, MuseGlimmerAssistantDraftModel
+
+__all__ = [
+    "MuseGlimmerAssistantConfig",
+    "ModelConfig",
+    "MuseGlimmerAssistantDraftModel",
+    "Model",
+]

--- a/mlx_vlm/speculative/drafters/muse_glimmer_assistant/config.py
+++ b/mlx_vlm/speculative/drafters/muse_glimmer_assistant/config.py
@@ -1,0 +1,83 @@
+from typing import Any, Dict, Optional
+
+
+class MuseGlimmerAssistantConfig:
+    """Config for the Muse-Glimmer DFlash drafter (``MuseGlimmerAssistantModel``).
+
+    Mirrors the published HF ``muse_glimmer_assistant`` config: a small stack of
+    sliding-window decoder layers (5 layers, hidden 6656, GQA 32/8, head_dim 128)
+    that denoise a block of ``block_size`` positions (an anchor token followed by
+    ``block_size - 1`` mask tokens) conditioned on the target model's aux hidden
+    states captured at ``target_layer_ids``.
+    """
+
+    model_type = "muse_glimmer_assistant"
+
+    def __init__(
+        self,
+        hidden_size: int = 6656,
+        num_hidden_layers: int = 5,
+        num_attention_heads: int = 32,
+        num_key_value_heads: int = 8,
+        head_dim: int = 128,
+        intermediate_size: int = 19968,
+        rms_norm_eps: float = 1e-05,
+        sliding_window: int = 2048,
+        block_size: int = 16,
+        mask_token_id: int = 201818,
+        target_layer_ids=None,
+        max_position_embeddings: int = 131072,
+        rope_theta: float = 500000.0,
+        layer_types: Optional[list] = None,
+        **kwargs: Any,
+    ):
+        self.hidden_size = hidden_size
+        self.num_hidden_layers = num_hidden_layers
+        self.num_attention_heads = num_attention_heads
+        self.num_key_value_heads = num_key_value_heads
+        self.head_dim = head_dim
+        self.intermediate_size = intermediate_size
+        self.rms_norm_eps = rms_norm_eps
+        self.sliding_window = sliding_window
+        self.block_size = block_size
+        self.mask_token_id = mask_token_id
+        self.target_layer_ids = (
+            list(target_layer_ids)
+            if target_layer_ids is not None
+            else [1, 13, 25, 37, 49]
+        )
+        self.max_position_embeddings = max_position_embeddings
+        self.rope_theta = rope_theta
+        self.layer_types = layer_types or ["sliding_attention"] * num_hidden_layers
+
+    @classmethod
+    def from_dict(cls, config: Dict[str, Any]) -> "MuseGlimmerAssistantConfig":
+        rope_params = config.get("rope_parameters", {}) or {}
+        return cls(
+            hidden_size=config.get("hidden_size", 6656),
+            num_hidden_layers=config.get("num_hidden_layers", 5),
+            num_attention_heads=config.get("num_attention_heads", 32),
+            num_key_value_heads=config.get("num_key_value_heads", 8),
+            head_dim=config.get("head_dim", 128),
+            intermediate_size=config.get("intermediate_size", 19968),
+            rms_norm_eps=config.get("rms_norm_eps", 1e-05),
+            sliding_window=config.get("sliding_window", 2048),
+            block_size=config.get("block_size", 16),
+            mask_token_id=config.get("mask_token_id", 201818),
+            target_layer_ids=config.get("target_layer_ids", [1, 13, 25, 37, 49]),
+            max_position_embeddings=config.get("max_position_embeddings", 131072),
+            rope_theta=rope_params.get("rope_theta", 500000.0),
+            layer_types=config.get("layer_types"),
+        )
+
+    def validate(self) -> None:
+        if len(self.target_layer_ids) < 1:
+            raise ValueError(
+                "Muse-Glimmer drafter requires at least one target aux layer id, "
+                f"got {self.target_layer_ids}"
+            )
+        if self.block_size < 2:
+            raise ValueError(f"block_size must be >= 2, got {self.block_size}")
+
+
+ModelConfig = MuseGlimmerAssistantConfig

--- a/mlx_vlm/speculative/drafters/muse_glimmer_assistant/muse_glimmer_assistant.py
+++ b/mlx_vlm/speculative/drafters/muse_glimmer_assistant/muse_glimmer_assistant.py
@@ -1,0 +1,280 @@
+from typing import Callable, List, Mapping
+
+import mlx.core as mx
+import mlx.nn as nn
+
+from ....models.base import scaled_dot_product_attention
+from ....models.cache import RotatingKVCache
+from ....models.rope_utils import initialize_rope
+from .config import MuseGlimmerAssistantConfig
+
+
+def _bidirectional_block_mask(query_length: int, context_length: int) -> mx.array:
+    """Block queries attend to all context keys and bidirectionally to each
+    other within the block.
+
+    With the drafter KV cache capped at ``sliding_window - 1`` and the block at
+    most ``sliding_window`` long, the sliding window is always satisfied by
+    construction, so a full-ones mask is correct.
+    """
+    context = mx.ones((query_length, context_length), dtype=mx.bool_)
+    proposal = mx.ones((query_length, query_length), dtype=mx.bool_)
+    return mx.concatenate([context, proposal], axis=-1)
+
+
+def _build_rope(config: MuseGlimmerAssistantConfig):
+    return initialize_rope(
+        dims=config.head_dim,
+        base=config.rope_theta,
+        traditional=False,
+        scaling_config={"rope_type": "default", "rope_theta": config.rope_theta},
+        max_position_embeddings=config.max_position_embeddings,
+    )
+
+
+class MuseGlimmerAssistantContextProjection(nn.Module):
+    """Fuse the target's aux hidden states (concatenated on features) into one
+    hidden-state stream for the drafter (``fc`` + ``output_norm_enc``)."""
+
+    def __init__(self, config: MuseGlimmerAssistantConfig):
+        super().__init__()
+        self.fc = nn.Linear(
+            len(config.target_layer_ids) * config.hidden_size,
+            config.hidden_size,
+            bias=False,
+        )
+        self.output_norm_enc = nn.RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+
+    def __call__(self, context_hidden_states: mx.array) -> mx.array:
+        return self.output_norm_enc(self.fc(context_hidden_states))
+
+
+class MuseGlimmerAssistantAttention(nn.Module):
+    def __init__(self, config: MuseGlimmerAssistantConfig, layer_idx: int):
+        super().__init__()
+        self.n_heads = config.num_attention_heads
+        self.n_kv_heads = config.num_key_value_heads
+        self.head_dim = config.head_dim
+        self.scale = self.head_dim**-0.5
+        self.sliding_window = config.sliding_window
+        dim = config.hidden_size
+        qkv_size = self.n_heads * self.head_dim
+        kv_size = self.n_kv_heads * self.head_dim
+        self.q_proj = nn.Linear(dim, qkv_size, bias=False)
+        self.k_proj = nn.Linear(dim, kv_size, bias=False)
+        self.v_proj = nn.Linear(dim, kv_size, bias=False)
+        self.o_proj = nn.Linear(qkv_size, dim, bias=False)
+        self.q_norm = nn.RMSNorm(self.head_dim, eps=config.rms_norm_eps)
+        self.k_norm = nn.RMSNorm(self.head_dim, eps=config.rms_norm_eps)
+        self.layer_idx = layer_idx
+
+    def __call__(
+        self,
+        x: mx.array,
+        context: mx.array,
+        rope,
+        cache: RotatingKVCache,
+    ) -> mx.array:
+        batch, length, _ = x.shape
+        context_length = context.shape[1]
+
+        queries = self.q_proj(x).reshape(batch, length, self.n_heads, self.head_dim)
+        context_keys = self.k_proj(context).reshape(
+            batch, context_length, self.n_kv_heads, self.head_dim
+        )
+        context_values = self.v_proj(context).reshape(
+            batch, context_length, self.n_kv_heads, self.head_dim
+        )
+        proposal_keys = self.k_proj(x).reshape(
+            batch, length, self.n_kv_heads, self.head_dim
+        )
+        proposal_values = self.v_proj(x).reshape(
+            batch, length, self.n_kv_heads, self.head_dim
+        )
+
+        queries = self.q_norm(queries.transpose(0, 2, 1, 3))
+        context_keys = self.k_norm(context_keys.transpose(0, 2, 1, 3))
+        proposal_keys = self.k_norm(proposal_keys.transpose(0, 2, 1, 3))
+        context_values = context_values.transpose(0, 2, 1, 3)
+        proposal_values = proposal_values.transpose(0, 2, 1, 3)
+
+        offset = cache.offset if cache is not None else 0
+        block_offset = offset + context_length
+        queries = rope(queries, offset=block_offset)
+        context_keys = rope(context_keys, offset=offset)
+        proposal_keys = rope(proposal_keys, offset=block_offset)
+
+        if cache is not None:
+            context_keys, context_values = cache.update_and_fetch(
+                context_keys, context_values
+            )
+        keys = mx.concatenate([context_keys, proposal_keys], axis=2)
+        values = mx.concatenate([context_values, proposal_values], axis=2)
+
+        mask = _bidirectional_block_mask(length, context_keys.shape[2])
+        output = scaled_dot_product_attention(
+            queries, keys, values, cache=None, scale=self.scale, mask=mask
+        )
+        output = output.transpose(0, 2, 1, 3).reshape(batch, length, -1)
+        return self.o_proj(output)
+
+
+class MuseGlimmerAssistantMLP(nn.Module):
+    def __init__(self, config: MuseGlimmerAssistantConfig):
+        super().__init__()
+        dim = config.hidden_size
+        self.gate_proj = nn.Linear(dim, config.intermediate_size, bias=False)
+        self.up_proj = nn.Linear(dim, config.intermediate_size, bias=False)
+        self.down_proj = nn.Linear(config.intermediate_size, dim, bias=False)
+
+    def __call__(self, x: mx.array) -> mx.array:
+        return self.down_proj(nn.silu(self.gate_proj(x)) * self.up_proj(x))
+
+
+class MuseGlimmerAssistantDecoderLayer(nn.Module):
+    def __init__(self, config: MuseGlimmerAssistantConfig, layer_idx: int):
+        super().__init__()
+        self.self_attn = MuseGlimmerAssistantAttention(config, layer_idx)
+        self.mlp = MuseGlimmerAssistantMLP(config)
+        self.input_layernorm = nn.RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.post_attention_layernorm = nn.RMSNorm(
+            config.hidden_size, eps=config.rms_norm_eps
+        )
+
+    def __call__(self, x, context, rope, cache):
+        h = x + self.self_attn(self.input_layernorm(x), context, rope, cache)
+        return h + self.mlp(self.post_attention_layernorm(h))
+
+
+class MuseGlimmerAssistantDraftModel(nn.Module):
+    """Muse-Glimmer DFlash drafter (EAGLE-style block-diffusion).
+
+    A small decoder stack that borrows the target's ``embed_tokens`` / ``lm_head``
+    (bound at ``reset`` time) and, conditioned on the target's aux hidden states,
+    denoises a block of ``[anchor, mask, ..., mask]`` tokens in a single forward.
+    Runs the single-stream (B=1) DFlash loop; batched DFlash for Muse is not wired
+    (its rotating/full caches can't express ragged per-row rollback — see
+    ``rollback_speculative_cache`` in ``models/muse_glimmer/language.py``).
+    """
+
+    def __init__(self, config: MuseGlimmerAssistantConfig):
+        super().__init__()
+        config.validate()
+        self.config = config
+        self.layers = [
+            MuseGlimmerAssistantDecoderLayer(config, index)
+            for index in range(config.num_hidden_layers)
+        ]
+        self.encoder = MuseGlimmerAssistantContextProjection(config)
+        self.norm = nn.RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.rope = _build_rope(config)
+
+        # Bound to the target model at reset() time.
+        self.embed_tokens = None
+        self.lm_head = None
+        self.accept_lens: List[int] = []
+        self.draft_lens: List[int] = []
+
+    def bind(self, target_model, tokenizer=None) -> "MuseGlimmerAssistantDraftModel":
+        inner = getattr(target_model, "model", target_model)
+        language_model = getattr(target_model, "language_model", None)
+        if language_model is not None:
+            inner = getattr(language_model, "model", language_model)
+        if not hasattr(inner, "embed_tokens"):
+            raise AttributeError(
+                f"Cannot find target embed_tokens in {type(target_model).__name__}."
+            )
+        self.embed_tokens = inner.embed_tokens
+        lm = getattr(target_model, "language_model", target_model)
+        self.lm_head = getattr(lm, "lm_head", None) or self.embed_tokens.as_linear
+        return self
+
+    def validate_target_compatibility(self, target_model) -> None:
+        target = getattr(target_model, "language_model", target_model)
+        target_inner = getattr(target, "model", target)
+        target_layers = getattr(target_inner, "layers", None)
+        if target_layers is None:
+            raise ValueError("Target model has no .layers attribute")
+        max_id = max(self.config.target_layer_ids)
+        if len(target_layers) <= max_id:
+            raise ValueError(
+                "Muse-Glimmer drafter needs a target with at least "
+                f"{max_id + 1} layers (aux ids {self.config.target_layer_ids}), "
+                f"got {len(target_layers)}"
+            )
+
+    def make_cache(self) -> List[RotatingKVCache]:
+        return [
+            RotatingKVCache(max_size=self.config.sliding_window - 1, keep=0)
+            for _ in self.layers
+        ]
+
+    def reset(self, target_model, tokenizer=None) -> List[RotatingKVCache]:
+        self.bind(target_model, tokenizer=tokenizer)
+        self.accept_lens = []
+        self.draft_lens = []
+        return self.make_cache()
+
+    def _embed_input_tokens(self, inputs: mx.array) -> mx.array:
+        if self.embed_tokens is None:
+            raise RuntimeError(
+                "bind(target_model) must run before Muse DFlash generation."
+            )
+        # The assistant blocks need the raw embedding lookup WITHOUT the target's
+        # NormedEmbedding RMS-norm (the drafter's own input norms normalize
+        # internally); mirrors transformers' DflashCandidateGenerator.
+        return self.embed_tokens.weight[inputs]
+
+    def _hidden(
+        self, inputs: mx.array, target_hidden: mx.array, cache: List[RotatingKVCache]
+    ) -> mx.array:
+        h = self._embed_input_tokens(inputs)
+        context = self.encoder(target_hidden)
+        for layer, layer_cache in zip(self.layers, cache):
+            h = layer(h, context, self.rope, layer_cache)
+        return self.norm(h)
+
+    def _logits(self, hidden: mx.array) -> mx.array:
+        if self.lm_head is None:
+            raise RuntimeError(
+                "bind(target_model) must run before Muse DFlash generation."
+            )
+        return self.lm_head(hidden)
+
+    def __call__(self, inputs, target_hidden, cache):
+        return self._logits(self._hidden(inputs, target_hidden, cache))
+
+    def draft_block(
+        self,
+        last_bonus,
+        hidden: mx.array,
+        cache: List[RotatingKVCache],
+        block_size: int,
+        sampler: Callable[[mx.array], mx.array],
+        token_dtype: mx.Dtype = mx.int32,
+    ) -> mx.array:
+        mask_id = self.config.mask_token_id
+        if isinstance(last_bonus, int):
+            block = mx.array(
+                [[last_bonus] + [mask_id] * (block_size - 1)], dtype=token_dtype
+            )
+        else:
+            batch = last_bonus.shape[0]
+            masks = mx.full((batch, block_size - 1), mask_id, dtype=token_dtype)
+            block = mx.concatenate(
+                [last_bonus[:, None].astype(token_dtype), masks], axis=1
+            )
+        logits = self._logits(self._hidden(block, hidden, cache))
+        return sampler(logits[:, 1:])
+
+    def sanitize(self, weights: Mapping[str, mx.array]) -> dict:
+        return {key.removeprefix("model."): value for key, value in weights.items()}
+
+
+Model = MuseGlimmerAssistantDraftModel
+
+__all__ = [
+    "MuseGlimmerAssistantConfig",
+    "MuseGlimmerAssistantDraftModel",
+    "Model",
+]

--- a/mlx_vlm/speculative/drafters/muse_glimmer_assistant/parity_check.py
+++ b/mlx_vlm/speculative/drafters/muse_glimmer_assistant/parity_check.py
@@ -1,0 +1,79 @@
+"""Structural smoke test for the Muse-Glimmer DFlash drafter.
+
+Exercises the drafter's forward + ``draft_block`` on random weights (no HF repo /
+network needed), asserting the block-diffusion contract the DFlash engine relies
+on: ``draft_block`` returns ``block_size - 1`` proposal tokens per row.
+
+Run: python -m mlx_vlm.speculative.drafters.muse_glimmer_assistant.parity_check
+Optionally point at a real drafter: ``--drafter meta-models/Muse-Glimmer-30B-assistant``.
+"""
+
+import argparse
+
+import mlx.core as mx
+import mlx.nn as nn
+
+from .config import MuseGlimmerAssistantConfig
+from .muse_glimmer_assistant import MuseGlimmerAssistantDraftModel
+
+
+class _DummyEmbed(nn.Module):
+    def __init__(self, vocab_size: int, hidden_size: int):
+        super().__init__()
+        self.weight = mx.random.normal((vocab_size, hidden_size)) * 0.02
+
+    def __call__(self, ids: mx.array) -> mx.array:
+        return self.weight[ids]
+
+    def as_linear(self, x: mx.array) -> mx.array:
+        return x @ self.weight.T
+
+
+def main() -> None:
+    p = argparse.ArgumentParser()
+    p.add_argument("--drafter", default=None, help="Optional HF drafter repo to load")
+    args = p.parse_args()
+
+    if args.drafter:
+        from ...drafters import load_drafter
+
+        model, _ = load_drafter(args.drafter)
+        cfg = model.config
+        vocab = cfg.mask_token_id + 1
+    else:
+        cfg = MuseGlimmerAssistantConfig()
+        model = MuseGlimmerAssistantDraftModel(cfg)
+        vocab = cfg.mask_token_id + 1
+
+    dummy = _DummyEmbed(vocab, cfg.hidden_size)
+    model.embed_tokens = dummy
+    model.lm_head = dummy.as_linear
+
+    block = cfg.block_size
+    aux_dim = len(cfg.target_layer_ids) * cfg.hidden_size
+
+    # Full-block forward: [B, block] tokens + [B, block] aux hidden -> logits.
+    ids = mx.zeros((1, block), dtype=mx.int32)
+    target_hidden = mx.random.normal((1, block, aux_dim)) * 0.02
+    cache = model.make_cache()
+    logits = model(ids, target_hidden, cache)
+    mx.eval(logits)
+    assert logits.shape == (1, block, vocab), logits.shape
+
+    # draft_block: anchor + (block-1) masks -> (block-1) proposal tokens.
+    cache = model.make_cache()
+    proposals = model.draft_block(
+        7, target_hidden, cache, block, lambda lg: mx.argmax(lg, axis=-1)
+    )
+    mx.eval(proposals)
+    assert proposals.shape == (1, block - 1), proposals.shape
+
+    print(
+        f"OK: forward logits {tuple(logits.shape)}, "
+        f"draft_block proposals {tuple(proposals.shape)} "
+        f"(block_size={block}, target_layer_ids={cfg.target_layer_ids})"
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Wires DFlash speculative decoding for the already-supported `muse_glimmer` model, following the existing `laguna_dflash` / `qwen3_dflash` drafters.

## What's here

- **`speculative/drafters/muse_glimmer_assistant/`** — the EAGLE-style block-diffusion drafter (borrows the target's `embed_tokens` / `lm_head`, denoises an `[anchor, mask, ...]` block conditioned on the target's aux hidden states at `target_layer_ids`), its config, and a `parity_check.py` smoke test.
- **`models/muse_glimmer/language.py`** — the two DFlash target hooks the engine requires:
  - hidden-state capture at `capture_layer_ids` (returned via `LanguageModelOutput.hidden_states`), and
  - `rollback_speculative_cache` — a scalar B=1 trim; it raises on a ragged batch accept array, which Muse's rotating/full KV caches can't roll back losslessly. The normal decode path is unchanged (no capture ⇒ no cost).
- Registered `muse_glimmer_assistant -> dflash` in the drafter registry.

Single-stream (B=1) DFlash, matching the `_dflash_rounds` path.

## Drafter checkpoint

`meta-models/Muse-Glimmer-30B-assistant` — public, non-gated, Apache-2.0 (`MuseGlimmerAssistantModel`, ~2.56B). Meta released it alongside the base model.

## Validation

- `parity_check.py` passes (forward `(1, 16, vocab)`; `draft_block` → `(1, block_size-1)` proposals).
- Real-weights load path exercised: `load_drafter("…/Muse-Glimmer-30B-assistant")` loads (config `from_dict` + `sanitize` + weights) and runs.
- Functional model tests: normal decode unchanged, `capture_layer_ids` populates `hidden_states`, `rollback_speculative_cache` trims and guards a ragged batch, registry resolves the kind.
- End-to-end bench (single-user B=1, 8-bit Muse target, cold-interleaved): **2.11× decode** over the no-draft baseline (17.6 → 37.2 t/s, ~2.1 accept/round).
- `black` and `isort --profile black` clean.

## Motivation

Requested downstream in Rapid-MLX (raullenchai/Rapid-MLX#1844) — their DFlash support bridges into mlx-vlm's `load_drafter` / `_dflash_rounds`, so Muse-Glimmer DFlash lands here first; the downstream side is then a one-line alias.

Happy to add a `test_speculative.py` case in the project's style if you'd prefer that over the `parity_check.py` the other DFlash drafters ship with.
