### PR TITLE
Fix LFM2.5-VL 3B checkpoint and image loading

### DIFF
--- a/mlx_vlm/models/lfm2_vl/config.py
+++ b/mlx_vlm/models/lfm2_vl/config.py
@@ -81,7 +81,8 @@ class ModelConfig(BaseModelConfig):
     do_image_splitting: bool = True
     downsample_factor: int = 2
     encoder_patch_size: int = 16
-    image_token_index: int = 396
+    image_token_id: int = 396
+    image_token_index: Optional[int] = None
     max_image_tokens: int = 256
     max_num_patches: int = 1024
     max_pixels_tolerance: float = 2.0
@@ -97,3 +98,7 @@ class ModelConfig(BaseModelConfig):
     projector_hidden_size: int = 2560
     eos_token_id: int = 7
     projector_use_layernorm: bool = True
+
+    def __post_init__(self):
+        if self.image_token_index is None:
+            self.image_token_index = self.image_token_id

--- a/mlx_vlm/models/lfm2_vl/config.py
+++ b/mlx_vlm/models/lfm2_vl/config.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import List, Tuple
+from typing import List, Optional, Tuple
 
 from ..base import BaseModelConfig
 
@@ -22,7 +22,7 @@ class TextConfig(BaseModelConfig):
     use_pos_enc: bool = True
     block_auto_adjust_ff_dim: bool = True
     block_dim: int = 1024
-    block_ff_dim: int = 6656
+    block_ff_dim: Optional[int] = None
     block_ffn_dim_multiplier: float = 1.0
     block_mlp_init_scale: float = 1.0
     block_multiple_of: int = 256
@@ -40,6 +40,11 @@ class TextConfig(BaseModelConfig):
     full_attn_idxs: List[int] = None
 
     def __post_init__(self):
