### PR TITLE
Skip conv transposes for pre-converted SAM 3.1 checkpoints (#1871)

### DIFF
--- a/mlx_vlm/models/sam3_1/sam3_1.py
+++ b/mlx_vlm/models/sam3_1/sam3_1.py
@@ -269,7 +269,18 @@ class Model(nn.Module):
 
         Handles Conv2d/ConvTranspose2d transpositions and key remapping
         for SAM 3.1 architecture.
+
+        Conv transposes are skipped for checkpoints already in MLX layout, so
+        sanitize is idempotent and does not double-transpose (see #1871).
         """
+        already_mlx = any(
+            k.endswith("patch_embeddings.projection.weight")
+            and v.ndim == 4
+            and v.shape[-1] == 3
+            and v.shape[1] != 3
+            for k, v in weights.items()
+        )
+
         sanitized = {}
 
         conv_transpose_patterns = ["scale_layers.", "upscale_conv", "output_upscaling"]
@@ -303,7 +314,7 @@ class Model(nn.Module):
                     "mask_downsampler.final_conv.",
                 )
 
-            if value.ndim == 4:
+            if value.ndim == 4 and not already_mlx:
                 if any(p in key for p in skip_patterns):
                     sanitized[key] = value
                     continue


### PR DESCRIPTION
sanitize() transposed every 4D weight unconditionally, so loading a checkpoint already stored in MLX layout transposed it a second time and produced (1024, 14, 3, 14) instead of (1024, 14, 14, 3). Detect the layout from the patch-embed conv, whose in_channels is unambiguously 3, and skip the transposes when the checkpoint is already converted, matching the fix SAM 3 received in #1545.

for https://github.com/Blaizzy/mlx-vlm/issues/1871 as well