### PR TITLE
Fix speculative decoding against a quantized KV cache

### DIFF
--- a/mlx_vlm/models/cache.py
+++ b/mlx_vlm/models/cache.py
@@ -1961,10 +1961,13 @@ class BatchQuantizedKVCache(_BaseCache):
         self._idx, self.group_size, self.bits = map(int, v)
 
     def is_trimmable(self):
-        return False
+        return True
 
     def trim(self, n):
-        return 0
+        n = min(self._idx, n)
+        self._idx -= n
+        self.offset -= n
+        return n
 
     def empty(self):
         return self.keys is None

--- a/mlx_vlm/models/qwen3_5/language.py
+++ b/mlx_vlm/models/qwen3_5/language.py
@@ -1449,6 +1449,22 @@ def _qwen3_5_ragged_decode_attention(
     return None if one_pass is None else one_pass[0]
 
 
+def _kv_seq_len(kv) -> int:
+    """Sequence length of a cache entry.
+
+    A quantized cache hands back (packed, scales, biases) rather than one
+    array, but every component still keeps the sequence on axis -2.
+    """
+    return (kv[0] if isinstance(kv, (tuple, list)) else kv).shape[-2]
+
+
+def _kv_prefix(kv, length: int):
+    """First length positions of a cache entry, quantized or not."""
+    if isinstance(kv, (tuple, list)):
+        return tuple(component[:, :, :length, :] for component in kv)
+    return kv[:, :, :length, :]
+
+
 def _target_verify_left_padded_attention(
     queries: mx.array,
     keys: mx.array,
@@ -1638,13 +1654,13 @@ class Qwen3_5Attention(nn.Module):
             output = None
 
         if output is None and target_verify and L > 1:
-            prefix_len = keys.shape[-2] - L
+            prefix_len = _kv_seq_len(keys) - L
             output = mx.concatenate(
                 [
                     scaled_dot_product_attention(
                         queries[:, :, i : i + 1, :],
-                        keys[:, :, : prefix_len + i + 1, :],
-                        values[:, :, : prefix_len + i + 1, :],
+                        _kv_prefix(keys, prefix_len + i + 1),
+                        _kv_prefix(values, prefix_len + i + 1),
                         cache=cache,
                         scale=self.scale,
                         mask=(

--- a/mlx_vlm/tests/test_speculative_quantized_kv.py
+++ b/mlx_vlm/tests/test_speculative_quantized_kv.py
@@ -1,0 +1,118 @@
+"""Speculative decoding against a quantized KV cache.
+
+Two things are required for a draft block to be verified and rolled back when
+the cache is quantized:
+
+1. ``BatchQuantizedKVCache`` must be trimmable, so rejected draft tokens can be
+   dropped after verification.
+2. The causal verify path in the attention block must slice a quantized cache
+   entry, which is a ``(packed, scales, biases)`` tuple rather than one array.
+"""
+
+import mlx.core as mx
+
+from mlx_vlm.models.base import scaled_dot_product_attention
+from mlx_vlm.models.cache import BatchKVCache, BatchQuantizedKVCache
+
+B, H, D = 1, 2, 64
+
+
+def _rand(steps, dim=D):
+    return mx.random.normal((B, H, steps, dim))
+
+
+def _quantized_cache(steps):
+    cache = BatchQuantizedKVCache(left_padding=[0] * B)
+    cache.update_and_fetch(_rand(steps), _rand(steps))
+    return cache
+
+
+def test_quantized_cache_is_trimmable():
+    assert BatchQuantizedKVCache(left_padding=[0]).is_trimmable()
+
+
+def test_trim_matches_unquantized_bookkeeping():
+    """Trimming is index arithmetic and must behave the same either way."""
+    quantized = _quantized_cache(10)
+    dense = BatchKVCache(left_padding=[0] * B)
+    dense.update_and_fetch(_rand(10), _rand(10))
+
+    assert quantized.trim(4) == dense.trim(4)
+    assert quantized._idx == dense._idx
+    assert quantized.offset.tolist() == dense.offset.tolist()
+
+
+def test_trim_never_exceeds_what_is_cached():
+    cache = _quantized_cache(3)
+    assert cache.trim(10) == 3
+    assert cache._idx == 0
+
+
+def test_appending_after_trim_yields_the_trimmed_length():
+    """A rejected draft block is dropped, then the accepted token is appended."""
+    cache = _quantized_cache(8)
+    cache.trim(3)
+    keys, _ = cache.update_and_fetch(_rand(1), _rand(1))
+    assert keys[0].shape[-2] == 6
+
+
+def test_kv_helpers_accept_arrays_and_quantized_tuples():
+    from mlx_vlm.models.qwen3_5.language import _kv_prefix, _kv_seq_len
+
+    dense = _rand(7)
+    assert _kv_seq_len(dense) == 7
+    assert _kv_prefix(dense, 4).shape[-2] == 4
+
+    # mx.quantize hands back a list; the cache wraps it in a tuple. Both shapes
+    # reach this code, so both have to work.
+    packed = mx.quantize(dense, group_size=64, bits=8)
+    for quantized in (list(packed), tuple(packed)):
+        assert _kv_seq_len(quantized) == 7
+        sliced = _kv_prefix(quantized, 4)
+        assert all(component.shape[-2] == 4 for component in sliced)
+
+
+def test_causal_verify_prefix_matches_dense_reference():
+    """The per-position slices must line up with an unquantized reference.
+
+    Quantization is lossy, so this checks agreement within tolerance rather
+    than equality — an off-by-one in the slicing would move the result far
+    outside it.
+    """
+    from mlx_vlm.models.qwen3_5.language import _kv_prefix
+
+    verify_len, prefix_len = 3, 5
+    total = prefix_len + verify_len
+    keys, values = _rand(total), _rand(total)
+    queries = _rand(verify_len)
+
+    # Go through the cache rather than quantizing by hand: this is exactly what
+    # the attention block receives during verification.
+    quantized_cache = BatchQuantizedKVCache(left_padding=[0] * B)
+    quantized_keys, quantized_values = quantized_cache.update_and_fetch(keys, values)
+
+    for i in range(verify_len):
+        length = prefix_len + i + 1
+        got = scaled_dot_product_attention(
+            queries[:, :, i : i + 1, :],
+            _kv_prefix(quantized_keys, length),
+            _kv_prefix(quantized_values, length),
+            cache=quantized_cache,
+            scale=D**-0.5,
+            mask=None,
+        )
+        want = mx.fast.scaled_dot_product_attention(
+            queries[:, :, i : i + 1, :],
+            keys[:, :, :length, :],
+            values[:, :, :length, :],
+            scale=D**-0.5,
+            mask=None,
+        )
+        assert got.shape == want.shape
+        assert mx.allclose(got, want, atol=0.05).item()
+
+
+if __name__ == "__main__":
+    import pytest
+
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
Running a draft model together with `--kv-bits` doesn't work today: it crashes,
and once you fix the crash it crashes again somewhere else. Both problems are
small, but they hide each other, so here they are together.

## What happens

With `--draft-model ... --draft-kind mtp --kv-bits 8`, every request dies in the
verify step:

```
File "mlx_vlm/models/qwen3_5/language.py", line 1641, in __call__
    prefix_len = keys.shape[-2] - L
AttributeError: 'tuple' object has no attribute 'shape'
```

The causal verify path slices the cache per verify position, and it assumes
`keys` is one array. A quantized cache returns `(packed, scales, biases)`.

Interestingly the attention kernel is already fine with this —
`scaled_dot_product_attention` dispatches on `hasattr(cache, "bits")` and takes
the tuple happily. Only the slicing around it never learned about quantization.

Fix that, and the next one shows up:

```
File "mlx_vlm/models/qwen3_5/language.py", line 2302, in rollback_speculative_cache
    c[1] = intermediate_states[:, a0]
TypeError: 'BatchQuantizedKVCache' object does not support item assignment
```

This one has a root cause worth spelling out. `BatchQuantizedKVCache.trim()` is
a stub:

```python
def is_trimmable(self):
    return False

def trim(self, n):
    return 0
```

Speculative decoding can't work without trimming — after a draft block is
verified you have to drop the rejected tokens from the cache. And because
`rollback_speculative_cache` identifies cache kinds by negation ("not trimmable
and no `zero_row_tail`" ⇒ SSM state), a quantized KV cache doesn't just fail to
trim, it gets routed into the SSM branch and dies on item assignment.

## The fixes

**Slicing** — two small helpers that read a length and take a prefix from either
an array or a quantized triple. Three call sites change.

**Trimming** — `BatchQuantizedKVCache` gets the same `trim` as `BatchKVCache`.
That's safe because the two classes store data identically: `_idx`, `offset`,
writes at `[..., prev:_idx, :]`, reads at `[..., :_idx, :]`. Trimming is pure
index arithmetic — nothing past `_idx` is ever read, and the next append
overwrites it. Quantization doesn't change that: packing lives in the last axis,
and we slice the sequence axis.

## Tests

`mlx_vlm/tests/test_speculative_quantized_kv.py`, six tests. All six fail on
current `main` and pass with this change. They cover trim bookkeeping against
the unquantized cache as the reference, appending after a trim, the helpers on
both list and tuple inputs (`mx.quantize` returns a list, the cache wraps it in
a tuple — both reach this code), and a numerical check that the per-position
slices line up with a dense reference within quantization tolerance, so an
off-by-one in the slicing would be caught rather than silently wrong.

`pytest mlx_vlm/tests` is otherwise unchanged: 1980 passed, 6 skipped.

One unrelated pre-existing failure on my machine, present before this change:
`test_qwen_target_verify_quantized_linear_matches_singleton_batch_path` asserts
bit-exact equality for a bfloat16 quantized matmul, and on mlx 0.32.0 the two
paths differ by 0.0078 — one bfloat16 ULP at that magnitude. Untouched here.

## Why it's worth having

This unblocks running speculative decoding and prefix caching (`APC_ENABLED=1`)
at the same time, which is a big deal for agent-style workloads where every step
resends the whole conversation.

Measured on a 36 GB M3 Pro, Qwen3.8-27B-4bit with its MTP draft head, ten
multi-step coding tasks, all solved correctly in every configuration:

| Setup | Time |
|---|---|
| draft, KV 8-bit, no prefix cache | 823 s |
| draft, KV 8-bit, prefix cache (this PR) | **405 s** |

Prefill on a single step drops from 39.1 s to 0.42 s (90 → 2777 tok/s). Before
this change the only way to get there was turning KV quantization off, which
costs memory and is about 7% slower on its own.

Tested on macOS 26.5, M3 Pro, mlx 0.32.0, mlx-vlm at 20eec6c.
