### PR TITLE
fix(sam3): let --threshold fall through to the documented per-task defaults

### DIFF
--- a/mlx_vlm/models/sam3/generate.py
+++ b/mlx_vlm/models/sam3/generate.py
@@ -1711,8 +1711,8 @@ def main():
     parser.add_argument(
         "--threshold",
         type=float,
-        default=0.5,
-        help="Score threshold (default: 0.3 image, 0.15 video)",
+        default=None,
+        help="Score threshold (default: 0.3 image, 0.15 video, 0.5 realtime)",
     )
     parser.add_argument(
         "--nms-thresh", type=float, default=0.5, help="NMS IoU threshold"

--- a/mlx_vlm/tests/test_sam3_cli_threshold.py
+++ b/mlx_vlm/tests/test_sam3_cli_threshold.py
@@ -1,0 +1,73 @@
+"""CLI wiring for the SAM3 ``--threshold`` flag.
+
+``main()`` dispatches every task with
+``args.threshold if args.threshold is not None else <per-task default>``, and
+the per-task defaults differ (0.3 for image detect/segment, 0.15 for track,
+0.5 for realtime) exactly as the flag's own help text documents.  Those
+fallbacks are only reachable while the flag itself defaults to ``None``.
+"""
+
+import sys
+import unittest
+from unittest.mock import patch
+
+from mlx_vlm.models.sam3 import generate as sam3_generate
+
+
+class TestSam3ThresholdDefaults(unittest.TestCase):
+    def _dispatch(self, argv):
+        recorded = {}
+
+        def recorder(name):
+            def _fn(**kwargs):
+                recorded[name] = kwargs
+
+            return _fn
+
+        with (
+            patch.object(sam3_generate, "run_image", recorder("run_image")),
+            patch.object(sam3_generate, "track_video", recorder("track_video")),
+            patch.object(
+                sam3_generate, "track_video_realtime", recorder("track_video_realtime")
+            ),
+            patch.object(sys, "argv", ["generate.py"] + argv),
+        ):
+            sam3_generate.main()
+
+        self.assertEqual(len(recorded), 1, f"expected one dispatch, got {recorded}")
+        return next(iter(recorded.values()))
+
+    def test_image_task_uses_its_documented_default(self):
+        kwargs = self._dispatch(
+            ["--task", "segment", "--image", "img.png", "--prompt", "a dog"]
+        )
+        self.assertEqual(kwargs["threshold"], 0.3)
+
+    def test_track_task_uses_its_documented_default(self):
+        kwargs = self._dispatch(
+            ["--task", "track", "--video", "clip.mp4", "--prompt", "a car"]
+        )
+        self.assertEqual(kwargs["threshold"], 0.15)
+
+    def test_realtime_task_default_is_unchanged(self):
+        kwargs = self._dispatch(["--task", "realtime", "--prompt", "a car"])
+        self.assertEqual(kwargs["threshold"], 0.5)
+
+    def test_explicit_threshold_wins_over_the_per_task_default(self):
+        kwargs = self._dispatch(
+            [
+                "--task",
+                "track",
+                "--video",
+                "clip.mp4",
+                "--prompt",
+                "a car",
+                "--threshold",
+                "0.9",
+            ]
+        )
+        self.assertEqual(kwargs["threshold"], 0.9)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### What

`mlx_vlm/models/sam3/generate.py` `main()` dispatches each task with a per-task
threshold fallback:

```python
# --task detect / segment
threshold=args.threshold if args.threshold is not None else 0.3,
# --task track
threshold=args.threshold if args.threshold is not None else 0.15,
# --task realtime
threshold=args.threshold if args.threshold is not None else 0.5,
```

and the flag's own help text documents the same contract —
`"Score threshold (default: 0.3 image, 0.15 video)"`.

But the flag is declared as:

```python
parser.add_argument("--threshold", type=float, default=0.5, ...)
```

so `args.threshold` is **never** `None`. All three `is not None` fallbacks are
dead code, and every task actually runs at `0.5` — including `--task track`,
which the help text says defaults to `0.15`.

The sibling CLI in `mlx_vlm/models/sam3_1/generate.py` has no such per-task
fallback: it passes `args.threshold` straight through, so its `default=0.5`
is consistent. `sam3` is the only one whose declared default contradicts its
own dispatch code.

### Fix

Declare `--threshold` with `default=None` so the per-task defaults the code
already contains become reachable, and extend the help text to name the
realtime default as well.

Behaviour change: `--task detect/segment` now defaults to `0.3` and
`--task track` to `0.15`, exactly as documented. `--task realtime` is
unchanged (`0.5`), and an explicit `--threshold` is honored everywhere as
before.

+7/-2 across two files (one of them a new test).

### Verification

Added `mlx_vlm/tests/test_sam3_cli_threshold.py`, which patches
`run_image` / `track_video` / `track_video_realtime` and drives the real
`main()` argument parser:

| test | before | after |
|---|---|---|
| `test_image_task_uses_its_documented_default` | ❌ `0.5 != 0.3` | ✅ |
| `test_track_task_uses_its_documented_default` | ❌ `0.5 != 0.15` | ✅ |
| `test_realtime_task_default_is_unchanged` | ✅ | ✅ |
| `test_explicit_threshold_wins_over_the_per_task_default` | ✅ | ✅ |

The two tests that pass on both sides are deliberate no-change nails: the
realtime default and the explicit-flag path must not move.

`black==26.3.1` and `isort==5.13.2 --profile=black` (the pinned
`.pre-commit-config.yaml` revisions) report both files unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
