### PR TITLE
Add native DSpark speculative decoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,15 +174,46 @@ Requests can override the server defaults with `enable_thinking`, `thinking_budg
 
 ### Speculative Decoding
 
-Speed up generation by drafting several candidate tokens with a small "drafter" model and verifying them in a single target forward pass. Three drafter families are supported.
+Speed up generation by drafting several candidate tokens with a small "drafter" model and verifying them in a single target forward pass. Four drafter families are supported.
 
 | Flag | Description |
 |------|-------------|
 | `--draft-model` | HuggingFace repo or local path for the drafter |
-| `--draft-kind` | Drafter family — `dflash` (default), `eagle3`, or `mtp` (native/assistant MTP) |
+| `--draft-kind` | Drafter family — `dflash` (default), `dspark`, `eagle3`, or `mtp` (native/assistant MTP) |
 | `--draft-block-size` | Override the drafter's configured block size |
+| `--draft-bits` | Quantize a dense DSpark drafter at load time (`4` by default, `0` keeps BF16) |
 
 See [docs/usage.md](docs/usage.md) for Python API examples including batch generation.
+
+#### DSpark (Qwen3.8)
+
+DSpark combines a parallel draft backbone with a sequential low-rank Markov
+head. The target verifies every proposal before it is emitted. The published
+Qwen3.8 drafter is BF16 and is quantized to 4-bit at load time by default.
+
+```sh
+mlx_vlm.generate \
+  --model mlx-community/Qwen3.8-27B-4bit \
+  --draft-model RadixArk/Qwen3.8-27B-DSpark \
+  --draft-kind dspark \
+  --prompt "Write a quicksort in Python." \
+  --max-tokens 512 --temperature 0
+
+# OpenAI-compatible server
+mlx_vlm.server \
+  --model mlx-community/Qwen3.8-27B-4bit \
+  --draft-model RadixArk/Qwen3.8-27B-DSpark \
+  --draft-kind dspark
+```
+
+The checkpoint's full trained width is available, but the default runtime is
+acceptance-adaptive: it starts with three proposals, backs off when deeper
+positions miss, and grows toward the checkpoint ceiling only when acceptance
+supports it. `--draft-block-size 4` fixes the runtime at three proposals plus
+the known target bonus token; benchmark fixed caps on the deployment Mac.
+Prefill follows the normal portable chunk ceiling and can reduce it when live
+Metal headroom cannot hold the requested DSpark hidden-state captures. The
+`--prefill-step-size` value remains the ceiling (`0` disables chunking).
 
 #### DFlash (Qwen3.5 and Muse Glimmer)
 
@@ -473,7 +504,8 @@ mlx_vlm.server --api-key <secret-token>
 - `--reranker-model`: Preload a supported reranker model at server startup
 - `--adapter-path`: Path for adapter weights to use with the preloaded model
 - `--draft-model`: Speculative drafter path or HF id (e.g. `z-lab/Qwen3.5-4B-DFlash`, `RedHatAI/gemma-4-31B-it-speculator.eagle3`, `google/gemma-4-31B-it-assistant`, `Inferact/MiniMax-M3-EAGLE3`) — enables speculative decoding for ~2× or higher throughput
-- `--draft-kind`: Drafter family — `dflash` (default), `eagle3`, or `mtp` (native/assistant MTP)
+- `--draft-kind`: Drafter family — `dflash` (default), `dspark`, `eagle3`, or `mtp` (native/assistant MTP)
+- `--draft-bits`: Quantize dense DSpark drafters at load time (`4` by default, `0` keeps BF16)
 - `--draft-block-size`: Override the drafter's configured block size
 - `--host`: Host address (default: `0.0.0.0`)
 - `--port`: Port number (default: `8080`)

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -39,6 +39,34 @@ print(output)
 
 Speed up generation 2–3× using a lightweight drafter model that predicts multiple tokens per round, verified in parallel by the target model.
 
+### DSpark
+
+Qwen3.8 uses a native DSpark drafter with a parallel backbone and sequential
+Markov head. The BF16 checkpoint is quantized to 4-bit at load time by default:
+
+```bash
+python -m mlx_vlm.generate \
+    --model mlx-community/Qwen3.8-27B-4bit \
+    --draft-model RadixArk/Qwen3.8-27B-DSpark \
+    --draft-kind dspark \
+    --prompt "Write a concise note about speculative decoding." \
+    --max-tokens 256 --temperature 0
+
+python -m mlx_vlm.server \
+    --model mlx-community/Qwen3.8-27B-4bit \
+    --draft-model RadixArk/Qwen3.8-27B-DSpark \
+    --draft-kind dspark
+```
+
+The checkpoint's full trained draft width is available as the ceiling. By
+default, the runtime starts with three proposals, backs off on low acceptance,
+and grows only when deeper positions pay off. A runtime block size includes the
+known target bonus token, so `--draft-block-size 4` fixes a round at three
+proposals. Benchmark fixed caps on the deployment Mac. Prefill follows the
+normal portable chunk ceiling and reduces it only when live Metal headroom
+cannot hold the requested hidden-state captures. `--prefill-step-size` remains
+the ceiling. Use `--draft-bits 0` to retain the BF16 drafter.
+
 ### CLI
 
 ```bash
@@ -191,6 +219,7 @@ for i in range(B):
 
 | Target | Drafter | Notes |
 |--------|---------|-------|
+| `mlx-community/Qwen3.8-27B-4bit` | `RadixArk/Qwen3.8-27B-DSpark` | Text generation. Native DSpark; adaptive draft depth or a fixed `--draft-block-size`. |
 | `Qwen/Qwen3.5-4B` | `z-lab/Qwen3.5-4B-DFlash` | Text + image. ~2.5× speedup on code/reasoning. |
 | `meta-models/Muse-Glimmer-30B` | `meta-models/Muse-Glimmer-30B-assistant` | Text + image. Native 5-layer, 16-token DFlash assistant. |
 | `MiniMaxAI/MiniMax-M3` | `Inferact/MiniMax-M3-EAGLE3` | Text, image, and video target. Uses `--draft-kind eagle3`. |

--- a/mlx_vlm/generate/ar.py
+++ b/mlx_vlm/generate/ar.py
@@ -26,6 +26,7 @@ from ..speculative.utils import (
     run_speculative_server_rounds,
     speculative_hidden_state,
     speculative_prefill_kwargs,
+    speculative_prefill_step_size,
 )
 from ..turboquant import BatchTurboQuantKVCache, turboquant_enabled
 from ..utils import group_images_by_shape, prepare_inputs, should_add_special_tokens
