### PR TITLE
Make LFM2 DSpark exact: 2.90x dense and 1.24x MoE

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,11 +221,13 @@ mlx_vlm.server --model LiquidAI/LFM2.5-2.6B \
   --draft-model LiquidAI/LFM2.5-2.6B-DSpark
 ```
 
-The published DSpark `block_size: 9` means nine proposals; mlx-vlm verifies
-those proposals together with the anchor token in a ten-token target pass.
-The checkpoint's confidence head is loaded for parity, and DSpark retains its
-trained nine-proposal width instead of using the generic DFlash backoff.
-DSpark decoding currently requires greedy sampling (`temperature=0`).
+The published DSpark `block_size: 9` means nine proposals, or ten target rows
+after adding the anchor token. On MLX, DSpark verifies seven proposals plus the
+anchor by default: eight rows exactly fill the verifier threadgroup, while nine
+or ten rows pad to sixteen and run slower. The trained width remains available
+with `--draft-block-size 10`. The checkpoint's confidence head is loaded for
+parity, and DSpark decoding currently requires greedy sampling
+(`temperature=0`).
 
 Muse Glimmer's published assistant checkpoint is auto-detected as DFlash:
 

--- a/mlx_vlm/models/exact_speculative_verify.py
+++ b/mlx_vlm/models/exact_speculative_verify.py
@@ -1,8 +1,8 @@
 import mlx.core as mx
 
-_TARGET_VERIFY_GEMV = (
+_EXACT_SPECULATIVE_VERIFY_GEMV = (
     mx.fast.metal_kernel(
-        name="target_verify_gemv",
+        name="exact_speculative_verify_gemv",
         input_names=["x", "weight"],
         output_names=["out"],
         header="#include <metal_simdgroup>\nusing namespace metal;\n",
@@ -83,13 +83,13 @@ _TARGET_VERIFY_GEMV = (
 )
 
 
-def target_verify_dense_available() -> bool:
-    return _TARGET_VERIFY_GEMV is not None
+def exact_speculative_verify_dense_available() -> bool:
+    return _EXACT_SPECULATIVE_VERIFY_GEMV is not None
 
 
-def target_verify_weight(weight: mx.array, x: mx.array) -> mx.array | None:
+def exact_speculative_verify_weight(weight: mx.array, x: mx.array) -> mx.array | None:
     """Multiply a small verification block by a dense BF16/FP16 weight."""
-    if _TARGET_VERIFY_GEMV is None or x.ndim != 3:
+    if _EXACT_SPECULATIVE_VERIFY_GEMV is None or x.ndim != 3:
         return None
 
     batch, length, dimensions = x.shape
@@ -104,7 +104,7 @@ def target_verify_weight(weight: mx.array, x: mx.array) -> mx.array | None:
 
     rows = batch * length
     padded_rows = ((rows + 7) // 8) * 8
-    out = _TARGET_VERIFY_GEMV(
+    out = _EXACT_SPECULATIVE_VERIFY_GEMV(
         inputs=[x.reshape(rows, dimensions), weight],
         template=[
             ("T", x.dtype),
@@ -121,6 +121,6 @@ def target_verify_weight(weight: mx.array, x: mx.array) -> mx.array | None:
 
 
 __all__ = [
-    "target_verify_dense_available",
-    "target_verify_weight",
+    "exact_speculative_verify_dense_available",
+    "exact_speculative_verify_weight",
 ]

--- a/mlx_vlm/models/exact_speculative_verify.py
+++ b/mlx_vlm/models/exact_speculative_verify.py
@@ -82,6 +82,90 @@ _EXACT_SPECULATIVE_VERIFY_GEMV = (
     else None
 )
 
+_EXACT_SPECULATIVE_VERIFY_SWITCH_GEMV = (
+    mx.fast.metal_kernel(
+        name="exact_speculative_verify_switch_gemv",
+        input_names=["x", "weight", "expert_indices"],
+        output_names=["out"],
+        header="#include <metal_simdgroup>\nusing namespace metal;\n",
+        source=r"""
+        uint lane = thread_position_in_grid.x;
+        uint out_block = thread_position_in_grid.y;
+        uint row = thread_position_in_grid.z;
+
+        constexpr int TM = 4;
+        constexpr int TN = 4;
+        constexpr int SN = 32;
+        constexpr int blockN = SN * TN;
+
+        if (row >= R) {
+            return;
+        }
+
+        int out_row = int(out_block * TM);
+        if (out_row >= O) {
+            return;
+        }
+
+        uint input_row = BROADCAST_EXPERTS ? row / S : row;
+        uint expert = expert_indices[row];
+        const device T* in_vec = x + input_row * K;
+        const device T* mat = weight + expert * O * K + out_row * K;
+
+        float result[TM] = {0.0f, 0.0f, 0.0f, 0.0f};
+        int col = int(lane * TN);
+        int n_iter = K / blockN;
+        int leftover = K - blockN * n_iter;
+
+        for (int iter = 0; iter < n_iter; ++iter) {
+            float v[TN];
+            for (int tn = 0; tn < TN; ++tn) {
+                v[tn] = static_cast<float>(in_vec[col + tn]);
+            }
+
+            for (int tm = 0; tm < TM; ++tm) {
+                for (int tn = 0; tn < TN; ++tn) {
+                    result[tm] +=
+                        static_cast<float>(mat[tm * K + col + tn]) * v[tn];
+                }
+            }
+
+            col += blockN;
+        }
+
+        if (leftover > 0) {
+            float v[TN];
+            for (int tn = 0; tn < TN; ++tn) {
+                v[tn] =
+                    (col + tn < K) ? static_cast<float>(in_vec[col + tn]) : 0.0f;
+            }
+
+            for (int tm = 0; tm < TM; ++tm) {
+                for (int tn = 0; tn < TN; ++tn) {
+                    T m =
+                        (col + tn < K) ? mat[tm * K + col + tn] : T(0);
+                    result[tm] += static_cast<float>(m) * v[tn];
+                }
+            }
+        }
+
+        for (int tm = 0; tm < TM; ++tm) {
+            for (ushort sn = (SN / 2); sn >= 1; sn >>= 1) {
+                result[tm] += simd_shuffle_down(result[tm], sn);
+            }
+        }
+
+        if (lane == 0) {
+            for (int tm = 0; tm < TM; ++tm) {
+                out[row * O + out_row + tm] = static_cast<T>(result[tm]);
+            }
+        }
+    """,
+    )
+    if mx.metal.is_available()
+    else None
+)
+
 
 def exact_speculative_verify_dense_available() -> bool:
     return _EXACT_SPECULATIVE_VERIFY_GEMV is not None
@@ -120,7 +204,59 @@ def exact_speculative_verify_weight(weight: mx.array, x: mx.array) -> mx.array |
     return out.reshape(batch, length, outputs)
 
 
+def exact_speculative_verify_switch_weight(
+    weight: mx.array,
+    x: mx.array,
+    expert_indices: mx.array,
+) -> mx.array | None:
+    """Apply selected expert weights with singleton-equivalent accumulation."""
+    if _EXACT_SPECULATIVE_VERIFY_SWITCH_GEMV is None or x.ndim < 3:
+        return None
+
+    broadcast_experts = x.shape[:-1] == expert_indices.shape[:-1]
+    aligned_experts = x.shape[:-1] == expert_indices.shape
+    if not broadcast_experts and not aligned_experts:
+        return None
+
+    dimensions = x.shape[-1]
+    outputs = weight.shape[-2]
+    if (
+        weight.ndim != 3
+        or weight.shape[-1] != dimensions
+        or outputs < 4
+        or outputs % 4 != 0
+        or dimensions >= 16 * outputs
+        or weight.dtype != x.dtype
+    ):
+        return None
+
+    selected_shape = expert_indices.shape
+    rows = expert_indices.size
+    padded_rows = ((rows + 7) // 8) * 8
+    out = _EXACT_SPECULATIVE_VERIFY_SWITCH_GEMV(
+        inputs=[
+            x.reshape(-1, dimensions),
+            weight,
+            expert_indices.astype(mx.uint32).reshape(-1),
+        ],
+        template=[
+            ("T", x.dtype),
+            ("K", dimensions),
+            ("O", outputs),
+            ("R", rows),
+            ("S", selected_shape[-1]),
+            ("BROADCAST_EXPERTS", broadcast_experts),
+        ],
+        grid=(32, outputs // 4, padded_rows),
+        threadgroup=(32, 1, 8),
+        output_shapes=[(rows, outputs)],
+        output_dtypes=[x.dtype],
+    )[0]
+    return out.reshape(*selected_shape, outputs)
+
+
 __all__ = [
     "exact_speculative_verify_dense_available",
+    "exact_speculative_verify_switch_weight",
     "exact_speculative_verify_weight",
 ]

--- a/mlx_vlm/models/lfm2/language.py
+++ b/mlx_vlm/models/lfm2/language.py
@@ -12,7 +12,16 @@ from ..base import (
 )
 from ..cache import ArraysCache, KVCache
 from ..switch_layers import SwitchGLU
+from ..target_verify import target_verify_weight
 from .config import ModelConfig
+
+
+def _linear(linear: nn.Linear, x: mx.array, target_verify: bool) -> mx.array:
+    if target_verify:
+        output = target_verify_weight(linear.weight, x)
+        if output is not None:
+            return output
+    return linear(x)
 
 
 class Attention(nn.Module):
@@ -46,10 +55,13 @@ class Attention(nn.Module):
         x: mx.array,
         mask: Optional[mx.array] = None,
         cache: Optional[Any] = None,
+        target_verify: bool = False,
     ) -> mx.array:
         B, L, D = x.shape
 
-        queries, keys, values = self.q_proj(x), self.k_proj(x), self.v_proj(x)
+        queries = _linear(self.q_proj, x, target_verify)
+        keys = _linear(self.k_proj, x, target_verify)
+        values = _linear(self.v_proj, x, target_verify)
 
         queries = self.q_layernorm(queries.reshape(B, L, self.n_heads, -1)).transpose(
             0, 2, 1, 3
@@ -67,11 +79,32 @@ class Attention(nn.Module):
             queries = self.rope(queries)
             keys = self.rope(keys)
 
-        output = scaled_dot_product_attention(
-            queries, keys, values, cache=cache, mask=mask, scale=self.scale
-        )
+        if target_verify and cache is not None and L > 1:
+            prefix_length = keys.shape[-2] - L
+            output = mx.concatenate(
+                [
+                    scaled_dot_product_attention(
+                        queries[:, :, i : i + 1, :],
+                        keys[:, :, : prefix_length + i + 1, :],
+                        values[:, :, : prefix_length + i + 1, :],
+                        cache=cache,
+                        mask=(
+                            mask[..., i : i + 1, : prefix_length + i + 1]
+                            if isinstance(mask, mx.array) and mask.ndim >= 4
+                            else None
+                        ),
+                        scale=self.scale,
+                    )
+                    for i in range(L)
+                ],
+                axis=2,
+            )
+        else:
+            output = scaled_dot_product_attention(
+                queries, keys, values, cache=cache, mask=mask, scale=self.scale
+            )
         output = output.transpose(0, 2, 1, 3).reshape(B, L, -1)
-        return self.out_proj(output)
+        return _linear(self.out_proj, output, target_verify)
 
 
 class ShortConv(nn.Module):
@@ -99,8 +132,9 @@ class ShortConv(nn.Module):
         mask: Optional[mx.array] = None,
         cache: Optional[Any] = None,
         gdn_sink: list | None = None,
+        target_verify: bool = False,
     ):
-        BCx = self.in_proj(x)
+        BCx = _linear(self.in_proj, x, target_verify)
         B, C, x = mx.split(BCx, 3, axis=-1)
         Bx = B * x
         if mask is not None:
@@ -151,7 +185,7 @@ class ShortConv(nn.Module):
         conv_out = self.conv(Bx)
 
         y = C * conv_out
-        return self.out_proj(y)
+        return _linear(self.out_proj, y, target_verify)
 
 
 class MLP(nn.Module):
@@ -174,8 +208,10 @@ class MLP(nn.Module):
         self.w3 = nn.Linear(dim, ff_dim, bias=False)
         self.w2 = nn.Linear(ff_dim, dim, bias=False)
 
-    def __call__(self, x) -> mx.array:
-        return self.w2(swiglu(self.w1(x), self.w3(x)))
+    def __call__(self, x, target_verify: bool = False) -> mx.array:
+        gate = _linear(self.w1, x, target_verify)
+        value = _linear(self.w3, x, target_verify)
+        return _linear(self.w2, swiglu(gate, value), target_verify)
 
 
 class GatedMLP(nn.Module):
@@ -260,18 +296,30 @@ class Lfm2DecoderLayer(nn.Module):
         mask: Optional[mx.array] = None,
         cache: Optional[Any] = None,
         gdn_sink: list | None = None,
+        target_verify: bool = False,
     ) -> mx.array:
         if self.is_attention_layer:
-            r = self.self_attn(self.operator_norm(x), mask=mask, cache=cache)
+            r = self.self_attn(
+                self.operator_norm(x),
+                mask=mask,
+                cache=cache,
+                target_verify=target_verify,
+            )
         else:
             r = self.conv(
                 self.operator_norm(x),
                 mask=mask,
                 cache=cache,
                 gdn_sink=gdn_sink,
+                target_verify=target_verify,
             )
         h = x + r
-        out = h + self.feed_forward(self.ffn_norm(h))
+        normed = self.ffn_norm(h)
+        if target_verify and isinstance(self.feed_forward, MLP):
+            feed_forward = self.feed_forward(normed, target_verify=True)
+        else:
+            feed_forward = self.feed_forward(normed)
+        out = h + feed_forward
         return out
 
 
@@ -304,6 +352,7 @@ class Lfm2Model(nn.Module):
         capture_layer_ids: list[int] | None = None,
         hidden_sink: list | None = None,
         gdn_sink: list | None = None,
+        target_verify: bool = False,
     ):
         if input_embeddings is not None:
             h = input_embeddings
@@ -319,7 +368,13 @@ class Lfm2Model(nn.Module):
         capture_set = set(capture_layer_ids) if capture_layer_ids else set()
         for index, (layer, c) in enumerate(zip(self.layers, cache)):
             mask = attn_mask if layer.is_attention_layer else conv_mask
-            h = layer(h, mask, cache=c, gdn_sink=gdn_sink)
+            h = layer(
+                h,
+                mask,
+                cache=c,
+                gdn_sink=gdn_sink,
+                target_verify=target_verify,
+            )
             if hidden_sink is not None and index in capture_set:
                 hidden_sink.append(h)
 
@@ -363,11 +418,21 @@ class LanguageModel(nn.Module):
             capture_layer_ids=capture_layer_ids,
             hidden_sink=hidden_sink,
             gdn_sink=gdn_sink,
+            target_verify=speculative_verify,
         )
         if self.args.tie_word_embeddings:
-            out = self.model.embed_tokens.as_linear(out)
+            verify_logits = (
+                target_verify_weight(self.model.embed_tokens.weight, out)
+                if speculative_verify
+                else None
+            )
+            out = (
+                verify_logits
+                if verify_logits is not None
+                else self.model.embed_tokens.as_linear(out)
+            )
         else:
-            out = self.lm_head(out)
+            out = _linear(self.lm_head, out, speculative_verify)
         return LanguageModelOutput(
             logits=out,
             hidden_states=hidden_sink,

--- a/mlx_vlm/models/lfm2/language.py
+++ b/mlx_vlm/models/lfm2/language.py
@@ -12,16 +12,10 @@ from ..base import (
 )
 from ..cache import ArraysCache, KVCache
 from ..switch_layers import SwitchGLU
-from ..target_verify import target_verify_weight
 from .config import ModelConfig
+from .speculative_verifier import Lfm2ExactSpeculativeVerifier
 
-
-def _linear(linear: nn.Linear, x: mx.array, target_verify: bool) -> mx.array:
-    if target_verify:
-        output = target_verify_weight(linear.weight, x)
-        if output is not None:
-            return output
-    return linear(x)
+_EXACT_SPECULATIVE_VERIFIER = Lfm2ExactSpeculativeVerifier()
 
 
 class Attention(nn.Module):
@@ -55,13 +49,20 @@ class Attention(nn.Module):
         x: mx.array,
         mask: Optional[mx.array] = None,
         cache: Optional[Any] = None,
-        target_verify: bool = False,
     ) -> mx.array:
-        B, L, D = x.shape
+        queries, keys, values = self.q_proj(x), self.k_proj(x), self.v_proj(x)
+        queries, keys, values = self._prepare_projected_qkv(
+            queries, keys, values, cache
+        )
 
-        queries = _linear(self.q_proj, x, target_verify)
-        keys = _linear(self.k_proj, x, target_verify)
-        values = _linear(self.v_proj, x, target_verify)
+        output = scaled_dot_product_attention(
+            queries, keys, values, cache=cache, mask=mask, scale=self.scale
+        )
+        output = output.transpose(0, 2, 1, 3).reshape(x.shape[0], x.shape[1], -1)
+        return self.out_proj(output)
+
+    def _prepare_projected_qkv(self, queries, keys, values, cache):
+        B, L, _ = queries.shape
 
         queries = self.q_layernorm(queries.reshape(B, L, self.n_heads, -1)).transpose(
             0, 2, 1, 3
@@ -79,32 +80,7 @@ class Attention(nn.Module):
             queries = self.rope(queries)
             keys = self.rope(keys)
 
-        if target_verify and cache is not None and L > 1:
-            prefix_length = keys.shape[-2] - L
-            output = mx.concatenate(
-                [
-                    scaled_dot_product_attention(
-                        queries[:, :, i : i + 1, :],
-                        keys[:, :, : prefix_length + i + 1, :],
-                        values[:, :, : prefix_length + i + 1, :],
-                        cache=cache,
-                        mask=(
-                            mask[..., i : i + 1, : prefix_length + i + 1]
-                            if isinstance(mask, mx.array) and mask.ndim >= 4
-                            else None
-                        ),
-                        scale=self.scale,
-                    )
-                    for i in range(L)
-                ],
-                axis=2,
-            )
-        else:
-            output = scaled_dot_product_attention(
-                queries, keys, values, cache=cache, mask=mask, scale=self.scale
-            )
-        output = output.transpose(0, 2, 1, 3).reshape(B, L, -1)
-        return _linear(self.out_proj, output, target_verify)
+        return queries, keys, values
 
 
 class ShortConv(nn.Module):
@@ -132,9 +108,11 @@ class ShortConv(nn.Module):
         mask: Optional[mx.array] = None,
         cache: Optional[Any] = None,
         gdn_sink: list | None = None,
-        target_verify: bool = False,
     ):
-        BCx = _linear(self.in_proj, x, target_verify)
+        projected = self.in_proj(x)
+        return self.out_proj(self._convolve_projected(projected, mask, cache, gdn_sink))
+
+    def _convolve_projected(self, BCx, mask, cache, gdn_sink):
         B, C, x = mx.split(BCx, 3, axis=-1)
         Bx = B * x
         if mask is not None:
@@ -185,7 +163,7 @@ class ShortConv(nn.Module):
         conv_out = self.conv(Bx)
 
         y = C * conv_out
-        return _linear(self.out_proj, y, target_verify)
+        return y
 
 
 class MLP(nn.Module):
@@ -208,10 +186,8 @@ class MLP(nn.Module):
         self.w3 = nn.Linear(dim, ff_dim, bias=False)
         self.w2 = nn.Linear(ff_dim, dim, bias=False)
 
-    def __call__(self, x, target_verify: bool = False) -> mx.array:
-        gate = _linear(self.w1, x, target_verify)
-        value = _linear(self.w3, x, target_verify)
-        return _linear(self.w2, swiglu(gate, value), target_verify)
+    def __call__(self, x) -> mx.array:
+        return self.w2(swiglu(self.w1(x), self.w3(x)))
 
 
 class GatedMLP(nn.Module):
@@ -296,30 +272,18 @@ class Lfm2DecoderLayer(nn.Module):
         mask: Optional[mx.array] = None,
         cache: Optional[Any] = None,
         gdn_sink: list | None = None,
-        target_verify: bool = False,
     ) -> mx.array:
         if self.is_attention_layer:
-            r = self.self_attn(
-                self.operator_norm(x),
-                mask=mask,
-                cache=cache,
-                target_verify=target_verify,
-            )
+            r = self.self_attn(self.operator_norm(x), mask=mask, cache=cache)
         else:
             r = self.conv(
                 self.operator_norm(x),
                 mask=mask,
                 cache=cache,
                 gdn_sink=gdn_sink,
-                target_verify=target_verify,
             )
         h = x + r
-        normed = self.ffn_norm(h)
-        if target_verify and isinstance(self.feed_forward, MLP):
-            feed_forward = self.feed_forward(normed, target_verify=True)
-        else:
-            feed_forward = self.feed_forward(normed)
-        out = h + feed_forward
+        out = h + self.feed_forward(self.ffn_norm(h))
         return out
 
 
@@ -352,7 +316,6 @@ class Lfm2Model(nn.Module):
         capture_layer_ids: list[int] | None = None,
         hidden_sink: list | None = None,
         gdn_sink: list | None = None,
-        target_verify: bool = False,
     ):
         if input_embeddings is not None:
             h = input_embeddings
@@ -368,13 +331,7 @@ class Lfm2Model(nn.Module):
         capture_set = set(capture_layer_ids) if capture_layer_ids else set()
         for index, (layer, c) in enumerate(zip(self.layers, cache)):
             mask = attn_mask if layer.is_attention_layer else conv_mask
-            h = layer(
-                h,
-                mask,
-                cache=c,
-                gdn_sink=gdn_sink,
-                target_verify=target_verify,
-            )
+            h = layer(h, mask, cache=c, gdn_sink=gdn_sink)
             if hidden_sink is not None and index in capture_set:
                 hidden_sink.append(h)
 
@@ -405,11 +362,19 @@ class LanguageModel(nn.Module):
             inputs_embeds = input_embeddings
 
         capture_layer_ids = kwargs.pop("capture_layer_ids", None)
-        speculative_verify = bool(kwargs.pop("speculative_verify", False))
+        exact_speculative_verify = bool(kwargs.pop("speculative_verify", False))
+        if exact_speculative_verify:
+            return _EXACT_SPECULATIVE_VERIFIER(
+                self,
+                inputs,
+                cache=cache,
+                input_embeddings=inputs_embeds,
+                capture_layer_ids=capture_layer_ids,
+            )
+
         hidden_sink: list[mx.array] | None = (
             [] if capture_layer_ids is not None else None
         )
-        gdn_sink: list | None = [] if speculative_verify else None
 
         out = self.model(
             inputs,
@@ -417,26 +382,15 @@ class LanguageModel(nn.Module):
             inputs_embeds,
             capture_layer_ids=capture_layer_ids,
             hidden_sink=hidden_sink,
-            gdn_sink=gdn_sink,
-            target_verify=speculative_verify,
         )
         if self.args.tie_word_embeddings:
-            verify_logits = (
-                target_verify_weight(self.model.embed_tokens.weight, out)
-                if speculative_verify
-                else None
-            )
-            out = (
-                verify_logits
-                if verify_logits is not None
-                else self.model.embed_tokens.as_linear(out)
-            )
+            out = self.model.embed_tokens.as_linear(out)
         else:
-            out = _linear(self.lm_head, out, speculative_verify)
+            out = self.lm_head(out)
         return LanguageModelOutput(
             logits=out,
             hidden_states=hidden_sink,
-            gdn_states=gdn_sink,
+            gdn_states=None,
         )
 
     def chunked_prefill_policy(

--- a/mlx_vlm/models/lfm2/speculative_verifier.py
+++ b/mlx_vlm/models/lfm2/speculative_verifier.py
@@ -9,7 +9,10 @@ from ..base import (
     create_ssm_mask,
     scaled_dot_product_attention,
 )
-from ..exact_speculative_verify import exact_speculative_verify_weight
+from ..exact_speculative_verify import (
+    exact_speculative_verify_switch_weight,
+    exact_speculative_verify_weight,
+)
 
 
 class Lfm2ExactSpeculativeVerifier:
@@ -76,13 +79,58 @@ class Lfm2ExactSpeculativeVerifier:
         return self._linear(conv.out_proj, output)
 
     def _feed_forward(self, feed_forward, x):
-        from .language import MLP
+        from .language import MLP, GatedMLP, Lfm2MoeSparseMoeBlock
 
-        if not isinstance(feed_forward, MLP):
-            return feed_forward(x)
-        gate = self._linear(feed_forward.w1, x)
-        value = self._linear(feed_forward.w3, x)
-        return self._linear(feed_forward.w2, swiglu(gate, value))
+        if isinstance(feed_forward, MLP):
+            gate = self._linear(feed_forward.w1, x)
+            value = self._linear(feed_forward.w3, x)
+            return self._linear(feed_forward.w2, swiglu(gate, value))
+        if isinstance(feed_forward, GatedMLP):
+            gate = self._linear(feed_forward.gate_proj, x)
+            value = self._linear(feed_forward.up_proj, x)
+            return self._linear(feed_forward.down_proj, swiglu(gate, value))
+        if isinstance(feed_forward, Lfm2MoeSparseMoeBlock):
+            gates = mx.softmax(
+                self._linear(feed_forward.gate, x).astype(mx.float32),
+                axis=-1,
+            )
+            if feed_forward.use_expert_bias:
+                gates += feed_forward.expert_bias
+            indices = mx.argpartition(gates, kth=-feed_forward.top_k, axis=-1)[
+                ..., -feed_forward.top_k :
+            ]
+            scores = mx.take_along_axis(gates, indices, axis=-1)
+            if feed_forward.norm_topk_prob:
+                scores /= mx.sum(scores, axis=-1, keepdims=True) + 1e-20
+            switch_mlp = feed_forward.switch_mlp
+            expert_up = self._switch_linear(switch_mlp.up_proj, x, indices)
+            expert_gate = self._switch_linear(switch_mlp.gate_proj, x, indices)
+            expert_output = self._switch_linear(
+                switch_mlp.down_proj,
+                swiglu(expert_gate, expert_up),
+                indices,
+            )
+            return (expert_output * scores.astype(x.dtype)[..., None]).sum(axis=-2)
+        return feed_forward(x)
+
+    @staticmethod
+    def _switch_linear(linear, x, indices):
+        output = exact_speculative_verify_switch_weight(linear.weight, x, indices)
+        if output is not None:
+            if hasattr(linear, "bias"):
+                output = output + linear.bias[indices]
+            return output
+
+        # Preserve exactness for unsupported (for example quantized) switch
+        # layers by retaining the singleton execution shape.
+        rows = []
+        input_has_expert_axis = x.shape[:-1] == indices.shape
+        for position in range(x.shape[1]):
+            row = x[:, position : position + 1]
+            row_indices = indices[:, position : position + 1]
+            row = mx.expand_dims(row, -2 if input_has_expert_axis else (-2, -3))
+            rows.append(linear(row, row_indices).squeeze(-2))
+        return mx.concatenate(rows, axis=1)
 
     def _layer(self, layer, x, mask, cache, gdn_sink):
         normed = layer.operator_norm(x)

--- a/mlx_vlm/models/lfm2/speculative_verifier.py
+++ b/mlx_vlm/models/lfm2/speculative_verifier.py
@@ -1,0 +1,179 @@
+from typing import Any
+
+import mlx.core as mx
+
+from ..activations import swiglu
+from ..base import (
+    LanguageModelOutput,
+    create_attention_mask,
+    create_ssm_mask,
+    scaled_dot_product_attention,
+)
+from ..exact_speculative_verify import exact_speculative_verify_weight
+
+
+class Lfm2ExactSpeculativeVerifier:
+    """Run block verification with singleton-equivalent LFM2 numerics."""
+
+    @staticmethod
+    def _linear(linear, x: mx.array) -> mx.array:
+        output = exact_speculative_verify_weight(linear.weight, x)
+        if output is None:
+            return linear(x)
+        if hasattr(linear, "bias"):
+            output = output + linear.bias
+        return output
+
+    def _attention(self, attention, x, mask, cache):
+        length = x.shape[1]
+        queries = self._linear(attention.q_proj, x)
+        keys = self._linear(attention.k_proj, x)
+        values = self._linear(attention.v_proj, x)
+        queries, keys, values = attention._prepare_projected_qkv(
+            queries, keys, values, cache
+        )
+
+        if cache is not None and length > 1:
+            prefix_length = keys.shape[-2] - length
+            output = mx.concatenate(
+                [
+                    scaled_dot_product_attention(
+                        queries[:, :, index : index + 1, :],
+                        keys[:, :, : prefix_length + index + 1, :],
+                        values[:, :, : prefix_length + index + 1, :],
+                        cache=cache,
+                        mask=(
+                            mask[
+                                ...,
+                                index : index + 1,
+                                : prefix_length + index + 1,
+                            ]
+                            if isinstance(mask, mx.array) and mask.ndim >= 4
+                            else None
+                        ),
+                        scale=attention.scale,
+                    )
+                    for index in range(length)
+                ],
+                axis=2,
+            )
+        else:
+            output = scaled_dot_product_attention(
+                queries,
+                keys,
+                values,
+                cache=cache,
+                mask=mask,
+                scale=attention.scale,
+            )
+
+        output = output.transpose(0, 2, 1, 3).reshape(x.shape[0], length, -1)
+        return self._linear(attention.out_proj, output)
+
+    def _short_conv(self, conv, x, mask, cache, gdn_sink):
+        projected = self._linear(conv.in_proj, x)
+        output = conv._convolve_projected(projected, mask, cache, gdn_sink)
+        return self._linear(conv.out_proj, output)
+
+    def _feed_forward(self, feed_forward, x):
+        from .language import MLP
+
+        if not isinstance(feed_forward, MLP):
+            return feed_forward(x)
+        gate = self._linear(feed_forward.w1, x)
+        value = self._linear(feed_forward.w3, x)
+        return self._linear(feed_forward.w2, swiglu(gate, value))
+
+    def _layer(self, layer, x, mask, cache, gdn_sink):
+        normed = layer.operator_norm(x)
+        if layer.is_attention_layer:
+            residual = self._attention(layer.self_attn, normed, mask, cache)
+        else:
+            residual = self._short_conv(
+                layer.conv,
+                normed,
+                mask,
+                cache,
+                gdn_sink,
+            )
+        hidden = x + residual
+        return hidden + self._feed_forward(
+            layer.feed_forward,
+            layer.ffn_norm(hidden),
+        )
+
+    def _model(
+        self,
+        model,
+        inputs,
+        cache,
+        input_embeddings,
+        capture_layer_ids,
+        hidden_sink,
+        gdn_sink,
+    ):
+        hidden = (
+            input_embeddings
+            if input_embeddings is not None
+            else model.embed_tokens(inputs)
+        )
+        if cache is None:
+            cache = [None] * len(model.layers)
+
+        attention_mask = create_attention_mask(hidden, cache[model.fa_idx])
+        conv_mask = create_ssm_mask(hidden, cache[model.conv_idx])
+        capture_set = set(capture_layer_ids) if capture_layer_ids else set()
+        for index, (layer, layer_cache) in enumerate(zip(model.layers, cache)):
+            mask = attention_mask if layer.is_attention_layer else conv_mask
+            hidden = self._layer(
+                layer,
+                hidden,
+                mask,
+                layer_cache,
+                gdn_sink,
+            )
+            if hidden_sink is not None and index in capture_set:
+                hidden_sink.append(hidden)
+
+        return model.embedding_norm(hidden)
+
+    def __call__(
+        self,
+        language_model,
+        inputs,
+        *,
+        cache: Any = None,
+        input_embeddings: mx.array | None = None,
+        capture_layer_ids: list[int] | None = None,
+    ) -> LanguageModelOutput:
+        hidden_sink: list[mx.array] | None = (
+            [] if capture_layer_ids is not None else None
+        )
+        gdn_sink: list = []
+        hidden = self._model(
+            language_model.model,
+            inputs,
+            cache,
+            input_embeddings,
+            capture_layer_ids,
+            hidden_sink,
+            gdn_sink,
+        )
+        if language_model.args.tie_word_embeddings:
+            logits = exact_speculative_verify_weight(
+                language_model.model.embed_tokens.weight,
+                hidden,
+            )
+            if logits is None:
+                logits = language_model.model.embed_tokens.as_linear(hidden)
+        else:
+            logits = self._linear(language_model.lm_head, hidden)
+
+        return LanguageModelOutput(
+            logits=logits,
+            hidden_states=hidden_sink,
+            gdn_states=gdn_sink,
+        )
+
+
+__all__ = ["Lfm2ExactSpeculativeVerifier"]

--- a/mlx_vlm/models/lfm2_moe/language.py
+++ b/mlx_vlm/models/lfm2_moe/language.py
@@ -1,44 +1,9 @@
-from typing import Optional
-
 import mlx.core as mx
-import mlx.nn as nn
 
-from ..base import LanguageModelOutput
-from ..cache import ArraysCache, KVCache
-from ..lfm2.language import Lfm2Model
-from .config import ModelConfig
+from ..lfm2.language import LanguageModel as Lfm2LanguageModel
 
 
-class LanguageModel(nn.Module):
-    def __init__(self, args: ModelConfig):
-        super().__init__()
-        self.args = args
-        self.config = args
-        self.model_type = args.model_type
-        self.model = Lfm2Model(args)
-        if not args.tie_word_embeddings:
-            self.lm_head = nn.Linear(args.hidden_size, args.vocab_size, bias=False)
-
-    def __call__(
-        self,
-        inputs: Optional[mx.array] = None,
-        cache=None,
-        input_embeddings: Optional[mx.array] = None,
-        inputs_embeds: Optional[mx.array] = None,
-        **kwargs,
-    ) -> LanguageModelOutput:
-        if inputs is None:
-            inputs = kwargs.get("input_ids")
-        if inputs_embeds is None:
-            inputs_embeds = input_embeddings
-
-        out = self.model(inputs, cache, inputs_embeds)
-        if self.args.tie_word_embeddings:
-            out = self.model.embed_tokens.as_linear(out)
-        else:
-            out = self.lm_head(out)
-        return LanguageModelOutput(logits=out)
-
+class LanguageModel(Lfm2LanguageModel):
     def sanitize(self, weights):
         if self.args.tie_word_embeddings:
             weights.pop("lm_head.weight", None)
@@ -92,21 +57,3 @@ class LanguageModel(nn.Module):
             return "expert_bias" not in k
 
         return predicate
-
-    @property
-    def layers(self):
-        return self.model.layers
-
-    @property
-    def head_dim(self):
-        return self.args.hidden_size // self.args.num_attention_heads
-
-    @property
-    def n_kv_heads(self):
-        return self.args.num_key_value_heads
-
-    def make_cache(self):
-        return [
-            KVCache() if layer.is_attention_layer else ArraysCache(size=1)
-            for layer in self.layers
-        ]

--- a/mlx_vlm/models/qwen3_5/language.py
+++ b/mlx_vlm/models/qwen3_5/language.py
@@ -11,9 +11,7 @@ from ..base import (
     scaled_dot_product_attention,
 )
 from ..cache import ArraysCache, KVCache
-from ..exact_speculative_verify import (
-    exact_speculative_verify_dense_available,
-)
+from ..exact_speculative_verify import exact_speculative_verify_dense_available
 from ..exact_speculative_verify import (
     exact_speculative_verify_weight as _target_verify_weight,
 )

--- a/mlx_vlm/models/qwen3_5/language.py
+++ b/mlx_vlm/models/qwen3_5/language.py
@@ -11,10 +11,14 @@ from ..base import (
     scaled_dot_product_attention,
 )
 from ..cache import ArraysCache, KVCache
+from ..exact_speculative_verify import (
+    exact_speculative_verify_dense_available,
+)
+from ..exact_speculative_verify import (
+    exact_speculative_verify_weight as _target_verify_weight,
+)
 from ..rope_utils import MRoPERotaryEmbedding
 from ..rope_utils import apply_multimodal_rotary_pos_emb as _apply_mrope
-from ..target_verify import target_verify_dense_available
-from ..target_verify import target_verify_weight as _target_verify_weight
 from .config import ModelConfig, TextConfig
 from .gated_delta import (
     gated_delta_accept_states,
@@ -76,7 +80,7 @@ def _qwen3_5_decode_depthwise_conv(conv_input: mx.array, weight: mx.array):
 
 def _use_target_verify_dense(linear, x: mx.array, target_verify: bool) -> bool:
     return (
-        target_verify_dense_available()
+        exact_speculative_verify_dense_available()
         and target_verify
         and x.ndim == 3
         and x.shape[1] > 1

--- a/mlx_vlm/models/qwen3_5/language.py
+++ b/mlx_vlm/models/qwen3_5/language.py
@@ -13,6 +13,8 @@ from ..base import (
 from ..cache import ArraysCache, KVCache
 from ..rope_utils import MRoPERotaryEmbedding
 from ..rope_utils import apply_multimodal_rotary_pos_emb as _apply_mrope
+from ..target_verify import target_verify_dense_available
+from ..target_verify import target_verify_weight as _target_verify_weight
 from .config import ModelConfig, TextConfig
 from .gated_delta import (
     gated_delta_accept_states,
@@ -72,113 +74,14 @@ def _qwen3_5_decode_depthwise_conv(conv_input: mx.array, weight: mx.array):
     return out.astype(conv_input.dtype)[:, None, :]
 
 
-_TARGET_VERIFY_GEMV = (
-    mx.fast.metal_kernel(
-        name="qwen3_5_target_verify_gemv",
-        input_names=["x", "weight"],
-        output_names=["out"],
-        header="#include <metal_simdgroup>\nusing namespace metal;\n",
-        source=r"""
-        uint lane = thread_position_in_grid.x;
-        uint out_block = thread_position_in_grid.y;
-        uint row = thread_position_in_grid.z;
-
-        constexpr int TM = 4;
-        constexpr int TN = 4;
-        constexpr int SN = 32;
-        constexpr int blockN = SN * TN;
-
-        if (row >= R) {
-            return;
-        }
-
-        int out_row = int(out_block * TM);
-        if (out_row >= O) {
-            return;
-        }
-
-        const device T* in_vec = x + row * K;
-        const device T* mat = weight + out_row * K;
-
-        float result[TM] = {0.0f, 0.0f, 0.0f, 0.0f};
-        int col = int(lane * TN);
-        int n_iter = K / blockN;
-        int leftover = K - blockN * n_iter;
-
-        for (int iter = 0; iter < n_iter; ++iter) {
-            float v[TN];
-            for (int tn = 0; tn < TN; ++tn) {
-                v[tn] = static_cast<float>(in_vec[col + tn]);
-            }
-
-            for (int tm = 0; tm < TM; ++tm) {
-                for (int tn = 0; tn < TN; ++tn) {
-                    result[tm] += static_cast<float>(mat[tm * K + col + tn]) * v[tn];
-                }
-            }
-
-            col += blockN;
-        }
-
-        if (leftover > 0) {
-            float v[TN];
-            for (int tn = 0; tn < TN; ++tn) {
-                v[tn] = (col + tn < K) ? static_cast<float>(in_vec[col + tn]) : 0.0f;
-            }
-
-            for (int tm = 0; tm < TM; ++tm) {
-                for (int tn = 0; tn < TN; ++tn) {
-                    T m = (col + tn < K) ? mat[tm * K + col + tn] : T(0);
-                    result[tm] += static_cast<float>(m) * v[tn];
-                }
-            }
-        }
-
-        for (int tm = 0; tm < TM; ++tm) {
-            for (ushort sn = (SN / 2); sn >= 1; sn >>= 1) {
-                result[tm] += simd_shuffle_down(result[tm], sn);
-            }
-        }
-
-        if (lane == 0) {
-            for (int tm = 0; tm < TM; ++tm) {
-                out[row * O + out_row + tm] = static_cast<T>(result[tm]);
-            }
-        }
-    """,
-    )
-    if mx.metal.is_available()
-    else None
-)
-
-
 def _use_target_verify_dense(linear, x: mx.array, target_verify: bool) -> bool:
     return (
-        _TARGET_VERIFY_GEMV is not None
+        target_verify_dense_available()
         and target_verify
         and x.ndim == 3
         and x.shape[1] > 1
         and isinstance(linear, (nn.Linear, nn.QuantizedLinear))
     )
-
-
-def _target_verify_weight(weight: mx.array, x: mx.array) -> Optional[mx.array]:
-    B, L, D = x.shape
-    O = weight.shape[0]
-    if O < 4 or O % 4 != 0 or D >= 16 * O or weight.dtype != x.dtype:
-        return None
-
-    rows = B * L
-    rows8 = ((rows + 7) // 8) * 8
-    out = _TARGET_VERIFY_GEMV(
-        inputs=[x.reshape(rows, D), weight],
-        template=[("T", x.dtype), ("K", D), ("O", O), ("R", rows)],
-        grid=(32, O // 4, rows8),
-        threadgroup=(32, 1, 8),
-        output_shapes=[(rows, O)],
-        output_dtypes=[x.dtype],
-    )[0]
-    return out.reshape(B, L, O)
 
 
 def _target_verify_qlinear_header(bits: int, group_size: int) -> str:

--- a/mlx_vlm/models/target_verify.py
+++ b/mlx_vlm/models/target_verify.py
@@ -1,0 +1,126 @@
+import mlx.core as mx
+
+_TARGET_VERIFY_GEMV = (
+    mx.fast.metal_kernel(
+        name="target_verify_gemv",
+        input_names=["x", "weight"],
+        output_names=["out"],
+        header="#include <metal_simdgroup>\nusing namespace metal;\n",
+        source=r"""
+        uint lane = thread_position_in_grid.x;
+        uint out_block = thread_position_in_grid.y;
+        uint row = thread_position_in_grid.z;
+
+        constexpr int TM = 4;
+        constexpr int TN = 4;
+        constexpr int SN = 32;
+        constexpr int blockN = SN * TN;
+
+        if (row >= R) {
+            return;
+        }
+
+        int out_row = int(out_block * TM);
+        if (out_row >= O) {
+            return;
+        }
+
+        const device T* in_vec = x + row * K;
+        const device T* mat = weight + out_row * K;
+
+        float result[TM] = {0.0f, 0.0f, 0.0f, 0.0f};
+        int col = int(lane * TN);
+        int n_iter = K / blockN;
+        int leftover = K - blockN * n_iter;
+
+        for (int iter = 0; iter < n_iter; ++iter) {
+            float v[TN];
+            for (int tn = 0; tn < TN; ++tn) {
+                v[tn] = static_cast<float>(in_vec[col + tn]);
+            }
+
+            for (int tm = 0; tm < TM; ++tm) {
+                for (int tn = 0; tn < TN; ++tn) {
+                    result[tm] +=
+                        static_cast<float>(mat[tm * K + col + tn]) * v[tn];
+                }
+            }
+
+            col += blockN;
+        }
+
+        if (leftover > 0) {
+            float v[TN];
+            for (int tn = 0; tn < TN; ++tn) {
+                v[tn] =
+                    (col + tn < K) ? static_cast<float>(in_vec[col + tn]) : 0.0f;
+            }
+
+            for (int tm = 0; tm < TM; ++tm) {
+                for (int tn = 0; tn < TN; ++tn) {
+                    T m =
+                        (col + tn < K) ? mat[tm * K + col + tn] : T(0);
+                    result[tm] += static_cast<float>(m) * v[tn];
+                }
+            }
+        }
+
+        for (int tm = 0; tm < TM; ++tm) {
+            for (ushort sn = (SN / 2); sn >= 1; sn >>= 1) {
+                result[tm] += simd_shuffle_down(result[tm], sn);
+            }
+        }
+
+        if (lane == 0) {
+            for (int tm = 0; tm < TM; ++tm) {
+                out[row * O + out_row + tm] = static_cast<T>(result[tm]);
+            }
+        }
+    """,
+    )
+    if mx.metal.is_available()
+    else None
+)
+
+
+def target_verify_dense_available() -> bool:
+    return _TARGET_VERIFY_GEMV is not None
+
+
+def target_verify_weight(weight: mx.array, x: mx.array) -> mx.array | None:
+    """Multiply a small verification block by a dense BF16/FP16 weight."""
+    if _TARGET_VERIFY_GEMV is None or x.ndim != 3:
+        return None
+
+    batch, length, dimensions = x.shape
+    outputs = weight.shape[0]
+    if (
+        outputs < 4
+        or outputs % 4 != 0
+        or dimensions >= 16 * outputs
+        or weight.dtype != x.dtype
+    ):
+        return None
+
+    rows = batch * length
+    padded_rows = ((rows + 7) // 8) * 8
+    out = _TARGET_VERIFY_GEMV(
+        inputs=[x.reshape(rows, dimensions), weight],
+        template=[
+            ("T", x.dtype),
+            ("K", dimensions),
+            ("O", outputs),
+            ("R", rows),
+        ],
+        grid=(32, outputs // 4, padded_rows),
+        threadgroup=(32, 1, 8),
+        output_shapes=[(rows, outputs)],
+        output_dtypes=[x.dtype],
+    )[0]
+    return out.reshape(batch, length, outputs)
+
+
+__all__ = [
+    "target_verify_dense_available",
+    "target_verify_weight",
+]

--- a/mlx_vlm/speculative/drafters/qwen3_dspark/config.py
+++ b/mlx_vlm/speculative/drafters/qwen3_dspark/config.py
@@ -51,7 +51,8 @@ class DSparkConfig(BaseModelConfig):
     mask_token_id: int = 125017
     target_layer_ids: list[int] = field(default_factory=list)
     num_target_layers: int = 30
-    runtime_block_size: int | None = None
+    # Eight rows fit one verifier threadgroup; nine or ten pad to sixteen.
+    runtime_block_size: int | None = 8
     draft_window_size: int | None = None
 
     markov_rank: int = 256
@@ -92,6 +93,12 @@ class DSparkConfig(BaseModelConfig):
         if self.block_size != self.proposal_length + 1:
             raise ValueError(
                 "LFM2 DSpark verification block_size must equal " "proposal_length + 1."
+            )
+        if self.runtime_block_size is not None and (
+            not isinstance(self.runtime_block_size, int) or self.runtime_block_size <= 0
+        ):
+            raise ValueError(
+                "LFM2 DSpark runtime_block_size must be a positive integer."
             )
         if self.hidden_size != self.num_attention_heads * self.head_dim:
             raise ValueError(

--- a/mlx_vlm/speculative/drafters/qwen3_dspark/dspark.py
+++ b/mlx_vlm/speculative/drafters/qwen3_dspark/dspark.py
@@ -66,9 +66,10 @@ def validate_lfm2_dspark_target(config: DSparkConfig, target_model) -> None:
     layers = getattr(inner, "layers", None)
 
     model_type = getattr(target_config, "model_type", None)
-    if model_type != "lfm2":
+    if model_type not in {"lfm2", "lfm2_moe"}:
         raise ValueError(
-            "LFM2 DSpark requires an LFM2 target, got " f"model_type={model_type!r}."
+            "LFM2 DSpark requires an LFM2 target (dense or MoE), got "
+            f"model_type={model_type!r}."
         )
     hidden_size = getattr(target_config, "hidden_size", None)
     if hidden_size != config.hidden_size:

--- a/mlx_vlm/tests/test_models_dspark.py
+++ b/mlx_vlm/tests/test_models_dspark.py
@@ -16,6 +16,7 @@ from mlx_vlm.speculative.drafters import (
     validate_drafter_compatibility,
 )
 from mlx_vlm.speculative.drafters.qwen3_dspark import DSparkDraftModel, ModelConfig
+from mlx_vlm.speculative.drafters.qwen3_dspark.dspark import validate_lfm2_dspark_target
 from mlx_vlm.speculative.utils import run_speculative_rounds
 from mlx_vlm.utils import get_model_and_args
 
@@ -85,6 +86,18 @@ def _published_moe_config():
         "mask_token_id": 125017,
         "target_layer_ids": [2, 6, 10, 14, 18],
         "num_target_layers": 24,
+    }
+    return config
+
+
+def _published_1_2b_config():
+    config = _published_config()
+    config["vocab_size"] = 65536
+    config["rope_theta"] = 1000000.0
+    config["dflash_config"] = {
+        "mask_token_id": 64402,
+        "target_layer_ids": [2, 5, 8, 11, 14],
+        "num_target_layers": 16,
     }
     return config
 
@@ -179,6 +192,37 @@ def test_published_lfm2_moe_dspark_config_preserves_target_layers():
     assert config.target_layer_ids == [2, 6, 10, 14, 18]
     assert config.num_target_layers == 24
     assert config.rope_theta == 5000000.0
+
+
+def test_published_1_2b_dspark_config_preserves_target_contract():
+    config = ModelConfig.from_dict(_published_1_2b_config())
+
+    assert config.proposal_length == 9
+    assert config.block_size == 10
+    assert config.runtime_block_size == 8
+    assert config.target_layer_ids == [2, 5, 8, 11, 14]
+    assert config.num_target_layers == 16
+    assert config.vocab_size == 65536
+    assert config.mask_token_id == 64402
+    assert config.rope_theta == 1000000.0
+
+
+def test_published_1_2b_dspark_accepts_matching_target_metadata():
+    config = ModelConfig.from_dict(_published_1_2b_config())
+    target = SimpleNamespace(
+        language_model=SimpleNamespace(
+            config=SimpleNamespace(
+                model_type="lfm2",
+                hidden_size=2048,
+                num_hidden_layers=16,
+                vocab_size=65536,
+            ),
+            model=SimpleNamespace(layers=[object()] * 16),
+            rollback_speculative_cache=lambda *args: None,
+        )
+    )
+
+    validate_lfm2_dspark_target(config, target)
 
 
 def test_generic_loader_routes_markov_dflash_checkpoint_to_dspark(tmp_path):

--- a/mlx_vlm/tests/test_models_dspark.py
+++ b/mlx_vlm/tests/test_models_dspark.py
@@ -6,9 +6,9 @@ import pytest
 
 from mlx_vlm.generate.ar import generate_step
 from mlx_vlm.models.cache import ArraysCache, BatchKVCache
+from mlx_vlm.models.exact_speculative_verify import exact_speculative_verify_weight
 from mlx_vlm.models.lfm2 import Model as Lfm2Model
 from mlx_vlm.models.lfm2 import ModelConfig as Lfm2Config
-from mlx_vlm.models.target_verify import target_verify_weight
 from mlx_vlm.speculative.drafters import (
     resolve_drafter_kind,
     validate_drafter_compatibility,
@@ -182,7 +182,7 @@ def test_tiny_dspark_forward_uses_markov_head_and_published_block_semantics():
     assert all(cache.offset == 3 for cache in draft_cache)
 
 
-def test_target_verify_dense_kernel_matches_mlx_linear():
+def test_exact_speculative_verify_dense_kernel_matches_mlx_linear():
     if not mx.metal.is_available():
         pytest.skip("The target-verification kernel requires Metal.")
 
@@ -190,7 +190,7 @@ def test_target_verify_dense_kernel_matches_mlx_linear():
     inputs = mx.random.normal((1, 5, 8)).astype(mx.bfloat16)
     weight = mx.random.normal((16, 8)).astype(mx.bfloat16)
     expected = inputs @ weight.T
-    actual = target_verify_weight(weight, inputs)
+    actual = exact_speculative_verify_weight(weight, inputs)
     assert actual is not None
     mx.eval(expected, actual)
 
@@ -198,7 +198,7 @@ def test_target_verify_dense_kernel_matches_mlx_linear():
     assert bool(mx.array_equal(actual, expected))
 
 
-def test_lfm2_target_verify_logits_exactly_match_single_token_decode():
+def test_lfm2_exact_speculative_verify_matches_single_token_decode():
     if not mx.metal.is_available():
         pytest.skip("Exact target verification requires Metal.")
 

--- a/mlx_vlm/tests/test_models_dspark.py
+++ b/mlx_vlm/tests/test_models_dspark.py
@@ -9,6 +9,8 @@ from mlx_vlm.models.cache import ArraysCache, BatchKVCache
 from mlx_vlm.models.exact_speculative_verify import exact_speculative_verify_weight
 from mlx_vlm.models.lfm2 import Model as Lfm2Model
 from mlx_vlm.models.lfm2 import ModelConfig as Lfm2Config
+from mlx_vlm.models.lfm2_moe import Model as Lfm2MoeModel
+from mlx_vlm.models.lfm2_moe import ModelConfig as Lfm2MoeConfig
 from mlx_vlm.speculative.drafters import (
     resolve_drafter_kind,
     validate_drafter_compatibility,
@@ -76,6 +78,17 @@ def _tiny_draft_config():
     )
 
 
+def _published_moe_config():
+    config = _published_config()
+    config["rope_theta"] = 5000000.0
+    config["dflash_config"] = {
+        "mask_token_id": 125017,
+        "target_layer_ids": [2, 6, 10, 14, 18],
+        "num_target_layers": 24,
+    }
+    return config
+
+
 def _tiny_target():
     config = Lfm2Config(
         model_type="lfm2",
@@ -99,6 +112,32 @@ def _tiny_target():
         tie_word_embeddings=True,
     )
     return Lfm2Model(config)
+
+
+def _tiny_moe_target():
+    config = Lfm2MoeConfig(
+        model_type="lfm2_moe",
+        vocab_size=32,
+        hidden_size=8,
+        intermediate_size=16,
+        moe_intermediate_size=8,
+        num_hidden_layers=3,
+        num_experts=4,
+        num_experts_per_tok=2,
+        norm_topk_prob=True,
+        num_attention_heads=2,
+        num_key_value_heads=1,
+        max_position_embeddings=128,
+        use_expert_bias=True,
+        num_dense_layers=1,
+        norm_eps=1e-5,
+        conv_bias=False,
+        conv_L_cache=3,
+        rope_theta=10000.0,
+        layer_types=["conv", "full_attention", "conv"],
+        tie_word_embeddings=True,
+    )
+    return Lfm2MoeModel(config)
 
 
 def _generated_tokens(target, prompt, drafter=None):
@@ -132,6 +171,16 @@ def test_published_config_normalizes_dspark_gamma_to_verify_width():
     assert DSparkDraftModel.prefer_requested_block_size is True
 
 
+def test_published_lfm2_moe_dspark_config_preserves_target_layers():
+    config = ModelConfig.from_dict(_published_moe_config())
+
+    assert config.proposal_length == 9
+    assert config.block_size == 10
+    assert config.target_layer_ids == [2, 6, 10, 14, 18]
+    assert config.num_target_layers == 24
+    assert config.rope_theta == 5000000.0
+
+
 def test_generic_loader_routes_markov_dflash_checkpoint_to_dspark(tmp_path):
     architecture, model_type = get_model_and_args(_published_config())
 
@@ -150,6 +199,12 @@ def test_dspark_requires_the_matching_lfm2_target():
     target.language_model.config.model_type = "other"
     with pytest.raises(ValueError, match="requires an LFM2 target"):
         validate_drafter_compatibility(target, drafter, "dflash")
+
+
+def test_dspark_accepts_matching_lfm2_moe_target():
+    drafter = DSparkDraftModel(_tiny_draft_config())
+
+    validate_drafter_compatibility(_tiny_moe_target(), drafter, "dflash")
 
 
 def test_tiny_dspark_forward_uses_markov_head_and_published_block_semantics():
@@ -231,9 +286,44 @@ def test_lfm2_exact_speculative_verify_matches_single_token_decode():
     assert bool(mx.array_equal(block_logits, singleton_logits))
 
 
-def test_lfm2_hybrid_cache_rollback_matches_committed_prefix():
+def test_lfm2_moe_exact_speculative_verify_matches_single_token_decode():
+    if not mx.metal.is_available():
+        pytest.skip("Exact target verification requires Metal.")
+
+    mx.random.seed(17)
+    target = _tiny_moe_target()
+    target.set_dtype(mx.bfloat16)
+    lm = target.language_model
+    mx.eval(target.parameters())
+
+    prompt = mx.array([[1, 2, 3, 4]], dtype=mx.int32)
+    verify = mx.array([[5, 6, 7, 8]], dtype=mx.int32)
+    block_cache = lm.make_cache()
+    singleton_cache = lm.make_cache()
+    lm(prompt, cache=block_cache)
+    lm(prompt, cache=singleton_cache)
+
+    block_logits = lm(
+        verify,
+        cache=block_cache,
+        speculative_verify=True,
+    ).logits
+    singleton_logits = mx.concatenate(
+        [
+            lm(verify[:, index : index + 1], cache=singleton_cache).logits
+            for index in range(verify.shape[1])
+        ],
+        axis=1,
+    )
+    mx.eval(block_logits, singleton_logits)
+
+    assert bool(mx.array_equal(block_logits, singleton_logits))
+
+
+@pytest.mark.parametrize("target_factory", [_tiny_target, _tiny_moe_target])
+def test_lfm2_hybrid_cache_rollback_matches_committed_prefix(target_factory):
     mx.random.seed(3)
-    target = _tiny_target()
+    target = target_factory()
     lm = target.language_model
     mx.eval(target.parameters())
 
@@ -314,6 +404,20 @@ def test_lfm2_ragged_batch_rollback_matches_each_committed_prefix():
 def test_greedy_dspark_generation_matches_lfm2_baseline():
     mx.random.seed(7)
     target = _tiny_target()
+    drafter = DSparkDraftModel(_tiny_draft_config())
+    mx.eval(target.parameters(), drafter.parameters())
+    prompt = mx.array([[1, 2, 3, 4]], dtype=mx.int32)
+
+    baseline = _generated_tokens(target, prompt)
+    speculative = _generated_tokens(target, prompt, drafter)
+
+    assert speculative == baseline
+    assert drafter.draft_lens
+
+
+def test_greedy_dspark_generation_matches_lfm2_moe_baseline():
+    mx.random.seed(19)
+    target = _tiny_moe_target()
     drafter = DSparkDraftModel(_tiny_draft_config())
     mx.eval(target.parameters(), drafter.parameters())
     prompt = mx.array([[1, 2, 3, 4]], dtype=mx.int32)

--- a/mlx_vlm/tests/test_models_dspark.py
+++ b/mlx_vlm/tests/test_models_dspark.py
@@ -8,6 +8,7 @@ from mlx_vlm.generate.ar import generate_step
 from mlx_vlm.models.cache import ArraysCache, BatchKVCache
 from mlx_vlm.models.lfm2 import Model as Lfm2Model
 from mlx_vlm.models.lfm2 import ModelConfig as Lfm2Config
+from mlx_vlm.models.target_verify import target_verify_weight
 from mlx_vlm.speculative.drafters import (
     resolve_drafter_kind,
     validate_drafter_compatibility,
@@ -124,6 +125,7 @@ def test_published_config_normalizes_dspark_gamma_to_verify_width():
 
     assert config.proposal_length == 9
     assert config.block_size == 10
+    assert config.runtime_block_size == 8
     assert config.target_layer_ids == [2, 9, 17, 21, 27]
     assert config.num_target_layers == 30
     assert config.markov_rank == 256
@@ -178,6 +180,55 @@ def test_tiny_dspark_forward_uses_markov_head_and_published_block_semantics():
     assert hidden.shape == (1, 3, 16)
     assert tokens.shape == (1, drafter.config.proposal_length)
     assert all(cache.offset == 3 for cache in draft_cache)
+
+
+def test_target_verify_dense_kernel_matches_mlx_linear():
+    if not mx.metal.is_available():
+        pytest.skip("The target-verification kernel requires Metal.")
+
+    mx.random.seed(11)
+    inputs = mx.random.normal((1, 5, 8)).astype(mx.bfloat16)
+    weight = mx.random.normal((16, 8)).astype(mx.bfloat16)
+    expected = inputs @ weight.T
+    actual = target_verify_weight(weight, inputs)
+    assert actual is not None
+    mx.eval(expected, actual)
+
+    assert actual.shape == expected.shape
+    assert bool(mx.array_equal(actual, expected))
+
+
+def test_lfm2_target_verify_logits_exactly_match_single_token_decode():
+    if not mx.metal.is_available():
+        pytest.skip("Exact target verification requires Metal.")
+
+    mx.random.seed(13)
+    target = _tiny_target()
+    lm = target.language_model
+    mx.eval(target.parameters())
+
+    prompt = mx.array([[1, 2, 3, 4]], dtype=mx.int32)
+    verify = mx.array([[5, 6, 7, 8]], dtype=mx.int32)
+    block_cache = lm.make_cache()
+    singleton_cache = lm.make_cache()
+    lm(prompt, cache=block_cache)
+    lm(prompt, cache=singleton_cache)
+
+    block_logits = lm(
+        verify,
+        cache=block_cache,
+        speculative_verify=True,
+    ).logits
+    singleton_logits = mx.concatenate(
+        [
+            lm(verify[:, index : index + 1], cache=singleton_cache).logits
+            for index in range(verify.shape[1])
+        ],
+        axis=1,
+    )
+    mx.eval(block_logits, singleton_logits)
+
+    assert bool(mx.array_equal(block_logits, singleton_logits))
 
 
 def test_lfm2_hybrid_cache_rollback_matches_committed_prefix():


### PR DESCRIPTION
Stacked on #1980.

## Summary

- add shared singleton-equivalent Metal GEMV kernels for dense and selected-expert target verification
- make LFM2 speculative projections, attention, short-conv, dense MLP, MoE routing/experts, and LM-head verification match ordinary one-token decoding exactly
- reuse the LFM2 hybrid-cache capture and rollback implementation for LFM2 MoE while preserving MoE checkpoint sanitization and quantization policies
- accept matching `lfm2` and `lfm2_moe` targets in DSpark compatibility validation
- default DSpark to an eight-row runtime verification width, avoiding the nine/ten-row padding cliff while retaining the trained width as an override
- add dense and MoE config, compatibility, bitwise-logit, rollback, and end-to-end parity coverage in `test_models_dspark`

## M5 Max benchmarks

Batch size 1, greedy decoding, warmed kernels.

### LFM2.5-2.6B

256 generated tokens per workload:

| Workload | Baseline | DSpark | Speedup | Parity |
|---|---:|---:|---:|---|
| MATH-500 | 87.20 tok/s | 324.05 tok/s | 3.72x | exact |
| GSM8K | 87.59 tok/s | 230.89 tok/s | 2.64x | exact |
| HumanEval | 87.65 tok/s | 254.12 tok/s | 2.90x | exact |
| MBPP | 87.55 tok/s | 264.50 tok/s | 3.02x | exact |
| MT | 87.83 tok/s | 247.76 tok/s | 2.82x | exact |

All 1,280 generated token IDs matched baseline. Median DSpark throughput was 254.12 tok/s with a 2.90x median speedup.

### LFM2.5-8B-A1B MoE

200 generated tokens on a math-reasoning prompt:

| Baseline | DSpark | Speedup | Parity |
|---:|---:|---:|---|
| 128.66 tok/s | 159.45 tok/s | 1.24x | exact |

All 200 generated token IDs matched baseline. The measured speedup is consistent with LiquidAI's published M4 Max range for this checkpoint (1.21x on MATH-500 and 1.18x mean).

## Tests

- 19 focused LFM2 dense/MoE DSpark and model regression tests passed
- real LFM2.5-8B-A1B verifier logits and five captured target layers matched singleton decoding bit-for-bit
- Black, Ruff, and git diff checks passed
