### PR TITLE
Anthropic route: keep in-conversation system messages in place (fixes prefix-cache defeat)

### DIFF
--- a/mlx_vlm/server/anthropic.py
+++ b/mlx_vlm/server/anthropic.py
@@ -116,13 +116,18 @@ def _normalize_anthropic_system_messages(body: Any) -> Any:
     normalized_messages = []
     system_parts = []
     saw_system_message = False
+    saw_conversation = False
     for message in messages:
         if isinstance(message, dict) and message.get("role") == "system":
             saw_system_message = True
-            text = _anthropic_system_text(message.get("content"))
-            if text:
-                system_parts.append(text)
-            continue
+            if not saw_conversation:
+                text = _anthropic_system_text(message.get("content"))
+                if text:
+                    system_parts.append(text)
+                continue
+            message = {**message, "role": "user"}
+        else:
+            saw_conversation = True
         normalized_messages.append(message)
 
     if not saw_system_message:

--- a/mlx_vlm/tests/test_server.py
+++ b/mlx_vlm/tests/test_server.py
@@ -4149,8 +4149,9 @@ def test_anthropic_messages_endpoint_accepts_system_role_in_messages(
 
     assert response.status_code == 200
     assert mock_template.call_args.args[2] == [
-        {"role": "system", "content": "Use short answers.\nBe precise."},
+        {"role": "system", "content": "Use short answers."},
         {"role": "user", "content": "Hello"},
+        {"role": "user", "content": "Be precise."},
         {"role": "user", "content": "Introduce the project."},
     ]
 


### PR DESCRIPTION
The Anthropic route hoisted every system-role message to the prompt head, including mid-conversation ones. Agent clients send an in-conversation system message that varies each turn, defeating prefix caching entirely. Now only leading system messages hoist; in-conversation ones stay in position, keeping the prefix cacheable. Verified: reusable prefix jumps 10% to 99% across turns, and the anthropic tests pass.

Fixes #2001.