### PR TITLE
Fix PoolingCache APC restoration

### DIFF
--- a/mlx_vlm/apc.py
+++ b/mlx_vlm/apc.py
@@ -3983,9 +3983,18 @@ def extract_prompt_cache_from_batch(
 
 def _prompt_cache_is_batch_shaped(caches: Sequence[Any]) -> bool:
     """True when every entry can row-extract (Batch* / ArraysCache layout)."""
+
+    def can_extract_row(cache: Any) -> bool:
+        if not callable(getattr(cache, "extract", None)):
+            return False
+        children = getattr(cache, "caches", None)
+        if children is None:
+            return True
+        return all(can_extract_row(child) for child in children)
+
     if not caches:
         return False
-    return all(callable(getattr(c, "extract", None)) for c in caches)
+    return all(can_extract_row(cache) for cache in caches)
 
 
 def snapshot_prompt_cache_row(

--- a/mlx_vlm/models/cache.py
+++ b/mlx_vlm/models/cache.py
@@ -2151,12 +2151,7 @@ class PoolingCache(_BaseCache):
 
     @classmethod
     def merge(cls, caches, prefix_lens=None):
-        # APC's generic exact-cache adapter passes prefix lengths to custom
-        # merge implementations. Pooling caches derive their batched progress
-        # from each row's pooled length and remainder, so no extra alignment is
-        # required here.
-        del prefix_lens
-        return BatchPoolingCache.merge(caches)
+        return BatchPoolingCache.merge(caches, prefix_lens)
 
 
 class BatchPoolingCache(_BaseCache):
@@ -2497,8 +2492,11 @@ class BatchPoolingCache(_BaseCache):
         return cache
 
     @classmethod
-    def merge(cls, caches):
+    def merge(cls, caches, prefix_lens=None):
         """Merge a list of PoolingCache instances into a BatchPoolingCache."""
+        # APC passes prefix lengths to custom merge implementations. Pooling
+        # caches derive progress from each row's pooled length and remainder.
+        del prefix_lens
         B = len(caches)
         if not all(c.ratio == caches[0].ratio for c in caches):
             raise ValueError(

--- a/mlx_vlm/models/cache.py
+++ b/mlx_vlm/models/cache.py
@@ -2118,6 +2118,14 @@ class PoolingCache(_BaseCache):
     def meta_state(self, v):
         self.ratio = v
 
+    @classmethod
+    def from_state(cls, state, meta_state):
+        # Restoring buffered state calls ``accumulate_windows``, which needs
+        # the compression ratio before the generic state setter can run.
+        obj = cls(meta_state)
+        obj.state = state
+        return obj
+
     def is_trimmable(self):
         return self.pooled is None
 
@@ -2142,7 +2150,12 @@ class PoolingCache(_BaseCache):
         return total
 
     @classmethod
-    def merge(cls, caches):
+    def merge(cls, caches, prefix_lens=None):
+        # APC's generic exact-cache adapter passes prefix lengths to custom
+        # merge implementations. Pooling caches derive their batched progress
+        # from each row's pooled length and remainder, so no extra alignment is
+        # required here.
+        del prefix_lens
         return BatchPoolingCache.merge(caches)
 
 

--- a/mlx_vlm/tests/test_apc_adapters.py
+++ b/mlx_vlm/tests/test_apc_adapters.py
@@ -49,9 +49,35 @@ def _max_abs_error(a: mx.array, b: mx.array) -> float:
     return mx.max(mx.abs(a - b)).item()
 
 
-def test_snapshot_nested_pooling_cache_restores_ratio_before_buffered_state():
+def test_snapshot_single_row_cache_list_clones_nested_pooling_cache():
     from mlx_vlm.apc import snapshot_prompt_cache_row
 
+    rotating = RotatingKVCache(max_size=16)
+    keys, values = _rand_kv(batch=1, seq_len=3, heads=1, dim=2)
+    rotating.update_and_fetch(keys, values)
+    pooling = PoolingCache(ratio=4)
+    kv = mx.arange(6, dtype=mx.float32).reshape(1, 3, 2)
+    gate = mx.arange(3, dtype=mx.float32).reshape(1, 3, 1)
+    pooling.accumulate_windows(kv, gate, offset=0)
+
+    snapshot = snapshot_prompt_cache_row([CacheList(rotating, pooling)], batch_idx=0)
+
+    assert snapshot is not None
+    cloned_rotating, cloned = snapshot[0].caches
+    assert isinstance(cloned_rotating, RotatingKVCache)
+    assert cloned_rotating.offset == 3
+    assert isinstance(cloned, PoolingCache)
+    assert cloned.ratio == 4
+    assert cloned.remainder == 3
+    mx.eval(*[value for value in cloned.state if value is not None])
+    assert mx.array_equal(cloned.state[0], kv).item()
+    assert mx.array_equal(cloned.state[1], gate).item()
+
+
+def test_snapshot_batch_cache_list_extracts_nested_pooling_cache():
+    from mlx_vlm.apc import snapshot_prompt_cache_row
+
+    rotating, _, _ = _fill_batch_rotating([0], seq_len=3, max_size=16)
     pooling = BatchPoolingCache(ratio=4, left_padding=[0])
     kv = mx.arange(6, dtype=mx.float32).reshape(1, 3, 2)
     gate = mx.arange(3, dtype=mx.float32).reshape(1, 3, 1)
@@ -59,10 +85,11 @@ def test_snapshot_nested_pooling_cache_restores_ratio_before_buffered_state():
     pooling.accumulate_windows(kv, gate, offset=0)
     pooling.finalize()
 
-    snapshot = snapshot_prompt_cache_row([CacheList(pooling)], batch_idx=0)
+    snapshot = snapshot_prompt_cache_row([CacheList(rotating, pooling)], batch_idx=0)
 
     assert snapshot is not None
-    cloned = snapshot[0][0]
+    cloned_rotating, cloned = snapshot[0].caches
+    assert isinstance(cloned_rotating, RotatingKVCache)
     assert isinstance(cloned, PoolingCache)
     assert cloned.ratio == 4
     assert cloned.remainder == 3

--- a/mlx_vlm/tests/test_apc_adapters.py
+++ b/mlx_vlm/tests/test_apc_adapters.py
@@ -20,9 +20,12 @@ from mlx_vlm.apc import (
 from mlx_vlm.models.cache import (
     ArraysCache,
     BatchKVCache,
+    BatchPoolingCache,
     BatchQuantizedKVCache,
     BatchRotatingKVCache,
+    CacheList,
     KVCache,
+    PoolingCache,
     QuantizedKVCache,
     RotatingKVCache,
 )
@@ -44,6 +47,51 @@ def _rand_kv(batch=B, seq_len=32, heads=H, dim=D):
 
 def _max_abs_error(a: mx.array, b: mx.array) -> float:
     return mx.max(mx.abs(a - b)).item()
+
+
+def test_snapshot_nested_pooling_cache_restores_ratio_before_buffered_state():
+    from mlx_vlm.apc import snapshot_prompt_cache_row
+
+    pooling = BatchPoolingCache(ratio=4, left_padding=[0])
+    kv = mx.arange(6, dtype=mx.float32).reshape(1, 3, 2)
+    gate = mx.arange(3, dtype=mx.float32).reshape(1, 3, 1)
+    pooling.prepare(lengths=[3])
+    pooling.accumulate_windows(kv, gate, offset=0)
+    pooling.finalize()
+
+    snapshot = snapshot_prompt_cache_row([CacheList(pooling)], batch_idx=0)
+
+    assert snapshot is not None
+    cloned = snapshot[0][0]
+    assert isinstance(cloned, PoolingCache)
+    assert cloned.ratio == 4
+    assert cloned.remainder == 3
+    mx.eval(*[value for value in cloned.state if value is not None])
+    assert mx.array_equal(cloned.state[0], kv).item()
+    assert mx.array_equal(cloned.state[1], gate).item()
+
+
+def test_pooling_cache_exact_batch_merge_accepts_prefix_lengths():
+    from mlx_vlm.apc_adapters import merge_cache_entries
+
+    warm = PoolingCache(ratio=4)
+    kv = mx.arange(18, dtype=mx.float32).reshape(1, 6, 3)
+    gate = mx.ones((1, 6, 2), dtype=mx.float32)
+    warm.accumulate_windows(kv, gate, offset=0)
+    warm.update_and_fetch(mx.ones((1, 1, 3), dtype=mx.float32))
+    cold = PoolingCache(ratio=4)
+
+    merged = merge_cache_entries([warm, cold], [6, 0])
+
+    assert isinstance(merged, BatchPoolingCache)
+    assert merged.remainder == [2, 0]
+    assert merged._pool_lengths == [1, 0]
+    assert merged._processed == [6, 0]
+    extracted_warm = merged.extract(0)
+    extracted_cold = merged.extract(1)
+    assert extracted_warm.remainder == 2
+    assert extracted_warm.pooled.shape == (1, 1, 3)
+    assert extracted_cold.empty()
 
 
 def _fill_batch_kv(left_padding, seq_len):

--- a/mlx_vlm/tests/test_apc_adapters.py
+++ b/mlx_vlm/tests/test_apc_adapters.py
@@ -98,7 +98,19 @@ def test_snapshot_batch_cache_list_extracts_nested_pooling_cache():
     assert mx.array_equal(cloned.state[1], gate).item()
 
 
-def test_pooling_cache_exact_batch_merge_accepts_prefix_lengths():
+def test_batch_pooling_cache_merge_accepts_prefix_lengths():
+    merged = BatchPoolingCache.merge(
+        [PoolingCache(ratio=4), PoolingCache(ratio=4)],
+        prefix_lens=[0, 0],
+    )
+
+    assert isinstance(merged, BatchPoolingCache)
+    assert merged.remainder == [0, 0]
+    assert merged._pool_lengths == [0, 0]
+    assert merged._processed == [0, 0]
+
+
+def test_pooling_cache_exact_batch_merge_forwards_prefix_lengths():
     from mlx_vlm.apc_adapters import merge_cache_entries
 
     warm = PoolingCache(ratio=4)

--- a/mlx_vlm/tests/test_apc_adapters.py
+++ b/mlx_vlm/tests/test_apc_adapters.py
@@ -98,6 +98,45 @@ def test_snapshot_batch_cache_list_extracts_nested_pooling_cache():
     assert mx.array_equal(cloned.state[1], gate).item()
 
 
+def test_pooling_cache_exact_apc_round_trips_warm_and_cold_rows():
+    from mlx_vlm.apc import make_warm_batch_exact_cache_multi, snapshot_prompt_cache_row
+
+    def make_row(prompt_length):
+        rotating = RotatingKVCache(max_size=16)
+        pooling = PoolingCache(ratio=4)
+        if prompt_length > 0:
+            keys = mx.arange(prompt_length * 3, dtype=mx.float32).reshape(
+                1, 1, prompt_length, 3
+            )
+            rotating.update_and_fetch(keys, keys + 1)
+            kv = keys.reshape(1, prompt_length, 3)
+            gate = mx.ones((1, prompt_length, 2), dtype=mx.float32)
+            ready_kv, _, _ = pooling.accumulate_windows(kv, gate, offset=0)
+            pooled_length = ready_kv.shape[1] // pooling.ratio
+            pooling.update_and_fetch(mx.ones((1, pooled_length, 3), dtype=mx.float32))
+        return [CacheList(rotating, pooling)]
+
+    warm = snapshot_prompt_cache_row(make_row(6), batch_idx=0)
+    cold = snapshot_prompt_cache_row(make_row(0), batch_idx=0)
+
+    assert warm is not None
+    assert cold is not None
+    merged, max_prefix = make_warm_batch_exact_cache_multi(
+        [warm, cold], prefix_lens=[6, 0]
+    )
+
+    assert merged is not None
+    assert max_prefix == 6
+    rotating, pooling = merged[0].caches
+    assert isinstance(rotating, BatchRotatingKVCache)
+    assert rotating.offset.tolist() == [6, 0]
+    assert isinstance(pooling, BatchPoolingCache)
+    assert pooling.ratio == 4
+    assert pooling.remainder == [2, 0]
+    assert pooling._pool_lengths == [1, 0]
+    assert pooling._processed == [6, 0]
+
+
 def test_batch_pooling_cache_merge_accepts_prefix_lengths():
     merged = BatchPoolingCache.merge(
         [PoolingCache(ratio=4), PoolingCache(ratio=4)],


### PR DESCRIPTION
Fixes #1928

## Summary

Exact APC could identify `PoolingCache` as snapshot-compatible, but restoring and merging pooling caches failed across several generic APC boundaries.

`PoolingCache.from_state()` now constructs the cache with its compression ratio before assigning buffered state. This ensures that restoring a remainder buffer can safely call `accumulate_windows()`.

APC batch-shape detection now inspects nested `CacheList` children recursively. A live single-row layout such as `CacheList(RotatingKVCache, PoolingCache)` is therefore cloned as a single-row cache instead of being incorrectly passed through `CacheList.extract()`. Genuinely batched composite layouts continue to use row extraction.

`PoolingCache.merge()` and `BatchPoolingCache.merge()` now both accept the optional `prefix_lens` argument supplied by the exact-cache adapter. The prefix lengths do not need to be applied directly because the batched pooling cache reconstructs each row’s progress from its pooled length, remainder, and compression ratio.

Regression tests cover:

- snapshotting a realistic single-row `CacheList(RotatingKVCache, PoolingCache)` while preserving the compression ratio and buffered KV/gate remainder;
- extracting the corresponding batched `CacheList(BatchRotatingKVCache, BatchPoolingCache)` layout;
- accepting and forwarding `prefix_lens` through the pooling-cache merge contract;
- rebuilding warm and cold composite rows end to end through `make_warm_batch_exact_cache_multi()`, including their rotating-cache offsets and pooling-cache progress metadata.


## Test plan

```text
python -m pytest mlx_vlm/tests/test_apc_adapters.py -q
```

```text
44 passed, 2 warnings
```