### PR TITLE
fix(server): honor speculative request cancellation

### DIFF
--- a/mlx_vlm/server/generation.py
+++ b/mlx_vlm/server/generation.py
@@ -1145,6 +1145,28 @@ class ResponseGenerator:
             pending, self._cancelled = self._cancelled, set()
             return pending
 
+    def _take_cancellation(self, uid) -> bool:
+        """Consume one request's cancellation without draining its peers."""
+        with self._cancel_lock:
+            if uid not in self._cancelled:
+                return False
+            self._cancelled.remove(uid)
+            return True
+
+    def _finish_cancelled_speculative_requests(
+        self, uids, rqueues, finished_uids
+    ) -> int:
+        """Close cancelled speculative rows at a safe round boundary."""
+        cancelled = 0
+        for uid in uids:
+            if uid in finished_uids or not self._take_cancellation(uid):
+                continue
+            rqueues[uid].put(None)
+            finished_uids.add(uid)
+            cancelled += 1
+            logger.info("Speculative generation cancelled: request=%s", uid)
+        return cancelled
+
     def _initialize_model(self):
         model, processor, config = load_model_resources(
             self.model_path, self.adapter_path
@@ -2197,9 +2219,18 @@ class ResponseGenerator:
 
                 finished_uids = set()
 
+                # A request may be cancelled while its prompt is in the
+                # uninterruptible target forward. Close it before exposing the
+                # first sampled token.
+                self._finish_cancelled_speculative_requests(
+                    uids, rqueues, finished_uids
+                )
+
                 # Send first bonus tokens to clients
                 fb_list = first_bonus.tolist()
                 for j, uid in enumerate(uids):
+                    if uid in finished_uids:
+                        continue
                     tok = int(fb_list[j])
                     token_lists[uid].append(tok)
                     is_stop = tok in self.stop_tokens
@@ -2228,6 +2259,15 @@ class ResponseGenerator:
                         rqueues[uid].put(None)
                         finished_uids.add(uid)
 
+                if len(finished_uids) == len(uids):
+                    continue
+
+                # A cancellation can arrive while the target is pre-filling.
+                # Consume only this batch's request IDs: draining the shared
+                # set here would discard cancellations for queued peers.
+                self._finish_cancelled_speculative_requests(
+                    uids, rqueues, finished_uids
+                )
                 if len(finished_uids) == len(uids):
                     continue
 
@@ -2270,6 +2310,13 @@ class ResponseGenerator:
                     row_ids=sample_row_ids,
                 )
                 for tok_list, _ in rounds_iter:
+                    # Every rounds backend yields at a committed decode
+                    # boundary. Check cancellation before emitting that
+                    # boundary's tokens, then let stop_check filter cancelled
+                    # rows from the next backend round.
+                    self._finish_cancelled_speculative_requests(
+                        uids, rqueues, finished_uids
+                    )
                     for j, tok in enumerate(tok_list):
                         if tok is None:
                             continue

--- a/mlx_vlm/tests/test_server.py
+++ b/mlx_vlm/tests/test_server.py
@@ -4635,6 +4635,22 @@ class TestResponseGenerator:
         gen._cpu_preprocess = lambda prompt, images, audio: {"input_ids": [1, 2, 3]}
         return gen
 
+    def test_speculative_cancellation_is_request_local(self):
+        gen = server.ResponseGenerator.__new__(server.ResponseGenerator)
+        gen._cancel_lock = Lock()
+        gen._cancelled = {11, 22}
+        rqueue = Queue()
+        finished = set()
+
+        cancelled = gen._finish_cancelled_speculative_requests(
+            [11], {11: rqueue}, finished
+        )
+
+        assert cancelled == 1
+        assert finished == {11}
+        assert rqueue.get_nowait() is None
+        assert gen._cancelled == {22}
+
     def test_generate_rejects_requests_over_configured_context_limit(self, monkeypatch):
         gen = server.ResponseGenerator.__new__(server.ResponseGenerator)
         gen.wait_until_ready = lambda: None


### PR DESCRIPTION
# fix(server): honor speculative request cancellation

## Summary

- consume cancellation for the matching speculative request at safe yielded
  boundaries;
- close only the cancelled request's response queue;
- preserve cancellation IDs belonging to peer requests;
- cover request-local cancellation with a focused regression test.

This PR is independent and rebased directly onto current `main`. It does not
depend on either closed APC PR. The cumulative resumable-prefill draft #1875
stacks this change after #1923.

## Problem

The regular generation path observes disconnect cancellation, but the
speculative server loop can continue decoding after its client has gone away.
Draining the shared cancellation set is also unsafe for batched work because
one request can consume a peer's cancellation.

## Implementation

`_take_cancellation(uid)` removes only the requested UID under the existing
lock. The speculative loop checks it after prefill and at committed round
boundaries. A cancelled row receives its terminal `None` without emitting the
pending token, while other rows and their cancellation state remain intact.

## Verification

- focused request-local regression: 1 passed;
- the current full `test_server.py` run reached 112 passed before reproducing
  the existing server-thread teardown hang in this environment.

The cancellation patch itself remains intentionally narrow and default-path
compatible.
