### PR TITLE
Fix MiniMax-M3 sparse-index compile re-trace leak (Metal 499k resource limit)

### DIFF
--- a/mlx_vlm/models/minimax_m3_vl/language.py
+++ b/mlx_vlm/models/minimax_m3_vl/language.py
@@ -103,14 +103,10 @@ def _minimax_moe_select(
     return inds, weights * routed_scaling_factor
 
 
-# NOTE: deliberately not @mx.compile. `idx_keys` arrives straight from
-# `update_index_and_fetch`, so its sequence dimension is the running context
-# length and changes on every decode step. A non-shapeless compiled function
-# keys its cache on input shapes, so it would re-trace continuously — the
-# compiled artifact is never reused, and each trace leaves permanent state in
-# MLX's compiler cache that `mx.clear_cache()` does not release, ending in
-# `[metal::malloc] Resource limit (499000) exceeded` (same ceiling as #1972,
-# different mechanism from the ArraysCache fix in #1984).
+# Deliberately not @mx.compile: `idx_keys` grows a position every decode step,
+# so a shape-keyed compiled function re-traces on every call and each trace
+# permanently grows MLX's compiler cache, eventually tripping
+# `[metal::malloc] Resource limit (499000) exceeded`. See the regression test.
 def _build_sparse_causal_mask_compiled(
     idx_queries: mx.array,
     idx_keys: mx.array,
@@ -195,8 +191,7 @@ def _build_sparse_causal_mask_compiled(
     return sparse_mask, topk_idx[:, None], topk_valid[:, None]
 
 
-# NOTE: deliberately not @mx.compile — same shape-varying `idx_keys` argument
-# and the same unbounded compiler-cache growth as
+# Deliberately not @mx.compile — same reason as
 # `_build_sparse_causal_mask_compiled` above.
 def _select_sparse_block_indices_compiled(
     idx_queries: mx.array,

--- a/mlx_vlm/models/minimax_m3_vl/language.py
+++ b/mlx_vlm/models/minimax_m3_vl/language.py
@@ -103,7 +103,14 @@ def _minimax_moe_select(
     return inds, weights * routed_scaling_factor
 
 
-@mx.compile
+# NOTE: deliberately not @mx.compile. `idx_keys` arrives straight from
+# `update_index_and_fetch`, so its sequence dimension is the running context
+# length and changes on every decode step. A non-shapeless compiled function
+# keys its cache on input shapes, so it would re-trace continuously — the
+# compiled artifact is never reused, and each trace leaves permanent state in
+# MLX's compiler cache that `mx.clear_cache()` does not release, ending in
+# `[metal::malloc] Resource limit (499000) exceeded` (same ceiling as #1972,
+# different mechanism from the ArraysCache fix in #1984).
 def _build_sparse_causal_mask_compiled(
     idx_queries: mx.array,
     idx_keys: mx.array,
@@ -188,7 +195,9 @@ def _build_sparse_causal_mask_compiled(
     return sparse_mask, topk_idx[:, None], topk_valid[:, None]
 
 
-@mx.compile
+# NOTE: deliberately not @mx.compile — same shape-varying `idx_keys` argument
+# and the same unbounded compiler-cache growth as
+# `_build_sparse_causal_mask_compiled` above.
 def _select_sparse_block_indices_compiled(
     idx_queries: mx.array,
     idx_keys: mx.array,

--- a/mlx_vlm/tests/test_minimax_m3.py
+++ b/mlx_vlm/tests/test_minimax_m3.py
@@ -3111,3 +3111,28 @@ def test_minimax_m3_get_input_embeddings_uses_cached_video_without_pixels():
     assert output.visual_pos_masks.tolist() == [[False, True, True, False]]
     assert output.inputs_embeds[0, 1].tolist() == [4.0, 5.0, 6.0]
     assert output.inputs_embeds[0, 2].tolist() == [7.0, 8.0, 9.0]
+
+
+def test_sparse_index_helpers_are_not_shape_compiled():
+    """The sparse index helpers must stay uncompiled.
+
+    Both take `idx_keys` straight from `update_index_and_fetch`, whose sequence
+    dimension is the running context length. A non-shapeless `mx.compile` keys
+    on input shapes, so it re-traces every decode step: the compiled artifact is
+    never reused and each trace leaves permanent state in MLX's compiler cache
+    that `mx.clear_cache()` does not release, eventually tripping
+    `[metal::malloc] Resource limit (499000) exceeded` on a long-running server.
+
+    If either of these ever needs compiling again, it has to be `shapeless=True`
+    with the shape-dependent work (`idx_keys.shape[2]`, `mx.arange(total_len)`)
+    lifted out first.
+    """
+
+    def is_compiled(fn):
+        return type(fn).__name__ == "gc_func"
+
+    assert not is_compiled(minimax_language._build_sparse_causal_mask_compiled)
+    assert not is_compiled(minimax_language._select_sparse_block_indices_compiled)
+
+    # Guard the check itself: a compiled function must be detected as one.
+    assert is_compiled(mx.compile(lambda x: x + 1))


### PR DESCRIPTION
## Summary

Two `@mx.compile` decorators in `minimax_m3_vl/language.py` sit on functions whose input shapes change every decode step. They re-trace continuously, and each re-trace leaks a permanent Metal resource handle. On a long-running server this ends in `[metal::malloc] Resource limit (499000) exceeded`.

This is the **same ceiling as #1972 but a different mechanism** from the `ArraysCache.advance` lazy-graph accrual fixed in #1984 — that fix is necessary and unrelated; this is a second, independent source on the MiniMax-M3 sparse-attention path.

## Why it's hard to find

The leaked state is handles, not bytes. Everything a user would check to diagnose a memory problem stays clean:

| signal | what it shows |
|---|---|
| `mx.clear_cache()` | releases nothing |
| `gc.collect()`, `del cache`, `del model` | release nothing |
| `mx.get_active_memory()` / `get_cache_memory()` | flat |
| Activity Monitor, `memory pressure`, swap | flat, green, no swap |
| `ioclasscount AGXResource` | **climbs monotonically until the process dies** |

That mismatch is the whole difficulty. #1972's reporter said it plainly: *"Memory was monitored using Activity Monitor, and memory pressure remained consistently in the green zone... there was still plenty of free memory available."* A cache-clearing call that reports success while the thing actually filling up keeps growing is a rough debugging experience, and it's why this took us three days and a kernel-object counter to localize.

## Mechanism

Both functions take `idx_keys` directly from `update_index_and_fetch`:

```python
return self.index_keys[..., : self.index_offset, :]   # language.py:620
```

so `idx_keys.shape[2]` is the running context length. `mx.compile` without `shapeless=True` keys its cache on input shapes, so every distinct context length is a new trace. Each trace leaves permanent state in MLX's compiler cache that no Python-side release path reaches.

Note the corollary: **these decorators were never buying anything.** A compiled function that re-traces on every call has no reuse to deliver — it was paying trace cost every step and getting no compiled fast path in return. The other two compiled functions in this file are fine and left alone: `_minimax_moe_select` sees a bounded set of shapes, and `_swiglu_oai` is already `shapeless=True`.

## Evidence

Measured on an M3 Ultra (512 GB) running MiniMax-M3, permanent `AGXResource` handles remaining after `mx.clear_cache()`, counted with `ioclasscount AGXResource`:

| arm | 44k-context generation | permanent | released by deleting the cache |
|---|---|---|---|
| A | unmodified | **+1,066** | +149 only |
| B | + `mx.disable_compile()` | **+186** | +184 → ~0 |
| C | + these two decorators removed | **+176** | +177 → **−1** |

Arm B isolates the compiler as the cause; arm C shows these two functions account for essentially all of it. The leak tracks 128-token block crossings (the shape granularity these functions see), not wall-clock or request count, and it survives deleting the KV cache, deleting the model, and `gc.collect()`.

Production, before and after, on a daily research pipeline that generates ~200–300k tokens/day:

| | before | after |
|---|---|---|
| generated tokens | 292,363 | 153,535 |
| retention slope | ~5.6 handles/token | **0.0093** (+1,421 total) |
| peak AGXResource | **489,640** (ceiling 499,000) | **15,824** |
| crashes / forced restarts | recurring | none |

Before this change the deployment needed a watchdog that preempted and restarted the worker whenever the count approached the ceiling. It hasn't fired since.

## Correctness and performance

- Outputs are **bit-identical** with and without the decorator, checked across sequence lengths spanning the sparse-selection threshold (`total_len > block_size × topk`) and non-multiple-of-block lengths.
- End-to-end decode throughput at 44k context: 2.4 vs 2.5 tok/s — within run-to-run noise, and consistent with the decorators never producing a reused compiled artifact.
- Added `test_sparse_index_helpers_are_not_shape_compiled` so the decorators don't come back without the `shapeless=True` rewrite that would be required to make them safe.

## Reproducing

Honest caveat: reproducing the *permanence* needs the real model. We tried hard to build a small standalone repro and could not — isolated `mx.compile` functions fed growing shapes do mint handles, but those release on `mx.clear_cache()`. Only the full MiniMax-M3 forward pass produces handles that survive it, and the sparse path itself has gates (selection needs `total_len > 2048`, sparse attention needs `key_len ≥ 32768` at `language.py:1351`) that short-prompt tests never cross — which is why every small-scale test we wrote came back clean.

For anyone chasing something similar: the counter to watch is `ioclasscount AGXResource`, sampled around requests with the process otherwise idle. The MLX-side memory counters will not show this class of problem.

One thing I deliberately left alone: both functions keep their `_compiled` suffix, which is now inaccurate. Renaming touches the call sites and would bury a two-line fix in churn — happy to do it here or in a follow-up, whichever you prefer.

Happy to adjust framing, split the test out, or add anything else that would help review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UxD3WgrGAjZy5oCKTUN1k4
