### PR TITLE
fix(rfdetr): honor --show-boxes instead of ignoring it

### DIFF
--- a/mlx_vlm/models/rfdetr/generate.py
+++ b/mlx_vlm/models/rfdetr/generate.py
@@ -619,8 +619,16 @@ def _get_annotator(
     task: str,
     opacity: float = 0.5,
     contour_thickness: int = 1,
+    show_boxes: bool = True,
 ):
-    """Build an annotator chain. Reuses SAM3's annotator system."""
+    """Build an annotator chain. Reuses SAM3's annotator system.
+
+    Args:
+        show_boxes: If False, a segment chain draws only mask overlays +
+            contours (no boxes/labels). Detect output has nothing but boxes
+            and labels, so it keeps them regardless. Ignored when ``name``
+            explicitly spells out the chain.
+    """
     from ..sam3.generate import build_annotator
 
     if name:
@@ -631,11 +639,10 @@ def _get_annotator(
     from ..sam3.annotators import BoxAnnotator, LabelAnnotator, MaskAnnotator
 
     if task == "segment":
-        return (
-            MaskAnnotator(opacity=opacity, contour_thickness=contour_thickness)
-            + BoxAnnotator()
-            + LabelAnnotator()
-        )
+        chain = MaskAnnotator(opacity=opacity, contour_thickness=contour_thickness)
+        if show_boxes:
+            chain = chain + BoxAnnotator() + LabelAnnotator()
+        return chain
     else:
         return BoxAnnotator() + LabelAnnotator()
 
@@ -679,6 +686,12 @@ def main():
         action="store_true",
         default=True,
         help="Show bounding boxes and labels (default: on)",
+    )
+    parser.add_argument(
+        "--no-show-boxes",
+        dest="show_boxes",
+        action="store_false",
+        help="Draw only mask overlays and contours on segment output",
     )
     parser.add_argument(
         "--show-fps", action="store_true", help="Show FPS overlay on video"
@@ -733,6 +746,7 @@ def main():
         effective_task,
         opacity=args.opacity,
         contour_thickness=args.contour_thickness,
+        show_boxes=args.show_boxes,
     )
 
     with wired_limit(model):

--- a/mlx_vlm/tests/test_rfdetr_show_boxes.py
+++ b/mlx_vlm/tests/test_rfdetr_show_boxes.py
@@ -1,0 +1,67 @@
+import argparse
+from unittest.mock import patch
+
+from mlx_vlm.models.rfdetr.generate import _get_annotator, main
+
+
+def _chain_names(annotator):
+    return [type(a).__name__ for a in getattr(annotator, "annotators", [annotator])]
+
+
+def test_segment_chain_drops_boxes_and_labels_when_show_boxes_is_off():
+    assert _chain_names(_get_annotator(None, "segment", show_boxes=True)) == [
+        "MaskAnnotator",
+        "BoxAnnotator",
+        "LabelAnnotator",
+    ]
+    assert _chain_names(_get_annotator(None, "segment", show_boxes=False)) == [
+        "MaskAnnotator"
+    ]
+
+
+def test_show_boxes_defaults_to_on():
+    assert _chain_names(_get_annotator(None, "segment")) == [
+        "MaskAnnotator",
+        "BoxAnnotator",
+        "LabelAnnotator",
+    ]
+
+
+def test_detect_keeps_boxes_because_nothing_else_is_drawn():
+    # A detect chain has nothing but boxes and labels, so turning them off
+    # would render an empty overlay.
+    for show_boxes in (True, False):
+        assert _chain_names(_get_annotator(None, "detect", show_boxes=show_boxes)) == [
+            "BoxAnnotator",
+            "LabelAnnotator",
+        ]
+
+
+def _capture_parser():
+    """Return the ArgumentParser that main() builds."""
+
+    class _Stop(Exception):
+        pass
+
+    captured = {}
+
+    def _fake_parse(self, *args, **kwargs):
+        captured["parser"] = self
+        raise _Stop()
+
+    with patch.object(argparse.ArgumentParser, "parse_args", _fake_parse):
+        try:
+            main()
+        except _Stop:
+            pass
+    return captured["parser"]
+
+
+def test_cli_can_turn_boxes_off():
+    parser = _capture_parser()
+
+    args = parser.parse_args(["--model", "m", "--image", "i.jpg"])
+    assert args.show_boxes is True
+
+    args = parser.parse_args(["--model", "m", "--image", "i.jpg", "--no-show-boxes"])
+    assert args.show_boxes is False


