### PR TITLE
feat(server): add opt-in resumable APC-aware DFlash prefill

### DIFF
--- a/mlx_vlm/server/generation.py
+++ b/mlx_vlm/server/generation.py
@@ -1186,6 +1186,28 @@ class ResponseGenerator:
             pending, self._cancelled = self._cancelled, set()
             return pending
 
+    def _take_cancellation(self, uid) -> bool:
+        """Consume one request's cancellation without draining its peers."""
+        with self._cancel_lock:
+            if uid not in self._cancelled:
+                return False
+            self._cancelled.remove(uid)
+            return True
+
+    def _finish_cancelled_speculative_requests(
+        self, uids, rqueues, finished_uids
+    ) -> int:
+        """Close cancelled speculative rows at a safe round boundary."""
+        cancelled = 0
+        for uid in uids:
+            if uid in finished_uids or not self._take_cancellation(uid):
+                continue
+            rqueues[uid].put(None)
+            finished_uids.add(uid)
+            cancelled += 1
+            logger.info("Speculative generation cancelled: request=%s", uid)
+        return cancelled
+
     def _initialize_model(self):
         model, processor, config = load_model_resources(
             self.model_path, self.adapter_path
@@ -2290,9 +2312,18 @@ class ResponseGenerator:
 
                 finished_uids = set()
 
+                # A request may be cancelled while its prompt is in the
+                # uninterruptible target forward. Close it before exposing the
+                # first sampled token.
+                self._finish_cancelled_speculative_requests(
+                    uids, rqueues, finished_uids
+                )
+
                 # Send first bonus tokens to clients
                 fb_list = first_bonus.tolist()
                 for j, uid in enumerate(uids):
+                    if uid in finished_uids:
+                        continue
                     tok = int(fb_list[j])
                     token_lists[uid].append(tok)
                     is_stop = tok in self.stop_tokens
@@ -2322,6 +2353,15 @@ class ResponseGenerator:
                         rqueues[uid].put(None)
                         finished_uids.add(uid)
 
+                if len(finished_uids) == len(uids):
+                    continue
+
+                # A cancellation can arrive while the target is pre-filling.
+                # Consume only this batch's request IDs: draining the shared
+                # set here would discard cancellations for queued peers.
+                self._finish_cancelled_speculative_requests(
+                    uids, rqueues, finished_uids
+                )
                 if len(finished_uids) == len(uids):
                     continue
 
@@ -2365,6 +2405,13 @@ class ResponseGenerator:
                     context_offset=apc_cached_tokens,
                 )
                 for tok_list, _ in rounds_iter:
+                    # Every rounds backend yields at a committed decode
+                    # boundary. Check cancellation before emitting that
+                    # boundary's tokens, then let stop_check filter cancelled
+                    # rows from the next backend round.
+                    self._finish_cancelled_speculative_requests(
+                        uids, rqueues, finished_uids
+                    )
                     for j, tok in enumerate(tok_list):
                         if tok is None:
                             continue

