### PR TITLE
feat(server): alias reasoning_effort to reasoning_strength (Glimmer; supersedes #1843)

### DIFF
--- a/mlx_vlm/server/generation.py
+++ b/mlx_vlm/server/generation.py
@@ -810,6 +810,8 @@ class GenerationArguments:
             kw["reasoning"] = self.reasoning
         if self.reasoning_effort is not None:
             kw["reasoning_effort"] = self.reasoning_effort
+            # Muse Glimmer's chat template reads the reasoning_strength alias.
+            kw["reasoning_strength"] = self.reasoning_effort
         if self.thinking_budget is not None:
             kw["thinking_budget"] = self.thinking_budget
         if self.thinking_start_token is not None:

--- a/mlx_vlm/tests/test_glimmer_reasoning_alias.py
+++ b/mlx_vlm/tests/test_glimmer_reasoning_alias.py
@@ -1,0 +1,37 @@
+"""Muse Glimmer reasoning_effort -> reasoning_strength alias.
+
+Glimmer's chat template renders the system reasoning prompt from the
+``reasoning_strength`` kwarg (``render_reasoning()``, default "high"):
+the server passes ``reasoning_effort`` (OpenAI standard), so without the
+alias the requested effort is silently dropped and the template always
+renders "high".
+"""
+from mlx_vlm.server.generation import GenerationArguments
+
+
+def test_reasoning_effort_emits_reasoning_strength_alias():
+    kw = GenerationArguments(
+        enable_thinking=True,
+        reasoning=True,
+        reasoning_effort="low",
+    ).to_template_kwargs()
+
+    assert kw["reasoning_effort"] == "low"
+    assert kw["reasoning_strength"] == "low"
+
+
+def test_reasoning_strength_alias_preserves_high():
+    kw = GenerationArguments(
+        enable_thinking=True,
+        reasoning=True,
+        reasoning_effort="high",
+    ).to_template_kwargs()
+
+    assert kw["reasoning_strength"] == "high"
+
+
+def test_no_reasoning_strength_when_effort_unset():
+    kw = GenerationArguments(enable_thinking=True, reasoning=True).to_template_kwargs()
+
+    assert "reasoning_strength" not in kw
+    assert "reasoning_effort" not in kw

--- a/mlx_vlm/tests/test_glimmer_reasoning_alias.py
+++ b/mlx_vlm/tests/test_glimmer_reasoning_alias.py
@@ -6,6 +6,7 @@ the server passes ``reasoning_effort`` (OpenAI standard), so without the
 alias the requested effort is silently dropped and the template always
 renders "high".
 """
+
 from mlx_vlm.server.generation import GenerationArguments
 
 


### PR DESCRIPTION
## Summary

Muse Glimmer's chat template renders its system reasoning prompt from the `reasoning_strength` kwarg (`render_reasoning()`, default `"high"`), but the server only passed `reasoning_effort` (the OpenAI-standard field). Requested effort was therefore **silently dropped** and the template always rendered `"high"`.

This PR emits `reasoning_strength` alongside `reasoning_effort` in `GenerationArguments.to_template_kwargs()` whenever an effort is set — 2 lines + tests.

## Why this PR exists (reconciliation of #1843)

This supersedes open PR **#1843** ("Wire Muse Glimmer's reasoning channel through the server"). Of #1843's 7 files, this PR keeps the only piece still missing on main:

- **Kept:** the `reasoning_strength` alias (this PR).
- **Already on main (merged #1848 "Use model reasoning config and response templates"):** the config-token fallback in `request_normalization.py` (`_request_field_or_default(..., config=...)`). Note the Glimmer model config itself carries no `thinking_start_token`/`thinking_end_token` (both `None`), so the fallback would be a no-op for Glimmer regardless.
- **Dropped:** `responses_state.py` harmony-marker stripping (targets the old `ThinkingStreamState` path; its unanchored header strip contradicts the anchored handling in #1878) and the old test file (superseded by #1878's `test_glimmer_server_handling.py` + the tests here).

Independent of #1878 (different files) — #1878 remains the primary Glimmer server-handling PR.

## Verification

- 3 unit tests (`test_glimmer_reasoning_alias.py`): effort emits the alias, `"high"` preserved, no alias when unset.
- Full suite: 2118 passed, 1 failed (pre-existing unrelated Qwen-speculative), 5 skipped.
- Template check: `render_reasoning()` reads `reasoning_strength` (verified against the shipped `chat_template.jinja`).
