### PR TITLE
Fix SmolVLM split-image token expansion

### DIFF
--- a/mlx_vlm/models/smolvlm/processing_smolvlm.py
+++ b/mlx_vlm/models/smolvlm/processing_smolvlm.py
@@ -174,8 +174,8 @@ class SmolVLMProcessor(ProcessorMixin):
             images = self.image_processor.fetch_images(images)
             images = make_nested_list_of_images(images)
 
-            # Separate image kwargs
-            images_kwargs = {}
+            # Separate image kwargs — always request row/col info for tiling
+            images_kwargs = {"return_row_col_info": True}
             for k in list(kwargs.keys()):
                 if k in ("return_row_col_info",):
                     images_kwargs[k] = kwargs.pop(k)

--- a/mlx_vlm/tests/test_models.py
+++ b/mlx_vlm/tests/test_models.py
@@ -1789,6 +1789,27 @@ class TestSmolVLMFlattenedImageFeatures(unittest.TestCase):
         self.assertEqual(output.shape, inputs_embeds.shape)
         self.assertTrue(mx.array_equal(output, expected).item())
 
+    def test_prepare_inputs_rejects_split_image_token_mismatch(self):
+        """#1919 production shape: 81 placeholders vs 13 flattened tiles.
+
+        The Idefics3 1:1 scatter must keep rejecting this. The processor is
+        what expands the prompt to 13 x 81 tokens; do not paper over the
+        mismatch by dropping extra tiles.
+        """
+        from mlx_vlm.models import smolvlm
+
+        model = SimpleNamespace(config=SimpleNamespace(image_token_index=9))
+        n_tokens, n_tiles, hidden = 81, 13, 3
+        seq = 1 + n_tokens + 1
+        input_ids = mx.array([[1] + [9] * n_tokens + [2]])
+        inputs_embeds = mx.zeros((1, seq, hidden))
+        image_features = mx.zeros((n_tiles * n_tokens, hidden))
+
+        with self.assertRaisesRegex(ValueError, r"tokens: 81, features 1053"):
+            smolvlm.Model._prepare_inputs_for_multimodal(
+                model, image_features, inputs_embeds, input_ids
+            )
+
 
 class TestModels(unittest.TestCase):
     def language_test_runner(self, model, model_type, vocab_size, num_layers):

--- a/mlx_vlm/tests/test_processors.py
+++ b/mlx_vlm/tests/test_processors.py
@@ -1108,6 +1108,83 @@ class TestSmolVLMProcessor(_ProcessorTestBase, unittest.TestCase):
     def _image_call_args(self):
         return {"text": ["<image> Describe"], "images": [[_make_image()]]}
 
+    def test_split_image_prompt_matches_flattened_feature_rows(self):
+        from mlx_vlm.models.smolvlm.processing_smolvlm import get_image_prompt_string
+
+        image_seq_len = 81
+        single = get_image_prompt_string(0, 0, image_seq_len, "<F>", "<image>", "<G>")
+        split = get_image_prompt_string(3, 4, image_seq_len, "<F>", "<image>", "<G>")
+
+        self.assertEqual(single.count("<image>"), image_seq_len)
+        self.assertEqual(split.count("<image>"), 13 * image_seq_len)
+        self.assertIn("<row_1_col_1>", split)
+        self.assertIn("<row_3_col_4>", split)
+
+    def test_split_image_requests_row_col_info_and_expands_tokens(self):
+        """SmolVLM2-2.2B (#1919): 3x4 tiles + global, image_seq_len=81.
+
+        The vision encoder emits 13 x 81 feature rows. Without
+        return_row_col_info the prompt stays on the single-image template
+        (81 <image> tokens) and Idefics3 scatter raises
+        tokens: 81, features 1053.
+        """
+        from mlx_vlm.models.smolvlm.processing_smolvlm import SmolVLMProcessor
+
+        image_seq_len = 81
+        rows, cols = 3, 4
+        n_tiles = rows * cols + 1
+        seen = {}
+        recorded = {}
+
+        class RecordingTokenizer:
+            model_input_names = ["input_ids", "attention_mask"]
+
+            def __call__(self, text, **kw):
+                recorded["text"] = text
+                texts = [text] if isinstance(text, str) else text
+                return {
+                    "input_ids": [list(range(10)) for _ in texts],
+                    "attention_mask": [[1] * 10 for _ in texts],
+                }
+
+        class SplittingImageProcessor:
+            model_input_names = ["pixel_values"]
+
+            def fetch_images(self, images):
+                return [images] if not isinstance(images, list) else images
+
+            def __call__(self, images=None, **kw):
+                seen.update(kw)
+                out = {
+                    "pixel_values": np.random.randn(1, n_tiles, 3, 32, 32).astype(
+                        np.float32
+                    )
+                }
+                if kw.get("return_row_col_info"):
+                    out["rows"] = [[rows]]
+                    out["cols"] = [[cols]]
+                return out
+
+        p = SmolVLMProcessor.__new__(SmolVLMProcessor)
+        p.fake_image_token = "<fake_token_around_image>"
+        p.image_token = "<image>"
+        p.image_token_id = 100
+        p.end_of_utterance_token = "<end_of_utterance>"
+        p.global_image_token = "<global-img>"
+        p.image_seq_len = image_seq_len
+        p.video_token = "<video>"
+        p.image_processor = SplittingImageProcessor()
+        p.tokenizer = RecordingTokenizer()
+
+        p(text=["<image> Describe"], images=[[_make_image()]])
+
+        self.assertTrue(seen.get("return_row_col_info"))
+        expanded = recorded["text"][0]
+        self.assertEqual(expanded.count("<image>"), n_tiles * image_seq_len)
+        self.assertIn("<row_1_col_1>", expanded)
+        self.assertIn("<row_3_col_4>", expanded)
+        self.assertIn("<global-img>", expanded)
+
 
 class TestMllamaProcessor(_ProcessorTestBase, unittest.TestCase):
     def _make_processor(self):


### PR DESCRIPTION
SmolVLMProcessor never asked the image processor for row/col info, so a split image kept the single-image 81-token prompt while the vision encoder emitted 13x81 features. After #1905 flattened onto the Idefics3 1:1 scatter, that shows up as `ValueError: tokens: 81, features 1053`.

I default `return_row_col_info` to True, same as Idefics3 here and HuggingFace's SmolVLM processor, so the prompt expands one image-token block per tile plus global. The flattened merge stays.

Fixes #1919

## Verification
- before, on current `main`: processor `__call__` did not pass `return_row_col_info`; a 3x4 split stayed at 81 `<image>` tokens
- after: 3x4 + global expands to 1053 `<image>` tokens; flattened 1:1 tests still pass; 81 vs 1053 still raises