### PR TITLE
Stop CI from installing an older mlx than requirements allow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   test:
     runs-on: macos-14
+    timeout-minutes: 30
 
     steps:
       - name: Checkout code
@@ -17,10 +18,6 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.10'
-
-      - name: Install MLX
-        run: |
-          pip install mlx>=0.15
 
       - name: Install pre-commit
         run: |


### PR DESCRIPTION
CI used to install an older mlx than requirements allow.

`tests.yml` has an `Install mlx` step that runs `pip install mlx>=0.15` *before* the package itself is installed, so the resolved version only has to satisfy a floor seventeen minor releases below the `mlx>=0.32.0` that `requirements.txt` demands.

`pip install -e .` pulls mlx via `requirements.txt` anyway, and the pre-commit hooks that run in between are `black`, `isort` and `autoflake`, none of which import the package.

Added `timeout-minutes: 30` for runners

### Verification

Workflow YAML parses. Hooks unaffected — `pre-commit run --all` needs no mlx.

