### PR TITLE
Add video subsampling to images fallback in the server

### DIFF
--- a/mlx_vlm/generate/dispatch.py
+++ b/mlx_vlm/generate/dispatch.py
@@ -1302,17 +1302,16 @@ def main():
         from .video import (
             pair_adjacent_frames,
             processor_handles_video,
+            resolve_video_inputs,
             sample_video_frames,
-            subsample_evenly,
             timestamped_frame_messages,
         )
 
         if not processor_handles_video(processor):
-            frames, frame_fps = sample_video_frames(args.video, args.fps or 2.0)
-            sampled = len(frames)
             max_frames = max(2, getattr(args, "video_max_frames", 16) or 16)
             pair_hook = getattr(model, "prepare_video_frame_pairs", None)
             if pair_hook is not None:
+                frames, frame_fps = sample_video_frames(args.video, args.fps or 2.0)
                 anchors, first_frames, second_frames = pair_adjacent_frames(
                     frames, max_frames
                 )
@@ -1338,15 +1337,23 @@ def main():
                 video_prompt = _tok.apply_chat_template(
                     msgs, add_generation_prompt=True, tokenize=False
                 )
+                args.video = None
             else:
-                frames = subsample_evenly(frames, max_frames)
+                resolution = resolve_video_inputs(
+                    processor,
+                    args.video,
+                    images=args.image,
+                    fps=args.fps or 2.0,
+                    max_frames=max_frames,
+                )
                 print(
                     f"{processor.__class__.__name__} has no native video "
-                    f"support; sending {len(frames)} of {sampled} sampled "
+                    f"support; sending {resolution.selected_count} of "
+                    f"{resolution.sampled_count} sampled "
                     f"frames as ordered images."
                 )
-                args.image = (args.image or []) + frames
-            args.video = None
+                args.image = resolution.images
+                args.video = resolution.videos or None
 
     num_images = len(args.image) if args.image is not None else 0
     num_audios = len(args.audio) if args.audio is not None else 0

--- a/mlx_vlm/generate/video.py
+++ b/mlx_vlm/generate/video.py
@@ -6,6 +6,8 @@ only processes them when a ``video_processor`` component exists, and silently
 discards them otherwise; the model then hallucinates an answer with no visual
 input at all. When that would happen, the caller samples the video into frames
 and sends them as ordered images, which any image-capable model handles.
+``resolve_video_inputs`` is the shared entrypoint for that generic fallback so
+CLI and server callers apply the same capability check and global frame budget.
 
 Models whose vision patches carry two temporal slots can opt into a richer
 fallback by defining a ``prepare_video_frame_pairs(processor, second_frames)``
