### PR TITLE
fix(models): honor a caller-supplied attention mask in five language models

### DIFF
--- a/mlx_vlm/models/deepseekocr/language.py
+++ b/mlx_vlm/models/deepseekocr/language.py
@@ -468,7 +468,8 @@ class DeepseekV2Model(nn.Module):
         if cache is None:
             cache = [None] * len(self.layers)
 
-        mask = create_attention_mask(h, cache[0])
+        if mask is None:
+            mask = create_attention_mask(h, cache[0])
 
         for layer, c in zip(self.layers, cache):
             h = layer(h, mask, c)

--- a/mlx_vlm/models/jina_vlm/language.py
+++ b/mlx_vlm/models/jina_vlm/language.py
@@ -268,7 +268,8 @@ class LanguageModel(nn.Module):
             cache = [None] * len(self.layers)
 
         # Create causal attention mask
-        mask = create_attention_mask(x, cache)
+        if mask is None:
+            mask = create_attention_mask(x, cache)
 
         for i, layer in enumerate(self.layers):
             x = layer(x, mask=mask, cache=cache[i])

--- a/mlx_vlm/models/llava/language.py
+++ b/mlx_vlm/models/llava/language.py
@@ -134,8 +134,8 @@ class Llama(nn.Module):
         if cache is None:
             cache = [None] * len(self.layers)
 
-        # if mask is None:
-        mask = create_attention_mask(h, cache)
+        if mask is None:
+            mask = create_attention_mask(h, cache)
 
         for layer, c in zip(self.layers, cache):
             h = layer(h, mask, c)

--- a/mlx_vlm/models/llmjpvl/language.py
+++ b/mlx_vlm/models/llmjpvl/language.py
@@ -144,8 +144,8 @@ class Llama(nn.Module):
         if cache is None:
             cache = [None] * len(self.layers)
 
-        # if mask is None:
-        mask = create_attention_mask(h, cache)
+        if mask is None:
+            mask = create_attention_mask(h, cache)
 
         for layer, c in zip(self.layers, cache):
             h = layer(h, mask, c)

--- a/mlx_vlm/models/minimax/language.py
+++ b/mlx_vlm/models/minimax/language.py
@@ -225,7 +225,8 @@ class MiniMaxModel(nn.Module):
         if cache is None:
             cache = [None] * len(self.layers)
 
-        mask = create_attention_mask(h, cache[0])
+        if mask is None:
+            mask = create_attention_mask(h, cache[0])
 
         for layer, c in zip(self.layers, cache):
             h = layer(h, mask, c)


### PR DESCRIPTION
## Problem

`mlx_vlm/models/{llava,llmjpvl,jina_vlm,minimax,deepseekocr}/language.py` each declare a `mask`
parameter on the inner transformer's `__call__`, and each overwrites it unconditionally:

```python
        if cache is None:
            cache = [None] * len(self.layers)

        # if mask is None:            <-- llava / llmjpvl only
        mask = create_attention_mask(h, cache)
```

The parameter is fully wired from the public surface — `Model.__call__(input_ids, pixel_values, mask, ...)`
→ `LanguageModel.__call__(..., mask=mask)` → inner `__call__(..., mask=mask)` — and then discarded on the
last hop. A caller-supplied mask has no effect; a causal mask is always used instead.

**This is reachable from the shipped trainers.** Both pass the batch's padding mask as the third
positional argument, which is `mask`:

- `mlx_vlm/trainer/sft_trainer.py:172` — `outputs = model(input_ids, pixel_values, model_attention_mask, **kwargs)`
- `mlx_vlm/trainer/orpo_trainer.py:54` — `outputs = model(shifted_input_ids, pixel_values, shifted_attention_mask, **kwargs)`

So for these five families, fine-tuning on any batch containing padding computes attention as if the
padding were real tokens.

## Why this reads as an omission rather than a decision

