### PR TITLE
Do not start KV quantization in the middle of prefill

### DIFF
--- a/mlx_vlm/generate/ar.py
+++ b/mlx_vlm/generate/ar.py
@@ -36,6 +36,7 @@ from .common import (
     _chunked_prefill_enabled,
     generation_stream,
     maybe_quantize_kv_cache,
+    resolve_quantized_kv_start,
     wired_limit,
 )
 from .types import GenerateKwargs, ProcessorLike, Unpack
@@ -247,6 +248,12 @@ def generate_step(
         Generator[Tuple[mx.array, mx.array], None, None]: A generator producing
           one token and a vector of log probabilities.
     """
+
+    quantized_kv_start = resolve_quantized_kv_start(
+        kv_bits,
+        quantized_kv_start,
+        input_ids.shape[-1] if input_ids is not None else None,
+    )
 
     quantize_cache_fn = functools.partial(
         _generate_module_override("maybe_quantize_kv_cache", maybe_quantize_kv_cache),

--- a/mlx_vlm/generate/common.py
+++ b/mlx_vlm/generate/common.py
@@ -62,6 +62,30 @@ def _chunked_prefill_enabled(
     return draft_model is None
 
 
+def resolve_quantized_kv_start(
+    kv_bits: Optional[float],
+    quantized_kv_start: int,
+    prompt_length: Optional[int],
+) -> int:
+    """Hold KV quantization until the prompt is in, when using the default.
+
+    Quantizing mid-prefill is close to pure cost: the conversion lands while the
+    run is still compute-bound, and every remaining prompt chunk then attends
+    through the slower quantized path. The saving only arrives at decode, once
+    the cache is large enough to dominate bandwidth. A fixed threshold means any
+    prompt longer than it pays that cost for the rest of prefill, so push the
+    conversion out to the prefill/decode boundary, where it happens once.
+
+    A caller who names a threshold means it, including one that fires during
+    prefill, so only the default is adjusted.
+    """
+    if kv_bits is None or prompt_length is None:
+        return quantized_kv_start
+    if quantized_kv_start != DEFAULT_QUANTIZED_KV_START:
+        return quantized_kv_start
+    return max(quantized_kv_start, int(prompt_length))
+
+
 def maybe_quantize_kv_cache(
     prompt_cache,
     quantized_kv_start,

--- a/mlx_vlm/tests/test_quantized_kv_start.py
+++ b/mlx_vlm/tests/test_quantized_kv_start.py
@@ -1,0 +1,62 @@
+import pytest
+
+from mlx_vlm.generate.common import (
+    DEFAULT_QUANTIZED_KV_START,
+    resolve_quantized_kv_start,
+)
+
+DEFAULT = DEFAULT_QUANTIZED_KV_START
+
+
+class TestQuantizedKvStartDefault:
+    """Quantizing mid-prefill costs prefill throughput and peak memory.
+
+    The saving only lands at decode, so the default threshold should not fire
+    while the prompt is still being ingested.
+    """
+
+    def test_long_prompt_defers_past_the_prompt(self):
+        assert resolve_quantized_kv_start(4, DEFAULT, DEFAULT * 4) == DEFAULT * 4
+
+    def test_short_prompt_keeps_the_default(self):
+        # Below the default nothing changes: the cache is too small for
+        # quantization to be worth anything either way.
+        assert resolve_quantized_kv_start(4, DEFAULT, DEFAULT // 10) == DEFAULT
+
+    def test_prompt_exactly_at_the_default(self):
+        assert resolve_quantized_kv_start(4, DEFAULT, DEFAULT) == DEFAULT
+
+    @pytest.mark.parametrize("explicit", [0, 128, DEFAULT + 1])
+    def test_explicit_threshold_is_respected(self, explicit):
+        # A caller who names a threshold means it, including one that fires
+        # during prefill, and including zero.
+        assert resolve_quantized_kv_start(4, explicit, 99999) == explicit
+
+    def test_unquantized_runs_are_untouched(self):
+        # With kv_bits=None the threshold is inert; leave it exactly as passed
+        # so nothing downstream sees a surprising value.
+        assert resolve_quantized_kv_start(None, DEFAULT, 99999) == DEFAULT
+
+    def test_unknown_prompt_length_is_untouched(self):
+        assert resolve_quantized_kv_start(4, DEFAULT, None) == DEFAULT
+
+    @pytest.mark.parametrize("bits", [2, 3, 4, 8, 3.5])
+    def test_applies_to_every_bit_width(self, bits):
+        assert resolve_quantized_kv_start(bits, DEFAULT, DEFAULT * 2) == DEFAULT * 2
+
+    def test_generate_step_uses_the_helper(self):
+        # Guard the wiring, not just the arithmetic: the resolved value has to
+        # reach the functools.partial that captures it.
+        import inspect
+
+        from mlx_vlm.generate import ar as ar_module
+
+        source = inspect.getsource(ar_module.generate_step)
+        resolve_at = source.find("resolve_quantized_kv_start(")
+        bind_at = source.find("quantize_cache_fn = functools.partial(")
+        assert resolve_at != -1, "generate_step no longer resolves the threshold"
+        assert bind_at != -1
+        assert resolve_at < bind_at, (
+            "the threshold must be resolved before quantize_cache_fn binds it, "
+            "or the adjustment is silently discarded"
+        )


### PR DESCRIPTION
> ⚠️ **Experimental / draft** — still validating.

`quantized_kv_start` is a fixed 5000, so any prompt longer than that crosses the threshold while the prompt is still being ingested: the cache converts mid-prefill and every remaining chunk then attends through the slower quantized path, paying for quantization during the phase that is compute-bound and before the cache is large enough for the bandwidth saving to arrive. It also inflates peak memory, because the conversion overlaps the float cache it replaces — enough that `--kv-bits` could push peak above running unquantized at all (13.0 GB against 7.9 GB on Qwen3-4B at 32K). Hold the default until the prompt is in, so the conversion happens once at the prefill/decode boundary; decode still runs fully quantized, which is where the saving was always coming from. An explicit `--quantized-kv-start` is honored untouched, including one that fires during prefill.

Prompts over 5000 tokens produce different tokens, since the prompt's KV is now quantized once rather than incrementally; shorter prompts are byte-identical.

| model | ctx | prefill tok/s | peak GB |
|---|---:|---:|---:|
| Qwen3-0.6B-4bit | 8K | 13,398 → 22,297 | 2.52 → 1.94 |
| Qwen3-0.6B-4bit | 32K | 2,578 → 8,097 | 8.30 → 4.81 |
| Qwen3-4B-4bit | 8K | 2,610 → 3,432 | 5.27 → 4.16 |
| Qwen3-4B-4bit | 32K | 802 → 1,978 | 13.01 → 7.92 |
| Qwen3-8B-4bit | 8K | 1,709 → 2,003 | 7.62 → 6.54 |
| Qwen3-8B-4bit | 32K | 687 → 1,421 | 15.44 → 10.40 |

`--kv-bits 4` on defaults, M5 Max. Each cell ran main/branch/branch/main so drift cancels; peak memory was identical across repeats. 54 checkpoints across 16 architectures, 3 trees × 15 cells, zero new failures.

WIP: 64K and 128K on Qwen3.6/3.8-27B next.

<img width="2520" height="920" alt="image" src="https://github.com/user-attachments/assets/54e9ccdf-fbd0-4a7b-a3b7-64318a9bc052" />

Prefill and peak memory at 8K and 32K, before and after. The gain grows with context because that is where the fixed threshold lands mid-prompt.
