### PR TITLE
Fix streamed responses after tool calls

### DIFF
--- a/mlx_vlm/server/__init__.py
+++ b/mlx_vlm/server/__init__.py
@@ -105,6 +105,7 @@ from .responses_state import (
     StoredResponse,
     ThinkingStreamDelta,
     ThinkingStreamState,
+    ToolCallStreamState,
     _normalize_response_input,
     _response_chain_items,
     _response_items_to_chat,
@@ -120,7 +121,6 @@ from .responses_state import (
     response_store,
     response_store_lock,
     response_store_order,
-    suppress_tool_call_content,
 )
 from .runtime import ModelCacheRegistry, runtime
 from .runtime_config import DEFAULT_TOKEN_QUEUE_TIMEOUT

--- a/mlx_vlm/server/anthropic.py
+++ b/mlx_vlm/server/anthropic.py
@@ -23,10 +23,10 @@ from .generation import (
 )
 from .openai import _prepare_chat_tool_choice
 from .responses_state import (
+    ToolCallStreamState,
     make_response_stream_state,
     process_tool_calls,
     prompt_has_open_thinking,
-    suppress_tool_call_content,
 )
 from .runtime import runtime
 from .schemas import AnthropicMessageResponse, AnthropicRequest, AnthropicUsage
@@ -561,8 +561,9 @@ async def anthropic_messages_endpoint(http_request: Request):
                     gen_args.thinking_start_token,
                     gen_args.thinking_end_token,
                 )
-                in_tool_call = False
                 tc_start = tool_module.tool_call_start if tool_module else None
+                tc_end = tool_module.tool_call_end if tool_module else None
+                tool_call_state = ToolCallStreamState(tc_start, tc_end)
                 message_started = False
 
                 def close_open_block():
@@ -688,8 +689,9 @@ async def anthropic_messages_endpoint(http_request: Request):
                         delta_reasoning = thinking_delta.reasoning
                         delta_content = thinking_delta.content
 