+
+        # LFM2.5-VL checkpoints expose the MLP width as ``intermediate_size``
+        # and omit the legacy ``block_ff_dim`` field.
+        if self.block_ff_dim is None:
+            self.block_ff_dim = self.intermediate_size
 
         if self.full_attn_idxs is None:
             self.full_attn_idxs = [

--- a/mlx_vlm/server/generation.py
+++ b/mlx_vlm/server/generation.py
@@ -1721,6 +1721,7 @@ class ResponseGenerator:
         max_num_seqs = get_max_num_seqs()
 
         while not self._stop:
+            new_items = []
             try:
                 # Poll the request queue — non-blocking when generating, short
                 # blocking wait when idle so we don't spin.
@@ -1866,12 +1867,13 @@ class ResponseGenerator:
 
             except Exception as e:
                 logger.exception("Error in generation thread")
-                for info in list(active.values()):
-                    try:
-                        info["rqueue"].put(e)
-                        info["rqueue"].put(None)
-                    except Exception:
-                        pass
+                error_queues = {
+                    id(info["rqueue"]): info["rqueue"] for info in active.values()
+                }
+                error_queues.update(
+                    {id(request.rqueue): request.rqueue for request in new_items}
+                )
+                _notify_queues(error_queues.values(), e, None)
                 active.clear()
                 batch_gen = None
                 mx.clear_cache()

--- a/mlx_vlm/tests/test_models.py
+++ b/mlx_vlm/tests/test_models.py
@@ -797,6 +797,18 @@ class TestModels(unittest.TestCase):
         self.assertNotIn("layer_norm", projector.parameters())
         self.assertEqual(projector(x).shape, (1, 4, config.text_config.hidden_size))
 
+    def test_lfm2_vl_uses_intermediate_size_when_block_ff_dim_is_omitted(self):
+        from mlx_vlm.models import lfm2_vl
+
+        config = lfm2_vl.TextConfig.from_dict(
+            {
+                "intermediate_size": 10752,
+                "layer_types": ["full_attention"],
+            }
+        )
+
+        self.assertEqual(config.block_ff_dim, 10752)
+
     def test_deepseek_v4_language_model(self):
         from mlx_vlm.models import deepseek_v4
         from mlx_vlm.models.deepseek_v4.hyper_connection import (

--- a/mlx_vlm/tests/test_models.py
+++ b/mlx_vlm/tests/test_models.py
@@ -809,6 +809,24 @@ class TestModels(unittest.TestCase):
 
         self.assertEqual(config.block_ff_dim, 10752)
 
+    def test_lfm2_vl_uses_image_token_id_when_index_is_omitted(self):
+        from mlx_vlm.models import lfm2_vl
+
+        current = lfm2_vl.ModelConfig(
+            text_config=lfm2_vl.TextConfig(layer_types=["full_attention"]),
+            vision_config=lfm2_vl.VisionConfig(),
+            image_token_id=124907,
+        )
+        legacy = lfm2_vl.ModelConfig(
+            text_config=lfm2_vl.TextConfig(layer_types=["full_attention"]),
+            vision_config=lfm2_vl.VisionConfig(),
+            image_token_id=124907,
+            image_token_index=396,
+        )
+
+        self.assertEqual(current.image_token_index, 124907)
+        self.assertEqual(legacy.image_token_index, 396)
+
     def test_deepseek_v4_language_model(self):
         from mlx_vlm.models import deepseek_v4
         from mlx_vlm.models.deepseek_v4.hyper_connection import (

--- a/mlx_vlm/tests/test_server.py
+++ b/mlx_vlm/tests/test_server.py
@@ -845,6 +845,49 @@ def test_speculative_thread_exception_reaches_client_queue(monkeypatch):
     assert rqueue.get(timeout=1) is None
 
 
+def test_ar_thread_exception_reaches_pending_client_queue(monkeypatch):
+    class FakeBatchGenerator:
+        def __init__(self, *_args, **_kwargs):
+            self.has_work = False
+
+        def close(self):
+            pass
+
+    gen = _unstarted_response_generator()
+
+    def initialize_model():
+        gen.model = SimpleNamespace(language_model=object())
+        gen.processor = SimpleNamespace()
+        gen.config = SimpleNamespace()
+        gen.tokenizer = SimpleNamespace()
+
+    error = RuntimeError("vision embedding failed")
+    gen._initialize_model = initialize_model
+    gen._gpu_embed = MagicMock(side_effect=error)
+    monkeypatch.setattr(server_generation, "BatchGenerator", FakeBatchGenerator)
+
+    rqueue = Queue()
+    gen.requests.put(
+        server_generation.QueuedGenerationRequest(
+            rqueue=rqueue,
+            raw_inputs={"input_ids": mx.array([[1]], dtype=mx.int32)},
+            prompt_tokens=1,
+            args=server.GenerationArguments(max_tokens=2),
+        )
+    )
+
+    worker = Thread(target=gen._run, daemon=True)
+    worker.start()
+    try:
+        assert rqueue.get(timeout=1) is error
+        assert rqueue.get(timeout=1) is None
+        assert worker.is_alive()
+    finally:
+        gen._stop = True
+        gen.requests.put(None)
+        worker.join(timeout=2)
+
+
 def test_speculative_thread_exception_skips_broken_queues(monkeypatch):
     gen = _unstarted_response_generator()
     gen.model = SimpleNamespace(language_model=SimpleNamespace())


### PR DESCRIPTION
## Summary

- derive `block_ff_dim` from `intermediate_size` when LFM2-VL checkpoints omit the legacy field
- map `image_token_id` to the runtime `image_token_index` while preserving explicit legacy indices
- propagate autoregressive worker failures to pending server requests instead of leaving them hanging
- add regression coverage for the LFM2.5-VL 3B configuration and server error delivery

## Root cause

`LiquidAI/LFM2.5-VL-3B` uses newer configuration names that were not normalized by the LFM2-VL loader:

- it declares an `intermediate_size` of 10,752 but omits `block_ff_dim`, causing MLX to instantiate feed-forward layers with width 6,656
- it declares `image_token_id=124907` but omits `image_token_index`, causing the model to search for the legacy default token `396` and find zero placeholders for valid image features

The continuous-batching worker only notified requests already admitted to the active batch when embedding failed. A request that failed during GPU embedding therefore waited indefinitely.

## Impact

The original 3B checkpoint now loads directly and serves text, single-image, and multi-image requests. Legacy checkpoints that explicitly provide `block_ff_dim` or `image_token_index` retain those values. Pre-admission worker failures now return to the HTTP layer rather than hanging.

## Validation

- 8 focused LFM2-VL model and processor tests passed
- 3 focused server worker-error tests passed
- all pre-commit hooks passed: Black, isort, and autoflake
- live single-image server request returned `2` for the two-cat fixture (HTTP 200)
- live two-image request correctly identified cats and a line graph (HTTP 200)
- 16 concurrent server requests returned 16/16 HTTP 200 with exact expected outputs
- exact 65,536-token context budget accepted: 65,528 prompt + 8 generation tokens
- 65,537 requested context tokens rejected with HTTP 400

Live tests used `LiquidAI/LFM2.5-VL-3B` with continuous batching and `--max-num-seqs 16 --max-kv-size 65536`.