### PR TITLE
fix(server): transcribe m4a and other non-encodable audio uploads

### DIFF
--- a/mlx_vlm/server/audio.py
+++ b/mlx_vlm/server/audio.py
@@ -527,11 +527,13 @@ def _run_stt_request(request: AudioInferenceRequest) -> None:
     transcription_request = payload.request
     model, _, _ = get_cached_model(transcription_request.model, model_kind="audio_stt")
 
-    suffix = os.path.splitext(payload.filename or "")[1] or ".wav"
     tmp_path = None
     emitted = False
     try:
-        with tempfile.NamedTemporaryFile(delete=False, suffix=suffix) as tmp:
+        # The audio is already decoded PCM and this file only gives the model a
+        # path to open, so always write WAV. Re-encoding the upload's own
+        # container is lossy at best and impossible for m4a/mp4/aac.
+        with tempfile.NamedTemporaryFile(delete=False, suffix=".wav") as tmp:
             tmp_path = tmp.name
         audio_write(tmp_path, payload.audio, payload.sample_rate)
 

--- a/mlx_vlm/tests/test_server_audio.py
+++ b/mlx_vlm/tests/test_server_audio.py
@@ -366,3 +366,46 @@ def _drain(handle, timeout=2.0):
         elif chunk.kind == "done":
             return chunks
     raise TimeoutError("timed out waiting for audio queue results")
+
+
+def test_audio_transcriptions_accepts_m4a_upload(client, monkeypatch):
+    fake_model = FakeSTTModel({"text": "Transcribed from m4a."})
+    monkeypatch.setattr(
+        server,
+        "get_cached_model",
+        lambda model, **kwargs: (fake_model, None, SimpleNamespace(model_type="audio")),
+    )
+    monkeypatch.setattr(
+        server_audio,
+        "audio_read",
+        lambda buffer, always_2d=False: (np.zeros(160, dtype=np.float32), 16000),
+    )
+    # Intentionally exercises the real writer: the bug was that the temp file
+    # inherited the upload's extension and m4a is not an encodable format.
+
+    response = client.post(
+        "/v1/audio/transcriptions",
+        files={"file": ("meeting.m4a", b"audio-bytes", "audio/mp4")},
+        data={"model": "fake-stt"},
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {"text": "Transcribed from m4a."}
+    assert fake_model.calls[0]["path"].endswith(".wav")
+
+
+def test_audio_transcriptions_undecodable_upload_returns_400(client, monkeypatch):
+    monkeypatch.setattr(
+        server,
+        "get_cached_model",
+        lambda model, **kwargs: pytest.fail("model must not load for a bad upload"),
+    )
+
+    response = client.post(
+        "/v1/audio/transcriptions",
+        files={"file": ("broken.m4a", b"not-audio", "audio/mp4")},
+        data={"model": "fake-stt"},
+    )
+
+    assert response.status_code == 400
+    assert "Invalid audio file" in response.json()["detail"]


### PR DESCRIPTION
Fixes Blaizzy/nativ#404.


Prevents re-encoding the temp file, which made  m4a, mp4 and aac readable but not writable, so those uploads fail with `Unsupported output format: m4a`.

- mp3 uploads no longer take a second lossy pass through ffmpeg at 128 kbps before transcription.
- Bad uploads no longer surface as a 500. The failure used to happen in the worker thread, which maps anything that is not an `HTTPException` to 500; undecodable input now returns the 400 the parser already raises.

### Before / after



| upload | before | after |
|---|---|---|
| `.m4a` | 500 `Unsupported output format: m4a` | 200 |
| `.mp4` | 500 `Unsupported output format: mp4` | 200 |
| `.mp3` | 200, re-encoded via ffmpeg | 200, no re-encode |

### Tests

An m4a upload through the real writer, and a 400 on a corrupt upload. The first fails on `main` with the exact error from the issue.

```
mlx_vlm/tests/test_server_audio.py ............ 12 passed
```

### Related

Blaizzy/mlx-audio#915 