### PR TITLE
feat(server): add conservative DFlash APC prefix reuse

### DIFF
--- a/mlx_vlm/server/generation.py
+++ b/mlx_vlm/server/generation.py
@@ -159,6 +159,47 @@ def _drop_prefill_kwargs(prompt_kwargs: dict, keys: List[str], n: int) -> dict:
     return out
 
 
+def _dflash_apc_text_only(request) -> bool:
+    """Return whether a queued request has no multimodal prompt state."""
+    if request.images or request.videos or request.audio:
+        return False
+    raw_inputs = request.raw_inputs or {}
+    return not any(
+        key in raw_inputs
+        for key in ("pixel_values", "pixel_values_videos", "input_features")
+    )
+
+
+def _dflash_apc_lookup(
+    request,
+    input_ids: List[int],
+    *,
+    batch_size: int,
+    draft_kind: str,
+    apc_manager,
+    apc_mode: Optional[str],
+):
+    """Look up a conservative B=1, text-only exact-cache DFlash prefix."""
+    if (
+        batch_size != 1
+        or draft_kind != "dflash"
+        or apc_manager is None
+        or apc_mode != "exact"
+        or request.apc_semantic_hash is None
+        or not _dflash_apc_text_only(request)
+    ):
+        return None
+    return _apc.apc_lookup_plan(
+        apc_manager,
+        input_ids,
+        extra_hash=int(request.apc_semantic_hash),
+        apc_mode="exact",
+        safe_lookup_min=0,
+        suffix_is_text_only=lambda _prefix_len: True,
+        prefix_has_media=lambda _prefix_len: False,
+    )
+
+
 def _run_chunked_speculative_prefill(
     lm,
     input_ids: mx.array,
@@ -2144,6 +2185,41 @@ class ResponseGenerator:
                     make_cache=_make_cache,
                 )
 
+                apc_cached_tokens = 0
+                apc_extra_hash = None
+                apc_manager = getattr(self, "apc_manager", None)
+                apc_mode = getattr(self, "apc_mode", None)
+                if B == 1:
+                    apc_extra_hash = pending[0].apc_semantic_hash
+                    try:
+                        apc_plan = _dflash_apc_lookup(
+                            pending[0],
+                            all_input_ids[0],
+                            batch_size=B,
+                            draft_kind=draft_kind,
+                            apc_manager=apc_manager,
+                            apc_mode=apc_mode,
+                        )
+                    except Exception as e:
+                        logger.warning(
+                            "DFlash APC lookup failed; using cold prefill: %s", e
+                        )
+                        apc_plan = None
+                    if apc_plan is not None:
+                        prefix_len = int(apc_plan["prefix_len"])
+                        sequence_keys = _sequence_aligned_prefill_keys(
+                            prompt_kwargs,
+                            batch_size=1,
+                            sequence_length=inputs_embeds_mx.shape[1],
+                        )
+                        input_mx = input_mx[:, prefix_len:]
+                        inputs_embeds_mx = inputs_embeds_mx[:, prefix_len:, :]
+                        prompt_kwargs = _drop_prefill_kwargs(
+                            prompt_kwargs, sequence_keys, prefix_len
+                        )
+                        prompt_cache = apc_plan["warm_cache"]
+                        apc_cached_tokens = prefix_len
+
                 prefill_step_size = self._effective_prefill_step_size()
                 policy_kwargs = {**prompt_kwargs, **prefill_kwargs}
                 if not _chunked_prefill_enabled(
@@ -2179,6 +2255,22 @@ class ResponseGenerator:
                 )
                 mx.eval(first_bonus, hidden, out.logits)
                 prompt_elapsed = time.perf_counter() - prompt_started
