### PR TITLE
fix(server): speculative-compat guards as real 400s, preflighted before SSE streams

### DIFF
--- a/mlx_vlm/server/anthropic.py
+++ b/mlx_vlm/server/anthropic.py
@@ -20,6 +20,7 @@ from .generation import (
     PromptTooLongError,
     _build_metrics_envelope,
     _count_prompt_tokens,
+    preflight_speculative_args,
 )
 from .responses_state import (
     ThinkingStreamState,
@@ -83,6 +84,32 @@ def _anthropic_error_response(
         },
         headers={"request-id": f"req_{uuid.uuid4().hex}"},
     )
+
+
+def _preflight_speculative_stream_args(*, endpoint: str, model: str, args) -> None:
+    """Run the speculative-compat guards BEFORE the SSE stream starts.
+
+    Mirror of the helper in ``openai.py``: for stream=true,
+    ``ResponseGenerator.generate()`` runs inside an already-started SSE
+    generator, so its ``HTTPException(400)`` would be swallowed by the
+    generator's ``except Exception`` and surface as error data under
+    HTTP 200. The caller converts the raised HTTPException to an
+    Anthropic-format error response.
+    """
+    rg = runtime.response_generator
+    if rg is None:
+        return
+    try:
+        preflight_speculative_args(getattr(rg, "draft_model", None), args)
+    except HTTPException as e:
+        if runtime.metrics is not None:
+            runtime.metrics.record_failure(
+                endpoint=endpoint,
+                model=model,
+                stream=True,
+                error=str(e.detail),
+            )
+        raise
 
 
 def _sse_event(event: str, payload: Dict[str, Any]) -> str:
@@ -527,13 +554,18 @@ async def anthropic_messages_endpoint(http_request: Request):
                     audio=None,
                     args=gen_args,
                 )
+                _preflight_speculative_stream_args(
+                    endpoint="/v1/messages",
+                    model=request.model,
+                    args=gen_args,
+                )
             except HTTPException as e:
-                # The preflight raises HTTPException(400) for an over-budget
-                # prompt and already records the failure. Convert it to an
-                # Anthropic-format error here; otherwise the endpoint's outer
-                # ``except Exception`` reports this client error as a 500
-                # api_error with a "400: ..." message. Mirrors the dedicated
-                # HTTPException handling in the OpenAI routers.
+                # Both preflights raise HTTPException(400) and record the
+                # failure themselves. Convert to an Anthropic-format error
+                # here; otherwise the endpoint's outer ``except Exception``
+                # reports these client errors as a 500 api_error with a
+                # "400: ..." message. Mirrors the dedicated HTTPException
+                # handling in the OpenAI routers.
                 return _anthropic_error_response(e.status_code, str(e.detail))
 
             async def stream_generator():

--- a/mlx_vlm/server/anthropic.py
+++ b/mlx_vlm/server/anthropic.py
@@ -8,7 +8,7 @@ import uuid
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 import mlx.core as mx
-from fastapi import Request
+from fastapi import HTTPException, Request
 from fastapi.responses import JSONResponse, StreamingResponse
 
 from ..generate import generate, stream_generate
@@ -518,14 +518,23 @@ async def anthropic_messages_endpoint(http_request: Request):
                 model=request.model,
                 stream=True,
             )
-            await _preflight_stream_context_budget(
-                endpoint="/v1/messages",
-                model=request.model,
-                prompt=formatted_prompt,
-                images=images if images else None,
-                audio=None,
-                args=gen_args,
-            )
+            try:
+                await _preflight_stream_context_budget(
+                    endpoint="/v1/messages",
+                    model=request.model,
+                    prompt=formatted_prompt,
+                    images=images if images else None,
+                    audio=None,
+                    args=gen_args,
+                )
+            except HTTPException as e:
+                # The preflight raises HTTPException(400) for an over-budget
+                # prompt and already records the failure. Convert it to an
+                # Anthropic-format error here; otherwise the endpoint's outer
+                # ``except Exception`` reports this client error as a 500
+                # api_error with a "400: ..." message. Mirrors the dedicated
+                # HTTPException handling in the OpenAI routers.
+                return _anthropic_error_response(e.status_code, str(e.detail))
 
             async def stream_generator():
                 token_iterator = None

