### PR TITLE
Fix Idefics3/SmolVLM LoRA training crashes (#1830)

### DIFF
--- a/mlx_vlm/models/base.py
+++ b/mlx_vlm/models/base.py
@@ -210,7 +210,11 @@ def create_attention_mask(
     h, cache=None, window_size: Optional[int] = None, return_array: bool = False
 ):
     N = h.shape[1]
-    if cache and hasattr(cache, "make_mask"):
+    if (
+        cache is not None
+        and not isinstance(cache, mx.array)
+        and hasattr(cache, "make_mask")
+    ):
         return cache.make_mask(N, return_array=return_array, window_size=window_size)
     if N == 1:
         return None
@@ -220,7 +224,11 @@ def create_attention_mask(
 
 
 def create_ssm_mask(h, cache=None):
-    if cache and hasattr(cache, "make_mask"):
+    if (
+        cache is not None
+        and not isinstance(cache, mx.array)
+        and hasattr(cache, "make_mask")
+    ):
         return cache.make_mask(h.shape[1])
     return None
 

--- a/mlx_vlm/models/idefics3/idefics3.py
+++ b/mlx_vlm/models/idefics3/idefics3.py
@@ -155,6 +155,7 @@ class Model(nn.Module):
 
             image_features = pooler_output.astype(pixel_values.dtype)
             image_features = self.connector(image_features)
+            image_features = image_features.reshape(-1, image_features.shape[-1])
 
         final_inputs_embeds = self._prepare_inputs_for_multimodal(
             image_features, inputs_embeds, input_ids
@@ -188,6 +189,7 @@ class Model(nn.Module):
         self,
         input_ids: mx.array,
         pixel_values: mx.array,
+        mask: Optional[mx.array] = None,
         cache=None,
         **kwargs,
     ):
@@ -196,6 +198,7 @@ class Model(nn.Module):
         )
         logits = self.language_model(
             inputs=input_ids,
+            mask=mask,
             cache=cache,
             inputs_embeds=input_embeddings_features.inputs_embeds,
         )

--- a/mlx_vlm/models/idefics3/language.py
+++ b/mlx_vlm/models/idefics3/language.py
@@ -50,7 +50,7 @@ class Attention(nn.Module):
         keys = keys.reshape(B, L, self.n_kv_heads, -1).transpose(0, 2, 1, 3)
         values = values.reshape(B, L, self.n_kv_heads, -1).transpose(0, 2, 1, 3)
 
-        if cache is not None:
+        if cache is not None and hasattr(cache, "update_and_fetch"):
             queries = self.rope(queries, offset=cache.offset)
             keys = self.rope(keys, offset=cache.offset)
             keys, values = cache.update_and_fetch(keys, values)

--- a/mlx_vlm/tests/test_trainer.py
+++ b/mlx_vlm/tests/test_trainer.py
@@ -312,6 +312,97 @@ class TestBatchCollation(unittest.TestCase):
         )
 
 
+class _VisionDatasetStub(list):
+    """A dataset list that also carries a model config, like VisionDataset."""
+
+    def __init__(self, items, config):
+        super().__init__(items)
+        self.config = config
+
+
+def _image_example(num_image_tokens, image_token_id=99, num_sub_images=2):
+    input_ids = mx.array([1] + [image_token_id] * num_image_tokens)
+    return {
+        "input_ids": input_ids,
+        "attention_mask": mx.ones(input_ids.shape, dtype=mx.int32),
+        "pixel_values": mx.zeros((num_sub_images, 4)),
+    }
+
+
+class TestImageTokenTruncationGuard(unittest.TestCase):
+    """Truncation must never cut image tokens (#1830).
+
+    ``pixel_values`` still yields one feature per image token, so an example whose
+    placeholders are truncated away fails the model's feature/token alignment
+    check. Such examples are skipped instead of corrupting the batch.
+    """
+
+    config = {"image_token_index": 99}
+
+    def test_skips_examples_whose_image_tokens_do_not_fit(self):
+        dataset = _VisionDatasetStub(
+            [_image_example(10), _image_example(3)], self.config
+        )
+
+        batch = next(iterate_batches(dataset, batch_size=1, max_seq_length=8))
+
+        # Only the short example survives; it keeps all 3 of its image tokens.
+        self.assertEqual(int((batch["input_ids"] == 99).sum()), 3)
+
+    def test_raises_when_no_example_fits(self):
+        dataset = _VisionDatasetStub(
+            [_image_example(10), _image_example(12)], self.config
+        )
+
+        with self.assertRaises(ValueError) as ctx:
+            next(iterate_batches(dataset, batch_size=1, max_seq_length=8))
+
+        self.assertIn("No trainable examples", str(ctx.exception))
+
+    def test_partially_filtered_batch_keeps_pixel_values_aligned(self):
+        # One example is dropped from a size-2 batch: the collated pixel_values
+        # must cover only the surviving example, or alignment breaks again.
+        dataset = _VisionDatasetStub(
+            [_image_example(10), _image_example(3)], self.config
+        )
+
+        batch = next(iterate_batches(dataset, batch_size=2, max_seq_length=8))
+
+        self.assertEqual(batch["input_ids"].shape[0], 1)
+        self.assertEqual(batch["pixel_values"].shape[0], 1)
+        self.assertEqual(int((batch["input_ids"] == 99).sum()), 3)
+
+    def test_keeps_examples_that_fit_untouched(self):
+        dataset = _VisionDatasetStub([_image_example(3)], self.config)
+
+        batch = next(iterate_batches(dataset, batch_size=1, max_seq_length=32))
+
+        self.assertEqual(int((batch["input_ids"] == 99).sum()), 3)
+
+    def test_text_only_datasets_are_unaffected(self):
+        # No image token in the config: long examples truncate as before.
+        dataset = _VisionDatasetStub([_image_example(10)], {"model_type": "llama"})
+
+        batch = next(iterate_batches(dataset, batch_size=1, max_seq_length=8))
+
+        self.assertEqual(batch["input_ids"].shape, (1, 8))
+
+
+class TestIdefics3MaskArgument(unittest.TestCase):
+    def test_call_accepts_mask_as_third_positional_argument(self):
+        """The trainer calls ``model(input_ids, pixel_values, attention_mask)``.
+
+        Idefics3 previously omitted ``mask``, so the attention mask bound to
+        ``cache`` and crashed in ``create_attention_mask`` (#1830).
+        """
+        import inspect
+
+        from mlx_vlm.models.idefics3.idefics3 import Model
+
+        params = list(inspect.signature(Model.__call__).parameters)
+        self.assertEqual(params[1:4], ["input_ids", "pixel_values", "mask"])
+
+
 class TestTrainer(unittest.TestCase):
     def setUp(self):
         class DummyOutput:

