### PR TITLE
Keep pending padding metadata aligned after filtering

### DIFF
--- a/mlx_vlm/models/cache.py
+++ b/mlx_vlm/models/cache.py
@@ -985,6 +985,8 @@ class BatchKVCache(_BaseCache):
             self.values = self.values[batch_indices]
         self.offset = self.offset[batch_indices]
         self.left_padding = self.left_padding[batch_indices]
+        if self._right_padding is not None:
+            self._right_padding = self._right_padding[batch_indices]
 
         # Shift left to reduce padding
         min_left_pad = self.left_padding.min().item()
@@ -1341,6 +1343,8 @@ class BatchRotatingKVCache(_BaseCache):
             self.values = self.values[batch_indices]
         self.offset = self.offset[batch_indices]
         self.left_padding = self.left_padding[batch_indices]
+        if self._lengths is not None:
+            self._lengths = self._lengths[batch_indices]
 
     def extend(self, other):
         """
@@ -1789,6 +1793,8 @@ class BatchQuantizedKVCache(_BaseCache):
             self.values = tuple(v[batch_indices] for v in self.values)
         self.offset = self.offset[batch_indices]
         self.left_padding = self.left_padding[batch_indices]
+        if self._right_padding is not None:
+            self._right_padding = self._right_padding[batch_indices]
 
         min_lp = self.left_padding.min().item()
         if min_lp > 0:

--- a/mlx_vlm/tests/test_apc_adapters.py
+++ b/mlx_vlm/tests/test_apc_adapters.py
@@ -472,7 +472,40 @@ def _fill_batch_turbo(left_padding, seq_len, bits=4.0):
     return cache, k, v
 
 
-class TestBatchRotatingRightPadPrefill:
+class TestBatchRightPadPrefill:
+    @staticmethod
+    def _filter_reordered_row(cache):
+        cache.prepare(right_padding=[2, 0], lengths=[4, 6])
+        k, v = _rand_kv(batch=2, seq_len=3)
+        cache.update_and_fetch(k, v)
+
+        cache.filter(mx.array([1, 0], dtype=mx.int32))
+        cache.filter(mx.array([1], dtype=mx.int32))
+
+    def test_batch_kv_filter_keeps_pending_right_padding_aligned(self):
+        cache = BatchKVCache([0, 0])
+
+        self._filter_reordered_row(cache)
+
+        assert cache._right_padding.tolist() == [2]
+        cache.finalize()
+        assert cache.keys.shape[0] == 1
+        assert cache.values.shape[0] == 1
+        assert cache.offset.tolist() == [1]
+        assert cache.left_padding.tolist() == [2]
+
+    def test_batch_quantized_filter_keeps_pending_right_padding_aligned(self):
+        cache = BatchQuantizedKVCache([0, 0], group_size=GROUP_SIZE, bits=BITS)
+
+        self._filter_reordered_row(cache)
+
+        assert cache._right_padding.tolist() == [2]
+        cache.finalize()
+        assert all(part.shape[0] == 1 for part in cache.keys)
+        assert all(part.shape[0] == 1 for part in cache.values)
+        assert cache.offset.tolist() == [1]
+        assert cache.left_padding.tolist() == [2]
+
     def test_single_token_update_while_lengths_pending(self):
         cache = BatchRotatingKVCache(32, [0, 0])
         k, v = _rand_kv(batch=2, seq_len=4)
@@ -486,6 +519,24 @@ class TestBatchRotatingRightPadPrefill:
         assert cache._lengths is None
         k2, v2 = _rand_kv(batch=2, seq_len=1)
         cache.update_and_fetch(k2, v2)
+
+    def test_rotating_filter_keeps_pending_lengths_aligned(self):
+        cache = BatchRotatingKVCache(32, [0, 0])
+
+        self._filter_reordered_row(cache)
+
+        assert cache._lengths.tolist() == [4]
+        k, v = _rand_kv(batch=1, seq_len=2)
+        out_k, out_v = cache.update_and_fetch(k, v)
+        mx.eval(out_k, out_v)
+        assert out_k.shape[0] == 1
+        assert out_v.shape[0] == 1
+
+        cache.finalize()
+        assert cache.keys.shape[0] == 1
+        assert cache.values.shape[0] == 1
+        assert cache.offset.tolist() == [4]
+        assert cache.left_padding.tolist() == [1]
 
 
 class TestBatchTurboQuantParity:


### PR DESCRIPTION
Fixes #1889

## Summary

Batch cache filtering already applies row indices to key/value tensors, offsets, and left padding, but it left temporary right-padding metadata unchanged. Filtering during a prepared prefill could therefore leave one-row cache tensors paired with metadata for the original batch.

For rotating caches, that mismatch caused the next chunk update to fail when stale `_lengths` broadcast the cache back to the old batch size. For standard and quantized batch caches, `finalize()` could silently expand a filtered cache back to the old number of rows.

This change keeps the pending metadata aligned in all affected cache implementations:

- filters `BatchKVCache._right_padding`;
- filters `BatchRotatingKVCache._lengths`;
- filters `BatchQuantizedKVCache._right_padding`.

Regression tests reorder rows before removing one, then continue or finalize prefill. This verifies both batch-size alignment and correct metadata association after filtering.

## Test plan

```text
python -m pytest mlx_vlm/tests/test_apc_adapters.py -k "BatchRightPadPrefill" -q
```