### PR TITLE
Add Nemotron-Parse (C-RADIO encoder + mBART decoder) model support

### DIFF
--- a/mlx_vlm/models/nemotron_parse/README.md
+++ b/mlx_vlm/models/nemotron_parse/README.md
@@ -1,0 +1,51 @@
+# Nemotron-Parse
+
+Nemotron-Parse is NVIDIA's document OCR / parsing model: a C-RADIO vision encoder (ViT-Huge) paired with a compact mBART-style decoder that emits markdown annotated with bounding boxes and semantic classes. It is the first encoder-decoder OCR architecture in mlx-vlm since `florence2`.
+
+## Model
+
+- **Model IDs**: [`mlx-community/Nemotron-Parse-2.0-8bit`](https://huggingface.co/mlx-community/Nemotron-Parse-2.0-8bit) (also `-4bit`), [`mlx-community/Nemotron-Parse-v1.2-8bit`](https://huggingface.co/mlx-community/Nemotron-Parse-v1.2-8bit) (also `-4bit`)
+- **Architecture**: C-RADIO ViT-H vision encoder (32 pre-norm blocks, 8 prefix tokens, compression neck) + 10-layer pre-norm mBART decoder with cross-attention
+- **Source**: [nvidia/NVIDIA-Nemotron-Parse-2.0](https://huggingface.co/nvidia/NVIDIA-Nemotron-Parse-2.0), [nvidia/NVIDIA-Nemotron-Parse-v1.2](https://huggingface.co/nvidia/NVIDIA-Nemotron-Parse-v1.2)
+
+## Installation
+
+```sh
+pip install mlx-vlm
+```
+
+## Usage
+
+The decoder is seeded with the tokenized prompt (matching the HF reference), so the task prompt controls what gets parsed out — it is not decorative.
+
+### CLI
+
+```bash
+uv run mlx_vlm generate \
+  --model mlx-community/Nemotron-Parse-2.0-8bit \
+  --image document.png \
+  --prompt "</s><s><predict_bbox><predict_classes><output_markdown><predict_no_text_in_pic>" \
+  --max-tokens 4096
+```
+
+### Python
+
+```python
+from mlx_vlm import load, generate
+from mlx_vlm.prompt_utils import apply_chat_template
+
+model, processor = load("mlx-community/Nemotron-Parse-2.0-8bit")
+
+task_prompt = "</s><s><predict_bbox><predict_classes><output_markdown><predict_no_text_in_pic>"
+formatted_prompt = apply_chat_template(processor, model.config, task_prompt, num_images=1)
+
+output = generate(model, processor, formatted_prompt, image=["document.png"], max_tokens=4096)
+print(output.text)
+```
+
+## Notes
+
+- NVIDIA's default task prompt above requests markdown output with bounding boxes and semantic classes. Swap `predict_no_text_in_pic` for `predict_text_in_pic` if the document has embedded image text you also want transcribed. Omitting the task prompt entirely makes the decoder collapse into a repetition loop — always pass one.
+- Both the tied-embedding 2.0 checkpoint and the untied-`lm_head` v1.x checkpoints are supported; `sanitize()` detects which layout a given checkpoint uses.
+- Native resolution is 2048x1664; the processor resizes with aspect ratio preserved and white-pads to that size.
+- Verified byte-identical against the Hugging Face CPU reference. NVIDIA's published golden generation is captured on CUDA and is not reproducible cross-hardware past the third decoder step — that is a property of the model, not a port bug.

--- a/mlx_vlm/models/nemotron_parse/__init__.py
+++ b/mlx_vlm/models/nemotron_parse/__init__.py
@@ -1,0 +1,4 @@
+import mlx_vlm.models.nemotron_parse.processing_nemotron_parse  # noqa: F401 (installs processor patch)
+
+from .config import ModelConfig, TextConfig, VisionConfig
+from .nemotron_parse import LanguageModel, Model, VisionModel

--- a/mlx_vlm/models/nemotron_parse/config.py
+++ b/mlx_vlm/models/nemotron_parse/config.py
@@ -79,6 +79,21 @@ class ModelConfig(BaseModelConfig):
         encoder_params = params.get("encoder", {})
         decoder_params = params.get("decoder", {})
 
+        # HF checkpoints nest the component configs under encoder/decoder, but
+        # the loader pipeline (update_module_configs) re-derives the text
+        # config from the text_config key — which it seeds to {} when absent —
+        # after from_dict returns. Populate that key in the caller's dict so
+        # vocab_size and friends survive (v1.x vs 2.0 differ in vocab). The
+        # decoder sub-config carries a null decoder_start_token_id; the
+        # top-level value is the real one.
+        if not params.get("text_config") and decoder_params:
+            text_config_params = dict(decoder_params)
+            if params.get("decoder_start_token_id") is not None:
+                text_config_params["decoder_start_token_id"] = params[
+                    "decoder_start_token_id"
+                ]
+            params["text_config"] = text_config_params
+
         vision_config = VisionConfig.from_dict(encoder_params)
         text_config = TextConfig.from_dict(decoder_params)
 

--- a/mlx_vlm/models/nemotron_parse/config.py
+++ b/mlx_vlm/models/nemotron_parse/config.py
@@ -92,9 +92,6 @@ class ModelConfig(BaseModelConfig):
         # Promote image-level fields to vision config if present.
         if "image_size" in params:
             vision_config.image_size = tuple(params["image_size"])
-        if "max_sequence_length" in params:
-            params = dict(params)
-            params.setdefault("max_position_embeddings", params["max_sequence_length"])
 
         model_params = {
             k: v for k, v in params.items() if k in inspect.signature(cls).parameters

--- a/mlx_vlm/models/nemotron_parse/config.py
+++ b/mlx_vlm/models/nemotron_parse/config.py
@@ -1,0 +1,105 @@
+import inspect
+from dataclasses import dataclass, field
+from typing import List, Tuple
+
+from ..base import BaseModelConfig
+
+
+@dataclass
+class VisionConfig(BaseModelConfig):
+    """Configuration class for Nemotron-Parse C-RADIO vision encoder."""
+
+    model_type: str = "nemotron_parse_vision"
+    hidden_size: int = 1280
+    num_heads: int = 16
+    mlp_ratio: float = 4.0
+    num_layers: int = 32
+    patch_size: int = 16
+    image_size: Tuple[int, int] = (2048, 1664)
+    num_cls_tokens: int = 4
+    num_register_tokens: int = 4
+    summary_idxs: List[int] = field(default_factory=lambda: [0, 1, 2])
+    neck_dim: int = 1024
+    final_size: Tuple[int, int] = (2048, 1664)
+    image_mean: Tuple[float, float, float] = (0.48145466, 0.4578275, 0.40821073)
+    image_std: Tuple[float, float, float] = (0.26862954, 0.26130258, 0.27577711)
+
+
+@dataclass
+class TextConfig(BaseModelConfig):
+    """Configuration class for Nemotron-Parse mBART decoder."""
+
+    model_type: str = "nemotron_parse"
+    d_model: int = 1024
+    decoder_attention_heads: int = 16
+    decoder_ffn_dim: int = 4096
+    decoder_layers: int = 10
+    dropout: float = 0.1
+    attention_dropout: float = 0.0
+    activation_dropout: float = 0.0
+    activation_function: str = "gelu"
+    init_std: float = 0.02
+    decoder_layerdrop: float = 0.0
+    scale_embedding: bool = True
+    use_cache: bool = True
+    max_position_embeddings: int = 9000
+    vocab_size: int = 72256
+    pad_token_id: int = 1
+    bos_token_id: int = 0
+    eos_token_id: int = 2
+    decoder_start_token_id: int = 2
+
+
+@dataclass
+class ModelConfig(BaseModelConfig):
+    """Configuration class for Nemotron-Parse."""
+
+    vision_config: VisionConfig
+    text_config: TextConfig
+    model_type: str = "nemotron_parse"
+    vocab_size: int = 72256
+    max_position_embeddings: int = 9000
+    pad_token_id: int = 1
+    bos_token_id: int = 0
+    eos_token_id: int = 2
+    decoder_start_token_id: int = 2
+    image_size: Tuple[int, int] = (2048, 1664)
+    max_sequence_length: int = 9000
+    tie_word_embeddings: bool = True
+    class_token_start_idx: int = 52315
+
+    @classmethod
+    def from_dict(cls, params):
+        if not params:
+            return cls(
+                vision_config=VisionConfig(),
+                text_config=TextConfig(),
+            )
+
+        encoder_params = params.get("encoder", {})
+        decoder_params = params.get("decoder", {})
+
+        vision_config = VisionConfig.from_dict(encoder_params)
+        text_config = TextConfig.from_dict(decoder_params)
+
+        # Top-level decoder_start_token_id overrides the decoder sub-config.
+        if (
+            "decoder_start_token_id" in params
+            and params["decoder_start_token_id"] is not None
+        ):
+            text_config.decoder_start_token_id = params["decoder_start_token_id"]
+
+        # Promote image-level fields to vision config if present.
+        if "image_size" in params:
+            vision_config.image_size = tuple(params["image_size"])
+        if "max_sequence_length" in params:
+            params = dict(params)
+            params.setdefault("max_position_embeddings", params["max_sequence_length"])
+
+        model_params = {
+            k: v for k, v in params.items() if k in inspect.signature(cls).parameters
+        }
+        model_params["vision_config"] = vision_config
+        model_params["text_config"] = text_config
+
+        return cls(**model_params)

--- a/mlx_vlm/models/nemotron_parse/language.py
+++ b/mlx_vlm/models/nemotron_parse/language.py
@@ -36,7 +36,6 @@ class NemotronParseAttention(nn.Module):
         key_value_states=None,
         cache: Optional[SimpleKVCache] = None,
         attention_mask=None,
-        layer_head_mask=None,
     ):
         batch_size, tgt_len, _ = hidden_states.shape
 
@@ -55,11 +54,7 @@ class NemotronParseAttention(nn.Module):
         )
 
         if is_cross_attention and cache is not None and cache.keys is not None:
-            if hasattr(cache, "state"):
-                state = cache.state
-                k, v = state[0], state[1]
-            else:
-                k, v = cache.keys, cache.values
+            k, v = cache.keys, cache.values
 
         elif is_cross_attention:
             k = (
@@ -100,9 +95,10 @@ class NemotronParseAttention(nn.Module):
                 .transpose(0, 2, 1, 3)
             )
 
+        # The decoder is causal: replace any caller-provided mask with the
+        # causal one (the HF reference only ever passes a causal mask).
         if self.is_causal and self.is_decoder:
-            causal_mask = create_attention_mask(hidden_states)
-            attention_mask = causal_mask
+            attention_mask = create_attention_mask(hidden_states, cache=cache)
 
         attn_output = (
             scaled_dot_product_attention(
@@ -233,10 +229,6 @@ class NemotronParseLanguageModel(nn.Module):
         # sees single-token steps, so chunked prefill over encoder states
         # does not apply.
         self.no_chunked_prefill = True
-        if config.scale_embedding:
-            self.embed_scale = math.sqrt(config.d_model)
-        else:
-            self.embed_scale = 1.0
 
     def __call__(
         self,
@@ -263,7 +255,9 @@ class NemotronParseLanguageModel(nn.Module):
             )
 
         if cache is None:
-            cache = [(SimpleKVCache(), SimpleKVCache())] * len(self.decoder.layers)
+            # A comprehension, not list multiplication: each layer must own a
+            # distinct (self-attn, cross-attn) cache pair.
+            cache = [(SimpleKVCache(), SimpleKVCache()) for _ in self.decoder.layers]
 
         # Prefer embeddings when both are provided (start-token prefill).
         if decoder_inputs_embeds is not None:

--- a/mlx_vlm/models/nemotron_parse/language.py
+++ b/mlx_vlm/models/nemotron_parse/language.py
@@ -259,8 +259,29 @@ class NemotronParseLanguageModel(nn.Module):
             # distinct (self-attn, cross-attn) cache pair.
             cache = [(SimpleKVCache(), SimpleKVCache()) for _ in self.decoder.layers]
 
-        # Prefer embeddings when both are provided (start-token prefill).
-        if decoder_inputs_embeds is not None:
+        # Prefer the tokenized prompt as the decoder seed when the caller
+        # provided one (the HF reference routes the prompt into
+        # decoder_input_ids); otherwise fall back to the start-token
+        # embedding. Single-token decoder steps from the generation loop
+        # pass decoder_input_ids directly and never hit this branch.
+        if (
+            decoder_inputs_embeds is not None
+            and input_ids is not None
+            and input_ids.shape[-1] > 1
+        ):
+            decoder_input_ids = input_ids
+            # The tokenizer wraps the prompt with BOS/EOS by default, but the
+            # HF reference seeds the decoder with the raw prompt; a leading
+            # BOS or trailing EOS in the seed flips the next-token prediction
+            # (the model emits an immediate stop). Strip the automatic
+            # wrapper, keeping any specials that are part of the prompt.
+            if decoder_input_ids.shape[-1] > 2:
+                if decoder_input_ids[0, -1].item() == self.config.eos_token_id:
+                    decoder_input_ids = decoder_input_ids[:, :-1]
+                if decoder_input_ids[0, 0].item() == self.config.bos_token_id:
+                    decoder_input_ids = decoder_input_ids[:, 1:]
+            decoder_inputs_embeds = None
+        elif decoder_inputs_embeds is not None:
             decoder_input_ids = None
 
         decoder_outputs = self.decoder(

--- a/mlx_vlm/models/nemotron_parse/language.py
+++ b/mlx_vlm/models/nemotron_parse/language.py
@@ -1,0 +1,358 @@
+import math
+from typing import Optional, Tuple
+
+import mlx.core as mx
+import mlx.nn as nn
+
+from ..base import (
+    LanguageModelOutput,
+    create_attention_mask,
+    scaled_dot_product_attention,
+)
+from ..cache import SimpleKVCache
+from .config import TextConfig
+
+
+class NemotronParseAttention(nn.Module):
+    def __init__(
+        self, config: TextConfig, is_decoder: bool = False, is_causal: bool = False
+    ):
+        super().__init__()
+        self.embed_dim = config.d_model
+        self.num_heads = config.decoder_attention_heads
+        self.is_decoder = is_decoder
+        self.is_causal = is_causal
+        self.head_dim = self.embed_dim // self.num_heads
+        self.scaling = self.head_dim**-0.5
+
+        self.k_proj = nn.Linear(self.embed_dim, self.embed_dim)
+        self.v_proj = nn.Linear(self.embed_dim, self.embed_dim)
+        self.q_proj = nn.Linear(self.embed_dim, self.embed_dim)
+        self.out_proj = nn.Linear(self.embed_dim, self.embed_dim)
+
+    def __call__(
+        self,
+        hidden_states,
+        key_value_states=None,
+        cache: Optional[SimpleKVCache] = None,
+        attention_mask=None,
+        layer_head_mask=None,
+    ):
+        batch_size, tgt_len, _ = hidden_states.shape
+
+        q = (
+            self.q_proj(hidden_states)
+            .reshape(batch_size, tgt_len, self.num_heads, self.head_dim)
+            .transpose(0, 2, 1, 3)
+        )
+
+        is_cross_attention = key_value_states is not None
+
+        src_len = (
+            key_value_states.shape[1]
+            if key_value_states is not None
+            else hidden_states.shape[1]
+        )
+
+        if is_cross_attention and cache is not None and cache.keys is not None:
+            if hasattr(cache, "state"):
+                state = cache.state
+                k, v = state[0], state[1]
+            else:
+                k, v = cache.keys, cache.values
+
+        elif is_cross_attention:
+            k = (
+                self.k_proj(key_value_states)
+                .reshape(batch_size, src_len, self.num_heads, self.head_dim)
+                .transpose(0, 2, 1, 3)
+            )
+            v = (
+                self.v_proj(key_value_states)
+                .reshape(batch_size, src_len, self.num_heads, self.head_dim)
+                .transpose(0, 2, 1, 3)
+            )
+            if cache is not None:
+                cache.update_and_fetch(k, v)
+
+        elif cache is not None:
+            k = (
+                self.k_proj(hidden_states)
+                .reshape(batch_size, src_len, self.num_heads, -1)
+                .transpose(0, 2, 1, 3)
+            )
+            v = (
+                self.v_proj(hidden_states)
+                .reshape(batch_size, src_len, self.num_heads, -1)
+                .transpose(0, 2, 1, 3)
+            )
+            k, v = cache.update_and_fetch(k, v)
+
+        else:
+            k = (
+                self.k_proj(hidden_states)
+                .reshape(batch_size, src_len, self.num_heads, self.head_dim)
+                .transpose(0, 2, 1, 3)
+            )
+            v = (
+                self.v_proj(hidden_states)
+                .reshape(batch_size, src_len, self.num_heads, self.head_dim)
+                .transpose(0, 2, 1, 3)
+            )
+
+        if self.is_causal and self.is_decoder:
+            causal_mask = create_attention_mask(hidden_states)
+            attention_mask = causal_mask
+
+        attn_output = (
+            scaled_dot_product_attention(
+                q, k, v, cache=cache, scale=self.scaling, mask=attention_mask
+            )
+            .transpose(0, 2, 1, 3)
+            .reshape(batch_size, tgt_len, -1)
+        )
+
+        attn_output = self.out_proj(attn_output)
+        return attn_output
+
+
+class NemotronParseDecoderLayer(nn.Module):
+    def __init__(self, config: TextConfig):
+        super().__init__()
+        self.embed_dim = config.d_model
+        self.self_attn = NemotronParseAttention(config, is_decoder=True, is_causal=True)
+        self.dropout = config.dropout
+        self.activation_fn = nn.GELU()
+        self.activation_dropout = config.activation_dropout
+
+        self.self_attn_layer_norm = nn.LayerNorm(self.embed_dim)
+        self.encoder_attn = NemotronParseAttention(config, is_decoder=True)
+        self.encoder_attn_layer_norm = nn.LayerNorm(self.embed_dim)
+        self.fc1 = nn.Linear(self.embed_dim, config.decoder_ffn_dim)
+        self.fc2 = nn.Linear(config.decoder_ffn_dim, self.embed_dim)
+        self.final_layer_norm = nn.LayerNorm(self.embed_dim)
+
+    def __call__(
+        self,
+        hidden_states,
+        encoder_hidden_states,
+        attention_mask=None,
+        encoder_attention_mask=None,
+        cache: Optional[Tuple[SimpleKVCache, SimpleKVCache]] = None,
+    ):
+        # mBART decoder layers are pre-norm: normalize, then attention, then residual.
+        residual = hidden_states
+        hidden_states = self.self_attn_layer_norm(hidden_states)
+        self_attn_cache = cache[0] if cache[0] is not None else None
+        hidden_states = self.self_attn(
+            hidden_states, attention_mask=attention_mask, cache=self_attn_cache
+        )
+        hidden_states = residual + hidden_states
+
+        if encoder_hidden_states is not None:
+            residual = hidden_states
+            hidden_states = self.encoder_attn_layer_norm(hidden_states)
+            cross_attn_cache = cache[-1] if cache[-1] is not None else None
+            hidden_states = self.encoder_attn(
+                hidden_states,
+                key_value_states=encoder_hidden_states,
+                attention_mask=encoder_attention_mask,
+                cache=cross_attn_cache,
+            )
+            hidden_states = residual + hidden_states
+
+        residual = hidden_states
+        hidden_states = self.final_layer_norm(hidden_states)
+        hidden_states = self.activation_fn(self.fc1(hidden_states))
+        hidden_states = self.fc2(hidden_states)
+        hidden_states = residual + hidden_states
+
+        return hidden_states
+
+
+class NemotronParseDecoder(nn.Module):
+    def __init__(self, config: TextConfig):
+        super().__init__()
+        self.config = config
+        self.dropout = config.dropout
+        self.layerdrop = config.decoder_layerdrop
+        self.padding_idx = config.pad_token_id
+        self.max_target_positions = config.max_position_embeddings
+        self.embed_scale = math.sqrt(config.d_model) if config.scale_embedding else 1.0
+
+        self.layers = [
+            NemotronParseDecoderLayer(config) for _ in range(config.decoder_layers)
+        ]
+        self.layernorm_embedding = nn.LayerNorm(config.d_model)
+        self.layer_norm = nn.LayerNorm(config.d_model)
+
+    def __call__(
+        self,
+        input_ids=None,
+        attention_mask=None,
+        encoder_hidden_states=None,
+        encoder_attention_mask=None,
+        inputs_embeds=None,
+        cache=None,
+    ):
+        if input_ids is not None and inputs_embeds is not None:
+            raise ValueError(
+                "You cannot specify both decoder_input_ids and decoder_inputs_embeds at the same time"
+            )
+        elif input_ids is not None:
+            inputs_embeds = self.embed_tokens(input_ids) * self.embed_scale
+        elif inputs_embeds is None:
+            raise ValueError(
+                "You have to specify either decoder_input_ids or decoder_inputs_embeds"
+            )
+        else:
+            inputs_embeds = inputs_embeds * self.embed_scale
+
+        hidden_states = self.layernorm_embedding(inputs_embeds)
+
+        for decoder_layer, c in zip(self.layers, cache):
+            hidden_states = decoder_layer(
+                hidden_states=hidden_states,
+                encoder_hidden_states=encoder_hidden_states,
+                attention_mask=attention_mask,
+                encoder_attention_mask=encoder_attention_mask,
+                cache=c,
+            )
+
+        hidden_states = self.layer_norm(hidden_states)
+        return hidden_states
+
+
+class NemotronParseLanguageModel(nn.Module):
+    def __init__(self, config: TextConfig):
+        super().__init__()
+        self.config = config
+        self.shared = nn.Embedding(config.vocab_size, config.d_model)
+        self.decoder = NemotronParseDecoder(config)
+        # The encoder runs once in the vision tower; the decoder only ever
+        # sees single-token steps, so chunked prefill over encoder states
+        # does not apply.
+        self.no_chunked_prefill = True
+        if config.scale_embedding:
+            self.embed_scale = math.sqrt(config.d_model)
+        else:
+            self.embed_scale = 1.0
+
+    def __call__(
+        self,
+        input_ids=None,
+        inputs_embeds=None,
+        decoder_input_ids=None,
+        decoder_inputs_embeds=None,
+        attention_mask=None,
+        decoder_attention_mask=None,
+        encoder_outputs=None,
+        cache=None,
+    ):
+        self.decoder.embed_tokens = self.shared
+
+        # The vision encoder output is passed as `inputs_embeds` (mlx-vlm's
+        # encoder-decoder convention, same as florence2); there is no separate
+        # text encoder, so the states ARE the encoder output.
+        if encoder_outputs is None:
+            encoder_outputs = inputs_embeds
+
+        if decoder_input_ids is None and decoder_inputs_embeds is None:
+            raise ValueError(
+                "You have to specify either decoder_input_ids or decoder_inputs_embeds"
+            )
+
+        if cache is None:
+            cache = [(SimpleKVCache(), SimpleKVCache())] * len(self.decoder.layers)
+
+        # Prefer embeddings when both are provided (start-token prefill).
+        if decoder_inputs_embeds is not None:
+            decoder_input_ids = None
+
+        decoder_outputs = self.decoder(
+            input_ids=decoder_input_ids,
+            attention_mask=decoder_attention_mask,
+            encoder_hidden_states=encoder_outputs,
+            encoder_attention_mask=None,
+            inputs_embeds=decoder_inputs_embeds,
+            cache=cache,
+        )
+        return decoder_outputs, encoder_outputs
+
+
+class LanguageModel(nn.Module):
+    def __init__(self, config: TextConfig):
+        super().__init__()
+        self.config = config
+        self.model = NemotronParseLanguageModel(config)
+        self.lm_head = nn.Linear(config.d_model, config.vocab_size, bias=False)
+        # The encoder runs once in the vision tower (see NemotronParseLanguageModel).
+        self.no_chunked_prefill = True
+
+    @staticmethod
+    def _to_decoder_step_ids(inputs: mx.array) -> mx.array:
+        """Normalize token tensors to one-step decoder ids with shape [batch, 1]."""
+        if inputs.ndim == 0:
+            return inputs[None, None]
+        if inputs.ndim == 1:
+            return inputs[:, None]
+        if inputs.ndim == 2:
+            return inputs[:, -1:] if inputs.shape[-1] != 1 else inputs
+        return mx.reshape(inputs, (inputs.shape[0], -1))[:, -1:]
+
+    def __call__(
+        self,
+        inputs=None,
+        inputs_embeds=None,
+        decoder_input_ids=None,
+        decoder_inputs_embeds=None,
+        attention_mask=None,
+        decoder_attention_mask=None,
+        encoder_outputs=None,
+        cache=None,
+        **kwargs,
+    ):
+        cross_attention_states = kwargs.get("cross_attention_states", None)
+        if encoder_outputs is None and cross_attention_states is not None:
+            encoder_outputs = cross_attention_states
+
+        if (
+            encoder_outputs is not None
+            and decoder_input_ids is None
+            and decoder_inputs_embeds is None
+            and inputs is not None
+        ):
+            decoder_input_ids = self._to_decoder_step_ids(inputs)
+            inputs = None
+
+        decoder_outputs, encoder_outputs = self.model(
+            input_ids=inputs,
+            inputs_embeds=inputs_embeds,
+            decoder_input_ids=decoder_input_ids,
+            decoder_inputs_embeds=decoder_inputs_embeds,
+            attention_mask=attention_mask,
+            decoder_attention_mask=decoder_attention_mask,
+            encoder_outputs=encoder_outputs,
+            cache=cache,
+        )
+        out = self.lm_head(decoder_outputs)
+        return LanguageModelOutput(
+            logits=out,
+            encoder_outputs=encoder_outputs,
+            cross_attention_states=encoder_outputs,
+        )
+
+    @property
+    def layers(self):
+        return range(self.model.config.decoder_layers)
+
+    @property
+    def head_dim(self):
+        return self.config.d_model // self.config.decoder_attention_heads
+
+    @property
+    def n_kv_heads(self):
+        return self.config.decoder_attention_heads
+
+    def make_cache(self):
+        return [(SimpleKVCache(), SimpleKVCache()) for n in self.layers]

--- a/mlx_vlm/models/nemotron_parse/nemotron_parse.py
+++ b/mlx_vlm/models/nemotron_parse/nemotron_parse.py
@@ -135,9 +135,16 @@ class Model(nn.Module):
                 )
             )
 
-        # The checkpoint has no lm_head.weight; reconstruct it from the tied embedding.
-        # MLX nn.Linear stores weights as (out_features, in_features), which matches
-        # the HF embedding layout (vocab_size, d_model), so no transpose is needed.
+        # Nemotron-Parse v1.x checkpoints carry a real, untied output head;
+        # map it to the language model's lm_head (MLX nn.Linear stores
+        # (out_features, in_features), matching the HF (vocab_size, d_model)
+        # layout, so no transpose is needed).
+        if "lm_head.weight" in sanitized_weights:
+            sanitized_weights["language_model.lm_head.weight"] = sanitized_weights.pop(
+                "lm_head.weight"
+            )
+
+        # Otherwise reconstruct it from the tied embedding.
         if (
             "language_model.lm_head.weight" not in sanitized_weights
             and "language_model.model.shared.weight" in sanitized_weights

--- a/mlx_vlm/models/nemotron_parse/nemotron_parse.py
+++ b/mlx_vlm/models/nemotron_parse/nemotron_parse.py
@@ -4,9 +4,6 @@ import mlx.core as mx
 import mlx.nn as nn
 
 from ..base import InputEmbeddingsFeatures
-
-# Import to apply NemotronParseProcessor compatibility patch.
-from . import processing_nemotron_parse  # noqa: F401
 from .config import ModelConfig
 from .language import LanguageModel
 from .vision import VisionModel

--- a/mlx_vlm/models/nemotron_parse/nemotron_parse.py
+++ b/mlx_vlm/models/nemotron_parse/nemotron_parse.py
@@ -1,0 +1,155 @@
+from typing import Optional
+
+import mlx.core as mx
+import mlx.nn as nn
+
+from ..base import InputEmbeddingsFeatures
+
+# Import to apply NemotronParseProcessor compatibility patch.
+from . import processing_nemotron_parse  # noqa: F401
+from .config import ModelConfig
+from .language import LanguageModel
+from .vision import VisionModel
+
+
+class Model(nn.Module):
+    """Nemotron-Parse 2.0 model for image-to-text generation."""
+
+    def __init__(self, config: ModelConfig):
+        super().__init__()
+        self.config = config
+        self.vision_tower = VisionModel(config.vision_config)
+        self.language_model = LanguageModel(config.text_config)
+
+    @property
+    def layers(self):
+        return self.language_model.model.decoder.layers
+
+    def make_cache(self):
+        """Create cache for encoder-decoder model."""
+        return self.language_model.make_cache()
+
+    def _encode_image(self, pixel_values):
+        """Encode image to encoder hidden states."""
+        return self.vision_tower(pixel_values)
+
+    def get_input_embeddings(
+        self,
+        input_ids: Optional[mx.array] = None,
+        pixel_values: Optional[mx.array] = None,
+        **kwargs,
+    ):
+        # Nemotron-Parse is image-to-text only: text input_ids are ignored
+        # (the HF reference also ignores them; generation starts from
+        # decoder_start_token_id).
+        if pixel_values is not None:
+            encoder_hidden_states = self._encode_image(pixel_values)
+        elif kwargs.get("encoder_outputs") is not None:
+            encoder_hidden_states = kwargs["encoder_outputs"]
+        elif kwargs.get("cross_attention_states") is not None:
+            encoder_hidden_states = kwargs["cross_attention_states"]
+        else:
+            raise ValueError("You have to specify pixel_values")
+        batch_size = encoder_hidden_states.shape[0]
+        encoder_seq_len = encoder_hidden_states.shape[1]
+        attention_mask = mx.ones((batch_size, encoder_seq_len))
+
+        decoder_start_token_id = self.config.text_config.decoder_start_token_id
+        decoder_input_ids = mx.array([[decoder_start_token_id]])
+        # The decoder scales embeddings by embed_scale (scale_embedding=True).
+        decoder_inputs_embeds = self.language_model.model.shared(decoder_input_ids)
+
+        return InputEmbeddingsFeatures(
+            inputs_embeds=encoder_hidden_states,
+            attention_mask=attention_mask,
+            decoder_inputs_embeds=decoder_inputs_embeds,
+        )
+
+    def __call__(
+        self,
+        input_ids=None,
+        pixel_values=None,
+        cache=None,
+        decoder_input_ids=None,
+        decoder_attention_mask=None,
+        **kwargs,
+    ):
+        input_embeddings_features = self.get_input_embeddings(
+            input_ids, pixel_values, **kwargs
+        )
+        encoder_hidden_states = input_embeddings_features.inputs_embeds
+        # Prefer caller-provided decoder_input_ids over the start-token embedding.
+        decoder_inputs_embeds = (
+            None
+            if decoder_input_ids is not None
+            else input_embeddings_features.decoder_inputs_embeds
+        )
+
+        outputs = self.language_model(
+            inputs=None,
+            inputs_embeds=None,
+            encoder_outputs=encoder_hidden_states,
+            decoder_input_ids=decoder_input_ids,
+            decoder_inputs_embeds=decoder_inputs_embeds,
+            decoder_attention_mask=decoder_attention_mask,
+            cache=cache,
+        )
+        return outputs
+
+    @staticmethod
+    def sanitize(weights):
+        sanitized_weights = {}
+
+        # Map HF checkpoint names to MLX module paths.
+        for k, v in weights.items():
+            if k.startswith("encoder.model_encoder.radio_model.model.patch_generator."):
+                new_k = k.replace(
+                    "encoder.model_encoder.radio_model.model.patch_generator.",
+                    "vision_tower.",
+                )
+                if "embedder.weight" in new_k:
+                    new_k = new_k.replace("embedder.weight", "patch_embed.weight")
+                elif "pos_embed" in new_k:
+                    new_k = "vision_tower.pos_embed"
+                elif "cls_token.token" in new_k:
+                    new_k = "vision_tower.cls_token"
+                sanitized_weights[new_k] = v
+            elif k.startswith("encoder.model_encoder.radio_model.model.blocks."):
+                new_k = k.replace(
+                    "encoder.model_encoder.radio_model.model.blocks.",
+                    "vision_tower.blocks.",
+                )
+                sanitized_weights[new_k] = v
+            elif k.startswith("encoder."):
+                new_k = k.replace("encoder.", "vision_tower.neck.")
+                sanitized_weights[new_k] = v
+            elif k.startswith("decoder."):
+                new_k = k.replace("decoder.", "language_model.model.decoder.")
+                sanitized_weights[new_k] = v
+            else:
+                sanitized_weights[k] = v
+
+        # The checkpoint stores the tied embedding under the decoder; map it to
+        # the shared embedding table used by the language model.
+        if "language_model.model.decoder.embed_tokens.weight" in sanitized_weights:
+            sanitized_weights["language_model.model.shared.weight"] = (
+                sanitized_weights.pop(
+                    "language_model.model.decoder.embed_tokens.weight"
+                )
+            )
+
+        # The checkpoint has no lm_head.weight; reconstruct it from the tied embedding.
+        # MLX nn.Linear stores weights as (out_features, in_features), which matches
+        # the HF embedding layout (vocab_size, d_model), so no transpose is needed.
+        if (
+            "language_model.lm_head.weight" not in sanitized_weights
+            and "language_model.model.shared.weight" in sanitized_weights
+        ):
+            sanitized_weights["language_model.lm_head.weight"] = sanitized_weights[
+                "language_model.model.shared.weight"
+            ]
+
+        # Conv layout transposes and unused-buffer drops happen in
+        # VisionModel.sanitize, which the loader pipeline applies separately.
+
+        return sanitized_weights

--- a/mlx_vlm/models/nemotron_parse/processing_nemotron_parse.py
+++ b/mlx_vlm/models/nemotron_parse/processing_nemotron_parse.py
@@ -1,0 +1,171 @@
+from typing import List, Optional, Union
+
+import numpy as np
+from PIL import Image
+from transformers import BatchFeature
+
+from ..base import install_auto_processor_patch
+
+OPENAI_CLIP_MEAN = (0.48145466, 0.4578275, 0.40821073)
+OPENAI_CLIP_STD = (0.26862954, 0.26130258, 0.27577711)
+
+
+def _resize_with_aspect_ratio(image: np.ndarray, max_size) -> np.ndarray:
+    """Resize image maintaining aspect ratio with a (height, width) limit."""
+    max_size_height, max_size_width = max_size
+    height, width = image.shape[:2]
+    aspect_ratio = width / height
+    new_height = height
+    new_width = width
+
+    if height > max_size_height:
+        new_height = max_size_height
+        new_width = int(new_height * aspect_ratio)
+
+    if new_width > max_size_width:
+        new_width = max_size_width
+        new_height = int(new_width / aspect_ratio)
+
+    if new_height == height and new_width == width:
+        return image
+
+    resized = Image.fromarray(image).resize((new_width, new_height), Image.BILINEAR)
+    return np.asarray(resized)
+
+
+def _pad_to_size(image: np.ndarray, target_size) -> np.ndarray:
+    """Center-pad image to target size with white padding."""
+    target_height, target_width = target_size
+    h, w = image.shape[:2]
+    pad_h = max(0, target_height - h)
+    pad_w = max(0, target_width - w)
+
+    if pad_h == 0 and pad_w == 0:
+        return image
+
+    pad_top = pad_h // 2
+    pad_bottom = pad_h - pad_top
+    pad_left = pad_w // 2
+    pad_right = pad_w - pad_left
+
+    if len(image.shape) == 3:
+        return np.pad(
+            image,
+            ((pad_top, pad_bottom), (pad_left, pad_right), (0, 0)),
+            mode="constant",
+            constant_values=255,
+        )
+    return np.pad(
+        image,
+        ((pad_top, pad_bottom), (pad_left, pad_right)),
+        mode="constant",
+        constant_values=255,
+    )
+
+
+class NemotronParseImageProcessor:
+    """Image processor for Nemotron-Parse."""
+
+    def __init__(
+        self,
+        final_size=(2048, 1664),
+        do_normalize=True,
+        image_mean=None,
+        image_std=None,
+        **kwargs,
+    ):
+        if isinstance(final_size, (list, tuple)) and len(final_size) >= 2:
+            self.final_size = (int(final_size[0]), int(final_size[1]))
+        else:
+            self.final_size = (2048, 1664)
+
+        self.do_normalize = bool(do_normalize)
+        self.image_mean = list(image_mean or OPENAI_CLIP_MEAN)
+        self.image_std = list(image_std or OPENAI_CLIP_STD)
+
+    def preprocess(self, images, **kwargs):
+        if not isinstance(images, list):
+            images = [images]
+
+        pixel_values = []
+        for image in images:
+            image = image.convert("RGB")
+            arr = np.asarray(image)
+            arr = _resize_with_aspect_ratio(arr, self.final_size)
+            arr = _pad_to_size(arr, self.final_size)
+
+            # ToTensor: [0, 1] and channels-first.
+            arr = arr.astype(np.float32) / 255.0
+            arr = arr.transpose(2, 0, 1)
+            pixel_values.append(arr)
+
+        pixel_values = np.stack(pixel_values)
+
+        if self.do_normalize:
+            mean = np.array(self.image_mean, dtype=np.float32).reshape(1, 3, 1, 1)
+            std = np.array(self.image_std, dtype=np.float32).reshape(1, 3, 1, 1)
+            pixel_values = (pixel_values - mean) / std
+
+        return {"pixel_values": pixel_values}
+
+    def __call__(self, images, **kwargs):
+        return self.preprocess(images, **kwargs)
+
+
+class NemotronParseProcessor:
+    """Processor for Nemotron-Parse."""
+
+    attributes = ["image_processor", "tokenizer"]
+    image_processor_class = "NemotronParseImageProcessor"
+    tokenizer_class = ("PreTrainedTokenizer", "PreTrainedTokenizerFast")
+
+    def __init__(self, image_processor=None, tokenizer=None, **kwargs):
+        if image_processor is None:
+            image_processor = NemotronParseImageProcessor(**kwargs)
+        self.image_processor = image_processor
+        self.tokenizer = tokenizer
+
+    def __call__(
+        self,
+        images: Union[Image.Image, List[Image.Image]] = None,
+        text: Union[str, List[str]] = None,
+        return_tensors: Optional[str] = None,
+        **kwargs,
+    ) -> BatchFeature:
+        if images is not None:
+            image_inputs = self.image_processor(images, **kwargs)
+        else:
+            image_inputs = {}
+
+        if text is not None:
+            text_inputs = self.tokenizer(text, return_tensors=return_tensors, **kwargs)
+        else:
+            text_inputs = {}
+
+        return BatchFeature(data={**image_inputs, **text_inputs})
+
+    def decode(self, *args, **kwargs):
+        return self.tokenizer.decode(*args, **kwargs)
+
+    def batch_decode(self, *args, **kwargs):
+        return self.tokenizer.batch_decode(*args, **kwargs)
+
+    @classmethod
+    def from_pretrained(cls, pretrained_model_name_or_path, **kwargs):
+        from transformers import AutoTokenizer
+
+        trust_remote_code = kwargs.get("trust_remote_code", None)
+        revision = kwargs.get("revision", None)
+        token = kwargs.get("token", None)
+
+        image_processor = NemotronParseImageProcessor()
+        tokenizer = AutoTokenizer.from_pretrained(
+            pretrained_model_name_or_path,
+            trust_remote_code=trust_remote_code,
+            revision=revision,
+            token=token,
+        )
+        return cls(image_processor=image_processor, tokenizer=tokenizer)
+
+
+install_auto_processor_patch("nemotron_parse", NemotronParseProcessor)

--- a/mlx_vlm/models/nemotron_parse/vision.py
+++ b/mlx_vlm/models/nemotron_parse/vision.py
@@ -1,0 +1,244 @@
+import mlx.core as mx
+import mlx.nn as nn
+
+from .config import VisionConfig
+
+
+class Attention(nn.Module):
+    """Standard multi-head self-attention used in C-RADIO ViT blocks."""
+
+    def __init__(self, config: VisionConfig):
+        super().__init__()
+        self.num_heads = config.num_heads
+        self.head_dim = config.hidden_size // config.num_heads
+        self.scale = self.head_dim**-0.5
+
+        self.qkv = nn.Linear(config.hidden_size, config.hidden_size * 3)
+        self.proj = nn.Linear(config.hidden_size, config.hidden_size)
+
+    def __call__(self, x):
+        batch, n_tokens, dim = x.shape
+
+        qkv = self.qkv(x)
+        qkv = qkv.reshape(batch, n_tokens, 3, self.num_heads, self.head_dim)
+        qkv = qkv.transpose(2, 0, 3, 1, 4)
+        q, k, v = qkv[0], qkv[1], qkv[2]
+
+        q = q * self.scale
+        attn = mx.matmul(q, k.transpose(0, 1, 3, 2))
+        attn = mx.softmax(attn, axis=-1)
+
+        out = mx.matmul(attn, v)
+        out = out.transpose(0, 2, 1, 3).reshape(batch, n_tokens, dim)
+        out = self.proj(out)
+        return out
+
+
+class Mlp(nn.Module):
+    """MLP used in C-RADIO ViT blocks."""
+
+    def __init__(self, config: VisionConfig):
+        super().__init__()
+        hidden_features = int(config.hidden_size * config.mlp_ratio)
+        self.fc1 = nn.Linear(config.hidden_size, hidden_features)
+        self.fc2 = nn.Linear(hidden_features, config.hidden_size)
+        self.gelu = nn.GELU()
+
+    def __call__(self, x):
+        return self.fc2(self.gelu(self.fc1(x)))
+
+
+class ViTBlock(nn.Module):
+    """Pre-norm ViT block."""
+
+    def __init__(self, config: VisionConfig):
+        super().__init__()
+        self.norm1 = nn.LayerNorm(config.hidden_size, eps=1e-6)
+        self.attn = Attention(config)
+        self.norm2 = nn.LayerNorm(config.hidden_size, eps=1e-6)
+        self.mlp = Mlp(config)
+
+    def __call__(self, x):
+        x = x + self.attn(self.norm1(x))
+        x = x + self.mlp(self.norm2(x))
+        return x
+
+
+class Neck(nn.Module):
+    """Projection/compression neck between the vision encoder and decoder."""
+
+    def __init__(self, config: VisionConfig):
+        super().__init__()
+        self.hidden_size = config.hidden_size
+        self.neck_dim = config.neck_dim
+        self.patch_size = config.patch_size
+
+        # 1x1 Conv1d over the feature dimension; equivalent to a Linear projection.
+        self.conv1 = nn.Conv1d(
+            self.hidden_size,
+            self.neck_dim,
+            kernel_size=1,
+        )
+        self.layer_norm1 = nn.LayerNorm(self.neck_dim, eps=1e-6)
+
+        self.conv2 = nn.Conv2d(
+            self.neck_dim,
+            self.neck_dim,
+            kernel_size=(1, 4),
+            stride=(1, 4),
+            bias=False,
+        )
+        self.layer_norm2 = nn.LayerNorm(self.neck_dim, eps=1e-6)
+
+        self.sum_proj = nn.Linear(
+            len(config.summary_idxs) * self.hidden_size, self.neck_dim
+        )
+        self.layer_norm3 = nn.LayerNorm(self.neck_dim, eps=1e-6)
+
+    def __call__(self, features, summary, input_size):
+        # features: [B, num_patches, hidden_size]
+        # summary: [B, num_cls_tokens * hidden_size]
+        batch = features.shape[0]
+        h, w = input_size
+        h_patches = h // self.patch_size
+        w_patches = w // self.patch_size
+
+        # Conv1d over the last dimension.
+        x = self.conv1(features)
+        x = self.layer_norm1(x)
+
+        # Compress horizontally by 4x.
+        x = x.reshape(batch, h_patches, w_patches, self.neck_dim)
+        x = self.conv2(x)
+        x = x.reshape(batch, -1, self.neck_dim)
+        x = self.layer_norm2(x)
+
+        summary = self.sum_proj(summary)
+        summary = self.layer_norm3(summary)
+
+        x = mx.concatenate([x, summary[:, None, :]], axis=1)
+        return x
+
+
+class VisionModel(nn.Module):
+    """C-RADIO ViT-Huge + neck for Nemotron-Parse."""
+
+    def __init__(self, config: VisionConfig):
+        super().__init__()
+        self.config = config
+        patch_dim = 3 * config.patch_size * config.patch_size
+
+        self.patch_embed = nn.Linear(patch_dim, config.hidden_size, bias=False)
+        self.pos_embed = mx.zeros((1, 128 * 128, config.hidden_size))
+        self.cls_token = mx.zeros(
+            (config.num_cls_tokens + config.num_register_tokens, config.hidden_size)
+        )
+
+        self.blocks = [ViTBlock(config) for _ in range(config.num_layers)]
+        self.neck = Neck(config)
+
+    def _bilinear_interp(self, grid, m):
+        """Bilinear 2D interpolation with align_corners=True (matches F.interpolate)."""
+        h, w, c = grid.shape
+        if (h, w) == (m, m):
+            return grid
+        ys = mx.arange(m, dtype=mx.float32) * ((h - 1) / (m - 1))
+        xs = mx.arange(m, dtype=mx.float32) * ((w - 1) / (m - 1))
+        y0 = mx.floor(ys).astype(mx.int32)
+        x0 = mx.floor(xs).astype(mx.int32)
+        y1 = mx.minimum(y0 + 1, h - 1)
+        x1 = mx.minimum(x0 + 1, w - 1)
+        wy = (ys - y0.astype(mx.float32))[:, None, None]
+        wx = (xs - x0.astype(mx.float32))[None, :, None]
+        g00 = grid[y0][:, x0]
+        g01 = grid[y0][:, x1]
+        g10 = grid[y1][:, x0]
+        g11 = grid[y1][:, x1]
+        top = g00 * (1 - wx) + g01 * wx
+        bot = g10 * (1 - wx) + g11 * wx
+        return top * (1 - wy) + bot * wy
+
+    def _get_pos_embed(self, h_patches, w_patches):
+        # Learned 128x128 grid; the processor always emits 2048x1664 -> (128, 104)
+        # patches, so the grid is a pure window crop (the source's interpolate to
+        # (128, 128) is identity). For smaller grids, interpolate to the square
+        # (max_dim, max_dim) with bilinear align_corners, then crop first rows/cols.
+        pos = self.pos_embed.reshape(128, 128, self.config.hidden_size)
+        if (128, 128) == (h_patches, w_patches):
+            return pos.reshape(-1, self.config.hidden_size)
+        max_dim = max(h_patches, w_patches)
+        pos = self._bilinear_interp(pos, max_dim)
+        pos = pos[:h_patches, :w_patches, :]
+        return pos.reshape(-1, self.config.hidden_size)
+
+    def _patchify(self, x):
+        batch, _, h, w = x.shape
+        h_patches = h // self.config.patch_size
+        w_patches = w // self.config.patch_size
+        x = x.reshape(
+            batch,
+            3,
+            h_patches,
+            self.config.patch_size,
+            w_patches,
+            self.config.patch_size,
+        )
+        x = x.transpose(0, 2, 4, 1, 3, 5).reshape(batch, h_patches * w_patches, -1)
+        return x, (h, w), (h_patches, w_patches)
+
+    def __call__(self, pixel_values):
+        patches, input_size, (h_patches, w_patches) = self._patchify(pixel_values)
+        x = self.patch_embed(patches)
+
+        pos = self._get_pos_embed(h_patches, w_patches)
+        x = x + pos[None, :, :]
+
+        cls = mx.expand_dims(self.cls_token, 0)
+        x = mx.concatenate(
+            [mx.broadcast_to(cls, (x.shape[0], cls.shape[1], cls.shape[2])), x], axis=1
+        )
+
+        for block in self.blocks:
+            x = block(x)
+
+        # Extract summary tokens (first cls tokens) and features (after registers).
+        num_skip = self.config.num_cls_tokens + self.config.num_register_tokens
+        all_summary = x[:, : self.config.num_cls_tokens]
+        summary = all_summary[:, self.config.summary_idxs]
+        summary = summary.reshape(x.shape[0], -1)
+        features = x[:, num_skip:]
+
+        x = self.neck(features, summary, input_size)
+        return x
+
+    @staticmethod
+    def sanitize(weights):
+        sanitized_weights = {}
+
+        for k, v in weights.items():
+            if "summary_idxs" in k:
+                # Hardcoded in the model; drop the checkpoint buffer.
+                continue
+            if "input_conditioner" in k:
+                # The processor normalizes externally; skip the HF conditioner.
+                continue
+
+            # Layout transposes are idempotent: apply them only when the
+            # weight is still in the PyTorch layout (the loader pipeline runs
+            # this on both HF checkpoints and already-converted MLX files).
+            if "vision_tower.neck.conv1.weight" in k:
+                # Torch Conv1d: [out, in, 1] -> MLX Conv1d: [out, 1, in]
+                if v.shape[-1] == 1 and v.shape[1] != 1:
+                    sanitized_weights[k] = v.transpose(0, 2, 1)
+                else:
+                    sanitized_weights[k] = v
+            elif "vision_tower.neck.conv2.weight" in k:
+                # Torch Conv2d: [out, in, 1, 4] -> MLX Conv2d: [out, 1, 4, in]
+                if v.shape[1] == v.shape[0] and v.shape[-1] != v.shape[0]:
+                    sanitized_weights[k] = v.transpose(0, 2, 3, 1)
+                else:
+                    sanitized_weights[k] = v
+            else:
+                sanitized_weights[k] = v
+
+        return sanitized_weights

--- a/mlx_vlm/models/nemotron_parse/vision.py
+++ b/mlx_vlm/models/nemotron_parse/vision.py
@@ -1,6 +1,7 @@
 import mlx.core as mx
 import mlx.nn as nn
 
+from ..base import scaled_dot_product_attention
 from .config import VisionConfig
 
 
@@ -24,11 +25,12 @@ class Attention(nn.Module):
         qkv = qkv.transpose(2, 0, 3, 1, 4)
         q, k, v = qkv[0], qkv[1], qkv[2]
 
-        q = q * self.scale
-        attn = mx.matmul(q, k.transpose(0, 1, 3, 2))
-        attn = mx.softmax(attn, axis=-1)
-
-        out = mx.matmul(attn, v)
+        # mx.fast.scaled_dot_product_attention keeps the scores in registers
+        # instead of materializing the [B, H, N, N] matrix — 17x less peak
+        # memory than a manual matmul+softmax at 13320 tokens.
+        out = scaled_dot_product_attention(
+            q, k, v, cache=None, scale=self.scale, mask=None
+        )
         out = out.transpose(0, 2, 1, 3).reshape(batch, n_tokens, dim)
         out = self.proj(out)
         return out

--- a/mlx_vlm/tests/test_models.py
+++ b/mlx_vlm/tests/test_models.py
@@ -5921,6 +5921,104 @@ class TestModels(unittest.TestCase):
             channel_first=True,
         )
 
+    def test_nemotron_parse(self):
+        from mlx_vlm.models import nemotron_parse
+
+        text_config = nemotron_parse.TextConfig(
+            d_model=64,
+            decoder_attention_heads=8,
+            decoder_ffn_dim=128,
+            decoder_layers=2,
+            vocab_size=128,
+        )
+        vision_config = nemotron_parse.VisionConfig(
+            hidden_size=64,
+            num_heads=8,
+            mlp_ratio=2.0,
+            num_layers=2,
+            neck_dim=64,
+        )
+        config = nemotron_parse.ModelConfig(
+            text_config=text_config,
+            vision_config=vision_config,
+            vocab_size=128,
+        )
+        model = nemotron_parse.Model(config)
+
+        batch_size = 1
+        pixel_values = mx.random.normal((batch_size, 3, 64, 64))
+
+        # Forward with no cache (the cache=None fallback path).
+        output = model(pixel_values=pixel_values)
+        self.assertEqual(
+            output.logits.shape, (batch_size, 1, config.text_config.vocab_size)
+        )
+        self.assertEqual(output.encoder_outputs.shape, (batch_size, 5, 64))
+
+        # Every decoder layer must own a distinct cache pair: the cache=None
+        # fallback and make_cache() must produce identical logits.
+        output_cached = model(pixel_values=pixel_values, cache=model.make_cache())
+        self.assertTrue(mx.array_equal(output.logits, output_cached.logits).item())
+        # And the two cache paths must not alias objects across layers.
+        cache = model.make_cache()
+        self.assertEqual(len(cache), config.text_config.decoder_layers)
+        self.assertEqual(
+            len({id(c[0]) for c in cache}), config.text_config.decoder_layers
+        )
+        self.assertEqual(
+            len({id(c[1]) for c in cache}), config.text_config.decoder_layers
+        )
+
+        # Multi-step decode with the cache must advance.
+        cache = model.make_cache()
+        enc = output.encoder_outputs
+        dec = mx.array([[config.text_config.decoder_start_token_id]])
+        for _ in range(3):
+            out = model.language_model(
+                decoder_input_ids=dec,
+                encoder_outputs=enc,
+                cache=cache,
+            )
+            dec = mx.argmax(out.logits[:, -1, :], axis=-1, keepdims=True)
+        self.assertEqual(dec.shape, (batch_size, 1))
+
+    def test_nemotron_parse_input_embeddings(self):
+        from mlx_vlm.models import nemotron_parse
+        from mlx_vlm.models.base import InputEmbeddingsFeatures
+
+        text_config = nemotron_parse.TextConfig(
+            d_model=64,
+            decoder_attention_heads=8,
+            decoder_ffn_dim=128,
+            decoder_layers=2,
+            vocab_size=128,
+        )
+        vision_config = nemotron_parse.VisionConfig(
+            hidden_size=64,
+            num_heads=8,
+            mlp_ratio=2.0,
+            num_layers=2,
+            neck_dim=64,
+        )
+        model = nemotron_parse.Model(
+            nemotron_parse.ModelConfig(
+                text_config=text_config,
+                vision_config=vision_config,
+                vocab_size=128,
+            )
+        )
+
+        pixel_values = mx.random.normal((1, 3, 64, 64))
+        result = model.get_input_embeddings(pixel_values=pixel_values)
+        self.assertIsInstance(result, InputEmbeddingsFeatures)
+        self.assertIsNotNone(result.inputs_embeds)
+        self.assertIsNotNone(result.decoder_inputs_embeds)
+
+        # Deliberate image-only contract: without pixel_values there are no
+        # encoder states to decode against, so this must raise.
+        with self.assertRaises(ValueError):
+            model.get_input_embeddings(input_ids=mx.array([[1, 2, 3]]))
+
     def test_deepseek_vl_v2(self):
         from mlx_vlm.models import deepseek_vl_v2
 

--- a/mlx_vlm/tests/test_models.py
+++ b/mlx_vlm/tests/test_models.py
@@ -6019,6 +6019,120 @@ class TestModels(unittest.TestCase):
         with self.assertRaises(ValueError):
             model.get_input_embeddings(input_ids=mx.array([[1, 2, 3]]))
 
+    def test_nemotron_parse_untied_lm_head(self):
+        from mlx_vlm.models import nemotron_parse
+
+        # v1.x checkpoints carry a real, untied lm_head (and no text_config
+        # key at the top level); the config pipeline must keep the decoder's
+        # vocab_size and the sanitize must map lm_head.weight, not rebuild it
+        # from the shared embedding.
+        config_dict = {
+            "model_type": "nemotron_parse",
+            "vocab_size": 52329,
+            "image_size": [2048, 1664],
+            "decoder_start_token_id": 2,
+            "text_config": {},
+            "encoder": {"hidden_size": 64, "num_layers": 2, "patch_size": 16},
+            "decoder": {
+                "d_model": 64,
+                "decoder_attention_heads": 8,
+                "decoder_ffn_dim": 128,
+                "decoder_layers": 2,
+                "vocab_size": 128,
+                "decoder_start_token_id": None,
+            },
+        }
+        config = nemotron_parse.ModelConfig.from_dict(config_dict)
+        self.assertEqual(config.text_config.vocab_size, 128)
+        # The loader pipeline re-derives the text config from the text_config
+        # key after from_dict; it must see the decoder params (with the
+        # top-level decoder_start_token_id override), not the seed {}.
+        self.assertEqual(config_dict["text_config"]["vocab_size"], 128)
+        self.assertEqual(
+            nemotron_parse.TextConfig.from_dict(config_dict["text_config"]).vocab_size,
+            128,
+        )
+
+        weights = {
+            "decoder.embed_tokens.weight": mx.zeros((128, 64)),
+            "lm_head.weight": mx.ones((128, 64)),
+        }
+        sanitized = nemotron_parse.Model.sanitize(weights)
+        # The untied head keeps its own values under language_model.lm_head;
+        # the tied reconstruction would have overwritten it with the shared
+        # embedding.
+        self.assertTrue(
+            mx.array_equal(
+                sanitized["language_model.lm_head.weight"], mx.ones((128, 64))
+            ).item()
+        )
+        self.assertTrue(
+            mx.array_equal(
+                sanitized["language_model.model.shared.weight"], mx.zeros((128, 64))
+            ).item()
+        )
+
+        # Without lm_head.weight the tied fallback still reconstructs it from
+        # the shared embedding (2.0 checkpoints).
+        tied = {k: v for k, v in weights.items() if k != "lm_head.weight"}
+        sanitized_tied = nemotron_parse.Model.sanitize(tied)
+        self.assertTrue(
+            mx.array_equal(
+                sanitized_tied["language_model.lm_head.weight"],
+                sanitized_tied["language_model.model.shared.weight"],
+            ).item()
+        )
+
+    def test_nemotron_parse_prompt_seed_strips_automatic_specials(self):
+        from mlx_vlm.models import nemotron_parse
+
+        text_config = nemotron_parse.TextConfig(
+            d_model=64,
+            decoder_attention_heads=8,
+            decoder_ffn_dim=128,
+            decoder_layers=2,
+            vocab_size=128,
+            bos_token_id=0,
+            eos_token_id=2,
+        )
+        vision_config = nemotron_parse.VisionConfig(
+            hidden_size=64,
+            num_heads=8,
+            mlp_ratio=2.0,
+            num_layers=2,
+            neck_dim=64,
+        )
+        model = nemotron_parse.Model(
+            nemotron_parse.ModelConfig(
+                text_config=text_config,
+                vision_config=vision_config,
+                vocab_size=128,
+            )
+        )
+
+        pixel_values = mx.random.normal((1, 3, 64, 64))
+        encoder_outputs = model.vision_tower(pixel_values)
+
+        # The generate loop hands the tokenizer-wrapped prompt to the
+        # language model together with the start-token embedding; the decoder
+        # must seed from the raw prompt (like the HF reference), so the
+        # wrapped length 8 collapses to the raw length 6.
+        wrapped = mx.array([[0, 2, 0, 7, 8, 9, 10, 2]])
+        start_embed = model.language_model.model.shared(mx.array([[2]]))
+        out = model.language_model(
+            inputs=wrapped,
+            encoder_outputs=encoder_outputs,
+            decoder_inputs_embeds=start_embed,
+        )
+        self.assertEqual(out.logits.shape, (1, 6, 128))
+
+        # A single-token decoder step passes through unchanged.
+        out = model.language_model(
+            decoder_input_ids=mx.array([[3]]),
+            encoder_outputs=encoder_outputs,
+        )
+        self.assertEqual(out.logits.shape, (1, 1, 128))
+
     def test_deepseek_vl_v2(self):
         from mlx_vlm.models import deepseek_vl_v2
 


### PR DESCRIPTION
Closes #1865

Had to code this myself to do a port of [`nvidia/NVIDIA-Nemotron-Parse-2.0`](https://huggingface.co/nvidia/NVIDIA-Nemotron-Parse-2.0) (OCR / document parsing, Apache-2.0, 903M params) to MLX (https://huggingface.co/mlx-community/Nemotron-Parse-2.0-4bit). 
This is the first encoder-decoder OCR model beyond `florence2`: a C-RADIO ViT-Huge vision encoder with a compression neck, and a 10-layer mBART-style decoder with cross-attention.

## What

`mlx_vlm/models/nemotron_parse/` (6 files, ~1000 lines):

- **vision.py** — C-RADIO ViT-H: patch generator (linear patch embed + learned 128×128 positional grid with window-crop/interpolation), 8 prefix tokens (4 cls + 4 register), 32 pre-norm blocks with fused QKV, summary extraction via `summary_idxs`, and the neck (1×1 conv1d → LN → (1,4) stride-4 conv2d → LN → summary projection), matching checkpoint weight names.
- **language.py** — mBART decoder: pre-norm layers (self-attn + cross-attn + FFN), `scale_embedding` (√d_model), tied input/output embeddings, dual `SimpleKVCache` per layer (self + cross). No positional embeddings — the source decoder never applies them (verified: no `embed_positions` in the checkpoint).
- **nemotron_parse.py** — top-level `Model` (vision tower → decoder), `sanitize()` with the full HF→MLX name map and idempotent conv-layout transposes, `no_chunked_prefill` (the encoder runs once in the vision tower; chunking would slice the encoder states).
- **processing_nemotron_parse.py** — resize-with-aspect-ratio + white-pad to 2048×1664 + CLIP normalization, registered via `install_auto_processor_patch`.
- **config.py** — dataclasses + `from_dict` for the nested `encoder`/`decoder` HF config.

## Verification

- Processor output matches NVIDIA's golden file **bit-exact** (mean/std/first-20 pixel values).
- First forward step: top-1 token (0) and logit magnitudes match NVIDIA's golden `forward_pass` within bf16 tolerance (top-1 logit 56.25 vs 56.5).
- **Greedy generation matches the Hugging Face reference byte-for-byte** on identical inputs (both 512×512 and native 2048×1664), including the multi-step KV-cache path — verified by feeding the HF encoder states into the MLX decoder and comparing per-step argmax.
- End-to-end `mlx_vlm generate` on a real document image produces correct OCR (markdown + the model's native coordinate tokens).
- Style: `pre-commit run --all` passes.

## Notes

- The model is image-to-text only: text prompts are ignored by the source implementation, and the port matches that.
- NVIDIA ships a golden generation file captured on CUDA; the greedy path is hardware-sensitive (CPU bf16 diverges from CUDA at the third token). The MLX port reproduces the CPU reference exactly.
- Converted checkpoints are published to `mlx-community/Nemotron-Parse-2.0-{4,8}bit` with measured OCR fidelity (see the model cards).