### PR TITLE
Add APC disk caching for Qwen3.8-Flash-Next

### DIFF
--- a/mlx_vlm/apc.py
+++ b/mlx_vlm/apc.py
@@ -695,6 +695,15 @@ def _safetensors_dtype_info(dtype: str):
     mapping = {
         "F16": (np.dtype("<f2"), mx.float16, None),
         "F32": (np.dtype("<f4"), mx.float32, None),
+        "I64": (np.dtype("<i8"), mx.int64, None),
+        "I32": (np.dtype("<i4"), mx.int32, None),
+        "I16": (np.dtype("<i2"), mx.int16, None),
+        "I8": (np.dtype("i1"), mx.int8, None),
+        "U64": (np.dtype("<u8"), mx.uint64, None),
+        "U32": (np.dtype("<u4"), mx.uint32, None),
+        "U16": (np.dtype("<u2"), mx.uint16, None),
+        "U8": (np.dtype("u1"), mx.uint8, None),
+        "BOOL": (np.dtype("?"), mx.bool_, None),
     }
     return mapping.get(dtype)
 
@@ -1413,6 +1422,86 @@ class DiskBlockStore:
         from .models import cache as lm_cache
 
         kind = metadata.get(f"{prefix}_kind")
+        if kind == "qwen4_exp_qsa_v1":
+            from .models.qwen4_exp.language import QSAKVCache
+
+            try:
+                off = int(metadata.get(f"{prefix}_offset", "0"))
+                step = int(metadata.get(f"{prefix}_step", "256"))
+            except (TypeError, ValueError):
+                return None
+            if off < 0:
+                return None
+
+            c = QSAKVCache()
+            if metadata.get(f"{prefix}_empty", "0") != "1":
+                k_entry = tensor_entries.get(f"{prefix}_k")
+                v_entry = tensor_entries.get(f"{prefix}_v")
+                if k_entry is None or v_entry is None:
+                    return None
+                k = _read_safetensors_tensor(path, data_start, k_entry)
+                v = _read_safetensors_tensor(path, data_start, v_entry)
+                if (
+                    k is None
+                    or v is None
+                    or k.ndim != 4
+                    or v.ndim != 4
+                    or k.shape[:3] != v.shape[:3]
+                    or off != k.shape[2]
+                ):
+                    return None
+                k, v = _pad_kv_for_capacity(
+                    k,
+                    v,
+                    offset=off,
+                    min_capacity_tokens=min_capacity_tokens,
+                    step=step,
+                )
+                c.keys = k
+                c.values = v
+                eval_targets.extend([k, v])
+            elif off != 0:
+                return None
+
+            index_empty = metadata.get(f"{prefix}_index_empty", "0") == "1"
+            if index_empty and off > 0:
+                return None
+            if not index_empty:
+                index_keys_entry = tensor_entries.get(f"{prefix}_index_keys")
+                position_ids_entry = tensor_entries.get(f"{prefix}_index_position_ids")
+                if index_keys_entry is None or position_ids_entry is None:
+                    return None
+                index_keys = _read_safetensors_tensor(
+                    path, data_start, index_keys_entry
+                )
+                position_ids = _read_safetensors_tensor(
+                    path, data_start, position_ids_entry
+                )
+                if (
+                    index_keys is None
+                    or position_ids is None
+                    or index_keys.ndim != 3
+                    or position_ids.ndim not in (2, 3)
+                    or index_keys.shape[1] != off
+                    or position_ids.shape[-1] != off
+                    or (c.keys is not None and index_keys.shape[0] != c.keys.shape[0])
+                    or (
+                        position_ids.ndim == 2
+                        and position_ids.shape[0] != index_keys.shape[0]
+                    )
+                    or (
+                        position_ids.ndim == 3
+                        and position_ids.shape[1] != index_keys.shape[0]
+                    )
+                ):
+                    return None
+                c.index_keys = index_keys
+                c.index_position_ids = position_ids
+                eval_targets.extend([index_keys, position_ids])
+
+            c.offset = off
+            return c
+
         if kind == "kv":
             if metadata.get(f"{prefix}_empty", "0") == "1":
                 c = lm_cache.KVCache()
@@ -2570,7 +2659,57 @@ class DiskBlockStore:
     ) -> bool:
         from .models import cache as lm_cache
 