--- a/mlx_vlm/server/generation.py
+++ b/mlx_vlm/server/generation.py
@@ -819,6 +819,106 @@ class GenerationArguments:
         return kw
 
 
+def _unsupported_speculative_sampling_fields(args: "GenerationArguments") -> List[str]:
+    """Sampling fields the speculative path would silently ignore.
+
+    The speculative round-loops sample with the sampler from ``_make_sampler``
+    and never apply ``_make_logits_processors``, so under a drafter:
+
+    - ``logit_bias`` and the repetition/presence/frequency penalties (logits
+      processors) are never applied;
+    - ``top_n_sigma`` / ``p_less`` / ``typical_p`` are exclusive-priority
+      branches — composing them keeps only the first;
+    - ``top_k`` / ``min_p`` composed with one of those branch fields are
+      dropped (the branch samplers are built without them). Plain
+      ``top_k`` / ``min_p`` are deliberately NOT flagged: implementing them
+      row-level in the positioned sampler is #1647's lane, and this guard
+      must not reject requests that PR makes correct.
+
+    Greedy (``temperature == 0``) ignores every sampler knob by design and is
+    never flagged here.
+    """
+    fields = []
+    if args.logit_bias:
+        fields.append("logit_bias")
+    if args.repetition_penalty is not None and args.repetition_penalty not in (0, 1.0):
+        fields.append("repetition_penalty")
+    if args.presence_penalty is not None and args.presence_penalty != 0:
+        fields.append("presence_penalty")
+    if args.frequency_penalty is not None and args.frequency_penalty != 0:
+        fields.append("frequency_penalty")
+
+    if args.temperature != 0:
+        branch_fields = [
+            name
+            for name, active in (
+                ("top_n_sigma", args.top_n_sigma > 0),
+                ("p_less", bool(args.p_less)),
+                ("typical_p", args.typical_p < 1.0),
+            )
+            if active
+        ]
+        if len(branch_fields) > 1:
+            # Exclusive-priority branch would honor only the first field.
+            fields.extend(branch_fields[1:])
+        if branch_fields:
+            # The branch samplers never see top_k/min_p.
+            if args.top_k > 0:
+                fields.append("top_k")
+            if args.min_p != 0.0:
+                fields.append("min_p")
+    return fields
+
+
+def preflight_speculative_args(draft_model, args: "GenerationArguments") -> None:
+    """Speculative-compat guards, raised as ``HTTPException(400)``.
+
+    Module-level and model-free so streaming endpoints can run it BEFORE
+    constructing/starting an SSE response: once the stream generator is
+    running, an exception from ``ResponseGenerator.generate`` is swallowed by
+    the generator's ``except Exception`` and surfaces as error data under
+    HTTP 200. ``generate()`` still calls this for defense in depth, so
+    non-stream behavior is unchanged.
+
+    No-op when ``draft_model`` is None (non-speculative serving honors all of
+    these fields).
+    """
+    if draft_model is None:
+        return
+    if args.logits_processors is not None:
+        raise HTTPException(
+            status_code=400,
+            detail="Structured response_format is not supported with "
+            "speculative decoding.",
+        )
+    if args.thinking_budget is not None:
+        raise HTTPException(
+            status_code=400,
+            detail="thinking_budget is not supported with speculative "
+            "decoding in the server.",
+        )
+    unsupported = _unsupported_speculative_sampling_fields(args)
+    if unsupported:
+        detail = ", ".join(unsupported)
+        if os.environ.get("MLX_VLM_SPEC_IGNORE_UNSUPPORTED_SAMPLING", "") == "1":
+            logger.warning(
+                "Speculative decoding ignores logits processors and "
+                "unsupported sampler fields; accepting request but NOT "
+                "applying: %s (MLX_VLM_SPEC_IGNORE_UNSUPPORTED_SAMPLING=1).",
+                detail,
+            )
+        else:
+            raise HTTPException(
+                status_code=400,
+                detail=f"{detail} not supported with speculative decoding "
+                "in the server: the speculative path samples with "
+                "temperature/top_p only and would silently ignore these "
+                "fields. Unset them, or set "
+                "MLX_VLM_SPEC_IGNORE_UNSUPPORTED_SAMPLING=1 to accept such "
+                "requests with a warning (the fields stay ignored).",
+            )
+
+
 @dataclass
 class GenerationContext:
     """Context returned when a request is queued."""
