### PR TITLE
Route speculative server decoding through BatchGenerator

### DIFF
--- a/mlx_vlm/generate/ar.py
+++ b/mlx_vlm/generate/ar.py
@@ -1401,7 +1401,7 @@ class GenerationBatch:
 
 
 class SpeculativeGenerationBatch:
-    """GenerationBatch-compatible wrapper for server-side MTP decode."""
+    """GenerationBatch-compatible wrapper for server-side speculative decode."""
 
     is_speculative = True
     Response = GenerationBatch.Response

--- a/mlx_vlm/server/__init__.py
+++ b/mlx_vlm/server/__init__.py
@@ -15,6 +15,7 @@ from ..generate import (
     stream_generate,
 )
 from ..prompt_utils import apply_chat_template, extract_text_from_content
+from ..speculative.utils import run_speculative_server_rounds
 from ..structured import build_json_schema_logits_processor
 from ..tool_parsers import _infer_tool_parser_from_processor, load_tool_module
 from ..version import __version__
@@ -89,7 +90,6 @@ from .generation import (
     get_top_logprobs_k,
     load_model_resources,
     make_streaming_detokenizer,
-    run_speculative_server_rounds,
 )
 from .openai import (
     chat_completions_endpoint,

--- a/mlx_vlm/server/generation.py
+++ b/mlx_vlm/server/generation.py
@@ -28,9 +28,7 @@ from ..generate import (
     DEFAULT_THINKING_START_TOKEN,
     DEFAULT_TOP_P,
     BatchGenerator,
-    _chunked_prefill_enabled,
     _make_cache,
-    _merge_prefill_prompt_kwargs,
 )
 from ..generate.diffusion import (
     is_diffusion_model,
@@ -38,10 +36,6 @@ from ..generate.diffusion import (
 )
 from ..sample_utils import make_logits_processors, make_sampler, top_p_sampling
 from ..speculative.utils import (
-    make_speculative_prompt_cache,
-    run_speculative_server_rounds,
-    speculative_hidden_state,
-    speculative_prefill_kwargs,
     speculative_stats_since,
     speculative_stats_snapshot,
 )
@@ -127,93 +121,6 @@ def get_log_progress_interval():
         return DEFAULT_LOG_PROGRESS_INTERVAL
 
 
-def _sequence_aligned_prefill_keys(
-    prompt_kwargs: dict, *, batch_size: int, sequence_length: int
-) -> List[str]:
-    return [
-        k
-        for k, v in (prompt_kwargs or {}).items()
-        if isinstance(v, mx.array)
-        and v.ndim >= 2
-        and v.shape[0] == batch_size
-        and v.shape[1] == sequence_length
-    ]
-
-
-def _slice_prefill_kwargs(prompt_kwargs: dict, keys: List[str], n: int) -> dict:
-    if not keys:
-        return prompt_kwargs
-    out = dict(prompt_kwargs)
-    for key in keys:
-        if key in out:
-            out[key] = out[key][:, :n, ...]
-    return out
-
-
-def _drop_prefill_kwargs(prompt_kwargs: dict, keys: List[str], n: int) -> dict:
-    if not keys:
-        return prompt_kwargs
-    out = dict(prompt_kwargs)
-    for key in keys:
-        if key in out:
-            out[key] = out[key][:, n:, ...]
-    return out
-
-
-def _run_chunked_speculative_prefill(
-    lm,
-    input_ids: mx.array,
-    inputs_embeds: mx.array,
-    prompt_cache,
-    prompt_kwargs: dict,
-    speculative_kwargs: dict,
-    *,
-    prefill_step_size: Optional[int],
-    generation_stream,
-) -> Tuple[object, mx.array]:
-    """Prefill target cache in chunks, capturing speculative state only at end."""
-    remaining_input_ids = input_ids
-    remaining_embeds = inputs_embeds
-    remaining_kwargs = dict(prompt_kwargs or {})
-    sequence_keys = _sequence_aligned_prefill_keys(
-        remaining_kwargs,
-        batch_size=input_ids.shape[0],
-        sequence_length=inputs_embeds.shape[1],
-    )
-
-    if (
-        prefill_step_size is not None
-        and prefill_step_size > 0
-        and remaining_embeds.shape[1] > prefill_step_size
-    ):
-        while remaining_embeds.shape[1] > 1:
-            n_to_process = min(prefill_step_size, remaining_embeds.shape[1] - 1)
-            chunk_kwargs = _slice_prefill_kwargs(
-                remaining_kwargs, sequence_keys, n_to_process
-            )
-            with mx.stream(generation_stream):
-                lm(
-                    remaining_input_ids[:, :n_to_process],
-                    cache=prompt_cache,
-                    inputs_embeds=remaining_embeds[:, :n_to_process],
-                    n_to_process=n_to_process,
-                    **chunk_kwargs,
-                )
-            mx.eval([c.state for c in prompt_cache])
-            remaining_input_ids = remaining_input_ids[:, n_to_process:]
-            remaining_embeds = remaining_embeds[:, n_to_process:]
-            remaining_kwargs = _drop_prefill_kwargs(
-                remaining_kwargs, sequence_keys, n_to_process
-            )
-            mx.clear_cache()
-
-    final_kwargs = {**remaining_kwargs, **speculative_kwargs}
-    final_kwargs["inputs_embeds"] = remaining_embeds
-    with mx.stream(generation_stream):
-        out = lm(remaining_input_ids, cache=prompt_cache, **final_kwargs)
-    return out, remaining_input_ids
-
-
 def _position_seed(seed: int, row_id: int, position: int) -> int:
     x = (int(seed) ^ 0x9E3779B9) & 0xFFFFFFFF
     x = (x + (int(row_id) + 1) * 0x85EBCA6B) & 0xFFFFFFFF
@@ -277,21 +184,6 @@ class _PositionedTargetSampler:
         )
         sampled_pos = mx.random.categorical(mx.log(top_probs), key=key)
         return mx.take_along_axis(sorted_indices, sampled_pos[..., None], axis=-1)[0]
-
-
-def _sample_last_token(
-    logits: mx.array,
-    sampler: Callable[[mx.array], mx.array],
-    *,
-    row_ids: Optional[List[int]] = None,
-    positions: Optional[List[int]] = None,
-):
-    logits = logits[:, -1, :]
-    logprobs = logits - mx.logsumexp(logits, axis=-1, keepdims=True)
-    sample_target = getattr(sampler, "sample_target", None)
-    if callable(sample_target) and row_ids is not None and positions is not None:
-        return sample_target(logprobs, row_ids=row_ids, positions=positions)
-    return sampler(logprobs)
 
 
 def get_server_enable_thinking():
@@ -1745,10 +1637,6 @@ class ResponseGenerator:
             self._run_diffusion()
             return
 
-        if self.draft_model is not None and self.draft_kind != "mtp":
-            self._run_speculative()
-            return
-
         generation_stream = mx.default_stream(mx.default_device())
 
         batch_gen = None
@@ -1764,11 +1652,7 @@ class ResponseGenerator:
                 active_batch = bool(active)
                 coalesce_s = (
                     get_speculative_batch_coalesce_s()
-                    if (
-                        not active_batch
-                        and self.draft_model is not None
-                        and self.draft_kind == "mtp"
-                    )
+                    if not active_batch and self.draft_model is not None
                     else 0.0
                 )
                 capacity = (
@@ -2062,337 +1946,6 @@ class ResponseGenerator:
                 pass
         finally:
             results.close()
-
-    def _run_speculative(self):
-        """GPU thread loop with DFlash, EAGLE-3, or MTP speculative decoding.
-
-        Collects incoming requests, prefills them as a batch with the
-        per-family hooks, then runs the matching round-loop for decode.
-        Finished sequences are filtered out automatically by the round-loop's
-        ``stop_check`` callback.
-        """
-        generation_stream = mx.default_stream(mx.default_device())
-
-        lm = self.model.language_model
-        drafter = self.draft_model
-        draft_kind = self.draft_kind
-        is_mtp = draft_kind == "mtp"
-        prefill_kwargs = speculative_prefill_kwargs(draft_kind, drafter)
-        eos_set = set(self.stop_tokens) if is_mtp else None
-        sampler = make_sampler(temp=0)
-        draft_block_size = _get_draft_block_size_from_env()
-
-        while not self._stop:
-            pending = []
-            rqueues = {}
-            try:
-                # --- Phase 1: collect pending requests ---
-                pending, should_stop = self._collect_pending_requests(
-                    active=False,
-                    coalesce_s=get_speculative_batch_coalesce_s(),
-                )
-                if should_stop:
-                    break
-
-                if not pending:
-                    continue
-                # --- Phase 2: prefill new batch ---
-                uids = []
-                rqueues = {}
-                token_lists = {}
-                stream_infos = {}
-                max_tokens_map = {}
-                prompt_tokens_map = {}
-                prompt_tps_map = {}
-                all_input_ids = []
-                prompt_kwargs_list = []
-
-                if hasattr(lm, "_position_ids"):
-                    lm._position_ids = None
-                if hasattr(lm, "_rope_deltas"):
-                    lm._rope_deltas = None
-
-                for request in pending:
-                    rqueue = request.rqueue
-                    raw_inputs = request.raw_inputs
-                    prompt_tokens = request.prompt_tokens
-                    args = request.args
-                    images = request.images
-                    log_state = self._log_prefill_started(
-                        request, backend=f"speculative_{draft_kind}"
-                    )
-                    input_ids, gen_kwargs = self._gpu_embed(
-                        raw_inputs,
-                        images,
-                        apc_semantic_hash=request.apc_semantic_hash,
-                    )
-                    uid = id(rqueue)
-                    uids.append(uid)
-                    rqueues[uid] = rqueue
-                    token_lists[uid] = []
-                    stream_infos[uid] = {
-                        "streamer": _ServerTokenStreamer(
-                            self.tokenizer,
-                            make_streaming_detokenizer(self.processor),
-                        ),
-                        **log_state,
-                    }
-                    max_tokens_map[uid] = args.max_tokens
-                    prompt_tokens_map[uid] = prompt_tokens
-                    all_input_ids.append(input_ids.squeeze(0).tolist())
-                    prompt_kwargs_list.append(gen_kwargs)
-                    rqueue.put(GenerationContext(uid=uid, prompt_tokens=prompt_tokens))
-                    sampler = self._make_sampler(args) or make_sampler(temp=0)
-
-                B = len(uids)
-                max_len = max(len(ids) for ids in all_input_ids)
-                left_padding = [max_len - len(ids) for ids in all_input_ids]
-                padded = [
-                    [0] * left_padding[i] + ids for i, ids in enumerate(all_input_ids)
-                ]
-                input_mx = mx.array(padded, dtype=mx.int32)
-
-                inputs_embeds_mx, prompt_kwargs = _merge_prefill_prompt_kwargs(
-                    prompt_kwargs_list, all_input_ids
-                )
-
-                prompt_cache = make_speculative_prompt_cache(
-                    lm,
-                    draft_kind=draft_kind,
-                    batch_size=B,
-                    left_padding=left_padding,
-                    make_cache=_make_cache,
-                )
-
-                prefill_step_size = self._effective_prefill_step_size()
-                policy_kwargs = {**prompt_kwargs, **prefill_kwargs}
-                if not _chunked_prefill_enabled(
-                    self.model,
-                    input_ids=input_mx,
-                    inputs_embeds=inputs_embeds_mx,
-                    prompt_cache=prompt_cache,
-                    draft_model=drafter,
-                    draft_kind=draft_kind,
-                    prefill_kwargs=policy_kwargs,
-                ):
-                    prefill_step_size = None
-
-                prompt_started = time.perf_counter()
-                out, input_mx = _run_chunked_speculative_prefill(
-                    lm,
-                    input_mx,
-                    inputs_embeds_mx,
-                    prompt_cache,
-                    prompt_kwargs,
-                    prefill_kwargs,
-                    prefill_step_size=prefill_step_size,
-                    generation_stream=generation_stream,
-                )
-                hidden = speculative_hidden_state(draft_kind, out)
-                shared_kv_states = out.shared_kv_states if is_mtp else None
-                sample_row_ids = [0] * B
-                first_bonus = _sample_last_token(
-                    out.logits,
-                    sampler,
-                    row_ids=sample_row_ids,
-                    positions=[0] * B,
-                )
-                mx.eval(first_bonus, hidden, out.logits)
-                prompt_elapsed = time.perf_counter() - prompt_started
-                for uid in uids:
-                    prompt_tokens = prompt_tokens_map[uid]
-                    prompt_tps_map[uid] = (
-                        prompt_tokens / prompt_elapsed
-                        if prompt_tokens > 0 and prompt_elapsed > 0
-                        else None
-                    )
-                    logger.info(
-                        "Prefill completed: request=%s prompt_tokens=%d "
-                        "cached_tokens=0 elapsed=%.3fs rate=%.1f tok/s",
-                        stream_infos[uid].get("request_id", uid),
-                        prompt_tokens,
-                        prompt_elapsed,
-                        float(prompt_tps_map[uid] or 0.0),
-                    )
-
-                finished_uids = set()
-
-                # Send first bonus tokens to clients
-                fb_list = first_bonus.tolist()
-                for j, uid in enumerate(uids):
-                    tok = int(fb_list[j])
-                    token_lists[uid].append(tok)
-                    is_stop = tok in self.stop_tokens
-                    is_max = len(token_lists[uid]) >= max_tokens_map[uid]
-                    finish = "stop" if is_stop else "length" if is_max else None
-                    text = self._stream_text(stream_infos[uid], tok, finish)
-                    emitted_at = self._log_decode_progress(
-                        uid,
-                        stream_infos[uid],
-                        token=tok,
-                        text=text,
-                        finish_reason=finish,
-                    )
-                    rqueues[uid].put(
-                        StreamingToken(
-                            text=text,
-                            token=tok,
-                            logprobs=0.0,
-                            finish_reason=finish,
-                            peak_memory=mx.get_peak_memory() / 1e9 if finish else 0,
-                            prompt_tps=prompt_tps_map.get(uid),
-                            emitted_at=emitted_at,
-                        )
-                    )
-                    if finish is not None:
-                        rqueues[uid].put(None)
-                        finished_uids.add(uid)
-
-                if len(finished_uids) == len(uids):
-                    continue
-
-                # --- Phase 3: speculative decode rounds ---
-                max_tok = max(max_tokens_map[u] for u in uids)
-
-                def stop_check(seq_idx, token_id):
-                    uid = uids[seq_idx]
-                    if uid in finished_uids:
-                        return True
-                    if token_id in self.stop_tokens:
-                        return True
-                    if len(token_lists[uid]) >= max_tokens_map[uid]:
-                        return True
-                    return False
-
-                spec_snapshot = speculative_stats_snapshot(drafter)
-
-                def spec_summary():
-                    return speculative_stats_since(drafter, spec_snapshot)
-
-                rounds_iter = run_speculative_server_rounds(
-                    self.model,
-                    drafter,
-                    prompt_cache,
-                    hidden,
-                    draft_kind=draft_kind,
-                    first_bonus=first_bonus,
-                    max_tokens=max_tok,
-                    sampler=sampler,
-                    draft_block_size=draft_block_size,
-                    token_dtype=mx.int32,
-                    stop_check=stop_check,
-                    greedy_sampling=all(
-                        request.args.temperature == 0 for request in pending
-                    ),
-                    shared_kv_states=shared_kv_states,
-                    eos_token_ids=eos_set,
-                    prompt_tokens=input_mx,
-                    row_ids=sample_row_ids,
-                )
-                for tok_list, _ in rounds_iter:
-                    for j, tok in enumerate(tok_list):
-                        if tok is None:
-                            continue
-                        uid = uids[j]
-                        if uid in finished_uids:
-                            continue
-
-                        token_lists[uid].append(tok)
-                        tokens = token_lists[uid]
-
-                        is_stop = tok in self.stop_tokens
-                        is_max = len(tokens) >= max_tokens_map[uid]
-                        finish = "stop" if is_stop else "length" if is_max else None
-                        text = self._stream_text(stream_infos[uid], tok, finish)
-
-                        emitted_at = self._log_decode_progress(
-                            uid,
-                            stream_infos[uid],
-                            token=tok,
-                            text=text,
-                            finish_reason=finish,
-                        )
-
-                        rounds, accepted, drafted = (
-                            spec_summary() if finish else (None, None, None)
-                        )
-                        rqueues[uid].put(
-                            StreamingToken(
-                                text=text,
-                                token=tok,
-                                logprobs=0.0,
-                                finish_reason=finish,
-                                peak_memory=mx.get_peak_memory() / 1e9 if finish else 0,
-                                prompt_tps=prompt_tps_map.get(uid),
-                                emitted_at=emitted_at,
-                                draft_kind=draft_kind if finish else None,
-                                draft_rounds=rounds,
-                                draft_n_accepted=accepted,
-                                draft_n=drafted,
-                            )
-                        )
-
-                        if finish is not None:
-                            rqueues[uid].put(None)
-                            finished_uids.add(uid)
-                    if len(finished_uids) == len(uids):
-                        break
-
-                # Log acceptance stats for this batch only, not the drafter's
-                # lifetime history.
-                rounds, accepted, drafted = spec_summary()
-                if rounds:
-                    mean_a = (accepted + rounds) / rounds
-                    logger.info(
-                        "Speculative decode: kind=%s batch=%d tokens=%d "
-                        "accept=%.2f rounds=%d drafted=%s",
-                        draft_kind,
-                        B,
-                        sum(len(token_lists[u]) for u in uids),
-                        mean_a,
-                        rounds,
-                        drafted,
-                    )
-
-                # Finalize any remaining
-                for uid in uids:
-                    if uid not in finished_uids:
-                        text = stream_infos[uid]["streamer"].finalize()
-                        emitted_at = self._log_decode_progress(
-                            uid,
-                            stream_infos[uid],
-                            token=0,
-                            text=text,
-                            finish_reason="length",
-                            token_count=0,
-                        )
-                        rqueues[uid].put(
-                            StreamingToken(
-                                text=text,
-                                token=0,
-                                logprobs=0.0,
-                                finish_reason="length",
-                                peak_memory=mx.get_peak_memory() / 1e9,
-                                prompt_tps=prompt_tps_map.get(uid),
-                                token_count=0,
-                                emitted_at=emitted_at,
-                                draft_kind=(draft_kind if rounds is not None else None),
-                                draft_rounds=rounds,
-                                draft_n_accepted=accepted,
-                                draft_n=drafted,
-                            )
-                        )
-                        rqueues[uid].put(None)
-
-            except Exception as e:
-                logger.exception("Error in speculative generation thread: %s", e)
-                error_queues = {id(rqueue): rqueue for rqueue in rqueues.values()}
-                error_queues.update(
-                    {id(request.rqueue): request.rqueue for request in pending}
-                )
-                _notify_queues(error_queues.values(), e, None)
-                mx.clear_cache()
-                gc.collect()
 
     def _step(self, batch_gen, active, gen_kwargs=None):
         """One batch generation step: prefill + decode."""

--- a/mlx_vlm/tests/test_server.py
+++ b/mlx_vlm/tests/test_server.py
@@ -419,68 +419,6 @@ def test_speculative_server_dispatches_mtp_batch_loop():
     )
 
 
-def test_speculative_server_samples_first_bonus_like_decode_step():
-    seen = {}
-    logits = mx.array(
-        [
-            [[1.0, 2.0, 3.0]],
-            [[4.0, 1.0, 0.0]],
-        ],
-        dtype=mx.float32,
-    )
-
-    def sampler(logprobs):
-        seen["shape"] = logprobs.shape
-        seen["values"] = logprobs
-        return mx.argmax(logprobs, axis=-1)
-
-    tokens = server_generation._sample_last_token(logits, sampler)
-    expected_logprobs = logits[:, -1, :] - mx.logsumexp(
-        logits[:, -1, :], axis=-1, keepdims=True
-    )
-    mx.eval(tokens, seen["values"], expected_logprobs)
-
-    assert seen["shape"] == (2, 3)
-    assert tokens.tolist() == [2, 0]
-    assert bool(mx.allclose(seen["values"], expected_logprobs).item())
-
-
-def test_speculative_server_samples_first_bonus_with_positioned_sampler():
-    seen = {}
-    logits = mx.array(
-        [
-            [[1.0, 2.0, 3.0]],
-            [[4.0, 1.0, 0.0]],
-        ],
-        dtype=mx.float32,
-    )
-
-    class Sampler:
-        def __call__(self, logprobs):
-            raise AssertionError("positioned sampler was not used")
-
-        def sample_target(self, logprobs, *, row_ids, positions):
-            seen["shape"] = logprobs.shape
-            seen["row_ids"] = list(row_ids)
-            seen["positions"] = list(positions)
-            return mx.argmax(logprobs, axis=-1)
-
-    tokens = server_generation._sample_last_token(
-        logits,
-        Sampler(),
-        row_ids=[0, 0],
-        positions=[0, 0],
-    )
-    mx.eval(tokens)
-
-    assert seen == {
-        "shape": (2, 3),
-        "row_ids": [0, 0],
-        "positions": [0, 0],
-    }
-    assert tokens.tolist() == [2, 0]
-
-
 def test_positioned_target_sampler_is_batch_grouping_invariant():
     sampler = server_generation._PositionedTargetSampler(
         temperature=0.7, top_p=1.0, seed=42
@@ -611,63 +549,6 @@ def test_speculative_prompt_cache_uses_batched_cache_for_batch(monkeypatch):
         )
         is batched_cache
     )
