### PR TITLE
Fix nemotron_h prefill crash when inputs and inputs_embeds are both passed

### DIFF
--- a/mlx_vlm/models/nemotron_h/language.py
+++ b/mlx_vlm/models/nemotron_h/language.py
@@ -442,8 +442,8 @@ class NemotronHModel(nn.Module):
         cache: Optional[Any] = None,
         inputs_embeds: Optional[mx.array] = None,
     ):
-        if (inputs is None) == (inputs_embeds is None):
-            raise ValueError("Provide exactly one of inputs or inputs_embeds")
+        if inputs is None and inputs_embeds is None:
+            raise ValueError("Provide either inputs or inputs_embeds")
         if inputs_embeds is not None:
             hidden_states = inputs_embeds
         elif self.with_embeddings:


### PR DESCRIPTION
Nemotron-H's backbone raised when it received both `inputs` and `inputs_embeds`, but prefill always passes both. This crashed every generation with `ValueError: Provide exactly one of inputs or inputs_embeds` during prompt processing. The fix prefers `inputs_embeds` when present, matching every other model in the repository.

cc @lucasnewman