### PR TITLE
Fix DeepSeek-V4 quantization path aliases

### DIFF
--- a/mlx_vlm/models/deepseek_v4/deepseek_v4.py
+++ b/mlx_vlm/models/deepseek_v4/deepseek_v4.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Optional, Tuple
 
 import mlx.core as mx
 import mlx.nn as nn
@@ -46,6 +46,36 @@ class Model(nn.Module):
             return key
 
         return {transform_key(k): v for k, v in weights.items()}
+
+    @staticmethod
+    def quantization_path_aliases(path: str) -> Tuple[str, ...]:
+        """Return legacy checkpoint names for a loaded DeepSeek-V4 module path."""
+        path = path.removeprefix("language_model.").removeprefix("model.")
+        aliases = [path]
+
+        if path == "embed_tokens":
+            aliases.append("embed")
+        elif path == "lm_head":
+            aliases.append("head")
+
+        for module_name, checkpoint_name in (
+            ("gate_proj", "w1"),
+            ("down_proj", "w2"),
+            ("up_proj", "w3"),
+        ):
+            module_path = f".ffn.shared_experts.{module_name}"
+            offset = path.find(module_path)
+            if offset < 0:
+                continue
+            end = offset + len(module_path)
+            if end == len(path) or path[end] == ".":
+                aliases.append(
+                    path[:offset]
+                    + f".ffn.shared_experts.{checkpoint_name}"
+                    + path[end:]
+                )
+
+        return tuple(dict.fromkeys(aliases))
 
     @property
     def quant_predicate(self):

--- a/mlx_vlm/tests/test_models.py
+++ b/mlx_vlm/tests/test_models.py
@@ -2720,6 +2720,41 @@ class TestModels(unittest.TestCase):
         self.assertTrue(mx.all(converted[wkey] == weight.view(mx.uint32)))
         self.assertEqual(converted[skey].shape, (128, 4))
 
+    def test_deepseek_v4_quantization_path_aliases(self):
+        from mlx_vlm.models import deepseek_v4
+
+        cases = (
+            (
+                "language_model.model.layers.0.attn.wq_a",
+                "layers.0.attn.wq_a",
+            ),
+            ("model.layers.0.attn.wq_a", "layers.0.attn.wq_a"),
+            ("language_model.model.embed_tokens", "embed"),
+            ("language_model.model.norm", "norm"),
+            ("language_model.lm_head", "head"),
+            (
+                "language_model.model.layers.0.ffn.shared_experts.gate_proj",
+                "layers.0.ffn.shared_experts.w1",
+            ),
+            (
+                "language_model.model.layers.0.ffn.shared_experts.down_proj",
+                "layers.0.ffn.shared_experts.w2",
+            ),
+            (
+                "language_model.model.layers.0.ffn.shared_experts.up_proj",
+                "layers.0.ffn.shared_experts.w3",
+            ),
+            (
+                "language_model.model.layers.0.ffn.shared_experts.gate_proj.weight",
+                "layers.0.ffn.shared_experts.w1.weight",
+            ),
+        )
+
+        for module_path, checkpoint_path in cases:
+            with self.subTest(module_path=module_path):
+                aliases = deepseek_v4.Model.quantization_path_aliases(module_path)
+                self.assertIn(checkpoint_path, aliases)
+
     def test_glm_moe_dsa_language_model(self):
         from mlx_vlm.models import glm_moe_dsa
 

--- a/mlx_vlm/tests/test_utils.py
+++ b/mlx_vlm/tests/test_utils.py
@@ -830,47 +830,24 @@ def test_load_model_uses_deepseek_v4_fp8_quantization_config():
     assert quantize.call_args.kwargs["mode"] == "affine"
 
 