-
-
-def test_speculative_prefill_keeps_short_prompt_in_one_forward():
-    calls = []
-    output = SimpleNamespace(logits=mx.zeros((1, 3, 5)))
-
-    def lm(inputs, cache=None, **kwargs):
-        calls.append((inputs, cache, kwargs))
-        return output
-
-    input_ids = mx.array([[1, 2, 3]], dtype=mx.int32)
-    inputs_embeds = mx.ones((1, 3, 4), dtype=mx.float32)
-    result, remaining_ids = server_generation._run_chunked_speculative_prefill(
-        lm,
-        input_ids,
-        inputs_embeds,
-        [],
-        {},
-        {"capture_layer_ids": [1, 2]},
-        prefill_step_size=4,
-        generation_stream=mx.default_stream(mx.default_device()),
-    )
-
-    assert result is output
-    assert remaining_ids.tolist() == [[1, 2, 3]]
-    assert len(calls) == 1
-    assert calls[0][0].tolist() == [[1, 2, 3]]
-    assert calls[0][2]["inputs_embeds"].shape == (1, 3, 4)
-    assert calls[0][2]["capture_layer_ids"] == [1, 2]
-    assert "n_to_process" not in calls[0][2]
-
-
-def test_speculative_prefill_chunks_only_above_step_size():
-    calls = []
-
-    def lm(inputs, cache=None, **kwargs):
-        calls.append((inputs, cache, kwargs))
-        return SimpleNamespace(logits=mx.zeros((1, inputs.shape[1], 5)))
-
-    input_ids = mx.array([[1, 2, 3]], dtype=mx.int32)
-    inputs_embeds = mx.ones((1, 3, 4), dtype=mx.float32)
-    _, remaining_ids = server_generation._run_chunked_speculative_prefill(
-        lm,
-        input_ids,
-        inputs_embeds,
-        [],
-        {},
-        {"capture_layer_ids": [1, 2]},
-        prefill_step_size=2,
-        generation_stream=mx.default_stream(mx.default_device()),
-    )
-
-    assert remaining_ids.tolist() == [[3]]
-    assert [call[0].tolist() for call in calls] == [[[1, 2]], [[3]]]
-    assert calls[0][2]["n_to_process"] == 2
-    assert "capture_layer_ids" not in calls[0][2]
-    assert calls[1][2]["capture_layer_ids"] == [1, 2]
 
 
 def test_speculative_server_reads_draft_block_size_env(monkeypatch):
