### PR TITLE
fix(server): enforce tool_choice on the Anthropic /v1/messages route (#2000)

### DIFF
--- a/mlx_vlm/server/anthropic.py
+++ b/mlx_vlm/server/anthropic.py
@@ -8,7 +8,7 @@ import uuid
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 import mlx.core as mx
-from fastapi import Request
+from fastapi import HTTPException, Request
 from fastapi.responses import JSONResponse, StreamingResponse
 
 from ..generate import generate, stream_generate
@@ -21,6 +21,7 @@ from .generation import (
     _build_metrics_envelope,
     _count_prompt_tokens,
 )
+from .openai import _prepare_chat_tool_choice
 from .responses_state import (
     make_response_stream_state,
     process_tool_calls,
@@ -366,6 +367,11 @@ def _anthropic_messages_to_internal(
 
     tools = _anthropic_tools_to_openai(request.tools)
     tool_choice = _anthropic_tool_choice_to_openai(request.tool_choice)
+    # Passing tool_choice through as a template kwarg only constrains the models
+    # whose chat template reads it, so enforce it the way /v1/chat/completions does.
+    processed_messages, tools, tool_choice = _prepare_chat_tool_choice(
+        processed_messages, tools, tool_choice
+    )
     return processed_messages, images, tools, tool_choice
 
 
@@ -469,9 +475,12 @@ async def anthropic_messages_endpoint(http_request: Request):
         )
         model, processor, config = get_cached_model(request.model, adapter_path)
 
-        processed_messages, images, tools, tool_choice = (
-            _anthropic_messages_to_internal(request)
-        )
+        try:
+            processed_messages, images, tools, tool_choice = (
+                _anthropic_messages_to_internal(request)
+            )
+        except HTTPException as e:
+            return _anthropic_error_response(e.status_code, str(e.detail))
         tool_parser_type = _infer_tool_parser_from_processor(processor)
         tool_module = load_tool_module(tool_parser_type) if tool_parser_type else None
 
@@ -1059,9 +1068,12 @@ async def anthropic_count_tokens_endpoint(http_request: Request):
         body = _normalize_anthropic_system_messages(await http_request.json())
         request = _anthropic_request_with_derived_fields(AnthropicRequest(**body))
         model, processor, config = get_cached_model(request.model)
-        processed_messages, images, tools, tool_choice = (
-            _anthropic_messages_to_internal(request)
-        )
+        try:
+            processed_messages, images, tools, tool_choice = (
+                _anthropic_messages_to_internal(request)
+            )
+        except HTTPException as e:
+            return _anthropic_error_response(e.status_code, str(e.detail))
         gen_args = _build_gen_args(
             request, processor, tenant_id=_read_tenant_id(http_request)
         )

--- a/mlx_vlm/tests/test_server.py
+++ b/mlx_vlm/tests/test_server.py
@@ -22,6 +22,7 @@ from transformers.utils.chat_parsing import ResponseParser, parse_response
 
 import mlx_vlm.reranker_loader as reranker_loader
 import mlx_vlm.server as server
+import mlx_vlm.server.anthropic as server_anthropic
 import mlx_vlm.server.cli as server_cli
 import mlx_vlm.server.generation as server_generation
 import mlx_vlm.server.openai as server_openai
@@ -4562,6 +4563,149 @@ def test_anthropic_messages_streaming_emits_tool_use_events(client, monkeypatch)
     assert '"type": "input_json_delta"' in body
     assert '"partial_json": "{\\"location\\": \\"SF\\"}"' in body
     assert '"stop_reason": "tool_use"' in body
+
+
+ANTHROPIC_TOOLS = [
+    {
+        "name": "get_time",
+        "description": "Get the current time",
+        "input_schema": {"type": "object", "properties": {}},
+    },
+    {
+        "name": "get_weather",
+        "description": "Get the current weather",
+        "input_schema": {"type": "object", "properties": {}},
+    },
+]
+
+
+def _anthropic_tool_choice_request(client, tool_choice, tools=ANTHROPIC_TOOLS):
+    model = SimpleNamespace()
+    processor = SimpleNamespace()
+    config = SimpleNamespace(model_type="qwen2_vl")
+    result = GenerationResult(text="done", prompt_tokens=5, generation_tokens=2)
+
+    with (
+        patch.object(
+            server, "get_cached_model", return_value=(model, processor, config)
+        ),
+        patch.object(
+            server, "apply_chat_template", return_value="prompt"
+        ) as mock_template,
+        patch.object(server, "generate", return_value=result),
+    ):
+        response = client.post(
+            "/v1/messages",
+            json={
+                "model": "demo",
+                "messages": [{"role": "user", "content": "Weather in Paris?"}],
+                "tools": tools,
+                "tool_choice": tool_choice,
+                "max_tokens": 32,
+            },
+        )
+    return response, mock_template
+
+
+def test_anthropic_messages_tool_choice_none_disables_tools(client, monkeypatch):
+    monkeypatch.setattr(server.runtime, "response_generator", None)
+
+    response, mock_template = _anthropic_tool_choice_request(client, {"type": "none"})
+
+    assert response.status_code == 200
+    assert mock_template.call_args.kwargs["tools"] is None
+    assert mock_template.call_args.kwargs["tool_choice"] == "none"
+
+
+def test_anthropic_messages_any_tool_choice_adds_instruction(client, monkeypatch):
+    monkeypatch.setattr(server.runtime, "response_generator", None)
+
+    response, mock_template = _anthropic_tool_choice_request(client, {"type": "any"})
+
+    assert response.status_code == 200
+    messages = mock_template.call_args.args[2]
+    assert "must call one or more" in messages[-1]["content"]
+    selected_tools = mock_template.call_args.kwargs["tools"]
+    assert [tool["function"]["name"] for tool in selected_tools] == [
+        "get_time",
+        "get_weather",
+    ]
+    assert mock_template.call_args.kwargs["tool_choice"] == "required"
+
+
+def test_anthropic_messages_forced_tool_choice_filters_tools(client, monkeypatch):
+    monkeypatch.setattr(server.runtime, "response_generator", None)
+
+    response, mock_template = _anthropic_tool_choice_request(
+        client, {"type": "tool", "name": "get_time"}
+    )
+
+    assert response.status_code == 200
+    messages = mock_template.call_args.args[2]
+    assert "must call the 'get_time' function" in messages[-1]["content"]
+    selected_tools = mock_template.call_args.kwargs["tools"]
+    assert [tool["function"]["name"] for tool in selected_tools] == ["get_time"]
+    assert mock_template.call_args.kwargs["tool_choice"] == {
+        "type": "function",
+        "function": {"name": "get_time"},
+    }
+
+
+@pytest.mark.parametrize(
+    ("tool_choice", "tools", "message"),
+    [
+        (
+            {"type": "tool", "name": "missing"},
+            ANTHROPIC_TOOLS,
+            "unknown function 'missing'",
+        ),
+        ({"type": "any"}, [], "requires at least one tool"),
+    ],
+)
+def test_anthropic_messages_rejects_unsatisfiable_tool_choice(
+    client, monkeypatch, tool_choice, tools, message
+):
+    monkeypatch.setattr(server.runtime, "response_generator", None)
+
+    response, _ = _anthropic_tool_choice_request(client, tool_choice, tools=tools)
+
+    assert response.status_code == 400
+    payload = response.json()
+    assert payload["type"] == "error"
+    assert payload["error"]["type"] == "invalid_request_error"
+    assert message in payload["error"]["message"]
+
+
+def test_anthropic_count_tokens_applies_tool_choice(client, monkeypatch):
+    monkeypatch.setattr(server.runtime, "response_generator", None)
+    model = SimpleNamespace()
+    processor = SimpleNamespace()
+    config = SimpleNamespace(model_type="qwen2_vl")
+
+    with (
+        patch.object(
+            server, "get_cached_model", return_value=(model, processor, config)
+        ),
+        patch.object(
+            server, "apply_chat_template", return_value="prompt"
+        ) as mock_template,
+        patch.object(server_anthropic, "prepare_inputs", return_value={}),
+        patch.object(server_anthropic, "_count_prompt_tokens", return_value=7),
+    ):
+        response = client.post(
+            "/v1/messages/count_tokens",
+            json={
+                "model": "demo",
+                "messages": [{"role": "user", "content": "Weather in Paris?"}],
+                "tools": ANTHROPIC_TOOLS,
+                "tool_choice": {"type": "tool", "name": "get_time"},
+            },
+        )
+
+    assert response.status_code == 200
+    assert response.json() == {"input_tokens": 7}
+    selected_tools = mock_template.call_args.kwargs["tools"]
+    assert [tool["function"]["name"] for tool in selected_tools] == ["get_time"]
 
 
 def test_cache_endpoints_report_disabled_stats_and_reset(client, monkeypatch):


### PR DESCRIPTION
Fixes #2000.

## Problem

`/v1/chat/completions` enforces `tool_choice` in `_prepare_chat_tool_choice` (`mlx_vlm/server/openai.py`): it filters the tool list down to the forced tool, drops the tools entirely for `"none"`, and injects an instruction into the prompt.

The Anthropic route never calls it. `_anthropic_messages_to_internal` converts the value to its OpenAI form and the endpoint then only does:

```python
template_kwargs = gen_args.to_template_kwargs()
if tool_choice is not None:
    template_kwargs["tool_choice"] = tool_choice
```

That constrains generation only for models whose chat template happens to read `tool_choice` (in this repo, `kimi_k3`). For every other model the full tool list is offered with no instruction, which is exactly the reported behaviour: `{"type": "none"}` still emits tool calls and `{"type": "tool", "name": "get_time"}` lets the model pick `get_weather` instead. A `tool_choice` naming a tool that was not supplied is also accepted silently rather than rejected.

## Fix

Apply `_prepare_chat_tool_choice` to the converted value inside `_anthropic_messages_to_internal`. That function is the single point both `/v1/messages` and `/v1/messages/count_tokens` go through, so both are covered, and `count_tokens` now counts the prompt that would actually be sent.

`_prepare_chat_tool_choice` raises `HTTPException`, which the Anthropic endpoints would otherwise surface as a `500 api_error`, so both call sites map it to `_anthropic_error_response` to keep the Anthropic error envelope and the 400 status.

The mapping from the Anthropic vocabulary was already in place and is unchanged (`auto`/`none` pass through, `any` → `required`, `{"type": "tool", "name": X}` → `{"type": "function", "function": {"name": X}}`), so `template_kwargs["tool_choice"]` keeps the same shape it had before — templates like `kimi_k3`'s that already read it see no change.

## Verification

`mlx` has no Windows wheel, so I could not run `mlx_vlm/tests/test_server.py` locally. Instead I drove the real `_anthropic_messages_to_internal` from the checked-out source (leaf imports stubbed, `_as_plain_dict` taken from `request_normalization.py`, `_prepare_chat_tool_choice` sliced out of `openai.py` — no hand-copied bodies), with two tools offered and a prompt favouring the tool that was *not* forced:

**Before** (`ffe22e1`) — every mode is indistinguishable from sending no `tool_choice` at all:

```
tool_choice absent           -> tools=['get_time', 'get_weather']   prompt unchanged
tool_choice auto             -> tools=['get_time', 'get_weather']   prompt unchanged
tool_choice none             -> tools=['get_time', 'get_weather']   prompt unchanged
tool_choice any              -> tools=['get_time', 'get_weather']   prompt unchanged
tool_choice tool=get_time    -> tools=['get_time', 'get_weather']   prompt unchanged
tool_choice tool=nope        -> tools=['get_time', 'get_weather']   prompt unchanged
```

**After:**

```
tool_choice absent           -> tools=['get_time', 'get_weather']   prompt unchanged
tool_choice auto             -> tools=['get_time', 'get_weather']   prompt unchanged
tool_choice none             -> tools=None
tool_choice any              -> tools=['get_time', 'get_weather']   + "You must call one or more of the available functions…"
tool_choice tool=get_time    -> tools=['get_time']                  + "You must call the 'get_time' function…"
tool_choice tool=nope        -> HTTP 400: tool_choice references unknown function 'nope'.
```

The `absent` and `auto` rows are byte-identical before and after, which is the no-`tool_choice` path that all existing traffic takes.

Added five tests in `mlx_vlm/tests/test_server.py`, mirroring the existing `test_chat_completions_*_tool_choice_*` tests: `none` disables tools, `any` adds the instruction, a forced tool filters the list, unsatisfiable choices return an Anthropic-shaped 400, and `count_tokens` applies the same filtering.

`black==26.3.1` and `isort --profile=black` (the pinned `.pre-commit-config.yaml` revisions) report both files unchanged.

## Note on the base commit

My fork's `main` is 10 commits behind upstream and I cannot sync it (`merge-upstream` returns 422 — my token lacks the `workflow` scope needed to update `.github/workflows/tests.yml`). Both files I touch are byte-identical between my fork's `main` and upstream `ffe22e1`, so the diff above is exactly my change and nothing else. Happy to rebase if you'd prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
