### PR TITLE
Key vision feature cache on content, not image path

### DIFF
--- a/mlx_vlm/generate/dispatch.py
+++ b/mlx_vlm/generate/dispatch.py
@@ -782,13 +782,16 @@ def stream_generate(
 
     # Vision feature caching: reuse cached image features across turns
     if vision_cache is not None and image is not None and pixel_values is not None:
-        cached = vision_cache.get(image)
+        # encode_image() below is called with pixel_values alone, so the pixels
+        # are the complete input to the cached computation on this path.
+        image_key = vision_cache.content_key(pixel_values)
+        cached = vision_cache.get(image_key)
         if cached is not None:
             kwargs["cached_image_features"] = cached
         elif hasattr(model, "encode_image"):
             features = model.encode_image(pixel_values)
             mx.eval(features)
-            vision_cache.put(image, features)
+            vision_cache.put(image_key, features)
             kwargs["cached_image_features"] = features
 
     # Prompt cache reuse: skip common prefix from previous turn

--- a/mlx_vlm/server/generation.py
+++ b/mlx_vlm/server/generation.py
@@ -1658,8 +1658,11 @@ class ResponseGenerator:
             and self.vision_cache is not None
             and images is not None
         ):
+            # data_kwargs carries the grid/position metadata the vision tower
+            # consumes alongside the pixels, so it belongs in the cache key.
+            image_key = self.vision_cache.content_key(pixel_values, data_kwargs)
             data_kwargs["vision_cache"] = self.vision_cache