@@ -975,47 +856,6 @@ def test_server_serves_ar_requests_after_drafter_mismatch(monkeypatch):
     assert gen.draft_kind is None
 
 
-def test_speculative_thread_exception_reaches_client_queue(monkeypatch):
-    gen = _unstarted_response_generator()
-    gen.model = SimpleNamespace(language_model=SimpleNamespace())
-    gen.processor = SimpleNamespace()
-    gen.draft_model = SimpleNamespace(
-        config=SimpleNamespace(target_layer_ids=[1, 2]), accept_lens=[]
-    )
-    gen.draft_kind = "dflash"
-    gen.stop_tokens = set()
-
-    rqueue = Queue()
-    pending = [
-        server_generation.QueuedGenerationRequest(
-            rqueue=rqueue,
-            raw_inputs={"input_ids": mx.array([[1]], dtype=mx.int32)},
-            prompt_tokens=1,
-            args=server.GenerationArguments(max_tokens=2),
-        )
-    ]
-    calls = {"count": 0}
-
-    def collect_pending_requests(**_kwargs):
-        calls["count"] += 1
-        if calls["count"] == 1:
-            return pending, False
-        return [], True
-
-    error = RuntimeError("speculative prefill failed")
-    gen._collect_pending_requests = collect_pending_requests
-    gen._gpu_embed = MagicMock(side_effect=error)
-    monkeypatch.setattr(
-        "mlx_vlm.speculative.utils.speculative_prefill_kwargs",
-        lambda *_args, **_kwargs: {},
-    )
-
-    gen._run_speculative()
-
-    assert rqueue.get(timeout=1) is error
-    assert rqueue.get(timeout=1) is None
-
-
 def test_ar_thread_exception_reaches_pending_client_queue(monkeypatch):
     class FakeBatchGenerator:
         def __init__(self, *_args, **_kwargs):
