### PR TITLE
Add DFlash 2 support to the qwen3_dflash drafter

### DIFF
--- a/mlx_vlm/speculative/drafters/qwen3_dflash/config.py
+++ b/mlx_vlm/speculative/drafters/qwen3_dflash/config.py
@@ -29,6 +29,15 @@ class DFlashConfig(BaseModelConfig):
     final_logit_softcapping: Optional[float] = None
     runtime_block_size: int | None = None
     draft_window_size: int | None = None
+    # DFlash 2 extras. All default to 0, which reproduces DFlash v1 exactly, so
+    # v1 checkpoints keep loading unchanged. The v2 modules are only built when
+    # the drafter's own dflash_config asks for them:
+    #   conv_*     -> GroupedDynamicCausalConv in every decoder layer
+    #   selector_* -> CandidateSelector (top-k per position + path search)
+    conv_kernel_size: int = 0
+    conv_group_size: int = 0
+    selector_rank: int = 0
+    selector_top_k: int = 0
 
     @classmethod
     def from_dict(cls, params: dict) -> "DFlashConfig":
@@ -42,6 +51,22 @@ class DFlashConfig(BaseModelConfig):
             flat["runtime_block_size"] = dflash_cfg["runtime_block_size"]
         if "draft_window_size" in dflash_cfg:
             flat["draft_window_size"] = dflash_cfg["draft_window_size"]
+        # DFlash 2 moved block_size into dflash_config; v1 kept it top-level.
+        if "block_size" in dflash_cfg:
+            flat["block_size"] = dflash_cfg["block_size"]
+        for key in (
+            "conv_kernel_size",
+            "conv_group_size",
+            "selector_rank",
+            "selector_top_k",
+        ):
+            if key in dflash_cfg:
+                flat[key] = int(dflash_cfg[key])
+        # transformers 5.x nests RoPE settings under rope_parameters. Without
+        # this, rope_theta silently falls back to the class default.
+        rope_params = flat.get("rope_parameters")
+        if isinstance(rope_params, dict) and "rope_theta" in rope_params:
+            flat.setdefault("rope_theta", rope_params["rope_theta"])
         sig = inspect.signature(cls).parameters
         return cls(**{k: v for k, v in flat.items() if k in sig})
 

--- a/mlx_vlm/speculative/drafters/qwen3_dflash/dflash.py
+++ b/mlx_vlm/speculative/drafters/qwen3_dflash/dflash.py
@@ -117,6 +117,134 @@ class DFlashDecoderLayer(nn.Module):
         return h + self.mlp(self.post_attention_layernorm(h))
 
 
