### PR TITLE
fix(molmo_point): honor point_color in draw_points_on_image

### DIFF
--- a/mlx_vlm/models/molmo_point/point_utils.py
+++ b/mlx_vlm/models/molmo_point/point_utils.py
@@ -79,7 +79,7 @@ def draw_points_on_image(
     points: List[Tuple[int, int, float, float]],
     output_path: Optional[str] = None,
     point_radius: int = 8,
-    point_color: str = "red",
+    point_color: Optional[str] = None,
     label: bool = True,
 ) -> Image.Image:
     """Draw point predictions on an image.
@@ -89,7 +89,9 @@ def draw_points_on_image(
         points: List of (object_id, image_num, x, y) tuples
         output_path: Optional path to save the annotated image
         point_radius: Radius of the point marker
-        point_color: Color of the point marker
+        point_color: Color of the point marker. When ``None`` (the default),
+            each object id is drawn in its own color so objects stay
+            distinguishable.
         label: Whether to draw object ID labels
 
     Returns:
@@ -101,7 +103,7 @@ def draw_points_on_image(
     colors = ["red", "blue", "green", "yellow", "purple", "orange", "cyan", "magenta"]
 
     for obj_id, img_num, x, y in points:
-        color = colors[obj_id % len(colors)]
+        color = point_color or colors[obj_id % len(colors)]
         r = point_radius
 
         # Draw filled circle


### PR DESCRIPTION
## What

`draw_points_on_image` accepts and documents a `point_color` parameter, but never reads it:

```python
colors = ["red", "blue", "green", "yellow", "purple", "orange", "cyan", "magenta"]

for obj_id, img_num, x, y in points:
    color = colors[obj_id % len(colors)]   # point_color is never consulted
```

So every marker is colored from the hardcoded per-object palette and an explicit
`point_color="blue"` silently does nothing. The declared default (`"red"`) also
misdescribes what actually happens — with the palette in place, object 0 is red,
object 1 is blue, object 2 is green, and so on.

## Fix

`color = point_color or colors[obj_id % len(colors)]`, with the default changed to
`None`. The per-object palette is clearly deliberate (it is what keeps several
predicted objects distinguishable in one image), so it stays the default; the
parameter now works when a caller actually passes one.

**No behavior change on the default path** — callers that don't pass `point_color`
get exactly the same image as before.

## Verification

`point_utils.py` imports only `numpy` and `PIL`, so it can be exercised standalone.
Three points with object ids 0/1/2 drawn on a blank canvas, sampling the fill pixel
inside each marker:

| call | before | after |
|---|---|---|
| `draw_points_on_image(img, points)` | `(255,0,0) (0,0,255) (0,128,0)` | `(255,0,0) (0,0,255) (0,128,0)` — unchanged |
| `draw_points_on_image(img, points, point_color="blue")` | `(255,0,0) (0,0,255) (0,128,0)` — ignored | `(0,0,255) (0,0,255) (0,0,255)` — honored |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
