### PR TITLE
Give the drafter real context after an APC warm hit (stacked on #1856)

### DIFF
--- a/mlx_vlm/apc.py
+++ b/mlx_vlm/apc.py
@@ -598,6 +598,7 @@ class APCStats:
     disk_writes: int = 0
     exact_hits: int = 0
     exact_stores: int = 0
+    exact_store_dedups: int = 0
     rejects: int = 0
     rejects_by_reason: Dict[str, int] = field(default_factory=dict)
     last_reject: Optional[Dict[str, Any]] = None
@@ -626,6 +627,7 @@ class APCStats:
             "disk_writes": self.disk_writes,
             "exact_hits": self.exact_hits,
             "exact_stores": self.exact_stores,
+            "exact_store_dedups": self.exact_store_dedups,
             "rejects": self.rejects,
             "rejects_by_reason": dict(self.rejects_by_reason),
             "last_reject": (
@@ -3124,28 +3126,78 @@ class APCManager:
         prompt_cache: Sequence[Any],
         *,
         extra_hash: int = 0,
+        clone: bool = True,
+        disk: bool = True,
     ) -> bool:
-        """Store a full prompt-cache snapshot for exact-prefix reuse."""
+        """Store a full prompt-cache snapshot for exact-prefix reuse.
+
+        With ``clone=False`` the caller transfers ownership of the snapshot to
+        the APC manager: ``prompt_cache`` is stored as-is (no defensive deep
+        copy), so the caller must not mutate it afterwards.
+
+        ``disk=False`` keeps the entry in the memory tier only. Use it for
+        entries whose reuse is confined to the current process -- persisting
+        those costs a large write per request and evicts entries that a later
+        run could actually hit. Both disk-write sites below honour it,
+        including the dedup path: a warm exact hit re-stores its full prefix
+        every time, so leaving that one ungated would keep writing the very
+        entry the flag exists to keep off disk.
+        """
         if (self._exact_cache_max <= 0 and self.disk is None) or not token_ids:
             return False
         token_tuple = tuple(int(t) for t in token_ids)
-        copied = _clone_prompt_cache_for_apc(prompt_cache)
-        if copied is None:
-            types = [type(c).__name__ for c in prompt_cache]
-            logger.warning(
-                "APC exact-cache store rejected: unclonable prompt cache types %s "
-                "(token_len=%d). Exact-mode APC will not reuse this prefix.",
-                types,
-                len(token_tuple),
-            )
-            with self.lock:
-                self.stats.record_reject(
-                    "unclonable",
-                    types=types,
-                    token_len=len(token_tuple),
-                )
-            return False
         key = _sequence_hash(token_tuple, extra_hash, self.block_size)
+        existing_cache: Optional[List[Any]] = None
+        with self.lock:
+            existing = self._exact_cache.get(key)
+            if (
+                existing is not None
+                and existing.token_ids == token_tuple
+                and existing.extra_hash == int(extra_hash)
+            ):
+                # Re-store of an identical entry (every warm exact hit
+                # re-stores its full prefix): refresh recency and skip the
+                # multi-GB clone that would otherwise sit between prefill and
+                # first token.
+                self._exact_cache.move_to_end(key)
+                existing.last_used = time.time()
+                self.stats.exact_store_dedups += 1
+                existing_cache = existing.prompt_cache
+        if existing_cache is not None:
+            if self.disk is not None and disk:
+                try:
+                    # Sharing the stored snapshot with the disk writer is safe:
+                    # _enqueue_exact_snapshot dedups an existing shard before
+                    # serializing, and LRU entries are never mutated in place.
+                    self.disk.save_exact_cache(
+                        key, token_tuple, extra_hash, existing_cache
+                    )
+                    with self.lock:
+                        self.stats.disk_writes += 1
+                except Exception as e:
+                    logger.warning("APC exact disk save scheduling failed: %s", e)
+            with self.lock:
+                self.stats.exact_stores += 1
+            return True
+        if clone:
+            copied = _clone_prompt_cache_for_apc(prompt_cache)
+            if copied is None:
+                types = [type(c).__name__ for c in prompt_cache]
+                logger.warning(
+                    "APC exact-cache store rejected: unclonable prompt cache types %s "
+                    "(token_len=%d). Exact-mode APC will not reuse this prefix.",
+                    types,
+                    len(token_tuple),
+                )
+                with self.lock:
+                    self.stats.record_reject(
+                        "unclonable",
+                        types=types,
+                        token_len=len(token_tuple),
+                    )
+                return False
+        else:
+            copied = list(prompt_cache)
         stored = False
         with self.lock:
             if self._exact_cache_max > 0:
@@ -3167,7 +3219,7 @@ class APCManager:
                 token_len=len(token_tuple),
                 layers=len(copied),
             )
-        if self.disk is not None:
+        if self.disk is not None and disk:
             try:
                 self.disk.save_exact_cache(key, token_tuple, extra_hash, copied)
                 with self.lock:

--- a/mlx_vlm/apc_adapters.py
+++ b/mlx_vlm/apc_adapters.py
@@ -353,7 +353,33 @@ class RotatingKVCacheCloneAdapter:
         out.offset = int(getattr(c, "offset", 0) or 0)
         out._idx = int(getattr(c, "_idx", 0) or 0)
         if c.keys is not None and c.values is not None:
-            out.keys, out.values = copy(c.keys), copy(c.values)
+            # A one-shot (S > 1) prefill concatenates from None, so the live
+            # buffer physically retains ALL tokens (keys.shape[2] == offset ==
+            # _idx even when offset >> max_size). Snapshotting that verbatim
+            # stores O(prompt) tokens per sliding layer instead of O(window):
+            # for Muse-Glimmer (39 sliding layers, window 2048, ~1 KB per
+            # token per layer) a 36k-token prompt wastes ~1.4 GB per entry.
+            # When the buffer is in this pure linear retained-all state — and
+            # keep == 0, so there are no sink tokens the tail slice would
+            # drop — keep only the last `max_size` positions. This is lossless
+            # for every downstream consumer: BatchRotatingKVCache.merge takes
+            # _temporal_order(keys)[..., -min(offset, max_size):, :], which is
+            # exactly this window (with _idx == keys.shape[2] the temporal
+            # order is a no-op), and a direct in-place decode continuation
+            # behaves identically to a cold cache after its first post-prefill
+            # trim.
+            if (
+                int(getattr(c, "keep", 0) or 0) == 0
+                and int(c._idx) == int(c.keys.shape[2])
+                and int(c.offset) == int(c._idx)
+                and int(c.offset) > int(c.max_size)
+            ):
+                out.keys = copy(c.keys[..., -int(c.max_size) :, :])
+                out.values = copy(c.values[..., -int(c.max_size) :, :])
+                out._idx = int(c.max_size)
+                # out.offset stays at the full logical length on purpose.
+            else:
+                out.keys, out.values = copy(c.keys), copy(c.values)
             eval_targets.extend([out.keys, out.values])
         return out
 

--- a/mlx_vlm/server/generation.py
+++ b/mlx_vlm/server/generation.py
@@ -37,6 +37,7 @@ from ..generate.diffusion import (
 )
 from ..sample_utils import make_logits_processors, make_sampler, top_p_sampling
 from ..speculative import apc_dflash as _apc_dflash
+from ..speculative.dflash import assemble_warm_drafter_context
 from ..speculative.utils import (
     make_speculative_prompt_cache,
     run_speculative_server_rounds,
@@ -2364,6 +2365,7 @@ class ResponseGenerator:
                 )
                 shared_kv_states = out.shared_kv_states if is_mtp else None
                 sample_row_ids = [0] * B
+                warm_context_offsets = None
                 if apc_active:
                     # Roll each row's right-pad KV out so offsets are correct
                     # for decode, then sample first-bonus + capture drafter aux
@@ -2390,9 +2392,16 @@ class ResponseGenerator:
                         row_ids=sample_row_ids,
                         positions=[0] * B,
                     ).astype(mx.int32)
+                    # Drafter round-1 context (Fix 1, 2026-08-11): the suffix
+                    # prefill captured aux hidden for ALL suffix positions, so
+                    # hand the drafter the full per-row suffix (ragged list) +
+                    # per-row absolute offsets (= cached_tokens) instead of the
+                    # old single last position. MUSE_WARMCTX=0 (call-time)
+                    # restores the old 1-position slice byte-identically.
                     hs = speculative_hidden_state(draft_kind, out)
-                    h_idx = mx.broadcast_to(li[:, None, None], (B, 1, hs.shape[-1]))
-                    hidden = mx.take_along_axis(hs, h_idx, axis=1)
+                    hidden, warm_context_offsets = assemble_warm_drafter_context(
+                        hs, apc_right_pad, apc_prefix_lens
+                    )
                 else:
                     hidden = speculative_hidden_state(draft_kind, out)
                     first_bonus = _sample_last_token(
@@ -2520,6 +2529,7 @@ class ResponseGenerator:
                     eos_token_ids=eos_set,
                     prompt_tokens=input_mx,
                     row_ids=sample_row_ids,
+                    context_offsets=warm_context_offsets,
                 )
                 for tok_list, _ in rounds_iter:
                     for j, tok in enumerate(tok_list):

--- a/mlx_vlm/server/generation.py
+++ b/mlx_vlm/server/generation.py
@@ -36,6 +36,7 @@ from ..generate.diffusion import (
     stream_diffusion_generate_from_kwargs,
 )
 from ..sample_utils import make_logits_processors, make_sampler, top_p_sampling
+from ..speculative import apc_dflash as _apc_dflash
 from ..speculative.utils import (
     make_speculative_prompt_cache,
     run_speculative_server_rounds,
@@ -184,8 +185,19 @@ def _run_chunked_speculative_prefill(
     *,
     prefill_step_size: Optional[int],
     generation_stream,
+    checkpoint_at: Optional[int] = None,
+    on_checkpoint=None,
 ) -> Tuple[object, mx.array]:
-    """Prefill target cache in chunks, capturing speculative state only at end."""
+    """Prefill target cache in chunks, capturing speculative state only at end.
+
+    ``checkpoint_at``/``on_checkpoint`` let a caller observe the cache exactly
+    once, at the moment the prefill has consumed that many positions. A chunk
+    edge is shortened so it lands on the position rather than straddling it.
+    Used to capture the static system+tools prefix while the sliding-window
+    layers still hold the window ending there (see apc_dflash's
+    store_prefix_checkpoint); after the full prefill those tokens have rotated
+    out and no trim can recover them.
+    """
     remaining_input_ids = input_ids
     remaining_embeds = inputs_embeds
     remaining_kwargs = dict(prompt_kwargs or {})
@@ -200,8 +212,17 @@ def _run_chunked_speculative_prefill(
         and prefill_step_size > 0
         and remaining_embeds.shape[1] > prefill_step_size
     ):
+        processed = 0
         while remaining_embeds.shape[1] > 1:
             n_to_process = min(prefill_step_size, remaining_embeds.shape[1] - 1)
+            # Land a chunk edge exactly on the checkpoint instead of stepping
+            # over it; without this the cache is only ever observable at
+            # multiples of the step size.
+            if (
+                checkpoint_at is not None
+                and processed < checkpoint_at < processed + n_to_process
+            ):
+                n_to_process = checkpoint_at - processed
             chunk_kwargs = _slice_prefill_kwargs(
                 remaining_kwargs, sequence_keys, n_to_process
             )
@@ -214,12 +235,63 @@ def _run_chunked_speculative_prefill(
                     **chunk_kwargs,
                 )
             mx.eval([c.state for c in prompt_cache])
+            processed += n_to_process
+            if (
+                checkpoint_at is not None
+                and on_checkpoint is not None
+                and processed == checkpoint_at
+            ):
+                try:
+                    on_checkpoint(prompt_cache)
+                except Exception:
+                    # A failed capture costs future reuse, never this request.
+                    logger.warning(
+                        "APC prefix checkpoint capture failed", exc_info=True
+                    )
+                on_checkpoint = None
             remaining_input_ids = remaining_input_ids[:, n_to_process:]
             remaining_embeds = remaining_embeds[:, n_to_process:]
             remaining_kwargs = _drop_prefill_kwargs(
                 remaining_kwargs, sequence_keys, n_to_process
             )
             mx.clear_cache()
+
+    elif (
+        checkpoint_at is not None
+        and on_checkpoint is not None
+        and 1 <= checkpoint_at < remaining_embeds.shape[1]
+    ):
+        # Unchunked prefill (the DFlash path: _chunked_prefill_enabled returns
+        # `draft_model is None`, so attaching a drafter disables chunking and
+        # the whole prompt goes through in one lm() call). There is no mid-point
+        # to observe, so split once at the checkpoint. The tail call below still
+        # carries speculative_kwargs, but relative to the previous one-shot
+        # DFlash prefill the speculative hidden states now cover only the TAIL,
+        # so the drafter's cross-attention context is shortened on cold
+        # captures too -- the same first-block acceptance-dip caveat as a warm
+        # hit, though milder here because the tail is usually much longer than
+        # the warm path's single position.
+        n_head = int(checkpoint_at)
+        head_kwargs = _slice_prefill_kwargs(remaining_kwargs, sequence_keys, n_head)
+        with mx.stream(generation_stream):
+            lm(
+                remaining_input_ids[:, :n_head],
+                cache=prompt_cache,
+                inputs_embeds=remaining_embeds[:, :n_head],
+                n_to_process=n_head,
+                **head_kwargs,
+            )
+        mx.eval([c.state for c in prompt_cache])
+        try:
+            on_checkpoint(prompt_cache)
+        except Exception:
+            logger.warning("APC prefix checkpoint capture failed", exc_info=True)
+        remaining_input_ids = remaining_input_ids[:, n_head:]
+        remaining_embeds = remaining_embeds[:, n_head:]
+        remaining_kwargs = _drop_prefill_kwargs(
+            remaining_kwargs, sequence_keys, n_head
+        )
+        mx.clear_cache()
 
     final_kwargs = {**remaining_kwargs, **speculative_kwargs}
     final_kwargs["inputs_embeds"] = remaining_embeds
@@ -1642,6 +1714,16 @@ class ResponseGenerator:
         }
         if apc_semantic_hash is not None:
             gen_kwargs["_apc_semantic_hash"] = apc_semantic_hash