-                        in_tool_call, delta_content = suppress_tool_call_content(
-                            full_output, in_tool_call, tc_start, delta_content
+                        delta_content = tool_call_state.feed(
+                            delta_content,
+                            last=bool(getattr(token, "finish_reason", None)),
                         )
 
                         if delta_reasoning is not None and gen_args.enable_thinking:

--- a/mlx_vlm/server/openai.py
+++ b/mlx_vlm/server/openai.py
@@ -33,6 +33,7 @@ from .generation import (
     _count_prompt_tokens,
 )
 from .responses_state import (
+    ToolCallStreamState,
     _normalize_response_input,
     _response_chain_items,
     _response_items_to_chat,
@@ -47,7 +48,6 @@ from .responses_state import (
     prompt_has_open_thinking,
     response_store,
     response_store_lock,
-    suppress_tool_call_content,
 )
 from .runtime import runtime
 from .schemas import (
@@ -1090,12 +1090,17 @@ async def responses_endpoint(request: Request):
                     # Stream text deltas using ResponseGenerator (continuous batching)
                     full_text = ""
                     usage_stats = {"input_tokens": 0, "output_tokens": 0}
-                    in_tool_call = False
                     tc_start = (
                         tool_module.tool_call_start
                         if tool_module is not None and chat_tools
                         else None
                     )
+                    tc_end = (
+                        tool_module.tool_call_end
+                        if tool_module is not None and chat_tools
+                        else None
+                    )
+                    tool_call_state = ToolCallStreamState(tc_start, tc_end)
                     thinking_state = make_response_stream_state(
                         processor,
                         prompt_has_open_thinking(
@@ -1156,8 +1161,8 @@ async def responses_endpoint(request: Request):
                                     },
                                 )
                             delta = thinking_delta.content
-                            in_tool_call, delta = suppress_tool_call_content(
-                                full_text, in_tool_call, tc_start, delta
+                            delta = tool_call_state.feed(
+                                delta, last=bool(token.finish_reason)
                             )
                             usage_stats = {
                                 "input_tokens": ctx.prompt_tokens,
@@ -1210,9 +1215,7 @@ async def responses_endpoint(request: Request):
                                     },
                                 )
                             delta = thinking_delta.content
-                            in_tool_call, delta = suppress_tool_call_content(
-                                full_text, in_tool_call, tc_start, delta
-                            )
+                            delta = tool_call_state.feed(delta, last=bool(chunk_finish))
                             if chunk_finish is not None:
                                 finish_reason = chunk_finish
                             usage_stats = {
@@ -1817,9 +1820,9 @@ async def chat_completions_endpoint(request: ChatRequest, http_request: Request)
                         )
                         full_output = ""  # raw output for tool call parsing
                         # Track tool-call state to suppress markup from content
-                        in_tool_call = False
                         tc_start = tool_module.tool_call_start if tool_module else None
                         tc_end = tool_module.tool_call_end if tool_module else None
+                        tool_call_state = ToolCallStreamState(tc_start, tc_end)
 
                         def _next_token():
                             try:
@@ -1843,8 +1846,8 @@ async def chat_completions_endpoint(request: ChatRequest, http_request: Request)
                             delta_content = thinking_delta.content
 
                             # Suppress tool-call markup from content
-                            in_tool_call, delta_content = suppress_tool_call_content(
-                                full_output, in_tool_call, tc_start, delta_content
+                            delta_content = tool_call_state.feed(
+                                delta_content, last=bool(token.finish_reason)
                             )
 
                             chunk_logprobs = None

--- a/mlx_vlm/server/responses_state.py
+++ b/mlx_vlm/server/responses_state.py
@@ -264,24 +264,69 @@ response_store_order: deque = deque()
 response_store_lock = Lock()
 
 
-def suppress_tool_call_content(
-    full_output: str,
-    in_tool_call: bool,
-    tc_start: Optional[str],
-    delta_content: Optional[str],
-) -> Tuple[bool, Optional[str]]:
-    """Suppress tool-call markup from streamed delta.content."""
-    if not tc_start:
-        return in_tool_call, delta_content
-    if not in_tool_call:
-        if tc_start in full_output:
-            return True, None
+class ToolCallStreamState:
+    """Remove tool-call spans from streamed content, independent of chunking.
 
-        if any(full_output.endswith(tc_start[:j]) for j in range(2, len(tc_start))):
-            return False, None
-    else:
-        return True, None
-    return in_tool_call, delta_content
+    Marker fragments are buffered until they either complete or stop matching.
+    Text outside calls is emitted exactly once; text and markup inside calls is
+    discarded. Parsers with no end marker keep the historical latching behavior
+    after the first start marker.
+    """
+
+    def __init__(
+        self,
+        tc_start: Optional[str],
+        tc_end: Optional[str],
+    ):
+        self.tc_start = tc_start or ""
+        self.tc_end = tc_end or ""
+        self.in_tool_call = False
+        self.buffer = ""
+
+    def feed(self, text: Optional[str], last: bool = False) -> Optional[str]:
+        if not self.tc_start:
+            return text
+
+        self.buffer += text or ""
+        visible = []
+
+        while self.buffer:
+            marker = self.tc_end if self.in_tool_call else self.tc_start
+            if not marker:
+                # A parser with no end marker treats the rest of the generation
+                # as tool-call content once its start marker has been seen.
+                self.buffer = ""
+                break
+
+            marker_at = self.buffer.find(marker)
+            if marker_at >= 0:
+                if not self.in_tool_call and marker_at:
+                    visible.append(self.buffer[:marker_at])
+                self.buffer = self.buffer[marker_at + len(marker) :]
+                self.in_tool_call = not self.in_tool_call
+                continue
+
+            stable, self.buffer = self._split_partial_marker(self.buffer, marker)
+            if stable and not self.in_tool_call:
+                visible.append(stable)
+            break
+
+        if last and self.buffer:
+            if not self.in_tool_call:
+                # An unfinished start-marker prefix is ordinary content when
+                # generation ends before the marker can complete.
+                visible.append(self.buffer)
+            self.buffer = ""
+
+        return "".join(visible) or None
+
+    @staticmethod
+    def _split_partial_marker(text: str, marker: str) -> Tuple[str, str]:
+        max_length = min(len(text), len(marker) - 1)
+        for length in range(max_length, 0, -1):
+            if text.endswith(marker[:length]):
+                return text[:-length], text[-length:]
+        return text, ""
 
 
 def process_tool_calls(model_output: str, tool_module, tools):

--- a/mlx_vlm/tests/test_responses_state.py
+++ b/mlx_vlm/tests/test_responses_state.py
@@ -4,7 +4,7 @@ import pytest
 from fastapi import HTTPException
 
 from mlx_vlm.prompt_utils import apply_chat_template
-from mlx_vlm.server.responses_state import _response_items_to_chat
+from mlx_vlm.server.responses_state import ToolCallStreamState, _response_items_to_chat
 
 
 def test_function_output_image_stays_after_tool_result():
@@ -179,3 +179,93 @@ def test_unknown_function_output_blocks_remain_text():
 
     assert images == []
     assert json.loads(messages[0]["content"]) == [unknown]
+
+
+def _stream_tool_content(chunks, tc_start="<tool_call>", tc_end="</tool_call>"):
+    state = ToolCallStreamState(tc_start, tc_end)
+    visible = []
+    for index, chunk in enumerate(chunks):
+        delta = state.feed(chunk, last=index == len(chunks) - 1)
+        if delta:
+            visible.append(delta)
+    return "".join(visible)
+
+
+def test_tool_content_resumes_after_completed_call():
+    content = _stream_tool_content(
+        [
+            "Let me look. ",
+            "<tool_call>",
+            '{"name": "get_weather"}',
+            "</tool_call>",
+            " The weather is sunny.",
+        ]
+    )
+
+    assert content == "Let me look.  The weather is sunny."
+
+
+def test_tool_content_preserves_both_sides_of_coalesced_call():
+    content = _stream_tool_content(
+        ['Before <tool_call>{"name": "a"}</tool_call> after.']
+    )
+
+    assert content == "Before  after."
+
+
+def test_tool_content_preserves_text_between_coalesced_calls():
+    content = _stream_tool_content(
+        [
+            '<tool_call>{"name": "a"}</tool_call>'
+            " between "
+            '<tool_call>{"name": "b"}</tool_call>'
+            " done."
+        ]
+    )
+
+    assert content == " between  done."
+
+
+def test_tool_content_handles_markers_split_across_chunks():
+    content = _stream_tool_content(
+        [
+            "Before <tool",
+            '_call>{"name": "a"}</tool',
+            "_call> after.",
+        ]
+    )
+
+    assert content == "Before  after."
+
+
+def test_tool_content_is_invariant_to_chunk_boundaries():
+    source = (
+        'Before <tool_call>{"name": "a"}</tool_call>'
+        ' between <tool_call>{"name": "b"}</tool_call> after.'
+    )
+    expected = "Before  between  after."
+
+    assert _stream_tool_content(list(source)) == expected
+    for split_at in range(len(source) + 1):
+        assert _stream_tool_content([source[:split_at], source[split_at:]]) == expected
+
+
+def test_tool_content_suppresses_unfinished_call():
+    content = _stream_tool_content(["Before ", "<tool_call>", '{"name": "a"}'])
+
+    assert content == "Before "
+
+
+def test_tool_content_without_end_marker_keeps_latching_behavior():
+    content = _stream_tool_content(
+        ["Before ", "<tool_call>", '{"name": "a"}', " trailing"],
+        tc_end="",
+    )
+
+    assert content == "Before "
+
+
+def test_unfinished_start_marker_is_released_when_stream_ends():
+    content = _stream_tool_content(["A literal <tool"])
+
+    assert content == "A literal <tool"

--- a/mlx_vlm/tests/test_server.py
+++ b/mlx_vlm/tests/test_server.py
@@ -4630,7 +4630,10 @@ def test_anthropic_messages_streaming_emits_tool_use_events(client, monkeypatch)
             return server.GenerationContext(uid=1, prompt_tokens=3), iter(
                 [
                     server.StreamingToken(
-                        text='<tool_call>{"name":"get_weather","arguments":{"location":"SF"}}</tool_call>',
+                        text=(
+                            '<tool_call>{"name":"get_weather","arguments":'
+                            '{"location":"SF"}}</tool_call> After the call.'
+                        ),
                         token=1,
                         logprobs=0.0,
                         finish_reason="stop",
@@ -4671,6 +4674,7 @@ def test_anthropic_messages_streaming_emits_tool_use_events(client, monkeypatch)
     assert '"name": "get_weather"' in body
     assert '"type": "input_json_delta"' in body
     assert '"partial_json": "{\\"location\\": \\"SF\\"}"' in body
+    assert '"text": " After the call."' in body
     assert '"stop_reason": "tool_use"' in body
 
 
@@ -7506,64 +7510,51 @@ class TestChatMessageSchema:
         assert msg.reasoning == "thought"
 
 
-class TestSuppressToolCallContent:
+class TestToolCallStreamState:
     """Tests for tool-call markup suppression in streaming."""
 
     def test_no_tool_module(self):
-        in_tc, content = server.suppress_tool_call_content(
-            "Hello world", False, None, "world"
-        )
-        assert in_tc is False
-        assert content == "world"
+        state = server.ToolCallStreamState(None, None)
+        assert state.feed("world") == "world"
 
     def test_normal_text_before_tool_call(self):
-        in_tc, content = server.suppress_tool_call_content(
-            "I will call", False, "<tool_call>", "call"
-        )
-        assert in_tc is False
-        assert content == "call"
+        state = server.ToolCallStreamState("<tool_call>", "</tool_call>")
+        assert state.feed("I will call") == "I will call"
+        assert state.in_tool_call is False
 
     def test_suppresses_on_start_marker(self):
-        in_tc, content = server.suppress_tool_call_content(
-            "text<tool_call>", False, "<tool_call>", ">"
-        )
-        assert in_tc is True
-        assert content is None
+        state = server.ToolCallStreamState("<tool_call>", "</tool_call>")
+        assert state.feed("text<tool_call>") == "text"
+        assert state.in_tool_call is True
 
     def test_suppresses_partial_marker(self):
-        in_tc, content = server.suppress_tool_call_content(
-            "text<tool", False, "<tool_call>", "<tool"
-        )
-        assert in_tc is False
-        assert content is None
+        state = server.ToolCallStreamState("<tool_call>", "</tool_call>")
+        assert state.feed("text<tool") == "text"
+        assert state.buffer == "<tool"
+        assert state.in_tool_call is False
 
     def test_stays_suppressed_after_entering(self):
-        in_tc, content = server.suppress_tool_call_content(
-            "text<tool_call>get_weather", True, "<tool_call>", "weather"
-        )
-        assert in_tc is True
-        assert content is None
+        state = server.ToolCallStreamState("<tool_call>", "</tool_call>")
+        assert state.feed("text<tool_call>") == "text"
+        assert state.feed("get_weather") is None
+        assert state.in_tool_call is True
 
     def test_pipe_delimited_marker(self):
-        in_tc, content = server.suppress_tool_call_content(
-            "text<|tool_call>call:get_weather", False, "<|tool_call>", "weather"
-        )
-        assert in_tc is True
-        assert content is None
+        state = server.ToolCallStreamState("<|tool_call>", "<|tool_call_end|>")
+        assert state.feed("text<|tool_call>call:get_weather") == "text"
+        assert state.in_tool_call is True
 
     def test_pipe_delimited_partial_marker(self):
-        in_tc, content = server.suppress_tool_call_content(
-            "text<|tool", False, "<|tool_call>", "<|tool"
-        )
-        assert in_tc is False
-        assert content is None
+        state = server.ToolCallStreamState("<|tool_call>", "<|tool_call_end|>")
+        assert state.feed("text<|tool") == "text"
+        assert state.buffer == "<|tool"
+        assert state.in_tool_call is False
 
     def test_literal_less_than_is_not_suppressed(self):
-        in_tc, content = server.suppress_tool_call_content(
-            "if n <", False, "<tool_call>", "<"
-        )
-        assert in_tc is False
-        assert content == "<"
+        state = server.ToolCallStreamState("<tool_call>", "</tool_call>")
+        assert state.feed("if n <") == "if n "
+        assert state.feed("x") == "<x"
+        assert state.in_tool_call is False
 
 
 class TestProcessToolCalls:


### PR DESCRIPTION
Based on https://github.com/Blaizzy/mlx-vlm/pull/2027 but also covering the `v1/messages` (aka Anthropic) API and covering some missing cases in that PR.