@@ -1057,98 +897,6 @@ def test_ar_thread_exception_reaches_pending_client_queue(monkeypatch):
         gen._stop = True
         gen.requests.put(None)
         worker.join(timeout=2)
-
-
-def test_speculative_thread_exception_skips_broken_queues(monkeypatch):
-    gen = _unstarted_response_generator()
-    gen.model = SimpleNamespace(language_model=SimpleNamespace())
-    gen.processor = SimpleNamespace()
-    gen.draft_model = SimpleNamespace(
-        config=SimpleNamespace(target_layer_ids=[1, 2]), accept_lens=[]
-    )
-    gen.draft_kind = "dflash"
-    gen.stop_tokens = set()
-
-    class BrokenQueue:
-        def put(self, item):
-            raise RuntimeError("client went away")
-
-    good_queue = Queue()
-    pending = [
-        server_generation.QueuedGenerationRequest(
-            rqueue=BrokenQueue(),
-            raw_inputs={"input_ids": mx.array([[1]], dtype=mx.int32)},
-            prompt_tokens=1,
-            args=server.GenerationArguments(max_tokens=2),
-        ),
-        server_generation.QueuedGenerationRequest(
-            rqueue=good_queue,
-            raw_inputs={"input_ids": mx.array([[1]], dtype=mx.int32)},
-            prompt_tokens=1,
-            args=server.GenerationArguments(max_tokens=2),
-        ),
-    ]
-    calls = {"count": 0}
-
-    def collect_pending_requests(**_kwargs):
-        calls["count"] += 1
-        if calls["count"] == 1:
-            return pending, False
-        return [], True
-
-    error = RuntimeError("speculative prefill failed")
-    gen._collect_pending_requests = collect_pending_requests
-    gen._gpu_embed = MagicMock(side_effect=error)
-
-    gen._run_speculative()
-
-    assert good_queue.get(timeout=1) is error
-    assert good_queue.get(timeout=1) is None
-
-
-def test_speculative_thread_exception_clears_runtime_cache(monkeypatch):
-    gen = _unstarted_response_generator()
-    gen.model = SimpleNamespace(language_model=SimpleNamespace())
-    gen.processor = SimpleNamespace()
-    gen.draft_model = SimpleNamespace(
-        config=SimpleNamespace(target_layer_ids=[1, 2]), accept_lens=[]
-    )
-    gen.draft_kind = "dflash"
-    gen.stop_tokens = set()
-    rqueue = Queue()
-
-    calls = {"clear_cache": 0, "collect": 0}
-    collect_calls = {"count": 0}
-
-    def collect_pending_requests(**_kwargs):
-        collect_calls["count"] += 1
-        if collect_calls["count"] > 1:
-            return [], True
-        return [
-            server_generation.QueuedGenerationRequest(
-                rqueue=rqueue,
-                raw_inputs={"input_ids": mx.array([[1]], dtype=mx.int32)},
-                prompt_tokens=1,
-                args=server.GenerationArguments(max_tokens=2),
-            )
-        ], False
-
-    gen._collect_pending_requests = collect_pending_requests
-    gen._gpu_embed = MagicMock(side_effect=RuntimeError("boom"))
-    monkeypatch.setattr(
-        server_generation.mx,
-        "clear_cache",
-        lambda: calls.__setitem__("clear_cache", calls["clear_cache"] + 1),
-    )
-    monkeypatch.setattr(
-        server_generation.gc,
-        "collect",
-        lambda: calls.__setitem__("collect", calls["collect"] + 1),
-    )
-
-    gen._run_speculative()
-
-    assert calls == {"clear_cache": 1, "collect": 1}
 
 
 def test_models_endpoint_lists_single_file_safetensors_models(client, monkeypatch):
