### PR TITLE
feat: ship a PEP 561 py.typed marker so mlx-vlm's annotations are usable (#1970)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,9 @@ Issues = "https://github.com/Blaizzy/mlx-vlm/issues"
 include = ["mlx_vlm*"]
 exclude = ["mlx_vlm.tests*"]
 
+[tool.setuptools.package-data]
+mlx_vlm = ["py.typed"]
+
 [tool.setuptools.dynamic]
 version = {attr = "mlx_vlm.version.__version__"}
 dependencies = {file = ["requirements.txt"]}


### PR DESCRIPTION
## What

Closes #1970.

Adds an empty `mlx_vlm/py.typed` and declares it as package data:

```toml
[tool.setuptools.package-data]
mlx_vlm = ["py.typed"]
```

mlx-vlm is pure Python and already annotates its public API, but without a PEP 561 marker every type checker treats imports from it as untyped, so downstream users lose all type coverage across the mlx-vlm boundary.

The `package-data` declaration is the load-bearing half. `pyproject.toml` currently sets no `package-data` and no `include-package-data`, so setuptools drops non-`.py` files from the built distributions — the marker would sit in the repo and never reach the wheel.

## Verified, built both ways

Built the wheel from a clean checkout at `1249c7d` before and after the change:

| | files in wheel | `mlx_vlm/py.typed` present |
|---|---|---|
| before | 1233 | ❌ |
| after | 1234 | ✅ |

The wheel differs by exactly that one file — nothing else moves. The sdist picks it up too (`mlx_vlm-0.6.15.tar.gz` → `mlx_vlm/py.typed` present).

Then installed each wheel into a clean venv (`--no-deps`) and ran mypy on a probe:

```python
from mlx_vlm.utils import load
reveal_type(load)
```

```
before: Revealed type is "Any"
after:  Revealed type is "def (path_or_hf_repo: str, adapter_path: str | None =,
                               lazy: bool =, revision: str | None =,
                               strict: bool =, **kwargs: Any) -> tuple[Any, Any]"
```

## Scope

No runtime effect, no annotation changes, no new dependency, no CI addition. This PR only makes the annotations mlx-vlm already ships visible to type checkers. `mlx-lm` made the same change in ml-explore/mlx-lm#389.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
