### PR TITLE
Stop a batched row's answer depending on its neighbour's length

### DIFF
--- a/mlx_vlm/generate/ar.py
+++ b/mlx_vlm/generate/ar.py
@@ -1601,6 +1601,7 @@ class PromptProcessingBatch:
         apc_meta: Optional[List[dict]] = None,
         apc_manager: Optional["_apc.APCManager"] = None,
         right_pad_per_row: Optional[List[int]] = None,
+        existing_left_padding: Optional[List[int]] = None,
         suffix_lens: Optional[List[int]] = None,
         apc_mode: Optional[str] = None,
         draft_model: Optional[nn.Module] = None,
@@ -1636,6 +1637,11 @@ class PromptProcessingBatch:
             self._input_ids = _right_pad_prompts(input_ids, max_length=max_length)
         else:
             left_padding = [max_length - l for l in lengths]
+            if existing_left_padding is not None:
+                left_padding = [
+                    pad + int(existing)
+                    for pad, existing in zip(left_padding, existing_left_padding)
+                ]
             self._input_ids = _left_pad_prompts(input_ids, max_length=max_length)
         self._left_padding_per_row = list(left_padding)
         self._total_prompt_tokens = sum(lengths)
@@ -2178,6 +2184,7 @@ class BatchGenerator:
         completion_batch_size: int = DEFAULT_COMPLETION_BATCH_SIZE,
         prefill_batch_size: int = DEFAULT_PREFILL_BATCH_SIZE,
         prefill_step_size: Optional[int] = DEFAULT_PREFILL_STEP_SIZE,
+        existing_left_padding: Optional[List[int]] = None,
         prompt_cache=None,
         kv_bits=None,
         kv_key_bits=None,
@@ -2251,6 +2258,7 @@ class BatchGenerator:
             top_logprobs_k=self.top_logprobs_k,
             greedy_sampling=self.greedy_sampling,
         )
+        self._existing_left_padding = existing_left_padding
         self._prompt_batch: Optional[PromptProcessingBatch] = None
         self._unprocessed_sequences = []
 
@@ -2810,6 +2818,7 @@ class BatchGenerator:
             self._prompt_batch = prompt_batch_cls(
                 model=self.model,
                 uids=uids,
+                existing_left_padding=getattr(self, "_existing_left_padding", None),
                 input_ids=input_ids,
                 max_tokens=max_tokens_list,
                 inputs_embeds=inputs_embeds,
@@ -3170,12 +3179,19 @@ def _generate_batch(
             kwargs["prefill_step_size"] = None
 
     # Use batch_size for prefill and completion to ensure consistent processing
+    existing_left_padding = None
+    if mask is not None and getattr(mask, "ndim", 0) == 2:
+        pads = [int(v) for v in (mask.shape[1] - mask.sum(axis=1)).tolist()]
+        if any(pads):
+            existing_left_padding = pads
+
     gen = BatchGenerator(
         model.language_model,
         processor,
         prefill_batch_size=batch_size,
         completion_batch_size=batch_size,
         compute_logprobs=False,
+        existing_left_padding=existing_left_padding,
         **kwargs,
     )
 

--- a/mlx_vlm/tests/test_generate.py
+++ b/mlx_vlm/tests/test_generate.py
@@ -3058,3 +3058,69 @@ class TestBatchTurboQuantizedKVStart:
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])
+
+
+class TestPrePaddedBatchRows:
+    """Rows that arrive already padded must still declare that padding.
+
+    The tokenizer squares a batch off with left padding and reports it in the
+    attention mask. If that never reaches the caches, every row looks the same
+    length: a causal mask does not exclude padding that comes first, and a
+    recurrent layer walks it like any other column.
+    """
+
+    def _batch(self, rows, existing_left_padding):
+        import mlx.nn as nn
+
+        from mlx_vlm.generate.ar import PromptProcessingBatch
+
+        class Tiny(nn.Module):
+            def make_cache(self):
+                from mlx_vlm.models.cache import ArraysCache, KVCache
+
+                return [KVCache(), ArraysCache(1)]
+
+        return PromptProcessingBatch(
+            model=Tiny(),
+            uids=list(range(len(rows))),
+            input_ids=rows,
+            max_tokens=[4] * len(rows),
+            inputs_embeds=None,
+            prompt_kwargs={},
+            existing_left_padding=existing_left_padding,
+        )
+
+    def test_declared_padding_reaches_the_caches(self):
+        rows = [list(range(8)), list(range(8))]
+
+        batch = self._batch(rows, existing_left_padding=[5, 0])
+
+        assert batch._left_padding_per_row == [5, 0]
+
+    def test_uniform_rows_without_a_declaration_record_none(self):
+        rows = [list(range(8)), list(range(8))]
+
+        batch = self._batch(rows, existing_left_padding=None)
+
+        assert batch._left_padding_per_row == [0, 0]
+
+    def test_a_declaration_adds_to_the_generator_s_own_padding(self):
+        rows = [list(range(4)), list(range(8))]
+
+        batch = self._batch(rows, existing_left_padding=[2, 1])
+
+        assert batch._left_padding_per_row == [6, 1]
+
+    def test_arrays_cache_masks_the_declared_padding(self):
+        import mlx.core as mx
+
+        from mlx_vlm.models.cache import ArraysCache
+
+        entry = ArraysCache(1)
+        entry.left_padding = mx.array([5, 0])
+
+        mask = entry.make_mask(8)
+
+        assert mask.shape == (2, 8)
+        assert mask[0].tolist() == [False] * 5 + [True] * 3
+        assert mask[1].tolist() == [True] * 8


### PR DESCRIPTION
The tokenizer squares a batch off with left padding and reports it in the attention mask, which is used to build embeddings and then dropped. The generator therefore receives rows of uniform length, computes no padding of its own, and records none on the caches, so every layer reads the pad tokens: a causal mask does not exclude padding that comes first, and a convolution or scan cannot mask a column out at all. A row's answer came to depend on how long its neighbour was, which for LFM2.5-1.2B meant a recurrent state differing from the same prompt run alone by more than half its own magnitude. Pass the padding on. Nothing else needs to change: ArraysCache.make_mask already turns left padding into a per-row validity mask, the conv state is already taken from the end of a left-padded row, and the attention caches already carry the offset.

LFM2.5-1.2B now generates the same tokens whatever it is batched with. Qwen3.5-0.8B matches for its first twelve tokens and drifts after, which is the arithmetic of decoding two rows together rather than padding.


Not specific to hybrids. Left padding sits in the causal past, so attention reads it as context and every batched model is affected; a hybrid only loses its recurrent state on top of that. Rows here share an opening and are batched against a peer of equal, medium or longer length, then compared against the same prompt alone.

| model | cache | before | after |
|---|---|---|---|
| Llama-3.2-1B | KVCache | 3 of 3 differ | none |
| Mistral-7B-v0.3 | KVCache | 3 of 3 differ | none |
| Phi-3.5-mini | KVCache | 3 of 3 differ | none |
| OLMo-1B | KVCache | 3 of 3 differ | none |
| Qwen2.5-0.5B | KVCache | 2 of 3 differ | none |
| OLMoE-1B-7B (MoE) | KVCache | 2 of 3 differ | none |
| LFM2.5-1.2B | ArraysCache + KVCache | 2 of 3 differ | none |

Needed for batched composite work following #1915