@@ -1753,221 +1501,6 @@ def test_images_edits_writes_paths(client, monkeypatch, tmp_path):
     assert [path.name for path in paths] == ["edit-40.png", "edit-41.png"]
     assert all(path.exists() for path in paths)
     assert all(item["b64_json"] is None for item in payload["data"])
-
-
-class _RecordingSpeculativeLM:
-    def __init__(self, draft_kind):
-        self.calls = []
-        self.draft_kind = draft_kind
-        self._position_ids = "stale"
-        self._rope_deltas = "stale"
-
-    def __call__(self, inputs, cache=None, **kwargs):
-        self.calls.append({"inputs": inputs, "cache": cache, **kwargs})
-        batch_size, seq_len = inputs.shape
-        logits = mx.broadcast_to(
-            mx.array([[[0.0, 1.0, 0.0, 0.0, 0.0]]], dtype=mx.float32),
-            (batch_size, seq_len, 5),
-        )
-        hidden = mx.ones((batch_size, seq_len, 2), dtype=mx.float32)
-        if self.draft_kind == "mtp":
-            return SimpleNamespace(
-                logits=logits,
-                hidden_states=[hidden],
-                shared_kv_states={"full_attention": ("k", "v")},
-            )
-        return SimpleNamespace(
-            logits=logits,
-            hidden_states=[hidden, hidden],
-            shared_kv_states=None,
-        )
-
-
-def _run_speculative_prefill_once(
-    monkeypatch, *, draft_kind, request_specs, prefill_step_size=2048
-):
-    lm = _RecordingSpeculativeLM(draft_kind)
-    gen = server.ResponseGenerator.__new__(server.ResponseGenerator)
-    gen.model = SimpleNamespace(language_model=lm)
-    gen.processor = SimpleNamespace()
-    gen.draft_model = SimpleNamespace(
-        config=SimpleNamespace(target_layer_ids=[1, 2]), accept_lens=[]
-    )
-    gen.draft_kind = draft_kind
-    gen.stop_tokens = {99}
-    gen.requests = Queue()
-    gen._stop = False
-    gen.prefill_step_size = prefill_step_size
-    gen._make_sampler = lambda args: None
-    gen.tokenizer = SimpleNamespace(
-        decode=lambda tokens: "".join(str(tok) for tok in tokens)
-    )
-
-    specs_iter = iter(request_specs)
-
-    def fake_gpu_embed(raw_inputs, images=None, apc_semantic_hash=None):
-        del raw_inputs, images, apc_semantic_hash
-        spec = next(specs_iter)
-        return spec["input_ids"], spec["gen_kwargs"]
-
-    gen._gpu_embed = fake_gpu_embed
-
-    monkeypatch.setattr(server_generation, "_make_cache", lambda *args, **kwargs: [])
-    monkeypatch.setattr(
-        server_generation, "_get_draft_block_size_from_env", lambda: None
-    )
-    monkeypatch.setattr(
-        server_generation, "get_speculative_batch_coalesce_s", lambda: 0.0
-    )
-
-    class _FakeDetokenizer:
-        def __init__(self):
-            self.last_segment = ""
-
-        def reset(self):
-            self.last_segment = ""
-
-        def add_token(self, token):
-            self.last_segment = str(token)
-
-        def finalize(self):
-            pass
-
-    monkeypatch.setattr(
-        server_generation,
-        "make_streaming_detokenizer",
-        lambda processor: _FakeDetokenizer(),
-    )
-
-    def fake_rounds(*args, **kwargs):
-        del args
-        gen.round_kwargs = kwargs
-        gen._stop = True
-        yield ([4] * int(kwargs["first_bonus"].shape[0]), None)
-
-    monkeypatch.setattr(server_generation, "run_speculative_server_rounds", fake_rounds)
-
-    args = server.GenerationArguments(max_tokens=2, temperature=0)
-    for spec in request_specs:
-        gen.requests.put(
-            server_generation.QueuedGenerationRequest(
-                rqueue=Queue(),
-                raw_inputs={"input_ids": spec["input_ids"]},
-                prompt_tokens=int(spec["input_ids"].shape[1]),
-                args=args,
-            )
-        )
-
-    gen._run_speculative()
-    call = lm.calls[0]
-    call["prefill_input_lengths"] = [item["inputs"].shape[1] for item in lm.calls]
-    call["round_kwargs"] = gen.round_kwargs
-    return call
-
-
-def test_speculative_server_threads_greedy_flag_to_mtp_loop(monkeypatch):
-    call = _run_speculative_prefill_once(
-        monkeypatch,
-        draft_kind="mtp",
-        request_specs=[
-            {
-                "input_ids": mx.array([[11, 12, 13]], dtype=mx.int32),
-                "gen_kwargs": {"inputs_embeds": mx.ones((1, 3, 4), dtype=mx.float32)},
-            },
-            {
-                "input_ids": mx.array([[21, 22, 23]], dtype=mx.int32),
-                "gen_kwargs": {"inputs_embeds": mx.ones((1, 3, 4), dtype=mx.float32)},
-            },
-        ],
-    )
-
-    assert call["round_kwargs"]["greedy_sampling"] is True
-
-
-def test_speculative_server_honors_prefill_step_override(monkeypatch):
-    monkeypatch.setattr(
-        server_generation, "_chunked_prefill_enabled", lambda *args, **kwargs: True
-    )
-    call = _run_speculative_prefill_once(
-        monkeypatch,
-        draft_kind="mtp",
-        prefill_step_size=2,
-        request_specs=[
-            {
-                "input_ids": mx.array([[11, 12, 13]], dtype=mx.int32),
-                "gen_kwargs": {"inputs_embeds": mx.ones((1, 3, 4), dtype=mx.float32)},
-            },
-            {
-                "input_ids": mx.array([[21, 22, 23]], dtype=mx.int32),
-                "gen_kwargs": {"inputs_embeds": mx.ones((1, 3, 4), dtype=mx.float32)},
-            },
-        ],
-    )
-
-    assert call["prefill_input_lengths"] == [2, 1]
-
-
-def test_speculative_server_prefill_threads_gemma4_per_layer_inputs(monkeypatch):
-    call = _run_speculative_prefill_once(
-        monkeypatch,
-        draft_kind="mtp",
-        request_specs=[
-            {
-                "input_ids": mx.array([[11, 12, 13]], dtype=mx.int32),
-                "gen_kwargs": {
-                    "inputs_embeds": mx.ones((1, 3, 4), dtype=mx.float32),
-                    "per_layer_inputs": mx.array(
-                        [[[1.0, 1.5], [2.0, 2.5], [3.0, 3.5]]], dtype=mx.float32
-                    ),
-                },
-            },
-            {
-                "input_ids": mx.array([[21, 22]], dtype=mx.int32),
-                "gen_kwargs": {
-                    "inputs_embeds": mx.full((1, 2, 4), 7.0, dtype=mx.float32),
-                    "per_layer_inputs": mx.array(
-                        [[[4.0, 4.5], [5.0, 5.5]]], dtype=mx.float32
-                    ),
-                },
-            },
-        ],
-    )
-
-    assert call["return_hidden"] is True
-    assert call["return_shared_kv"] is True
-    assert call["per_layer_inputs"].shape == (2, 3, 2)
-    assert call["per_layer_inputs"].tolist()[1][0] == [0.0, 0.0]
-    assert call["inputs_embeds"].shape == (2, 3, 4)
-
-
-def test_speculative_server_prefill_threads_qwen_dflash_prompt_kwargs(monkeypatch):
-    call = _run_speculative_prefill_once(
-        monkeypatch,
-        draft_kind="dflash",
-        request_specs=[
-            {
-                "input_ids": mx.array([[31, 32, 33]], dtype=mx.int32),
-                "gen_kwargs": {
-                    "inputs_embeds": mx.ones((1, 3, 4), dtype=mx.float32),
-                    "image_grid_thw": mx.array([[1, 2, 3]], dtype=mx.int32),
-                    "_apc_semantic_hash": 123,
-                },
-            },
-            {
-                "input_ids": mx.array([[41, 42]], dtype=mx.int32),
-                "gen_kwargs": {
-                    "inputs_embeds": mx.full((1, 2, 4), 9.0, dtype=mx.float32),
-                    "image_grid_thw": mx.array([[4, 5, 6]], dtype=mx.int32),
-                },
-            },
-        ],
-    )
-
-    assert call["capture_layer_ids"] == [1, 2]
-    assert call["image_grid_thw"].tolist() == [[1, 2, 3], [4, 5, 6]]
-    assert call["inputs_embeds"].shape == (2, 3, 4)
-    assert call["inputs_embeds"].tolist()[1][0] == [0.0, 0.0, 0.0, 0.0]
-    assert "_apc_semantic_hash" not in call
 
 
 def test_responses_endpoint_forwards_new_sampling_args(client):
