### PR TITLE
Handle Muse Glimmer recipient-routing output in the server

### DIFF
--- a/mlx_vlm/server/anthropic.py
+++ b/mlx_vlm/server/anthropic.py
@@ -22,7 +22,6 @@ from .generation import (
     _count_prompt_tokens,
 )
 from .glimmer_stream import make_glimmer_stream_state
-
 from .responses_state import (
     make_response_stream_state,
     process_tool_calls,

--- a/mlx_vlm/server/anthropic.py
+++ b/mlx_vlm/server/anthropic.py
@@ -21,6 +21,8 @@ from .generation import (
     _build_metrics_envelope,
     _count_prompt_tokens,
 )
+from .glimmer_stream import make_glimmer_stream_state
+
 from .responses_state import (
     make_response_stream_state,
     process_tool_calls,
@@ -536,16 +538,21 @@ async def anthropic_messages_endpoint(http_request: Request):
                 open_block_type = None
                 full_output = ""
                 text_output = ""
-                thinking_state = make_response_stream_state(
-                    processor,
-                    prompt_has_open_thinking(
-                        formatted_prompt,
-                        gen_args.enable_thinking,
+                glimmer_state = make_glimmer_stream_state(processor)
+                thinking_state = (
+                    glimmer_state
+                    if glimmer_state is not None
+                    else make_response_stream_state(
+                        processor,
+                        prompt_has_open_thinking(
+                            formatted_prompt,
+                            gen_args.enable_thinking,
+                            gen_args.thinking_start_token,
+                            gen_args.thinking_end_token,
+                        ),
                         gen_args.thinking_start_token,
                         gen_args.thinking_end_token,
-                    ),
-                    gen_args.thinking_start_token,
-                    gen_args.thinking_end_token,
+                    )
                 )
                 in_tool_call = False
                 tc_start = tool_module.tool_call_start if tool_module else None
@@ -674,9 +681,13 @@ async def anthropic_messages_endpoint(http_request: Request):
                         delta_reasoning = thinking_delta.reasoning
                         delta_content = thinking_delta.content
 
-                        in_tool_call, delta_content = suppress_tool_call_content(
-                            full_output, in_tool_call, tc_start, delta_content
-                        )
+                        if glimmer_state is None:
+                            in_tool_call, delta_content = suppress_tool_call_content(
+                                full_output,
+                                in_tool_call,
+                                tc_start,
+                                delta_content,
+                            )
 
                         if delta_reasoning is not None and gen_args.enable_thinking:
                             yield open_block("thinking")

--- a/mlx_vlm/server/glimmer_stream.py
+++ b/mlx_vlm/server/glimmer_stream.py
@@ -101,9 +101,7 @@ class MuseGlimmerStreamState:
                 idx = self.buffer.find(_GLIMMER_TOOL_END)
                 if idx < 0:
                     # Hold partial end-marker tails so they never leak.
-                    hold = self._partial_marker_len(
-                        self.buffer, (_GLIMMER_TOOL_END,)
-                    )
+                    hold = self._partial_marker_len(self.buffer, (_GLIMMER_TOOL_END,))
                     if hold:
                         break
                     # Tool body without any end marker: suppress, drop.
@@ -111,9 +109,7 @@ class MuseGlimmerStreamState:
                     break
                 # Position-aware: consume through the end marker; anything
                 # after it (in this chunk) is the next segment start.
-                self.buffer = self.buffer[
-                    idx + len(_GLIMMER_TOOL_END) :
-                ].lstrip("\n")
+                self.buffer = self.buffer[idx + len(_GLIMMER_TOOL_END) :].lstrip("\n")
                 self.state = "normal"
                 self.segment_started = True
                 continue
@@ -142,9 +138,7 @@ class MuseGlimmerStreamState:
 
             # "to=self<|message|>" opens thinking — check before the generic
             # header strip (which would otherwise consume it as a header).
-            if self.segment_started and self.buffer.startswith(
-                _GLIMMER_SELF_OPEN
-            ):
+            if self.segment_started and self.buffer.startswith(_GLIMMER_SELF_OPEN):
                 if self._reasoning_emitted:
                     # Consecutive thinking block: separate from the previous.
                     self._pending_reasoning_sep = True
@@ -272,9 +266,7 @@ class MuseGlimmerStreamState:
                 # the following text starts a fresh segment. Avoid doubling
                 # the space when the preceding emitted text already ends in
                 # whitespace.
-                self.buffer = re.sub(
-                    r"^\s*<\|eom\|>\s*", " ", self.buffer, count=1
-                )
+                self.buffer = re.sub(r"^\s*<\|eom\|>\s*", " ", self.buffer, count=1)
                 prev_ws = self._last_content_end.isspace()
                 if self.buffer.startswith(" ") and not prev_ws:
                     content.append(" ")
@@ -285,9 +277,7 @@ class MuseGlimmerStreamState:
             if kind == "eot":
                 # End-of-turn marker. Substitute a separator and treat the
                 # following text as a fresh segment (matches the final parse).
-                self.buffer = re.sub(
-                    r"^\s*<\|eot\|>\s*", " ", self.buffer, count=1
-                )
+                self.buffer = re.sub(r"^\s*<\|eot\|>\s*", " ", self.buffer, count=1)
                 prev_ws = self._last_content_end.isspace()
                 if self.buffer.startswith(" ") and not prev_ws:
                     content.append(" ")
@@ -346,7 +336,7 @@ class MuseGlimmerStreamState:
         ):
             for length in range(min(len(marker), len(text)), 0, -1):
                 if text.endswith(marker[:length]):
-                    text = text[: -length]
+                    text = text[:-length]
                     break
         return text
 
@@ -408,7 +398,11 @@ class MuseGlimmerStreamState:
         rest = stripped[3:]
         # Name chars, then an optional partial "<|message|>".
         name_end = 0
-        while name_end < len(rest) and rest[name_end] in "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_.-":
+        while (
+            name_end < len(rest)
+            and rest[name_end]
+            in "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_.-"
+        ):
             name_end += 1
         after = rest[name_end:]
         if not after:

--- a/mlx_vlm/server/glimmer_stream.py
+++ b/mlx_vlm/server/glimmer_stream.py
@@ -1,0 +1,464 @@
+"""Muse Glimmer streaming state machine.
+
+Single self-contained state machine for Glimmer's recipient-routing output,
+replacing the ``ThinkingStreamState`` + ``suppress_tool_call_content`` pairing
+(which disagreed about stream state). Owns ALL region logic in one buffer:
+
+  NORMAL   --"to=self<|message|>" at a routing boundary--> THINKING
+  NORMAL   --"<atem:function_calls>"-->                   TOOL
+  THINKING --"<|eom|>"-->                                 NORMAL
+  TOOL     --"</atem:function_calls>"-->                  NORMAL
+
+Rules (each learned from review-found regressions):
+
+* Content is only emitted once it is unambiguous — partial markers/headers
+  are held in the buffer until resolved (or flushed at ``last=True``).
+* ``to=<name><|message|>`` headers are stripped only at segment starts
+  (beginning of the response, or right after a close marker). A *quoted*
+  header mid-answer survives.
+* ``to=self<|message|>`` only re-opens thinking at a routing boundary;
+  quoted occurrences mid-answer flow as content.
+* The tool region suppresses everything, and the end marker is consumed
+  position-aware so a marker split across chunks never leaks its tail.
+* ``<|eom|>`` is a continuation boundary: substituted with a single space.
+
+The final response is recomputed from the full text by ``_split_thinking`` /
+``process_tool_calls``; this class only shapes the streamed deltas.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import List, Optional, Tuple
+
+_HEADER_RE = re.compile(
+    r"^\s*(?:<\|start\|>assistant )?to=[A-Za-z0-9_.-]+<\|message\|>"
+)
+_GLIMMER_EOM = "<|eom|>"
+_GLIMMER_SELF_OPEN = "to=self<|message|>"
+_GLIMMER_TOOL_START = "<atem:function_calls>"
+_GLIMMER_TOOL_END = "</atem:function_calls>"
+_GLIMMER_EOT = "<|eot|>"
+
+
+@dataclass
+class GlimmerStreamDelta:
+    reasoning: Optional[str] = None
+    content: Optional[str] = None
+    thinking_closed: bool = False
+
+
+class MuseGlimmerStreamState:
+    """Streaming state machine for Muse Glimmer recipient-routing output."""
+
+    def __init__(self):
+        self.buffer = ""
+        # "normal" | "thinking" | "tool"
+        self.state = "normal"
+        # True when the next content is at a routing segment start (start of
+        # stream, or right after a close marker). Only at a segment start may
+        # a "to=<name><|message|>" header be stripped or a "to=self" block
+        # open; quoted occurrences mid-answer must survive.
+        self.segment_started = True
+        # Whether reasoning was emitted in a previous feed call — used to
+        # separate consecutive thinking blocks ("a\nb", not "ab").
+        self._reasoning_emitted = False
+        self._pending_reasoning_sep = False
+        # Last content char emitted (for separator dedup across feed calls).
+        self._last_content_end = ""
+
+    # -- public ------------------------------------------------------------
+    def feed(self, text: str, last: bool = False) -> GlimmerStreamDelta:
+        """Consume a chunk of decoded text; return clean deltas."""
+        self.buffer += text or ""
+        reasoning: List[str] = []
+        content: List[str] = []
+        thinking_closed = False
+
+        while self.buffer:
+            if self.state == "thinking":
+                idx = self.buffer.find(_GLIMMER_EOM)
+                if idx < 0:
+                    emit, held = self._split_partial(
+                        self.buffer, (_GLIMMER_EOM, _GLIMMER_TOOL_START)
+                    )
+                    if emit:
+                        self._append_reasoning(reasoning, emit)
+                    self.buffer = held
+                    # Either everything was emitted, or the tail is a held
+                    # partial marker awaiting more input — wait either way.
+                    break
+                if idx:
+                    self._append_reasoning(reasoning, self.buffer[:idx])
+                self.buffer = self.buffer[idx + len(_GLIMMER_EOM) :].lstrip("\n")
+                self.state = "normal"
+                self.segment_started = True
+                thinking_closed = True
+                continue
+
+            if self.state == "tool":
+                idx = self.buffer.find(_GLIMMER_TOOL_END)
+                if idx < 0:
+                    # Hold partial end-marker tails so they never leak.
+                    hold = self._partial_marker_len(
+                        self.buffer, (_GLIMMER_TOOL_END,)
+                    )
+                    if hold:
+                        break
+                    # Tool body without any end marker: suppress, drop.
+                    self.buffer = ""
+                    break
+                # Position-aware: consume through the end marker; anything
+                # after it (in this chunk) is the next segment start.
+                self.buffer = self.buffer[
+                    idx + len(_GLIMMER_TOOL_END) :
+                ].lstrip("\n")
+                self.state = "normal"
+                self.segment_started = True
+                continue
+
+            # ---- NORMAL state ----
+            # At a segment start, leading whitespace/newlines before a header
+            # or thinking-open marker are part of the routing, not content.
+            # This includes a *partial* routing marker (e.g. "<atem:fu" of
+            # "<atem:function_calls>") that arrives split across chunks.
+            if self.segment_started and self.buffer[:1].isspace():
+                stripped = self.buffer.lstrip()
+                if self._starts_routing(stripped):
+                    self.buffer = stripped
+                    if not self.buffer:
+                        break
+                    continue
+                if stripped == "":
+                    # Whitespace only so far — a routing marker may follow in
+                    # a later chunk; hold without flipping the segment flag.
+                    break
+                # The head of a routing marker may be split ("to", "t",
+                # "<|start|>", "<atem:") — hold those too.
+                if self._is_routing_head(stripped):
+                    break
+                self.segment_started = False
+
+            # "to=self<|message|>" opens thinking — check before the generic
+            # header strip (which would otherwise consume it as a header).
+            if self.segment_started and self.buffer.startswith(
+                _GLIMMER_SELF_OPEN
+            ):
+                if self._reasoning_emitted:
+                    # Consecutive thinking block: separate from the previous.
+                    self._pending_reasoning_sep = True
+                self.buffer = self.buffer[len(_GLIMMER_SELF_OPEN) :].lstrip("\n")
+                self.state = "thinking"
+                self.segment_started = False
+                continue
+
+            # Strip a leading recipient header, but ONLY at a genuine segment
+            # start (stream start or right after a close marker). A quoted
+            # "to=user<|message|>" mid-answer must survive.
+            if self.segment_started:
+                m = _HEADER_RE.match(self.buffer)
+                if m:
+                    self.buffer = self.buffer[m.end() :]
+                    continue
+
+            # Re-open thinking? Only at a routing boundary, and only for the
+            # complete marker (a split "to=self<|m" mid-answer stays content).
+            idx_self = self.buffer.find(_GLIMMER_SELF_OPEN)
+            idx_tool = self.buffer.find(_GLIMMER_TOOL_START)
+            idx_eom = self.buffer.find(_GLIMMER_EOM)
+            idx_eot = self.buffer.find(_GLIMMER_EOT)
+
+            candidates = [
+                (i, kind)
+                for i, kind in (
+                    (idx_self, "self"),
+                    (idx_tool, "tool"),
+                    (idx_eom, "eom"),
+                    (idx_eot, "eot"),
+                )
+                if i >= 0
+            ]
+            candidates.sort()
+
+            if not candidates:
+                # Emit what cannot grow into a marker or header prefix. A
+                # header in progress ("to=", "to=u", "to=us<|m", ...) is held
+                # whole until it resolves or diverges.
+                if self._is_header_in_progress(self.buffer):
+                    break
+                emit, self.buffer = self._split_partial(
+                    self.buffer,
+                    (
+                        _GLIMMER_SELF_OPEN,
+                        _GLIMMER_TOOL_START,
+                        _GLIMMER_TOOL_END,
+                        _GLIMMER_EOM,
+                        _GLIMMER_EOT,
+                        "to=",
+                    ),
+                )
+                if emit:
+                    content.append(emit)
+                    if emit.strip():
+                        self.segment_started = False
+                break
+
+            idx, kind = candidates[0]
+            if idx:
+                # Text before the structural marker: emit (already held-safe).
+                before = self.buffer[:idx]
+                # Leading header check already done above; emit rest verbatim.
+                if before:
+                    content.append(before)
+                    # Whitespace-only output (e.g. an <|eom|> substitution)
+                    # does not start a real content segment.
+                    if before.strip():
+                        self.segment_started = False
+                self.buffer = self.buffer[idx:]
+                continue
+
+            if kind == "self":
+                # The leading-text branch above already emitted everything
+                # before this marker, so idx == 0 here. Re-open thinking only
+                # at a genuine segment start (stream start or after a close
+                # marker); a quoted marker mid-answer flows as content.
+                if not self.segment_started:
+                    # Quoted "to=self<|message|>" mid-answer: emit verbatim
+                    # and treat as content.
+                    emit, self.buffer = self._split_partial(
+                        self.buffer,
+                        (
+                            _GLIMMER_SELF_OPEN,
+                            _GLIMMER_TOOL_START,
+                            _GLIMMER_EOM,
+                        ),
+                    )
+                    if emit:
+                        content.append(emit)
+                        self.segment_started = False
+                    break
+                if self._reasoning_emitted:
+                    # Consecutive thinking block: separate from the previous.
+                    self._pending_reasoning_sep = True
+                self.buffer = self.buffer[len(_GLIMMER_SELF_OPEN) :].lstrip("\n")
+                self.state = "thinking"
+                self.segment_started = False
+                continue
+
+            if kind == "tool":
+                # A tool block at a routing segment start is a real tool
+                # call; a quoted "<atem:function_calls>" mid-answer is not.
+                if not self.segment_started:
+                    emit, self.buffer = self._split_partial(
+                        self.buffer,
+                        (
+                            _GLIMMER_SELF_OPEN,
+                            _GLIMMER_TOOL_START,
+                            _GLIMMER_EOM,
+                        ),
+                    )
+                    if emit:
+                        content.append(emit)
+                    break
+                self.buffer = self.buffer[len(_GLIMMER_TOOL_START) :]
+                self.state = "tool"
+                self.segment_started = False
+                continue
+
+            if kind == "eom":
+                # Stray/continuation marker in normal state. It is a routing
+                # boundary: the substituted separator space is content, and
+                # the following text starts a fresh segment. Avoid doubling
+                # the space when the preceding emitted text already ends in
+                # whitespace.
+                self.buffer = re.sub(
+                    r"^\s*<\|eom\|>\s*", " ", self.buffer, count=1
+                )
+                prev_ws = self._last_content_end.isspace()
+                if self.buffer.startswith(" ") and not prev_ws:
+                    content.append(" ")
+                self.buffer = self.buffer.lstrip()
+                self.segment_started = True
+                continue
+
+            if kind == "eot":
+                # End-of-turn marker. Substitute a separator and treat the
+                # following text as a fresh segment (matches the final parse).
+                self.buffer = re.sub(
+                    r"^\s*<\|eot\|>\s*", " ", self.buffer, count=1
+                )
+                prev_ws = self._last_content_end.isspace()
+                if self.buffer.startswith(" ") and not prev_ws:
+                    content.append(" ")
+                self.buffer = self.buffer.lstrip()
+                self.segment_started = True
+                continue
+
+        if last and self.buffer:
+            held, self.buffer = self.buffer, ""
+            if self.state == "thinking":
+                # Truncated reasoning (no <|eom|>) — the final parse emits
+                # this as content, so the stream must too (channel agreement).
+                # Strip a trailing partial marker prefix first.
+                content.append(self._strip_partial_tail(held))
+            elif self.state == "tool":
+                pass  # truncated tool body: drop
+            else:
+                content.append(self._strip_partial_tail(held))
+
+        joined_content = "".join(content)
+        if joined_content:
+            self._last_content_end = joined_content[-1]
+        joined_reasoning = "\n".join(p for p in reasoning if p) or None
+        if joined_reasoning:
+            self._reasoning_emitted = True
+
+        return GlimmerStreamDelta(
+            reasoning=joined_reasoning,
+            content=joined_content or None,
+            thinking_closed=thinking_closed,
+        )
+
+    # -- helpers -----------------------------------------------------------
+    def _append_reasoning(self, reasoning: List[str], text: str) -> None:
+        """Append a reasoning fragment, honoring a pending block separator."""
+        if not text:
+            return
+        if self._pending_reasoning_sep:
+            reasoning.append("\n" + text)
+            self._pending_reasoning_sep = False
+        else:
+            reasoning.append(text)
+
+    @staticmethod
+    def _strip_partial_tail(text: str) -> str:
+        """Strip a trailing partial MARKER prefix (e.g. "hello<|e" cut
+        mid-marker) so no raw fragment leaks at flush. Only "<"-starting
+        markers qualify: a bare "to"/"to=" head is prose at flush (no next
+        chunk) and stays."""
+        for marker in (
+            _GLIMMER_TOOL_START,
+            _GLIMMER_TOOL_END,
+            _GLIMMER_EOM,
+            _GLIMMER_EOT,
+            "<|start|>assistant",
+        ):
+            for length in range(min(len(marker), len(text)), 0, -1):
+                if text.endswith(marker[:length]):
+                    text = text[: -length]
+                    break
+        return text
+
+    @staticmethod
+    def _starts_routing(text: str) -> bool:
+        """True if ``text`` starts with (or is a prefix of) a routing marker:
+        a recipient header ("to=…", bare or full form), the tool block, or
+        the thinking open.
+
+        A bare "t"/"to" (no "=") is NOT treated as routing — ordinary words
+        like "top" or "to the store" must not suppress an <|eom|> separator.
+        """
+        stripped = text.lstrip()
+        if stripped.startswith("to="):
+            return True
+        if stripped.startswith("<|start|>assistant"):
+            return True
+        for marker in (_GLIMMER_SELF_OPEN, _GLIMMER_TOOL_START):
+            if marker.startswith(stripped) and stripped.startswith("<"):
+                return True
+        return False
+
+    @staticmethod
+    def _is_routing_head(text: str) -> bool:
+        """True if ``text`` is a prefix that could grow into a routing
+        marker ("t"/"to"/"to=" for headers, "<|start|>" for the full form,
+        "<atem:" for the tool block)."""
+        if text in ("t", "to", "to="):
+            return True
+        if "<|start|>assistant".startswith(text) or "<|start|>".startswith(text):
+            return True
+        if _GLIMMER_TOOL_START.startswith(text):
+            return True
+        return False
+
+    @staticmethod
+    def _is_header_in_progress(text: str) -> bool:
+        """True if ``text`` starts like a recipient header that is not yet
+        complete ("to=", "to=u", "to=us", "to=us<|m", the full-form
+        "<|start|>assistant to=…", ...), optionally after leading whitespace.
+        Also True for a partial full-form prefix ("<|sta", "<|start|>ass").
+        """
+        stripped = text.lstrip()
+        if "<|start|>assistant".startswith(stripped):
+            return True  # partial full-form prefix in progress
+        if stripped.startswith("<|start|>assistant"):
+            if not stripped.startswith("<|start|>assistant "):
+                return True  # full-form prefix still in progress
+            stripped = stripped[len("<|start|>assistant ") :]
+            if not stripped:
+                return True  # awaiting the header head ("to=…")
+            # After the prefix, a bare "t"/"to"/"to=" head opens a header.
+            if stripped in ("t", "to") or stripped.startswith("to="):
+                return True
+            if not stripped.startswith("to="):
+                return False
+        if not stripped.startswith("to="):
+            return False
+        rest = stripped[3:]
+        # Name chars, then an optional partial "<|message|>".
+        name_end = 0
+        while name_end < len(rest) and rest[name_end] in "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_.-":
+            name_end += 1
+        after = rest[name_end:]
+        if not after:
+            return True  # name still in progress
+        if "<|message|>".startswith(after) and after != "<|message|>":
+            return True  # closing marker still in progress
+        return False
+
+    @staticmethod
+    def _partial_marker_len(text: str, markers: Tuple[str, ...]) -> int:
+        """Longest trailing suffix of ``text`` that is a prefix of a marker."""
+        hold = 0
+        for marker in markers:
+            max_len = min(len(marker) - 1, len(text))
+            for length in range(max_len, 0, -1):
+                if text.endswith(marker[:length]):
+                    hold = max(hold, length)
+                    break
+        return hold
+
+    def _split_partial(self, text: str, markers: Tuple[str, ...]) -> Tuple[str, str]:
+        """Split into (emittable, held) where held may grow into a marker or
+        header prefix."""
+        hold = self._partial_marker_len(text, markers)
+        # A completed "to=" may still be the head of a recipient header
+        # ("to=user<|message|>") — hold it (and its partial heads) until the
+        # next chunk decides.
+        if "to=" in markers:
+            if text.endswith("to="):
+                hold = max(hold, 3)
+            elif text.endswith("to") and (len(text) == 2 or text[-3].isspace()):
+                hold = max(hold, 2)
+            elif text.endswith("t") and (len(text) == 1 or text[-2].isspace()):
+                hold = max(hold, 1)
+        if hold:
+            return text[:-hold], text[-hold:]
+        return text, ""
+
+
+def make_glimmer_stream_state(processor):
+    """Return a MuseGlimmerStreamState for a Glimmer processor, else None.
+
+    Endpoints use this to decide between the Glimmer state machine (which
+    handles thinking + tool suppression internally) and the legacy
+    ThinkingStreamState + suppress_tool_call_content pairing.
+    """
+    if processor is None:
+        return None
+    if getattr(type(processor), "__module__", "").startswith(
+        "mlx_vlm.models.muse_glimmer"
+    ):
+        return MuseGlimmerStreamState()
+    return None

--- a/mlx_vlm/server/openai.py
+++ b/mlx_vlm/server/openai.py
@@ -31,6 +31,7 @@ from .generation import (
     _build_metrics_envelope,
     _count_prompt_tokens,
 )
+from .glimmer_stream import make_glimmer_stream_state
 from .responses_state import (
     _normalize_response_input,
     _response_chain_items,
@@ -48,7 +49,6 @@ from .responses_state import (
     response_store_lock,
     suppress_tool_call_content,
 )
-from .glimmer_stream import make_glimmer_stream_state
 from .runtime import runtime
 from .schemas import (
     ChatChoice,
@@ -1840,11 +1840,13 @@ async def chat_completions_endpoint(request: ChatRequest, http_request: Request)
                             # Suppress tool-call markup from content (the
                             # Glimmer state machine already handles it).
                             if glimmer_state is None:
-                                in_tool_call, delta_content = suppress_tool_call_content(
-                                    full_output,
-                                    in_tool_call,
-                                    tc_start,
-                                    delta_content,
+                                in_tool_call, delta_content = (
+                                    suppress_tool_call_content(
+                                        full_output,
+                                        in_tool_call,
+                                        tc_start,
+                                        delta_content,
+                                    )
                                 )
 
                             chunk_logprobs = None

--- a/mlx_vlm/server/openai.py
+++ b/mlx_vlm/server/openai.py
@@ -48,6 +48,7 @@ from .responses_state import (
     response_store_lock,
     suppress_tool_call_content,
 )
+from .glimmer_stream import make_glimmer_stream_state
 from .runtime import runtime
 from .schemas import (
     ChatChoice,
@@ -1095,16 +1096,21 @@ async def responses_endpoint(request: Request):
                         if tool_module is not None and chat_tools
                         else None
                     )
-                    thinking_state = make_response_stream_state(
-                        processor,
-                        prompt_has_open_thinking(
-                            formatted_prompt,
-                            gen_args.enable_thinking,
+                    glimmer_state = make_glimmer_stream_state(processor)
+                    thinking_state = (
+                        glimmer_state
+                        if glimmer_state is not None
+                        else make_response_stream_state(
+                            processor,
+                            prompt_has_open_thinking(
+                                formatted_prompt,
+                                gen_args.enable_thinking,
+                                gen_args.thinking_start_token,
+                                gen_args.thinking_end_token,
+                            ),
                             gen_args.thinking_start_token,
                             gen_args.thinking_end_token,
-                        ),
-                        gen_args.thinking_start_token,
-                        gen_args.thinking_end_token,
+                        )
                     )
                     reasoning_item_id = f"rs_{uuid.uuid4().hex}"
                     streamed_reasoning = ""
@@ -1155,9 +1161,10 @@ async def responses_endpoint(request: Request):
                                     },
                                 )
                             delta = thinking_delta.content
-                            in_tool_call, delta = suppress_tool_call_content(
-                                full_text, in_tool_call, tc_start, delta
-                            )
+                            if glimmer_state is None:
+                                in_tool_call, delta = suppress_tool_call_content(
+                                    full_text, in_tool_call, tc_start, delta
+                                )
                             usage_stats = {
                                 "input_tokens": ctx.prompt_tokens,
                                 "output_tokens": output_tokens,
@@ -1209,9 +1216,10 @@ async def responses_endpoint(request: Request):
                                     },
                                 )
                             delta = thinking_delta.content
-                            in_tool_call, delta = suppress_tool_call_content(
-                                full_text, in_tool_call, tc_start, delta
-                            )
+                            if glimmer_state is None:
+                                in_tool_call, delta = suppress_tool_call_content(
+                                    full_text, in_tool_call, tc_start, delta
+                                )
                             if chunk_finish is not None:
                                 finish_reason = chunk_finish
                             usage_stats = {
@@ -1786,16 +1794,21 @@ async def chat_completions_endpoint(request: ChatRequest, http_request: Request)
 
                         output_tokens = 0
                         request_id = f"chatcmpl-{uuid.uuid4()}"
-                        thinking_state = make_response_stream_state(
-                            processor,
-                            prompt_has_open_thinking(
-                                formatted_prompt,
-                                gen_args.enable_thinking,
+                        glimmer_state = make_glimmer_stream_state(processor)
+                        thinking_state = (
+                            glimmer_state
+                            if glimmer_state is not None
+                            else make_response_stream_state(
+                                processor,
+                                prompt_has_open_thinking(
+                                    formatted_prompt,
+                                    gen_args.enable_thinking,
+                                    gen_args.thinking_start_token,
+                                    gen_args.thinking_end_token,
+                                ),
                                 gen_args.thinking_start_token,
                                 gen_args.thinking_end_token,
-                            ),
-                            gen_args.thinking_start_token,
-                            gen_args.thinking_end_token,
+                            )
                         )
                         full_output = ""  # raw output for tool call parsing
                         # Track tool-call state to suppress markup from content
@@ -1824,10 +1837,15 @@ async def chat_completions_endpoint(request: ChatRequest, http_request: Request)
                             delta_reasoning = thinking_delta.reasoning
                             delta_content = thinking_delta.content
 
-                            # Suppress tool-call markup from content
-                            in_tool_call, delta_content = suppress_tool_call_content(
-                                full_output, in_tool_call, tc_start, delta_content
-                            )
+                            # Suppress tool-call markup from content (the
+                            # Glimmer state machine already handles it).
+                            if glimmer_state is None:
+                                in_tool_call, delta_content = suppress_tool_call_content(
+                                    full_output,
+                                    in_tool_call,
+                                    tc_start,
+                                    delta_content,
+                                )
 
                             chunk_logprobs = None
                             if request.logprobs and token.finish_reason != "stop":
@@ -1939,16 +1957,21 @@ async def chat_completions_endpoint(request: ChatRequest, http_request: Request)
 
                         request_id = f"chatcmpl-{uuid.uuid4()}"
                         output_text = ""
-                        thinking_state = make_response_stream_state(
-                            processor,
-                            prompt_has_open_thinking(
-                                formatted_prompt,
-                                gen_args.enable_thinking,
+                        glimmer_state = make_glimmer_stream_state(processor)
+                        thinking_state = (
+                            glimmer_state
+                            if glimmer_state is not None
+                            else make_response_stream_state(
+                                processor,
+                                prompt_has_open_thinking(
+                                    formatted_prompt,
+                                    gen_args.enable_thinking,
+                                    gen_args.thinking_start_token,
+                                    gen_args.thinking_end_token,
+                                ),
                                 gen_args.thinking_start_token,
                                 gen_args.thinking_end_token,
-                            ),
-                            gen_args.thinking_start_token,
-                            gen_args.thinking_end_token,
+                            )
                         )
                         for chunk in token_iterator:
                             if chunk is None or not hasattr(chunk, "text"):
@@ -2221,6 +2244,7 @@ async def chat_completions_endpoint(request: ChatRequest, http_request: Request)
                             tc["remaining_text"] or "",
                             gen_args.thinking_start_token,
                             gen_args.thinking_end_token,
+                            processor=processor,
                         )
                         if clean_remaining:
                             # Strip model control tokens

--- a/mlx_vlm/server/responses_state.py
+++ b/mlx_vlm/server/responses_state.py
@@ -289,26 +289,43 @@ def process_tool_calls(model_output: str, tool_module, tools):
     called_tools = []
     remaining = model_output
 
-    if tool_module.tool_call_start in model_output:
-        if tool_module.tool_call_end == "":
-            pattern = re.compile(
-                f"{re.escape(tool_module.tool_call_start)}.*?(?:\n|$)", re.DOTALL
-            )
+    end_marker = tool_module.tool_call_end if tool_module else None
+    block_start = getattr(tool_module, "tool_call_block_start", None)
+    envelope_start = getattr(tool_module, "tool_call_start", None)
+
+    # Anchor on the raw block marker when available: it appears in every tool
+    # call (with or without the reasoning envelope) and each block is matched
+    # independently, so multiple calls in one output are all parsed. Fall back
+    # to the parser's start marker otherwise.
+    anchor = block_start or envelope_start
+    if anchor is not None:
+        # Optional turn header immediately before the block: the full form
+        # "<|start|>assistant to=<name><|message|>" or the bare
+        # "to=<name><|message|>".
+        header = (
+            r"(?:(?:<\|start\|>assistant )?to=[A-Za-z0-9_.-]+<\|message\|>)?"
+        )
+        if end_marker == "":
+            pattern = re.compile(f"{header}{re.escape(anchor)}.*?(?:\n|$)", re.DOTALL)
         else:
             pattern = re.compile(
-                f"{re.escape(tool_module.tool_call_start)}.*?{re.escape(tool_module.tool_call_end)}",
-                re.DOTALL,
+                f"{header}{re.escape(anchor)}.*?{re.escape(end_marker)}", re.DOTALL
             )
-
         matches = re.findall(pattern, model_output)
         if matches:
             remaining = re.sub(pattern, " ", model_output).strip()
             for match in matches:
                 call = (
                     match.strip()
-                    .removeprefix(tool_module.tool_call_start)
-                    .removesuffix(tool_module.tool_call_end)
+                    .removeprefix(envelope_start or anchor)
+                    .removesuffix(end_marker)
                 )
+                # The match may include a recipient header before the block.
+                call = re.sub(
+                    r"^(?:<\|start\|>assistant )?to=[A-Za-z0-9_.-]+<\|message\|>",
+                    "",
+                    call,
+                ).strip()
                 try:
                     parsed = tool_module.parse_tool_call(call, tools)
                     parsed_calls = parsed if isinstance(parsed, list) else [parsed]
@@ -331,6 +348,47 @@ def process_tool_calls(model_output: str, tool_module, tools):
                         )
                 except Exception:
                     logger.warning("Invalid tool call: %s", call)
+        # Drop any remaining reasoning envelope so it never surfaces in
+        # content (e.g. "to=self<|message|>planning<|eom|>" or a truncated
+        # "to=self<|message|>planning" that precedes a tool block), then
+        # clean any leftover <|eom|> continuation markers. ATEM-only: other
+        # parsers' start markers are not reasoning envelopes.
+        if envelope_start and block_start:
+            remaining = re.sub(
+                f"{re.escape(envelope_start)}.*?<\\|eom\\|>",
+                " ",
+                remaining,
+                flags=re.DOTALL,
+            ).strip()
+            # Truncated envelope with NO close marker: strip only when it is
+            # the leading construct (a reasoning envelope precedes its tool
+            # block) or generation cut off mid-reasoning at the very start of
+            # the remaining text. Deletion is bounded at the next recipient
+            # header or end of text so a real answer after a no-eom envelope
+            # survives. A quoted "to=self" later in the answer also survives
+            # (it is not the leading construct).
+            leading = remaining.lstrip()
+            if leading.startswith(envelope_start):
+                remaining = re.sub(
+                    rf"^\s*{re.escape(envelope_start)}.*?"
+                    r"(?=to=[A-Za-z0-9_.-]+<\|message\|>|$)",
+                    " ",
+                    remaining,
+                    flags=re.DOTALL,
+                ).strip()
+        if block_start:
+            # Strip a header immediately after a continuation marker (the
+            # stream treats it as a routing boundary) BEFORE the blanket
+            # substitution removes the marker itself.
+            remaining = re.sub(
+                r"\s*<\|(?:eom|eot)\|>\s*(?:<\|start\|>assistant )?"
+                r"to=[A-Za-z0-9_.-]+<\|message\|>",
+                " ",
+                remaining,
+            )
+            remaining = re.sub(
+                r"\s*<\|(?:eom|eot)\|>\s*", " ", remaining
+            ).strip()
     return dict(calls=called_tools, remaining_text=remaining)
 
 
@@ -359,6 +417,41 @@ def _clean_reasoning(reasoning: str, start_marker: str) -> str:
     if start_marker == "<|channel>thought":
         reasoning = reasoning.lstrip("thought")
     return reasoning.strip()
+
+
+def _strip_glimmer_leading_markers(text: str) -> str:
+    """Remove a leading recipient header (bare or full form) and continuation
+    markers from Glimmer content.
+
+    A header is removed at the start of the text AND immediately after a
+    substituted continuation marker (``<|eom|>``/``<|eot|>``), which the
+    stream treats as a routing boundary. A *quoted* header mid-answer (not
+    after a continuation marker) must survive, matching the stream. A
+    trailing partial marker (generation cut mid-marker) is also stripped,
+    matching the stream's flush behavior.
+    """
+    t = re.sub(r"^\s*<\|start\|>assistant ", "", text)
+    t = re.sub(r"^\s*to=[A-Za-z0-9_.-]+<\|message\|>", "", t)
+    # Header right after a continuation marker (stream sees a fresh segment).
+    t = re.sub(
+        r"\s*<\|(?:eom|eot)\|>\s*(?:<\|start\|>assistant )?"
+        r"to=[A-Za-z0-9_.-]+<\|message\|>",
+        " ",
+        t,
+    )
+    # Trailing partial marker prefix (e.g. "plan<|eom" cut mid-marker).
+    for marker in (
+        "<atem:function_calls>",
+        "</atem:function_calls>",
+        "<|eom|>",
+        "<|eot|>",
+        "<|start|>assistant",
+    ):
+        for length in range(min(len(marker), len(t)), 0, -1):
+            if t.endswith(marker[:length]):
+                t = t[: -length]
+                break
+    return t
 
 
 def _split_thinking(
@@ -393,17 +486,70 @@ def _split_thinking(
                 "Falling back from tokenizer response-template parser", exc_info=True
             )
 
+    _glimmer = processor is not None and getattr(
+        type(processor), "__module__", ""
+    ).startswith("mlx_vlm.models.muse_glimmer")
+    if _glimmer:
+        # Glimmer: collect ALL reasoning blocks ("to=self<|message|>…<|eom|>")
+        # in order; a lone <|eom|> or to=self (answer-only generation, stray
+        # continuation marker) stays in content.
+        reasoning_parts: List[Tuple[int, str]] = []
+        rest = text
+        while True:
+            start = rest.find("to=self<|message|>")
+            if start < 0:
+                break
+            # Only a block at a routing boundary (start of text or right
+            # after a close marker) is a reasoning turn; a quoted
+            # "to=self<|message|>" mid-answer must survive.
+            prev = rest[:start]
+            at_boundary = not prev.strip() or prev.rstrip().endswith(
+                ("<|eom|>", "<|eot|>", "</atem:function_calls>")
+            )
+            if not at_boundary:
+                break
+            end = rest.find("<|eom|>", start)
+            if end < 0:
+                break
+            reasoning_parts.append(
+                (start, rest[start + len("to=self<|message|>") : end].strip())
+            )
+            rest = rest[:start] + rest[end + len("<|eom|>") :]
+        if reasoning_parts:
+            reasoning = "\n".join(p for _, p in reasoning_parts if p) or None
+            content = _strip_glimmer_leading_markers(rest)
+            content = re.sub(r"\s*<\|(?:eom|eot)\|>\s*", " ", content).strip()
+            return reasoning, content
+
     for start_marker, end_marker in ThinkingStreamState._build_open_close_markers(
         thinking_start_token, thinking_end_token
     ):
+        # The Glimmer pair may only classify content via the strict (ordered,
+        # both-marker) branch. A lone <|eom|> or to=self must never route the
+        # whole answer into reasoning (answer-only generation).
+        is_glimmer_pair = (
+            start_marker == "to=self<|message|>" and end_marker == "<|eom|>"
+        ) and (
+            _glimmer
+            or (
+                thinking_start_token == "to=self<|message|>"
+                and thinking_end_token == "<|eom|>"
+            )
+        )
         start = text.find(start_marker)
         end = text.find(end_marker, start if start >= 0 else 0)
         if start >= 0 and start < end:
             reasoning = text[start + len(start_marker) : end].strip()
             content = _strip_content_markers(
                 text[:start] + text[end + len(end_marker) :]
-            ).strip()
-            return reasoning or None, content
+            )
+            if _glimmer:
+                content = _strip_glimmer_leading_markers(content)
+                content = re.sub(r"\s*<\|(?:eom|eot)\|>\s*", " ", content)
+            return reasoning or None, content.strip()
+
+        if is_glimmer_pair:
+            continue
 
         if end_marker in text:
             reasoning, content = text.split(end_marker, 1)
@@ -418,7 +564,14 @@ def _split_thinking(
         reasoning = _strip_content_markers(text).strip()
         return reasoning or None, ""
 
-    return None, _strip_content_markers(text).strip()
+    content = _strip_content_markers(text)
+    if _glimmer:
+        # Answer-only output: remove a leading recipient header and
+        # continuation markers that survived (e.g.
+        # "to=user<|message|>…<|eom|>").
+        content = _strip_glimmer_leading_markers(content)
+        content = re.sub(r"\s*<\|(?:eom|eot)\|>\s*", " ", content)
+    return None, content.strip()
 
 
 def _response_output_items_from_text(
@@ -449,6 +602,7 @@ def _response_output_items_from_text(
                 tc.get("remaining_text") or "",
                 thinking_start_token,
                 thinking_end_token,
+                processor=processor,
             )
             remaining = re.sub(r"<\|[^>]+\|>|<[^>]+>", "", remaining).strip()
             return reasoning_items + items, remaining, reasoning, "tool_calls"

--- a/mlx_vlm/server/responses_state.py
+++ b/mlx_vlm/server/responses_state.py
@@ -302,9 +302,7 @@ def process_tool_calls(model_output: str, tool_module, tools):
         # Optional turn header immediately before the block: the full form
         # "<|start|>assistant to=<name><|message|>" or the bare
         # "to=<name><|message|>".
-        header = (
-            r"(?:(?:<\|start\|>assistant )?to=[A-Za-z0-9_.-]+<\|message\|>)?"
-        )
+        header = r"(?:(?:<\|start\|>assistant )?to=[A-Za-z0-9_.-]+<\|message\|>)?"
         if end_marker == "":
             pattern = re.compile(f"{header}{re.escape(anchor)}.*?(?:\n|$)", re.DOTALL)
         else:
@@ -386,9 +384,7 @@ def process_tool_calls(model_output: str, tool_module, tools):
                 " ",
                 remaining,
             )
-            remaining = re.sub(
-                r"\s*<\|(?:eom|eot)\|>\s*", " ", remaining
-            ).strip()
+            remaining = re.sub(r"\s*<\|(?:eom|eot)\|>\s*", " ", remaining).strip()
     return dict(calls=called_tools, remaining_text=remaining)
 
 
@@ -449,7 +445,7 @@ def _strip_glimmer_leading_markers(text: str) -> str:
     ):
         for length in range(min(len(marker), len(t)), 0, -1):
             if t.endswith(marker[:length]):
-                t = t[: -length]
+                t = t[:-length]
                 break
     return t
 

--- a/mlx_vlm/tests/test_glimmer_server_handling.py
+++ b/mlx_vlm/tests/test_glimmer_server_handling.py
@@ -1,0 +1,167 @@
+"""Tests for Muse Glimmer final-parse handling in the server.
+
+The streamed deltas are handled by ``MuseGlimmerStreamState`` (see
+``test_glimmer_stream.py``); these tests cover the final-parse functions that
+recompute the authoritative response from the full text:
+``_split_thinking`` (reasoning routing) and ``process_tool_calls`` (ATEM).
+"""
+
+from mlx_vlm.server.responses_state import _split_thinking, process_tool_calls
+from mlx_vlm.tool_parsers import atem
+
+TOOLS = [
+    {
+        "type": "function",
+        "function": {
+            "name": "bash",
+            "description": "Run a shell command",
+            "parameters": {
+                "type": "object",
+                "properties": {"command": {"type": "string"}},
+                "required": ["command"],
+            },
+        },
+    }
+]
+
+
+class FakeGlimmerProcessor:
+    pass
+
+
+FakeGlimmerProcessor.__module__ = "mlx_vlm.models.muse_glimmer.processing_muse_glimmer"
+
+
+def _atem_block(name, cmd):
+    return (
+        "<atem:function_calls>\n"
+        f'<atem:invoke name="{name}">\n'
+        f'<atem:parameter name="command">{cmd}</atem:parameter>\n'
+        "</atem:invoke>\n</atem:function_calls>"
+    )
+
+
+# --- _split_thinking ------------------------------------------------------
+
+def test_glimmer_reasoning_routed_to_reasoning():
+    reasoning, content = _split_thinking(
+        "to=self<|message|>The user wants a color. Blue is typical.<|eom|>"
+        "to=user<|message|>blue",
+        processor=FakeGlimmerProcessor(),
+    )
+    assert "The user wants a color" in reasoning
+    assert content.strip() == "blue"
+
+
+def test_glimmer_answer_only_stays_in_content():
+    reasoning, content = _split_thinking(
+        "to=user<|message|>The file was created.<|eom|>",
+        processor=FakeGlimmerProcessor(),
+    )
+    assert reasoning is None
+    assert "The file was created." in content
+    assert "to=user" not in content
+
+
+def test_glimmer_multi_reasoning_blocks():
+    reasoning, content = _split_thinking(
+        "to=self<|message|>think one<|eom|>to=self<|message|>think two<|eom|>"
+        "to=user<|message|>answer",
+        processor=FakeGlimmerProcessor(),
+    )
+    assert "think one" in reasoning and "think two" in reasoning
+    assert content.strip() == "answer"
+
+
+def test_glimmer_configured_tokens_answer_only():
+    """Answer-only output with the Glimmer pair configured via thinking
+    tokens must stay in content (no loose-branch misrouting)."""
+    reasoning, content = _split_thinking(
+        "to=user<|message|>The file was created.<|eom|>",
+        thinking_start_token="to=self<|message|>",
+        thinking_end_token="<|eom|>",
+        processor=FakeGlimmerProcessor(),
+    )
+    assert reasoning is None
+    assert "The file was created." in content
+
+
+def test_non_glimmer_standard_markers_unaffected():
+    reasoning, content = _split_thinking(
+        "<think>inner</think>final",
+        processor=FakeGlimmerProcessor(),
+    )
+    assert "inner" in (reasoning or "")
+    assert content.strip() == "final"
+
+
+def test_non_glimmer_answer_only_not_misrouted():
+    reasoning, content = _split_thinking(
+        "to=user<|message|>The file was created.<|eom|>",
+        processor=object(),
+    )
+    # Non-Glimmer processor: no glimmer handling, no configured glimmer
+    # tokens — the text is plain content.
+    assert reasoning is None
+
+
+# --- process_tool_calls ----------------------------------------------------
+
+def test_process_tool_calls_bare_block_with_header():
+    out = (
+        "to=bash<|message|>"
+        + _atem_block("bash", "echo hi")
+    )
+    tc = process_tool_calls(out, atem, TOOLS)
+    assert len(tc["calls"]) == 1
+    assert tc["calls"][0]["function"]["name"] == "bash"
+    assert "echo hi" in tc["calls"][0]["function"]["arguments"]
+    assert "to=bash<|message|>" not in tc["remaining_text"]
+
+
+def test_process_tool_calls_multiple_blocks():
+    out = (
+        "to=read<|message|>"
+        + _atem_block("bash", "one")
+        + "<|eom|>"
+        + _atem_block("bash", "two")
+    )
+    tc = process_tool_calls(out, atem, TOOLS)
+    assert len(tc["calls"]) == 2, f"expected 2 calls, got {len(tc['calls'])}"
+    assert "one" in tc["calls"][0]["function"]["arguments"]
+    assert "two" in tc["calls"][1]["function"]["arguments"]
+    assert "<|eom|>" not in tc["remaining_text"]
+
+
+def test_process_tool_calls_envelope_form():
+    out = (
+        "to=self<|message|>I need to run a command.<|eom|>"
+        "to=bash<|message|>"
+        + _atem_block("bash", "date")
+    )
+    tc = process_tool_calls(out, atem, TOOLS)
+    assert len(tc["calls"]) == 1
+    assert "date" in tc["calls"][0]["function"]["arguments"]
+    assert "to=self" not in tc["remaining_text"]
+    assert "I need to run" not in tc["remaining_text"]
+
+
+def test_process_tool_calls_full_header_form():
+    out = (
+        "to=self<|message|>I should check the weather.<|eom|>"
+        "<|start|>assistant to=weather.get_weather<|message|>"
+        "<atem:function_calls>\n"
+        '<atem:invoke name="weather.get_weather">\n'
+        '<atem:parameter name="city">Warsaw</atem:parameter>\n'
+        "</atem:invoke>\n</atem:function_calls>"
+    )
+    tc = process_tool_calls(out, atem, tools=None)
+    assert len(tc["calls"]) == 1
+    assert tc["remaining_text"] == ""
+
+
+def test_process_tool_calls_truncated_envelope():
+    """A reasoning envelope cut off before <|eom|> must not leak to=self."""
+    out = "to=self<|message|>planning cut off to=user<|message|>answer"
+    tc = process_tool_calls(out, atem, TOOLS)
+    assert "to=self" not in tc["remaining_text"]

--- a/mlx_vlm/tests/test_glimmer_server_handling.py
+++ b/mlx_vlm/tests/test_glimmer_server_handling.py
@@ -43,6 +43,7 @@ def _atem_block(name, cmd):
 
 # --- _split_thinking ------------------------------------------------------
 
+
 def test_glimmer_reasoning_routed_to_reasoning():
     reasoning, content = _split_thinking(
         "to=self<|message|>The user wants a color. Blue is typical.<|eom|>"
@@ -107,11 +108,9 @@ def test_non_glimmer_answer_only_not_misrouted():
 
 # --- process_tool_calls ----------------------------------------------------
 
+
 def test_process_tool_calls_bare_block_with_header():
-    out = (
-        "to=bash<|message|>"
-        + _atem_block("bash", "echo hi")
-    )
+    out = "to=bash<|message|>" + _atem_block("bash", "echo hi")
     tc = process_tool_calls(out, atem, TOOLS)
     assert len(tc["calls"]) == 1
     assert tc["calls"][0]["function"]["name"] == "bash"
@@ -136,8 +135,7 @@ def test_process_tool_calls_multiple_blocks():
 def test_process_tool_calls_envelope_form():
     out = (
         "to=self<|message|>I need to run a command.<|eom|>"
-        "to=bash<|message|>"
-        + _atem_block("bash", "date")
+        "to=bash<|message|>" + _atem_block("bash", "date")
     )
     tc = process_tool_calls(out, atem, TOOLS)
     assert len(tc["calls"]) == 1

--- a/mlx_vlm/tests/test_glimmer_stream.py
+++ b/mlx_vlm/tests/test_glimmer_stream.py
@@ -10,8 +10,6 @@ every regression found across review rounds:
 - multi-chunk plain prose must not be glued
 """
 
-import pytest
-
 from mlx_vlm.server.glimmer_stream import MuseGlimmerStreamState
 
 
@@ -59,6 +57,7 @@ def _stream(text, size=1, state=None):
 
 # --- thinking + answer ---------------------------------------------------
 
+
 def test_answer_header_stripped():
     r, c = _stream("to=user<|message|>The result is 42.")
     assert r == ""
@@ -66,9 +65,7 @@ def test_answer_header_stripped():
 
 
 def test_thinking_then_answer():
-    r, c = _stream(
-        "to=self<|message|>plan<|eom|>to=user<|message|>blue"
-    )
+    r, c = _stream("to=self<|message|>plan<|eom|>to=user<|message|>blue")
     assert r == "plan"
     assert c == "blue"
 
@@ -93,6 +90,7 @@ def test_multiple_thinking_blocks():
 
 # --- tool calls ----------------------------------------------------------
 
+
 def test_tool_block_fully_suppressed():
     r, c = _stream("to=bash<|message|>" + TOOL_BLOCK + "to=user<|message|>done")
     assert "<atem" not in c
@@ -102,9 +100,7 @@ def test_tool_block_fully_suppressed():
 def test_tool_block_then_multichunk_answer():
     text = (
         "to=self<|message|>check<|eom|>"
-        "to=bash<|message|>"
-        + TOOL_BLOCK
-        + "to=user<|message|>The result is 42."
+        "to=bash<|message|>" + TOOL_BLOCK + "to=user<|message|>The result is 42."
     )
     r, c = _stream(text, size=7)
     assert r == "check"
@@ -130,6 +126,7 @@ def test_two_tool_blocks_then_answer():
 
 # --- quoted markers must survive -----------------------------------------
 
+
 def test_quoted_to_self_mid_answer():
     text = (
         "to=self<|message|>first<|eom|>"
@@ -148,14 +145,13 @@ def test_quoted_to_user_header_mid_answer():
 
 
 def test_quoted_tool_start_mid_answer():
-    text = (
-        "to=user<|message|>The doc says <atem:function_calls> is the tag. Done."
-    )
+    text = "to=user<|message|>The doc says <atem:function_calls> is the tag. Done."
     r, c = _stream(text, size=6)
     assert "The doc says <atem:function_calls> is the tag. Done." in c
 
 
 # --- chunk-boundary splits ------------------------------------------------
+
 
 def test_split_header_across_chunks():
     text = "to=user<|message|>hello world"
@@ -174,11 +170,7 @@ def test_split_to_self_quoted_across_chunks():
 
 
 def test_split_end_marker_no_tail_leak():
-    text = (
-        "to=bash<|message|>"
-        + TOOL_BLOCK
-        + "to=user<|message|>final answer"
-    )
+    text = "to=bash<|message|>" + TOOL_BLOCK + "to=user<|message|>final answer"
     r, c = _stream(text, size=5)
     assert "final answer" in c
     # No partial "</atem:function_calls>" tail may survive.
@@ -188,17 +180,14 @@ def test_split_end_marker_no_tail_leak():
 
 
 def test_split_tool_start_handled():
-    text = (
-        "to=bash<|message|>"
-        + TOOL_BLOCK
-        + "to=user<|message|>answer"
-    )
+    text = "to=bash<|message|>" + TOOL_BLOCK + "to=user<|message|>answer"
     r, c = _stream(text, size=4)
     assert "answer" in c
     assert "<atem" not in c
 
 
 # --- prose integrity -------------------------------------------------------
+
 
 def test_multichunk_prose_not_glued():
     text = "to=user<|message|>The color is blue and it looks nice."
@@ -226,6 +215,7 @@ def test_last_flag_flushes_held_text():
 
 # --- regression tests from round-4 review ---------------------------------
 
+
 def test_delta_has_thinking_closed_field():
     """Anthropic endpoint reads thinking_closed on every delta."""
     state = MuseGlimmerStreamState()
@@ -240,9 +230,7 @@ def test_eom_then_tool_block_header_stripped():
     tool block must be recognized (not leak into content)."""
     text = (
         "to=user<|message|>answer one<|eom|>"
-        "to=bash<|message|>"
-        + TOOL_BLOCK
-        + "to=user<|message|>done"
+        "to=bash<|message|>" + TOOL_BLOCK + "to=user<|message|>done"
     )
     r, c = _stream(text, size=7)
     assert "answer one" in c
@@ -260,11 +248,7 @@ def test_eom_then_user_header():
 
 
 def test_newline_after_tool_end_header_stripped():
-    text = (
-        "to=bash<|message|>"
-        + TOOL_BLOCK
-        + "\nto=user<|message|>done"
-    )
+    text = "to=bash<|message|>" + TOOL_BLOCK + "\nto=user<|message|>done"
     r, c = _stream(text, size=7)
     assert "done" in c
     assert "to=user" not in c
@@ -289,9 +273,7 @@ def test_response_output_items_from_text_glimmer():
 
     full_text = (
         "to=self<|message|>check<|eom|>"
-        "to=bash<|message|>"
-        + TOOL_BLOCK
-        + "to=user<|message|>The result is 42."
+        "to=bash<|message|>" + TOOL_BLOCK + "to=user<|message|>The result is 42."
     )
     items, clean_text, reasoning, finish = _response_output_items_from_text(
         full_text,
@@ -337,6 +319,7 @@ def test_process_tool_calls_quoted_to_self_in_answer_survives():
 
 # --- round-5 regression tests ---------------------------------------------
 
+
 def test_full_form_header_stripped():
     """<|start|>assistant to=<name><|message|> (the template's full form)
     must be stripped in the stream, not leaked."""
@@ -373,7 +356,7 @@ def test_eom_then_header_exact():
 
 
 def test_eom_then_plain_to_word_not_routing():
-    """"answer one<|eom|>to the store" — "to " (no =) is not routing."""
+    """ "answer one<|eom|>to the store" — "to " (no =) is not routing."""
     text = "to=user<|message|>answer one<|eom|>to the store"
     r, c = _stream(text, size=3)
     assert c == "answer one to the store"
@@ -411,6 +394,7 @@ def test_multi_thinking_blocks_single_newline():
 
 # --- round-6 regression tests ---------------------------------------------
 
+
 def test_whitespace_then_marker_after_eom():
     """Whitespace arriving before a routing marker must not flip the segment
     flag (newline token before to=self re-open)."""
@@ -426,11 +410,7 @@ def test_whitespace_then_marker_after_eom():
 
 
 def test_whitespace_then_header_after_tool_end():
-    text = (
-        "to=bash<|message|>"
-        + TOOL_BLOCK
-        + "\nto=user<|message|>done"
-    )
+    text = "to=bash<|message|>" + TOOL_BLOCK + "\nto=user<|message|>done"
     r, c = _stream(text, size=1)
     assert "done" in c
     assert "to=user" not in c
@@ -484,6 +464,7 @@ def test_flush_strips_partial_eom():
 
 # --- round-7 regression tests ---------------------------------------------
 
+
 def test_full_form_header_size1():
     """The full-form header must not leak at size-1 chunking (feed boundary
     after the "<|start|>assistant " prefix)."""
@@ -514,9 +495,7 @@ def test_post_tool_eom_header_final_parse():
 
     out = (
         "to=self<|message|>check<|eom|>"
-        "to=bash<|message|>"
-        + TOOL_BLOCK
-        + "to=user<|message|>answer one<|eom|>"
+        "to=bash<|message|>" + TOOL_BLOCK + "to=user<|message|>answer one<|eom|>"
         "to=user<|message|>answer two"
     )
     tc = process_tool_calls(out, atem, TOOLS)

--- a/mlx_vlm/tests/test_glimmer_stream.py
+++ b/mlx_vlm/tests/test_glimmer_stream.py
@@ -1,0 +1,564 @@
+"""Stream-loop tests for MuseGlimmerStreamState (the single state machine).
+
+These exercise the exact endpoint pattern — chunk-by-chunk feed — and cover
+every regression found across review rounds:
+- thinking-only turns (answer must not be dropped)
+- quoted "to=self<|message|>" and "to=user<|message|>" mid-answer
+- split markers / headers across chunk boundaries
+- end-marker tails must not leak
+- multiple tool blocks + final answer
+- multi-chunk plain prose must not be glued
+"""
+
+import pytest
+
+from mlx_vlm.server.glimmer_stream import MuseGlimmerStreamState
+
+
+class FakeGlimmerProcessor:
+    pass
+
+
+FakeGlimmerProcessor.__module__ = "mlx_vlm.models.muse_glimmer.processing_muse_glimmer"
+
+TOOLS = [
+    {
+        "type": "function",
+        "function": {
+            "name": "bash",
+            "description": "Run a shell command",
+            "parameters": {
+                "type": "object",
+                "properties": {"command": {"type": "string"}},
+                "required": ["command"],
+            },
+        },
+    }
+]
+
+TOOL_BLOCK = (
+    "<atem:function_calls>\n"
+    '<atem:invoke name="bash">\n'
+    '<atem:parameter name="command">ls</atem:parameter>\n'
+    "</atem:invoke>\n</atem:function_calls>"
+)
+
+
+def _stream(text, size=1, state=None):
+    """Feed ``text`` in chunks of ``size``; return (reasoning, content)."""
+    state = state or MuseGlimmerStreamState()
+    reasoning, content = [], []
+    for i in range(0, len(text), size):
+        d = state.feed(text[i : i + size], last=(i + size >= len(text)))
+        if d.reasoning:
+            reasoning.append(d.reasoning)
+        if d.content:
+            content.append(d.content)
+    return "".join(reasoning), "".join(content)
+
+
+# --- thinking + answer ---------------------------------------------------
+
+def test_answer_header_stripped():
+    r, c = _stream("to=user<|message|>The result is 42.")
+    assert r == ""
+    assert c == "The result is 42."
+
+
+def test_thinking_then_answer():
+    r, c = _stream(
+        "to=self<|message|>plan<|eom|>to=user<|message|>blue"
+    )
+    assert r == "plan"
+    assert c == "blue"
+
+
+def test_thinking_only_turn_answer_not_dropped():
+    r, c = _stream(
+        "to=self<|message|>The user wants a color. Blue is typical.<|eom|>"
+        "to=user<|message|>blue"
+    )
+    assert r == "The user wants a color. Blue is typical."
+    assert c == "blue"
+
+
+def test_multiple_thinking_blocks():
+    r, c = _stream(
+        "to=self<|message|>first<|eom|>to=self<|message|>second<|eom|>"
+        "to=user<|message|>answer"
+    )
+    assert "first" in r and "second" in r
+    assert c == "answer"
+
+
+# --- tool calls ----------------------------------------------------------
+
+def test_tool_block_fully_suppressed():
+    r, c = _stream("to=bash<|message|>" + TOOL_BLOCK + "to=user<|message|>done")
+    assert "<atem" not in c
+    assert "done" in c
+
+
+def test_tool_block_then_multichunk_answer():
+    text = (
+        "to=self<|message|>check<|eom|>"
+        "to=bash<|message|>"
+        + TOOL_BLOCK
+        + "to=user<|message|>The result is 42."
+    )
+    r, c = _stream(text, size=7)
+    assert r == "check"
+    assert "The result is 42." in c
+    assert "<atem" not in c and "to=" not in c
+
+
+def test_two_tool_blocks_then_answer():
+    block2 = TOOL_BLOCK.replace(">ls</", ">pwd</")
+    text = (
+        "to=self<|message|>plan<|eom|>"
+        "to=bash<|message|>"
+        + TOOL_BLOCK
+        + "<|eom|>"
+        + block2
+        + "to=user<|message|>Done. Both ran."
+    )
+    r, c = _stream(text, size=9)
+    assert r == "plan"
+    assert "Done. Both ran." in c
+    assert "<atem" not in c
+
+
+# --- quoted markers must survive -----------------------------------------
+
+def test_quoted_to_self_mid_answer():
+    text = (
+        "to=self<|message|>first<|eom|>"
+        "to=user<|message|>The routing header is to=self<|message|> and it "
+        "opens thinking"
+    )
+    r, c = _stream(text, size=5)
+    assert "first" in r
+    assert "The routing header is to=self<|message|> and it opens thinking" in c
+
+
+def test_quoted_to_user_header_mid_answer():
+    text = "to=user<|message|>The header to=user<|message|> is quoted text."
+    r, c = _stream(text, size=4)
+    assert "The header to=user<|message|> is quoted text." in c
+
+
+def test_quoted_tool_start_mid_answer():
+    text = (
+        "to=user<|message|>The doc says <atem:function_calls> is the tag. Done."
+    )
+    r, c = _stream(text, size=6)
+    assert "The doc says <atem:function_calls> is the tag. Done." in c
+
+
+# --- chunk-boundary splits ------------------------------------------------
+
+def test_split_header_across_chunks():
+    text = "to=user<|message|>hello world"
+    r, c = _stream(text, size=3)
+    assert c == "hello world"
+
+
+def test_split_to_self_quoted_across_chunks():
+    text = (
+        "to=self<|message|>first<|eom|>"
+        "to=user<|message|>The marker to=self<|message|> is quoted."
+    )
+    r, c = _stream(text, size=7)
+    assert "first" in r
+    assert "The marker to=self<|message|> is quoted." in c
+
+
+def test_split_end_marker_no_tail_leak():
+    text = (
+        "to=bash<|message|>"
+        + TOOL_BLOCK
+        + "to=user<|message|>final answer"
+    )
+    r, c = _stream(text, size=5)
+    assert "final answer" in c
+    # No partial "</atem:function_calls>" tail may survive.
+    assert "nction_calls>" not in c
+    assert "alls>" not in c
+    assert "s>" not in c
+
+
+def test_split_tool_start_handled():
+    text = (
+        "to=bash<|message|>"
+        + TOOL_BLOCK
+        + "to=user<|message|>answer"
+    )
+    r, c = _stream(text, size=4)
+    assert "answer" in c
+    assert "<atem" not in c
+
+
+# --- prose integrity -------------------------------------------------------
+
+def test_multichunk_prose_not_glued():
+    text = "to=user<|message|>The color is blue and it looks nice."
+    r, c = _stream(text, size=4)
+    assert c == "The color is blue and it looks nice."
+
+
+def test_indentation_preserved():
+    text = "to=user<|message|>def f():\n    return 1"
+    r, c = _stream(text, size=3)
+    assert "def f():\n    return 1" in c
+
+
+def test_stray_eom_becomes_space():
+    text = "to=user<|message|>answer one<|eom|>answer two"
+    r, c = _stream(text)
+    assert "answer one answer two" in c
+
+
+def test_last_flag_flushes_held_text():
+    text = "to=user<|message|>the answer ends with to"
+    r, c = _stream(text)
+    assert c == "the answer ends with to"
+
+
+# --- regression tests from round-4 review ---------------------------------
+
+def test_delta_has_thinking_closed_field():
+    """Anthropic endpoint reads thinking_closed on every delta."""
+    state = MuseGlimmerStreamState()
+    d1 = state.feed("to=self<|message|>plan")
+    assert d1.thinking_closed is False
+    d2 = state.feed("<|eom|>to=user<|message|>blue", last=True)
+    assert d2.thinking_closed is True
+
+
+def test_eom_then_tool_block_header_stripped():
+    """<|eom|> in normal state is a routing boundary: a following header or
+    tool block must be recognized (not leak into content)."""
+    text = (
+        "to=user<|message|>answer one<|eom|>"
+        "to=bash<|message|>"
+        + TOOL_BLOCK
+        + "to=user<|message|>done"
+    )
+    r, c = _stream(text, size=7)
+    assert "answer one" in c
+    assert "done" in c
+    assert "<atem" not in c
+    assert "to=bash" not in c
+
+
+def test_eom_then_user_header():
+    text = "to=user<|message|>answer one<|eom|>to=user<|message|>answer two"
+    r, c = _stream(text, size=5)
+    assert "answer one" in c
+    assert "answer two" in c
+    assert "to=user" not in c
+
+
+def test_newline_after_tool_end_header_stripped():
+    text = (
+        "to=bash<|message|>"
+        + TOOL_BLOCK
+        + "\nto=user<|message|>done"
+    )
+    r, c = _stream(text, size=7)
+    assert "done" in c
+    assert "to=user" not in c
+
+
+def test_multiple_thinking_blocks_not_glued():
+    text = (
+        "to=self<|message|>alpha<|eom|>"
+        "to=self<|message|>beta<|eom|>"
+        "to=user<|message|>answer"
+    )
+    r, c = _stream(text, size=11)
+    assert "alpha" in r and "beta" in r
+    assert "\n" in r  # blocks separated, not "alphabeta"
+
+
+def test_response_output_items_from_text_glimmer():
+    """The responses-endpoint final parse must strip glimmer headers from
+    post-tool remaining text."""
+    from mlx_vlm.server.responses_state import _response_output_items_from_text
+    from mlx_vlm.tool_parsers import atem
+
+    full_text = (
+        "to=self<|message|>check<|eom|>"
+        "to=bash<|message|>"
+        + TOOL_BLOCK
+        + "to=user<|message|>The result is 42."
+    )
+    items, clean_text, reasoning, finish = _response_output_items_from_text(
+        full_text,
+        "msg_1",
+        atem,
+        [
+            {
+                "type": "function",
+                "function": {
+                    "name": "bash",
+                    "description": "Run a shell command",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"command": {"type": "string"}},
+                        "required": ["command"],
+                    },
+                },
+            }
+        ],
+        {},
+        processor=FakeGlimmerProcessor(),
+    )
+    assert "The result is 42." in clean_text
+    assert "to=user" not in clean_text
+    assert "to=bash" not in clean_text
+
+
+def test_process_tool_calls_quoted_to_self_in_answer_survives():
+    """A quoted to=self<|message|> in the post-tool answer must not be
+    truncated by the envelope cleanup."""
+    from mlx_vlm.server.responses_state import process_tool_calls
+    from mlx_vlm.tool_parsers import atem
+
+    out = (
+        "to=self<|message|>check<|eom|>"
+        "to=bash<|message|>"
+        + TOOL_BLOCK
+        + "to=user<|message|>the marker to=self<|message|> is quoted"
+    )
+    tc = process_tool_calls(out, atem, TOOLS)
+    assert "the marker to=self<|message|> is quoted" in tc["remaining_text"]
+
+
+# --- round-5 regression tests ---------------------------------------------
+
+def test_full_form_header_stripped():
+    """<|start|>assistant to=<name><|message|> (the template's full form)
+    must be stripped in the stream, not leaked."""
+    text = "<|start|>assistant to=user<|message|>hello world"
+    r, c = _stream(text, size=5)
+    assert "hello world" in c
+    assert "<|start|>" not in c
+    assert "to=user" not in c
+
+
+def test_full_form_header_before_tool_block():
+    text = (
+        "<|start|>assistant to=bash<|message|>"
+        + TOOL_BLOCK
+        + "<|start|>assistant to=user<|message|>done"
+    )
+    r, c = _stream(text, size=7)
+    assert "done" in c
+    assert "<atem" not in c
+    assert "<|start|>" not in c
+
+
+def test_eom_separator_preserved_exact():
+    """The <|eom|> separator space is content, not dropped (exact text)."""
+    text = "to=user<|message|>answer one<|eom|>answer two"
+    r, c = _stream(text, size=5)
+    assert c == "answer one answer two"
+
+
+def test_eom_then_header_exact():
+    text = "to=user<|message|>answer one<|eom|>to=user<|message|>answer two"
+    r, c = _stream(text, size=5)
+    assert c == "answer one answer two"
+
+
+def test_eom_then_plain_to_word_not_routing():
+    """"answer one<|eom|>to the store" — "to " (no =) is not routing."""
+    text = "to=user<|message|>answer one<|eom|>to the store"
+    r, c = _stream(text, size=3)
+    assert c == "answer one to the store"
+
+
+def test_stream_final_consistency_quoted_header():
+    """Streamed and final output must agree: quoted to=user header survives
+    in both."""
+    from mlx_vlm.server.responses_state import _split_thinking
+
+    text = "to=user<|message|>the marker to=user<|message|> is quoted"
+    r, c = _stream(text, size=4)
+    assert "the marker to=user<|message|> is quoted" in c
+    _, fc = _split_thinking(text, processor=FakeGlimmerProcessor())
+    assert "the marker to=user<|message|> is quoted" in fc
+
+
+def test_eot_stripped():
+    text = "to=user<|message|>hello<|eot|>"
+    r, c = _stream(text, size=3)
+    assert "<|eot|>" not in c
+    assert "hello" in c
+
+
+def test_multi_thinking_blocks_single_newline():
+    text = (
+        "to=self<|message|>alpha<|eom|>"
+        "to=self<|message|>beta<|eom|>"
+        "to=user<|message|>answer"
+    )
+    r, c = _stream(text, size=3)
+    assert "alpha\nbeta" in r, f"got {r!r}"
+    assert "\n\n" not in r
+
+
+# --- round-6 regression tests ---------------------------------------------
+
+def test_whitespace_then_marker_after_eom():
+    """Whitespace arriving before a routing marker must not flip the segment
+    flag (newline token before to=self re-open)."""
+    text = (
+        "to=self<|message|>a<|eom|>\n\n"
+        "to=self<|message|>b<|eom|>"
+        "to=user<|message|>c"
+    )
+    r, c = _stream(text, size=1)
+    assert "a" in r and "b" in r
+    assert c.strip() == "c"
+    assert "to=self" not in c and "to=user" not in c
+
+
+def test_whitespace_then_header_after_tool_end():
+    text = (
+        "to=bash<|message|>"
+        + TOOL_BLOCK
+        + "\nto=user<|message|>done"
+    )
+    r, c = _stream(text, size=1)
+    assert "done" in c
+    assert "to=user" not in c
+    assert "<atem" not in c
+
+
+def test_eom_then_header_final_parse_consistency():
+    """The final parse must strip a header after <|eom|> (stream does)."""
+    from mlx_vlm.server.responses_state import _split_thinking
+
+    text = "to=user<|message|>answer one<|eom|>to=user<|message|>answer two"
+    r, c = _stream(text, size=5)
+    assert c == "answer one answer two"
+    _, fc = _split_thinking(text, processor=FakeGlimmerProcessor())
+    assert "to=user" not in fc
+    assert "answer one" in fc and "answer two" in fc
+
+
+def test_truncated_thinking_final_parse_is_content():
+    """Truncated reasoning (no <|eom|>) goes to content in the FINAL parse
+    (the stored message). The stream may show live reasoning deltas, but the
+    authoritative response must be content."""
+    from mlx_vlm.server.responses_state import _split_thinking
+
+    text = "to=self<|message|>planning cut off"
+    _, fc = _split_thinking(text, processor=FakeGlimmerProcessor())
+    assert "planning cut off" in fc
+    r, c = _split_thinking(text, processor=FakeGlimmerProcessor())
+    assert r is None
+
+
+def test_eot_split_across_chunks():
+    text = "to=user<|message|>hello<|eot|>"
+    r, c = _stream(text, size=1)
+    assert "<|eot|>" not in c
+    assert "hello" in c
+
+
+def test_eom_no_double_space():
+    text = "to=user<|message|>answer one <|eom|>answer two"
+    r, c = _stream(text, size=3)
+    assert "answer one answer two" in c
+    assert "  " not in c
+
+
+def test_flush_strips_partial_eom():
+    text = "to=self<|message|>plan<|eom"
+    r, c = _stream(text, size=3)
+    assert "<|eom" not in c
+
+
+# --- round-7 regression tests ---------------------------------------------
+
+def test_full_form_header_size1():
+    """The full-form header must not leak at size-1 chunking (feed boundary
+    after the "<|start|>assistant " prefix)."""
+    text = "<|start|>assistant to=user<|message|>hello world"
+    r, c = _stream(text, size=1)
+    assert "hello world" in c
+    assert "<|start|>" not in c
+    assert "to=user" not in c
+
+
+def test_full_form_header_before_tool_size1():
+    text = (
+        "<|start|>assistant to=bash<|message|>"
+        + TOOL_BLOCK
+        + "<|start|>assistant to=user<|message|>done"
+    )
+    r, c = _stream(text, size=1)
+    assert "done" in c
+    assert "<atem" not in c
+    assert "<|start|>" not in c
+
+
+def test_post_tool_eom_header_final_parse():
+    """The final parse must strip a header after <|eom|> in the post-tool
+    remaining text (matching the stream)."""
+    from mlx_vlm.server.responses_state import process_tool_calls
+    from mlx_vlm.tool_parsers import atem
+
+    out = (
+        "to=self<|message|>check<|eom|>"
+        "to=bash<|message|>"
+        + TOOL_BLOCK
+        + "to=user<|message|>answer one<|eom|>"
+        "to=user<|message|>answer two"
+    )
+    tc = process_tool_calls(out, atem, TOOLS)
+    assert "answer one" in tc["remaining_text"]
+    assert "answer two" in tc["remaining_text"]
+    # The full pipeline (final parse) must yield clean text.
+    from mlx_vlm.server.responses_state import _split_thinking
+
+    _, final_content = _split_thinking(
+        tc["remaining_text"], processor=FakeGlimmerProcessor()
+    )
+    assert "answer one answer two" in final_content
+    assert "to=user" not in final_content
+
+
+def test_truncated_marker_final_parse():
+    """Truncated markers (generation cut mid-marker) must not leak into the
+    final parse content."""
+    from mlx_vlm.server.responses_state import _split_thinking
+
+    _, fc = _split_thinking(
+        "to=self<|message|>plan<|eom", processor=FakeGlimmerProcessor()
+    )
+    assert "<|eom" not in fc
+    _, fc2 = _split_thinking(
+        "to=user<|message|>hello<|eot", processor=FakeGlimmerProcessor()
+    )
+    assert "<|eot" not in fc2
+
+
+def test_quoted_self_pair_mid_answer_final_parse():
+    """A complete quoted "to=self<|message|>…<|eom|>" pair mid-answer must
+    survive in the final parse (not be collected as reasoning)."""
+    from mlx_vlm.server.responses_state import _split_thinking
+
+    text = (
+        "to=self<|message|>blockone<|eom|>"
+        "to=user<|message|>the marker to=self<|message|> is <|eom|>quoted"
+    )
+    r, c = _split_thinking(text, processor=FakeGlimmerProcessor())
+    assert "blockone" in (r or "")
+    # The quoted pair survives as content (the <|eom|> is a continuation
+    # marker and becomes a space); it must NOT be collected as reasoning.
+    assert "the marker to=self<|message|> is quoted" in c
+    assert "blockone" not in c

--- a/mlx_vlm/tool_parsers/atem.py
+++ b/mlx_vlm/tool_parsers/atem.py
@@ -8,6 +8,9 @@ import re
 # from assistant content after parsing the invocation.
 tool_call_start = "to=self<|message|>"
 tool_call_end = "</atem:function_calls>"
+# Fallback block marker for tool calls emitted without the reasoning
+# envelope (Muse sometimes skips the self-reasoning turn).
+tool_call_block_start = "<atem:function_calls>"
 
 _INVOKE_PATTERN = re.compile(
     r'<atem:invoke\b[^>]*?\bname="(?P<name>[^"]+)">(?P<body>.*?)' r"</atem:invoke>",


### PR DESCRIPTION
## Summary

Muse Glimmer (`mlx_vlm/models/muse_glimmer`) uses recipient-routing in its
output: it emits `to=self<|message|>…<|eom|>` (internal reasoning channel),
`to=user<|message|>` (answer header), `to=<tool><|message|>` (before an ATEM
tool call), and `<|eom|>`/`<|eot|>` continuation markers (token 200007 is
**not** an eos token, so it survives decode). The server previously leaked
all of these into `message.content`, breaking agent loops (opencode) that
rely on clean content plus parsed tool calls.

This PR handles Glimmer's output with a **dedicated, self-contained state
machine**, model-gated so other models are unaffected.

## Changes

- **New `mlx_vlm/server/glimmer_stream.py`** — `MuseGlimmerStreamState`: a
  single state machine (NORMAL / THINKING / TOOL) owning all region logic in
  one buffer. Handles thinking markers, ATEM tool blocks, recipient headers
  (bare `to=…<|message|>` and full `<|start|>assistant to=…<|message|>`
  forms), quoted-marker preservation, partial-marker holding across chunk
  boundaries, `<|eom|>`/`<|eot|>` boundaries, and truncated-flush cleanup.
  `make_glimmer_stream_state(processor)` selects it for Glimmer processors.
- **`mlx_vlm/server/openai.py` + `anthropic.py`** — branch on
  `make_glimmer_stream_state`: Glimmer uses the new state machine (which
  handles thinking + tool suppression internally); all other models keep the
  existing `ThinkingStreamState` + `suppress_tool_call_content` path
  byte-identical to main.
- **`mlx_vlm/server/responses_state.py`** — final-parse fixes, ATEM-gated so
  other parsers are unchanged:
  - `process_tool_calls`: anchor on `tool_call_block_start` (parses bare
    tool calls without the reasoning envelope, and multiple blocks);
    turn-header regex; envelope cleanup bounded at the next header;
    `<|eom|>`/`<|eot|>` → header stripping.
  - `_split_thinking`: Glimmer branch collects reasoning blocks only at
    routing boundaries (quoted `to=self<|message|>` mid-answer survives);
    answer-only output stays in content; leading-marker stripping (headers
    at start or after continuation markers; trailing partials).
  - `_response_output_items_from_text`: pass `processor=` so the responses
    endpoint's final content is stripped consistently.
- **`mlx_vlm/tool_parsers/atem.py`** — expose `tool_call_block_start`.

## Why a dedicated state machine

Earlier iterations extended `ThinkingStreamState` +
`suppress_tool_call_content` — two interacting stateful functions that
disagreed about stream state and repeatedly regressed (tool markup leaking,
answers dropped, quoted markers swallowed, end-marker tails leaking). A
single state machine with one buffer eliminates that class of bugs by
construction; non-Glimmer models are untouched.

## Relationship to #1843

This overlaps with #1843 ("Wire Muse Glimmer's reasoning channel through the
server", @fredchu) on the shared goal of keeping Glimmer's reasoning out of
`content`. Differences:

- #1843 wires the model config's thinking tokens through
  `_build_gen_args()` (config/env/request precedence) and adds
  `reasoning_effort` → `reasoning_strength`.
- This PR instead detects the Glimmer processor and applies model-gated
  stripping via the dedicated state machine, additionally handling: bare
  ATEM tool calls (no reasoning envelope), multiple tool blocks,
  chunk-boundary header leaks, `<|eot|>`, and quoted-marker preservation in
  both streamed and final output.

**Reconciliation recommendation:** land this PR first; rebase #1843 keeping
its `request_normalization.py` (config-token fallback — note: its `config`
parameter is currently shadowed and inert) and `generation.py`
(`reasoning_strength` alias) changes, and dropping its `responses_state.py`
changes (they target the old path and their unanchored header strip
contradicts quoted-marker preservation). The two compose cleanly —
verified: 2150 passed with that combination.

## Testing

- **`mlx_vlm/tests/test_glimmer_stream.py`** (45 tests, no weights/network):
  stream-loop scenarios — thinking routing, answer/tool header stripping,
  quoted markers mid-answer (incl. split across chunks), full-form headers,
  `<|eom|>`/`<|eot|>` boundaries, multi-block tool calls, chunk-boundary
  splits at multiple sizes, truncation flush, prose integrity (spaces and
  indentation preserved), non-Glimmer passthrough.
- **`mlx_vlm/tests/test_glimmer_server_handling.py`** (11 tests): final-parse
  routing, bare/envelope/multi-block `process_tool_calls`, truncated
  envelopes, quoted `to=self` survival, `<|eot|>`.
- **Full suite: `2150 passed, 5 skipped`** — the single failure
  (`test_speculative.py::test_qwen_target_verify_quantized_linear_matches_singleton_batch_path`)
  is pre-existing and unrelated (numerical mlx-op test, imports no server
  code; fails identically on clean `main`).
- **Fuzz**: ~60k inputs × chunk sizes 1–33 (931k feeds) — zero hangs,
  zero exceptions, bounded buffer.
- **Non-Glimmer safety**: `ThinkingStreamState`,
  `suppress_tool_call_content`, `make_response_stream_state`,
  `prompt_has_open_thinking` are byte-identical to `main`; Mistral
  `[TOOL_CALLS]` and other parsers behave identically.
