### PR TITLE
Fix instances of mx.arrays being implicitly used as integers

### DIFF
--- a/mlx_vlm/models/aya_vision/vision.py
+++ b/mlx_vlm/models/aya_vision/vision.py
@@ -165,7 +165,7 @@ class VisionEmbeddings(nn.Module):
 
         for i in range(batch_size):
             # (1, dim, height, width) -> (1, dim, target_height, target_width)
-            height, width = spatial_shapes[i]
+            height, width = spatial_shapes[i].tolist()
             # Then upsample width dimension
             resized_embeddings = resize_bilinear(
                 positional_embeddings,

--- a/mlx_vlm/models/dots_ocr/vision.py
+++ b/mlx_vlm/models/dots_ocr/vision.py
@@ -283,7 +283,7 @@ class VisionModel(nn.Module):
         cu_seqlens = []
         for i in range(grid_thw.shape[0]):
             seq_len = grid_thw[i, 1] * grid_thw[i, 2]
-            cu_seqlens.append(mx.repeat(seq_len, grid_thw[i, 0]))
+            cu_seqlens.append(mx.repeat(seq_len, int(grid_thw[i, 0])))
         cu_seqlens = mx.concatenate(cu_seqlens).astype(mx.int32)
         cu_seqlens = mx.cumsum(cu_seqlens, axis=0)
         cu_seqlens = mx.pad(cu_seqlens, (1, 0), constant_values=0)

--- a/mlx_vlm/models/glm4v/vision.py
+++ b/mlx_vlm/models/glm4v/vision.py
@@ -107,10 +107,16 @@ class Glm4vVisionEmbeddings(nn.Module):
 
             # Calculate target dimensions for each patch
             target_h = mx.concatenate(
-                [mx.repeat(image_shapes[i, 1], lengths[i]) for i in range(len(lengths))]
+                [
+                    mx.repeat(image_shapes[i, 1], int(lengths[i]))
+                    for i in range(len(lengths))
+                ]
             ).astype(mx.float32)
             target_w = mx.concatenate(
-                [mx.repeat(image_shapes[i, 2], lengths[i]) for i in range(len(lengths))]
+                [
+                    mx.repeat(image_shapes[i, 2], int(lengths[i]))
+                    for i in range(len(lengths))
+                ]
             ).astype(mx.float32)
 
             # Normalize coordinates to [-1, 1] range for grid_sample

--- a/mlx_vlm/models/glm4v_moe/vision.py
+++ b/mlx_vlm/models/glm4v_moe/vision.py
@@ -107,10 +107,16 @@ class Glm4vVisionEmbeddings(nn.Module):
 
             # Calculate target dimensions for each patch
             target_h = mx.concatenate(
-                [mx.repeat(image_shapes[i, 1], lengths[i]) for i in range(len(lengths))]
+                [
+                    mx.repeat(image_shapes[i, 1], int(lengths[i]))
+                    for i in range(len(lengths))
+                ]
             ).astype(mx.float32)
             target_w = mx.concatenate(
-                [mx.repeat(image_shapes[i, 2], lengths[i]) for i in range(len(lengths))]
+                [
+                    mx.repeat(image_shapes[i, 2], int(lengths[i]))
+                    for i in range(len(lengths))
+                ]
             ).astype(mx.float32)
 
             # Normalize coordinates to [-1, 1] range for grid_sample

--- a/mlx_vlm/models/lfm2_vl/lfm2_vl.py
+++ b/mlx_vlm/models/lfm2_vl/lfm2_vl.py
@@ -144,7 +144,9 @@ class Model(nn.Module):
 
                 feature = feature[: img_feature_lengths[img_idx], :][None, ...]
 
-                feature_org_h, feature_org_w = spatial_shapes[img_idx]
+                feature_org_h, feature_org_w = (
+                    int(dim) for dim in spatial_shapes[img_idx]
+                )
                 feature = feature.reshape(1, feature_org_h, feature_org_w, -1)
                 feature = self.pixel_unshuffle(feature)
 

--- a/mlx_vlm/models/minimax_h3/references.py
+++ b/mlx_vlm/models/minimax_h3/references.py
@@ -195,7 +195,7 @@ def _video_positions(
     frame_time = _temporal_position_grid(num_latent_frames, rotary_time)
     return mx.concatenate(
         [
-            mx.repeat(frame_time, frame_grid.shape[0]).reshape(-1, 1),
+            mx.repeat(frame_time, int(frame_grid.shape[0])).reshape(-1, 1),
             mx.tile(frame_grid, (num_latent_frames, 1)),
         ],
         axis=-1,

--- a/mlx_vlm/models/paddleocr_vl/vision.py
+++ b/mlx_vlm/models/paddleocr_vl/vision.py
@@ -392,7 +392,7 @@ class VisionModel(nn.Module):
         cu_seqlens = []
         for i in range(grid_thw.shape[0]):
             seq_len = grid_thw[i, 1] * grid_thw[i, 2]
-            cu_seqlens.append(mx.repeat(seq_len, grid_thw[i, 0]))
+            cu_seqlens.append(mx.repeat(seq_len, int(grid_thw[i, 0])))
 
         cu_seqlens = mx.concatenate(cu_seqlens)
         cu_seqlens = mx.cumsum(cu_seqlens.astype(mx.int32), axis=0)

--- a/mlx_vlm/models/qwen2_5_vl/vision.py
+++ b/mlx_vlm/models/qwen2_5_vl/vision.py
@@ -364,7 +364,7 @@ class VisionModel(nn.Module):
         cu_seqlens = []
         for i in range(batch_size):
             seq_len = grid_thw[i, 1] * grid_thw[i, 2]
-            cu_seqlens.append(mx.repeat(seq_len, grid_thw[i, 0]))
+            cu_seqlens.append(mx.repeat(seq_len, int(grid_thw[i, 0])))
 
         # Concatenate the cu_seqlens for all items in the batch
         cu_seqlens = mx.concatenate(cu_seqlens)

--- a/mlx_vlm/models/qwen2_vl/vision.py
+++ b/mlx_vlm/models/qwen2_vl/vision.py
@@ -220,7 +220,7 @@ class VisionModel(nn.Module):
         pos_ids = []
 
         for t, h, w in grid_thw:
-            h, w = int(h), int(w)  # Ensure h and w are integers
+            t, h, w = int(t), int(h), int(w)
             hpos_ids = mx.expand_dims(mx.arange(h), 1)
             hpos_ids = mx.repeat(hpos_ids, w, axis=1)
             hpos_ids = hpos_ids.reshape(
@@ -270,7 +270,7 @@ class VisionModel(nn.Module):
         cu_seqlens = []
         for i in range(batch_size):
             seq_len = grid_thw[i, 1] * grid_thw[i, 2]
-            cu_seqlens.append(mx.repeat(seq_len, grid_thw[i, 0]))
+            cu_seqlens.append(mx.repeat(seq_len, int(grid_thw[i, 0])))
 
         # Concatenate the cu_seqlens for all items in the batch
         cu_seqlens = mx.concatenate(cu_seqlens)

--- a/mlx_vlm/models/qwen3_omni_moe/vision.py
+++ b/mlx_vlm/models/qwen3_omni_moe/vision.py
@@ -379,7 +379,7 @@ class VisionModel(nn.Module):
         cu_seqlens = []
         for i in range(batch_size):
             seq_len = grid_thw[i, 1] * grid_thw[i, 2]
-            cu_seqlens.append(mx.repeat(seq_len, grid_thw[i, 0]))
+            cu_seqlens.append(mx.repeat(seq_len, int(grid_thw[i, 0])))
 
         cu_seqlens = mx.concatenate(cu_seqlens)
 

--- a/mlx_vlm/models/qwen3_vl/vision.py
+++ b/mlx_vlm/models/qwen3_vl/vision.py
@@ -399,7 +399,7 @@ class VisionModel(nn.Module):
         cu_seqlens = []
         for i in range(batch_size):
             seq_len = grid_thw[i, 1] * grid_thw[i, 2]
-            cu_seqlens.append(mx.repeat(seq_len, grid_thw[i, 0]))
+            cu_seqlens.append(mx.repeat(seq_len, int(grid_thw[i, 0])))
 
         # Concatenate the cu_seqlens for all items in the batch
         cu_seqlens = mx.concatenate(cu_seqlens)

--- a/mlx_vlm/models/qwen3_vl_moe/vision.py
+++ b/mlx_vlm/models/qwen3_vl_moe/vision.py
@@ -394,7 +394,7 @@ class VisionModel(nn.Module):
         cu_seqlens = []
         for i in range(batch_size):
             seq_len = grid_thw[i, 1] * grid_thw[i, 2]
-            cu_seqlens.append(mx.repeat(seq_len, grid_thw[i, 0]))
+            cu_seqlens.append(mx.repeat(seq_len, int(grid_thw[i, 0])))
 
         # Concatenate the cu_seqlens for all items in the batch
         cu_seqlens = mx.concatenate(cu_seqlens)


### PR DESCRIPTION
This will break some models in the next MLX release due to an upstream change to nanobind. Resolves https://github.com/Blaizzy/mlx-vlm/issues/1981