### PR TITLE
perf(qwen3.8): adapt MTP draft depth

### DIFF
--- a/mlx_vlm/models/qwen4_exp/language.py
+++ b/mlx_vlm/models/qwen4_exp/language.py
@@ -1181,7 +1181,8 @@ class Qwen4ExpPLELayer(nn.Module):
 class Qwen4ExpDecoderLayer(nn.Module):
     def __init__(self, config: TextConfig, layer_idx: int):
         super().__init__()
-        self.is_linear = config.layer_types[layer_idx] == "linear_attention"
+        self.layer_type = config.layer_types[layer_idx]
+        self.is_linear = self.layer_type == "linear_attention"
         if self.is_linear:
             self.linear_attn = Qwen4ExpGatedDeltaNet(config)
         else:

--- a/mlx_vlm/speculative/drafters/qwen4_exp_mtp/qwen4_exp_mtp.py
+++ b/mlx_vlm/speculative/drafters/qwen4_exp_mtp/qwen4_exp_mtp.py
@@ -23,7 +23,10 @@ class Qwen4ExpMTPDraftModel(DeepseekV4MTPDraftModel):
     """
 
     supports_greedy_draft_argmax = True
-    prefer_requested_block_size = True
+    # A caller-provided block size is an adaptive ceiling. Longer
+    # autoregressive tails are useful only after the native one-token prefix
+    # has demonstrated enough acceptance to amortize them.
+    prefer_requested_block_size = False
     requires_uniform_batch_acceptance = True
 
     def __init__(self, config: Qwen4ExpMTPConfig):

--- a/mlx_vlm/tests/test_qwen4_mtp.py
+++ b/mlx_vlm/tests/test_qwen4_mtp.py
@@ -6,7 +6,7 @@ import mlx.nn as nn
 import pytest
 
 from mlx_vlm.models.qwen4_exp.config import TextConfig
-from mlx_vlm.models.qwen4_exp.language import LanguageModel
+from mlx_vlm.models.qwen4_exp.language import LanguageModel, Qwen4ExpDecoderLayer
 from mlx_vlm.speculative.drafters.mtp_split import detect_mtp_splitter, get_mtp_splitter
 from mlx_vlm.speculative.drafters.qwen4_exp_mtp import (
     ModelConfig,
@@ -64,6 +64,13 @@ def _outer_config():
         video_token_id=61,
         vision_start_token_id=59,
     )
+
+
+def test_qwen4_decoder_layers_expose_normalized_layer_types_for_mtp():
+    config = _tiny_text_config()
+
+    assert Qwen4ExpDecoderLayer(config, 0).layer_type == "linear_attention"
+    assert Qwen4ExpDecoderLayer(config, 1).layer_type == "qwen_sparse_attention"
 
 
 def test_qwen4_mtp_fusion_matches_released_equations():

--- a/mlx_vlm/tests/test_qwen4_mtp.py
+++ b/mlx_vlm/tests/test_qwen4_mtp.py
@@ -13,6 +13,7 @@ from mlx_vlm.speculative.drafters.qwen4_exp_mtp import (
     Qwen4ExpMTPDraftModel,
 )
 from mlx_vlm.speculative.drafters.qwen4_exp_mtp.split import split_qwen4_exp_mtp
+from mlx_vlm.speculative.mtp import _mtp_next_block_size
 
 
 def _tiny_text_config():
@@ -90,6 +91,18 @@ def test_qwen4_mtp_fusion_matches_released_equations():
     expected = (expected_embedding[..., None, :] + expected_hidden).reshape(1, 1, 64)
 
     assert mx.allclose(actual, expected, atol=2e-5).item()
+
+
+def test_qwen4_mtp_uses_requested_block_size_as_adaptive_ceiling():
+    drafter = Qwen4ExpMTPDraftModel(ModelConfig(text_config=_tiny_text_config()))
+
+    assert _mtp_next_block_size(drafter, 4, 2, 32) == 2
+
+    drafter.accept_lens.extend([1] * 8)
+    assert _mtp_next_block_size(drafter, 4, 2, 32) == 4
+
+    drafter.accept_lens.extend([0] * 16)
+    assert _mtp_next_block_size(drafter, 4, 2, 32) == 2
 
 
 def test_qwen4_mtp_draft_block_uses_hyper_connection_hidden():


### PR DESCRIPTION
Treat the requested Qwen3.8 MTP block size as an adaptive ceiling. Start at the native two-token verification block, expand only after sustained prefix acceptance, and back off when acceptance falls.

Also expose each Qwen4 decoder layer type. The MTP drafter needs this metadata to build the correct cache; without it, drafting fails before the first verification step.

Matched Q4 target/drafter A/B, same prompts, seeds, vendor sampling, 256-token outputs, block size 4:
- thinking: 37.2% → 55.1% acceptance; 13.53 → 18.87 tok/s
- instruct: 49.0% → 60.8% acceptance; 16.24 → 20.50 tok/s

Checks:
- 31 focused Qwen4 and Qwen4 MTP tests after the metadata fix
- 199 speculative and Qwen3.8 MTP tests for the adaptive policy
- no behavior change unless the caller requests more than the native depth