@@ -387,6 +388,11 @@ def generate_step(
                 kwargs = {}
 
             return y, logprobs.squeeze(0) if logprobs.shape[0] == 1 else logprobs
+
+    if draft_model is not None:
+        prefill_step_size = speculative_prefill_step_size(
+            prefill_step_size, draft_model
+        )
 
     with mx.stream(generation_stream):
         # Get input embeddings (handles both multimodal and text-only)
@@ -1613,7 +1619,11 @@ class PromptProcessingBatch:
         self.uids = uids
         self._prompt_uids = list(uids)
         self.max_tokens = max_tokens
-        self.prefill_step_size = prefill_step_size
+        self.prefill_step_size = (
+            speculative_prefill_step_size(prefill_step_size, draft_model)
+            if draft_model is not None
+            else prefill_step_size
+        )
         self.draft_model = draft_model
         self.draft_kind = draft_kind
         self.draft_block_size = draft_block_size

--- a/mlx_vlm/generate/dispatch.py
+++ b/mlx_vlm/generate/dispatch.py
@@ -515,8 +515,9 @@ def parse_arguments():
         "--draft-kind",
         type=str,
         default=None,
-        choices=["dflash", "eagle3", "mtp"],
+        choices=["dflash", "dspark", "eagle3", "mtp"],
         help="Drafter family. Supported: 'dflash' (Qwen3.5 DFlash), "
+        "'dspark' (DSpark semi-autoregressive drafter), "
         "'eagle3' (Speculators/SGLang EAGLE-3), "
         "'mtp' (Gemma 4 Multi-Token Prediction / Assistant model). "
         "Default: auto-detected from the drafter's HF model_type.",
@@ -526,6 +527,13 @@ def parse_arguments():
         type=int,
         default=None,
         help="Override the drafter's configured block size.",
+    )
+    parser.add_argument(
+        "--draft-bits",
+        type=int,
+        choices=[0, 2, 3, 4, 5, 6, 8],
+        default=4,
+        help="Quantize a dense DSpark drafter to this bit width (0 keeps BF16).",
     )
     parser.add_argument(
         "--enable-thinking",
@@ -1266,7 +1274,9 @@ def main():
 
         print(f"Loading drafter ({args.draft_kind or 'auto'}): {args.draft_model}")
         draft_model, resolved_kind = load_drafter(
-            args.draft_model, kind=args.draft_kind
+            args.draft_model,
+            kind=args.draft_kind,
+            draft_bits=args.draft_bits,
         )
         if args.draft_kind is None:
             print(f"  → auto-detected --draft-kind={resolved_kind!r}.")

--- a/mlx_vlm/models/muse_glimmer/language.py
+++ b/mlx_vlm/models/muse_glimmer/language.py
@@ -291,7 +291,7 @@ class LanguageModel(nn.Module):
         if draft_model is None:
             return True
         prefill_kwargs = prefill_kwargs or {}
-        if draft_kind in ("dflash", "eagle3"):
+        if draft_kind in ("dflash", "dspark", "eagle3"):
             return prefill_kwargs.get("capture_layer_ids") is not None
         return False
 

--- a/mlx_vlm/models/qwen3_5/language.py
+++ b/mlx_vlm/models/qwen3_5/language.py
@@ -2097,6 +2097,8 @@ class Qwen3_5Model(nn.Module):
 
 
 class LanguageModel(nn.Module):
+    requires_speculative_gdn_states = True
+
     def __init__(self, args: TextConfig, config: ModelConfig = None):
         super().__init__()
         self.args = args
@@ -2127,7 +2129,7 @@ class LanguageModel(nn.Module):
             return bool(prefill_kwargs.get("return_hidden", False)) and bool(
                 prefill_kwargs.get("return_shared_kv", False)
             )
-        if draft_kind in ("dflash", "eagle3"):
+        if draft_kind in ("dflash", "dspark", "eagle3"):
             return prefill_kwargs.get("capture_layer_ids") is not None
         return draft_kind is None
 
@@ -2605,6 +2607,7 @@ class LanguageModel(nn.Module):
         video_grid_thw = kwargs.pop("video_grid_thw", None)
         attention_mask = kwargs.pop("attention_mask", None)
         capture_layer_ids = kwargs.pop("capture_layer_ids", None)
+        capture_gdn_states = kwargs.pop("capture_gdn_states", False)
         return_hidden = kwargs.pop("return_hidden", False)
         return_shared_kv = kwargs.pop("return_shared_kv", False)
         skip_logits = kwargs.pop("skip_logits", False)
@@ -2742,7 +2745,7 @@ class LanguageModel(nn.Module):
         hidden_sink: Optional[List[mx.array]] = (
             [] if capture_layer_ids is not None else None
         )
-        gdn_sink: Optional[list] = [] if capture_layer_ids is not None else None
+        gdn_sink: Optional[list] = [] if capture_gdn_states else None
         target_verify = gdn_sink is not None
 
         out = self.model(
@@ -2857,6 +2860,7 @@ class LanguageModel(nn.Module):
             inputs,
             cache=cache,
             capture_layer_ids=[],
+            capture_gdn_states=True,
             return_hidden=True,
             return_shared_kv=True,
         )
@@ -2872,6 +2876,7 @@ class LanguageModel(nn.Module):
             inputs,
             cache=cache,
             capture_layer_ids=[],
+            capture_gdn_states=True,
             return_hidden=True,
             return_shared_kv=True,
             skip_logits=True,

--- a/mlx_vlm/server/cli.py
+++ b/mlx_vlm/server/cli.py
@@ -221,8 +221,8 @@ def main():
         "--draft-kind",
         type=str,
         default=None,
-        choices=["dflash", "eagle3", "mtp"],
-        help="Drafter family -- 'dflash', 'eagle3', or 'mtp' (Gemma 4). "
+        choices=["dflash", "dspark", "eagle3", "mtp"],
+        help="Drafter family -- 'dflash', 'dspark', 'eagle3', or 'mtp'. "
         "Default: auto-detected from the drafter's HF model_type.",
     )
     parser.add_argument(
@@ -230,6 +230,13 @@ def main():
         type=int,
         default=None,
         help="Override the drafter's configured block size.",
+    )
+    parser.add_argument(
+        "--draft-bits",
+        type=int,
+        choices=[0, 2, 3, 4, 5, 6, 8],
+        default=4,
+        help="Quantize a dense DSpark drafter to this bit width (0 keeps BF16).",
     )
     parser.add_argument(
         "--max-num-seqs",
@@ -297,9 +304,10 @@ def main():
         os.environ["MLX_VLM_DRAFT_KIND"] = args.draft_kind
     if args.draft_block_size is not None:
         os.environ["MLX_VLM_DRAFT_BLOCK_SIZE"] = str(args.draft_block_size)
+    os.environ["MLX_VLM_DRAFT_BITS"] = str(args.draft_bits)
     if args.max_num_seqs is not None:
         os.environ["MLX_VLM_MAX_NUM_SEQS"] = str(args.max_num_seqs)
-    if args.prefill_step_size:
+    if args.prefill_step_size is not None:
         os.environ["PREFILL_STEP_SIZE"] = str(args.prefill_step_size)
     os.environ["MLX_VLM_LOG_PROGRESS_INTERVAL"] = str(args.log_progress_interval)
     os.environ["MLX_VLM_MAX_TOKENS"] = str(args.max_tokens)

--- a/mlx_vlm/server/generation.py
+++ b/mlx_vlm/server/generation.py
@@ -42,6 +42,7 @@ from ..speculative.utils import (
     run_speculative_server_rounds,
     speculative_hidden_state,
     speculative_prefill_kwargs,
+    speculative_prefill_step_size,
     speculative_stats_since,
     speculative_stats_snapshot,
 )
@@ -2047,7 +2048,7 @@ class ResponseGenerator:
             results.close()
 
     def _run_speculative(self):
-        """GPU thread loop with DFlash, EAGLE-3, or MTP speculative decoding.
+        """GPU thread loop with DFlash, DSpark, EAGLE-3, or MTP decoding.
 
         Collects incoming requests, prefills them as a batch with the
         per-family hooks, then runs the matching round-loop for decode.
@@ -2147,7 +2148,9 @@ class ResponseGenerator:
                     make_cache=_make_cache,
                 )
 