An AST scan over `mlx_vlm/models/**/language.py` for `__call__` methods that take a `mask` parameter and
build one with `create_attention_mask` gives **41 guarded vs 5 unguarded**. The guarded ones are all

```python
        if mask is None:
            mask = create_attention_mask(...)
```

The tightest comparison is inside the llava family itself: `llava_next/language.py` and
`llava_bunny/language.py` are otherwise identical in this block and both guard, while `llava` has the
guard commented out. `llmjpvl` was added later and carries the same commented-out line, so the artifact
looks copy-pasted rather than deliberate. `paligemma` also takes `mask` and rebuilds it, but does so
inside an explicit `elif` for cache-offset re-derivation — that one is intentional and is left alone.

## The change

Restore the `if mask is None:` guard in the five files. 10 lines, no other behavior touched.

## Verification

`mlx` does not install off Apple silicon, so I drove the affected `__call__` bodies directly: each method
is extracted with `ast` and executed verbatim against a recording layer stub, with `create_attention_mask`
stubbed to return the sentinel `AUTO_CAUSAL`. The check is what the first layer actually receives.
`llava_next` / `llava_bunny` / `qwen2_vl` are included as already-correct controls.

Before:

```
llava          Llama              mask=given -> AUTO_CAUSAL  [DISCARDED]   mask=None -> AUTO_CAUSAL  [SAME]
llmjpvl        Llama              mask=given -> AUTO_CAUSAL  [DISCARDED]   mask=None -> AUTO_CAUSAL  [SAME]
jina_vlm       LanguageModel      mask=given -> AUTO_CAUSAL  [DISCARDED]   mask=None -> AUTO_CAUSAL  [SAME]
minimax        MiniMaxModel       mask=given -> AUTO_CAUSAL  [DISCARDED]   mask=None -> AUTO_CAUSAL  [SAME]
deepseekocr    DeepseekV2Model    mask=given -> AUTO_CAUSAL  [DISCARDED]   mask=None -> AUTO_CAUSAL  [SAME]
llava_next     Llama              mask=given -> CALLER_MASK  [HONORED ]    mask=None -> AUTO_CAUSAL  [SAME]
llava_bunny    Qwen2Model         mask=given -> CALLER_MASK  [HONORED ]    mask=None -> AUTO_CAUSAL  [SAME]
qwen2_vl       Qwen2Model         mask=given -> CALLER_MASK  [HONORED ]    mask=None -> AUTO_CAUSAL  [SAME]
```

After:

```
llava          Llama              mask=given -> CALLER_MASK  [HONORED ]    mask=None -> AUTO_CAUSAL  [SAME]
llmjpvl        Llama              mask=given -> CALLER_MASK  [HONORED ]    mask=None -> AUTO_CAUSAL  [SAME]
jina_vlm       LanguageModel      mask=given -> CALLER_MASK  [HONORED ]    mask=None -> AUTO_CAUSAL  [SAME]
minimax        MiniMaxModel       mask=given -> CALLER_MASK  [HONORED ]    mask=None -> AUTO_CAUSAL  [SAME]
deepseekocr    DeepseekV2Model    mask=given -> CALLER_MASK  [HONORED ]    mask=None -> AUTO_CAUSAL  [SAME]
llava_next     Llama              mask=given -> CALLER_MASK  [HONORED ]    mask=None -> AUTO_CAUSAL  [SAME]
llava_bunny    Qwen2Model         mask=given -> CALLER_MASK  [HONORED ]    mask=None -> AUTO_CAUSAL  [SAME]
qwen2_vl       Qwen2Model         mask=given -> CALLER_MASK  [HONORED ]    mask=None -> AUTO_CAUSAL  [SAME]
```

The `mask=None` column is the regression guard: the default path is byte-for-byte the behavior it had
before, in every model including the controls. Re-running the AST scan after the patch leaves only
`paligemma` (the intentional `elif`).

`black==26.3.1` (the pinned `.pre-commit-config.yaml` rev) reports all five files unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