+# --- DFlash 2 -----------------------------------------------------------------
+# Ported from the reference MLX implementation in z-lab/dflash (MIT),
+# dflash/model_mlx.py: GroupedDynamicCausalConv, DFlash2DecoderLayer and
+# CandidateSelector. Its decoder-layer signature already matches the one above,
+# so the round loop in mlx_vlm/speculative/dflash.py is untouched: the selector
+# runs inside draft_block and still returns a plain token array.
+#
+# The drafter only proposes; the target verifies every token. A bug in the conv
+# or the selector therefore costs acceptance, never correctness. That is also
+# why the reference's distribution-preserving sampling path (q rows) is not
+# needed here -- _speculative_walk compares the draft against the target sample.
+
+
+def _grouped_dynamic_convolve(hidden, dynamic, base, group_size):
+    """Two-tap causal conv with a static kernel plus an input-dependent part.
+
+    The dynamic part is shared per group (group_size channels each), which is
+    why kernel_projection emits 2 * kernel_size * groups values instead of a
+    full per-channel matrix.
+    """
+    batch, length, hidden_size = hidden.shape
+    groups = hidden_size // group_size
+    blocks = hidden.reshape(batch, length, groups, group_size)
+    dynamic = dynamic.reshape(batch, length, base.shape[0], groups, 1)
+    output = mx.zeros_like(blocks)
+    for offset in range(base.shape[0]):
+        values = (
+            blocks
+            if offset == 0
+            else mx.concatenate(
+                (mx.zeros_like(blocks[:, :offset]), blocks[:, :-offset]), axis=1
+            )
+        )
+        kernel = base[offset].reshape(1, 1, groups, group_size).astype(hidden.dtype)
+        output = output + kernel * values
+        output = output + dynamic[:, :, offset] * values
+    return output.reshape(hidden.shape)
+
+
+class GroupedDynamicCausalConv(nn.Module):
+    def __init__(self, hidden_size, kernel_size, group_size):
+        super().__init__()
+        self.kernel_size = kernel_size
+        self.group_size = group_size
+        groups = hidden_size // group_size
+        self.base_kernel = mx.zeros((2, kernel_size, hidden_size))
+        self.kernel_projection = nn.Linear(
+            hidden_size, 2 * kernel_size * groups, bias=False
+        )
+
+    def prepare(self, hidden):
+        groups = hidden.shape[-1] // self.group_size
+        dynamic = self.kernel_projection(hidden).reshape(
+            *hidden.shape[:-1], 2, self.kernel_size, groups
+        )
+        return (
+            _grouped_dynamic_convolve(
+                hidden, dynamic[..., 0, :, :], self.base_kernel[0], self.group_size
+            ),
+            dynamic[..., 1, :, :],
+        )
+
+    def finish(self, hidden, dynamic):
+        return _grouped_dynamic_convolve(
+            hidden, dynamic, self.base_kernel[1], self.group_size
+        )
+
+
+class DFlash2DecoderLayer(DFlashDecoderLayer):
+    def __init__(self, config: DFlashConfig, layer_idx: int):
+        super().__init__(config, layer_idx)
+        self.attention_conv = GroupedDynamicCausalConv(
+            config.hidden_size, config.conv_kernel_size, config.conv_group_size
+        )
+        self.mlp_conv = GroupedDynamicCausalConv(
+            config.hidden_size, config.conv_kernel_size, config.conv_group_size
+        )
+
+    def __call__(self, x, x_ctx, rope, cache):
+        residual = x
+        x, kernel = self.attention_conv.prepare(self.input_layernorm(x))
+        x = residual + self.attention_conv.finish(
+            self.self_attn(x, x_ctx, rope, cache), kernel
+        )
+        residual = x
+        x, kernel = self.mlp_conv.prepare(self.post_attention_layernorm(x))
+        return residual + self.mlp_conv.finish(self.mlp(x), kernel)
+
+
+class CandidateSelector(nn.Module):
+    """Pick one coherent path through the top-k candidates of a draft block.
+
+    Instead of taking an independent argmax per position, adjacent token pairs
+    are scored with a low-rank bilinear form (predecessor codebook x projected
+    hidden state x successor codebook) and the best path is traced once,
+    left to right.
+    """
+
+    def __init__(self, config: DFlashConfig):
+        super().__init__()
+        self.top_k = config.selector_top_k
+        self.predecessor_codebook = nn.Embedding(config.vocab_size, config.selector_rank)
+        self.successor_codebook = nn.Embedding(config.vocab_size, config.selector_rank)
+        self.hidden_projection = nn.Linear(
+            config.hidden_size, config.selector_rank, bias=False
+        )
+
+    def select(self, hidden: mx.array, logits: mx.array, anchor_ids: mx.array):
+        candidates = mx.argpartition(logits, -self.top_k, axis=-1)[..., -self.top_k :]
+        unary = mx.take_along_axis(logits, candidates, axis=-1)
+        hidden = self.hidden_projection(hidden)
+        predecessor = anchor_ids
+        path = []
+        for position in range(hidden.shape[1]):
+            edges = mx.sum(
+                self.predecessor_codebook(predecessor)[:, None]
+                * hidden[:, position, None]
+                * self.successor_codebook(candidates[:, position]),
+                axis=-1,
+            )
+            selected = mx.argmax(unary[:, position] + edges, axis=-1)
+            predecessor = mx.take_along_axis(
+                candidates[:, position], selected[:, None], axis=-1
+            )[:, 0]
+            path.append(predecessor)
+        return mx.stack(path, axis=1)
+
+
 class DFlashDraftModel(nn.Module):
     def __init__(self, config: DFlashConfig):
         super().__init__()
@@ -126,9 +254,15 @@ class DFlashDraftModel(nn.Module):
         concat_dim = len(config.target_layer_ids) * config.hidden_size
         self.fc = nn.Linear(concat_dim, config.hidden_size, bias=False)
         self.hidden_norm = nn.RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