### PR DESCRIPTION
## Problem

The RF-DETR CLI declares `--show-boxes` with `help="Show bounding boxes and labels (default: on)"`, but the parsed value is never used. `show_boxes` as an identifier appears nowhere in `mlx_vlm/models/rfdetr/` outside that one `add_argument` call:

```console
$ grep -rn "show_boxes" mlx_vlm/models/rfdetr/
$          # (no output — only the "--show-boxes" string literal exists)
```

Two things are wrong, and the file itself supplies the baseline for both:

1. **The value never reaches the annotator.** The adjacent `--show-fps` flag in the very same parser *is* threaded through (`predict_video(..., show_fps=args.show_fps)` at `generate.py:802`). Both sibling backends honor `show_boxes` too — `sam3/generate.py` passes `args.show_boxes` into three call sites, and `sam3_1/generate.py` threads it down to `draw_frame`.

2. **The flag could not be turned off even once wired up.** It is `action="store_true"` with `default=True`, so passing `--show-boxes` is a no-op and there is no way to get boxes off. `sam3_1/generate.py:1002-1003` pairs exactly this flag with a `--no-show-boxes` dual; the RF-DETR parser only has the positive half.

Net effect: a user following the documented `(default: on)` wording has no way to render mask-only segment output, which is the one thing the option exists for.

## Fix

- `_get_annotator()` takes `show_boxes: bool = True`. When it is off, the default **segment** chain keeps `MaskAnnotator` and drops `BoxAnnotator`/`LabelAnnotator` — the same meaning `sam3/generate.py` documents for `draw_frame`: *"If False, draw only mask overlays + contours (no boxes/labels)."*
- A **detect** chain contains nothing but boxes and labels, so it keeps them regardless. This mirrors sam3's `show_boxes=args.show_boxes if args.task == "segment" else True`, and avoids rendering an empty overlay.
- An explicit `--annotator` chain still wins, since it names the annotators outright.
- Added `--no-show-boxes` (`dest="show_boxes"`, `action="store_false"`), matching `sam3_1/generate.py`.

**The default path is unchanged.** With `show_boxes=True` the chain is the same `MaskAnnotator + BoxAnnotator + LabelAnnotator` as before, and the two internal `_get_annotator(None, ...)` calls in `predict_video`/`predict_realtime` keep the default.

## Verification

`mlx` is Apple-silicon only, so I exercised the real module on another platform by stubbing `mlx` alone and importing `mlx_vlm/models/rfdetr/generate.py` unmodified — `sam3/annotators.py` is numpy+cv2 only, so the annotator chain under test is the real one, not a mock.

Before the change (3 of the 4 new tests fail):

```
FAILED test_rfdetr_show_boxes.py::test_segment_chain_drops_boxes_and_labels_when_show_boxes_is_off
FAILED test_rfdetr_show_boxes.py::test_detect_keeps_boxes_because_nothing_else_is_drawn
FAILED test_rfdetr_show_boxes.py::test_cli_can_turn_boxes_off - SystemExit: 2
   __main__.py: error: unrecognized arguments: --no-show-boxes
3 failed, 1 passed
```

After: `4 passed`.

`test_show_boxes_defaults_to_on` is the one that passes on both sides — it pins the unchanged default chain so this stays a no-op for existing invocations.

Observed chains:

| task | `show_boxes` | annotator chain |
|---|---|---|
| segment | `True` (default) | `MaskAnnotator, BoxAnnotator, LabelAnnotator` |
| segment | `False` | `MaskAnnotator` |
| detect | either | `BoxAnnotator, LabelAnnotator` |

`black==26.3.1`, `isort==5.13.2` and `autoflake==2.2.1` (the pinned `.pre-commit-config.yaml` revisions) leave both files unchanged.

## Not in scope

`sam3/generate.py` declares `--show-boxes` without `default=True`, so it defaults to off there and is already honored — I left its semantics alone rather than unifying the two defaults, since that would change existing sam3 output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
