### PR TITLE
Add Qwen3.8 27B DFlash2 speculative decoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ MLX-VLM is a package for inference and fine-tuning of Vision Language Models (VL
   - [Command Line Interface (CLI)](#command-line-interface-cli)
     - [Thinking Budget](#thinking-budget)
   - [Speculative Decoding](#speculative-decoding)
-    - [DFlash (Qwen3.5)](#dflash-qwen35)
+    - [DFlash, DFlash2, and DSpark](#dflash-dflash2-and-dspark)
     - [Gemma 4 MTP](#gemma-4-mtp)
     - [Gemma 4 EAGLE-3](#gemma-4-eagle-3)
     - [MiniMax M3 EAGLE-3](#minimax-m3-eagle-3)
@@ -184,7 +184,7 @@ Speed up generation by drafting several candidate tokens with a small "drafter" 
 
 See [docs/usage.md](docs/usage.md) for Python API examples including batch generation.
 
-#### DFlash and DSpark (Qwen3.5, LFM2.5, and Muse Glimmer)
+#### DFlash, DFlash2, and DSpark
 
 A lightweight block-diffusion drafter that predicts multiple tokens per round, typically 2–3× faster.
 
@@ -205,6 +205,25 @@ mlx_vlm.generate --model Qwen/Qwen3.5-4B \
 # Server with speculative decoding
 mlx_vlm.server --model Qwen/Qwen3.5-4B \
   --draft-model z-lab/Qwen3.5-4B-DFlash
+```
+
+DFlash2 adds dynamic convolutions and a candidate-path selector. The published
+Qwen3.8-27B checkpoint is auto-detected and uses the shared exact DFlash target
+verification path. For the fastest quantized setup, convert the drafter to
+4-bit and use the default three-row verification block:
+
+```sh
+mlx_vlm.convert --hf-path z-lab/Qwen3.8-27B-DFlash2 \
+  --mlx-path Qwen3.8-27B-DFlash2-4bit \
+  --quantize --q-bits 4 --q-group-size 64
+
+mlx_vlm.generate --model mlx-community/Qwen3.8-27B-4bit \
+  --draft-model Qwen3.8-27B-DFlash2-4bit \
+  --prompt "Write a quicksort in Python." \
+  --max-tokens 512 --temperature 0
+
+mlx_vlm.server --model mlx-community/Qwen3.8-27B-4bit \
+  --draft-model Qwen3.8-27B-DFlash2-4bit
 ```
 
 Liquid AI's DSpark checkpoint uses a Qwen3-style block drafter plus a learned
@@ -494,7 +513,7 @@ mlx_vlm.server --api-key <secret-token>
 - `--embedding-model`: Preload an embedding model at server startup
 - `--reranker-model`: Preload a supported reranker model at server startup
 - `--adapter-path`: Path for adapter weights to use with the preloaded model
-- `--draft-model`: Speculative drafter path or HF id (e.g. `z-lab/Qwen3.5-4B-DFlash`, `RedHatAI/gemma-4-31B-it-speculator.eagle3`, `google/gemma-4-31B-it-assistant`, `Inferact/MiniMax-M3-EAGLE3`) — enables speculative decoding for ~2× or higher throughput
+- `--draft-model`: Speculative drafter path or HF id (e.g. `z-lab/Qwen3.8-27B-DFlash2`, `z-lab/Qwen3.5-4B-DFlash`, `RedHatAI/gemma-4-31B-it-speculator.eagle3`, `google/gemma-4-31B-it-assistant`, `Inferact/MiniMax-M3-EAGLE3`) — enables speculative decoding for ~2× or higher throughput
 - `--draft-kind`: Drafter family — `dflash` (default), `eagle3`, or `mtp` (native/assistant MTP)
 - `--draft-block-size`: Override the drafter's configured block size
 - `--host`: Host address (default: `0.0.0.0`)

--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ mlx_vlm.server --model Qwen/Qwen3.5-4B \
 DFlash2 adds dynamic convolutions and a candidate-path selector. The published
 Qwen3.8-27B checkpoint is auto-detected and uses the shared exact DFlash target
 verification path. For the fastest quantized setup, convert the drafter to
-4-bit and use the default three-row verification block:
+4-bit; the verifier adapts between three and five rows from recent acceptance:
 
 ```sh
 mlx_vlm.convert --hf-path z-lab/Qwen3.8-27B-DFlash2 \

--- a/mlx_vlm/generate/ar.py
+++ b/mlx_vlm/generate/ar.py
@@ -112,6 +112,16 @@ class _PositionedTargetSampler:
             return mx.vmap(self._sample_top_p_one, in_axes=(0, 0))(logprobs, keys)
         return mx.vmap(self._sample_one, in_axes=(0, 0))(logprobs, keys)
 
+    def sample_proposal(
+        self,
+        logprobs: mx.array,
+        *,
+        row_ids: List[int],
+        positions: List[int],
+    ) -> mx.array:
+        keys = _position_keys(self.seed ^ 0x0DFA5202, row_ids, positions)
+        return mx.vmap(self._sample_one, in_axes=(0, 0))(logprobs, keys)
+
     def _sample_one(self, logprobs: mx.array, key: mx.array) -> mx.array:
         return mx.random.categorical(logprobs * (1 / self.temperature), key=key)
 

--- a/mlx_vlm/models/qwen3_5/gated_delta.py
+++ b/mlx_vlm/models/qwen3_5/gated_delta.py
@@ -516,9 +516,11 @@ def _gated_delta_with_states_ops(
     beta: mx.array,
     state: mx.array,
     mask: Optional[mx.array] = None,
+    state_steps: Optional[int] = None,
 ):
     B, T, Hk, _Dk = q.shape
     Hv = v.shape[-2]
+    state_steps = T if state_steps is None else int(state_steps)
     if (repeat_factor := Hv // Hk) > 1:
         q = mx.repeat(q, repeat_factor, -2)
         k = mx.repeat(k, repeat_factor, -2)
@@ -540,8 +542,12 @@ def _gated_delta_with_states_ops(
             y = mx.where(valid[:, None, None], y, 0)
 
         ys.append(y.astype(q.dtype))
-        states.append(state)
-    stacked_states = mx.stack(states, axis=1)
+        if t < state_steps:
+            states.append(state)
+    if states:
+        stacked_states = mx.stack(states, axis=1)
+    else:
+        stacked_states = mx.zeros((B, 0, *state.shape[1:]), dtype=state.dtype)
     return mx.stack(ys, axis=1), state, stacked_states
 
 
@@ -556,10 +562,14 @@ def gated_delta_update_with_states(
     state: Optional[mx.array] = None,
     mask: Optional[mx.array] = None,
     use_kernel: bool = True,
+    state_steps: Optional[int] = None,
 ):
     g, beta = _compute_g_beta(A_log, a, b, dt_bias)
+    B, T, Hk, Dk = k.shape
+    state_steps = T if state_steps is None else int(state_steps)
+    if not 0 <= state_steps <= T:
+        raise ValueError("state_steps must be between zero and the sequence length.")
     if state is None:
-        B, _, _Hk, Dk = q.shape
         Hv, Dv = v.shape[-2:]
         state = mx.zeros((B, Hv, Dv, Dk), dtype=mx.float32)
 
@@ -569,11 +579,9 @@ def gated_delta_update_with_states(
         or mx.default_device() != mx.gpu
         or not mx.metal.is_available()
     ):
-        return _gated_delta_with_states_ops(q, k, v, g, beta, state, mask)
+        return _gated_delta_with_states_ops(q, k, v, g, beta, state, mask, state_steps)
 
-    B, T, Hk, Dk = k.shape
     Hv, Dv = v.shape[2:]
-    state_steps = T
 
     input_type = q.dtype
     state_type = state.dtype
@@ -583,7 +591,7 @@ def gated_delta_update_with_states(
         kernel = _gated_delta_with_states_kernel_masked
         inputs.append(mask)
     if kernel is None:
-        return _gated_delta_with_states_ops(q, k, v, g, beta, state, mask)
+        return _gated_delta_with_states_ops(q, k, v, g, beta, state, mask, state_steps)
 
     return kernel(
         inputs=inputs,

--- a/mlx_vlm/models/qwen3_5/speculative_verifier.py
+++ b/mlx_vlm/models/qwen3_5/speculative_verifier.py
@@ -22,8 +22,11 @@ def _use_target_verify_dense(linear, x: mx.array) -> bool:
     )
 
 
-def _target_verify_qlinear_header(bits: int, group_size: int) -> str:
-    return r"""
+def _target_verify_qlinear_header(
+    bits: int, group_size: int, results_per_simdgroup: int = 4
+) -> str:
+    return (
+        r"""
     using namespace metal;
 
     constant constexpr int SIMD_SIZE = 32;
@@ -35,7 +38,7 @@ def _target_verify_qlinear_header(bits: int, group_size: int) -> str:
     constant constexpr int VALUES_PER_THREAD = PACK_FACTOR * PACKS_PER_THREAD;
     constant constexpr int BLOCK_SIZE = VALUES_PER_THREAD * SIMD_SIZE;
     constant constexpr int SCALE_STEP_PER_THREAD = GS / VALUES_PER_THREAD;
-    constant constexpr int RESULTS_PER_SIMDGROUP = 4;
+    constant constexpr int RESULTS_PER_SIMDGROUP = __RESULTS_PER_SIMDGROUP__;
     constant constexpr int NUM_SIMDGROUPS = 2;
     constant constexpr int BN = RESULTS_PER_SIMDGROUP * NUM_SIMDGROUPS;
 
@@ -114,7 +117,31 @@ def _target_verify_qlinear_header(bits: int, group_size: int) -> str:
       }
       return scale * accum + sum * bias;
     }
-""".replace("__BITS__", str(bits)).replace("__GS__", str(group_size))
+
+    inline float qdot_exact(
+        const thread uint16_t* ws,
+        const thread float* x_thread,
+        float scale,
+        float bias,
+        float sum) {
+      float accum = 0.0f;
+      if (BITS == 4) {
+        for (int i = 0; i < (VALUES_PER_THREAD / 4); i++) {
+          uint packed = ws[i];
+          accum +=
+              (x_thread[4 * i] * (packed & 0x000f) +
+               x_thread[4 * i + 1] * ((packed >> 4) & 0x000f) +
+               x_thread[4 * i + 2] * ((packed >> 8) & 0x000f) +
+               x_thread[4 * i + 3] * ((packed >> 12) & 0x000f));
+        }
+      }
+      return scale * accum + sum * bias;
+    }
+
+""".replace("__BITS__", str(bits))
+        .replace("__GS__", str(group_size))
+        .replace("__RESULTS_PER_SIMDGROUP__", str(results_per_simdgroup))
+    )
 
 
 _TARGET_VERIFY_QMV_SOURCE = r"""
@@ -455,6 +482,171 @@ _TARGET_VERIFY_QARGMAX_TOKEN_TILED_SOURCE = r"""
     }
 """
 
+
+_TARGET_VERIFY_QMV_STREAMED_SOURCE = r"""
+    uint n_tile = threadgroup_position_in_grid.y;
+    uint b_idx = threadgroup_position_in_grid.z;
+    uint simd_gid = simdgroup_index_in_threadgroup;
+    uint simd_lid = thread_index_in_simdgroup;
+
+    int out_row = int(n_tile) * BN + int(simd_gid) * RESULTS_PER_SIMDGROUP;
+    int in_vec_size_w = K_SIZE * BYTES_PER_PACK / PACK_FACTOR;
+    int in_vec_size_g = K_SIZE / GS;
+
+    const device uint8_t* ws =
+        (const device uint8_t*)w + out_row * in_vec_size_w +
+        int(simd_lid) * PACKS_PER_THREAD * BYTES_PER_PACK;
+    const device T* sc =
+        scales + out_row * in_vec_size_g +
+        int(simd_lid) / SCALE_STEP_PER_THREAD;
+    const device T* bs =
+        biases + out_row * in_vec_size_g +
+        int(simd_lid) / SCALE_STEP_PER_THREAD;
+    const device T* xk =
+        x + int(b_idx) * VERIFY_T * K_SIZE +
+        int(simd_lid) * VALUES_PER_THREAD;
+
+    float result[VERIFY_T][RESULTS_PER_SIMDGROUP];
+    for (int t = 0; t < VERIFY_T; ++t) {
+      for (int row = 0; row < RESULTS_PER_SIMDGROUP; ++row) {
+        result[t][row] = 0.0f;
+      }
+    }
+
+    for (int k = 0; k < K_SIZE; k += BLOCK_SIZE) {
+      for (int row = 0; row < RESULTS_PER_SIMDGROUP; ++row) {
+        const device uint16_t* source =
+            (const device uint16_t*)(ws + row * in_vec_size_w);
+        uint16_t packed[VALUES_PER_THREAD / 4];
+        for (int index = 0; index < VALUES_PER_THREAD / 4; ++index) {
+          packed[index] = source[index];
+        }
+        float scale = float(sc[row * in_vec_size_g]);
+        float bias = float(bs[row * in_vec_size_g]);
+        for (int t = 0; t < VERIFY_T; ++t) {
+          float x_thread[VALUES_PER_THREAD];
+          float sum = load_vector_exact<T>(
+              xk + t * K_SIZE, x_thread);
+          result[t][row] += qdot_exact(
+              packed, x_thread, scale, bias, sum);
+        }
+      }
+
+      ws += BLOCK_SIZE * BYTES_PER_PACK / PACK_FACTOR;
+      sc += BLOCK_SIZE / GS;
+      bs += BLOCK_SIZE / GS;
+      xk += BLOCK_SIZE;
+    }
+
+    for (int row = 0; row < RESULTS_PER_SIMDGROUP; ++row) {
+      int n = out_row + row;
+      for (int t = 0; t < VERIFY_T; ++t) {
+        float value = simd_sum(result[t][row]);
+        if (simd_lid == 0) {
+          y[(int(b_idx) * VERIFY_T + t) * N_SIZE + n] = T(value);
+        }
+      }
+    }
+"""
+
+
+_TARGET_VERIFY_QARGMAX_STREAMED_SOURCE = r"""
+    uint n_tile = threadgroup_position_in_grid.y;
+    uint b_idx = threadgroup_position_in_grid.z;
+    uint simd_gid = simdgroup_index_in_threadgroup;
+    uint simd_lid = thread_index_in_simdgroup;
+
+    int out_row = int(n_tile) * BN + int(simd_gid) * RESULTS_PER_SIMDGROUP;
+    int in_vec_size_w = K_SIZE * BYTES_PER_PACK / PACK_FACTOR;
+    int in_vec_size_g = K_SIZE / GS;
+
+    threadgroup float tile_best_values[VERIFY_T][NUM_SIMDGROUPS];
+    threadgroup int tile_best_indices[VERIFY_T][NUM_SIMDGROUPS];
+
+    const device uint8_t* ws =
+        (const device uint8_t*)w + out_row * in_vec_size_w +
+        int(simd_lid) * PACKS_PER_THREAD * BYTES_PER_PACK;
+    const device T* sc =
+        scales + out_row * in_vec_size_g +
+        int(simd_lid) / SCALE_STEP_PER_THREAD;
+    const device T* bs =
+        biases + out_row * in_vec_size_g +
+        int(simd_lid) / SCALE_STEP_PER_THREAD;
+    const device T* xk =
+        x + int(b_idx) * VERIFY_T * K_SIZE +
+        int(simd_lid) * VALUES_PER_THREAD;
+
+    float result[VERIFY_T][RESULTS_PER_SIMDGROUP];
+    for (int t = 0; t < VERIFY_T; ++t) {
+      for (int row = 0; row < RESULTS_PER_SIMDGROUP; ++row) {
+        result[t][row] = 0.0f;
+      }
+    }
+
+    for (int k = 0; k < K_SIZE; k += BLOCK_SIZE) {
+      for (int row = 0; row < RESULTS_PER_SIMDGROUP; ++row) {
+        const device uint16_t* source =
+            (const device uint16_t*)(ws + row * in_vec_size_w);
+        uint16_t packed[VALUES_PER_THREAD / 4];
+        for (int index = 0; index < VALUES_PER_THREAD / 4; ++index) {
+          packed[index] = source[index];
+        }
+        float scale = float(sc[row * in_vec_size_g]);
+        float bias = float(bs[row * in_vec_size_g]);
+        for (int t = 0; t < VERIFY_T; ++t) {
+          float x_thread[VALUES_PER_THREAD];
+          float sum = load_vector_exact<T>(
+              xk + t * K_SIZE, x_thread);
+          result[t][row] += qdot_exact(
+              packed, x_thread, scale, bias, sum);
+        }
+      }
+
+      ws += BLOCK_SIZE * BYTES_PER_PACK / PACK_FACTOR;
+      sc += BLOCK_SIZE / GS;
+      bs += BLOCK_SIZE / GS;
+      xk += BLOCK_SIZE;
+    }
+
+    for (int t = 0; t < VERIFY_T; ++t) {
+      float best_value = -3.4028234663852886e38f;
+      int best_index = 0;
+      for (int row = 0; row < RESULTS_PER_SIMDGROUP; ++row) {
+        int n = out_row + row;
+        float rounded = float(T(simd_sum(result[t][row])));
+        if (n < N_SIZE && rounded > best_value) {
+          best_value = rounded;
+          best_index = n;
+        }
+      }
+
+      if (simd_lid == 0) {
+        tile_best_values[t][simd_gid] = best_value;
+        tile_best_indices[t][simd_gid] = best_index;
+      }
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    if (simd_gid == 0 && simd_lid == 0) {
+      for (int t = 0; t < VERIFY_T; ++t) {
+        float best = tile_best_values[t][0];
+        int best_idx = tile_best_indices[t][0];
+        for (int i = 1; i < NUM_SIMDGROUPS; ++i) {
+          float candidate = tile_best_values[t][i];
+          int candidate_idx = tile_best_indices[t][i];
+          if (candidate > best) {
+            best = candidate;
+            best_idx = candidate_idx;
+          }
+        }
+        int offset =
+            (int(b_idx) * VERIFY_T + t) * NUM_TILES + int(n_tile);
+        tile_values[offset] = T(best);
+        tile_indices[offset] = best_idx;
+      }
+    }
+"""
+
 _TARGET_VERIFY_MASKED_QARGMAX_SOURCE = _TARGET_VERIFY_QARGMAX_SOURCE.replace(
     "if (n < N_SIZE) {",
     """if (
@@ -471,6 +663,16 @@ _TARGET_VERIFY_MASKED_QARGMAX_TOKEN_TILED_SOURCE = _TARGET_VERIFY_QARGMAX_TOKEN_
           ((as_type<uint>(mask[
                 (flat_token_start + t) * mask_shape[1] + (n >> 5)]) >>
             (n & 31)) & 1u) != 0u) {""",
+)
+
+_TARGET_VERIFY_MASKED_QARGMAX_STREAMED_SOURCE = _TARGET_VERIFY_QARGMAX_STREAMED_SOURCE.replace(
+    "if (n < N_SIZE && rounded > best_value) {",
+    """if (
+          n < N_SIZE &&
+          ((as_type<uint>(mask[
+                (int(b_idx) * VERIFY_T + t) * mask_shape[1] + (n >> 5)]) >>
+            (n & 31)) & 1u) != 0u &&
+          rounded > best_value) {""",
 )
 
 
@@ -659,6 +861,57 @@ def _target_verify_masked_qargmax_token_tiled_kernel(
 
 
 @lru_cache(maxsize=None)
+def _target_verify_qmv_streamed_kernel(
+    bits, group_size, dtype, verify_t, k_size, n_size
+):
+    dtype_name = {mx.bfloat16: "bf16", mx.float16: "fp16"}.get(dtype, "unk")
+    return mx.fast.metal_kernel(
+        name=(
+            "qwen3_5_target_verify_qmv_streamed_"
+            f"b{bits}_gs{group_size}_t{verify_t}_k{k_size}_n{n_size}_{dtype_name}"
+        ),
+        input_names=["x", "w", "scales", "biases"],
+        output_names=["y"],
+        header=_target_verify_qlinear_header(bits, group_size, 1),
+        source=_TARGET_VERIFY_QMV_STREAMED_SOURCE,
+    )
+
+
+@lru_cache(maxsize=None)
+def _target_verify_qargmax_streamed_kernel(
+    bits, group_size, dtype, verify_t, k_size, n_size
+):
+    dtype_name = {mx.bfloat16: "bf16", mx.float16: "fp16"}.get(dtype, "unk")
+    return mx.fast.metal_kernel(
+        name=(
+            "qwen3_5_target_verify_qargmax_streamed_"
+            f"b{bits}_gs{group_size}_t{verify_t}_k{k_size}_n{n_size}_{dtype_name}"
+        ),
+        input_names=["x", "w", "scales", "biases"],
+        output_names=["tile_values", "tile_indices"],
+        header=_target_verify_qlinear_header(bits, group_size, 1),
+        source=_TARGET_VERIFY_QARGMAX_STREAMED_SOURCE,
+    )
+
+
+@lru_cache(maxsize=None)
+def _target_verify_masked_qargmax_streamed_kernel(
+    bits, group_size, dtype, verify_t, k_size, n_size
+):
+    dtype_name = {mx.bfloat16: "bf16", mx.float16: "fp16"}.get(dtype, "unk")
+    return mx.fast.metal_kernel(
+        name=(
+            "qwen3_5_target_verify_masked_qargmax_streamed_"
+            f"b{bits}_gs{group_size}_t{verify_t}_k{k_size}_n{n_size}_{dtype_name}"
+        ),
+        input_names=["x", "w", "scales", "biases", "mask"],
+        output_names=["tile_values", "tile_indices"],
+        header=_target_verify_qlinear_header(bits, group_size, 1),
+        source=_TARGET_VERIFY_MASKED_QARGMAX_STREAMED_SOURCE,
+    )
+
+
+@lru_cache(maxsize=None)
 def _target_verify_fused_qmv_kernel(bits, group_size, dtype, verify_t, k_size, n_sizes):
     dtype_name = {mx.bfloat16: "bf16", mx.float16: "fp16"}.get(dtype, "unk")
     shape_name = "_".join(str(n) for n in n_sizes)
@@ -714,13 +967,15 @@ def _target_verify_quantized_linear(linear, x: mx.array) -> Optional[mx.array]:
     N = linear.weight.shape[0]
 
     x = mx.contiguous(x)
-    token_tiled = linear.bits == 4 and T >= 6
-    results_per_simdgroup = 4
-    kernel_factory = (
-        _target_verify_qmv_token_tiled_kernel
-        if token_tiled
-        else _target_verify_qmv_kernel
-    )
+    streamed = linear.bits == 4 and 6 <= T <= 8
+    token_tiled = linear.bits == 4 and T >= 6 and not streamed
+    results_per_simdgroup = 1 if streamed else 4
+    if streamed:
+        kernel_factory = _target_verify_qmv_streamed_kernel
+    elif token_tiled:
+        kernel_factory = _target_verify_qmv_token_tiled_kernel
+    else:
+        kernel_factory = _target_verify_qmv_kernel
     kernel_args = (linear.bits, linear.group_size, x.dtype, T, K, N)
     kernel = kernel_factory(*kernel_args)
     rows_per_threadgroup = 2 * results_per_simdgroup
@@ -778,13 +1033,20 @@ def _target_verify_quantized_argmax(
             return out.transpose(1, 0)
 
     N = linear.weight.shape[0]
-    token_tiled = linear.bits == 4 and T >= 6
-    results_per_simdgroup = 4
+    streamed = linear.bits == 4 and 6 <= T <= 8
+    token_tiled = linear.bits == 4 and T >= 6 and not streamed
+    results_per_simdgroup = 1 if streamed else 4
     rows_per_threadgroup = 2 * results_per_simdgroup
     num_tiles = N // rows_per_threadgroup
 
     x = mx.contiguous(x)
-    if token_tiled:
+    if streamed:
+        kernel_factory = (
+            _target_verify_masked_qargmax_streamed_kernel
+            if token_mask is not None
+            else _target_verify_qargmax_streamed_kernel
+        )
+    elif token_tiled:
         kernel_factory = (
             _target_verify_masked_qargmax_token_tiled_kernel
             if token_mask is not None

--- a/mlx_vlm/models/qwen3_5/speculative_verifier.py
+++ b/mlx_vlm/models/qwen3_5/speculative_verifier.py
@@ -676,77 +676,7 @@ _TARGET_VERIFY_MASKED_QARGMAX_STREAMED_SOURCE = _TARGET_VERIFY_QARGMAX_STREAMED_
 )
 
 
-_TARGET_VERIFY_FUSED_QMV_SOURCE = r"""
-    uint n_tile = threadgroup_position_in_grid.y;
-    uint b_idx = threadgroup_position_in_grid.z;
-    uint simd_gid = simdgroup_index_in_threadgroup;
-    uint simd_lid = thread_index_in_simdgroup;
-
-    int global_out = int(n_tile) * BN + int(simd_gid) * RESULTS_PER_SIMDGROUP;
-    int local_out = global_out;
-    int in_vec_size_w = K_SIZE * BYTES_PER_PACK / PACK_FACTOR;
-    int in_vec_size_g = K_SIZE / GS;
-    const device uint8_t* selected_w = (const device uint8_t*)w0;
-    const device T* selected_scales = scales0;
-    const device T* selected_biases = biases0;
-__SELECT_LINEAR__
-
-    const device uint8_t* ws =
-        selected_w + local_out * in_vec_size_w +
-        int(simd_lid) * PACKS_PER_THREAD * BYTES_PER_PACK;
-    const device T* sc =
-        selected_scales + local_out * in_vec_size_g +
-        int(simd_lid) / SCALE_STEP_PER_THREAD;
-    const device T* bs =
-        selected_biases + local_out * in_vec_size_g +
-        int(simd_lid) / SCALE_STEP_PER_THREAD;
-    const device T* xk =
-        x + int(b_idx) * VERIFY_T * K_SIZE + int(simd_lid) * VALUES_PER_THREAD;
-
-    float result[VERIFY_T][RESULTS_PER_SIMDGROUP];
-    float x_thread[VERIFY_T][VALUES_PER_THREAD];
-    for (int t = 0; t < VERIFY_T; ++t) {
-      for (int row = 0; row < RESULTS_PER_SIMDGROUP; ++row) {
-        result[t][row] = 0.0f;
-      }
-    }
-
-    for (int k = 0; k < K_SIZE; k += BLOCK_SIZE) {
-      float sums[VERIFY_T];
-      for (int t = 0; t < VERIFY_T; ++t) {
-        sums[t] = load_vector_exact<T>(xk + t * K_SIZE, x_thread[t]);
-      }
-
-      for (int row = 0; row < RESULTS_PER_SIMDGROUP; ++row) {
-        const device uint8_t* wl = ws + row * in_vec_size_w;
-        const device T* sl = sc + row * in_vec_size_g;
-        const device T* bl = bs + row * in_vec_size_g;
-        float s = float(sl[0]);
-        float b = float(bl[0]);
-        for (int t = 0; t < VERIFY_T; ++t) {
-          result[t][row] += qdot_exact(wl, x_thread[t], s, b, sums[t]);
-        }
-      }
-
-      ws += BLOCK_SIZE * BYTES_PER_PACK / PACK_FACTOR;
-      sc += BLOCK_SIZE / GS;
-      bs += BLOCK_SIZE / GS;
-      xk += BLOCK_SIZE;
-    }
-
-    for (int row = 0; row < RESULTS_PER_SIMDGROUP; ++row) {
-      int n = global_out + row;
-      for (int t = 0; t < VERIFY_T; ++t) {
-        float r = simd_sum(result[t][row]);
-        if (simd_lid == 0) {
-          y[(int(b_idx) * VERIFY_T + t) * N_SIZE + n] = T(r);
-        }
-      }
-    }
-"""
-
-
-def _target_verify_fused_qmv_source(n_sizes) -> str:
+def _target_verify_fused_qmv_source(source: str, n_sizes) -> str:
     selections = []
     offset = int(n_sizes[0])
     for index, n_size in enumerate(n_sizes[1:], start=1):
@@ -757,8 +687,30 @@ def _target_verify_fused_qmv_source(n_sizes) -> str:
       selected_biases = biases{index};
     }}""")
         offset += int(n_size)
-    return _TARGET_VERIFY_FUSED_QMV_SOURCE.replace(
-        "__SELECT_LINEAR__", "\n".join(selections)
+    selection = "\n".join(selections)
+    source = source.replace(
+        "    int out_row = int(n_tile) * BN + int(simd_gid) * RESULTS_PER_SIMDGROUP;",
+        f"""    int global_out = int(n_tile) * BN + int(simd_gid) * RESULTS_PER_SIMDGROUP;
+    int local_out = global_out;
+    const device uint8_t* selected_w = (const device uint8_t*)w0;
+    const device T* selected_scales = scales0;
+    const device T* selected_biases = biases0;
+{selection}""",
+    )
+    return (
+        source.replace(
+            "(const device uint8_t*)w + out_row * in_vec_size_w",
+            "selected_w + local_out * in_vec_size_w",
+        )
+        .replace(
+            "scales + out_row * in_vec_size_g",
+            "selected_scales + local_out * in_vec_size_g",
+        )
+        .replace(
+            "biases + out_row * in_vec_size_g",
+            "selected_biases + local_out * in_vec_size_g",
+        )
+        .replace("int n = out_row + row;", "int n = global_out + row;")
     )
 
 
@@ -926,7 +878,30 @@ def _target_verify_fused_qmv_kernel(bits, group_size, dtype, verify_t, k_size, n
         input_names=input_names,
         output_names=["y"],
         header=_target_verify_qlinear_header(bits, group_size),
-        source=_target_verify_fused_qmv_source(n_sizes),
+        source=_target_verify_fused_qmv_source(_TARGET_VERIFY_QMV_SOURCE, n_sizes),
+    )
+
+
+@lru_cache(maxsize=None)
+def _target_verify_fused_qmv_streamed_kernel(
+    bits, group_size, dtype, verify_t, k_size, n_sizes
+):
+    dtype_name = {mx.bfloat16: "bf16", mx.float16: "fp16"}.get(dtype, "unk")
+    shape_name = "_".join(str(n) for n in n_sizes)
+    input_names = ["x"]
+    for index in range(len(n_sizes)):
+        input_names.extend([f"w{index}", f"scales{index}", f"biases{index}"])
+    return mx.fast.metal_kernel(
+        name=(
+            "qwen3_5_target_verify_fused_qmv_streamed_"
+            f"b{bits}_gs{group_size}_t{verify_t}_k{k_size}_n{shape_name}_{dtype_name}"
+        ),
+        input_names=input_names,
+        output_names=["y"],
+        header=_target_verify_qlinear_header(bits, group_size, 1),
+        source=_target_verify_fused_qmv_source(
+            _TARGET_VERIFY_QMV_STREAMED_SOURCE, n_sizes
+        ),
     )
 
 
@@ -1133,7 +1108,7 @@ def _target_verify_quantized_linears(linears, x: mx.array):
     if (
         not 2 <= len(linears) <= 4
         or x.ndim != 3
-        or not 1 < x.shape[1] < 6
+        or not 1 < x.shape[1] <= 8
         or not all(
             isinstance(linear, nn.QuantizedLinear)
             and linear.bits == 4
@@ -1150,9 +1125,13 @@ def _target_verify_quantized_linears(linears, x: mx.array):
     n_sizes = tuple(int(linear.weight.shape[0]) for linear in linears)
     total_n = sum(n_sizes)
     x = mx.contiguous(x)
-    kernel = _target_verify_fused_qmv_kernel(
-        4, linears[0].group_size, x.dtype, T, K, n_sizes
+    streamed = T >= 6
+    kernel_factory = (
+        _target_verify_fused_qmv_streamed_kernel
+        if streamed
+        else _target_verify_fused_qmv_kernel
     )
+    kernel = kernel_factory(4, linears[0].group_size, x.dtype, T, K, n_sizes)
     inputs = [x]
     for linear in linears:
         inputs.extend([linear.weight, linear.scales, linear.biases])
@@ -1164,7 +1143,7 @@ def _target_verify_quantized_linears(linears, x: mx.array):
             ("K_SIZE", int(K)),
             ("N_SIZE", int(total_n)),
         ],
-        grid=(32, 2 * (total_n // 8), B),
+        grid=(32, 2 * (total_n // (2 if streamed else 8)), B),
         threadgroup=(32, 2, 1),
         output_shapes=[(B, T, total_n)],
         output_dtypes=[x.dtype],
@@ -1439,6 +1418,7 @@ class Qwen3_5ExactSpeculativeVerifier:
             state,
             mask,
             use_kernel=not layer.training,
+            state_steps=length - 1,
         )
         gdn_sink.append(
             (

--- a/mlx_vlm/server/generation.py
+++ b/mlx_vlm/server/generation.py
@@ -278,6 +278,16 @@ class _PositionedTargetSampler:
             return mx.vmap(self._sample_top_p_one, in_axes=(0, 0))(logprobs, keys)
         return mx.vmap(self._sample_one, in_axes=(0, 0))(logprobs, keys)
 
+    def sample_proposal(
+        self,
+        logprobs: mx.array,
+        *,
+        row_ids: List[int],
+        positions: List[int],
+    ) -> mx.array:
+        keys = _position_keys(self.seed ^ 0x0DFA5202, row_ids, positions)
+        return mx.vmap(self._sample_one, in_axes=(0, 0))(logprobs, keys)
+
     def _sample_one(self, logprobs: mx.array, key: mx.array) -> mx.array:
         return mx.random.categorical(logprobs * (1 / self.temperature), key=key)
 

--- a/mlx_vlm/speculative/dflash.py
+++ b/mlx_vlm/speculative/dflash.py
@@ -45,7 +45,10 @@ def _dflash_next_block_size(
         return block_total
 
     current = min(block_total, max(2, recent[-1][1] + 1))
-    min_total = min(block_total, 4)
+    min_total = min(
+        block_total,
+        max(2, int(getattr(draft_model, "dflash_min_block_size", 4))),
+    )
     drafted = sum(d for _, d in recent)
     accepted = sum(a for a, _ in recent)
     accept_rate = accepted / drafted

--- a/mlx_vlm/speculative/dflash.py
+++ b/mlx_vlm/speculative/dflash.py
@@ -116,6 +116,32 @@ class _PositionedDraftSampler:
         self.positions = [position + length for position in self.positions]
         return sampled.reshape(logits.shape[:-1])
 
+    def sample_proposal(self, logits: mx.array) -> mx.array:
+        sample_proposal = getattr(self.sampler, "sample_proposal", None)
+        if not callable(sample_proposal):
+            return mx.argmax(logits, axis=-1)
+        if logits.ndim == 1:
+            batch, length = 1, 1
+        elif logits.ndim == 2:
+            batch, length = logits.shape[0], 1
+        else:
+            batch, length = logits.shape[0], logits.shape[1]
+        if batch != len(self.row_ids):
+            raise ValueError(
+                "Draft sampler row count does not match logits batch size."
+            )
+        rows = [row_id for row_id in self.row_ids for _ in range(length)]
+        positions = [
+            position + offset for position in self.positions for offset in range(length)
+        ]
+        sampled = sample_proposal(
+            logits.reshape(batch * length, logits.shape[-1]),
+            row_ids=rows,
+            positions=positions,
+        )
+        self.positions = [position + length for position in self.positions]
+        return sampled.reshape(logits.shape[:-1])
+
 
 def _sample_dflash_target_block(
     logits: mx.array,

--- a/mlx_vlm/speculative/drafters/__init__.py
+++ b/mlx_vlm/speculative/drafters/__init__.py
@@ -2,6 +2,7 @@ import json
 import logging
 from typing import Any, Optional, Tuple
 
+from .dflash2 import DFlash2DraftModel
 from .dspark import DSparkDraftModel
 from .laguna_dflash import LagunaDFlashDraftModel
 from .muse_glimmer_assistant import MuseGlimmerAssistantDraftModel
@@ -178,6 +179,7 @@ __all__ = [
     "DRAFTER_KIND_BY_MODEL_TYPE",
     "KNOWN_DRAFTER_KINDS",
     "DFlashDraftModel",
+    "DFlash2DraftModel",
     "DSparkDraftModel",
     "LagunaDFlashDraftModel",
     "MuseGlimmerAssistantDraftModel",

--- a/mlx_vlm/speculative/drafters/compatibility.py
+++ b/mlx_vlm/speculative/drafters/compatibility.py
@@ -1,0 +1,53 @@
+from collections.abc import Mapping
+
+
+def _config_value(config, name):
+    if isinstance(config, Mapping):
+        return config.get(name)
+    return getattr(config, name, None)
+
+
+def _target_metadata(target_model):
+    language_model = getattr(target_model, "language_model", target_model)
+    outer_config = getattr(language_model, "config", None)
+    target_config = _config_value(outer_config, "text_config") or outer_config
+    if target_config is None:
+        target_config = getattr(language_model, "args", None)
+    inner = getattr(language_model, "model", language_model)
+    layers = getattr(inner, "layers", None)
+    return language_model, target_config, layers
+
+
+def validate_dflash_target(config, target_model, algorithm: str) -> None:
+    language_model, target_config, layers = _target_metadata(target_model)
+
+    hidden_size = _config_value(target_config, "hidden_size")
+    if hidden_size != config.hidden_size:
+        raise ValueError(
+            f"{algorithm} target hidden-size mismatch: "
+            f"draft={config.hidden_size}, target={hidden_size}."
+        )
+    layer_count = (
+        len(layers)
+        if layers is not None
+        else _config_value(target_config, "num_hidden_layers")
+    )
+    if layer_count != config.num_target_layers:
+        raise ValueError(
+            f"{algorithm} target layer-count mismatch: "
+            f"draft={config.num_target_layers}, target={layer_count}."
+        )
+    vocab_size = _config_value(target_config, "vocab_size")
+    if vocab_size != config.vocab_size:
+        raise ValueError(
+            f"{algorithm} target vocabulary mismatch: "
+            f"draft={config.vocab_size}, target={vocab_size}."
+        )
+    if not hasattr(language_model, "rollback_speculative_cache"):
+        raise ValueError(
+            f"{algorithm} target {type(language_model).__name__} does not expose "
+            "speculative cache rollback support."
+        )
+
+
+__all__ = ["validate_dflash_target"]

--- a/mlx_vlm/speculative/drafters/dflash2/__init__.py
+++ b/mlx_vlm/speculative/drafters/dflash2/__init__.py
@@ -1,5 +1,6 @@
 from .config import DFlash2Config as ModelConfig
-from .dflash2 import CandidateSelector, DFlash2DraftModel
+from .dflash2 import CandidateSelector
+from .dflash2 import DFlash2DraftModel
 from .dflash2 import DFlash2DraftModel as Model
 from .dflash2 import GroupedDynamicCausalConv, _grouped_dynamic_convolve
 

--- a/mlx_vlm/speculative/drafters/dflash2/__init__.py
+++ b/mlx_vlm/speculative/drafters/dflash2/__init__.py
@@ -1,0 +1,13 @@
+from .config import DFlash2Config as ModelConfig
+from .dflash2 import CandidateSelector, DFlash2DraftModel
+from .dflash2 import DFlash2DraftModel as Model
+from .dflash2 import GroupedDynamicCausalConv, _grouped_dynamic_convolve
+
+__all__ = [
+    "CandidateSelector",
+    "DFlash2DraftModel",
+    "GroupedDynamicCausalConv",
+    "Model",
+    "ModelConfig",
+    "_grouped_dynamic_convolve",
+]

--- a/mlx_vlm/speculative/drafters/dflash2/config.py
+++ b/mlx_vlm/speculative/drafters/dflash2/config.py
@@ -137,7 +137,7 @@ class DFlash2Config(DFlashConfig):
             flat["rope_scaling"] = rope_parameters
 
         if "runtime_block_size" not in flat:
-            flat["runtime_block_size"] = min(3, int(flat["block_size"]))
+            flat["runtime_block_size"] = min(5, int(flat["block_size"]))
 
         signature = inspect.signature(cls).parameters
         return cls(**{key: value for key, value in flat.items() if key in signature})

--- a/mlx_vlm/speculative/drafters/dflash2/config.py
+++ b/mlx_vlm/speculative/drafters/dflash2/config.py
@@ -1,0 +1,148 @@
+import inspect
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+
+from ..qwen3_dflash.config import DFlashConfig
+
+
+def _is_strictly_increasing_ints(values: list[int]) -> bool:
+    return all(
+        isinstance(value, int) and (index == 0 or values[index - 1] < value)
+        for index, value in enumerate(values)
+    )
+
+
+@dataclass
+class DFlash2Config(DFlashConfig):
+    model_type: str = "dflash2"
+    backbone_model_type: str = "qwen3"
+    architectures: list[str] = field(default_factory=list)
+    hidden_act: str = "silu"
+    rope_is_neox_style: bool = True
+    input_embedding_scale: float = 1.0
+    output_multiplier: float = 1.0
+    conv_kernel_size: int = 0
+    conv_group_size: int = 0
+    selector_rank: int = 0
+    selector_top_k: int = 0
+    is_causal: bool = False
+
+    def __post_init__(self) -> None:
+        if not self.layer_types:
+            self.layer_types = ["full_attention"] * self.num_hidden_layers
+        self.validate()
+
+    def validate(self) -> None:
+        positive_fields = (
+            "hidden_size",
+            "intermediate_size",
+            "num_hidden_layers",
+            "num_attention_heads",
+            "num_key_value_heads",
+            "head_dim",
+            "vocab_size",
+            "max_position_embeddings",
+            "block_size",
+            "num_target_layers",
+            "conv_kernel_size",
+            "conv_group_size",
+            "selector_rank",
+            "selector_top_k",
+        )
+        for key in positive_fields:
+            value = getattr(self, key)
+            if not isinstance(value, int) or value <= 0:
+                raise ValueError(f"DFlash2 requires a positive integer {key}.")
+        if self.model_type != "dflash2":
+            raise ValueError(
+                f"DFlash2 requires normalized model_type='dflash2', got "
+                f"{self.model_type!r}."
+            )
+        if self.num_attention_heads % self.num_key_value_heads:
+            raise ValueError("DFlash2 attention heads must be divisible by KV heads.")
+        if self.hidden_size % self.conv_group_size:
+            raise ValueError(
+                "DFlash2 hidden_size must be divisible by conv_group_size."
+            )
+        if self.hidden_act != "silu":
+            raise ValueError("DFlash2 currently supports only hidden_act='silu'.")
+        if not 0 < self.selector_top_k <= self.vocab_size:
+            raise ValueError("DFlash2 selector_top_k must fit inside the vocabulary.")
+        if not 0 <= self.mask_token_id < self.vocab_size:
+            raise ValueError("DFlash2 mask_token_id must be inside the vocabulary.")
+        if len(self.layer_types) != self.num_hidden_layers or any(
+            layer_type not in {"full_attention", "sliding_attention"}
+            for layer_type in self.layer_types
+        ):
+            raise ValueError(
+                "DFlash2 requires one supported attention type per draft layer."
+            )
+        if "sliding_attention" in self.layer_types and self.sliding_window is None:
+            raise ValueError(
+                "DFlash2 requires sliding_window for sliding_attention layers."
+            )
+        if (
+            not self.target_layer_ids
+            or not _is_strictly_increasing_ints(self.target_layer_ids)
+            or any(
+                layer_id < 0 or layer_id >= self.num_target_layers
+                for layer_id in self.target_layer_ids
+            )
+        ):
+            raise ValueError(
+                "DFlash2 target_layer_ids must be unique, increasing indices "
+                "inside the target layer range."
+            )
+        if self.runtime_block_size is not None and (
+            not isinstance(self.runtime_block_size, int)
+            or not 2 <= self.runtime_block_size <= self.block_size
+        ):
+            raise ValueError(
+                "DFlash2 runtime_block_size must be between 2 and block_size."
+            )
+        if self.is_causal:
+            raise ValueError("DFlash2 causal draft blocks are not currently supported.")
+
+    @classmethod
+    def from_dict(cls, params: dict) -> "DFlash2Config":
+        flat = dict(params)
+        dflash = flat.pop("dflash_config", None)
+        if not isinstance(dflash, Mapping):
+            raise TypeError("DFlash2 requires a dflash_config object.")
+
+        flat["backbone_model_type"] = str(flat.pop("model_type", "qwen3"))
+        flat["model_type"] = "dflash2"
+        for key in (
+            "block_size",
+            "mask_token_id",
+            "target_layer_ids",
+            "runtime_block_size",
+            "draft_window_size",
+            "final_logit_softcapping",
+            "input_embedding_scale",
+            "output_multiplier",
+            "conv_kernel_size",
+            "conv_group_size",
+            "selector_rank",
+            "selector_top_k",
+        ):
+            if key in dflash:
+                flat[key] = dflash[key]
+
+        rope_parameters = flat.pop("rope_parameters", None)
+        if isinstance(rope_parameters, Mapping):
+            rope_parameters = dict(rope_parameters)
+            if "rope_theta" in rope_parameters:
+                flat["rope_theta"] = rope_parameters.pop("rope_theta")
+            flat["rope_scaling"] = rope_parameters
+
+        if "runtime_block_size" not in flat:
+            flat["runtime_block_size"] = min(3, int(flat["block_size"]))
+
+        signature = inspect.signature(cls).parameters
+        return cls(**{key: value for key, value in flat.items() if key in signature})
+
+    from_hf_dict = from_dict
+
+
+__all__ = ["DFlash2Config"]

--- a/mlx_vlm/speculative/drafters/dflash2/dflash2.py
+++ b/mlx_vlm/speculative/drafters/dflash2/dflash2.py
@@ -1,0 +1,225 @@
+from collections.abc import Callable, Mapping
+
+import mlx.core as mx
+import mlx.nn as nn
+
+from ..compatibility import validate_dflash_target
+from ..qwen3_dflash.dflash import DFlashDecoderLayer, DFlashDraftModel
+from .config import DFlash2Config
+
+
+def _grouped_dynamic_convolve(
+    hidden: mx.array,
+    dynamic: mx.array,
+    base: mx.array,
+    group_size: int,
+) -> mx.array:
+    batch, length, hidden_size = hidden.shape
+    groups = hidden_size // group_size
+    blocks = hidden.reshape(batch, length, groups, group_size)
+    dynamic = dynamic.reshape(batch, length, base.shape[0], groups, 1)
+    output = mx.zeros_like(blocks)
+    for offset in range(base.shape[0]):
+        values = (
+            blocks
+            if offset == 0
+            else mx.concatenate(
+                [mx.zeros_like(blocks[:, :offset]), blocks[:, :-offset]], axis=1
+            )
+        )
+        kernel = base[offset].reshape(1, 1, groups, group_size).astype(hidden.dtype)
+        output = output + (kernel + dynamic[:, :, offset]) * values
+    return output.reshape(hidden.shape)
+
+
+class GroupedDynamicCausalConv(nn.Module):
+    def __init__(self, hidden_size: int, kernel_size: int, group_size: int):
+        super().__init__()
+        self.kernel_size = kernel_size
+        self.group_size = group_size
+        groups = hidden_size // group_size
+        self.base_kernel = mx.zeros((2, kernel_size, hidden_size))
+        self.kernel_projection = nn.Linear(
+            hidden_size, 2 * kernel_size * groups, bias=False
+        )
+
+    def prepare(self, hidden: mx.array) -> tuple[mx.array, mx.array]:
+        groups = hidden.shape[-1] // self.group_size
+        dynamic = self.kernel_projection(hidden).reshape(
+            *hidden.shape[:-1], 2, self.kernel_size, groups
+        )
+        prepared = _grouped_dynamic_convolve(
+            hidden,
+            dynamic[..., 0, :, :],
+            self.base_kernel[0],
+            self.group_size,
+        )
+        return prepared, dynamic[..., 1, :, :]
+
+    def finish(self, hidden: mx.array, dynamic: mx.array) -> mx.array:
+        return _grouped_dynamic_convolve(
+            hidden, dynamic, self.base_kernel[1], self.group_size
+        )
+
+
+class DFlash2DecoderLayer(DFlashDecoderLayer):
+    def __init__(self, config: DFlash2Config, layer_idx: int):
+        super().__init__(config, layer_idx)
+        self.attention_conv = GroupedDynamicCausalConv(
+            config.hidden_size, config.conv_kernel_size, config.conv_group_size
+        )
+        self.mlp_conv = GroupedDynamicCausalConv(
+            config.hidden_size, config.conv_kernel_size, config.conv_group_size
+        )
+
+    def __call__(self, x, x_ctx, rope, cache):
+        residual = x
+        x, kernel = self.attention_conv.prepare(self.input_layernorm(x))
+        x = residual + self.attention_conv.finish(
+            self.self_attn(x, x_ctx, rope, cache), kernel
+        )
+        residual = x
+        x, kernel = self.mlp_conv.prepare(self.post_attention_layernorm(x))
+        return residual + self.mlp_conv.finish(self.mlp(x), kernel)
+
+
+class CandidateSelector(nn.Module):
+    def __init__(self, config: DFlash2Config):
+        super().__init__()
+        self.top_k = config.selector_top_k
+        self.predecessor_codebook = nn.Embedding(
+            config.vocab_size, config.selector_rank
+        )
+        self.successor_codebook = nn.Embedding(config.vocab_size, config.selector_rank)
+        self.hidden_projection = nn.Linear(
+            config.hidden_size, config.selector_rank, bias=False
+        )
+
+    def select(
+        self,
+        hidden: mx.array,
+        logits: mx.array,
+        anchor_ids: mx.array,
+        sampler: Callable[[mx.array], mx.array],
+    ) -> mx.array:
+        candidates = mx.argpartition(logits, -self.top_k, axis=-1)[
+            ..., -self.top_k :
+        ]
+        unary = mx.take_along_axis(logits, candidates, axis=-1)
+        hidden = self.hidden_projection(hidden)
+        predecessor = anchor_ids.reshape(-1)
+        path = []
+        sample_proposal = getattr(sampler, "sample_proposal", None)
+        for position in range(hidden.shape[1]):
+            edges = mx.sum(
+                self.predecessor_codebook(predecessor)[:, None]
+                * hidden[:, position, None]
+                * self.successor_codebook(candidates[:, position]),
+                axis=-1,
+            )
+            scores = unary[:, position] + edges
+            selected = (
+                sample_proposal(scores)
+                if callable(sample_proposal)
+                else mx.argmax(scores, axis=-1)
+            ).reshape(-1)
+            predecessor = mx.take_along_axis(
+                candidates[:, position], selected[:, None], axis=-1
+            )[:, 0]
+            path.append(predecessor)
+        return mx.stack(path, axis=1)
+
+
+class DFlash2DraftModel(DFlashDraftModel):
+    layer_class = DFlash2DecoderLayer
+    prefer_requested_block_size = True
+
+    def __init__(self, config: DFlash2Config):
+        super().__init__(config)
+        self.candidate_selector = CandidateSelector(config)
+
+    def validate_target_compatibility(self, target_model) -> None:
+        validate_dflash_target(self.config, target_model, "DFlash2")
+
+    def bind(self, target_model) -> "DFlash2DraftModel":
+        self.validate_target_compatibility(target_model)
+        super().bind(target_model)
+        return self
+
+    def _embed_input_tokens(self, inputs: mx.array) -> mx.array:
+        return (
+            self.embed_tokens(inputs)
+            * self.embed_scale
+            * self.config.input_embedding_scale
+        )
+
+    def _logits(self, hidden: mx.array) -> mx.array:
+        logits = self.lm_head(hidden) * self.config.output_multiplier
+        if self.config.final_logit_softcapping is not None:
+            softcap = self.config.final_logit_softcapping
+            logits = mx.tanh(logits / softcap) * softcap
+        return logits
+
+    def draft_block(
+        self,
+        last_bonus,
+        hidden: mx.array,
+        cache,
+        block_size: int,
+        sampler: Callable[[mx.array], mx.array],
+        token_dtype: mx.Dtype = mx.int32,
+    ) -> mx.array:
+        proposal_length = int(block_size) - 1
+        if proposal_length <= 0:
+            batch = 1 if isinstance(last_bonus, int) else int(last_bonus.shape[0])
+            return mx.zeros((batch, 0), dtype=token_dtype)
+        anchor = (
+            mx.array([last_bonus], dtype=token_dtype)
+            if isinstance(last_bonus, int)
+            else last_bonus.reshape(-1).astype(token_dtype)
+        )
+        masks = mx.full(
+            (anchor.shape[0], proposal_length),
+            int(self.config.mask_token_id),
+            dtype=token_dtype,
+        )
+        draft_inputs = mx.concatenate([anchor[:, None], masks], axis=1)
+        draft_hidden = self._hidden(draft_inputs, hidden, cache)[:, 1:]
+        return self.candidate_selector.select(
+            draft_hidden,
+            self._logits(draft_hidden),
+            anchor,
+            sampler,
+        ).astype(token_dtype)
+
+    def sanitize(
+        self, weights: Mapping[str, mx.array]
+    ) -> dict[str, mx.array]:
+        normalized = {}
+        codebooks = {
+            "candidate_selector.predecessor_codebook",
+            "candidate_selector.successor_codebook",
+        }
+        for key, value in weights.items():
+            key = key.removeprefix("model.")
+            if key in codebooks:
+                key = f"{key}.weight"
+            if key in normalized:
+                raise ValueError(
+                    f"Duplicate DFlash2 weight key after sanitization: {key}"
+                )
+            normalized[key] = value
+        return normalized
+
+
+Model = DFlash2DraftModel
+
+
+__all__ = [
+    "CandidateSelector",
+    "DFlash2DecoderLayer",
+    "DFlash2DraftModel",
+    "GroupedDynamicCausalConv",
+    "Model",
+    "_grouped_dynamic_convolve",
+]

--- a/mlx_vlm/speculative/drafters/dflash2/dflash2.py
+++ b/mlx_vlm/speculative/drafters/dflash2/dflash2.py
@@ -102,9 +102,7 @@ class CandidateSelector(nn.Module):
         anchor_ids: mx.array,
         sampler: Callable[[mx.array], mx.array],
     ) -> mx.array:
-        candidates = mx.argpartition(logits, -self.top_k, axis=-1)[
-            ..., -self.top_k :
-        ]
+        candidates = mx.argpartition(logits, -self.top_k, axis=-1)[..., -self.top_k :]
         unary = mx.take_along_axis(logits, candidates, axis=-1)
         hidden = self.hidden_projection(hidden)
         predecessor = anchor_ids.reshape(-1)
@@ -132,7 +130,9 @@ class CandidateSelector(nn.Module):
 
 class DFlash2DraftModel(DFlashDraftModel):
     layer_class = DFlash2DecoderLayer
-    prefer_requested_block_size = True
+    prefer_requested_block_size = False
+    dflash_initial_block_size = 3
+    dflash_min_block_size = 3
 
     def __init__(self, config: DFlash2Config):
         super().__init__(config)
@@ -192,9 +192,7 @@ class DFlash2DraftModel(DFlashDraftModel):
             sampler,
         ).astype(token_dtype)
 
-    def sanitize(
-        self, weights: Mapping[str, mx.array]
-    ) -> dict[str, mx.array]:
+    def sanitize(self, weights: Mapping[str, mx.array]) -> dict[str, mx.array]:
         normalized = {}
         codebooks = {
             "candidate_selector.predecessor_codebook",

--- a/mlx_vlm/speculative/drafters/dspark/dspark.py
+++ b/mlx_vlm/speculative/drafters/dspark/dspark.py
@@ -3,6 +3,7 @@ from collections.abc import Callable, Mapping
 import mlx.core as mx
 import mlx.nn as nn
 
+from ..compatibility import validate_dflash_target
 from ..qwen3_dflash.dflash import DFlashDraftModel
 from .config import DSparkConfig
 
@@ -70,55 +71,8 @@ class DSparkConfidenceHead(nn.Module):
         return mx.sigmoid(self.proj(features).squeeze(-1).astype(mx.float32))
 
 
-def _config_value(config, name):
-    if isinstance(config, Mapping):
-        return config.get(name)
-    return getattr(config, name, None)
-
-
-def _target_metadata(target_model):
-    language_model = getattr(target_model, "language_model", target_model)
-    outer_config = getattr(language_model, "config", None)
-    target_config = _config_value(outer_config, "text_config") or outer_config
-    if target_config is None:
-        target_config = getattr(language_model, "args", None)
-    inner = getattr(language_model, "model", language_model)
-    layers = getattr(inner, "layers", None)
-    return language_model, target_config, layers
-
-
 def validate_dspark_target(config: DSparkConfig, target_model) -> None:
-    """Validate the structural contract required by DSpark verification."""
-
-    language_model, target_config, layers = _target_metadata(target_model)
-
-    hidden_size = _config_value(target_config, "hidden_size")
-    if hidden_size != config.hidden_size:
-        raise ValueError(
-            "DSpark target hidden-size mismatch: "
-            f"draft={config.hidden_size}, target={hidden_size}."
-        )
-    layer_count = (
-        len(layers)
-        if layers is not None
-        else _config_value(target_config, "num_hidden_layers")
-    )
-    if layer_count != config.num_target_layers:
-        raise ValueError(
-            "DSpark target layer-count mismatch: "
-            f"draft={config.num_target_layers}, target={layer_count}."
-        )
-    vocab_size = _config_value(target_config, "vocab_size")
-    if vocab_size != config.vocab_size:
-        raise ValueError(
-            "DSpark target vocabulary mismatch: "
-            f"draft={config.vocab_size}, target={vocab_size}."
-        )
-    if not hasattr(language_model, "rollback_speculative_cache"):
-        raise ValueError(
-            f"DSpark target {type(language_model).__name__} does not expose "
-            "speculative cache rollback support."
-        )
+    validate_dflash_target(config, target_model, "DSpark")
 
 
 class DSparkDraftModel(DFlashDraftModel):

--- a/mlx_vlm/speculative/drafters/qwen3_dflash/dflash.py
+++ b/mlx_vlm/speculative/drafters/qwen3_dflash/dflash.py
@@ -122,6 +122,8 @@ class DFlashDecoderLayer(nn.Module):
 
 
 class DFlashDraftModel(nn.Module):
+    layer_class = DFlashDecoderLayer
+
     def __init__(self, config: DFlashConfig):
         super().__init__()
         self.config = config
@@ -131,7 +133,7 @@ class DFlashDraftModel(nn.Module):
         self.fc = nn.Linear(concat_dim, config.hidden_size, bias=False)
         self.hidden_norm = nn.RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
         self.layers = [
-            DFlashDecoderLayer(config, i) for i in range(config.num_hidden_layers)
+            self.layer_class(config, i) for i in range(config.num_hidden_layers)
         ]
         self.norm = nn.RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
         self.rope = _build_rope(config)

--- a/mlx_vlm/tests/test_models_dflash2.py
+++ b/mlx_vlm/tests/test_models_dflash2.py
@@ -141,9 +141,7 @@ def _generated_tokens(target, prompt, drafter=None, temperature=0, seed=None):
         get_input_embeddings=get_input_embeddings,
     )
     kwargs = (
-        {"draft_model": drafter, "draft_kind": "dflash"}
-        if drafter is not None
-        else {}
+        {"draft_model": drafter, "draft_kind": "dflash"} if drafter is not None else {}
     )
     return [
         int(token.item()) if hasattr(token, "item") else int(token)
@@ -169,7 +167,7 @@ def test_published_dflash2_config_and_loader_routing(tmp_path):
     assert config.model_type == "dflash2"
     assert config.backbone_model_type == "qwen3"
     assert config.block_size == 8
-    assert config.runtime_block_size == 3
+    assert config.runtime_block_size == 5
     assert config.target_layer_ids == [5, 19, 33, 47, 61]
     assert config.conv_kernel_size == 2
     assert config.conv_group_size == 16
@@ -179,6 +177,11 @@ def test_published_dflash2_config_and_loader_routing(tmp_path):
     assert config.rope_scaling == {"rope_type": "default"}
     assert model_type == "dflash2"
     assert architecture.Model is DFlash2DraftModel
+
+    drafter = DFlash2DraftModel(config)
+    assert drafter.prefer_requested_block_size is False
+    assert drafter.dflash_initial_block_size == 3
+    assert drafter.dflash_min_block_size == 3
 
     (tmp_path / "config.json").write_text(json.dumps(published))
     assert resolve_drafter_kind(tmp_path) == "dflash"
@@ -220,9 +223,7 @@ def test_candidate_selector_uses_coherent_top_candidate_path():
     selector.successor_codebook.weight = mx.zeros((32, 4))
     selector.hidden_projection.weight = mx.zeros((4, 16))
     hidden = mx.zeros((1, 2, 16))
-    logits = mx.array(
-        [[[0, 1, 5, 2] + [0] * 28, [0, 7, 2, 3] + [0] * 28]]
-    )
+    logits = mx.array([[[0, 1, 5, 2] + [0] * 28, [0, 7, 2, 3] + [0] * 28]])
 
     selected = selector.select(
         hidden,

--- a/mlx_vlm/tests/test_models_dflash2.py
+++ b/mlx_vlm/tests/test_models_dflash2.py
@@ -1,0 +1,290 @@
+import json
+from types import SimpleNamespace
+
+import mlx.core as mx
+import pytest
+
+from mlx_vlm.generate.ar import generate_step
+from mlx_vlm.models.base import InputEmbeddingsFeatures
+from mlx_vlm.models.qwen3_5 import language as qwen_language
+from mlx_vlm.models.qwen3_5.config import TextConfig as Qwen3_5TextConfig
+from mlx_vlm.server.generation import _PositionedTargetSampler
+from mlx_vlm.speculative.drafters import (
+    resolve_drafter_kind,
+    validate_drafter_compatibility,
+)
+from mlx_vlm.speculative.drafters.dflash2 import (
+    CandidateSelector,
+    DFlash2DraftModel,
+    ModelConfig,
+    _grouped_dynamic_convolve,
+)
+from mlx_vlm.utils import get_model_and_args
+
+
+def _published_config():
+    return {
+        "architectures": ["DFlash2DraftModel"],
+        "model_type": "qwen3",
+        "is_causal": False,
+        "hidden_size": 5120,
+        "intermediate_size": 17408,
+        "num_hidden_layers": 5,
+        "num_attention_heads": 32,
+        "num_key_value_heads": 8,
+        "head_dim": 128,
+        "hidden_act": "silu",
+        "rms_norm_eps": 1e-6,
+        "vocab_size": 248320,
+        "max_position_embeddings": 262144,
+        "num_target_layers": 64,
+        "layer_types": ["sliding_attention"] * 5,
+        "sliding_window": 2048,
+        "rope_parameters": {
+            "rope_type": "default",
+            "rope_theta": 10000000,
+        },
+        "dflash_config": {
+            "block_size": 8,
+            "conv_group_size": 16,
+            "conv_kernel_size": 2,
+            "mask_token_id": 248070,
+            "selector_rank": 256,
+            "selector_top_k": 16,
+            "target_layer_ids": [5, 19, 33, 47, 61],
+        },
+    }
+
+
+def _tiny_config():
+    config = _published_config()
+    config.update(
+        hidden_size=16,
+        intermediate_size=32,
+        num_hidden_layers=1,
+        num_attention_heads=2,
+        num_key_value_heads=1,
+        head_dim=8,
+        vocab_size=32,
+        max_position_embeddings=128,
+        num_target_layers=2,
+        layer_types=["full_attention"],
+        sliding_window=None,
+        rope_parameters={"rope_type": "default", "rope_theta": 10000},
+    )
+    config["dflash_config"] = {
+        "block_size": 3,
+        "runtime_block_size": 3,
+        "conv_group_size": 4,
+        "conv_kernel_size": 2,
+        "mask_token_id": 31,
+        "selector_rank": 4,
+        "selector_top_k": 4,
+        "target_layer_ids": [0],
+    }
+    return ModelConfig.from_dict(config)
+
+
+def _tiny_target():
+    config = Qwen3_5TextConfig(
+        model_type="qwen3_5_text",
+        hidden_size=16,
+        intermediate_size=32,
+        linear_num_value_heads=2,
+        linear_num_key_heads=2,
+        linear_key_head_dim=4,
+        linear_value_head_dim=4,
+        linear_conv_kernel_dim=4,
+        num_hidden_layers=2,
+        num_attention_heads=2,
+        rms_norm_eps=1e-6,
+        vocab_size=32,
+        num_key_value_heads=1,
+        max_position_embeddings=128,
+        tie_word_embeddings=True,
+        head_dim=8,
+        full_attention_interval=2,
+        rope_parameters={
+            "type": "default",
+            "mrope_section": [1, 0, 0],
+            "rope_theta": 10000,
+            "partial_rotary_factor": 0.25,
+        },
+    )
+    outer_config = SimpleNamespace(
+        model_type="qwen3_5",
+        text_config=config,
+        vision_config=SimpleNamespace(spatial_merge_size=2),
+        image_token_id=30,
+        video_token_id=29,
+        vision_start_token_id=28,
+    )
+    model = qwen_language.LanguageModel(config, outer_config)
+    model.set_dtype(mx.bfloat16)
+    return model
+
+
+def _generated_tokens(target, prompt, drafter=None, temperature=0, seed=None):
+    def get_input_embeddings(input_ids, pixel_values=None, mask=None, **kwargs):
+        del pixel_values, kwargs
+        position_ids, rope_deltas = target.get_rope_index(
+            input_ids, attention_mask=mask
+        )
+        return InputEmbeddingsFeatures(
+            inputs_embeds=target.model.embed_tokens(input_ids),
+            position_ids=position_ids,
+            rope_deltas=rope_deltas,
+        )
+
+    generation_target = SimpleNamespace(
+        language_model=target,
+        get_input_embeddings=get_input_embeddings,
+    )
+    kwargs = (
+        {"draft_model": drafter, "draft_kind": "dflash"}
+        if drafter is not None
+        else {}
+    )
+    return [
+        int(token.item()) if hasattr(token, "item") else int(token)
+        for token, _ in generate_step(
+            prompt,
+            generation_target,
+            None,
+            None,
+            max_tokens=10,
+            temperature=temperature,
+            seed=seed,
+            prefill_step_size=None,
+            **kwargs,
+        )
+    ]
+
+
+def test_published_dflash2_config_and_loader_routing(tmp_path):
+    published = _published_config()
+    config = ModelConfig.from_dict(published)
+    architecture, model_type = get_model_and_args(published)
+
+    assert config.model_type == "dflash2"
+    assert config.backbone_model_type == "qwen3"
+    assert config.block_size == 8
+    assert config.runtime_block_size == 3
+    assert config.target_layer_ids == [5, 19, 33, 47, 61]
+    assert config.conv_kernel_size == 2
+    assert config.conv_group_size == 16
+    assert config.selector_rank == 256
+    assert config.selector_top_k == 16
+    assert config.rope_theta == 10000000
+    assert config.rope_scaling == {"rope_type": "default"}
+    assert model_type == "dflash2"
+    assert architecture.Model is DFlash2DraftModel
+
+    (tmp_path / "config.json").write_text(json.dumps(published))
+    assert resolve_drafter_kind(tmp_path) == "dflash"
+
+
+def test_dflash2_sanitize_normalizes_published_codebooks():
+    drafter = DFlash2DraftModel(_tiny_config())
+    predecessor = mx.zeros((32, 4))
+    successor = mx.ones((32, 4))
+
+    weights = drafter.sanitize(
+        {
+            "candidate_selector.predecessor_codebook": predecessor,
+            "candidate_selector.successor_codebook": successor,
+        }
+    )
+
+    assert weights == {
+        "candidate_selector.predecessor_codebook.weight": predecessor,
+        "candidate_selector.successor_codebook.weight": successor,
+    }
+
+
+def test_grouped_dynamic_convolution_is_causal():
+    hidden = mx.array([[[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12]]])
+    dynamic = mx.zeros((1, 3, 2, 2))
+    base = mx.array([[1, 1, 1, 1], [2, 2, 2, 2]])
+
+    actual = _grouped_dynamic_convolve(hidden, dynamic, base, group_size=2)
+    expected = mx.array([[[1, 2, 3, 4], [7, 10, 13, 16], [19, 22, 25, 28]]])
+
+    assert bool(mx.array_equal(actual, expected))
+
+
+def test_candidate_selector_uses_coherent_top_candidate_path():
+    config = _tiny_config()
+    selector = CandidateSelector(config)
+    selector.predecessor_codebook.weight = mx.zeros((32, 4))
+    selector.successor_codebook.weight = mx.zeros((32, 4))
+    selector.hidden_projection.weight = mx.zeros((4, 16))
+    hidden = mx.zeros((1, 2, 16))
+    logits = mx.array(
+        [[[0, 1, 5, 2] + [0] * 28, [0, 7, 2, 3] + [0] * 28]]
+    )
+
+    selected = selector.select(
+        hidden,
+        logits,
+        mx.array([4]),
+        sampler=lambda scores: mx.argmax(scores, axis=-1),
+    )
+
+    assert selected.tolist() == [[2, 1]]
+
+
+def test_positioned_proposal_sampling_is_independent_of_target_filters():
+    sampler = _PositionedTargetSampler(
+        temperature=1.0,
+        top_p=0.95,
+        top_k=20,
+        seed=7,
+    )
+    scores = mx.zeros((1, 16))
+
+    first = sampler.sample_proposal(scores, row_ids=[0], positions=[3])
+    second = sampler.sample_proposal(scores, row_ids=[0], positions=[3])
+
+    assert first.shape == (1,)
+    assert bool(mx.array_equal(first, second))
+
+
+def test_dflash2_target_validation_is_structural():
+    config = _tiny_config()
+    target = SimpleNamespace(
+        language_model=SimpleNamespace(
+            config=SimpleNamespace(
+                hidden_size=16,
+                num_hidden_layers=2,
+                vocab_size=32,
+            ),
+            model=SimpleNamespace(layers=[object(), object()]),
+            rollback_speculative_cache=lambda *args: None,
+        )
+    )
+
+    validate_drafter_compatibility(
+        target, DFlash2DraftModel(config), draft_kind="dflash"
+    )
+
+
+@pytest.mark.parametrize(("temperature", "seed"), [(0, None), (1.0, 17)])
+def test_dflash2_generation_has_exact_target_parity(temperature, seed):
+    mx.random.seed(7)
+    target = _tiny_target()
+    drafter = DFlash2DraftModel(_tiny_config())
+    mx.eval(target.parameters(), drafter.parameters())
+    prompt = mx.array([[1, 2, 3, 4]], dtype=mx.int32)
+
+    baseline = _generated_tokens(target, prompt, temperature=temperature, seed=seed)
+    speculative = _generated_tokens(
+        target,
+        prompt,
+        drafter,
+        temperature=temperature,
+        seed=seed,
+    )
+
+    assert speculative == baseline
+    assert drafter.draft_lens

--- a/mlx_vlm/tests/test_speculative.py
+++ b/mlx_vlm/tests/test_speculative.py
@@ -405,6 +405,26 @@ def test_qwen_gated_delta_accept_states_matches_python_gather():
     assert bool(mx.array_equal(ref_conv, out_conv).item())
 
 
+def test_qwen_gated_delta_accept_states_uses_live_state_after_last_saved_step():
+    intermediate_states = mx.zeros((1, 2, 2, 3, 5), dtype=mx.float32)
+    conv_input = mx.zeros((1, 5, 6), dtype=mx.float32)
+    live_state = mx.full((1, 2, 3, 5), 7.0, dtype=mx.float32)
+    live_conv = mx.full((1, 3, 6), 8.0, dtype=mx.float32)
+
+    state, conv = qwen_language.gated_delta_accept_states(
+        intermediate_states,
+        conv_input,
+        live_state,
+        live_conv,
+        mx.array([2], dtype=mx.int32),
+        kernel_size=4,
+    )
+    mx.eval(state, conv)
+
+    assert bool(mx.array_equal(state, live_state).item())
+    assert bool(mx.array_equal(conv, live_conv).item())
+
+
 def test_qwen_rollback_speculative_cache_zero_inits_missing_state():
     accepted = mx.array([1, 0], dtype=mx.int32)
     caches = [ArraysCache(size=2)]
@@ -444,12 +464,25 @@ def test_qwen_gdn_sink_captures_intermediate_states_for_batched_verify():
     layer = qwen_language.Qwen3_5GatedDeltaNet(config)
     sink = []
 
-    def fake_update(q, k, v, a, b, A_log, dt_bias, state, mask, use_kernel=True):
+    def fake_update(
+        q,
+        k,
+        v,
+        a,
+        b,
+        A_log,
+        dt_bias,
+        state,
+        mask,
+        use_kernel=True,
+        state_steps=None,
+    ):
         del k, v, a, b, A_log, dt_bias, state, mask, use_kernel
         B, S = q.shape[:2]
+        state_steps = S if state_steps is None else state_steps
         out = mx.zeros((B, S, 2, 4), dtype=mx.float32)
         next_state = mx.zeros((B, 2, 4, 4), dtype=mx.float32)
-        states = mx.ones((B, S, 2, 4, 4), dtype=mx.float32)
+        states = mx.ones((B, state_steps, 2, 4, 4), dtype=mx.float32)
         return out, next_state, states
 
     verifier = qwen_verifier.Qwen3_5ExactSpeculativeVerifier()
@@ -466,7 +499,7 @@ def test_qwen_gdn_sink_captures_intermediate_states_for_batched_verify():
 
     mx.eval(out)
     assert out.shape == (2, 3, 16)
-    assert sink[0][11].shape == (2, 3, 2, 4, 4)
+    assert sink[0][11].shape == (2, 2, 2, 4, 4)
 
 
 def test_qwen_gdn_sink_captures_intermediate_states_for_singleton_verify():
@@ -482,12 +515,25 @@ def test_qwen_gdn_sink_captures_intermediate_states_for_singleton_verify():
     layer = qwen_language.Qwen3_5GatedDeltaNet(config)
     sink = []
 
-    def fake_update(q, k, v, a, b, A_log, dt_bias, state, mask, use_kernel=True):
+    def fake_update(
+        q,
+        k,
+        v,
+        a,
+        b,
+        A_log,
+        dt_bias,
+        state,
+        mask,
+        use_kernel=True,
+        state_steps=None,
+    ):
         del k, v, a, b, A_log, dt_bias, state, mask, use_kernel
         B, S = q.shape[:2]
+        state_steps = S if state_steps is None else state_steps
         out = mx.zeros((B, S, 2, 4), dtype=mx.float32)
         next_state = mx.zeros((B, 2, 4, 4), dtype=mx.float32)
-        states = mx.ones((B, S, 2, 4, 4), dtype=mx.float32)
+        states = mx.ones((B, state_steps, 2, 4, 4), dtype=mx.float32)
         return out, next_state, states
 
     verifier = qwen_verifier.Qwen3_5ExactSpeculativeVerifier()
@@ -504,7 +550,7 @@ def test_qwen_gdn_sink_captures_intermediate_states_for_singleton_verify():
 
     mx.eval(out)
     assert out.shape == (1, 3, 16)
-    assert sink[0][11].shape == (1, 3, 2, 4, 4)
+    assert sink[0][11].shape == (1, 2, 2, 4, 4)
 
 
 def test_qwen_gdn_verify_update_matches_stepwise_path():
@@ -545,6 +591,31 @@ def test_qwen_gdn_verify_update_matches_stepwise_path():
     mx.eval(*ref, *out)
 
     assert all(bool(mx.array_equal(a, b).item()) for a, b in zip(ref, out))
+
+
+def test_qwen_gdn_verify_can_omit_the_live_final_state():
+    mx.random.seed(27)
+    B, S, Hk, D, Hv, Dv = 1, 3, 2, 64, 4, 16
+    q = mx.random.normal((B, S, Hk, D)).astype(mx.bfloat16)
+    k = mx.random.normal((B, S, Hk, D)).astype(mx.bfloat16)
+    v = mx.random.normal((B, S, Hv, Dv)).astype(mx.bfloat16)
+    a = mx.random.normal((B, S, Hv)).astype(mx.bfloat16)
+    b = mx.random.normal((B, S, Hv)).astype(mx.bfloat16)
+    A_log = mx.random.normal((Hv,)).astype(mx.bfloat16)
+    dt_bias = mx.ones((Hv,), dtype=mx.bfloat16)
+    state = mx.zeros((B, Hv, Dv, D), dtype=mx.float32)
+
+    full = qwen_verifier.gated_delta_update_with_states(
+        q, k, v, a, b, A_log, dt_bias, state, state_steps=S
+    )
+    shortened = qwen_verifier.gated_delta_update_with_states(
+        q, k, v, a, b, A_log, dt_bias, state, state_steps=S - 1
+    )
+    mx.eval(*full, *shortened)
+
+    assert bool(mx.array_equal(full[0], shortened[0]).item())
+    assert bool(mx.array_equal(full[1], shortened[1]).item())
+    assert bool(mx.array_equal(full[2][:, :-1], shortened[2]).item())
 
 
 def test_qwen_target_verify_linear_matches_singleton_dense_gemv():
@@ -632,8 +703,9 @@ def test_qwen_target_verify_4bit_linear_matches_singleton_path_exactly(
 
 
 @pytest.mark.parametrize("output_dims", [(16, 24), (16, 24, 32), (8, 16, 24, 32)])
-def test_qwen_target_verify_4bit_linears_fuse_exactly(output_dims):
-    mx.random.seed(51 + len(output_dims))
+@pytest.mark.parametrize("verify_length", [3, 6, 8])
+def test_qwen_target_verify_4bit_linears_fuse_exactly(output_dims, verify_length):
+    mx.random.seed(51 + len(output_dims) + verify_length)
     linears = tuple(
         nn.QuantizedLinear(512, output_dim, bias=False, group_size=64, bits=4)
         for output_dim in output_dims
@@ -641,7 +713,7 @@ def test_qwen_target_verify_4bit_linears_fuse_exactly(output_dims):
     for linear in linears:
         linear.scales = linear.scales.astype(mx.bfloat16)
         linear.biases = linear.biases.astype(mx.bfloat16)
-    x = mx.random.normal((1, 3, 512)).astype(mx.bfloat16)
+    x = mx.random.normal((1, verify_length, 512)).astype(mx.bfloat16)
 
     ref = tuple(qwen_verifier._target_verify_timewise(linear, x) for linear in linears)
     out = qwen_verifier._target_verify_linears(linears, x)

--- a/mlx_vlm/tests/test_speculative.py
+++ b/mlx_vlm/tests/test_speculative.py
@@ -614,7 +614,7 @@ def test_qwen_target_verify_quantized_linear_matches_singleton_batch_path():
 
 
 @pytest.mark.parametrize("input_dims", [512, 6144])
-@pytest.mark.parametrize("verify_length", [3, 4, 6])
+@pytest.mark.parametrize("verify_length", [3, 4, 6, 7, 8])
 def test_qwen_target_verify_4bit_linear_matches_singleton_path_exactly(
     input_dims, verify_length
 ):
@@ -789,18 +789,22 @@ def test_qwen3_5_quantized_argmax_batch_as_time_matches_rowwise():
     assert bool(mx.array_equal(out, ref).item())
 
 
-def test_qwen3_5_4bit_quantized_argmax_token_tiles_match_singletons():
-    mx.random.seed(38)
+@pytest.mark.parametrize("verify_length", [6, 7, 8])
+def test_qwen3_5_4bit_quantized_argmax_wide_blocks_match_singletons(verify_length):
+    mx.random.seed(32 + verify_length)
     linear = nn.QuantizedLinear(512, 32, bias=False, group_size=64, bits=4)
     linear.scales = linear.scales.astype(mx.bfloat16)
     linear.biases = linear.biases.astype(mx.bfloat16)
-    x = mx.random.normal((1, 6, 512), dtype=mx.bfloat16)
+    x = mx.random.normal((1, verify_length, 512), dtype=mx.bfloat16)
 
     out = qwen_verifier._target_verify_quantized_argmax(linear, x)
+    mask = mx.full((verify_length, 1), -1, dtype=mx.int32)
+    masked = qwen_verifier._target_verify_quantized_argmax(linear, x, token_mask=mask)
     ref = mx.argmax(qwen_verifier._target_verify_timewise(linear, x), axis=-1)
-    mx.eval(out, ref)
+    mx.eval(out, masked, ref)
 
     assert bool(mx.array_equal(out, ref).item())
+    assert bool(mx.array_equal(masked, ref).item())
 
 
 def _qwen3_5_ragged_attention_reference(queries, keys, values, pads, scale):

--- a/mlx_vlm/tests/test_speculative.py
+++ b/mlx_vlm/tests/test_speculative.py
@@ -2105,6 +2105,26 @@ def test_dflash_next_block_size_uses_model_initial_size():
     assert _dflash_next_block_size(draft_model, 16, 20, 4) == 4
 
 
+def test_dflash_next_block_size_honors_model_minimum():
+    draft_model = SimpleNamespace(
+        accept_lens=[0, 1],
+        draft_lens=[2, 3],
+        dflash_min_block_size=3,
+    )
+
+    assert _dflash_next_block_size(draft_model, 5, 20) == 3
+
+
+def test_dflash_next_block_size_grows_from_model_minimum():
+    draft_model = SimpleNamespace(
+        accept_lens=[2, 2, 2, 2],
+        draft_lens=[2, 2, 2, 2],
+        dflash_min_block_size=3,
+    )
+
+    assert _dflash_next_block_size(draft_model, 5, 20) == 5
+
+
 def test_dflash_next_block_size_backs_off_on_low_acceptance():
     draft_model = SimpleNamespace(accept_lens=[1, 2], draft_lens=[15, 7])
 

--- a/mlx_vlm/utils.py
+++ b/mlx_vlm/utils.py
@@ -611,8 +611,11 @@ def get_model_and_args(config: dict, model_path: Optional[Path] = None):
 
     model_type = MODEL_REMAPPING.get(model_type, model_type)
 
+    architectures = set(config.get("architectures") or ())
     dflash_config = config.get("dflash_config")
-    if dflash_config is not None:
+    if "DFlash2DraftModel" in architectures:
+        model_type = "dflash2"
+    elif dflash_config is not None:
         is_dspark = (
             dflash_config.get("projector_type") == "dspark"
             or int(config.get("markov_rank") or dflash_config.get("markov_rank") or 0)


### PR DESCRIPTION
## Summary

- add architecture-routed support for `z-lab/Qwen3.8-27B-DFlash2` through the shared DFlash runtime
- implement grouped dynamic causal convolutions and coherent candidate-path selection without repository-name or Qwen-specific runtime branches
- share structural target validation with DSpark and keep proposal sampling independent from target `top_k`/`top_p` filters
- default to a three-row MLX verification block based on the M5 Max sweep
- add exact greedy and sampled parity, loader, selector, convolution, compatibility, and documentation coverage

## M5 Max results

Apple M5 Max, 48 GB, `mlx-community/Qwen3.8-27B-4bit`, DFlash2 drafter converted to 4-bit, warmed server runs, 200 generated tokens:

| Sampling | Baseline | DFlash2 | Speedup | Accepted drafts | Exact parity |
|---|---:|---:|---:|---:|---:|
| Greedy | 33.40 tok/s | 58.58 tok/s | 1.75x | 117/164 (71.3%) | 200/200 |
| `temperature=1`, `top_p=0.95`, `top_k=20`, `seed=1234` | 32.93 tok/s | 49.96 tok/s | 1.52x | 109/181 (60.2%) | 200/200 |

Direct generate verification-block sweep, greedy, warmed two-run averages:

| Block size | Speed | Speedup vs. 32.81 tok/s baseline | Exact parity |
|---:|---:|---:|---:|
| 3 | 55.64 tok/s | 1.70x | 200/200 |
| 4 | 52.64 tok/s | 1.60x | 200/200 |
| 5 | 49.56 tok/s | 1.51x | 200/200 |

## Validation

- strict-loaded the published BF16 checkpoint and its converted 4-bit drafter
- `uvx pre-commit run --all-files`
- `.venv/bin/python -m pytest mlx_vlm/tests/test_models_dflash2.py mlx_vlm/tests/test_models_dspark.py mlx_vlm/tests/test_speculative.py mlx_vlm/tests/test_server.py -q` (580 passed)