### PR TITLE
qwen3_omni_moe: fix audio output-length off-by-one (floor division)

### DIFF
--- a/mlx_vlm/models/qwen3_omni_moe/audio.py
+++ b/mlx_vlm/models/qwen3_omni_moe/audio.py
@@ -8,14 +8,22 @@ import numpy as np
 from mlx_vlm.models.qwen3_omni_moe.config import AudioConfig
 
 
+def _round_up_half(x):
+    """``(x - 1) // 2 + 1`` without the negative intermediate.
+
+    Identical for every ``x >= 0``, but ``x - 1`` is ``-1`` at ``x == 0``, and
+    MLX truncates that toward zero where NumPy and PyTorch floor it. Writing it
+    this way keeps the two in agreement and stays on device.
+    """
+    return (x + 1) // 2
+
+
 def _get_feat_extract_output_lengths(input_lengths):
-    input_lengths = np.array(input_lengths)
-    input_lengths_leave = input_lengths % 100
-    feat_lengths = (input_lengths_leave - 1) // 2 + 1
-    output_lengths = (
-        ((feat_lengths - 1) // 2 + 1 - 1) // 2 + 1 + (input_lengths // 100) * 13
-    )
-    return mx.array(output_lengths.astype(np.int32))
+    # Three round-up halvings of the sub-window remainder, plus 13 frames per
+    # whole 100-frame window. Matches the reference processor that sets the
+    # audio placeholder count, so emitted embeddings stay in sync with it.
+    remainder = _round_up_half(_round_up_half(_round_up_half(input_lengths % 100)))
+    return remainder + (input_lengths // 100) * 13
 
 
 class Attention(nn.Module):

--- a/mlx_vlm/models/qwen3_omni_moe/audio.py
+++ b/mlx_vlm/models/qwen3_omni_moe/audio.py
@@ -9,12 +9,13 @@ from mlx_vlm.models.qwen3_omni_moe.config import AudioConfig
 
 
 def _get_feat_extract_output_lengths(input_lengths):
+    input_lengths = np.array(input_lengths)
     input_lengths_leave = input_lengths % 100
     feat_lengths = (input_lengths_leave - 1) // 2 + 1
     output_lengths = (
         ((feat_lengths - 1) // 2 + 1 - 1) // 2 + 1 + (input_lengths // 100) * 13
     )
-    return output_lengths
+    return mx.array(output_lengths.astype(np.int32))
 
 
 class Attention(nn.Module):

--- a/mlx_vlm/tests/test_qwen3_omni_moe.py
+++ b/mlx_vlm/tests/test_qwen3_omni_moe.py
@@ -16,22 +16,34 @@ from mlx_vlm.models.qwen3_omni_moe.config import (
 from mlx_vlm.models.qwen3_omni_moe.qwen3_omni_moe import Model
 
 
-def _floor_output_lengths(input_lengths):
-    leave = input_lengths % 100
-    feat = (leave - 1) // 2 + 1
-    return ((feat - 1) // 2 + 1 - 1) // 2 + 1 + (input_lengths // 100) * 13
-
-
 class Qwen3OmniAudioLengthTest(unittest.TestCase):
-    def test_matches_floor_reference(self):
-        for length in [100, 320, 500, 1000, 2800, 2900, 2999, 3000, 3100, 6000]:
-            got = int(_get_feat_extract_output_lengths(mx.array([length]))[0])
-            self.assertEqual(got, _floor_output_lengths(length), msg=f"length={length}")
+    # Pinned against the reference processor that sets the audio placeholder
+    # count. Literal values rather than a re-implementation of the formula, so
+    # the test still fails if the formula itself drifts.
+    EXPECTED = (
+        (0, 0),
+        (100, 13),
+        (320, 42),
+        (500, 65),
+        (999, 130),
+        (1000, 130),
+        (2800, 364),
+        (2900, 377),
+        (2999, 390),
+        (3000, 390),  # the 30s clamp -- MLX truncation returned 391 here
+        (3100, 403),
+        (6000, 780),
+    )
 
-    def test_multiple_of_100_not_overcounted(self):
-        for length in (2900, 3000, 6000):
+    def test_matches_reference_output_lengths(self):
+        for length, expected in self.EXPECTED:
             got = int(_get_feat_extract_output_lengths(mx.array([length]))[0])
-            self.assertEqual(got, _floor_output_lengths(length), msg=f"length={length}")
+            self.assertEqual(got, expected, msg=f"length={length}")
+
+    def test_batched_lengths_match_scalar(self):
+        lengths = [length for length, _ in self.EXPECTED]
+        got = _get_feat_extract_output_lengths(mx.array(lengths)).tolist()
+        self.assertEqual(got, [expected for _, expected in self.EXPECTED])
 
 
 IMAGE_TOKEN = 60

--- a/mlx_vlm/tests/test_qwen3_omni_moe.py
+++ b/mlx_vlm/tests/test_qwen3_omni_moe.py
@@ -2,6 +2,7 @@ import unittest
 
 import mlx.core as mx
 
+from mlx_vlm.models.qwen3_omni_moe.audio import _get_feat_extract_output_lengths
 from mlx_vlm.models.qwen3_omni_moe.config import (
     AudioConfig,
     Code2WavConfig,
@@ -13,6 +14,25 @@ from mlx_vlm.models.qwen3_omni_moe.config import (
     VisionConfig,
 )
 from mlx_vlm.models.qwen3_omni_moe.qwen3_omni_moe import Model
+
+
+def _floor_output_lengths(input_lengths):
+    leave = input_lengths % 100
+    feat = (leave - 1) // 2 + 1
+    return ((feat - 1) // 2 + 1 - 1) // 2 + 1 + (input_lengths // 100) * 13
+
+
+class Qwen3OmniAudioLengthTest(unittest.TestCase):
+    def test_matches_floor_reference(self):
+        for length in [100, 320, 500, 1000, 2800, 2900, 2999, 3000, 3100, 6000]:
+            got = int(_get_feat_extract_output_lengths(mx.array([length]))[0])
+            self.assertEqual(got, _floor_output_lengths(length), msg=f"length={length}")
+
+    def test_multiple_of_100_not_overcounted(self):
+        for length in (2900, 3000, 6000):
+            got = int(_get_feat_extract_output_lengths(mx.array([length]))[0])
+            self.assertEqual(got, _floor_output_lengths(length), msg=f"length={length}")
+
 
 IMAGE_TOKEN = 60
 VISION_START = 63


### PR DESCRIPTION
`_get_feat_extract_output_lengths` computes `(input_lengths % 100 - 1) // 2 + 1`. When the length is a multiple of 100 that inner term is `-1 // 2`, which **MLX truncates toward zero (`0`)** while NumPy and the PyTorch reference **floor it (`-1`)** — so the MLX path returned one more than the processor that sets the audio **placeholder** count, desyncing emitted audio embeddings from the placeholders.

3000 frames is the 30s clamp, so this fires exactly in the long-audio regime of #1768.

## Fix

`(x - 1) // 2 + 1` is identically `(x + 1) // 2` for every `x >= 0`, but without the negative intermediate — so it agrees under both division semantics and needs no NumPy round-trip:

```python
def _round_up_half(x):
    return (x + 1) // 2

remainder = _round_up_half(_round_up_half(_round_up_half(input_lengths % 100)))
return remainder + (input_lengths // 100) * 13
```

Stays on device (no forced evaluation of a lazy array) and the return type is unchanged.

## Verification

- Matches the floor reference for **every length in 0–20000**, under both NumPy and MLX.
- Exactly **201 lengths were affected before the fix — all multiples of 100**; nothing else changes.
- On `mlx-community/Qwen3-Omni-30B-A3B-Instruct-4bit`, emitted vs placeholders was 378/377 at 29s and 391/390 at 31s; both are now Δ=0.
- Tests pin literal expected lengths rather than re-deriving them with the same formula, so a drift in the formula still fails.

Towards #1768 — this removes the count desync, but I have not yet captured a before/after generation transcript on a >30s clip, so I'm not claiming it closes the issue on its own.
