### PR TITLE
Optimize Qwen4 n-gram shard gathers

### DIFF
--- a/mlx_vlm/models/glm5_next/config.py
+++ b/mlx_vlm/models/glm5_next/config.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Any, Dict, List, Optional
 
 from ..base import BaseModelConfig

--- a/mlx_vlm/models/glm5_next/language.py
+++ b/mlx_vlm/models/glm5_next/language.py
@@ -10,13 +10,12 @@ from ..base import (
     scaled_dot_product_attention,
 )
 from ..cache import ArraysCache, CacheList, KVCache
+from ..deepseek_v4.hyper_connection import HyperConnection, hc_expand
 from ..deepseek_v32.language import DeepseekV32MoE
 from ..deepseek_v32.language import Model as DSV32Model
-from ..deepseek_v4.hyper_connection import HyperConnection, hc_expand
 from ..gated_delta import gated_delta_update
 from ..mla import MultiLinear
 from ..mlp import DeepseekMLP
-from ..rope_utils import initialize_rope
 from .config import ModelConfig, TextConfig
 
 
@@ -397,7 +396,9 @@ class Glm5NextIndexer(nn.Module):
             c1 = min(c0 + chunk, S)
             cs = c1 - c0
             q_pos = offset + mx.arange(c0, c1)
-            visible = (kv_pos[None, None, :] <= q_pos[None, :, None]) & valid[:, None, :]
+            visible = (kv_pos[None, None, :] <= q_pos[None, :, None]) & valid[
+                :, None, :
+            ]
             scores = q[:, c0:c1] @ pool_keys_t
             scores = mx.maximum(scores * self.softmax_scale, 0.0)
             weights = self.weights_proj(x[:, c0:c1]) * (self.n_heads**-0.5)
@@ -421,7 +422,9 @@ class Glm5NextIndexer(nn.Module):
             ).reshape(B, cs, select_k * self.index_kpool)
             topk = mx.where(sv, topk, -1)
             if tail_on:
