### PR TITLE
fix(apc): exact-mode restore for integer state tensors and unmergeable cache subclasses

### DIFF
--- a/mlx_vlm/apc.py
+++ b/mlx_vlm/apc.py
@@ -695,6 +695,14 @@ def _safetensors_dtype_info(dtype: str):
     mapping = {
         "F16": (np.dtype("<f2"), mx.float16, None),
         "F32": (np.dtype("<f4"), mx.float32, None),
+        "I64": (np.dtype("<i8"), mx.int64, None),
+        "I32": (np.dtype("<i4"), mx.int32, None),
+        "I16": (np.dtype("<i2"), mx.int16, None),
+        "I8": (np.dtype("i1"), mx.int8, None),
+        "U8": (np.dtype("u1"), mx.uint8, None),
+        "U32": (np.dtype("<u4"), mx.uint32, None),
+        "U64": (np.dtype("<u8"), mx.uint64, None),
+        "BOOL": (np.dtype("?"), mx.bool_, None),
     }
     return mapping.get(dtype)
 
@@ -3954,6 +3962,22 @@ def make_warm_batch_exact_cache_multi(
             prefix_lens,
         )
         if merged is None:
+            # Single-row fallback: a model-specific cache subclass (e.g.
+            # qwen4_exp's QSAKVCache with indexer state) has no batch merge
+            # adapter. With one row there is nothing to merge — the snapshot
+            # caches are exactly what a cold b=1 prefill would use (and what
+            # speculative/MTP decoding already runs against), so serve them
+            # directly instead of silently dropping the warm hit. Restricted
+            # to float KV (no quant policy) since exact snapshots are stored
+            # in float and could not join a quantized live batch.
+            if len(row_caches) == 1 and kv_quant_config is None:
+                single = list(row_caches[0])
+                eval_targets: List[mx.array] = []
+                for c in single:
+                    _collect_mx_arrays(c.state, eval_targets)
+                if eval_targets:
+                    mx.eval(eval_targets)
+                return single, int(prefix_lens[0])
             return None, 0
         out.append(merged)
 

--- a/mlx_vlm/tests/test_apc.py
+++ b/mlx_vlm/tests/test_apc.py
@@ -1242,3 +1242,102 @@ def test_positive_desired_prefix_is_unchanged():
     tokens = list(range(1, 100))
 
     assert apc_module.adjust_prefix_to_text_suffix_boundary(tokens, 40, []) == 40
+
+
+def test_exact_cache_disk_restore_preserves_integer_states(tmp_path, monkeypatch):
+    """Exact snapshots with integer state tensors must roundtrip via disk.
+
+    Hybrid models keep non-KV per-layer state in ``ArraysCache`` slots; for
+    qwen4_exp (Qwen3.8-Flash-Next) one DeltaNet slot is an int64 tensor. The
+    bespoke safetensors reader previously only mapped BF16/F16/F32, so
+    ``_read_safetensors_tensor`` returned None for the int64 slot and the
+    whole exact snapshot silently failed to load (lookup hit, restore no-op,
+    full re-prefill on every request).
+    """
+    from mlx_vlm.models.cache import ArraysCache, KVCache
+
+    monkeypatch.setenv("APC_EXACT_CACHE_ENTRIES", "0")
+
+    token_ids = list(range(40))
+    kv = KVCache()
+    kv.keys = mx.ones((1, 1, len(token_ids), 2))
+    kv.values = mx.ones((1, 1, len(token_ids), 2)) * 2
+    kv.offset = len(token_ids)
+    arrays = ArraysCache(size=4)
+    arrays[0] = mx.ones((1, 3, 4), dtype=mx.bfloat16)
+    arrays[1] = mx.ones((1, 2, 3)) * 3
+    arrays[2] = mx.array([[len(token_ids), 0]], dtype=mx.int64)
+    arrays[3] = mx.array([[7]], dtype=mx.int32)
+
+    disk = DiskBlockStore(tmp_path, namespace="exact-int")
+    manager = APCManager(num_blocks=1, block_size=16, disk=disk)
+    assert manager.store_exact_cache(token_ids, [arrays, kv], extra_hash=23)
+    disk._q.join()
+    manager.close()
+
+    disk = DiskBlockStore(tmp_path, namespace="exact-int")
+    manager = APCManager(num_blocks=1, block_size=16, disk=disk)
+    warm, matched_tokens = manager.lookup_exact_cache(
+        token_ids + [999],
+        extra_hash=23,
+    )
+
+    assert matched_tokens == len(token_ids)
+    assert warm is not None
+    assert warm[0][2].dtype == mx.int64
+    assert warm[0][3].dtype == mx.int32
+    assert mx.array_equal(warm[0][2], arrays[2])
+    assert mx.array_equal(warm[0][3], arrays[3])
+    _assert_allclose(warm[0][1], arrays[1])
+    manager.close()
+
+
+def test_make_warm_batch_exact_cache_multi_single_row_preserves_subclass():
+    """A single-row exact restore must serve model-specific cache subclasses.
+
+    ``merge_cache_entries`` matches plain ``KVCache`` by exact type and has
+    no adapter for model-specific subclasses (e.g. qwen4_exp's QSAKVCache,
+    which carries indexer state), so batch-merging a single row silently
+    returned None and the warm hit was dropped. With one row there is
+    nothing to merge: the snapshot caches are exactly what a cold b=1
+    prefill uses, so they can be served directly.
+    """
+    from mlx_vlm.models.cache import KVCache
+
+    class _AuxKVCache(KVCache):
+        """Minimal stand-in for QSAKVCache-style subclasses."""
+
+        def __init__(self):
+            super().__init__()
+            self.aux = None
+
+        @property
+        def state(self):
+            return self.keys, self.values, self.aux
+
+        @state.setter
+        def state(self, value):
+            self.keys, self.values, self.aux = value
+            self.offset = 0 if self.keys is None else self.keys.shape[2]
+
+    n = 24
+    kv = KVCache()
+    kv.keys = mx.ones((1, 1, n, 2))
+    kv.values = mx.ones((1, 1, n, 2)) * 2
+    kv.offset = n
+    aux = _AuxKVCache()
+    aux.keys = mx.ones((1, 1, n, 2)) * 3
+    aux.values = mx.ones((1, 1, n, 2)) * 4
+    aux.offset = n
+    aux.aux = mx.arange(n)[None, :]
+
+    warm, served = make_warm_batch_exact_cache_multi([[kv, aux]], [n])
+
+    assert warm is not None
+    assert served == n
+    assert type(warm[0]) is KVCache
+    assert type(warm[1]) is _AuxKVCache
+    assert warm[1].offset == n
+    assert warm[1].aux is not None
+    assert mx.array_equal(warm[1].aux, aux.aux)
+    _assert_allclose(warm[0].keys, kv.keys)