-        self.layers = [
-            DFlashDecoderLayer(config, i) for i in range(config.num_hidden_layers)
-        ]
+        # DFlash 2 adds per-layer convs and the path selector. Both are driven
+        # purely by the drafter config, so a v1 checkpoint builds as before.
+        layer_class = (
+            DFlash2DecoderLayer if config.conv_kernel_size > 0 else DFlashDecoderLayer
+        )
+        self.layers = [layer_class(config, i) for i in range(config.num_hidden_layers)]
+        self.candidate_selector = (
+            CandidateSelector(config) if config.selector_rank > 0 else None
+        )
         self.norm = nn.RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
         self.rope = _build_rope(config)
         self.embed_tokens = None
@@ -216,6 +350,13 @@ class DFlashDraftModel(nn.Module):
             )
         draft_hidden = self._hidden(block, hidden, cache)
         draft_logits = self._logits(draft_hidden[:, 1:])
+        if self.candidate_selector is not None:
+            # DFlash 2: trace a path through the per-position top-k instead of
+            # taking an argmax per position. The anchor is the first block
+            # token, i.e. the bonus token that was already accepted.
+            return self.candidate_selector.select(
+                draft_hidden[:, 1:], draft_logits, block[:, 0]
+            ).astype(token_dtype)
         return sampler(draft_logits)
 
     def _hidden(
@@ -253,6 +394,13 @@ class DFlashDraftModel(nn.Module):
         for k, v in weights.items():
             if k.startswith("model."):
                 k = k[len("model.") :]
+            # DFlash 2 stores the selector codebooks as bare tensors, but they
+            # are nn.Embedding here, which expects the .weight suffix.
+            if k in (
+                "candidate_selector.predecessor_codebook",
+                "candidate_selector.successor_codebook",
+            ):
+                k = f"{k}.weight"
             out[k] = v
         return out
 

--- a/mlx_vlm/tests/test_qwen3_dflash2_drafter.py
+++ b/mlx_vlm/tests/test_qwen3_dflash2_drafter.py
@@ -1,0 +1,154 @@
+import mlx.core as mx
+import pytest
+from mlx.utils import tree_flatten
+
+from mlx_vlm.speculative.drafters.qwen3_dflash import Model, ModelConfig
+from mlx_vlm.speculative.drafters.qwen3_dflash.dflash import (
+    CandidateSelector,
+    DFlash2DecoderLayer,
+    DFlashDecoderLayer,
+)
+
+HIDDEN = 64
+LAYERS = 2
+VOCAB = 128
+GROUP = 16
+RANK = 8
+TOP_K = 4
+
+
+def _config_dict(dflash_extra=None):
+    dflash_config = {
+        "block_size": 8,
+        "mask_token_id": 120,
+        "target_layer_ids": [0, 1, 2, 3, 4],
+    }
+    dflash_config.update(dflash_extra or {})
+    return {
+        "model_type": "qwen3",
+        "hidden_size": HIDDEN,
+        "intermediate_size": 128,
+        "num_hidden_layers": LAYERS,
+        "num_attention_heads": 4,
+        "num_key_value_heads": 2,
+        "head_dim": 16,
+        "rms_norm_eps": 1e-6,
+        "vocab_size": VOCAB,
+        "num_target_layers": 8,
+        "max_position_embeddings": 4096,
+        "layer_types": ["sliding_attention"] * LAYERS,
+        "sliding_window": 32,
+        "rope_parameters": {"rope_theta": 1234567.0, "rope_type": "default"},
+        "dflash_config": dflash_config,
+    }
+
+
+def _v2_config_dict():
+    return _config_dict(
+        {
+            "conv_kernel_size": 2,
+            "conv_group_size": GROUP,
+            "selector_rank": RANK,
+            "selector_top_k": TOP_K,
+        }
+    )
+
+
+def test_v1_config_is_unchanged_and_disables_the_v2_modules():
+    config = ModelConfig.from_dict(_config_dict())
+
+    assert config.conv_kernel_size == 0
+    assert config.conv_group_size == 0
+    assert config.selector_rank == 0
+    assert config.selector_top_k == 0
+
+    model = Model(config)
+    assert model.candidate_selector is None
+    assert all(isinstance(layer, DFlashDecoderLayer) for layer in model.layers)
+    assert not any(isinstance(layer, DFlash2DecoderLayer) for layer in model.layers)
+
+
+def test_v2_config_reads_the_dflash_block():
+    config = ModelConfig.from_dict(_v2_config_dict())
+
+    assert config.block_size == 8  # DFlash 2 nests this inside dflash_config
+    assert config.conv_kernel_size == 2
+    assert config.conv_group_size == GROUP
+    assert config.selector_rank == RANK
+    assert config.selector_top_k == TOP_K
+    # transformers 5.x nests RoPE settings, which must not fall back to the default
+    assert config.rope_theta == 1234567.0
+
+
+def test_v2_model_parameters_match_the_checkpoint_layout():
+    model = Model(ModelConfig.from_dict(_v2_config_dict()))
+    params = dict(tree_flatten(model.parameters()))
+
+    groups = HIDDEN // GROUP
+    expected = {
+        "candidate_selector.hidden_projection.weight": (RANK, HIDDEN),
+        "candidate_selector.predecessor_codebook.weight": (VOCAB, RANK),
+        "candidate_selector.successor_codebook.weight": (VOCAB, RANK),
+    }
+    for layer in range(LAYERS):
+        for conv in ("attention_conv", "mlp_conv"):
+            expected[f"layers.{layer}.{conv}.base_kernel"] = (2, 2, HIDDEN)
+            expected[f"layers.{layer}.{conv}.kernel_projection.weight"] = (
+                2 * 2 * groups,
+                HIDDEN,
+            )
+
+    for name, shape in expected.items():
+        assert name in params, f"missing parameter {name}"
+        assert tuple(params[name].shape) == shape, name
+
+
+def test_sanitize_adds_the_weight_suffix_to_the_codebooks():
+    model = Model(ModelConfig.from_dict(_v2_config_dict()))
+    raw = {
+        "model.candidate_selector.predecessor_codebook": mx.zeros((VOCAB, RANK)),
+        "candidate_selector.successor_codebook": mx.zeros((VOCAB, RANK)),
+        "candidate_selector.hidden_projection.weight": mx.zeros((RANK, HIDDEN)),
+    }
+    out = model.sanitize(raw)
+
+    assert "candidate_selector.predecessor_codebook.weight" in out
+    assert "candidate_selector.successor_codebook.weight" in out
+    assert "candidate_selector.hidden_projection.weight" in out
+
+
+def test_selector_falls_back_to_argmax_without_edge_scores():
+    config = ModelConfig.from_dict(_v2_config_dict())
+    selector = CandidateSelector(config)
+    # Zeroed codebooks remove the pairwise term, so the path must follow the
+    # per-position argmax of the logits.
+    selector.predecessor_codebook.weight = mx.zeros((VOCAB, RANK))
+    selector.successor_codebook.weight = mx.zeros((VOCAB, RANK))
+
+    block = 3
+    logits = mx.random.normal((1, block, VOCAB))
+    hidden = mx.random.normal((1, block, HIDDEN))
+    path = selector.select(hidden, logits, mx.array([0]))
+
+    assert path.shape == (1, block)
+    assert mx.array_equal(path, mx.argmax(logits, axis=-1))
+
+
+@pytest.mark.parametrize("kernel_size", [1, 2])
+def test_grouped_dynamic_conv_is_causal(kernel_size):
+    from mlx_vlm.speculative.drafters.qwen3_dflash.dflash import (
+        GroupedDynamicCausalConv,
+    )
+
+    conv = GroupedDynamicCausalConv(HIDDEN, kernel_size, GROUP)
+    conv.base_kernel = mx.random.normal((2, kernel_size, HIDDEN)) * 0.1
+
+    x = mx.random.normal((1, 6, HIDDEN))
+    out, _ = conv.prepare(x)
+
+    # Changing a later position must not alter earlier outputs.
+    x2 = mx.array(x)
+    x2[:, 4:] = mx.random.normal((1, 2, HIDDEN))
+    out2, _ = conv.prepare(x2)
+
+    assert mx.allclose(out[:, :4], out2[:, :4], atol=1e-5)


### PR DESCRIPTION
DFlash 2 drafters carry two modules the current drafter does not implement: grouped dynamic causal convolutions in every decoder layer, and a candidate path selector on top of the per-position logits. Loading such a checkpoint therefore fails on unexpected weights.

This ports both modules from the reference MLX implementation in z-lab/dflash (MIT), dflash/model_mlx.py, and reads the matching fields from the drafter's dflash_config. Everything is config-driven and defaults to 0, so DFlash v1 checkpoints build and load exactly as before.

The selector runs inside draft_block and still returns a plain token array, so the round loop in speculative/dflash.py is unchanged. Because the target verifies every drafted token, the reference's distribution-preserving sampling path is not needed here: a selector mistake can only cost acceptance, never correctness.

Also reads block_size from dflash_config (DFlash 2 moved it there) and honors rope_parameters, which transformers 5.x uses instead of a top-level rope_theta.