### PR TITLE
fix(deps): declare sentencepiece explicitly (fixes ernie4_5_moe_vl import / red CI)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 mlx>=0.32.0
 transformers>=5.14.0
+sentencepiece>=0.2.0
 miniaudio>=1.59
 tqdm>=4.66.2
 Pillow>=10.3.0


### PR DESCRIPTION
## Problem

`main` CI is red on every PR opened after ~17:50 UTC today, and a fresh `pip install mlx-vlm` can no longer load ERNIE 4.5 VL:

```
mlx_vlm/models/ernie4_5_moe_vl/processing_ernie4_5_moe_vl.py:10: in <module>
    import sentencepiece as spm
E   ModuleNotFoundError: No module named 'sentencepiece'
```

8 tests fail (`test_models.py::TestModels::test_ernie4_5_moe_vl`, `TestChunkedPrefillRoPE::test_ernie_chunked_prefill_rope`, and all 5 `TestErnie4_5VLProcessor` / `TestErnie4_5VLPatch` cases).

## Root cause

`processing_ernie4_5_moe_vl.py` imports `sentencepiece` at module scope (it backs `Ernie4_5_VLTokenizer.sp_model`), but `requirements.txt` never declared it. Until today it happened to be installed transitively:

* **mlx-audio 0.4.8** (2026-08-10) → `mlx-lm>=0.31.1` as a **core** dependency → `sentencepiece`
* **mlx-audio 0.5.0** (2026-08-17 17:47 UTC) → `mlx-lm` moved to the `sts` / `llm` / `all` / `parity` **extras**, so it is no longer installed by default

The CI logs show the transition exactly. Run at 16:29 UTC (passing):

```
Collecting sentencepiece (from mlx-lm>=0.31.1->mlx-audio>=0.4.3->mlx-vlm==0.6.14)
Successfully installed ... mlx-audio-0.4.8 mlx-lm-0.31.3 ... sentencepiece-0.2.2 ...
```

Run at 19:02 UTC (failing), same workflow, same `pip install -e .`:

```
Successfully installed ... mlx-audio-0.5.0 ...      # no mlx-lm, no sentencepiece
```

Nothing in the repo imports `mlx_lm`, so `sentencepiece` is the only casualty.

## Fix

Declare the dependency the code actually uses — one line in `requirements.txt`. `sentencepiece>=0.2.0` matches the floor mlx-audio itself uses in its extras.

No source changes, no behaviour changes; it just makes the existing import satisfiable on a clean install again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
