### PR TITLE
Add MTP support for Qwen3.8-Flash-Next

### DIFF
--- a/mlx_vlm/models/qwen3_5/speculative_verifier.py
+++ b/mlx_vlm/models/qwen3_5/speculative_verifier.py
@@ -1352,6 +1352,14 @@ class Qwen3_5ExactSpeculativeVerifier:
 
         return feed_forward(x)
 
+    @staticmethod
+    def _normalize_gated_delta_qk(layer, q, k):
+        del layer
+        inv_scale = k.shape[-1] ** -0.5
+        q = (inv_scale**2) * mx.fast.rms_norm(q, None, 1e-6)
+        k = inv_scale * mx.fast.rms_norm(k, None, 1e-6)
+        return q, k
+
     def _gated_delta(self, layer, inputs, mask, cache, gdn_sink):
         helpers = self._helpers()
         batch, length, _ = inputs.shape
@@ -1402,9 +1410,7 @@ class Qwen3_5ExactSpeculativeVerifier:
         state = cache[1] if cache else None
         if state is not None and state.shape[0] != batch:
             state = None
-        inv_scale = k.shape[-1] ** -0.5
-        q = (inv_scale**2) * mx.fast.rms_norm(q, None, 1e-6)
-        k = inv_scale * mx.fast.rms_norm(k, None, 1e-6)
+        q, k = self._normalize_gated_delta_qk(layer, q, k)
 
         initial_state = state
         output, state, intermediate_states = gated_delta_update_with_states(

--- a/mlx_vlm/models/qwen4_exp/README.md
+++ b/mlx_vlm/models/qwen4_exp/README.md
@@ -74,6 +74,29 @@ result = generate(
 print(result.text)
 ```
 
+## MTP speculative decoding
+
+The official checkpoint also contains a native multi-token prediction (MTP)
+head. Extract it into a standalone draft model, then use it for speculative
+decoding with the official model:
+
+```sh
+python -m mlx_vlm.split_mtp \
+  --model Qwen/Qwen3.8-Flash-Next \
+  --output ./Qwen3.8-Flash-Next-MTP
+
+mlx_vlm.generate \
+  --model Qwen/Qwen3.8-Flash-Next \
+  --draft-model ./Qwen3.8-Flash-Next-MTP \
+  --draft-kind mtp \
+  --prompt "Explain speculative decoding in one paragraph." \
+  --max-tokens 128
+```
+
+The released checkpoint contains one MTP layer, so the default draft block is
+one speculative token. `--draft-block-size` can chain the head for additional
+draft tokens; the best value depends on the prompt and hardware.
+
 ## Optional quantization
 
 The official BF16 checkpoint is approximately 360 GB. Depending on the
@@ -92,11 +115,21 @@ mlx_vlm.convert \
 Group size 32 allows the PLE embedding dimensions to be quantized. The bit
 width and output path can be adjusted for the target hardware.
 
+The extracted MTP head can be quantized independently:
+
+```sh
+python -m mlx_vlm.split_mtp \
+  --model Qwen/Qwen3.8-Flash-Next \
+  --output ./Qwen3.8-Flash-Next-MTP-3bit \
+  --q-group-size 32 \
+  --q-bits 3
+```
+
 ## Notes
 
-- The upstream checkpoint includes a separate MTP predictor; the base
-  conditional-generation runtime loads the text and vision model and ignores
-  the MTP tensors.
+- The base conditional-generation runtime ignores the embedded `mtp.*`
+  tensors. `mlx_vlm.split_mtp` extracts them into the standalone draft model
+  used by speculative decoding.
 - QSA maintains an auxiliary index-key cache in addition to the normal KV
   cache. Single-request generation, chunked prefill, and uniform KV-cache
   quantization are supported.

--- a/mlx_vlm/models/qwen4_exp/config.py
+++ b/mlx_vlm/models/qwen4_exp/config.py
@@ -61,6 +61,9 @@ class TextConfig(BaseModelConfig):
     output_gate_type: str = "sigmoid"
     hidden_act: str = "silu"
     norm_topk_prob: bool = True
+    mtp_num_hidden_layers: int = 1
+    mtp_use_dedicated_embeddings: bool = False
+    mtp: Optional[Dict] = None
     eos_token_id: Optional[Union[int, List[int]]] = None
     tie_word_embeddings: bool = False
     attention_bias: bool = False

--- a/mlx_vlm/models/qwen4_exp/language.py
+++ b/mlx_vlm/models/qwen4_exp/language.py
@@ -7,6 +7,7 @@ from typing import Any, Optional
 import mlx.core as mx
 import mlx.nn as nn
 
+from ..base import LanguageModelOutput
 from ..cache import ArraysCache, KVCache, QuantizedKVCache
 from ..qwen3_5.language import LanguageModel as Qwen3_5LanguageModel
 from ..qwen3_5.language import (
@@ -15,6 +16,7 @@ from ..qwen3_5.language import (
     _create_qwen3_5_attention_mask,
     _create_qwen3_5_ssm_mask,
 )
+from ..qwen3_5.speculative_verifier import Qwen3_5ExactSpeculativeVerifier
 from ..qwen3_5_moe.language import Qwen3_5MoeSparseMoeBlock
 from .config import ModelConfig, TextConfig
 
@@ -310,14 +312,22 @@ class Qwen4ExpQSAIndexer(nn.Module):
         cache: Optional[QSAKVCache],
         position_ids: Optional[mx.array],
     ) -> Optional[mx.array]:
-        batch, seq_len, _ = hidden_states.shape
+        return self.from_projected(
+            self.index_qk_proj(hidden_states), cache, position_ids
+        )
+
+    def from_projected(
+        self,
+        qk: mx.array,
+        cache: Optional[QSAKVCache],
+        position_ids: Optional[mx.array],
+    ) -> Optional[mx.array]:
+        batch, seq_len, _ = qk.shape
         past_len = cache.offset if cache is not None else 0
         if position_ids is None:
             position_ids = self._default_position_ids(batch, past_len, seq_len)
 
-        qk = self.index_qk_proj(hidden_states).reshape(
-            batch, seq_len, self.n_heads + self.kv_heads, self.head_dim
-        )
+        qk = qk.reshape(batch, seq_len, self.n_heads + self.kv_heads, self.head_dim)
         query = qk[:, :, : self.n_heads]
         raw_keys = qk[:, :, self.n_heads :].squeeze(2)
         query = self.q_layernorm(query).transpose(0, 2, 1, 3)
@@ -845,7 +855,186 @@ class Qwen4ExpModel(nn.Module):
             if hidden_sink is not None and index in capture:
                 hidden_sink.append(self.hyper_connection_mixer(hidden_states))
 
+        if hidden_sink is not None and capture_layer_ids == []:
+            # Native Qwen4 MTP consumes the complete hyper-connection state,
+            # before the final 4-stream mixer.  An explicit empty capture list
+            # is reserved for that final pre-mixer capture; ordinary layer
+            # captures above retain their public, mixed hidden-state contract.
+            hidden_sink.append(hidden_states)
         return self.hyper_connection_mixer(hidden_states)
+
+
+class Qwen4ExpExactSpeculativeVerifier(Qwen3_5ExactSpeculativeVerifier):
+    """Batched verifier with Qwen4's singleton-equivalent dense operations."""
+
+    @staticmethod
+    def _normalize_gated_delta_qk(layer, q, k):
+        return layer._normalize_qk(q, k)
+
+    def _hyper_connection(self, module, hidden_states):
+        normed = module.hc_norm(hidden_states)
+        mix = nn.silu(
+            self._linear(module.input_mix_weight_down, normed) / module.hc_count
+        )
+        mix = mx.sigmoid(self._linear(module.input_mix_weight_up, mix))
+        mix = mix.reshape(*mix.shape[:-1], module.hc_count, module.hidden_size)
+        streams = normed.reshape(
+            *normed.shape[:-1], module.hc_count, module.hidden_size
+        )
+        mixed = mx.mean(mix * streams, axis=-2)
+        if "block_inject_weight" not in module:
+            return mixed
+        injection = 2 * mx.sigmoid(
+            self._linear(module.block_inject_weight, normed) / module.hc_count
+        )
+        return mixed, hidden_states, injection
+
+    @staticmethod
+    def _inject(branch, hyper_input, injection_weights):
+        injection = branch[..., None, :] * injection_weights[..., None]
+        return hyper_input + injection.reshape(*hyper_input.shape)
+
+    def _ple(self, module, hidden_states, input_ids, cache, mask):
+        embeddings = module.ple_embedding(input_ids, cache)
+        keys = module.norm_key(self._linear(module.key_proj, embeddings)).reshape(
+            *hidden_states.shape[:-1], module.hc_count, module.hidden_size
+        )
+        values = self._linear(module.value_proj, embeddings)
+        queries = module.norm_query(hidden_states).reshape(
+            *hidden_states.shape[:-1], module.hc_count, module.hidden_size
+        )
+        gate = mx.sum(keys * queries, axis=-1, keepdims=True) / math.sqrt(
+            module.hidden_size
+        )
+        gate = mx.sign(gate) * mx.sqrt(mx.maximum(mx.abs(gate), 1e-6))
+        gated_values = (mx.sigmoid(gate) * values[..., None, :]).reshape(
+            *hidden_states.shape
+        )
+        normed = module.norm_conv(gated_values)
+        if mask is not None and isinstance(mask, mx.array) and mask.ndim == 2:
+            gated_values = mx.where(mask[..., None], gated_values, 0)
+            normed = mx.where(mask[..., None], normed, 0)
+        return gated_values + module._short_conv(normed, cache)
+
+    def _qsa_mask(self, attention, hidden_states, cache, position_ids, mask):
+        projected = self._linear(attention.indexer.index_qk_proj, hidden_states)
+        qsa_mask = attention.indexer.from_projected(projected, cache, position_ids)
+        if qsa_mask is None:
+            return mask
+        if mask is None or (isinstance(mask, str) and mask == "causal"):
+            return qsa_mask
+        if isinstance(mask, mx.array):
+            if mask.dtype == mx.bool_:
+                return mask & qsa_mask
+            sparse_bias = mx.where(qsa_mask, 0.0, -mx.inf).astype(mask.dtype)
+            return mask + sparse_bias
+        return mask
+
+    def _layer(
+        self,
+        layer,
+        hidden,
+        input_ids,
+        mask,
+        cache,
+        position_ids,
+        gdn_sink,
+    ):
+        if "ple" in layer:
+            hidden = hidden + self._ple(layer.ple, hidden, input_ids, cache, mask)
+
+        mixed, hyper_input, injection = self._hyper_connection(
+            layer.attn_hyper_connection, hidden
+        )
+        if layer.is_linear:
+            branch = self._gated_delta(layer.linear_attn, mixed, mask, cache, gdn_sink)
+        else:
+            attention_mask = self._qsa_mask(
+                layer.self_attn, mixed, cache, position_ids, mask
+            )
+            branch = self._attention(
+                layer.self_attn,
+                mixed,
+                attention_mask,
+                cache,
+                position_ids,
+                None,
+            )
+        hidden = self._inject(branch, hyper_input, injection)
+
+        mixed, hyper_input, injection = self._hyper_connection(
+            layer.mlp_hyper_connection, hidden
+        )
+        branch = self._feed_forward(layer.mlp, mixed)
+        return self._inject(branch, hyper_input, injection)
+
+    def _model(
+        self,
+        model,
+        inputs,
+        cache,
+        inputs_embeds,
+        position_ids,
+        gdn_sink,
+    ):
+        hidden = model.embed_tokens(inputs) if inputs_embeds is None else inputs_embeds
+        hidden = mx.tile(hidden, (1, 1, model.args.hc_count))
+        if cache is None:
+            cache = [None] * len(model.layers)
+        fa_mask = _create_qwen3_5_attention_mask(hidden, cache[model.fa_idx])
+        ssm_mask = _create_qwen3_5_ssm_mask(hidden, cache[model.ssm_idx])
+        for layer, layer_cache in zip(model.layers, cache):
+            layer_mask = ssm_mask if layer.is_linear else fa_mask
+            hidden = self._layer(
+                layer,
+                hidden,
+                inputs,
+                layer_mask,
+                layer_cache,
+                position_ids,
+                gdn_sink,
+            )
+        return hidden
+
+    def __call__(
+        self,
+        language_model,
+        inputs,
+        *,
+        cache=None,
+        inputs_embeds=None,
+        position_ids=None,
+        skip_logits=False,
+    ):
+        gdn_sink = []
+        hidden = self._model(
+            language_model.model,
+            inputs,
+            cache,
+            inputs_embeds,
+            position_ids,
+            gdn_sink,
+        )
+        logits_hidden = self._hyper_connection(
+            language_model.model.hyper_connection_mixer, hidden
+        )
+        if skip_logits:
+            logits = None
+        elif language_model.args.tie_word_embeddings:
+            logits = self._embedding_as_linear(
+                language_model.model.embed_tokens, logits_hidden
+            )
+        else:
+            logits = self._linear(language_model.lm_head, logits_hidden)
+        return LanguageModelOutput(
+            logits=logits,
+            hidden_states=[hidden],
+            gdn_states=gdn_sink,
+            shared_kv_states={},
+        )
+
+
+_QWEN4_EXACT_SPECULATIVE_VERIFIER = Qwen4ExpExactSpeculativeVerifier()
 
 
 class LanguageModel(Qwen3_5LanguageModel):
@@ -859,6 +1048,197 @@ class LanguageModel(Qwen3_5LanguageModel):
         self._rope_deltas = None
         if not args.tie_word_embeddings:
             self.lm_head = nn.Linear(args.hidden_size, args.vocab_size, bias=False)
+
+    def __call__(self, inputs, inputs_embeds=None, mask=None, cache=None, **kwargs):
+        return_hidden = bool(kwargs.get("return_hidden", False))
+        if return_hidden and kwargs.get("capture_layer_ids") is None:
+            # Force Qwen4ExpModel to capture its final pre-mixer HC state.  The
+            # inherited wrapper also appends the mixed output; keep only the
+            # first entry so MTP always sees [B, L, hc_count * hidden_size].
+            kwargs["capture_layer_ids"] = []
+        output = super().__call__(inputs, inputs_embeds, mask, cache, **kwargs)
+        if return_hidden and output.hidden_states:
+            output.hidden_states = [output.hidden_states[0]]
+        return output
+
+    def _mtp_logits_hidden(self, hidden: mx.array) -> mx.array:
+        hc_width = self.args.hc_count * self.args.hidden_size
+        if hidden.shape[-1] == hc_width:
+            return self.model.hyper_connection_mixer(hidden)
+        return hidden
+
+    def speculative_logits_from_hidden(self, hidden: mx.array) -> mx.array:
+        return super().speculative_logits_from_hidden(self._mtp_logits_hidden(hidden))
+
+    def speculative_argmax_from_hidden(self, hidden: mx.array):
+        return super().speculative_argmax_from_hidden(self._mtp_logits_hidden(hidden))
+
+    def speculative_draft_hidden(self, hidden: mx.array) -> mx.array:
+        expected = self.args.hc_count * self.args.hidden_size
+        if hidden.ndim != 3 or hidden.shape[-1] != expected:
+            raise ValueError(
+                "Qwen4-Exp MTP expects target hidden shape "
+                "[batch, tokens, hc_count * hidden_size]."
+            )
+        return hidden
+
+    def fused_greedy_decode(
+        self,
+        inputs: mx.array,
+        cache=None,
+        logits_processors=None,
+        **kwargs,
+    ):
+        if (
+            self.args.tie_word_embeddings
+            or not _QWEN4_EXACT_SPECULATIVE_VERIFIER.can_quantized_head(self.lm_head)
+            or "bias" in self.lm_head
+        ):
+            return None
+
+        token_mask = None
+        if logits_processors:
+            if not self.supports_fused_greedy_logits_processors(logits_processors):
+                return None
+            token_mask = mx.concatenate(
+                [
+                    processors[0].prepare_next_token_mask(token)
+                    for processors, token in zip(
+                        logits_processors, inputs[:, -1].tolist()
+                    )
+                ],
+                axis=0,
+            )
+            token_mask = _QWEN4_EXACT_SPECULATIVE_VERIFIER.pad_token_mask(
+                token_mask, self.lm_head.weight.shape[0]
+            )
+
+        output = self(
+            inputs,
+            cache=cache,
+            return_hidden=True,
+            skip_logits=True,
+            **kwargs,
+        )
+        hidden = self._mtp_logits_hidden(output.hidden_states[-1])
+        sampled = _QWEN4_EXACT_SPECULATIVE_VERIFIER.quantized_argmax(
+            self.lm_head, hidden, token_mask=token_mask
+        )
+        if sampled is not None:
+            return sampled
+        if token_mask is not None:
+            raise RuntimeError("masked fused greedy decode became unsupported")
+        return mx.argmax(self.speculative_logits_from_hidden(hidden), axis=-1)
+
+    @staticmethod
+    def _snapshot_speculative_cache(caches):
+        snapshots = []
+        for entry in caches:
+            if isinstance(entry, ArraysCache):
+                snapshots.append(
+                    (
+                        "arrays",
+                        list(entry.state),
+                        getattr(entry, "_left_padding", None),
+                        getattr(entry, "_left_padding_advance", 0),
+                        getattr(entry, "_lengths", None),
+                        getattr(entry, "_lengths_advance", 0),
+                    )
+                )
+            else:
+                state = entry.state
+                if isinstance(state, list):
+                    state = list(state)
+                elif isinstance(state, tuple):
+                    state = tuple(state)
+                snapshots.append(("cache", state, entry.meta_state))
+        return snapshots
+
+    @staticmethod
+    def _restore_speculative_cache(caches, snapshots):
+        for entry, snapshot in zip(caches, snapshots):
+            if snapshot[0] == "arrays":
+                (
+                    _,
+                    state,
+                    left_padding,
+                    left_padding_advance,
+                    lengths,
+                    lengths_advance,
+                ) = snapshot
+                entry.state = list(state)
+                entry._left_padding = left_padding
+                entry._left_padding_advance = left_padding_advance
+                entry._lengths = lengths
+                entry._lengths_advance = lengths_advance
+            else:
+                _, state, meta_state = snapshot
+                entry.state = state
+                entry.meta_state = meta_state
+
+    def _speculative_verify(self, inputs: mx.array, cache, sampler=None):
+        snapshot = self._snapshot_speculative_cache(cache)
+        batch, length = inputs.shape
+        cache_entry = cache[self.model.fa_idx]
+        cache_offset = getattr(cache_entry, "offset", 0)
+        if isinstance(cache_offset, mx.array) and cache_offset.ndim > 0:
+            offsets = cache_offset[:batch].astype(mx.int64)
+        else:
+            offsets = mx.full((batch,), int(cache_offset), dtype=mx.int64)
+        rope_deltas = self._rope_deltas
+        if rope_deltas is not None:
+            offsets = offsets + rope_deltas[:batch].reshape(-1).astype(mx.int64)
+        position_ids = offsets[:, None] + mx.arange(length, dtype=mx.int64)[None]
+        if self._position_ids is not None and self._position_ids.ndim == 3:
+            position_ids = mx.broadcast_to(position_ids[None], (3, batch, length))
+        output = _QWEN4_EXACT_SPECULATIVE_VERIFIER(
+            self,
+            inputs,
+            cache=cache,
+            position_ids=position_ids,
+            skip_logits=sampler is None,
+        )
+        rollback_state = (snapshot, inputs)
+        hidden = output.hidden_states[-1]
+        if sampler is None:
+            return hidden, {}, rollback_state
+        return hidden, {}, rollback_state, sampler(output.logits)
+
+    def speculative_verify_hidden(self, inputs: mx.array, cache):
+        return self._speculative_verify(inputs, cache)
+
+    def speculative_verify_logits(self, inputs: mx.array, cache, sampler):
+        return self._speculative_verify(inputs, cache, sampler)
+
+    def rollback_speculative_cache(
+        self,
+        caches,
+        rollback_state,
+        accepted,
+        block_size: int,
+    ) -> int:
+        del block_size
+        if isinstance(accepted, int):
+            accepted_list = [accepted]
+        elif isinstance(accepted, mx.array):
+            accepted_list = [int(x) for x in accepted.reshape(-1).tolist()]
+        else:
+            accepted_list = [int(x) for x in accepted]
+        if len(set(accepted_list)) != 1:
+            raise ValueError(
+                "Qwen4-Exp MTP batched rollback requires uniform acceptance."
+            )
+
+        snapshots, verify_inputs = rollback_state
+        self._restore_speculative_cache(caches, snapshots)
+        keep = accepted_list[0] + 1
+        for index in range(keep):
+            self(
+                verify_inputs[:, index : index + 1],
+                cache=caches,
+                skip_logits=True,
+            )
+        return accepted_list[0]
 
     def make_cache(self):
         caches = []

--- a/mlx_vlm/speculative/drafters/README.md
+++ b/mlx_vlm/speculative/drafters/README.md
@@ -33,6 +33,7 @@ source (which still carries `mtp.*`).
 |---|---|
 | `qwen3_5`, `qwen3_5_moe` | `qwen3_5_mtp` |
 | `qwen3_next` | `qwen3_5_mtp` (reuses the runtime) |
+| `qwen4_exp` | `qwen4_exp_mtp` |
 | `deepseek_v4` | `deepseek_v4_mtp` |
 | `glm4_moe_lite` | `glm4_moe_lite_mtp` |
 | `inkling_mm_model` | `inkling_mtp` |

--- a/mlx_vlm/speculative/drafters/__init__.py
+++ b/mlx_vlm/speculative/drafters/__init__.py
@@ -21,6 +21,7 @@ DRAFTER_KIND_BY_MODEL_TYPE = {
     "glm4_moe_lite_mtp": "mtp",
     "inkling_mtp": "mtp",
     "qwen3_5_mtp": "mtp",
+    "qwen4_exp_mtp": "mtp",
     "laguna": "dflash",
     "muse_glimmer_assistant": "dflash",
 }

--- a/mlx_vlm/speculative/drafters/mtp_split.py
+++ b/mlx_vlm/speculative/drafters/mtp_split.py
@@ -260,6 +260,8 @@ MTP_SPLITTERS: Dict[str, str] = {
     "qwen3_5": "mlx_vlm.speculative.drafters.qwen3_5_mtp.split:Qwen3_5MTPSplitter",
     "qwen3_5_moe": "mlx_vlm.speculative.drafters.qwen3_5_mtp.split:Qwen3_5MTPSplitter",
     "qwen3_next": "mlx_vlm.speculative.drafters.qwen3_5_mtp.split:Qwen3NextMTPSplitter",
+    "qwen4_exp": "mlx_vlm.speculative.drafters.qwen4_exp_mtp.split:Qwen4ExpMTPSplitter",
+    "qwen4_exp_text": "mlx_vlm.speculative.drafters.qwen4_exp_mtp.split:Qwen4ExpMTPSplitter",
     "deepseek_v4": "mlx_vlm.speculative.drafters.deepseek_v4_mtp.split:DeepseekV4MTPSplitter",
     "glm4_moe_lite": "mlx_vlm.speculative.drafters.glm4_moe_lite_mtp.split:Glm4MoeLiteMTPSplitter",
     "inkling_mm_model": "mlx_vlm.speculative.drafters.inkling_mtp.split:InklingMTPSplitter",

--- a/mlx_vlm/speculative/drafters/qwen4_exp_mtp/README.md
+++ b/mlx_vlm/speculative/drafters/qwen4_exp_mtp/README.md
@@ -1,0 +1,37 @@
+# Qwen4-Exp MTP
+
+This drafter runs the native multi-token prediction head embedded in Qwen4-Exp
+checkpoints. Extract it with the generic splitter, then pass the resulting
+folder as an MTP draft model:
+
+```bash
+python -m mlx_vlm.split_mtp \
+  --model Qwen/Qwen3.8-Flash-Next \
+  --output ./Qwen3.8-Flash-Next-MTP
+
+mlx_vlm.generate \
+  --model Qwen/Qwen3.8-Flash-Next \
+  --draft-model ./Qwen3.8-Flash-Next-MTP \
+  --draft-kind mtp \
+  --max-tokens 128 \
+  --prompt "Explain speculative decoding in one paragraph."
+```
+
+The native checkpoint contains one MTP layer, so the default draft block is
+one speculative token. A larger `--draft-block-size` chains the same head
+autoregressively; whether that is faster depends on prompt and hardware.
+
+## Optional quantization
+
+The head can be quantized independently when it is extracted:
+
+```bash
+python -m mlx_vlm.split_mtp \
+  --model Qwen/Qwen3.8-Flash-Next \
+  --output ./Qwen3.8-Flash-Next-MTP-3bit \
+  --q-bits 3 \
+  --q-group-size 32
+```
+
+A locally converted target model can be supplied to `--model` in the
+generation command as well.

--- a/mlx_vlm/speculative/drafters/qwen4_exp_mtp/__init__.py
+++ b/mlx_vlm/speculative/drafters/qwen4_exp_mtp/__init__.py
@@ -1,0 +1,6 @@
+from .config import Qwen4ExpMTPConfig as ModelConfig
+from .config import TextConfig
+from .qwen4_exp_mtp import Qwen4ExpMTPDraftModel
+from .qwen4_exp_mtp import Qwen4ExpMTPDraftModel as Model
+
+__all__ = ["Model", "ModelConfig", "Qwen4ExpMTPDraftModel", "TextConfig"]

--- a/mlx_vlm/speculative/drafters/qwen4_exp_mtp/config.py
+++ b/mlx_vlm/speculative/drafters/qwen4_exp_mtp/config.py
@@ -1,0 +1,31 @@
+import inspect
+from dataclasses import dataclass
+from typing import Optional
+
+from ....models.base import BaseModelConfig
+from ....models.qwen4_exp.config import TextConfig
+
+
+@dataclass
+class Qwen4ExpMTPConfig(BaseModelConfig):
+    model_type: str = "qwen4_exp_mtp"
+    text_config: Optional[TextConfig] = None
+    block_size: int = 2
+    tie_word_embeddings: bool = False
+
+    def __post_init__(self):
+        if isinstance(self.text_config, dict):
+            self.text_config = TextConfig.from_dict(self.text_config)
+        if self.text_config is not None:
+            self.tie_word_embeddings = bool(self.text_config.tie_word_embeddings)
+
+    @classmethod
+    def from_dict(cls, params: dict) -> "Qwen4ExpMTPConfig":
+        flat = dict(params)
+        text_config = flat.get("text_config") or {}
+        mtp_depth = int(text_config.get("mtp_num_hidden_layers", 1) or 1)
+        flat.setdefault("block_size", mtp_depth + 1)
+        sig = inspect.signature(cls).parameters
+        return cls(**{key: value for key, value in flat.items() if key in sig})
+
+    from_hf_dict = from_dict

--- a/mlx_vlm/speculative/drafters/qwen4_exp_mtp/qwen4_exp_mtp.py
+++ b/mlx_vlm/speculative/drafters/qwen4_exp_mtp/qwen4_exp_mtp.py
@@ -1,0 +1,181 @@
+from dataclasses import replace
+from typing import Dict, List, Optional, Tuple
+
+import mlx.core as mx
+import mlx.nn as nn
+
+from ....models.qwen3_5.language import _create_qwen3_5_attention_mask
+from ....models.qwen4_exp.language import (
+    QSAKVCache,
+    Qwen4ExpDecoderLayer,
+    Qwen4ExpGatedResidual,
+    Qwen4ExpRMSNorm,
+)
+from ..deepseek_v4_mtp.deepseek_v4_mtp import DeepseekV4MTPDraftModel
+from .config import Qwen4ExpMTPConfig
+
+
+class Qwen4ExpMTPDraftModel(DeepseekV4MTPDraftModel):
+    """Standalone runtime for Qwen4's native hyper-connection MTP head.
+
+    The draft lifecycle is shared with the DeepSeek-V4 hyper-connection head,
+    while input fusion and the decoder block follow Qwen4's released tensors.
+    """
+
+    supports_greedy_draft_argmax = True
+    prefer_requested_block_size = True
+    requires_uniform_batch_acceptance = True
+
+    def __init__(self, config: Qwen4ExpMTPConfig):
+        nn.Module.__init__(self)
+        self.config = config
+        text_config = config.text_config
+        if text_config is None:
+            raise ValueError("Qwen4ExpMTPConfig.text_config must be set")
+
+        self.args = text_config
+        hidden_size = text_config.hidden_size
+        hc_hidden_size = text_config.hc_count * hidden_size
+        self.pre_fc_norm_embedding = Qwen4ExpRMSNorm(
+            hidden_size, eps=text_config.rms_norm_eps
+        )
+        # The released head applies one global RMS normalization across all
+        # hyper-connection streams before projecting them independently.
+        self.pre_fc_norm_hidden = Qwen4ExpRMSNorm(
+            hc_hidden_size, eps=text_config.rms_norm_eps
+        )
+        self.fc_embedding = nn.Linear(hidden_size, hidden_size, bias=False)
+        self.fc_hidden = nn.Linear(hidden_size, hidden_size, bias=False)
+
+        layer_config = replace(
+            text_config,
+            num_hidden_layers=1,
+            layer_types=["qwen_sparse_attention"],
+            full_attention_interval=1,
+            ple_layer_ids=[],
+        )
+        self.layers = [Qwen4ExpDecoderLayer(layer_config, layer_idx=0)]
+        self.hyper_connection_mixer = Qwen4ExpGatedResidual(
+            layer_config, use_combine=False
+        )
+
+        self._input_embed = None
+        self._lm_head_fn = None
+        self._cache: List[QSAKVCache] = []
+        self._seed_token: Optional[mx.array] = None
+        self._seed_hidden: Optional[mx.array] = None
+        self._next_position = 0
+        self._round_appended = 0
+        self._kv_valid_len = 0
+        self._position = 0
+        self._draft_round = 0
+
+        self.accept_lens: List[int] = []
+        self.draft_lens: List[int] = []
+
+    @property
+    def quant_predicate(self):
+        def predicate(path, _):
+            return not path.endswith("mlp.gate")
+
+        return predicate
+
+    def validate_target_compatibility(self, target_model) -> None:
+        target = getattr(target_model, "language_model", target_model)
+        args = getattr(target, "args", None)
+        model_type = getattr(args, "model_type", "")
+        if not str(model_type).startswith("qwen4_exp"):
+            raise ValueError(
+                "Qwen4-Exp MTP requires a Qwen4-Exp target model, got "
+                f"model_type={model_type!r}."
+            )
+        if getattr(args, "hc_count", None) != self.args.hc_count:
+            raise ValueError("Qwen4-Exp target and MTP hc_count do not match.")
+
+    def make_cache(self) -> List[QSAKVCache]:
+        return [QSAKVCache() for _ in self.layers]
+
+    def _target_hidden(self, hidden: mx.array) -> mx.array:
+        expected = self.args.hc_count * self.args.hidden_size
+        if hidden.ndim == 4:
+            hidden = hidden.reshape(*hidden.shape[:-2], expected)
+        if hidden.ndim != 3 or hidden.shape[-1] != expected:
+            raise ValueError(
+                "Qwen4-Exp MTP expects target hidden shape "
+                "[batch, tokens, hc_count * hidden_size]."
+            )
+        return hidden
+
+    def fuse_inputs(
+        self,
+        token_embed: mx.array,
+        hidden: mx.array,
+    ) -> mx.array:
+        hidden = self._target_hidden(hidden)
+        projected_embedding = self.fc_embedding(self.pre_fc_norm_embedding(token_embed))
+        hidden_streams = self.pre_fc_norm_hidden(hidden).reshape(
+            *hidden.shape[:-1], self.args.hc_count, self.args.hidden_size
+        )
+        projected_hidden = self.fc_hidden(hidden_streams)
+        return (projected_embedding[..., None, :] + projected_hidden).reshape(
+            hidden.shape
+        )
+
+    def _forward_hidden(
+        self,
+        token_embed: mx.array,
+        hidden: mx.array,
+        tokens: mx.array,
+        cache: Optional[List[QSAKVCache]],
+    ) -> Tuple[mx.array, mx.array]:
+        hidden = self.fuse_inputs(token_embed, hidden)
+        if cache is None:
+            cache = [None] * len(self.layers)
+        position_ids = self._position_ids(length=tokens.shape[1])
+        mask = _create_qwen3_5_attention_mask(hidden, cache[0])
+        for layer, layer_cache in zip(self.layers, cache):
+            hidden = layer(
+                hidden,
+                tokens,
+                mask=mask,
+                cache=layer_cache,
+                position_ids=position_ids,
+            )
+        return self.hyper_connection_mixer(hidden), hidden
+
+    def filter_batch(self, keep) -> None:
+        if not isinstance(keep, mx.array):
+            keep = mx.array(keep, dtype=mx.int32)
+        for cache in self._cache:
+            cache.filter(keep)
+        if self._seed_token is not None:
+            self._seed_token = self._seed_token[keep]
+        if self._seed_hidden is not None:
+            self._seed_hidden = self._seed_hidden[keep]
+        for attr in ("_next_position", "_kv_valid_len", "_position"):
+            value = getattr(self, attr)
+            if isinstance(value, mx.array) and value.ndim > 0 and value.size > 1:
+                setattr(self, attr, value[keep])
+
+    def sanitize(self, weights: Dict[str, mx.array]) -> Dict[str, mx.array]:
+        weights = dict(weights)
+        stripped = {}
+        for key, value in weights.items():
+            for prefix in ("language_model.mtp.", "model.mtp.", "mtp."):
+                if key.startswith(prefix):
+                    key = key[len(prefix) :]
+                    break
+            stripped[key] = value
+
+        gate_up_key = "layers.0.mlp.experts.gate_up_proj"
+        down_key = "layers.0.mlp.experts.down_proj"
+        if gate_up_key in stripped:
+            gate_up = stripped.pop(gate_up_key)
+            gate, up = mx.split(gate_up, 2, axis=-2)
+            stripped["layers.0.mlp.switch_mlp.gate_proj.weight"] = gate
+            stripped["layers.0.mlp.switch_mlp.up_proj.weight"] = up
+        if down_key in stripped:
+            stripped["layers.0.mlp.switch_mlp.down_proj.weight"] = stripped.pop(
+                down_key
+            )
+        return stripped

--- a/mlx_vlm/speculative/drafters/qwen4_exp_mtp/split.py
+++ b/mlx_vlm/speculative/drafters/qwen4_exp_mtp/split.py
@@ -1,0 +1,33 @@
+from typing import Dict
+
+import mlx.core as mx
+
+from ..mtp_split import MTPSplitter
+from .qwen4_exp_mtp import Qwen4ExpMTPDraftModel
+
+
+class Qwen4ExpMTPSplitter(MTPSplitter):
+    output_model_type = "qwen4_exp_mtp"
+    draft_model_cls = Qwen4ExpMTPDraftModel
+    tie_word_embeddings_default = False
+    depth_field = "mtp_num_hidden_layers"
+    block_size_extra = 1
+
+    def select_keys(self, key: str, text_config: dict) -> bool:
+        del text_config
+        return key.startswith(("mtp.", "language_model.mtp.", "model.mtp."))
+
+    def should_quantize_key(self, key: str) -> bool:
+        return super().should_quantize_key(key) and not key.endswith(
+            "layers.0.mlp.gate.weight"
+        )
+
+    def rename(
+        self, tensors: Dict[str, mx.array], text_config: dict
+    ) -> Dict[str, mx.array]:
+        del text_config
+        return tensors
+
+
+def split_qwen4_exp_mtp(source: str, output: str, **kwargs):
+    return Qwen4ExpMTPSplitter().split(source, output, **kwargs)

--- a/mlx_vlm/tests/test_qwen4_mtp.py
+++ b/mlx_vlm/tests/test_qwen4_mtp.py
@@ -1,0 +1,249 @@
+import json
+from types import SimpleNamespace
+
+import mlx.core as mx
+import mlx.nn as nn
+import pytest
+
+from mlx_vlm.models.qwen4_exp.config import TextConfig
+from mlx_vlm.models.qwen4_exp.language import LanguageModel
+from mlx_vlm.speculative.drafters.mtp_split import detect_mtp_splitter, get_mtp_splitter
+from mlx_vlm.speculative.drafters.qwen4_exp_mtp import (
+    ModelConfig,
+    Qwen4ExpMTPDraftModel,
+)
+from mlx_vlm.speculative.drafters.qwen4_exp_mtp.split import split_qwen4_exp_mtp
+
+
+def _tiny_text_config():
+    return TextConfig.from_dict(
+        {
+            "model_type": "qwen4_exp_text",
+            "hidden_size": 32,
+            "num_hidden_layers": 2,
+            "num_attention_heads": 2,
+            "linear_num_value_heads": 2,
+            "linear_num_key_heads": 1,
+            "linear_key_head_dim": 16,
+            "linear_value_head_dim": 16,
+            "linear_conv_kernel_dim": 4,
+            "num_experts": 4,
+            "num_experts_per_tok": 2,
+            "shared_expert_intermediate_size": 16,
+            "moe_intermediate_size": 16,
+            "rms_norm_eps": 1e-6,
+            "vocab_size": 64,
+            "num_key_value_heads": 1,
+            "max_position_embeddings": 128,
+            "hc_count": 2,
+            "hc_lowrank": 8,
+            "head_dim": 16,
+            "layer_types": ["linear_attention", "full_attention"],
+            "ple_layer_ids": [],
+            "indexer_n_heads": 1,
+            "indexer_kv_heads": 1,
+            "indexer_head_dim": 16,
+            "indexer_budget": 8,
+            "indexer_compress_ratio": 4,
+            "rope_parameters": {
+                "rope_type": "default",
+                "mrope_section": [1, 1, 0],
+                "rope_theta": 10_000,
+                "partial_rotary_factor": 0.25,
+            },
+            "mtp_num_hidden_layers": 1,
+        }
+    )
+
+
+def _outer_config():
+    return SimpleNamespace(
+        vision_config=SimpleNamespace(spatial_merge_size=2),
+        image_token_id=60,
+        video_token_id=61,
+        vision_start_token_id=59,
+    )
+
+
+def test_qwen4_mtp_fusion_matches_released_equations():
+    config = _tiny_text_config()
+    drafter = Qwen4ExpMTPDraftModel(ModelConfig(text_config=config))
+    drafter.fc_embedding.weight = mx.eye(config.hidden_size)
+    drafter.fc_hidden.weight = mx.eye(config.hidden_size)
+    embedding_weight = mx.linspace(-0.8, -0.2, config.hidden_size)
+    hidden_weight = mx.linspace(-0.6, 0.3, config.hc_count * config.hidden_size)
+    drafter.pre_fc_norm_embedding.weight = embedding_weight
+    drafter.pre_fc_norm_hidden.weight = hidden_weight
+    embedding = mx.arange(1, 33, dtype=mx.float32).reshape(1, 1, 32)
+    hidden = mx.arange(1, 65, dtype=mx.float32).reshape(1, 1, 64)
+
+    actual = drafter.fuse_inputs(embedding, hidden)
+    expected_embedding = embedding * mx.rsqrt(
+        mx.mean(embedding * embedding, axis=-1, keepdims=True) + config.rms_norm_eps
+    )
+    expected_embedding = expected_embedding * (1 + embedding_weight)
+    expected_hidden = hidden * mx.rsqrt(
+        mx.mean(hidden * hidden, axis=-1, keepdims=True) + config.rms_norm_eps
+    )
+    expected_hidden = expected_hidden * (1 + hidden_weight)
+    expected_hidden = expected_hidden.reshape(1, 1, config.hc_count, 32)
+    expected = (expected_embedding[..., None, :] + expected_hidden).reshape(1, 1, 64)
+
+    assert mx.allclose(actual, expected, atol=2e-5).item()
+
+
+def test_qwen4_mtp_draft_block_uses_hyper_connection_hidden():
+    config = _tiny_text_config()
+    drafter = Qwen4ExpMTPDraftModel(ModelConfig(text_config=config))
+    target = SimpleNamespace(
+        language_model=SimpleNamespace(
+            args=config,
+            model=SimpleNamespace(embed_tokens=nn.Embedding(64, 32)),
+            lm_head=nn.Linear(32, 64, bias=False),
+        )
+    )
+    drafter.reset(target)
+    drafter.set_shared_kv({}, kv_offset=4, position=3, kv_valid_len=4)
+    tokens = drafter.draft_block(
+        7,
+        mx.zeros((1, 1, 64)),
+        None,
+        2,
+        lambda logits: mx.argmax(logits, axis=-1),
+        mx.int32,
+        greedy=True,
+    )
+    mx.eval(tokens)
+
+    assert tokens.shape == (1, 1)
+    assert drafter._cache[0].offset == 1
+
+
+@pytest.mark.parametrize("accepted", [0, 1])
+def test_qwen4_target_exposes_pre_mixer_hidden_and_replays_rejection_exactly(
+    accepted,
+):
+    config = _tiny_text_config()
+    language = LanguageModel(config, _outer_config())
+    prompt = mx.array([[1, 2, 3]], dtype=mx.int32)
+    verify = mx.array([[4, 5, 6]], dtype=mx.int32)
+
+    speculative_cache = language.make_cache()
+    prefill = language(prompt, cache=speculative_cache, return_hidden=True)
+    hidden, _, rollback = language.speculative_verify_hidden(verify, speculative_cache)
+    language.rollback_speculative_cache(
+        speculative_cache, rollback, accepted=accepted, block_size=3
+    )
+
+    reference_cache = language.make_cache()
+    language(prompt, cache=reference_cache)
+    for index in range(accepted + 1):
+        language(verify[:, index : index + 1], cache=reference_cache)
+    probe = mx.array([[7]], dtype=mx.int32)
+    speculative_logits = language(probe, cache=speculative_cache).logits
+    reference_logits = language(probe, cache=reference_cache).logits
+    mx.eval(prefill.hidden_states, hidden, speculative_logits, reference_logits)
+
+    assert prefill.hidden_states[-1].shape == (1, 3, 64)
+    assert hidden.shape == (1, 3, 64)
+    assert mx.array_equal(speculative_logits, reference_logits).item()
+
+
+def test_qwen4_speculative_verifier_matches_tokenwise_hidden_and_logits():
+    config = _tiny_text_config()
+    language = LanguageModel(config, _outer_config())
+    prompt = mx.array([[1, 2, 3]], dtype=mx.int32)
+    verify = mx.array([[4, 5, 6]], dtype=mx.int32)
+
+    batched_cache = language.make_cache()
+    language(prompt, cache=batched_cache)
+    batched_hidden, _, _, batched_logits = language.speculative_verify_logits(
+        verify, batched_cache, lambda logits: logits
+    )
+
+    tokenwise_cache = language.make_cache()
+    language(prompt, cache=tokenwise_cache)
+    tokenwise_hidden = []
+    tokenwise_logits = []
+    for index in range(verify.shape[1]):
+        output = language(
+            verify[:, index : index + 1],
+            cache=tokenwise_cache,
+            return_hidden=True,
+        )
+        tokenwise_hidden.append(output.hidden_states[-1])
+        tokenwise_logits.append(output.logits)
+    tokenwise_hidden = mx.concatenate(tokenwise_hidden, axis=1)
+    tokenwise_logits = mx.concatenate(tokenwise_logits, axis=1)
+    mx.eval(batched_hidden, batched_logits, tokenwise_hidden, tokenwise_logits)
+
+    assert mx.allclose(batched_hidden, tokenwise_hidden, rtol=0, atol=1e-6).item()
+    assert mx.allclose(batched_logits, tokenwise_logits, rtol=0, atol=1e-6).item()
+    assert mx.array_equal(
+        mx.argmax(batched_logits, axis=-1),
+        mx.argmax(tokenwise_logits, axis=-1),
+    ).item()
+
+
+def test_qwen4_fused_greedy_mixes_captured_hyper_state_before_lm_head(monkeypatch):
+    from mlx_vlm.models.qwen4_exp import language as qwen4_language
+
+    config = _tiny_text_config()
+    language = LanguageModel(config, _outer_config())
+    verifier = qwen4_language._QWEN4_EXACT_SPECULATIVE_VERIFIER
+    monkeypatch.setattr(verifier, "can_quantized_head", lambda linear: True)
+    monkeypatch.setattr(
+        verifier,
+        "quantized_argmax",
+        lambda linear, hidden, token_mask=None: mx.argmax(linear(hidden), axis=-1),
+    )
+    inputs = mx.array([[1, 2, 3]], dtype=mx.int32)
+    expected = mx.argmax(language(inputs, cache=language.make_cache()).logits, axis=-1)
+    language._position_ids = None
+    language._rope_deltas = None
+    actual = language.fused_greedy_decode(inputs, cache=language.make_cache())
+    mx.eval(expected, actual)
+
+    assert mx.array_equal(actual, expected).item()
+
+
+def test_qwen4_mtp_splitter_maps_fused_experts_and_quantizes(tmp_path):
+    source = tmp_path / "source"
+    output = tmp_path / "mtp"
+    source.mkdir()
+    text_config = _tiny_text_config().to_dict()
+    (source / "config.json").write_text(
+        json.dumps({"model_type": "qwen4_exp", "text_config": text_config})
+    )
+    mx.save_safetensors(
+        str(source / "model.safetensors"),
+        {
+            "mtp.pre_fc_norm_hidden.weight": mx.zeros((64,)),
+            "mtp.fc_hidden.weight": mx.ones((32, 32)),
+            "mtp.layers.0.mlp.experts.gate_up_proj": mx.ones((4, 32, 32)),
+            "mtp.layers.0.mlp.experts.down_proj": mx.ones((4, 32, 16)),
+            "mtp.layers.0.mlp.gate.weight": mx.ones((4, 32)),
+        },
+    )
+
+    splitter = detect_mtp_splitter(source)
+    assert splitter is not None
+    assert splitter.output_model_type == "qwen4_exp_mtp"
+    assert get_mtp_splitter("qwen4_exp").output_model_type == "qwen4_exp_mtp"
+
+    split_qwen4_exp_mtp(str(source), str(output), q_bits=3, q_group_size=32)
+    weights = mx.load(str(output / "model.safetensors"))
+    config = json.loads((output / "config.json").read_text())
+
+    assert "layers.0.mlp.switch_mlp.gate_proj.weight" in weights
+    assert "layers.0.mlp.switch_mlp.up_proj.weight" in weights
+    assert "layers.0.mlp.switch_mlp.down_proj.weight" in weights
+    assert "fc_hidden.scales" in weights
+    assert "layers.0.mlp.gate.scales" not in weights
+    assert config["model_type"] == "qwen4_exp_mtp"
+    assert config["block_size"] == 2
+    assert config["quantization"] == {
+        "group_size": 32,
+        "bits": 3,
+        "mode": "affine",
+    }


### PR DESCRIPTION
Nice speedup with `--draft-block-size 4` across two runs with 1024 tokens max. I used a 3-bit quant since that's what I can fit into memory on my M5 Max 128GB.

| Mode | Run 1 | Run 2 | Average | Gen. time | Peak memory |
|---|---:|---:|---:|---:|---:|
| MTP inactive | 27.682 tok/s | 27.747 tok/s | **27.715 tok/s** | 36.95s | 89.701 GB |
| MTP active | 43.286 tok/s | 42.353 tok/s | **42.820 tok/s** | 23.91s | 91.192 GB |

- 54.5% higher throughput
- 35.3% less generation time
- 1.49 GB additional peak memory
- 90.7% draft acceptance
- 3.72 accepted tokens per verification round