+        # Image-presence signal for APC (apc_dflash._text_only): the vision
+        # encoder above REPLACES pixel_values with inputs_embeds, so without
+        # this key an image-bearing request is indistinguishable from text
+        # downstream and its KV could be stored/reused under a text-only key.
+        if images is not None:
+            gen_kwargs["_apc_image_hash"] = _apc.hash_image_payload(image_ref=images)
+        elif pixel_values is not None:
+            gen_kwargs["_apc_image_hash"] = _apc.hash_image_payload(
+                pixel_values=pixel_values
+            )
         return input_ids, gen_kwargs
 
     def _collect_pending_requests(
@@ -2112,9 +2194,80 @@ class ResponseGenerator:
                     make_cache=_make_cache,
                 )
 
+                # --- APC cross-request prefix reuse (DFlash, per-row, exact) ---
+                # No-op unless APC is enabled (apc_manager is None by default),
+                # so the default serving path is unchanged. Each row looks up its
+                # own exact prefix; hits are merged into a batched warm cache and
+                # only the (right-padded) per-row suffixes are prefilled.
+                # prepare()/finalize() roll the right-pad KV out so every row's
+                # offset is correct for decode. Fail-safe: any fault → cold.
+                apc_active = False
+                apc_prefix_lens = [0] * B
+                apc_extra_hashes = [None] * B
+                apc_right_pad = [0] * B
+                if draft_kind == "dflash" and self.apc_manager is not None:
+                    try:
+                        plan = _apc_dflash.lookup_batch(
+                            self.apc_manager,
+                            lm,
+                            self.model,
+                            self.processor,
+                            all_input_ids,
+                            prompt_kwargs_list,
+                        )
+                        if plan is not None:
+                            # Build the APC path into TEMP locals; only commit to
+                            # input_mx/inputs_embeds_mx/prompt_cache after every
+                            # step (incl. prepare) succeeds, so an exception leaves
+                            # the cold path fully intact (Codex #4).
+                            _prefix_lens = plan["prefix_lens"]
+                            _extra_hashes = plan["extra_hashes"]
+                            _right_pad = plan["right_pad"]
+                            _lengths = plan["lengths"]
+                            _suffixes = plan["suffixes"]
+                            _input_mx = mx.array(
+                                [s + [0] * _right_pad[i] for i, s in enumerate(_suffixes)],
+                                dtype=mx.int32,
+                            )
+                            _embeds = None
+                            if inputs_embeds_mx is not None:
+                                D = inputs_embeds_mx.shape[-1]
+                                emb_rows = []
+                                for i in range(B):
+                                    fe = prompt_kwargs_list[i].get("inputs_embeds")
+                                    e = fe[:, _prefix_lens[i]:, :]
+                                    if _right_pad[i] > 0:
+                                        e = mx.concatenate(
+                                            [e, mx.zeros((1, _right_pad[i], D), dtype=e.dtype)],
+                                            axis=1,
+                                        )
+                                    emb_rows.append(e)
+                                _embeds = mx.concatenate(emb_rows, axis=0)
+                            _warm = plan["warm_cache"]
+                            for c in _warm:
+                                prep = getattr(c, "prepare", None)
+                                if prep is not None:
+                                    prep(right_padding=_right_pad, lengths=_lengths)
+                            # Commit (all steps above succeeded).
+                            apc_prefix_lens = _prefix_lens
+                            apc_extra_hashes = _extra_hashes
+                            apc_right_pad = _right_pad
+                            input_mx = _input_mx
+                            if _embeds is not None:
+                                inputs_embeds_mx = _embeds
+                            prompt_cache = _warm
+                            apc_active = True
+                    except Exception:
+                        logger.warning(
+                            "APC batched lookup failed; cold prefill", exc_info=True
+                        )
+                        apc_active = False
+
                 prefill_step_size = get_prefill_step_size()
                 policy_kwargs = {**prompt_kwargs, **prefill_kwargs}
-                if not _chunked_prefill_enabled(
+                # No chunking on the APC path: prepare()/finalize() wrap the
+                # whole suffix prefill, and suffixes are short anyway.
+                if apc_active or not _chunked_prefill_enabled(
                     self.model,
                     input_ids=input_mx,
                     inputs_embeds=inputs_embeds_mx,
@@ -2123,7 +2276,78 @@ class ResponseGenerator:
                     draft_kind=draft_kind,
                     prefill_kwargs=policy_kwargs,
                 ):
+                    _would_chunk_at = prefill_step_size  # step size before disabling
                     prefill_step_size = None
+                    # The "suffixes are short anyway" invariant holds only when
+                    # every row hit. At B>=2 a cold-miss row (prefix 0, suffix =
+                    # whole prompt) coalesced with a warm hit prefills unchunked
+                    # at the batch's max width — a memory-spike risk the cold path
+                    # would have chunked away. Never triggers at B==1 (a miss
+                    # there takes the cold, chunked path). Diagnostic only so the
+                    # rare case is visible rather than a silent OOM (Fable F2).
+                    if (
+                        apc_active
+                        and _would_chunk_at
+                        and getattr(input_mx, "ndim", 0) >= 2
+                        and input_mx.shape[1] > _would_chunk_at
+                    ):
+                        logger.warning(
+                            "APC prefill unchunked across %d suffix positions "
+                            "(> %d step size), B=%d: a long cold-miss row is "
+                            "coalesced with a warm hit — memory-spike risk "
+                            "(Fable F2).",
+                            int(input_mx.shape[1]), int(_would_chunk_at), B,
+                        )
+
+                # --- static system+tools prefix checkpoint (B==1, cold only) ---
+                # Capture the cache at the first user-turn boundary while the
+                # sliding layers still hold the window ending there. Restricted
+                # to B==1 because rows in a coalesced batch have different
+                # boundaries and right-padding, and to cold prefills because a
+                # warm row's cache does not start at position 0. B==1 cold is
+                # the case that matters: a fresh session on a long system
+                # prompt, which is exactly what pays the full prefill today.
+                _ckpt_at = None
+                _on_ckpt = None
+                if (
+                    draft_kind == "dflash"
+                    and self.apc_manager is not None
+                    and not apc_active
+                    and B == 1
+                ):
+                    try:
+                        _ids0 = all_input_ids[0]
+                        _pk0 = (
+                            prompt_kwargs_list[0]
+                            if prompt_kwargs_list and len(prompt_kwargs_list) > 0
+                            else None
+                        )
+                        _b = _apc_dflash.static_prefix_boundary(self.processor, _ids0)
+                        if _b and 1 <= _b < len(_ids0):
+                            _ckpt_at = _b
+
+                            def _on_ckpt(cache, _ids0=_ids0, _pk0=_pk0, _b=_b):
+                                stored = _apc_dflash.store_prefix_checkpoint(
+                                    self.apc_manager,
+                                    self.model,
+                                    self.processor,
+                                    _ids0,
+                                    cache,
+                                    _b,
+                                    extra_hash=apc_extra_hashes[0],
+                                    prompt_kwargs=_pk0,
+                                )
+                                logger.debug(
+                                    "APC static-prefix checkpoint at %d: %s",
+                                    _b,
+                                    "stored" if stored else "skipped",
+                                )
+                    except Exception:
+                        logger.warning(
+                            "APC prefix checkpoint setup failed", exc_info=True
+                        )
+                        _ckpt_at = None
+                        _on_ckpt = None
 
                 prompt_started = time.perf_counter()
                 out, input_mx = _run_chunked_speculative_prefill(
@@ -2135,30 +2359,89 @@ class ResponseGenerator:
                     prefill_kwargs,
                     prefill_step_size=prefill_step_size,
                     generation_stream=generation_stream,
+                    checkpoint_at=_ckpt_at,
+                    on_checkpoint=_on_ckpt,
                 )
-                hidden = speculative_hidden_state(draft_kind, out)
                 shared_kv_states = out.shared_kv_states if is_mtp else None
                 sample_row_ids = [0] * B
-                first_bonus = _sample_last_token(
-                    out.logits,
-                    sampler,
-                    row_ids=sample_row_ids,
-                    positions=[0] * B,
-                )
+                if apc_active:
+                    # Roll each row's right-pad KV out so offsets are correct
+                    # for decode, then sample first-bonus + capture drafter aux
+                    # at each row's real last position (max_suf - 1 - right_pad).
+                    for c in prompt_cache:
+                        fin = getattr(c, "finalize", None)
+                        if fin is not None:
+                            fin()
+                    seq = out.logits.shape[1]
+                    li = mx.array(
+                        [seq - 1 - rp for rp in apc_right_pad], dtype=mx.int32
+                    )
+                    logit_idx = mx.broadcast_to(
+                        li[:, None, None], (B, 1, out.logits.shape[-1])
+                    )
+                    # Sample the per-row last-real position through the request's
+                    # sampler (temperature/top-p), NOT unconditional argmax, so an
+                    # APC hit doesn't silently make a sampled request greedy for
+                    # its first token (Codex #3). Shape [B,1,vocab] -> _sample_last_token.
+                    last_logits_3d = mx.take_along_axis(out.logits, logit_idx, axis=1)
+                    first_bonus = _sample_last_token(
+                        last_logits_3d,
+                        sampler,
+                        row_ids=sample_row_ids,
+                        positions=[0] * B,
+                    ).astype(mx.int32)
+                    hs = speculative_hidden_state(draft_kind, out)
+                    h_idx = mx.broadcast_to(li[:, None, None], (B, 1, hs.shape[-1]))
+                    hidden = mx.take_along_axis(hs, h_idx, axis=1)
+                else:
+                    hidden = speculative_hidden_state(draft_kind, out)
+                    first_bonus = _sample_last_token(
+                        out.logits,
+                        sampler,
+                        row_ids=sample_row_ids,
+                        positions=[0] * B,
+                    )
                 mx.eval(first_bonus, hidden, out.logits)
                 prompt_elapsed = time.perf_counter() - prompt_started
-                for uid in uids:
+
+                # Store each row's full post-prefill prefix for future reuse.
+                # Done after eval so the caches are materialized. Fail-safe.
+                if draft_kind == "dflash" and self.apc_manager is not None:
+                    try:
+                        _apc_dflash.store_batch(
+                            self.apc_manager,
+                            self.model,
+                            self.processor,
+                            all_input_ids,
+                            prompt_cache,
+                            apc_extra_hashes,
+                            prompt_kwargs_list=prompt_kwargs_list,
+                        )
+                    except Exception:
+                        logger.warning("APC dflash store failed", exc_info=True)
+
+                for ri, uid in enumerate(uids):
                     prompt_tokens = prompt_tokens_map[uid]
+                    cached = apc_prefix_lens[ri] if ri < len(apc_prefix_lens) else 0
+                    # Report the TRUE prefill rate: only the tokens actually
+                    # prefilled this request (prompt_tokens - cached) were
+                    # computed in prompt_elapsed; the cached tokens were restored
+                    # from APC, not processed. Dividing the full prompt_tokens by
+                    # the suffix-only elapsed inflated the rate ~20x on a high
+                    # hit (Fable F7).
+                    prefilled = max(0, prompt_tokens - cached)
                     prompt_tps_map[uid] = (
-                        prompt_tokens / prompt_elapsed
-                        if prompt_tokens > 0 and prompt_elapsed > 0
+                        prefilled / prompt_elapsed
+                        if prefilled > 0 and prompt_elapsed > 0
                         else None
                     )
                     logger.info(
                         "Prefill completed: request=%s prompt_tokens=%d "
-                        "cached_tokens=0 elapsed=%.3fs rate=%.1f tok/s",
+                        "cached_tokens=%d prefilled=%d elapsed=%.3fs rate=%.1f tok/s",
                         stream_infos[uid].get("request_id", uid),
                         prompt_tokens,
+                        cached,
+                        prefilled,
                         prompt_elapsed,
                         float(prompt_tps_map[uid] or 0.0),
                     )
@@ -2189,6 +2472,7 @@ class ResponseGenerator:
                             finish_reason=finish,
                             peak_memory=mx.get_peak_memory() / 1e9 if finish else 0,
                             prompt_tps=prompt_tps_map.get(uid),
+                            cached_tokens=apc_prefix_lens[j] if j < len(apc_prefix_lens) else 0,
                             emitted_at=emitted_at,
                         )
                     )