@@ -5597,7 +5130,10 @@ class TestResponseGenerator:
                 (str(uid * 10 + 1), "length"),
             ]
 
-    def test_run_routes_mtp_through_batch_generator(self, monkeypatch):
+    @pytest.mark.parametrize("draft_kind", ["dflash", "eagle3", "mtp"])
+    def test_run_routes_speculative_decode_through_batch_generator(
+        self, monkeypatch, draft_kind
+    ):
         batch_state = {}
         draft_model = object()
 
@@ -5683,7 +5219,8 @@ class TestResponseGenerator:
         gen.kv_quant_scheme = server.DEFAULT_KV_QUANT_SCHEME
         gen.quantized_kv_start = server.DEFAULT_QUANTIZED_KV_START
         gen.top_logprobs_k = 0
-        gen.apc_manager = None
+        apc_manager = object()
+        gen.apc_manager = apc_manager
         gen.prefill_step_size = 3072
         gen.tokenizer = SimpleNamespace()
         gen.requests = Queue()
@@ -5699,11 +5236,10 @@ class TestResponseGenerator:
             gen.config = SimpleNamespace()
             gen.stop_tokens = set()
             gen.draft_model = draft_model
-            gen.draft_kind = "mtp"
+            gen.draft_kind = draft_kind
             gen.tokenizer = SimpleNamespace()
 
         gen._initialize_model = fake_initialize_model
