### PR TITLE
Stop Kimi-VL generation at turn boundary tokens

### DIFF
--- a/mlx_vlm/models/kimi_vl/processing_kimi_vl.py
+++ b/mlx_vlm/models/kimi_vl/processing_kimi_vl.py
@@ -327,6 +327,28 @@ class KimiVLProcessor(ProcessorMixin):
     image_processor_class = "KimiVLImageProcessor"
     tokenizer_class = "AutoTokenizer"
 
+    # The chat template terminates every turn with <|im_end|>, which is not an
+    # eos id in the shipped configs, so generation runs past the model's turn
+    # boundary. Role openers are included because the published MLX conversions
+    # renumber the special tokens relative to the upstream tiktoken vocabulary
+    # (e.g. the model's <|im_end|> id decodes as <|im_assistant|>), so the
+    # boundary the model actually emits can surface as any of these.
+    turn_boundary_tokens = (
+        "<|im_end|>",
+        "<|im_user|>",
+        "<|im_assistant|>",
+        "<|im_system|>",
+    )
+
+    @property
+    def additional_eos_token_ids(self):
+        token_ids = []
+        for token in self.turn_boundary_tokens:
+            token_id = self.tokenizer.convert_tokens_to_ids(token)
+            if token_id is not None and token_id not in token_ids:
+                token_ids.append(token_id)
+        return token_ids
+
     def __init__(
         self,
         image_processor=None,

--- a/mlx_vlm/tests/test_processors.py
+++ b/mlx_vlm/tests/test_processors.py
@@ -2707,6 +2707,38 @@ class TestKimiVLPatch(unittest.TestCase):
         )
 
 
+class TestKimiVLProcessor(unittest.TestCase):
+    def test_turn_boundary_tokens_are_additional_eos_tokens(self):
+        from mlx_vlm.models.kimi_vl.processing_kimi_vl import KimiVLProcessor
+
+        token_ids = {
+            "<|im_end|>": 163584,
+            "<|im_user|>": 163585,
+            "<|im_assistant|>": 163586,
+            "<|im_system|>": 163587,
+        }
+        processor = KimiVLProcessor.__new__(KimiVLProcessor)
+        processor.tokenizer = SimpleNamespace(
+            convert_tokens_to_ids=lambda token: token_ids.get(token)
+        )
+
+        self.assertEqual(
+            processor.additional_eos_token_ids, [163584, 163585, 163586, 163587]
+        )
+
+    def test_missing_boundary_tokens_are_skipped(self):
+        from mlx_vlm.models.kimi_vl.processing_kimi_vl import KimiVLProcessor
+
+        processor = KimiVLProcessor.__new__(KimiVLProcessor)
+        processor.tokenizer = SimpleNamespace(
+            convert_tokens_to_ids=lambda token: (
+                163584 if token == "<|im_end|>" else None
+            )
+        )
+
+        self.assertEqual(processor.additional_eos_token_ids, [163584])
+
+
 class TestKimiK3Patch(unittest.TestCase):
     def test_patch_intercepts(self):
         _assert_patch_intercepts(


### PR DESCRIPTION
# Stop Kimi-VL generation at turn boundary tokens

## Problem

Kimi-VL generation runs past the model's turn boundary and leaks control tokens into the returned text — the Kimi-VL case reported in the follow-up on #1932 (answers ending in a literal `<|im_assistant|>`, then generation continuing).

The chat template terminates every turn with `<|im_end|>`, but that token is not an eos id anywhere in the shipped configs: `tokenizer_config.json` declares `[EOS]` as the eos token, and `generation_config.json` carries `eos_token_id: [163585]`. So the token the model was trained to end its turn with is invisible to the stopping criteria — the same shape as the Idefics3 `<end_of_utterance>` bug fixed in #1936.

## Why stopping on `<|im_end|>` alone would not fix it

While reproducing this I found a second layer to the bug: **the published MLX conversions renumber the special tokens relative to the upstream tiktoken vocabulary.**

| id | upstream (`moonshotai/…-2506`, what the weights were trained on) | shipped `tokenizer.json` (bf16 and 8bit repos) |
|---|---|---|
| 163584 | `[BOS]` | `<\|im_end\|>` |
| 163585 | `[EOS]` | `<\|im_user\|>` |
| 163586 | `<\|im_end\|>` | `<\|im_assistant\|>` |
| 163587 | `<\|im_user\|>` | `<\|im_system\|>` |

(Upstream leaves reserved gaps — `<|im_system|>` is 163594, `<|im_middle|>` is 163601; the conversion packed everything contiguously from 163584. The shipped `tokenizer_class` is `PreTrainedTokenizerFast` with no `auto_map`, so the renumbered `tokenizer.json` is what actually runs; the bundled `tiktoken.model` is not wired up. `generation_config.json` still carries the upstream ids, which is how the mismatch is visible from the outside.)

So when the model emits its true `<|im_end|>` (id 163586), the shipped tokenizer decodes it as `<|im_assistant|>` — exactly the leak observed in #1932. Adding only `convert_tokens_to_ids("<|im_end|>")` (= 163584) to the stopping criteria would be a no-op on these checkpoints: to the model that id is `[BOS]`.

## Fix

Expose the turn and role boundary tokens (`<|im_end|>`, `<|im_user|>`, `<|im_assistant|>`, `<|im_system|>`) as `additional_eos_token_ids` on `KimiVLProcessor` — the same mechanism #1936 added for Idefics3; the direct and server paths both already consume it.

A legitimate assistant reply never contains any of these four tokens, so stopping on all of them is correct under either vocabulary layout:

- shipped (renumbered) layout: ids 163584–163587 cover the model's true `[BOS]`, `[EOS]`, `<|im_end|>`, `<|im_user|>` — generation now stops at the first boundary token the model emits;
- a correctly-numbered checkpoint: the ids are the turn terminator and the role openers themselves.

The renumbering itself is a checkpoint bug that only re-uploading corrected `tokenizer.json` files can fully fix (the prompt the model sees is also shifted); I'll leave that note on #1932. This PR makes generation stop at the model's actual turn boundary in both worlds.

## Verification

On an M5 / 32 GB, macOS 26, with `mlx-community/Kimi-VL-A3B-Thinking-2506-8bit` (the issue was reported on bf16; I verified both repos ship the identical renumbered `tokenizer.json`, and the stop-token logic is precision-independent):

```
python -m mlx_vlm.generate --model mlx-community/Kimi-VL-A3B-Thinking-2506-8bit \
  --image red_circle.png --prompt "What shape and colour is in this image?" \
  --max-tokens 250 --temperature 0.0
```

- main (`625f71fa`): `…Therefore, the shape is a circle and the color is red.<|im_assistant|>`
- this branch: `…Therefore, the shape is a circle and the color is red.` — identical answer, leak gone, generation stops at the model's turn boundary.

At the processor level, `load_processor` on the real checkpoint now yields stopping criteria `[163594, 163584, 163585, 163586, 163587]` (`[EOS]` + the four boundary ids), and the additional ids survive `StoppingCriteria.reset()`, covering the direct and server paths alike.

Tests: two new unit tests for the property (mirroring the Idefics3 ones from #1936); `mlx_vlm/tests/test_processors.py` + `test_utils.py` pass locally (176 passed, 2 skipped), and `black --check` is clean on the touched files.
