### PR TITLE
Fix DeepSeek-V4 MTP speculative cache rollback with Python-list acceptance

### DIFF
--- a/mlx_vlm/models/deepseek_v4/language.py
+++ b/mlx_vlm/models/deepseek_v4/language.py
@@ -1341,6 +1341,8 @@ class LanguageModel(nn.Module):
     ) -> int:
         if isinstance(accepted, int):
             accepted = mx.array([accepted])
+        if isinstance(accepted, (list, tuple)):
+            accepted = mx.array(accepted, dtype=mx.int32)
 
         max_a = int(accepted.max().item())
         if gdn_states:

--- a/mlx_vlm/tests/test_speculative.py
+++ b/mlx_vlm/tests/test_speculative.py
@@ -3082,6 +3082,46 @@ def test_gemma4_rollback_speculative_cache_handles_turboquant_batch_tail_zero():
     assert mx.any(cache.keys.norms[1, :, 3:5] != 0).item()
 
 
+def test_deepseek_v4_rollback_speculative_cache_accepts_python_list():
+    class DummyCache:
+        keys = None
+
+        def __init__(self):
+            self.trims = []
+
+        def trim(self, n):
+            self.trims.append(n)
+
+    cache = DummyCache()
+
+    max_a = deepseek_language.LanguageModel.rollback_speculative_cache(
+        SimpleNamespace(), [cache], None, [0], block_size=2
+    )
+
+    assert max_a == 0
+    assert cache.trims == [1]
+
+
+def test_deepseek_v4_rollback_speculative_cache_accepts_python_list_batched():
+    class DummyCache:
+        keys = None
+
+        def __init__(self):
+            self.trims = []
+
+        def trim(self, n):
+            self.trims.append(n)
+
+    cache = DummyCache()
+
+    max_a = deepseek_language.LanguageModel.rollback_speculative_cache(
+        SimpleNamespace(), [cache], None, [0, 2], block_size=4
+    )
+
+    assert max_a == 2
+    assert cache.trims == [1]
+
+
 def test_deepseek_v4_rollback_speculative_cache_handles_turboquant_batch_tail_zero():
     cache = BatchTurboQuantKVCache([0, 0], bits=3.5)
     keys = mx.arange(2 * 1 * 5 * 8, dtype=mx.float32).reshape(2, 1, 5, 8)


### PR DESCRIPTION
## Summary

Fixes #1896.

The batched MTP generation path (`_mtp_rounds_batch` in `mlx_vlm/speculative/mtp.py`) tracks per-row accepted-token counts as a Python `list` and passes it to the language model's `rollback_speculative_cache`. DeepSeek-V4's implementation only normalized a scalar `int` before calling `.max()`/`.size()`/`.tolist()`, so any partially-rejected speculative block crashed with:

```
AttributeError: 'list' object has no attribute 'max'
```

This prevented DeepSeek-V4 MTP generation from recovering from a partial rejection.

## Fix

Normalize `list`/`tuple` acceptance inputs to an int32 MLX array in `DeepSeek-V4.rollback_speculative_cache`, matching the pattern Gemma4 already uses. Both the GDN-restore branch and the per-row tail-zero path now receive a uniform array, and scalar-int and MLX-array inputs remain supported unchanged.

## Validation

- Issue reproduction script now prints `0` / `[1]` as expected.
- Added regression tests for single-row (`[0]`) and batched (`[0, 2]`) cases.
- `test_speculative.py`: 159 passed.
- `test_models_dspark.py` + `test_models.py` (deepseek_v4/dspark filter): 20 passed.
- `black --check` clean.