### PR TITLE
fix(prompt_utils): match prompt-only model types case-insensitively

### DIFF
--- a/mlx_vlm/prompt_utils.py
+++ b/mlx_vlm/prompt_utils.py
@@ -989,7 +989,7 @@ def apply_chat_template(
         return messages
 
     # Some models only need the last message
-    if model_type in ["paligemma", "florence2", "falcon_ocr"]:
+    if model_type.lower() in ["paligemma", "florence2", "falcon_ocr"]:
         return messages[-1]
 
     return get_chat_template(processor, messages, add_generation_prompt, **kwargs)

--- a/mlx_vlm/tests/test_prompt_utils.py
+++ b/mlx_vlm/tests/test_prompt_utils.py
@@ -849,3 +849,44 @@ class TestModelSpecificPromptContracts:
             "text",
         ]
         assert result[0]["content"][-1]["text"] == "OCR:"
+
+
+class TestApplyChatTemplateModelTypeCasing:
+    """``config.json`` is free to ship any casing for ``model_type``.
+
+    ``MODEL_CONFIG`` membership is matched case-insensitively, so a mixed-case
+    model reaches the multimodal path. The prompt-only models must keep their
+    last-message-only handling on that path too, otherwise the whole
+    conversation is rendered with the generic fallback template.
+    """
+
+    CONVERSATION = [
+        {"role": "user", "content": "First question."},
+        {"role": "assistant", "content": "First answer."},
+        {"role": "user", "content": "Describe this image."},
+    ]
+
+    def _render(self, model_type):
+        return apply_chat_template(
+            None,
+            {"model_type": model_type},
+            self.CONVERSATION,
+            num_images=1,
+        )
+
+    def test_paligemma_last_message_only_ignores_casing(self):
+        assert self._render("PaliGemma") == self._render("paligemma")
+
+    def test_florence2_last_message_only_ignores_casing(self):
+        assert self._render("Florence2") == self._render("florence2")
+
+    def test_falcon_ocr_last_message_only_ignores_casing(self):
+        assert self._render("Falcon_OCR") == self._render("falcon_ocr")
+
+    def test_prompt_only_models_drop_the_earlier_turns(self):
+        """The prompt-only rendering must not carry the earlier turns."""
+        rendered = self._render("PaliGemma")
+
+        assert "First question." not in rendered
+        assert "First answer." not in rendered
+        assert "Describe this image." in rendered


### PR DESCRIPTION
## Summary

Follow-up to #1961, which made the multimodal gate in `apply_chat_template` case-insensitive:

```python
# mlx_vlm/prompt_utils.py:859
if model_type.lower() not in MODEL_CONFIG:
```

The same function has a second lookup of the same raw `model_type` further down, and it was left case-sensitive:

```python
# mlx_vlm/prompt_utils.py:992
# Some models only need the last message
if model_type in ["paligemma", "florence2", "falcon_ocr"]:
    return messages[-1]
```

Every other read of that value normalizes: `MODEL_CONFIG` membership via `.lower()` (line 859), and `MessageFormatter.__init__` via `self.model_name = model_name.lower()` (line 266), which is also what `SINGLE_IMAGE_ONLY_MODELS` is matched against. Line 992 is the one site that compares the unnormalized string against a lowercase list.

Because #1961 fixed line 859 first, a mixed-case prompt-only model now *reaches* this branch instead of bailing out into the text-only path earlier — so the inconsistency became observable rather than masked.

## Effect

With `"model_type": "PaliGemma"` and a multi-turn conversation, the last-message-only rule is skipped and the entire conversation is rendered with the generic fallback template:

```
# before
'User: First question.\nUser: First answer.\nUser: <image>Describe this image.\nAssistant:'

# after (and what lowercase "paligemma" has always produced)
'<image>Describe this image.'
```

Note the fallback also relabels the assistant turn as `User:`. The same applies to `florence2` and `falcon_ocr`.

As #1721 established, `config.json` is free to ship any casing for `model_type` — `mlx-community/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-*` ships `"NemotronH_Nano_Omni_Reasoning_V3"` — so this is not hypothetical for models registered under a lowercase key.

## Change

One line, matching #1961 exactly:

```python
if model_type.lower() in ["paligemma", "florence2", "falcon_ocr"]:
```

## Tests

Added `TestApplyChatTemplateModelTypeCasing` to `mlx_vlm/tests/test_prompt_utils.py`: three tests asserting the mixed-case rendering equals the lowercase rendering for each prompt-only model, plus one asserting the earlier turns are actually dropped.

Verified on this machine (`prompt_utils.py` is stdlib-only, so it loads without `mlx`):

- against current `main`: **4 failed, 39 passed** — the new tests fail exactly as described above
- with this patch: **43 passed**

The 39 pre-existing tests are unaffected in both runs. `black==26.3.1` and `isort` (per `.pre-commit-config.yaml`) report both files unchanged.

The commit is signature-verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
