### PR TITLE
Fix Gemma 4 Unified HF vision weight mapping

### DIFF
--- a/mlx_vlm/models/gemma4_unified/gemma4_unified.py
+++ b/mlx_vlm/models/gemma4_unified/gemma4_unified.py
@@ -361,7 +361,13 @@ class Model(nn.Module):
             if self.embed_audio is None and "embed_audio" in k:
                 continue
 
-            if k.startswith("model."):
+            if k.startswith("model.embed_vision.multimodal_embedder."):
+                new_key = "embed_vision." + k.removeprefix(
+                    "model.embed_vision.multimodal_embedder."
+                )
+            elif k.startswith("model.embed_vision."):
+                new_key = "vision_embedder." + k.removeprefix("model.embed_vision.")
+            elif k.startswith("model."):
                 new_key = k[len("model.") :]
             else:
                 new_key = k

--- a/mlx_vlm/models/gemma4_unified/gemma4_unified.py
+++ b/mlx_vlm/models/gemma4_unified/gemma4_unified.py
@@ -365,6 +365,8 @@ class Model(nn.Module):
                 new_key = "embed_vision." + k.removeprefix(
                     "model.embed_vision.multimodal_embedder."
                 )
+            elif k.startswith("model.embed_vision.embedding_projection."):
+                new_key = k.removeprefix("model.")
             elif k.startswith("model.embed_vision."):
                 new_key = "vision_embedder." + k.removeprefix("model.embed_vision.")
             elif k.startswith("model."):

--- a/mlx_vlm/tests/test_models.py
+++ b/mlx_vlm/tests/test_models.py
@@ -6994,6 +6994,17 @@ class TestModels(unittest.TestCase):
         self.assertIn("vision_embedder.patch_dense.weight", sanitized)
         self.assertNotIn("lm_head.weight", sanitized)
 
+        hf_vision_weights = model.sanitize(
+            {
+                "model.embed_vision.patch_dense.weight": mx.zeros((32, 48)),
+                "model.embed_vision.multimodal_embedder.embedding_projection.weight": mx.zeros(
+                    (32, 32)
+                ),
+            }
+        )
+        self.assertIn("vision_embedder.patch_dense.weight", hf_vision_weights)
+        self.assertIn("embed_vision.embedding_projection.weight", hf_vision_weights)
+
         loaded = gemma4_unified.ModelConfig.from_dict(
             {
                 "model_type": "gemma4_unified",

--- a/mlx_vlm/tests/test_models.py
+++ b/mlx_vlm/tests/test_models.py
@@ -7005,6 +7005,19 @@ class TestModels(unittest.TestCase):
         self.assertIn("vision_embedder.patch_dense.weight", hf_vision_weights)
         self.assertIn("embed_vision.embedding_projection.weight", hf_vision_weights)
 
+        google_vision_weights = model.sanitize(
+            {
+                "model.vision_embedder.patch_dense.weight": mx.zeros((32, 48)),
+                "model.embed_vision.embedding_projection.weight": mx.zeros(
+                    (32, 32)
+                ),
+            }
+        )
+        self.assertIn("vision_embedder.patch_dense.weight", google_vision_weights)
+        self.assertIn(
+            "embed_vision.embedding_projection.weight", google_vision_weights
+        )
+
         loaded = gemma4_unified.ModelConfig.from_dict(
             {
                 "model_type": "gemma4_unified",


### PR DESCRIPTION
## Summary

- map Hugging Face Gemma 4 Unified `model.embed_vision.*` vision-tower weights to MLX's `vision_embedder.*`
- map the nested multimodal projector to MLX's `embed_vision.*`
- leave weights already saved in native MLX naming unchanged
- cover both Hugging Face key forms in the existing Gemma 4 Unified model test

## Reproduction

`OBLITERATUS/Gemma-4-12B-OBLITERATED` contains these checkpoint key families:

```text
model.embed_vision.patch_dense.*
model.embed_vision.patch_ln1.*
model.embed_vision.patch_ln2.*
model.embed_vision.pos_embedding
model.embed_vision.pos_norm.*
model.embed_vision.multimodal_embedder.embedding_projection.weight
```

The MLX model expects the tower under `vision_embedder.*` and the projector under `embed_vision.*`. Without this mapping, strict loading reports nine missing and nine unexpected parameters.

## Verification

```text
mlx_vlm/tests/test_models.py::TestModels::test_gemma4_unified: 1 passed
```

The test also exercises save/load round-tripping so native MLX keys remain idempotent. The real 12B checkpoint completed an 11-step MLX QLoRA run and adapter inference with this mapping.