--- a/mlx_vlm/trainer/sft_trainer.py
+++ b/mlx_vlm/trainer/sft_trainer.py
@@ -1,5 +1,6 @@
 # Copyright © 2026 MLX-VLM
 
+import logging
 import time
 from dataclasses import dataclass, field
 from functools import partial
@@ -217,6 +218,33 @@ def vision_language_loss_fn(
     return (ce * loss_mask).sum() / mx.maximum(loss_mask.sum(), 1)
 
 
+def _dataset_image_token_id(dataset):
+    """The placeholder token id a vision dataset expands one image feature into.
+
+    Returns ``None`` for text-only datasets, which are never image-aligned and so
+    are unaffected by the truncation guard below.
+    """
+    config = getattr(dataset, "config", None)
+    if not isinstance(config, dict):
+        return None
+    token_id = config.get("image_token_index") or config.get("image_token_id")
+    return int(token_id) if token_id else None
+
+
+def _drops_image_tokens(input_ids, image_token_id, max_seq_length):
+    """True when truncating to ``max_seq_length`` would cut image placeholders.
+
+    The model derives one image feature per placeholder token from
+    ``pixel_values``, which truncation does not shrink. Losing placeholders
+    therefore breaks the feature/token alignment the model asserts on.
+    """
+    if image_token_id is None or len(input_ids) <= max_seq_length:
+        return False
+    kept = int((input_ids[:max_seq_length] == image_token_id).sum())
+    total = int((input_ids == image_token_id).sum())
+    return kept != total
+
+
 def iterate_batches(dataset, batch_size, max_seq_length, train=False):
     indices = list(range(len(dataset)))
     if len(dataset) < batch_size:
@@ -231,14 +259,49 @@ def iterate_batches(dataset, batch_size, max_seq_length, train=False):
         for i in range(0, len(indices) - batch_size + 1, batch_size)
     ]
 
+    image_token_id = _dataset_image_token_id(dataset)
+    warned_indices = set()
+
     while True:
         order = (
             np.random.permutation(len(batch_indices))
             if train
             else range(len(batch_indices))
         )
+        yielded_any = False
         for b in order:
             items = [dataset[idx] for idx in batch_indices[b]]
+
+            # Drop examples whose image placeholders would not survive truncation:
+            # pixel_values keeps every sub-image, so training on them would fail the
+            # model's feature/token alignment check.
+            if image_token_id is not None:
+                kept = []
+                for idx, item in zip(batch_indices[b], items):
+                    input_ids = np.array(
+                        _squeeze_leading_batch_dim(item["input_ids"])
+                    ).reshape(-1)
+                    if _drops_image_tokens(input_ids, image_token_id, max_seq_length):
+                        if idx not in warned_indices:
+                            warned_indices.add(idx)
+                            total = int((input_ids == image_token_id).sum())
+                            fits = int(
+                                (input_ids[:max_seq_length] == image_token_id).sum()
+                            )
+                            logging.warning(
+                                f"Skipping example {idx}: its {total} image tokens do "
+                                f"not fit in max_seq_length={max_seq_length} (only "
+                                f"{fits} would remain). Raise max_seq_length or use a "
+                                "lower image resolution to train on this example."
+                            )
+                        continue
+                    kept.append(item)
+                if not kept:
+                    # Every example here was skipped; move on rather than failing
+                    # the run, since other batches may still be trainable.
+                    continue
+                items = kept
+
             lengths = [
                 min(_flat_seq_len(x["input_ids"]), max_seq_length) for x in items
             ]
@@ -313,7 +376,15 @@ def iterate_batches(dataset, batch_size, max_seq_length, train=False):
                 else:
                     batch[k] = vals[0]
 
+            yielded_any = True
             yield batch
+
+        if not yielded_any:
+            raise ValueError(
+                "No trainable examples: every example has more image tokens than "
+                f"max_seq_length={max_seq_length} allows. Raise max_seq_length or "
+                "lower the image resolution."
+            )
         if not train:
             break
 


### PR DESCRIPTION
Idefics3's forward omitted the `mask` argument that every other VLM accepts, so the trainer's positional call bound the attention mask to `cache` and crashed in create_attention_mask. Accept and forward `mask`, which also fixes SmolVLM (an Idefics3 subclass).

Sequence truncation also cut image placeholder tokens while pixel_values kept every sub-image, breaking the one-feature-per-image-token alignment the model asserts on. iterate_batches now skips examples whose image tokens would not survive truncation, warns once per example with the max_seq_length to raise, and fails only when no example is trainable.