### PR TITLE
APC: anchor checkpoints at semantic boundaries for checkpoint-mode caches

### DIFF
--- a/mlx_vlm/apc.py
+++ b/mlx_vlm/apc.py
@@ -71,6 +71,31 @@ DEFAULT_BLOCK_SIZE = 16
 DEFAULT_NUM_BLOCKS = 2048
 SEED_PARENT_HASH = 0
 
+# Matching is by token-id sequence, so a marker is reliable when it is a single
+# special token in the target vocabulary. Multi-token markers still match when
+# BPE happens to segment them the same way in context, but that is not
+# guaranteed -- keep genuine special tokens for each family in this list.
+DEFAULT_SEMANTIC_BOUNDARY_MARKERS = (
+    "</tool_call>",
+    "</tool_response>",
+    "</tool_output>",
+    "</think>",
+    "<|observation|>",
+    "<|user|>",
+    "<|assistant|>",
+    "<|im_end|>",
+    "<|end|>",
+    "<end_of_turn>",
+    "<start_of_turn>",
+    "<|eot_id|>",
+)
+DEFAULT_SEMANTIC_MIN_GAP = 256
+# Checkpoints are whole prompt-cache snapshots, so the pool grows with both the
+# checkpoint count and the context length. Left uncapped, a large budget on a
+# long context can exhaust memory. Applied only when semantic checkpoints are
+# enabled, so the default (feature off) pool is unchanged.
+DEFAULT_SEMANTIC_MAX_POOL_GB = 4.0
+
 
 def _env_truthy(name: str, default: str = "") -> bool:
     """Return True when env var is a common truthy string (1/true/yes)."""
@@ -492,6 +517,131 @@ def adjust_prefix_to_text_suffix_boundary(
     if prefix_len > max_len:
         return 0
     return prefix_len
+
+
+def semantic_checkpoint_config() -> Tuple[int, Tuple[str, ...], int, int]:
+    """Read the semantic-checkpoint policy from the environment.
+
+    Returns ``(max_checkpoints, markers, min_gap, max_pool_bytes)``.
+    ``max_checkpoints == 0`` disables the feature, leaving checkpoint mode on
+    its existing tail-only behaviour and the pool uncapped as before.
+    """
+    try:
+        max_checkpoints = max(0, int(os.environ.get("APC_SEMANTIC_CHECKPOINTS", "0")))
+    except ValueError:
+        max_checkpoints = 0
+    raw = os.environ.get("APC_SEMANTIC_BOUNDARY_TOKENS")
+    markers = (
+        tuple(m for m in (s.strip() for s in raw.split(",")) if m)
+        if raw
+        else DEFAULT_SEMANTIC_BOUNDARY_MARKERS
+    )
+    try:
+        min_gap = max(
+            1,
+            int(os.environ.get("APC_SEMANTIC_MIN_GAP", str(DEFAULT_SEMANTIC_MIN_GAP))),
+        )
+    except ValueError:
+        min_gap = DEFAULT_SEMANTIC_MIN_GAP
+    # Checkpoints are whole prompt-cache snapshots, so the pool grows with both
+    # count and context length; cap it, but only once the feature is on.
+    max_pool_bytes = 0
+    if max_checkpoints > 0:
+        try:
+            gb = float(
+                os.environ.get("APC_SEMANTIC_MAX_POOL_GB", DEFAULT_SEMANTIC_MAX_POOL_GB)
+            )
+        except ValueError:
+            gb = DEFAULT_SEMANTIC_MAX_POOL_GB
+        max_pool_bytes = int(gb * (1 << 30)) if gb > 0 else 0
+    return max_checkpoints, markers, min_gap, max_pool_bytes
+
+
+def resolve_boundary_sequences(
+    tokenizer: Any, markers: Optional[Sequence[str]] = None
+) -> Tuple[Tuple[int, ...], ...]:
+    """Encode boundary markers into token-id sequences for ``tokenizer``.
+
+    Matching is on id sequences rather than single ids, so a marker works
+    whether or not it is a special token in this vocabulary. Markers that fail
+    to encode are dropped; duplicates collapse.
+    """
+    encode = getattr(tokenizer, "encode", None)
+    if not callable(encode):
+        return ()
+    seqs: List[Tuple[int, ...]] = []
+    for marker in markers or DEFAULT_SEMANTIC_BOUNDARY_MARKERS:
+        try:
+            ids = encode(marker, add_special_tokens=False)
+        except TypeError:  # tokenizer without the kwarg
+            try:
+                ids = encode(marker)
+            except Exception:
+                continue
+        except Exception:
+            continue
+        if ids:
+            seqs.append(tuple(int(t) for t in ids))
+    return tuple(dict.fromkeys(seqs))  # ordered dedup
+
+
+def semantic_checkpoint_offsets(
+    token_ids: Sequence[int],
+    boundary_seqs: Sequence[Sequence[int]],
+    *,
+    max_checkpoints: int,
+    min_gap: int = DEFAULT_SEMANTIC_MIN_GAP,
+    guard: int = 0,
+) -> List[int]:
+    """Prefix lengths just after each semantic boundary, thinned to a budget.
+
+    Offsets are ascending, at least ``min_gap`` apart, and kept inside
+    ``[min_gap, len(token_ids) - guard]`` so every checkpoint has tokens on
+    both sides.
+    Returns ``[]`` when the feature is off or nothing qualifies, which leaves
+    the caller on the existing tail-only path.
+    """
+    if max_checkpoints <= 0 or not boundary_seqs:
+        return []
+    ids = tuple(int(t) for t in token_ids)
+    n = len(ids)
+    limit = min(n - max(0, int(guard)), n - 1)
+    if limit <= min_gap:
+        return []
+
+    # Bucket by first token so the scan touches each position once.
+    by_first: Dict[int, List[Tuple[int, ...]]] = {}
+    for seq in boundary_seqs:
+        s = tuple(int(t) for t in seq)
+        if s:
+            by_first.setdefault(s[0], []).append(s)
+
+    hits: set = set()
+    for i, tok in enumerate(ids):
+        for s in by_first.get(tok, ()):
+            end = i + len(s)
+            if end <= n and ids[i:end] == s:
+                hits.add(end)  # checkpoint lands just *after* the marker
+                break
+
+    candidates = sorted(h for h in hits if min_gap <= h <= limit)
+    if not candidates:
+        return []
+
+    spaced: List[int] = []
+    for off in candidates:
+        if not spaced or off - spaced[-1] >= min_gap:
+            spaced.append(off)
+    if len(spaced) <= max_checkpoints:
+        return spaced
+
+    # Over budget: spread evenly across the prompt, always keeping the
+    # shallowest and deepest. An edit is about as likely early as late, and the
+    # deepest offset is what still serves plain append-only turns.
+    if max_checkpoints == 1:
+        return [spaced[-1]]
+    step = (len(spaced) - 1) / (max_checkpoints - 1)
+    return [spaced[round(i * step)] for i in range(max_checkpoints)]
 
 
 @dataclass
@@ -2857,15 +3007,27 @@ class APCManager:
                 self._record_disk_writes,
                 self._record_disk_write_failures,
             )
