### PR TITLE
Add LFM2.5 DSpark speculative decoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ Speed up generation by drafting several candidate tokens with a small "drafter" 
 
 See [docs/usage.md](docs/usage.md) for Python API examples including batch generation.
 
-#### DFlash (Qwen3.5 and Muse Glimmer)
+#### DFlash and DSpark (Qwen3.5, LFM2.5, and Muse Glimmer)
 
 A lightweight block-diffusion drafter that predicts multiple tokens per round, typically 2–3× faster.
 
@@ -206,6 +206,26 @@ mlx_vlm.generate --model Qwen/Qwen3.5-4B \
 mlx_vlm.server --model Qwen/Qwen3.5-4B \
   --draft-model z-lab/Qwen3.5-4B-DFlash
 ```
+
+Liquid AI's DSpark checkpoint uses a Qwen3-style block drafter plus a learned
+Markov correction head. It is auto-detected and runs through the exact target
+verification path:
+
+```sh
+mlx_vlm.generate --model LiquidAI/LFM2.5-2.6B \
+  --draft-model LiquidAI/LFM2.5-2.6B-DSpark \
+  --prompt "Explain speculative decoding in three sentences." \
+  --max-tokens 256 --temperature 0
+
+mlx_vlm.server --model LiquidAI/LFM2.5-2.6B \
+  --draft-model LiquidAI/LFM2.5-2.6B-DSpark
+```
+
+The published DSpark `block_size: 9` means nine proposals; mlx-vlm verifies
+those proposals together with the anchor token in a ten-token target pass.
+The checkpoint's confidence head is loaded for parity, and DSpark retains its
+trained nine-proposal width instead of using the generic DFlash backoff.
+DSpark decoding currently requires greedy sampling (`temperature=0`).
 
 Muse Glimmer's published assistant checkpoint is auto-detected as DFlash:
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -49,6 +49,18 @@ python -m mlx_vlm.generate \
     --max-tokens 512 --temperature 0 --enable-thinking
 ```
 
