### PR TITLE
Load text-only checkpoints that still advertise a vision tower

### DIFF
--- a/mlx_vlm/tests/test_utils.py
+++ b/mlx_vlm/tests/test_utils.py
@@ -746,6 +746,119 @@ class TestDropModulesWithoutWeights:
         assert "vision_tower" in caplog.text
         assert model.loaded_strict is True
 
+    def test_keeps_module_declared_in_manifest_but_not_loaded(self):
+        # The manifest claims vision weights but none loaded (missing shard or a
+        # rename/sanitize bug). The tower must be kept so strict fails loudly
+        # instead of silently degrading the checkpoint to text-only (#1963).
+        model = self.FakeModel()
+        weights = {"language_model.weight": mx.zeros((2, 2))}
+        declared = {
+            "language_model.weight",
+            "vision_tower.weight",
+            "vision_tower.bias",
+        }
+
+        _drop_modules_without_weights(model, weights, declared)
+
+        assert model.vision_tower is not None
+        with pytest.raises(ValueError, match="Missing"):
+            model.load_weights(list(weights.items()), strict=True)
+
+    def test_drops_module_absent_from_manifest(self, caplog):
+        # The manifest also omits vision -> an intentional text-only conversion.
+        model = self.FakeModel()
+        weights = {"language_model.weight": mx.zeros((2, 2))}
+        declared = {"language_model.weight"}
+
+        with caplog.at_level(logging.WARNING):
+            _drop_modules_without_weights(model, weights, declared)
+
+        assert model.vision_tower is None
+        assert "vision_tower" in caplog.text
+
+    def test_load_model_prunes_when_config_still_advertises_vision(self, caplog):
+        # Text-only conversions on the Hub keep a populated vision_config while
+        # shipping no vision weights and no manifest entry for them; the tower
+        # must still be dropped so the checkpoint loads (regression for #1958).
+        class FakeConfig:
+            @classmethod
+            def from_dict(cls, config):
+                return cls()
+
+        class FakeModel(self.FakeModel):
+            def load_weights(self, weights, strict=True):
+                self.loaded_weights = weights
+                self.loaded_strict = strict
+
+        fake_model_class = SimpleNamespace(ModelConfig=FakeConfig, Model=FakeModel)
+        weights = {"language_model.weight": mx.zeros((2, 2))}
+
+        with (
+            patch(
+                "mlx_vlm.utils.load_config",
+                return_value={
+                    "model_type": "fake",
+                    "vision_config": {"hidden_size": 8, "num_hidden_layers": 2},
+                },
+            ),
+            patch(
+                "mlx_vlm.utils.glob.glob",
+                return_value=["/tmp/model/model.safetensors"],
+            ),
+            patch("mlx_vlm.utils._load_safetensors", return_value=weights),
+            patch(
+                "mlx_vlm.utils.get_model_and_args",
+                return_value=(fake_model_class, "fake"),
+            ),
+            caplog.at_level(logging.WARNING),
+        ):
+            model = load_model(Path("/tmp/model"), lazy=True)
+
+        assert model.vision_tower is None
+        assert model.loaded_strict is True
+
+    def test_load_model_errors_when_manifest_shard_missing(self, tmp_path):
+        # End-to-end: the index declares vision weights but the shard is absent.
+        # load_model must keep the tower and let the strict load fail loudly.
+        (tmp_path / "model.safetensors").write_bytes(b"")
+        (tmp_path / "model.safetensors.index.json").write_text(
+            json.dumps(
+                {
+                    "weight_map": {
+                        "language_model.weight": "model.safetensors",
+                        "vision_tower.weight": "model-vision.safetensors",
+                        "vision_tower.bias": "model-vision.safetensors",
+                    }
+                }
+            )
+        )
+
+        class FakeConfig:
+            @classmethod
+            def from_dict(cls, config):
+                return cls()
+
+        # real nn.Module.load_weights -> strict failure surfaces
+        fake_model_class = SimpleNamespace(ModelConfig=FakeConfig, Model=self.FakeModel)
+        weights = {"language_model.weight": mx.zeros((2, 2))}
+
+        with (
+            patch(
+                "mlx_vlm.utils.load_config",
+                return_value={
+                    "model_type": "fake",
+                    "vision_config": {"hidden_size": 8, "num_hidden_layers": 2},
+                },
+            ),
+            patch("mlx_vlm.utils._load_safetensors", return_value=weights),
+            patch(
+                "mlx_vlm.utils.get_model_and_args",
+                return_value=(fake_model_class, "fake"),
+            ),
+            pytest.raises(ValueError, match="Missing"),
+        ):
+            load_model(tmp_path, lazy=True)
+
 
 def test_load_safetensors_reinterprets_f8_e8m0_header(tmp_path):
     path = tmp_path / "model.safetensors"

--- a/mlx_vlm/utils.py
+++ b/mlx_vlm/utils.py
@@ -635,18 +635,6 @@ def get_model_and_args(config: dict, model_path: Optional[Path] = None):
     raise ValueError(msg)
 
 
