### PR TITLE
fix(server): remove the `thought` prefix by prefix, not by character set

### DIFF
--- a/mlx_vlm/server/responses_state.py
+++ b/mlx_vlm/server/responses_state.py
@@ -357,7 +357,10 @@ def _sse_event(event_type: str, payload: Dict[str, Any]) -> str:
 def _clean_reasoning(reasoning: str, start_marker: str) -> str:
     reasoning = reasoning.replace(start_marker, "")
     if start_marker == "<|channel>thought":
-        reasoning = reasoning.lstrip("thought")
+        # removeprefix, not lstrip: lstrip takes a character *set*, so
+        # lstrip("thought") eats every leading t/h/o/u/g of the reasoning
+        # itself when the opener is absent ("got it" -> "it").
+        reasoning = reasoning.removeprefix("thought")
     return reasoning.strip()
 
 

--- a/mlx_vlm/tests/test_server.py
+++ b/mlx_vlm/tests/test_server.py
@@ -6996,6 +6996,31 @@ class TestSplitThinking:
         assert reasoning == "Only thinking."
         assert content == ""
 
+    def test_channel_close_only_keeps_leading_reasoning_characters(self):
+        # Without the opener, the reasoning is whatever precedes <channel|>.
+        # It must survive verbatim, including a leading t/h/o/u/g.
+        for text, expected in (
+            ("got it, the answer is 42<channel|>42", "got it, the answer is 42"),
+            (
+                "the user wants the capital of France<channel|>Paris",
+                "the user wants the capital of France",
+            ),
+            (
+                "hoping to use the tool here<channel|>Done.",
+                "hoping to use the tool here",
+            ),
+        ):
+            reasoning, _ = server._split_thinking(text)
+            assert reasoning == expected
+
+    def test_channel_close_only_still_drops_a_literal_thought_prefix(self):
+        from mlx_vlm.server.responses_state import _clean_reasoning
+
+        assert (
+            _clean_reasoning("thought\nThe user asks X", "<|channel>thought")
+            == "The user asks X"
+        )
+
     def test_custom_thinking_markers(self):
         text = "<analysis>Custom reasoning.</analysis>Custom answer."
         reasoning, content = server._split_thinking(text, "<analysis>", "</analysis>")


### PR DESCRIPTION
## Problem

`_clean_reasoning` in `mlx_vlm/server/responses_state.py` strips a leading `thought`
token with `lstrip("thought")`. `str.lstrip` takes a **character set**, not a prefix, so
it removes every leading character that is one of `t`, `h`, `o`, `u`, `g` — not the word
`thought`.

This is reached from `_split_thinking` on the `end_marker in text` branch: the model
emitted the `<channel|>` closer but no `<|channel>thought` opener, so the reasoning is
whatever precedes the closer and gets fed to `_clean_reasoning` verbatim. Any reasoning
that happens to begin with one of those five letters is silently truncated:

| input | reasoning returned on `main` | expected |
|---|---|---|
| `got it, the answer is 42<channel\|>42` | `it, the answer is 42` | `got it, the answer is 42` |
| `the user wants the capital of France<channel\|>Paris` | `e user wants the capital of France` | `the user wants the capital of France` |
| `hoping to use the tool here<channel\|>Done.` | `ping to use the tool here` | `hoping to use the tool here` |
| `though it is subtle, this matters<channel\|>Yes.` | `it is subtle, this matters` | `though it is subtle, this matters` |

Leading `the`/`to`/`that`/`got`/`hoping`/`only` are ordinary openings for a reasoning
trace, so this is not an edge case. Nothing errors — the text is just quietly shortened
in the `reasoning` field.

## Fix

Use `removeprefix("thought")`, which is what the line intends. This also matches the
marker handling already used a few lines above in the same module:

```python
.removeprefix(tool_module.tool_call_start)
.removesuffix(tool_module.tool_call_end)
```

`requires-python = ">=3.10"`, so `removeprefix` is available.

Behaviour is unchanged wherever the opener is present (the common path), and a literal
leading `thought` token is still dropped exactly as before.

## Verification

`mlx` is Apple-Silicon only, so `mlx_vlm/tests/test_server.py` cannot be imported on this
machine (Windows). `responses_state.py` imports only stdlib + `fastapi`, so I loaded the
real module by path and ran the **existing** `TestSplitThinking` cases against it — the
12 that need only `_split_thinking` — plus the new ones, before and after the change:

```
                                             OLD    NEW
EXIST channel_tags                           PASS   PASS
EXIST think_tags                             PASS   PASS
EXIST partial_close_tag_only                 PASS   PASS
EXIST no_thinking                            PASS   PASS
EXIST unterminated_is_reasoning              PASS   PASS
EXIST unterminated_stays_content             PASS   PASS
EXIST starts_in_thinking_close               PASS   PASS
EXIST starts_in_thinking_paired              PASS   PASS
EXIST empty_content_after                    PASS   PASS
EXIST custom_markers                         PASS   PASS
EXIST cohere_markers                         PASS   PASS
EXIST capital-T close-only                   PASS   PASS
NEW  leading 'got'                           FAIL   PASS
NEW  leading 'the'                           FAIL   PASS
NEW  leading 'hoping'                        FAIL   PASS
NEW  literal 'thought' prefix still dropped  PASS   PASS
```

The two tests I skipped need `prompt_has_open_thinking` and a `transformers` response
template, neither of which touches this function. `black` 26.3.1 and `isort --profile=black`
(the pinned pre-commit revisions) both report the two changed files clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
