### PR TITLE
feat(server): expose process and speculative runtime identity

### DIFF
--- a/mlx_vlm/server/app.py
+++ b/mlx_vlm/server/app.py
@@ -5,6 +5,7 @@ import os
 import secrets
 import sys
 import time
+import uuid
 from contextlib import asynccontextmanager
 from threading import Lock
 from types import SimpleNamespace
@@ -50,6 +51,7 @@ from .schemas import ChatLogprobContent, ModelsResponse, TopLogprob
 DEFAULT_SERVER_HOST = "0.0.0.0"
 DEFAULT_SERVER_PORT = 8080
 SERVER_API_KEY_ENV = "MLX_VLM_SERVER_API_KEY"
+SERVER_INSTANCE_ID = uuid.uuid4().hex
 
 logger = logging.getLogger("mlx_vlm.server")
 
@@ -132,7 +134,20 @@ def _server_runtime_snapshot() -> dict:
             audio_queue_depth = runtime.audio_queue.qsize()
         except Exception:
             audio_queue_depth = 0
+    response_generator = runtime.response_generator
+    speculative = {
+        "enabled": bool(
+            response_generator is not None
+            and getattr(response_generator, "draft_model", None) is not None
+        ),
+        "kind": (
+            getattr(response_generator, "draft_kind", None)
+            if response_generator is not None
+            else None
+        ),
+    }
     return {
+        "server_instance_id": SERVER_INSTANCE_ID,
         "loaded_model": default_cache.get("model_path", None),
         "loaded_adapter": default_cache.get("adapter_path", None),
         "loaded_models": {
@@ -153,6 +168,7 @@ def _server_runtime_snapshot() -> dict:
         "continuous_batching_enabled": runtime.response_generator is not None,
         "request_queue_depth": queue_depth,
         "audio_queue_depth": audio_queue_depth,
+        "speculative_decode": speculative,
         "preload_failures": dict(runtime.preload_failures),
         "apc": (
             {"enabled": False}
@@ -912,6 +928,7 @@ async def health_check(request: Request):
     runtime = _server_runtime_snapshot()
     return {
         "status": "healthy",
+        "server_instance_id": runtime["server_instance_id"],
         "loaded_model": runtime["loaded_model"],
         "loaded_adapter": runtime["loaded_adapter"],
         "loaded_models": runtime["loaded_models"],
@@ -921,6 +938,7 @@ async def health_check(request: Request):
         "loaded_tool_parser": runtime["loaded_tool_parser"],
         "continuous_batching_enabled": runtime["continuous_batching_enabled"],
         "apc_enabled": runtime["apc"]["enabled"],
+        "speculative_decode": runtime["speculative_decode"],
     }
 
 

--- a/mlx_vlm/tests/test_server.py
+++ b/mlx_vlm/tests/test_server.py
@@ -731,6 +731,25 @@ def test_unsupported_model_request_does_not_crash_server(client, monkeypatch):
     assert client.get("/health").status_code == 200
 
 
+def test_health_reports_process_and_speculative_identity(client, monkeypatch):
+    response_generator = SimpleNamespace(
+        requests=Queue(),
+        draft_model=object(),
+        draft_kind="dflash",
+    )
+    monkeypatch.setattr(server.runtime, "response_generator", response_generator)
+
+    response = client.get("/health")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["server_instance_id"] == server._app_module.SERVER_INSTANCE_ID
+    assert payload["speculative_decode"] == {
+        "enabled": True,
+        "kind": "dflash",
+    }
+
+
 def _unstarted_response_generator():
     gen = server.ResponseGenerator.__new__(server.ResponseGenerator)
     gen.model_path = "demo"


### PR DESCRIPTION
# feat(server): expose process and speculative runtime identity

## Summary

- add a per-process `server_instance_id`;
- expose whether speculative decoding is enabled and its effective kind;
- return both fields from `/health` and the internal runtime snapshot;
- add focused endpoint coverage.

## Motivation

Operational gates need to distinguish a real process restart from a successful
probe against the old process. They also need to verify that the expected
speculative backend is active instead of trusting an operator label or launch
command.

The instance ID is generated once at module load and is intentionally opaque.
The speculative snapshot reports `enabled` plus `kind`, using the server's
effective runtime state.

## Verification

- focused health test — 1 passed, 287 deselected;
- Black 26.3.1 — pass for changed files.

This draft is independent of the cancellation and resumable-prefill work.
