### PR TITLE
fix(server): stop dropping streamed content after a tool call ends

### DIFF
--- a/mlx_vlm/server/openai.py
+++ b/mlx_vlm/server/openai.py
@@ -1096,6 +1096,11 @@ async def responses_endpoint(request: Request):
                         if tool_module is not None and chat_tools
                         else None
                     )
+                    tc_end = (
+                        tool_module.tool_call_end
+                        if tool_module is not None and chat_tools
+                        else None
+                    )
                     thinking_state = make_response_stream_state(
                         processor,
                         prompt_has_open_thinking(
@@ -1157,7 +1162,7 @@ async def responses_endpoint(request: Request):
                                 )
                             delta = thinking_delta.content
                             in_tool_call, delta = suppress_tool_call_content(
-                                full_text, in_tool_call, tc_start, delta
+                                full_text, in_tool_call, tc_start, delta, tc_end
                             )
                             usage_stats = {
                                 "input_tokens": ctx.prompt_tokens,
@@ -1211,7 +1216,7 @@ async def responses_endpoint(request: Request):
                                 )
                             delta = thinking_delta.content
                             in_tool_call, delta = suppress_tool_call_content(
-                                full_text, in_tool_call, tc_start, delta
+                                full_text, in_tool_call, tc_start, delta, tc_end
                             )
                             if chunk_finish is not None:
                                 finish_reason = chunk_finish
@@ -1844,7 +1849,11 @@ async def chat_completions_endpoint(request: ChatRequest, http_request: Request)
 
                             # Suppress tool-call markup from content
                             in_tool_call, delta_content = suppress_tool_call_content(
-                                full_output, in_tool_call, tc_start, delta_content
+                                full_output,
+                                in_tool_call,
+                                tc_start,
+                                delta_content,
+                                tc_end,
                             )
 
                             chunk_logprobs = None

--- a/mlx_vlm/server/responses_state.py
+++ b/mlx_vlm/server/responses_state.py
@@ -269,10 +269,25 @@ def suppress_tool_call_content(
     in_tool_call: bool,
     tc_start: Optional[str],
     delta_content: Optional[str],
+    tc_end: Optional[str] = None,
 ) -> Tuple[bool, Optional[str]]:
     """Suppress tool-call markup from streamed delta.content."""
     if not tc_start:
         return in_tool_call, delta_content
+    if tc_end:
+        # Suppression must stop where the call does, otherwise every token
+        # after it is dropped: `tc_start in full_output` stays true for the
+        # rest of the stream. Only the text after the last completed call
+        # can open a new one, so match against that tail.
+        closed_at = full_output.rfind(tc_end)
+        if closed_at != -1:
+            in_tool_call = False
+            full_output = full_output[closed_at + len(tc_end) :]
+            # Whatever part of this delta fell inside the completed call must
+            # still be withheld -- it is markup. Keep only the tail that comes
+            # after the end marker.
+            if delta_content is not None and len(full_output) < len(delta_content):
+                delta_content = full_output or None
     if not in_tool_call:
         if tc_start in full_output:
             return True, None

--- a/mlx_vlm/tests/test_responses_state.py
+++ b/mlx_vlm/tests/test_responses_state.py
@@ -4,7 +4,10 @@ import pytest
 from fastapi import HTTPException
 
 from mlx_vlm.prompt_utils import apply_chat_template
-from mlx_vlm.server.responses_state import _response_items_to_chat
+from mlx_vlm.server.responses_state import (
+    _response_items_to_chat,
+    suppress_tool_call_content,
+)
 
 
 def test_function_output_image_stays_after_tool_result():
@@ -179,3 +182,98 @@ def test_unknown_function_output_blocks_remain_text():
 
     assert images == []
     assert json.loads(messages[0]["content"]) == [unknown]
+
+
+def _stream(chunks, tc_start, tc_end):
+    """Feed chunks through suppress_tool_call_content, return visible content."""
+    full = ""
+    in_tool_call = False
+    content = ""
+    for chunk in chunks:
+        full += chunk
+        in_tool_call, delta = suppress_tool_call_content(
+            full, in_tool_call, tc_start, chunk, tc_end
+        )
+        if delta:
+            content += delta
+    return content
+
+
+def test_streamed_content_resumes_after_a_tool_call_ends():
+    """Text after a completed tool call must not be swallowed.
+
+    Suppression used to latch on for the rest of the stream, because
+    `tc_start in full_output` stays true once the call has been seen.
+    """
+    content = _stream(
+        [
+            "Let me look. ",
+            "<tool_call>",
+            '{"name": "get_weather"}',
+            "</tool_call>",
+            " The weather is sunny.",
+        ],
+        "<tool_call>",
+        "</tool_call>",
+    )
+
+    assert "get_weather" not in content
+    assert content == "Let me look.  The weather is sunny."
+
+
+def test_streamed_content_resumes_between_consecutive_tool_calls():
+    content = _stream(
+        [
+            "<tool_call>",
+            '{"name": "a"}',
+            "</tool_call>",
+            " then ",
+            "<tool_call>",
+            '{"name": "b"}',
+            "</tool_call>",
+            " done.",
+        ],
+        "<tool_call>",
+        "</tool_call>",
+    )
+
+    assert content == " then  done."
+
+
+def test_streamed_tool_call_markup_is_still_suppressed():
+    content = _stream(
+        ["Hello ", "<tool_call>", '{"name": "a"}'],
+        "<tool_call>",
+        "</tool_call>",
+    )
+
+    assert content == "Hello "
+
+
+def test_suppression_without_an_end_marker_is_unchanged():
+    """Parsers with an empty tool_call_end keep the latching behavior."""
+    content = _stream(
+        ["Hello ", "<tool_call>", '{"name": "a"}', " trailing"],
+        "<tool_call>",
+        "",
+    )
+
+    assert content == "Hello "
+
+
+def test_tool_call_markup_inside_a_single_chunk_is_still_suppressed():
+    """A chunk that carries a whole call, or the end marker plus trailing
+    text, must not leak the markup itself into content."""
+    whole_call = _stream(
+        ['<tool_call>{"name": "shell", "command": "pwd"}</tool_call>'],
+        "<tool_call>",
+        "</tool_call>",
+    )
+    assert whole_call == ""
+
+    end_and_tail = _stream(
+        ["<tool_call>", '{"name": "shell"}', "</tool_call> done."],
+        "<tool_call>",
+        "</tool_call>",
+    )
+    assert end_and_tail == " done."


### PR DESCRIPTION
### The bug

`suppress_tool_call_content()` keeps tool-call markup out of the streamed
`delta.content`. It is given the tool parser's **start** marker only:

```python
tc_start = tool_module.tool_call_start if tool_module else None
tc_end   = tool_module.tool_call_end   if tool_module else None   # never used

in_tool_call, delta_content = suppress_tool_call_content(
    full_output, in_tool_call, tc_start, delta_content
)
```

Inside the helper, once `in_tool_call` flips on it never flips back, because the
opening test is against the whole accumulated output:

```python
if not in_tool_call:
    if tc_start in full_output:   # stays true for the rest of the stream
        return True, None
else:
    return True, None             # suppress everything from here on
```

So the suppression is not scoped to the call — **every token generated after the
first tool call is dropped from the stream**, including the model's own prose.

### Why this is a bug and not the intended behaviour

The non-streaming path in the same file keeps that text. `process_tool_calls()`
uses *both* markers, removes only the call spans, and returns the rest as
`remaining_text`, which `chat_completions_endpoint` then stores as the message
content.

And `tc_end` is already read for exactly this purpose in
`chat_completions_endpoint` — it is just never passed anywhere.

### Reproduction

Feeding one stream through the helper, and the same output through the
non-streaming sibling:

| | visible content |
|---|---|
| streaming (`suppress_tool_call_content`) | `'Let me look. '` |
| non-streaming (`process_tool_calls` → `remaining_text`) | `'Let me look.   The weather is sunny.'` |

`" The weather is sunny."` is silently lost, and with two calls in a turn
everything between and after them is lost too.

### The fix

Pass `tc_end` through, and stop suppressing at the end of the last **completed**
call so that later text is matched against the tail rather than the whole
output. Both endpoints (`/v1/chat/completions` and `/v1/responses`) are wired up.

`tc_end` defaults to `None`, and parsers whose `tool_call_end` is `""` (handled
explicitly in `process_tool_calls`) fall through to the previous behaviour, so
no existing parser changes shape.

### Tests

Four cases added to `mlx_vlm/tests/test_responses_state.py`, which had no
coverage for this helper:

- content resumes after a completed tool call
- content resumes between two consecutive calls
- markup is still suppressed while a call is open (unchanged)
- an empty `tool_call_end` keeps the old latching behaviour (unchanged)

The first two fail on `main` and pass with this change; the last two pass on
both. `black` 26.3.1 and `isort` 5.13.2 (the pinned pre-commit revisions) are
clean on the three touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
