### PR TITLE
Eager-eval cached RoPE arrays in the remaining variants

### DIFF
--- a/mlx_vlm/models/rope_utils.py
+++ b/mlx_vlm/models/rope_utils.py
@@ -53,6 +53,7 @@ class SuScaledRoPE(nn.Module):
 
         freqs = base ** (mx.arange(0, dims, 2, dtype=mx.float32) / dims)
         self._freqs = mx.array(long_factor, dtype=mx.float32) * freqs
+        self.eval_cached_arrays()
 
         def default_scale(factor):
             return math.sqrt(
@@ -61,6 +62,14 @@ class SuScaledRoPE(nn.Module):
 
         factor = max_position_embeddings / original_max_position_embeddings
         self._scale = long_mscale or (1.0 if factor <= 1.0 else default_scale(factor))
+
+    def eager_eval_arrays(self):
+        return [self._freqs]
+
+    def eval_cached_arrays(self):
+        arrays = self.eager_eval_arrays()
+        if arrays:
+            mx.eval(*arrays)
 
     def __call__(self, x, offset: Union[int, mx.array] = 0):
         x = x[...]
@@ -111,12 +120,21 @@ class Llama3RoPE(nn.Module):
         )
         smooth_freqs = freqs / ((1 - smooth_factors) / factor + smooth_factors)
         self._freqs = mx.where(is_medium_freq, smooth_freqs, freqs)
+        self.eval_cached_arrays()
 
     def extra_repr(self):
         return (
             f"{self.dims}, traditional={self.traditional}, "
             f"max_position_embeddings={self.max_position_embeddings}"
         )
+
+    def eager_eval_arrays(self):
+        return [self._freqs]
+
+    def eval_cached_arrays(self):
+        arrays = self.eager_eval_arrays()
+        if arrays:
+            mx.eval(*arrays)
 
     def __call__(self, x, offset: int = 0):
         return mx.fast.rope(
@@ -185,6 +203,15 @@ class YarnRoPE(nn.Module):
         )
         self.dims = dims
         self.traditional = traditional
+        self.eval_cached_arrays()
+
+    def eager_eval_arrays(self):
+        return [self._freqs]
+
+    def eval_cached_arrays(self):
+        arrays = self.eager_eval_arrays()
+        if arrays:
+            mx.eval(*arrays)
 
     def __call__(self, x, offset=0):
         if self.mscale != 1.0:

