### PR TITLE
Add GOT-OCR 2.0 model support

### DIFF
--- a/mlx_vlm/models/got/README.md
+++ b/mlx_vlm/models/got/README.md
@@ -1,0 +1,98 @@
+# GOT-OCR 2.0 (General OCR Theory 2.0)
+
+GOT-OCR 2.0 is an 8.3B parameter vision-language model developed by StepFun for unified OCR tasks, including document OCR, formatted scene text recognition, table and formula parsing, chart processing, and fine-grained visual text grounding.
+
+## Model Overview
+
+- **Model IDs**:
+  - [`stepfun-ai/GOT-OCR2_0`](https://huggingface.co/stepfun-ai/GOT-OCR2_0) (Upstream)
+  - [`mlx-community/GOT-OCR2_0-bf16`](https://huggingface.co/mlx-community/GOT-OCR2_0-bf16)
+  - [`mlx-community/GOT-OCR2_0-4bit`](https://huggingface.co/mlx-community/GOT-OCR2_0-4bit)
+  - [`mlx-community/GOT-OCR2_0-8bit`](https://huggingface.co/mlx-community/GOT-OCR2_0-8bit)
+- **Architecture**: ViT-based `ImageEncoderViT` (1024x1024 input downsampled to 256 visual tokens) with window attention and decomposed relative positional embeddings + linear projector + Qwen2-based language decoder.
+- **Source**: [stepfun-ai/GOT-OCR2_0](https://huggingface.co/stepfun-ai/GOT-OCR2_0)
+
+## Installation
+
+```bash
+pip install mlx-vlm
+```
+
+or with `uv`:
+
+```bash
+uv pip install mlx-vlm
+```
+
+## Usage
+
+### CLI
+
+**Plain Text OCR:**
+```bash
+mlx_vlm generate \
+  --model mlx-community/GOT-OCR2_0-bf16 \
+  --image document.png \
+  --prompt "OCR:" \
+  --max-tokens 1024
+```
+
+**Formatted Document OCR (Markdown):**
+```bash
+mlx_vlm generate \
+  --model mlx-community/GOT-OCR2_0-bf16 \
+  --image document.png \
+  --prompt "format:" \
+  --max-tokens 2048
+```
+
+**Fine-grained / Crop Region OCR:**
+```bash
+mlx_vlm generate \
+  --model mlx-community/GOT-OCR2_0-bf16 \
+  --image document.png \
+  --prompt 'OCR with format: {"box": [100, 100, 500, 500]}' \
+  --max-tokens 1024
+```
+
+### Python Script
+
+```python
+from mlx_vlm import load, generate
+from mlx_vlm.prompt_utils import apply_chat_template
+
+# Load model
+model, processor = load("mlx-community/GOT-OCR2_0-bf16")
+
+# Document OCR (formatted markdown output)
+prompt = "format:"
+formatted_prompt = apply_chat_template(processor, model.config, prompt, num_images=1)
+
+output = generate(
+    model,
+    processor,
+    formatted_prompt,
+    image="document.png",
+    max_tokens=2048,
+    temperature=0.0,
+)
+print(output.text)
+```
+
+## Prompting Modes
+
+GOT-OCR 2.0 supports several task modes specified in the prompt:
+
+| Mode | Prompt | Description |
+|---|---|---|
+| **Plain Text OCR** | `OCR:` | Standard text extraction without special markdown layout. |
+| **Formatted OCR** | `format:` | Extracts text with layout preservation (markdown tables, headers, formulas). |
+| **Fine-grained Box OCR** | `OCR with format: {"box": [y1, x1, y2, x2]}` | OCR restricted to a normalized bounding box range `[0, 1000]`. |
+| **Fine-grained Color OCR** | `OCR with format: {"color": "red"}` | OCR restricted to text rendered in a specific color. |
+
+## Technical Details
+
+- **Resolution & Padding**: Input images are resized to `1024x1024` using bicubic interpolation.
+- **Visual Tokens**: The vision encoder produces 256 image tokens wrapped in `<img><imgpad>...<imgpad></img>`.
+- **Conversation Template**: Prompts are automatically wrapped into the MPT conversation template (`<|im_start|>system...<|im_end|>`) used during training.
+- **Stop Tokens**: Stop token IDs include both `<|im_end|>` (`151645`) and `<|endoftext|>` (`151643`).

--- a/mlx_vlm/models/got/README.md
+++ b/mlx_vlm/models/got/README.md
@@ -9,6 +9,7 @@ GOT-OCR 2.0 is an 8.3B parameter vision-language model developed by StepFun for 
   - [`mlx-community/GOT-OCR2_0-bf16`](https://huggingface.co/mlx-community/GOT-OCR2_0-bf16)
   - [`mlx-community/GOT-OCR2_0-4bit`](https://huggingface.co/mlx-community/GOT-OCR2_0-4bit)
   - [`mlx-community/GOT-OCR2_0-8bit`](https://huggingface.co/mlx-community/GOT-OCR2_0-8bit)
+- **Quantizations Collection**: [axiom-of-choice/mlx-quantizations](https://huggingface.co/collections/axiom-of-choice/mlx-quantizations)
 - **Architecture**: ViT-based `ImageEncoderViT` (1024x1024 input downsampled to 256 visual tokens) with window attention and decomposed relative positional embeddings + linear projector + Qwen2-based language decoder.
 - **Source**: [stepfun-ai/GOT-OCR2_0](https://huggingface.co/stepfun-ai/GOT-OCR2_0)
 

--- a/mlx_vlm/models/got/__init__.py
+++ b/mlx_vlm/models/got/__init__.py
@@ -1,0 +1,6 @@
+import mlx_vlm.models.got.processing_got  # noqa: F401
+
+from .config import ModelConfig, TextConfig, VisionConfig
+from .got import Model
+
+__all__ = ["Model", "ModelConfig", "TextConfig", "VisionConfig"]

--- a/mlx_vlm/models/got/config.py
+++ b/mlx_vlm/models/got/config.py
@@ -4,6 +4,27 @@ from typing import Dict, List, Optional, Union
 
 from ..base import BaseModelConfig
 
+ENDOFTEXT_TOKEN = 151643
+IM_END_TOKEN = 151645
+
+
+def _stop_token_ids(eos_token_id) -> List[int]:
+    """Stop ids for GOT, which ends a turn with <|im_end|>, not with eos.
+
+    The config declares only 151643, so without 151645 generation never stops.
+    """
+    if eos_token_id is None:
+        ids = []
+    elif isinstance(eos_token_id, int):
+        ids = [eos_token_id]
+    else:
+        ids = list(eos_token_id)
+
+    for token_id in (ENDOFTEXT_TOKEN, IM_END_TOKEN):
+        if token_id not in ids:
+            ids.append(token_id)
+    return ids
+
 
 @dataclass
 class VisionConfig(BaseModelConfig):
@@ -17,6 +38,7 @@ class VisionConfig(BaseModelConfig):
     num_heads: int = 12
     mlp_ratio: float = 4.0
     out_chans: int = 256
+    out_dim: int = 1024
     qkv_bias: bool = True
     use_abs_pos: bool = True
     use_rel_pos: bool = True
@@ -58,10 +80,14 @@ class ModelConfig(BaseModelConfig):
     im_start_token: int = 151857
     im_end_token: int = 151858
     vocab_size: int = 151860
-    eos_token_id: Optional[Union[int, List[int]]] = 151643
+    eos_token_id: Optional[Union[int, List[int]]] = None
 
     @classmethod
     def from_dict(cls, params):
+        # Written back into params, not just onto the instance: load_model
+        # reapplies this same dict through apply_generation_config_defaults.
+        params["eos_token_id"] = _stop_token_ids(params.get("eos_token_id"))
+
         # The GOT-OCR config is flat.
         # Text params are in the root.
         excluded_keys = {"vision_config"}

--- a/mlx_vlm/models/got/config.py
+++ b/mlx_vlm/models/got/config.py
@@ -1,0 +1,85 @@
+import inspect
+from dataclasses import dataclass
+from typing import Dict, List, Optional, Union
+
+from ..base import BaseModelConfig
+
+
+@dataclass
+class VisionConfig(BaseModelConfig):
+    model_type: str = "got"
+    # GOT-OCR vision parameters
+    img_size: int = 1024
+    patch_size: int = 16
+    in_chans: int = 3
+    embed_dim: int = 768
+    depth: int = 12
+    num_heads: int = 12
+    mlp_ratio: float = 4.0
+    out_chans: int = 256
+    qkv_bias: bool = True
+    use_abs_pos: bool = True
+    use_rel_pos: bool = True
+    window_size: int = 14
+    global_attn_indexes: tuple = (2, 5, 8, 11)
+
+
+@dataclass
+class TextConfig(BaseModelConfig):
+    model_type: str
+    hidden_size: int
+    num_hidden_layers: int
+    intermediate_size: int
+    num_attention_heads: int
+    rms_norm_eps: float
+    vocab_size: int
+    num_key_value_heads: Optional[int] = None
+    max_position_embeddings: Optional[int] = 32768
+    rope_theta: float = 1000000.0
+    rope_traditional: bool = False
+    rope_scaling: Optional[Dict[str, Union[float, str]]] = None
+    tie_word_embeddings: bool = True
+    sliding_window: int = 32768
+    use_sliding_window: bool = False
+    use_cache: bool = True
+
+    def __post_init__(self):
+        if self.num_key_value_heads is None:
+            self.num_key_value_heads = self.num_attention_heads
+
+
+@dataclass
+class ModelConfig(BaseModelConfig):
+    text_config: TextConfig
+    vision_config: VisionConfig
+    model_type: str
+    ignore_index: int = -100
+    im_patch_token: int = 151859
+    im_start_token: int = 151857
+    im_end_token: int = 151858
+    vocab_size: int = 151860
+    eos_token_id: Optional[Union[int, List[int]]] = 151643
+
+    @classmethod
+    def from_dict(cls, params):
+        # The GOT-OCR config is flat.
+        # Text params are in the root.
+        excluded_keys = {"vision_config"}
+        text_params = {
+            k: v
+            for k, v in params.items()
+            if k not in excluded_keys and k in inspect.signature(TextConfig).parameters
+        }
+        params["text_config"] = text_params
+
+        # Vision params are fixed in GOT-OCR, but we allow override if present
+        vision_params = params.get("vision_config", {})
+        params["vision_config"] = vision_params
+
+        return cls(
+            **{
+                k: v
+                for k, v in params.items()
+                if k in inspect.signature(cls).parameters
+            }
+        )

--- a/mlx_vlm/models/got/got.py
+++ b/mlx_vlm/models/got/got.py
@@ -15,7 +15,9 @@ class Model(nn.Module):
         super().__init__()
         self.config = config
         self.vision_tower = VisionModel(config.vision_config)
-        self.mm_projector = nn.Linear(1024, 1024)
+        self.multi_modal_projector = nn.Linear(
+            config.vision_config.out_dim, config.text_config.hidden_size
+        )
         self.language_model = LanguageModel(config.text_config)
 
     def get_input_embeddings(
@@ -39,7 +41,7 @@ class Model(nn.Module):
         hidden_states = self.vision_tower(pixel_values)
 
         # Project features
-        image_features = self.mm_projector(hidden_states)
+        image_features = self.multi_modal_projector(hidden_states)
 
         # In GOT-OCR, the image token is represented by im_patch_token.
         # We replace the embeddings at these positions with the image features.
@@ -61,19 +63,15 @@ class Model(nn.Module):
     ):
         image_positions = input_ids == image_token_id
 
-        batch_size, seq_len = input_ids.shape
+        batch_size, _ = input_ids.shape
         batch_outputs = []
-        feature_start_idx = 0
 
         for batch_idx in range(batch_size):
             image_mask = image_positions[batch_idx]
             num_positions = mx.sum(image_mask).item()
 
             if num_positions > 0:
-                # Shape of image_features is (B, seq, C).
-                # GOT-OCR batches image generation, so we assume image_features[batch_idx] holds features.
-                # However, usually image_features is passed flattened or per batch.
-                # In GOT-OCR, it's (B, 256, 1024).
+                # (B, 256, 1024): one image per sequence, image_token_len each.
                 batch_features = image_features[batch_idx]
 
                 if batch_features.shape[0] != num_positions:
@@ -122,6 +120,16 @@ class Model(nn.Module):
         return logits
 
     def sanitize(self, weights):
+        # Skip the conv transposes for checkpoints already in MLX layout, so
+        # sanitize stays idempotent and does not double-transpose (see #1871).
+        already_mlx = any(
+            k.endswith("patch_embed.proj.weight")
+            and v.ndim == 4
+            and v.shape[-1] == 3
+            and v.shape[1] != 3
+            for k, v in weights.items()
+        )
+
         sanitized_weights = {}
         for k, v in weights.items():
             if k.startswith("model.vision_tower_high."):
@@ -137,8 +145,9 @@ class Model(nn.Module):
                 else:
                     sanitized_weights[k_vis] = v
             elif k.startswith("model.mm_projector_vary."):
+                # Named so skip_multimodal_module() keeps it unquantized.
                 sanitized_weights[
-                    k.replace("model.mm_projector_vary.", "mm_projector.")
+                    k.replace("model.mm_projector_vary.", "multi_modal_projector.")
                 ] = v
             elif k.startswith("model."):
                 new_k = k.replace("model.", "language_model.model.")
@@ -160,7 +169,7 @@ class Model(nn.Module):
                 # PyTorch conv2d weight shape: (out_channels, in_channels, kH, kW)
                 # MLX conv2d weight shape: (out_channels, kH, kW, in_channels)
                 w = sanitized_weights[k]
-                if len(w.shape) == 4:
+                if w.ndim == 4 and not already_mlx:
                     sanitized_weights[k] = w.transpose(0, 2, 3, 1)
 
         if self.config.text_config.tie_word_embeddings:

--- a/mlx_vlm/models/got/got.py
+++ b/mlx_vlm/models/got/got.py
@@ -1,0 +1,169 @@
+from typing import Optional
+
+import mlx.core as mx
+import mlx.nn as nn
+
+from ..base import InputEmbeddingsFeatures
+from ..qwen2.language import LanguageModel
+from . import processing_got  # noqa: F401
+from .config import ModelConfig
+from .vision import VisionModel
+
+
+class Model(nn.Module):
+    def __init__(self, config: ModelConfig):
+        super().__init__()
+        self.config = config
+        self.vision_tower = VisionModel(config.vision_config)
+        self.mm_projector = nn.Linear(1024, 1024)
+        self.language_model = LanguageModel(config.text_config)
+
+    def get_input_embeddings(
+        self,
+        input_ids: Optional[mx.array] = None,
+        pixel_values: Optional[mx.array] = None,
+        **kwargs,
+    ):
+        if pixel_values is None:
+            return InputEmbeddingsFeatures(
+                inputs_embeds=self.language_model.model.embed_tokens(input_ids)
+            )
+
+        dtype = self.vision_tower.patch_embed.proj.weight.dtype
+        pixel_values = pixel_values.astype(dtype)
+
+        # Get the input embeddings from the language model
+        inputs_embeds = self.language_model.model.embed_tokens(input_ids)
+
+        # Output from VisionModel is (B, H*W, 1024)
+        hidden_states = self.vision_tower(pixel_values)
+
+        # Project features
+        image_features = self.mm_projector(hidden_states)
+
+        # In GOT-OCR, the image token is represented by im_patch_token.
+        # We replace the embeddings at these positions with the image features.
+        final_inputs_embeds = self.merge_input_ids_with_image_features(
+            self.config.im_patch_token,
+            image_features,
+            inputs_embeds,
+            input_ids,
+        )
+
+        return InputEmbeddingsFeatures(inputs_embeds=final_inputs_embeds)
+
+    @staticmethod
+    def merge_input_ids_with_image_features(
+        image_token_id,
+        image_features,
+        inputs_embeds,
+        input_ids,
+    ):
+        image_positions = input_ids == image_token_id
+
+        batch_size, seq_len = input_ids.shape
+        batch_outputs = []
+        feature_start_idx = 0
+
+        for batch_idx in range(batch_size):
+            image_mask = image_positions[batch_idx]
+            num_positions = mx.sum(image_mask).item()
+
+            if num_positions > 0:
+                # Shape of image_features is (B, seq, C).
+                # GOT-OCR batches image generation, so we assume image_features[batch_idx] holds features.
+                # However, usually image_features is passed flattened or per batch.
+                # In GOT-OCR, it's (B, 256, 1024).
+                batch_features = image_features[batch_idx]
+
+                if batch_features.shape[0] != num_positions:
+                    raise ValueError(
+                        f"Number of image token positions ({num_positions}) does not match "
+                        f"number of image features ({batch_features.shape[0]}) for batch {batch_idx}"
+                    )
+
+                cumsum = mx.cumsum(image_mask.astype(mx.int32))
+                feature_indices = mx.where(image_mask, cumsum - 1, 0)
+                gathered_features = batch_features[feature_indices]
+
+                image_mask_expanded = mx.expand_dims(image_mask, axis=-1)
+                batch_output = mx.where(
+                    image_mask_expanded, gathered_features, inputs_embeds[batch_idx]
+                )
+            else:
+                batch_output = inputs_embeds[batch_idx]
+
+            batch_outputs.append(batch_output)
+
+        return mx.stack(batch_outputs, axis=0)
+
+    @property
+    def layers(self):
+        return self.language_model.model.layers
+
+    def __call__(
+        self,
+        input_ids: mx.array,
+        pixel_values: Optional[mx.array] = None,
+        mask: Optional[mx.array] = None,
+        cache=None,
+        **kwargs,
+    ):
+
+        input_embeddings_features = self.get_input_embeddings(
+            input_ids, pixel_values, **kwargs
+        )
+        logits = self.language_model(
+            input_ids=input_ids,
+            inputs_embeds=input_embeddings_features.inputs_embeds,
+            mask=mask,
+            cache=cache,
+        )
+        return logits
+
+    def sanitize(self, weights):
+        sanitized_weights = {}
+        for k, v in weights.items():
+            if k.startswith("model.vision_tower_high."):
+                k_vis = k.replace("model.vision_tower_high.", "vision_tower.")
+                if "neck.0." in k_vis:
+                    sanitized_weights[k_vis.replace("neck.0.", "conv1.")] = v
+                elif "neck.1." in k_vis:
+                    sanitized_weights[k_vis.replace("neck.1.", "norm1.")] = v
+                elif "neck.2." in k_vis:
+                    sanitized_weights[k_vis.replace("neck.2.", "conv2.")] = v
+                elif "neck.3." in k_vis:
+                    sanitized_weights[k_vis.replace("neck.3.", "norm2.")] = v
+                else:
+                    sanitized_weights[k_vis] = v
+            elif k.startswith("model.mm_projector_vary."):
+                sanitized_weights[
+                    k.replace("model.mm_projector_vary.", "mm_projector.")
+                ] = v
+            elif k.startswith("model."):
+                new_k = k.replace("model.", "language_model.model.")
+                sanitized_weights[new_k] = v
+            elif k.startswith("lm_head."):
+                sanitized_weights[k.replace("lm_head.", "language_model.lm_head.")] = v
+            else:
+                sanitized_weights[k] = v
+
+        # Transpose PyTorch Conv2d weights (O, I, H, W) to MLX Conv2d weights (O, H, W, I)
+        for k in list(sanitized_weights.keys()):
+            if (
+                "patch_embed.proj.weight" in k
+                or "conv1.weight" in k
+                or "conv2.weight" in k
+                or "net_2.weight" in k
+                or "net_3.weight" in k
+            ):
+                # PyTorch conv2d weight shape: (out_channels, in_channels, kH, kW)
+                # MLX conv2d weight shape: (out_channels, kH, kW, in_channels)
+                w = sanitized_weights[k]
+                if len(w.shape) == 4:
+                    sanitized_weights[k] = w.transpose(0, 2, 3, 1)
+
+        if self.config.text_config.tie_word_embeddings:
+            sanitized_weights.pop("language_model.lm_head.weight", None)
+
+        return sanitized_weights

--- a/mlx_vlm/models/got/processing_got.py
+++ b/mlx_vlm/models/got/processing_got.py
@@ -10,7 +10,18 @@ from ..base import install_auto_processor_patch
 GOT_OCR_MEAN = (0.48145466, 0.4578275, 0.40821073)
 GOT_OCR_STD = (0.26862954, 0.26130258, 0.27577711)
 
+# Image tags from tokenization_qwen.py. ModelConfig carries the same three
+# tokens as ids under im_start_token / im_end_token / im_patch_token, which
+# despite the names are <img> / </img> / <imgpad>, not <|im_start|> / <|im_end|>.
+IMG_START_TAG = "<img>"
+IMG_END_TAG = "</img>"
+IMG_PAD_TAG = "<imgpad>"
+
+# config.image_token_len: 1024/16 patches, downsampled twice, is a 16x16 grid.
 IMAGE_TOKEN_LEN = 256
+
+# mlx-vlm's generic placeholder, substituted in place when the caller uses one.
+IMAGE_PLACEHOLDER = "<image>"
 
 # The MPT conversation GOT was trained with, from modeling_GOT.py. The tokenizer
 # ships no chat template, so otherwise the model gets a bare instruction.
@@ -24,15 +35,21 @@ GOT_USER_ROLE = "<|im_start|>user\n"
 GOT_ASSISTANT_ROLE = "<|im_start|>assistant\n"
 
 
-def build_got_prompt(instruction: str, has_image: bool = True) -> str:
+def build_got_prompt(
+    instruction: str,
+    has_image: bool = True,
+    image_token_len: int = IMAGE_TOKEN_LEN,
+) -> str:
     """Wrap an OCR instruction in the MPT conversation GOT expects."""
     if GOT_SEP in instruction or GOT_USER_ROLE in instruction:
         return instruction
 
-    image_tokens = "<img>" + "<imgpad>" * IMAGE_TOKEN_LEN + "</img>\n"
     if has_image:
-        if "<image>" in instruction:
-            instruction = instruction.replace("<image>", image_tokens)
+        image_tokens = (
+            IMG_START_TAG + IMG_PAD_TAG * image_token_len + IMG_END_TAG + "\n"
+        )
+        if IMAGE_PLACEHOLDER in instruction:
+            instruction = instruction.replace(IMAGE_PLACEHOLDER, image_tokens)
         else:
             instruction = image_tokens + instruction
 

--- a/mlx_vlm/models/got/processing_got.py
+++ b/mlx_vlm/models/got/processing_got.py
@@ -1,3 +1,4 @@
+import os
 from typing import List, Optional, Union
 
 import numpy as np
@@ -8,6 +9,41 @@ from ..base import install_auto_processor_patch
 
 GOT_OCR_MEAN = (0.48145466, 0.4578275, 0.40821073)
 GOT_OCR_STD = (0.26862954, 0.26130258, 0.27577711)
+
+IMAGE_TOKEN_LEN = 256
+
+# The MPT conversation GOT was trained with, from modeling_GOT.py. The tokenizer
+# ships no chat template, so otherwise the model gets a bare instruction.
+GOT_SYSTEM = (
+    "<|im_start|>system\n"
+    "        You should follow the instructions carefully and "
+    "explain your answers in detail."
+)
+GOT_SEP = "<|im_end|>"
+GOT_USER_ROLE = "<|im_start|>user\n"
+GOT_ASSISTANT_ROLE = "<|im_start|>assistant\n"
+
+
+def build_got_prompt(instruction: str, has_image: bool = True) -> str:
+    """Wrap an OCR instruction in the MPT conversation GOT expects."""
+    if GOT_SEP in instruction or GOT_USER_ROLE in instruction:
+        return instruction
+
+    image_tokens = "<img>" + "<imgpad>" * IMAGE_TOKEN_LEN + "</img>\n"
+    if has_image:
+        if "<image>" in instruction:
+            instruction = instruction.replace("<image>", image_tokens)
+        else:
+            instruction = image_tokens + instruction
+
+    return (
+        GOT_SYSTEM
+        + GOT_SEP
+        + GOT_USER_ROLE
+        + instruction
+        + GOT_SEP
+        + GOT_ASSISTANT_ROLE
+    )
 
 
 class GotOcrImageProcessor:
@@ -75,26 +111,17 @@ class GotOcrProcessor:
         return_tensors: Optional[str] = None,
         **kwargs,
     ) -> BatchFeature:
-        if images is not None:
+        has_image = images is not None
+        if has_image:
             image_inputs = self.image_processor(images, **kwargs)
-            # Insert image tokens if images are provided
-            image_tokens = "<img>" + "<imgpad>" * 256 + "</img>\n"
-            if text is not None:
-                if isinstance(text, str):
-                    if "<image>" in text:
-                        text = text.replace("<image>", image_tokens)
-                    else:
-                        text = image_tokens + text
-                elif isinstance(text, list):
-                    new_text = []
-                    for t in text:
-                        if "<image>" in t:
-                            new_text.append(t.replace("<image>", image_tokens))
-                        else:
-                            new_text.append(image_tokens + t)
-                    text = new_text
         else:
             image_inputs = {}
+
+        if text is not None:
+            if isinstance(text, str):
+                text = build_got_prompt(text, has_image=has_image)
+            elif isinstance(text, list):
+                text = [build_got_prompt(t, has_image=has_image) for t in text]
 
         if text is not None:
             text_inputs = self.tokenizer(text, return_tensors=return_tensors, **kwargs)
@@ -102,6 +129,14 @@ class GotOcrProcessor:
             text_inputs = {}
 
         return BatchFeature(data={**image_inputs, **text_inputs})
+
+    def save_pretrained(self, save_directory, **kwargs):
+        # Writes qwen.tiktoken, which the tokenizer needs to reload. Without
+        # this, convert.py copies only *.py and *.json and the converted repo
+        # ships no vocab file, hidden locally by the HF cache still having one.
+        os.makedirs(save_directory, exist_ok=True)
+        if self.tokenizer is not None:
+            self.tokenizer.save_pretrained(save_directory, **kwargs)
 
     def decode(self, *args, **kwargs):
         return self.tokenizer.decode(*args, **kwargs)

--- a/mlx_vlm/models/got/processing_got.py
+++ b/mlx_vlm/models/got/processing_got.py
@@ -1,0 +1,130 @@
+from typing import List, Optional, Union
+
+import numpy as np
+from PIL import Image
+from transformers import BatchFeature
+
+from ..base import install_auto_processor_patch
+
+GOT_OCR_MEAN = (0.48145466, 0.4578275, 0.40821073)
+GOT_OCR_STD = (0.26862954, 0.26130258, 0.27577711)
+
+
+class GotOcrImageProcessor:
+    """Image processor for GOT-OCR."""
+
+    def __init__(
+        self,
+        image_size=1024,
+        do_normalize=True,
+        image_mean=None,
+        image_std=None,
+        **kwargs,
+    ):
+        self.image_size = int(image_size)
+        self.do_normalize = bool(do_normalize)
+        self.image_mean = list(image_mean or GOT_OCR_MEAN)
+        self.image_std = list(image_std or GOT_OCR_STD)
+
+    def preprocess(self, images, **kwargs):
+        if not isinstance(images, list):
+            images = [images]
+
+        pixel_values = []
+        for image in images:
+            image = image.convert("RGB")
+            # Resize using BICUBIC exactly to image_size x image_size
+            image = image.resize((self.image_size, self.image_size), Image.BICUBIC)
+
+            arr = np.asarray(image)
+
+            # ToTensor: [0, 1]
+            arr = arr.astype(np.float32) / 255.0
+            pixel_values.append(arr)
+
+        pixel_values = np.stack(pixel_values)
+
+        if self.do_normalize:
+            mean = np.array(self.image_mean, dtype=np.float32).reshape(1, 1, 1, 3)
+            std = np.array(self.image_std, dtype=np.float32).reshape(1, 1, 1, 3)
+            pixel_values = (pixel_values - mean) / std
+
+        return {"pixel_values": pixel_values}
+
+    def __call__(self, images, **kwargs):
+        return self.preprocess(images, **kwargs)
+
+
+class GotOcrProcessor:
+    """Processor for GOT-OCR."""
+
+    attributes = ["image_processor", "tokenizer"]
+    image_processor_class = "GotOcrImageProcessor"
+    tokenizer_class = ("PreTrainedTokenizer", "PreTrainedTokenizerFast")
+
+    def __init__(self, image_processor=None, tokenizer=None, **kwargs):
+        if image_processor is None:
+            image_processor = GotOcrImageProcessor(**kwargs)
+        self.image_processor = image_processor
+        self.tokenizer = tokenizer
+
+    def __call__(
+        self,
+        images: Union[Image.Image, List[Image.Image]] = None,
+        text: Union[str, List[str]] = None,
+        return_tensors: Optional[str] = None,
+        **kwargs,
+    ) -> BatchFeature:
+        if images is not None:
+            image_inputs = self.image_processor(images, **kwargs)
+            # Insert image tokens if images are provided
+            image_tokens = "<img>" + "<imgpad>" * 256 + "</img>\n"
+            if text is not None:
+                if isinstance(text, str):
+                    if "<image>" in text:
+                        text = text.replace("<image>", image_tokens)
+                    else:
+                        text = image_tokens + text
+                elif isinstance(text, list):
+                    new_text = []
+                    for t in text:
+                        if "<image>" in t:
+                            new_text.append(t.replace("<image>", image_tokens))
+                        else:
+                            new_text.append(image_tokens + t)
+                    text = new_text
+        else:
+            image_inputs = {}
+
+        if text is not None:
+            text_inputs = self.tokenizer(text, return_tensors=return_tensors, **kwargs)
+        else:
+            text_inputs = {}
+
+        return BatchFeature(data={**image_inputs, **text_inputs})
+
+    def decode(self, *args, **kwargs):
+        return self.tokenizer.decode(*args, **kwargs)
+
+    def batch_decode(self, *args, **kwargs):
+        return self.tokenizer.batch_decode(*args, **kwargs)
+
+    @classmethod
+    def from_pretrained(cls, pretrained_model_name_or_path, **kwargs):
+        from transformers import AutoTokenizer
+
+        trust_remote_code = True
+        revision = kwargs.get("revision", None)
+        token = kwargs.get("token", None)
+
+        image_processor = GotOcrImageProcessor()
+        tokenizer = AutoTokenizer.from_pretrained(
+            pretrained_model_name_or_path,
+            trust_remote_code=trust_remote_code,
+            revision=revision,
+            token=token,
+        )
+        return cls(image_processor=image_processor, tokenizer=tokenizer)
+
+
+install_auto_processor_patch("got", GotOcrProcessor)

--- a/mlx_vlm/models/got/vision.py
+++ b/mlx_vlm/models/got/vision.py
@@ -73,8 +73,10 @@ def add_decomposed_rel_pos(
     B, _, dim = q.shape
     r_q = q.reshape(B, q_h, q_w, dim)
 
-    rel_h = mx.sum(r_q[:, :, :, None, :] * Rh[None, :, None, :, :], axis=-1)
-    rel_w = mx.sum(r_q[:, :, :, None, :] * Rw[None, None, :, :, :], axis=-1)
+    # einsum, not broadcast-then-sum: the latter materialises 201M elements
+    # per global block.
+    rel_h = mx.einsum("bhwc,hkc->bhwk", r_q, Rh)
+    rel_w = mx.einsum("bhwc,wkc->bhwk", r_q, Rw)
 
     attn = (
         attn.reshape(B, q_h, q_w, k_h, k_w)
@@ -233,9 +235,22 @@ class VisionModel(nn.Module):
         )
         self.norm2 = nn.LayerNorm(config.out_chans, eps=1e-6)
 
-        self.net_2 = nn.Conv2d(256, 512, kernel_size=3, stride=2, padding=1, bias=False)
+        # Two stride-2 convs: 64x64 neck output down to the 16x16 patch grid.
+        self.net_2 = nn.Conv2d(
+            config.out_chans,
+            config.out_chans * 2,
+            kernel_size=3,
+            stride=2,
+            padding=1,
+            bias=False,
+        )
         self.net_3 = nn.Conv2d(
-            512, 1024, kernel_size=3, stride=2, padding=1, bias=False
+            config.out_chans * 2,
+            config.out_dim,
+            kernel_size=3,
+            stride=2,
+            padding=1,
+            bias=False,
         )
 
     def __call__(self, x: mx.array) -> mx.array:

--- a/mlx_vlm/models/got/vision.py
+++ b/mlx_vlm/models/got/vision.py
@@ -1,0 +1,264 @@
+
+import mlx.core as mx
+import mlx.nn as nn
+
+from .config import VisionConfig
+
+
+class MLPBlock(nn.Module):
+    def __init__(self, embedding_dim: int, mlp_dim: int):
+        super().__init__()
+        self.lin1 = nn.Linear(embedding_dim, mlp_dim)
+        self.lin2 = nn.Linear(mlp_dim, embedding_dim)
+        self.act = nn.GELU()
+
+    def __call__(self, x: mx.array) -> mx.array:
+        return self.lin2(self.act(self.lin1(x)))
+
+
+def window_partition(x: mx.array, window_size: int):
+    B, H, W, C = x.shape
+    pad_h = (window_size - H % window_size) % window_size
+    pad_w = (window_size - W % window_size) % window_size
+    if pad_h > 0 or pad_w > 0:
+        x = mx.pad(x, ((0, 0), (0, pad_h), (0, pad_w), (0, 0)))
+    Hp, Wp = H + pad_h, W + pad_w
+    x = x.reshape(B, Hp // window_size, window_size, Wp // window_size, window_size, C)
+    windows = x.transpose(0, 1, 3, 2, 4, 5).reshape(-1, window_size, window_size, C)
+    return windows, (Hp, Wp)
+
+
+def window_unpartition(windows: mx.array, window_size: int, pad_hw: tuple, hw: tuple):
+    Hp, Wp = pad_hw
+    H, W = hw
+    B = windows.shape[0] // ((Hp * Wp) // (window_size * window_size))
+    x = windows.reshape(
+        B, Hp // window_size, Wp // window_size, window_size, window_size, -1
+    )
+    x = x.transpose(0, 1, 3, 2, 4, 5).reshape(B, Hp, Wp, -1)
+    if Hp > H or Wp > W:
+        x = x[:, :H, :W, :]
+    return x
+
+
+def get_rel_pos(q_size: int, k_size: int, rel_pos: mx.array) -> mx.array:
+    max_rel_dist = int(2 * max(q_size, k_size) - 1)
+    if rel_pos.shape[0] != max_rel_dist:
+        raise NotImplementedError(
+            "Dynamic resolution rel_pos interpolation not yet supported in MLX port."
+        )
+    else:
+        rel_pos_resized = rel_pos
+
+    q_coords = mx.arange(q_size)[:, None] * max(k_size / q_size, 1.0)
+    k_coords = mx.arange(k_size)[None, :] * max(q_size / k_size, 1.0)
+    relative_coords = (q_coords - k_coords) + (k_size - 1) * max(q_size / k_size, 1.0)
+
+    return rel_pos_resized[relative_coords.astype(mx.int32)]
+
+
+def add_decomposed_rel_pos(
+    attn: mx.array,
+    q: mx.array,
+    rel_pos_h: mx.array,
+    rel_pos_w: mx.array,
+    q_size: tuple,
+    k_size: tuple,
+):
+    q_h, q_w = q_size
+    k_h, k_w = k_size
+    Rh = get_rel_pos(q_h, k_h, rel_pos_h)
+    Rw = get_rel_pos(q_w, k_w, rel_pos_w)
+
+    B, _, dim = q.shape
+    r_q = q.reshape(B, q_h, q_w, dim)
+
+    rel_h = mx.sum(r_q[:, :, :, None, :] * Rh[None, :, None, :, :], axis=-1)
+    rel_w = mx.sum(r_q[:, :, :, None, :] * Rw[None, None, :, :, :], axis=-1)
+
+    attn = (
+        attn.reshape(B, q_h, q_w, k_h, k_w)
+        + rel_h[:, :, :, :, None]
+        + rel_w[:, :, :, None, :]
+    )
+    return attn.reshape(B, q_h * q_w, k_h * k_w)
+
+
+class Attention(nn.Module):
+    def __init__(
+        self,
+        dim: int,
+        num_heads: int = 8,
+        qkv_bias: bool = True,
+        use_rel_pos: bool = False,
+        input_size: tuple = None,
+    ):
+        super().__init__()
+        self.num_heads = num_heads
+        head_dim = dim // num_heads
+        self.scale = head_dim**-0.5
+
+        self.qkv = nn.Linear(dim, dim * 3, bias=qkv_bias)
+        self.proj = nn.Linear(dim, dim)
+
+        self.use_rel_pos = use_rel_pos
+        if self.use_rel_pos:
+            assert input_size is not None
+            self.rel_pos_h = mx.zeros((2 * input_size[0] - 1, head_dim))
+            self.rel_pos_w = mx.zeros((2 * input_size[1] - 1, head_dim))
+
+    def __call__(self, x: mx.array) -> mx.array:
+        B, H, W, _ = x.shape
+        qkv = self.qkv(x).reshape(B, H * W, 3, self.num_heads, -1)
+        qkv = qkv.transpose(2, 0, 3, 1, 4)
+        q = qkv[0]
+        k = qkv[1]
+        v = qkv[2]
+
+        q = q.reshape(B * self.num_heads, H * W, -1)
+        k = k.reshape(B * self.num_heads, H * W, -1)
+        v = v.reshape(B * self.num_heads, H * W, -1)
+
+        attn = (q * self.scale) @ k.transpose(0, 2, 1)
+
+        if self.use_rel_pos:
+            attn = add_decomposed_rel_pos(
+                attn, q, self.rel_pos_h, self.rel_pos_w, (H, W), (H, W)
+            )
+
+        attn = mx.softmax(attn, axis=-1)
+
+        out = (attn @ v).reshape(B, self.num_heads, H, W, -1)
+        out = out.transpose(0, 2, 3, 1, 4).reshape(B, H, W, -1)
+
+        return self.proj(out)
+
+
+class Block(nn.Module):
+    def __init__(
+        self,
+        dim: int,
+        num_heads: int,
+        mlp_ratio: float = 4.0,
+        qkv_bias: bool = True,
+        use_rel_pos: bool = False,
+        window_size: int = 0,
+        input_size: tuple = None,
+    ):
+        super().__init__()
+        self.norm1 = nn.LayerNorm(dim, eps=1e-6)
+        self.attn = Attention(
+            dim,
+            num_heads=num_heads,
+            qkv_bias=qkv_bias,
+            use_rel_pos=use_rel_pos,
+            input_size=input_size if window_size == 0 else (window_size, window_size),
+        )
+
+        self.norm2 = nn.LayerNorm(dim, eps=1e-6)
+        self.mlp = MLPBlock(embedding_dim=dim, mlp_dim=int(dim * mlp_ratio))
+        self.window_size = window_size
+
+    def __call__(self, x: mx.array) -> mx.array:
+        shortcut = x
+        x = self.norm1(x)
+        if self.window_size > 0:
+            H, W = x.shape[1], x.shape[2]
+            x, pad_hw = window_partition(x, self.window_size)
+
+        x = self.attn(x)
+        if self.window_size > 0:
+            x = window_unpartition(x, self.window_size, pad_hw, (H, W))
+
+        x = shortcut + x
+        x = x + self.mlp(self.norm2(x))
+        return x
+
+
+class PatchEmbed(nn.Module):
+    def __init__(
+        self, kernel_size=(16, 16), stride=(16, 16), in_chans=3, embed_dim=768
+    ):
+        super().__init__()
+        self.proj = nn.Conv2d(
+            in_chans, embed_dim, kernel_size=kernel_size, stride=stride
+        )
+
+    def __call__(self, x: mx.array) -> mx.array:
+        return self.proj(x)
+
+
+class VisionModel(nn.Module):
+    def __init__(self, config: VisionConfig):
+        super().__init__()
+        self.img_size = config.img_size
+
+        self.patch_embed = PatchEmbed(
+            kernel_size=(config.patch_size, config.patch_size),
+            stride=(config.patch_size, config.patch_size),
+            in_chans=config.in_chans,
+            embed_dim=config.embed_dim,
+        )
+
+        if config.use_abs_pos:
+            grid_size = config.img_size // config.patch_size
+            self.pos_embed = mx.zeros((1, grid_size, grid_size, config.embed_dim))
+        else:
+            self.pos_embed = None
+
+        self.blocks = []
+        for i in range(config.depth):
+            block = Block(
+                dim=config.embed_dim,
+                num_heads=config.num_heads,
+                mlp_ratio=config.mlp_ratio,
+                qkv_bias=config.qkv_bias,
+                use_rel_pos=config.use_rel_pos,
+                window_size=(
+                    config.window_size if i not in config.global_attn_indexes else 0
+                ),
+                input_size=(
+                    config.img_size // config.patch_size,
+                    config.img_size // config.patch_size,
+                ),
+            )
+            self.blocks.append(block)
+
+        self.conv1 = nn.Conv2d(
+            config.embed_dim, config.out_chans, kernel_size=1, bias=False
+        )
+        self.norm1 = nn.LayerNorm(config.out_chans, eps=1e-6)
+        self.conv2 = nn.Conv2d(
+            config.out_chans, config.out_chans, kernel_size=3, padding=1, bias=False
+        )
+        self.norm2 = nn.LayerNorm(config.out_chans, eps=1e-6)
+
+        self.net_2 = nn.Conv2d(256, 512, kernel_size=3, stride=2, padding=1, bias=False)
+        self.net_3 = nn.Conv2d(
+            512, 1024, kernel_size=3, stride=2, padding=1, bias=False
+        )
+
+    def __call__(self, x: mx.array) -> mx.array:
+        x = self.patch_embed(x)
+        if self.pos_embed is not None:
+            x = x + self.pos_embed
+
+        for blk in self.blocks:
+            x = blk(x)
+
+        x = self.conv1(x)
+        x = self.norm1(x)
+        x = self.conv2(x)
+        x = self.norm2(x)
+
+        x = self.net_2(x)
+        x = self.net_3(x)
+
+        # Output in PyTorch is B, C, H, W.
+        # In MLX it is B, H, W, C.
+        # modeling_GOT.py does: image_features.flatten(2).transpose(1, 2)
+        # Which transforms B, C, H, W to B, H*W, C.
+        B, H, W, C = x.shape
+        x = x.reshape(B, H * W, C)
+
+        return x

--- a/mlx_vlm/models/got/vision.py
+++ b/mlx_vlm/models/got/vision.py
@@ -1,4 +1,3 @@
-
 import mlx.core as mx
 import mlx.nn as nn
 

--- a/mlx_vlm/tests/test_models.py
+++ b/mlx_vlm/tests/test_models.py
@@ -10638,6 +10638,111 @@ class TestGetInputEmbeddings(unittest.TestCase):
         for key in sanitized:
             self.assertNotIn("language_language_model", key)
 
+    def _got_tiny_config(self):
+        from mlx_vlm.models import got
+
+        return got.ModelConfig(
+            text_config=got.TextConfig(
+                model_type="qwen2",
+                hidden_size=8,
+                num_hidden_layers=1,
+                intermediate_size=16,
+                num_attention_heads=2,
+                rms_norm_eps=1e-6,
+                vocab_size=32,
+            ),
+            vision_config=got.VisionConfig(
+                img_size=32,
+                patch_size=16,
+                embed_dim=8,
+                depth=1,
+                num_heads=2,
+                out_chans=4,
+                out_dim=8,
+                window_size=2,
+                global_attn_indexes=(0,),
+            ),
+            model_type="GOT",
+        )
+
+    def test_got_sanitize_is_idempotent(self):
+        from mlx_vlm.models import got
+
+        model = got.Model(self._got_tiny_config())
+
+        hf_weights = {
+            # torch conv layout: (out_channels, in_channels, kH, kW)
+            "model.vision_tower_high.patch_embed.proj.weight": mx.zeros((8, 3, 16, 16)),
+            "model.vision_tower_high.neck.0.weight": mx.zeros((4, 8, 1, 1)),
+            "model.vision_tower_high.neck.1.weight": mx.zeros((4,)),
+            "model.vision_tower_high.net_2.weight": mx.zeros((8, 4, 3, 3)),
+            "model.mm_projector_vary.weight": mx.zeros((8, 8)),
+            "model.embed_tokens.weight": mx.zeros((32, 8)),
+            "lm_head.weight": mx.zeros((32, 8)),
+        }
+
+        sanitized = model.sanitize(dict(hf_weights))
+
+        self.assertEqual(
+            sanitized["vision_tower.patch_embed.proj.weight"].shape, (8, 16, 16, 3)
+        )
+        self.assertEqual(sanitized["vision_tower.conv1.weight"].shape, (4, 1, 1, 8))
+        self.assertEqual(sanitized["vision_tower.norm1.weight"].shape, (4,))
+        self.assertEqual(sanitized["vision_tower.net_2.weight"].shape, (8, 3, 3, 4))
+        self.assertIn("multi_modal_projector.weight", sanitized)
+        self.assertIn("language_model.model.embed_tokens.weight", sanitized)
+        # tie_word_embeddings is on, so the stored lm_head is dropped
+        self.assertNotIn("language_model.lm_head.weight", sanitized)
+
+        # Converted checkpoints go through sanitize again on load. Transposing a
+        # second time would give (8, 16, 3, 16) and fail load_weights (#1871).
+        twice = model.sanitize(dict(sanitized))
+        for key, value in sanitized.items():
+            self.assertEqual(twice[key].shape, value.shape, key)
+
+    def test_got_config_adds_im_end_to_stop_ids(self):
+        from mlx_vlm.models import got
+
+        params = {
+            "model_type": "GOT",
+            "hidden_size": 8,
+            "num_hidden_layers": 1,
+            "intermediate_size": 16,
+            "num_attention_heads": 2,
+            "rms_norm_eps": 1e-6,
+            "vocab_size": 32,
+            "eos_token_id": 151643,
+        }
+        config = got.ModelConfig.from_dict(params)
+
+        # GOT ends a turn with <|im_end|>, which upstream does not declare.
+        self.assertEqual(config.eos_token_id, [151643, 151645])
+        # Written back, because load_model reapplies the raw dict afterwards.
+        self.assertEqual(params["eos_token_id"], [151643, 151645])
+
+    def test_got_prompt_matches_reference_conversation(self):
+        from mlx_vlm.models.got.processing_got import build_got_prompt
+
+        prompt = build_got_prompt("OCR: ")
+
+        self.assertTrue(prompt.startswith("<|im_start|>system\n"))
+        self.assertIn("<img>" + "<imgpad>" * 256 + "</img>\nOCR: ", prompt)
+        self.assertTrue(prompt.endswith("<|im_end|><|im_start|>assistant\n"))
+        # An already wrapped prompt is passed through untouched.
+        self.assertEqual(build_got_prompt(prompt), prompt)
+        # Without an image there are no patch tokens.
+        self.assertNotIn("<imgpad>", build_got_prompt("OCR: ", has_image=False))
+
+    def test_got_vision_produces_one_token_per_downsampled_patch(self):
+        from mlx_vlm.models import got
+
+        config = self._got_tiny_config()
+        vision_tower = got.Model(config).vision_tower
+
+        # 32/16 = 2x2 patches, then two stride-2 convs -> 1x1 grid.
+        out = vision_tower(mx.zeros((1, 32, 32, 3)))
+        self.assertEqual(out.shape, (1, 1, config.vision_config.out_dim))
+
     def test_paddleocr_vl_text_only_clears_mrope_state(self):
         from mlx_vlm.models import paddleocr_vl
 


### PR DESCRIPTION
Closes #1907

Adds support for the [stepfun-ai/GOT-OCR2_0](https://huggingface.co/stepfun-ai/GOT-OCR2_0) model (8.3B params), a highly optimized OCR VLM.

### Changes
*   **Vision Encoder (`vision.py`)**: Custom `ImageEncoderViT` with decomposed relative positional embeddings and window attention. Converts PyTorch's `Conv2d` `(O, I, H, W)` layout to MLX's native `(O, H, W, I)`.
*   **Language Wrapper (`got.py`)**: Reuses the `Qwen2` language logic, injected with the `mm_projector_vary` linear layer.
*   **Processor (`processing_got.py`)**: Exact 1024x1024 bicubic resizing and `<imgpad>` token insertion (256 tokens) per the original architecture.

### Evaluations
*   **Sanitization**: Verified mapping of the custom vision tower, neck, and tied embeddings.
*   **E2E Generation**: Tested locally on macOS. Successfully extracts document and barcode OCR.
*   **Security**: Bypasses `trust_remote_code` (which requires `verovio`) by securely loading `QWenTokenizer` directly.
*   **Quality**: Passed `pre-commit` (black, isort, autoflake).

### Post-Merge Steps
- [ ] Upload converted weights to `mlx-community/GOT-OCR2_0-bf16` and 4-bit variants.