@@ -1208,14 +1308,7 @@ class ResponseGenerator:
     ) -> Tuple[GenerationContext, "_TokenIterator"]:
         self.wait_until_ready()
         args = args or GenerationArguments(max_tokens=get_server_max_tokens())
-        if self.draft_model is not None and args.logits_processors is not None:
-            raise ValueError(
-                "Structured response_format is not supported with speculative decoding."
-            )
-        if self.draft_model is not None and args.thinking_budget is not None:
-            raise ValueError(
-                "thinking_budget is not supported with speculative decoding in the server."
-            )
+        preflight_speculative_args(self.draft_model, args)
         rqueue: Queue = Queue()
         request_started_at = time.perf_counter()
 

--- a/mlx_vlm/server/openai.py
+++ b/mlx_vlm/server/openai.py
@@ -30,6 +30,7 @@ from .generation import (
     PromptTooLongError,
     _build_metrics_envelope,
     _count_prompt_tokens,
+    preflight_speculative_args,
 )
 from .responses_state import (
     ThinkingStreamState,
@@ -156,6 +157,33 @@ def _ensure_effective_input(messages, *, images=None, audio=None):
     if any(_message_has_effective_input(message) for message in messages or []):
         return
     raise HTTPException(status_code=400, detail=_MISSING_INPUT_DETAIL)
+
+
+def _preflight_speculative_stream_args(*, endpoint: str, model: str, args) -> None:
+    """Run the speculative-compat guards BEFORE the SSE stream starts.
+
+    For stream=true, ``ResponseGenerator.generate()`` runs inside an
+    already-started SSE generator, so its ``HTTPException(400)`` would be
+    swallowed by the generator's ``except Exception`` and surface as error
+    data under HTTP 200. Preflighting here turns the guards
+    (logits_processors/response_format, thinking_budget,
+    unsupported-sampling) into real 400 responses; ``generate()`` keeps the
+    same guards for defense in depth.
+    """
+    rg = runtime.response_generator
+    if rg is None:
+        return
+    try:
+        preflight_speculative_args(getattr(rg, "draft_model", None), args)
+    except HTTPException as e:
+        if runtime.metrics is not None:
+            runtime.metrics.record_failure(
+                endpoint=endpoint,
+                model=model,
+                stream=True,
+                error=str(e.detail),
+            )
+        raise
 
 
 def _tool_function_name(tool: Any) -> Optional[str]:
@@ -1034,6 +1062,11 @@ async def responses_endpoint(request: Request):
                 audio=None,
                 args=gen_args,
             )
+            _preflight_speculative_stream_args(
+                endpoint="/responses",
+                model=openai_request.model,
+                args=gen_args,
+            )
 
             async def stream_generator():
                 token_iterator = None
@@ -1748,6 +1781,11 @@ async def chat_completions_endpoint(request: ChatRequest, http_request: Request)
                 images=images if images else None,
                 audio=audio if audio else None,
                 videos=videos if videos else None,
+                args=gen_args,
+            )
+            _preflight_speculative_stream_args(
+                endpoint="/chat/completions",
+                model=request.model,
                 args=gen_args,
             )
 