-        gen._run_speculative = lambda: pytest.fail("MTP should use BatchGenerator")
         gen._gpu_embed = lambda raw_inputs, images=None, apc_semantic_hash=None: (
             mx.array([[raw_inputs["request_id"]]], dtype=mx.int32),
             {},
@@ -5739,14 +5275,18 @@ class TestResponseGenerator:
 
         kwargs = batch_state["kwargs"]
         assert kwargs["draft_model"] is draft_model
-        assert kwargs["draft_kind"] == "mtp"
+        assert kwargs["draft_kind"] == draft_kind
         assert kwargs["draft_block_size"] == 6
         assert kwargs["greedy_sampling"] is True
         assert kwargs["compute_logprobs"] is False
         assert kwargs["prefill_step_size"] == 3072
+        assert kwargs["apc_manager"] is apc_manager
         assert batch_state["instance"].next_active_sizes == [2]
 
-    def test_run_coalesces_idle_mtp_batch_generator(self, monkeypatch):
+    @pytest.mark.parametrize("draft_kind", ["dflash", "eagle3", "mtp"])
+    def test_run_coalesces_idle_speculative_batch_generator(
+        self, monkeypatch, draft_kind
+    ):
         monkeypatch.setenv("MLX_VLM_SPEC_BATCH_COALESCE_MS", "37")
         calls = []
         draft_model = object()
@@ -5764,7 +5304,7 @@ class TestResponseGenerator:
             gen.config = SimpleNamespace()
             gen.stop_tokens = set()
             gen.draft_model = draft_model
-            gen.draft_kind = "mtp"
+            gen.draft_kind = draft_kind
             gen.tokenizer = SimpleNamespace()
 
         def fake_collect_pending_requests(
@@ -5775,7 +5315,6 @@ class TestResponseGenerator:
             return [], True
 
         gen._initialize_model = fake_initialize_model
-        gen._run_speculative = lambda: pytest.fail("MTP should use BatchGenerator")
         gen._collect_pending_requests = fake_collect_pending_requests
 
         gen._run_impl()


### PR DESCRIPTION
## Summary

- Route DFlash, EAGLE3, and MTP server decoding through BatchGenerator.
- Remove the duplicate ModelThread speculative loop and its legacy helpers.
- Preserve APC manager handoff and idle-request coalescing for every draft model.

This is a stacked PR targeting the APC branch from #1960. It intentionally contains no APC implementation changes or DSpark tuning changes.

## Validation

- Focused generation, server, speculative, and DSpark suite: 650 passed.
- APC suite: 402 passed, 1 skipped.
- Broader compatible suite: 2,593 passed, 4 skipped, 66 subtests passed.
- Black and git diff checks pass.
- Live LFM2.5 DSpark run: exact 256-token parity with fixed width-8 full rounds.

## 64K context, 200 generated tokens

Speedup is throughput ratio for generation and inverse latency ratio for prefill and total time. Values above 1.00x are faster than no DSpark.

| Cache | Metric | No DSpark | Width 8 | Width 8 speedup | Width 5 | Width 5 speedup |
|---|---|---:|---:|---:|---:|---:|
| Cold | Prefill | 19.224s | 19.227s | 1.00x | 19.234s | 1.00x |
| Cold | Generation | 83.5 tok/s | 79.3 tok/s | 0.95x | 106.6 tok/s | 1.28x |
| Cold | Total | 21.746s | 21.867s | 0.99x | 21.229s | 1.02x |
| RAM | Prefill | 64.2ms | 63.1ms | 1.02x | 62.9ms | 1.02x |
| RAM | Generation | 80.5 tok/s | 71.8 tok/s | 0.89x | 99.4 tok/s | 1.24x |
| RAM | Total | 2.674s | 2.984s | 0.90x | 2.219s | 1.20x |
| Restart SSD | Prefill | 79.9ms | 80.8ms | 0.99x | 79.4ms | 1.01x |
| Restart SSD | Generation | 80.4 tok/s | 71.3 tok/s | 0.89x | 99.4 tok/s | 1.24x |
| Restart SSD | Total | 3.007s | 3.280s | 0.92x | 2.503s | 1.20x |

Width 8 accepted 127 of 498 drafted tokens across 73 rounds. Width 5 accepted 129 of 281 across 71 rounds, preserving useful acceptance with substantially less verification work.

All configurations generated the same 200-token output. RAM and restart-SSD restored exactly 64,033 of 64,034 prompt tokens with zero APC rejects. Width 5 used the explicit --draft-block-size 5 override; this PR does not change the DSpark default.