@@ -15,9 +17,22 @@ returned generation kwargs.
 """
 
 import inspect
+from dataclasses import dataclass
 
 import numpy as np
 from PIL import Image
+
+
+@dataclass(frozen=True)
+class VideoInputResolution:
+    """Image/video inputs after resolving the generic frames fallback."""
+
+    images: list
+    videos: list
+    used_fallback: bool = False
+    sampled_count: int = 0
+    selected_count: int = 0
+    frame_fps: float | None = None
 
 
 def processor_handles_video(processor) -> bool:
@@ -57,6 +72,45 @@ def subsample_evenly(frames, max_frames):
         return frames
     idxs = [round(i * (len(frames) - 1) / (max_frames - 1)) for i in range(max_frames)]
     return [frames[i] for i in idxs]
+
+
+def resolve_video_inputs(
+    processor,
+    videos=None,
+    *,
+    images=None,
+    fps=2.0,
+    max_frames=16,
+) -> VideoInputResolution:
+    """Resolve unsupported videos into a globally capped list of still images.
+
+    Native-video processors receive their inputs unchanged. Otherwise all videos
+    are decoded first, then subsampled once so ``max_frames`` is a request-wide
+    budget rather than a per-video budget. Inputs are copied and only returned
+    after the complete conversion succeeds, avoiding partially converted media.
+    """
+    resolved_images = list(images or [])
+    resolved_videos = list(videos or [])
+    if not resolved_videos or processor_handles_video(processor):
+        return VideoInputResolution(
+            images=resolved_images,
+            videos=resolved_videos,
+        )
+
+    max_frames = max(2, int(max_frames or 16))
+    frames, frame_fps = sample_video_frames(resolved_videos, fps or 2.0)
+    sampled_count = len(frames)
+    if not sampled_count:
+        raise ValueError("Video frame fallback decoded no frames.")
+    selected = subsample_evenly(frames, max_frames)
+    return VideoInputResolution(
+        images=resolved_images + selected,
+        videos=[],
+        used_fallback=True,
+        sampled_count=sampled_count,
+        selected_count=len(selected),
+        frame_fps=frame_fps,
+    )
 
 
 def pair_adjacent_frames(frames, max_pairs):

--- a/mlx_vlm/server/openai.py
+++ b/mlx_vlm/server/openai.py
@@ -22,6 +22,7 @@ from ..generate.edit_image import ImageEditRequest as CoreImageEditRequest
 from ..generate.edit_image import edit_image
 from ..generate.image import ImageGenerationRequest as CoreImageGenerationRequest
 from ..generate.image import generate_image, parse_size
+from ..generate.video import resolve_video_inputs
 from ..prompt_utils import apply_chat_template, extract_text_from_content
 from ..tool_parsers import _infer_tool_parser_from_processor, load_tool_module
 from ..utils import prepare_inputs
@@ -1694,6 +1695,23 @@ async def chat_completions_endpoint(request: ChatRequest, http_request: Request)
         )
 
         model, processor, config = get_cached_model(request.model, adapter_path)
+
+        video_resolution = resolve_video_inputs(
+            processor,
+            videos,
+            images=images,
+            fps=2.0,
+            max_frames=16,
+        )
+        images, videos = video_resolution.images, video_resolution.videos
+        if video_resolution.used_fallback:
+            logger.info(
+                "Processor %s has no native video support; sending %d of %d "
+                "sampled frames as ordered images.",
+                processor.__class__.__name__,
+                video_resolution.selected_count,
+                video_resolution.sampled_count,
+            )
 
         # Detect tool parser from chat template
         tool_parser_type = _infer_tool_parser_from_processor(processor)

--- a/mlx_vlm/tests/test_generate.py
+++ b/mlx_vlm/tests/test_generate.py
@@ -2277,6 +2277,82 @@ def test_generate_cli_forwards_video_to_template_and_generate(capsys):
     assert capsys.readouterr().out.strip() == "done"
 
 
+def test_resolve_video_inputs_keeps_native_video_unchanged():
+    video_module = __import__("mlx_vlm.generate.video", fromlist=[""])
+    images = [object()]
+    videos = ["first.mp4", "second.mp4"]
+    processor = SimpleNamespace(
+        video_processor=SimpleNamespace(),
+        process=lambda text=None, images=None, videos=None, **kwargs: None,
+    )
+
+    with patch.object(video_module, "sample_video_frames") as mock_sample:
+        resolution = video_module.resolve_video_inputs(
+            processor,
+            videos,
+            images=images,
+        )
+
+    assert resolution.images == images
+    assert resolution.videos == videos
+    assert resolution.used_fallback is False
+    mock_sample.assert_not_called()
+
+
+def test_resolve_video_inputs_uses_one_global_frame_budget():
+    video_module = __import__("mlx_vlm.generate.video", fromlist=[""])
+    still = object()
+    images = [still]
+    videos = ["first.mp4", "second.mp4"]
+    frames = [object() for _ in range(10)]
+
+    with patch.object(
+        video_module,
+        "sample_video_frames",
+        return_value=(frames, 1.5),
+    ) as mock_sample:
+        resolution = video_module.resolve_video_inputs(
+            SimpleNamespace(),
+            videos,
+            images=images,
+            fps=1.5,
+            max_frames=4,
+        )
+
+    assert resolution.images == [still, frames[0], frames[3], frames[6], frames[9]]
+    assert resolution.videos == []
+    assert resolution.used_fallback is True
+    assert resolution.sampled_count == 10
+    assert resolution.selected_count == 4
+    assert resolution.frame_fps == pytest.approx(1.5)
+    assert images == [still]
+    assert videos == ["first.mp4", "second.mp4"]
+    mock_sample.assert_called_once_with(videos, 1.5)
+
+
+def test_resolve_video_inputs_does_not_partially_mutate_on_decode_failure():
+    video_module = __import__("mlx_vlm.generate.video", fromlist=[""])
+    images = [object()]
+    videos = ["good.mp4", "bad.mp4"]
+
+    with (
+        patch.object(
+            video_module,
+            "sample_video_frames",
+            side_effect=RuntimeError("decode failed"),
+        ),
+        pytest.raises(RuntimeError, match="decode failed"),
+    ):
+        video_module.resolve_video_inputs(
+            SimpleNamespace(),
+            videos,
+            images=images,
+        )
+
+    assert len(images) == 1
+    assert videos == ["good.mp4", "bad.mp4"]
+
+
 def test_generate_cli_video_frames_fallback_without_video_processor(capsys):
     video_module = __import__("mlx_vlm.generate.video", fromlist=[""])
 

--- a/mlx_vlm/tests/test_server.py
+++ b/mlx_vlm/tests/test_server.py
@@ -3695,9 +3695,12 @@ def test_chat_completions_endpoint_flattens_text_content_parts(client):
     ]
 
 
-def test_chat_completions_endpoint_forwards_video_content(client):
+def test_chat_completions_endpoint_forwards_native_video_content(client):
     model = SimpleNamespace()
-    processor = SimpleNamespace()
+    processor = SimpleNamespace(
+        video_processor=SimpleNamespace(),
+        process=lambda text=None, images=None, videos=None, **kwargs: None,
+    )
     config = SimpleNamespace(model_type="gemma4")
     result = GenerationResult(
         text="done",
@@ -3708,6 +3711,7 @@ def test_chat_completions_endpoint_forwards_video_content(client):
         generation_tps=5.0,
         peak_memory=0.1,
     )
+    from mlx_vlm.generate import video as video_module
 
     with (
         patch.object(
@@ -3717,6 +3721,7 @@ def test_chat_completions_endpoint_forwards_video_content(client):
             server, "apply_chat_template", return_value="prompt"
         ) as mock_template,
         patch.object(server, "generate", return_value=result) as mock_generate,
+        patch.object(video_module, "sample_video_frames") as mock_sample,
     ):
         response = client.post(
             "/chat/completions",
@@ -3740,6 +3745,61 @@ def test_chat_completions_endpoint_forwards_video_content(client):
         {"role": "user", "content": "Describe this video."}
     ]
     assert mock_generate.call_args.kwargs["video"] == ["clip.mp4"]
+    mock_sample.assert_not_called()
+
+
+def test_chat_completions_endpoint_falls_back_from_video_to_images(client):
+    model = SimpleNamespace()
+    processor = SimpleNamespace()
+    config = SimpleNamespace(model_type="mage_vl")
+    result = GenerationResult(
+        text="done",
+        prompt_tokens=8,
+        generation_tokens=4,
+        total_tokens=12,
+        prompt_tps=10.0,
+        generation_tps=5.0,
+        peak_memory=0.1,
+    )
+    frames = [object(), object()]
+    from mlx_vlm.generate import video as video_module
+
+    with (
+        patch.object(
+            server, "get_cached_model", return_value=(model, processor, config)
+        ),
+        patch.object(
+            server, "apply_chat_template", return_value="prompt"
+        ) as mock_template,
+        patch.object(server, "generate", return_value=result) as mock_generate,
+        patch.object(
+            video_module,
+            "sample_video_frames",
+            return_value=(frames, 2.0),
+        ) as mock_sample,
+    ):
+        response = client.post(
+            "/chat/completions",
+            json={
+                "model": "demo",
+                "messages": [
+                    {
+                        "role": "user",
+                        "content": [
+                            {"type": "video_url", "video_url": {"url": "clip.mp4"}},
+                            {"type": "text", "text": "Describe this video."},
+                        ],
+                    }
+                ],
+            },
+        )
+
+    assert response.status_code == 200
+    assert mock_template.call_args.kwargs["num_images"] == 2
+    assert mock_template.call_args.kwargs["video"] is None
+    assert mock_generate.call_args.kwargs["image"] == frames
+    assert mock_generate.call_args.kwargs["video"] == []
+    mock_sample.assert_called_once_with(["clip.mp4"], 2.0)
 
 
 def test_chat_completions_endpoint_preserves_assistant_reasoning_content(client):


### PR DESCRIPTION
Same idea as https://github.com/Blaizzy/mlx-vlm/pull/1836 but using our existing helper file for video (used by the cli for e.g. Inkling) so we can keep the server-side minimal.