### PR TITLE
Drop unused DeepSeek-V4 rotating-cache value graphs

### DIFF
--- a/mlx_vlm/models/deepseek_v4/language.py
+++ b/mlx_vlm/models/deepseek_v4/language.py
@@ -56,6 +56,13 @@ def _score_func(scores: mx.array, func: str) -> mx.array:
     raise ValueError(f"Unsupported DeepSeek-V4 scoring function: {func}")
 
 
+def _update_key_only_cache(cache: Any, keys: mx.array) -> mx.array:
+    """Update a rotating key-only cache without retaining a values graph."""
+    cached_keys, _ = cache.update_and_fetch(keys, keys[..., :0])
+    cache.values = cache.keys[..., :0]
+    return cached_keys
+
+
 @mx.compile
 def _expert_select(
     logits: mx.array,
@@ -679,7 +686,7 @@ class LocalAttention(nn.Module):
         kv = self.kv_norm(self.wkv(x)).reshape(B, 1, L, self.head_dim)
         kv = self.rope(kv, offset)
         if cache is not None:
-            kv, _ = cache.update_and_fetch(kv, mx.zeros((B, 1, L, 0)))
+            kv = _update_key_only_cache(cache, kv)
         mask = _align_local_mask(mask, kv.shape[2])
 
         out = scaled_dot_product_attention(
@@ -776,7 +783,7 @@ class CompressedAttention(nn.Module):
         kv = self.kv_norm(self.wkv(x)).reshape(B, 1, L, self.head_dim)
         kv = self.rope(kv, offset)
         if local_cache is not None:
-            kv, _ = local_cache.update_and_fetch(kv, mx.zeros((B, 1, L, 0)))
+            kv = _update_key_only_cache(local_cache, kv)
         mask = _align_local_mask(mask, kv.shape[2])
 
         # Pool tokens into compressed KV and concatenate with local KV
@@ -885,7 +892,7 @@ class SparseCompressedAttention(nn.Module):
         kv = self.kv_norm(self.wkv(x)).reshape(B, 1, L, self.head_dim)
         kv = self.rope(kv, offset)
         if local_cache is not None:
-            kv, _ = local_cache.update_and_fetch(kv, mx.zeros((B, 1, L, 0)))
+            kv = _update_key_only_cache(local_cache, kv)
         mask = _align_local_mask(mask, kv.shape[2])
 
         pooled = self.compressor(x, comp_cache, offset)

--- a/mlx_vlm/tests/test_models.py
+++ b/mlx_vlm/tests/test_models.py
@@ -1,5 +1,6 @@
 import importlib
 import inspect
+import io
 import threading
 import unittest
 from types import SimpleNamespace
@@ -2499,6 +2500,7 @@ class TestModels(unittest.TestCase):
 
     def test_deepseek_v4_language_model(self):
         from mlx_vlm.models import deepseek_v4
+        from mlx_vlm.models.cache import CacheList
         from mlx_vlm.models.deepseek_v4.hyper_connection import (
             _hc_split_sinkhorn_ops,
             hc_expand,
@@ -2541,7 +2543,7 @@ class TestModels(unittest.TestCase):
             head_dim=16,
             qk_rope_head_dim=4,
             sliding_window=16,
-            compress_ratios=[0, 0, 4, 0],
+            compress_ratios=[0, 128, 4, 0],
             index_n_heads=4,
             index_head_dim=8,
             index_topk=4,
@@ -2559,6 +2561,15 @@ class TestModels(unittest.TestCase):
         self.assertEqual(loaded_config.eos_token_id, 1)
 
         model = deepseek_v4.Model(config)
+        self.assertEqual(
+            [type(layer.attn).__name__ for layer in model.language_model.layers],
+            [
+                "LocalAttention",
+                "CompressedAttention",
+                "SparseCompressedAttention",
+                "LocalAttention",
+            ],
+        )
 
         self.language_test_runner(
             model.language_model,
@@ -2574,6 +2585,19 @@ class TestModels(unittest.TestCase):
         cache = model.make_cache()
         self.assertEqual(type(cache[0]).__name__, "RotatingKVCache")
         self.assertEqual(type(cache[2]).__name__, "CacheList")
+        cached_out = model.language_model(inputs, cache=cache)
+        mx.eval(cached_out.logits)
+        for step in range(16):
+            cached_out = model.language_model(mx.array([[step % 7]]), cache=cache)
+            mx.eval(cached_out.logits)
+        for layer_cache in cache:
+            local_cache = (
+                layer_cache[0] if isinstance(layer_cache, CacheList) else layer_cache
+            )
+            self.assertEqual(local_cache.values.shape[-1], 0)
+            graph = io.StringIO()
+            mx.export_to_dot(graph, local_cache.values)
+            self.assertLessEqual(graph.getvalue().count("->"), 4)
 
         weight = mx.to_fp8(mx.ones((128, 128), dtype=mx.float32))
         converted = model.sanitize(
@@ -2588,6 +2612,41 @@ class TestModels(unittest.TestCase):
         self.assertIn(skey, converted)
         self.assertTrue(mx.all(converted[wkey] == weight.view(mx.uint32)))
         self.assertEqual(converted[skey].shape, (128, 4))
+
+    def test_deepseek_v4_key_only_cache_graph_stays_bounded(self):
+        from mlx_vlm.models.cache import BatchRotatingKVCache, RotatingKVCache
+        from mlx_vlm.models.deepseek_v4 import language
+
+        def graph_edges(array):
+            graph = io.StringIO()
+            mx.export_to_dot(graph, array)
+            return graph.getvalue().count("->")
+
+        def run(cache, batch_size, steps):
+            for step in range(steps):
+                keys = mx.full(
+                    (batch_size, 1, 1, 4),
+                    step % 7,
+                    dtype=mx.float32,
+                )
+                cached_keys = language._update_key_only_cache(cache, keys)
+                mx.eval(cached_keys)
+            self.assertEqual(cache.values.shape, (*cache.keys.shape[:-1], 0))
+            return graph_edges(cache.values)
+
+        cases = (
+            ("RotatingKVCache", lambda: RotatingKVCache(max_size=8), 1),
+            (
+                "BatchRotatingKVCache",
+                lambda: BatchRotatingKVCache(max_size=8, left_padding=[0, 1]),
+                2,
+            ),
+        )
+        for cache_name, make_cache, batch_size in cases:
+            with self.subTest(cache=cache_name):
+                short = run(make_cache(), batch_size, 16)
+                long = run(make_cache(), batch_size, 64)
+                self.assertLessEqual(long, short + 2)
 
     def test_deepseek_v4_quantization_path_aliases(self):
         from mlx_vlm.models import deepseek_v4


### PR DESCRIPTION
Fixes #2042

## Summary

DeepSeek-V4 local attention uses `RotatingKVCache` as a key-only cache. Each update previously supplied a newly created zero-width values array, but attention only consumed the cached keys. The cache therefore retained an unevaluated values update chain that grew once per layer and decode step, eventually exhausting Metal's resident-resource count during long generations.

This PR updates the key-only cache at the point where that unused graph is created. After each rotating-cache update, the values field is rebound to a zero-width view of the cached keys. This preserves the cache's expected key/value shape and state interface while discarding the preceding values chain. The cached keys returned to attention are unchanged.

The helper is used by `LocalAttention`, `CompressedAttention`, and `SparseCompressedAttention`, covering regular and batched rotating caches without adding a model-wide synchronization or changing shared cache behavior for other model families.

## Why this is model-specific

The shared rotating cache supports models that store distinct keys and values. DeepSeek-V4 is different: its local attention uses the same KV representation for both sides of attention and only needs to retain keys. Keeping the chain cut in the DeepSeek-V4 model makes that key-only ownership explicit without weakening the shared cache contract.

Speculative target verification calls the same DeepSeek-V4 attention implementations and is therefore covered by the same update helper. The separate MTP drafter already exposes its cache state to the speculative execution machinery for asynchronous evaluation.

## Tests

The regression coverage verifies that:

- repeated cached forwards keep the unused values graph bounded across local, compressed, and sparse-compressed attention;
- fresh per-step inputs do not make the retained values graph grow with total decode length;
- both `RotatingKVCache` and `BatchRotatingKVCache` are covered;

The full model and speculative decoding suites also verify cached forward behavior, target verification, MTP drafting, and rollback handling.

## Test plan

```text
python -m pytest mlx_vlm/tests/test_models.py -q
```

```text
369 passed, 2 warnings, 55 subtests passed
```

```text
python -m pytest mlx_vlm/tests/test_speculative.py -q
```

```text
190 passed, 2 warnings
```