+Liquid AI's LFM2.5 DSpark drafter is also auto-detected:
+
+```bash
+python -m mlx_vlm.generate \
+    --model LiquidAI/LFM2.5-2.6B \
+    --draft-model LiquidAI/LFM2.5-2.6B-DSpark \
+    --prompt "Write a concise note about speculative decoding." \
+    --max-tokens 256 --temperature 0
+```
+
+DSpark decoding currently supports greedy sampling (`temperature=0`).
+
 EAGLE-3 speculators are also supported and auto-detected from Speculators configs:
 
 ```bash
@@ -192,6 +204,7 @@ for i in range(B):
 | Target | Drafter | Notes |
 |--------|---------|-------|
 | `Qwen/Qwen3.5-4B` | `z-lab/Qwen3.5-4B-DFlash` | Text + image. ~2.5× speedup on code/reasoning. |
+| `LiquidAI/LFM2.5-2.6B` | `LiquidAI/LFM2.5-2.6B-DSpark` | Text. Nine Markov-corrected proposals with exact LFM2 target verification. |
 | `meta-models/Muse-Glimmer-30B` | `meta-models/Muse-Glimmer-30B-assistant` | Text + image. Native 5-layer, 16-token DFlash assistant. |
 | `MiniMaxAI/MiniMax-M3` | `Inferact/MiniMax-M3-EAGLE3` | Text, image, and video target. Uses `--draft-kind eagle3`. |
 

--- a/mlx_vlm/models/lfm2/language.py
+++ b/mlx_vlm/models/lfm2/language.py
@@ -98,6 +98,7 @@ class ShortConv(nn.Module):
         x: mx.array,
         mask: Optional[mx.array] = None,
         cache: Optional[Any] = None,
+        gdn_sink: list | None = None,
     ):
         BCx = self.in_proj(x)
         B, C, x = mx.split(BCx, 3, axis=-1)
@@ -106,6 +107,14 @@ class ShortConv(nn.Module):
             Bx = mx.where(mask[..., None], Bx, 0)
 
         if cache is not None:
+            previous_state = mx.array(cache[0]) if cache[0] is not None else None
+            previous_left_padding = (
+                mx.array(cache.left_padding) if cache.left_padding is not None else None
+            )
+            previous_lengths = (
+                mx.array(cache.lengths) if cache.lengths is not None else None
+            )
+            conv_inputs = Bx
             if cache[0] is None:
                 state = mx.zeros(
                     (Bx.shape[0], self.L_cache - 1, self.args.hidden_size),
@@ -123,6 +132,16 @@ class ShortConv(nn.Module):
             else:
                 cache[0] = Bx[:, -n_keep:, :]
             cache.advance(t)
+            if gdn_sink is not None:
+                gdn_sink.append(
+                    (
+                        self.layer_idx,
+                        previous_state,
+                        previous_left_padding,
+                        previous_lengths,
+                        conv_inputs,
+                    )
+                )
         elif self.causal:
             Bx = mx.pad(Bx, [(0, 0), (self.L_cache - 1, 0), (0, 0)])
         else:
@@ -240,6 +259,7 @@ class Lfm2DecoderLayer(nn.Module):
         x: mx.array,
         mask: Optional[mx.array] = None,
         cache: Optional[Any] = None,
+        gdn_sink: list | None = None,
     ) -> mx.array:
         if self.is_attention_layer:
             r = self.self_attn(self.operator_norm(x), mask=mask, cache=cache)
@@ -248,6 +268,7 @@ class Lfm2DecoderLayer(nn.Module):
                 self.operator_norm(x),
                 mask=mask,
                 cache=cache,
+                gdn_sink=gdn_sink,
             )
         h = x + r
         out = h + self.feed_forward(self.ffn_norm(h))
@@ -280,6 +301,9 @@ class Lfm2Model(nn.Module):
         inputs: mx.array,
         cache=None,
         input_embeddings: Optional[mx.array] = None,
+        capture_layer_ids: list[int] | None = None,
+        hidden_sink: list | None = None,
+        gdn_sink: list | None = None,
     ):
         if input_embeddings is not None:
             h = input_embeddings
@@ -292,9 +316,12 @@ class Lfm2Model(nn.Module):
         attn_mask = create_attention_mask(h, cache[self.fa_idx])
         conv_mask = create_ssm_mask(h, cache[self.conv_idx])
 
-        for layer, c in zip(self.layers, cache):
+        capture_set = set(capture_layer_ids) if capture_layer_ids else set()
+        for index, (layer, c) in enumerate(zip(self.layers, cache)):
             mask = attn_mask if layer.is_attention_layer else conv_mask
-            h = layer(h, mask, cache=c)
+            h = layer(h, mask, cache=c, gdn_sink=gdn_sink)
+            if hidden_sink is not None and index in capture_set:
+                hidden_sink.append(h)
 
         return self.embedding_norm(h)
 
@@ -322,12 +349,168 @@ class LanguageModel(nn.Module):
         if inputs_embeds is None:
             inputs_embeds = input_embeddings
 
-        out = self.model(inputs, cache, inputs_embeds)
+        capture_layer_ids = kwargs.pop("capture_layer_ids", None)
+        speculative_verify = bool(kwargs.pop("speculative_verify", False))
+        hidden_sink: list[mx.array] | None = (
+            [] if capture_layer_ids is not None else None
+        )
+        gdn_sink: list | None = [] if speculative_verify else None
+
+        out = self.model(
+            inputs,
+            cache,
+            inputs_embeds,
+            capture_layer_ids=capture_layer_ids,
+            hidden_sink=hidden_sink,
+            gdn_sink=gdn_sink,
+        )
         if self.args.tie_word_embeddings:
             out = self.model.embed_tokens.as_linear(out)
         else:
             out = self.lm_head(out)
-        return LanguageModelOutput(logits=out)
+        return LanguageModelOutput(
+            logits=out,
+            hidden_states=hidden_sink,
+            gdn_states=gdn_sink,
+        )
+
+    def chunked_prefill_policy(
+        self,
+        *,
+        input_ids=None,
+        inputs_embeds=None,
+        prompt_cache=None,
+        draft_model=None,
+        draft_kind=None,
+        prefill_kwargs=None,
+    ) -> bool:
+        del input_ids, inputs_embeds, prompt_cache
+        if draft_model is None:
+            return True
+        prefill_kwargs = prefill_kwargs or {}
+        if draft_kind == "dflash":
+            return prefill_kwargs.get("capture_layer_ids") is not None
+        return False
+
+    @staticmethod
+    def _restore_conv_cache(
+        cache: ArraysCache,
+        previous_state: mx.array | None,
+        previous_left_padding: mx.array | None,
+        previous_lengths: mx.array | None,
+        conv_inputs: mx.array,
+        valid_lengths: list[int],
+        state_size: int,
+    ) -> None:
+        rows = []
+        for row, valid in enumerate(valid_lengths):
+            if previous_state is None:
+                state = mx.zeros(
+                    (1, state_size, conv_inputs.shape[-1]),
+                    dtype=conv_inputs.dtype,
+                )
+            else:
+                state = previous_state[row : row + 1]
+            committed = conv_inputs[row : row + 1, :valid]
+            rows.append(mx.concatenate([state, committed], axis=1)[:, -state_size:])
+        cache[0] = mx.concatenate(rows, axis=0)
+        cache.left_padding = (
+            None
+            if previous_left_padding is None
+            else previous_left_padding
+            - mx.array(valid_lengths, dtype=previous_left_padding.dtype)
+        )
+        cache.lengths = (
+            None
+            if previous_lengths is None
+            else previous_lengths
+            - mx.array(valid_lengths, dtype=previous_lengths.dtype)
+        )
+
+    def rollback_speculative_cache(
+        self,
+        caches: list[Any],
+        gdn_states: Any,
+        accepted: Any,
+        block_size: int,
+    ) -> int:
+        """Commit the accepted LFM2 prefix across attention and conv caches."""
+        if isinstance(accepted, int):
+            accepted = mx.array([accepted], dtype=mx.int32)
+        elif not isinstance(accepted, mx.array):
+            accepted = mx.array(accepted, dtype=mx.int32)
+        if accepted.ndim == 0:
+            accepted = accepted.reshape(1)
+
+        accepted_values = [int(value) for value in accepted.tolist()]
+        valid_lengths = [value + 1 for value in accepted_values]
+        max_accepted = max(accepted_values)
+        max_valid = max_accepted + 1
+        trim = int(block_size) - max_valid
+        is_batch = len(accepted_values) > 1
+
+        for cache in caches:
+            if cache is None or isinstance(cache, ArraysCache):
+                continue
+            if trim > 0 and hasattr(cache, "trim"):
+                cache.trim(trim)
+
+            if not is_batch:
+                continue
+            extra_trim = [max_accepted - value for value in accepted_values]
+            prepare = getattr(cache, "prepare", None)
+            finalize = getattr(cache, "finalize", None)
+            keys = getattr(cache, "keys", None)
+            values = getattr(cache, "values", None)
+            if any(extra_trim) and callable(prepare) and callable(finalize):
+                prepare(right_padding=extra_trim)
+                finalize()
+                continue
+
+            # Dense caches without row-wise padding retain a common physical
+            # width, so clear rejected tails inside the committed window.
+            if not hasattr(cache, "_idx"):
+                continue
+            if not isinstance(keys, mx.array) or not isinstance(values, mx.array):
+                raise NotImplementedError(
+                    "Ragged LFM2 DSpark rollback currently requires dense KV caches."
+                )
+            kv_length = int(cache._idx)
+            verify_start = kv_length - max_valid
+            for row, valid in enumerate(valid_lengths):
+                start = verify_start + valid
+                if start < kv_length:
+                    keys[row, :, start:kv_length, :] = 0
+                    values[row, :, start:kv_length, :] = 0
+
+        if gdn_states is None:
+            raise RuntimeError(
+                "LFM2 speculative rollback requires convolution state captured "
+                "with speculative_verify=True."
+            )
+        for (
+            layer_index,
+            previous_state,
+            previous_left_padding,
+            previous_lengths,
+            conv_inputs,
+        ) in gdn_states:
+            cache = caches[layer_index]
+            if not isinstance(cache, ArraysCache):
+                raise TypeError(
+                    "LFM2 convolution rollback expected ArraysCache at layer "
+                    f"{layer_index}, got {type(cache).__name__}."
+                )
+            self._restore_conv_cache(
+                cache,
+                previous_state,
+                previous_left_padding,
+                previous_lengths,
+                conv_inputs,
+                valid_lengths,
+                self.args.conv_L_cache - 1,
+            )
+        return max_accepted
 
     def sanitize(self, weights):
         if self.args.tie_word_embeddings:

--- a/mlx_vlm/speculative/dflash.py
+++ b/mlx_vlm/speculative/dflash.py
@@ -148,6 +148,7 @@ def _dflash_rounds(
                 verify_input,
                 cache=prompt_cache,
                 capture_layer_ids=target_layer_ids,
+                speculative_verify=True,
             )
             hidden = mx.concatenate(verify_out.hidden_states, axis=-1)
             target_tokens = sampler(verify_out.logits)
@@ -271,6 +272,7 @@ def _dflash_rounds_batch(
                 verify_input,
                 cache=prompt_cache,
                 capture_layer_ids=target_layer_ids,
+                speculative_verify=True,
             )
             hidden_full = mx.concatenate(verify_out.hidden_states, axis=-1)
             target_tokens = sampler(verify_out.logits)

--- a/mlx_vlm/speculative/drafters/__init__.py
+++ b/mlx_vlm/speculative/drafters/__init__.py
@@ -5,6 +5,7 @@ from typing import Any, Optional, Tuple
 from .laguna_dflash import LagunaDFlashDraftModel
 from .muse_glimmer_assistant import MuseGlimmerAssistantDraftModel
 from .qwen3_dflash import DFlashDraftModel
+from .qwen3_dspark import DSparkDraftModel
 
 KNOWN_DRAFTER_KINDS = {"dflash", "mtp", "eagle3"}
 
@@ -176,6 +177,7 @@ __all__ = [
     "DRAFTER_KIND_BY_MODEL_TYPE",
     "KNOWN_DRAFTER_KINDS",
     "DFlashDraftModel",
+    "DSparkDraftModel",
     "LagunaDFlashDraftModel",
     "MuseGlimmerAssistantDraftModel",
     "load_drafter",

--- a/mlx_vlm/speculative/drafters/qwen3_dflash/dflash.py
+++ b/mlx_vlm/speculative/drafters/qwen3_dflash/dflash.py
@@ -10,10 +10,14 @@ from .config import DFlashConfig
 
 
 def _build_rope(config: DFlashConfig):
+    # Qwen-family checkpoints normally use split-half (NeoX) pairing. DSpark
+    # checkpoints expose rope_is_neox_style explicitly; MLX calls the
+    # interleaved GPT-J pairing "traditional".
+    traditional = not bool(getattr(config, "rope_is_neox_style", True))
     return initialize_rope(
         dims=config.head_dim,
         base=config.rope_theta,
-        traditional=False,
+        traditional=traditional,
         scaling_config=config.rope_scaling,
         max_position_embeddings=config.max_position_embeddings,
     )

--- a/mlx_vlm/speculative/drafters/qwen3_dspark/__init__.py
+++ b/mlx_vlm/speculative/drafters/qwen3_dspark/__init__.py
@@ -1,0 +1,11 @@
+from .config import DSparkConfig as ModelConfig
+from .dspark import DSparkDraftModel
+from .dspark import DSparkDraftModel as Model
+from .dspark import VanillaMarkov
+
+__all__ = [
+    "DSparkDraftModel",
+    "Model",
+    "ModelConfig",
+    "VanillaMarkov",
+]

--- a/mlx_vlm/speculative/drafters/qwen3_dspark/config.py
+++ b/mlx_vlm/speculative/drafters/qwen3_dspark/config.py
@@ -1,0 +1,159 @@
+import inspect
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from typing import Any
+
+from ....models.base import BaseModelConfig
+
+
+def _is_strictly_increasing_ints(values: list[int]) -> bool:
+    return all(
+        isinstance(value, int) and (index == 0 or values[index - 1] < value)
+        for index, value in enumerate(values)
+    )
+
+
+@dataclass
+class DSparkConfig(BaseModelConfig):
+    """Configuration for the Qwen3-backbone DSpark LFM2 drafter.
+
+    The published ``block_size`` is DSpark's proposal count (``gamma``).
+    mlx-vlm's DFlash loop uses the total verification width, which also
+    includes the anchor token, so ``block_size`` is normalized to
+    ``proposal_length + 1`` while loading the checkpoint.
+    """
+
+    model_type: str = "qwen3"
+    architectures: list[str] = field(default_factory=list)
+    hidden_size: int = 2048
+    intermediate_size: int = 6144
+    num_hidden_layers: int = 5
+    num_attention_heads: int = 32
+    num_key_value_heads: int = 8
+    head_dim: int = 64
+    hidden_act: str = "silu"
+    rms_norm_eps: float = 1e-5
+    vocab_size: int = 128000
+    max_position_embeddings: int = 128000
+    rope_theta: float = 10000000.0
+    rope_scaling: dict[str, Any] | None = None
+    rope_is_neox_style: bool = False
+    attention_bias: bool = False
+    tie_word_embeddings: bool = True
+    final_logit_softcapping: float | None = None
+    layer_types: list[str] = field(default_factory=list)
+    sliding_window: int | None = None
+
+    # mlx-vlm verification width (anchor + proposals).
+    block_size: int = 10
+    # DSpark checkpoint proposal count (called gamma upstream).
+    proposal_length: int = 9
+    mask_token_id: int = 125017
+    target_layer_ids: list[int] = field(default_factory=list)
+    num_target_layers: int = 30
+    runtime_block_size: int | None = None
+    draft_window_size: int | None = None
+
+    markov_rank: int = 256
+    markov_head_type: str = "vanilla"
+    enable_confidence_head: bool = True
+    confidence_head_with_markov: bool = True
+
+    def __post_init__(self) -> None:
+        if not self.layer_types:
+            self.layer_types = ["full_attention"] * self.num_hidden_layers
+        if not self.target_layer_ids:
+            self.target_layer_ids = [2, 9, 17, 21, 27]
+        self.validate()
+
+    def validate(self) -> None:
+        if self.model_type != "qwen3":
+            raise ValueError(
+                f"LFM2 DSpark requires model_type='qwen3', got {self.model_type!r}."
+            )
+        positive_fields = (
+            "hidden_size",
+            "intermediate_size",
+            "num_hidden_layers",
+            "num_attention_heads",
+            "num_key_value_heads",
+            "head_dim",
+            "vocab_size",
+            "max_position_embeddings",
+            "block_size",
+            "proposal_length",
+            "num_target_layers",
+            "markov_rank",
+        )
+        for key in positive_fields:
+            value = getattr(self, key)
+            if not isinstance(value, int) or value <= 0:
+                raise ValueError(f"LFM2 DSpark requires a positive integer {key}.")
+        if self.block_size != self.proposal_length + 1:
+            raise ValueError(
+                "LFM2 DSpark verification block_size must equal " "proposal_length + 1."
+            )
+        if self.hidden_size != self.num_attention_heads * self.head_dim:
+            raise ValueError(
+                "LFM2 DSpark hidden_size must equal attention heads * head_dim."
+            )
+        if self.num_attention_heads % self.num_key_value_heads:
+            raise ValueError(
+                "LFM2 DSpark attention heads must be divisible by KV heads."
+            )
+        if self.hidden_act != "silu":
+            raise ValueError("LFM2 DSpark currently supports only hidden_act='silu'.")
+        if self.markov_head_type != "vanilla":
+            raise ValueError(
+                "LFM2 DSpark currently supports only markov_head_type='vanilla'."
+            )
+        if not 0 <= self.mask_token_id < self.vocab_size:
+            raise ValueError(
+                "LFM2 DSpark mask_token_id must be inside the target vocabulary."
+            )
+        if len(self.layer_types) != self.num_hidden_layers or any(
+            layer_type != "full_attention" for layer_type in self.layer_types
+        ):
+            raise ValueError(
+                "LFM2 DSpark requires one full_attention type per draft layer."
+            )
+        if (
+            not self.target_layer_ids
+            or not _is_strictly_increasing_ints(self.target_layer_ids)
+            or any(
+                layer_id < 0 or layer_id >= self.num_target_layers
+                for layer_id in self.target_layer_ids
+            )
+        ):
+            raise ValueError(
+                "LFM2 DSpark target_layer_ids must be unique, increasing indices "
+                "inside the target layer range."
+            )
+
+    @classmethod
+    def from_dict(cls, params: dict) -> "DSparkConfig":
+        flat = dict(params)
+        dflash = flat.pop("dflash_config", None)
+        if not isinstance(dflash, Mapping):
+            raise TypeError("LFM2 DSpark requires a dflash_config object.")
+
+        for key in (
+            "mask_token_id",
+            "target_layer_ids",
+            "num_target_layers",
+            "runtime_block_size",
+            "draft_window_size",
+        ):
+            if key in dflash:
+                flat[key] = dflash[key]
+
+        raw_block_size = dflash.get("block_size", flat.get("block_size"))
+        if raw_block_size is None:
+            raise ValueError("LFM2 DSpark requires a checkpoint block_size.")
+        flat["proposal_length"] = int(raw_block_size)
+        flat["block_size"] = int(raw_block_size) + 1
+
+        signature = inspect.signature(cls).parameters
+        return cls(**{key: value for key, value in flat.items() if key in signature})
+
+    from_hf_dict = from_dict

--- a/mlx_vlm/speculative/drafters/qwen3_dspark/dspark.py
+++ b/mlx_vlm/speculative/drafters/qwen3_dspark/dspark.py
@@ -1,0 +1,196 @@
+from collections.abc import Callable, Mapping
+
+import mlx.core as mx
+import mlx.nn as nn
+
+from ..qwen3_dflash.dflash import DFlashDraftModel
+from .config import DSparkConfig
+
+
+class VanillaMarkov(nn.Module):
+    """Low-rank token-transition correction used by DSpark proposals."""
+
+    def __init__(self, vocab_size: int, rank: int):
+        super().__init__()
+        self.markov_w1 = nn.Embedding(vocab_size, rank)
+        self.markov_w2 = nn.Linear(rank, vocab_size, bias=False)
+
+    def get_prev_embeddings(self, token_ids: mx.array) -> mx.array:
+        return self.markov_w1(token_ids)
+
+    def apply_step_logits(
+        self,
+        logits: mx.array,
+        token_ids: mx.array,
+    ) -> mx.array:
+        return logits + self.markov_w2(self.get_prev_embeddings(token_ids))
+
+    def sample_block(
+        self,
+        base_logits: mx.array,
+        *,
+        first_prev_tokens: mx.array,
+        sampler: Callable[[mx.array], mx.array],
+    ) -> mx.array:
+        proposal_length = int(base_logits.shape[1])
+        if proposal_length == 0:
+            return mx.zeros((base_logits.shape[0], 0), dtype=mx.int32)
+
+        prev_tokens = first_prev_tokens.reshape(-1)
+        sampled = []
+        for step in range(proposal_length):
+            step_logits = self.apply_step_logits(base_logits[:, step], prev_tokens)
+            prev_tokens = sampler(step_logits).reshape(-1)
+            sampled.append(prev_tokens[:, None])
+        return mx.concatenate(sampled, axis=1)
+
+
+class DSparkConfidenceHead(nn.Module):
+    def __init__(self, hidden_size: int, markov_rank: int):
+        super().__init__()
+        self.proj = nn.Linear(hidden_size + markov_rank, 1, bias=True)
+
+    def __call__(
+        self,
+        hidden_states: mx.array,
+        markov_embeddings: mx.array,
+    ) -> mx.array:
+        features = mx.concatenate([hidden_states, markov_embeddings], axis=-1)
+        return mx.sigmoid(self.proj(features).squeeze(-1).astype(mx.float32))
+
+
+def validate_lfm2_dspark_target(config: DSparkConfig, target_model) -> None:
+    language_model = getattr(target_model, "language_model", target_model)
+    target_config = getattr(language_model, "config", None)
+    inner = getattr(language_model, "model", language_model)
+    layers = getattr(inner, "layers", None)
+
+    model_type = getattr(target_config, "model_type", None)
+    if model_type != "lfm2":
+        raise ValueError(
+            "LFM2 DSpark requires an LFM2 target, got " f"model_type={model_type!r}."
+        )
+    hidden_size = getattr(target_config, "hidden_size", None)
+    if hidden_size != config.hidden_size:
+        raise ValueError(
+            "LFM2 DSpark target hidden-size mismatch: "
+            f"draft={config.hidden_size}, target={hidden_size}."
+        )
+    layer_count = (
+        len(layers)
+        if layers is not None
+        else getattr(target_config, "num_hidden_layers", None)
+    )
+    if layer_count != config.num_target_layers:
+        raise ValueError(
+            "LFM2 DSpark target layer-count mismatch: "
+            f"draft={config.num_target_layers}, target={layer_count}."
+        )
+    vocab_size = getattr(target_config, "vocab_size", None)
+    if vocab_size != config.vocab_size:
+        raise ValueError(
+            "LFM2 DSpark target vocabulary mismatch: "
+            f"draft={config.vocab_size}, target={vocab_size}."
+        )
+    if not hasattr(language_model, "rollback_speculative_cache"):
+        raise ValueError(
+            "The LFM2 target does not expose speculative cache rollback support."
+        )
+
+
+class DSparkDraftModel(DFlashDraftModel):
+    """MLX port of Liquid AI's LFM2.5 DSpark draft model."""
+
+    requires_greedy_sampling = True
+    # DSpark is trained for a fixed semi-autoregressive proposal block. The
+    # generic DFlash acceptance controller is counterproductive here because
+    # it quickly collapses the nine-token block to only 2-4 proposals.
+    prefer_requested_block_size = True
+
+    def __init__(self, config: DSparkConfig):
+        super().__init__(config)
+        self.markov_head = VanillaMarkov(config.vocab_size, config.markov_rank)
+        self.confidence_head: DSparkConfidenceHead | None = (
+            DSparkConfidenceHead(config.hidden_size, config.markov_rank)
+            if config.enable_confidence_head
+            else None
+        )
+
+    def validate_target_compatibility(self, target_model) -> None:
+        validate_lfm2_dspark_target(self.config, target_model)
+
+    def bind(self, target_model) -> "DSparkDraftModel":
+        self.validate_target_compatibility(target_model)
+        super().bind(target_model)
+        return self
+
+    def confidence(
+        self,
+        draft_hidden: mx.array,
+        anchor_tokens: mx.array,
+        draft_tokens: mx.array,
+    ) -> mx.array | None:
+        if self.confidence_head is None:
+            return None
+        previous = mx.concatenate(
+            [anchor_tokens.reshape(-1, 1), draft_tokens[:, :-1]], axis=1
+        )
+        markov_embeddings = self.markov_head.get_prev_embeddings(previous)
+        return self.confidence_head(draft_hidden, markov_embeddings)
+
+    def draft_block(
+        self,
+        last_bonus,
+        hidden: mx.array,
+        cache,
+        block_size: int,
+        sampler: Callable[[mx.array], mx.array],
+        token_dtype: mx.Dtype = mx.int32,
+    ) -> mx.array:
+        # mlx-vlm's block_size includes the anchor; DSpark produces one token
+        # per draft hidden position, so its denoising input has gamma positions.
+        proposal_length = int(block_size) - 1
+        if proposal_length <= 0:
+            batch = 1 if isinstance(last_bonus, int) else int(last_bonus.shape[0])
+            return mx.zeros((batch, 0), dtype=token_dtype)
+
+        if isinstance(last_bonus, int):
+            anchor = mx.array([last_bonus], dtype=token_dtype)
+        else:
+            anchor = last_bonus.reshape(-1).astype(token_dtype)
+        masks = mx.full(
+            (anchor.shape[0], proposal_length - 1),
+            int(self.config.mask_token_id),
+            dtype=token_dtype,
+        )
+        draft_inputs = mx.concatenate([anchor[:, None], masks], axis=1)
+        draft_hidden = self._hidden(draft_inputs, hidden, cache)
+        base_logits = self._logits(draft_hidden)
+        return self.markov_head.sample_block(
+            base_logits,
+            first_prev_tokens=anchor,
+            sampler=sampler,
+        ).astype(token_dtype)
+
+    def sanitize(self, weights: Mapping[str, mx.array]) -> dict[str, mx.array]:
+        normalized = {}
+        for key, value in weights.items():
+            key = key.removeprefix("model.")
+            if key in normalized:
+                raise ValueError(
+                    f"Duplicate LFM2 DSpark weight key after sanitization: {key}"
+                )
+            normalized[key] = value
+        return normalized
+
+
+Model = DSparkDraftModel
+
+
+__all__ = [
+    "DSparkConfidenceHead",
+    "DSparkDraftModel",
+    "Model",
+    "VanillaMarkov",
+    "validate_lfm2_dspark_target",
+]

--- a/mlx_vlm/speculative/utils.py
+++ b/mlx_vlm/speculative/utils.py
@@ -72,6 +72,14 @@ def format_speculative_stats(draft_model: nn.Module) -> Optional[str]:
     return _format_speculative_stats(draft_model)
 
 
+def _validate_speculative_sampling(draft_model: nn.Module, greedy: bool) -> None:
+    if getattr(draft_model, "requires_greedy_sampling", False) and not greedy:
+        raise ValueError(
+            f"{type(draft_model).__name__} supports greedy speculative decoding "
+            "only; set temperature=0."
+        )
+
+
 def get_speculative_rounds_batch(draft_kind: str):
     if draft_kind == "eagle3":
         return _eagle3_rounds_batch
@@ -139,6 +147,7 @@ def run_speculative_server_rounds(
     row_ids: Optional[List[int]] = None,
 ) -> Generator[Tuple[List[Optional[int]], None], None, None]:
     batch_size = int(first_bonus.shape[0]) if first_bonus.ndim > 0 else 1
+    _validate_speculative_sampling(draft_model, greedy_sampling)
 
     if draft_kind == "eagle3":
         if batch_size == 1:
@@ -249,6 +258,7 @@ def run_speculative_rounds(
     sampler_is_greedy: bool = False,
 ) -> Generator[Tuple[Any, mx.array], None, None]:
     B = input_ids.shape[0]
+    _validate_speculative_sampling(draft_model, sampler_is_greedy)
 
     if draft_kind == "mtp":
         shared_kv_states = last_outputs.shared_kv_states

--- a/mlx_vlm/tests/test_models_dspark.py
+++ b/mlx_vlm/tests/test_models_dspark.py
@@ -1,0 +1,313 @@
+import json
+from types import SimpleNamespace
+
+import mlx.core as mx
+import pytest
+
+from mlx_vlm.generate.ar import generate_step
+from mlx_vlm.models.cache import ArraysCache, BatchKVCache
+from mlx_vlm.models.lfm2 import Model as Lfm2Model
+from mlx_vlm.models.lfm2 import ModelConfig as Lfm2Config
+from mlx_vlm.speculative.drafters import (
+    resolve_drafter_kind,
+    validate_drafter_compatibility,
+)
+from mlx_vlm.speculative.drafters.qwen3_dspark import DSparkDraftModel, ModelConfig
+from mlx_vlm.speculative.utils import run_speculative_rounds
+from mlx_vlm.utils import get_model_and_args
+
+
+def _published_config():
+    return {
+        "architectures": ["Lfm2DSparkDraftModel"],
+        "model_type": "qwen3",
+        "hidden_size": 2048,
+        "num_hidden_layers": 5,
+        "num_attention_heads": 32,
+        "num_key_value_heads": 8,
+        "head_dim": 64,
+        "intermediate_size": 6144,
+        "hidden_act": "silu",
+        "rms_norm_eps": 1e-5,
+        "vocab_size": 128000,
+        "rope_theta": 10000000.0,
+        "max_position_embeddings": 128000,
+        "layer_types": ["full_attention"] * 5,
+        "block_size": 9,
+        "dflash_config": {
+            "mask_token_id": 125017,
+            "target_layer_ids": [2, 9, 17, 21, 27],
+            "num_target_layers": 30,
+        },
+        "markov_rank": 256,
+        "rope_is_neox_style": False,
+        "enable_confidence_head": True,
+        "markov_head_type": "vanilla",
+    }
+
+
+def _tiny_draft_config():
+    return ModelConfig.from_dict(
+        {
+            "architectures": ["Lfm2DSparkDraftModel"],
+            "model_type": "qwen3",
+            "hidden_size": 8,
+            "num_hidden_layers": 1,
+            "num_attention_heads": 2,
+            "num_key_value_heads": 1,
+            "head_dim": 4,
+            "intermediate_size": 16,
+            "rms_norm_eps": 1e-5,
+            "vocab_size": 32,
+            "rope_theta": 10000.0,
+            "max_position_embeddings": 128,
+            "layer_types": ["full_attention"],
+            "block_size": 3,
+            "dflash_config": {
+                "mask_token_id": 31,
+                "target_layer_ids": [0, 2],
+                "num_target_layers": 3,
+            },
+            "markov_rank": 4,
+            "markov_head_type": "vanilla",
+            "enable_confidence_head": True,
+        }
+    )
+
+
+def _tiny_target():
+    config = Lfm2Config(
+        model_type="lfm2",
+        vocab_size=32,
+        hidden_size=8,
+        num_hidden_layers=3,
+        num_attention_heads=2,
+        num_key_value_heads=1,
+        max_position_embeddings=128,
+        norm_eps=1e-5,
+        conv_bias=False,
+        conv_L_cache=3,
+        block_dim=8,
+        block_ff_dim=16,
+        block_multiple_of=1,
+        block_ffn_dim_multiplier=1.0,
+        block_auto_adjust_ff_dim=False,
+        rope_theta=10000.0,
+        layer_types=["conv", "full_attention", "conv"],
+        full_attn_idxs=[1],
+        tie_word_embeddings=True,
+    )
+    return Lfm2Model(config)
+
+
+def _generated_tokens(target, prompt, drafter=None):
+    kwargs = {}
+    if drafter is not None:
+        kwargs.update(draft_model=drafter, draft_kind="dflash")
+    return [
+        int(token.item()) if hasattr(token, "item") else int(token)
+        for token, _ in generate_step(
+            prompt,
+            target,
+            None,
+            None,
+            max_tokens=10,
+            temperature=0,
+            prefill_step_size=None,
+            **kwargs,
+        )
+    ]
+
+
+def test_published_config_normalizes_dspark_gamma_to_verify_width():
+    config = ModelConfig.from_dict(_published_config())
+
+    assert config.proposal_length == 9
+    assert config.block_size == 10
+    assert config.target_layer_ids == [2, 9, 17, 21, 27]
+    assert config.num_target_layers == 30
+    assert config.markov_rank == 256
+    assert DSparkDraftModel.prefer_requested_block_size is True
+
+
+def test_generic_loader_routes_markov_dflash_checkpoint_to_dspark(tmp_path):
+    architecture, model_type = get_model_and_args(_published_config())
+
+    assert model_type == "qwen3_dspark"
+    assert architecture.Model is DSparkDraftModel
+
+    (tmp_path / "config.json").write_text(json.dumps(_published_config()))
+    assert resolve_drafter_kind(tmp_path) == "dflash"
+
+
+def test_dspark_requires_the_matching_lfm2_target():
+    drafter = DSparkDraftModel(_tiny_draft_config())
+    target = _tiny_target()
+
+    validate_drafter_compatibility(target, drafter, "dflash")
+    target.language_model.config.model_type = "other"
+    with pytest.raises(ValueError, match="requires an LFM2 target"):
+        validate_drafter_compatibility(target, drafter, "dflash")
+
+
+def test_tiny_dspark_forward_uses_markov_head_and_published_block_semantics():
+    mx.random.seed(0)
+    target = _tiny_target()
+    drafter = DSparkDraftModel(_tiny_draft_config())
+    mx.eval(target.parameters(), drafter.parameters())
+
+    assert drafter.rope.traditional is True
+    target_cache = target.make_cache()
+    prompt = mx.array([[1, 2, 3]], dtype=mx.int32)
+    output = target.language_model(
+        prompt,
+        cache=target_cache,
+        capture_layer_ids=drafter.config.target_layer_ids,
+    )
+    hidden = mx.concatenate(output.hidden_states, axis=-1)
+    draft_cache = drafter.reset(target)
+    tokens = drafter.draft_block(
+        4,
+        hidden,
+        draft_cache,
+        block_size=drafter.config.block_size,
+        sampler=lambda logits: mx.argmax(logits, axis=-1),
+    )
+    mx.eval(tokens)
+
+    assert hidden.shape == (1, 3, 16)
+    assert tokens.shape == (1, drafter.config.proposal_length)
+    assert all(cache.offset == 3 for cache in draft_cache)
+
+
+def test_lfm2_hybrid_cache_rollback_matches_committed_prefix():
+    mx.random.seed(3)
+    target = _tiny_target()
+    lm = target.language_model
+    mx.eval(target.parameters())
+
+    prompt = mx.array([[1, 2, 3, 4, 5]], dtype=mx.int32)
+    verify = mx.array([[6, 7, 8, 9]], dtype=mx.int32)
+    accepted = 1
+
+    rolled_cache = lm.make_cache()
+    lm(prompt, cache=rolled_cache)
+    verify_out = lm(
+        verify,
+        cache=rolled_cache,
+        capture_layer_ids=[0, 2],
+        speculative_verify=True,
+    )
+    lm.rollback_speculative_cache(
+        rolled_cache,
+        verify_out.gdn_states,
+        accepted,
+        block_size=verify.shape[1],
+    )
+
+    reference_cache = lm.make_cache()
+    committed = mx.concatenate([prompt, verify[:, : accepted + 1]], axis=1)
+    lm(committed, cache=reference_cache)
+
+    probe = mx.array([[10]], dtype=mx.int32)
+    rolled_logits = lm(probe, cache=rolled_cache).logits
+    reference_logits = lm(probe, cache=reference_cache).logits
+    mx.eval(rolled_logits, reference_logits)
+
+    assert rolled_cache[1].offset == reference_cache[1].offset
+    assert bool(mx.allclose(rolled_cache[0][0], reference_cache[0][0], atol=1e-5))
+    assert bool(mx.allclose(rolled_cache[2][0], reference_cache[2][0], atol=1e-5))
+    assert bool(mx.allclose(rolled_logits, reference_logits, atol=1e-4))
+
+
+def test_lfm2_ragged_batch_rollback_matches_each_committed_prefix():
+    mx.random.seed(5)
+    target = _tiny_target()
+    lm = target.language_model
+    mx.eval(target.parameters())
+
+    prompt = mx.array([[1, 2, 3, 4], [5, 6, 7, 8]], dtype=mx.int32)
+    verify = mx.array([[9, 10, 11, 12], [13, 14, 15, 16]], dtype=mx.int32)
+    accepted = mx.array([0, 2], dtype=mx.int32)
+    rolled_cache = [
+        BatchKVCache([0, 0]) if layer.is_attention_layer else ArraysCache(size=1)
+        for layer in lm.model.layers
+    ]
+
+    lm(prompt, cache=rolled_cache)
+    verify_out = lm(verify, cache=rolled_cache, speculative_verify=True)
+    lm.rollback_speculative_cache(
+        rolled_cache,
+        verify_out.gdn_states,
+        accepted,
+        block_size=verify.shape[1],
+    )
+    assert rolled_cache[1].offset.tolist() == [5, 7]
+    probes = mx.array([[17], [18]], dtype=mx.int32)
+    rolled_logits = lm(probes, cache=rolled_cache).logits
+
+    reference_logits = []
+    for row, accepted_count in enumerate(accepted.tolist()):
+        reference_cache = lm.make_cache()
+        committed = mx.concatenate(
+            [prompt[row], verify[row, : int(accepted_count) + 1]], axis=0
+        )[None, :]
+        lm(committed, cache=reference_cache)
+        reference_logits.append(lm(probes[row : row + 1], cache=reference_cache).logits)
+    reference_logits = mx.concatenate(reference_logits, axis=0)
+    mx.eval(rolled_logits, reference_logits)
+
+    assert bool(mx.allclose(rolled_logits, reference_logits, atol=1e-4))
+
+
+def test_greedy_dspark_generation_matches_lfm2_baseline():
+    mx.random.seed(7)
+    target = _tiny_target()
+    drafter = DSparkDraftModel(_tiny_draft_config())
+    mx.eval(target.parameters(), drafter.parameters())
+    prompt = mx.array([[1, 2, 3, 4]], dtype=mx.int32)
+
+    baseline = _generated_tokens(target, prompt)
+    speculative = _generated_tokens(target, prompt, drafter)
+
+    assert speculative == baseline
+    assert drafter.draft_lens
+
+
+def test_dspark_rejects_non_greedy_speculative_sampling():
+    drafter = DSparkDraftModel(_tiny_draft_config())
+    rounds = run_speculative_rounds(
+        None,
+        drafter,
+        [],
+        mx.array([[1]], dtype=mx.int32),
+        mx.array([2], dtype=mx.int32),
+        mx.array([0.0]),
+        None,
+        draft_kind="dflash",
+        max_tokens=1,
+        sampler=lambda logits: mx.argmax(logits, axis=-1),
+        sampler_is_greedy=False,
+    )
+
+    with pytest.raises(ValueError, match="temperature=0"):
+        next(rounds)
+
+
+def test_target_compatibility_rejects_wrong_size():
+    drafter = DSparkDraftModel(_tiny_draft_config())
+    target = SimpleNamespace(
+        language_model=SimpleNamespace(
+            config=SimpleNamespace(
+                model_type="lfm2",
+                hidden_size=16,
+                num_hidden_layers=3,
+                vocab_size=32,
+            ),
+            model=SimpleNamespace(layers=[object()] * 3),
+            rollback_speculative_cache=lambda *args: None,
+        )
+    )
+
+    with pytest.raises(ValueError, match="hidden-size mismatch"):
+        validate_drafter_compatibility(target, drafter, "dflash")

--- a/mlx_vlm/utils.py
+++ b/mlx_vlm/utils.py
@@ -613,7 +613,11 @@ def get_model_and_args(config: dict, model_path: Optional[Path] = None):
 
     is_dflash = config.get("dflash_config", None) is not None
     if is_dflash:
-        model_type += "_dflash"
+        # DSpark checkpoints deliberately reuse a Qwen3 draft backbone and
+        # model_type, but their Markov head changes proposal semantics. Route
+        # them before the generic DFlash suffix is applied.
+        suffix = "_dspark" if int(config.get("markov_rank", 0) or 0) > 0 else "_dflash"
+        model_type += suffix
 
     last_err: Optional[ImportError] = None
     for pkg in ("mlx_vlm.models", "mlx_vlm.speculative.drafters"):


### PR DESCRIPTION
## Summary

- add auto-detection and strict loading for `LiquidAI/LFM2.5-2.6B-DSpark`
- implement the Qwen3 DSpark backbone, low-rank Markov proposal head, confidence head, and fixed nine-token proposal width
- add LFM2 hidden-state capture plus exact hybrid convolution/KV cache rollback for single and ragged batches
- honor the checkpoint’s interleaved RoPE configuration and reject unsupported non-greedy sampling
- document CLI/server usage and add dedicated `test_models_dspark.py` coverage

## Validation

- `1023 passed, 3 warnings, 44 subtests passed`
- strict-load validation with the published 327.7M-parameter drafter and matching LFM2.5-2.6B target
- M5 Max benchmark reaches 2.13x-2.66x on high-acceptance reasoning workloads

## Notes

DSpark currently supports greedy speculative decoding (`temperature=0`).