### PR TITLE
Allow CacheList extraction with plain KVCache children

### DIFF
--- a/mlx_vlm/models/cache.py
+++ b/mlx_vlm/models/cache.py
@@ -343,6 +343,26 @@ class KVCache(_BaseCache):
         self.offset -= n
         return n
 
+    def extract(self, idx):
+        cache = KVCache()
+        if self.keys is None:
+            if idx not in (0, -1):
+                raise IndexError("KVCache row index out of range")
+            return cache
+
+        batch_size = int(self.keys.shape[0])
+        if idx < 0:
+            idx += batch_size
+        if idx < 0 or idx >= batch_size:
+            raise IndexError(
+                f"KVCache row index {idx} out of range for batch size {batch_size}"
+            )
+
+        cache.keys = mx.contiguous(self.keys[idx : idx + 1, :, : self.offset, :])
+        cache.values = mx.contiguous(self.values[idx : idx + 1, :, : self.offset, :])
+        cache.offset = self.offset
+        return cache
+
     def to_quantized(self, group_size: int = 64, bits: int = 4) -> QuantizedKVCache:
         quant_cache = QuantizedKVCache(group_size=group_size, bits=bits)
         quant_cache.offset = self.offset

--- a/mlx_vlm/tests/test_cache.py
+++ b/mlx_vlm/tests/test_cache.py
@@ -1,0 +1,55 @@
+import mlx.core as mx
+import pytest
+
+from mlx_vlm.models.cache import CacheList, KVCache
+
+
+def _make_kv_cache(batch_size=1, length=3):
+    cache = KVCache()
+    keys = mx.arange(batch_size * 2 * length * 4).reshape(batch_size, 2, length, 4)
+    values = keys + 100
+    cache.update_and_fetch(keys, values)
+    return cache, keys, values
+
+
+def test_kv_cache_extracts_one_active_row():
+    cache, keys, values = _make_kv_cache(batch_size=2)
+
+    extracted = cache.extract(1)
+
+    assert extracted.offset == 3
+    assert extracted.keys.shape == (1, 2, 3, 4)
+    assert extracted.values.shape == (1, 2, 3, 4)
+    assert mx.array_equal(extracted.keys, keys[1:2]).item()
+    assert mx.array_equal(extracted.values, values[1:2]).item()
+
+
+def test_cache_list_can_extract_an_already_extracted_kv_cache():
+    first, _, _ = _make_kv_cache()
+    second, _, _ = _make_kv_cache()
+    batched = CacheList.merge([CacheList(first), CacheList(second)])
+
+    extracted = batched.extract(0)
+    extracted_again = extracted.extract(0)
+
+    assert isinstance(extracted_again[0], KVCache)
+    assert extracted_again[0].offset == first.offset
+    assert mx.array_equal(extracted_again[0].keys, first.state[0]).item()
+    assert mx.array_equal(extracted_again[0].values, first.state[1]).item()
+
+
+def test_kv_cache_extract_validates_row_index():
+    cache, _, _ = _make_kv_cache(batch_size=2)
+
+    assert mx.array_equal(cache.extract(-1).keys, cache.extract(1).keys).item()
+    with pytest.raises(IndexError):
+        cache.extract(2)
+    with pytest.raises(IndexError):
+        cache.extract(-3)
+
+
+def test_empty_kv_cache_extracts_as_empty():
+    extracted = KVCache().extract(0)
+
+    assert extracted.empty()
+    assert extracted.offset == 0


### PR DESCRIPTION
Fixes #1869

## Summary

`CacheList.extract()` delegates extraction to its children, but extracting a `BatchKVCache` produces a plain `KVCache`. Because `KVCache` did not implement `extract()`, the resulting composite cache could not be extracted again.

This change adds row extraction support directly to `KVCache` so that the child cache continues to satisfy the interface expected by `CacheList`.

The implementation:

- extracts one batch row while preserving the batch dimension;
- copies only the active key/value prefix up to `offset`;
- makes the extracted arrays contiguous;
- preserves empty-cache behavior;
- supports Python-style negative row indices;
- raises `IndexError` for out-of-range row indices.

Regression coverage includes populated multi-row caches, repeated `CacheList` extraction, negative and invalid indices, and empty caches.

## Tests

```text
python -m pytest mlx_vlm/tests/test_cache.py -q
```

Results:

- 4 tests passed.