-@pytest.mark.parametrize(
-    ("module_path", "checkpoint_path"),
-    [
-        (
-            "language_model.model.layers.0.attn.wq_a",
-            "layers.0.attn.wq_a",
-        ),
-        ("model.layers.0.attn.wq_a", "layers.0.attn.wq_a"),
-        ("language_model.model.embed_tokens", "embed"),
-        ("language_model.model.norm", "norm"),
-        ("language_model.lm_head", "head"),
-        (
-            "language_model.model.layers.0.ffn.shared_experts.gate_proj",
-            "layers.0.ffn.shared_experts.w1",
-        ),
-        (
-            "language_model.model.layers.0.ffn.shared_experts.down_proj",
-            "layers.0.ffn.shared_experts.w2",
-        ),
-        (
-            "language_model.model.layers.0.ffn.shared_experts.up_proj",
-            "layers.0.ffn.shared_experts.w3",
-        ),
-    ],
-)
-def test_deepseek_v4_quantization_path_aliases(module_path, checkpoint_path):
-    aliases = _quantization_path_aliases(module_path, "deepseek_v4")
-
-    assert checkpoint_path in aliases
-
-
-def test_deepseek_v4_sanitized_aliases_are_model_specific():
+def test_quantization_path_aliases_require_a_model_hook_for_model_specific_names():
     module_path = "language_model.model.layers.0.ffn.shared_experts.gate_proj"
 
-    aliases = _quantization_path_aliases(module_path, "qwen3")
+    aliases = _quantization_path_aliases(module_path)
 
-    assert "layers.0.ffn.shared_experts.gate_proj" in aliases
+    assert "model.layers.0.ffn.shared_experts.gate_proj" in aliases
+    assert "layers.0.ffn.shared_experts.gate_proj" not in aliases
     assert "layers.0.ffn.shared_experts.w1" not in aliases
 
 
 def test_deepseek_v4_module_path_spelling_wins_over_sanitized_alias():
+    from mlx_vlm.models import deepseek_v4
+
+    class AliasModel(nn.Module):
+        @staticmethod
+        def quantization_path_aliases(path):
+            return deepseek_v4.Model.quantization_path_aliases(path)
+
     module_path = "language_model.model.layers.0.ffn.shared_experts.gate_proj"
     module_path_spec = {"group_size": 32, "bits": 8, "mode": "mxfp8"}
     sanitized_alias_spec = {"group_size": 32, "bits": 4, "mode": "mxfp4"}
@@ -882,13 +859,15 @@ def test_deepseek_v4_module_path_spelling_wins_over_sanitized_alias():
     resolved = _quantization_for_module_path(
         quantization,
         module_path,
-        "deepseek_v4",
+        AliasModel(),
     )
 
     assert resolved == module_path_spec
 
 
 def test_load_model_matches_deepseek_v4_quantization_aliases():
+    from mlx_vlm.models import deepseek_v4
+
     class FakeConfig:
         @classmethod
         def from_dict(cls, config):
@@ -911,6 +890,10 @@ def test_load_model_matches_deepseek_v4_quantization_aliases():
         def load_weights(self, weights, strict=True):
             self.loaded_weights = weights
             self.loaded_strict = strict
