### PR TITLE
fix(thinking): budget a model-generated `<think>` opener (#1819)

### DIFF
--- a/mlx_vlm/generate/dispatch.py
+++ b/mlx_vlm/generate/dispatch.py
@@ -914,7 +914,12 @@ def stream_generate(
         thinking_start_token_id = tokenizer.encode(
             thinking_start_token, add_special_tokens=False
         )[-1]
-        enable_thinking = enable_thinking and (
+        # Whether the rendered prompt already left a thinking block open only
+        # decides the criteria's *initial* state. It must not disarm the
+        # budget: a template that seeds no opener (GLM-4.1V) leaves the model
+        # to emit `<think>` on its first generated token, and that block needs
+        # capping just as much as a template-seeded one.
+        thinking_open_in_prompt = enable_thinking and (
             thinking_start_token_id in input_ids.flatten().tolist()
         )
         tokenizer.thinking_budget_criteria = ThinkingBudgetCriteria(
@@ -923,6 +928,7 @@ def stream_generate(
             thinking_end_token=thinking_end_token,
             thinking_start_token=thinking_start_token,
             enable_thinking=enable_thinking,
+            thinking_open_in_prompt=thinking_open_in_prompt,
         )
         kwargs["thinking_budget_criteria"] = tokenizer.thinking_budget_criteria
     else:

--- a/mlx_vlm/server/generation.py
+++ b/mlx_vlm/server/generation.py
@@ -1596,13 +1596,16 @@ class ResponseGenerator:
         tokenizer = self.tokenizer
         thinking_start_token = args.thinking_start_token or DEFAULT_THINKING_START_TOKEN
         thinking_end_token = args.thinking_end_token or DEFAULT_THINKING_END_TOKEN
-        enable_thinking = self._prompt_has_open_thinking(args, input_ids)
+        # An open block in the prompt seeds the initial state; it does not
+        # decide whether the budget is armed. Templates that seed no opener
+        # leave the model to emit `<think>` itself, which must still be capped.
         return ThinkingBudgetCriteria(
             tokenizer=tokenizer,
             thinking_budget=args.thinking_budget,
             thinking_end_token=thinking_end_token,
             thinking_start_token=thinking_start_token,
-            enable_thinking=enable_thinking,
+            enable_thinking=bool(args.enable_thinking),
+            thinking_open_in_prompt=self._prompt_has_open_thinking(args, input_ids),
         )
 
     def _gpu_embed(

--- a/mlx_vlm/tests/test_generate.py
+++ b/mlx_vlm/tests/test_generate.py
@@ -1676,6 +1676,73 @@ class TestThinkingBudgetCriteria:
         assert criteria.thinking_token_count == 0
         assert criteria.budget_exceeded is False
 
+    def test_model_generated_start_token_is_budgeted(self):
+        """The model may open `<think>` itself when the template seeds nothing.
+
+        GLM-4.1V-style templates render no opener, so the prompt contains no
+        `<think>` and the block starts on the first generated token. That block
+        still has to be capped: arming the budget is the caller's
+        `enable_thinking`, not whether the prompt happened to seed a delimiter.
+        """
+        criteria = ThinkingBudgetCriteria(
+            tokenizer=FakeTokenizer(),
+            thinking_budget=5,
+            thinking_end_token="</think>",
+            thinking_start_token="<think>",
+            enable_thinking=True,
+            thinking_open_in_prompt=False,
+        )
+
+        # Nothing open yet, so tokens before the opener are not counted.
+        assert criteria.in_thinking is False
+
+        # The model emits its own opener.
+        assert criteria(99) is None
+        assert criteria.in_thinking is True
+
+        for i in range(5):
+            assert criteria(50 + i) is None
+        assert criteria.thinking_token_count == 5
+        assert criteria.budget_exceeded is False
+
+        assert criteria(60) == 10  # \n
+        assert criteria.pop_forced_token_id() == 10
+        assert criteria(60) == 100  # </think>
+        assert criteria.pop_forced_token_id() == 100
+        assert criteria.budget_exceeded is True
+
+    def test_thinking_open_in_prompt_defaults_to_enable_thinking(self):
+        """Callers that never made the distinction keep the old initial state."""
+        for enable_thinking in (True, False):
+            criteria = ThinkingBudgetCriteria(
+                tokenizer=FakeTokenizer(),
+                thinking_budget=5,
+                thinking_end_token="</think>",
+                thinking_start_token="<think>",
+                enable_thinking=enable_thinking,
+            )
+            assert criteria.thinking_open_in_prompt is enable_thinking
+            assert criteria.in_thinking is enable_thinking
+
+    def test_reset_restores_the_prompt_open_state_not_the_arm_flag(self):
+        """Between generations the block is closed again unless the prompt opened one."""
+        criteria = ThinkingBudgetCriteria(
+            tokenizer=FakeTokenizer(),
+            thinking_budget=5,
+            thinking_end_token="</think>",
+            thinking_start_token="<think>",
+            enable_thinking=True,
+            thinking_open_in_prompt=False,
+        )
+        assert criteria(99) is None
+        assert criteria.in_thinking is True
+
+        criteria.reset_thinking_state()
+
+        assert criteria.in_thinking is False
+        assert criteria.thinking_token_count == 0
+        assert criteria.budget_exceeded is False
+
     def _make_criteria(self, enable_thinking=True):
         return ThinkingBudgetCriteria(
             tokenizer=FakeTokenizer(),

--- a/mlx_vlm/utils.py
+++ b/mlx_vlm/utils.py
@@ -2044,6 +2044,16 @@ class ThinkingBudgetCriteria:
 
     Tracks tokens within thinking blocks (between start and end tokens) and
     forces a closing sequence (e.g. ``\\n</think>``) when budget is exceeded.
+
+    ``enable_thinking`` arms the budget; it says the caller wants reasoning and
+    wants it capped. ``thinking_open_in_prompt`` is the separate question of
+    whether the *rendered prompt* already left a thinking block open, and only
+    seeds the initial state. Templates differ here: Qwen3-VL seeds an open
+    ``<think>``, while GLM-4.1V seeds nothing and the model emits its own
+    opener on the first generated token. Both must be budgeted, so a prompt
+    without a seeded opener may not disarm the criteria. Defaults to
+    ``enable_thinking`` so callers that never made the distinction are
+    unaffected.
     """
 
     def __init__(
@@ -2053,10 +2063,16 @@ class ThinkingBudgetCriteria:
         thinking_end_token: str = "</think>",
         thinking_start_token: Optional[str] = None,
         enable_thinking: bool = False,
+        thinking_open_in_prompt: Optional[bool] = None,
     ):
         self.tokenizer = tokenizer
         self.thinking_budget = thinking_budget
         self.enable_thinking = enable_thinking
+        self.thinking_open_in_prompt = (
+            enable_thinking
+            if thinking_open_in_prompt is None
+            else bool(thinking_open_in_prompt)
+        )
 
         # Resolve token IDs from strings
         self.thinking_end_token_id = tokenizer.encode(
@@ -2074,14 +2090,14 @@ class ThinkingBudgetCriteria:
         self._forced_sequence.append(self.thinking_end_token_id)
         self._forced_index = 0
 
-        self.in_thinking = self.enable_thinking
+        self.in_thinking = self.thinking_open_in_prompt
         self.thinking_token_count = 0
         self.budget_exceeded = False
         self.forced_token_id = None
 
     def reset_thinking_state(self):
         """Reset thinking state between generations."""
-        self.in_thinking = self.enable_thinking
+        self.in_thinking = self.thinking_open_in_prompt
         self.thinking_token_count = 0
         self.budget_exceeded = False
         self._forced_index = 0


### PR DESCRIPTION
Fixes #1819 (the `--thinking-budget` half of it).

## The bug

`ThinkingBudgetCriteria` uses one flag for two different questions, and `dispatch.py` answers the wrong one:

```python
# mlx_vlm/generate/dispatch.py
enable_thinking = enable_thinking and (
    thinking_start_token_id in input_ids.flatten().tolist()
)
tokenizer.thinking_budget_criteria = ThinkingBudgetCriteria(..., enable_thinking=enable_thinking)
```

Inside the criteria that flag guards three things:

| use | correct meaning |
| --- | --- |
| `self.in_thinking = self.enable_thinking` | did the *prompt* leave a block open? |
| `if self.enable_thinking and token_id == self.thinking_start_token_id:` | is the budget armed? |
| `pop_forced_token_id()` early return | is the budget armed? |

So when the rendered prompt contains no `<think>`, the criteria is built with `enable_thinking=False` and the start-token branch — the one written precisely to catch an opener the model generates itself — is dead in exactly the case it exists for.

Chat templates split on this, as the issue's template survey shows:

* `Qwen3-VL-*-Thinking`, `ERNIE-4.5-VL-*-Thinking` seed an **open** `<think>` in the prompt.
* `GLM-4.1V-9B-Thinking` seeds **nothing**; the model emits its own opener on the first generated token.

The issue reports the second shape running an unclosed `<think>` to the 1000-token cap with `thinking_budget=300`. The budget was never armed.

## The fix

Separate the two meanings. `enable_thinking` keeps its name's meaning — the caller wants reasoning and wants it capped — and a new `thinking_open_in_prompt` seeds `in_thinking` (and `reset_thinking_state`). It **defaults to `enable_thinking`**, so every existing call site and test keeps its behaviour byte for byte.

`dispatch.py` and the server's `_make_thinking_budget_criteria` then pass the prompt-open state through the new parameter instead of folding it into the arm switch. Both call sites had the identical conflation, so both are fixed here; the server's `_prompt_has_open_thinking` helper already returns `False` when the caller disabled thinking, so a disabled request stays fully inert.

## Verification

mlx is Metal-only, so `mlx_vlm.utils` cannot be imported on this host. `ThinkingBudgetCriteria`'s body has no mlx dependency, so I extracted the class and the repo's own `TestThinkingBudgetCriteria` / `FakeTokenizer` verbatim by AST and ran the real test bodies against the real class source.

**On `main`:**

```
FAIL  test_model_generated_start_token_is_budgeted
FAIL  test_reset_restores_the_prompt_open_state_not_the_arm_flag
FAIL  test_thinking_open_in_prompt_defaults_to_enable_thinking
7/10 passed
```

**With this change:**

```
10/10 passed
```

The seven pre-existing `ThinkingBudgetCriteria` tests pass on both. The GLM-4.1V scenario, driven token by token:

| | `in_thinking` | tokens counted | budget tripped | forced |
| --- | --- | --- | --- | --- |
| before | `False` | 0 | no | — |
| after | `True` | 12 | yes | `\n`, `</think>` |

Formatted with the pinned `black` 26.3.1.

## Not addressed

The issue covers more than the budget gate. Models that reason with their own delimiters (Kimi-VL's `◁think▷` pair) or with no delimiters at all still fall outside a delimiter-based budget, and templates that seed an open `<think>` when thinking was never requested are a separate template-rendering question. Those want a design call rather than this patch, so I left them in the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