+                if (
+                    B == 1
+                    and draft_kind == "dflash"
+                    and apc_manager is not None
+                    and apc_mode == "exact"
+                    and apc_extra_hash is not None
+                    and _dflash_apc_text_only(pending[0])
+                ):
+                    try:
+                        apc_manager.store_exact_cache(
+                            all_input_ids[0],
+                            prompt_cache,
+                            extra_hash=int(apc_extra_hash),
+                        )
+                    except Exception as e:
+                        logger.warning("DFlash APC store failed: %s", e)
                 for uid in uids:
                     prompt_tokens = prompt_tokens_map[uid]
                     prompt_tps_map[uid] = (
@@ -2188,9 +2280,10 @@ class ResponseGenerator:
                     )
                     logger.info(
                         "Prefill completed: request=%s prompt_tokens=%d "
-                        "cached_tokens=0 elapsed=%.3fs rate=%.1f tok/s",
+                        "cached_tokens=%d elapsed=%.3fs rate=%.1f tok/s",
                         stream_infos[uid].get("request_id", uid),
                         prompt_tokens,
+                        apc_cached_tokens,
                         prompt_elapsed,
                         float(prompt_tps_map[uid] or 0.0),
                     )
@@ -2221,6 +2314,7 @@ class ResponseGenerator:
                             finish_reason=finish,
                             peak_memory=mx.get_peak_memory() / 1e9 if finish else 0,
                             prompt_tps=prompt_tps_map.get(uid),
+                            cached_tokens=apc_cached_tokens,
                             emitted_at=emitted_at,
                         )
                     )
@@ -2268,6 +2362,7 @@ class ResponseGenerator:
                     eos_token_ids=eos_set,
                     prompt_tokens=input_mx,
                     row_ids=sample_row_ids,
+                    context_offset=apc_cached_tokens,
                 )
                 for tok_list, _ in rounds_iter:
                     for j, tok in enumerate(tok_list):

--- a/mlx_vlm/speculative/dflash.py
+++ b/mlx_vlm/speculative/dflash.py
@@ -75,6 +75,12 @@ def _dflash_committed_hidden_segments(
     ]
 
 