+
+        @staticmethod
+        def quantization_path_aliases(path):
+            return deepseek_v4.Model.quantization_path_aliases(path)
 
     fake_model_class = SimpleNamespace(
         ModelConfig=FakeConfig, Model=FakeDeepseekV4Model

--- a/mlx_vlm/tests/test_utils.py
+++ b/mlx_vlm/tests/test_utils.py
@@ -17,6 +17,7 @@ from mlx_vlm.utils import (
     StoppingCriteria,
     _drop_modules_without_weights,
     _load_safetensors,
+    _quantization_for_module_path,
     _quantization_path_aliases,
     _transform_modelopt_nvfp4_weights,
     apply_generation_config_defaults,
@@ -841,10 +842,6 @@ def test_load_model_uses_deepseek_v4_fp8_quantization_config():
         ("language_model.model.norm", "norm"),
         ("language_model.lm_head", "head"),
         (
-            "language_model.model.layers.0.ffn.gate.e_score_correction_bias",
-            "layers.0.ffn.gate",
-        ),
-        (
             "language_model.model.layers.0.ffn.shared_experts.gate_proj",
             "layers.0.ffn.shared_experts.w1",
         ),
@@ -871,6 +868,24 @@ def test_deepseek_v4_sanitized_aliases_are_model_specific():
 
     assert "layers.0.ffn.shared_experts.gate_proj" in aliases
     assert "layers.0.ffn.shared_experts.w1" not in aliases
+
+
+def test_deepseek_v4_module_path_spelling_wins_over_sanitized_alias():
+    module_path = "language_model.model.layers.0.ffn.shared_experts.gate_proj"
+    module_path_spec = {"group_size": 32, "bits": 8, "mode": "mxfp8"}
+    sanitized_alias_spec = {"group_size": 32, "bits": 4, "mode": "mxfp4"}
+    quantization = {
+        "model.layers.0.ffn.shared_experts.gate_proj": module_path_spec,
+        "layers.0.ffn.shared_experts.w1": sanitized_alias_spec,
+    }
+
+    resolved = _quantization_for_module_path(
+        quantization,
+        module_path,
+        "deepseek_v4",
+    )
+
+    assert resolved == module_path_spec
 
 
 def test_load_model_matches_deepseek_v4_quantization_aliases():

--- a/mlx_vlm/tests/test_utils.py
+++ b/mlx_vlm/tests/test_utils.py
@@ -17,6 +17,7 @@ from mlx_vlm.utils import (
     StoppingCriteria,
     _drop_modules_without_weights,
     _load_safetensors,
+    _quantization_path_aliases,
     _transform_modelopt_nvfp4_weights,
     apply_generation_config_defaults,
     estimate_num_image_tokens,
@@ -826,6 +827,119 @@ def test_load_model_uses_deepseek_v4_fp8_quantization_config():
     assert quantize.call_args.kwargs["group_size"] == 64
     assert quantize.call_args.kwargs["bits"] == 8
     assert quantize.call_args.kwargs["mode"] == "affine"
+
+
+@pytest.mark.parametrize(
+    ("module_path", "checkpoint_path"),
+    [
+        (
+            "language_model.model.layers.0.attn.wq_a",
+            "layers.0.attn.wq_a",
+        ),
+        ("model.layers.0.attn.wq_a", "layers.0.attn.wq_a"),
+        ("language_model.model.embed_tokens", "embed"),
+        ("language_model.model.norm", "norm"),
+        ("language_model.lm_head", "head"),
+        (
+            "language_model.model.layers.0.ffn.gate.e_score_correction_bias",
+            "layers.0.ffn.gate",
+        ),
+        (
+            "language_model.model.layers.0.ffn.shared_experts.gate_proj",
+            "layers.0.ffn.shared_experts.w1",
+        ),
+        (
+            "language_model.model.layers.0.ffn.shared_experts.down_proj",
+            "layers.0.ffn.shared_experts.w2",
+        ),
+        (
+            "language_model.model.layers.0.ffn.shared_experts.up_proj",
+            "layers.0.ffn.shared_experts.w3",
+        ),
+    ],
+)
+def test_deepseek_v4_quantization_path_aliases(module_path, checkpoint_path):
+    aliases = _quantization_path_aliases(module_path, "deepseek_v4")
+
+    assert checkpoint_path in aliases
+
+
+def test_deepseek_v4_sanitized_aliases_are_model_specific():
+    module_path = "language_model.model.layers.0.ffn.shared_experts.gate_proj"
+
+    aliases = _quantization_path_aliases(module_path, "qwen3")
+
+    assert "layers.0.ffn.shared_experts.gate_proj" in aliases
+    assert "layers.0.ffn.shared_experts.w1" not in aliases
+
+
+def test_load_model_matches_deepseek_v4_quantization_aliases():
+    class FakeConfig:
+        @classmethod
+        def from_dict(cls, config):
+            return cls()
+
+    class FakeDeepseekV4Model(nn.Module):
+        def __init__(self, config):
+            super().__init__()
+            self.config = config
+            self.language_model = nn.Module()
+            self.language_model.model = nn.Module()
+            self.language_model.model.layers = [nn.Module()]
+            self.language_model.model.layers[0].ffn = nn.Module()
+            self.language_model.model.layers[0].ffn.shared_experts = nn.Module()
+            self.language_model.model.layers[0].ffn.shared_experts.gate_proj = (
+                nn.Linear(64, 64, bias=False)
+            )
+            self.language_model.lm_head = nn.Linear(64, 64, bias=False)
+
+        def load_weights(self, weights, strict=True):
+            self.loaded_weights = weights
+            self.loaded_strict = strict
+
+    fake_model_class = SimpleNamespace(
+        ModelConfig=FakeConfig, Model=FakeDeepseekV4Model
+    )
+    mxfp8 = {"group_size": 32, "bits": 8, "mode": "mxfp8"}
+    quantization = {
+        "group_size": 32,
+        "bits": 4,
+        "mode": "mxfp4",
+        "layers.0.ffn.shared_experts.w1": mxfp8,
+        "head": False,
+    }
+
+    with (
+        patch(
+            "mlx_vlm.utils.load_config",
+            return_value={
+                "model_type": "deepseek_v4",
+                "quantization": quantization,
+            },
+        ),
+        patch("mlx_vlm.utils.glob.glob", return_value=["/tmp/model/model.safetensors"]),
+        patch("mlx_vlm.utils._load_safetensors", return_value={}),
+        patch(
+            "mlx_vlm.utils.get_model_and_args",
+            return_value=(fake_model_class, "deepseek_v4"),
+        ),
+        patch("mlx_vlm.utils.nn.quantize") as quantize,
+    ):
+        load_model(Path("/tmp/model"), lazy=True)
+
+    predicate = quantize.call_args.kwargs["class_predicate"]
+    fake_model = FakeDeepseekV4Model(FakeConfig())
+    shared_expert_spec = predicate(
+        "language_model.model.layers.0.ffn.shared_experts.gate_proj",
+        fake_model.language_model.model.layers[0].ffn.shared_experts.gate_proj,
+    )
+    head_spec = predicate(
+        "language_model.lm_head",
+        fake_model.language_model.lm_head,
+    )
+
+    assert shared_expert_spec == mxfp8
+    assert head_spec == {}
 
 
 def test_load_model_uses_qwen_fine_grained_fp8_quantization_config():

--- a/mlx_vlm/utils.py
+++ b/mlx_vlm/utils.py
@@ -658,9 +658,6 @@ def _quantization_path_aliases(
             aliases.append(alias.replace("model.embed_tokens", "embed"))
             aliases.append(alias.replace("model.norm", "norm"))
             aliases.append(alias.replace("lm_head", "head"))
-            aliases.append(
-                alias.replace(".ffn.gate.e_score_correction_bias", ".ffn.gate")
-            )
 
         for alias in tuple(aliases):
             for module_name, checkpoint_name in (

--- a/mlx_vlm/utils.py
+++ b/mlx_vlm/utils.py
@@ -644,46 +644,24 @@ def _is_text_only_config(config: dict) -> bool:
 
 
 def _quantization_path_aliases(
-    path: str, model_type: Optional[str] = None
+    path: str, model: Optional[nn.Module] = None
 ) -> Tuple[str, ...]:
     """Return checkpoint quantization keys that may refer to a module path."""
     aliases = [path]
-    for prefix in ("language_model.", "model."):
-        for alias in tuple(aliases):
-            if alias.startswith(prefix):
-                aliases.append(alias[len(prefix) :])
+    if path.startswith("language_model."):
+        aliases.append(path[len("language_model.") :])
 
-    if model_type == "deepseek_v4":
-        for alias in tuple(aliases):
-            aliases.append(alias.replace("model.embed_tokens", "embed"))
-            aliases.append(alias.replace("model.norm", "norm"))
-            aliases.append(alias.replace("lm_head", "head"))
-
-        for alias in tuple(aliases):
-            for module_name, checkpoint_name in (
-                ("gate_proj", "w1"),
-                ("down_proj", "w2"),
-                ("up_proj", "w3"),
-            ):
-                module_path = f".ffn.shared_experts.{module_name}"
-                offset = alias.find(module_path)
-                if offset < 0:
-                    continue
-                end = offset + len(module_path)
-                if end == len(alias) or alias[end] == ".":
-                    aliases.append(
-                        alias[:offset]
-                        + f".ffn.shared_experts.{checkpoint_name}"
-                        + alias[end:]
-                    )
+    model_aliases = getattr(model, "quantization_path_aliases", None)
+    if callable(model_aliases):
+        aliases.extend(model_aliases(path))
 
     return tuple(dict.fromkeys(aliases))
 
 
 def _quantization_for_module_path(
-    quantization: dict, path: str, model_type: Optional[str] = None
+    quantization: dict, path: str, model: Optional[nn.Module] = None
 ) -> Optional[dict]:
-    for alias in _quantization_path_aliases(path, model_type):
+    for alias in _quantization_path_aliases(path, model):
         value = quantization.get(alias)
         if isinstance(value, dict):
             return value
@@ -946,7 +924,7 @@ python -m mlx_vlm.convert --hf-path <local_dir> --mlx-path <mlx_dir>
 
         def get_class_predicate(p, m):
             per_module_quantization = _quantization_for_module_path(
-                config["quantization"], p, config.get("model_type")
+                config["quantization"], p, model
             )
             # Skip legacy multimodal layers unless the checkpoint has quantized
             # tensors for this exact module.
@@ -964,8 +942,8 @@ python -m mlx_vlm.convert --hf-path <local_dir> --mlx-path <mlx_dir>
             )
             if module_quantization.get("bits") == 1:
                 return False
-            # Handle custom per-layer quantization, including aliases introduced
-            # by model wrappers and checkpoint-name sanitization.
+            # Handle custom per-layer quantization, including aliases supplied
+            # by the model.
             if per_module_quantization is not None:
                 return per_module_quantization
             if not hasattr(m, "to_quantized"):

--- a/mlx_vlm/utils.py
+++ b/mlx_vlm/utils.py
@@ -643,6 +643,58 @@ def _is_text_only_config(config: dict) -> bool:
     )
 
 
+def _quantization_path_aliases(
+    path: str, model_type: Optional[str] = None
+) -> Tuple[str, ...]:
+    """Return checkpoint quantization keys that may refer to a module path."""
+    aliases = [path]
+    for prefix in ("language_model.", "model."):
+        for alias in tuple(aliases):
+            if alias.startswith(prefix):
+                aliases.append(alias[len(prefix) :])
+
+    if model_type == "deepseek_v4":
+        for alias in tuple(aliases):
+            aliases.append(alias.replace("model.embed_tokens", "embed"))
+            aliases.append(alias.replace("model.norm", "norm"))
+            aliases.append(alias.replace("lm_head", "head"))
+            aliases.append(
+                alias.replace(".ffn.gate.e_score_correction_bias", ".ffn.gate")
+            )
+
+        for alias in tuple(aliases):
+            for module_name, checkpoint_name in (
+                ("gate_proj", "w1"),
+                ("down_proj", "w2"),
+                ("up_proj", "w3"),
+            ):
+                module_path = f".ffn.shared_experts.{module_name}"
+                offset = alias.find(module_path)
+                if offset < 0:
+                    continue
+                end = offset + len(module_path)
+                if end == len(alias) or alias[end] == ".":
+                    aliases.append(
+                        alias[:offset]
+                        + f".ffn.shared_experts.{checkpoint_name}"
+                        + alias[end:]
+                    )
+
+    return tuple(dict.fromkeys(aliases))
+
+
+def _quantization_for_module_path(
+    quantization: dict, path: str, model_type: Optional[str] = None
+) -> Optional[dict]:
+    for alias in _quantization_path_aliases(path, model_type):
+        value = quantization.get(alias)
+        if isinstance(value, dict):
+            return value
+        if value is False:
+            return {}
+    return None
+
+
 def _drop_modules_without_weights(model: nn.Module, weights: dict) -> None:
     weighted_modules = {key.partition(".")[0] for key in weights}
     dropped_modules = []
@@ -896,6 +948,9 @@ python -m mlx_vlm.convert --hf-path <local_dir> --mlx-path <mlx_dir>
         replace_one_bit_modules(quantized_model, quantization, weights)
 
         def get_class_predicate(p, m):
+            per_module_quantization = _quantization_for_module_path(
+                config["quantization"], p, config.get("model_type")
+            )
             # Skip legacy multimodal layers unless the checkpoint has quantized
             # tensors for this exact module.
             if (
@@ -905,17 +960,17 @@ python -m mlx_vlm.convert --hf-path <local_dir> --mlx-path <mlx_dir>
             ):
                 return False
             # Skip 1-bit layers already replaced above.
-            if _quantization_for_path(config["quantization"], p).get("bits") == 1:
+            module_quantization = (
+                per_module_quantization
+                if per_module_quantization is not None
+                else _quantization_for_path(config["quantization"], p)
+            )
+            if module_quantization.get("bits") == 1:
                 return False
-            # Handle custom per layer quantizations. Config keys from the
-            # underlying text checkpoint omit the mlx-vlm ``language_model.``
-            # wrapper prefix that loaded module paths carry, so also match with
-            # that prefix stripped (e.g. per-layer 8-bit MoE router gates).
-            override = config["quantization"].get(p)
-            if override is None and p.startswith("language_model."):
-                override = config["quantization"].get(p[len("language_model.") :])
-            if isinstance(override, dict):
-                return override
+            # Handle custom per-layer quantization, including aliases introduced
+            # by model wrappers and checkpoint-name sanitization.
+            if per_module_quantization is not None:
+                return per_module_quantization
             if not hasattr(m, "to_quantized"):
                 return False
             # Skip layers not divisible by 64


### PR DESCRIPTION
Fixes #1976

## Summary

DeepSeek-V4 per-module quantization entries use checkpoint names that do not always match the module paths produced by the loaded VLM hierarchy. The existing lookup only accounts for the `language_model.` wrapper, so overrides can be missed when a path also contains `model.` or when the checkpoint uses a sanitized module name.

This change lets models expose additional checkpoint names for their loaded module paths. The generic loader preserves its existing `language_model.` fallback and consults the optional model hook without containing model-specific path knowledge. DeepSeek-V4 implements the hook for its additional `model.` wrapper and the checkpoint aliases used by embeddings, normalization, the language-model head, and shared-expert projections.

The shared-expert mappings cover both terminal module paths and their descendants:

- `gate_proj` to `w1`;
- `down_proj` to `w2`;
- `up_proj` to `w3`.

An aliased dictionary entry is returned as the module's quantization specification. An explicit `False` entry is converted to an empty specification so MLX skips quantizing that module. All DeepSeek-V4 mappings remain in the DeepSeek-V4 model implementation; the utility code only provides the general hook.

## Relation to existing work

PR #1793 documents the same family of mixed-quantization failures caused by wrapped module paths. The `language_model.` unwrapping needed for those paths was subsequently merged through PR #1791 and is already present in the base branch.

This PR is a focused continuation of that path-matching work. It handles the remaining `model.` wrapper and DeepSeek-V4 checkpoint aliases that neither the merged fix nor PR #1793 covers. It does not include the broader DeepSeek-V4 and MTP predicate changes proposed in #1793, and keeps the additional path knowledge within the DeepSeek-V4 model.

Regression tests cover:

- delegation from the generic loader to a model-provided alias hook;
- nested `language_model.model` and standalone `model` wrappers in DeepSeek-V4;
- embedding, normalization, and language-model head aliases;
- all three shared-expert projection aliases without requiring a trailing dot;
- isolation of DeepSeek-V4-specific aliases from other model types;
- precedence of a current module-path entry over its sanitized legacy alias;
- end-to-end predicate selection for an MXFP8 shared expert and an explicitly unquantized head.

## Test plan

```text
python -m pytest mlx_vlm/tests/test_utils.py \
  mlx_vlm/tests/test_models.py::TestModels::test_deepseek_v4_language_model \
  mlx_vlm/tests/test_models.py::TestModels::test_deepseek_v4_quantization_path_aliases -q
```

```text
62 passed, 2 warnings, 9 subtests passed
```