### PR TITLE
Stop a short first prompt from disabling prefix caching

### DIFF
--- a/mlx_vlm/apc.py
+++ b/mlx_vlm/apc.py
@@ -492,7 +492,9 @@ def adjust_prefix_to_text_suffix_boundary(
     )
     if max_len <= 0:
         return 0
-    desired = max(1, int(desired_prefix_len))
+    if int(desired_prefix_len) <= 0:
+        return 0
+    desired = int(desired_prefix_len)
     prefix_len = max(desired, media_safe_prefix_min(token_ids, media_token_ids))
     if prefix_len > max_len:
         return 0
@@ -2871,6 +2873,9 @@ class APCManager:
         self.exact_cache_guard_tokens = max(
             1, int(os.environ.get("APC_EXACT_PREFIX_GUARD_TOKENS", "16"))
         )
+        self.exact_cache_min_tokens = max(
+            1, int(os.environ.get("APC_EXACT_MIN_TOKENS", "16"))
+        )
         # If free RAM (best-effort reading) drops below this, skip disk
         # promotion this turn and fall back to memory-only matching. The
         # request still serves correctly — it just doesn't get the warm-
@@ -3126,6 +3131,8 @@ class APCManager:
         extra_hash: int = 0,
     ) -> bool:
         """Store a full prompt-cache snapshot for exact-prefix reuse."""
+        if len(token_ids) < self.exact_cache_min_tokens:
+            return False
         if (self._exact_cache_max <= 0 and self.disk is None) or not token_ids:
             return False
         token_tuple = tuple(int(t) for t in token_ids)

--- a/mlx_vlm/server/app.py
+++ b/mlx_vlm/server/app.py
@@ -183,12 +183,15 @@ def _build_gen_args(
 def _read_tenant_id(http_request) -> Optional[str]:
     """Pull a per-tenant APC salt from the request headers.
 
-    Honoured headers (in order): ``X-APC-Tenant``, ``X-Tenant-Id``.
+    Honoured headers (in order): ``X-APC-Tenant``, ``X-Tenant-Id``. Falls back to
+    ``APC_DEFAULT_TENANT`` so a single-tenant deployment shares one cache without
+    every client sending a header.
     """
+    default = os.environ.get("APC_DEFAULT_TENANT") or None
     if http_request is None or not hasattr(http_request, "headers"):
-        return None
+        return default
     h = http_request.headers
-    return h.get("x-apc-tenant") or h.get("x-tenant-id") or None
+    return h.get("x-apc-tenant") or h.get("x-tenant-id") or default
 
 
 async def _preflight_stream_context_budget(

--- a/mlx_vlm/tests/test_apc.py
+++ b/mlx_vlm/tests/test_apc.py
@@ -309,7 +309,7 @@ def test_single_row_prompt_batch_exact_checkpoint_stores_without_extract():
     from mlx_vlm.generate.ar import PromptProcessingBatch
     from mlx_vlm.models.cache import ArraysCache, KVCache, RotatingKVCache
 
-    token_ids = list(range(12))
+    token_ids = list(range(32))
     arrays = ArraysCache(size=1)
     arrays[0] = mx.ones((1, 3, 5))
     kv = KVCache()
@@ -1181,3 +1181,50 @@ def test_exact_disk_hit_promotion_with_nonzero_extra_hash(tmp_path, monkeypatch)
     assert warm_wrong is None
 
     manager.close()
+
+
+def _tiny_exact_cache(tokens):
+    from mlx_vlm.models.cache import ArraysCache
+
+    c = ArraysCache(size=1)
+    c[0] = mx.zeros((1, 2, max(1, len(tokens)), 32))
+    return [c]
+
+
+def test_a_short_first_prompt_does_not_store_a_one_token_snapshot():
+    manager = APCManager(num_blocks=8, block_size=16)
+    short = [1, 2, 3]
+
+    desired = len(short) - manager.exact_cache_guard_tokens
+    prefix_len = apc_module.adjust_prefix_to_text_suffix_boundary(short, desired, [])
+
+    assert prefix_len == 0
+    assert not manager.store_exact_cache(short[:1], _tiny_exact_cache(short[:1]))
+
+
+def test_a_short_prompt_cannot_poison_later_lookups():
+    manager = APCManager(num_blocks=8, block_size=16)
+    manager.store_exact_cache([1], _tiny_exact_cache([1]))
+
+    later = list(range(1, 400))
+    cache, reused = manager.lookup_exact_cache(later)
+
+    assert cache is None
+    assert reused == 0
+
+
+def test_a_useful_prefix_is_still_stored():
+    manager = APCManager(num_blocks=8, block_size=16)
+    tokens = list(range(1, 200))
+
+    assert manager.store_exact_cache(tokens[:128], _tiny_exact_cache(tokens[:128]))
+
+    cache, reused = manager.lookup_exact_cache(tokens)
+    assert cache is not None
+    assert reused == 128
+
+
+def test_positive_desired_prefix_is_unchanged():
+    tokens = list(range(1, 100))
+
+    assert apc_module.adjust_prefix_to_text_suffix_boundary(tokens, 40, []) == 40

--- a/mlx_vlm/tests/test_apc_exact_mode.py
+++ b/mlx_vlm/tests/test_apc_exact_mode.py
@@ -158,6 +158,7 @@ def test_apc_exact_store_materializes_its_snapshot(monkeypatch):
     cache.values = mx.ones((1, 1, 4, 2))
     cache.offset = 4
     apc = APCManager(num_blocks=4, block_size=4)
+    apc.exact_cache_min_tokens = 1
     real_eval = mx.eval
     eval_calls = []
 


### PR DESCRIPTION
A prompt shorter than the guard made the desired checkpoint length negative, and clamping it to one stored a one-token snapshot that matched the start of every later prompt; because a new checkpoint is only taken when nothing was reused, that tenant never stored a useful one again. Treat a non-positive length as no useful prefix and refuse snapshots too short to be worth an entry, and honour APC_DEFAULT_TENANT so single-tenant deployments share one cache without a header.

Closes #1617
Closes #1632