### PR TITLE
Load a custom model class from a model_file declared in config.json

### DIFF
--- a/mlx_vlm/tests/test_model_file_loading.py
+++ b/mlx_vlm/tests/test_model_file_loading.py
@@ -1,0 +1,98 @@
+"""Tests for `model_file` checkpoint-supplied model classes.
+
+A checkpoint's config.json may declare `model_file: <name>.py`; load_model
+then imports the model class from that file inside the checkpoint instead
+of the built-in registry (the same mechanism mlx_lm supports). These tests
+build a minimal synthetic checkpoint on disk and load it through the real
+load_model path.
+"""
+
+import json
+import textwrap
+
+import mlx.core as mx
+import pytest
+
+from mlx_vlm.utils import load_model
+
+MODEL_PY = textwrap.dedent(
+    '''
+    import mlx.core as mx
+    import mlx.nn as nn
+
+
+    class ModelConfig:
+        # Deliberately minimal: exposing text_config/vision_config attributes
+        # opts in to update_module_configs, which then requires TextConfig /
+        # VisionConfig classes in this module. A model_file module controls
+        # both sides of that contract.
+        def __init__(self, model_type="custom"):
+            self.model_type = model_type
+
+        @classmethod
+        def from_dict(cls, params):
+            return cls(model_type=params.get("model_type", "custom"))
+
+
+    class Model(nn.Module):
+        loaded_via_model_file = True
+
+        def __init__(self, config):
+            super().__init__()
+            self.config = config
+            self.proj = nn.Linear(4, 4, bias=False)
+
+        def __call__(self, x):
+            return self.proj(x)
+    '''
+)
+
+
+def _write_checkpoint(path, config_extra=None):
+    config = {
+        "model_type": "does-not-exist-in-registry",
+        "model_file": "model.py",
+    }
+    config.update(config_extra or {})
+    (path / "config.json").write_text(json.dumps(config), encoding="utf-8")
+    (path / "model.py").write_text(MODEL_PY, encoding="utf-8")
+    mx.save_safetensors(
+        str(path / "model.safetensors"),
+        {"proj.weight": mx.zeros((4, 4))},
+        metadata={"format": "mlx"},
+    )
+
+
+def test_load_model_uses_checkpoint_model_file(tmp_path):
+    _write_checkpoint(tmp_path)
+
+    model = _load(tmp_path)
+
+    # the class must come from the checkpoint's model.py, not the registry
+    # (the registry would have raised: model_type does not exist there)
+    assert getattr(model, "loaded_via_model_file", False) is True
+    assert model.proj.weight.shape == (4, 4)
+
+
+def test_missing_model_file_raises_clearly(tmp_path):
+    _write_checkpoint(tmp_path)
+    (tmp_path / "model.py").unlink()
+
+    with pytest.raises(FileNotFoundError, match="model_file"):
+        _load(tmp_path)
+
+
+def test_registry_path_untouched_without_model_file(tmp_path):
+    """A config WITHOUT model_file must go through the registry exactly as
+    before — here that means the unknown model_type raises ValueError."""
+    _write_checkpoint(tmp_path)
+    config = json.loads((tmp_path / "config.json").read_text())
+    del config["model_file"]
+    (tmp_path / "config.json").write_text(json.dumps(config), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="not supported"):
+        _load(tmp_path)
+
+
+def _load(path):
+    return load_model(path)

--- a/mlx_vlm/tests/test_model_file_loading.py
+++ b/mlx_vlm/tests/test_model_file_loading.py
@@ -15,8 +15,7 @@ import pytest
 
 from mlx_vlm.utils import load_model
 