### PR DESCRIPTION
Fixes #2048

Two independent bugs made exact-mode APC a silent no-op for hybrid models whose caches carry integer state tensors or model-specific `KVCache` subclasses (e.g. `qwen4_exp` / Qwen3.8-Flash-Next): lookups hit and `exact_hits`/`matched_tokens` climbed, but every request re-prefilled from scratch. Same failure class as #1443/#1463, but in the exact/checkpoint path.

## Change 1: integer/bool dtypes in `_safetensors_dtype_info`

`qwen4_exp`'s DeltaNet `ArraysCache` state includes an int64 tensor. The bespoke snapshot reader only mapped `BF16/F16/F32`, so `_read_safetensors_tensor` returned `None` for that slot and `_load_exact_cache_file` dropped the entire snapshot — every exact **disk** restore failed silently. The write side already serialized these tensors correctly; only the reader was missing the dtypes (`I64/I32/I16/I8/U8/U32/U64/BOOL`).

## Change 2: single-row fallback in `make_warm_batch_exact_cache_multi`

`merge_cache_entries` matches plain `KVCache` by exact `type()` and has no adapter for subclasses like `QSAKVCache` (which carries QSA indexer state), so batch-merging returned `None` and the warm hit was dropped — every exact **in-memory** restore failed silently for these models.

With exactly one row there is nothing to merge: the snapshot caches are precisely the classes a cold b=1 prefill would use (and what speculative/MTP decoding already runs against), so on merge failure the single row is now served directly. Constraints preserved:

- Mergeable types keep the existing batch-shaped path unchanged, so warm rows can still join live batches (`TestExactHybridColdStaggeredJoin` still passes).
- Restricted to `kv_quant_config is None`: float snapshots never join a quantized live batch.
- Multi-row merges of unmergeable subclasses still return `None` (cold), as before.

## Tests

- `test_exact_cache_disk_restore_preserves_integer_states` — int64/int32 `ArraysCache` slots roundtrip through the disk exact tier (fails on `main`: restore returns `None`).
- `test_make_warm_batch_exact_cache_multi_single_row_preserves_subclass` — a `KVCache` subclass with auxiliary state survives single-row warm materialization with type, offset, and aux state intact (fails on `main`: returns `None`).

All existing APC suites pass: `test_apc.py`, `test_apc_adapters.py`, `test_apc_exact_mode.py`, `test_apc_component_adapters.py`, `test_apc_observability.py`, `test_apc_quantized.py`, `test_apc_semantic_key.py` — 205 passed, 1 skipped.

## Measured result

Qwen3.8-Flash-Next-oQ6 (`qwen4_exp`), Apple Silicon 256 GB, b=1, **MTP draft enabled**, live server:

| request | prompt tokens | cached | wall clock |
|---|---:|---:|---:|
| cold | 9740 | 0 | 16.2 s |
| warm (same prefix + tail) | 9763 | 9740 | **0.32 s** |

Exact-mode APC and MTP speculative decoding now compose: ~50× faster warm TTFT while keeping MTP's decode speedup. On agent-style workloads with 32–38k-token growing contexts this removes a 50–65 s re-prefill from every turn.
