### PR TITLE
fix(qwen3_omni): convert audio_feature_lengths to mel frames (#1620)

### DIFF
--- a/mlx_vlm/models/qwen3_omni_moe/omni_utils.py
+++ b/mlx_vlm/models/qwen3_omni_moe/omni_utils.py
@@ -62,8 +62,21 @@ def prepare_omni_inputs(
         "feature_attention_mask" in model_inputs
         and "audio_feature_lengths" not in model_inputs
     ):
-        model_inputs["audio_feature_lengths"] = (
-            model_inputs["feature_attention_mask"].sum(axis=1).astype(mx.int32)
-        )
+        mask = model_inputs["feature_attention_mask"]
+        lengths = mask.sum(axis=1)
+        # feature_attention_mask is sample-domain, while the audio encoder counts
+        # mel frames; convert each item's length via the mask/mel hop ratio so
+        # audio_feature_lengths matches the encoder's true frame count. Otherwise
+        # the sample-domain length (~160x too large) is forwarded to the model,
+        # which skips the mel-frame conversion in Thinker.get_audio_features and
+        # blows up the audio position/placeholder tensors (see #1620). This mirrors
+        # the same conversion already done in the processor and thinker.
+        input_features = model_inputs.get("input_features")
+        if input_features is not None:
+            mel_frames = input_features.shape[-1]
+            mask_len = mask.shape[-1]
+            if mask_len > mel_frames:
+                lengths = lengths // (mask_len // mel_frames)
+        model_inputs["audio_feature_lengths"] = lengths.astype(mx.int32)
 
     return model_inputs, text


### PR DESCRIPTION
## What

`prepare_omni_inputs` derives `audio_feature_lengths` directly from the **sample-domain** `feature_attention_mask`:

```python
model_inputs["audio_feature_lengths"] = (
    model_inputs["feature_attention_mask"].sum(axis=1).astype(mx.int32)
)
```

But `feature_attention_mask` is over raw audio samples while the audio encoder counts **mel frames**. For a 15 s / 16 kHz clip the mask is `(1, 240396)` whereas `input_features` is `(1, 128, 1502)` — the length is ~160× too large.

Because `audio_feature_lengths` is then non-`None`, it **bypasses** the sample→mel conversion that `Thinker.get_audio_features` performs when the field is absent:

```python
if audio_feature_lengths is None:
    if feature_attention_mask is not None:
        ...
        if mask_len > mel_frames:
            lengths = lengths // (mask_len // mel_frames)   # never reached
```

so the oversized sample-domain length is forwarded straight to the audio tower (`feature_lens`), producing the shape mismatch / oversized position tensors reported in #1620 for the documented `examples/qwen3_omni_demo.py` path.

## Fix

Apply the same mask/mel hop-ratio conversion already used by the processor (`processing_qwen3_omni_moe.py`) and by `Thinker.get_audio_features` (`thinker.py`), so all three sites agree. With the fix, a 15 s clip yields `audio_feature_lengths == 1502` (the true mel-frame count) instead of `240396`.

The conversion is guarded (`if mask_len > mel_frames`) so already-mel-frame inputs and the padded-batch case are unchanged.

Fixes #1620 (audio-tower half; the placeholder-count OOM half is already handled by the processor conversion).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
