### PR TITLE
fix: Idefics3/SmolVLM LoRA training - 4 bug fixes

### DIFF
--- a/mlx_vlm/models/base.py
+++ b/mlx_vlm/models/base.py
@@ -210,7 +210,7 @@ def create_attention_mask(
     h, cache=None, window_size: Optional[int] = None, return_array: bool = False
 ):
     N = h.shape[1]
-    if cache and hasattr(cache, "make_mask"):
+    if cache is not None and not isinstance(cache, mx.array) and hasattr(cache, "make_mask"):
         return cache.make_mask(N, return_array=return_array, window_size=window_size)
     if N == 1:
         return None
@@ -220,7 +220,7 @@ def create_attention_mask(
 
 
 def create_ssm_mask(h, cache=None):
-    if cache and hasattr(cache, "make_mask"):
+    if cache is not None and not isinstance(cache, mx.array) and hasattr(cache, "make_mask"):
         return cache.make_mask(h.shape[1])
     return None
 

--- a/mlx_vlm/models/idefics3/idefics3.py
+++ b/mlx_vlm/models/idefics3/idefics3.py
@@ -155,6 +155,7 @@ class Model(nn.Module):
 
             image_features = pooler_output.astype(pixel_values.dtype)
             image_features = self.connector(image_features)
+            image_features = image_features.reshape(-1, image_features.shape[-1])
 
         final_inputs_embeds = self._prepare_inputs_for_multimodal(
             image_features, inputs_embeds, input_ids

--- a/mlx_vlm/models/idefics3/language.py
+++ b/mlx_vlm/models/idefics3/language.py
@@ -50,7 +50,7 @@ class Attention(nn.Module):
         keys = keys.reshape(B, L, self.n_kv_heads, -1).transpose(0, 2, 1, 3)
         values = values.reshape(B, L, self.n_kv_heads, -1).transpose(0, 2, 1, 3)
 
-        if cache is not None:
+        if cache is not None and hasattr(cache, 'update_and_fetch'):
             queries = self.rope(queries, offset=cache.offset)
             keys = self.rope(keys, offset=cache.offset)
             keys, values = cache.update_and_fetch(keys, values)

--- a/mlx_vlm/trainer/sft_trainer.py
+++ b/mlx_vlm/trainer/sft_trainer.py
@@ -279,6 +279,23 @@ def iterate_batches(dataset, batch_size, max_seq_length, train=False):
                 pixel_values_batch = _collate_arrays(
                     [_squeeze_leading_batch_dim(item["pixel_values"]) for item in items]
                 )
+                # Fix: trim pixel_values when truncation removes image tokens.
+                # Count remaining image tokens in truncated input_ids and trim
+                # pixel_values to match (each sub-image = tokens_per_image features).
+                if pixel_values_batch is not None and hasattr(dataset, 'config'):
+                    config = dataset.config if hasattr(dataset, 'config') else {}
+                    image_token_id = config.get("image_token_id", 49153)
+                    for i in range(len(items)):
+                        n_image_tokens = int((input_ids_batch[i] == image_token_id).sum())
+                        pv = pixel_values_batch[i] if isinstance(pixel_values_batch, list) else None
+                        if pv is not None and hasattr(pv, 'shape'):
+                            n_sub_images = pv.shape[0] if len(pv.shape) >= 3 else 1
+                            tokens_per_image = 81  # Idefics3 perceiver resampler output
+                            expected_tokens = n_sub_images * tokens_per_image
+                            if n_image_tokens < expected_tokens and n_image_tokens > 0:
+                                keep_images = n_image_tokens // tokens_per_image
+                                if keep_images > 0 and keep_images < n_sub_images:
+                                    pixel_values_batch[i] = pv[:keep_images]
 
             batch = {
                 "input_ids": mx.array(input_ids_batch),


### PR DESCRIPTION
## Summary

Fixes all 3 bugs reported in #1830 plus an additional `create_attention_mask` crash, enabling LoRA fine-tuning of Idefics3/SmolVLM models via the trainer.

## Fixes

1. **`mlx_vlm/models/idefics3/idefics3.py`** — Reshape connector output from 3D `(n_sub_images, 81, hidden)` to 2D `(total_features, hidden)` after perceiver resampler
2. **`mlx_vlm/trainer/sft_trainer.py`** — Trim `pixel_values` when sequence truncation removes image tokens (maintains alignment)
3. **`mlx_vlm/models/idefics3/language.py`** — Guard cache access with `hasattr(cache, 'update_and_fetch')` for grad_checkpoint compatibility
4. **`mlx_vlm/models/base.py`** — Guard `create_attention_mask` against mlx array cache during grad_checkpoint backward pass

## Verification

All 24 decoder layers targeted (168 LoRA modules = 7 per layer × 24):

```
#trainable params: 9.043968 M || all params: 1812.051968 M || trainable%: 0.499%
LoRA modules: 168
Layers: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23]
```

## Benchmark

Apple M1 8GB, `SmolVLM-Instruct-4bit`, rank=8, batch=1, max_seq_length=2048, grad_checkpoint=True:

| Metric | Result |
|--------|--------|
| Throughput | 159 tok/sec |
| Peak memory | 2.99 GB |
| Trained tokens (10 iter) | 15,688 |
| Wall time (10 iter) | 101s |
| Decoder layers | 24/24 |
| LoRA modules | 168 |
| Training | Loss converges, adapters save |

## Reproduction

```python
import time
import mlx.core as mx
import mlx.optimizers as optim
from PIL import Image
import json
from huggingface_hub import hf_hub_download
from mlx_vlm import load
from mlx_vlm.trainer import train, TrainingArgs, VisionDataset
from mlx_vlm.trainer.utils import get_peft_model, find_all_linear_names

model, processor = load("mlx-community/SmolVLM-Instruct-4bit")
config_path = hf_hub_download("mlx-community/SmolVLM-Instruct-4bit", "config.json")
with open(config_path) as f:
    config = json.load(f)

model = get_peft_model(model, find_all_linear_names(model), rank=8)

img = Image.new("RGB", (384, 384), (128, 128, 128))
train_data = [
    {"messages": [{"role": "user", "content": "Describe this."},
                  {"role": "assistant", "content": "A gray image."}], "images": [img]},
    {"messages": [{"role": "user", "content": "What is this?"},
                  {"role": "assistant", "content": "Plain gray rectangle."}], "images": [img]},
    {"messages": [{"role": "user", "content": "Classify."},
                  {"role": "assistant", "content": "test image"}], "images": [img]},
]
dataset = VisionDataset(train_data, config, processor)

optimizer = optim.Adam(learning_rate=1e-5)
args = TrainingArgs(batch_size=1, iters=10, max_seq_length=2048, grad_checkpoint=True)
start = time.time()
train(model, optimizer, dataset, args=args)
print(f"Time: {time.time() - start:.1f}s | Peak: {mx.get_peak_memory() / 1e9:.2f} GB")
```

Closes #1830