### PR TITLE
Checkpoint hybrid prompts at a stride so divergent requests can resume

### DIFF
--- a/mlx_vlm/apc.py
+++ b/mlx_vlm/apc.py
@@ -592,6 +592,7 @@ class APCStats:
     matched_tokens: int = 0
     served_tokens: int = 0
     evictions: int = 0
+    budget_evictions: int = 0
     stores: int = 0
     pool_used: int = 0
     disk_hits: int = 0
@@ -621,6 +622,7 @@ class APCStats:
             "served_tokens": self.served_tokens,
             "token_hit_rate": hit_rate,
             "evictions": self.evictions,
+            "budget_evictions": self.budget_evictions,
             "stores": self.stores,
             "disk_hits": self.disk_hits,
             "disk_writes": self.disk_writes,
@@ -2868,6 +2870,11 @@ class APCManager:
         self._exact_cache_max = max(
             0, int(os.environ.get("APC_EXACT_CACHE_ENTRIES", "2"))
         )
+        self._max_resident_bytes = int(
+            float(os.environ.get("APC_MAX_RESIDENT_GB", "0")) * (1 << 30)
+        )
+        stride = max(block_size, int(os.environ.get("APC_STATE_STRIDE", "512")))
+        self.state_stride = ((stride + block_size - 1) // block_size) * block_size
         self.exact_cache_guard_tokens = max(
             1, int(os.environ.get("APC_EXACT_PREFIX_GUARD_TOKENS", "16"))
         )
@@ -2978,6 +2985,20 @@ class APCManager:
     def resident_bytes(self) -> int:
         with self.lock:
             return self._resident_bytes_locked()
+
+    def _shrink_to_resident_budget_locked(self) -> None:
+        limit = self._max_resident_bytes
+        if limit <= 0:
+            return
+        resident = self._resident_bytes_locked()
+        while resident > limit and self._free_head is not None:
+            freed = self._free_head.resident_bytes()
+            block = self._evict_lru()
+            if block is None:
+                return
+            self._free_push(block)
+            resident -= freed
+            self.stats.budget_evictions += 1
 
     # ---------- Public API ----------
     def lookup_exact_cache(
@@ -3446,6 +3467,7 @@ class APCManager:
                     self.stats.disk_writes += len(disk_blocks)
                 except Exception as e:
                     logger.warning("APC disk save scheduling failed: %s", e)
+            self._shrink_to_resident_budget_locked()
             self.stats.pool_used = sum(1 for x in self.pool if x.block_hash is not None)
             return new_blocks
 

--- a/mlx_vlm/apc.py
+++ b/mlx_vlm/apc.py
@@ -2868,13 +2868,16 @@ class APCManager:
         self.lock = threading.RLock()
         self.disk = disk
         self._exact_cache_max = max(
-            0, int(os.environ.get("APC_EXACT_CACHE_ENTRIES", "2"))
+            0, int(os.environ.get("APC_EXACT_CACHE_ENTRIES", "8"))
         )
         self._max_resident_bytes = int(
             float(os.environ.get("APC_MAX_RESIDENT_GB", "0")) * (1 << 30)
         )
         stride = max(block_size, int(os.environ.get("APC_STATE_STRIDE", "512")))
         self.state_stride = ((stride + block_size - 1) // block_size) * block_size
+        self.exact_checkpoint_limit = max(
+            1, int(os.environ.get("APC_EXACT_CHECKPOINTS", "4"))
+        )
         self.exact_cache_guard_tokens = max(
             1, int(os.environ.get("APC_EXACT_PREFIX_GUARD_TOKENS", "16"))
         )

--- a/mlx_vlm/apc.py
+++ b/mlx_vlm/apc.py
@@ -531,6 +531,13 @@ class APCBlock(APCNode):
         return self.ref_cnt
 
 
+def _prompt_cache_bytes(prompt_cache: Sequence[Any]) -> int:
+    arrays: List[mx.array] = []
+    for entry in prompt_cache:
+        _collect_mx_arrays(getattr(entry, "state", None), arrays)
+    return sum(a.nbytes for a in arrays)
+
+
 @dataclass
 class APCExactCacheEntry:
     """Exact-prefix prompt-cache snapshot for custom cache layouts."""
@@ -539,6 +546,7 @@ class APCExactCacheEntry:
     extra_hash: int
     prompt_cache: List[Any]
     last_used: float
+    nbytes: int = 0
 
 
 @dataclass(frozen=True)
@@ -593,6 +601,7 @@ class APCStats:
     served_tokens: int = 0
     evictions: int = 0
     budget_evictions: int = 0
+    exact_budget_evictions: int = 0
     stores: int = 0
     pool_used: int = 0
     disk_hits: int = 0
@@ -623,6 +632,7 @@ class APCStats:
             "token_hit_rate": hit_rate,
             "evictions": self.evictions,
             "budget_evictions": self.budget_evictions,
+            "exact_budget_evictions": self.exact_budget_evictions,
             "stores": self.stores,
             "disk_hits": self.disk_hits,
             "disk_writes": self.disk_writes,
@@ -2873,6 +2883,9 @@ class APCManager:
         self._max_resident_bytes = int(
             float(os.environ.get("APC_MAX_RESIDENT_GB", "0")) * (1 << 30)
         )
+        self._max_exact_bytes = int(
+            float(os.environ.get("APC_EXACT_MAX_GB", "2.0")) * (1 << 30)
+        )
         stride = max(block_size, int(os.environ.get("APC_STATE_STRIDE", "512")))
         self.state_stride = ((stride + block_size - 1) // block_size) * block_size
         self.exact_checkpoint_limit = max(
@@ -2988,6 +3001,20 @@ class APCManager:
     def resident_bytes(self) -> int:
         with self.lock:
             return self._resident_bytes_locked()
+
+    def exact_cache_bytes(self) -> int:
+        with self.lock:
+            return sum(e.nbytes for e in self._exact_cache.values())
+
+    def _shrink_exact_cache_locked(self) -> None:
+        limit = self._max_exact_bytes
+        if limit <= 0:
+            return
+        resident = sum(e.nbytes for e in self._exact_cache.values())
+        while resident > limit and len(self._exact_cache) > 1:
+            _, evicted = self._exact_cache.popitem(last=False)
+            resident -= evicted.nbytes
+            self.stats.exact_budget_evictions += 1
 
     def _shrink_to_resident_budget_locked(self) -> None:
         limit = self._max_resident_bytes
@@ -3181,10 +3208,12 @@ class APCManager:
                     extra_hash=int(extra_hash),
                     prompt_cache=copied,
                     last_used=time.time(),
+                    nbytes=_prompt_cache_bytes(copied),
                 )
                 self._exact_cache.move_to_end(key)
                 while len(self._exact_cache) > self._exact_cache_max:
                     self._exact_cache.popitem(last=False)
+                self._shrink_exact_cache_locked()
                 stored = True
         if stored:
             apc_trace(

--- a/mlx_vlm/apc.py
+++ b/mlx_vlm/apc.py
@@ -2991,14 +2991,17 @@ class APCManager:
         if limit <= 0:
             return
         resident = self._resident_bytes_locked()
-        while resident > limit and self._free_head is not None:
+        for _ in range(len(self.pool)):
+            if resident <= limit or self._free_head is None:
+                return
             freed = self._free_head.resident_bytes()
             block = self._evict_lru()
             if block is None:
                 return
             self._free_push(block)
             resident -= freed
-            self.stats.budget_evictions += 1
+            if freed:
+                self.stats.budget_evictions += 1
 
     # ---------- Public API ----------
     def lookup_exact_cache(

--- a/mlx_vlm/apc_aligned_state.py
+++ b/mlx_vlm/apc_aligned_state.py
@@ -1,17 +1,4 @@
-"""Where to checkpoint a prompt so a divergent request can resume.
-
-Recurrent and convolution state summarises every token before it, so it cannot
-be sliced to an arbitrary position the way attention KV can. Reuse therefore
-happens at boundaries: a request stores the whole cache at chosen prefix
-lengths, and a later request sharing that prefix restores the longest boundary
-it matches.
-
-One checkpoint near the end of a prompt only helps a request that repeats it.
-Boundaries spread across the prompt are what let a request that shares an
-opening and then diverges start from the last common point, so the schedule
-below walks a fixed stride and keeps every boundary that leaves a text-only
-suffix.
-"""
+"""Checkpoint boundaries for caches whose state cannot be sliced."""
 
 from __future__ import annotations
 
@@ -30,14 +17,7 @@ def checkpoint_schedule(
     guard_tokens: int = 1,
     limit: Optional[int] = None,
 ) -> List[int]:
-    """Prefix lengths at which to store a reusable checkpoint.
-
-    Boundaries are multiples of ``stride`` that keep at least ``guard_tokens``
-    to generate from, moved forward when needed so no media placeholder is left
-    in the suffix. ``limit`` keeps the earliest boundaries when a prompt would
-    otherwise produce more than the cache should hold, since a request that
-    shares an opening and then diverges can only resume from an early one.
-    """
+    """Prefix lengths at which to store a reusable checkpoint."""
     if stride <= 0:
         raise ValueError(f"stride must be positive, got {stride}")
 

--- a/mlx_vlm/apc_aligned_state.py
+++ b/mlx_vlm/apc_aligned_state.py
@@ -1,0 +1,104 @@
+"""Block-aligned reuse for non-pageable cache state.
+
+Recurrent and convolution state summarises every token before it, so it cannot
+be sliced to an arbitrary position the way attention KV can. It can, however,
+be checkpointed: a node that covers a block boundary can hold the state as it
+stood at that boundary, and a later request sharing that prefix resumes from
+it.
+
+The planner below turns one scheduling step into the two motions that keep such
+state coherent:
+
+``zero`` starts a request whose prefix is empty, because the node it lands on
+may still hold another request's bytes. ``copy`` carries state from the node a
+request just left into the node it is entering, leaving the old node intact as
+a checkpoint.
+
+A prefix hit needs no third motion: the request is admitted with its matched
+length, so the first copy of the step reads the checkpoint it hit.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import List, Optional, Sequence, Tuple
+
+__all__ = ["StatePlan", "StateStep", "plan_state_motions"]
+
+
+@dataclass(frozen=True)
+class StateStep:
+    """One request's position in a step: what it had, and what it runs now."""
+
+    node_ids: Sequence[int]
+    computed: int
+    scheduled: int
+    shareable: Optional[Sequence[bool]] = None
+
+
+@dataclass
+class StatePlan:
+    """Node ids to clear, node pairs to carry forward, and each step's target."""
+
+    zero: List[int] = field(default_factory=list)
+    copy: List[Tuple[int, int]] = field(default_factory=list)
+    targets: List[int] = field(default_factory=list)
+
+
+def _node_index(position: int, stride: int) -> int:
+    return position // stride
+
+
+def plan_state_motions(
+    steps: Sequence[StateStep],
+    stride: int,
+    copy_on_write: bool = True,
+) -> StatePlan:
+    """Plan state motion for one scheduling step.
+
+    ``stride`` is the checkpoint interval in tokens. With ``copy_on_write`` a
+    node is only carried forward when it is shareable, since a node no other
+    request can reach is free to advance in place.
+    """
+    if stride <= 0:
+        raise ValueError(f"stride must be positive, got {stride}")
+
+    plan = StatePlan()
+    for step in steps:
+        if step.scheduled <= 0:
+            raise ValueError("every scheduled step must run at least one token")
+
+        last_position = step.computed + step.scheduled - 1
+        target_index = _node_index(last_position, stride)
+        if target_index >= len(step.node_ids):
+            raise ValueError(
+                f"step needs node index {target_index} but was given "
+                f"{len(step.node_ids)} nodes"
+            )
+
+        target = step.node_ids[target_index]
+        plan.targets.append(target)
+
+        if step.computed == 0:
+            plan.zero.append(target)
+            continue
+
+        source_index = _node_index(step.computed - 1, stride)
+        source = step.node_ids[source_index]
+        if source == target:
+            continue
+
+        if copy_on_write and not _is_shareable(step, source_index):
+            continue
+
+        plan.copy.append((source, target))
+
+    return plan
+
+
+def _is_shareable(step: StateStep, index: int) -> bool:
+    if step.shareable is None:
+        return True
+    if index >= len(step.shareable):
+        return True
+    return bool(step.shareable[index])

--- a/mlx_vlm/apc_aligned_state.py
+++ b/mlx_vlm/apc_aligned_state.py
@@ -1,104 +1,65 @@
-"""Block-aligned reuse for non-pageable cache state.
+"""Where to checkpoint a prompt so a divergent request can resume.
 
 Recurrent and convolution state summarises every token before it, so it cannot
-be sliced to an arbitrary position the way attention KV can. It can, however,
-be checkpointed: a node that covers a block boundary can hold the state as it
-stood at that boundary, and a later request sharing that prefix resumes from
-it.
+be sliced to an arbitrary position the way attention KV can. Reuse therefore
+happens at boundaries: a request stores the whole cache at chosen prefix
+lengths, and a later request sharing that prefix restores the longest boundary
+it matches.
 
-The planner below turns one scheduling step into the two motions that keep such
-state coherent:
-
-``zero`` starts a request whose prefix is empty, because the node it lands on
-may still hold another request's bytes. ``copy`` carries state from the node a
-request just left into the node it is entering, leaving the old node intact as
-a checkpoint.
-
-A prefix hit needs no third motion: the request is admitted with its matched
-length, so the first copy of the step reads the checkpoint it hit.
+One checkpoint near the end of a prompt only helps a request that repeats it.
+Boundaries spread across the prompt are what let a request that shares an
+opening and then diverges start from the last common point, so the schedule
+below walks a fixed stride and keeps every boundary that leaves a text-only
+suffix.
 """
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
-from typing import List, Optional, Sequence, Tuple
+from typing import Iterable, List, Optional, Sequence
 
-__all__ = ["StatePlan", "StateStep", "plan_state_motions"]
+from .apc import adjust_prefix_to_text_suffix_boundary
 
-
-@dataclass(frozen=True)
-class StateStep:
-    """One request's position in a step: what it had, and what it runs now."""
-
-    node_ids: Sequence[int]
-    computed: int
-    scheduled: int
-    shareable: Optional[Sequence[bool]] = None
+__all__ = ["checkpoint_schedule"]
 
 
-@dataclass
-class StatePlan:
-    """Node ids to clear, node pairs to carry forward, and each step's target."""
-
-    zero: List[int] = field(default_factory=list)
-    copy: List[Tuple[int, int]] = field(default_factory=list)
-    targets: List[int] = field(default_factory=list)
-
-
-def _node_index(position: int, stride: int) -> int:
-    return position // stride
-
-
-def plan_state_motions(
-    steps: Sequence[StateStep],
+def checkpoint_schedule(
+    token_ids: Sequence[int],
     stride: int,
-    copy_on_write: bool = True,
-) -> StatePlan:
-    """Plan state motion for one scheduling step.
+    media_token_ids: Iterable[int] = (),
+    *,
+    guard_tokens: int = 1,
+    limit: Optional[int] = None,
+) -> List[int]:
+    """Prefix lengths at which to store a reusable checkpoint.
 
-    ``stride`` is the checkpoint interval in tokens. With ``copy_on_write`` a
-    node is only carried forward when it is shareable, since a node no other
-    request can reach is free to advance in place.
+    Boundaries are multiples of ``stride`` that keep at least ``guard_tokens``
+    to generate from, moved forward when needed so no media placeholder is left
+    in the suffix. ``limit`` keeps the earliest boundaries when a prompt would
+    otherwise produce more than the cache should hold, since a request that
+    shares an opening and then diverges can only resume from an early one.
     """
     if stride <= 0:
         raise ValueError(f"stride must be positive, got {stride}")
 
-    plan = StatePlan()
-    for step in steps:
-        if step.scheduled <= 0:
-            raise ValueError("every scheduled step must run at least one token")
+    media_token_ids = tuple(media_token_ids)
+    highest = len(token_ids) - max(1, guard_tokens)
+    if highest <= 0:
+        return []
 
-        last_position = step.computed + step.scheduled - 1
-        target_index = _node_index(last_position, stride)
-        if target_index >= len(step.node_ids):
-            raise ValueError(
-                f"step needs node index {target_index} but was given "
-                f"{len(step.node_ids)} nodes"
-            )
-
-        target = step.node_ids[target_index]
-        plan.targets.append(target)
-
-        if step.computed == 0:
-            plan.zero.append(target)
+    boundaries: List[int] = []
+    for candidate in range(stride, highest + 1, stride):
+        safe = adjust_prefix_to_text_suffix_boundary(
+            token_ids,
+            candidate,
+            media_token_ids,
+            max_prefix_tokens=highest,
+        )
+        if safe <= 0:
             continue
-
-        source_index = _node_index(step.computed - 1, stride)
-        source = step.node_ids[source_index]
-        if source == target:
+        if boundaries and safe <= boundaries[-1]:
             continue
+        boundaries.append(safe)
 
-        if copy_on_write and not _is_shareable(step, source_index):
-            continue
-
-        plan.copy.append((source, target))
-
-    return plan
-
-
-def _is_shareable(step: StateStep, index: int) -> bool:
-    if step.shareable is None:
-        return True
-    if index >= len(step.shareable):
-        return True
-    return bool(step.shareable[index])
+    if limit is not None and limit >= 0 and len(boundaries) > limit:
+        boundaries = boundaries[:limit]
+    return boundaries

--- a/mlx_vlm/apc_storage.py
+++ b/mlx_vlm/apc_storage.py
@@ -58,26 +58,6 @@ class KVBlockHandle:
         self.values = None
 
 
-class ArrayStateHandle:
-    """Fixed-size arrays for a node's non-pageable component.
-
-    Recurrent and convolution state is a summary of every token before it, so
-    it cannot be sliced like KV. A node stores it whole and reuse restores it
-    at the boundary the node covers.
-    """
-
-    __slots__ = ("arrays",)
-
-    def __init__(self, arrays: Optional[List[mx.array]] = None):
-        self.arrays = arrays
-
-    def resident_bytes(self) -> int:
-        return sum(_array_bytes(t) for t in self.arrays or ())
-
-    def release(self) -> None:
-        self.arrays = None
-
-
 class APCNode:
     """Logical prefix-index entry: identity plus per-component storage handles.
 
@@ -106,15 +86,6 @@ class APCNode:
 
     def set_kv(self, keys: List[mx.array], values: List[mx.array]) -> None:
         self.components[self.KV_COMPONENT] = KVBlockHandle(keys, values)
-
-    def state_arrays(self, component_id: ComponentId) -> Optional[List[mx.array]]:
-        handle = self.components.get(component_id)
-        return handle.arrays if isinstance(handle, ArrayStateHandle) else None
-
-    def set_state(self, component_id: ComponentId, arrays: List[mx.array]) -> None:
-        if component_id == self.KV_COMPONENT:
-            raise ValueError("kv is a pageable component, use set_kv")
-        self.components[component_id] = ArrayStateHandle(list(arrays))
 
     def release_components(self) -> None:
         for handle in self.components.values():

--- a/mlx_vlm/apc_storage.py
+++ b/mlx_vlm/apc_storage.py
@@ -58,6 +58,26 @@ class KVBlockHandle:
         self.values = None
 
 
+class ArrayStateHandle:
+    """Fixed-size arrays for a node's non-pageable component.
+
+    Recurrent and convolution state is a summary of every token before it, so
+    it cannot be sliced like KV. A node stores it whole and reuse restores it
+    at the boundary the node covers.
+    """
+
+    __slots__ = ("arrays",)
+
+    def __init__(self, arrays: Optional[List[mx.array]] = None):
+        self.arrays = arrays
+
+    def resident_bytes(self) -> int:
+        return sum(_array_bytes(t) for t in self.arrays or ())
+
+    def release(self) -> None:
+        self.arrays = None
+
+
 class APCNode:
     """Logical prefix-index entry: identity plus per-component storage handles.
 
@@ -86,6 +106,15 @@ class APCNode:
 
     def set_kv(self, keys: List[mx.array], values: List[mx.array]) -> None:
         self.components[self.KV_COMPONENT] = KVBlockHandle(keys, values)
+
+    def state_arrays(self, component_id: ComponentId) -> Optional[List[mx.array]]:
+        handle = self.components.get(component_id)
+        return handle.arrays if isinstance(handle, ArrayStateHandle) else None
+
+    def set_state(self, component_id: ComponentId, arrays: List[mx.array]) -> None:
+        if component_id == self.KV_COMPONENT:
+            raise ValueError("kv is a pageable component, use set_kv")
+        self.components[component_id] = ArrayStateHandle(list(arrays))
 
     def release_components(self) -> None:
         for handle in self.components.values():

--- a/mlx_vlm/generate/ar.py
+++ b/mlx_vlm/generate/ar.py
@@ -9,7 +9,7 @@ import time
 import warnings
 from collections.abc import Generator
 from dataclasses import dataclass
-from typing import Any, Callable, Dict, List, Optional, Tuple, Union
+from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, Union
 
 import mlx.core as mx
 import mlx.nn as nn
@@ -148,6 +148,15 @@ def normalize_resize_shape(values):
     return (values[0], values[0]) if len(values) == 1 else tuple(values)
 
 
+def _pending_checkpoint_lens(checkpoint, lengths, prompt_len):
+    """Ascending prompt-cache checkpoint lengths that fall inside the prompt."""
+    if checkpoint is None or lengths is None:
+        return []
+    if isinstance(lengths, int):
+        lengths = (lengths,)
+    return sorted({int(n) for n in lengths if 0 < int(n) < prompt_len})
+
+
 def generate_step(
     input_ids: mx.array,
     model: nn.Module,
@@ -186,7 +195,7 @@ def generate_step(
     draft_kind: str = "dflash",
     draft_block_size: Optional[int] = None,
     prompt_cache_checkpoint: Optional[Callable[[int, List[Any]], None]] = None,
-    prompt_cache_checkpoint_len: Optional[int] = None,
+    prompt_cache_checkpoint_len: Optional[Union[int, Sequence[int]]] = None,
     seed: Optional[int] = None,
     verbose: bool = False,
     **kwargs,
@@ -416,18 +425,15 @@ def generate_step(
             prefill_kwargs=policy_kwargs,
         ):
             prefill_step_size = None
-        checkpoint_len = (
-            int(prompt_cache_checkpoint_len)
-            if prompt_cache_checkpoint is not None
-            and prompt_cache_checkpoint_len is not None
-            else None
+        pending_checkpoints = _pending_checkpoint_lens(
+            prompt_cache_checkpoint,
+            prompt_cache_checkpoint_len,
+            inputs_embeds.shape[1],
         )
-        checkpoint_done = False
+        checkpoint_len = pending_checkpoints[0] if pending_checkpoints else None
         should_chunk = (
             prefill_step_size is not None and inputs_embeds.shape[1] > prefill_step_size
-        ) or (
-            checkpoint_len is not None and 0 < checkpoint_len < inputs_embeds.shape[1]
-        )
+        ) or bool(pending_checkpoints)
         if prefill_step_size is not None and should_chunk:
             # Chunked prefill with embeddings
             total_tokens = inputs_embeds.shape[1]
@@ -439,9 +445,9 @@ def generate_step(
                     n_to_process = min(prefill_step_size, inputs_embeds.shape[1] - 1)
                     if (
                         checkpoint_len is not None
-                        and not checkpoint_done
-                        and processed_tokens < checkpoint_len
-                        and processed_tokens + n_to_process > checkpoint_len
+                        and processed_tokens
+                        < checkpoint_len
+                        < processed_tokens + n_to_process
                     ):
                         n_to_process = checkpoint_len - processed_tokens
                     chunk_kwargs = kwargs
@@ -459,11 +465,17 @@ def generate_step(
                     processed_tokens += n_to_process
                     if (
                         checkpoint_len is not None
-                        and not checkpoint_done
-                        and processed_tokens == checkpoint_len
+                        and processed_tokens >= checkpoint_len
                     ):
-                        prompt_cache_checkpoint(processed_tokens, prompt_cache)
-                        checkpoint_done = True
+                        while pending_checkpoints and processed_tokens >= (
+                            pending_checkpoints[0]
+                        ):
+                            reached = pending_checkpoints.pop(0)
+                            if reached == processed_tokens:
+                                prompt_cache_checkpoint(reached, prompt_cache)
+                        checkpoint_len = (
+                            pending_checkpoints[0] if pending_checkpoints else None
+                        )
                     inputs_embeds = inputs_embeds[:, n_to_process:]
                     input_ids = input_ids[:, n_to_process:]
                     mx.clear_cache()

--- a/mlx_vlm/generate/dispatch.py
+++ b/mlx_vlm/generate/dispatch.py
@@ -11,6 +11,7 @@ import mlx.nn as nn
 from transformers import PreTrainedTokenizer
 
 from .. import apc as _apc
+from ..apc_aligned_state import checkpoint_schedule
 from ..kv_quant import from_legacy as kv_quant_from_legacy
 from ..models import cache
 from ..prompt_utils import apply_chat_template
@@ -944,13 +945,22 @@ def stream_generate(
         exact_checkpoint_len = None
         exact_checkpoint = None
         if apc_manager is not None and apc_mode == "exact" and reused_prefix_len == 0:
-            exact_checkpoint_len = _apc.adjust_prefix_to_text_suffix_boundary(
+            final_checkpoint = _apc.adjust_prefix_to_text_suffix_boundary(
                 full_input_ids_list,
                 len(full_input_ids_list) - apc_manager.exact_cache_guard_tokens,
                 multimodal_token_ids,
                 max_prefix_tokens=len(full_input_ids_list) - 1,
             )
-            if exact_checkpoint_len <= 0:
+            exact_checkpoint_len = checkpoint_schedule(
+                full_input_ids_list,
+                apc_manager.state_stride,
+                multimodal_token_ids,
+                guard_tokens=apc_manager.exact_cache_guard_tokens,
+                limit=apc_manager.exact_checkpoint_limit,
+            )
+            if final_checkpoint > 0 and final_checkpoint not in exact_checkpoint_len:
+                exact_checkpoint_len.append(final_checkpoint)
+            if not exact_checkpoint_len:
                 exact_checkpoint_len = None
 
             def exact_checkpoint(prefix_len: int, prompt_cache: List[Any]) -> None:

--- a/mlx_vlm/tests/test_apc.py
+++ b/mlx_vlm/tests/test_apc.py
@@ -1257,3 +1257,21 @@ def test_state_stride_rounds_up_to_whole_kv_blocks():
         assert manager.state_stride % manager.block_size == 0
     finally:
         del os.environ["APC_STATE_STRIDE"]
+
+
+def test_resident_budget_never_evicts_a_held_block():
+    block_size = 16
+    manager = APCManager(num_blocks=16, block_size=block_size)
+    token_ids = list(range(4 * block_size))
+    layer_keys, layer_values = _make_fake_kv(seq_len=len(token_ids))
+
+    manager._max_resident_bytes = 1
+    stored = manager.store_kv_blocks(token_ids, layer_keys, layer_values)
+
+    assert stored
+    assert all(b.resident_bytes() > 0 for b in stored)
+    assert manager.resident_bytes() > manager._max_resident_bytes
+
+    manager.release(stored)
+    manager._shrink_to_resident_budget_locked()
+    assert manager.resident_bytes() == 0

--- a/mlx_vlm/tests/test_apc.py
+++ b/mlx_vlm/tests/test_apc.py
@@ -1259,3 +1259,48 @@ def test_resident_budget_never_evicts_a_held_block():
     manager.release(stored)
     manager._shrink_to_resident_budget_locked()
     assert manager.resident_bytes() == 0
+
+
+def _exact_entry_cache(tokens):
+    from mlx_vlm.models.cache import ArraysCache
+
+    c = ArraysCache(size=1)
+    c[0] = mx.zeros((1, 4, len(tokens), 32))
+    return [c]
+
+
+def test_exact_cache_respects_its_byte_budget():
+    manager = APCManager(num_blocks=8, block_size=16)
+    manager._max_exact_bytes = 0
+    for i in range(4):
+        tokens = list(range(100 + i))
+        manager.store_exact_cache(tokens, _exact_entry_cache(tokens))
+    unbounded = manager.exact_cache_bytes()
+    assert len(manager._exact_cache) == 4
+
+    manager._max_exact_bytes = unbounded // 2
+    manager._shrink_exact_cache_locked()
+
+    assert manager.exact_cache_bytes() <= unbounded // 2
+    assert manager.stats.exact_budget_evictions > 0
+
+
+def test_exact_cache_budget_keeps_at_least_one_entry():
+    manager = APCManager(num_blocks=8, block_size=16)
+    tokens = list(range(100))
+    manager.store_exact_cache(tokens, _exact_entry_cache(tokens))
+
+    manager._max_exact_bytes = 1
+    manager._shrink_exact_cache_locked()
+
+    assert len(manager._exact_cache) == 1
+
+
+def test_exact_cache_entries_record_their_size():
+    manager = APCManager(num_blocks=8, block_size=16)
+    tokens = list(range(100))
+    manager.store_exact_cache(tokens, _exact_entry_cache(tokens))
+
+    entry = next(iter(manager._exact_cache.values()))
+    assert entry.nbytes > 0
+    assert manager.exact_cache_bytes() == entry.nbytes

--- a/mlx_vlm/tests/test_apc.py
+++ b/mlx_vlm/tests/test_apc.py
@@ -1217,22 +1217,6 @@ def test_resident_budget_disabled_by_default_keeps_every_block():
     manager.release(matched)
 
 
-def test_resident_budget_counts_every_component_not_just_kv():
-    block_size = 16
-    manager = APCManager(num_blocks=4, block_size=block_size)
-    token_ids = list(range(block_size))
-    layer_keys, layer_values = _make_fake_kv(seq_len=len(token_ids))
-    stored = manager.store_kv_blocks(token_ids, layer_keys, layer_values)
-    kv_only = manager.resident_bytes()
-    manager.release(stored)
-
-    block = stored[0]
-    extra = mx.zeros((1024,), dtype=mx.float32)
-    block.set_state("state", [extra])
-
-    assert manager.resident_bytes() == kv_only + extra.nbytes
-
-
 def test_state_stride_is_coarser_than_the_kv_block_size():
     manager = APCManager(num_blocks=4, block_size=16)
 

--- a/mlx_vlm/tests/test_apc.py
+++ b/mlx_vlm/tests/test_apc.py
@@ -1181,3 +1181,79 @@ def test_exact_disk_hit_promotion_with_nonzero_extra_hash(tmp_path, monkeypatch)
     assert warm_wrong is None
 
     manager.close()
+
+
+def test_resident_budget_evicts_until_pool_fits():
+    block_size = 16
+    manager = APCManager(num_blocks=16, block_size=block_size)
+    token_ids = list(range(4 * block_size))
+    layer_keys, layer_values = _make_fake_kv(seq_len=len(token_ids))
+
+    stored = manager.store_kv_blocks(token_ids, layer_keys, layer_values)
+    manager.release(stored)
+    full = manager.resident_bytes()
+    assert full > 0
+
+    manager._max_resident_bytes = full // 2
+    manager._shrink_to_resident_budget_locked()
+
+    assert manager.resident_bytes() <= full // 2
+    assert manager.stats.budget_evictions > 0
+
+
+def test_resident_budget_disabled_by_default_keeps_every_block():
+    block_size = 16
+    manager = APCManager(num_blocks=16, block_size=block_size)
+    assert manager._max_resident_bytes == 0
+
+    token_ids = list(range(4 * block_size))
+    layer_keys, layer_values = _make_fake_kv(seq_len=len(token_ids))
+    stored = manager.store_kv_blocks(token_ids, layer_keys, layer_values)
+    manager.release(stored)
+
+    matched, matched_tokens = manager.lookup_prefix(token_ids)
+    assert matched_tokens == 4 * block_size
+    assert manager.stats.budget_evictions == 0
+    manager.release(matched)
+
+
+def test_resident_budget_counts_every_component_not_just_kv():
+    block_size = 16
+    manager = APCManager(num_blocks=4, block_size=block_size)
+    token_ids = list(range(block_size))
+    layer_keys, layer_values = _make_fake_kv(seq_len=len(token_ids))
+    stored = manager.store_kv_blocks(token_ids, layer_keys, layer_values)
+    kv_only = manager.resident_bytes()
+    manager.release(stored)
+
+    block = stored[0]
+    extra = mx.zeros((1024,), dtype=mx.float32)
+    block.set_state("state", [extra])
+
+    assert manager.resident_bytes() == kv_only + extra.nbytes
+
+
+def test_state_stride_is_coarser_than_the_kv_block_size():
+    manager = APCManager(num_blocks=4, block_size=16)
+
+    assert manager.state_stride >= manager.block_size
+    assert manager.state_stride % manager.block_size == 0
+
+
+def test_state_stride_never_drops_below_the_block_size():
+    os.environ["APC_STATE_STRIDE"] = "4"
+    try:
+        manager = APCManager(num_blocks=4, block_size=16)
+        assert manager.state_stride == 16
+    finally:
+        del os.environ["APC_STATE_STRIDE"]
+
+
+def test_state_stride_rounds_up_to_whole_kv_blocks():
+    os.environ["APC_STATE_STRIDE"] = "500"
+    try:
+        manager = APCManager(num_blocks=4, block_size=16)
+        assert manager.state_stride == 512
+        assert manager.state_stride % manager.block_size == 0
+    finally:
+        del os.environ["APC_STATE_STRIDE"]

--- a/mlx_vlm/tests/test_apc_aligned_state.py
+++ b/mlx_vlm/tests/test_apc_aligned_state.py
@@ -1,89 +1,73 @@
 import pytest
 
-from mlx_vlm.apc_aligned_state import StateStep, plan_state_motions
+from mlx_vlm.apc_aligned_state import checkpoint_schedule
+from mlx_vlm.generate.ar import _pending_checkpoint_lens
+
+IMAGE = 900
 
 
-def test_fresh_request_zeroes_its_first_node():
-    plan = plan_state_motions([StateStep([7, 8], computed=0, scheduled=4)], stride=16)
+def test_schedule_walks_the_stride():
+    tokens = list(range(100))
 
-    assert plan.zero == [7]
-    assert plan.copy == []
-    assert plan.targets == [7]
+    assert checkpoint_schedule(tokens, stride=25) == [25, 50, 75]
 
 
-def test_step_inside_one_node_moves_nothing():
-    plan = plan_state_motions([StateStep([3, 4], computed=2, scheduled=4)], stride=16)
+def test_schedule_leaves_room_to_generate():
+    tokens = list(range(100))
 
-    assert plan.zero == []
-    assert plan.copy == []
-    assert plan.targets == [3]
+    assert checkpoint_schedule(tokens, stride=25, guard_tokens=30) == [25, 50]
 
 
-def test_crossing_a_boundary_carries_state_forward():
-    plan = plan_state_motions([StateStep([3, 9], computed=15, scheduled=2)], stride=16)
-
-    assert plan.copy == [(3, 9)]
-    assert plan.targets == [9]
+def test_short_prompt_has_no_boundary():
+    assert checkpoint_schedule(list(range(10)), stride=25) == []
 
 
-def test_prefix_hit_resumes_from_the_checkpoint_it_matched():
-    hit = StateStep([4, 5, 6], computed=32, scheduled=1)
+def test_schedule_keeps_the_earliest_boundaries_under_a_limit():
+    tokens = list(range(1000))
 
-    plan = plan_state_motions([hit], stride=16)
-
-    assert plan.zero == []
-    assert plan.copy == [(5, 6)]
-    assert plan.targets == [6]
+    assert checkpoint_schedule(tokens, stride=100, limit=3) == [100, 200, 300]
 
 
-def test_private_nodes_advance_in_place_under_copy_on_write():
-    private = StateStep([3, 9], computed=15, scheduled=2, shareable=[False, False])
-
-    assert plan_state_motions([private], stride=16).copy == []
-    assert plan_state_motions([private], stride=16, copy_on_write=False).copy == [
-        (3, 9)
-    ]
+def test_a_limit_of_zero_disables_checkpointing():
+    assert checkpoint_schedule(list(range(100)), stride=25, limit=0) == []
 
 
-def test_shareable_nodes_are_always_carried_forward():
-    shared = StateStep([3, 9], computed=15, scheduled=2, shareable=[True, False])
+def test_boundaries_move_past_media_so_the_suffix_is_text_only():
+    tokens = list(range(40)) + [IMAGE] * 20 + list(range(40))
 
-    assert plan_state_motions([shared], stride=16).copy == [(3, 9)]
+    schedule = checkpoint_schedule(tokens, stride=25, media_token_ids=[IMAGE])
 
-
-def test_motions_batch_across_requests():
-    steps = [
-        StateStep([1, 2], computed=0, scheduled=1),
-        StateStep([3, 4], computed=15, scheduled=2),
-        StateStep([5, 6], computed=4, scheduled=2),
-    ]
-
-    plan = plan_state_motions(steps, stride=16)
-
-    assert plan.zero == [1]
-    assert plan.copy == [(3, 4)]
-    assert plan.targets == [1, 4, 5]
+    assert schedule
+    assert all(IMAGE not in tokens[boundary:] for boundary in schedule)
 
 
-def test_a_long_step_lands_on_the_node_holding_its_last_token():
-    plan = plan_state_motions(
-        [StateStep([1, 2, 3], computed=0, scheduled=40)], stride=16
-    )
+def test_boundaries_are_strictly_increasing():
+    tokens = list(range(30)) + [IMAGE] * 30 + list(range(40))
 
-    assert plan.targets == [3]
-    assert plan.zero == [3]
+    schedule = checkpoint_schedule(tokens, stride=10, media_token_ids=[IMAGE])
+
+    assert schedule == sorted(set(schedule))
 
 
 def test_stride_must_be_positive():
     with pytest.raises(ValueError):
-        plan_state_motions([StateStep([1], computed=0, scheduled=1)], stride=0)
+        checkpoint_schedule([1, 2, 3], stride=0)
 
 
-def test_empty_step_is_rejected():
-    with pytest.raises(ValueError):
-        plan_state_motions([StateStep([1], computed=0, scheduled=0)], stride=16)
+def test_pending_lengths_accept_one_value_or_many():
+    def store(prefix_len, cache):
+        return None
+
+    assert _pending_checkpoint_lens(store, 32, prompt_len=100) == [32]
+    assert _pending_checkpoint_lens(store, [64, 32], prompt_len=100) == [32, 64]
 
 
-def test_missing_node_for_target_is_rejected():
-    with pytest.raises(ValueError):
-        plan_state_motions([StateStep([1], computed=0, scheduled=40)], stride=16)
+def test_pending_lengths_drop_values_outside_the_prompt():
+    def store(prefix_len, cache):
+        return None
+
+    assert _pending_checkpoint_lens(store, [0, 50, 100, 250], prompt_len=100) == [50]
+
+
+def test_pending_lengths_are_empty_without_a_store_callback():
+    assert _pending_checkpoint_lens(None, [10, 20], prompt_len=100) == []

--- a/mlx_vlm/tests/test_apc_aligned_state.py
+++ b/mlx_vlm/tests/test_apc_aligned_state.py
@@ -1,0 +1,89 @@
+import pytest
+
+from mlx_vlm.apc_aligned_state import StateStep, plan_state_motions
+
+
+def test_fresh_request_zeroes_its_first_node():
+    plan = plan_state_motions([StateStep([7, 8], computed=0, scheduled=4)], stride=16)
+
+    assert plan.zero == [7]
+    assert plan.copy == []
+    assert plan.targets == [7]
+
+
+def test_step_inside_one_node_moves_nothing():
+    plan = plan_state_motions([StateStep([3, 4], computed=2, scheduled=4)], stride=16)
+
+    assert plan.zero == []
+    assert plan.copy == []
+    assert plan.targets == [3]
+
+
+def test_crossing_a_boundary_carries_state_forward():
+    plan = plan_state_motions([StateStep([3, 9], computed=15, scheduled=2)], stride=16)
+
+    assert plan.copy == [(3, 9)]
+    assert plan.targets == [9]
+
+
+def test_prefix_hit_resumes_from_the_checkpoint_it_matched():
+    hit = StateStep([4, 5, 6], computed=32, scheduled=1)
+
+    plan = plan_state_motions([hit], stride=16)
+
+    assert plan.zero == []
+    assert plan.copy == [(5, 6)]
+    assert plan.targets == [6]
+
+
+def test_private_nodes_advance_in_place_under_copy_on_write():
+    private = StateStep([3, 9], computed=15, scheduled=2, shareable=[False, False])
+
+    assert plan_state_motions([private], stride=16).copy == []
+    assert plan_state_motions([private], stride=16, copy_on_write=False).copy == [
+        (3, 9)
+    ]
+
+
+def test_shareable_nodes_are_always_carried_forward():
+    shared = StateStep([3, 9], computed=15, scheduled=2, shareable=[True, False])
+
+    assert plan_state_motions([shared], stride=16).copy == [(3, 9)]
+
+
+def test_motions_batch_across_requests():
+    steps = [
+        StateStep([1, 2], computed=0, scheduled=1),
+        StateStep([3, 4], computed=15, scheduled=2),
+        StateStep([5, 6], computed=4, scheduled=2),
+    ]
+
+    plan = plan_state_motions(steps, stride=16)
+
+    assert plan.zero == [1]
+    assert plan.copy == [(3, 4)]
+    assert plan.targets == [1, 4, 5]
+
+
+def test_a_long_step_lands_on_the_node_holding_its_last_token():
+    plan = plan_state_motions(
+        [StateStep([1, 2, 3], computed=0, scheduled=40)], stride=16
+    )
+
+    assert plan.targets == [3]
+    assert plan.zero == [3]
+
+
+def test_stride_must_be_positive():
+    with pytest.raises(ValueError):
+        plan_state_motions([StateStep([1], computed=0, scheduled=1)], stride=0)
+
+
+def test_empty_step_is_rejected():
+    with pytest.raises(ValueError):
+        plan_state_motions([StateStep([1], computed=0, scheduled=0)], stride=16)
+
+
+def test_missing_node_for_target_is_rejected():
+    with pytest.raises(ValueError):
+        plan_state_motions([StateStep([1], computed=0, scheduled=40)], stride=16)

--- a/mlx_vlm/tests/test_apc_exact_mode.py
+++ b/mlx_vlm/tests/test_apc_exact_mode.py
@@ -15,6 +15,7 @@ import mlx.core as mx
 import pytest
 
 from mlx_vlm.apc import APCManager, model_apc_mode
+from mlx_vlm.apc_aligned_state import checkpoint_schedule
 from mlx_vlm.models.cache import KVCache
 
 # ============================================================================
@@ -550,3 +551,53 @@ def test_block_eligible_layers_have_extractable_kv_after_prefill():
             assert mx.any(
                 c.values != 0
             ).item(), f"Block-eligible layer {i} values are all zeros"
+
+
+def _prefill(lm, tokens):
+    cache = lm.make_cache()
+    lm(mx.array([tokens]), cache=cache)
+    mx.eval([c for c in cache if c is not None])
+    return cache
+
+
+def test_divergent_suffix_resumes_from_an_earlier_checkpoint():
+    """A request that shares an opening and then diverges needs a boundary.
+
+    With a single checkpoint near the end of the prompt there is nothing for it
+    to match, which is what kept hybrid reuse all-or-nothing.
+    """
+    lm = _make_tiny_qwen35()
+    prompt = list(range(1, 97))
+    boundaries = checkpoint_schedule(prompt, stride=16, guard_tokens=8)
+    assert len(boundaries) > 1
+
+    shared = 40
+    divergent = prompt[:shared] + [700 + i for i in range(24)]
+
+    final_only = APCManager(num_blocks=64, block_size=16)
+    final_only.store_exact_cache(prompt[: boundaries[-1]], _prefill(lm, prompt))
+    _, reused_final_only = final_only.lookup_exact_cache(divergent)
+
+    scheduled = APCManager(num_blocks=64, block_size=16)
+    for boundary in boundaries:
+        scheduled.store_exact_cache(prompt[:boundary], _prefill(lm, prompt[:boundary]))
+    restored, reused_scheduled = scheduled.lookup_exact_cache(divergent)
+
+    assert reused_final_only == 0
+    assert 0 < reused_scheduled <= shared
+    assert reused_scheduled == max(b for b in boundaries if b <= shared)
+    assert restored is not None
+
+
+def test_scheduled_checkpoints_still_serve_an_exact_repeat():
+    lm = _make_tiny_qwen35()
+    prompt = list(range(1, 97))
+    boundaries = checkpoint_schedule(prompt, stride=16, guard_tokens=8)
+
+    apc = APCManager(num_blocks=64, block_size=16)
+    for boundary in boundaries:
+        apc.store_exact_cache(prompt[:boundary], _prefill(lm, prompt[:boundary]))
+
+    _, reused = apc.lookup_exact_cache(prompt)
+
+    assert reused == boundaries[-1]

--- a/mlx_vlm/tests/test_apc_quantized.py
+++ b/mlx_vlm/tests/test_apc_quantized.py
@@ -1491,3 +1491,75 @@ def test_live_batch_generator_staggered_apc_kv_join():
     finally:
         close(gen)
         apc.close()
+
+
+def _quant_config() -> dict:
+    return {"bits": 8, "group_size": GROUP_SIZE}
+
+
+def _warm_block(num_layers: int, block_size: int):
+    class Block:
+        def __init__(self):
+            shape = (1, H, block_size, GROUP_SIZE)
+            self.keys = [mx.zeros(shape) for _ in range(num_layers)]
+            self.values = [mx.zeros(shape) for _ in range(num_layers)]
+
+    return Block()
+
+
+def _layer_is_quantized(cache) -> bool:
+    return "Quantized" in type(cache).__name__ or isinstance(
+        cache, BatchTurboQuantKVCache
+    )
+
+
+@pytest.mark.parametrize("num_layers", [2, 4, 8, 28])
+def test_warm_block_restore_matches_live_layer_quantization(num_layers):
+    block_size = 16
+    picks = [
+        {
+            "matched_blocks": [_warm_block(num_layers, block_size) for _ in range(2)],
+            "prefix_len": 2 * block_size,
+        },
+        None,
+    ]
+
+    warm, _ = make_warm_batch_kv_cache_multi(picks, num_layers, _quant_config())
+
+    expected = [should_quantize_kv_layer(i, num_layers) for i in range(num_layers)]
+    assert [_layer_is_quantized(c) for c in warm] == expected
+
+
+def _hybrid_exact_row(num_layers: int, prefix_len: int, full_attn_every: int = 4):
+    row = []
+    for layer_idx in range(num_layers):
+        if layer_idx % full_attn_every == 0:
+            entry = KVCache()
+            slab = mx.zeros((1, H, prefix_len, GROUP_SIZE))
+            entry.update_and_fetch(slab, slab)
+        else:
+            entry = ArraysCache(size=2)
+            entry[0] = mx.zeros((1, H, 4, GROUP_SIZE))
+            entry[1] = mx.zeros((1, H, 4, GROUP_SIZE))
+        row.append(entry)
+    return row
+
+
+@pytest.mark.parametrize("num_layers", [4, 8])
+def test_exact_hybrid_restore_matches_live_layer_quantization(num_layers):
+    prefix_len = 64
+    rows = [_hybrid_exact_row(num_layers, prefix_len) for _ in range(2)]
+
+    merged, restored_prefix = make_warm_batch_exact_cache_multi(
+        rows, [prefix_len, prefix_len], _quant_config()
+    )
+
+    assert merged is not None
+    assert restored_prefix == prefix_len
+    for layer_idx, entry in enumerate(merged):
+        if layer_idx % 4:
+            assert isinstance(entry, ArraysCache)
+        else:
+            assert _layer_is_quantized(entry) == should_quantize_kv_layer(
+                layer_idx, num_layers
+            )


### PR DESCRIPTION
Hybrid models cannot slice recurrent or convolution state to a position the way attention KV can, so prefix reuse happens at boundaries. Exact mode stored one snapshot just before the end of a prompt, which only serves a request that repeats it: a request sharing an opening and then diverging matched nothing and re-prefilled from zero. Walk the prompt at a stride instead, keep boundaries that leave a text-only suffix, and bound the resulting snapshots by bytes.