### PR TITLE
Support text-only Qwen3.5 checkpoints (#1812)

### DIFF
--- a/mlx_vlm/models/qwen3_5/config.py
+++ b/mlx_vlm/models/qwen3_5/config.py
@@ -110,7 +110,7 @@ class TextConfig(BaseModelConfig):
 @dataclass
 class ModelConfig(BaseModelConfig):
     text_config: TextConfig
-    vision_config: VisionConfig
+    vision_config: Optional[VisionConfig]
     model_type: str
     ignore_index: int = -100
     image_token_id: int = 248056
@@ -121,6 +121,7 @@ class ModelConfig(BaseModelConfig):
     vision_end_token_id: int = 248046
     vocab_size: int = 248320
     eos_token_id: Optional[Union[int, List[int]]] = None
+    language_model_only: bool = False
     quantization: Optional[Dict] = None
     quantization_config: Optional[Dict] = None
 

--- a/mlx_vlm/models/qwen3_5/qwen3_5.py
+++ b/mlx_vlm/models/qwen3_5/qwen3_5.py
@@ -52,7 +52,10 @@ class Model(Qwen3VLModel):
         # only initialize nn.Module, skip the initialization of vision_tower and language_model in the parent class
         nn.Module.__init__(self)
         self.config = config
-        self.vision_tower = VisionModel(config.vision_config)
+        if config.vision_config is None or config.language_model_only:
+            self.vision_tower = None
+        else:
+            self.vision_tower = VisionModel(config.vision_config)
         self.language_model = LanguageModel(config.text_config, config)
 
     def get_input_embeddings(
@@ -78,6 +81,9 @@ class Model(Qwen3VLModel):
                 position_ids=position_ids,
                 rope_deltas=rope_deltas,
             )
+
+        if self.vision_tower is None:
+            raise ValueError("this Qwen3.5 model was loaded without a vision tower")
 
         dtype = self.vision_tower.patch_embed.proj.weight.dtype
         pixel_values = pixel_values.astype(dtype)

--- a/mlx_vlm/tests/test_models.py
+++ b/mlx_vlm/tests/test_models.py
@@ -2940,6 +2940,58 @@ class TestModels(unittest.TestCase):
         self.assertEqual(config.vision_end_token_id, 151653)
         self.assertEqual(config.vision_config.patch_size, 16)
 
+    def test_qwen3_5_text_only_config_skips_vision_tower(self):
+        from mlx.utils import tree_flatten
+
+        from mlx_vlm.models import qwen3_5
+
+        tiny_text = {
+            "model_type": "qwen3_5_text",
+            "hidden_size": 64,
+            "intermediate_size": 128,
+            "linear_num_value_heads": 4,
+            "linear_num_key_heads": 2,
+            "linear_key_head_dim": 16,
+            "linear_value_head_dim": 16,
+            "linear_conv_kernel_dim": 4,
+            "num_hidden_layers": 2,
+            "num_attention_heads": 4,
+            "num_key_value_heads": 2,
+            "head_dim": 16,
+            "rms_norm_eps": 1e-6,
+            "vocab_size": 128,
+            "max_position_embeddings": 128,
+            "full_attention_interval": 4,
+        }
+
+        text_only_configs = (
+            {"vision_config": None},
+            {
+                "vision_config": {"model_type": "qwen3_5"},
+                "language_model_only": True,
+            },
+        )
+        for text_only_config in text_only_configs:
+            with self.subTest(config=text_only_config):
+                config = qwen3_5.ModelConfig.from_dict(
+                    {
+                        "model_type": "qwen3_5",
+                        "text_config": tiny_text,
+                        **text_only_config,
+                    }
+                )
+                model = qwen3_5.Model(config)
+
+                self.assertIsNone(model.vision_tower)
+                keys = [key for key, _ in tree_flatten(model.parameters())]
+                self.assertFalse(any("vision_tower" in key for key in keys))
+
+                with self.assertRaisesRegex(ValueError, "without a vision tower"):
+                    model.get_input_embeddings(
+                        input_ids=mx.array([[1, 2, 3]]),
+                        pixel_values=mx.zeros((1, 4)),
+                    )
+
     def test_qwen3_5_decode_uses_rope_deltas_kwarg(self):
         from mlx_vlm.models import qwen3_5
 

--- a/mlx_vlm/utils.py
+++ b/mlx_vlm/utils.py
@@ -678,6 +678,7 @@ python -m mlx_vlm.convert --hf-path <local_dir> --mlx-path <mlx_dir>
         weights.update(_load_safetensors(wf))
 
     model_class, _ = get_model_and_args(config=config)
+    text_only_config = _is_text_only_config(config)
 
     # Initialize text and vision configs if not present
     config.setdefault("text_config", config.pop("llm_config", {}))
@@ -691,6 +692,8 @@ python -m mlx_vlm.convert --hf-path <local_dir> --mlx-path <mlx_dir>
     modules = ["text", "vision", "perceiver", "projector", "audio"]
     model_config = update_module_configs(model_config, model_class, config, modules)
     model_config = apply_generation_config_defaults(model_config, config)
+    if text_only_config and hasattr(model_config, "language_model_only"):
+        model_config.language_model_only = True
 
     model = model_class.Model(model_config)
 


### PR DESCRIPTION
Treat an absent or null vision_config, or an explicit language_model_only flag, as a text-only configuration. Skip constructing the vision tower in that case and reject image or video inputs with a clear error.

