### PR TITLE
fix(server): stop skipping KV cache quantization on "qat" model paths

### DIFF
--- a/mlx_vlm/server/app.py
+++ b/mlx_vlm/server/app.py
@@ -788,9 +788,7 @@ def get_cached_model(
     vision_cache_size = cfg.vision_cache_size
     vision_cache = VisionFeatureCache(max_size=vision_cache_size)
 
-    kv_bits = (
-        cfg.kv_bits if cfg.kv_bits is not None else get_quantized_kv_bits(model_path)
-    )
+    kv_bits = cfg.kv_bits if cfg.kv_bits is not None else get_quantized_kv_bits()
     default_key_bits, default_value_bits = get_quantized_kv_split_bits()
     kv_key_bits = cfg.kv_key_bits if cfg.kv_key_bits is not None else default_key_bits
     kv_value_bits = (

--- a/mlx_vlm/server/generation.py
+++ b/mlx_vlm/server/generation.py
@@ -314,16 +314,9 @@ def get_server_thinking_end_token():
     return os.environ.get("MLX_VLM_THINKING_END_TOKEN")
 
 
-def get_quantized_kv_bits(model: str):
+def get_quantized_kv_bits():
     kv_bits = float(os.environ.get("KV_BITS", 0))
-    if kv_bits == 0:
-        return None
-    if "qat" in model:
-        logger.info(
-            "Model %s is quantization aware; KV cache will not be quantized.", model
-        )
-        return None
-    return kv_bits
+    return kv_bits or None
 
 
 def get_quantized_kv_split_bits():
@@ -350,7 +343,7 @@ def get_max_kv_size(model: str):
     max_kv_tokens = int(os.environ.get("MAX_KV_SIZE", 0))
     if max_kv_tokens == 0:
         return None
-    if get_quantized_kv_bits(model) is not None:
+    if get_quantized_kv_bits() is not None:
         logger.warning("Model %s uses QuantizedKVCache; MAX_KV_SIZE is ignored.", model)
         return None
     return max_kv_tokens

--- a/mlx_vlm/tests/test_server.py
+++ b/mlx_vlm/tests/test_server.py
@@ -7364,6 +7364,41 @@ class TestCountThinkingTagTokens:
         assert server._count_thinking_tag_tokens("plain text") == 0
 
 
+class TestQuantizedKVBits:
+    def test_kv_bits_unset_returns_none(self, monkeypatch):
+        monkeypatch.delenv("KV_BITS", raising=False)
+        assert server_generation.get_quantized_kv_bits() is None
+
+    def test_kv_bits_applies(self, monkeypatch):
+        monkeypatch.setenv("KV_BITS", "3.5")
+        assert server_generation.get_quantized_kv_bits() == 3.5
+
+    @pytest.mark.parametrize(
+        "model_path",
+        [
+            "mlx-community/gemma-4-31B-it-qat-mxfp4",
+            "mlx-community/gemma-4-31B-it-QAT-mxfp4",
+            "/models/qat-experiments/llama-3",
+            "some-org/qatar-news-llm",
+        ],
+    )
+    def test_kv_bits_not_suppressed_by_model_path(self, monkeypatch, model_path):
+        # KV cache quantization is independent of how the weights were trained,
+        # so nothing in the model path may suppress it (#1333).
+        monkeypatch.setenv("KV_BITS", "3.5")
+        monkeypatch.setenv("MAX_KV_SIZE", "0")
+        assert server_generation.get_quantized_kv_bits() == 3.5
+        assert server_generation.get_max_kv_size(model_path) is None
+
+    def test_split_bits_agree_with_uniform_bits(self, monkeypatch):
+        # The split path never had a model-path guard; both must behave alike.
+        monkeypatch.setenv("KV_BITS", "3.5")
+        monkeypatch.setenv("KV_KEY_BITS", "3")
+        monkeypatch.setenv("KV_VALUE_BITS", "4")
+        assert server_generation.get_quantized_kv_bits() == 3.5
+        assert server_generation.get_quantized_kv_split_bits() == (3.0, 4.0)
+
+
 class TestRuntimeConfig:
     def test_from_env_seeds_defaults(self, monkeypatch):
         monkeypatch.setenv("KV_QUANT_SCHEME", "group")


### PR DESCRIPTION
Fixes #1333

`get_quantized_kv_bits()` skipped KV cache quantization whenever `"qat"` showed up in the model path. KV cache quantization is a runtime thing and has nothing to do with how the weights were trained, so the path shouldn't be deciding this.

it was also just a case-sensitive substring match, so it was wrong in both directions:

| model path | before | after |
|---|---|---|
| `mlx-community/gemma-4-31B-it-qat-mxfp4` | skipped | quantized |
| `some-org/qatar-news-llm` | skipped | quantized |
| `/models/qat-experiments/llama-3` | skipped | quantized |
| `mlx-community/gemma-4-31B-it-QAT-mxfp4` | quantized | quantized |

and the guard was never on `get_quantized_kv_split_bits()` — `KV_KEY_BITS`/`KV_VALUE_BITS` have always quantized these same models fine, so there was no constraint being protected. same for the live `/v1/settings` path, which sets `cfg.kv_bits` and bypasses the check entirely. so it was already inconsistent 3 ways.

`model` had no other use in the function so it's dropped, and the two callers updated.

## Tests

`TestQuantizedKVBits` in `test_server.py` — parametrized over the four paths above, plus a check that uniform and split bits agree. all 7 fail on main, pass here.

```
pytest mlx_vlm/tests/test_server.py -q            -> 351 passed
pytest test_server.py test_apc_adapters.py test_cache.py -q -> 400 passed
pre-commit run --all                              -> pass
```