--- a/mlx_vlm/speculative/apc_dflash.py
+++ b/mlx_vlm/speculative/apc_dflash.py
@@ -1,0 +1,611 @@
+# Cross-request prefix reuse (APC) for the DFlash B=1 speculative path.
+#
+# The server's _run_speculative loop never consulted the automatic-prefix-cache
+# subsystem (apc.py) — it always prefilled the whole prompt and reported
+# cached_tokens=0. For agent traffic (stable system prompt + tools + growing
+# conversation) that re-prefills a large shared prefix every turn.
+#
+# This module adds exact-mode prefix reuse for the DFlash path. At B=1 a cold
+# Muse request runs on a plain per-layer cache (make_speculative_prompt_cache);
+# on an APC warm hit it decodes on a BatchRotatingKVCache/BatchKVCache restored
+# from the snapshot. That warm decode is correct (no miscompute — three reviews
+# traced the mask/offset/rollback math) and deterministic (warm-vs-warm
+# identical); it is usually byte-identical to the cold path and can occasionally
+# diverge at a near-tie greedy fork on the 4-bit target (numerical tie-flip, same
+# class as spec-vs-plain — see utils.py and the wiki lever record). It is a no-op
+# unless an APCManager is present (APC_ENABLED=1), so with APC off the serving
+# path is unchanged.
+#
+# Design notes:
+#   * We compute our OWN extra_hash here, from the image payload only (0 for
+#     text), so store and lookup always agree WITHOUT depending on the shared
+#     _apc_extra_hash, which folds in inputs_embeds and is therefore unstable
+#     across requests (the salt bug that makes the CB path miss). We do not
+#     touch that shared path.
+#   * Text-only guard: if the request carries pixel_values we skip APC
+#     entirely (DFlash image handling is unsettled, and multimodal prefixes
+#     need the media-safe machinery we're deliberately not invoking here).
+#   * Every entry point is wrapped by the caller in try/except so an APC fault
+#     degrades to a cold prefill, never a failed request.
+#
+# Caveat to measure, not a correctness bug: on a warm restore the target hidden
+# states captured during suffix prefill cover only the suffix, so the drafter's
+# cross-attention context is short for the first block — expect a one-block
+# acceptance dip right after a hit. The same shortened-drafter-context caveat
+# applies to COLD requests when a mid-prefill static-prefix checkpoint is
+# captured — the head/tail prefill split means DFlash hidden states cover only
+# the tail, so a first-block acceptance dip is expected there too (milder than
+# the warm single-position case).
+import logging
+import os
+from typing import Any, List, Optional, Sequence
+
+from .. import apc as _apc
+
+logger = logging.getLogger("mlx_vlm.apc")
+
+# Store-size floor for post-prefill stores (review #2): with the in-memory LRU
+# capped at APC_EXACT_CACHE_ENTRIES=2, tiny entries just churn it. At Muse's
+# measured ~600 tok/s M5 prefill a 1024-token hit saves ~1.7 s, and a
+# 1024-token entry is ~55 MB post-compaction — below that the entry churns the
+# small LRU for sub-second savings. Deliberately NOT applied to
+# store_prefix_checkpoint, which is already gated by STATIC_PREFIX_MIN_TOKENS
+# (2048) via static_prefix_boundary.
+STORE_MIN_TOKENS = max(0, int(os.environ.get("APC_DFLASH_STORE_MIN_TOKENS", "1024")))
+
+
+def _text_only(prompt_kwargs: Optional[dict]) -> bool:
+    if not prompt_kwargs:
+        return True
+    # The server's _gpu_embed runs the vision encoder and REPLACES pixel_values
+    # with inputs_embeds, setting `_apc_image_hash` iff the request carried an
+    # image (absent for pure text). So `_apc_image_hash` is the signal that
+    # survives; checking only pixel_values would miss every real image request
+    # and let its KV be stored/reused under a text key (Codex #1).
+    if prompt_kwargs.get("_apc_image_hash") is not None:
+        return False
+    for k in ("pixel_values", "pixel_values_videos", "input_features"):
+        if prompt_kwargs.get(k) is not None:
+            return False
+    return True
+
+
+def _stable_extra_hash(model: Any, processor: Any) -> int:
+    """Request-independent salt: image payload None (text) + model/processor
+    deps. Identical for every text request against this model, so exact-prefix
+    keys line up across requests."""
+    return _apc.semantic_extra_hash(
+        tenant=None,
+        image_hash=_apc.hash_image_payload(pixel_values=None, image_ref=None),
+        media={},
+        model=model,
+        processor=processor,
+    )
+
+
+def dflash_apc_mode(language_model: Any) -> Optional[str]:
+    """Only exact mode is wired here (Muse uses RotatingKVCache/KVCache ->
+    exact). Return None for block-only models so the caller skips APC.
+
+    Builds ``make_cache()`` exactly ONCE and derives both the mode
+    classification and the sink guard from that single list (Codex r1 #1:
+    ``model_apc_mode`` plus a second probe built two throwaway per-layer cache
+    lists per row per lookup — ~1.6k empty objects on a 16-row batch). The
+    classification mirrors ``model_apc_mode``'s ordering: all-block-eligible
+    is "block" (refused here), else all-exact-eligible is "exact".
+    """
+    make_cache = getattr(language_model, "make_cache", None)
+    if not callable(make_cache):
+        return None  # model_apc_mode calls this "block"; block is refused here
+    try:
+        caches = make_cache()
+        if not caches:
+            return None
+        if all(_apc._cache_entry_supports_block_apc(c) for c in caches):
+            return None  # "block" — not wired on this path
+        if not all(_apc._cache_entry_supports_exact_apc(c) for c in caches):
+            return None
+        # keep>0 guard (review #4): BatchRotatingKVCache — used on every warm
+        # restore — has no `keep` support (merge takes the last window tokens,
+        # extract drops `keep`), so an attention-sink model would be silently
+        # corrupted on reuse. Refuse APC outright for such models. Recursive
+        # (Codex r2 #3): exact eligibility admits CacheList/tuple composites,
+        # so the sink probe must look inside them too. Any fault while probing
+        # degrades to None (cold path), never a failed request.
+        for c in caches:
+            if _has_sink(c):
+                return None
+    except Exception:
+        return None
+    return "exact"
+
+
+def _has_sink(c) -> bool:
+    """True if ``c`` or any nested sub-cache carries an attention sink
+    (keep > 0). Exact-mode eligibility recurses through CacheList/tuple
+    composites, so this check must recurse too (Codex r2 #3) — a composite
+    hiding a RotatingKVCache(keep>0) would otherwise slip past the flat
+    guard and be corrupted by the keep-blind batch merge/extract."""
+    if c is None:
+        return False
+    if getattr(c, "keep", 0):
+        return True
+    subs = getattr(c, "caches", None)
+    if subs is not None:
+        return any(_has_sink(s) for s in subs)
+    if isinstance(c, tuple):
+        return any(_has_sink(s) for s in c)
+    return False
+
+
+def _snapshot_reuse_safe(snap) -> bool:
+    """False if any cache entry (at any nesting depth) carries an attention
+    sink (keep > 0). Batch merge/extract are keep-blind (review #4), so sink
+    caches must never enter the exact store — a warm restore through
+    BatchRotatingKVCache would silently drop or misplace the sink tokens."""
+    return not any(_has_sink(c) for c in snap)
+
+
+def lookup(
+    apc_manager: Any,
+    language_model: Any,
+    model: Any,
+    processor: Any,
+    ids_list: Sequence[int],
+    prompt_kwargs: Optional[dict],
+) -> Optional[dict]:
+    """Return an APC plan ({'warm_cache', 'prefix_len', 'extra_hash'}) for a
+    reusable exact prefix, or None. Text-only, exact-mode, B=1.
+
+    Cheap request-local guards run BEFORE the mode probe (Codex r2 #4):
+    probing calls ``language_model.make_cache()``, which a disabled-APC or
+    media-bearing request should never trigger.
+    """
+    if apc_manager is None or not _text_only(prompt_kwargs):
+        return None
+    if not ids_list or len(ids_list) < 2:
+        return None
+    if dflash_apc_mode(language_model) != "exact":
+        return None
+    return _lookup_row(apc_manager, model, processor, ids_list, prompt_kwargs)
+
+
+def _lookup_row(
+    apc_manager: Any,
+    model: Any,
+    processor: Any,
+    ids_list: Sequence[int],
+    prompt_kwargs: Optional[dict],
+) -> Optional[dict]:
+    """``lookup`` minus the mode gate — for callers that have already checked
+    ``dflash_apc_mode`` once for the whole batch (Codex r1 #1: the per-row
+    gate rebuilt the model's cache list B times per coalesced lookup)."""
+    if apc_manager is None or not _text_only(prompt_kwargs):
+        return None
+    if not ids_list or len(ids_list) < 2:
+        return None
+    extra_hash = _stable_extra_hash(model, processor)
+    plan = _apc.apc_lookup_plan(
+        apc_manager,
+        list(ids_list),
+        extra_hash=extra_hash,
+        apc_mode="exact",
+        safe_lookup_min=0,           # text-only: no media-safe floor
+        suffix_is_text_only=lambda pl: True,
+        prefix_has_media=lambda pl: False,
+    )
+    if plan is not None:
+        plan["extra_hash"] = extra_hash
+    return plan
+
+
+def store(
+    apc_manager: Any,
+    model: Any,
+    processor: Any,
+    ids_list: Sequence[int],
+    prompt_cache: Sequence[Any],
+    extra_hash: Optional[int] = None,
+    prompt_kwargs: Optional[dict] = None,
+) -> bool:
+    """Snapshot the post-prefill cache for exact reuse.
+
+    Stores two entries:
+      * full length L — reused when this whole prompt is a literal prefix of a
+        later (strictly longer) request, i.e. a growing multi-turn conversation.
+      * checkpoint L-guard — a copy trimmed back by the manager's guard tokens.
+        lookup_exact_cache rejects an entry whose length equals the query
+        length (no suffix to generate from), and the generation-prompt marker
+        makes a full prior prompt rarely a literal prefix of the next one; the
+        guard checkpoint is what lets an identical / small-tail-variation
+        re-request hit. Trimming a clone is exact for KVCache/RotatingKVCache
+        (guard << window), and avoids a second prefill pass.
+
+    A static-prefix checkpoint is pinned at static_prefix_boundary (end of the
+    FIRST rendered message, min STATIC_PREFIX_MIN_TOKENS) when one exists — NOT
+    at the first user-turn marker, which sits after the context gateway's
+    per-request control packet and therefore never repeats (see
+    static_prefix_boundary).
+    """
+    if apc_manager is None or not ids_list:
+        return False
+    # Symmetric with lookup(): never snapshot a media-bearing prompt under a
+    # text-ignoring key. Dead today (only store_batch is wired), but keeps this
+    # B=1 entry point from becoming a media-KV footgun for a future caller
+    # (Fable verify #1a).
+    if prompt_kwargs is not None and not _text_only(prompt_kwargs):
+        return False
+    if extra_hash is None:
+        extra_hash = _stable_extra_hash(model, processor)
+    boundary = static_prefix_boundary(processor, ids_list)
+    return _store_row(
+        apc_manager, ids_list, prompt_cache, 0, extra_hash,
+        boundaries=[boundary] if boundary else None,
+    )
+
+
+def store_prefix_checkpoint(
+    apc_manager: Any,
+    model: Any,
+    processor: Any,
+    ids_list: Sequence[int],
+    prompt_cache: Sequence[Any],
+    cp: int,
+    extra_hash: Optional[int] = None,
+    row_idx: int = 0,
+    prompt_kwargs: Optional[dict] = None,
+) -> bool:
+    """Store a static-prefix checkpoint captured DURING prefill, at length ``cp``.
+
+    _store_trimmed builds checkpoints after the fact by trimming the finished
+    cache, which it must refuse once a RotatingKVCache has wrapped -- the
+    rotated-out tokens are gone and the trim would key an incomplete window as
+    tokens[:cp]. Muse's sliding layers are 2048 wide, so on any real prompt
+    every checkpoint is refused and only the full-length entry survives; since
+    lookup rejects an entry whose length equals the query length, an identical
+    or same-system re-request can never hit.
+
+    Captured mid-prefill there is nothing to recover: at the moment the cache
+    offset IS cp, the sliding layers physically hold the true window ending at
+    cp -- the same state a cold prefill of tokens[:cp] leaves behind. No trim,
+    so the wrap guard does not apply.
+
+    Fail-safe: any fault returns False. A missed checkpoint costs reuse, never
+    correctness.
+    """
+    if apc_manager is None or not ids_list:
+        return False
+    if prompt_kwargs is not None and not _text_only(prompt_kwargs):
+        return False  # symmetric with lookup()/store(): never key media under text
+    n = len(ids_list)
+    cp = int(cp)
+    if not 1 <= cp < n:
+        return False
+    if extra_hash is None:
+        extra_hash = _stable_extra_hash(model, processor)
+    snap = _apc.snapshot_prompt_cache_row(prompt_cache, row_idx)
+    if snap is None:
+        return False
+    # Batch merge/extract are keep-blind (review #4): sink caches must never
+    # enter the exact store, or a warm restore would silently corrupt them.
+    if not _snapshot_reuse_safe(snap):
+        return False
+    # Snapshot is fresh and never reused by us -> manager may own it without
+    # recloning (review #5).
+    return bool(
+        apc_manager.store_exact_cache(
+            [int(t) for t in ids_list[:cp]], snap, extra_hash=extra_hash, clone=False
+        )
+    )
+
+
+# --- static-prefix (system+tools) boundary detection ------------------------
+# Fallback ONLY (review #6): keyed by id(tok), so after GC a recycled id could
+# serve a stale header id and the dict grows unbounded. Used solely for
+# tokenizers that reject attribute writes; the primary cache lives on the
+# tokenizer object itself and dies with it.
+_START_HEADER_CACHE: dict = {}
+_UNSET = object()  # distinguishes "not computed" from a computed None
+# Below this the checkpoint is not worth ~1.5 GB of cache for a 30B: the prefill
+# it saves is a rounding error, and storing it would churn the disk tier.
+STATIC_PREFIX_MIN_TOKENS = 2048
+
+
+def _start_header_id(processor) -> Optional[int]:
+    """Token id of the harmony "<|start|>" message header, if it is a single id."""
+    tok = processor.tokenizer if hasattr(processor, "tokenizer") else processor
+    cached = getattr(tok, "_apc_start_header_id", _UNSET)
+    if cached is not _UNSET:
+        return cached
+    key = id(tok)
+    if key in _START_HEADER_CACHE:  # fallback hit: attribute-rejecting tokenizer
+        return _START_HEADER_CACHE[key]
+    out = None
+    try:
+        ids = list(tok.encode("<|start|>"))
+        bos = getattr(tok, "bos_token_id", None)
+        if bos is not None and ids and ids[0] == bos:
+            ids = ids[1:]
+        if len(ids) == 1:
+            out = int(ids[0])
+    except Exception:
+        out = None
+    try:
+        setattr(tok, "_apc_start_header_id", out)
+    except Exception:
+        # Some tokenizers (__slots__/frozen wrappers) reject attribute writes;
+        # only those fall back to the id()-keyed module dict.
+        _START_HEADER_CACHE[key] = out
+    return out
+
+
+def static_prefix_boundary(
+    processor, ids_list: Sequence[int], min_tokens: int = STATIC_PREFIX_MIN_TOKENS
+) -> Optional[int]:
+    """End of the FIRST rendered message -- the reusable static prefix.
+
+    Deliberately not the first user-turn marker. Anything sitting between the
+    system prompt and the user turn lands inside that prefix, and the context
+    gateway puts a per-request control packet exactly there (as a developer
+    message, which _qwen_compatible_body rewrites to system, so it is inside
+    the system block). That packet embeds the request, so a user-marker
+    boundary changes on every single call and never hits -- while still costing
+    a full checkpoint store each time.
+
+    The first message is the big stable one (the agent's system prompt), so
+    cutting at the second "<|start|>" header keeps the prefix identical across
+    both a varying gateway packet and a varying question. Verified: two
+    renders differing in packet AND question produced byte-identical prefixes.
+
+    Returns None when the model is not harmony-framed, when there is only one
+    message, or when the prefix is shorter than ``min_tokens``.
+    """
+    start_id = _start_header_id(processor)
+    if start_id is None:
+        return None
+    seen = 0
+    for i, tid in enumerate(ids_list):
+        if tid == start_id:
+            seen += 1
+            if seen == 2:
+                return i if i >= int(min_tokens) else None
+    return None
+
+
+def _ckpt_key(ids_list, cp, extra_hash):
+    # Exact tuple, not hash(), so dedup never suffers a hash collision that would
+    # silently drop a distinct checkpoint (Codex #5). The set is per-store_batch
+    # call and holds at most a few short-lived entries per row.
+    return (int(extra_hash), int(cp), tuple(int(t) for t in ids_list[:cp]))
+
+
+def _store_row(
+    apc_manager, ids_list, prompt_cache, row_idx, extra_hash, boundaries=None, seen=None
+) -> bool:
+    """Store one row of a (batched or single) prompt cache: the full length,
+    a guard-checkpoint at L-guard, and any pinned boundary checkpoints (e.g. the
+    static system+tools boundary). Each checkpoint is a clone trimmed to that
+    length. ``seen`` dedups identical checkpoints across rows in one store_batch
+    (rows sharing a system prefix produce an identical boundary checkpoint —
+    storing it once avoids double-counting disk bytes; Codex #5). A key is marked
+    seen ONLY after a successful store, so a row that skips a checkpoint (e.g. a
+    wrapped rotating cache) does not suppress a later row that could store it.
+
+    Checkpoints are stored FIRST and the full-length entry LAST (review #1):
+    the manager's in-memory LRU holds APC_EXACT_CACHE_ENTRIES=2 and evicts
+    oldest-inserted, so full-then-checkpoints made a row evict its OWN full
+    entry — the one a growing conversation needs next turn."""
+    n = len(ids_list)
+    # Store-size floor (review #2, rationale at STORE_MIN_TOKENS): tiny entries
+    # churn the 2-entry LRU for sub-second prefill savings.
+    if n < STORE_MIN_TOKENS:
+        return False
+    # Batch merge/extract are keep-blind (review #4): sink caches must never
+    # enter the exact store, or a warm restore through BatchRotatingKVCache
+    # would silently corrupt them.
+    if not _snapshot_reuse_safe(prompt_cache):
+        return False
+    # Collect checkpoint lengths: guard + pinned boundaries, deduped, valid.
+    cps = set()
+    guard = int(getattr(apc_manager, "exact_cache_guard_tokens", 0) or 0)
+    if guard > 0:
+        cps.add(n - guard)
+    for b in boundaries or []:
+        if b:
+            cps.add(int(b))
+    for cp in sorted(c for c in cps if 1 <= c < n):
+        k = _ckpt_key(ids_list, cp, extra_hash)
+        if seen is not None and k in seen:
+            continue
+        stored = _store_trimmed(
+            apc_manager, ids_list, prompt_cache, row_idx, extra_hash, cp, n
+        )
+        if stored and seen is not None:
+            seen.add(k)
+    ok = False
+    fk = _ckpt_key(ids_list, n, extra_hash)
+    if seen is None or fk not in seen:
+        snap_full = _apc.snapshot_prompt_cache_row(prompt_cache, row_idx)
+        if snap_full is not None:
+            # Snapshot is fresh and never reused by us -> manager may own it
+            # without recloning (review #5).
+            # Memory tier only. A full-length entry is hit exactly when this
+            # whole prompt is a literal prefix of a later, longer one -- i.e.
+            # the next turn of THIS conversation, in this process. It is never
+            # hit by a new session, whose prompt diverges before the end (a
+            # fresh question, and a fresh gateway control packet). Persisting
+            # it wrote ~870 MB per session that nothing could ever read, and
+            # that pressure evicts the static-prefix checkpoint, which every
+            # new session does hit. The checkpoint still goes to disk.
+            ok = apc_manager.store_exact_cache(
+                list(ids_list), snap_full, extra_hash=extra_hash, clone=False,
+                disk=False,
+            )
+            if ok and seen is not None:
+                seen.add(fk)
+    return ok
+
+
+def _store_trimmed(apc_manager, ids_list, prompt_cache, row_idx, extra_hash, cp, n) -> bool:
+    """Store a checkpoint at length ``cp`` (a snapshot trimmed by n-cp). Returns
+    True iff the checkpoint was actually stored (False if skipped due to a
+    wrapped rotating cache or an untrimmable cache). Trimming is exact for
+    KVCache/RotatingKVCache when the cache has not wrapped."""
+    snap = _apc.snapshot_prompt_cache_row(prompt_cache, row_idx)
+    if snap is None:
+        return False
+    trim_n = n - cp
+    if trim_n <= 0:
+        return False
+    # Correctness guard (Codex #2): a trimmed checkpoint at cp is only lossless
+    # if every sliding layer still physically holds the full window ending at cp.
+    # Once a RotatingKVCache has WRAPPED (offset > max_size at length n), a trim
+    # cannot recover the rotated-out tokens — it would silently store an
+    # incomplete window keyed as tokens[:cp] (e.g. a far-back system boundary in
+    # a 32K multi-turn prompt). Skip the checkpoint in that case; the full-length
+    # store (untrimmed, window-correct at n) still handles growing conversations.
+    # (Deliberately conservative: an oversized one-shot prefill that still
+    # retains all tokens is skipped too — a missed checkpoint, never a wrong one.)
+    for c in snap:
+        if c is None:
+            continue
+        max_size = getattr(c, "max_size", None)
+        if max_size is not None:
+            off = getattr(c, "offset", 0)
+            off = int(off) if not hasattr(off, "shape") else int(off.max())
+            if off > int(max_size):  # wrapped -> checkpoint would be corrupt
+                return False
+    for c in snap:
+        if c is None:
+            continue
+        trim = getattr(c, "trim", None)
+        if trim is None:
+            return False  # can't trim this cache type; skip the checkpoint
+        trim(trim_n)
+    # Return the manager's actual result: if the store is rejected (e.g. an
+    # unclonable cache, or APC disabled), the caller must NOT mark this key
+    # `seen`, or it would suppress a later identical row that could store it
+    # (Fable verify #5).
+    # Snapshot is fresh and never reused by us -> manager may own it without
+    # recloning (review #5).
+    return bool(
+        apc_manager.store_exact_cache(
+            list(ids_list[:cp]), snap, extra_hash=extra_hash, clone=False
+        )
+    )
+
+
+def lookup_batch(
+    apc_manager: Any,
+    language_model: Any,
+    model: Any,
+    processor: Any,
+    all_input_ids: Sequence[Sequence[int]],
+    prompt_kwargs_list: Sequence[Optional[dict]],
+) -> Optional[dict]:
+    """Per-row exact-prefix lookup, merged into a batched warm cache.
+
+    Returns {'warm_cache' (batched, per-row offset=prefix_len), 'prefix_lens',
+    'extra_hashes', 'right_pad', 'lengths', 'suffixes'} or None if no row hits.
+    Each hit row contributes its exact-prefix cache; miss rows get an empty
+    cache. make_warm_batch_exact_cache_multi aligns them into batch caches.
+    """
+    if apc_manager is None:
+        return None
+    # One mode/sink probe for the whole batch (Codex r1 #1) — the per-row
+    # lookup below skips it via _lookup_row.
+    if dflash_apc_mode(language_model) != "exact":
+        return None
+    B = len(all_input_ids)
+    picks = []
+    extra_hashes = []
+    for i in range(B):
+        pk = prompt_kwargs_list[i] if i < len(prompt_kwargs_list) else None
+        if not _text_only(pk):
+            picks.append(None)
+            extra_hashes.append(_stable_extra_hash(model, processor))
+            continue
+        plan = _lookup_row(apc_manager, model, processor, all_input_ids[i], pk)
+        picks.append(plan)
+        extra_hashes.append(
+            plan.get("extra_hash") if plan else _stable_extra_hash(model, processor)
+        )
+    prefix_lens = []
+    for i in range(B):
+        p = picks[i]
+        pl = int(p["prefix_len"]) if (p and p.get("warm_cache") is not None) else 0
+        if pl >= len(all_input_ids[i]):  # need >=1 suffix token
+            pl = 0
+            picks[i] = None
+        prefix_lens.append(pl)
+    if not any(pl > 0 for pl in prefix_lens):
+        return None
+    row_caches = [
+        picks[i]["warm_cache"] if (picks[i] and picks[i].get("warm_cache") is not None)
+        else language_model.make_cache()
+        for i in range(B)
+    ]
+    merged, _ = _apc.make_warm_batch_exact_cache_multi(row_caches, prefix_lens)
+    if merged is None:
+        return None
+    suffixes = [list(all_input_ids[i][prefix_lens[i]:]) for i in range(B)]
+    lengths = [len(s) for s in suffixes]
+    max_suf = max(lengths)
+    right_pad = [max_suf - l for l in lengths]
+    return {
+        "warm_cache": merged,
+        "prefix_lens": prefix_lens,
+        "extra_hashes": extra_hashes,
+        "right_pad": right_pad,
+        "lengths": lengths,
+        "suffixes": suffixes,
+    }
+
+
+def store_batch(
+    apc_manager: Any,
+    model: Any,
+    processor: Any,
+    all_input_ids: Sequence[Sequence[int]],
+    prompt_cache: Sequence[Any],
+    extra_hashes: Sequence[Optional[int]],
+    prompt_kwargs_list: Optional[Sequence[Optional[dict]]] = None,
+) -> None:
+    """Store each row of the post-prefill batched cache for future reuse.
+
+    Skips non-text-only rows (image/audio/video): the extra_hash intentionally
+    ignores media, so storing a media-bearing prompt under a text key would let a
+    later text request with matching token ids reuse media-derived KV (Codex #1).
+    Boundary checkpoints are pinned at static_prefix_boundary (end of the FIRST
+    rendered message, min STATIC_PREFIX_MIN_TOKENS) — not the first user-turn
+    marker, which sits after the context gateway's per-request control packet
+    and therefore never repeats (see static_prefix_boundary).
+    ``seen`` dedups identical checkpoints across rows (Codex #5)."""
+    if apc_manager is None:
+        return
+    seen: set = set()
+    for i in range(len(all_input_ids)):
+        try:
+            pk = (
+                prompt_kwargs_list[i]
+                if prompt_kwargs_list and i < len(prompt_kwargs_list)
+                else None
+            )
+            if not _text_only(pk):
+                continue  # never store media-bearing prompts under a text key
+            eh = (
+                extra_hashes[i]
+                if extra_hashes and i < len(extra_hashes) and extra_hashes[i] is not None
+                else _stable_extra_hash(model, processor)
+            )
+            boundary = static_prefix_boundary(processor, all_input_ids[i])
+            _store_row(
+                apc_manager, all_input_ids[i], prompt_cache, i, eh,
+                boundaries=[boundary] if boundary else None, seen=seen,
+            )
+        except Exception as e:
+            # Non-fatal: a failed store just means missed future reuse, never a
+            # failed request. But it must not be silent — a store regression
+            # (e.g. an unclonable cache) would otherwise be invisible in
+            # production (Fable F5). debug-level to avoid hot-path spam.
+            logger.debug("APC store_batch row %d failed: %s", i, e, exc_info=True)