-                prefill_step_size = self._effective_prefill_step_size()
+                prefill_step_size = speculative_prefill_step_size(
+                    self._effective_prefill_step_size(), drafter
+                )
                 policy_kwargs = {**prompt_kwargs, **prefill_kwargs}
                 if not _chunked_prefill_enabled(
                     self.model,

--- a/mlx_vlm/speculative/common.py
+++ b/mlx_vlm/speculative/common.py
@@ -6,6 +6,13 @@ import mlx.nn as nn
 generation_stream = mx.new_thread_local_stream(mx.default_device())
 
 
+def _target_verify_kwargs(lm: nn.Module) -> dict:
+    """Return target-specific state capture needed for speculative rollback."""
+    if getattr(lm, "requires_speculative_gdn_states", False):
+        return {"capture_gdn_states": True}
+    return {}
+
+
 def _copy_rng_state() -> List[mx.array]:
     return [mx.array(state) for state in mx.random.state]
 
@@ -259,7 +266,9 @@ def _dflash_block_total(draft_model: nn.Module, draft_block_size: Optional[int])
     if draft_block_size is not None:
         return int(draft_block_size)
 
-    configured = int(draft_model.config.block_size)
+    configured = int(
+        getattr(draft_model, "max_runtime_block_size", draft_model.config.block_size)
+    )
     runtime = getattr(draft_model.config, "runtime_block_size", None)
     if runtime is None:
         return configured

--- a/mlx_vlm/speculative/dflash.py
+++ b/mlx_vlm/speculative/dflash.py
@@ -8,6 +8,7 @@ from .common import (
     _record_speculative_round,
     _speculative_walk,
     _speculative_walk_batch,
+    _target_verify_kwargs,
     generation_stream,
 )
 
@@ -44,7 +45,9 @@ def _dflash_next_block_size(
         return block_total
 
     current = min(block_total, max(2, recent[-1][1] + 1))
-    min_total = min(block_total, 4)
+    min_total = min(
+        block_total, max(2, int(getattr(draft_model, "dflash_min_block_size", 4)))
+    )
     drafted = sum(d for _, d in recent)
     accepted = sum(a for a, _ in recent)
     accept_rate = accepted / drafted
@@ -114,16 +117,22 @@ def _dflash_rounds(
     emitted = 1  # the first bonus has already been yielded by the caller
 
     while emitted < max_tokens:
-        bs = _dflash_next_block_size(
-            draft_model,
-            block_total,
-            max_tokens - emitted + 1,
-            (
-                getattr(draft_model, "dflash_initial_block_size", None)
-                if use_model_initial_block_size
-                else None
-            ),
-        )
+        remaining = max_tokens - emitted + 1
+        if draft_block_size is not None and getattr(
+            draft_model, "fixed_requested_block_size", False
+        ):
+            bs = min(block_total, remaining)
+        else:
+            bs = _dflash_next_block_size(
+                draft_model,
+                block_total,
+                remaining,
+                (
+                    getattr(draft_model, "dflash_initial_block_size", None)
+                    if use_model_initial_block_size
+                    else None
+                ),
+            )
         if bs <= 1:
             break
 
@@ -148,6 +157,7 @@ def _dflash_rounds(
                 verify_input,
                 cache=prompt_cache,
                 capture_layer_ids=target_layer_ids,
+                **_target_verify_kwargs(lm),
             )
             hidden = mx.concatenate(verify_out.hidden_states, axis=-1)
             target_tokens = sampler(verify_out.logits)
@@ -230,14 +240,19 @@ def _dflash_rounds_batch(
     active_idx = list(range(B))  # maps active-slot → original-index
     hidden_by_orig = [hidden[i : i + 1] for i in range(B)]
 
-    total_emitted = sum(emitted)
-
     while len(active_idx) > 0:
         remaining = [
             max(1, max_tokens - emitted[active_idx[j]] + 1)
             for j in range(len(active_idx))
         ]
-        bs = _dflash_next_block_size(draft_model, block_total, min(remaining))
+        if draft_block_size is not None and getattr(
+            draft_model, "fixed_requested_block_size", False
+        ):
+            bs = min(block_total, min(remaining))
+        else:
+            bs = _dflash_next_block_size(
+                draft_model, block_total, min(remaining)
+            )
         if bs <= 1:
             break
 
@@ -271,6 +286,7 @@ def _dflash_rounds_batch(
                 verify_input,
                 cache=prompt_cache,
                 capture_layer_ids=target_layer_ids,
+                **_target_verify_kwargs(lm),
             )
             hidden_full = mx.concatenate(verify_out.hidden_states, axis=-1)
             target_tokens = sampler(verify_out.logits)
@@ -338,4 +354,3 @@ def _dflash_rounds_batch(
             active_idx = [active_idx[j] for j in keep_slots]
 
         verify_out = None
-        total_emitted = sum(emitted)

--- a/mlx_vlm/speculative/dflash.py
+++ b/mlx_vlm/speculative/dflash.py
@@ -250,9 +250,7 @@ def _dflash_rounds_batch(
         ):
             bs = min(block_total, min(remaining))
         else:
-            bs = _dflash_next_block_size(
-                draft_model, block_total, min(remaining)
-            )
+            bs = _dflash_next_block_size(draft_model, block_total, min(remaining))
         if bs <= 1:
             break
 

--- a/mlx_vlm/speculative/drafters/__init__.py
+++ b/mlx_vlm/speculative/drafters/__init__.py
@@ -1,12 +1,17 @@
+import gc
 import json
 import logging
+import os
 from typing import Any, Optional, Tuple
+
+import mlx.core as mx
+import mlx.nn as nn
 
 from .laguna_dflash import LagunaDFlashDraftModel
 from .muse_glimmer_assistant import MuseGlimmerAssistantDraftModel
 from .qwen3_dflash import DFlashDraftModel
 
-KNOWN_DRAFTER_KINDS = {"dflash", "mtp", "eagle3"}
+KNOWN_DRAFTER_KINDS = {"dflash", "dspark", "mtp", "eagle3"}
 
 # Drafter HF ``model_type`` → required round-loop kind. Anything not listed
 # here falls back to ``DEFAULT_DRAFTER_KIND`` when the caller didn't pass one.
@@ -18,6 +23,7 @@ DRAFTER_KIND_BY_MODEL_TYPE = {
     "glm4_moe_lite_mtp": "mtp",
     "inkling_mtp": "mtp",
     "qwen3_5_mtp": "mtp",
+    "dspark": "dspark",
     "laguna": "dflash",
     "muse_glimmer_assistant": "dflash",
 }
@@ -106,6 +112,8 @@ def _peek_drafter_model_type(model_path) -> Optional[str]:
     try:
         with open(model_path / "config.json") as f:
             config = json.load(f)
+            if (config.get("dflash_config") or {}).get("projector_type") == "dspark":
+                return "dspark"
             return config.get("model_type") or config.get("speculators_model_type")
     except (FileNotFoundError, json.JSONDecodeError, OSError):
         return None
@@ -151,7 +159,10 @@ def resolve_drafter_kind(model_path, kind: Optional[str] = None) -> str:
 
 
 def load_drafter(
-    path_or_repo: str, kind: Optional[str] = None, **kwargs
+    path_or_repo: str,
+    kind: Optional[str] = None,
+    draft_bits: Optional[int] = None,
+    **kwargs,
 ) -> Tuple[object, str]:
     """Load a speculative drafter and return ``(model, resolved_kind)``.
 
@@ -168,7 +179,42 @@ def load_drafter(
 
     path = get_model_path(path_or_repo)
     resolved = resolve_drafter_kind(path, kind)
-    return load_model(path, **kwargs), resolved
+    model = load_model(path, **kwargs)
+
+    if resolved == "dspark" and getattr(model, "quantize_on_load", False):
+        bits = (
+            int(os.environ.get("MLX_VLM_DRAFT_BITS", "4"))
+            if draft_bits is None
+            else int(draft_bits)
+        )
+        if bits not in (0, 2, 3, 4, 5, 6, 8):
+            raise ValueError(
+                "DSpark draft_bits must be 0 (BF16) or one of 2, 3, 4, 5, 6, 8."
+            )
+        with open(path / "config.json") as f:
+            checkpoint_config = json.load(f)
+        already_quantized = bool(
+            checkpoint_config.get("quantization")
+            or checkpoint_config.get("quantization_config")
+        )
+        if bits and not already_quantized:
+            nn.quantize(
+                model,
+                group_size=64,
+                bits=bits,
+                class_predicate=lambda _path, module: isinstance(
+                    module, (nn.Linear, nn.Embedding)
+                ),
+            )
+            mx.eval(model.parameters())
+            # ``nn.quantize`` replaces the dense modules, but the released
+            # BF16 tensors can remain in Python reference cycles until GC.
+            # Reclaim them before target prefill instead of carrying both
+            # dense and quantized copies into its peak-memory phase.
+            gc.collect()
+            mx.clear_cache()
+
+    return model, resolved
 
 
 __all__ = [

--- a/mlx_vlm/speculative/drafters/qwen3_dspark/__init__.py
+++ b/mlx_vlm/speculative/drafters/qwen3_dspark/__init__.py
@@ -1,0 +1,5 @@
+from .config import DSparkConfig as ModelConfig
+from .dspark import DSparkDraftModel
+from .dspark import DSparkDraftModel as Model
+
+__all__ = ["DSparkDraftModel", "Model", "ModelConfig"]

--- a/mlx_vlm/speculative/drafters/qwen3_dspark/config.py
+++ b/mlx_vlm/speculative/drafters/qwen3_dspark/config.py
@@ -1,0 +1,53 @@
+import inspect
+from dataclasses import dataclass
+
+from ..qwen3_dflash.config import DFlashConfig
+
+
+@dataclass
+class DSparkConfig(DFlashConfig):
+    """Qwen3 DSpark checkpoint configuration.
+
+    SpecForge stores DSpark as a Qwen3 DFlash backbone plus Markov and
+    confidence heads. ``block_size`` is the trained draft width; the runtime
+    block size includes the target bonus token, matching mlx-vlm's other
+    speculative backends.
+    """
+
+    model_type: str = "dspark"
+    logits_start: int = 0
+    markov_rank: int = 256
+    markov_head_type: str = "vanilla"
+    enable_confidence_head: bool = True
+    confidence_head_with_markov: bool = True
+    runtime_block_size: int | None = None
+
+    @classmethod
+    def from_dict(cls, params: dict) -> "DSparkConfig":
+        flat = dict(params)
+        dflash_cfg = flat.pop("dflash_config", None) or {}
+        if dflash_cfg.get("projector_type") != "dspark":
+            raise ValueError(
+                "DSpark checkpoints require "
+                "dflash_config.projector_type='dspark'."
+            )
+
+        for key in ("mask_token_id", "target_layer_ids"):
+            if key in dflash_cfg:
+                flat[key] = dflash_cfg[key]
+
+        # SpecForge Qwen3 drafters build RoPE from ``rope_parameters``. In
+        # particular, Qwen3.8 uses YaRN even at short positions through mscale.
+        rope = flat.get("rope_parameters") or flat.get("rope_scaling")
+        if rope:
+            flat["rope_scaling"] = dict(rope)
+            flat["rope_theta"] = rope.get(
+                "rope_theta", flat.get("rope_theta", cls.rope_theta)
+            )
+
+        flat["model_type"] = "dspark"
+        flat.setdefault("logits_start", 0)
+        sig = inspect.signature(cls).parameters
+        return cls(**{key: value for key, value in flat.items() if key in sig})
+
+    from_hf_dict = from_dict

--- a/mlx_vlm/speculative/drafters/qwen3_dspark/config.py
+++ b/mlx_vlm/speculative/drafters/qwen3_dspark/config.py
@@ -28,8 +28,7 @@ class DSparkConfig(DFlashConfig):
         dflash_cfg = flat.pop("dflash_config", None) or {}
         if dflash_cfg.get("projector_type") != "dspark":
             raise ValueError(
-                "DSpark checkpoints require "
-                "dflash_config.projector_type='dspark'."
+                "DSpark checkpoints require " "dflash_config.projector_type='dspark'."
             )
 
         for key in ("mask_token_id", "target_layer_ids"):

--- a/mlx_vlm/speculative/drafters/qwen3_dspark/dspark.py
+++ b/mlx_vlm/speculative/drafters/qwen3_dspark/dspark.py
@@ -12,9 +12,7 @@ class VanillaMarkov(nn.Module):
     def __init__(self, config: DSparkConfig):
         super().__init__()
         self.markov_w1 = nn.Embedding(config.vocab_size, config.markov_rank)
-        self.markov_w2 = nn.Linear(
-            config.markov_rank, config.vocab_size, bias=False
-        )
+        self.markov_w2 = nn.Linear(config.markov_rank, config.vocab_size, bias=False)
 
     def prev_embeddings(self, token_ids: mx.array) -> mx.array:
         return self.markov_w1(token_ids)

--- a/mlx_vlm/speculative/drafters/qwen3_dspark/dspark.py
+++ b/mlx_vlm/speculative/drafters/qwen3_dspark/dspark.py
@@ -1,0 +1,150 @@
+import mlx.core as mx
+import mlx.nn as nn
+
+from ....models.cache import KVCache
+from ..qwen3_dflash.dflash import DFlashDraftModel
+from .config import DSparkConfig
+
+
+class VanillaMarkov(nn.Module):
+    """Low-rank previous-token bias used by DSpark draft heads."""
+
+    def __init__(self, config: DSparkConfig):
+        super().__init__()
+        self.markov_w1 = nn.Embedding(config.vocab_size, config.markov_rank)
+        self.markov_w2 = nn.Linear(
+            config.markov_rank, config.vocab_size, bias=False
+        )
+
+    def prev_embeddings(self, token_ids: mx.array) -> mx.array:
+        return self.markov_w1(token_ids)
+
+    def step_bias(self, token_ids: mx.array) -> mx.array:
+        return self.markov_w2(self.prev_embeddings(token_ids))
+
+
+class ConfidenceHead(nn.Module):
+    def __init__(self, input_dim: int):
+        super().__init__()
+        self.proj = nn.Linear(input_dim, 1)
+
+    def __call__(self, features: mx.array) -> mx.array:
+        return self.proj(features).squeeze(-1)
+
+
+class DSparkDraftModel(DFlashDraftModel):
+    """Native DSpark drafter using mlx-vlm's verify and rollback engine."""
+
+    prefer_requested_block_size = False
+    fixed_requested_block_size = True
+    dflash_initial_block_size = 4
+    dflash_min_block_size = 3
+    quantize_on_load = True
+
+    def __init__(self, config: DSparkConfig):
+        super().__init__(config)
+        self.config = config
+        # DSpark's anchor position also predicts the first proposal, so a
+        # trained width of N can draft N tokens and verifies N + 1 positions.
+        self.max_runtime_block_size = int(config.block_size) + 1
+        # DSpark prefill retains only the requested target hidden-state taps.
+        # Budget four bytes per value conservatively; the Qwen target normally
+        # emits BF16 activations, but this also covers FP32 target variants.
+        self.prefill_memory_bytes_per_token = (
+            int(config.hidden_size) * len(config.target_layer_ids) * 4
+        )
+        if config.markov_head_type != "vanilla":
+            raise ValueError(
+                "Only DSpark's vanilla Markov head is currently supported."
+            )
+        self.markov_head = (
+            VanillaMarkov(config) if int(config.markov_rank) > 0 else None
+        )
+        self.confidence_head = None
+        if config.enable_confidence_head:
+            input_dim = config.hidden_size
+            if config.confidence_head_with_markov:
+                if self.markov_head is None:
+                    raise ValueError(
+                        "confidence_head_with_markov requires markov_rank > 0."
+                    )
+                input_dim += config.markov_rank
+            self.confidence_head = ConfidenceHead(input_dim)
+
+    def draft_block(
+        self,
+        last_bonus,
+        hidden: mx.array,
+        cache: list[KVCache],
+        block_size: int,
+        sampler,
+        token_dtype: mx.Dtype = mx.int32,
+    ) -> mx.array:
+        # mlx-vlm's runtime block size includes the known bonus token. The
+        # checkpoint width counts predictive block positions, including the
+        # anchor position that predicts the first proposal.
+        draft_count = min(
+            max(0, int(block_size) - 1),
+            int(self.config.block_size) - int(self.config.logits_start),
+        )
+        if draft_count == 0:
+            if isinstance(last_bonus, int):
+                return mx.zeros((1, 0), dtype=token_dtype)
+            return mx.zeros((int(last_bonus.shape[0]), 0), dtype=token_dtype)
+
+        if isinstance(last_bonus, int):
+            bonus = mx.array([last_bonus], dtype=token_dtype)
+        else:
+            bonus = last_bonus.reshape(-1).astype(token_dtype)
+
+        batch_size = int(bonus.shape[0])
+        trained_width = int(self.config.block_size)
+        masks = mx.full(
+            (batch_size, trained_width - 1),
+            int(self.config.mask_token_id),
+            dtype=token_dtype,
+        )
+        block = mx.concatenate([bonus[:, None], masks], axis=1)
+
+        # The published Qwen3.8 head is bidirectional inside its seven-token
+        # block. Always run that full width; truncating it changes every row.
+        draft_hidden = self._hidden(block, hidden, cache)
+        start = int(self.config.logits_start)
+        head_hidden = draft_hidden[:, start : start + draft_count]
+        base_logits = self._logits(head_hidden)
+
+        if self.markov_head is None:
+            return sampler(base_logits).astype(token_dtype)
+
+        tokens = []
+        previous = bonus
+        for position in range(draft_count):
+            logits = base_logits[:, position] + self.markov_head.step_bias(previous)
+            next_token = sampler(logits[:, None, :]).reshape(batch_size)
+            next_token = next_token.astype(token_dtype)
+            tokens.append(next_token[:, None])
+            previous = next_token
+        return mx.concatenate(tokens, axis=1)
+
+    def validate_target_compatibility(self, target_model) -> None:
+        target_config = getattr(target_model, "config", None)
+        target_config = getattr(target_config, "text_config", target_config)
+        if target_config is None:
+            return
+
+        for field in ("hidden_size", "vocab_size"):
+            expected = getattr(self.config, field)
+            actual = getattr(target_config, field, None)
+            if actual is not None and int(actual) != int(expected):
+                raise ValueError(
+                    "DSpark drafter is incompatible with the target model: "
+                    f"{field}={expected} for the drafter, {actual} for the target."
+                )
+
+        target_layers = getattr(target_config, "num_hidden_layers", None)
+        last_capture = max(self.config.target_layer_ids)
+        if target_layers is not None and last_capture >= int(target_layers):
+            raise ValueError(
+                "DSpark drafter capture layer is outside the target model: "
+                f"layer {last_capture}, target has {target_layers} layers."
+            )

--- a/mlx_vlm/speculative/eagle3.py
+++ b/mlx_vlm/speculative/eagle3.py
@@ -7,6 +7,7 @@ from .common import (
     _batch_cache_left_padding,
     _record_speculative_round,
     _SpeculativeSamplerRNG,
+    _target_verify_kwargs,
     generation_stream,
 )
 
@@ -170,6 +171,7 @@ def _eagle3_verify_target(
             verify_input[:, :1],
             cache=prompt_cache,
             capture_layer_ids=target_layer_ids,
+            **_target_verify_kwargs(lm),
         )
         hidden_chunks = [mx.concatenate(first_out.hidden_states, axis=-1)]
         target_chunks = [sampler(first_out.logits)]
@@ -180,6 +182,7 @@ def _eagle3_verify_target(
                 verify_input[:, 1:],
                 cache=prompt_cache,
                 capture_layer_ids=target_layer_ids,
+                **_target_verify_kwargs(lm),
             )
             hidden_chunks.append(mx.concatenate(tail_out.hidden_states, axis=-1))
             target_chunks.append(sampler(tail_out.logits))
@@ -194,6 +197,7 @@ def _eagle3_verify_target(
         verify_input,
         cache=prompt_cache,
         capture_layer_ids=target_layer_ids,
+        **_target_verify_kwargs(lm),
     )
     hidden = mx.concatenate(verify_out.hidden_states, axis=-1)
     target_tokens = sampler(verify_out.logits)

--- a/mlx_vlm/speculative/utils.py
+++ b/mlx_vlm/speculative/utils.py
@@ -61,6 +61,7 @@ __all__ = [
     "make_speculative_prompt_cache",
     "run_speculative_rounds",
     "run_speculative_server_rounds",
+    "speculative_prefill_step_size",
     "speculative_hidden_state",
     "speculative_prefill_kwargs",
     "speculative_stats_since",
@@ -77,10 +78,11 @@ def get_speculative_rounds_batch(draft_kind: str):
         return _eagle3_rounds_batch
     if draft_kind == "mtp":
         return _mtp_rounds_batch
-    if draft_kind == "dflash":
+    if draft_kind in ("dflash", "dspark"):
         return _dflash_rounds_batch
     raise ValueError(
-        f"Unknown draft_kind {draft_kind!r}. Supported: ['dflash', 'eagle3', 'mtp']"
+        f"Unknown draft_kind {draft_kind!r}. Supported: "
+        "['dflash', 'dspark', 'eagle3', 'mtp']"
     )
 
 
@@ -89,20 +91,71 @@ def speculative_prefill_kwargs(draft_kind: str, drafter) -> dict:
         return {"return_hidden": True, "return_shared_kv": True}
     if draft_kind == "eagle3":
         return {"capture_layer_ids": _eagle3_capture_layer_ids(drafter)}
-    if draft_kind == "dflash":
+    if draft_kind in ("dflash", "dspark"):
         return {"capture_layer_ids": list(drafter.config.target_layer_ids)}
     raise ValueError(
-        f"Unknown draft_kind {draft_kind!r}. Supported: ['dflash', 'eagle3', 'mtp']"
+        f"Unknown draft_kind {draft_kind!r}. Supported: "
+        "['dflash', 'dspark', 'eagle3', 'mtp']"
     )
+
+
+def speculative_prefill_step_size(
+    prefill_step_size,
+    drafter,
+    *,
+    device_info=None,
+    active_memory=None,
+    cache_memory=None,
+):
+    """Choose a power-of-two prefill chunk from live Metal headroom.
+
+    ``prefill_step_size`` remains the caller's ceiling. Drafters may provide a
+    conservative per-token working-memory estimate; without one, the caller's
+    value is returned unchanged. Passing zero keeps chunking disabled.
+    """
+    if prefill_step_size is None:
+        return None
+    requested = int(prefill_step_size)
+    if requested <= 0:
+        return None
+
+    bytes_per_token = getattr(drafter, "prefill_memory_bytes_per_token", None)
+    if bytes_per_token is None or int(bytes_per_token) <= 0:
+        return requested
+
+    try:
+        info = device_info if device_info is not None else mx.device_info()
+        working_set = int(info["max_recommended_working_set_size"])
+        active = (
+            int(active_memory)
+            if active_memory is not None
+            else int(mx.get_active_memory())
+        )
+        cached = (
+            int(cache_memory)
+            if cache_memory is not None
+            else int(mx.get_cache_memory())
+        )
+    except (AttributeError, KeyError, TypeError, ValueError):
+        return requested
+
+    # Preserve room for Metal kernels, command buffers, the OS, and growth of
+    # the target/drafter KV caches. The remainder funds the transient prefill.
+    reserve = max(512 * 1024**2, working_set // 10)
+    available = max(0, working_set - active - cached - reserve)
+    estimated = max(8, available // int(bytes_per_token))
+    power_of_two = 1 << (int(estimated).bit_length() - 1)
+    return min(requested, power_of_two)
 
 
 def speculative_hidden_state(draft_kind: str, outputs):
     if draft_kind == "mtp":
         return outputs.hidden_states[-1]
-    if draft_kind in ("dflash", "eagle3"):
+    if draft_kind in ("dflash", "dspark", "eagle3"):
         return mx.concatenate(outputs.hidden_states, axis=-1)
     raise ValueError(
-        f"Unknown draft_kind {draft_kind!r}. Supported: ['dflash', 'eagle3', 'mtp']"
+        f"Unknown draft_kind {draft_kind!r}. Supported: "
+        "['dflash', 'dspark', 'eagle3', 'mtp']"
     )
 
 
@@ -196,7 +249,7 @@ def run_speculative_server_rounds(
         )
         return
 
-    if draft_kind == "dflash":
+    if draft_kind in ("dflash", "dspark"):
         if batch_size == 1:
             for tok, state in _dflash_rounds(
                 model,
@@ -229,7 +282,8 @@ def run_speculative_server_rounds(
         return
 
     raise ValueError(
-        f"Unknown draft_kind {draft_kind!r}. Supported: ['dflash', 'eagle3', 'mtp']"
+        f"Unknown draft_kind {draft_kind!r}. Supported: "
+        "['dflash', 'dspark', 'eagle3', 'mtp']"
     )
 
 
@@ -347,9 +401,10 @@ def run_speculative_rounds(
             )
         return
 
-    if draft_kind != "dflash":
+    if draft_kind not in ("dflash", "dspark"):
         raise ValueError(
-            f"Unknown draft_kind {draft_kind!r}. Supported: ['dflash', 'eagle3', 'mtp']"
+            f"Unknown draft_kind {draft_kind!r}. Supported: "
+            "['dflash', 'dspark', 'eagle3', 'mtp']"
         )
 
     hidden = mx.concatenate(last_outputs.hidden_states, axis=-1)

--- a/mlx_vlm/tests/test_speculative.py
+++ b/mlx_vlm/tests/test_speculative.py
@@ -2257,18 +2257,18 @@ def test_dspark_draft_uses_full_trained_block_for_two_proposals():
     assert drafter.max_runtime_block_size == 8
     assert drafter.prefill_memory_bytes_per_token == 16
     assert speculative_utils._dflash_block_total(drafter, None) == 8
-    assert _dflash_next_block_size(
-        drafter,
-        drafter.max_runtime_block_size,
-        64,
-        drafter.dflash_initial_block_size,
-    ) == 4
+    assert (
+        _dflash_next_block_size(
+            drafter,
+            drafter.max_runtime_block_size,
+            64,
+            drafter.dflash_initial_block_size,
+        )
+        == 4
+    )
     drafter.accept_lens = [0]
     drafter.draft_lens = [3]
-    assert (
-        _dflash_next_block_size(drafter, drafter.max_runtime_block_size, 64)
-        == 3
-    )
+    assert _dflash_next_block_size(drafter, drafter.max_runtime_block_size, 64) == 3
     seen = {}
 
     def fake_hidden(self, inputs, target_hidden, cache):
@@ -2277,9 +2277,7 @@ def test_dspark_draft_uses_full_trained_block_for_two_proposals():
 
     def fake_logits(self, hidden):
         assert hidden.shape[1] == 2
-        return mx.array(
-            [[[0.0, 5.0, 0.0, 0.0], [0.0, 0.0, 5.0, 0.0]]]
-        )
+        return mx.array([[[0.0, 5.0, 0.0, 0.0], [0.0, 0.0, 5.0, 0.0]]])
 
     drafter._hidden = MethodType(fake_hidden, drafter)
     drafter._logits = MethodType(fake_logits, drafter)

--- a/mlx_vlm/tests/test_speculative.py
+++ b/mlx_vlm/tests/test_speculative.py
@@ -57,6 +57,8 @@ from mlx_vlm.speculative.drafters.qwen3_5_mtp import ModelConfig as Qwen3_5MTPCo
 from mlx_vlm.speculative.drafters.qwen3_5_mtp import Qwen3_5MTPDraftModel
 from mlx_vlm.speculative.drafters.qwen3_5_mtp.split import split_qwen3_5_mtp
 from mlx_vlm.speculative.drafters.qwen3_dflash import DFlashDraftModel, ModelConfig
+from mlx_vlm.speculative.drafters.qwen3_dspark import DSparkDraftModel
+from mlx_vlm.speculative.drafters.qwen3_dspark import ModelConfig as DSparkConfig
 from mlx_vlm.speculative.eagle3 import (
     _eagle3_block_settings,
     _eagle3_next_block_size,
@@ -79,6 +81,7 @@ from mlx_vlm.speculative.utils import (
     _speculative_walk_batch_uniform_acceptance,
     _speculative_walk_deferred_greedy,
     speculative_prefill_kwargs,
+    speculative_prefill_step_size,
 )
 from mlx_vlm.turboquant import BatchTurboQuantKVCache
 from mlx_vlm.utils import get_model_and_args
@@ -2159,6 +2162,140 @@ def test_dflash_drafter_uses_bound_target_embedding_scale():
     assert embedded.tolist() == [[[2.0] * 4, [2.0] * 4]]
 
 
+def test_dspark_config_parses_specforge_metadata():
+    config = DSparkConfig.from_dict(
+        {
+            "model_type": "qwen3",
+            "hidden_size": 4,
+            "intermediate_size": 8,
+            "num_hidden_layers": 0,
+            "num_attention_heads": 1,
+            "num_key_value_heads": 1,
+            "head_dim": 4,
+            "vocab_size": 8,
+            "block_size": 7,
+            "num_target_layers": 64,
+            "markov_rank": 2,
+            "rope_parameters": {
+                "rope_type": "yarn",
+                "rope_theta": 10000000,
+                "factor": 32.0,
+                "original_max_position_embeddings": 8192,
+            },
+            "dflash_config": {
+                "projector_type": "dspark",
+                "mask_token_id": 6,
+                "target_layer_ids": [4, 16, 28, 40, 52],
+            },
+        }
+    )
+
+    assert config.model_type == "dspark"
+    assert config.block_size == 7
+    assert config.runtime_block_size is None
+    assert config.mask_token_id == 6
+    assert config.target_layer_ids == [4, 16, 28, 40, 52]
+    assert config.rope_scaling["rope_type"] == "yarn"
+    assert config.rope_theta == 10000000
+
+
+def test_dspark_prefill_step_size_scales_with_metal_headroom():
+    gib = 1024**3
+    drafter = SimpleNamespace(prefill_memory_bytes_per_token=64 * 1024**2)
+
+    assert (
+        speculative_prefill_step_size(
+            2048,
+            drafter,
+            device_info={"max_recommended_working_set_size": 20 * gib},
+            active_memory=8 * gib,
+            cache_memory=0,
+        )
+        == 128
+    )
+    assert (
+        speculative_prefill_step_size(
+            2048,
+            drafter,
+            device_info={"max_recommended_working_set_size": 40 * gib},
+            active_memory=20 * gib,
+            cache_memory=0,
+        )
+        == 256
+    )
+    assert (
+        speculative_prefill_step_size(
+            2048,
+            drafter,
+            device_info={"max_recommended_working_set_size": 80 * gib},
+            active_memory=20 * gib,
+            cache_memory=0,
+        )
+        == 512
+    )
+    assert speculative_prefill_step_size(64, drafter, device_info={}) == 64
+    assert speculative_prefill_step_size(0, drafter) is None
+    assert speculative_prefill_step_size(None, drafter) is None
+
+
+def test_dspark_draft_uses_full_trained_block_for_two_proposals():
+    config = DSparkConfig(
+        hidden_size=4,
+        intermediate_size=8,
+        num_hidden_layers=0,
+        num_attention_heads=1,
+        num_key_value_heads=1,
+        head_dim=4,
+        vocab_size=4,
+        block_size=7,
+        mask_token_id=3,
+        target_layer_ids=[0],
+        markov_rank=0,
+        enable_confidence_head=False,
+    )
+    drafter = DSparkDraftModel(config)
+    assert drafter.max_runtime_block_size == 8
+    assert drafter.prefill_memory_bytes_per_token == 16
+    assert speculative_utils._dflash_block_total(drafter, None) == 8
+    assert _dflash_next_block_size(
+        drafter,
+        drafter.max_runtime_block_size,
+        64,
+        drafter.dflash_initial_block_size,
+    ) == 4
+    drafter.accept_lens = [0]
+    drafter.draft_lens = [3]
+    assert (
+        _dflash_next_block_size(drafter, drafter.max_runtime_block_size, 64)
+        == 3
+    )
+    seen = {}
+
+    def fake_hidden(self, inputs, target_hidden, cache):
+        seen["inputs"] = inputs
+        return mx.zeros((1, inputs.shape[1], 4), dtype=mx.float32)
+
+    def fake_logits(self, hidden):
+        assert hidden.shape[1] == 2
+        return mx.array(
+            [[[0.0, 5.0, 0.0, 0.0], [0.0, 0.0, 5.0, 0.0]]]
+        )
+
+    drafter._hidden = MethodType(fake_hidden, drafter)
+    drafter._logits = MethodType(fake_logits, drafter)
+    drafted = drafter.draft_block(
+        1,
+        mx.zeros((1, 1, 4), dtype=mx.float32),
+        [],
+        block_size=3,
+        sampler=lambda logits: mx.argmax(logits, axis=-1),
+    )
+
+    assert seen["inputs"].shape == (1, 7)
+    assert seen["inputs"].tolist() == [[1, 3, 3, 3, 3, 3, 3]]
+    assert drafted.tolist() == [[1, 2]]
+
+
 def test_dflash_config_parses_sliding_attention_metadata():
     config = ModelConfig.from_dict(
         {
@@ -2447,6 +2584,22 @@ def test_kind_none_autodetects_eagle3_speculators_config(tmp_path):
     assert resolve_drafter_kind(path, "dflash") == "eagle3"
 
 
+def test_kind_none_autodetects_specforge_dspark_config(tmp_path):
+    path = tmp_path / "drafter"
+    path.mkdir()
+    (path / "config.json").write_text(
+        json.dumps(
+            {
+                "model_type": "qwen3",
+                "dflash_config": {"projector_type": "dspark"},
+            }
+        )
+    )
+
+    assert resolve_drafter_kind(path, None) == "dspark"
+    assert resolve_drafter_kind(path, "dflash") == "dspark"
+
+
 @pytest.mark.parametrize("model_type,hidden_size_field", MTP_DRAFTER_COMPAT_CASES)
 def test_mtp_drafter_compatibility_accepts_matching_target(
     model_type, hidden_size_field
@@ -2512,6 +2665,18 @@ def test_model_loader_uses_speculators_model_type_for_eagle3_config():
     assert arch.Model is Eagle3DraftModel
 
 
+def test_model_loader_routes_specforge_dspark_checkpoint():
+    arch, model_type = get_model_and_args(
+        {
+            "model_type": "qwen3",
+            "dflash_config": {"projector_type": "dspark"},
+        }
+    )
+
+    assert model_type == "qwen3_dspark"
+    assert arch.Model is DSparkDraftModel
+
+
 def test_model_loader_uses_gemma4_unified_assistant_drafter():
     arch, model_type = get_model_and_args({"model_type": "gemma4_unified_assistant"})
 
@@ -2573,6 +2738,47 @@ def _tiny_qwen3_5_text_config():
             "partial_rotary_factor": 0.25,
         },
     )
+
+
+def test_qwen3_5_prefill_hidden_capture_does_not_retain_gdn_rollback_state():
+    from mlx_vlm.models import qwen3_5
+
+    text_config = _tiny_qwen3_5_text_config()
+    text_config.num_hidden_layers = 2
+    text_config.full_attention_interval = 2
+    config = qwen3_5.ModelConfig(
+        text_config=text_config,
+        vision_config=qwen3_5.VisionConfig(
+            model_type="qwen3_5",
+            depth=1,
+            hidden_size=16,
+            intermediate_size=32,
+            out_hidden_size=16,
+            num_heads=2,
+        ),
+        model_type="qwen3_5",
+    )
+    model = qwen3_5.LanguageModel(text_config, config)
+    mx.eval(model.parameters())
+    tokens = mx.array([[1, 2, 3]], dtype=mx.int32)
+
+    prefill = model(
+        tokens,
+        cache=model.make_cache(),
+        capture_layer_ids=[0],
+    )
+    verify = model(
+        tokens,
+        cache=model.make_cache(),
+        capture_layer_ids=[0],
+        capture_gdn_states=True,
+    )
+    mx.eval(prefill.logits, verify.logits)
+
+    assert len(prefill.hidden_states) == 1
+    assert prefill.gdn_states is None
+    assert len(verify.hidden_states) == 1
+    assert len(verify.gdn_states) == 1
 
 
 def _tiny_deepseek_v4_config():
@@ -2638,6 +2844,16 @@ def test_eagle3_prefill_uses_mlx_capture_layer_indexes():
 
     assert speculative_prefill_kwargs("eagle3", drafter) == {
         "capture_layer_ids": [1, 29, 56]
+    }
+
+
+def test_dspark_prefill_captures_checkpoint_target_layers():
+    drafter = SimpleNamespace(
+        config=SimpleNamespace(target_layer_ids=[4, 16, 28, 40, 52])
+    )
+
+    assert speculative_prefill_kwargs("dspark", drafter) == {
+        "capture_layer_ids": [4, 16, 28, 40, 52]
     }
 
 

--- a/mlx_vlm/utils.py
+++ b/mlx_vlm/utils.py
@@ -611,8 +611,11 @@ def get_model_and_args(config: dict, model_path: Optional[Path] = None):
 
     model_type = MODEL_REMAPPING.get(model_type, model_type)
 
-    is_dflash = config.get("dflash_config", None) is not None
-    if is_dflash:
+    dflash_config = config.get("dflash_config") or {}
+    is_dspark = dflash_config.get("projector_type") == "dspark"
+    if is_dspark:
+        model_type += "_dspark"
+    elif dflash_config:
         model_type += "_dflash"
 
     last_err: Optional[ImportError] = None


### PR DESCRIPTION
## Summary

- add native DSpark checkpoint loading and speculative decoding for `RadixArk/Qwen3.8-27B-DSpark`
- auto-detect DSpark checkpoints and expose `--draft-kind dspark` plus load-time `--draft-bits` quantization
- add acceptance-adaptive draft depth while keeping explicit block sizes fixed for reproducible tuning
- make speculative prefill sizing depend on live Metal headroom instead of a specific Mac tier
- document CLI and server usage for Qwen3.8

## Root cause and memory fix

Qwen3.5/3.8 previously coupled hidden-layer capture with Gated DeltaNet rollback capture. DSpark prefill only needs five hidden-state taps, but a 1k prompt retained per-token rollback intermediates across all 48 linear-attention layers. This could require more than 150 GB before other activations and caused unchunked prefill to be killed.

This change separates hidden capture from rollback-state capture. Rollback intermediates are now retained only for short speculative verification rounds. It also explicitly collects and clears the dense BF16 drafter tensors after load-time quantization.

## Impact

On an Apple M5 Max with 48 GB unified memory, using Qwen3.8-27B-4bit with a fixed three-proposal DSpark block:

- 1,029-token unchunked prefill: 857.6 tok/s
- 64-token decode: 43.57 tok/s
- peak Metal memory: 19.54 GB
- baseline decode: ~33.6 tok/s (about 30% slower)
- the same unchunked prefill previously OOMed

The quantized drafter's live parameter footprint is about 0.765 GB after reclaiming the dense load-time copy.

## Validation

- `162 passed, 1 deselected` in `mlx_vlm/tests/test_speculative.py`
- `31 passed` targeted server and prompt tests
- targeted Ruff fatal/error checks passed
- `git diff --check` passed
- real-model 1k-input/64-output server benchmark passed

The deselected speculative test is the existing exact-BF16 quantized-linear equality check; it remains unrelated to DSpark and differs only in numerical accumulation.