### PR TITLE
fix(attention): materialize a quantized KV state before hand-rolled attention (#2060)

### DIFF
--- a/mlx_vlm/models/base.py
+++ b/mlx_vlm/models/base.py
@@ -225,6 +225,36 @@ def slice_kv_sequence(state, end: int):
     return state[:, :, :end, :]
 
 
+def dequantize_kv_state(cache, keys, values):
+    """Return plain ``[B, H, S, D]`` arrays for a state ``update_and_fetch`` returned.
+
+    Unquantized caches already hand back arrays and are passed through. Uniform
+    quantized caches return ``(packed, scales, biases)`` tuples and TurboQuant
+    caches return codec-state named tuples, neither of which can be indexed,
+    expanded or matmul'd like an array. Attention paths that cannot go through
+    :func:`scaled_dot_product_attention` -- logit softcapping, block-sparse
+    masking -- need real arrays, so they materialize the state here first.
+    """
+    if isinstance(keys, mx.array) or hasattr(keys, "shape"):
+        return keys, values
+    # Plain tuple/list only: TurboQuant states are NamedTuples and dequantize
+    # through their own cache method.
+    if type(keys) in (tuple, list):
+        return (
+            mx.dequantize(
+                *(mx.contiguous(x) for x in keys),
+                group_size=cache.group_size,
+                bits=cache.bits,
+            ),
+            mx.dequantize(
+                *(mx.contiguous(x) for x in values),
+                group_size=cache.group_size,
+                bits=cache.bits,
+            ),
+        )
+    return cache.dequantize(keys, values)
+
+
 def create_attention_mask(
     h, cache=None, window_size: Optional[int] = None, return_array: bool = False
 ):

--- a/mlx_vlm/models/gemma2/language.py
+++ b/mlx_vlm/models/gemma2/language.py
@@ -3,7 +3,7 @@ from typing import Any, Optional
 import mlx.core as mx
 import mlx.nn as nn
 
-from ..base import LanguageModelOutput, create_attention_mask
+from ..base import LanguageModelOutput, create_attention_mask, dequantize_kv_state
 from .config import ModelConfig
 
 
@@ -56,6 +56,10 @@ class Attention(nn.Module):
             queries = self.rope(queries, offset=cache.offset)
             keys = self.rope(keys, offset=cache.offset)
             keys, values = cache.update_and_fetch(keys, values)
+            # Logit softcapping rules out mx.fast.scaled_dot_product_attention,
+            # so the scores are built by hand below and the packed state a
+            # quantized cache returns has to be materialized first.
+            keys, values = dequantize_kv_state(cache, keys, values)
         else:
             queries = self.rope(queries)
             keys = self.rope(keys)

--- a/mlx_vlm/models/phi3small/language.py
+++ b/mlx_vlm/models/phi3small/language.py
@@ -8,6 +8,7 @@ import mlx.nn as nn
 from ..base import (
     LanguageModelOutput,
     create_attention_mask,
+    dequantize_kv_state,
     scaled_dot_product_attention,
 )
 from .config import ModelConfig
@@ -150,6 +151,9 @@ class Attention(nn.Module):
             keys = self.rope(keys)
 
         if self.block_sparse:
+            # The block-sparse path builds the scores by hand, so the packed
+            # state a quantized cache returns has to be materialized first.
+            keys, values = dequantize_kv_state(cache, keys, values)
             output = self._block_sparse_attention(
                 queries, keys, values, scale=self.scale, mask=mask
             )

--- a/mlx_vlm/tests/test_kv_cache_quantization.py
+++ b/mlx_vlm/tests/test_kv_cache_quantization.py
@@ -684,5 +684,74 @@ class TestKVCacheQuantization:
                 assert first_call_kwargs["quantized_kv_start"] == quantized_kv_start
 
 
+class TestQuantizedCacheInHandRolledAttention:
+    """Models whose attention cannot go through scaled_dot_product_attention.
+
+    ``QuantizedKVCache.update_and_fetch`` hands back ``(packed, scales,
+    biases)`` tuples. Attention paths that build the scores by hand -- gemma2
+    because of its logit softcapping, phi3small because of its block-sparse
+    mask -- have to materialize that state before touching it, or every call
+    dies in ``mx.expand_dims`` on a tuple.
+    """
+
+    @pytest.mark.parametrize("kv_bits", [None, 4])
+    def test_gemma2_attention_with_quantized_cache(self, kv_bits):
+        from mlx_vlm.models.cache import KVCache, QuantizedKVCache
+        from mlx_vlm.models.gemma2.config import ModelConfig
+        from mlx_vlm.models.gemma2.language import Attention
+
+        args = ModelConfig(
+            model_type="gemma2",
+            hidden_size=128,
+            num_hidden_layers=1,
+            intermediate_size=256,
+            num_attention_heads=8,
+            head_dim=64,
+            rms_norm_eps=1e-6,
+            vocab_size=32,
+            num_key_value_heads=4,
+        )
+        attention = Attention(args)
+        assert attention.repeats > 1
+
+        cache = KVCache() if kv_bits is None else QuantizedKVCache(bits=kv_bits)
+        x = mx.random.normal((1, 6, args.hidden_size))
+
+        out = attention(x, mask=None, cache=cache)
+
+        assert out.shape == (1, 6, args.hidden_size)
+        assert not mx.any(mx.isnan(out))
+
+    @pytest.mark.parametrize("kv_bits", [None, 4])
+    def test_phi3small_block_sparse_attention_with_quantized_cache(self, kv_bits):
+        from mlx_vlm.models.cache import KVCache, QuantizedKVCache
+        from mlx_vlm.models.phi3small.config import ModelConfig
+        from mlx_vlm.models.phi3small.language import Attention
+
+        args = ModelConfig(
+            model_type="phi3small",
+            hidden_size=256,
+            dense_attention_every_n_layers=2,
+            ff_intermediate_size=512,
+            gegelu_limit=20.0,
+            num_hidden_layers=2,
+            num_attention_heads=4,
+            layer_norm_epsilon=1e-5,
+            vocab_size=32,
+            num_key_value_heads=2,
+        )
+        # layer 0 is a block-sparse layer, which is the hand-rolled path.
+        attention = Attention(args, layer_idx=0)
+        assert attention.block_sparse
+
+        cache = KVCache() if kv_bits is None else QuantizedKVCache(bits=kv_bits)
+        x = mx.random.normal((1, 6, args.hidden_size))
+
+        out = attention(x, mask=None, cache=cache)
+
+        assert out.shape == (1, 6, args.hidden_size)
+        assert not mx.any(mx.isnan(out))
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
Fixes #2060.

## The defect

`gemma2` and `phi3small` are the only two models in the repo that build their
attention scores by hand rather than going through
`base.scaled_dot_product_attention`:

- `gemma2` because `attn_logit_softcapping` has to be applied *between* the two
  matmuls, which `mx.fast.scaled_dot_product_attention` cannot express;
- `phi3small` because its block-sparse layers add a per-block mask.

`QuantizedKVCache.update_and_fetch` does not return arrays — it returns
`(packed, scales, biases)` tuples:

```python
return tree_map(lambda x: x[..., : self.offset, :], (self.keys, self.values))
```

So both paths hand a tuple to `mx.expand_dims` and die:

```
TypeError: expand_dims(): incompatible function arguments
```

`maybe_quantize_kv_cache` swaps `KVCache` for `QuantizedKVCache` without
consulting the model, so any `kv_bits=...` run on these two architectures fails
once `quantized_kv_start` is reached — `quantized_kv_start=0` fails on the
first token. These are the only two `mx.expand_dims(keys, ...)` call sites in
`mlx_vlm/models`, so the blast radius is exactly these two files.

## The fix

`base.py` already carries a small family of helpers that exist so model code can
cope with non-array cache states (`kv_sequence_length`, `slice_kv_sequence`,
`align_attention_mask_to_scores`). This adds one more in the same shape:

```python
def dequantize_kv_state(cache, keys, values):
    if isinstance(keys, mx.array) or hasattr(keys, "shape"):
        return keys, values
    if type(keys) in (tuple, list):
        return (mx.dequantize(*keys, group_size=cache.group_size, bits=cache.bits), ...)
    return cache.dequantize(keys, values)
```

The dispatch deliberately mirrors `kv_sequence_length`: `type(x) in (tuple, list)`
rather than `isinstance`, so TurboQuant's `NamedTuple` codec states fall through
to `cache.dequantize()` instead of being mistaken for a uniform
`(packed, scales, biases)` triple. `HybridQuantKVCache` already returns
dequantized arrays from `update_and_fetch`, so it takes the pass-through arm.
Components are run through `mx.contiguous` first, matching
`cache._dequantize_uniform`, because the state comes out of a
`[..., :offset, :]` slice.

Only the two hand-rolled paths call it. Everything that goes through
`scaled_dot_product_attention` still receives the packed state and still uses
`quantized_matmul`, so no other model changes behaviour and no unquantized path
gains work — `dequantize_kv_state` returns its arguments unchanged when the
cache is unquantized or absent.

## Tests

`TestQuantizedCacheInHandRolledAttention` in
`mlx_vlm/tests/test_kv_cache_quantization.py` drives both `Attention` modules
directly, parameterized over `kv_bits ∈ {None, 4}`, asserting the output shape
and that no `NaN` escapes. Both new cases fail on `main` with the `expand_dims`
`TypeError` and pass with this change; the `kv_bits=None` cases pin the
unquantized path against regression. The `phi3small` case asserts
`attention.block_sparse` so it cannot silently drift onto the dense path and
stop covering the fix.

Formatted with the pinned `black` 26.3.1 / `isort` 5.13.2 from
`.pre-commit-config.yaml`.

## Out of scope

#2061 (`phi3` head dim not divisible by the KV quantization group size) is a
different failure — a group-size constraint in the quantizer, not a tuple
reaching array-only ops — and is not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
