### PR TITLE
lfm2_vl: implement official image splitting (tiling)

### DIFF
--- a/mlx_vlm/models/lfm2_vl/processing_lfm2_vl.py
+++ b/mlx_vlm/models/lfm2_vl/processing_lfm2_vl.py
@@ -34,7 +34,6 @@ from transformers.models.lfm2_vl.processing_lfm2_vl import (
 
 from ..base import install_auto_processor_patch, load_chat_template
 
-
 # Official transformers preprocessing defaults for LFM2-VL: images larger than
 # `max_pixels_tolerance` * `max_image_tokens` * patch^2 * factor^2 pixels are
 # split into a grid of `tile_size` tiles (grid within [min_tiles, max_tiles],
@@ -707,9 +706,7 @@ def _patched_call(self, images=None, text=None, **kwargs):
     # max_tiles, use_thumbnail) regardless of how the processor's kwarg
     # routing classifies them.
     splitting_overrides = {
-        key: kwargs.pop(key)
-        for key in _OFFICIAL_SPLITTING_DEFAULTS
-        if key in kwargs
+        key: kwargs.pop(key) for key in _OFFICIAL_SPLITTING_DEFAULTS if key in kwargs
     }
 
     # Ensure we're using the slow processor (fast requires PyTorch tensors)

--- a/mlx_vlm/models/lfm2_vl/processing_lfm2_vl.py
+++ b/mlx_vlm/models/lfm2_vl/processing_lfm2_vl.py
@@ -453,9 +453,13 @@ class Lfm2VlNumpyImageProcessor(ImageProcessingMixin):
         return self.preprocess(images, return_tensors=return_tensors, **kwargs)
 
 
-# Try to import the slow image processor to force its use. Some Transformers
-# versions import torch from the SigLIP2 processor module, so fall back to a
-# local PIL/NumPy implementation when torch/torchvision are absent.
+# Try to import the slow image processor. Some Transformers versions import
+# torch from the SigLIP2 processor module. Historically the real Siglip2
+# processor was used when importable, but it has no LFM2-VL tiling and its
+# (B, C, H, W) output never matched the packed-patch contract the MLX model
+# consumes — so behavior silently differed between torch and torch-free
+# environments. The NumPy processor below is now used unconditionally; this
+# import only feeds the _SLOW_PROCESSOR_AVAILABLE fallback below.
 try:
     from transformers.models.siglip2.image_processing_siglip2 import (
         Siglip2ImageProcessor,
@@ -488,10 +492,14 @@ def _patched_init(self, image_processor, tokenizer, chat_template=None, **kwargs
     # Check if we got the fast image processor and need to replace it with the slow one
     # The fast processor requires PyTorch tensors which we don't have
     processor_class_name = type(image_processor).__name__
-    if "Fast" in processor_class_name and _SLOW_PROCESSOR_AVAILABLE:
-        # Replace with slow processor using the same config
+    # Always swap in the NumPy image processor: it is the only implementation
+    # with the official LFM2-VL tiling + thumbnail and the packed-patch output
+    # the MLX model consumes. The real Siglip2ImageProcessor (instantiated
+    # when torch is installed) has neither.
+    if processor_class_name != "Lfm2VlNumpyImageProcessor":
+        # Replace with the NumPy processor using the same config
         if hasattr(image_processor, "to_dict"):
-            # Use the config dict to create the slow processor
+            # Use the config dict to create the replacement
             config = image_processor.to_dict()
         else:
             # Fallback to copying attributes
@@ -501,10 +509,10 @@ def _patched_init(self, image_processor, tokenizer, chat_template=None, **kwargs
                 if not k.startswith("_") and k not in ["name_or_path"]
             }
         # Apply the official tiling defaults (see _OFFICIAL_SPLITTING_DEFAULTS):
-        # MLX repos ship tiling disabled, which the slow processor can now do.
+        # MLX repos ship tiling disabled, which the NumPy processor can now do.
         for key in _OFFICIAL_SPLITTING_DEFAULTS:
             config.pop(key, None)
-        image_processor = Siglip2ImageProcessor(**config)
+        image_processor = Lfm2VlNumpyImageProcessor(**config)
 
     # Call original __init__
     _original_init(
@@ -608,7 +616,9 @@ def _patched_from_pretrained(cls, pretrained_model_name_or_path, **kwargs):
         image_processor_config.pop(key, None)
         image_processor_config[key] = kwargs.pop(key, default)
 
-    image_processor = Siglip2ImageProcessor(**image_processor_config)
+    # The NumPy image processor is used unconditionally (torch or not): it is
+    # the only implementation with official tiling + the packed-patch output.
+    image_processor = Lfm2VlNumpyImageProcessor(**image_processor_config)
     return cls(image_processor=image_processor, tokenizer=tokenizer)
 
 
@@ -654,15 +664,17 @@ _original_call = Lfm2VlProcessor.__call__
 
 def _ensure_slow_processor(processor_instance):
     """
-    Ensure we're using the slow image processor, not the fast one.
-    The fast processor only supports PyTorch tensors which we can't use without PyTorch.
+    Ensure we're using the NumPy image processor.
+
+    The fast (torchvision) processor needs PyTorch tensors and the real slow
+    Siglip2ImageProcessor has no LFM2-VL tiling — neither matches the packed
+    patch input the MLX model expects, so both are swapped for the NumPy one.
     """
     image_processor = processor_instance.image_processor
     processor_class_name = type(image_processor).__name__
 
-    if "Fast" in processor_class_name and _SLOW_PROCESSOR_AVAILABLE:
-        # Need to replace with slow processor
-        # Get the config from the fast processor
+    if processor_class_name != "Lfm2VlNumpyImageProcessor":
+        # Get the config from the existing processor
         config = (
             image_processor.to_dict() if hasattr(image_processor, "to_dict") else {}
         )
@@ -671,13 +683,13 @@ def _ensure_slow_processor(processor_instance):
         config.pop("auto_map", None)
         config.pop("_processor_class", None)
         # Apply the official tiling defaults (see _OFFICIAL_SPLITTING_DEFAULTS):
-        # MLX repos ship tiling disabled, which the slow processor can now do.
+        # MLX repos ship tiling disabled, which the NumPy processor can now do.
         for key in _OFFICIAL_SPLITTING_DEFAULTS:
             config.pop(key, None)
 
-        # Create slow processor with the same config
-        slow_processor = Siglip2ImageProcessor(**config)
-        processor_instance.image_processor = slow_processor
+        # Create the NumPy processor with the same config
+        numpy_processor = Lfm2VlNumpyImageProcessor(**config)
+        processor_instance.image_processor = numpy_processor
 
         # Re-add missing attributes
         if not hasattr(processor_instance.image_processor, "tile_size"):

--- a/mlx_vlm/models/lfm2_vl/processing_lfm2_vl.py
+++ b/mlx_vlm/models/lfm2_vl/processing_lfm2_vl.py
@@ -13,6 +13,10 @@ This patch:
    defaults for tile-related parameters
 4. Patches the `__init__` to add missing attributes to the slow image processor
 5. Forces the use of the slow image processor to avoid PyTorch tensor requirements
+6. Implements the official image splitting (tiling) in the numpy image processor:
+   large images are split into a grid of `tile_size` tiles (plus a downsampled
+   thumbnail) and the text is expanded with the official per-tile
+   `<|img_row_r_col_c|>` / `<|img_thumbnail|>` marker tokens
 """
 
 import json
@@ -29,6 +33,23 @@ from transformers.models.lfm2_vl.processing_lfm2_vl import (
 )
 
 from ..base import install_auto_processor_patch, load_chat_template
+
+
+# Official transformers preprocessing defaults for LFM2-VL: images larger than
+# `max_pixels_tolerance` * `max_image_tokens` * patch^2 * factor^2 pixels are
+# split into a grid of `tile_size` tiles (grid within [min_tiles, max_tiles],
+# aspect ratio preserved) plus a downsampled thumbnail appended last.
+# LiquidAI's MLX repos ship `do_image_splitting: false` / `use_thumbnail: false`
+# — a handicap left over from the pre-tiling numpy processor that notably
+# hurts grounding accuracy on large screenshots — so these defaults are
+# re-applied when loading unless the user overrides them explicitly (via
+# `from_pretrained` kwargs or per-call processor kwargs).
+_OFFICIAL_SPLITTING_DEFAULTS = {
+    "do_image_splitting": True,
+    "min_tiles": 2,
+    "max_tiles": 10,
+    "use_thumbnail": True,
+}
 
 
 def _num_image_tokens_from_patch_grid(
@@ -101,6 +122,100 @@ def _smart_resize(
     return w_bar, h_bar
 
 
+def _find_closest_aspect_ratio(
+    aspect_ratio: float,
+    target_ratios: list[tuple[int, int]],
+    width: int,
+    height: int,
+    image_size: int,
+) -> tuple[int, int]:
+    """
+    Find the target aspect ratio closest to the given one.
+
+    Ties are broken in favor of the ratio whose tile area best matches the
+    original image area, mirroring the official LFM2-VL image processor.
+    """
+    best_ratio_diff = float("inf")
+    best_ratio = (1, 1)
+    area = width * height
+
+    for ratio in target_ratios:
+        target_aspect_ratio = ratio[0] / ratio[1]
+        ratio_diff = abs(aspect_ratio - target_aspect_ratio)
+
+        # update best ratio if we found a closer match
+        if ratio_diff < best_ratio_diff:
+            best_ratio_diff = ratio_diff
+            best_ratio = ratio
+        # if equally close, prefer the ratio that better matches the original area
+        elif ratio_diff == best_ratio_diff:
+            target_area = image_size * image_size * ratio[0] * ratio[1]
+            if area > 0.5 * target_area:
+                best_ratio = ratio
+
+    return best_ratio
+
+
+def _target_tile_ratios(min_tiles: int, max_tiles: int) -> list[tuple[int, int]]:
+    """All (width, height) tile grids whose tile count fits the budget."""
+    ratios = [
+        (w, h)
+        for n in range(min_tiles, max_tiles + 1)
+        for w in range(1, n + 1)
+        for h in range(1, n + 1)
+        if min_tiles <= w * h <= max_tiles
+    ]
+    return sorted(set(ratios), key=lambda x: x[0] * x[1])
+
+
+def _get_grid_layout(
+    height: int,
+    width: int,
+    min_tiles: int,
+    max_tiles: int,
+    tile_size: int,
+) -> tuple[int, int, int, int]:
+    """
+    Pick the tile grid for an image: (grid_width, grid_height, target_w, target_h).
+
+    The grid preserves the image aspect ratio as closely as possible while
+    keeping the tile count within [min_tiles, max_tiles].
+    """
+    aspect_ratio = width / height
+    target_ratios = _target_tile_ratios(min_tiles, max_tiles)
+    grid_width, grid_height = _find_closest_aspect_ratio(
+        aspect_ratio, target_ratios, width, height, tile_size
+    )
+    return (
+        grid_width,
+        grid_height,
+        tile_size * grid_width,
+        tile_size * grid_height,
+    )
+
+
+def _is_image_too_large(
+    height: int,
+    width: int,
+    max_image_tokens: int,
+    encoder_patch_size: int,
+    downsample_factor: int,
+    max_pixels_tolerance: float,
+) -> bool:
+    """Check if the image is too large to be processed as a single tile."""
+    total_factor = encoder_patch_size * downsample_factor
+
+    h_bar = max(encoder_patch_size, _round_by_factor(height, total_factor))
+    w_bar = max(encoder_patch_size, _round_by_factor(width, total_factor))
+    return (
+        h_bar * w_bar
+        > max_image_tokens
+        * encoder_patch_size**2
+        * downsample_factor**2
+        * max_pixels_tolerance
+    )
+
+
 def _convert_image_to_patches(image: np.ndarray, patch_size: int) -> np.ndarray:
     height, width, channels = image.shape
     num_patches_height = height // patch_size
@@ -156,11 +271,18 @@ class Lfm2VlNumpyImageProcessor(ImageProcessingMixin):
         self.max_image_tokens = kwargs.get("max_image_tokens", 256)
         self.tile_size = kwargs.get("tile_size", 512)
         self.max_pixels_tolerance = kwargs.get("max_pixels_tolerance", 2.0)
-        self.do_image_splitting = False
-        self.use_thumbnail = False
+        for key, value in _OFFICIAL_SPLITTING_DEFAULTS.items():
+            setattr(self, key, kwargs.get(key, value))
+        # Each vision-tower row holds one tile or the thumbnail; both must fit
+        # within the padded patch budget.
+        tile_size_patches = (
+            (self.tile_size // self.encoder_patch_size) ** 2
+            if self.do_image_splitting
+            else 0
+        )
         self.max_num_patches = kwargs.get(
             "max_num_patches",
-            self.max_image_tokens * self.downsample_factor**2,
+            max(self.max_image_tokens * self.downsample_factor**2, tile_size_patches),
         )
 
     def fetch_images(self, images):
@@ -187,56 +309,143 @@ class Lfm2VlNumpyImageProcessor(ImageProcessingMixin):
             return flattened
         return [images]
 
+    def _views_for_image(
+        self,
+        image: Image.Image,
+        do_image_splitting: bool,
+        min_tiles: int,
+        max_tiles: int,
+        use_thumbnail: bool,
+    ) -> tuple[list[Image.Image], int, int, tuple[int, int]]:
+        """
+        Build the vision-tower views for one source image.
+
+        Large images are resized to a `tile_size` grid and split into tiles
+        (row-major), with a smart-resized thumbnail appended last. Smaller
+        images yield the single smart-resized view, exactly as before.
+
+        Returns (views, grid_rows, grid_cols, resized_size) where
+        `resized_size` is the (height, width) used for the single view and the
+        thumbnail.
+        """
+        width, height = image.size
+        resized_width, resized_height = _smart_resize(
+            height=height,
+            width=width,
+            downsample_factor=self.downsample_factor,
+            min_image_tokens=self.min_image_tokens,
+            max_image_tokens=self.max_image_tokens,
+            encoder_patch_size=self.encoder_patch_size,
+        )
+        is_image_large = _is_image_too_large(
+            height=height,
+            width=width,
+            max_image_tokens=self.max_image_tokens,
+            encoder_patch_size=self.encoder_patch_size,
+            downsample_factor=self.downsample_factor,
+            max_pixels_tolerance=self.max_pixels_tolerance,
+        )
+
+        if self.do_resize and do_image_splitting and is_image_large:
+            grid_width, grid_height, target_width, target_height = _get_grid_layout(
+                height, width, min_tiles, max_tiles, self.tile_size
+            )
+            resized = image.resize(
+                (target_width, target_height), Image.Resampling.BILINEAR
+            )
+            tile = self.tile_size
+            views = [
+                resized.crop(
+                    (col * tile, row * tile, (col + 1) * tile, (row + 1) * tile)
+                )
+                for row in range(grid_height)
+                for col in range(grid_width)
+            ]
+            if use_thumbnail and grid_width * grid_height > 1:
+                views.append(
+                    image.resize(
+                        (resized_width, resized_height), Image.Resampling.BILINEAR
+                    )
+                )
+            return views, grid_height, grid_width, (resized_height, resized_width)
+
+        if self.do_resize:
+            image = image.resize(
+                (resized_width, resized_height), Image.Resampling.BILINEAR
+            )
+            return [image], 1, 1, (resized_height, resized_width)
+
+        return [image], 1, 1, (height, width)
+
+    def _view_to_patches(
+        self, image: Image.Image
+    ) -> tuple[np.ndarray, np.ndarray, int, int]:
+        """Rescale/normalize one view and pack it into flattened patch rows."""
+        width, height = image.size
+
+        array = np.array(image, dtype=np.float32)
+        if self.do_rescale:
+            array *= self.rescale_factor
+        if self.do_normalize:
+            mean = np.array(self.image_mean, dtype=np.float32)
+            std = np.array(self.image_std, dtype=np.float32)
+            array = (array - mean) / std
+
+        patches = _convert_image_to_patches(array, self.encoder_patch_size)
+        h_patches = height // self.encoder_patch_size
+        w_patches = width // self.encoder_patch_size
+
+        if self.do_pad:
+            patches, mask = _pad_along_first_dim(patches, self.max_num_patches)
+        else:
+            mask = np.ones((patches.shape[0],), dtype=np.int32)
+
+        return patches, mask, h_patches, w_patches
+
     def preprocess(self, images, return_tensors=None, **kwargs):
         images = self._flatten_images(self.fetch_images(images))
+
+        # Per-call overrides win over the processor defaults.
+        do_image_splitting = bool(
+            kwargs.get("do_image_splitting", self.do_image_splitting)
+        )
+        min_tiles = int(kwargs.get("min_tiles", self.min_tiles))
+        max_tiles = int(kwargs.get("max_tiles", self.max_tiles))
+        use_thumbnail = bool(kwargs.get("use_thumbnail", self.use_thumbnail))
+
+        if do_image_splitting and min_tiles > max_tiles:
+            raise ValueError("min_tiles must be less than or equal to max_tiles")
+
         pixel_values = []
         pixel_attention_mask = []
         spatial_shapes = []
+        # Official layout metadata per source image: tile-grid dims and the
+        # smart-resized (height, width), used to expand the text placeholders.
+        image_rows = []
+        image_cols = []
+        image_sizes = []
 
         for image in images:
             image = self._to_rgb_image(image)
-            width, height = image.size
-
-            if self.do_resize:
-                target_width, target_height = _smart_resize(
-                    height=height,
-                    width=width,
-                    downsample_factor=self.downsample_factor,
-                    min_image_tokens=self.min_image_tokens,
-                    max_image_tokens=self.max_image_tokens,
-                    encoder_patch_size=self.encoder_patch_size,
-                )
-                image = image.resize(
-                    (target_width, target_height), Image.Resampling.BILINEAR
-                )
-            else:
-                target_width, target_height = width, height
-
-            array = np.array(image, dtype=np.float32)
-            if self.do_rescale:
-                array *= self.rescale_factor
-            if self.do_normalize:
-                mean = np.array(self.image_mean, dtype=np.float32)
-                std = np.array(self.image_std, dtype=np.float32)
-                array = (array - mean) / std
-
-            patches = _convert_image_to_patches(array, self.encoder_patch_size)
-            h_patches = target_height // self.encoder_patch_size
-            w_patches = target_width // self.encoder_patch_size
-
-            if self.do_pad:
-                patches, mask = _pad_along_first_dim(patches, self.max_num_patches)
-            else:
-                mask = np.ones((patches.shape[0],), dtype=np.int32)
-
-            pixel_values.append(patches)
-            pixel_attention_mask.append(mask)
-            spatial_shapes.append((h_patches, w_patches))
+            views, rows, cols, resized_size = self._views_for_image(
+                image, do_image_splitting, min_tiles, max_tiles, use_thumbnail
+            )
+            for view in views:
+                patches, mask, h_patches, w_patches = self._view_to_patches(view)
+                pixel_values.append(patches)
+                pixel_attention_mask.append(mask)
+                spatial_shapes.append((h_patches, w_patches))
+            image_rows.append(rows)
+            image_cols.append(cols)
+            image_sizes.append(list(resized_size))
 
         data = {
             "pixel_values": np.stack(pixel_values),
             "pixel_attention_mask": np.stack(pixel_attention_mask),
             "spatial_shapes": np.array(spatial_shapes, dtype=np.int32),
+            "image_rows": np.array(image_rows, dtype=np.int32),
+            "image_cols": np.array(image_cols, dtype=np.int32),
+            "image_sizes": np.array(image_sizes, dtype=np.int32),
         }
         tensor_type = "np" if return_tensors == "np" else None
         return BatchFeature(data=data, tensor_type=tensor_type)
@@ -284,17 +493,19 @@ def _patched_init(self, image_processor, tokenizer, chat_template=None, **kwargs
         # Replace with slow processor using the same config
         if hasattr(image_processor, "to_dict"):
             # Use the config dict to create the slow processor
-            slow_processor = Siglip2ImageProcessor(**image_processor.to_dict())
+            config = image_processor.to_dict()
         else:
             # Fallback to copying attributes
-            slow_processor = Siglip2ImageProcessor(
-                **{
-                    k: v
-                    for k, v in image_processor.__dict__.items()
-                    if not k.startswith("_") and k not in ["name_or_path"]
-                }
-            )
-        image_processor = slow_processor
+            config = {
+                k: v
+                for k, v in image_processor.__dict__.items()
+                if not k.startswith("_") and k not in ["name_or_path"]
+            }
+        # Apply the official tiling defaults (see _OFFICIAL_SPLITTING_DEFAULTS):
+        # MLX repos ship tiling disabled, which the slow processor can now do.
+        for key in _OFFICIAL_SPLITTING_DEFAULTS:
+            config.pop(key, None)
+        image_processor = Siglip2ImageProcessor(**config)
 
     # Call original __init__
     _original_init(
@@ -313,12 +524,9 @@ def _patched_init(self, image_processor, tokenizer, chat_template=None, **kwargs
         self.image_processor.downsample_factor = 2
     if not hasattr(self.image_processor, "encoder_patch_size"):
         self.image_processor.encoder_patch_size = 16
-    if not hasattr(self.image_processor, "do_image_splitting"):
-        self.image_processor.do_image_splitting = (
-            False  # Disable tiling for slow processor
-        )
-    if not hasattr(self.image_processor, "use_thumbnail"):
-        self.image_processor.use_thumbnail = False
+    for key, value in _OFFICIAL_SPLITTING_DEFAULTS.items():
+        if not hasattr(self.image_processor, key):
+            setattr(self.image_processor, key, value)
 
 
 # Apply the __init__ patch
@@ -389,9 +597,17 @@ def _patched_from_pretrained(cls, pretrained_model_name_or_path, **kwargs):
         image_processor_config.pop(key, None)
 
     # The upstream config is tuned for the fast processor; the slow Siglip2 path
-    # needs resizing enabled and no image splitting metadata.
+    # needs resizing enabled.
     image_processor_config["do_resize"] = True
-    image_processor_config["do_image_splitting"] = False
+
+    # Re-apply the official tiling defaults (see _OFFICIAL_SPLITTING_DEFAULTS):
+    # the LiquidAI MLX repos ship `do_image_splitting: false` / `use_thumbnail:
+    # false`, which disables the high-resolution splitting the model was trained
+    # and evaluated with. Users can still opt out explicitly, e.g.
+    # `Lfm2VlProcessor.from_pretrained(model, do_image_splitting=False)`.
+    for key, default in _OFFICIAL_SPLITTING_DEFAULTS.items():
+        image_processor_config.pop(key, None)
+        image_processor_config[key] = kwargs.pop(key, default)
 
     image_processor = Siglip2ImageProcessor(**image_processor_config)
     return cls(image_processor=image_processor, tokenizer=tokenizer)
@@ -455,6 +671,10 @@ def _ensure_slow_processor(processor_instance):
         config.pop("image_processor_type", None)
         config.pop("auto_map", None)
         config.pop("_processor_class", None)
+        # Apply the official tiling defaults (see _OFFICIAL_SPLITTING_DEFAULTS):
+        # MLX repos ship tiling disabled, which the slow processor can now do.
+        for key in _OFFICIAL_SPLITTING_DEFAULTS:
+            config.pop(key, None)
 
         # Create slow processor with the same config
         slow_processor = Siglip2ImageProcessor(**config)
@@ -465,10 +685,9 @@ def _ensure_slow_processor(processor_instance):
             processor_instance.image_processor.tile_size = 512
         if not hasattr(processor_instance.image_processor, "downsample_factor"):
             processor_instance.image_processor.downsample_factor = 2
-        if not hasattr(processor_instance.image_processor, "do_image_splitting"):
-            processor_instance.image_processor.do_image_splitting = False
-        if not hasattr(processor_instance.image_processor, "use_thumbnail"):
-            processor_instance.image_processor.use_thumbnail = False
+        for key, value in _OFFICIAL_SPLITTING_DEFAULTS.items():
+            if not hasattr(processor_instance.image_processor, key):
+                setattr(processor_instance.image_processor, key, value)
 
     return processor_instance.image_processor
 
@@ -483,6 +702,15 @@ def _patched_call(self, images=None, text=None, **kwargs):
     """
     from transformers.feature_extraction_utils import BatchFeature
     from transformers.image_utils import make_nested_list_of_images
+
+    # Allow explicit per-call tiling overrides (do_image_splitting, min_tiles,
+    # max_tiles, use_thumbnail) regardless of how the processor's kwarg
+    # routing classifies them.
+    splitting_overrides = {
+        key: kwargs.pop(key)
+        for key in _OFFICIAL_SPLITTING_DEFAULTS
+        if key in kwargs
+    }
 
     # Ensure we're using the slow processor (fast requires PyTorch tensors)
     if images is not None:
@@ -514,6 +742,7 @@ def _patched_call(self, images=None, text=None, **kwargs):
         tokenizer_init_kwargs=self.tokenizer.init_kwargs,
         **kwargs,
     )
+    output_kwargs["images_kwargs"].update(splitting_overrides)
 
     if isinstance(text, str):
         text = [text]
@@ -545,55 +774,88 @@ def _patched_call(self, images=None, text=None, **kwargs):
             f"The number of images in the text {n_images_in_text} and images {n_images_in_images} should be the same."
         )
 
-    # Check if image_rows/cols/sizes are present (fast processor case)
+    # Check if image_rows/cols/sizes are present (numpy processor with tiling)
     if "image_rows" in vision_inputs:
         image_rows = vision_inputs.pop("image_rows")
         image_cols = vision_inputs.pop("image_cols")
         image_sizes = vision_inputs.pop("image_sizes")
     else:
-        # Slow processor case - compute from spatial_shapes or pixel_attention_mask
-        # The spatial_shapes gives the actual (height, width) in patches for each image
+        # Image processors without layout metadata (e.g. the slow Siglip2 one):
+        # every row of spatial_shapes is a single-tile image, so derive the
+        # per-image pixel size from its patch grid.
+        patch_size = getattr(self.image_processor, "patch_size", 16)
         spatial_shapes = vision_inputs.get("spatial_shapes")
         if spatial_shapes is not None:
-            # spatial_shapes is array of shape (batch, 2) with [height, width] in patches
-            image_rows = [[int(ss[0])] for ss in spatial_shapes]
-            image_cols = [[int(ss[1])] for ss in spatial_shapes]
-            image_sizes = [[int(ss[0] * ss[1])] for ss in spatial_shapes]
+            image_sizes = [
+                (int(ss[0]) * patch_size, int(ss[1]) * patch_size)
+                for ss in spatial_shapes
+            ]
         else:
-            # Fallback to computing from pixel_values
+            # Fallback to estimating from pixel_values
             pixel_values = vision_inputs.get("pixel_values")
-            patch_size = getattr(self.image_processor, "patch_size", 16)
-            image_rows, image_cols, image_sizes = _compute_image_grid_info(
-                pixel_values, patch_size
-            )
+            grid_rows, grid_cols, _ = _compute_image_grid_info(pixel_values, patch_size)
+            image_sizes = [
+                (int(rows[0]) * patch_size, int(cols[0]) * patch_size)
+                for rows, cols in zip(grid_rows, grid_cols)
+            ]
+        image_rows = [1] * len(image_sizes)
+        image_cols = [1] * len(image_sizes)
 
-    # For slow processor, use simplified text expansion
-    # (no tiling support, just add image tokens)
-    # Account for downsample_factor: the model pads odd patch-grid dimensions
-    # before downsampling, so the token count is ceil(rows/f)*ceil(cols/f).
+    n_images = sum(len(sublist) for sublist in batched_images)
+    flat_rows = _normalize_image_layout_axis(image_rows, n_images)
+    flat_cols = _normalize_image_layout_axis(image_cols, n_images)
+    flat_sizes = list(image_sizes)
+
+    # Mirror the official Lfm2VlProcessor text expansion: a multi-tile image
+    # becomes one section of row/col-marked tiles (row-major) followed by the
+    # thumbnail, each tile contributing ceil(tile_patches / f)^2 tokens after
+    # the pixel-unshuffle downsampling.
     downsample_factor = getattr(self.image_processor, "downsample_factor", 2)
+    encoder_patch_size = getattr(self.image_processor, "encoder_patch_size", 16)
+    tile_size = getattr(self.image_processor, "tile_size", 512)
+    tile_patches = tile_size // encoder_patch_size
+    tokens_per_tile = _num_image_tokens_from_patch_grid(
+        tile_patches, tile_patches, downsample_factor
+    )
+    use_thumbnail = output_kwargs["images_kwargs"].get(
+        "use_thumbnail", getattr(self.image_processor, "use_thumbnail", False)
+    )
+    image_thumbnail_token = getattr(self, "image_thumbnail_token", "<|img_thumbnail|>")
 
     expanded_text = []
-    for sample_text, sample_images, rows, cols, _sizes in zip(
-        text, batched_images, image_rows, image_cols, image_sizes
-    ):
-        rows = _normalize_image_layout_axis(rows, len(sample_images))
-        cols = _normalize_image_layout_axis(cols, len(sample_images))
+    image_idx = 0
+    for sample_text, sample_images in zip(text, batched_images):
         split_sample = sample_text.split(self.image_token)
         result = ""
-        for i, _ in enumerate(sample_images):
+        for i in range(len(sample_images)):
             result += split_sample[i]
+            rows = int(flat_rows[image_idx])
+            cols = int(flat_cols[image_idx])
+            image_height, image_width = flat_sizes[image_idx]
+            image_idx += 1
+
+            # Tokens for the resized image (single-tile) or the thumbnail,
+            # accounting for the pixel-unshuffle padding of odd patch grids.
+            tokens_for_image = _num_image_tokens_from_patch_grid(
+                image_height // encoder_patch_size,
+                image_width // encoder_patch_size,
+                downsample_factor,
+            )
+
             if use_image_special_tokens:
                 result += self.image_start_token
-            # Add image tokens based on the number of patches AFTER downsampling
-            # The model pads odd patch-grid dimensions before downsampling.
-            # Use rows/cols (patch grid) rather than total patches to mirror it.
-            num_rows = rows[i] if i < len(rows) else rows[0]
-            num_cols = cols[i] if i < len(cols) else cols[0]
-            num_image_tokens = _num_image_tokens_from_patch_grid(
-                int(num_rows), int(num_cols), downsample_factor
-            )
-            result += self.image_token * num_image_tokens
+            if rows > 1 or cols > 1:
+                for row in range(rows):
+                    for col in range(cols):
+                        if use_image_special_tokens:
+                            result += f"<|img_row_{row + 1}_col_{col + 1}|>"
+                        result += self.image_token * tokens_per_tile
+                if use_thumbnail:
+                    if use_image_special_tokens:
+                        result += image_thumbnail_token
+                    result += self.image_token * tokens_for_image
+            else:
+                result += self.image_token * tokens_for_image
             if use_image_special_tokens:
                 result += self.image_end_token
         # Add any remaining text after the last image

--- a/mlx_vlm/tests/test_processors.py
+++ b/mlx_vlm/tests/test_processors.py
@@ -2211,6 +2211,69 @@ class TestLfm2VlProcessorPatch(unittest.TestCase):
         # 8 tiles * 256 tokens + 252 thumbnail tokens
         self.assertEqual(expanded.count("<image>"), 8 * 256 + 252)
 
+    def test_non_numpy_image_processor_swapped_with_tiling(self):
+        # Regression test for the torch-installed case: the real
+        # Siglip2ImageProcessor (no tiling, (B, C, H, W) output) must be
+        # swapped for the NumPy processor before any image is processed.
+        from mlx_vlm.models.lfm2_vl.processing_lfm2_vl import _patched_call
+
+        class FakeTorchSiglip2:
+            def __init__(self, **kwargs):
+                self.__dict__.update(kwargs)
+
+            def to_dict(self):
+                return {k: v for k, v in self.__dict__.items() if not k.startswith("_")}
+
+            def __call__(self, images, **kwargs):
+                raise AssertionError(
+                    "non-NumPy image processor should have been swapped out"
+                )
+
+        class RecordingTokenizer(type(_mock_tokenizer())):
+            def __init__(self):
+                self.texts = []
+
+            def __call__(self, text, **kwargs):
+                self.texts.append(text)
+                return super().__call__(text, **kwargs)
+
+        tokenizer = RecordingTokenizer()
+
+        class DummyProcessor:
+            pass
+
+        processor = DummyProcessor()
+        processor.image_processor = FakeTorchSiglip2(do_resize=True)
+        processor.tokenizer = tokenizer
+        processor.image_token = "<image>"
+        processor.image_start_token = "<|image_start|>"
+        processor.image_end_token = "<|image_end|>"
+        processor.image_thumbnail_token = "<|img_thumbnail|>"
+        processor._merge_kwargs = lambda *args, **kwargs: {
+            "text_kwargs": {},
+            "images_kwargs": {},
+        }
+
+        image = Image.fromarray(
+            np.random.randint(0, 255, (1440, 2560, 3), dtype=np.uint8)
+        )
+        result = _patched_call(
+            processor,
+            images=[image],
+            text="<image>Describe this image",
+        )
+
+        self.assertEqual(
+            type(processor.image_processor).__name__, "Lfm2VlNumpyImageProcessor"
+        )
+        self.assertEqual(result["pixel_values"].shape, (9, 1024, 768))
+        self.assertEqual(result["spatial_shapes"].tolist()[:8], [[32, 32]] * 8)
+        expanded = tokenizer.texts[0][0]
+        self.assertTrue(expanded.startswith("<|image_start|><|img_row_1_col_1|>"))
+        self.assertIn("<|img_thumbnail|>", expanded)
+        # 8 tiles * 256 tokens + 252 thumbnail tokens
+        self.assertEqual(expanded.count("<image>"), 8 * 256 + 252)
+
     def test_scalar_image_rows_and_cols_are_supported(self):
         from mlx_vlm.models.lfm2_vl.processing_lfm2_vl import _patched_call
 
@@ -2256,13 +2319,20 @@ class TestLfm2VlProcessorPatch(unittest.TestCase):
         self.assertIn("input_ids", result)
         self.assertIn("attention_mask", result)
 
-    def test_from_pretrained_uses_slow_image_processor(self):
+    def test_from_pretrained_uses_numpy_image_processor_despite_siglip2(self):
+        # Even when the real Siglip2ImageProcessor is importable (torch
+        # installed), from_pretrained must build the NumPy processor: it is
+        # the only implementation with official tiling and the packed-patch
+        # output the MLX model consumes.
         import json
         import tempfile
         from pathlib import Path
         from unittest.mock import patch
 
-        from mlx_vlm.models.lfm2_vl.processing_lfm2_vl import Lfm2VlProcessor
+        from mlx_vlm.models.lfm2_vl.processing_lfm2_vl import (
+            Lfm2VlNumpyImageProcessor,
+            Lfm2VlProcessor,
+        )
 
         with tempfile.TemporaryDirectory() as tmpdir:
             (Path(tmpdir) / "processor_config.json").write_text(
@@ -2322,7 +2392,7 @@ class TestLfm2VlProcessorPatch(unittest.TestCase):
             ):
                 processor = Lfm2VlProcessor.from_pretrained(tmpdir)
 
-        self.assertIsInstance(processor.image_processor, DummySiglip2ImageProcessor)
+        self.assertIsInstance(processor.image_processor, Lfm2VlNumpyImageProcessor)
         self.assertTrue(processor.image_processor.do_resize)
         # The official tiling defaults are re-applied even when the repo config
         # ships `do_image_splitting: false` (the LiquidAI MLX repos do).

--- a/mlx_vlm/tests/test_processors.py
+++ b/mlx_vlm/tests/test_processors.py
@@ -2102,9 +2102,7 @@ class TestLfm2VlProcessorPatch(unittest.TestCase):
         self.assertEqual(_num_image_tokens_from_patch_grid(16, 16, 2), 64)
 
     def test_large_image_is_split_into_tiles_and_thumbnail(self):
-        from mlx_vlm.models.lfm2_vl.processing_lfm2_vl import (
-            Lfm2VlNumpyImageProcessor,
-        )
+        from mlx_vlm.models.lfm2_vl.processing_lfm2_vl import Lfm2VlNumpyImageProcessor
 
         processor = Lfm2VlNumpyImageProcessor(
             encoder_patch_size=16,
@@ -2121,9 +2119,7 @@ class TestLfm2VlProcessorPatch(unittest.TestCase):
         result = processor([image], return_tensors="np")
 
         self.assertEqual(result["pixel_values"].shape, (9, 1024, 768))
-        self.assertEqual(
-            result["spatial_shapes"].tolist(), [[32, 32]] * 8 + [[24, 42]]
-        )
+        self.assertEqual(result["spatial_shapes"].tolist(), [[32, 32]] * 8 + [[24, 42]])
         self.assertEqual(result["image_rows"].tolist(), [2])
         self.assertEqual(result["image_cols"].tolist(), [4])
         self.assertEqual(result["image_sizes"].tolist(), [[384, 672]])
@@ -2132,9 +2128,7 @@ class TestLfm2VlProcessorPatch(unittest.TestCase):
         )
 
     def test_small_image_stays_single_view_with_tiling_enabled(self):
-        from mlx_vlm.models.lfm2_vl.processing_lfm2_vl import (
-            Lfm2VlNumpyImageProcessor,
-        )
+        from mlx_vlm.models.lfm2_vl.processing_lfm2_vl import Lfm2VlNumpyImageProcessor
 
         processor = Lfm2VlNumpyImageProcessor()
 
@@ -2212,9 +2206,7 @@ class TestLfm2VlProcessorPatch(unittest.TestCase):
         self.assertLess(
             expanded.index(markers[-1]), expanded.index("<|img_thumbnail|>")
         )
-        self.assertIn(
-            "<|img_thumbnail|>" + "<image>" * 252 + "<|image_end|>", expanded
-        )
+        self.assertIn("<|img_thumbnail|>" + "<image>" * 252 + "<|image_end|>", expanded)
         self.assertTrue(expanded.endswith("Describe this image"))
         # 8 tiles * 256 tokens + 252 thumbnail tokens
         self.assertEqual(expanded.count("<image>"), 8 * 256 + 252)

--- a/mlx_vlm/tests/test_processors.py
+++ b/mlx_vlm/tests/test_processors.py
@@ -2101,6 +2101,124 @@ class TestLfm2VlProcessorPatch(unittest.TestCase):
         self.assertEqual(int(result["pixel_attention_mask"].sum()), 256)
         self.assertEqual(_num_image_tokens_from_patch_grid(16, 16, 2), 64)
 
+    def test_large_image_is_split_into_tiles_and_thumbnail(self):
+        from mlx_vlm.models.lfm2_vl.processing_lfm2_vl import (
+            Lfm2VlNumpyImageProcessor,
+        )
+
+        processor = Lfm2VlNumpyImageProcessor(
+            encoder_patch_size=16,
+            downsample_factor=2,
+            min_image_tokens=64,
+            max_image_tokens=256,
+            max_num_patches=1024,
+        )
+
+        # 2560x1440 screenshot: 8 tiles in a 4x2 grid + one thumbnail
+        image = Image.fromarray(
+            np.random.randint(0, 255, (1440, 2560, 3), dtype=np.uint8)
+        )
+        result = processor([image], return_tensors="np")
+
+        self.assertEqual(result["pixel_values"].shape, (9, 1024, 768))
+        self.assertEqual(
+            result["spatial_shapes"].tolist(), [[32, 32]] * 8 + [[24, 42]]
+        )
+        self.assertEqual(result["image_rows"].tolist(), [2])
+        self.assertEqual(result["image_cols"].tolist(), [4])
+        self.assertEqual(result["image_sizes"].tolist(), [[384, 672]])
+        self.assertEqual(
+            result["pixel_attention_mask"].sum(axis=1).tolist(), [1024] * 8 + [1008]
+        )
+
+    def test_small_image_stays_single_view_with_tiling_enabled(self):
+        from mlx_vlm.models.lfm2_vl.processing_lfm2_vl import (
+            Lfm2VlNumpyImageProcessor,
+        )
+
+        processor = Lfm2VlNumpyImageProcessor()
+
+        # Below the too-large threshold: identical to the pre-tiling behavior
+        image = Image.fromarray(
+            np.random.randint(0, 255, (540, 960, 3), dtype=np.uint8)
+        )
+        result = processor([image], return_tensors="np")
+
+        self.assertEqual(result["pixel_values"].shape, (1, 1024, 768))
+        self.assertEqual(result["spatial_shapes"].tolist(), [[24, 42]])
+        self.assertEqual(result["image_rows"].tolist(), [1])
+        self.assertEqual(result["image_cols"].tolist(), [1])
+        self.assertEqual(result["image_sizes"].tolist(), [[384, 672]])
+
+        # Explicitly disabling splitting on a large image keeps one view
+        large = Image.fromarray(
+            np.random.randint(0, 255, (1440, 2560, 3), dtype=np.uint8)
+        )
+        result = processor([large], return_tensors="np", do_image_splitting=False)
+        self.assertEqual(result["pixel_values"].shape, (1, 1024, 768))
+        self.assertEqual(result["image_rows"].tolist(), [1])
+        self.assertEqual(result["image_cols"].tolist(), [1])
+
+    def test_patched_call_expands_multi_tile_markers(self):
+        from mlx_vlm.models.lfm2_vl.processing_lfm2_vl import (
+            Lfm2VlNumpyImageProcessor,
+            _patched_call,
+        )
+
+        class RecordingTokenizer(type(_mock_tokenizer())):
+            def __init__(self):
+                self.texts = []
+
+            def __call__(self, text, **kwargs):
+                self.texts.append(text)
+                return super().__call__(text, **kwargs)
+
+        tokenizer = RecordingTokenizer()
+
+        class DummyProcessor:
+            pass
+
+        processor = DummyProcessor()
+        processor.image_processor = Lfm2VlNumpyImageProcessor()
+        processor.tokenizer = tokenizer
+        processor.image_token = "<image>"
+        processor.image_start_token = "<|image_start|>"
+        processor.image_end_token = "<|image_end|>"
+        processor.image_thumbnail_token = "<|img_thumbnail|>"
+        processor._merge_kwargs = lambda *args, **kwargs: {
+            "text_kwargs": {},
+            "images_kwargs": {},
+        }
+
+        image = Image.fromarray(
+            np.random.randint(0, 255, (1440, 2560, 3), dtype=np.uint8)
+        )
+        result = _patched_call(
+            processor,
+            images=[image],
+            text="<image>Describe this image",
+        )
+
+        self.assertEqual(result["pixel_values"].shape, (9, 1024, 768))
+
+        expanded = tokenizer.texts[0][0]
+        self.assertTrue(expanded.startswith("<|image_start|><|img_row_1_col_1|>"))
+        # Row-major tile markers, thumbnail marker last, then the image end
+        markers = [
+            f"<|img_row_{row}_col_{col}|>" for row in (1, 2) for col in (1, 2, 3, 4)
+        ]
+        for marker in markers:
+            self.assertIn(marker, expanded)
+        self.assertLess(
+            expanded.index(markers[-1]), expanded.index("<|img_thumbnail|>")
+        )
+        self.assertIn(
+            "<|img_thumbnail|>" + "<image>" * 252 + "<|image_end|>", expanded
+        )
+        self.assertTrue(expanded.endswith("Describe this image"))
+        # 8 tiles * 256 tokens + 252 thumbnail tokens
+        self.assertEqual(expanded.count("<image>"), 8 * 256 + 252)
+
     def test_scalar_image_rows_and_cols_are_supported(self):
         from mlx_vlm.models.lfm2_vl.processing_lfm2_vl import _patched_call
 
@@ -2214,12 +2332,65 @@ class TestLfm2VlProcessorPatch(unittest.TestCase):
 
         self.assertIsInstance(processor.image_processor, DummySiglip2ImageProcessor)
         self.assertTrue(processor.image_processor.do_resize)
-        self.assertFalse(processor.image_processor.do_image_splitting)
+        # The official tiling defaults are re-applied even when the repo config
+        # ships `do_image_splitting: false` (the LiquidAI MLX repos do).
+        self.assertTrue(processor.image_processor.do_image_splitting)
         tokenizer_from_pretrained.assert_called_once_with(
             tmpdir,
             trust_remote_code=False,
             local_files_only=True,
         )
+
+    def test_from_pretrained_honors_explicit_splitting_override(self):
+        import json
+        import tempfile
+        from pathlib import Path
+        from unittest.mock import patch
+
+        from mlx_vlm.models.lfm2_vl.processing_lfm2_vl import Lfm2VlProcessor
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            (Path(tmpdir) / "processor_config.json").write_text(
+                json.dumps({"processor_class": "Lfm2VlProcessor"})
+            )
+
+            class DummySiglip2ImageProcessor:
+                def __init__(self, **kwargs):
+                    self.do_image_splitting = kwargs.get("do_image_splitting")
+                    self.use_thumbnail = kwargs.get("use_thumbnail")
+
+            def _fake_init(
+                self, image_processor, tokenizer, chat_template=None, **kwargs
+            ):
+                self.image_processor = image_processor
+                self.tokenizer = tokenizer
+                self.chat_template = chat_template
+
+            with (
+                patch(
+                    "transformers.AutoTokenizer.from_pretrained",
+                    return_value=_mock_tokenizer(),
+                ),
+                patch(
+                    "mlx_vlm.models.lfm2_vl.processing_lfm2_vl.Siglip2ImageProcessor",
+                    DummySiglip2ImageProcessor,
+                    create=True,
+                ),
+                patch(
+                    "mlx_vlm.models.lfm2_vl.processing_lfm2_vl._SLOW_PROCESSOR_AVAILABLE",
+                    True,
+                ),
+                patch(
+                    "mlx_vlm.models.lfm2_vl.processing_lfm2_vl._original_init",
+                    _fake_init,
+                ),
+            ):
+                processor = Lfm2VlProcessor.from_pretrained(
+                    tmpdir, do_image_splitting=False
+                )
+
+        self.assertFalse(processor.image_processor.do_image_splitting)
+        self.assertTrue(processor.image_processor.use_thumbnail)
 
 
 class TestMolmoPointProcessor(unittest.TestCase):


### PR DESCRIPTION
## Problem

The LFM2-VL compat patch in `mlx_vlm/models/lfm2_vl/processing_lfm2_vl.py` disables image splitting, so every image — including large screenshots — is downscaled to a single view capped at `max_image_tokens` (256 tokens ≈ 512×512 px). The official LFM2.5-VL pipeline (`Lfm2VlImageProcessorFast` in transformers) splits large images into up to 10 tiles of 512×512 plus a thumbnail, with each tile introduced by `<|img_row_R_col_C|>` marker tokens and the thumbnail by `<|img_thumbnail|>`.

The accuracy impact is large. Measured on ScreenSpot-v2 with `LiquidAI/LFM2.5-VL-3B-MLX-8bit`, identical prompt/scoring/decoding:

| web items | untiled (current) | tiled (this PR) |
|---|---|---|
| 15-item subset | 33.3% | **80.0%** |
| 40-item subset | 37.5% | **75.0%** |

(Liquid's published ScreenSpot-v2 web number for this model is 82.2% on vLLM with the official tiled preprocessing.)

## Changes

- `Lfm2VlNumpyImageProcessor`: transformers-parity tiling — `_is_image_too_large` (area > `max_image_tokens × patch² × downsample² × max_pixels_tolerance`), aspect-preserving grid layout within `[min_tiles, max_tiles]` (`_find_closest_aspect_ratio`), resize → row-major 512² tiles + downsampled thumbnail last, each emitted as its own `pixel_values` row / `spatial_shapes` entry with its own attention mask.
- `_patched_call`: official text expansion — `<|image_start|>`, `<|img_row_r_col_c|>` before each tile's `<image>`×256, `<|img_thumbnail|>` before the thumbnail tokens, `<|image_end|>`, mirroring `Lfm2VlProcessor._build_image_tokens` in transformers (including ceil-per-dimension downsampling padding via `_num_image_tokens_from_patch_grid`).
- Small images (below the too-large threshold) keep the exact previous single-view behavior; multi-image interleaving unchanged.

No shared code changes: `merge_input_ids_with_image_features` already scatters concatenated per-row embeddings into all `<image>` positions with an exact-count check, so tiles-as-rows aligns natively.

## Config policy (point for discussion)

The official defaults (`do_image_splitting=True, min_tiles=2, max_tiles=10, use_thumbnail=True`) are re-applied on load because the LiquidAI `*-MLX-*` repos currently ship `do_image_splitting: false`, which reproduces the handicap rather than reflecting a deliberate user choice. Overrides are honored via `Lfm2VlProcessor.from_pretrained(model, do_image_splitting=False)` or per-call processor kwargs (popped before kwarg routing). Happy to invert this if you prefer strict config honoring.

## Validation

- `LiquidAI/LFM2.5-VL-3B-MLX-8bit`, torch-free path:
  - 2560×1440 → grid 4×2, 8 tiles (32,32) + thumbnail (24,42), expanded prompt contains the full marker sequence and exactly 2300 `<image>` tokens (8×256 + 252); per-row embedding count matches token count.
  - 960×540 → single view, 252 tokens, no markers, `input_ids` byte-identical to the previous path.
  - Multi-image (tiled + small) alignment verified; marker tokens resolve as single tokenizer ids (124908–124921, 125008).
- E2E grounding generation on ScreenSpot web items parses cleanly with no embedding/token misalignment.
- Tests: 3 new processor tests + 1 updated (it asserted the old single-view behavior), all 129 `test_processors` tests and 13 `test_models` lfm2_vl tests pass; the 2 `TestAWQ` failures are pre-existing on `main`.

References implemented against: `transformers` `models/lfm2_vl/image_processing_lfm2_vl.py` / `processing_lfm2_vl.py` (authoritative), and llama.cpp ≥ b10107 `tools/mtmd/mtmd-image.cpp` `mtmd_image_preprocessor_lfm2` (which shipped the same tiling for GGUF).