### PR TITLE
Fix SmolVLM inference with flattened image features

### DIFF
--- a/mlx_vlm/models/smolvlm/smolvlm.py
+++ b/mlx_vlm/models/smolvlm/smolvlm.py
@@ -1,61 +1,6 @@
-import mlx.core as mx
-import numpy as np
-
 from ..idefics3 import Model as Idefics3Model
 from . import processing_smolvlm  # noqa: F401
 
 
 class Model(Idefics3Model):
-    def _prepare_inputs_for_multimodal(self, image_features, inputs_embeds, input_ids):
-        # Assumes bs == 1
-
-        B, T, D_text = inputs_embeds.shape
-        N, S, D_img = image_features.shape
-
-        image_offset = 0
-        cur_embeds = inputs_embeds[0]
-
-        # Find positions of <image> tokens in the text
-        image_token_index = self.config.image_token_index
-        image_positions = np.where(input_ids == image_token_index)[1].tolist()
-        num_image_tokens = len(image_positions)
-
-        # If no <image> => text-only
-        if num_image_tokens == 0:
-            empty_slice = image_features[0][:0, :]  # shape (0, D)
-            return mx.concatenate([cur_embeds, empty_slice], axis=0)
-
-        # Typically, if each image is S embeddings, we expect the total # of <image> tokens
-        # in this sample to be multiple of S => each group of S tokens = 1 image
-        if num_image_tokens % S != 0:
-            raise ValueError(
-                f"Input has {num_image_tokens} <image> tokens, not a multiple of S={S}. "
-                "Cannot map them to blocks of shape (S, D)."
-            )
-
-        chunks = [image_positions[i : i + S] for i in range(0, num_image_tokens, S)]
-
-        segments = []
-        text_start = 0
-
-        # For each chunk (each chunk => 1 image)
-        for chunk in chunks:
-            cur_block = image_features[image_offset]
-            image_offset += 1
-
-            # We'll iterate over the S positions in ascending order
-            for i_s, pos in enumerate(chunk):
-                if pos > text_start:
-                    segments.append(cur_embeds[text_start:pos])
-                # Then add one row from cur_block => shape (1, D)
-                row_of_block = cur_block[i_s : i_s + 1, :]
-                segments.append(row_of_block)
-                text_start = pos + 1
-
-        # leftover text after the final <image> token
-        if text_start < T:
-            segments.append(cur_embeds[text_start:])
-
-        # cat them into a single (T_b, D) tensor
-        merged_sample = mx.concatenate(segments, axis=0)
-        return mx.expand_dims(merged_sample, axis=0)
+    """SmolVLM uses Idefics3's multimodal feature layout and model path."""

--- a/mlx_vlm/tests/test_models.py
+++ b/mlx_vlm/tests/test_models.py
@@ -1730,6 +1730,66 @@ class TestOlmoModel(unittest.TestCase):
         )
 
 
+class TestSmolVLMFlattenedImageFeatures(unittest.TestCase):
+    def test_get_input_embeddings_uses_flattened_connector_output(self):
+        from mlx_vlm.models import smolvlm
+
+        text_config = smolvlm.TextConfig(
+            hidden_size=8,
+            intermediate_size=16,
+            num_attention_heads=2,
+            num_key_value_heads=1,
+            num_hidden_layers=1,
+            vocab_size=32,
+        )
+        vision_config = smolvlm.VisionConfig(
+            hidden_size=8,
+            intermediate_size=16,
+            num_attention_heads=2,
+            num_hidden_layers=1,
+            image_size=4,
+            patch_size=2,
+        )
+        model = smolvlm.Model(
+            smolvlm.ModelConfig(
+                text_config=text_config,
+                vision_config=vision_config,
+                image_token_id=31,
+                scale_factor=1,
+            )
+        )
+        input_ids = mx.array([[1, 31, 31, 31, 31, 2]])
+        pixel_values = mx.random.uniform(shape=(1, 1, 3, 4, 4))
+
+        output = model.get_input_embeddings(input_ids, pixel_values=pixel_values)
+
+        self.assertEqual(output.inputs_embeds.shape, (1, 6, 8))
+
+    def test_prepare_inputs_accepts_flattened_image_features(self):
+        from mlx_vlm.models import smolvlm
+
+        model = SimpleNamespace(config=SimpleNamespace(image_token_index=9))
+        input_ids = mx.array([[1, 9, 2, 9, 3]])
+        inputs_embeds = mx.arange(15).reshape(1, 5, 3)
+        image_features = mx.array([[101, 102, 103], [201, 202, 203]])
+
+        output = smolvlm.Model._prepare_inputs_for_multimodal(
+            model, image_features, inputs_embeds, input_ids
+        )
+
+        expected = mx.stack(
+            [
+                inputs_embeds[0, 0],
+                image_features[0],
+                inputs_embeds[0, 2],
+                image_features[1],
+                inputs_embeds[0, 4],
+            ]
+        )[None]
+        self.assertEqual(output.shape, inputs_embeds.shape)
+        self.assertTrue(mx.array_equal(output, expected).item())
+
+
 class TestModels(unittest.TestCase):
     def language_test_runner(self, model, model_type, vocab_size, num_layers):
         self.assertEqual(model.model_type, model_type)


### PR DESCRIPTION
in #1852, we made a fix for Idefics3/SmolVLM lora training crash, but it's 3D→2D flatten fixed Idefics3 training, and upstream, still expects 3D, causing the new inference regression.

Closes #1904