-MODEL_PY = textwrap.dedent(
-    '''
+MODEL_PY = textwrap.dedent("""
     import mlx.core as mx
     import mlx.nn as nn
 
@@ -44,8 +43,7 @@ MODEL_PY = textwrap.dedent(
 
         def __call__(self, x):
             return self.proj(x)
-    '''
-)
+    """)
 
 
 def _write_checkpoint(path, config_extra=None):

--- a/mlx_vlm/utils.py
+++ b/mlx_vlm/utils.py
@@ -599,9 +599,7 @@ def get_model_and_args(config: dict, model_path: Optional[Path] = None):
                 f"config.json declares model_file={model_file!r} but "
                 f"{model_file_path} does not exist"
             )
-        spec = importlib.util.spec_from_file_location(
-            "custom_model", model_file_path
-        )
+        spec = importlib.util.spec_from_file_location("custom_model", model_file_path)
         arch = importlib.util.module_from_spec(spec)
         spec.loader.exec_module(arch)
         return arch, "custom"

--- a/mlx_vlm/utils.py
+++ b/mlx_vlm/utils.py
@@ -585,8 +585,27 @@ def get_class_predicate(skip_vision=False, weights=None, quantization_config=Non
     return predicate
 
 
-def get_model_and_args(config: dict):
-    """Resolve a model package and its normalized model type."""
+def get_model_and_args(config: dict, model_path: Optional[Path] = None):
+    """Resolve a model package and its normalized model type.
+
+    If the config declares ``model_file`` and ``model_path`` is provided, the
+    model module is imported from that file inside the checkpoint (the same
+    mechanism mlx_lm supports) instead of the built-in registry.
+    """
+    if model_path is not None and (model_file := config.get("model_file")):
+        model_file_path = Path(model_path) / model_file
+        if not model_file_path.is_file():
+            raise FileNotFoundError(
+                f"config.json declares model_file={model_file!r} but "
+                f"{model_file_path} does not exist"
+            )
+        spec = importlib.util.spec_from_file_location(
+            "custom_model", model_file_path
+        )
+        arch = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(arch)
+        return arch, "custom"
+
     raw_model_type = config.get("model_type") or config.get("speculators_model_type")
     if raw_model_type is None:
         raise KeyError("model_type")
@@ -756,24 +775,7 @@ python -m mlx_vlm.convert --hf-path <local_dir> --mlx-path <mlx_dir>
     for wf in weight_files:
         weights.update(_load_safetensors(wf))
 
-    if (model_file := config.get("model_file")) is not None:
-        # Load the model module from inside the checkpoint (same mechanism as
-        # mlx_lm): config.json names a Python file shipped with the weights,
-        # letting a stock install read checkpoints that need a custom model
-        # class (e.g. novel quantization formats).
-        model_file_path = model_path / model_file
-        if not model_file_path.is_file():
-            raise FileNotFoundError(
-                f"config.json declares model_file={model_file!r} but "
-                f"{model_file_path} does not exist"
-            )
-        spec = importlib.util.spec_from_file_location(
-            "custom_model", model_file_path
-        )
-        model_class = importlib.util.module_from_spec(spec)
-        spec.loader.exec_module(model_class)
-    else:
-        model_class, _ = get_model_and_args(config=config)
+    model_class, _ = get_model_and_args(config=config, model_path=model_path)
     text_only_config = _is_text_only_config(config)
 
     # Initialize text and vision configs if not present

--- a/mlx_vlm/utils.py
+++ b/mlx_vlm/utils.py
@@ -1,5 +1,6 @@
 import glob
 import importlib
+import importlib.util
 import inspect
 import json
 import logging
@@ -755,7 +756,24 @@ python -m mlx_vlm.convert --hf-path <local_dir> --mlx-path <mlx_dir>
     for wf in weight_files:
         weights.update(_load_safetensors(wf))
 
-    model_class, _ = get_model_and_args(config=config)
+    if (model_file := config.get("model_file")) is not None:
+        # Load the model module from inside the checkpoint (same mechanism as
+        # mlx_lm): config.json names a Python file shipped with the weights,
+        # letting a stock install read checkpoints that need a custom model
+        # class (e.g. novel quantization formats).
+        model_file_path = model_path / model_file
+        if not model_file_path.is_file():
+            raise FileNotFoundError(
+                f"config.json declares model_file={model_file!r} but "
+                f"{model_file_path} does not exist"
+            )
+        spec = importlib.util.spec_from_file_location(
+            "custom_model", model_file_path
+        )
+        model_class = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(model_class)
+    else:
+        model_class, _ = get_model_and_args(config=config)
     text_only_config = _is_text_only_config(config)
 
     # Initialize text and vision configs if not present


### PR DESCRIPTION
## What

Ports `mlx_lm`'s `model_file` mechanism to `load_model`: when a checkpoint's `config.json` declares `model_file: <name>.py`, the model class is imported from that file inside the checkpoint instead of the built-in registry.

**No behavior change for any existing model** — the new branch only triggers when the key is present, and the registry path is byte-for-byte what it was (there's a test asserting exactly that).

## Why

Checkpoints with custom weight formats can then run on a **stock mlx-vlm install** — the runtime travels with the weights, no fork or patch required. `mlx_lm` users already rely on this mechanism for text-only use of such checkpoints (it resolves `model_file` the same way, via `importlib.util.spec_from_file_location`); this brings vision-language parity.

Concrete motivation: we ship vector-quantized builds of Qwen3.5-397B-A17B (custom expert format decoded by JIT `mx.fast.metal_kernel` kernels bundled in the checkpoint's `model.py`). They load under stock `mlx_lm` today; with this hook the same checkpoints gain vision under stock `mlx-vlm`.

## Tests

`mlx_vlm/tests/test_model_file_loading.py`:
- loads a synthetic checkpoint end-to-end through the real `load_model` and asserts the class came from the checkpoint's `model.py`
- asserts a clear `FileNotFoundError` when the declared file is missing
- asserts the registry path is untouched (unknown `model_type` without `model_file` still raises `ValueError`)

All existing `test_utils.py` tests pass.