-                topk = mx.concatenate([topk, self._visible_tail(visible, valid)], axis=-1)
+                topk = mx.concatenate(
+                    [topk, self._visible_tail(visible, valid)], axis=-1
+                )
             if topk.shape[-1] < output_width:
                 pad = mx.full(
                     (B, cs, output_width - topk.shape[-1]), -1, dtype=topk.dtype

--- a/mlx_vlm/models/qwen4_exp/language.py
+++ b/mlx_vlm/models/qwen4_exp/language.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import math
+from bisect import bisect_right
 from typing import Any, Optional
 
 import mlx.core as mx
@@ -522,16 +523,34 @@ class ShardedEmbedding(nn.Module):
 
     def __call__(self, indices: mx.array) -> mx.array:
         flat = indices.reshape(-1)
+        # One tiny host sync avoids scheduling gathers against all 128 giant
+        # PLE shards for every token.
+        mx.eval(flat)
+        host_indices = [int(index) for index in flat.tolist()]
+        if not host_indices:
+            return self.shards[0](flat).reshape(*indices.shape, self.dims)
+        if any(index < 0 or index >= self.shard_offsets[-1] for index in host_indices):
+            raise IndexError("embedding index is outside the sharded vocabulary")
+
+        shard_indices = [
+            bisect_right(self.shard_offsets, index) - 1 for index in host_indices
+        ]
         result = None
-        for shard, start, end in zip(
-            self.shards, self.shard_offsets[:-1], self.shard_offsets[1:]
-        ):
-            local = mx.clip(flat - start, 0, end - start - 1)
-            values = shard(local)
-            mask = (flat >= start) & (flat < end)
-            result = (
-                values if result is None else mx.where(mask[:, None], values, result)
-            )
+        for shard_index in sorted(set(shard_indices)):
+            positions_list = [
+                position
+                for position, current_shard in enumerate(shard_indices)
+                if current_shard == shard_index
+            ]
+            local_indices = [
+                host_indices[position] - self.shard_offsets[shard_index]
+                for position in positions_list
+            ]
+            positions = mx.array(positions_list, dtype=mx.int32)
+            values = self.shards[shard_index](mx.array(local_indices, dtype=mx.int32))
+            if result is None:
+                result = mx.zeros((len(host_indices), self.dims), dtype=values.dtype)
+            result = result.at[positions].add(values)
         return result.reshape(*indices.shape, self.dims)
 
 

--- a/mlx_vlm/tests/test_qwen4_exp.py
+++ b/mlx_vlm/tests/test_qwen4_exp.py
@@ -1,6 +1,7 @@
 import unittest
 
 import mlx.core as mx
+import mlx.nn as nn
 
 from mlx_vlm.generate import maybe_quantize_kv_cache
 from mlx_vlm.models import qwen4_exp
@@ -10,6 +11,7 @@ from mlx_vlm.models.qwen4_exp.language import (
     QSAQuantizedKVCache,
     Qwen4ExpGatedDeltaNet,
     Qwen4ExpNGramEmbedding,
+    ShardedEmbedding,
 )
 from mlx_vlm.prompt_utils import MessageFormat, MessageFormatter
 
@@ -120,6 +122,41 @@ class Qwen4ExpTests(unittest.TestCase):
         self.assertTrue(mx.array_equal(full[:, :4], prefix).item())
         self.assertTrue(mx.array_equal(full[:, 4:], suffix).item())
         self.assertEqual(cache[3].shape, (1, config.ngram_size - 1))
+
+    def test_sharded_embedding_only_gathers_addressed_shards(self):
+        embedding = ShardedEmbedding(num_embeddings=10, dims=4, num_shards=3)
+        table = mx.arange(40, dtype=mx.float32).reshape(10, 4)
+        calls = [0, 0, 0]
+
+        class TrackingEmbedding(nn.Module):
+            def __init__(self, wrapped, shard_index):
+                super().__init__()
+                self.wrapped = wrapped
+                self.shard_index = shard_index
+
+            def __call__(self, indices):
+                calls[self.shard_index] += 1
+                return self.wrapped(indices)
+
+        tracked_shards = []
+        for shard_index, (shard, start, end) in enumerate(
+            zip(
+                embedding.shards,
+                embedding.shard_offsets[:-1],
+                embedding.shard_offsets[1:],
+            )
+        ):
+            shard.weight = table[start:end]
+            tracked_shards.append(TrackingEmbedding(shard, shard_index))
+        embedding.shards = tracked_shards
+
+        indices = mx.array([[0, 3, 7, 9, 1, 7]], dtype=mx.int32)
+        actual = embedding(indices)
+        expected = table[indices]
+        mx.eval(actual, expected)
+
+        self.assertTrue(mx.array_equal(actual, expected).item())
+        self.assertEqual(calls, [1, 0, 1])
 
     def test_gated_delta_uses_reference_l2_normalization(self):
         layer = Qwen4ExpGatedDeltaNet(tiny_config().text_config)


### PR DESCRIPTION
## Summary

Qwen4's PLE table is split into 128 very large embedding shards. The current lookup evaluates every shard and masks away the 127-ish answers it did not need. Correct, but a fairly expensive way to rediscover which shard owns an index.

This change materializes the small n-gram ID tensor once, maps IDs to the existing shard offsets, gathers only the addressed shards, and scatters those rows back into their original positions.

## Benchmark

M5 Max, 128 GiB unified memory, `Qwen3.8-Flash-Next-MLX-4bit`, 128-token single-sequence decode:

| Lookup | Decode | Prompt | Peak memory |
| --- | ---: | ---: | ---: |
| all 128 shards + mask | 27.62 tok/s | 8.41 tok/s | 103.31 GiB |
| addressed shards only | 31.10 tok/s | 8.41 tok/s | 103.34 GiB |

That is a 12.6% decode improvement. A separate 64-token run reproduced the result at 28.08 vs 31.48 tok/s. Generated token IDs were identical between both paths.

The intentional tradeoff is one host sync of the tiny ID tensor. It replaces 128 quantized embedding gathers per PLE invocation with gathers for only the shards actually addressed by those IDs.

## Tests

- Adds an uneven-shard regression that verifies bit-exact output, order preservation, repeated indices, and that an untouched shard is never called.
- `pytest -q mlx_vlm/tests/test_qwen4_exp.py`: 8 passed.
- All configured pre-commit hooks pass.