-            data_kwargs["_image_key"] = images
+            data_kwargs["_image_key"] = image_key
 
         # Always call get_input_embeddings — BatchGenerator requires inputs_embeds
         embed = self.model.get_input_embeddings(

--- a/mlx_vlm/tests/test_vision_cache.py
+++ b/mlx_vlm/tests/test_vision_cache.py
@@ -1,3 +1,5 @@
+from types import SimpleNamespace
+
 import mlx.core as mx
 import pytest
 
@@ -86,6 +88,111 @@ class TestVisionFeatureCache:
         assert len(cache) == 0
         for i in range(5):
             assert cache.get(f"img{i}.jpg") is None
+
+
+class TestContentKey:
+    """Keys must track the pixels the encoder sees, not the image's name.
+
+    A path or URL is not a safe key: the bytes behind a stable name change
+    between requests (a camera overwriting frame.jpg, a snapshot URL), which
+    previously served the earlier frame's features and silently answered
+    about the wrong image.
+    """
+
+    def test_same_pixels_same_key(self):
+        pixels = mx.zeros((1, 3, 8, 8))
+        assert VisionFeatureCache.content_key(pixels) == VisionFeatureCache.content_key(
+            mx.zeros((1, 3, 8, 8))
+        )
+
+    def test_different_pixels_different_key(self):
+        assert VisionFeatureCache.content_key(
+            mx.zeros((1, 3, 8, 8))
+        ) != VisionFeatureCache.content_key(mx.ones((1, 3, 8, 8)))
+
+    def test_rewritten_frame_misses(self):
+        cache = VisionFeatureCache()
+        features = mx.ones((1, 4, 8))
+        cache.put(VisionFeatureCache.content_key(mx.zeros((1, 3, 8, 8))), features)
+        assert (
+            cache.get(VisionFeatureCache.content_key(mx.zeros((1, 3, 8, 8))))
+            is not None
+        )
+        assert cache.get(VisionFeatureCache.content_key(mx.ones((1, 3, 8, 8)))) is None
+
+    def test_grid_metadata_separates_identical_pixels(self):
+        """Qwen-style towers consume grid metadata alongside the pixels.
+
+        Two solid-colour images with transposed grids preprocess to the same
+        flattened patches, so the pixels alone are not a complete key.
+        """
+        pixels = mx.ones((8, 12))
+        wide = VisionFeatureCache.content_key(
+            pixels, {"image_grid_thw": mx.array([[1, 2, 4]])}
+        )
+        tall = VisionFeatureCache.content_key(
+            pixels, {"image_grid_thw": mx.array([[1, 4, 2]])}
+        )
+        assert wide is not None and tall is not None
+        assert wide != tall
+
+    def test_nested_fragments_are_unambiguous(self):
+        """Distinct structures must not serialise to the same byte stream."""
+        pixels = mx.ones((2, 2))
+        a = VisionFeatureCache.content_key(pixels, {"a": [1, 23]})
+        b = VisionFeatureCache.content_key(pixels, {"a": [12, 3]})
+        assert a is not None and b is not None
+        assert a != b
+        assert VisionFeatureCache.content_key(
+            pixels, {"ab": 1}
+        ) != VisionFeatureCache.content_key(pixels, {"a": "b1"})
+
+    def test_unhashable_extra_disables_caching(self):
+        assert (
+            VisionFeatureCache.content_key(mx.ones((2, 2)), {"proc": object()}) is None
+        )
+
+    def test_unhashable_pixels_disable_caching(self):
+        cache = VisionFeatureCache()
+        key = VisionFeatureCache.content_key(object())
+        assert key is None
+        cache.put(key, mx.ones((1, 4, 8)))
+        assert len(cache) == 0
+        assert cache.get(key) is None
+
+    def test_server_keys_on_pixels_not_image_source(self):
+        """Regression for the server's continuous-batching path.
+
+        _gpu_embed used to set _image_key to the request's image sources, so
+        two different frames posted under one path shared a cache entry.
+        """
+        from mlx_vlm.server.generation import ResponseGenerator
+
+        captured = {}
+
+        class _Model:
+            def get_input_embeddings(self, input_ids, pixel_values, mask=None, **kw):
+                captured["key"] = kw.get("_image_key")
+                return SimpleNamespace(to_dict=lambda: {})
+
+        gen = object.__new__(ResponseGenerator)
+        gen.model = _Model()
+        gen.vision_cache = VisionFeatureCache()
+
+        same_source = ["/tmp/frame.jpg"]
+        gen._gpu_embed(
+            {"input_ids": mx.zeros((1, 4)), "pixel_values": mx.zeros((1, 3, 8, 8))},
+            images=same_source,
+        )
+        first = captured["key"]
+        gen._gpu_embed(
+            {"input_ids": mx.zeros((1, 4)), "pixel_values": mx.ones((1, 3, 8, 8))},
+            images=same_source,
+        )
+        second = captured["key"]
+
+        assert first is not None and second is not None
+        assert first != second, "two different frames shared one cache key"
 
 
 class TestCachedImageFeaturesKwarg:

--- a/mlx_vlm/vision_cache.py
+++ b/mlx_vlm/vision_cache.py
@@ -10,6 +10,7 @@ from collections import OrderedDict
 from typing import Any, Optional
 
 import mlx.core as mx
+import numpy as np
 
 
 class VisionFeatureCache:
@@ -32,26 +33,100 @@ class VisionFeatureCache:
         self.max_size = max_size
         self._cache: OrderedDict[str, mx.array] = OrderedDict()
 
-    def _make_key(self, image_source: Any) -> str:
+    def _make_key(self, image_source: Any) -> Optional[str]:
         """Derive a cache key from an image source.
 
         For str/Path: use the string directly (path or URL).
         For lists: create a composite key from individual keys.
         For PIL images: hash the image bytes.
         """
+        if image_source is None:
+            return None
         if isinstance(image_source, str):
             return image_source
         elif isinstance(image_source, list):
-            return "|".join(self._make_key(img) for img in image_source)
+            keys = []
+            for img in image_source:
+                key = self._make_key(img)
+                if key is None:
+                    return None
+                keys.append(key)
+            return "|".join(keys)
         else:
             if hasattr(image_source, "tobytes"):
                 h = hashlib.sha256(image_source.tobytes()).hexdigest()[:16]
                 return f"pil:{h}"
-            return f"obj:{id(image_source)}"
+            # id() is reused after garbage collection, so it cannot key a cache.
+            return None
+
+    @staticmethod
+    def _update_hash(hasher: "hashlib._Hash", value: Any) -> bool:
+        """Fold ``value`` into ``hasher``. Returns False if it cannot be hashed."""
+        # Every fragment is type-tagged and delimited so that distinct structures
+        # cannot serialise to the same byte stream (without this, {"a": [1, 23]}
+        # and {"a": [12, 3]} hash identically).
+        if isinstance(value, mx.array):
+            try:
+                value = np.asarray(value)
+            except Exception:
+                # numpy has no bfloat16; fall back to a lossless-enough widening
+                value = np.asarray(value.astype(mx.float32))
+        if isinstance(value, np.ndarray):
+            if not np.issubdtype(value.dtype, np.number):
+                return False
+            value = np.ascontiguousarray(value)
+            hasher.update(f"arr|{value.shape}|{value.dtype}|".encode())
+            hasher.update(value.tobytes())
+            return True
+        if value is None or isinstance(value, (str, bytes, int, float, bool)):
+            hasher.update(f"val|{value!r}|".encode())
+            return True
+        if isinstance(value, (list, tuple)):
+            hasher.update(f"seq|{len(value)}|".encode())
+            for item in value:
+                if not VisionFeatureCache._update_hash(hasher, item):
+                    return False
+                hasher.update(b";")
+            return True
+        if isinstance(value, dict):
+            hasher.update(f"map|{len(value)}|".encode())
+            for k in sorted(value, key=repr):
+                hasher.update(f"key|{k!r}|".encode())
+                if not VisionFeatureCache._update_hash(hasher, value[k]):
+                    return False
+                hasher.update(b";")
+            return True
+        return False
+
+    @staticmethod
+    def content_key(pixel_values: Any, *extra: Any) -> Optional[str]:
+        """Key on everything the cached vision features are computed from.
+
+        Image paths and URLs are not safe cache keys: the bytes behind a stable
+        name can change between requests (a camera overwriting frame.jpg, a
+        snapshot URL), which would serve a previous image's features.
+
+        ``extra`` must carry every other input the vision tower consumes —
+        grid metadata such as ``image_grid_thw`` or ``image_position_ids``
+        changes the features even when the pixel bytes are byte-identical
+        (two solid-colour images with transposed grids preprocess to the same
+        flattened patches). Returns None when any part cannot be hashed,
+        disabling caching for that request rather than risking a stale hit.
+        """
+        try:
+            hasher = hashlib.sha256()
+            for value in (pixel_values, *extra):
+                if not VisionFeatureCache._update_hash(hasher, value):
+                    return None
+            return f"px:{hasher.hexdigest()}"
+        except Exception:
+            return None
 
     def get(self, image_source: Any) -> Optional[mx.array]:
         """Look up cached features. Returns None on miss."""
         key = self._make_key(image_source)
+        if key is None:
+            return None
         if key in self._cache:
             self._cache.move_to_end(key)
             return self._cache[key]
@@ -60,6 +135,8 @@ class VisionFeatureCache:
     def put(self, image_source: Any, features: mx.array) -> None:
         """Store features in the cache, evicting LRU if full."""
         key = self._make_key(image_source)
+        if key is None:
+            return
         if key in self._cache:
             self._cache.move_to_end(key)
         else:

--- a/mlx_vlm/vision_cache.py
+++ b/mlx_vlm/vision_cache.py
@@ -66,6 +66,7 @@ class VisionFeatureCache:
         # cannot serialise to the same byte stream (without this, {"a": [1, 23]}
         # and {"a": [12, 3]} hash identically).
         if isinstance(value, mx.array):
+            hasher.update(f"mx|{value.dtype}|".encode())  # np widens bf16
             try:
                 value = np.asarray(value)
             except Exception:


### PR DESCRIPTION
**The vision feature cache is keyed on the image's *name*, so a path or URL whose bytes change between requests serves the previous image's features — the model answers about the wrong frame, silently.** Reproduced end-to-end on `mlx-community/gemma-4-e2b-it-4bit`: a blue image written over `frame.jpg` was answered `"Red"`. This patch keys on the preprocessed pixels plus the grid metadata the vision tower consumes.

Verdict: correctness fix, 74 lines of source change, no behaviour change for legitimate cache hits (measured 2.07× speedup on repeated identical images, preserved).

---

### The bug

`VisionFeatureCache._make_key()` returns the image source string verbatim for `str` inputs, and both sites that produce keys pass the raw request sources:

- `server/generation.py::_gpu_embed` → `data_kwargs["_image_key"] = images`
- `generate/dispatch.py` → `vision_cache.get(image)`

`images` comes straight from the request (`openai.py`: `images.append(item["image_url"]["url"])`). So the key for a CCTV snapshot URL, or a local path a camera keeps overwriting, is **constant while the content changes**. After the first request the entry never misses, and `encode_image()` never runs again.

This is not a perf miss — it is a wrong answer that looks like a right one. Reachable today on `gemma4`, `gemma4_unified` and `qwen3_5` (the models that consume `vision_cache` in `get_input_embeddings`), plus any model with `encode_image` on the `stream_generate` path.

Base64 data-URI callers are unaffected: the whole payload is the key, which is content-addressed by accident.

<details>
<summary><b>Runnable MRE</b> — same path + new bytes vs. same bytes + new path</summary>

```
mlx_vlm.server --model mlx-community/gemma-4-e2b-it-4bit --port 8914
```

```python
import json, tempfile, urllib.request
from pathlib import Path
from PIL import Image

URL, MODEL = "http://127.0.0.1:8914/v1/chat/completions", "mlx-community/gemma-4-e2b-it-4bit"
tmp = Path(tempfile.mkdtemp())

def ask(p):
    body = json.dumps({"model": MODEL, "max_tokens": 12, "temperature": 0.0, "messages": [
        {"role": "user", "content": [
            {"type": "text", "text": "What color is this image? Answer with one word."},
            {"type": "image_url", "image_url": {"url": str(p)}}]}]}).encode()
    req = urllib.request.Request(URL, data=body, headers={"Content-Type": "application/json"})
    with urllib.request.urlopen(req, timeout=300) as r:
        return json.load(r)["choices"][0]["message"]["content"].strip()

frame = tmp / "frame.jpg"
Image.new("RGB", (256, 256), (255, 0, 0)).save(frame); first = ask(frame)
Image.new("RGB", (256, 256), (0, 0, 255)).save(frame); second = ask(frame)   # same path, new bytes
fresh = tmp / "frame_other.jpg"
Image.new("RGB", (256, 256), (0, 0, 255)).save(fresh); control = ask(fresh)  # same bytes, new path

print(first, second, control)
assert control != first, "control failed — model cannot tell the frames apart"
assert second == first, "no bug"
```

**Before this patch** (`edf7b77`, macOS 26.5 / M4, mlx 0.31.1, Python 3.12):

```
1. red  @ frame.jpg       -> 'Red'
2. blue @ frame.jpg       -> 'Red'    <-- same path, new bytes
3. blue @ frame_other.jpg -> 'Blue'   <-- same bytes, new path

BUG: step 2 returned the RED answer 'Red' for a BLUE image.
```

Step 3 is the control: the model distinguishes the two images fine, so the only variable is the cache key.

**After this patch**, step 2 returns `'Blue'` and the bug assertion fails as intended.

</details>

### The fix

Key on what the features are actually computed from, at the two sites that produce keys:

- `VisionFeatureCache.content_key(pixel_values, *extra)` hashes the preprocessed pixel tensor **and** every other encoder input.
- `_gpu_embed` passes `data_kwargs`, which carries `image_grid_thw` / `image_position_ids` etc. Pixels alone are **not** a complete key: two solid-colour images with transposed grids preprocess to byte-identical flattened patches while the tower lays them out differently. Covered by `test_grid_metadata_separates_identical_pixels`.
- `get`/`put` no-op on an unhashable input, so an unrecognised source disables caching instead of risking a stale hit. This also removes the `obj:{id(...)}` fallback — `id()` is reused after GC, so it could alias a dead object's entry.

`_make_key` itself is unchanged for string keys, so existing behaviour (including `test_url_key`) is preserved.

<details>
<summary><b>Verification</b> — including the cache still doing its job</summary>

A fix that merely disabled the cache would also make the MRE pass, so that was measured separately.

| Check | Result |
|---|---|
| MRE on unpatched `edf7b77` | reproduces (`'Red'` for a blue image) |
| MRE on this branch | fixed (`'Blue'`) |
| New tests with the fix reverted | **8 failed**, 55 passed |
| New tests with the fix | 63 passed |
| `test_vision_cache.py` + `test_server.py` | 404 passed, 0 skipped |
| Repeated identical image vs. distinct images | **1.96–2.07×** faster — cache still hits |

Cache-benefit measurement (5 requests each, 512×512, gemma-4-e2b-it-4bit):

```
same image  : first  3469.6 ms | repeats median  1634.7 ms
distinct    : median 3386.1 ms
repeat-vs-distinct speedup: 2.07x
```

Hashing cost is negligible against a ViT forward pass; the encoder it avoids is ~1.8 s on this model.

</details>

<details>
<summary><b>Adversarial review</b> (GPT-5.2-codex, different lineage) and what changed because of it</summary>

Reviewed twice. The first pass (6/10) raised a BLOCKER against an earlier revision:

> `content_key(pixel_values)` is not a complete key for models whose cached vision features are a function of `pixel_values + grid/layout kwargs`, so the patch can reintroduce silent wrong-image-feature reuse under a different shape/layout condition.

That was correct — `qwen3_5.py` computes `self.vision_tower(pixel_values, grid_thw)`, and gemma4's `_encode_image` closes over `image_position_ids`. Fixed by making `content_key` variadic and passing `data_kwargs` at the server site, plus a regression test for the transposed-grid collision. It also confirmed the patch does not disable caching, and that SHA-256 collisions are not a practical concern.

A second pass on the current revision raised a hash-framing collision — `{"a": [1, 23]}` and `{"a": [12, 3]}` serialised to the same byte stream. Fixed by type-tagging and delimiting every fragment, with `test_nested_fragments_are_unambiguous` as the guard.

That pass also flagged the `stream_generate` path as still keying on pixels alone. That one is intentional and I disagree it is a defect: `dispatch.py` calls `model.encode_image(pixel_values)` with no metadata, so the pixels *are* the complete input to the computation being cached — a cached hit is byte-identical to a fresh call. The underlying issue is that this path ignores metadata at all, which is pre-existing and unchanged here (see below).

**Known adjacent issue, deliberately not fixed here:** on the `stream_generate` path, `dispatch.py` calls `model.encode_image(pixel_values)` without auxiliary args, which is already wrong for models like MiniMax that require `image_grid_thw`. That predates this patch and is left alone to keep the diff minimal — happy to follow up separately if you want it in scope.

**Known fragility:** `test_server_keys_on_pixels_not_image_source` constructs `object.__new__(ResponseGenerator)` to exercise `_gpu_embed` without loading a model. It guards key derivation, not end-to-end cache correctness, and would need updating if `_gpu_embed`'s signature moves.

</details>

Environment: macOS 26.5 (M4), Python 3.12, mlx 0.31.1, branched from `edf7b77`.
