### PR TITLE
Fix Qwen3-Omni decode assigning RoPE position 0 to every token

### DIFF
--- a/mlx_vlm/models/qwen3_omni_moe/thinker.py
+++ b/mlx_vlm/models/qwen3_omni_moe/thinker.py
@@ -351,6 +351,26 @@ class Thinker(nn.Module):
             **kwargs,
         }
 
+        # Forward RoPE positions only on the prefill pass. ``get_input_embeddings``
+        # builds ``position_ids`` with ``get_rope_index``, which restarts at 0 on
+        # every call; on decode (seq_len 1) that pins each generated token to RoPE
+        # position 0 (#1983). Instead, on decode let the language model continue
+        # positions from the cache offset via the ``rope_deltas`` it seeded at
+        # prefill -- this is correct for both the text-only and multimodal paths.
+        c0 = cache[0] if cache else None
+        if c0 is not None:
+            offset = getattr(c0, "_idx", None)
+            if offset is None:
+                offset = getattr(c0, "offset", 0)
+            offset = (
+                int(offset.max().item())
+                if isinstance(offset, mx.array)
+                else int(offset)
+            )
+            if offset > 0:
+                kwargs.pop("position_ids", None)
+                kwargs.pop("rope_deltas", None)
+
         logits = self.language_model(input_ids, mask=mask, cache=cache, **kwargs)
 
         return logits

--- a/mlx_vlm/models/qwen3_omni_moe/thinker.py
+++ b/mlx_vlm/models/qwen3_omni_moe/thinker.py
@@ -351,7 +351,6 @@ class Thinker(nn.Module):
             **kwargs,
         }
 
-
         c0 = cache[0] if cache else None
         if c0 is not None:
             offset = getattr(c0, "_idx", None)

--- a/mlx_vlm/models/qwen3_omni_moe/thinker.py
+++ b/mlx_vlm/models/qwen3_omni_moe/thinker.py
@@ -351,12 +351,7 @@ class Thinker(nn.Module):
             **kwargs,
         }
 
-        # Forward RoPE positions only on the prefill pass. ``get_input_embeddings``
-        # builds ``position_ids`` with ``get_rope_index``, which restarts at 0 on
-        # every call; on decode (seq_len 1) that pins each generated token to RoPE
-        # position 0 (#1983). Instead, on decode let the language model continue
-        # positions from the cache offset via the ``rope_deltas`` it seeded at
-        # prefill -- this is correct for both the text-only and multimodal paths.
+
         c0 = cache[0] if cache else None
         if c0 is not None:
             offset = getattr(c0, "_idx", None)

--- a/mlx_vlm/tests/test_qwen3_omni_moe.py
+++ b/mlx_vlm/tests/test_qwen3_omni_moe.py
@@ -252,6 +252,61 @@ class Qwen3OmniMoeTest(unittest.TestCase):
             bool(mx.allclose(batch[1:2], solo_text, rtol=1e-4, atol=1e-5).item())
         )
 
+    def _thinker_logits(self, model, ids, cache, **kw):
+        x = ids if isinstance(ids, mx.array) else mx.array(ids, dtype=mx.int32)
+        out = model.thinker(x, cache=cache, **kw)
+        return out.logits if hasattr(out, "logits") else out
+
+    def _assert_prefill_decode_match(self, pre, step, pos):
+        a, b = pre.reshape(-1), step[:, -1].reshape(-1)
+        cosine = float((a * b).sum() / (mx.linalg.norm(a) * mx.linalg.norm(b) + 1e-9))
+        self.assertGreater(cosine, 0.999, f"decode diverges from prefill at pos {pos}")
+
+    def test_decode_continues_rope_positions_from_cache_offset(self):
+        # Prefill and step-by-step decode of the same text tokens must agree.
+        # get_rope_index restarts positions at 0 on every call, so without
+        # cache-offset-aware positions each decoded token collapses to RoPE
+        # position 0 and diverges from prefill (#1983).
+        from mlx_vlm.models.cache import make_prompt_cache
+
+        model = _tiny_model()
+        inner = model.thinker.language_model.model
+        ids = [20, 21, 22, 23, 24, 25, 26, 27]
+        pre = self._thinker_logits(model, [ids], make_prompt_cache(inner))
+        cache = make_prompt_cache(inner)
+        for pos, tok in enumerate(ids):
+            step = self._thinker_logits(model, [[tok]], cache)
+            self._assert_prefill_decode_match(pre[:, pos], step, pos)
+
+    def test_decode_continues_rope_positions_multimodal(self):
+        # After an image+text prefill, decoded text tokens must continue mRoPE
+        # positions from the cache offset (via rope_deltas), matching a single
+        # full prefill of image+text+continuation (#1983).
+        from mlx_vlm.models.cache import make_prompt_cache
+
+        model = _tiny_vision_model()
+        inner = model.thinker.language_model.model
+        img_ids, pixel_values, grid = _image_inputs()
+        cont = [30, 31, 32, 33]
+        prefix_len = img_ids.shape[1]
+        full = mx.concatenate([img_ids, mx.array([cont], dtype=mx.int32)], axis=1)
+        pre = self._thinker_logits(
+            model,
+            full,
+            make_prompt_cache(inner),
+            pixel_values=pixel_values,
+            image_grid_thw=grid,
+        )
+        cache = make_prompt_cache(inner)
+        self._thinker_logits(
+            model, img_ids, cache, pixel_values=pixel_values, image_grid_thw=grid
+        )
+        for i, tok in enumerate(cont):
+            step = self._thinker_logits(model, [[tok]], cache)
+            self._assert_prefill_decode_match(
+                pre[:, prefix_len + i], step, prefix_len + i
+            )
+
     def test_quant_predicate_forwarded_to_top_level_model(self):
         model = _tiny_model()
         predicate = model.quant_predicate


### PR DESCRIPTION
Forward the thinker's `get_rope_index` positions only on prefill so that during decode the language model continues RoPE positions from the cache offset (via the `rope_deltas` it seeds at prefill) instead of pinning every generated token to position 0 (fixes #1983).