### PR TITLE
Make LFM2.5 MoE DSpark stochastic verification exact

### DIFF
--- a/mlx_vlm/models/lfm2/speculative_verifier.py
+++ b/mlx_vlm/models/lfm2/speculative_verifier.py
@@ -22,6 +22,14 @@ class Lfm2ExactSpeculativeVerifier:
     def _linear(linear, x: mx.array) -> mx.array:
         output = exact_speculative_verify_weight(linear.weight, x)
         if output is None:
+            if x.ndim == 3 and x.shape[1] > 1:
+                return mx.concatenate(
+                    [
+                        linear(x[:, position : position + 1])
+                        for position in range(x.shape[1])
+                    ],
+                    axis=1,
+                )
             return linear(x)
         if hasattr(linear, "bias"):
             output = output + linear.bias

--- a/mlx_vlm/speculative/dflash.py
+++ b/mlx_vlm/speculative/dflash.py
@@ -125,7 +125,7 @@ def _sample_dflash_target_block(
     base_positions: List[int],
 ) -> mx.array:
     batch, length, vocab_size = logits.shape
-    logprobs = logits - mx.logsumexp(logits, axis=-1, keepdims=True)
+    logprobs = _dflash_target_logprobs(logits)
     flat_logprobs = logprobs.reshape(batch * length, vocab_size)
     positions = [
         int(base_position) + position
@@ -138,6 +138,16 @@ def _sample_dflash_target_block(
         row_ids=rows,
         positions=positions,
     ).reshape(batch, length)
+
+
+def _dflash_target_logprobs(logits: mx.array) -> mx.array:
+    return mx.stack(
+        [
+            row - mx.logsumexp(row, axis=-1, keepdims=True)
+            for row in (logits[:, position, :] for position in range(logits.shape[1]))
+        ],
+        axis=1,
+    )
 
 
 def _sample_dflash_target_walk(
@@ -162,7 +172,7 @@ def _sample_dflash_target_walk(
     batch, length, _ = logits.shape
     draft_count = int(draft_tokens.shape[1])
     draft_rows = draft_tokens.tolist()
-    logprobs = logits - mx.logsumexp(logits, axis=-1, keepdims=True)
+    logprobs = _dflash_target_logprobs(logits)
 
     for position in range(length):
         target_tokens = sampler(logprobs[:, position, :])

--- a/mlx_vlm/tests/test_models_dspark.py
+++ b/mlx_vlm/tests/test_models_dspark.py
@@ -10,6 +10,8 @@ from mlx_vlm.models.cache import ArraysCache, BatchKVCache
 from mlx_vlm.models.exact_speculative_verify import exact_speculative_verify_weight
 from mlx_vlm.models.lfm2 import Model as Lfm2Model
 from mlx_vlm.models.lfm2 import ModelConfig as Lfm2Config
+from mlx_vlm.models.lfm2.language import Lfm2MoeSparseMoeBlock
+from mlx_vlm.models.lfm2.speculative_verifier import Lfm2ExactSpeculativeVerifier
 from mlx_vlm.models.lfm2_moe import Model as Lfm2MoeModel
 from mlx_vlm.models.lfm2_moe import ModelConfig as Lfm2MoeConfig
 from mlx_vlm.models.qwen3_5 import language as qwen_language
@@ -565,6 +567,30 @@ def test_exact_speculative_verify_dense_kernel_matches_mlx_linear():
     mx.eval(expected, actual)
 
     assert actual.shape == expected.shape
+    assert bool(mx.array_equal(actual, expected))
+
+
+def test_lfm2_moe_exact_speculative_verify_narrow_router_matches_singletons():
+    mx.random.seed(12)
+    moe = Lfm2MoeSparseMoeBlock(
+        SimpleNamespace(
+            hidden_size=64,
+            moe_intermediate_size=32,
+            num_experts=4,
+            num_experts_per_tok=2,
+            norm_topk_prob=True,
+            use_expert_bias=True,
+        )
+    )
+    moe.set_dtype(mx.bfloat16)
+    inputs = mx.random.normal((1, 5, 64)).astype(mx.bfloat16)
+    expected = mx.concatenate(
+        [moe(inputs[:, position : position + 1]) for position in range(5)],
+        axis=1,
+    )
+    actual = Lfm2ExactSpeculativeVerifier()._feed_forward(moe, inputs)
+    mx.eval(expected, actual)
+
     assert bool(mx.array_equal(actual, expected))
 
 


### PR DESCRIPTION
Stacked on #1998.

## Summary
- preserve singleton-exact behavior for narrow LFM2 MoE router projections during block verification
- normalize stochastic target log probabilities independently per verifier row
- add a regression test for narrow MoE router verification

## Correctness
On Apple M5 Max with 200 generated tokens, all LFM2.5 DSpark pairs preserve 200/200 token parity at temperatures 0, 0.25, 0.5, 0.75, and 1.0:
- LFM2.5-1.2B-Instruct
- LFM2.5-2.6B
- LFM2.5-8B-A1B MoE

This fixes the 8B MoE stochastic divergence caused by batched narrow-router projections differing from singleton target decoding.

## Validation
- `uvx pre-commit run --all-files`
- `python -m pytest -q mlx_vlm/tests/test_models_dspark.py mlx_vlm/tests/test_speculative.py` — 210 passed