+        (
+            self.semantic_checkpoints,
+            self.semantic_markers,
+            self.semantic_min_gap,
+            self._semantic_max_pool_bytes,
+        ) = semantic_checkpoint_config()
+        # Each semantic checkpoint needs a pool slot of its own, on top of the
+        # tail snapshots checkpoint mode already takes. With the feature off the
+        # default is unchanged at 2.
         self._exact_cache_max = max(
             0,
             int(
                 os.environ.get(
                     "APC_CHECKPOINT_ENTRIES",
-                    os.environ.get("APC_EXACT_CACHE_ENTRIES", "2"),
+                    os.environ.get(
+                        "APC_EXACT_CACHE_ENTRIES", str(2 + self.semantic_checkpoints)
+                    ),
                 )
             ),
         )
+        self._boundary_seqs: Optional[Tuple[Any, Tuple[Tuple[int, ...], ...]]] = None
         self.exact_cache_guard_tokens = max(
             1,
             int(
@@ -2968,6 +3130,41 @@ class APCManager:
 
     def _resident_bytes_locked(self) -> int:
         return sum(b.resident_bytes() for b in self.pool)
+
+    @staticmethod
+    def _entry_bytes(entry: "APCExactCacheEntry") -> int:
+        arrays: List[mx.array] = []
+        for layer in entry.prompt_cache:
+            _collect_mx_arrays(getattr(layer, "state", None), arrays)
+        return sum({id(a): a.nbytes for a in arrays}.values())
+
+    def _trim_exact_cache_locked(self) -> None:
+        """Evict LRU-first until the pool is within both the count and byte caps."""
+        while len(self._exact_cache) > self._exact_cache_max:
+            self._exact_cache.popitem(last=False)
+        budget = self._semantic_max_pool_bytes
+        if budget <= 0 or len(self._exact_cache) <= 1:
+            return
+        total = sum(self._entry_bytes(e) for e in self._exact_cache.values())
+        # Always keep the most recent entry, even if it alone exceeds the cap --
+        # dropping it would make the feature silently useless.
+        while total > budget and len(self._exact_cache) > 1:
+            _, evicted = self._exact_cache.popitem(last=False)
+            total -= self._entry_bytes(evicted)
+            self.stats.record_reject("pool_bytes", budget=budget)
+
+    def boundary_sequences(self, tokenizer: Any) -> Tuple[Tuple[int, ...], ...]:
+        """Semantic boundary markers encoded for ``tokenizer``, memoized.
+
+        Encoding is a handful of tokenizer calls, but it would otherwise run on
+        every request; the tokenizer is stable for the life of a manager.
+        """
+        cached = self._boundary_seqs
+        if cached is not None and cached[0] is tokenizer:
+            return cached[1]
+        seqs = resolve_boundary_sequences(tokenizer, self.semantic_markers)
+        self._boundary_seqs = (tokenizer, seqs)
+        return seqs
 
     def resident_bytes(self) -> int:
         with self.lock:
@@ -3153,9 +3350,8 @@ class APCManager:
                     prompt_cache=copied,
                 )
                 self._exact_cache.move_to_end(key)
-                while len(self._exact_cache) > self._exact_cache_max:
-                    self._exact_cache.popitem(last=False)
-                stored = True
+                self._trim_exact_cache_locked()
+                stored = key in self._exact_cache
         if stored:
             apc_trace(
                 "store",
@@ -3347,8 +3543,7 @@ class APCManager:
                         prompt_cache=copied,
                     )
                     self._exact_cache.move_to_end(key)
-                    while len(self._exact_cache) > self._exact_cache_max:
-                        self._exact_cache.popitem(last=False)
+                    self._trim_exact_cache_locked()
                     self.stats.exact_stores += 1
                     layer_major_stored = True
             parent = SEED_PARENT_HASH

--- a/mlx_vlm/apc_coordinator.py
+++ b/mlx_vlm/apc_coordinator.py
@@ -94,6 +94,43 @@ class APCCoordinator:
             max_prefix_tokens=len(token_ids) - 1,
         )
 