-        if isinstance(c, lm_cache.KVCache):
+        if type(c).__dict__.get("exact_cache_disk_kind") == "qwen4_exp_qsa_v1":
+            off = int(getattr(c, "offset", 0) or 0)
+            if off < 0:
+                return False
+            if (c.keys is None) != (c.values is None):
+                return False
+            if (c.index_keys is None) != (c.index_position_ids is None):
+                return False
+            if off > 0 and (c.keys is None or c.index_keys is None):
+                return False
+            if c.keys is not None and (
+                c.keys.ndim != 4
+                or c.values.ndim != 4
+                or c.keys.shape[:3] != c.values.shape[:3]
+                or off > c.keys.shape[2]
+            ):
+                return False
+            if c.index_keys is not None and (
+                c.index_keys.ndim != 3
+                or c.index_position_ids.ndim not in (2, 3)
+                or off > c.index_keys.shape[1]
+                or off > c.index_position_ids.shape[-1]
+                or (c.keys is not None and c.index_keys.shape[0] != c.keys.shape[0])
+                or (
+                    c.index_position_ids.ndim == 2
+                    and c.index_position_ids.shape[0] != c.index_keys.shape[0]
+                )
+                or (
+                    c.index_position_ids.ndim == 3
+                    and c.index_position_ids.shape[1] != c.index_keys.shape[0]
+                )
+            ):
+                return False
+            metadata[f"{prefix}_kind"] = "qwen4_exp_qsa_v1"
+            metadata[f"{prefix}_offset"] = str(off)
+            metadata[f"{prefix}_step"] = str(
+                int(getattr(c, "step", getattr(type(c), "step", 256)) or 0)
+            )
+            if c.keys is None or c.values is None or off <= 0:
+                metadata[f"{prefix}_empty"] = "1"
+            else:
+                arrays[f"{prefix}_k"] = c.keys[..., :off, :]
+                arrays[f"{prefix}_v"] = c.values[..., :off, :]
+            if c.index_keys is None or c.index_position_ids is None:
+                metadata[f"{prefix}_index_empty"] = "1"
+            else:
+                arrays[f"{prefix}_index_keys"] = c.index_keys[:, :off]
+                arrays[f"{prefix}_index_position_ids"] = c.index_position_ids[..., :off]
+            return True
+
+        if type(c) is lm_cache.KVCache:
             off = int(getattr(c, "offset", 0) or 0)
             metadata[f"{prefix}_kind"] = "kv"
             metadata[f"{prefix}_offset"] = str(off)