--- a/mlx_vlm/server/generation.py
+++ b/mlx_vlm/server/generation.py
@@ -47,6 +47,8 @@ from ..speculative.utils import (
 from ..structured import ThinkingAwareLogitsProcessor
 from ..tokenizer_utils import _ServerTokenStreamer, make_streaming_detokenizer
 from ..utils import ThinkingBudgetCriteria, load, prepare_inputs
+from .prefill_scheduler import ResumablePrefill, TailFairScheduler, TailWork
+from .resumable_dflash_prefill import DFlashPrefillContinuation
 from .runtime import runtime
 
 logger = logging.getLogger("mlx_vlm.server")
@@ -78,6 +80,52 @@ def _notify_queues(queues, *items):
 
 def get_prefill_step_size():
     return int(os.environ.get("PREFILL_STEP_SIZE", DEFAULT_PREFILL_STEP_SIZE))
+
+
+def _resumable_dflash_prefill_enabled() -> bool:
+    return os.environ.get("MLX_VLM_RESUMABLE_DFLASH_PREFILL", "0") == "1"
+
+
+def _resumable_dflash_slice_tokens() -> int:
+    raw = os.environ.get("MLX_VLM_RESUMABLE_PREFILL_SLICE_TOKENS", "2048")
+    try:
+        return max(128, int(raw))
+    except ValueError:
+        return 2048
+
+
+def _resumable_dflash_max_deferrals() -> int:
+    raw = os.environ.get("MLX_VLM_RESUMABLE_PREFILL_MAX_DEFERRALS", "3")
+    try:
+        return max(0, int(raw))
+    except ValueError:
+        return 3
+
+
+def _resumable_dflash_max_seqs() -> int:
+    """Bound resident prompt caches even when the global cap is unset."""
+    global_cap = get_max_num_seqs()
+    raw = os.environ.get("MLX_VLM_RESUMABLE_PREFILL_MAX_SEQS", "4")
+    try:
+        local_cap = max(2, int(raw))
+    except ValueError:
+        local_cap = 4
+    return min(global_cap, local_cap) if global_cap is not None else local_cap
+
+
+def _resumable_dflash_request_eligible(request) -> bool:
+    """The resumable lane currently owns text-only, single-request work."""
+    return _dflash_apc_text_only(request)
+
+
+def _partition_resumable_dflash_requests(requests):
+    """Return ``(eligible, fallback, reason)`` at one admission boundary."""
+    requests = list(requests)
+    if len(requests) > 1:
+        return [], requests, "coalesced_batch"
+    if requests and not _resumable_dflash_request_eligible(requests[0]):
+        return [], requests, "multimodal"
+    return requests, [], None
 
 
 def get_max_num_seqs():
@@ -161,9 +209,13 @@ def _drop_prefill_kwargs(prompt_kwargs: dict, keys: List[str], n: int) -> dict:
 
 def _dflash_apc_text_only(request) -> bool:
     """Return whether a queued request has no multimodal prompt state."""
-    if request.images or request.videos or request.audio:
+    if (
+        getattr(request, "images", None)
+        or getattr(request, "videos", None)
+        or getattr(request, "audio", None)
+    ):
         return False
-    raw_inputs = request.raw_inputs or {}
+    raw_inputs = getattr(request, "raw_inputs", None) or {}
     return not any(
         key in raw_inputs
         for key in ("pixel_values", "pixel_values_videos", "input_features")
@@ -198,6 +250,28 @@ def _dflash_apc_lookup(
         suffix_is_text_only=lambda _prefix_len: True,
         prefix_has_media=lambda _prefix_len: False,
     )
+
+
+def _resumable_dflash_context_limit(draft_model) -> Optional[int]:
+    """Bound retained round-one hidden context to the drafter window."""
+    window = getattr(getattr(draft_model, "config", None), "sliding_window", None)
+    if not window or int(window) <= 1:
+        return None
+    return int(window) - 1
+
+
+def _append_dflash_context(existing, new_hidden, limit: Optional[int], dropped: int):
+    """Keep the newest round-1 target context and its absolute start offset."""
+    combined = (
+        new_hidden
+        if existing is None
+        else mx.concatenate([existing, new_hidden], axis=1)
+    )
+    if limit is not None and int(combined.shape[1]) > int(limit):
+        trim = int(combined.shape[1]) - int(limit)
+        combined = combined[:, -int(limit) :, :]
+        dropped += trim
+    return combined, int(dropped)
 
 
 def _run_chunked_speculative_prefill(
@@ -2106,7 +2180,596 @@ class ResponseGenerator:
         finally:
             results.close()
 
+    def _prepare_resumable_dflash_request(self, request, lm, prefill_kwargs):
+        """Prepare one text-only B=1 request through APC restore, without prefill."""
+        if not _resumable_dflash_request_eligible(request):
+            raise ValueError(
+                "resumable DFlash prefill currently supports text-only requests"
+            )
+        log_state = self._log_prefill_started(
+            request, backend="speculative_dflash_resumable"
+        )
+        log_state["streamer"] = _ServerTokenStreamer(
+            self.tokenizer,
+            make_streaming_detokenizer(self.processor),
+        )
+        if hasattr(lm, "_position_ids"):
+            lm._position_ids = None
+        if hasattr(lm, "_rope_deltas"):
+            lm._rope_deltas = None
+        input_ids, gen_kwargs = self._gpu_embed(
+            request.raw_inputs,
+            None,
+            apc_semantic_hash=request.apc_semantic_hash,
+        )
+        ids_list = input_ids.squeeze(0).tolist()
+        inputs_embeds, prompt_kwargs = _merge_prefill_prompt_kwargs(
+            [gen_kwargs], [ids_list]
+        )
+        prompt_cache = make_speculative_prompt_cache(
+            lm,
+            draft_kind="dflash",
+            batch_size=1,
+            left_padding=[0],
+            make_cache=_make_cache,
+        )
+        prefix_len = 0
+        extra_hash = request.apc_semantic_hash
+        apc_active = False
+        apc_manager = getattr(self, "apc_manager", None)
+        apc_mode = getattr(self, "apc_mode", None)
+        if apc_manager is not None:
+            try:
+                plan = _dflash_apc_lookup(
+                    request,
+                    ids_list,
+                    batch_size=1,
+                    draft_kind="dflash",
+                    apc_manager=apc_manager,
+                    apc_mode=apc_mode,
+                )
+                if plan is not None:
+                    # Build the warm path in temporary locals.  APC faults must
+                    # leave the pristine cold cache/input path usable.
+                    warm_prefix_len = int(plan["prefix_len"])
+                    sequence_keys = _sequence_aligned_prefill_keys(
+                        prompt_kwargs,
+                        batch_size=1,
+                        sequence_length=inputs_embeds.shape[1],
+                    )
+                    input_ids = input_ids[:, warm_prefix_len:]
+                    inputs_embeds = inputs_embeds[:, warm_prefix_len:, :]
+                    prompt_kwargs = _drop_prefill_kwargs(
+                        prompt_kwargs, sequence_keys, warm_prefix_len
+                    )
+                    prompt_cache = plan["warm_cache"]
+                    prefix_len = warm_prefix_len
+                    apc_active = True
+            except Exception:
+                logger.warning(
+                    "APC resumable lookup failed; cold prefill", exc_info=True
+                )
+
+        request_id = self._request_log_id(request)
+        scheduler_id = str(id(request.rqueue))
+        continuation = DFlashPrefillContinuation(
+            request_id=request_id,
+            prompt_cache=prompt_cache,
+            remaining_input_ids=input_ids,
+            remaining_embeds=inputs_embeds,
+            prompt_kwargs=prompt_kwargs,
+            cached_tokens=prefix_len,
+            full_input_ids=ids_list,
+            metadata={
+                "request": request,
+                "log_state": log_state,
+                "extra_hash": extra_hash,
+                "apc_active": apc_active,
+                "prompt_started": time.perf_counter(),
+                "prefill_compute_s": 0.0,
+                "draft_context": None,
+                "draft_context_dropped": 0,
+                "draft_context_limit": _resumable_dflash_context_limit(
+                    self.draft_model
+                ),
+            },
+        )
+        work = TailWork(
+            prompt_tokens=len(ids_list),
+            cached_tokens=prefix_len,
+        )
+        scheduled = ResumablePrefill(
+            request_id=scheduler_id,
+            work=work,
+            cache_state=prompt_cache,
+            remaining_input=continuation,
+            metadata={"continuation": continuation},
+        )
+        request.rqueue.put(
+            GenerationContext(
+                uid=id(request.rqueue), prompt_tokens=request.prompt_tokens
+            )
+        )
+        logger.info(
+            "Resumable prefill admitted: request=%s prompt_tokens=%d "
+            "cached_tokens=%d uncached_tokens=%d",
+            request_id,
+            len(ids_list),
+            prefix_len,
+            work.uncached_tokens,
+        )
+        return scheduled
+
+    def _advance_one_resumable_dflash_segment(
+        self, scheduled, tokens, lm, prefill_kwargs, generation_stream
+    ):
+        continuation = scheduled.metadata["continuation"]
+        segment_tokens = continuation.next_segment_tokens(tokens)
+        if segment_tokens <= 0:
+            return False
+
+        keys = _sequence_aligned_prefill_keys(
+            continuation.prompt_kwargs,
+            batch_size=1,
+            sequence_length=continuation.remaining_tokens,
+        )
+        segment_kwargs = _slice_prefill_kwargs(
+            continuation.prompt_kwargs, keys, segment_tokens
+        )
+        # Retain only the drafter's round-1 window. Discarding every prior slice
+        # collapses context to one position and reverses the measured warm-context
+        # acceptance win; retaining the bounded tail restores that contract
+        # without keeping full-prompt hidden state resident.
+        call_kwargs = {**segment_kwargs, **prefill_kwargs}
+        call_kwargs["inputs_embeds"] = continuation.remaining_embeds[:, :segment_tokens]
+        segment_started = time.perf_counter()
+        with mx.stream(generation_stream):
+            output = lm(
+                continuation.remaining_input_ids[:, :segment_tokens],
+                cache=continuation.prompt_cache,
+                n_to_process=segment_tokens,
+                **call_kwargs,
+            )
+        context, dropped = _append_dflash_context(
+            continuation.metadata.get("draft_context"),
+            speculative_hidden_state("dflash", output),
+            continuation.metadata.get("draft_context_limit"),
+            continuation.metadata.get("draft_context_dropped", 0),
+        )
+        mx.eval([c.state for c in continuation.prompt_cache], context)
+        continuation.metadata["prefill_compute_s"] += (
+            time.perf_counter() - segment_started
+        )
+        continuation.metadata["draft_context"] = context
+        continuation.metadata["draft_context_dropped"] = dropped
+
+        next_kwargs = _drop_prefill_kwargs(
+            continuation.prompt_kwargs, keys, segment_tokens
+        )
+        continuation.commit_segment(
+            segment_tokens,
+            next_ids=continuation.remaining_input_ids[:, segment_tokens:],
+            next_embeds=continuation.remaining_embeds[:, segment_tokens:],
+            next_kwargs=next_kwargs,
+        )
+        scheduled.commit_segment(segment_tokens, continuation)
+
+        logger.info(
+            "Resumable prefill progress: request=%s cached=%d processed=%d "
+            "remaining=%d segments=%d",
+            continuation.request_id,
+            continuation.cached_tokens,
+            continuation.processed_uncached,
+            continuation.remaining_tokens,
+            continuation.segment_count,
+        )
+        return True
+
+    def _advance_resumable_dflash_segment(
+        self,
+        scheduled,
+        tokens,
+        lm,
+        prefill_kwargs,
+        generation_stream,
+        should_yield=None,
+    ):
+        """Run adjacent slices without leaving the MLX prefill hot path.
+
+        A request or cancellation still interrupts at every evaluated slice
+        boundary.  When neither exists, staying in this method avoids the
+        allocator/graph churn observed when each slice made a full trip through
+        the outer admission scheduler (most visible around 3--4k prompts).
+        """
+        advanced = False
+        continuation = scheduled.metadata["continuation"]
+        while not continuation.ready_for_final:
+            if not self._advance_one_resumable_dflash_segment(
+                scheduled, tokens, lm, prefill_kwargs, generation_stream
+            ):
+                break
+            advanced = True
+            mx.clear_cache()
+            if should_yield is not None and should_yield():
+                break
+            if not self.requests.empty():
+                break
+            with self._cancel_lock:
+                if self._cancelled:
+                    break
+        return advanced
+
+    def _finish_resumable_dflash_request(
+        self,
+        scheduled,
+        lm,
+        drafter,
+        prefill_kwargs,
+        draft_block_size,
+        generation_stream,
+    ):
+        """Run final target position and the unchanged B=1 DFlash decode."""
+        continuation = scheduled.metadata["continuation"]
+        if not continuation.ready_for_final:
+            raise RuntimeError("resumable DFlash continuation is not final-ready")
+        request = continuation.metadata["request"]
+        uid = id(request.rqueue)
+        sampler = self._make_sampler(request.args) or make_sampler(temp=0)
+        final_kwargs = {**continuation.prompt_kwargs, **prefill_kwargs}
+        final_kwargs["inputs_embeds"] = continuation.remaining_embeds
+        final_started = time.perf_counter()
+        with mx.stream(generation_stream):
+            output = lm(
+                continuation.remaining_input_ids,
+                cache=continuation.prompt_cache,
+                **final_kwargs,
+            )
+        final_hidden = speculative_hidden_state("dflash", output)
+        all_hidden, context_dropped = _append_dflash_context(
+            continuation.metadata.get("draft_context"),
+            final_hidden,
+            continuation.metadata.get("draft_context_limit"),
+            continuation.metadata.get("draft_context_dropped", 0),
+        )
+
+        hidden = all_hidden
+        context_offset = continuation.cached_tokens + context_dropped
+
+        row_ids = [0]
+        first_bonus = _sample_last_token(
+            output.logits,
+            sampler,
+            row_ids=row_ids,
+            positions=[0],
+        ).astype(mx.int32)
+        mx.eval(first_bonus, hidden, output.logits)
+        continuation.metadata["prefill_compute_s"] += (
+            time.perf_counter() - final_started
+        )
+        scheduled.commit_segment(1, continuation)
+        prompt_elapsed = time.perf_counter() - continuation.metadata["prompt_started"]
+
+        extra_hash = continuation.metadata.get("extra_hash")
+        if (
+            self.apc_manager is not None
+            and self.apc_mode == "exact"
+            and extra_hash is not None
+            and _dflash_apc_text_only(request)
+        ):
+            try:
+                self.apc_manager.store_exact_cache(
+                    continuation.full_input_ids,
+                    continuation.prompt_cache,
+                    extra_hash=int(extra_hash),
+                )
+            except Exception as error:
+                logger.warning("Failed to store DFlash APC entry: %s", error)
+
+        prefilled = scheduled.work.uncached_tokens
+        prompt_compute = continuation.metadata["prefill_compute_s"]
+        prompt_tps = (
+            scheduled.work.prompt_tokens / prompt_compute
+            if prompt_compute > 0
+            else None
+        )
+        logger.info(
+            "Prefill completed: request=%s prompt_tokens=%d cached_tokens=%d "
+            "prefilled=%d wall=%.3fs compute=%.3fs rate=%.1f tok/s segments=%d",
+            continuation.request_id,
+            scheduled.work.prompt_tokens,
+            continuation.cached_tokens,
+            prefilled,
+            prompt_elapsed,
+            prompt_compute,
+            float(prompt_tps or 0.0),
+            continuation.segment_count + 1,
+        )
+
+        log_state = continuation.metadata["log_state"]
+        if self._take_cancellation(uid):
+            request.rqueue.put(None)
+            return
+        token_list = []
+        token = int(first_bonus.tolist()[0])
+        token_list.append(token)
+        is_stop = token in self.stop_tokens
+        is_max = len(token_list) >= request.args.max_tokens
+        finish = "stop" if is_stop else "length" if is_max else None
+        text = self._stream_text(log_state, token, finish)
+        emitted_at = self._log_decode_progress(
+            uid, log_state, token=token, text=text, finish_reason=finish
+        )
+        request.rqueue.put(
+            StreamingToken(
+                text=text,
+                token=token,
+                logprobs=0.0,
+                finish_reason=finish,
+                peak_memory=mx.get_peak_memory() / 1e9 if finish else 0,
+                prompt_tps=prompt_tps,
+                cached_tokens=continuation.cached_tokens,
+                emitted_at=emitted_at,
+            )
+        )
+        if finish:
+            request.rqueue.put(None)
+            return
+
+        cancelled = set()
+
+        def stop_check(_seq_idx, token_id):
+            if self._take_cancellation(uid):
+                cancelled.add(uid)
+            return (
+                uid in cancelled
+                or self._stop
+                or token_id in self.stop_tokens
+                or len(token_list) >= request.args.max_tokens
+            )
+
+        snapshot = speculative_stats_snapshot(drafter)
+        rounds_iter = run_speculative_server_rounds(
+            self.model,
+            drafter,
+            continuation.prompt_cache,
+            hidden,
+            draft_kind="dflash",
+            first_bonus=first_bonus,
+            max_tokens=request.args.max_tokens,
+            sampler=sampler,
+            draft_block_size=draft_block_size,
+            token_dtype=mx.int32,
+            stop_check=stop_check,
+            greedy_sampling=request.args.temperature == 0,
+            prompt_tokens=continuation.remaining_input_ids,
+            row_ids=row_ids,
+            context_offset=context_offset,
+        )
+        finished = False
+        for tokens, _ in rounds_iter:
+            if uid in cancelled or self._take_cancellation(uid):
+                cancelled.add(uid)
+                break
+            token = tokens[0]
+            if token is None:
+                continue
+            token = int(token)
+            token_list.append(token)
+            is_stop = token in self.stop_tokens
+            is_max = len(token_list) >= request.args.max_tokens
+            finish = "stop" if is_stop else "length" if is_max else None
+            text = self._stream_text(log_state, token, finish)
+            emitted_at = self._log_decode_progress(
+                uid, log_state, token=token, text=text, finish_reason=finish
+            )
+            rounds, accepted, drafted = (
+                speculative_stats_since(drafter, snapshot)
+                if finish
+                else (None, None, None)
+            )
+            request.rqueue.put(
+                StreamingToken(
+                    text=text,
+                    token=token,
+                    logprobs=0.0,
+                    finish_reason=finish,
+                    peak_memory=mx.get_peak_memory() / 1e9 if finish else 0,
+                    prompt_tps=prompt_tps,
+                    emitted_at=emitted_at,
+                    draft_kind="dflash" if finish else None,
+                    draft_rounds=rounds,
+                    draft_n_accepted=accepted,
+                    draft_n=drafted,
+                    cached_tokens=continuation.cached_tokens,
+                )
+            )
+            if finish:
+                request.rqueue.put(None)
+                finished = True
+                break
+
+        rounds, accepted, drafted = speculative_stats_since(drafter, snapshot)
+        if rounds:
+            logger.info(
+                "Speculative decode: kind=dflash batch=1 tokens=%d accept=%.2f "
+                "rounds=%d drafted=%s resumable_prefill=1",
+                len(token_list),
+                (accepted + rounds) / rounds,
+                rounds,
+                drafted,
+            )
+        if not finished and uid not in cancelled:
+            text = log_state["streamer"].finalize()
+            emitted_at = self._log_decode_progress(
+                uid,
+                log_state,
+                token=0,
+                text=text,
+                finish_reason="length",
+                token_count=0,
+            )
+            request.rqueue.put(
+                StreamingToken(
+                    text=text,
+                    token=0,
+                    logprobs=0.0,
+                    finish_reason="length",
+                    peak_memory=mx.get_peak_memory() / 1e9,
+                    prompt_tps=prompt_tps,
+                    token_count=0,
+                    emitted_at=emitted_at,
+                    cached_tokens=continuation.cached_tokens,
+                    draft_kind="dflash" if rounds else None,
+                    draft_rounds=rounds,
+                    draft_n_accepted=accepted,
+                    draft_n=drafted,
+                )
+            )
+            request.rqueue.put(None)
+        elif uid in cancelled:
+            request.rqueue.put(None)
+
+    def _run_speculative_resumable_dflash(self):
+        """Experimental B=1 text lane: interleave APC-aware prefill slices."""
+        generation_stream = mx.default_stream(mx.default_device())
+        lm = self.model.language_model
+        drafter = self.draft_model
+        prefill_kwargs = speculative_prefill_kwargs("dflash", drafter)
+        draft_block_size = _get_draft_block_size_from_env()
+        scheduler = TailFairScheduler(
+            slice_tokens=_resumable_dflash_slice_tokens(),
+            max_deferrals=_resumable_dflash_max_deferrals(),
+        )
+        max_resident = _resumable_dflash_max_seqs()
+
+        while not self._stop:
+            current = None
+            preparing = None
+            try:
+                scheduler_active = bool(len(scheduler))
+                room = max(0, max_resident - len(scheduler))
+                # Preserve ordinary coalescing while idle. Once continuations
+                # are resident, admit at most one request at a slice boundary.
+                capacity = min(1, room) if scheduler_active else room
+                coalesce_s = (
+                    0.0
+                    if scheduler_active
+                    else get_speculative_batch_coalesce_s()
+                )
+                new_requests, should_stop = self._collect_pending_requests(
+                    active=scheduler_active,
+                    capacity=capacity,
+                    coalesce_s=coalesce_s,
+                )
+                if should_stop:
+                    break
+                # A coalesced batch and every media request keep the established
+                # non-resumable implementation. This is a real fallback, not a
+                # rejection: the same model owner runs one batch to completion,
+                # then returns to the resumable scheduler.
+                new_requests, fallback, fallback_reason = (
+                    _partition_resumable_dflash_requests(new_requests)
+                )
+                if fallback:
+                    logger.info(
+                        "Resumable prefill fallback: requests=%d reason=%s",
+                        len(fallback),
+                        fallback_reason,
+                    )
+                    self._run_speculative_nonresumable(
+                        initial_pending=fallback, return_after_batch=True
+                    )
+                    continue
+                for request in new_requests:
+                    preparing = request
+                    scheduler.enqueue(
+                        self._prepare_resumable_dflash_request(
+                            request, lm, prefill_kwargs
+                        )
+                    )
+                    preparing = None
+                if not len(scheduler):
+                    continue
+
+                resident_ids = set(scheduler.pending_ids())
+                with self._cancel_lock:
+                    cancelled = {
+                        uid for uid in self._cancelled if str(uid) in resident_ids
+                    }
+                    self._cancelled.difference_update(cancelled)
+                for uid in cancelled:
+                    removed = scheduler.cancel(str(uid))
+                    if removed is not None:
+                        continuation = removed.metadata["continuation"]
+                        continuation.metadata["request"].rqueue.put(None)
+                        logger.info(
+                            "Resumable prefill cancelled: request=%s "
+                            "processed=%d remaining=%d",
+                            continuation.request_id,
+                            continuation.processed_uncached,
+                            continuation.remaining_tokens,
+                        )
+
+                choice = scheduler.choose()
+                if choice is None:
+                    continue
+                current, budget = choice
+                continuation = current.metadata["continuation"]
+                if continuation.ready_for_final:
+                    self._finish_resumable_dflash_request(
+                        current,
+                        lm,
+                        drafter,
+                        prefill_kwargs,
+                        draft_block_size,
+                        generation_stream,
+                    )
+                    mx.clear_cache()
+                    continue
+
+                self._advance_resumable_dflash_segment(
+                    current,
+                    budget,
+                    lm,
+                    prefill_kwargs,
+                    generation_stream,
+                    should_yield=lambda: bool(len(scheduler)),
+                )
+                scheduler.requeue(current)
+            except Exception as error:
+                logger.exception("Error in resumable DFlash generation: %s", error)
+                if preparing is not None:
+                    _notify_queues([preparing.rqueue], error, None)
+                elif current is not None:
+                    request = current.metadata["continuation"].metadata["request"]
+                    _notify_queues([request.rqueue], error, None)
+                mx.clear_cache()
+                gc.collect()
+
+        # stop_and_join must not strand clients that already received a
+        # GenerationContext. Notify every resident continuation immediately.
+        for item in scheduler.drain():
+            request = item.metadata["continuation"].metadata["request"]
+            _notify_queues(
+                [request.rqueue], RuntimeError("generation server stopped"), None
+            )
+
     def _run_speculative(self):
+        if self.draft_kind == "dflash" and _resumable_dflash_prefill_enabled():
+            logger.info(
+                "Resumable DFlash prefill enabled "
+                "(slice_tokens=%d max_deferrals=%d max_seqs=%d, hybrid routing)",
+                _resumable_dflash_slice_tokens(),
+                _resumable_dflash_max_deferrals(),
+                _resumable_dflash_max_seqs(),
+            )
+            self._run_speculative_resumable_dflash()
+            return
+        self._run_speculative_nonresumable()
+
+    def _run_speculative_nonresumable(
+        self, initial_pending=None, return_after_batch=False
+    ):
         """GPU thread loop with DFlash, EAGLE-3, or MTP speculative decoding.
 
         Collects incoming requests, prefills them as a batch with the
@@ -2130,10 +2793,15 @@ class ResponseGenerator:
             rqueues = {}
             try:
                 # --- Phase 1: collect pending requests ---
-                pending, should_stop = self._collect_pending_requests(
-                    active=False,
-                    coalesce_s=get_speculative_batch_coalesce_s(),
-                )
+                if initial_pending is not None:
+                    pending = initial_pending
+                    initial_pending = None
+                    should_stop = False
+                else:
+                    pending, should_stop = self._collect_pending_requests(
+                        active=False,
+                        coalesce_s=get_speculative_batch_coalesce_s(),
+                    )
                 if should_stop:
                     break
 
@@ -2506,6 +3174,9 @@ class ResponseGenerator:
                         )
                         rqueues[uid].put(None)
 
+                if return_after_batch:
+                    return
+
             except Exception as e:
                 logger.exception("Error in speculative generation thread: %s", e)
                 error_queues = {id(rqueue): rqueue for rqueue in rqueues.values()}
@@ -2515,6 +3186,8 @@ class ResponseGenerator:
                 _notify_queues(error_queues.values(), e, None)
                 mx.clear_cache()
                 gc.collect()
+                if return_after_batch:
+                    return
 
     def _step(self, batch_gen, active, gen_kwargs=None):
         """One batch generation step: prefill + decode."""

--- a/mlx_vlm/server/generation.py
+++ b/mlx_vlm/server/generation.py
@@ -159,6 +159,47 @@ def _drop_prefill_kwargs(prompt_kwargs: dict, keys: List[str], n: int) -> dict:
     return out
 
 
+def _dflash_apc_text_only(request) -> bool:
+    """Return whether a queued request has no multimodal prompt state."""
+    if request.images or request.videos or request.audio:
+        return False
+    raw_inputs = request.raw_inputs or {}
+    return not any(
+        key in raw_inputs
+        for key in ("pixel_values", "pixel_values_videos", "input_features")
+    )
+
+
+def _dflash_apc_lookup(
+    request,
+    input_ids: List[int],
+    *,
+    batch_size: int,
+    draft_kind: str,
+    apc_manager,
+    apc_mode: Optional[str],
+):
+    """Look up a conservative B=1, text-only exact-cache DFlash prefix."""
+    if (
+        batch_size != 1
+        or draft_kind != "dflash"
+        or apc_manager is None
+        or apc_mode != "exact"
+        or request.apc_semantic_hash is None
+        or not _dflash_apc_text_only(request)
+    ):
+        return None
+    return _apc.apc_lookup_plan(
+        apc_manager,
+        input_ids,
+        extra_hash=int(request.apc_semantic_hash),
+        apc_mode="exact",
+        safe_lookup_min=0,
+        suffix_is_text_only=lambda _prefix_len: True,
+        prefix_has_media=lambda _prefix_len: False,
+    )
+
+
 def _run_chunked_speculative_prefill(
     lm,
     input_ids: mx.array,
@@ -2144,6 +2185,41 @@ class ResponseGenerator:
                     make_cache=_make_cache,
                 )
 
+                apc_cached_tokens = 0
+                apc_extra_hash = None
+                apc_manager = getattr(self, "apc_manager", None)
+                apc_mode = getattr(self, "apc_mode", None)
+                if B == 1:
+                    apc_extra_hash = pending[0].apc_semantic_hash
+                    try:
+                        apc_plan = _dflash_apc_lookup(
+                            pending[0],
+                            all_input_ids[0],
+                            batch_size=B,
+                            draft_kind=draft_kind,
+                            apc_manager=apc_manager,
+                            apc_mode=apc_mode,
+                        )
+                    except Exception as e:
+                        logger.warning(
+                            "DFlash APC lookup failed; using cold prefill: %s", e
+                        )
+                        apc_plan = None
+                    if apc_plan is not None:
+                        prefix_len = int(apc_plan["prefix_len"])
+                        sequence_keys = _sequence_aligned_prefill_keys(
+                            prompt_kwargs,
+                            batch_size=1,
+                            sequence_length=inputs_embeds_mx.shape[1],
+                        )
+                        input_mx = input_mx[:, prefix_len:]
+                        inputs_embeds_mx = inputs_embeds_mx[:, prefix_len:, :]
+                        prompt_kwargs = _drop_prefill_kwargs(
+                            prompt_kwargs, sequence_keys, prefix_len
+                        )
+                        prompt_cache = apc_plan["warm_cache"]
+                        apc_cached_tokens = prefix_len
+
                 prefill_step_size = self._effective_prefill_step_size()
                 policy_kwargs = {**prompt_kwargs, **prefill_kwargs}
                 if not _chunked_prefill_enabled(
@@ -2179,6 +2255,22 @@ class ResponseGenerator:
                 )
                 mx.eval(first_bonus, hidden, out.logits)
                 prompt_elapsed = time.perf_counter() - prompt_started
+                if (
+                    B == 1
+                    and draft_kind == "dflash"
+                    and apc_manager is not None
+                    and apc_mode == "exact"
+                    and apc_extra_hash is not None
+                    and _dflash_apc_text_only(pending[0])
+                ):
+                    try:
+                        apc_manager.store_exact_cache(
+                            all_input_ids[0],
+                            prompt_cache,
+                            extra_hash=int(apc_extra_hash),
+                        )
+                    except Exception as e:
+                        logger.warning("DFlash APC store failed: %s", e)
                 for uid in uids:
                     prompt_tokens = prompt_tokens_map[uid]
                     prompt_tps_map[uid] = (
@@ -2188,9 +2280,10 @@ class ResponseGenerator:
                     )
                     logger.info(
                         "Prefill completed: request=%s prompt_tokens=%d "
-                        "cached_tokens=0 elapsed=%.3fs rate=%.1f tok/s",
+                        "cached_tokens=%d elapsed=%.3fs rate=%.1f tok/s",
                         stream_infos[uid].get("request_id", uid),
                         prompt_tokens,
+                        apc_cached_tokens,
                         prompt_elapsed,
                         float(prompt_tps_map[uid] or 0.0),
                     )
@@ -2221,6 +2314,7 @@ class ResponseGenerator:
                             finish_reason=finish,
                             peak_memory=mx.get_peak_memory() / 1e9 if finish else 0,
                             prompt_tps=prompt_tps_map.get(uid),
+                            cached_tokens=apc_cached_tokens,
                             emitted_at=emitted_at,
                         )
                     )
@@ -2268,6 +2362,7 @@ class ResponseGenerator:
                     eos_token_ids=eos_set,
                     prompt_tokens=input_mx,
                     row_ids=sample_row_ids,
+                    context_offset=apc_cached_tokens,
                 )
                 for tok_list, _ in rounds_iter:
                     for j, tok in enumerate(tok_list):

--- a/mlx_vlm/server/prefill_scheduler.py
+++ b/mlx_vlm/server/prefill_scheduler.py
@@ -1,0 +1,106 @@
+"""Transactional admission for resumable prompt prefill."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, Iterable, Optional
+
+
+@dataclass(frozen=True)
+class TailWork:
+    """Prompt work remaining after a validated prefix-cache restore."""
+
+    prompt_tokens: int
+    cached_tokens: int = 0
+
+    def __post_init__(self):
+        if self.prompt_tokens < 1:
+            raise ValueError("prompt_tokens must be positive")
+        if not 0 <= self.cached_tokens < self.prompt_tokens:
+            raise ValueError("cached_tokens must leave at least one tail token")
+
+    @property
+    def uncached_tokens(self) -> int:
+        return self.prompt_tokens - self.cached_tokens
+
+
+@dataclass
+class ResumablePrefill:
+    """Opaque cache/input state owned by the generation thread."""
+
+    request_id: str
+    work: TailWork
+    cache_state: Any
+    remaining_input: Any
+    processed_tokens: int = 0
+    deferrals: int = 0
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+    @property
+    def remaining_tokens(self) -> int:
+        return self.work.uncached_tokens - self.processed_tokens
+
+    @property
+    def complete(self) -> bool:
+        return self.remaining_tokens == 0
+
+    def commit_segment(self, tokens: int, next_remaining_input: Any) -> None:
+        """Commit only after the generation thread materializes cache writes."""
+        if tokens < 1 or tokens > self.remaining_tokens:
+            raise ValueError("segment must be within remaining uncached tail")
+        self.processed_tokens += int(tokens)
+        self.remaining_input = next_remaining_input
+        self.deferrals = 0
+
+
+class TailFairScheduler:
+    """Shortest-remaining-tail scheduling with bounded starvation."""
+
+    def __init__(self, *, slice_tokens: int, max_deferrals: int = 3):
+        if slice_tokens < 1:
+            raise ValueError("slice_tokens must be positive")
+        if max_deferrals < 0:
+            raise ValueError("max_deferrals must be non-negative")
+        self.slice_tokens = int(slice_tokens)
+        self.max_deferrals = int(max_deferrals)
+        self._pending: list[ResumablePrefill] = []
+
+    def enqueue(self, item: ResumablePrefill) -> None:
+        if item.complete:
+            raise ValueError("cannot schedule a completed prefill")
+        self._pending.append(item)
+
+    def __len__(self) -> int:
+        return len(self._pending)
+
+    def choose(self) -> Optional[tuple[ResumablePrefill, int]]:
+        if not self._pending:
+            return None
+        forced = [x for x in self._pending if x.deferrals >= self.max_deferrals]
+        chosen = (
+            forced[0]
+            if forced
+            else min(self._pending, key=lambda x: x.remaining_tokens)
+        )
+        self._pending.remove(chosen)
+        for other in self._pending:
+            other.deferrals += 1
+        return chosen, min(self.slice_tokens, chosen.remaining_tokens)
+
+    def requeue(self, item: ResumablePrefill) -> None:
+        if not item.complete:
+            self._pending.append(item)
+
+    def pending_ids(self) -> Iterable[str]:
+        return tuple(x.request_id for x in self._pending)
+
+    def cancel(self, request_id: str) -> Optional[ResumablePrefill]:
+        for index, item in enumerate(self._pending):
+            if item.request_id == request_id:
+                return self._pending.pop(index)
+        return None
+
+    def drain(self) -> tuple[ResumablePrefill, ...]:
+        pending = tuple(self._pending)
+        self._pending.clear()
+        return pending

--- a/mlx_vlm/server/resumable_dflash_prefill.py
+++ b/mlx_vlm/server/resumable_dflash_prefill.py
@@ -1,0 +1,49 @@
+"""Cache-safe continuation state for segmented DFlash prefill."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, Sequence
+
+
+@dataclass
+class DFlashPrefillContinuation:
+    request_id: str
+    prompt_cache: Sequence[Any]
+    remaining_input_ids: Any
+    remaining_embeds: Any
+    prompt_kwargs: Dict[str, Any]
+    cached_tokens: int
+    full_input_ids: Sequence[int]
+    processed_uncached: int = 0
+    segment_count: int = 0
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+    @property
+    def remaining_tokens(self) -> int:
+        return int(self.remaining_input_ids.shape[1])
+
+    @property
+    def ready_for_final(self) -> bool:
+        return self.remaining_tokens == 1
+
+    def next_segment_tokens(self, limit: int) -> int:
+        if limit < 1:
+            raise ValueError("limit must be positive")
+        return max(0, min(int(limit), self.remaining_tokens - 1))
+
+    def commit_segment(
+        self,
+        tokens: int,
+        *,
+        next_ids: Any,
+        next_embeds: Any,
+        next_kwargs: Dict[str, Any],
+    ) -> None:
+        if tokens < 1 or tokens >= self.remaining_tokens:
+            raise ValueError("segment must leave one token for the final forward")
+        self.remaining_input_ids = next_ids
+        self.remaining_embeds = next_embeds
+        self.prompt_kwargs = next_kwargs
+        self.processed_uncached += int(tokens)
+        self.segment_count += 1

--- a/mlx_vlm/speculative/dflash.py
+++ b/mlx_vlm/speculative/dflash.py
@@ -75,6 +75,12 @@ def _dflash_committed_hidden_segments(
     ]
 
 
+def _drafter_pos_shift(cache_list, extra: int) -> None:
+    """Shift drafter RoPE positions without changing cache bookkeeping."""
+    for cache in cache_list:
+        cache.pos_shift = int(getattr(cache, "pos_shift", 0)) + int(extra)
+
+
 def _dflash_rounds(
     model: nn.Module,
     draft_model: nn.Module,
@@ -87,6 +93,7 @@ def _dflash_rounds(
     draft_block_size: Optional[int] = None,
     token_dtype: mx.Dtype = mx.int32,
     use_model_initial_block_size: bool = True,
+    context_offset: int = 0,
 ) -> Generator[Tuple[int, None], None, None]:
     """DFlash speculative-decoding **round loop**.
 
@@ -104,6 +111,8 @@ def _dflash_rounds(
     target_layer_ids = list(draft_model.config.target_layer_ids)
     block_total = _dflash_block_total(draft_model, draft_block_size)
     draft_cache = draft_model.reset(model)
+    if context_offset > 0:
+        _drafter_pos_shift(draft_cache, context_offset)
     prepare_target_hidden = getattr(draft_model, "prepare_target_hidden", None)
     hidden_is_prepared = callable(prepare_target_hidden)
     if hidden_is_prepared:

--- a/mlx_vlm/speculative/drafters/laguna_dflash/dflash.py
+++ b/mlx_vlm/speculative/drafters/laguna_dflash/dflash.py
@@ -89,9 +89,10 @@ def _normalize_dflash_qkv(projected, q_norm, k_norm):
 
 def _apply_dflash_attention(attention, x, projected, rope, cache):
     queries, context_keys, proposal_keys, context_values, proposal_values = projected
-    queries = rope(queries, offset=cache.offset + context_keys.shape[2])
-    context_keys = rope(context_keys, offset=cache.offset)
-    proposal_keys = rope(proposal_keys, offset=cache.offset + context_keys.shape[2])
+    offset = cache.offset + int(getattr(cache, "pos_shift", 0))
+    queries = rope(queries, offset=offset + context_keys.shape[2])
+    context_keys = rope(context_keys, offset=offset)
+    proposal_keys = rope(proposal_keys, offset=offset + context_keys.shape[2])
     cached_keys, cached_values = cache.update_and_fetch(context_keys, context_values)
     keys = mx.concatenate([cached_keys, proposal_keys], axis=2)
     values = mx.concatenate([cached_values, proposal_values], axis=2)

--- a/mlx_vlm/speculative/drafters/muse_glimmer_assistant/dflash.py
+++ b/mlx_vlm/speculative/drafters/muse_glimmer_assistant/dflash.py
@@ -80,7 +80,9 @@ class MuseGlimmerAssistantAttention(nn.Module):
             context_length = context_hidden_states.shape[1]
             cache.offset += skip
 
-        cache_offset = cache.offset
+        # The shift affects absolute RoPE only. The sliding mask below uses
+        # relative positions, so its raw cache offsets remain unchanged.
+        cache_offset = cache.offset + int(getattr(cache, "pos_shift", 0))
         queries = self.q_proj(hidden_states)
         kv_hidden_states = mx.concatenate(
             [context_hidden_states, hidden_states], axis=1

--- a/mlx_vlm/speculative/drafters/qwen3_dflash/dflash.py
+++ b/mlx_vlm/speculative/drafters/qwen3_dflash/dflash.py
@@ -73,9 +73,10 @@ class DFlashAttention(nn.Module):
         prop_values = prop_values.reshape(B, L, self.n_kv_heads, -1).transpose(
             0, 2, 1, 3
         )
-        queries = rope(queries, offset=cache.offset + S)
-        ctx_keys = rope(ctx_keys, offset=cache.offset)
-        prop_keys = rope(prop_keys, offset=cache.offset + S)
+        offset = cache.offset + int(getattr(cache, "pos_shift", 0))
+        queries = rope(queries, offset=offset + S)
+        ctx_keys = rope(ctx_keys, offset=offset)
+        prop_keys = rope(prop_keys, offset=offset + S)
         keys, values = cache.update_and_fetch(ctx_keys, ctx_values)
         keys = mx.concatenate([keys, prop_keys], axis=2)
         values = mx.concatenate([values, prop_values], axis=2)

--- a/mlx_vlm/speculative/utils.py
+++ b/mlx_vlm/speculative/utils.py
@@ -137,6 +137,7 @@ def run_speculative_server_rounds(
     eos_token_ids: Optional[set] = None,
     prompt_tokens: Optional[mx.array] = None,
     row_ids: Optional[List[int]] = None,
+    context_offset: int = 0,
 ) -> Generator[Tuple[List[Optional[int]], None], None, None]:
     batch_size = int(first_bonus.shape[0]) if first_bonus.ndim > 0 else 1
 
@@ -208,6 +209,7 @@ def run_speculative_server_rounds(
                 sampler=sampler,
                 draft_block_size=draft_block_size,
                 token_dtype=token_dtype,
+                context_offset=context_offset,
             ):
                 yield [tok], state
                 if stop_check is not None and stop_check(0, tok):

--- a/mlx_vlm/tests/test_prefill_scheduler.py
+++ b/mlx_vlm/tests/test_prefill_scheduler.py
@@ -1,0 +1,81 @@
+from mlx_vlm.server.prefill_scheduler import (
+    ResumablePrefill,
+    TailFairScheduler,
+    TailWork,
+)
+
+
+def item(name, prompt, cached=0):
+    return ResumablePrefill(
+        name,
+        TailWork(prompt, cached),
+        cache_state=object(),
+        remaining_input=object(),
+    )
+
+
+def test_scheduler_charges_suffix_not_prompt():
+    assert TailWork(30_000, 29_988).uncached_tokens == 12
+
+
+def test_scheduler_runs_shortest_tail_first():
+    scheduler = TailFairScheduler(slice_tokens=64)
+    long, hit = item("long", 4096), item("hit", 30_000, 29_988)
+    scheduler.enqueue(long)
+    scheduler.enqueue(hit)
+
+    selected, budget = scheduler.choose()
+
+    assert selected is hit
+    assert budget == 12
+
+
+def test_scheduler_commit_is_transactional():
+    pending = item("pending", 100)
+    pending.commit_segment(64, "suffix")
+
+    assert pending.processed_tokens == 64
+    assert pending.remaining_tokens == 36
+
+    try:
+        pending.commit_segment(37, "invalid")
+    except ValueError:
+        pass
+    else:
+        raise AssertionError("overflow segment accepted")
+
+    assert pending.processed_tokens == 64
+
+
+def test_scheduler_bounds_starvation():
+    scheduler = TailFairScheduler(slice_tokens=32, max_deferrals=1)
+    long, first, second = item("long", 1000), item("first", 10), item("second", 11)
+    scheduler.enqueue(long)
+    scheduler.enqueue(first)
+    scheduler.enqueue(second)
+
+    assert scheduler.choose()[0] is first
+    scheduler.requeue(first)
+    assert scheduler.choose()[0] is long
+
+
+def test_scheduler_cancel_is_request_local():
+    scheduler = TailFairScheduler(slice_tokens=32)
+    first, second = item("first", 100), item("second", 100)
+    scheduler.enqueue(first)
+    scheduler.enqueue(second)
+
+    assert scheduler.cancel("first") is first
+    assert tuple(scheduler.pending_ids()) == ("second",)
+    assert scheduler.cancel("missing") is None
+
+
+def test_scheduler_drain_detaches_resident_work():
+    scheduler = TailFairScheduler(slice_tokens=32)
+    first, second = item("first", 100), item("second", 100)
+    scheduler.enqueue(first)
+    scheduler.enqueue(second)
+
+    assert scheduler.drain() == (first, second)
+    assert len(scheduler) == 0
+    assert scheduler.drain() == ()

--- a/mlx_vlm/tests/test_resumable_dflash_prefill.py
+++ b/mlx_vlm/tests/test_resumable_dflash_prefill.py
@@ -1,0 +1,202 @@
+from queue import Queue
+from threading import Lock
+from types import SimpleNamespace
+
+import mlx.core as mx
+
+from mlx_vlm.server import generation
+
+
+def test_continuation_segments_leave_final_token():
+    continuation = generation.DFlashPrefillContinuation(
+        request_id="request",
+        prompt_cache=[],
+        remaining_input_ids=mx.array([[1, 2, 3, 4]]),
+        remaining_embeds=mx.zeros((1, 4, 2)),
+        prompt_kwargs={"mask": mx.ones((1, 4))},
+        cached_tokens=10,
+        full_input_ids=list(range(14)),
+    )
+
+    assert continuation.next_segment_tokens(10) == 3
+    continuation.commit_segment(
+        3,
+        next_ids=continuation.remaining_input_ids[:, 3:],
+        next_embeds=continuation.remaining_embeds[:, 3:],
+        next_kwargs={"mask": continuation.prompt_kwargs["mask"][:, 3:]},
+    )
+
+    assert continuation.ready_for_final
+    assert continuation.processed_uncached == 3
+    assert continuation.segment_count == 1
+
+
+def test_prepare_exception_notifies_submitting_queue(monkeypatch):
+    monkeypatch.setattr(generation, "speculative_prefill_kwargs", lambda *a, **k: {})
+    monkeypatch.setattr(generation, "_get_draft_block_size_from_env", lambda: 1)
+    rqueue = Queue()
+    request = SimpleNamespace(rqueue=rqueue, images=[], audio=[], videos=[])
+
+    class Fake:
+        _stop = False
+        _cancel_lock = Lock()
+        _cancelled = set()
+        model = SimpleNamespace(language_model=object())
+        draft_model = object()
+
+        def __init__(self):
+            self.calls = 0
+
+        def _collect_pending_requests(self, **_kwargs):
+            self.calls += 1
+            return ([request], False) if self.calls == 1 else ([], True)
+
+        def _prepare_resumable_dflash_request(self, *_args):
+            raise RuntimeError("synthetic prepare failure")
+
+    generation.ResponseGenerator._run_speculative_resumable_dflash(Fake())
+
+    error = rqueue.get_nowait()
+    assert isinstance(error, RuntimeError)
+    assert str(error) == "synthetic prepare failure"
+    assert rqueue.get_nowait() is None
+
+
+def test_hot_loop_yields_at_an_evaluated_slice_boundary():
+    continuation = SimpleNamespace(ready_for_final=False)
+    scheduled = SimpleNamespace(metadata={"continuation": continuation})
+
+    class Fake:
+        requests = Queue()
+        _cancel_lock = Lock()
+        _cancelled = set()
+
+        def __init__(self):
+            self.advances = 0
+
+        def _advance_one_resumable_dflash_segment(self, *_args):
+            self.advances += 1
+            return True
+
+    fake = Fake()
+    assert generation.ResponseGenerator._advance_resumable_dflash_segment(
+        fake,
+        scheduled,
+        64,
+        object(),
+        {},
+        object(),
+        should_yield=lambda: True,
+    )
+    assert fake.advances == 1
+
+
+def test_shutdown_notifies_resident_client(monkeypatch):
+    monkeypatch.setattr(generation, "speculative_prefill_kwargs", lambda *a, **k: {})
+    monkeypatch.setattr(generation, "_get_draft_block_size_from_env", lambda: 1)
+    rqueue = Queue()
+    request = SimpleNamespace(rqueue=rqueue, images=[], audio=[], videos=[])
+    continuation = SimpleNamespace(
+        ready_for_final=False,
+        metadata={"request": request},
+        processed_uncached=0,
+        remaining_tokens=10,
+    )
+    item = generation.ResumablePrefill(
+        request_id="resident",
+        work=generation.TailWork(10),
+        cache_state=object(),
+        remaining_input=continuation,
+        metadata={"continuation": continuation},
+    )
+
+    class Fake:
+        _stop = False
+        _cancel_lock = Lock()
+        _cancelled = set()
+        model = SimpleNamespace(language_model=object())
+        draft_model = object()
+
+        def _collect_pending_requests(self, **_kwargs):
+            return [request], False
+
+        def _prepare_resumable_dflash_request(self, *_args):
+            return item
+
+        def _drain_cancellations(self):
+            return set()
+
+        def _advance_resumable_dflash_segment(self, *_args, **_kwargs):
+            self._stop = True
+            return True
+
+    generation.ResponseGenerator._run_speculative_resumable_dflash(Fake())
+
+    error = rqueue.get_nowait()
+    assert isinstance(error, RuntimeError)
+    assert str(error) == "generation server stopped"
+    assert rqueue.get_nowait() is None
+
+
+def test_scheduler_cancellation_preserves_foreign_request(monkeypatch):
+    monkeypatch.setattr(generation, "speculative_prefill_kwargs", lambda *a, **k: {})
+    monkeypatch.setattr(generation, "_get_draft_block_size_from_env", lambda: 1)
+    rqueue = Queue()
+    request = SimpleNamespace(rqueue=rqueue, images=[], audio=[], videos=[])
+    continuation = SimpleNamespace(
+        ready_for_final=False,
+        metadata={"request": request},
+        processed_uncached=0,
+        remaining_tokens=10,
+    )
+    item = generation.ResumablePrefill(
+        request_id=str(id(rqueue)),
+        work=generation.TailWork(10),
+        cache_state=object(),
+        remaining_input=continuation,
+        metadata={"continuation": continuation},
+    )
+    foreign_uid = id(rqueue) + 1
+
+    class Fake:
+        _stop = False
+        _cancel_lock = Lock()
+        _cancelled = {id(rqueue), foreign_uid}
+        model = SimpleNamespace(language_model=object())
+        draft_model = object()
+
+        def __init__(self):
+            self.calls = 0
+
+        def _collect_pending_requests(self, **_kwargs):
+            self.calls += 1
+            return ([request], False) if self.calls == 1 else ([], True)
+
+        def _prepare_resumable_dflash_request(self, *_args):
+            return item
+
+    fake = Fake()
+    generation.ResponseGenerator._run_speculative_resumable_dflash(fake)
+
+    assert fake._cancelled == {foreign_uid}
+    assert rqueue.get_nowait() is None
+
+
+def test_context_accumulator_keeps_bounded_tail_and_offset():
+    first = mx.array([[[1], [2], [3]]])
+    second = mx.array([[[4], [5]]])
+
+    combined, dropped = generation._append_dflash_context(first, second, 4, 0)
+
+    assert combined.tolist() == [[[2], [3], [4], [5]]]
+    assert dropped == 1
+
+
+def test_resident_cap_is_bounded_and_honors_global_cap(monkeypatch):
+    monkeypatch.delenv("MLX_VLM_MAX_NUM_SEQS", raising=False)
+    monkeypatch.delenv("MLX_VLM_RESUMABLE_PREFILL_MAX_SEQS", raising=False)
+    assert generation._resumable_dflash_max_seqs() == 4
+
+    monkeypatch.setenv("MLX_VLM_RESUMABLE_PREFILL_MAX_SEQS", "8")
+    monkeypatch.setenv("MLX_VLM_MAX_NUM_SEQS", "3")
+    assert generation._resumable_dflash_max_seqs() == 3

--- a/mlx_vlm/tests/test_server.py
+++ b/mlx_vlm/tests/test_server.py
@@ -1757,6 +1757,8 @@ def _run_speculative_prefill_once(
     gen.stop_tokens = {99}
     gen.requests = Queue()
     gen._stop = False
+    gen._cancel_lock = Lock()
+    gen._cancelled = set()
     gen.prefill_step_size = prefill_step_size
     gen.apc_manager = apc_manager
     gen.apc_mode = apc_mode

--- a/mlx_vlm/tests/test_server.py
+++ b/mlx_vlm/tests/test_server.py
@@ -1738,7 +1738,13 @@ class _RecordingSpeculativeLM:
 
 
 def _run_speculative_prefill_once(
-    monkeypatch, *, draft_kind, request_specs, prefill_step_size=2048
+    monkeypatch,
+    *,
+    draft_kind,
+    request_specs,
+    prefill_step_size=2048,
+    apc_manager=None,
+    apc_mode=None,
 ):
     lm = _RecordingSpeculativeLM(draft_kind)
     gen = server.ResponseGenerator.__new__(server.ResponseGenerator)
@@ -1752,6 +1758,8 @@ def _run_speculative_prefill_once(
     gen.requests = Queue()
     gen._stop = False
     gen.prefill_step_size = prefill_step_size
+    gen.apc_manager = apc_manager
+    gen.apc_mode = apc_mode
     gen._make_sampler = lambda args: None
     gen.tokenizer = SimpleNamespace(
         decode=lambda tokens: "".join(str(tok) for tok in tokens)
@@ -1767,6 +1775,11 @@ def _run_speculative_prefill_once(
     gen._gpu_embed = fake_gpu_embed
 
     monkeypatch.setattr(server_generation, "_make_cache", lambda *args, **kwargs: [])
+    monkeypatch.setattr(
+        server_generation,
+        "make_speculative_prompt_cache",
+        lambda *args, **kwargs: [],
+    )
     monkeypatch.setattr(
         server_generation, "_get_draft_block_size_from_env", lambda: None
     )
@@ -1809,6 +1822,10 @@ def _run_speculative_prefill_once(
                 raw_inputs={"input_ids": spec["input_ids"]},
                 prompt_tokens=int(spec["input_ids"].shape[1]),
                 args=args,
+                images=spec.get("images"),
+                videos=spec.get("videos"),
+                audio=spec.get("audio"),
+                apc_semantic_hash=spec.get("apc_semantic_hash"),
             )
         )
 
@@ -1817,6 +1834,121 @@ def _run_speculative_prefill_once(
     call["prefill_input_lengths"] = [item["inputs"].shape[1] for item in lm.calls]
     call["round_kwargs"] = gen.round_kwargs
     return call
+
+
+def test_dflash_singleton_apc_hit_prefills_suffix_and_reuses_semantic_hash(
+    monkeypatch,
+):
+    lookup = {}
+
+    class _APCManager:
+        def __init__(self):
+            self.stores = []
+
+        def store_exact_cache(self, token_ids, prompt_cache, *, extra_hash):
+            self.stores.append((list(token_ids), prompt_cache, extra_hash))
+
+    manager = _APCManager()
+    warm_cache = [SimpleNamespace(offset=2)]
+
+    def fake_lookup(manager_arg, ids, **kwargs):
+        lookup.update(manager=manager_arg, ids=list(ids), kwargs=kwargs)
+        return {"warm_cache": warm_cache, "prefix_len": 2}
+
+    monkeypatch.setattr(server_generation._apc, "apc_lookup_plan", fake_lookup)
+    call = _run_speculative_prefill_once(
+        monkeypatch,
+        draft_kind="dflash",
+        apc_manager=manager,
+        apc_mode="exact",
+        request_specs=[
+            {
+                "input_ids": mx.array([[11, 12, 13, 14]], dtype=mx.int32),
+                "gen_kwargs": {
+                    "inputs_embeds": mx.ones((1, 4, 4), dtype=mx.float32),
+                    "attention_mask": mx.array([[1, 1, 1, 1]], dtype=mx.int32),
+                },
+                "apc_semantic_hash": 991,
+            }
+        ],
+    )
+
+    assert call["inputs"].tolist() == [[13, 14]]
+    assert call["inputs_embeds"].shape[1] == 2
+    assert call["attention_mask"].tolist() == [[1, 1]]
+    assert call["cache"] is warm_cache
+    assert call["round_kwargs"]["context_offset"] == 2
+    assert lookup["manager"] is manager
+    assert lookup["ids"] == [11, 12, 13, 14]
+    assert lookup["kwargs"]["extra_hash"] == 991
+    assert manager.stores == [([11, 12, 13, 14], warm_cache, 991)]
+
+
+@pytest.mark.parametrize(
+    "request_overrides",
+    [
+        {"images": ["image"]},
+        {"videos": ["video"]},
+        {"audio": ["audio"]},
+        {"raw_inputs": {"input_ids": [1, 2], "pixel_values": object()}},
+        {"raw_inputs": {"input_ids": [1, 2], "pixel_values_videos": object()}},
+        {"raw_inputs": {"input_ids": [1, 2], "input_features": object()}},
+    ],
+)
+def test_dflash_apc_lookup_rejects_multimodal_requests(request_overrides):
+    request = SimpleNamespace(
+        images=None,
+        videos=None,
+        audio=None,
+        raw_inputs={"input_ids": [1, 2]},
+        apc_semantic_hash=7,
+    )
+    for key, value in request_overrides.items():
+        setattr(request, key, value)
+
+    assert (
+        server_generation._dflash_apc_lookup(
+            request,
+            [1, 2],
+            batch_size=1,
+            draft_kind="dflash",
+            apc_manager=object(),
+            apc_mode="exact",
+        )
+        is None
+    )
+
+
+@pytest.mark.parametrize(
+    ("batch_size", "draft_kind", "apc_mode", "semantic_hash"),
+    [
+        (2, "dflash", "exact", 7),
+        (1, "mtp", "exact", 7),
+        (1, "dflash", "block", 7),
+        (1, "dflash", "exact", None),
+    ],
+)
+def test_dflash_apc_lookup_rejects_unsupported_modes(
+    batch_size, draft_kind, apc_mode, semantic_hash
+):
+    request = SimpleNamespace(
+        images=None,
+        videos=None,
+        audio=None,
+        raw_inputs={"input_ids": [1, 2]},
+        apc_semantic_hash=semantic_hash,
+    )
+    assert (
+        server_generation._dflash_apc_lookup(
+            request,
+            [1, 2],
+            batch_size=batch_size,
+            draft_kind=draft_kind,
+            apc_manager=object(),
+            apc_mode=apc_mode,
+        )
+        is None
+    )
 
 
 def test_speculative_server_threads_greedy_flag_to_mtp_loop(monkeypatch):

--- a/mlx_vlm/tests/test_server.py
+++ b/mlx_vlm/tests/test_server.py
@@ -4767,6 +4767,22 @@ class TestResponseGenerator:
         gen._cpu_preprocess = lambda prompt, images, audio: {"input_ids": [1, 2, 3]}
         return gen
 
+    def test_speculative_cancellation_is_request_local(self):
+        gen = server.ResponseGenerator.__new__(server.ResponseGenerator)
+        gen._cancel_lock = Lock()
+        gen._cancelled = {11, 22}
+        rqueue = Queue()
+        finished = set()
+
+        cancelled = gen._finish_cancelled_speculative_requests(
+            [11], {11: rqueue}, finished
+        )
+
+        assert cancelled == 1
+        assert finished == {11}
+        assert rqueue.get_nowait() is None
+        assert gen._cancelled == {22}
+
     def test_generate_rejects_requests_over_configured_context_limit(self, monkeypatch):
         gen = server.ResponseGenerator.__new__(server.ResponseGenerator)
         gen.wait_until_ready = lambda: None

--- a/mlx_vlm/tests/test_speculative.py
+++ b/mlx_vlm/tests/test_speculative.py
@@ -32,6 +32,7 @@ from mlx_vlm.models.cache import (
 )
 from mlx_vlm.quantization.one_bit import OneBitLinear
 from mlx_vlm.speculative.common import _SpeculativeSamplerRNG
+from mlx_vlm.speculative.dflash import _drafter_pos_shift
 from mlx_vlm.speculative.drafters import (
     DEFAULT_DRAFTER_KIND,
     DRAFTER_KIND_BY_MODEL_TYPE,
@@ -1617,13 +1618,24 @@ def test_dflash_server_singleton_dispatches_single_rounds(monkeypatch):
             token_dtype=mx.int32,
             greedy_sampling=True,
             stop_check=lambda _seq_idx, token_id: token_id == 4,
+            context_offset=123,
         )
     )
 
     assert result == [([3], None), ([4], None)]
     assert calls
     assert calls[0][1]["first_bonus"] == 2
+    assert calls[0][1]["context_offset"] == 123
     assert "use_model_initial_block_size" not in calls[0][1]
+
+
+def test_dflash_context_shift_does_not_mutate_cache_offsets():
+    caches = [SimpleNamespace(offset=3), SimpleNamespace(offset=8, pos_shift=2)]
+
+    _drafter_pos_shift(caches, 11)
+
+    assert [cache.offset for cache in caches] == [3, 8]
+    assert [cache.pos_shift for cache in caches] == [11, 13]
 
 
 def test_mtp_uses_uniform_deferred_walk_for_batched_sampling():


### PR DESCRIPTION
# feat(server): add opt-in resumable APC-aware DFlash prefill

## Stack

This draft is intentionally cumulative against `main` and now stacks on:

1. #1923 — conservative text-only B=1 exact-mode DFlash APC reuse;
2. #1873 — request-local speculative cancellation;
3. this PR — opt-in resumable DFlash prefill.

It no longer contains the closed #1856/#1857 implementation. In particular,
this version does not add multimodal APC hashing, a separate APC adapter, or
static-prefix checkpoint storage.

## Summary

- make long text-only B=1 DFlash prefills resumable at evaluated cache
  boundaries;
- restore an exact APC prefix through #1923, then schedule the remaining tail;
- schedule by shortest uncached APC tail with bounded deferrals;
- preserve a bounded DFlash round-one hidden-state window and its absolute
  context offset;
- keep adjacent slices in the hot MLX loop until an arrival, resident peer, or
  cancellation requires a yield;
- cap resident prompt-cache state and terminate the correct client queue on
  prepare failure, cancellation, or shutdown;
- preserve ordinary idle coalescing and fall back to the established
  non-resumable path for B>=2 or multimodal work;
- keep the entire feature default-off.

Enable with:

```sh
MLX_VLM_RESUMABLE_DFLASH_PREFILL=1
```

Optional controls:

- `MLX_VLM_RESUMABLE_PREFILL_SLICE_TOKENS` (default 2048, minimum 128);
- `MLX_VLM_RESUMABLE_PREFILL_MAX_DEFERRALS` (default 3);
- `MLX_VLM_RESUMABLE_PREFILL_MAX_SEQS` (default 4, bounded by
  `MLX_VLM_MAX_NUM_SEQS`).

## Safety contracts

- A continuation always reserves the final prompt token for the logits/hidden
  forward.
- Scheduler state advances only after cache writes and retained hidden state
  are evaluated.
- APC lookup faults retain a pristine cold path.
- APC storage uses the shared exact-cache manager and remains fail-safe.
- Raw media tensors, explicit media inputs, B>=2 batches, and unsupported APC
  modes stay on the established path.
- Cancellation consumption is resident/request-local; unmatched IDs remain for
  their future owner.

## Verification on the restacked head

- `mlx_vlm/tests/test_server.py`: 353 passed;
- all `test_apc*.py` files: 199 passed, 1 skipped;
- scheduler and resumable-prefill tests: 13 passed;
- APC warm-hit/rejection and request-local cancellation integration: 12 passed;
- combined speculative/APC/DFlash-drafter dependency set: 314 passed, 1 known
  baseline failure.

The lone dependency-suite failure is
`test_qwen_target_verify_quantized_linear_matches_singleton_batch_path`; the
same exact-equality failure reproduces on current `main` at `0558cbee` in the
same MLX environment. Python compilation and `git diff --check` pass.

## Model-backed evidence status

The earlier draft recorded lossless Muse-Glimmer output, throughput, contention,
and cancellation gates. Because this restack deliberately changed the APC
contract and removed checkpoint storage, those measurements are historical
evidence only; the current head still needs a fresh target-specific model gate
before this draft is marked ready for review.
