### PR TITLE
Fused batched decode for BatchTurboQuantKVCache

### DIFF
--- a/mlx_vlm/models/base.py
+++ b/mlx_vlm/models/base.py
@@ -341,6 +341,16 @@ def scaled_dot_product_attention(
         )
 
     if isinstance(cache, BatchTurboQuantKVCache):
+        if sinks is None and queries.shape[-2] == 1:
+            fused = cache.decode_attention(
+                queries,
+                keys_state=keys,
+                values_state=values,
+                scale=scale,
+                mask=mask,
+            )
+            if fused is not None:
+                return fused
         dequantized_keys, dequantized_values = cache.dequantize(keys, values)
         return mx.fast.scaled_dot_product_attention(
             queries,

--- a/mlx_vlm/tests/test_turboquant.py
+++ b/mlx_vlm/tests/test_turboquant.py
@@ -255,6 +255,80 @@ def test_turboquant_cache_preserves_attention_shape_and_compresses_memory():
     assert diff < 0.35
 
 
+def _build_ragged_batch_turbo(lengths, nkv, D, bits, seed=0):
+    mx.random.seed(seed)
+    base = None
+    for L in lengths:
+        c = BatchTurboQuantKVCache([0], bits=bits)
+        c.update_and_fetch(
+            mx.random.normal((1, nkv, L, D)).astype(mx.float16),
+            mx.random.normal((1, nkv, L, D)).astype(mx.float16),
+        )
+        base = c if base is None else (base.extend(c) or base)
+    return base
+
+
+def test_batch_turboquant_fused_decode_matches_reference():
+    """Fused ragged batch decode == per-row single-row fused == dequantized SDPA,
+    across 1-pass/2-pass, GQA ratios, head dims and bit widths."""
+    if not mx.metal.is_available():
+        pytest.skip("requires Metal")
+
+    # (lengths, n_kv_heads, n_q_heads, head_dim, bits)
+    cases = [
+        ([64, 40, 100, 16], 4, 8, 128, 4),  # 1-pass, ragged
+        ([200, 50, 300, 17, 128, 33, 256, 8], 2, 16, 128, 4),  # 1-pass, B=8
+        ([500, 128], 8, 8, 64, 8),  # 1-pass, 8-bit
+        ([3000, 1500, 4096, 500], 4, 8, 128, 4),  # 2-pass (>2048)
+        ([2048, 1000, 512, 1500], 4, 24, 256, 4),  # GQA-6, D=256
+    ]
+    for lengths, nkv, nq, D, bits in cases:
+        cache = _build_ragged_batch_turbo(lengths, nkv, D, bits)
+        B = len(lengths)
+        mx.random.seed(1)
+        q = mx.random.normal((B, nq, 1, D)).astype(mx.float16)
+        scale = D**-0.5
+        fused = cache.decode_attention(q, scale=scale)
+        assert fused is not None, f"fused decode not taken for {lengths}"
+        assert fused.shape == (B, nq, 1, D)
+        for i in range(B):
+            single = cache.extract(i)
+            qi = q[i : i + 1]
+            ref_fused = single.decode_attention(qi, scale=scale)
+            dk, dv = single.dequantize()
+            ref_dq = mx.fast.scaled_dot_product_attention(
+                qi, dk.astype(qi.dtype), dv.astype(qi.dtype), scale=scale
+            )
+            f = fused[i : i + 1].astype(mx.float32)
+            assert float(mx.max(mx.abs(f - ref_fused.astype(mx.float32)))) < 1e-4
+            assert float(mx.max(mx.abs(f - ref_dq.astype(mx.float32)))) < 5e-3
+
+
+def test_batch_turboquant_fused_decode_respects_left_padding_mask():
+    """The fused path reproduces the left-padding causal mask via `pads`, so it
+    matches dequantize->SDPA with the explicit mask."""
+    if not mx.metal.is_available():
+        pytest.skip("requires Metal")
+    lengths, nkv, nq, D = [64, 40, 100, 16], 4, 8, 128
+    cache = _build_ragged_batch_turbo(lengths, nkv, D, 4)
+    B = len(lengths)
+    mx.random.seed(1)
+    q = mx.random.normal((B, nq, 1, D)).astype(mx.float16)
+    scale = D**-0.5
+    T = cache._idx
+    rinds = mx.arange(T)
+    mask = (rinds[None, :] >= cache.left_padding[:, None]).reshape(B, 1, 1, T)
+    fused = cache.decode_attention(q, scale=scale, mask=mask)
+    assert fused is not None
+    dk, dv = cache.dequantize()
+    ref = mx.fast.scaled_dot_product_attention(
+        q, dk.astype(q.dtype), dv.astype(q.dtype), scale=scale, mask=mask
+    )
+    assert (
+        float(mx.max(mx.abs(fused.astype(mx.float32) - ref.astype(mx.float32)))) < 5e-3
+    )
+
+
 def test_turboquant_decode_attention_matches_dequantized_attention():
     keys = mx.random.normal((1, 2, 16, 32))
     values = mx.random.normal((1, 2, 16, 32))

--- a/mlx_vlm/turboquant.py
+++ b/mlx_vlm/turboquant.py
@@ -2300,8 +2300,14 @@ def _gen_unrolled_value(bits: int, n_elems: int, bit_off_var: str = "") -> str:
 
 
 @lru_cache(maxsize=None)
-def _fused_mse_decode_kernel(key_bits: int, val_bits: int, dim: int = 256):
-    """Fused MSE decode: 32 simdgroups × 32 lanes, online softmax + weighted sum."""
+def _fused_mse_decode_kernel(
+    key_bits: int, val_bits: int, dim: int = 256, ragged: bool = False
+):
+    """Fused MSE decode: 32 simdgroups × 32 lanes, online softmax + weighted sum.
+
+    ragged=True adds a per-row ``pads`` input (left-padding count per batch row) so a
+    left-padded continuous-batch cache skips its padding tokens; ragged=False is the
+    original single-length path, byte-identical."""
     if not _metal_available() or key_bits <= 0 or val_bits <= 0:
         return None
     if dim < 32 or dim % 32 != 0:
@@ -2331,6 +2337,7 @@ def _fused_mse_decode_kernel(key_bits: int, val_bits: int, dim: int = 256):
         auto token_count = key_norms_shape[2];
         auto kv_heads = key_norms_shape[1];
         auto bh = bqh / RepeatCount;  // map q_head -> kv_head
+        {"int pad = (int)pads[bqh / (kv_heads * RepeatCount)];" if ragged else ""}
 
         auto k_nm = key_norms + bh * token_count;
         auto k_pk = key_packed + bh * token_count * KPackedWidth;
@@ -2362,7 +2369,7 @@ def _fused_mse_decode_kernel(key_bits: int, val_bits: int, dim: int = 256):
         {"int v_bit_off = v_bit_start & 7;" if (elems_per_lane * val_bits) % 8 else ""}
 
         // KV loop: each simdgroup handles tokens simd_gid, simd_gid+32, ...
-        for (int t = simd_gid; t < (int)token_count; t += BN) {{
+        for (int t = {"(int)pad + " if ragged else ""}simd_gid; t < (int)token_count; t += BN) {{
             U kn = static_cast<U>(k_nm[t]);
 
             // Key score — unrolled byte extraction
@@ -2418,25 +2425,33 @@ def _fused_mse_decode_kernel(key_bits: int, val_bits: int, dim: int = 256):
         }}
     """
 
+    input_names = [
+        "queries",
+        "key_norms",
+        "key_packed",
+        "key_codebook",
+        "val_norms",
+        "val_packed",
+        "val_codebook",
+    ]
+    if ragged:
+        input_names.append("pads")
     return mx.fast.metal_kernel(
-        name=f"turboquant_fused_mse_sdpa_k{key_bits}_v{val_bits}_d{dim}",
-        input_names=[
-            "queries",
-            "key_norms",
-            "key_packed",
-            "key_codebook",
-            "val_norms",
-            "val_packed",
-            "val_codebook",
-        ],
+        name=f"turboquant_fused_mse_sdpa_k{key_bits}_v{val_bits}_d{dim}"
+        f"{'_ragged' if ragged else ''}",
+        input_names=input_names,
         output_names=["out"],
         source=source,
     )
 
 
 @lru_cache(maxsize=None)
-def _fused_mse_decode_2pass_1_kernel(key_bits: int, val_bits: int, dim: int = 256):
-    """2-pass decode pass 1: block-parallel quantized attention."""
+def _fused_mse_decode_2pass_1_kernel(
+    key_bits: int, val_bits: int, dim: int = 256, ragged: bool = False
+):
+    """2-pass decode pass 1: block-parallel quantized attention.
+
+    ragged=True skips per-row left-padding via a ``pads`` input."""
     if not _metal_available() or key_bits <= 0 or val_bits <= 0:
         return None
     if dim < 32 or dim % 32 != 0:
@@ -2472,6 +2487,7 @@ def _fused_mse_decode_2pass_1_kernel(key_bits: int, val_bits: int, dim: int = 25
         auto k_pk = key_packed + bh * token_count * KPackedWidth;
         auto v_nm = val_norms + bh * token_count;
         auto v_pk = val_packed + bh * token_count * VPackedWidth;
+        {"int pad = (int)pads[batch_idx];" if ragged else ""}
 
         // Load pre-rotated query
         thread U q[qk_per_thread];
@@ -2492,7 +2508,7 @@ def _fused_mse_decode_2pass_1_kernel(key_bits: int, val_bits: int, dim: int = 25
         {"int v_bit_off = v_bit_start & 7;" if (elems_per_lane * val_bits) % 8 else ""}
 
         // KV loop: stride by blocks (each block handles a different subset)
-        for (int t = block_idx; t < (int)token_count; t += Blocks) {{
+        for (int t = {"(int)pad + " if ragged else ""}block_idx; t < (int)token_count; t += Blocks) {{
             U kn = static_cast<U>(k_nm[t]);
 
             // Key score — unrolled byte extraction
@@ -2522,17 +2538,21 @@ def _fused_mse_decode_2pass_1_kernel(key_bits: int, val_bits: int, dim: int = 25
                 static_cast<U>(o[i]);
     """
 
+    input_names = [
+        "queries",
+        "key_norms",
+        "key_packed",
+        "key_codebook",
+        "val_norms",
+        "val_packed",
+        "val_codebook",
+    ]
+    if ragged:
+        input_names.append("pads")
     return mx.fast.metal_kernel(
-        name=f"turboquant_mse_sdpa_2pass1_k{key_bits}_v{val_bits}_d{dim}",
-        input_names=[
-            "queries",
-            "key_norms",
-            "key_packed",
-            "key_codebook",
-            "val_norms",
-            "val_packed",
-            "val_codebook",
-        ],
+        name=f"turboquant_mse_sdpa_2pass1_k{key_bits}_v{val_bits}_d{dim}"
+        f"{'_ragged' if ragged else ''}",
+        input_names=input_names,
         output_names=["out_acc", "out_sums", "out_maxs"],
         source=source,
     )
@@ -6338,6 +6358,120 @@ class BatchTurboQuantKVCache(_BaseCache):
         k = self.key_codec.dequantize(keys_state).astype(mx.float32)
         v = self.value_codec.dequantize(values_state).astype(mx.float32)
         return k, v
+
+    def decode_attention(
+        self, queries, keys_state=None, values_state=None, scale=1.0, mask=None
+    ):
+        """Fused ragged decode over the left-padded batch. Returns None to signal
+        the caller to fall back to dequantize->SDPA (unsupported codec/bits/shape)."""
+        if keys_state is None or values_state is None:
+            keys_state = _slice_state(self.keys, self._idx)
+            values_state = _slice_state(self.values, self._idx)
+        if isinstance(keys_state, _QuantizedStateProxy):
+            keys_state = keys_state._state
+        if isinstance(values_state, _QuantizedStateProxy):
+            values_state = values_state._state
+
+        if queries.shape[-2] != 1:
+            return None
+        if not (
+            isinstance(self.key_codec, _TurboQuantMSECodec)
+            and isinstance(self.value_codec, _TurboQuantMSECodec)
+            and isinstance(keys_state, TurboQuantMSEState)
+            and isinstance(values_state, TurboQuantMSEState)
+        ):
+            return None
+        # Left-padding is reproduced by `pads`; BatchTurboQuant is only used for
+        # non-windowed causal attention (windowed -> RotatingKVCache, excluded from
+        # turbo), so a None/"causal"/left-padding-array mask is handled. Reject only
+        # unexpected string masks.
+        if isinstance(mask, str) and mask != "causal":
+            return None
+
+        B, n_q_heads, L, D = queries.shape
+        n_kv_heads = keys_state.norms.shape[1]
+        n_repeats = n_q_heads // n_kv_heads
+        total_tokens = _state_length(keys_state)
+        key_bits = int(self.key_codec.bits)
+        val_bits = int(self.value_codec.bits)
+        dtype = queries.dtype
+        value_dim = self.value_codec.dim
+
+        grouped = (queries * scale).reshape(B, n_kv_heads, n_repeats, L, D)
+        q_rot_flat = self.key_codec.prepare_queries(grouped).reshape(
+            B * n_kv_heads * n_repeats, D
+        )
+        BQH = B * n_q_heads
+        pads = self.left_padding.astype(mx.int32)
+        kv_inputs = [
+            q_rot_flat,
+            keys_state.norms,
+            keys_state.indices,
+            self.key_codec.codebook,
+            values_state.norms,
+            values_state.indices,
+            self.value_codec.codebook,
+            pads,
+        ]
+        packed = [
+            ("KPackedWidth", keys_state.indices.shape[-1]),
+            ("VPackedWidth", values_state.indices.shape[-1]),
+        ]
+
+        if total_tokens <= 2048:
+            kernel = _fused_mse_decode_kernel(key_bits, val_bits, D, ragged=True)
+            if kernel is None:
+                return None
+            out = kernel(
+                inputs=kv_inputs,
+                template=[("Dim", D), ("RepeatCount", n_repeats), *packed],
+                grid=(BQH * 1024, 1, 1),
+                threadgroup=(1024, 1, 1),
+                output_shapes=[(BQH, D)],
+                output_dtypes=[mx.float32],
+            )[0]
+        else:
+            pass1 = _fused_mse_decode_2pass_1_kernel(key_bits, val_bits, D, ragged=True)
+            pass2 = _fused_mse_decode_2pass_2_kernel()
+            if pass1 is None or pass2 is None:
+                return None
+            if total_tokens <= 8192:
+                num_blocks = 64
+            elif total_tokens <= 32768:
+                num_blocks = 128
+            elif total_tokens <= 65536:
+                num_blocks = 256
+            else:
+                num_blocks = 512
+            out_acc, out_sums, out_maxs = pass1(
+                inputs=kv_inputs,
+                template=[
+                    ("Dim", D),
+                    ("RepeatCount", n_repeats),
+                    ("Blocks", num_blocks),
+                    *packed,
+                ],
+                grid=(n_kv_heads * 32, B * n_repeats, num_blocks),
+                threadgroup=(32, n_repeats, 1),
+                output_shapes=[
+                    (BQH * num_blocks, D),
+                    (BQH * num_blocks,),
+                    (BQH * num_blocks,),
+                ],
+                output_dtypes=[mx.float32, mx.float32, mx.float32],
+            )
+            out = pass2(
+                inputs=[out_acc, out_sums, out_maxs],
+                template=[("Dim", D), ("Blocks", num_blocks)],
+                grid=(BQH * 1024, 1, 1),
+                threadgroup=(1024, 1, 1),
+                output_shapes=[(BQH, D)],
+                output_dtypes=[mx.float32],
+            )[0]
+
+        out_rotated = out.reshape(B, n_kv_heads, n_repeats, D)
+        output = self.value_codec._rotate_inverse(out_rotated)
+        return output.reshape(B, n_q_heads, L, value_dim).astype(dtype)
 
     def dequantize_for_apc(self):
         """Return raw float (keys, values) for APC storage.


### PR DESCRIPTION
> ⚠️ **Experimental / draft** — still validating.

`BatchTurboQuantKVCache` had no fused attention: every decode step dequantized the whole KV cache and ran SDPA. I extended the single-sequence fused decode kernels to the batched, left-padded cache (`pads`-aware, 1-pass + 2-pass), wired through the `base.py` dispatcher with the old dequant→SDPA path kept as fallback.

**Decode-only.** Prefill is untouched (still the old path), so it's unchanged.

### Speedup vs the current dequant→SDPA path (4-bit KV, ctx 8192)

| model | prefill | decode ×B1 | decode ×B4 |
|--|--|--|--|
| Qwen2.5-0.5B | 1.0× | 3.3× | 7.5× |
| Qwen2.5-1.5B | 1.0× | 4.3× | 6.0× |
| Qwen2.5-3B   | 1.0× | 3.6× | 6.9× |
| Qwen2.5-7B   | 1.0× | 3.2× | 5.9× |
| Llama-3.2-1B | 1.0× | 5.7× | 9.7× |
| Llama-3.2-3B | 1.0× | 8.4× | 10.6× |
| Llama-3.1-8B | 1.0× | 5.4× | 9.1× |
| Mistral-7B   | 1.0× | 5.7× | 8.5× |

<img width="2100" height="1120" alt="turbo_16k" src="https://github.com/user-attachments/assets/06833913-8e27-4d54-a131-e9de65faa248" />

<img width="2100" height="1120" alt="turbo_mac_64k" src="https://github.com/user-attachments/assets/ee3bb22a-8181-4107-8c53-adb7ae574c42" />