-def _has_config(config: dict, key: str) -> bool:
-    value = config.get(key)
-    return value is not None and value != {}
-
-
-def _is_text_only_config(config: dict) -> bool:
-    return not any(
-        _has_config(config, key)
-        for key in ("vision_config", "audio_config", "dflash_config")
-    )
-
-
 def _quantization_path_aliases(
     path: str, model: Optional[nn.Module] = None
 ) -> Tuple[str, ...]:
@@ -674,22 +662,45 @@ def _quantization_for_module_path(
     return None
 
 
-def _drop_modules_without_weights(model: nn.Module, weights: dict) -> None:
+def _drop_modules_without_weights(
+    model: nn.Module, weights: dict, declared_keys: Optional[set] = None
+) -> None:
+    """Drop top-level VLM modules the checkpoint carries no weights for.
+
+    Text-only conversions of VLM families often keep a populated
+    ``vision_config``/``audio_config`` in ``config.json`` while shipping no
+    weights for that tower, so the module gets built and then fails a strict
+    weight load. Removing the weightless tower lets the checkpoint load and
+    leaves it as ``None`` (an image/audio request then errors instead of
+    running an uninitialized tower).
+
+    A module is dropped only when the checkpoint's own weight manifest omits it
+    too. If the manifest (the safetensors index) *declares* weights for the
+    module but none were loaded -- a missing shard, or a rename/sanitize bug --
+    the module is kept so the strict load fails loudly rather than silently
+    degrading a multimodal checkpoint to text-only. Partially weighted modules
+    are likewise kept, so strict still catches genuine mismatches.
+    """
     weighted_modules = {key.partition(".")[0] for key in weights}
+    declared_modules = {key.partition(".")[0] for key in (declared_keys or weights)}
     dropped_modules = []
     for name, child in list(model.items()):
         if name == "language_model" or not isinstance(child, nn.Module):
             continue
-        if not tree_flatten(child.parameters()) or name in weighted_modules:
+        params = tree_flatten(child.parameters())
+        if not params or name in weighted_modules:
+            continue
+        if name in declared_modules:
             continue
         setattr(model, name, None)
-        dropped_modules.append(name)
+        dropped_modules.append((name, sum(int(p.size) for _, p in params)))
 
     if dropped_modules:
         logging.warning(
-            "Text-only checkpoint has no weights for VLM module(s): %s. "
-            "Disabling those modules.",
-            ", ".join(dropped_modules),
+            "Checkpoint has no weights for module(s) %s; disabling them and "
+            "loading as text-only. An image/audio request to this model will "
+            "error rather than run an uninitialized tower.",
+            ", ".join(f"{name} ({count} params)" for name, count in dropped_modules),
         )
 
 
@@ -760,10 +771,12 @@ def load_model(model_path: Path, lazy: bool = False, **kwargs) -> nn.Module:
 
     index_file = model_path / "model.safetensors.index.json"
     weight_files = []
+    declared_keys: set = set()
     if index_file.exists():
         try:
             with open(index_file) as f:
                 weight_map = json.load(f).get("weight_map", {})
+            declared_keys = set(weight_map)
             weight_files = [
                 str(model_path / shard)
                 for shard in sorted(set(weight_map.values()))
@@ -771,6 +784,7 @@ def load_model(model_path: Path, lazy: bool = False, **kwargs) -> nn.Module:
             ]
         except (ValueError, OSError):
             weight_files = []
+            declared_keys = set()
     if not weight_files:
         weight_files = [
             wf
@@ -805,7 +819,6 @@ python -m mlx_vlm.convert --hf-path <local_dir> --mlx-path <mlx_dir>
         weights.update(_load_safetensors(wf))
 
     model_class, _ = get_model_and_args(config=config, model_path=model_path)
-    text_only_config = _is_text_only_config(config)
 
     # Initialize text and vision configs if not present
     config.setdefault("text_config", config.pop("llm_config", {}))
@@ -974,8 +987,7 @@ python -m mlx_vlm.convert --hf-path <local_dir> --mlx-path <mlx_dir>
             )
         model = quantize_activations(model)
 
-    if text_only_config:
-        _drop_modules_without_weights(model, weights)
+    _drop_modules_without_weights(model, weights, declared_keys)
 
     model.load_weights(list(weights.items()), strict=strict)
 


### PR DESCRIPTION
Fixes #1958. Text-only conversions of VLM families commonly strip the vision/audio weights but leave a populated `vision_config`/`audio_config` in `config.json`, so `load_model` built the weightless tower and it failed the strict weight load (`Missing N parameters: vision_tower...`). This makes `_drop_modules_without_weights` run unconditionally, so any top-level VLM module that carries parameters but has no weights in the checkpoint is dropped and the model loads — fixing `mlx_vlm.server` (and `convert`/`generate`) with no new flag. The check stays conservative — partially-weighted modules are kept so genuine multimodal checkpoints still fail loudly, and a dropped module is left as `None` so an image request raises instead of running an uninitialized tower.