+    def checkpoint_lens(
+        self,
+        token_ids: Sequence[int],
+        media_token_ids: set[int],
+        tokenizer: Any = None,
+    ) -> List[int]:
+        """Ascending prefix lengths to snapshot: the tail one, plus any
+        semantic boundaries APC is configured to keep.
+
+        Recurrent state is not sliceable, so an edited history can only resume
+        from a stored point -- a tail-only checkpoint means any earlier edit
+        re-prefills everything. Offsets whose suffix still contains media
+        tokens are dropped: a warm restore drops pixel_values, so they would
+        never match.
+        """
+        # checkpoint_len already returns 0 unless enabled and in checkpoint
+        # mode, and `enabled` implies a manager, so no further guard is needed.
+        tail = self.checkpoint_len(token_ids, media_token_ids)
+        lens = [tail] if tail > 0 else []
+        mgr = self.manager
+        if tail > 0 and tokenizer is not None and mgr.semantic_checkpoints > 0:
+            from .apc import media_safe_prefix_min, semantic_checkpoint_offsets
+
+            media_min = media_safe_prefix_min(token_ids, media_token_ids)
+            lens.extend(
+                off
+                for off in semantic_checkpoint_offsets(
+                    token_ids,
+                    mgr.boundary_sequences(tokenizer),
+                    max_checkpoints=mgr.semantic_checkpoints,
+                    min_gap=mgr.semantic_min_gap,
+                    guard=mgr.exact_cache_guard_tokens,
+                )
+                if off >= media_min
+            )
+        return sorted(set(lens))
+
     def merge_rows(
         self,
         picks: Sequence[Optional[dict]],

--- a/mlx_vlm/generate/ar.py
+++ b/mlx_vlm/generate/ar.py
@@ -9,7 +9,7 @@ import time
 import warnings
 from collections.abc import Generator
 from dataclasses import dataclass
-from typing import Any, Callable, Dict, List, Optional, Tuple, Union
+from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, Union
 
 import mlx.core as mx
 import mlx.nn as nn
@@ -148,6 +148,31 @@ def normalize_resize_shape(values):
     return (values[0], values[0]) if len(values) == 1 else tuple(values)
 
 
+def _clip_chunk_to_checkpoint(
+    n_to_process: int,
+    processed_tokens: int,
+    checkpoint_lens: Sequence[int],
+    checkpoint_idx: int,
+) -> Tuple[int, int]:
+    """Shorten a prefill chunk so it ends exactly on the next pending checkpoint.
+
+    Snapshots are only meaningful at an exact prefix length, so a chunk that
+    would straddle one is cut short. Also advances ``checkpoint_idx`` past any
+    checkpoint prefill has already run beyond. Returns the possibly-reduced
+    chunk size and the new cursor.
+    """
+    while (
+        checkpoint_idx < len(checkpoint_lens)
+        and checkpoint_lens[checkpoint_idx] <= processed_tokens
+    ):
+        checkpoint_idx += 1
+    if checkpoint_idx < len(checkpoint_lens):
+        target = checkpoint_lens[checkpoint_idx]
+        if processed_tokens + n_to_process > target:
+            n_to_process = target - processed_tokens
+    return n_to_process, checkpoint_idx
+
+
 def generate_step(
     input_ids: mx.array,
     model: nn.Module,
@@ -186,7 +211,7 @@ def generate_step(
     draft_kind: str = "dflash",
     draft_block_size: Optional[int] = None,
     prompt_cache_checkpoint: Optional[Callable[[int, List[Any]], None]] = None,
-    prompt_cache_checkpoint_len: Optional[int] = None,
+    prompt_cache_checkpoint_len: Optional[Union[int, Sequence[int]]] = None,
     seed: Optional[int] = None,
     verbose: bool = False,
     **kwargs,
@@ -426,18 +451,22 @@ def generate_step(
             prefill_kwargs=policy_kwargs,
         ):
             prefill_step_size = None
-        checkpoint_len = (
-            int(prompt_cache_checkpoint_len)
-            if prompt_cache_checkpoint is not None
+        # One or more prefix lengths at which to hand the caller a snapshot of
+        # the prompt cache. A bare int keeps the historical single-checkpoint
+        # contract; a sequence drives APC's semantic checkpoints.
+        checkpoint_lens: List[int] = []
+        if (
+            prompt_cache_checkpoint is not None
             and prompt_cache_checkpoint_len is not None
-            else None
-        )
-        checkpoint_done = False
+        ):
+            raw = prompt_cache_checkpoint_len
+            if isinstance(raw, int):
+                raw = [raw]
+            checkpoint_lens = sorted({c for c in map(int, raw) if c > 0})
+        checkpoint_idx = 0
         should_chunk = (
             prefill_step_size is not None and inputs_embeds.shape[1] > prefill_step_size
-        ) or (
-            checkpoint_len is not None and 0 < checkpoint_len < inputs_embeds.shape[1]
-        )
+        ) or any(0 < c < inputs_embeds.shape[1] for c in checkpoint_lens)
         if prefill_step_size is not None and should_chunk:
             # Chunked prefill with embeddings
             total_tokens = inputs_embeds.shape[1]
@@ -447,13 +476,12 @@ def generate_step(
             ) as pbar:
                 while inputs_embeds.shape[1] > 1:
                     n_to_process = min(prefill_step_size, inputs_embeds.shape[1] - 1)
-                    if (
-                        checkpoint_len is not None
-                        and not checkpoint_done
-                        and processed_tokens < checkpoint_len
-                        and processed_tokens + n_to_process > checkpoint_len
-                    ):
-                        n_to_process = checkpoint_len - processed_tokens
+                    n_to_process, checkpoint_idx = _clip_chunk_to_checkpoint(
+                        n_to_process,
+                        processed_tokens,
+                        checkpoint_lens,
+                        checkpoint_idx,
+                    )
                     chunk_kwargs = kwargs
                     if getattr(model.language_model, "supports_logits_to_keep", False):
                         chunk_kwargs = {**kwargs, "logits_to_keep": 1}
@@ -468,12 +496,11 @@ def generate_step(
                     mx.eval([c.state for c in prompt_cache])
                     processed_tokens += n_to_process
                     if (
-                        checkpoint_len is not None
-                        and not checkpoint_done
-                        and processed_tokens == checkpoint_len
+                        checkpoint_idx < len(checkpoint_lens)
+                        and processed_tokens == checkpoint_lens[checkpoint_idx]
                     ):
                         prompt_cache_checkpoint(processed_tokens, prompt_cache)
-                        checkpoint_done = True
+                        checkpoint_idx += 1
                     inputs_embeds = inputs_embeds[:, n_to_process:]
                     input_ids = input_ids[:, n_to_process:]
                     mx.clear_cache()
@@ -1808,26 +1835,29 @@ class PromptProcessingBatch:
             return True
         return self._inputs_embeds.shape[1] > self.prefill_step_size
 
+    def _pending_checkpoint_lens(self, meta: dict) -> List[int]:
+        """Checkpoint prefix lengths for this row that have not been stored yet."""
+        lens = meta.get("checkpoint_lens") or []
+        return [int(c) for c in lens[int(meta.get("checkpoint_idx", 0)) :]]
+
     def _apc_checkpoint_column_for_meta(
         self, batch_idx: int, meta: dict
     ) -> Optional[int]:
-        checkpoint_len = int(meta.get("checkpoint_len") or 0)
-        if (
-            not self._apc_uses_checkpoints()
-            or checkpoint_len <= 0
-            or meta.get("checkpoint_done")
-        ):
+        if not self._apc_uses_checkpoints():
             return None
         prefix_len = int(meta.get("prefix_len", 0) or 0)
-        if checkpoint_len <= prefix_len:
-            meta["checkpoint_done"] = True
-            return None
-        if self._right_pad_per_row is not None:
-            suffix_checkpoint = checkpoint_len - prefix_len
-            if suffix_checkpoint >= self._suffix_lens[batch_idx]:
-                return None
-            return suffix_checkpoint
-        return self._left_padding_per_row[batch_idx] + checkpoint_len
+        for checkpoint_len in self._pending_checkpoint_lens(meta):
+            if checkpoint_len <= 0 or checkpoint_len <= prefix_len:
+                # Already covered by the restored prefix; retire it.
+                meta["checkpoint_idx"] = int(meta.get("checkpoint_idx", 0)) + 1
+                continue
+            if self._right_pad_per_row is not None:
+                suffix_checkpoint = checkpoint_len - prefix_len
+                if suffix_checkpoint >= self._suffix_lens[batch_idx]:
+                    return None
+                return suffix_checkpoint
+            return self._left_padding_per_row[batch_idx] + checkpoint_len
+        return None
 
     def _next_apc_checkpoint_column(self) -> Optional[int]:
         if (
@@ -1870,9 +1900,12 @@ class PromptProcessingBatch:
         if self._apc_manager is None or not self._apc_uses_checkpoints():
             return
         for batch_idx, meta in enumerate(self._apc_meta):
-            if meta is None or meta.get("checkpoint_done"):
+            if meta is None:
                 continue
-            checkpoint_len = int(meta.get("checkpoint_len") or 0)
+            pending = self._pending_checkpoint_lens(meta)
+            if not pending:
+                continue
+            checkpoint_len = pending[0]
             if checkpoint_len <= 0:
                 continue
             if self._row_real_tokens_processed(batch_idx) != checkpoint_len:
@@ -1893,7 +1926,7 @@ class PromptProcessingBatch:
                     prompt_cache,
                     extra_hash=meta.get("extra_hash", 0),
                 )
-            meta["checkpoint_done"] = True
+            meta["checkpoint_idx"] = int(meta.get("checkpoint_idx", 0)) + 1
 
     def _prompt_kwargs_for_step(self, n: Optional[int] = None) -> dict:
         if n is None or not self._prompt_length_aware_keys:
@@ -2377,17 +2410,14 @@ class BatchGenerator:
             self._apc_media_token_ids(),
         )
 
-    def _apc_exact_checkpoint_len(self, ids_list: List[int]) -> int:
-        coordinator = getattr(self, "apc", None)
-        if coordinator is not None:
-            return coordinator.checkpoint_len(ids_list, self._apc_media_token_ids())
-        if self.apc_manager is None or getattr(self, "apc_mode", "block") != "exact":
-            return 0
-        return _apc.adjust_prefix_to_text_suffix_boundary(
-            ids_list,
-            len(ids_list) - self.apc_manager.exact_cache_guard_tokens,
-            self._apc_media_token_ids(),
-            max_prefix_tokens=len(ids_list) - 1,
+    def _apc_exact_checkpoint_lens(self, ids_list: List[int]) -> List[int]:
+        """Ascending prefix lengths to snapshot: the tail one, plus any
+        semantic boundaries APC is configured to keep."""
+        coordinator = getattr(self, "apc_coordinator", None)
+        if coordinator is None:
+            return []
+        return coordinator.checkpoint_lens(
+            ids_list, self._apc_media_token_ids(), self.tokenizer
         )
 
     def _apc_pick_for(self, sequence) -> Optional[dict]:
@@ -2561,7 +2591,8 @@ class BatchGenerator:
                     else self._apc_extra_hash(prompt_kwargs_list[i] or {})
                 ),
                 "apc_blocks": picks[i].get("matched_blocks", []) if picks[i] else [],
-                "checkpoint_len": self._apc_exact_checkpoint_len(full_ids[i]),
+                "checkpoint_lens": self._apc_exact_checkpoint_lens(full_ids[i]),
+                "checkpoint_idx": 0,
             }
             for i in range(len(sequences))
         ]
