### PR TITLE
Report why an APC lookup reused a prefix or did not

### DIFF
--- a/mlx_vlm/apc.py
+++ b/mlx_vlm/apc.py
@@ -2988,9 +2988,10 @@ class APCManager:
             counts = self.stats.reuse_outcomes
             counts[outcome] = counts.get(outcome, 0) + 1
 
-    def _record_store_outcome_locked(self, outcome: str) -> None:
-        counts = self.stats.store_outcomes
-        counts[outcome] = counts.get(outcome, 0) + 1
+    def record_store_outcome(self, outcome: str) -> None:
+        with self.lock:
+            counts = self.stats.store_outcomes
+            counts[outcome] = counts.get(outcome, 0) + 1
 
     # ---------- Public API ----------
     def lookup_exact_cache(
@@ -3416,7 +3417,7 @@ class APCManager:
                         i,
                         n_full,
                     )
-                    self._record_store_outcome_locked(StoreOutcome.TENSOR_LIMIT)
+                    self.record_store_outcome(StoreOutcome.TENSOR_LIMIT)
                     if self.disk is None:
                         break
                     parent = h
@@ -3428,7 +3429,7 @@ class APCManager:
                         i,
                         n_full,
                     )
-                    self._record_store_outcome_locked(StoreOutcome.POOL_EXHAUSTED)
+                    self.record_store_outcome(StoreOutcome.POOL_EXHAUSTED)
                     if self.disk is None:
                         break
                     parent = h
@@ -3451,7 +3452,7 @@ class APCManager:
                 self.hash_table[h] = b
                 new_blocks.append(b)
                 self.stats.stores += 1
-                self._record_store_outcome_locked(StoreOutcome.STORED)
+                self.record_store_outcome(StoreOutcome.STORED)
                 self.stats.served_tokens += self.block_size
                 parent = h
             if self.disk is not None and disk_blocks:

--- a/mlx_vlm/apc.py
+++ b/mlx_vlm/apc.py
@@ -589,6 +589,7 @@ class _DiskExactCacheSnapshot:
 class APCStats:
     hits: int = 0
     misses: int = 0
+    reuse_outcomes: Dict[str, int] = field(default_factory=dict)
     matched_tokens: int = 0
     served_tokens: int = 0
     evictions: int = 0
@@ -621,6 +622,7 @@ class APCStats:
             "served_tokens": self.served_tokens,
             "token_hit_rate": hit_rate,
             "evictions": self.evictions,
+            "reuse_outcomes": dict(self.reuse_outcomes),
             "stores": self.stores,
             "disk_hits": self.disk_hits,
             "disk_writes": self.disk_writes,
@@ -2979,6 +2981,11 @@ class APCManager:
         with self.lock:
             return self._resident_bytes_locked()
 
