### PR TITLE
Optimize Qwen4-Exp QSA indexer mask construction

### DIFF
--- a/mlx_vlm/models/qwen4_exp/language.py
+++ b/mlx_vlm/models/qwen4_exp/language.py
@@ -364,11 +364,17 @@ class Qwen4ExpQSAIndexer(nn.Module):
         ]
 
         token_indices = mx.arange(key_len)
-        token_blocks = token_indices // self.compress_ratio
-        selected_tokens = mx.any(
-            token_blocks[None, None, None, :] == selected_blocks[..., None],
-            axis=2,
+        block_selected = mx.zeros((batch, seq_len, max_complete_blocks), dtype=mx.bool_)
+        block_selected = mx.put_along_axis(
+            block_selected, selected_blocks, mx.array(True), axis=-1
         )
+        selected_tokens = mx.repeat(block_selected, self.compress_ratio, axis=-1)
+        if selected_tokens.shape[-1] < key_len:
+            pad = mx.zeros(
+                (batch, seq_len, key_len - selected_tokens.shape[-1]),
+                dtype=mx.bool_,
+            )
+            selected_tokens = mx.concatenate([selected_tokens, pad], axis=-1)
         tail_starts = complete_counts * self.compress_ratio
         tail = (token_indices[None, None, :] >= tail_starts[None, :, None]) & (
             token_indices[None, None, :] < query_ends[None, :, None]


### PR DESCRIPTION
The Qwen4-Exp sparse-attention indexer materialized a large per-block boolean tensor, wasting memory on long prefills. This scatters the selected block ids and repeats them into tokens, avoiding that quadratic intermediate. Output stays bit-identical while long-context prefill runs several times faster using far less peak memory.

> **Preliminary numbers** — synthetic random-init model at the real architecture dims (M5 Max, bf16, single batch); real-checkpoint numbers pending. Output verified **bit-identical** to `main` (max|Δ|=0.000) across dense / sparse / batched / decode. Below the 2048 indexer budget the code path is identical (no-op); decode is unchanged.

| Prefill context | main | this PR | speedup | peak mem (main → PR) |
|--:|--:|--:|:--:|--:|
| ≤ 2048 | 192 ms | 192 ms | 1.0× (identical path) | 5.9 → 5.9 GB |
| 4096 | 499 ms | 393 ms | 1.3× | 6.9 → 5.9 GB |
| 8192 | 1302 ms | 819 ms | 1.6× | 8.0 → 5.9 GB |
| 16384 | 5892 ms | 1779 ms | 3.3× | 10.4 → 6.2 GB |
| 32768 | 29319 ms | 4301 ms | **6.8×** | 15.1 → **6.7 GB** |
