### PR TITLE
Let a batched request reuse a prefix

### DIFF
--- a/mlx_vlm/apc.py
+++ b/mlx_vlm/apc.py
@@ -367,6 +367,21 @@ def _sequence_hash(token_ids: Sequence[int], extra_hash: int, block_size: int) -
     return int.from_bytes(h.digest()[:8], "little", signed=True)
 
 
+def _in_memory_image_bytes(image_ref: Any) -> Optional[bytes]:
+    """Raw pixels of an in-memory image, or None if this is not one.
+
+    An image handed over as an object rather than a path would otherwise fall
+    back to ``repr``, which carries its address: not stable across processes,
+    and not unique once the allocator reuses that address.
+    """
+    if not (hasattr(image_ref, "mode") and hasattr(image_ref, "size")):
+        return None
+    try:
+        return np.asarray(image_ref).tobytes()
+    except Exception:
+        return None
+
+
 def hash_image_payload(
     pixel_values: Optional[mx.array] = None,
     image_ref: Any = None,
@@ -396,6 +411,11 @@ def hash_image_payload(
     if isinstance(image_ref, bytes):
         return int.from_bytes(
             hashlib.sha256(image_ref).digest()[:8], "little", signed=True
+        )
+    pixels = _in_memory_image_bytes(image_ref)
+    if pixels is not None:
+        return int.from_bytes(
+            hashlib.sha256(pixels).digest()[:8], "little", signed=True
         )
     digest = hashlib.sha256(repr(image_ref).encode("utf-8")).digest()
     return int.from_bytes(digest[:8], "little", signed=True)

--- a/mlx_vlm/generate/ar.py
+++ b/mlx_vlm/generate/ar.py
@@ -717,6 +717,38 @@ def _concat_prompt_kwarg_rows(key: str, rows: List[mx.array]) -> mx.array:
     return mx.concatenate(rows, axis=0)
 
 
+def _drop_row_left_padding(
+    row_ids: List[List[int]],
+    prompt_kwargs_rows: List[dict],
+    left_padding: List[int],
+) -> List[List[int]]:
+    """Hand each row its own tokens, without the batch's left padding.
+
+    ``prepare_inputs`` squares the batch off before the generator sees it, so a
+    shorter row's ids and embeddings start with padding. APC walks its hash
+    chain from position zero, so a padded row hashes to nothing in common with
+    the same prompt sent on its own and only the longest rows in a batch can
+    match a prefix. The generator pads ragged rows itself in
+    ``_merge_prefill_prompt_kwargs``, to the same width, so handing it real
+    tokens keeps the prefill shape and gives APC the sequence it was given.
+    """
+    trimmed: List[List[int]] = []
+    for ids, row, pad in zip(row_ids, prompt_kwargs_rows, left_padding):
+        if pad <= 0:
+            trimmed.append(ids)
+            continue
+        trimmed.append(ids[pad:])
+        embeds = row.get("inputs_embeds")
+        if embeds is not None:
+            row["inputs_embeds"] = embeds[:, pad:, :]
+        for key, value in list(row.items()):
+            if key == "inputs_embeds" or not isinstance(value, mx.array):
+                continue
+            if _is_sequence_aligned_prompt_kwarg(key, value, len(ids)):
+                row[key] = _slice_sequence_aligned_prompt_kwarg(key, value, start=pad)
+    return trimmed
+
+
 def _merge_prefill_prompt_kwargs(
     prompt_kwargs_list: List[Optional[dict]],
     input_ids: List[List[int]],
@@ -3258,8 +3290,15 @@ def _generate_batch(
             images=images,
         )
 
+    row_ids = input_ids.tolist()
+    if existing_left_padding is not None:
+        row_ids = _drop_row_left_padding(
+            row_ids, prompt_kwargs_rows, existing_left_padding
+        )
+        gen._existing_left_padding = None
+
     uids = gen.insert(
-        input_ids.tolist(),
+        row_ids,
         max_tokens,
         prompt_kwargs=prompt_kwargs_rows,
         logits_processors=logits_processors,

--- a/mlx_vlm/generate/ar.py
+++ b/mlx_vlm/generate/ar.py
@@ -599,6 +599,51 @@ def _prompt_kwarg_row(key: str, v: mx.array, row_idx: int, batch_size: int) -> m
     return v[:1]
 
 
+def _apply_apc_row_semantic_hash(
+    prompt_kwargs_rows: List[dict],
+    *,
+    model: Any,
+    processor: Any,
+    pixel_values: Optional[mx.array],
+    images: Optional[List[Any]],
+) -> None:
+    """Key each batch row by its media rather than by its prompt embeddings.
+
+    ``inputs_embeds`` in a batch row is derived from that row's tokens and
+    media, and ``_apc_extra_hash`` would otherwise fold its contents into the
+    cache key. That makes the key unique to the whole prompt, so two prompts
+    sharing an opening can never share a prefix. The media hash carries the
+    only information the token chain does not already cover. The server
+    precomputes the same value for the same reason.
+    """
+    rows = len(prompt_kwargs_rows)
+    row_major_pixels = (
+        pixel_values is not None
+        and int(getattr(pixel_values, "shape", (0,))[0] or 0) == rows
+    )
+    for i, row in enumerate(prompt_kwargs_rows):
+        if row.get("_apc_semantic_hash") is not None:
+            continue
+        row_pixels = pixel_values[i : i + 1] if row_major_pixels else None
+        image_ref = None
+        if row_pixels is None:
+            if images and i < len(images):
+                image_ref = images[i]
+            elif images:
+                image_ref = images
+        row["_apc_semantic_hash"] = _apc.semantic_extra_hash(
+            image_hash=_apc.hash_image_payload(
+                pixel_values=row_pixels, image_ref=image_ref
+            ),
+            media={
+                "audio": row.get("input_features"),
+                "video": row.get("pixel_values_videos"),
+            },
+            model=getattr(model, "language_model", model),
+            processor=processor,
+        )
+
+
 def _split_prompt_kwargs_per_row(prompt_kwargs: dict, batch_size: int) -> List[dict]:
     """Normalize batched prompt kwargs into one dict per batch row.
 
@@ -3203,10 +3248,20 @@ def _generate_batch(
             for _ in range(batch_size)
         ]
 
+    prompt_kwargs_rows = _split_prompt_kwargs_per_row(gen_kwargs, batch_size)
+    if getattr(gen, "apc_manager", None) is not None:
+        _apply_apc_row_semantic_hash(
+            prompt_kwargs_rows,
+            model=model,
+            processor=processor,
+            pixel_values=pixel_values,
+            images=images,
+        )
+
     uids = gen.insert(
         input_ids.tolist(),
         max_tokens,
-        prompt_kwargs=_split_prompt_kwargs_per_row(gen_kwargs, batch_size),
+        prompt_kwargs=prompt_kwargs_rows,
         logits_processors=logits_processors,
     )
     results = {uid: [] for uid in uids}

--- a/mlx_vlm/tests/test_apc.py
+++ b/mlx_vlm/tests/test_apc.py
@@ -81,6 +81,27 @@ def test_hash_chain_and_image_hash_are_deterministic():
     )
 
 
+def test_image_hash_reads_in_memory_image_content_not_identity():
+    """An image passed as an object must key by its pixels.
+
+    Falling back to ``repr`` would key by address: two runs of the same request
+    would miss each other, and a reused address would collide.
+    """
+    from PIL import Image
+
+    def solid(colour):
+        return Image.fromarray(np.full((8, 8, 3), colour, dtype=np.uint8))
+
+    red, red_again, blue = (
+        solid((220, 30, 30)),
+        solid((220, 30, 30)),
+        solid((30, 30, 220)),
+    )
+
+    assert hash_image_payload(image_ref=red) == hash_image_payload(image_ref=red_again)
+    assert hash_image_payload(image_ref=red) != hash_image_payload(image_ref=blue)
+
+
 def test_image_hash_preserves_tensor_shape_and_dtype():
     flat_values = mx.arange(12, dtype=mx.float32)
     first_shape = flat_values.reshape(1, 3, 2, 2)

--- a/mlx_vlm/tests/test_generate.py
+++ b/mlx_vlm/tests/test_generate.py
@@ -2727,6 +2727,75 @@ def test_batch_apc_extra_hash_returns_precomputed_semantic_hash():
     assert extended_hash == semantic_hash
 
 
+def test_batch_rows_sharing_a_prefix_get_one_apc_key():
+    """Two prompts with a shared opening must land on the same APC salt.
+
+    Their derived ``inputs_embeds`` differ, so hashing those would make every
+    row's key unique to its whole prompt and prefix reuse impossible.
+    """
+    rows = [
+        {"inputs_embeds": mx.ones((1, 8, 4))},
+        {"inputs_embeds": mx.zeros((1, 12, 4))},
+    ]
+
+    ar_module._apply_apc_row_semantic_hash(
+        rows,
+        model=SimpleNamespace(language_model=SimpleNamespace()),
+        processor=SimpleNamespace(),
+        pixel_values=None,
+        images=None,
+    )
+
+    generator = SimpleNamespace(apc_manager=object())
+    salts = [BatchGenerator._apc_extra_hash(generator, row) for row in rows]
+    assert salts[0] == salts[1]
+
+
+def test_batch_rows_with_different_images_get_different_apc_keys():
+    rows = [{"inputs_embeds": mx.ones((1, 8, 4))} for _ in range(2)]
+    pixel_values = mx.stack([mx.zeros((3, 2, 2)), mx.ones((3, 2, 2))])
+
+    ar_module._apply_apc_row_semantic_hash(
+        rows,
+        model=SimpleNamespace(language_model=SimpleNamespace()),
+        processor=SimpleNamespace(),
+        pixel_values=pixel_values,
+        images=None,
+    )
+
+    assert rows[0]["_apc_semantic_hash"] != rows[1]["_apc_semantic_hash"]
+
+
+def test_batch_row_image_key_falls_back_to_the_row_reference():
+    """A processor that flattens patches leaves no per-row slice to hash."""
+    rows = [{"inputs_embeds": mx.ones((1, 8, 4))} for _ in range(2)]
+    flattened = mx.ones((37, 8))
+
+    ar_module._apply_apc_row_semantic_hash(
+        rows,
+        model=SimpleNamespace(language_model=SimpleNamespace()),
+        processor=SimpleNamespace(),
+        pixel_values=flattened,
+        images=["red.png", "blue.png"],
+    )
+
+    assert rows[0]["_apc_semantic_hash"] != rows[1]["_apc_semantic_hash"]
+
+
+def test_batch_row_semantic_hash_keeps_a_precomputed_value():
+    rows = [{"_apc_semantic_hash": 4242, "inputs_embeds": mx.ones((1, 8, 4))}]
+
+    ar_module._apply_apc_row_semantic_hash(
+        rows,
+        model=SimpleNamespace(language_model=SimpleNamespace()),
+        processor=SimpleNamespace(),
+        pixel_values=mx.ones((1, 3, 2, 2)),
+        images=None,
+    )
+
+    assert rows[0]["_apc_semantic_hash"] == 4242
+
+
 def test_batch_apc_extra_hash_still_tracks_non_text_media():
     batch_generator = SimpleNamespace(apc_manager=object())
     base = {

--- a/mlx_vlm/tests/test_generate.py
+++ b/mlx_vlm/tests/test_generate.py
@@ -3129,6 +3129,46 @@ if __name__ == "__main__":
     pytest.main([__file__, "-v"])
 
 
+class TestRowsKeepTheirOwnTokens:
+    """A batch's padding must not follow a row into APC.
+
+    ``prepare_inputs`` squares the batch off before the generator sees it, so a
+    shorter row's ids start with padding. APC hashes from position zero, so a
+    padded row shares no block with the same prompt sent alone.
+    """
+
+    def _rows(self, pad):
+        prompt_kwargs_rows = [
+            {
+                "inputs_embeds": mx.arange(6 * 2, dtype=mx.float32).reshape(1, 6, 2),
+                "position_ids": mx.arange(6, dtype=mx.int32).reshape(1, 6),
+            }
+            for _ in pad
+        ]
+        row_ids = [[9, 9, 1, 2, 3, 4][:6] for _ in pad]
+        trimmed = ar_module._drop_row_left_padding(row_ids, prompt_kwargs_rows, pad)
+        return trimmed, prompt_kwargs_rows
+
+    def test_a_padded_row_hands_over_its_real_tokens(self):
+        trimmed, rows = self._rows([2, 0])
+
+        assert trimmed[0] == [1, 2, 3, 4]
+        assert trimmed[1] == [9, 9, 1, 2, 3, 4]
+
+    def test_embeddings_and_positions_follow_the_tokens(self):
+        _, rows = self._rows([2, 0])
+
+        assert rows[0]["inputs_embeds"].shape == (1, 4, 2)
+        assert rows[0]["position_ids"].shape == (1, 4)
+        assert rows[1]["inputs_embeds"].shape == (1, 6, 2)
+
+    def test_an_unpadded_row_is_left_alone(self):
+        trimmed, rows = self._rows([0, 0])
+
+        assert trimmed == [[9, 9, 1, 2, 3, 4]] * 2
+        assert all(row["inputs_embeds"].shape == (1, 6, 2) for row in rows)
+
+
 class TestPrePaddedBatchRows:
     """Rows that arrive already padded must still declare that padding.
 


### PR DESCRIPTION
Two things stop a batched request from reusing a prefix, so batched APC only ever hits a byte-identical repeat of a whole prompt.

`inputs_embeds` is derived from a row's tokens and media before insert and left in the row's prompt kwargs, and `_apc_extra_hash` folded that tensor's contents into the cache key. A row's key was therefore unique to its whole prompt: two prompts sharing an opening landed on different keys and no block was shared, so four rows of one batch stored 164 blocks where 42 describe them. The embeddings add nothing the key does not already have, being a function of the token ids the hash chain walks and of the media hashed beside them, so a row now carries the media-only `_apc_semantic_hash` the server has computed per request since #1638 and `_apc_extra_hash` short-circuits on it. Single stream already excluded its derived tensors. `pixel_values` never reaches prompt kwargs, so image identity comes from the row itself: its slice of `pixel_values` when that tensor is row-major, its own image otherwise. `hash_image_payload` now hashes an in-memory image's pixels rather than its `repr`, which carried an address, neither stable across processes nor unique once the allocator reuses it.

`prepare_inputs` then squares the batch off with left padding, so a shorter row's ids and embeddings begin with pad tokens while its cache, since #1946, holds only its real ones. The ids and the K/V they key describe spans a few tokens apart, and all three consequences follow: the harvest cuts blocks on the wrong boundary and stores short ones, 11 and 15 tokens beside 162 full ones; the hash chain walks padding, so only the rows that happen to be longest in a batch match anything; and a batch whose rows match prefixes of different lengths dies in `make_warm_batch_kv_cache_multi` on a shape mismatch, which four of the nine models tested do on a second identical batch. The generator pads ragged rows itself, to the same width, so rows now arrive with their own tokens and #1946's declaration is left to the callers that really do pre-pad.

Second request keeps the opening and changes every row's question, which is what a server sees when several users share a system prompt. M4 mini, median of three, prefill time and prompt tokens actually processed:

| model | rows | no cache | APC before | APC after |
|---|---|---|---|---|
| Llama-3.2-1B | 2 | 3.47s, 5294 tok | 3.86s, 5294 tok, no reuse | 0.09s, 46 tok, 41x |
| Llama-3.2-1B | 4 | 7.66s, 10592 tok | 7.76s, 10596 tok, no reuse | 0.18s, 96 tok, 43x |
| Llama-3.2-1B | 8 | 14.81s, 21185 tok | 15.25s, 21192 tok, no reuse | 0.33s, 193 tok, 44x |
| Qwen2.5-1.5B | 2 | 4.94s, 5280 tok | 5.09s, 5280 tok, no reuse | 0.08s, 32 tok, 65x |
| Qwen2.5-1.5B | 4 | 10.06s, 10564 tok | 10.38s, 10568 tok, no reuse | 0.18s, 68 tok, 57x |
| Qwen2.5-1.5B | 8 | 20.02s, 21129 tok | 20.88s, 21136 tok, no reuse | 0.34s, 137 tok, 58x |
| Llama-3.2-3B | 2 | 10.50s, 5294 tok | 10.81s, 5294 tok, no reuse | 0.21s, 46 tok, 49x |
| Llama-3.2-3B | 4 | 21.11s, 10592 tok | 21.72s, 10596 tok, no reuse | 0.46s, 96 tok, 46x |

Generated text is unchanged with the cache off on Llama-3.2-1B and 3B, Qwen2.5-0.5B and 1.5B, Phi-3.5-mini, Mistral-7B-v0.3, OLMo-1B, LFM2.5-1.2B and Qwen3.5-0.8B. Turning reuse on still changes text on some models, as it does today and as it does single stream, because reuse shortens the suffix and these models are sensitive to how prefill splits: before this change every model that hit diverged, after it three of nine do.

Hybrids gain nothing yet, for a reason that is not keying. Their exact-mode snapshot is bounded by `APC_EXACT_CACHE_ENTRIES`, two by default, while a batch of B rows stores 2B of them, so the checkpoints worth reusing are evicted before the next request arrives: one row hits, two rows at the default hit nothing, two rows with the bound raised to twenty hit again. The unit is wrong rather than the number, and a byte budget is what #1915's composite state store already uses. LFM2.5-1.2B shows it: 3.51s against 3.51s at 2 rows, 7.10s against 7.06s at 4 rows, 14.87s against 14.42s at 8 rows, no hits either way.

Needed for batched composite work following #1915.