--- a/mlx_vlm/models/qwen4_exp/language.py
+++ b/mlx_vlm/models/qwen4_exp/language.py
@@ -49,6 +49,8 @@ def _append_indexer_positions(
 class QSAKVCache(KVCache):
     """KV cache with the raw indexer keys and multimodal positions used by QSA."""
 
+    exact_cache_disk_kind = "qwen4_exp_qsa_v1"
+
     # Hybrid/TurboQuant caches do not currently expose a way to carry the
     # indexer's unprojected keys. Uniform quantization uses the specialized
     # QSAQuantizedKVCache below; other schemes leave this cache in float.

--- a/mlx_vlm/tests/test_apc.py
+++ b/mlx_vlm/tests/test_apc.py
@@ -675,6 +675,113 @@ def test_exact_cache_disk_restore_rebuilds_index(tmp_path, monkeypatch):
     manager.close()
 
 
+def test_exact_cache_disk_restore_preserves_safetensors_dtypes(tmp_path, monkeypatch):
+    from mlx_vlm.models.cache import ArraysCache
+
+    monkeypatch.setenv("APC_EXACT_CACHE_ENTRIES", "0")
+
+    states = [
+        mx.array([[-4, 7]], dtype=mx.int64),
+        mx.array([[-4, 7]], dtype=mx.int32),
+        mx.array([[-4, 7]], dtype=mx.int16),
+        mx.array([[-4, 7]], dtype=mx.int8),
+        mx.array([[4, 7]], dtype=mx.uint64),
+        mx.array([[4, 7]], dtype=mx.uint32),
+        mx.array([[4, 7]], dtype=mx.uint16),
+        mx.array([[4, 7]], dtype=mx.uint8),
+        mx.array([[True, False]], dtype=mx.bool_),
+    ]
+    arrays = ArraysCache(size=len(states))
+    arrays.cache = states
+    token_ids = list(range(40))
+
+    disk = DiskBlockStore(tmp_path, namespace="exact-dtypes")
+    manager = APCManager(num_blocks=1, block_size=16, disk=disk)
+    assert manager.store_exact_cache(token_ids, [arrays])
+    disk._q.join()
+    manager.close()
+
+    disk = DiskBlockStore(tmp_path, namespace="exact-dtypes")
+    manager = APCManager(num_blocks=1, block_size=16, disk=disk)
+    warm, matched_tokens = manager.lookup_exact_cache(token_ids + [999])
+
+    assert matched_tokens == len(token_ids)
+    assert warm is not None
+    assert manager.stats_snapshot()["disk_hits"] == 1
+    for expected, restored in zip(states, warm[0].cache):
+        assert restored is not None
+        assert restored.dtype == expected.dtype
+        assert bool(mx.array_equal(restored, expected).item())
+    manager.close()
+
+
+def test_exact_cache_disk_restore_preserves_qsa_state(tmp_path, monkeypatch):
+    from mlx_vlm.models.cache import ArraysCache
+    from mlx_vlm.models.qwen4_exp.language import BatchQSAKVCache, QSAKVCache
+
+    monkeypatch.setenv("APC_EXACT_CACHE_ENTRIES", "0")
+
+    token_ids = list(range(40))
+    arrays = ArraysCache(size=1)
+    arrays[0] = mx.arange(6, dtype=mx.int64).reshape(1, 2, 3)
+    qsa = QSAKVCache()
+    qsa.keys = mx.arange(1 * 2 * len(token_ids) * 4, dtype=mx.float32).reshape(
+        1, 2, len(token_ids), 4
+    )
+    qsa.values = qsa.keys + 1000
+    qsa.offset = len(token_ids)
+    qsa.index_keys = mx.arange(1 * len(token_ids) * 6, dtype=mx.float32).reshape(
+        1, len(token_ids), 6
+    )
+    qsa.index_position_ids = mx.arange(3 * len(token_ids), dtype=mx.int64).reshape(
+        3, 1, len(token_ids)
+    )
+    mx.eval(
+        arrays[0],
+        qsa.keys,
+        qsa.values,
+        qsa.index_keys,
+        qsa.index_position_ids,
+    )
+
+    disk = DiskBlockStore(tmp_path, namespace="qsa-exact")
+    manager = APCManager(num_blocks=1, block_size=16, disk=disk)
+    assert manager.store_exact_cache(token_ids, [arrays, qsa], extra_hash=19)
+    disk._q.join()
+    manager.close()
+
+    disk = DiskBlockStore(tmp_path, namespace="qsa-exact")
+    manager = APCManager(num_blocks=1, block_size=16, disk=disk)
+    warm, matched_tokens = manager.lookup_exact_cache(token_ids + [999], extra_hash=19)
+
+    assert matched_tokens == len(token_ids)
+    assert warm is not None
+    assert manager.stats_snapshot()["disk_hits"] == 1
+    assert isinstance(warm[1], QSAKVCache)
+    assert warm[1].offset == len(token_ids)
+    assert warm[1].keys.shape[2] >= len(token_ids) + 1
+    _assert_allclose(warm[1].keys[..., : len(token_ids), :], qsa.keys)
+    _assert_allclose(warm[1].values[..., : len(token_ids), :], qsa.values)
+    _assert_allclose(warm[1].index_keys, qsa.index_keys)
+    assert warm[1].index_position_ids.dtype == mx.int64
+    assert bool(
+        mx.array_equal(warm[1].index_position_ids, qsa.index_position_ids).item()
+    )
+
+    batch_cache, max_prefix = make_warm_batch_exact_cache_multi(
+        [warm], [len(token_ids)]
+    )
+    assert max_prefix == len(token_ids)
+    assert batch_cache is not None
+    assert isinstance(batch_cache[1], BatchQSAKVCache)
+    extracted = batch_cache[1].extract(0)
+    _assert_allclose(extracted.index_keys, qsa.index_keys)
+    assert bool(
+        mx.array_equal(extracted.index_position_ids, qsa.index_position_ids).item()
+    )
+    manager.close()
+
+
 def test_exact_cache_disk_restore_preserves_rotating_kv(tmp_path, monkeypatch):
     from mlx_vlm.models.cache import KVCache, RotatingKVCache
 


### PR DESCRIPTION
This allows saving extended dtypes to the APC disk cache and adds a path for QSA caching.