@@ -2621,7 +2652,8 @@ class BatchGenerator:
                     "prefix_len": 0,
                     "extra_hash": extra_hash,
                     "apc_blocks": [],
-                    "checkpoint_len": self._apc_exact_checkpoint_len(list(ids_list)),
+                    "checkpoint_lens": self._apc_exact_checkpoint_lens(list(ids_list)),
+                    "checkpoint_idx": 0,
                 }
             )
         return meta

--- a/mlx_vlm/generate/dispatch.py
+++ b/mlx_vlm/generate/dispatch.py
@@ -967,11 +967,12 @@ def stream_generate(
             and apc_coordinator.is_checkpoint
             and reused_prefix_len == 0
         ):
-            exact_checkpoint_len = apc_coordinator.checkpoint_len(
-                full_input_ids_list, multimodal_token_ids
+            exact_checkpoint_len = (
+                apc_coordinator.checkpoint_lens(
+                    full_input_ids_list, multimodal_token_ids, tokenizer
+                )
+                or None
             )
-            if exact_checkpoint_len <= 0:
-                exact_checkpoint_len = None
 
             def exact_checkpoint(prefix_len: int, prompt_cache: List[Any]) -> None:
                 apc_coordinator.store_checkpoint(

--- a/mlx_vlm/tests/test_apc.py
+++ b/mlx_vlm/tests/test_apc.py
@@ -335,7 +335,8 @@ def test_single_row_prompt_batch_exact_checkpoint_stores_without_extract():
         {
             "full_input_ids": token_ids,
             "prefix_len": 0,
-            "checkpoint_len": len(token_ids),
+            "checkpoint_lens": [len(token_ids)],
+            "checkpoint_idx": 0,
             "extra_hash": 0,
         }
     ]
@@ -344,7 +345,7 @@ def test_single_row_prompt_batch_exact_checkpoint_stores_without_extract():
 
     batch._store_apc_exact_checkpoints()
 
-    assert batch._apc_meta[0]["checkpoint_done"] is True
+    assert batch._apc_meta[0]["checkpoint_idx"] == 1
     assert batch._apc_manager.stats_snapshot()["exact_stores"] == 1
 
 

--- a/mlx_vlm/tests/test_apc_exact_mode.py
+++ b/mlx_vlm/tests/test_apc_exact_mode.py
@@ -14,7 +14,16 @@ from __future__ import annotations
 import mlx.core as mx
 import pytest
 
-from mlx_vlm.apc import APCManager, model_apc_mode
+from mlx_vlm.apc import (
+    DEFAULT_SEMANTIC_BOUNDARY_MARKERS,
+    DEFAULT_SEMANTIC_MAX_POOL_GB,
+    APCManager,
+    model_apc_mode,
+    resolve_boundary_sequences,
+    semantic_checkpoint_config,
+    semantic_checkpoint_offsets,
+)
+from mlx_vlm.generate.ar import _clip_chunk_to_checkpoint
 from mlx_vlm.models.cache import KVCache
 
 # ============================================================================
@@ -551,3 +560,418 @@ def test_block_eligible_layers_have_extractable_kv_after_prefill():
             assert mx.any(
                 c.values != 0
             ).item(), f"Block-eligible layer {i} values are all zeros"
+
+
+# ============================================================================
+# Semantic checkpoint boundaries
+#
+# Recurrent state is a fold over every token up to t, so it can only be
+# restored at a prefix that was actually snapshotted. A tail-only checkpoint
+# therefore gives up all reuse the moment an agent edits its history. These
+# tests cover boundary selection, the widened multi-checkpoint prefill
+# contract, and the reuse behaviour that motivates both.
+# ============================================================================
+
+MARK = 900  # stand-in for a boundary marker token id
+MARK2 = 901
+
+
+def _seq_with_markers(segment_len, n_segments, marker=MARK):
+    """[filler * segment_len, marker] * n_segments -> ids, boundary offsets."""
+    ids, offsets = [], []
+    for _ in range(n_segments):
+        ids.extend(range(1, segment_len + 1))
+        ids.append(marker)
+        offsets.append(len(ids))
+    return ids, offsets
+
+
+def test_semantic_offsets_disabled_by_default():
+    ids, _ = _seq_with_markers(100, 6)
+    assert (
+        semantic_checkpoint_offsets(ids, [(MARK,)], max_checkpoints=0, min_gap=50) == []
+    )
+
+
+def test_semantic_offsets_land_just_after_the_marker():
+    ids, offsets = _seq_with_markers(100, 4)
+    got = semantic_checkpoint_offsets(ids, [(MARK,)], max_checkpoints=8, min_gap=50)
+    # Last boundary is inside the guard-free tail, so it drops out; the rest
+    # must line up exactly with the token following each marker.
+    assert got == [o for o in offsets if o <= len(ids) - 1]
+    for off in got:
+        assert ids[off - 1] == MARK
+
+
+def test_semantic_offsets_enforce_min_gap():
+    ids, _ = _seq_with_markers(10, 30)  # a boundary every 11 tokens
+    got = semantic_checkpoint_offsets(ids, [(MARK,)], max_checkpoints=64, min_gap=100)
+    assert got, "expected at least one boundary"
+    assert all(b - a >= 100 for a, b in zip(got, got[1:]))
+
+
+def test_semantic_offsets_thin_to_budget_keeping_both_ends():
+    ids, _ = _seq_with_markers(60, 20)
+    dense = semantic_checkpoint_offsets(ids, [(MARK,)], max_checkpoints=64, min_gap=1)
+    thin = semantic_checkpoint_offsets(ids, [(MARK,)], max_checkpoints=4, min_gap=1)
+    assert len(thin) == 4
+    assert set(thin) <= set(dense)
+    # Shallowest and deepest are the two that must survive: the first covers
+    # early edits, the last is what still serves plain append-only turns.
+    assert thin[0] == dense[0]
+    assert thin[-1] == dense[-1]
+
+
+def test_semantic_offsets_respect_guard_and_stay_in_bounds():
+    ids, _ = _seq_with_markers(100, 5)
+    got = semantic_checkpoint_offsets(
+        ids, [(MARK,)], max_checkpoints=8, min_gap=50, guard=250
+    )
+    assert got
+    assert max(got) <= len(ids) - 250
+    assert min(got) >= 50
+
+
+def test_semantic_offsets_empty_without_boundaries():
+    ids = list(range(1, 600))
+    assert semantic_checkpoint_offsets(ids, [(MARK,)], max_checkpoints=4) == []
+    assert semantic_checkpoint_offsets(ids, [], max_checkpoints=4) == []
+
+
+def test_semantic_offsets_match_multi_token_markers():
+    marker = (MARK, MARK2)
+    ids = []
+    expected = []
+    for _ in range(4):
+        ids.extend(range(1, 101))
+        ids.extend(marker)
+        expected.append(len(ids))
+    got = semantic_checkpoint_offsets(ids, [marker], max_checkpoints=8, min_gap=50)
+    assert got == [o for o in expected if o <= len(ids) - 1]
+
+
+def test_resolve_boundary_sequences_dedups_and_drops_unencodable():
+    class Tok:
+        def encode(self, text, add_special_tokens=False):
+            if text == "boom":
+                raise ValueError("unencodable")
+            return {"a": [1, 2], "b": [1, 2], "c": [3]}[text]
+
+    assert resolve_boundary_sequences(Tok(), ["a", "b", "c", "boom"]) == ((1, 2), (3,))
+    assert resolve_boundary_sequences(object(), ["a"]) == ()
+
+
+def test_semantic_checkpoint_config_reads_env(monkeypatch):
+    monkeypatch.delenv("APC_SEMANTIC_CHECKPOINTS", raising=False)
+    monkeypatch.delenv("APC_SEMANTIC_BOUNDARY_TOKENS", raising=False)
+    monkeypatch.delenv("APC_SEMANTIC_MIN_GAP", raising=False)
+    count, markers, gap, _ = semantic_checkpoint_config()
+    assert count == 0  # off unless asked for
+    assert markers == DEFAULT_SEMANTIC_BOUNDARY_MARKERS
+
+    monkeypatch.setenv("APC_SEMANTIC_CHECKPOINTS", "5")
+    monkeypatch.setenv("APC_SEMANTIC_BOUNDARY_TOKENS", "</a>, </b> ,")
+    monkeypatch.setenv("APC_SEMANTIC_MIN_GAP", "64")
+    assert semantic_checkpoint_config()[:3] == (5, ("</a>", "</b>"), 64)
+
+    monkeypatch.setenv("APC_SEMANTIC_CHECKPOINTS", "not-a-number")
+    assert semantic_checkpoint_config()[0] == 0
+
+
+def test_exact_pool_grows_with_the_semantic_budget(monkeypatch):
+    monkeypatch.delenv("APC_EXACT_CACHE_ENTRIES", raising=False)
+    monkeypatch.delenv("APC_SEMANTIC_CHECKPOINTS", raising=False)
+    assert APCManager(num_blocks=4, block_size=4)._exact_cache_max == 2
+
+    monkeypatch.setenv("APC_SEMANTIC_CHECKPOINTS", "4")
+    assert APCManager(num_blocks=4, block_size=4)._exact_cache_max == 6
+
+    # An explicit override still wins.
+    monkeypatch.setenv("APC_EXACT_CACHE_ENTRIES", "3")
+    assert APCManager(num_blocks=4, block_size=4)._exact_cache_max == 3
+
+
+def test_boundary_sequences_are_memoized_per_tokenizer(monkeypatch):
+    monkeypatch.setenv("APC_SEMANTIC_CHECKPOINTS", "2")
+    monkeypatch.setenv("APC_SEMANTIC_BOUNDARY_TOKENS", "</x>")
+    calls = []
+
+    class Tok:
+        def encode(self, text, add_special_tokens=False):
+            calls.append(text)
+            return [7]
+
+    apc = APCManager(num_blocks=4, block_size=4)
+    tok = Tok()
+    assert apc.boundary_sequences(tok) == ((7,),)
+    assert apc.boundary_sequences(tok) == ((7,),)
+    assert len(calls) == 1
+
+    apc.boundary_sequences(Tok())  # different tokenizer re-encodes
+    assert len(calls) == 2
+
+
+def _kv_at(offset, fill=1.0):
+    kv = KVCache()
+    kv.keys = mx.full((1, 1, offset, 2), fill)
+    kv.values = mx.full((1, 1, offset, 2), fill)
+    kv.offset = offset
+    return kv
+
+
+def test_chunk_clipping_lands_on_every_checkpoint():
+    """Prefill chunks must be cut so each checkpoint prefix is hit exactly."""
+    lens = [10, 25, 40]
+    total, step = 64, 16
+    processed, idx, fired = 0, 0, []
+    while processed < total - 1:
+        n = min(step, total - 1 - processed)
+        n, idx = _clip_chunk_to_checkpoint(n, processed, lens, idx)
+        assert n > 0
+        processed += n
+        if idx < len(lens) and processed == lens[idx]:
+            fired.append(processed)
+            idx += 1
+    assert fired == lens
+
+
+def test_chunk_clipping_is_a_noop_without_checkpoints():
+    assert _clip_chunk_to_checkpoint(16, 0, [], 0) == (16, 0)
+    # A checkpoint already behind us just advances the cursor.
+    assert _clip_chunk_to_checkpoint(16, 40, [10, 25], 0) == (16, 2)
+
+
+def test_edited_history_resumes_from_deepest_semantic_checkpoint(monkeypatch):
+    """The point of the feature: an edit mid-history still finds a warm prefix."""
+    monkeypatch.setenv("APC_SEMANTIC_CHECKPOINTS", "4")
+    ids, _ = _seq_with_markers(100, 6)
+    apc = APCManager(num_blocks=8, block_size=16)
+    chosen = semantic_checkpoint_offsets(
+        ids, [(MARK,)], max_checkpoints=4, min_gap=50, guard=16
+    )
+    assert len(chosen) >= 3
+    for off in chosen:
+        assert apc.store_exact_cache(ids[:off], [_kv_at(off)])
+
+    # An agent rewrites everything after a point past the third checkpoint.
+    edit_at = chosen[2] + 30
+    edited = ids[:edit_at] + [777] * 200
+
+    restored, prefix_len = apc.lookup_exact_cache(edited)
+    assert restored is not None
+    assert prefix_len == chosen[2]
+
+
+def test_tail_only_checkpoint_misses_the_same_edit(monkeypatch):
+    """Control for the test above: today's tail-only policy salvages nothing."""
+    monkeypatch.delenv("APC_SEMANTIC_CHECKPOINTS", raising=False)
+    ids, _ = _seq_with_markers(100, 6)
+    apc = APCManager(num_blocks=8, block_size=16)
+    tail = len(ids) - apc.exact_cache_guard_tokens
+    assert apc.store_exact_cache(ids[:tail], [_kv_at(tail)])
+
+    chosen = semantic_checkpoint_offsets(
+        ids, [(MARK,)], max_checkpoints=4, min_gap=50, guard=16
+    )
+    edited = ids[: chosen[2] + 30] + [777] * 200
+
+    restored, prefix_len = apc.lookup_exact_cache(edited)
+    assert restored is None
+    assert prefix_len == 0
+
+
+def test_semantic_checkpoints_still_serve_append_only_turns(monkeypatch):
+    """Adding boundaries must not cost the deepest-prefix hit on plain appends."""
+    monkeypatch.setenv("APC_SEMANTIC_CHECKPOINTS", "4")
+    ids, _ = _seq_with_markers(100, 6)
+    apc = APCManager(num_blocks=8, block_size=16)
+    chosen = semantic_checkpoint_offsets(
+        ids, [(MARK,)], max_checkpoints=4, min_gap=50, guard=16
+    )
+    for off in chosen:
+        apc.store_exact_cache(ids[:off], [_kv_at(off)])
+
+    appended = ids + [55] * 120
+    _, prefix_len = apc.lookup_exact_cache(appended)
+    assert prefix_len == max(chosen)
+
+
+def _kda_states(prompt_cache):
+    """Every recurrent KDA state array in a GLM-5-Next prompt cache."""
+    from mlx_vlm.models.cache import ArraysCache
+
+    return [
+        a
+        for c in prompt_cache
+        if isinstance(c, ArraysCache)
+        for a in c.state
+        if a is not None
+    ]
+
+
+def test_checkpoint_restore_reproduces_recurrent_state():
+    """A checkpoint is only sound if resuming the fold matches never breaking it.
+
+    KDA state at token t depends on every token before it, so a restore that
+    lost information would silently diverge for the whole rest of the sequence.
+    """
+    lm = _make_tiny_qwen35()
+    ids = [(i * 7 + 3) % 32 for i in range(96)]
+
+    cold = lm.make_cache()
+    lm(mx.array([ids]), cache=cold)
+    mx.eval([c.state for c in cold])
+
+    split = 48
+    warm = lm.make_cache()
+    lm(mx.array([ids[:split]]), cache=warm)
+    mx.eval([c.state for c in warm])
+
+    apc = APCManager(num_blocks=16, block_size=16)
+    assert apc.store_exact_cache(ids[:split], warm)
+    restored, prefix_len = apc.lookup_exact_cache(ids)
+    assert restored is not None and prefix_len == split
+
+    lm(mx.array([ids[split:]]), cache=restored)
+    mx.eval([c.state for c in restored])
+
+    cold_states, warm_states = _kda_states(cold), _kda_states(restored)
+    assert cold_states, "factory produced no recurrent state to compare"
+    for a, b in zip(cold_states, warm_states):
+        assert a.shape == b.shape
+        assert mx.allclose(a, b, atol=1e-5, rtol=1e-5).item()
+
+
+def test_multiple_checkpoints_each_restore_correctly(monkeypatch):
+    """Every stored boundary must be independently resumable, not just the last.
+
+    Also covers the pool sizing: without a semantic budget the default of two
+    entries would evict the shallowest checkpoint as the third is stored.
+    """
+    monkeypatch.setenv("APC_SEMANTIC_CHECKPOINTS", "3")
+    lm = _make_tiny_qwen35()
+    ids = [(i * 5 + 11) % 32 for i in range(120)]
+
+    cold = lm.make_cache()
+    lm(mx.array([ids]), cache=cold)
+    mx.eval([c.state for c in cold])
+    expected = _kda_states(cold)
+
+    apc = APCManager(num_blocks=16, block_size=16)
+    splits = [30, 60, 90]
+    for split in splits:
+        cache = lm.make_cache()
+        lm(mx.array([ids[:split]]), cache=cache)
+        mx.eval([c.state for c in cache])
+        assert apc.store_exact_cache(ids[:split], cache)
+
+    for split in splits:
+        restored, prefix_len = apc.lookup_exact_cache(
+            ids[:split] + [31] * 4, max_prefix_tokens=split
+        )
+        assert prefix_len == split, f"no checkpoint recovered at {split}"
+        lm(mx.array([ids[split:]]), cache=restored)
+        mx.eval([c.state for c in restored])
+        for a, b in zip(expected, _kda_states(restored)):
+            assert mx.allclose(a, b, atol=1e-5, rtol=1e-5).item()
+
+
+def test_single_checkpoint_schedule_matches_the_pre_list_behaviour():
+    """The list-based clip must reproduce the old scalar logic exactly.
+
+    Widening ``prompt_cache_checkpoint_len`` from an int to a sequence is only
+    safe if a one-element list drives the identical chunk schedule, so this
+    replays the pre-change branch and compares step for step.
+    """
+
+    def legacy_schedule(total, step, checkpoint_len):
+        processed, done, chunks, fired = 0, False, [], []
+        while processed < total - 1:
+            n = min(step, total - 1 - processed)
+            if (
+                checkpoint_len is not None
+                and not done
+                and processed < checkpoint_len
+                and processed + n > checkpoint_len
+            ):
+                n = checkpoint_len - processed
+            chunks.append(n)
+            processed += n
+            if checkpoint_len is not None and not done and processed == checkpoint_len:
+                fired.append(processed)
+                done = True
+        return chunks, fired
+
+    def new_schedule(total, step, checkpoint_len):
+        lens = [] if checkpoint_len is None else [checkpoint_len]
+        processed, idx, chunks, fired = 0, 0, [], []
+        while processed < total - 1:
+            n = min(step, total - 1 - processed)
+            n, idx = _clip_chunk_to_checkpoint(n, processed, lens, idx)
+            chunks.append(n)
+            processed += n
+            if idx < len(lens) and processed == lens[idx]:
+                fired.append(processed)
+                idx += 1
+        return chunks, fired
+
+    for total in (33, 64, 100, 257):
+        for step in (8, 16, 64):
+            for checkpoint_len in [None] + list(range(1, total, 7)):
+                assert legacy_schedule(total, step, checkpoint_len) == new_schedule(
+                    total, step, checkpoint_len
+                ), (total, step, checkpoint_len)
+
+
+def test_pool_byte_budget_is_off_when_feature_is_off(monkeypatch):
+    """The historical two-entry pool must not gain a byte cap."""
+    monkeypatch.delenv("APC_SEMANTIC_CHECKPOINTS", raising=False)
+    monkeypatch.delenv("APC_SEMANTIC_MAX_POOL_GB", raising=False)
+    assert semantic_checkpoint_config()[3] == 0
+    assert APCManager(num_blocks=4, block_size=4)._semantic_max_pool_bytes == 0
+
+
+def test_pool_byte_budget_defaults_on_when_feature_is_on(monkeypatch):
+    monkeypatch.setenv("APC_SEMANTIC_CHECKPOINTS", "8")
+    monkeypatch.delenv("APC_SEMANTIC_MAX_POOL_GB", raising=False)
+    gb = 1 << 30
+    assert semantic_checkpoint_config()[3] == int(DEFAULT_SEMANTIC_MAX_POOL_GB * gb)
+    monkeypatch.setenv("APC_SEMANTIC_MAX_POOL_GB", "0")
+    assert semantic_checkpoint_config()[3] == 0  # explicit opt-out
+    monkeypatch.setenv("APC_SEMANTIC_MAX_POOL_GB", "1.5")
+    assert semantic_checkpoint_config()[3] == int(1.5 * gb)
+    monkeypatch.setenv("APC_SEMANTIC_MAX_POOL_GB", "junk")
+    assert semantic_checkpoint_config()[3] == int(DEFAULT_SEMANTIC_MAX_POOL_GB * gb)
+
+
+def test_pool_evicts_on_bytes_not_just_count(monkeypatch):
+    """A budget smaller than the working set must evict LRU-first, keeping the newest."""
+    monkeypatch.setenv("APC_SEMANTIC_CHECKPOINTS", "8")
+    # the clone trims K/V to the stored prefix, so an entry at offset N costs
+    # 2 * N * 64 * 4 B. Offsets 40..200 total ~300 KiB; cap below that.
+    monkeypatch.setenv("APC_SEMANTIC_MAX_POOL_GB", str(150 * 1024 / (1 << 30)))
+    apc = APCManager(num_blocks=8, block_size=16)
+    assert apc._semantic_max_pool_bytes > 0
+
+    def big(n):
+        kv = KVCache()
+        kv.keys = mx.zeros((1, 1, 512, 64))
+        kv.values = mx.zeros((1, 1, 512, 64))
+        kv.offset = n
+        return [kv]
+
+    ids = list(range(1, 400))
+    for off in (40, 80, 120, 160, 200):
+        apc.store_exact_cache(ids[:off], big(off))
+
+    assert len(apc._exact_cache) < 5, "byte cap did not evict anything"
+    total = sum(apc._entry_bytes(e) for e in apc._exact_cache.values())
+    assert total <= apc._semantic_max_pool_bytes
+    # the newest checkpoint survives — it is the one most likely to be reused
+    assert max(len(e.token_ids) for e in apc._exact_cache.values()) == 200
+
+
+def test_default_markers_cover_non_qwen_families():
+    """gemma / llama turn markers must be present, plus the paper's tool_output."""
+    for m in ("</tool_output>", "<end_of_turn>", "<start_of_turn>", "<|eot_id|>"):
+        assert m in DEFAULT_SEMANTIC_BOUNDARY_MARKERS

--- a/mlx_vlm/tests/test_generate.py
+++ b/mlx_vlm/tests/test_generate.py
@@ -2160,11 +2160,15 @@ def test_stream_generate_stores_checkpoint_only_before_decode():
     coordinator.is_checkpoint = True
     coordinator.lookup.return_value = None
     coordinator.checkpoint_len.return_value = 3
+    # dispatch asks for the plural form; the tail entry is the same prefix
+    coordinator.checkpoint_lens.return_value = [3]
 
     def fake_generate_step(*args, **kwargs):
-        kwargs["prompt_cache_checkpoint"](
-            kwargs["prompt_cache_checkpoint_len"], kwargs["prompt_cache"]
-        )
+        # prompt_cache_checkpoint_len accepts an int or a sequence; the real
+        # prefill fires the callback once per checkpoint prefix.
+        lens = kwargs["prompt_cache_checkpoint_len"]
+        for n in lens if isinstance(lens, (list, tuple)) else [lens]:
+            kwargs["prompt_cache_checkpoint"](n, kwargs["prompt_cache"])
         yield 7, mx.zeros((4,))
 
     processor = SimpleNamespace(


### PR DESCRIPTION
Checkpoint-mode caches snapshot only at the prompt tail, so any small history edit re-prefills everything.

`semantic_checkpoint_offsets` picks extra snapshot points at tool-call and turn markers that agents actually edit around.

Recurrent and windowed layers cannot slice prefixes, so stored checkpoints are their only reuse mechanism.

Restore resumes from the deepest surviving boundary; block-mode models are untouched and see no change.

| model | attention | cache | tokens reused | TTFT |
|:--|:--|:--|--:|--:|
| Falcon-H1-1.5B | SSM / Mamba hybrid | `CacheList` ×24 | 0 → 11,141 | **3.17×** |
| LFM2-1.2B | conv-recurrent | `ArraysCache` ×10 | 0 → 9,757 | **3.12×** |
| Falcon-H1-0.5B | SSM / Mamba hybrid | `CacheList` ×36 | 0 → 11,021 | **3.08×** |
| Qwen3.5-4B | KDA recurrent | `ArraysCache` ×24 | 0 → 10,192 | **3.05×** |
| Qwen3.5-2B | recurrent | `ArraysCache` ×18 | 0 → 10,192 | **2.98×** |
| gemma-3-1b-it | sliding window | `RotatingKVCache` ×22 | 0 → 10,633 | **2.93×** |
| LFM2-700M | conv-recurrent | `ArraysCache` ×10 | 0 → 9,852 | **2.90×** |
| Qwen3.5-0.8B | recurrent | `ArraysCache` ×18 | 0 → 10,091 | **2.85×** |
| Llama-3.2-1B, Phi-3.5-mini, gemma-2-2b, Qwen2.5-VL-3B, paligemma-3b, Qwen2.5-0.5B | dense | `KVCache` (block mode) | n/a | 1.00× |

8-turn tool-calling transcript, context compaction at turn 5, budget 8 vs tail-only.


There is more benefits across more models, I didn't register any regressions across 30+ model sweeps :)


btw this builds off of #1960