### PR TITLE
Load pre-converted MLX Inkling checkpoints

### DIFF
--- a/mlx_vlm/models/inkling/inkling.py
+++ b/mlx_vlm/models/inkling/inkling.py
@@ -36,6 +36,12 @@ def _split_gate_up(v):
     return mx.contiguous(w[..., 0, :]), mx.contiguous(w[..., 1, :])
 
 
+def _to_mlx_conv(v):
+    if v.ndim == 3 and v.shape[-1] == 1:
+        return v
+    return v.transpose(0, 2, 1)
+
+
 class Model(nn.Module):
     def __init__(self, config: ModelConfig):
         super().__init__()
@@ -146,7 +152,7 @@ class Model(nn.Module):
             elif name in ("q_norm", "k_norm"):
                 out[base + f"self_attn.{name}.weight"] = v
             elif name in ("k_sconv", "v_sconv"):
-                out[base + f"self_attn.{name}.conv.weight"] = v.transpose(0, 2, 1)
+                out[base + f"self_attn.{name}.conv.weight"] = _to_mlx_conv(v)
             elif name == "rel_logits_proj":
                 out[base + "self_attn.rel_proj"] = v
             else:
@@ -156,9 +162,9 @@ class Model(nn.Module):
         elif sub == "mlp_norm.weight":
             out[base + "post_attention_layernorm.weight"] = v
         elif sub == "attn_sconv.weight":
-            out[base + "attn_sconv.conv.weight"] = v.transpose(0, 2, 1)
+            out[base + "attn_sconv.conv.weight"] = _to_mlx_conv(v)
         elif sub == "mlp_sconv.weight":
-            out[base + "mlp_sconv.conv.weight"] = v.transpose(0, 2, 1)
+            out[base + "mlp_sconv.conv.weight"] = _to_mlx_conv(v)
         elif sub.startswith("mlp."):
             m = sub[len("mlp.") :]
             p = base + "mlp."
@@ -180,6 +186,8 @@ class Model(nn.Module):
                 out[p + "up_proj.weight"] = u
             elif m == "w2_md.weight":
                 out[p + "down_proj.weight"] = v
+            elif m.startswith("experts."):
+                out[p + "switch_mlp." + m[len("experts.") :]] = v
             else:
                 out[p + m] = v
         else:
@@ -258,17 +266,17 @@ class Model(nn.Module):
             elif k.startswith("model.visual."):
                 sub = k[len("model.visual.") :]
                 if sub.startswith("layers.linear_"):
-                    j = sub[len("layers.linear_") :].split(".")[0]
-                    out[f"vision_tower.encoder_layers.{j}.projection.weight"] = v
+                    j, leaf = sub[len("layers.linear_") :].split(".", 1)
+                    out[f"vision_tower.encoder_layers.{j}.projection.{leaf}"] = v
                 elif sub.startswith("layers.norm_"):
-                    j = sub[len("layers.norm_") :].split(".")[0]
-                    out[f"vision_tower.encoder_layers.{j}.layer_norm.weight"] = v
+                    j, leaf = sub[len("layers.norm_") :].split(".", 1)
+                    out[f"vision_tower.encoder_layers.{j}.layer_norm.{leaf}"] = v
                 else:
                     out["vision_tower." + sub] = v
             elif k.startswith("model.audio."):
                 sub = k[len("model.audio.") :]
-                if sub == "encoder.weight":
-                    out["audio_tower.embed_audio_tokens.weight"] = v
+                if sub.startswith("encoder."):
+                    out["audio_tower.embed_audio_tokens." + sub[len("encoder.") :]] = v
                 elif sub == "final_norm.weight":
                     out["audio_tower.norm.weight"] = v
                 else:
@@ -277,6 +285,11 @@ class Model(nn.Module):
                 out[k] = v
         for i, buf in experts.items():
             out.update(self._map_experts(i, buf))
+        for k in [k for k in out if k.endswith("switch_mlp.gate_proj.weight")]:
+            p = k[: -len("gate_proj.weight")]
+            n = out[k].shape[0]
+            out.setdefault(p + "gate_scale", mx.ones((n,)))
+            out.setdefault(p + "out_scale", mx.ones((n,)))
         return fuse_qkvr(shared_experts_to_dense(out))
 
     def make_cache(self):

--- a/mlx_vlm/tests/test_inkling.py
+++ b/mlx_vlm/tests/test_inkling.py
@@ -404,3 +404,43 @@ def test_from_pretrained_builds_native_audio_extractor(tmp_path, monkeypatch):
     assert processor.feature_extractor.feature_size == 12
     assert processor.feature_extractor.sampling_rate == 8000
     assert processor.feature_extractor.hop_length == 400
+
+
+def test_sanitize_maps_pre_converted_mlx_checkpoint():
+    from mlx_vlm.models.inkling.inkling import Model
+
+    model = Model.__new__(Model)
+    weights = {
+        "model.llm.layers.0.mlp.experts.gate_proj.weight": mx.zeros(
+            (4, 8, 2), mx.uint32
+        ),
+        "model.llm.layers.0.mlp.experts.gate_proj.scales": mx.zeros((4, 8, 2)),
+        "model.llm.layers.0.mlp.experts.down_proj.weight": mx.zeros(
+            (4, 8, 2), mx.uint32
+        ),
+        "model.llm.layers.0.attn.k_sconv.weight": mx.zeros((6, 4, 1)),
+        "model.audio.encoder.weight": mx.zeros((5, 3)),
+        "model.audio.encoder.scales": mx.zeros((5, 3)),
+        "model.visual.layers.linear_1.weight": mx.zeros((3, 2)),
+        "model.visual.layers.linear_1.scales": mx.zeros((3, 2)),
+    }
+
+    out = model.sanitize(weights)
+    prefix = "language_model.model.layers.0.mlp.switch_mlp."
+
+    assert prefix + "gate_proj.weight" in out
+    assert prefix + "gate_proj.scales" in out
+    assert not any(".mlp.experts." in k for k in out)
+
+    assert out[prefix + "gate_scale"].shape == (4,)
+    assert out[prefix + "out_scale"].shape == (4,)
+
+    assert out["language_model.model.layers.0.self_attn.k_sconv.conv.weight"].shape == (
+        6,
+        4,
+        1,
+    )
+
+    assert "audio_tower.embed_audio_tokens.scales" in out
+    assert "vision_tower.encoder_layers.1.projection.scales" in out
+    assert out["vision_tower.encoder_layers.1.projection.weight"].shape == (3, 2)


### PR DESCRIPTION
`mlx-community/Inkling-Small-mlx-4bit` stores experts already stacked under `mlp.experts`, and the sanitizer only recognised the original ModelOpt names, so 362 tensors never reached the model. Map those names onto `switch_mlp`, keep the quantization leaves when renaming the audio and vision projections, default the per-expert scales the NVFP4 path supplies, and leave short-conv weights alone when they are already in MLX layout.

Closes #1810

I couldn't download 153 GB, so I ran the real load_model() against the checkpoint's true metadata, using only config.json and the 30 safetensors headers