+    def record_reuse_outcome(self, outcome: str) -> None:
+        with self.lock:
+            counts = self.stats.reuse_outcomes
+            counts[outcome] = counts.get(outcome, 0) + 1
+
     # ---------- Public API ----------
     def lookup_exact_cache(
         self,
@@ -4153,6 +4160,27 @@ def model_supports_apc(language_model: Any) -> bool:
     return model_apc_mode(language_model) is not None
 
 
+class ReuseOutcome:
+    EXACT = "exact"
+    DISK = "disk"
+    BLOCK = "block"
+    PROMPT_TOO_SHORT = "prompt_too_short"
+    NO_STORED_PREFIX = "no_stored_prefix"
+    MEDIA_SUFFIX = "media_suffix"
+    MEDIA_PREFIX = "media_prefix"
+
+
+@dataclass(frozen=True)
+class PrefixDecision:
+    plan: Optional[dict]
+    outcome: str
+    prefix_len: int = 0
+
+    @property
+    def reused(self) -> bool:
+        return self.plan is not None
+
+
 def apc_lookup_plan(
     manager: "APCManager",
     ids_list: Sequence[int],
@@ -4163,10 +4191,53 @@ def apc_lookup_plan(
     suffix_is_text_only,
     prefix_has_media,
 ) -> Optional[dict]:
-    """Pick the best APC prefix (disk > exact > block); shared by both generate paths, releases losers, callers apply."""
+    return apc_lookup_decision(
+        manager,
+        ids_list,
+        extra_hash=extra_hash,
+        apc_mode=apc_mode,
+        safe_lookup_min=safe_lookup_min,
+        suffix_is_text_only=suffix_is_text_only,
+        prefix_has_media=prefix_has_media,
+    ).plan
+
+
+def apc_lookup_decision(
+    manager: "APCManager",
+    ids_list: Sequence[int],
+    *,
+    extra_hash: int,
+    apc_mode: str,
+    safe_lookup_min: int,
+    suffix_is_text_only,
+    prefix_has_media,
+) -> PrefixDecision:
+    decision = _decide_prefix(
+        manager,
+        ids_list,
+        extra_hash=extra_hash,
+        apc_mode=apc_mode,
+        safe_lookup_min=safe_lookup_min,
+        suffix_is_text_only=suffix_is_text_only,
+        prefix_has_media=prefix_has_media,
+    )
+    manager.record_reuse_outcome(decision.outcome)
+    return decision
+
+
+def _decide_prefix(
+    manager: "APCManager",
+    ids_list: Sequence[int],
+    *,
+    extra_hash: int,
+    apc_mode: str,
+    safe_lookup_min: int,
+    suffix_is_text_only,
+    prefix_has_media,
+) -> PrefixDecision:
     n = len(ids_list)
     if not ids_list or n < 2:
-        return None
+        return PrefixDecision(None, ReuseOutcome.PROMPT_TOO_SHORT)
 
     if apc_mode == "exact":
         exact_cache, exact_prefix_len = manager.lookup_exact_cache(
@@ -4174,21 +4245,27 @@ def apc_lookup_plan(
         )
         if exact_cache is not None and 0 < exact_prefix_len < n:
             if not suffix_is_text_only(exact_prefix_len):
-                return None
-            return {
-                "matched_blocks": [],
-                "warm_cache": exact_cache,
-                "prefix_len": exact_prefix_len,
-                "extra_hash": extra_hash,
-                "full_input_ids": list(ids_list),
-            }
-        return None
+                return PrefixDecision(None, ReuseOutcome.MEDIA_SUFFIX, exact_prefix_len)
+            return PrefixDecision(
+                {
+                    "matched_blocks": [],
+                    "warm_cache": exact_cache,
+                    "prefix_len": exact_prefix_len,
+                    "extra_hash": extra_hash,
+                    "full_input_ids": list(ids_list),
+                },
+                ReuseOutcome.EXACT,
+                exact_prefix_len,
+            )
+        return PrefixDecision(None, ReuseOutcome.NO_STORED_PREFIX)
 
     matched, prefix_len = manager.lookup_prefix(ids_list, extra_hash=extra_hash)
+    media_prefix_dropped = False
     if prefix_len > 0 and prefix_has_media(prefix_len):
         manager.release(matched)
         matched = []
         prefix_len = 0
+        media_prefix_dropped = True
     exact_cache = None
     exact_prefix_len = 0
     if prefix_len < n:
@@ -4210,39 +4287,53 @@ def apc_lookup_plan(
         if matched:
             manager.release(matched)
         if not suffix_is_text_only(disk_prefix_len):
-            return None
-        return {
-            "matched_blocks": [],
-            "warm_cache": warm_cache,
-            "prefix_len": disk_prefix_len,
-            "extra_hash": extra_hash,
-            "full_input_ids": list(ids_list),
-        }
+            return PrefixDecision(None, ReuseOutcome.MEDIA_SUFFIX, disk_prefix_len)
+        return PrefixDecision(
+            {
+                "matched_blocks": [],
+                "warm_cache": warm_cache,
+                "prefix_len": disk_prefix_len,
+                "extra_hash": extra_hash,
+                "full_input_ids": list(ids_list),
+            },
+            ReuseOutcome.DISK,
+            disk_prefix_len,
+        )
     if exact_prefix_len > prefix_len and exact_prefix_len < n:
         if matched:
             manager.release(matched)
         if not suffix_is_text_only(exact_prefix_len):
-            return None
-        return {
-            "matched_blocks": [],
-            "warm_cache": exact_cache,
-            "prefix_len": exact_prefix_len,
-            "extra_hash": extra_hash,
-            "full_input_ids": list(ids_list),
-        }
+            return PrefixDecision(None, ReuseOutcome.MEDIA_SUFFIX, exact_prefix_len)
+        return PrefixDecision(
+            {
+                "matched_blocks": [],
+                "warm_cache": exact_cache,
+                "prefix_len": exact_prefix_len,
+                "extra_hash": extra_hash,
+                "full_input_ids": list(ids_list),
+            },
+            ReuseOutcome.EXACT,
+            exact_prefix_len,
+        )
     if 0 < prefix_len < n:
         if not suffix_is_text_only(prefix_len):
             manager.release(matched)
-            return None
-        return {
-            "matched_blocks": matched,
-            "prefix_len": prefix_len,
-            "extra_hash": extra_hash,
-            "full_input_ids": list(ids_list),
-        }
+            return PrefixDecision(None, ReuseOutcome.MEDIA_SUFFIX, prefix_len)
+        return PrefixDecision(
+            {
+                "matched_blocks": matched,
+                "prefix_len": prefix_len,
+                "extra_hash": extra_hash,
+                "full_input_ids": list(ids_list),
+            },
+            ReuseOutcome.BLOCK,
+            prefix_len,
+        )
     if matched:
         manager.release(matched)
-    return None
+    if media_prefix_dropped:
+        return PrefixDecision(None, ReuseOutcome.MEDIA_PREFIX)
+    return PrefixDecision(None, ReuseOutcome.NO_STORED_PREFIX)
 
 
 def _adapter_schema_version() -> int:

--- a/mlx_vlm/apc.py
+++ b/mlx_vlm/apc.py
@@ -590,6 +590,7 @@ class APCStats:
     hits: int = 0
     misses: int = 0
     reuse_outcomes: Dict[str, int] = field(default_factory=dict)
+    store_outcomes: Dict[str, int] = field(default_factory=dict)
     matched_tokens: int = 0
     served_tokens: int = 0
     evictions: int = 0
@@ -623,6 +624,7 @@ class APCStats:
             "token_hit_rate": hit_rate,
             "evictions": self.evictions,
             "reuse_outcomes": dict(self.reuse_outcomes),
+            "store_outcomes": dict(self.store_outcomes),
             "stores": self.stores,
             "disk_hits": self.disk_hits,
             "disk_writes": self.disk_writes,
@@ -2986,6 +2988,10 @@ class APCManager:
             counts = self.stats.reuse_outcomes
             counts[outcome] = counts.get(outcome, 0) + 1
 
+    def _record_store_outcome_locked(self, outcome: str) -> None:
+        counts = self.stats.store_outcomes
+        counts[outcome] = counts.get(outcome, 0) + 1
+
     # ---------- Public API ----------
     def lookup_exact_cache(
         self,
@@ -3410,6 +3416,7 @@ class APCManager:
                         i,
                         n_full,
                     )
+                    self._record_store_outcome_locked(StoreOutcome.TENSOR_LIMIT)
                     if self.disk is None:
                         break
                     parent = h
@@ -3421,6 +3428,7 @@ class APCManager:
                         i,
                         n_full,
                     )
+                    self._record_store_outcome_locked(StoreOutcome.POOL_EXHAUSTED)
                     if self.disk is None:
                         break
                     parent = h
@@ -3443,6 +3451,7 @@ class APCManager:
                 self.hash_table[h] = b
                 new_blocks.append(b)
                 self.stats.stores += 1
+                self._record_store_outcome_locked(StoreOutcome.STORED)
                 self.stats.served_tokens += self.block_size
                 parent = h
             if self.disk is not None and disk_blocks:
@@ -4158,6 +4167,12 @@ def model_apc_mode(language_model: Any) -> Optional[str]:
 
 def model_supports_apc(language_model: Any) -> bool:
     return model_apc_mode(language_model) is not None
+
+
+class StoreOutcome:
+    STORED = "stored"
+    POOL_EXHAUSTED = "pool_exhausted"
+    TENSOR_LIMIT = "tensor_limit"
 
 
 class ReuseOutcome:

--- a/mlx_vlm/generate/ar.py
+++ b/mlx_vlm/generate/ar.py
@@ -2339,6 +2339,7 @@ class BatchGenerator:
             return None
         uid, ids_list, max_toks, prompt_kwargs, lps, criteria = sequence
         if not ids_list or len(ids_list) < 2:
+            self.apc_manager.record_reuse_outcome(_apc.ReuseOutcome.PROMPT_TOO_SHORT)
             return None
         return _apc.apc_lookup_plan(
             self.apc_manager,

--- a/mlx_vlm/generate/dispatch.py
+++ b/mlx_vlm/generate/dispatch.py
@@ -867,7 +867,7 @@ def stream_generate(
     # APC: cross-request, hash-based prefix lookup. Only consulted if a per-turn
     # PromptCacheState didn't already produce a hit.
     if apc_manager is not None and reused_prefix_len == 0:
-        plan = _apc.apc_lookup_plan(
+        decision = _apc.apc_lookup_decision(
             apc_manager,
             full_input_ids_list,
             extra_hash=apc_extra_hash,
@@ -876,6 +876,14 @@ def stream_generate(
             suffix_is_text_only=_apc_suffix_is_text_only,
             prefix_has_media=_apc_prefix_has_media_tokens,
         )
+        logger.debug(
+            "APC %s mode=%s prompt=%d prefix=%d",
+            decision.outcome,
+            apc_mode,
+            len(full_input_ids_list),
+            decision.prefix_len,
+        )
+        plan = decision.plan
         if plan is not None:
             plen = plan["prefix_len"]
             warm_cache = plan.get("warm_cache")

--- a/mlx_vlm/tests/test_apc_diagnostics.py
+++ b/mlx_vlm/tests/test_apc_diagnostics.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+import mlx.core as mx
+
+from mlx_vlm.apc import APCManager, ReuseOutcome, apc_lookup_decision, apc_lookup_plan
+
+BLOCK = 16
+LAYERS, HEADS, DIM = 2, 2, 8
+
+
+def _kv(seq_len):
+    keys = [mx.zeros((1, HEADS, seq_len, DIM)) for _ in range(LAYERS)]
+    return keys, [mx.zeros((1, HEADS, seq_len, DIM)) for _ in range(LAYERS)]
+
+
+def _decide(manager, tokens, *, apc_mode="block", suffix_ok=True, prefix_media=False):
+    return apc_lookup_decision(
+        manager,
+        tokens,
+        extra_hash=0,
+        apc_mode=apc_mode,
+        safe_lookup_min=0,
+        suffix_is_text_only=lambda prefix_len: suffix_ok,
+        prefix_has_media=lambda prefix_len: prefix_media,
+    )
+
+
+def test_short_prompt_reports_prompt_too_short():
+    manager = APCManager(num_blocks=8, block_size=BLOCK)
+
+    decision = _decide(manager, [7])
+
+    assert not decision.reused
+    assert decision.outcome == ReuseOutcome.PROMPT_TOO_SHORT
+
+
+def test_cold_lookup_reports_no_stored_prefix():
+    manager = APCManager(num_blocks=8, block_size=BLOCK)
+
+    decision = _decide(manager, list(range(4 * BLOCK)))
+
+    assert not decision.reused
+    assert decision.outcome == ReuseOutcome.NO_STORED_PREFIX
+
+
+def test_block_hit_reports_block_and_its_length():
+    manager = APCManager(num_blocks=8, block_size=BLOCK)
+    stored = list(range(4 * BLOCK))
+    keys, values = _kv(len(stored))
+    manager.release(manager.store_kv_blocks(stored, keys, values))
+
+    decision = _decide(manager, stored + list(range(900, 908)))
+
+    assert decision.reused
+    assert decision.outcome == ReuseOutcome.BLOCK
+    assert decision.prefix_len > 0
+    manager.release(decision.plan["matched_blocks"])
+
+
+def test_media_in_the_suffix_reports_media_suffix_not_a_cold_miss():
+    manager = APCManager(num_blocks=8, block_size=BLOCK)
+    stored = list(range(4 * BLOCK))
+    keys, values = _kv(len(stored))
+    manager.release(manager.store_kv_blocks(stored, keys, values))
+
+    decision = _decide(manager, stored + list(range(900, 908)), suffix_ok=False)
+
+    assert not decision.reused
+    assert decision.outcome == ReuseOutcome.MEDIA_SUFFIX
+
+
+def test_media_in_the_prefix_is_distinct_from_nothing_stored():
+    manager = APCManager(num_blocks=8, block_size=BLOCK)
+    stored = list(range(4 * BLOCK))
+    keys, values = _kv(len(stored))
+    manager.release(manager.store_kv_blocks(stored, keys, values))
+
+    decision = _decide(manager, stored + list(range(900, 908)), prefix_media=True)
+
+    assert not decision.reused
+    assert decision.outcome == ReuseOutcome.MEDIA_PREFIX
+
+
+def test_outcomes_accumulate_on_the_manager():
+    manager = APCManager(num_blocks=8, block_size=BLOCK)
+
+    _decide(manager, [1])
+    _decide(manager, list(range(4 * BLOCK)))
+    _decide(manager, list(range(4 * BLOCK)))
+
+    counts = manager.stats_snapshot()["reuse_outcomes"]
+    assert counts[ReuseOutcome.PROMPT_TOO_SHORT] == 1
+    assert counts[ReuseOutcome.NO_STORED_PREFIX] == 2
+
+
+def test_plan_helper_still_returns_a_plan_or_none():
+    manager = APCManager(num_blocks=8, block_size=BLOCK)
+
+    plan = apc_lookup_plan(
+        manager,
+        [1],
+        extra_hash=0,
+        apc_mode="block",
+        safe_lookup_min=0,
+        suffix_is_text_only=lambda n: True,
+        prefix_has_media=lambda n: False,
+    )
+
+    assert plan is None
+    assert manager.stats_snapshot()["reuse_outcomes"]

--- a/mlx_vlm/tests/test_apc_diagnostics.py
+++ b/mlx_vlm/tests/test_apc_diagnostics.py
@@ -2,7 +2,13 @@ from __future__ import annotations
 
 import mlx.core as mx
 
-from mlx_vlm.apc import APCManager, ReuseOutcome, apc_lookup_decision, apc_lookup_plan
+from mlx_vlm.apc import (
+    APCManager,
+    ReuseOutcome,
+    StoreOutcome,
+    apc_lookup_decision,
+    apc_lookup_plan,
+)
 
 BLOCK = 16
 LAYERS, HEADS, DIM = 2, 2, 8
@@ -108,3 +114,33 @@ def test_plan_helper_still_returns_a_plan_or_none():
 
     assert plan is None
     assert manager.stats_snapshot()["reuse_outcomes"]
+
+
+def test_store_outcomes_count_successful_stores():
+    manager = APCManager(num_blocks=8, block_size=BLOCK)
+    tokens = list(range(4 * BLOCK))
+    keys, values = _kv(len(tokens))
+
+    manager.release(manager.store_kv_blocks(tokens, keys, values))
+
+    counts = manager.stats_snapshot()["store_outcomes"]
+    assert counts[StoreOutcome.STORED] == 4
+
+
+def test_store_outcomes_expose_an_exhausted_pool():
+    manager = APCManager(num_blocks=2, block_size=BLOCK)
+    tokens = list(range(6 * BLOCK))
+    keys, values = _kv(len(tokens))
+
+    manager.store_kv_blocks(tokens, keys, values)
+
+    counts = manager.stats_snapshot()["store_outcomes"]
+    assert counts.get(StoreOutcome.POOL_EXHAUSTED, 0) > 0
+
+
+def test_store_and_reuse_outcomes_are_separate_counters():
+    manager = APCManager(num_blocks=8, block_size=BLOCK)
+    snapshot = manager.stats_snapshot()
+
+    assert snapshot["store_outcomes"] == {}
+    assert snapshot["reuse_outcomes"] == {}

--- a/mlx_vlm/tests/test_generate.py
+++ b/mlx_vlm/tests/test_generate.py
@@ -11,6 +11,7 @@ from unittest.mock import MagicMock, patch
 import mlx.core as mx
 import pytest
 
+from mlx_vlm import apc as _apc_module
 from mlx_vlm import apc as apc_module
 from mlx_vlm.generate import (
     BatchGenerationResult,
@@ -2023,7 +2024,13 @@ def test_stream_generate_excludes_prepared_sequence_tensors_from_apc_hash():
         patch.object(
             dispatch_module._apc, "semantic_extra_hash", side_effect=capture_hash
         ),
-        patch.object(dispatch_module._apc, "apc_lookup_plan", return_value=None),
+        patch.object(
+            dispatch_module._apc,
+            "apc_lookup_decision",
+            return_value=_apc_module.PrefixDecision(
+                None, _apc_module.ReuseOutcome.NO_STORED_PREFIX
+            ),
+        ),
         patch.object(dispatch_module.cache, "make_prompt_cache", return_value=[]),
         patch.object(
             dispatch_module, "wired_limit", return_value=contextlib.nullcontext()
@@ -2065,7 +2072,13 @@ def test_stream_generate_hashes_explicit_sequence_tensors_for_apc_safety():
         patch.object(
             dispatch_module._apc, "semantic_extra_hash", side_effect=capture_hash
         ),
-        patch.object(dispatch_module._apc, "apc_lookup_plan", return_value=None),
+        patch.object(
+            dispatch_module._apc,
+            "apc_lookup_decision",
+            return_value=_apc_module.PrefixDecision(
+                None, _apc_module.ReuseOutcome.NO_STORED_PREFIX
+            ),
+        ),
         patch.object(dispatch_module.cache, "make_prompt_cache", return_value=[]),
         patch.object(
             dispatch_module, "wired_limit", return_value=contextlib.nullcontext()


### PR DESCRIPTION
A deployment can see an aggregate hit rate but not why a request re-prefilled, so a cold miss looks the same as a usable prefix that a media constraint rejected. The lookup now returns its outcome alongside the plan and counts outcomes in the stats snapshot.