--- a/mlx_vlm/tests/test_rope_utils.py
+++ b/mlx_vlm/tests/test_rope_utils.py
@@ -5,8 +5,11 @@ from mlx.utils import tree_flatten
 
 import mlx_vlm.models.rope_utils as rope_utils
 from mlx_vlm.models.rope_utils import (
+    Llama3RoPE,
     MRoPERotaryEmbedding,
     ProportionalRoPE,
+    SuScaledRoPE,
+    YarnRoPE,
     apply_mrope_frequency_layout,
     apply_multimodal_rotary_pos_emb,
     apply_rotary_pos_emb_even_odd,
@@ -86,6 +89,77 @@ def test_proportional_rope_evals_private_helper_arrays_on_init(monkeypatch):
     assert tree_flatten(host.trainable_parameters()) == []
     eager_arrays = host.rope.eager_eval_arrays()
     assert eager_arrays[0] is host.rope.freqs
+    assert len(eval_args) == 1
+    assert eval_args[0][0] is eager_arrays[0]
+
+
+def test_su_scaled_rope_evals_private_helper_arrays_on_init(monkeypatch):
+    eval_args = []
+    monkeypatch.setattr(mx, "eval", lambda *args: eval_args.append(args))
+
+    class Host(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.rope = SuScaledRoPE(dims=8, long_factor=[1.0] * 4)
+
+    host = Host()
+
+    assert isinstance(host.rope, nn.Module)
+    assert tree_flatten(host.parameters()) == []
+    assert tree_flatten(host.trainable_parameters()) == []
+    eager_arrays = host.rope.eager_eval_arrays()
+    assert eager_arrays[0] is host.rope._freqs
+    assert len(eval_args) == 1
+    assert eval_args[0][0] is eager_arrays[0]
+
+
+def test_llama3_rope_evals_private_helper_arrays_on_init(monkeypatch):
+    eval_args = []
+    monkeypatch.setattr(mx, "eval", lambda *args: eval_args.append(args))
+
+    class Host(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.rope = Llama3RoPE(
+                dims=8,
+                max_position_embeddings=64,
+                traditional=False,
+                base=10000.0,
+                scaling_config={
+                    "factor": 2.0,
+                    "low_freq_factor": 1.0,
+                    "high_freq_factor": 4.0,
+                    "original_max_position_embeddings": 32,
+                },
+            )
+
+    host = Host()
+
+    assert isinstance(host.rope, nn.Module)
+    assert tree_flatten(host.parameters()) == []
+    assert tree_flatten(host.trainable_parameters()) == []
+    eager_arrays = host.rope.eager_eval_arrays()
+    assert eager_arrays[0] is host.rope._freqs
+    assert len(eval_args) == 1
+    assert eval_args[0][0] is eager_arrays[0]
+
+
+def test_yarn_rope_evals_private_helper_arrays_on_init(monkeypatch):
+    eval_args = []
+    monkeypatch.setattr(mx, "eval", lambda *args: eval_args.append(args))
+
+    class Host(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.rope = YarnRoPE(dims=8, traditional=False, base=10000.0)
+
+    host = Host()
+
+    assert isinstance(host.rope, nn.Module)
+    assert tree_flatten(host.parameters()) == []
+    assert tree_flatten(host.trainable_parameters()) == []
+    eager_arrays = host.rope.eager_eval_arrays()
+    assert eager_arrays[0] is host.rope._freqs
     assert len(eval_args) == 1
     assert eval_args[0][0] is eager_arrays[0]
 

--- a/mlx_vlm/tests/test_rope_utils.py
+++ b/mlx_vlm/tests/test_rope_utils.py
@@ -1,3 +1,5 @@
+from concurrent.futures import ThreadPoolExecutor
+
 import mlx.core as mx
 import mlx.nn as nn
 import pytest
@@ -423,3 +425,40 @@ def test_selected_mrope_cos_sin_applies_section_selectors():
     expected = mx.cos(emb), mx.sin(emb)
 
     _assert_pair_close(fast, expected)
+
+
+def _build_on_worker(factory):
+    """Build on one thread, use on another, as the server does."""
+    with ThreadPoolExecutor(max_workers=1) as loader:
+        rope = loader.submit(factory).result()
+
+    def use():
+        return mx.eval(rope(mx.ones((1, 2, 4, 8))))
+
+    with ThreadPoolExecutor(max_workers=1) as worker:
+        worker.submit(use).result()
+
+
+def test_su_scaled_rope_runs_on_a_thread_it_was_not_built_on():
+    _build_on_worker(lambda: SuScaledRoPE(dims=8, long_factor=[1.0] * 4))
+
+
+def test_llama3_rope_runs_on_a_thread_it_was_not_built_on():
+    _build_on_worker(
+        lambda: Llama3RoPE(
+            dims=8,
+            max_position_embeddings=64,
+            traditional=False,
+            base=10000.0,
+            scaling_config={
+                "factor": 2.0,
+                "low_freq_factor": 1.0,
+                "high_freq_factor": 4.0,
+                "original_max_position_embeddings": 32,
+            },
+        )
+    )
+
+
+def test_yarn_rope_runs_on_a_thread_it_was_not_built_on():
+    _build_on_worker(lambda: YarnRoPE(dims=8, traditional=False, base=10000.0))


### PR DESCRIPTION
`SuScaledRoPE`, `Llama3RoPE` and `YarnRoPE` build `_freqs` lazily. Load on one thread, run on another:

```
RuntimeError: There is no Stream(gpu, 1) in current thread.
```

That is what the server does. `get_cached_model` and the `/v1/embeddings` worker are different threads, so `POST /v1/embeddings` 500s for any model on one of these three. Once `_freqs` is built lazily on the loading thread nothing can evaluate it afterwards, so it has to happen in `__init__`.

#1272 fixed this for `MRoPERotaryEmbedding`, `ProportionalRoPE` followed. This gives the remaining three the same `eager_eval_arrays` / `eval_cached_arrays` pair.

## Validation

Six tests in `test_rope_utils.py`. Three follow `test_proportional_rope_evals_private_helper_arrays_on_init`; three build each variant on one thread and run it on another. Against `rope_utils.py` from main:

```
                on main           with this
SuScaledRoPE    Stream(gpu, 0)    ok
Llama3RoPE      Stream(gpu, 2)    ok
YarnRoPE        Stream(gpu, 4)    ok
```

29 passed. `pre-commit run --all-files` clean.

End to end with `nvidia/Nemotron-3-Embed-1B-BF16`, loaded via #1851:

```
before   POST /v1/embeddings -> 500
after    2048 dim, "a cat sat on the mat" scores 0.4698 against
         "a kitten rested on the rug", 0.0632 against "quarterly earnings rose"
```
