### PR TITLE
Let non-MTP drafters use the batching generator (fixes missing prefix cache)

### DIFF
--- a/mlx_vlm/server/generation.py
+++ b/mlx_vlm/server/generation.py
@@ -68,6 +68,26 @@ def _get_draft_block_size_from_env():
     return int(draft_block_size_str) if draft_block_size_str else None
 
 
+def _speculative_batch_path_enabled() -> bool:
+    """Route non-MTP drafters through the continuous-batching generator.
+
+    Non-MTP drafters are dispatched to the standalone ``_run_speculative`` loop,
+    which builds its own prompt cache and never receives ``apc_manager`` — so
+    automatic prefix caching is silently unavailable for them and every request
+    reports ``cached_tokens=0``. The batching generator is already generic over
+    ``draft_kind`` and is handed ``apc_manager``, ``draft_kind`` and
+    ``draft_block_size``, so it can drive those drafters as well.
+
+    Opt-in via ``MLX_VLM_SPECULATIVE_BATCH=1`` until the two paths have been
+    compared on more setups.
+    """
+    return os.environ.get("MLX_VLM_SPECULATIVE_BATCH", "0").lower() in (
+        "1",
+        "true",
+        "yes",
+    )
+
+
 def _notify_queues(queues, *items):
     for queue in queues:
         for item in items:
@@ -1742,7 +1762,11 @@ class ResponseGenerator:
             self._run_diffusion()
             return
 
-        if self.draft_model is not None and self.draft_kind != "mtp":
+        if (
+            self.draft_model is not None
+            and self.draft_kind != "mtp"
+            and not _speculative_batch_path_enabled()
+        ):
             self._run_speculative()
             return
 

--- a/mlx_vlm/tests/test_speculative_batch_path.py
+++ b/mlx_vlm/tests/test_speculative_batch_path.py
@@ -1,0 +1,18 @@
+import mlx_vlm.server.generation as generation
+
+
+def test_batch_path_is_opt_in(monkeypatch):
+    monkeypatch.delenv("MLX_VLM_SPECULATIVE_BATCH", raising=False)
+    assert generation._speculative_batch_path_enabled() is False
+
+
+def test_batch_path_accepts_the_usual_truthy_spellings(monkeypatch):
+    for value in ("1", "true", "TRUE", "yes"):
+        monkeypatch.setenv("MLX_VLM_SPECULATIVE_BATCH", value)
+        assert generation._speculative_batch_path_enabled() is True
+
+
+def test_batch_path_stays_off_for_other_values(monkeypatch):
+    for value in ("0", "false", "no", ""):
+        monkeypatch.setenv("MLX_VLM_SPECULATIVE_BATCH", value)
+        assert generation._speculative_batch_path_enabled() is False


### PR DESCRIPTION
Drafters other than MTP are dispatched to the standalone _run_speculative loop, which builds its own prompt cache and never receives apc_manager. Automatic prefix caching is therefore silently unavailable for them: every request reports cached_tokens=0, including the second turn of a conversation, and APC_TRACE=1 logs no lookup or store events at all.

The batching generator already handles this: it is generic over draft_kind (speculative_prefill_kwargs, speculative_hidden_state, SpeculativeGenerationBatch) and is handed apc_manager, draft_kind and draft_block_size right next to each other in the same call. Only the routing condition kept non-MTP drafters away from it.

Gated behind MLX_VLM_SPECULATIVE_BATCH=1 so the default is unchanged and both paths stay comparable.

Measured on an M5 Pro with Qwen3.8-27B-4bit and a DFlash 2 drafter, 5.8k-token conversation, second turn:

  legacy loop   cached_tokens=0     (every turn re-prefills)
  batching path cached_tokens=5748/5788

Decode throughput is unchanged within noise (short prompts 40.8 t/s legacy vs 40.8 t/s batching on average) and better on the long prompt (38.4 -> 40.9 t/s), greedy output stays bit-identical, --draft-block-size keeps taking effect (block 4 beats block 8 on both paths), and two concurrent requests with --max-num-seqs 2 complete correctly.