### PR TITLE
Fix tool call parsing with quotes and nested values

### DIFF
--- a/mlx_vlm/tests/test_pythonic_tool_parser.py
+++ b/mlx_vlm/tests/test_pythonic_tool_parser.py
@@ -70,6 +70,69 @@ def test_double_quoted_string_preserves_embedded_commas():
     }
 
 
+def test_multiline_string_is_preserved():
+    result = parse_tool_call(
+        "[write_file(path='game.html', content='<!doctype html>\n"
+        "<canvas></canvas>\n</html>')]"
+    )
+
+    assert result == {
+        "name": "write_file",
+        "arguments": {
+            "path": "game.html",
+            "content": "<!doctype html>\n<canvas></canvas>\n</html>",
+        },
+    }
+
+
+def test_string_with_unescaped_matching_quotes_is_preserved():
+    result = parse_tool_call(
+        "[write_file(path='game.html', "
+        "content='<script>const label = 'Score';</script>')]"
+    )
+
+    assert result == {
+        "name": "write_file",
+        "arguments": {
+            "path": "game.html",
+            "content": "<script>const label = 'Score';</script>",
+        },
+    }
+
+
+def test_multiline_double_quoted_html_is_preserved():
+    result = parse_tool_call(
+        '[write_file(path="game.html", content="<canvas id="game">\n</canvas>")]'
+    )
+
+    assert result == {
+        "name": "write_file",
+        "arguments": {
+            "path": "game.html",
+            "content": '<canvas id="game">\n</canvas>',
+        },
+    }
+
+
+def test_multiline_write_file_output_parses_for_server_response():
+    parser = load_tool_module("pythonic")
+    result = process_tool_calls(
+        "<|tool_call_start|>[write_file(path='game.html', "
+        "content='<!doctype html>\n<script>const label = 'Score';</script>')]"
+        "<|tool_call_end|>",
+        parser,
+        tools=[{"type": "function", "function": {"name": "write_file"}}],
+    )
+
+    assert result["remaining_text"] == ""
+    assert len(result["calls"]) == 1
+    assert result["calls"][0]["function"]["name"] == "write_file"
+    assert json.loads(result["calls"][0]["function"]["arguments"]) == {
+        "path": "game.html",
+        "content": "<!doctype html>\n<script>const label = 'Score';</script>",
+    }
+
+
 def test_nested_literal_arguments_are_parsed_without_splitting():
     result = parse_tool_call(
         "[configure(options={'position': [0, 1], 'enabled': True})]"

--- a/mlx_vlm/tests/test_pythonic_tool_parser.py
+++ b/mlx_vlm/tests/test_pythonic_tool_parser.py
@@ -1,12 +1,15 @@
 import json
 from types import SimpleNamespace
 
+import pytest
+
 from mlx_vlm.server.responses_state import process_tool_calls
 from mlx_vlm.tool_parsers import (
     _infer_tool_parser,
     _infer_tool_parser_from_processor,
     load_tool_module,
 )
+from mlx_vlm.tool_parsers.pythonic import parse_tool_call
 
 LFM_TOOL_TEMPLATE = """
 {{ '<|tool_call_start|>[' + tool_calls + ']<|tool_call_end|>' }}
@@ -40,3 +43,49 @@ def test_lfm_tool_call_output_parses_for_server_response():
         "location": "Warsaw",
         "unit": "celsius",
     }
+
+
+def test_single_quoted_string_preserves_embedded_commas():
+    result = parse_tool_call(
+        "[write_file(path='game.js', content='const player = { x: 0, y: 1 };')]"
+    )
+
+    assert result == {
+        "name": "write_file",
+        "arguments": {
+            "path": "game.js",
+            "content": "const player = { x: 0, y: 1 };",
+        },
+    }
+
+
+def test_double_quoted_string_preserves_embedded_commas():
+    result = parse_tool_call(
+        '[write_file(content="width=device-width, initial-scale=1.0")]'
+    )
+
+    assert result == {
+        "name": "write_file",
+        "arguments": {"content": "width=device-width, initial-scale=1.0"},
+    }
+
+
+def test_nested_literal_arguments_are_parsed_without_splitting():
+    result = parse_tool_call(
+        "[configure(options={'position': [0, 1], 'enabled': True})]"
+    )
+
+    assert result == {
+        "name": "configure",
+        "arguments": {"options": {"position": [0, 1], "enabled": True}},
+    }
+
+
+def test_malformed_quoted_argument_is_rejected():
+    with pytest.raises(ValueError, match="Invalid Pythonic tool call"):
+        parse_tool_call("[write_file(content='const player = { x: 0, y: 1 };)]")
+
+
+def test_non_literal_argument_is_rejected():
+    with pytest.raises(ValueError, match="must be a literal value"):
+        parse_tool_call("[write_file(content=get_content())]")

--- a/mlx_vlm/tool_parsers/pythonic.py
+++ b/mlx_vlm/tool_parsers/pythonic.py
@@ -2,6 +2,7 @@
 # Copyright © 2026 Apple Inc.
 
 import ast
+import re
 from typing import Any
 
 """
@@ -12,18 +13,111 @@ Parses assistant responses containing tool calls in formats like:
 """
 
 
+def _parse_keyword_arguments(arguments_text: str) -> dict[str, Any]:
+    arguments: dict[str, Any] = {}
+    position = 0
+
+    while position < len(arguments_text):
+        keyword = re.match(r"\s*([A-Za-z_]\w*)\s*=", arguments_text[position:])
+        if keyword is None:
+            raise ValueError("Tool calls must use keyword arguments.")
+
+        key = keyword.group(1)
+        if key in arguments:
+            raise ValueError(f"Duplicate tool argument: {key!r}.")
+
+        value_start = position + keyword.end()
+        value_end = _find_argument_end(arguments_text, value_start)
+        value_text = arguments_text[value_start:value_end].strip()
+        if not value_text:
+            raise ValueError(f"Tool argument {key!r} is missing a value.")
+
+        try:
+            value = ast.literal_eval(value_text)
+        except (ValueError, TypeError, SyntaxError) as exc:
+            if (
+                len(value_text) >= 2
+                and value_text[0] in {'"', "'"}
+                and value_text[-1] == value_text[0]
+            ):
+                value = value_text[1:-1]
+            else:
+                raise ValueError(
+                    f"Tool argument {key!r} must be a literal value."
+                ) from exc
+
+        arguments[key] = value
+        position = value_end
+        if position < len(arguments_text):
+            position += 1
+
+    return arguments
+
+
+def _find_argument_end(text: str, start: int) -> int:
+    quote = None
+    escaped = False
+    nesting = 0
+
+    for index in range(start, len(text)):
+        character = text[index]
+        if quote is not None:
+            if escaped:
+                escaped = False
+            elif character == "\\":
+                escaped = True
+            elif character == quote:
+                quote = None
+            continue
+
+        if character in {'"', "'"}:
+            quote = character
+        elif character in "([{":
+            nesting += 1
+        elif character in ")]}":
+            nesting -= 1
+            if nesting < 0:
+                raise ValueError("Invalid Pythonic tool call.")
+        elif character == "," and nesting == 0:
+            remainder = text[index + 1 :]
+            if re.match(r"\s*[A-Za-z_]\w*\s*=", remainder):
+                return index
+
+    if quote is not None or nesting != 0:
+        raise ValueError("Invalid Pythonic tool call.")
+    return len(text)
+
+
+def _parse_tolerant_tool_call(text: str) -> dict[str, Any]:
+    match = re.fullmatch(
+        r"\s*\[\s*([A-Za-z_]\w*)\s*\((.*)\)\s*\]\s*",
+        text,
+        re.DOTALL,
+    )
+    if match is None:
+        raise ValueError("Invalid Pythonic tool call.")
+
+    return {
+        "name": match.group(1),
+        "arguments": _parse_keyword_arguments(match.group(2)),
+    }
+
+
 def parse_tool_call(text: str, tools: Any | None = None):
     try:
         expression = ast.parse(text.strip(), mode="eval").body
     except SyntaxError as exc:
-        raise ValueError("Invalid Pythonic tool call.") from exc
+        try:
+            return _parse_tolerant_tool_call(text)
+        except ValueError as fallback_exc:
+            raise fallback_exc from exc
 
     if not isinstance(expression, ast.List) or len(expression.elts) != 1:
         raise ValueError("Expected a single tool call inside a list.")
 
     call = expression.elts[0]
     if not isinstance(call, ast.Call) or not isinstance(call.func, ast.Name):
-        raise ValueError("Expected a named function call.")
+        raise TypeError("Expected a named function call.")
     if call.args:
         raise ValueError("Tool calls must use keyword arguments.")
 
@@ -40,7 +134,7 @@ def parse_tool_call(text: str, tools: Any | None = None):
                 f"Tool argument {keyword.arg!r} must be a literal value."
             ) from exc
 
-    return dict(name=call.func.id, arguments=arguments)
+    return {"name": call.func.id, "arguments": arguments}
 
 
 tool_call_start = "<|tool_call_start|>"

--- a/mlx_vlm/tool_parsers/pythonic.py
+++ b/mlx_vlm/tool_parsers/pythonic.py
@@ -4,8 +4,6 @@
 import ast
 from typing import Any
 
-import regex as re
-
 """
 Tool parser for Pythonic function call formats.
 
@@ -14,36 +12,35 @@ Parses assistant responses containing tool calls in formats like:
 """
 
 
-_tool_call_regex = re.compile(r"\[(\w+)\((.*?)\)\]", re.DOTALL)
-_tool_args_regex = re.compile(r'(\w+)=(?:"([^"]*)"|([^,]+))(?:,\s*|$)', re.DOTALL)
-
-
 def parse_tool_call(text: str, tools: Any | None = None):
-    match = _tool_call_regex.search(text)
-    if not match:
-        raise ValueError("No function provided.")
+    try:
+        expression = ast.parse(text.strip(), mode="eval").body
+    except SyntaxError as exc:
+        raise ValueError("Invalid Pythonic tool call.") from exc
 
-    func_name = match.group(1)
-    args_str = match.group(2)
+    if not isinstance(expression, ast.List) or len(expression.elts) != 1:
+        raise ValueError("Expected a single tool call inside a list.")
+
+    call = expression.elts[0]
+    if not isinstance(call, ast.Call) or not isinstance(call.func, ast.Name):
+        raise ValueError("Expected a named function call.")
+    if call.args:
+        raise ValueError("Tool calls must use keyword arguments.")
 
     arguments = {}
-    if args_str:
-        matches = _tool_args_regex.findall(args_str)
-        for pair in matches:
-            key = pair[0].strip()
-            # pair[1] is quoted value, pair[2] is unquoted value
-            value = pair[1] if pair[1] else pair[2].strip()
+    for keyword in call.keywords:
+        if keyword.arg is None:
+            raise ValueError("Tool calls do not support unpacked arguments.")
+        if keyword.arg in arguments:
+            raise ValueError(f"Duplicate tool argument: {keyword.arg!r}.")
+        try:
+            arguments[keyword.arg] = ast.literal_eval(keyword.value)
+        except (ValueError, TypeError, SyntaxError) as exc:
+            raise ValueError(
+                f"Tool argument {keyword.arg!r} must be a literal value."
+            ) from exc
 
-            # Try to parse the value using ast.literal_eval
-            try:
-                value = ast.literal_eval(value)
-            except (ValueError, SyntaxError):
-                # If parsing fails, keep as string
-                pass
-
-            arguments[key] = value
-
-    return dict(name=func_name, arguments=arguments)
+    return dict(name=call.func.id, arguments=arguments)
 
 
 tool_call_start = "<|tool_call_start|>"


### PR DESCRIPTION
The regex used to parse tool calls was insufficient for handling things like commands inside of quoted strings and nested lists & dictionaries. This updates it to actually parse the AST so we can reliably handle a wider range of tool call formats.