--- a/mlx_vlm/speculative/dflash.py
+++ b/mlx_vlm/speculative/dflash.py
@@ -1,3 +1,4 @@
+import os
 from typing import Any, Callable, Generator, List, Optional, Tuple
 
 import mlx.core as mx
@@ -10,6 +11,15 @@ from .common import (
     _speculative_walk_batch,
     generation_stream,
 )
+
+
+def _env_flag(name: str, default: bool) -> bool:
+    """Call-time env flag with a default. Deliberately NOT hoisted to import
+    time so benches can toggle per-arm in-process (2026-08-11)."""
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    return raw.strip().lower() not in ("", "0", "false", "no", "off")
 
 
 def _dflash_next_block_size(
@@ -73,6 +83,103 @@ def _dflash_committed_hidden_segments(
         hidden_full[i : i + 1, : len(new_tokens), :]
         for i, new_tokens in enumerate(new_tokens_list)
     ]
+
+
+# --- Round-1 drafter-context assembly (2026-08-11) --------------------------
+#
+# RoPE-offset design (Fixes 1+2). The DFlash drafter is trained with ABSOLUTE
+# positions: HF's DFlashTokenCandidateGenerator sets noise_position_ids =
+# arange + last_ctx_pos + 1, and context keys carry their true sequence
+# positions. The z-lab MLX reference (model_mlx.py:85-91) keeps that invariant
+# when it drops context: it slices the round-1 context to the last
+# sliding_window-1 positions and bumps its drafter cache offset by the number
+# skipped, so kept keys still get absolute RoPE positions.
+#
+# We implement the same semantics, but the shift is carried as an additive
+# ``pos_shift`` attribute on each drafter layer cache (read by the DFlash
+# drafter attentions: rope offset = cache.offset + pos_shift) instead of
+# mutating cache.offset directly. Rationale: RotatingKVCache's ``offset``
+# doubles as storage bookkeeping — pre-seeding it while the buffer is not
+# exactly full corrupts _update_in_place (growth size ``max_size - offset``
+# can go negative, and the write index rewinds to ``offset``, past the buffer
+# end, leaving attended zero-KV garbage). The additive shift keeps every cache
+# code path byte-identical to the validated cold flow, and shifts compose: an
+# APC warm hit contributes cached_tokens, a round-1 truncation adds the
+# skipped count.
+
+
+def _drafter_pos_shift(cache_list, extra: int) -> None:
+    """Add ``extra`` to each drafter layer-cache's absolute-position shift."""
+    for c in cache_list:
+        c.pos_shift = int(getattr(c, "pos_shift", 0)) + int(extra)
+
+
+def _round1_window_limit(draft_model: nn.Module) -> Optional[int]:
+    """Max round-1 context positions = sliding_window - 1 (the drafter cache's
+    max_size), or None when the drafter has no window (nothing to enforce) or
+    MUSE_ROUND1_TRUNC=0 (call-time A/B kill switch restoring the old
+    full-length round-1 context)."""
+    if not _env_flag("MUSE_ROUND1_TRUNC", True):
+        return None
+    window = getattr(getattr(draft_model, "config", None), "sliding_window", None)
+    if not window or int(window) <= 1:
+        return None
+    return int(window) - 1
+
+
+def _apply_round1_window(
+    hidden: mx.array, cache_list, keep: int
+) -> mx.array:
+    """Enforce the drafter's training-time sliding window on the round-1
+    context: keep the LAST ``keep`` positions and bump ``pos_shift`` by the
+    number skipped so the kept keys' RoPE positions stay absolute. Off-window
+    context is off-training-distribution AND transiently stores a 5-layer x
+    prompt_len KV spike in the rotating cache's first _update_concat.
+    Continuation rounds carry accepted+1 positions (far below the window) and
+    are naturally unaffected."""
+    skipped = int(hidden.shape[1]) - int(keep)
+    if skipped <= 0:
+        return hidden
+    _drafter_pos_shift(cache_list, skipped)
+    return hidden[:, -int(keep):, :]
+
+
+def assemble_warm_drafter_context(
+    hidden_states: mx.array,
+    right_pad: List[int],
+    prefix_lens: List[int],
+):
+    """APC warm-hit drafter context (Fix 1, 2026-08-11).
+
+    After a warm hit only the suffix (prompt_len - cached) was prefilled, and
+    the forward captured aux hidden states for ALL suffix positions — but the
+    old code handed the drafter a single position, versus ~2047 in the z-lab/HF
+    reference flow (the top acceptance lever found by the reference audit).
+
+    Default (MUSE_WARMCTX unset/on): returns ``(rows, context_offsets)`` where
+    ``rows[i]`` is row i's FULL un-padded suffix hidden ``[1, S_i, D]`` (ragged
+    per-row is fine — drafting is row-wise in the batched loop) and
+    ``context_offsets[i] = prefix_lens[i]`` seeds the drafter cache's absolute
+    position shift, so suffix context keys get RoPE positions
+    cached..cached+S_i-1 exactly as the cold path gives 0..P-1.
+
+    MUSE_WARMCTX=0 (call-time read, per-request A/B): the exact old behavior —
+    one hidden position per row (each row's last real position) and no offsets,
+    byte-identical to the pre-fix take_along_axis slice.
+    """
+    B = int(hidden_states.shape[0])
+    seq = int(hidden_states.shape[1])
+    if _env_flag("MUSE_WARMCTX", True):
+        rows = [
+            hidden_states[i : i + 1, : seq - int(right_pad[i]), :]
+            for i in range(B)
+        ]
+        return rows, [int(p) for p in prefix_lens]
+    li = mx.array([seq - 1 - int(rp) for rp in right_pad], dtype=mx.int32)
+    idx = mx.broadcast_to(
+        li[:, None, None], (B, 1, int(hidden_states.shape[-1]))
+    )
+    return mx.take_along_axis(hidden_states, idx, axis=1), None
 
 
 def _dflash_rounds(
@@ -196,6 +303,7 @@ def _dflash_rounds_batch(
     draft_block_size: Optional[int] = None,
     token_dtype: mx.Dtype = mx.int32,
     stop_check: Optional[Callable[[int, int], bool]] = None,
+    context_offsets: Optional[List[int]] = None,
 ) -> Generator[Tuple[List[Optional[int]], None], None, None]:
     """Batch DFlash speculative-decoding round loop (B > 1).
 
@@ -205,6 +313,14 @@ def _dflash_rounds_batch(
 
     ``stop_check(seq_idx, token_id) -> bool`` is an optional callback
     that returns True to stop a sequence (e.g. EOS detection).
+
+    ``hidden`` may be a single ``[B, S, D]`` array (cold path) or a per-row
+    ragged list of ``[1, S_i, D]`` arrays (APC warm hits with per-row suffix
+    lengths — drafting is row-wise, so raggedness is free here).
+
+    ``context_offsets[i]``: absolute position of row i's first context
+    position (cached_tokens on a warm hit); seeds that row's drafter-cache
+    RoPE position shift. None/0 == historical behavior.
 
     Yields ``(tokens_list, None)`` where ``tokens_list[i]`` is the
     token for sequence ``i`` (or ``None`` if that sequence has nothing
@@ -228,7 +344,24 @@ def _dflash_rounds_batch(
     emitted = [1] * B
     finished = [False] * B
     active_idx = list(range(B))  # maps active-slot → original-index
-    hidden_by_orig = [hidden[i : i + 1] for i in range(B)]
+    if isinstance(hidden, (list, tuple)):
+        hidden_by_orig = [hidden[i] for i in range(B)]
+    else:
+        hidden_by_orig = [hidden[i : i + 1] for i in range(B)]
+    if context_offsets:
+        for i in range(B):
+            off = int(context_offsets[i]) if i < len(context_offsets) else 0
+            if off > 0:
+                _drafter_pos_shift(draft_caches[i], off)
+    # Round-1 window truncation (see _apply_round1_window). Runs AFTER the
+    # warm-context offsets above so a warm suffix longer than the window
+    # composes: pos_shift = cached_tokens + skipped.
+    _keep = _round1_window_limit(draft_model)
+    if _keep is not None:
+        for i in range(B):
+            hidden_by_orig[i] = _apply_round1_window(
+                hidden_by_orig[i], draft_caches[i], _keep
+            )
 
     total_emitted = sum(emitted)
 

--- a/mlx_vlm/speculative/drafters/laguna_dflash/dflash.py
+++ b/mlx_vlm/speculative/drafters/laguna_dflash/dflash.py
@@ -89,9 +89,14 @@ def _normalize_dflash_qkv(projected, q_norm, k_norm):
 
 def _apply_dflash_attention(attention, x, projected, rope, cache):
     queries, context_keys, proposal_keys, context_values, proposal_values = projected
-    queries = rope(queries, offset=cache.offset + context_keys.shape[2])
-    context_keys = rope(context_keys, offset=cache.offset)
-    proposal_keys = rope(proposal_keys, offset=cache.offset + context_keys.shape[2])
+    # Additive absolute-position shift (APC warm hits / round-1 window
+    # truncation), set by speculative/dflash.py's _drafter_pos_shift; see the
+    # rationale comment in speculative/drafters/qwen3_dflash/dflash.py.
+    # Default 0 == old behavior.
+    offset = cache.offset + int(getattr(cache, "pos_shift", 0))
+    queries = rope(queries, offset=offset + context_keys.shape[2])
+    context_keys = rope(context_keys, offset=offset)
+    proposal_keys = rope(proposal_keys, offset=offset + context_keys.shape[2])
     cached_keys, cached_values = cache.update_and_fetch(context_keys, context_values)
     keys = mx.concatenate([cached_keys, proposal_keys], axis=2)
     values = mx.concatenate([cached_values, proposal_values], axis=2)

--- a/mlx_vlm/speculative/drafters/muse_glimmer_assistant/dflash.py
+++ b/mlx_vlm/speculative/drafters/muse_glimmer_assistant/dflash.py
@@ -80,7 +80,13 @@ class MuseGlimmerAssistantAttention(nn.Module):
             context_length = context_hidden_states.shape[1]
             cache.offset += skip
 
-        cache_offset = cache.offset
+        # Additive absolute-position shift (APC warm hits / round-1 window
+        # truncation), set by speculative/dflash.py's _drafter_pos_shift; see
+        # the rationale comment in speculative/drafters/qwen3_dflash/dflash.py.
+        # Only RoPE consumes the shift: the bidirectional sliding mask below
+        # compares position differences, which the shift leaves unchanged.
+        # Default 0 == old behavior.
+        cache_offset = cache.offset + int(getattr(cache, "pos_shift", 0))
         queries = self.q_proj(hidden_states)
         kv_hidden_states = mx.concatenate(
             [context_hidden_states, hidden_states], axis=1

--- a/mlx_vlm/speculative/drafters/qwen3_dflash/dflash.py
+++ b/mlx_vlm/speculative/drafters/qwen3_dflash/dflash.py
@@ -73,9 +73,20 @@ class DFlashAttention(nn.Module):
         prop_values = prop_values.reshape(B, L, self.n_kv_heads, -1).transpose(
             0, 2, 1, 3
         )
-        queries = rope(queries, offset=cache.offset + S)
-        ctx_keys = rope(ctx_keys, offset=cache.offset)
-        prop_keys = rope(prop_keys, offset=cache.offset + S)
+        # Absolute-position RoPE: ``pos_shift`` counts positions that exist in
+        # the absolute sequence but were never stored in this cache (APC warm
+        # hit: the suffix starts at cached_tokens; round-1 window truncation:
+        # the kept context starts at the number skipped). It is an additive
+        # attribute set by speculative/dflash.py's _drafter_pos_shift rather
+        # than a pre-seeded cache.offset because RotatingKVCache's offset
+        # doubles as storage bookkeeping — seeding it while the buffer is not
+        # exactly full corrupts _update_in_place (the in-place trim above is
+        # safe only because it fills the buffer to max_size on the same call).
+        # Default 0 == old behavior.
+        offset = cache.offset + int(getattr(cache, "pos_shift", 0))
+        queries = rope(queries, offset=offset + S)
+        ctx_keys = rope(ctx_keys, offset=offset)
+        prop_keys = rope(prop_keys, offset=offset + S)
         keys, values = cache.update_and_fetch(ctx_keys, ctx_values)
         keys = mx.concatenate([keys, prop_keys], axis=2)
         values = mx.concatenate([values, prop_values], axis=2)

--- a/mlx_vlm/speculative/utils.py
+++ b/mlx_vlm/speculative/utils.py
@@ -137,6 +137,7 @@ def run_speculative_server_rounds(
     eos_token_ids: Optional[set] = None,
     prompt_tokens: Optional[mx.array] = None,
     row_ids: Optional[List[int]] = None,
+    context_offsets: Optional[List[int]] = None,
 ) -> Generator[Tuple[List[Optional[int]], None], None, None]:
     batch_size = int(first_bonus.shape[0]) if first_bonus.ndim > 0 else 1
 
@@ -197,7 +198,11 @@ def run_speculative_server_rounds(
         return
 
     if draft_kind == "dflash":
-        if batch_size == 1:
+        # An APC warm hit hands over ragged per-row hidden plus
+        # context_offsets, which only the batch loop consumes (pos_shift
+        # seeding + per-row suffix context), so a warm B==1 keeps the
+        # batched flow; the singleton fast path stays for cold requests.
+        if batch_size == 1 and not context_offsets:
             for tok, state in _dflash_rounds(
                 model,
                 draft_model,
@@ -225,6 +230,7 @@ def run_speculative_server_rounds(
             draft_block_size=draft_block_size,
             token_dtype=token_dtype,
             stop_check=stop_check,
+            context_offsets=context_offsets,
         )
         return
 

--- a/mlx_vlm/tests/test_apc_dflash_exact.py
+++ b/mlx_vlm/tests/test_apc_dflash_exact.py
@@ -1,0 +1,613 @@
+"""Regression tests for exact-mode APC reuse on the DFlash speculative path.
+
+Covered behavior (all pure cache math, no model load, no downloads):
+  * store order            -- _store_row stores checkpoints FIRST and the
+                              full-length entry LAST, so a row does not evict
+                              its OWN full entry out of the 2-entry LRU.
+  * store floor            -- _store_row refuses rows below STORE_MIN_TOKENS
+                              (APC_DFLASH_STORE_MIN_TOKENS, read at import).
+  * rotating-window snapshot compaction
+                           -- RotatingKVCacheCloneAdapter.clone keeps only the
+                              last max_size positions of a one-shot retained-all
+                              buffer (O(window) not O(prompt) per entry), and a
+                              warm merge/decode round-trip through the compacted
+                              snapshot matches the cold window exactly.
+  * keep>0 guard           -- attention-sink caches (keep > 0) are refused at
+                              store (_snapshot_reuse_safe), refused at mode
+                              probe (dflash_apc_mode), and never compacted.
+  * identical re-store dedup
+                           -- store_exact_cache skips the multi-GB reclone on a
+                              byte-identical re-store, counts it in
+                              stats.exact_store_dedups, keeps the entry object.
+  * clone=False ownership  -- store_exact_cache(clone=False) takes the caller's
+                              snapshot as-is (identity), while lookup still
+                              hands out clones.
+  * static-prefix boundary -- store_batch pins a checkpoint at
+                              static_prefix_boundary (second harmony <|start|>
+                              header, min STATIC_PREFIX_MIN_TOKENS) through the
+                              same _store_row path as guard + full entries.
+  * composite/sink probes  -- compacted-entry re-clone round-trip, in-place
+                              decode continuation on a restored compacted
+                              cache, store_prefix_checkpoint success path,
+                              cross-row `seen` dedup in store_batch, and the
+                              dflash_apc_mode gates (single make_cache build).
+
+Like test_apc.py this exercises APC mechanics with synthetic arrays; the
+tokenizer is a tiny fake that renders the harmony "<|start|>" header as one id.
+"""
+
+from __future__ import annotations
+
+import importlib
+import os
+
+# The store floor is read once when apc_dflash is imported. Set the knob first;
+# if another test module in this session already imported apc_dflash with a
+# different floor, reload it so the override takes.
+os.environ["APC_DFLASH_STORE_MIN_TOKENS"] = "32"
+# Deliberately NOT setting APC_EXACT_CACHE_ENTRIES here: the LRU-order test
+# needs the default cap of 2. One boundary test widens it for a single manager.
+
+import mlx.core as mx
+
+from mlx_vlm.apc import APCManager, snapshot_prompt_cache_row
+from mlx_vlm.models.cache import (
+    BatchKVCache,
+    BatchRotatingKVCache,
+    CacheList,
+    KVCache,
+    RotatingKVCache,
+)
+from mlx_vlm.speculative import apc_dflash
+
+if apc_dflash.STORE_MIN_TOKENS != 32:
+    apc_dflash = importlib.reload(apc_dflash)
+
+
+# ============================================================================
+# Helpers
+# ============================================================================
+
+
+def kv(pos, n):
+    """Deterministic K/V of shape (1, 2, n, 4): slot t encodes position pos+t."""
+    base = mx.arange(pos, pos + n, dtype=mx.float32).reshape(1, 1, n, 1)
+    k = mx.contiguous(mx.broadcast_to(base, (1, 2, n, 4)))
+    v = mx.contiguous(mx.broadcast_to(base + 0.5, (1, 2, n, 4)))
+    return k, v
+
+
+def one_shot_kvcache(n):
+    c = KVCache()
+    c.update_and_fetch(*kv(0, n))
+    return c
+
+
+def one_shot_rot(n, max_size, keep=0):
+    c = RotatingKVCache(max_size=max_size, keep=keep)
+    c.update_and_fetch(*kv(0, n))
+    return c
+
+
+def aeq(a, b):
+    return bool(mx.array_equal(a, b))
+
+
+def new_manager():
+    return APCManager(num_blocks=4, block_size=16)
+
+
+class FakeHarmonyTok:
+    """encode('<|start|>') -> [7], so static_prefix_boundary looks for id 7."""
+
+    bos_token_id = None
+
+    def encode(self, s, **kw):
+        if s == "<|start|>":
+            return [7]
+        return [1, 2, 3]
+
+
+# ============================================================================
+# 1. store order / full-entry survival
+# ============================================================================
+# With full-then-checkpoints store order the guard checkpoint would evict the
+# row's OWN full entry out of the 2-entry LRU -- the one a growing
+# conversation needs next turn. Checkpoints first, full last.
+
+
+def test_store_order_full_entry_survives():
+    mgr = new_manager()
+    assert mgr._exact_cache_max == 2, "default LRU cap is 2"
+    ids = list(range(200))
+    c = one_shot_kvcache(200)
+    ok = apc_dflash._store_row(mgr, ids, [c], 0, 7, boundaries=None, seen=set())
+    assert ok is True, "_store_row returns True"
+    hit, plen = mgr.lookup_exact_cache(ids + [9999], extra_hash=7)
+    assert hit is not None, "full entry survived the LRU (hit)"
+    assert plen == 200, "full entry prefix_len == 200"
+    hit2, plen2 = mgr.lookup_exact_cache(ids, extra_hash=7)
+    assert (hit2 is not None, plen2) == (True, 184), "guard checkpoint hit at 200-16"
+
+
+# ============================================================================
+# 2. store floor
+# ============================================================================
+
+
+def test_store_floor():
+    assert apc_dflash.STORE_MIN_TOKENS == 32, "STORE_MIN_TOKENS env override took"
+    mgr = new_manager()
+    ids = list(range(20))  # < 32 floor
+    c = one_shot_kvcache(20)
+    ok = apc_dflash._store_row(mgr, ids, [c], 0, 7, boundaries=None, seen=set())
+    assert ok is False, "sub-floor _store_row refused"
+    hit, plen = mgr.lookup_exact_cache(ids + [1], extra_hash=7)
+    assert (hit, plen) == (None, 0), "sub-floor lookup misses"
+
+
+# ============================================================================
+# 3. rotating snapshot compaction
+# ============================================================================
+# A one-shot prefill leaves a RotatingKVCache retaining ALL tokens; the
+# snapshot must keep only the last max_size positions (keep == 0 only).
+
+
+def test_snapshot_compaction():
+    c = one_shot_rot(512, 64)
+    snap = snapshot_prompt_cache_row([c], 0)
+    e = snap[0]
+    assert int(e.keys.shape[2]) == 64, "compacted slot count == window (64)"
+    assert int(e.offset) == 512, "compacted offset keeps logical length (512)"
+    assert int(e._idx) == 64, "compacted _idx == window (64)"
+    lk, lv = kv(511, 1)
+    assert aeq(e.keys[..., -1:, :], lk) and aeq(
+        e.values[..., -1:, :], lv
+    ), "last slot holds position 511"
+    assert int(c.keys.shape[2]) == 512, "source cache untouched (512 slots)"
+
+    c40 = one_shot_rot(40, 64)
+    s40 = snapshot_prompt_cache_row([c40], 0)
+    assert int(s40[0].keys.shape[2]) == 40, "no compaction below window (40 slots)"
+
+    ck = one_shot_rot(512, 64, keep=4)
+    sk = snapshot_prompt_cache_row([ck], 0)
+    assert int(sk[0].keys.shape[2]) == 512, "keep>0 snapshot NOT compacted (512 slots)"
+
+
+# ============================================================================
+# 4. warm round-trip equivalence (compaction active)
+# ============================================================================
+# Cold: one-shot 320 tokens. Warm: one-shot 300 -> compacted snapshot ->
+# batch merge -> prefill the 20-token suffix -> extract. Windows must match.
+
+
+def test_warm_round_trip():
+    W, cp_len, suf, total = 64, 300, 20, 320
+
+    cold = one_shot_rot(total, W)
+    cold_k = cold._temporal_order(cold.keys)[..., -W:, :]
+    cold_v = cold._temporal_order(cold.values)[..., -W:, :]
+
+    warm_src = one_shot_rot(cp_len, W)
+    snap = snapshot_prompt_cache_row([warm_src], 0)
+    assert int(snap[0].keys.shape[2]) == W, "snapshot compacted to window"
+    assert int(snap[0].offset) == cp_len, "snapshot logical offset == 300"
+
+    batch = BatchRotatingKVCache.merge(snap)
+    batch.prepare(right_padding=[0], lengths=[suf])
+    batch.update_and_fetch(*kv(cp_len, suf))  # suffix positions 300..319
+    batch.finalize()
+    out = batch.extract(0)
+
+    assert int(out.offset) == total, "warm extract offset == 320"
+    assert aeq(out.keys[..., -W:, :], cold_k), "warm last-64 keys == cold window"
+    assert aeq(out.values[..., -W:, :], cold_v), "warm last-64 values == cold window"
+
+
+# ============================================================================
+# 5. keep>0 store guard
+# ============================================================================
+
+
+def test_keep_store_guard():
+    mgr = new_manager()
+    ids = list(range(200))
+    ck = one_shot_rot(200, 64, keep=4)
+    ok = apc_dflash._store_row(mgr, ids, [ck], 0, 7, boundaries=None, seen=set())
+    assert ok is False, "keep=4 _store_row refused"
+    hit, plen = mgr.lookup_exact_cache(ids + [1], extra_hash=7)
+    assert (hit, plen) == (None, 0), "keep=4 lookup misses"
+    assert (
+        apc_dflash._snapshot_reuse_safe([RotatingKVCache(max_size=64, keep=4)])
+        is False
+    ), "keep=4 unsafe"
+    assert (
+        apc_dflash._snapshot_reuse_safe([RotatingKVCache(max_size=64, keep=0)])
+        is True
+    ), "keep=0 safe"
+    assert apc_dflash._snapshot_reuse_safe([KVCache()]) is True, "KVCache safe"
+    assert apc_dflash._snapshot_reuse_safe([None]) is True, "None entry safe"
+
+
+# ============================================================================
+# 6. keep>0 lookup gate
+# ============================================================================
+
+
+def test_keep_lookup_gate():
+    class SinkLM:
+        def make_cache(self):
+            return [RotatingKVCache(max_size=64, keep=4)]
+
+    class PlainLM:
+        def make_cache(self):
+            return [RotatingKVCache(max_size=64, keep=0)]
+
+    assert (
+        apc_dflash.dflash_apc_mode(SinkLM()) is None
+    ), "dflash_apc_mode refuses keep=4 model"
+    assert (
+        apc_dflash.dflash_apc_mode(PlainLM()) == "exact"
+    ), "dflash_apc_mode allows keep=0 model"
+
+
+# ============================================================================
+# 7. identical re-store dedup
+# ============================================================================
+
+
+def test_restore_dedup():
+    mgr = new_manager()
+    ids = list(range(200))
+    c = one_shot_kvcache(200)
+    ok1 = mgr.store_exact_cache(ids, [c], extra_hash=5)  # clone defaults True
+    assert ok1 is True, "first store ok"
+    entry = next(e for e in mgr._exact_cache.values() if e.extra_hash == 5)
+    pc_before = entry.prompt_cache
+    ok2 = mgr.store_exact_cache(ids, [c], extra_hash=5)
+    assert ok2 is True, "identical re-store returns True"
+    assert mgr.stats.exact_store_dedups == 1, "exact_store_dedups == 1"
+    entry_after = next(e for e in mgr._exact_cache.values() if e.extra_hash == 5)
+    assert entry_after.prompt_cache is pc_before, "entry prompt_cache identity kept"
+    ok3 = mgr.store_exact_cache(ids, [c], extra_hash=6)
+    assert ok3 is True, "different extra_hash stores (True)"
+    assert mgr.stats.exact_store_dedups == 1, "different extra_hash did NOT dedup"
+    stats = mgr.stats.snapshot(mgr.num_blocks, mgr.block_size)
+    assert "exact_store_dedups" in stats, "exact_store_dedups in stats snapshot"
+
+
+# ============================================================================
+# 8. clone=False ownership
+# ============================================================================
+
+
+def test_clone_false_ownership():
+    mgr = new_manager()
+    ids = list(range(200))
+    c = one_shot_kvcache(200)
+    snap = snapshot_prompt_cache_row([c], 0)
+    ok = mgr.store_exact_cache(ids, snap, extra_hash=3, clone=False)
+    assert ok is True, "clone=False store ok"
+    entry = next(e for e in mgr._exact_cache.values() if e.extra_hash == 3)
+    assert entry.prompt_cache[0] is snap[0], "stored entry owns snap[0] (identity)"
+    hit, plen = mgr.lookup_exact_cache(ids + [1], extra_hash=3)
+    assert plen == 200, "lookup hits at 200"
+    assert hit is not None, "lookup returned a cache"
+    assert hit[0] is not snap[0], "lookup hands out a clone (not snap[0])"
+    assert aeq(hit[0].keys[..., :200, :], snap[0].keys[..., :200, :]) and aeq(
+        hit[0].values[..., :200, :], snap[0].values[..., :200, :]
+    ), "clone content equals stored snapshot"
+
+
+# ============================================================================
+# 9. static-prefix boundary unification in store_batch
+# ============================================================================
+# store_batch pins a checkpoint at the SECOND harmony <|start|> header id when
+# it sits at >= STATIC_PREFIX_MIN_TOKENS (2048, frozen at def time).
+
+
+def test_store_batch_boundary_positive():
+    fake = FakeHarmonyTok()
+
+    # Stores land as boundary(2050), guard(2084), full(2100); the default
+    # 2-entry LRU would evict the boundary, so this ONE manager is built with
+    # APC_EXACT_CACHE_ENTRIES=4 (read in APCManager.__init__).
+    ids = [7] + [1] * 2049 + [7] + [2] * 49  # len 2100, second 7 at index 2050
+    assert (len(ids), ids[2050]) == (2100, 7), "positive ids shape sane"
+    assert (
+        apc_dflash.static_prefix_boundary(fake, ids) == 2050
+    ), "static_prefix_boundary finds index 2050"
+    os.environ["APC_EXACT_CACHE_ENTRIES"] = "4"
+    try:
+        mgr = APCManager(num_blocks=4, block_size=16)
+    finally:
+        del os.environ["APC_EXACT_CACHE_ENTRIES"]
+    assert mgr._exact_cache_max == 4, "widened LRU cap took"
+    c = one_shot_kvcache(2100)
+    apc_dflash.store_batch(
+        mgr,
+        model=None,
+        processor=fake,
+        all_input_ids=[ids],
+        prompt_cache=[c],
+        extra_hashes=[11],
+    )
+    hit, plen = mgr.lookup_exact_cache(ids[:2050] + [8888], extra_hash=11)
+    assert (hit is not None, plen) == (True, 2050), "boundary checkpoint hit at 2050"
+    hit, plen = mgr.lookup_exact_cache(ids + [8888], extra_hash=11)
+    assert plen == 2100, "full entry also present (2100)"
+    hit, plen = mgr.lookup_exact_cache(ids, extra_hash=11)
+    assert plen == 2084, "guard checkpoint also present (2084)"
+
+
+def test_store_batch_boundary_negative():
+    fake = FakeHarmonyTok()
+    # Second header below the 2048 minimum -> no boundary checkpoint.
+    mgr_n = new_manager()  # default cap 2 is fine: only guard + full stored
+    ids_n = [7] + [1] * 99 + [7] + [2] * 99  # len 200, second 7 at index 100
+    assert (len(ids_n), ids_n[100]) == (200, 7), "negative ids shape sane"
+    assert (
+        apc_dflash.static_prefix_boundary(fake, ids_n) is None
+    ), "static_prefix_boundary rejects sub-min index"
+    c_n = one_shot_kvcache(200)
+    apc_dflash.store_batch(
+        mgr_n,
+        model=None,
+        processor=fake,
+        all_input_ids=[ids_n],
+        prompt_cache=[c_n],
+        extra_hashes=[12],
+    )
+    hit, plen = mgr_n.lookup_exact_cache(ids_n[:100] + [8888], extra_hash=12)
+    assert (hit, plen) == (None, 0), "no checkpoint at sub-min boundary"
+    hit, plen = mgr_n.lookup_exact_cache(ids_n, extra_hash=12)
+    assert plen == 184, "negative row still stored guard (184)"
+
+
+# ============================================================================
+# 10. trimmed-checkpoint exactness
+# ============================================================================
+# _store_trimmed on an unwrapped RotatingKVCache must store exactly
+# tokens[:cp]. (STORE_MIN_TOKENS does not apply to _store_trimmed.)
+
+
+def test_trimmed_exactness():
+    mgr = new_manager()
+    ids = list(range(40))
+    c = one_shot_rot(40, 64)  # unwrapped: offset 40 <= max_size 64
+    ok = apc_dflash._store_trimmed(mgr, ids, [c], 0, 3, 30, 40)
+    assert ok is True, "_store_trimmed returns True"
+    hit, plen = mgr.lookup_exact_cache(ids, extra_hash=3)
+    assert (hit is not None, plen) == (True, 30), "lookup hits at cp=30"
+    row = BatchRotatingKVCache.merge(hit).extract(0)
+    ek, ev = kv(0, 30)
+    assert aeq(row.keys, ek), "restored keys == positions 0..29"
+    assert aeq(row.values, ev), "restored values == positions 0..29"
+    assert int(row.offset) == 30, "restored offset == 30"
+
+
+# ============================================================================
+# 11. second-clone path round-trip
+# ============================================================================
+# lookup_exact_cache clones the stored entry through
+# RotatingKVCacheCloneAdapter AGAIN. On an already-compacted entry (offset 512
+# != _idx 64) the compaction branch must NOT re-fire -- it requires offset ==
+# _idx -- so the clone is a verbatim fresh copy that still merges/extracts to
+# the correct window.
+
+
+def test_second_clone_round_trip():
+    mgr = new_manager()
+    ids = list(range(512))
+    c = one_shot_rot(512, 64)
+    snap = snapshot_prompt_cache_row([c], 0)  # compacted: 64 slots, offset 512
+    ok = mgr.store_exact_cache(ids, snap, extra_hash=21, clone=False)
+    assert ok is True, "compacted store ok"
+    hit, hlen = mgr.lookup_exact_cache(ids + [9999], extra_hash=21)
+    assert (hit is not None, hlen) == (True, 512), "lookup hits at 512"
+    assert int(hit[0].keys.shape[2]) == 64, "re-clone keeps window slots (64)"
+    assert int(hit[0].offset) == 512, "re-clone keeps logical offset (512)"
+    assert int(hit[0]._idx) == 64, "re-clone keeps _idx (64)"
+    assert hit[0].keys is not snap[0].keys, "re-clone is a fresh copy"
+    row = BatchRotatingKVCache.merge(hit).extract(0)
+    ek, ev = kv(448, 64)
+    assert aeq(row.keys, ek), "merged extract keys == positions 448..511"
+    assert aeq(row.values, ev), "merged extract values == positions 448..511"
+
+
+# ============================================================================
+# 12. in-place decode continuation on a restored compacted cache
+# ============================================================================
+# Warm: the lookup clone of a compacted 512-token snapshot (64 slots, offset
+# 512). Cold: a live one-shot 512-token cache (512 retained slots). One S=1
+# decode step at position 512 must converge them bit-identically: the cold
+# path trims its buffer to the 64-token window and rotates; the warm cache
+# starts at exactly that window.
+
+
+def test_decode_continuation():
+    mgr = new_manager()
+    ids = list(range(512))
+    src = one_shot_rot(512, 64)
+    snap = snapshot_prompt_cache_row([src], 0)
+    mgr.store_exact_cache(ids, snap, extra_hash=22, clone=False)
+    hit, hlen = mgr.lookup_exact_cache(ids + [9999], extra_hash=22)
+    assert (hit is not None, hlen) == (True, 512), "warm lookup hits at 512"
+    warm = hit[0]
+    cold = one_shot_rot(512, 64)  # live cache, NOT compacted (512 slots)
+    assert int(cold.keys.shape[2]) == 512, "cold retains all slots pre-decode"
+    dk, dv = kv(512, 1)  # single decode token at position 512, shape (1,2,1,4)
+    warm.update_and_fetch(dk, dv)
+    cold.update_and_fetch(dk, dv)
+    assert aeq(warm.keys, cold.keys), "warm keys == cold keys after step"
+    assert aeq(warm.values, cold.values), "warm values == cold values after step"
+    assert (int(warm.offset), int(cold.offset)) == (513, 513), "offsets converge"
+    assert int(warm._idx) == int(cold._idx), "_idx converges"
+
+
+# ============================================================================
+# 13. mid-prefill checkpoint success path
+# ============================================================================
+# store_prefix_checkpoint stores the cache state captured DURING prefill at
+# cp, keyed as ids[:cp] -- no trim, so the _store_trimmed wrap guard does not
+# apply.
+
+
+def test_prefix_checkpoint_success():
+    mgr = new_manager()
+    ids = list(range(60))  # FULL prompt is longer than cp
+    c = one_shot_rot(40, 64)  # cache state mid-prefill at cp=40
+    fake = FakeHarmonyTok()
+    ok = apc_dflash.store_prefix_checkpoint(
+        mgr, None, fake, ids, [c], 40, extra_hash=23
+    )
+    assert ok is True, "store_prefix_checkpoint returns True"
+    hit, plen = mgr.lookup_exact_cache(ids, extra_hash=23)
+    assert (hit is not None, plen) == (True, 40), "lookup hits at cp=40"
+    row = BatchRotatingKVCache.merge(hit).extract(0)
+    ek, ev = kv(0, 40)
+    assert aeq(row.keys, ek), "restored keys == positions 0..39"
+    assert aeq(row.values, ev), "restored values == positions 0..39"
+    assert int(row.offset) == 40, "restored offset == 40"
+
+
+# ============================================================================
+# 14. cross-row `seen` dedup in store_batch
+# ============================================================================
+# Two IDENTICAL rows in one batched cache: row 0 stores guard(184) +
+# full(200); row 1's identical stores are suppressed by the cross-row `seen`
+# set BEFORE reaching the manager, so exact_stores stays 2 and the
+# manager-level dedup counter never fires. (No boundary checkpoint: these ids
+# carry no second harmony start header at >= 2048; guard is the default 16.)
+
+
+def test_cross_row_seen_dedup():
+    mgr = new_manager()
+    fake = FakeHarmonyTok()
+    ids = list(range(1000, 1200))  # len 200, no header id 7 anywhere
+    k, v = kv(0, 200)
+    batch = BatchKVCache([0, 0])
+    batch.update_and_fetch(
+        mx.concatenate([k, k], axis=0), mx.concatenate([v, v], axis=0)
+    )  # two identical rows, shape (2, 2, 200, 4)
+    apc_dflash.store_batch(
+        mgr,
+        model=None,
+        processor=fake,
+        all_input_ids=[ids, ids],
+        prompt_cache=[batch],
+        extra_hashes=[27, 27],
+    )
+    assert mgr.stats.exact_stores == 2, "exact_stores == 2 (row 0 only)"
+    assert mgr.stats.exact_store_dedups == 0, "manager-level dedups == 0"
+    hit, plen = mgr.lookup_exact_cache(ids + [1], extra_hash=27)
+    assert (hit is not None, plen) == (True, 200), "full entry survived (200)"
+    hit, plen = mgr.lookup_exact_cache(ids, extra_hash=27)
+    assert (hit is not None, plen) == (True, 184), "guard checkpoint present (184)"
+
+
+# ============================================================================
+# 15. mode-classification gates (single make_cache build)
+# ============================================================================
+# dflash_apc_mode builds make_cache() ONCE and classifies block/exact itself.
+# All-block-eligible models, models without make_cache, and models whose
+# make_cache raises must all degrade to None (cold path); a mixed keep=0
+# Rotating+KVCache list is "exact".
+
+
+def test_mode_classification_gates():
+    class BlockLM:
+        def make_cache(self):
+            return [KVCache()]  # all block-eligible -> "block" -> refused here
+
+    class NoMakeCacheLM:
+        pass
+
+    class RaisingLM:
+        def make_cache(self):
+            raise RuntimeError("boom")
+
+    class MixedLM:
+        def make_cache(self):
+            return [RotatingKVCache(max_size=64, keep=0), KVCache()]
+
+    assert apc_dflash.dflash_apc_mode(BlockLM()) is None, "all-block model refused"
+    assert (
+        apc_dflash.dflash_apc_mode(NoMakeCacheLM()) is None
+    ), "missing make_cache refused"
+    assert (
+        apc_dflash.dflash_apc_mode(RaisingLM()) is None
+    ), "raising make_cache refused"
+    assert (
+        apc_dflash.dflash_apc_mode(MixedLM()) == "exact"
+    ), "mixed keep=0 Rotating+KVCache -> exact"
+
+
+# ============================================================================
+# 16. composite sink guard + single-probe accounting
+# ============================================================================
+# Exact eligibility recurses into CacheList/tuple composites, so the keep>0
+# sink guard must recurse too -- a composite hiding a RotatingKVCache(keep>0)
+# must be refused at lookup AND at store. The whole-batch gate probes
+# make_cache exactly once per lookup_batch call, and the mode probe runs
+# AFTER the cheap request-local guards in the public lookup().
+
+
+def test_composite_sink_and_probe_count():
+    class CompositeSinkLM:
+        def make_cache(self):
+            return [CacheList(RotatingKVCache(max_size=64, keep=4)), KVCache()]
+
+    class TupleSinkLM:
+        def make_cache(self):
+            return [(RotatingKVCache(max_size=64, keep=4), KVCache())]
+
+    class CompositeCleanLM:
+        def make_cache(self):
+            return [CacheList(RotatingKVCache(max_size=64, keep=0)), KVCache()]
+
+    assert (
+        apc_dflash.dflash_apc_mode(CompositeSinkLM()) is None
+    ), "CacheList-nested keep=4 refused"
+    assert (
+        apc_dflash.dflash_apc_mode(TupleSinkLM()) is None
+    ), "tuple-nested keep=4 refused"
+    assert (
+        apc_dflash.dflash_apc_mode(CompositeCleanLM()) == "exact"
+    ), "CacheList-nested keep=0 still exact"
+    assert (
+        apc_dflash._snapshot_reuse_safe(
+            [CacheList(RotatingKVCache(max_size=64, keep=4))]
+        )
+        is False
+    ), "nested sink unsafe"
+    assert (
+        apc_dflash._snapshot_reuse_safe(
+            [CacheList(RotatingKVCache(max_size=64, keep=0)), None]
+        )
+        is True
+    ), "nested keep=0 safe"
+
+    class CountingLM:
+        def __init__(self):
+            self.calls = 0
+
+        def make_cache(self):
+            self.calls += 1
+            return [RotatingKVCache(max_size=64, keep=0), KVCache()]
+
+    mgr = APCManager(num_blocks=4, block_size=16)
+    lm = CountingLM()
+    ids = list(range(200))
+    plan = apc_dflash.lookup_batch(
+        mgr, lm, None, FakeHarmonyTok(), [ids, ids, ids], [None, None, None]
+    )
+    assert plan is None, "empty-manager lookup_batch returns None"
+    assert lm.calls == 1, "make_cache probed once for the whole batch"
+
+    lm2 = CountingLM()
+    assert (
+        apc_dflash.lookup(None, lm2, None, FakeHarmonyTok(), ids, None) is None
+        and lm2.calls == 0
+    ), "lookup(None manager) short-circuits before mode probe"

--- a/mlx_vlm/tests/test_dflash_warm_context.py
+++ b/mlx_vlm/tests/test_dflash_warm_context.py
@@ -1,0 +1,235 @@
+"""Model-free tests for the DFlash warm-hit drafter-context fix.
+
+After an APC warm hit the drafter used to receive a SINGLE hidden-state
+position (each row's last real position). ``assemble_warm_drafter_context``
+now hands it each row's FULL un-padded suffix hidden states plus per-row
+absolute RoPE offsets (``context_offsets[i] = prefix_lens[i]``), and
+``_apply_round1_window`` enforces the drafter's training-time sliding window
+on the round-1 context while keeping RoPE positions absolute via the additive
+per-cache ``pos_shift``.
+
+Covered behavior (all pure array math, no model load, no downloads):
+  * default path        -- ragged rows returned un-padded with correct
+                           per-row lengths; context_offsets == prefix_lens.
+  * MUSE_WARMCTX=0      -- reproduces the pre-fix single-position
+                           take_along_axis slice byte-identically.
+  * _apply_round1_window -- keeps the LAST ``keep`` positions and bumps
+                           pos_shift by the number skipped; no-op (same
+                           object, no shift) when already within the window;
+                           composes additively with a warm-hit offset.
+  * _round1_window_limit -- window - 1; None for windowless configs; None
+                           under the MUSE_ROUND1_TRUNC=0 kill switch.
+  * _env_flag           -- call-time parse semantics backing both hatches.
+"""
+
+from __future__ import annotations
+
+import mlx.core as mx
+import pytest
+
+from mlx_vlm.speculative.dflash import (
+    _apply_round1_window,
+    _drafter_pos_shift,
+    _env_flag,
+    _round1_window_limit,
+    assemble_warm_drafter_context,
+)
+
+
+# ============================================================================
+# Helpers
+# ============================================================================
+
+
+def _hs(B, S, D):
+    """Hidden states with a distinct value at every (row, position, dim) so
+    any slicing/indexing mistake changes the result."""
+    return mx.arange(B * S * D, dtype=mx.float32).reshape(B, S, D)
+
+
+class _CacheStub:
+    """Drafter layer-cache stand-in for _drafter_pos_shift's contract: any
+    object accepting attribute assignment. ``pos_shift`` is deliberately NOT
+    pre-declared -- the real caches also grow it on first bump (getattr
+    default 0)."""
+
+
+class _DrafterStub:
+    def __init__(self, sliding_window=None):
+        class _Cfg:
+            pass
+
+        self.config = _Cfg()
+        self.config.sliding_window = sliding_window
+
+
+# ============================================================================
+# assemble_warm_drafter_context
+# ============================================================================
+
+
+def test_warm_context_default_returns_ragged_unpadded_rows():
+    B, S, D = 3, 7, 4
+    hs = _hs(B, S, D)
+    right_pad = [0, 3, 5]
+    prefix_lens = [1000, 250, 0]
+
+    rows, offsets = assemble_warm_drafter_context(hs, right_pad, prefix_lens)
+
+    assert offsets == prefix_lens
+    assert isinstance(rows, list) and len(rows) == B
+    for i in range(B):
+        expect = hs[i : i + 1, : S - right_pad[i], :]
+        assert rows[i].shape == (1, S - right_pad[i], D)
+        assert mx.array_equal(rows[i], expect).item()
+
+
+def test_warm_context_offsets_are_plain_ints():
+    hs = _hs(2, 4, 3)
+    _, offsets = assemble_warm_drafter_context(hs, [0, 1], [mx.array(17), 5])
+    assert offsets == [17, 5]
+    assert all(type(o) is int for o in offsets)
+
+
+def test_warm_context_kill_switch_matches_single_position_slice(monkeypatch):
+    monkeypatch.setenv("MUSE_WARMCTX", "0")
+    B, S, D = 3, 6, 5
+    hs = _hs(B, S, D)
+    right_pad = [0, 2, 4]  # non-uniform: per-row last real position differs
+    prefix_lens = [10, 20, 30]
+
+    hidden, offsets = assemble_warm_drafter_context(hs, right_pad, prefix_lens)
+
+    assert offsets is None
+    # The exact pre-fix computation from server/generation.py.
+    li = mx.array([S - 1 - rp for rp in right_pad], dtype=mx.int32)
+    idx = mx.broadcast_to(li[:, None, None], (B, 1, D))
+    expect = mx.take_along_axis(hs, idx, axis=1)
+    assert hidden.shape == (B, 1, D)
+    assert mx.array_equal(hidden, expect).item()
+
+
+# ============================================================================
+# _apply_round1_window / _drafter_pos_shift
+# ============================================================================
+
+
+def test_apply_round1_window_keeps_tail_and_bumps_pos_shift():
+    S, keep = 9, 4
+    hidden = _hs(1, S, 3)
+    caches = [_CacheStub(), _CacheStub()]
+
+    out = _apply_round1_window(hidden, caches, keep)
+
+    assert out.shape == (1, keep, 3)
+    assert mx.array_equal(out, hidden[:, -keep:, :]).item()
+    assert all(c.pos_shift == S - keep for c in caches)
+
+
+def test_apply_round1_window_noop_within_window():
+    hidden = _hs(1, 3, 2)
+    caches = [_CacheStub()]
+
+    out = _apply_round1_window(hidden, caches, 4)
+
+    assert out is hidden  # untouched, not a copy
+    assert getattr(caches[0], "pos_shift", 0) == 0
+
+
+def test_pos_shift_composes_warm_offset_then_truncation():
+    # A warm suffix longer than the window: the APC offset lands first, the
+    # round-1 truncation adds the skipped count on top (additive shifts).
+    caches = [_CacheStub()]
+    _drafter_pos_shift(caches, 100)  # APC warm hit: cached_tokens
+    hidden = _hs(1, 8, 2)
+    out = _apply_round1_window(hidden, caches, 5)  # skips 3
+    assert out.shape == (1, 5, 2)
+    assert caches[0].pos_shift == 103
+
+
+# ============================================================================
+# _round1_window_limit
+# ============================================================================
+
+
+def test_round1_window_limit_is_window_minus_one():
+    assert _round1_window_limit(_DrafterStub(2048)) == 2047
+
+
+def test_round1_window_limit_none_for_windowless_configs():
+    assert _round1_window_limit(_DrafterStub(None)) is None
+    assert _round1_window_limit(_DrafterStub(0)) is None
+    assert _round1_window_limit(_DrafterStub(1)) is None
+
+
+def test_round1_window_limit_kill_switch(monkeypatch):
+    monkeypatch.setenv("MUSE_ROUND1_TRUNC", "0")
+    assert _round1_window_limit(_DrafterStub(2048)) is None
+
+
+# ============================================================================
+# _env_flag (call-time hatch semantics)
+# ============================================================================
+
+
+@pytest.mark.parametrize("raw", ["0", "false", "no", "off", "", " OFF "])
+def test_env_flag_falsy_spellings(monkeypatch, raw):
+    monkeypatch.setenv("MUSE_TEST_FLAG", raw)
+    assert _env_flag("MUSE_TEST_FLAG", True) is False
+
+
+@pytest.mark.parametrize("raw", ["1", "true", "yes", "on"])
+def test_env_flag_truthy_spellings(monkeypatch, raw):
+    monkeypatch.setenv("MUSE_TEST_FLAG", raw)
+    assert _env_flag("MUSE_TEST_FLAG", False) is True
+
+
+def test_env_flag_unset_returns_default(monkeypatch):
+    monkeypatch.delenv("MUSE_TEST_FLAG", raising=False)
+    assert _env_flag("MUSE_TEST_FLAG", True) is True
+    assert _env_flag("MUSE_TEST_FLAG", False) is False
+
+
+# ============================================================================
+# Server-rounds dispatch (B==1)
+# ============================================================================
+
+
+def test_warm_hit_batch_size_one_dispatches_batch_rounds(monkeypatch):
+    """A B==1 APC warm hit (ragged hidden + context_offsets) must route
+    through _dflash_rounds_batch — the only loop that consumes the offsets
+    and per-row ragged hidden — while cold B==1 keeps the singleton fast
+    path (covered by test_speculative's dispatch test)."""
+    from types import SimpleNamespace
+
+    from mlx_vlm.speculative import utils as speculative_utils
+
+    calls = []
+
+    def fake_batch(*args, **kwargs):
+        calls.append((args, kwargs))
+        yield [3], None
+
+    def fake_single(*args, **kwargs):
+        raise AssertionError("warm B==1 must not take the singleton path")
+
+    monkeypatch.setattr(speculative_utils, "_dflash_rounds", fake_single)
+    monkeypatch.setattr(speculative_utils, "_dflash_rounds_batch", fake_batch)
+
+    result = list(
+        speculative_utils.run_speculative_server_rounds(
+            SimpleNamespace(language_model=SimpleNamespace()),
+            SimpleNamespace(),
+            prompt_cache=[],
+            hidden=[mx.zeros((1, 5, 1), dtype=mx.float32)],  # ragged, one row
+            draft_kind="dflash",
+            first_bonus=mx.array([2], dtype=mx.int32),
+            max_tokens=4,
+            sampler=lambda logprobs: mx.argmax(logprobs, axis=-1),
+            token_dtype=mx.int32,
+            context_offsets=[1000],
+        )
+    )
+
+    assert result == [([3], None)]
+    assert calls and calls[0][1]["context_offsets"] == [1000]


### PR DESCRIPTION
## Summary

**Stacked on #1856** (same branch lineage — the diff shows both until that merges; only the top commit `4881886` is this PR). Happy to fold it into #1856 instead if you'd rather review once.

#1856 ships the APC warm path handing the drafter a **single** hidden-state position after a warm hit (the per-row last-real-position gather — the simple correct-for-verification choice at ragged right-padding). That's a measured acceptance tax. This follow-up gives the drafter its real context back.

### The fix

- `assemble_warm_drafter_context` (speculative/dflash.py): after a warm hit, each row gets its **full un-padded suffix** hidden states (ragged per-row — drafting is row-wise in the batch loop), plus `context_offsets[i] = prefix_len[i]` seeding an absolute RoPE position shift so suffix keys sit at positions `cached..cached+S−1`, exactly where a cold prefill would put them.
- `_drafter_pos_shift` / `pos_shift`: an **additive attribute** on the drafter cache rather than a pre-seeded `cache.offset` — the rotating cache's offset doubles as storage bookkeeping, and pre-seeding it while the buffer isn't exactly full corrupts `_update_in_place`. The qwen3/laguna DFlash attentions now read `offset = cache.offset + pos_shift` (default 0 ⇒ byte-identical old behavior; gemma4 inherits qwen3's).
- `_apply_round1_window`: companion round-1 context truncation to the drafter's training window (window−1), applied **after** the warm offsets so a warm suffix longer than the window composes (`pos_shift = cached + skipped`). This also bounds the transient 5-layer × prompt-length KV spike the old full-length round-1 context stored on long prompts.

### Measured (30B sliding-window target, 17.3k-token prompt, greedy, same-question continuations, n=3/arm)

| drafter context on warm hit | accept |
|---|---:|
| full prompt (cold reference) | 4.41 |
| suffix + pos-shift (**this PR**) | **4.47** |
| single position (#1856 as filed) | 3.88 |

The −12% warm-hit acceptance dip is eliminated; warm hits now decode at reference acceptance. We also measured the obvious next step — persisting ~136 MB/entry of *prefix* hidden states so warm hits start with the full window — and it bought nothing over the suffix (+0.06, noise): drafter acceptance is driven by local context. So this small version is the complete fix, not a first installment.

### Notes for review

- `MUSE_WARMCTX=0` and `MUSE_ROUND1_TRUNC=0` are call-time A/B kill switches restoring the old behaviors (that's how the table above was produced).
- One behavior caveat, documented in-code: a hypothetical drafter config with `sliding_window` set but **mixed** sliding/full layer types would now have its full-attention layers' round-1 context trimmed too (the old in-attention trim was sliding-layers-only). No in-tree checkpoint has that shape; `MUSE_ROUND1_TRUNC=0` restores the old behavior.
- Cold-path RoPE equivalence with the previous in-attention trim (`cache.offset += skip`) is preserved: after the rounds-loop truncation, S arrives at ≤ window−1, the internal trim no-ops, and `pos_shift(skipped)` reproduces the exact offsets it used to produce. Covered by `mlx_vlm/tests/test_dflash_warm_context.py` (numeric equality of the `MUSE_WARMCTX=0` path against the old gather, tail-keep/pos-shift math, offset+truncation composition) plus the existing dflash/laguna/APC packs (92 + 12 + 16 + 38 green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