+def _drafter_pos_shift(cache_list, extra: int) -> None:
+    """Shift drafter RoPE positions without changing cache bookkeeping."""
+    for cache in cache_list:
+        cache.pos_shift = int(getattr(cache, "pos_shift", 0)) + int(extra)
+
+
 def _dflash_rounds(
     model: nn.Module,
     draft_model: nn.Module,
@@ -87,6 +93,7 @@ def _dflash_rounds(
     draft_block_size: Optional[int] = None,
     token_dtype: mx.Dtype = mx.int32,
     use_model_initial_block_size: bool = True,
+    context_offset: int = 0,
 ) -> Generator[Tuple[int, None], None, None]:
     """DFlash speculative-decoding **round loop**.
 
@@ -104,6 +111,8 @@ def _dflash_rounds(
     target_layer_ids = list(draft_model.config.target_layer_ids)
     block_total = _dflash_block_total(draft_model, draft_block_size)
     draft_cache = draft_model.reset(model)
+    if context_offset > 0:
+        _drafter_pos_shift(draft_cache, context_offset)
     prepare_target_hidden = getattr(draft_model, "prepare_target_hidden", None)
     hidden_is_prepared = callable(prepare_target_hidden)
     if hidden_is_prepared:

--- a/mlx_vlm/speculative/drafters/laguna_dflash/dflash.py
+++ b/mlx_vlm/speculative/drafters/laguna_dflash/dflash.py
@@ -89,9 +89,10 @@ def _normalize_dflash_qkv(projected, q_norm, k_norm):
 
 def _apply_dflash_attention(attention, x, projected, rope, cache):
     queries, context_keys, proposal_keys, context_values, proposal_values = projected
-    queries = rope(queries, offset=cache.offset + context_keys.shape[2])
-    context_keys = rope(context_keys, offset=cache.offset)
-    proposal_keys = rope(proposal_keys, offset=cache.offset + context_keys.shape[2])
+    offset = cache.offset + int(getattr(cache, "pos_shift", 0))
+    queries = rope(queries, offset=offset + context_keys.shape[2])
+    context_keys = rope(context_keys, offset=offset)
+    proposal_keys = rope(proposal_keys, offset=offset + context_keys.shape[2])
     cached_keys, cached_values = cache.update_and_fetch(context_keys, context_values)
     keys = mx.concatenate([cached_keys, proposal_keys], axis=2)
     values = mx.concatenate([cached_values, proposal_values], axis=2)

--- a/mlx_vlm/speculative/drafters/muse_glimmer_assistant/dflash.py
+++ b/mlx_vlm/speculative/drafters/muse_glimmer_assistant/dflash.py
@@ -80,7 +80,9 @@ class MuseGlimmerAssistantAttention(nn.Module):
             context_length = context_hidden_states.shape[1]
             cache.offset += skip
 
-        cache_offset = cache.offset
+        # The shift affects absolute RoPE only. The sliding mask below uses
+        # relative positions, so its raw cache offsets remain unchanged.
+        cache_offset = cache.offset + int(getattr(cache, "pos_shift", 0))
         queries = self.q_proj(hidden_states)
         kv_hidden_states = mx.concatenate(
             [context_hidden_states, hidden_states], axis=1

--- a/mlx_vlm/speculative/drafters/qwen3_dflash/dflash.py
+++ b/mlx_vlm/speculative/drafters/qwen3_dflash/dflash.py
@@ -73,9 +73,10 @@ class DFlashAttention(nn.Module):
         prop_values = prop_values.reshape(B, L, self.n_kv_heads, -1).transpose(
             0, 2, 1, 3
         )
-        queries = rope(queries, offset=cache.offset + S)
-        ctx_keys = rope(ctx_keys, offset=cache.offset)
-        prop_keys = rope(prop_keys, offset=cache.offset + S)
+        offset = cache.offset + int(getattr(cache, "pos_shift", 0))
+        queries = rope(queries, offset=offset + S)
+        ctx_keys = rope(ctx_keys, offset=offset)
+        prop_keys = rope(prop_keys, offset=offset + S)
         keys, values = cache.update_and_fetch(ctx_keys, ctx_values)
         keys = mx.concatenate([keys, prop_keys], axis=2)
         values = mx.concatenate([values, prop_values], axis=2)

--- a/mlx_vlm/speculative/utils.py
+++ b/mlx_vlm/speculative/utils.py
@@ -137,6 +137,7 @@ def run_speculative_server_rounds(
     eos_token_ids: Optional[set] = None,
     prompt_tokens: Optional[mx.array] = None,
     row_ids: Optional[List[int]] = None,
+    context_offset: int = 0,
 ) -> Generator[Tuple[List[Optional[int]], None], None, None]:
     batch_size = int(first_bonus.shape[0]) if first_bonus.ndim > 0 else 1
 
@@ -208,6 +209,7 @@ def run_speculative_server_rounds(
                 sampler=sampler,
                 draft_block_size=draft_block_size,
                 token_dtype=token_dtype,
+                context_offset=context_offset,
             ):
                 yield [tok], state
                 if stop_check is not None and stop_check(0, tok):

--- a/mlx_vlm/tests/test_server.py
+++ b/mlx_vlm/tests/test_server.py
@@ -1738,7 +1738,13 @@ class _RecordingSpeculativeLM:
 
 
 def _run_speculative_prefill_once(
-    monkeypatch, *, draft_kind, request_specs, prefill_step_size=2048
+    monkeypatch,
+    *,
+    draft_kind,
+    request_specs,
+    prefill_step_size=2048,
+    apc_manager=None,
+    apc_mode=None,
 ):
     lm = _RecordingSpeculativeLM(draft_kind)
     gen = server.ResponseGenerator.__new__(server.ResponseGenerator)
@@ -1752,6 +1758,8 @@ def _run_speculative_prefill_once(
     gen.requests = Queue()
     gen._stop = False
     gen.prefill_step_size = prefill_step_size
+    gen.apc_manager = apc_manager
+    gen.apc_mode = apc_mode
     gen._make_sampler = lambda args: None
     gen.tokenizer = SimpleNamespace(
         decode=lambda tokens: "".join(str(tok) for tok in tokens)
@@ -1767,6 +1775,11 @@ def _run_speculative_prefill_once(
     gen._gpu_embed = fake_gpu_embed
 
     monkeypatch.setattr(server_generation, "_make_cache", lambda *args, **kwargs: [])
+    monkeypatch.setattr(
+        server_generation,
+        "make_speculative_prompt_cache",
+        lambda *args, **kwargs: [],
+    )
     monkeypatch.setattr(
         server_generation, "_get_draft_block_size_from_env", lambda: None
     )
@@ -1809,6 +1822,10 @@ def _run_speculative_prefill_once(
                 raw_inputs={"input_ids": spec["input_ids"]},
                 prompt_tokens=int(spec["input_ids"].shape[1]),
                 args=args,
+                images=spec.get("images"),
+                videos=spec.get("videos"),
+                audio=spec.get("audio"),
+                apc_semantic_hash=spec.get("apc_semantic_hash"),
             )
         )
 
@@ -1817,6 +1834,121 @@ def _run_speculative_prefill_once(
     call["prefill_input_lengths"] = [item["inputs"].shape[1] for item in lm.calls]
     call["round_kwargs"] = gen.round_kwargs
     return call
+
+
+def test_dflash_singleton_apc_hit_prefills_suffix_and_reuses_semantic_hash(
+    monkeypatch,
+):
+    lookup = {}
+
+    class _APCManager:
+        def __init__(self):
+            self.stores = []
+
+        def store_exact_cache(self, token_ids, prompt_cache, *, extra_hash):
+            self.stores.append((list(token_ids), prompt_cache, extra_hash))
+
+    manager = _APCManager()
+    warm_cache = [SimpleNamespace(offset=2)]
+
+    def fake_lookup(manager_arg, ids, **kwargs):
+        lookup.update(manager=manager_arg, ids=list(ids), kwargs=kwargs)
+        return {"warm_cache": warm_cache, "prefix_len": 2}
+
+    monkeypatch.setattr(server_generation._apc, "apc_lookup_plan", fake_lookup)
+    call = _run_speculative_prefill_once(
+        monkeypatch,
+        draft_kind="dflash",
+        apc_manager=manager,
+        apc_mode="exact",
+        request_specs=[
+            {
+                "input_ids": mx.array([[11, 12, 13, 14]], dtype=mx.int32),
+                "gen_kwargs": {
+                    "inputs_embeds": mx.ones((1, 4, 4), dtype=mx.float32),
+                    "attention_mask": mx.array([[1, 1, 1, 1]], dtype=mx.int32),
+                },
+                "apc_semantic_hash": 991,
+            }
+        ],
+    )
+
+    assert call["inputs"].tolist() == [[13, 14]]
+    assert call["inputs_embeds"].shape[1] == 2
+    assert call["attention_mask"].tolist() == [[1, 1]]
+    assert call["cache"] is warm_cache
+    assert call["round_kwargs"]["context_offset"] == 2
+    assert lookup["manager"] is manager
+    assert lookup["ids"] == [11, 12, 13, 14]
+    assert lookup["kwargs"]["extra_hash"] == 991
+    assert manager.stores == [([11, 12, 13, 14], warm_cache, 991)]
+
+
+@pytest.mark.parametrize(
+    "request_overrides",
+    [
+        {"images": ["image"]},
+        {"videos": ["video"]},
+        {"audio": ["audio"]},
+        {"raw_inputs": {"input_ids": [1, 2], "pixel_values": object()}},
+        {"raw_inputs": {"input_ids": [1, 2], "pixel_values_videos": object()}},
+        {"raw_inputs": {"input_ids": [1, 2], "input_features": object()}},
+    ],
+)
+def test_dflash_apc_lookup_rejects_multimodal_requests(request_overrides):
+    request = SimpleNamespace(
+        images=None,
+        videos=None,
+        audio=None,
+        raw_inputs={"input_ids": [1, 2]},
+        apc_semantic_hash=7,
+    )
+    for key, value in request_overrides.items():
+        setattr(request, key, value)
+
+    assert (
+        server_generation._dflash_apc_lookup(
+            request,
+            [1, 2],
+            batch_size=1,
+            draft_kind="dflash",
+            apc_manager=object(),
+            apc_mode="exact",
+        )
+        is None
+    )
+
+
+@pytest.mark.parametrize(
+    ("batch_size", "draft_kind", "apc_mode", "semantic_hash"),
+    [
+        (2, "dflash", "exact", 7),
+        (1, "mtp", "exact", 7),
+        (1, "dflash", "block", 7),
+        (1, "dflash", "exact", None),
+    ],
+)
+def test_dflash_apc_lookup_rejects_unsupported_modes(
+    batch_size, draft_kind, apc_mode, semantic_hash
+):
+    request = SimpleNamespace(
+        images=None,
+        videos=None,
+        audio=None,
+        raw_inputs={"input_ids": [1, 2]},
+        apc_semantic_hash=semantic_hash,
+    )
+    assert (
+        server_generation._dflash_apc_lookup(
+            request,
+            [1, 2],
+            batch_size=batch_size,
+            draft_kind=draft_kind,
+            apc_manager=object(),
+            apc_mode=apc_mode,
+        )
+        is None
+    )
 
 
 def test_speculative_server_threads_greedy_flag_to_mtp_loop(monkeypatch):

--- a/mlx_vlm/tests/test_speculative.py
+++ b/mlx_vlm/tests/test_speculative.py
@@ -32,6 +32,7 @@ from mlx_vlm.models.cache import (
 )
 from mlx_vlm.quantization.one_bit import OneBitLinear
 from mlx_vlm.speculative.common import _SpeculativeSamplerRNG
+from mlx_vlm.speculative.dflash import _drafter_pos_shift
 from mlx_vlm.speculative.drafters import (
     DEFAULT_DRAFTER_KIND,
     DRAFTER_KIND_BY_MODEL_TYPE,
@@ -1617,13 +1618,24 @@ def test_dflash_server_singleton_dispatches_single_rounds(monkeypatch):
             token_dtype=mx.int32,
             greedy_sampling=True,
             stop_check=lambda _seq_idx, token_id: token_id == 4,
+            context_offset=123,
         )
     )
 
     assert result == [([3], None), ([4], None)]
     assert calls
     assert calls[0][1]["first_bonus"] == 2
+    assert calls[0][1]["context_offset"] == 123
     assert "use_model_initial_block_size" not in calls[0][1]
+
+
+def test_dflash_context_shift_does_not_mutate_cache_offsets():
+    caches = [SimpleNamespace(offset=3), SimpleNamespace(offset=8, pos_shift=2)]
+
+    _drafter_pos_shift(caches, 11)
+
+    assert [cache.offset for cache in caches] == [3, 8]
+    assert [cache.pos_shift for cache in caches] == [11, 13]
 
 
 def test_mtp_uses_uniform_deferred_walk_for_batched_sampling():


### PR DESCRIPTION
## Summary

This is the smaller single-PR replacement requested in the review of #1856
and #1857.

- add opt-in exact-prefix APC reuse to the text-only B=1 DFlash server path;
- reuse the request's existing tenant-scoped semantic key;
- restore one exact prompt cache directly and prefill only its uncached suffix;
- report cached tokens through the existing streaming metrics;
- preserve absolute drafter RoPE positions with an additive offset that does
  not alter cache storage bookkeeping; and
- leave batched and multimodal requests on the existing cold path.

The implementation calls the shared `apc_lookup_plan()` and
`store_exact_cache()` APIs directly. It does not add a parallel APC module or
change the shared APC manager/adapters.

## Scope

Deliberately excluded from this PR:

- multimodal APC or multimodal hashing changes;
- mixed warm/cold batches and B>=2 reuse;
- static system-prefix checkpoints;
- disk/LRU policy changes; and
- resumable prefill scheduling.

Those are independent concerns and are not required for the conservative
growing-conversation path here.

## Validation

- 13 focused DFlash APC/offset regressions passed;
- full server suite: 352 passed;
- generate/APC suites: 189 passed;
- speculative, Laguna, Muse, and APC suites: 208 passed, with one unrelated
  quantized-linear exact-equality failure reproduced on pristine `main`.

The change is default-off unless an APC manager is configured. A live
model-backed cold/warm parity run remains a follow-up gate before this draft is
marked ready for review.
