### PR TITLE
Fix ArraysCache per-token Metal buffer leak on long hybrid-model generation (#1972)

### DIFF
--- a/mlx_vlm/models/cache.py
+++ b/mlx_vlm/models/cache.py
@@ -626,8 +626,10 @@ class RotatingKVCache(_BaseCache):
 class ArraysCache(_BaseCache):
     def __new__(cls, *args, **kwargs):
         instance = super().__new__(cls)
-        instance.left_padding = None
-        instance.lengths = None
+        instance._left_padding = None
+        instance._left_padding_advance = 0
+        instance._lengths = None
+        instance._lengths_advance = 0
         return instance
 
     def __init__(self, size, left_padding: Optional[List[int]] = None):
@@ -636,14 +638,40 @@ class ArraysCache(_BaseCache):
             self.left_padding = mx.array(left_padding)
 
     @property
+    def left_padding(self):
+        if self._left_padding is None:
+            return None
+        if self._left_padding_advance == 0:
+            return self._left_padding
+        return self._left_padding - self._left_padding_advance
+
+    @left_padding.setter
+    def left_padding(self, value):
+        self._left_padding = value
+        self._left_padding_advance = 0
+
+    @property
+    def lengths(self):
+        if self._lengths is None:
+            return None
+        if self._lengths_advance == 0:
+            return self._lengths
+        return self._lengths - self._lengths_advance
+
+    @lengths.setter
+    def lengths(self, value):
+        self._lengths = value
+        self._lengths_advance = 0
+
+    @property
     def batch_size(self):
         for c in self.cache:
             if c is not None:
                 return c.shape[0]
-        if self.left_padding is not None:
-            return self.left_padding.size
-        elif self.lengths is not None:
-            return self.lengths.size
+        if self._left_padding is not None:
+            return self._left_padding.size
+        elif self._lengths is not None:
+            return self._lengths.size
         else:
             return 1
 
@@ -715,10 +743,10 @@ class ArraysCache(_BaseCache):
         self.left_padding = None
 
     def advance(self, N):
-        if self.lengths is not None:
-            self.lengths -= N
-        if self.left_padding is not None:
-            self.left_padding -= N
+        if self._lengths is not None:
+            self._lengths_advance += N
+        if self._left_padding is not None:
+            self._left_padding_advance += N
 
     def make_mask(self, N: int):
         if self.left_padding is not None:

--- a/mlx_vlm/tests/test_cache.py
+++ b/mlx_vlm/tests/test_cache.py
@@ -2,6 +2,7 @@ import mlx.core as mx
 import pytest
 
 from mlx_vlm.models.cache import (
+    ArraysCache,
     BatchPoolingCache,
     BatchRotatingKVCache,
     CacheList,
@@ -42,6 +43,40 @@ def test_cache_list_can_extract_an_already_extracted_kv_cache():
     assert extracted_again[0].offset == first.offset
     assert mx.array_equal(extracted_again[0].keys, first.state[0]).item()
     assert mx.array_equal(extracted_again[0].values, first.state[1]).item()
+
+
+def test_arrays_cache_advance_matches_decremented_values():
+    cache = ArraysCache(1, left_padding=[3, 1])
+    cache.prepare(lengths=[10, 7])
+    cache.advance(1)
+    cache.advance(2)
+
+    assert cache.left_padding.tolist() == [0, -2]
+    assert cache.lengths.tolist() == [7, 4]
+
+    mask = cache.make_mask(4)
+    assert mask.tolist() == [[p >= lp for p in range(4)] for lp in (0, -2)]
+
+    cache.filter([1, 0])
+    assert cache.left_padding.tolist() == [-2, 0]
+    assert cache.lengths.tolist() == [4, 7]
+
+    cache.finalize()
+    assert cache.left_padding is None and cache.lengths is None
+
+
+def test_arrays_cache_advance_does_not_accumulate_buffers():
+    cache = ArraysCache(1, left_padding=[0, 0])
+    cache.prepare(lengths=[8, 8])
+
+    mx.clear_cache()
+    base = mx.get_active_memory()
+    for _ in range(20000):
+        cache.advance(1)
+    delta = mx.get_active_memory() - base
+
+    assert delta < 4096, f"advance leaked {delta} bytes over 20k steps"
+    assert cache.lengths.tolist() == [8 - 20000, 8 - 20000]
 
 
 def test_kv_cache_extract_validates_row_index():


### PR DESCRIPTION
The `ArraysCache.advance` would decrease `left_padding`/`lengths` with a lazy `array -= N` each decode step, which allocates a scalar-operand buffer per call. 

Since only one of hybrid models layer cache is ever evaluated, every other layer leaks ~1 Metal buffer per token and hits the `[metal::malloc] Resource limit (499000) exceeded` reported by #1972 and other adjacent issues. 

Instead we can use a python int value to store the decrement and apply it to `left_padding`/`lengths`  when only read so `advance` builds no graph and unused caches accrue nothing with values unchanged. 

I verified cache/APC/generate/hybrid-model tests green and that unused-cache metadata stays O(1) vs the pre-fix graph growing 19×→44× over 600→1500 decode steps.


Closes #1972.