### PR TITLE
Use correct RoPE scaling for several models

### DIFF
--- a/mlx_vlm/models/gemma3/language.py
+++ b/mlx_vlm/models/gemma3/language.py
@@ -11,6 +11,7 @@ from ..base import (
     scaled_dot_product_attention,
 )
 from ..cache import KVCache, RotatingKVCache
+from ..rope_utils import initialize_rope
 from .config import TextConfig
 
 
@@ -46,14 +47,16 @@ class Attention(nn.Module):
         self.k_norm = RMSNorm(dims=head_dim, eps=config.rms_norm_eps)
         self.is_sliding = (layer_idx + 1) % config.sliding_window_pattern != 0
 
-        self.rope = nn.RoPE(
-            head_dim,
+        self.rope = initialize_rope(
+            dims=head_dim,
             traditional=config.rope_traditional,
             base=(
                 config.rope_local_base_freq
                 if self.is_sliding
                 else config.rope_global_base_freq
             ),
+            scaling_config=None if self.is_sliding else config.rope_scaling,
+            max_position_embeddings=config.max_position_embeddings,
         )
 
     def __call__(

--- a/mlx_vlm/models/gemma3n/language.py
+++ b/mlx_vlm/models/gemma3n/language.py
@@ -12,6 +12,7 @@ from ..base import (
     scaled_dot_product_attention,
 )
 from ..cache import KVCache, RotatingKVCache
+from ..rope_utils import initialize_rope
 from .config import TextConfig
 
 
@@ -107,12 +108,14 @@ class Gemma3nAttention(nn.Module):
 
         self.is_kv_shared_layer = is_kv_shared_layer
 
-        self.rope = nn.RoPE(
-            head_dim,
+        self.rope = initialize_rope(
+            dims=head_dim,
             traditional=False,
             base=(
                 config.rope_local_base_freq if self.is_sliding else config.rope_theta
             ),
+            scaling_config=None if self.is_sliding else config.rope_scaling,
+            max_position_embeddings=config.max_position_embeddings,
         )
 
     def __call__(

--- a/mlx_vlm/models/glm4_moe/language.py
+++ b/mlx_vlm/models/glm4_moe/language.py
@@ -11,6 +11,7 @@ from ..base import (
 )
 from ..mlp import DeepseekMLP as MLP
 from ..pipeline import PipelineMixin
+from ..rope_utils import initialize_rope
 from ..switch_layers import SwitchGLU
 from .config import ModelConfig
 
@@ -36,10 +37,12 @@ class Attention(nn.Module):
             self.q_norm = nn.RMSNorm(head_dim, eps=args.rms_norm_eps)
             self.k_norm = nn.RMSNorm(head_dim, eps=args.rms_norm_eps)
 
-        self.rope = nn.RoPE(
-            int(head_dim * args.partial_rotary_factor),
-            traditional=False,
+        self.rope = initialize_rope(
+            dims=int(head_dim * args.partial_rotary_factor),
             base=args.rope_theta,
+            traditional=False,
+            scaling_config=args.rope_scaling,
+            max_position_embeddings=args.max_position_embeddings,
         )
 
     def __call__(

--- a/mlx_vlm/models/granite4_vision/language.py
+++ b/mlx_vlm/models/granite4_vision/language.py
@@ -8,6 +8,7 @@ from ..base import (
     create_attention_mask,
     scaled_dot_product_attention,
 )
+from ..rope_utils import initialize_rope
 from .config import TextConfig
 
 
@@ -26,10 +27,12 @@ class Attention(nn.Module):
         self.v_proj = nn.Linear(dim, n_kv_heads * head_dim, bias=config.attention_bias)
         self.o_proj = nn.Linear(n_heads * head_dim, dim, bias=config.attention_bias)
 
-        self.rope = nn.RoPE(
-            head_dim,
-            traditional=config.rope_traditional,
+        self.rope = initialize_rope(
+            dims=head_dim,
             base=config.rope_theta,
+            traditional=config.rope_traditional,
+            scaling_config=config.rope_scaling,
+            max_position_embeddings=config.max_position_embeddings,
         )
 
     def __call__(self, x, mask=None, cache=None):

--- a/mlx_vlm/models/granite_vision/language.py
+++ b/mlx_vlm/models/granite_vision/language.py
@@ -9,6 +9,7 @@ from ..base import (
     scaled_dot_product_attention,
 )
 from ..cache import KVCache
+from ..rope_utils import initialize_rope
 from .config import TextConfig
 
 
@@ -30,10 +31,12 @@ class Attention(nn.Module):
         self.v_proj = nn.Linear(dim, n_kv_heads * head_dim, bias=config.attention_bias)
         self.o_proj = nn.Linear(n_heads * head_dim, dim, bias=config.attention_bias)
 
-        self.rope = nn.RoPE(
-            head_dim,
-            traditional=config.rope_traditional,
+        self.rope = initialize_rope(
+            dims=head_dim,
             base=config.rope_theta,
+            traditional=config.rope_traditional,
+            scaling_config=config.rope_scaling,
+            max_position_embeddings=config.max_position_embeddings,
         )
 
     def __call__(

--- a/mlx_vlm/models/locateanything/language.py
+++ b/mlx_vlm/models/locateanything/language.py
@@ -10,6 +10,7 @@ from ..base import (
 )
 from ..cache import KVCache
 from ..mlp import SwiGLUMLP as MLP
+from ..rope_utils import initialize_rope
 from .config import TextConfig
 
 
@@ -68,8 +69,12 @@ class Attention(nn.Module):
         self.v_proj = nn.Linear(dim, n_kv_heads * head_dim, bias=True)
         self.o_proj = nn.Linear(n_heads * head_dim, dim, bias=False)
 
-        self.rope = nn.RoPE(
-            head_dim, traditional=args.rope_traditional, base=args.rope_theta
+        self.rope = initialize_rope(
+            dims=head_dim,
+            base=args.rope_theta,
+            traditional=args.rope_traditional,
+            scaling_config=args.rope_scaling,
+            max_position_embeddings=args.max_position_embeddings,
         )
 
     def __call__(

--- a/mlx_vlm/models/mixtral/language.py
+++ b/mlx_vlm/models/mixtral/language.py
@@ -8,6 +8,7 @@ from ..base import (
     create_attention_mask,
     scaled_dot_product_attention,
 )
+from ..rope_utils import initialize_rope
 from ..switch_layers import SwitchGLU
 from .config import ModelConfig
 
@@ -36,10 +37,11 @@ class MixtralAttention(nn.Module):
             self.num_heads * self.head_dim, self.hidden_size, bias=False
         )
 
-        self.rope = nn.RoPE(
-            self.head_dim,
-            traditional=args.rope_traditional,
+        self.rope = initialize_rope(
+            dims=self.head_dim,
             base=args.rope_theta,
+            traditional=args.rope_traditional,
+            scaling_config=args.rope_scaling,
         )
 
     def __call__(

--- a/mlx_vlm/models/mllama/language.py
+++ b/mlx_vlm/models/mllama/language.py
@@ -9,6 +9,7 @@ from ..base import (
     scaled_dot_product_attention,
 )
 from ..cache import KVCache
+from ..rope_utils import initialize_rope
 from .config import TextConfig
 
 
@@ -115,11 +116,12 @@ class MllamaTextSelfAttention(nn.Module):
             self.num_heads * self.head_dim, self.hidden_size, bias=False
         )
 
-        self.rope = nn.RoPE(
-            self.head_dim,
-            traditional=config.rope_traditional,
+        self.rope = initialize_rope(
+            dims=self.head_dim,
             base=config.rope_theta,
-            scale=1,
+            traditional=config.rope_traditional,
+            scaling_config=config.rope_scaling,
+            max_position_embeddings=config.max_position_embeddings,
         )
 
     def __call__(

--- a/mlx_vlm/models/molmo2/language.py
+++ b/mlx_vlm/models/molmo2/language.py
@@ -9,6 +9,7 @@ from ..base import (
     scaled_dot_product_attention,
 )
 from ..cache import KVCache
+from ..rope_utils import initialize_rope
 from .config import ModelConfig, TextConfig
 
 
@@ -70,7 +71,13 @@ class Molmo2Attention(nn.Module):
             bias=False,
         )
 
-        self.rotary_emb = nn.RoPE(self.head_dim, base=config.rope_theta)
+        self.rotary_emb = initialize_rope(
+            dims=self.head_dim,
+            base=config.rope_theta,
+            traditional=False,
+            scaling_config=config.rope_scaling,
+            max_position_embeddings=config.max_position_embeddings,
+        )
 
     def __call__(
         self,

--- a/mlx_vlm/models/molmo_point/language.py
+++ b/mlx_vlm/models/molmo_point/language.py
@@ -9,6 +9,7 @@ from ..base import (
     scaled_dot_product_attention,
 )
 from ..cache import KVCache
+from ..rope_utils import initialize_rope
 from .config import ModelConfig, TextConfig
 
 
@@ -36,7 +37,7 @@ class LanguageModelMLP(nn.Module):
 
 
 class Molmo2Attention(nn.Module):
-    def __init__(self, config: TextConfig):
+    def __init__(self, config: TextConfig, layer_idx: int = 0):
         super().__init__()
         self.config = config
         self.num_heads = config.num_attention_heads
@@ -65,7 +66,20 @@ class Molmo2Attention(nn.Module):
             bias=False,
         )
 
-        self.rotary_emb = nn.RoPE(self.head_dim, base=config.rope_theta)
+        scaling_config = config.rope_scaling
+        if (
+            config.rope_scaling_layers is not None
+            and layer_idx not in config.rope_scaling_layers
+        ):
+            scaling_config = None
+
+        self.rotary_emb = initialize_rope(
+            dims=self.head_dim,
+            base=config.rope_theta,
+            traditional=False,
+            scaling_config=scaling_config,
+            max_position_embeddings=config.max_position_embeddings,
+        )
 
     def __call__(
         self,
@@ -106,9 +120,9 @@ class Molmo2Attention(nn.Module):
 
 
 class Molmo2DecoderLayer(nn.Module):
-    def __init__(self, config: TextConfig):
+    def __init__(self, config: TextConfig, layer_idx: int = 0):
         super().__init__()
-        self.self_attn = Molmo2Attention(config)
+        self.self_attn = Molmo2Attention(config, layer_idx)
         self.attn_norm = nn.RMSNorm(config.hidden_size, eps=config.layer_norm_eps)
         self.ff_norm = nn.RMSNorm(config.hidden_size, eps=config.layer_norm_eps)
         self.mlp = LanguageModelMLP(config.hidden_size, config.intermediate_size)
@@ -138,7 +152,8 @@ class Molmo2Transformer(nn.Module):
             config.vocab_size, config.additional_vocab_size, config.hidden_size
         )
         self.blocks = [
-            Molmo2DecoderLayer(config) for _ in range(config.num_hidden_layers)
+            Molmo2DecoderLayer(config, layer_idx)
+            for layer_idx in range(config.num_hidden_layers)
         ]
         self.ln_f = nn.RMSNorm(config.hidden_size, eps=config.layer_norm_eps)
 

--- a/mlx_vlm/models/phi4mm/language.py
+++ b/mlx_vlm/models/phi4mm/language.py
@@ -5,6 +5,7 @@ import mlx.nn as nn
 
 from ..base import LanguageModelOutput, create_attention_mask
 from ..cache import KVCache
+from ..rope_utils import initialize_rope
 from .config import ModelConfig
 
 
@@ -23,10 +24,13 @@ class Attention(nn.Module):
         self.o_proj = nn.Linear(n_heads * head_dim, dim, bias=False)
 
         rope_dim = int(head_dim * config.partial_rotary_factor)
-        self.rope = nn.RoPE(
-            rope_dim,
-            traditional=config.rope_traditional,
+        self.rope = initialize_rope(
+            dims=rope_dim,
             base=config.rope_theta,
+            traditional=config.rope_traditional,
+            scaling_config=config.rope_scaling,
+            max_position_embeddings=config.max_position_embeddings,
+            original_max_position_embeddings=config.original_max_position_embeddings,
         )
 
     def __call__(

--- a/mlx_vlm/models/qwen3_moe/language.py
+++ b/mlx_vlm/models/qwen3_moe/language.py
@@ -9,6 +9,7 @@ from ..base import (
     scaled_dot_product_attention,
 )
 from ..mlp import SwiGLUMLP as MLP
+from ..rope_utils import initialize_rope
 from ..switch_layers import SwitchGLU
 from .config import ModelConfig
 
@@ -35,10 +36,12 @@ class Attention(nn.Module):
         self.q_norm = nn.RMSNorm(head_dim, eps=args.rms_norm_eps)
         self.k_norm = nn.RMSNorm(head_dim, eps=args.rms_norm_eps)
 
-        self.rope = nn.RoPE(
-            head_dim,
-            traditional=False,
+        self.rope = initialize_rope(
+            dims=head_dim,
             base=args.rope_theta,
+            traditional=False,
+            scaling_config=args.rope_scaling,
+            max_position_embeddings=args.max_position_embeddings,
         )
 
     def __call__(

--- a/mlx_vlm/models/rope_utils.py
+++ b/mlx_vlm/models/rope_utils.py
@@ -126,8 +126,8 @@ class SuScaledRoPE(nn.Module):
         self.dim = dims
 
         freqs = base ** (mx.arange(0, dims, 2, dtype=mx.float32) / dims)
-        self._freqs = mx.array(long_factor, dtype=mx.float32) * freqs
-        self.eval_cached_arrays()
+        self._short_freqs = mx.array(short_factor, dtype=mx.float32) * freqs
+        self._long_freqs = mx.array(long_factor, dtype=mx.float32) * freqs
 
         def default_scale(factor):
             return math.sqrt(
@@ -135,10 +135,24 @@ class SuScaledRoPE(nn.Module):
             )
 
         factor = max_position_embeddings / original_max_position_embeddings
-        self._scale = long_mscale or (1.0 if factor <= 1.0 else default_scale(factor))
+        scale = 1.0 if factor <= 1.0 else default_scale(factor)
+        self._short_scale = mx.array(
+            scale if short_mscale is None else short_mscale,
+            dtype=mx.float32,
+        )
+        self._long_scale = mx.array(
+            scale if long_mscale is None else long_mscale,
+            dtype=mx.float32,
+        )
+        self.eval_cached_arrays()
 
     def eager_eval_arrays(self):
-        return [self._freqs]
+        return [
+            self._short_freqs,
+            self._long_freqs,
+            self._short_scale,
+            self._long_scale,
+        ]
 
     def eval_cached_arrays(self):
         arrays = self.eager_eval_arrays()
@@ -146,8 +160,16 @@ class SuScaledRoPE(nn.Module):
             mx.eval(*arrays)
 
     def __call__(self, x, offset: Union[int, mx.array] = 0):
-        x = x[...]
-        x[..., : self.dim] = self._scale * x[..., : self.dim]
+        position_end = mx.max(mx.array(offset, dtype=mx.int32)) + x.shape[-2]
+        use_long = position_end > self.original_max_position_embeddings
+        freqs = mx.where(use_long, self._long_freqs, self._short_freqs)
+        scale = mx.where(use_long, self._long_scale, self._short_scale)
+
+        x_rope = scale.astype(x.dtype) * x[..., : self.dim]
+        if self.dim < x.shape[-1]:
+            x = mx.concatenate([x_rope, x[..., self.dim :]], axis=-1)
+        else:
+            x = x_rope
         return mx.fast.rope(
             x,
             self.dim,
@@ -155,7 +177,7 @@ class SuScaledRoPE(nn.Module):
             base=None,
             scale=1.0,
             offset=offset,
-            freqs=self._freqs,
+            freqs=freqs,
         )
 
 
@@ -374,6 +396,7 @@ def initialize_rope(
     scaling_config: Optional[dict] = None,
     max_position_embeddings: Optional[int] = None,
     implementation: str = "fast",
+    original_max_position_embeddings: Optional[int] = None,
 ):
     if scaling_config is not None:
         rope_type = scaling_config.get("type") or scaling_config.get(
@@ -433,15 +456,27 @@ def initialize_rope(
         )
 
     if rope_type == "longrope":
+        original_max_position_embeddings = (
+            original_max_position_embeddings
+            if original_max_position_embeddings is not None
+            else scaling_config.get("original_max_position_embeddings")
+        )
+        if original_max_position_embeddings is None:
+            raise ValueError(
+                "LongRoPE requires original_max_position_embeddings either as an "
+                "argument or in scaling_config"
+            )
+        if max_position_embeddings is None:
+            raise ValueError("LongRoPE requires max_position_embeddings")
         return SuScaledRoPE(
             dims=dims,
             base=base,
             max_position_embeddings=max_position_embeddings,
-            original_max_position_embeddings=scaling_config[
-                "original_max_position_embeddings"
-            ],
+            original_max_position_embeddings=original_max_position_embeddings,
             short_factor=scaling_config["short_factor"],
             long_factor=scaling_config["long_factor"],
+            short_mscale=scaling_config.get("short_mscale"),
+            long_mscale=scaling_config.get("long_mscale"),
         )
 
     if rope_type == "proportional":

--- a/mlx_vlm/tests/test_models.py
+++ b/mlx_vlm/tests/test_models.py
@@ -3018,6 +3018,75 @@ class TestModels(unittest.TestCase):
         self.assertEqual(logits.shape, (1, 1, config.vocab_size))
         self.assertTrue(mx.all(mx.isfinite(logits)).item())
 
+    def test_gemma3_rope_scaling_applies_only_to_global_attention(self):
+        from mlx_vlm.models import gemma3
+        from mlx_vlm.models.gemma3.language import LanguageModel
+
+        config = gemma3.TextConfig(
+            model_type="gemma3_text",
+            hidden_size=16,
+            num_hidden_layers=6,
+            intermediate_size=32,
+            num_attention_heads=2,
+            num_key_value_heads=1,
+            head_dim=8,
+            vocab_size=32,
+            sliding_window_pattern=3,
+            rope_scaling={"rope_type": "linear", "factor": 8.0},
+        )
+
+        model = LanguageModel(config)
+
+        for layer_idx, layer in enumerate(model.layers):
+            expected_scale = 0.125 if (layer_idx + 1) % 3 == 0 else 1.0
+            self.assertEqual(layer.self_attn.rope.scale, expected_scale)
+
+    def test_gemma3_rope_without_scaling(self):
+        from mlx_vlm.models import gemma3
+        from mlx_vlm.models.gemma3.language import LanguageModel
+
+        config = gemma3.TextConfig(
+            model_type="gemma3_text",
+            hidden_size=16,
+            num_hidden_layers=3,
+            intermediate_size=32,
+            num_attention_heads=2,
+            num_key_value_heads=1,
+            head_dim=8,
+            vocab_size=32,
+            sliding_window_pattern=3,
+        )
+
+        model = LanguageModel(config)
+
+        for layer in model.layers:
+            self.assertEqual(layer.self_attn.rope.scale, 1.0)
+
+    def test_gemma3n_rope_scaling_applies_only_to_global_attention(self):
+        from mlx_vlm.models import gemma3n
+        from mlx_vlm.models.gemma3n.language import Gemma3nAttention
+
+        config = gemma3n.TextConfig(
+            model_type="gemma3n_text",
+            hidden_size=16,
+            num_hidden_layers=2,
+            intermediate_size=[32, 32],
+            num_attention_heads=2,
+            num_key_value_heads=1,
+            head_dim=8,
+            vocab_size=32,
+            layer_types=["sliding_attention", "full_attention"],
+            rope_scaling={"rope_type": "linear", "factor": 8.0},
+        )
+
+        sliding = Gemma3nAttention(config, layer_idx=0, is_kv_shared_layer=False)
+        global_attention = Gemma3nAttention(
+            config, layer_idx=1, is_kv_shared_layer=False
+        )
+
+        self.assertEqual(sliding.rope.scale, 1.0)
+        self.assertEqual(global_attention.rope.scale, 0.125)
+
     def test_llama_language_model(self):
         from mlx_vlm.models import llama
 
@@ -5678,6 +5747,39 @@ class TestModels(unittest.TestCase):
 
         self.assertEqual(output.shape, (1, 1, 1, 4))
 
+    def test_mllama_rope_scaling_is_applied(self):
+        from mlx_vlm.models import mllama
+        from mlx_vlm.models.rope_utils import Llama3RoPE
+
+        config = mllama.TextConfig(
+            hidden_size=16,
+            num_attention_heads=2,
+            num_key_value_heads=1,
+            rope_scaling={
+                "rope_type": "llama3",
+                "factor": 8.0,
+                "high_freq_factor": 4.0,
+                "low_freq_factor": 1.0,
+                "original_max_position_embeddings": 8192,
+            },
+        )
+
+        attn = mllama.language.MllamaTextSelfAttention(config, layer_idx=0)
+        self.assertIsInstance(attn.rope, Llama3RoPE)
+
+    def test_mllama_without_rope_scaling_is_plain(self):
+        from mlx_vlm.models import mllama
+
+        config = mllama.TextConfig(
+            hidden_size=16,
+            num_attention_heads=2,
+            num_key_value_heads=1,
+            rope_scaling=None,
+        )
+        attn = mllama.language.MllamaTextSelfAttention(config, layer_idx=0)
+
+        self.assertAlmostEqual(attn.rope.scale, 1.0)
+
     def test_mllama(self):
         from mlx_vlm.models import mllama
 
@@ -5851,6 +5953,28 @@ class TestModels(unittest.TestCase):
         apply_generation_config_defaults(config, {"eos_token_id": [151645, 151646]})
 
         self.assertEqual(config.eos_token_id, [151645, 151646])
+
+    def test_molmo_point_applies_rope_scaling_only_to_configured_layers(self):
+        from mlx_vlm.models import molmo_point
+
+        config = molmo_point.TextConfig(
+            hidden_size=16,
+            num_attention_heads=4,
+            num_key_value_heads=2,
+            head_dim=4,
+            vocab_size=16,
+            additional_vocab_size=4,
+            num_hidden_layers=2,
+            intermediate_size=32,
+            max_position_embeddings=16,
+            rope_scaling={"type": "linear", "factor": 2.0},
+            rope_scaling_layers=[1],
+        )
+
+        transformer = molmo_point.language.Molmo2Transformer(config)
+
+        self.assertAlmostEqual(transformer.blocks[0].self_attn.rotary_emb.scale, 1.0)
+        self.assertAlmostEqual(transformer.blocks[1].self_attn.rotary_emb.scale, 0.5)
 
     def test_molmo2_sanitizes_non_finite_image_features(self):
         from mlx_vlm.models.molmo2.molmo2 import (
@@ -7331,6 +7455,29 @@ class TestModels(unittest.TestCase):
             (config.vision_config.image_size, config.vision_config.image_size),
             vision_feature_layer=0,
         )
+
+    def test_phi4mm_longrope_uses_top_level_original_context_length(self):
+        from mlx_vlm.models import phi4mm
+        from mlx_vlm.models.rope_utils import SuScaledRoPE
+
+        config = phi4mm.ModelConfig(
+            hidden_size=16,
+            num_attention_heads=2,
+            num_key_value_heads=1,
+            partial_rotary_factor=0.5,
+            max_position_embeddings=16,
+            original_max_position_embeddings=8,
+            rope_scaling={
+                "type": "longrope",
+                "short_factor": [1.0, 1.0],
+                "long_factor": [2.0, 2.0],
+            },
+        )
+
+        attn = phi4mm.language.Attention(config)
+
+        self.assertIsInstance(attn.rope, SuScaledRoPE)
+        self.assertEqual(attn.rope.original_max_position_embeddings, 8)
 
     def test_phi4mm(self):
         from mlx_vlm.models import phi4mm

--- a/mlx_vlm/tests/test_rope_utils.py
+++ b/mlx_vlm/tests/test_rope_utils.py
@@ -152,9 +152,76 @@ def test_su_scaled_rope_evals_private_helper_arrays_on_init(monkeypatch):
     assert tree_flatten(host.parameters()) == []
     assert tree_flatten(host.trainable_parameters()) == []
     eager_arrays = host.rope.eager_eval_arrays()
-    assert eager_arrays[0] is host.rope._freqs
+    assert eager_arrays[0] is host.rope._short_freqs
+    assert eager_arrays[1] is host.rope._long_freqs
+    assert eager_arrays[2] is host.rope._short_scale
+    assert eager_arrays[3] is host.rope._long_scale
     assert len(eval_args) == 1
-    assert eval_args[0][0] is eager_arrays[0]
+    assert len(eval_args[0]) == len(eager_arrays)
+    for actual, expected in zip(eval_args[0], eager_arrays):
+        assert actual is expected
+
+
+def test_su_scaled_rope_selects_factors_from_position_span():
+    dims = 8
+    base = 100.0
+    short_factor = [1.0, 1.25, 1.5, 1.75]
+    long_factor = [2.0, 2.25, 2.5, 2.75]
+    rope = SuScaledRoPE(
+        dims=dims,
+        base=base,
+        max_position_embeddings=8,
+        original_max_position_embeddings=4,
+        short_factor=short_factor,
+        long_factor=long_factor,
+        short_mscale=1.0,
+        long_mscale=2.0,
+    )
+    inputs = (mx.arange(16, dtype=mx.float32) / 10).reshape(1, 1, 2, dims)
+    base_freqs = base ** (mx.arange(0, dims, 2, dtype=mx.float32) / dims)
+
+    short = rope(inputs, offset=2)
+    expected_short = mx.fast.rope(
+        inputs,
+        dims,
+        traditional=False,
+        base=None,
+        scale=1.0,
+        offset=2,
+        freqs=mx.array(short_factor) * base_freqs,
+    )
+    long = rope(inputs, offset=3)
+    expected_long = mx.fast.rope(
+        2.0 * inputs,
+        dims,
+        traditional=False,
+        base=None,
+        scale=1.0,
+        offset=3,
+        freqs=mx.array(long_factor) * base_freqs,
+    )
+
+    mx.eval(short, expected_short, long, expected_long)
+    assert _max_diff(short, expected_short) < 1e-5
+    assert _max_diff(long, expected_long) < 1e-5
+
+
+def test_initialize_longrope_accepts_top_level_original_context_length():
+    rope = initialize_rope(
+        dims=8,
+        base=10000.0,
+        traditional=False,
+        scaling_config={
+            "type": "longrope",
+            "short_factor": [1.0] * 4,
+            "long_factor": [2.0] * 4,
+        },
+        max_position_embeddings=16,
+        original_max_position_embeddings=8,
+    )
+
+    assert isinstance(rope, SuScaledRoPE)
+    assert rope.original_max_position_embeddings == 8
 
 
 def test_llama3_rope_evals_private_helper_arrays_on_init(monkeypatch):


### PR DESCRIPTION
Supersedes https://github.com/Blaizzy/mlx-vlm/pull/1709 and https://github.com/Blaizzy/mlx-vlm/pull/1710 which were the same class of issue, and fixes some issues with short/long extrapolation for SuScaledRoPE and LongRoPE.