--- a/mlx_vlm/tests/test_server_anthropic_stream_preflight.py
+++ b/mlx_vlm/tests/test_server_anthropic_stream_preflight.py
@@ -1,0 +1,121 @@
+"""Regression test for the /v1/messages streaming context-budget preflight.
+
+``_preflight_stream_context_budget`` raises ``HTTPException(400)`` for an
+over-budget prompt (and records the failure itself). The streaming branch of
+``anthropic_messages_endpoint`` used to call it without an ``except
+HTTPException`` handler, so the client error fell through to the endpoint's
+outer ``except Exception`` and was reported as a ``500`` ``api_error`` with a
+``"400: ..."`` message. The OpenAI routers already convert such errors; this
+test pins the same behaviour for the Anthropic-compatible endpoint.
+
+Model-free: the request path up to the preflight is patched out.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+from fastapi import HTTPException
+from fastapi.testclient import TestClient
+
+import mlx_vlm.server as server
+import mlx_vlm.server.anthropic as server_anthropic
+from mlx_vlm.server.generation import GenerationArguments
+
+
+@pytest.fixture
+def client():
+    with TestClient(server.app) as test_client:
+        yield test_client
+
+
+def _patched_request_path(preflight):
+    """Patch every step between the endpoint entry and the preflight call so
+    the request reaches the preflight without loading a model."""
+    model = SimpleNamespace()
+    processor = SimpleNamespace()
+    config = SimpleNamespace()
+    return (
+        patch.object(
+            server_anthropic,
+            "get_cached_model",
+            return_value=(model, processor, config),
+        ),
+        patch.object(
+            server_anthropic,
+            "_anthropic_messages_to_internal",
+            return_value=(["msg"], [], None, None),
+        ),
+        patch.object(
+            server_anthropic, "_infer_tool_parser_from_processor", return_value=None
+        ),
+        patch.object(
+            server_anthropic,
+            "_build_gen_args",
+            return_value=GenerationArguments(temperature=0.7),
+        ),
+        patch.object(server_anthropic, "apply_chat_template", return_value="prompt"),
+        patch.object(server_anthropic, "_preflight_stream_context_budget", preflight),
+    )
+
+
+def test_stream_over_budget_returns_anthropic_400_not_500(client, monkeypatch):
+    monkeypatch.setattr(server.runtime, "response_generator", SimpleNamespace())
+
+    async def _reject(**_kwargs):
+        raise HTTPException(status_code=400, detail="prompt is too long")
+
+    patches = _patched_request_path(_reject)
+    for p in patches:
+        p.start()
+    try:
+        response = client.post(
+            "/v1/messages",
+            json={
+                "model": "demo",
+                "max_tokens": 16,
+                "stream": True,
+                "messages": [{"role": "user", "content": "Hello"}],
+            },
+        )
+    finally:
+        for p in patches:
+            p.stop()
+
+    assert response.status_code == 400
+    payload = response.json()
+    assert payload["type"] == "error"
+    assert payload["error"]["type"] == "invalid_request_error"
+    assert payload["error"]["message"] == "prompt is too long"
+    # The old behaviour leaked the HTTPException's "400: " prefix into a 500.
+    assert not payload["error"]["message"].startswith("400:")
+
+
+def test_stream_within_budget_starts_stream(client, monkeypatch):
+    monkeypatch.setattr(server.runtime, "response_generator", SimpleNamespace())
+
+    async def _ok(**_kwargs):
+        return None
+
+    patches = _patched_request_path(_ok)
+    # When the preflight passes it must not short-circuit: the endpoint returns
+    # a streaming 200 response instead of an error. The generated SSE body is
+    # out of scope here.
+    for p in patches:
+        p.start()
+    try:
+        with client.stream(
+            "POST",
+            "/v1/messages",
+            json={
+                "model": "demo",
+                "max_tokens": 16,
+                "stream": True,
+                "messages": [{"role": "user", "content": "Hello"}],
+            },
+        ) as response:
+            assert response.status_code == 200
+            assert response.headers["content-type"].startswith("text/event-stream")
+    finally:
+        for p in patches:
+            p.stop()

--- a/mlx_vlm/tests/test_server_spec_stream_preflight.py
+++ b/mlx_vlm/tests/test_server_spec_stream_preflight.py
@@ -1,0 +1,353 @@
+"""Speculative-compat guards: real 400s, preflighted before SSE streams start.
+
+Under a drafter the server's speculative round-loops sample with the sampler
+from ``_make_sampler`` and never apply ``_make_logits_processors`` — so
+``logit_bias``, the repetition/presence/frequency penalties, compositions of
+the exclusive-priority branch fields (``top_n_sigma``/``p_less``/
+``typical_p``), and ``top_k``/``min_p`` composed with a branch field are
+silently ignored. (Plain ``top_k``/``min_p`` are #1647's lane and stay
+unflagged.) ``generate()`` already rejected ``logits_processors`` and
+``thinking_budget``, but as ``ValueError``:
+
+- non-stream requests reported a 500 instead of a 400;
+- stream=true requests ran ``generate()`` inside an already-started SSE
+  generator, so the rejection surfaced as error data under HTTP 200.
+
+The guards now live in the module-level ``preflight_speculative_args``
+(HTTPException(400)); the /chat/completions, /responses, and /v1/messages
+stream branches call it BEFORE any StreamingResponse is constructed, and
+``generate()`` keeps it for defense in depth.
+``MLX_VLM_SPEC_IGNORE_UNSUPPORTED_SAMPLING=1`` downgrades the sampling-field
+guard to a warning for deployments that prefer the old silent behavior.
+
+Model-free: unit tests use fakes; endpoint tests patch the request path up to
+the preflight (same approach as test_server_anthropic_stream_preflight).
+"""
+
+import inspect
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+from fastapi import HTTPException
+from fastapi.testclient import TestClient
+
+import mlx_vlm.server as server
+import mlx_vlm.server.anthropic as server_anthropic
+import mlx_vlm.server.openai as server_openai
+from mlx_vlm.server.generation import (
+    GenerationArguments,
+    ResponseGenerator,
+    _unsupported_speculative_sampling_fields,
+    preflight_speculative_args,
+)
+
+
+def _fields(**kwargs):
+    return _unsupported_speculative_sampling_fields(GenerationArguments(**kwargs))
+
+
+def _preflight(draft=True, **kwargs):
+    """Run the guard; return the HTTPException or None."""
+    try:
+        preflight_speculative_args(
+            object() if draft else None, GenerationArguments(**kwargs)
+        )
+    except HTTPException as e:
+        return e
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Which sampling fields the speculative path would silently ignore
+# ---------------------------------------------------------------------------
+
+
+def test_supported_sampler_shapes_not_flagged():
+    assert _fields(temperature=0.7, top_p=0.95) == []
+    assert _fields(temperature=0.7, top_n_sigma=2.0) == []
+    assert _fields(temperature=0.7, p_less=True) == []
+    assert _fields(temperature=0.7, typical_p=0.8) == []
+
+
+def test_branch_composition_flagged():
+    assert _fields(temperature=0.7, top_n_sigma=2.0, typical_p=0.8) == ["typical_p"]
+    assert _fields(temperature=0.7, top_n_sigma=1.0, p_less=True, typical_p=0.5) == [
+        "p_less",
+        "typical_p",
+    ]
+
+
+def test_branch_plus_top_k_min_p_flagged():
+    # The top_n_sigma/p_less/typical_p branch samplers are built without
+    # top_k/min_p, so composing drops them.
+    assert _fields(temperature=0.7, top_n_sigma=2.0, top_k=64) == ["top_k"]
+    assert _fields(temperature=0.7, typical_p=0.8, min_p=0.05) == ["min_p"]
+    assert _fields(temperature=0.7, p_less=True, top_k=64, min_p=0.05) == [
+        "top_k",
+        "min_p",
+    ]
+
+
+def test_plain_top_k_min_p_not_flagged():
+    # Plain top_k/min_p are silently dropped on main today too, but
+    # implementing them row-level is #1647's lane — the guard must not
+    # reject requests that PR makes correct.
+    assert _fields(temperature=0.7, top_k=64) == []
+    assert _fields(temperature=0.7, min_p=0.05) == []
+
+
+def test_logits_processor_fields_flagged():
+    assert _fields(repetition_penalty=1.3) == ["repetition_penalty"]
+    assert _fields(repetition_penalty=1.0) == []
+    assert _fields(logit_bias={5: 2.0}) == ["logit_bias"]
+    assert _fields(presence_penalty=0.5, frequency_penalty=0.5) == [
+        "presence_penalty",
+        "frequency_penalty",
+    ]
+
+
+def test_greedy_ignores_every_sampler_knob():
+    assert (
+        _fields(
+            temperature=0,
+            top_n_sigma=2.0,
+            p_less=True,
+            typical_p=0.8,
+            top_k=64,
+            min_p=0.05,
+        )
+        == []
+    )
+
+
+# ---------------------------------------------------------------------------
+# The extracted preflight raises 400; escape hatch covers sampling fields only
+# ---------------------------------------------------------------------------
+
+
+def test_preflight_rejects_offending_args():
+    e = _preflight(logits_processors=[lambda tokens, logits: logits])
+    assert e is not None and e.status_code == 400
+    assert "response_format" in str(e.detail)
+    e = _preflight(thinking_budget=512)
+    assert e is not None and e.status_code == 400
+    assert "thinking_budget" in str(e.detail)
+    e = _preflight(repetition_penalty=1.3)
+    assert e is not None and e.status_code == 400
+    assert "repetition_penalty" in str(e.detail)
+    assert "MLX_VLM_SPEC_IGNORE_UNSUPPORTED_SAMPLING" in str(e.detail)
+    e = _preflight(temperature=0.7, top_n_sigma=2.0, top_k=64)
+    assert e is not None and e.status_code == 400 and "top_k" in str(e.detail)
+
+
+def test_preflight_accepts_supported_args():
+    assert _preflight(temperature=0.7, top_p=0.95) is None
+    assert _preflight(temperature=0.7, typical_p=0.8) is None
+    assert _preflight(temperature=0.7, top_k=64, min_p=0.05) is None
+    assert _preflight(temperature=0) is None
+
+
+def test_preflight_noop_without_drafter():
+    assert (
+        _preflight(
+            draft=False,
+            repetition_penalty=1.3,
+            thinking_budget=512,
+            logits_processors=[lambda tokens, logits: logits],
+        )
+        is None
+    )
+
+
+def test_preflight_escape_hatch_covers_sampling_fields_only(monkeypatch):
+    monkeypatch.setenv("MLX_VLM_SPEC_IGNORE_UNSUPPORTED_SAMPLING", "1")
+    assert _preflight(repetition_penalty=1.3) is None
+    assert _preflight(temperature=0.7, top_n_sigma=2.0, top_k=64) is None
+    # The response_format/thinking_budget guards have no escape hatch.
+    assert _preflight(logits_processors=[lambda tokens, logits: logits]) is not None
+    assert _preflight(thinking_budget=512) is not None
+    monkeypatch.delenv("MLX_VLM_SPEC_IGNORE_UNSUPPORTED_SAMPLING")
+    assert _preflight(repetition_penalty=1.3) is not None
+
+
+def test_generate_keeps_guard_defense_in_depth():
+    """generate() must reject on its own — with a 400, not a ValueError —
+    so the non-stream path is covered even if an endpoint forgets to
+    preflight."""
+
+    class _Sentinel(Exception):
+        pass
+
+    def _boom(prompt, images=None, audio=None, videos=None):
+        raise _Sentinel
+
+    fake = SimpleNamespace(
+        draft_model=object(),
+        wait_until_ready=lambda: None,
+        _preprocess_request=_boom,
+    )
+    with pytest.raises(HTTPException) as excinfo:
+        ResponseGenerator.generate(
+            fake, "hi", args=GenerationArguments(repetition_penalty=1.3)
+        )
+    assert excinfo.value.status_code == 400
+    # Clean args reach preprocessing (the sentinel), not a guard rejection.
+    with pytest.raises(_Sentinel):
+        ResponseGenerator.generate(fake, "hi", args=GenerationArguments())
+
+
+# ---------------------------------------------------------------------------
+# Router wiring: the stream preflight records the failure and raises before
+# any SSE byte can be produced
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "module,endpoint",
+    [(server_openai, "/chat/completions"), (server_anthropic, "/v1/messages")],
+)
+def test_stream_preflight_helper_with_fake_runtime(monkeypatch, module, endpoint):
+    failures = []
+    monkeypatch.setattr(
+        server.runtime, "response_generator", SimpleNamespace(draft_model=object())
+    )
+    monkeypatch.setattr(
+        server.runtime,
+        "metrics",
+        SimpleNamespace(record_failure=lambda **kwargs: failures.append(kwargs)),
+    )
+    with pytest.raises(HTTPException) as excinfo:
+        module._preflight_speculative_stream_args(
+            endpoint=endpoint,
+            model="demo",
+            args=GenerationArguments(repetition_penalty=1.3),
+        )
+    assert excinfo.value.status_code == 400
+    assert failures and failures[0]["stream"] is True
+    assert failures[0]["endpoint"] == endpoint
+
+    # Supported args pass through silently.
+    module._preflight_speculative_stream_args(
+        endpoint=endpoint, model="demo", args=GenerationArguments(temperature=0.7)
+    )
+    # No drafter -> no-op even with offending args.
+    monkeypatch.setattr(
+        server.runtime, "response_generator", SimpleNamespace(draft_model=None)
+    )
+    module._preflight_speculative_stream_args(
+        endpoint=endpoint,
+        model="demo",
+        args=GenerationArguments(repetition_penalty=1.3),
+    )
+    # No response generator at all -> no-op.
+    monkeypatch.setattr(server.runtime, "response_generator", None)
+    module._preflight_speculative_stream_args(
+        endpoint=endpoint,
+        model="demo",
+        args=GenerationArguments(repetition_penalty=1.3),
+    )
+    assert len(failures) == 1
+
+
+def test_endpoints_preflight_before_stream_generator_starts():
+    """Structural audit: in every streaming endpoint the speculative
+    preflight call must appear before the stream generator is even defined,
+    i.e. before any SSE byte can be produced."""
+    for endpoint in (
+        server_openai.chat_completions_endpoint,
+        server_openai.responses_endpoint,
+        server_anthropic.anthropic_messages_endpoint,
+    ):
+        src = inspect.getsource(endpoint)
+        assert "_preflight_speculative_stream_args" in src, endpoint.__name__
+        assert src.index("_preflight_speculative_stream_args") < src.index(
+            "async def stream_generator"
+        ), f"{endpoint.__name__}: preflight after generator definition"
+
+
+# ---------------------------------------------------------------------------
+# End-to-end through the Anthropic router: 400 with the proper error
+# envelope, not error data under an HTTP 200 SSE stream
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def client():
+    with TestClient(server.app) as test_client:
+        yield test_client
+
+
+def _patched_request_path(gen_args):
+    """Patch every step between the endpoint entry and the preflights so the
+    request reaches them without loading a model."""
+
+    async def _budget_ok(**_kwargs):
+        return None
+
+    model = SimpleNamespace()
+    processor = SimpleNamespace()
+    config = SimpleNamespace()
+    return (
+        patch.object(
+            server_anthropic,
+            "get_cached_model",
+            return_value=(model, processor, config),
+        ),
+        patch.object(
+            server_anthropic,
+            "_anthropic_messages_to_internal",
+            return_value=(["msg"], [], None, None),
+        ),
+        patch.object(
+            server_anthropic, "_infer_tool_parser_from_processor", return_value=None
+        ),
+        patch.object(server_anthropic, "_build_gen_args", return_value=gen_args),
+        patch.object(server_anthropic, "apply_chat_template", return_value="prompt"),
+        patch.object(server_anthropic, "_preflight_stream_context_budget", _budget_ok),
+    )
+
+
+_STREAM_BODY = {
+    "model": "demo",
+    "max_tokens": 16,
+    "stream": True,
+    "messages": [{"role": "user", "content": "Hello"}],
+}
+
+
+def test_stream_with_drafter_returns_400_not_sse_200(client, monkeypatch):
+    monkeypatch.setattr(
+        server.runtime, "response_generator", SimpleNamespace(draft_model=object())
+    )
+    patches = _patched_request_path(GenerationArguments(repetition_penalty=1.3))
+    for p in patches:
+        p.start()
+    try:
+        response = client.post("/v1/messages", json=_STREAM_BODY)
+    finally:
+        for p in patches:
+            p.stop()
+
+    assert response.status_code == 400
+    payload = response.json()
+    assert payload["type"] == "error"
+    assert payload["error"]["type"] == "invalid_request_error"
+    assert "repetition_penalty" in payload["error"]["message"]
+    assert not payload["error"]["message"].startswith("400:")
+
+
+def test_stream_with_drafter_and_supported_args_starts_stream(client, monkeypatch):
+    monkeypatch.setattr(
+        server.runtime, "response_generator", SimpleNamespace(draft_model=object())
+    )
+    patches = _patched_request_path(GenerationArguments(temperature=0.7, top_p=0.95))
+    for p in patches:
+        p.start()
+    try:
+        with client.stream("POST", "/v1/messages", json=_STREAM_BODY) as response:
+            assert response.status_code == 200
+            assert response.headers["content-type"].startswith("text/event-stream")
+    finally:
+        for p in patches:
+            p.stop()


### PR DESCRIPTION
### What

Three related defects when the server runs with a speculative drafter:

1. **Guard rejections never reached streaming clients as errors.** `generate()` rejects `logits_processors` (structured `response_format`) and `thinking_budget` under a drafter — but for `stream: true` it runs inside the already-started SSE generator, so the rejection is swallowed by the generator's `except Exception` and surfaces as error data under **HTTP 200**. Clients that dispatch on status code treat the request as successful.
2. **Non-stream rejections were 500s.** The same guards raised bare `ValueError`, which the routers' generic handlers report as a 500 server fault instead of a 400 client error.
3. **Several request fields are silently ignored under a drafter, with no guard at all.** The speculative round-loops sample with `_make_sampler`'s sampler and never apply `_make_logits_processors`. So with a drafter loaded:
   - `logit_bias` and the repetition/presence/frequency penalties are never applied;
   - composing `top_n_sigma` / `p_less` / `typical_p` keeps only the first (exclusive-priority branches in `_make_sampler`);
   - `top_k` / `min_p` composed with one of those branch fields are dropped (the branch samplers are built without them).

   A request asking for `repetition_penalty: 1.3` gets an answer generated without it, with no indication anything was dropped.

### Fix

- The guards move to a **module-level `preflight_speculative_args(draft_model, args)`** in `server/generation.py`, raising `HTTPException(400)`, extended to cover the silently-ignored fields above. Greedy (`temperature == 0`) ignores every sampler knob by design and is never flagged.
- The **/chat/completions, /responses, and /v1/messages stream branches call it before constructing the `StreamingResponse`** (mirroring the existing `_preflight_stream_context_budget` pattern), recording the failure metric. `generate()` keeps the same guards for defense in depth, now as proper 400s.
- The `/v1/messages` call site rides on the `except HTTPException` conversion introduced in #1860 (this PR is stacked on it and shows both commits until it lands — happy to rebase either way).

This is one of the follow-ups offered in #1856 ("sampler-coalescing + logits-guard fixes ... as separate PRs").

### Relationship to #1647

Plain `top_k` / `min_p` are **deliberately not flagged**, even though today's `main` drops them too: #1647 implements them row-level in the positioned sampler, and this guard must not 400 requests that PR makes correct. The two compose: after #1647, everything this guard flags is still genuinely ignored (the `top_n_sigma`/`p_less`/`typical_p` branch samplers remain built without `top_k`/`min_p`, and the round-loops still don't run logits processors). If #1647 stalls, extending the guard to plain `top_k`/`min_p` is a two-line follow-up.

### Behavior change, called out explicitly

Requests that previously "succeeded" with silently wrong sampling (drafter + penalties/`logit_bias`/branch-field combos) now fail loudly with a 400 naming the unsupported fields. For deployments that prefer the old behavior, `MLX_VLM_SPEC_IGNORE_UNSUPPORTED_SAMPLING=1` accepts such requests with a warning log (the fields stay ignored); the `response_format`/`thinking_budget` guards have no escape hatch, matching current `main`. If you'd rather ship warn-only as the default, that's a one-line flip — the guard machinery is the same either way.

### Tests

`mlx_vlm/tests/test_server_spec_stream_preflight.py` — 18 tests, model-free:

- field matrix for `_unsupported_speculative_sampling_fields` (supported shapes incl. plain `top_k`/`min_p` stay clean; branch combos, branch+`top_k`/`min_p`, penalties, `logit_bias` flagged; greedy never flagged);
- preflight unit tests incl. the escape hatch scoping;
- `generate()` defense in depth (rejects on its own with a 400; clean args reach preprocessing);
- per-router preflight helpers with a fake runtime (records `record_failure`, no-ops without a drafter or response generator);
- structural source-order audit: in all three endpoints the preflight appears before `async def stream_generator` — i.e. before any SSE byte can be produced;
- TestClient regressions through `/v1/messages`: drafter + `repetition_penalty` → **400** `invalid_request_error` (not SSE-200); drafter + supported args → streaming 200.

Local run: the two preflight test files + `test_server.py` = **296 passed** (Python 3.12, macOS/M5). `black` 26.3.1 + `isort --profile=black` 5.13.2 clean (repo pre-commit pins).
