### PR TITLE
Fix quantization divisibility guard to respect per-module group_size

### DIFF
--- a/mlx_vlm/models/qwen4_exp/language.py
+++ b/mlx_vlm/models/qwen4_exp/language.py
@@ -1610,6 +1610,21 @@ class LanguageModel(Qwen3_5LanguageModel):
             )
         return hidden
 
+    @property
+    def quant_predicate(self):
+        base = super().quant_predicate
+
+        def predicate(path, module):
+            # PLE n-gram table dims are not divisible by 64; group 32 lets it
+            # quantize instead of falling back to full precision.
+            if "ngram_embedding" in path:
+                return {"group_size": 32, "bits": 4}
+            if base is None:
+                return True
+            return base(path, module)
+
+        return predicate
+
     def fused_greedy_decode(
         self,
         inputs: mx.array,

--- a/mlx_vlm/quant_utils.py
+++ b/mlx_vlm/quant_utils.py
@@ -113,7 +113,8 @@ def quantize_model(
         # applied: a per-module predicate may request a smaller group size
         # (e.g. 32) precisely because the dims don't divide the global one.
         effective_group_size = (
-            bool_or_params.get("group_size", group_size)
+            # `or` also covers an explicit {"group_size": None} ("use default")
+            (bool_or_params.get("group_size") or group_size)
             if isinstance(bool_or_params, dict)
             else group_size
         )

--- a/mlx_vlm/quant_utils.py
+++ b/mlx_vlm/quant_utils.py
@@ -106,11 +106,19 @@ def quantize_model(
     def wrapped_predicate(path, module):
         if not hasattr(module, "to_quantized"):
             return False
-        if module.weight.shape[-1] % group_size != 0:
-            return False
         bool_or_params = True
         if quant_predicate is not None:
             bool_or_params = quant_predicate(path, module)
+        # The divisibility guard must use the group size that will actually be
+        # applied: a per-module predicate may request a smaller group size
+        # (e.g. 32) precisely because the dims don't divide the global one.
+        effective_group_size = (
+            bool_or_params.get("group_size", group_size)
+            if isinstance(bool_or_params, dict)
+            else group_size
+        )
+        if module.weight.shape[-1] % effective_group_size != 0:
+            return False
         if isinstance(bool_or_params, dict):
             quantized_config["quantization"][path] = bool_or_params
         elif fine_grained_config and bool_or_params:


### PR DESCRIPTION
## Problem

`quantize_model`'s `wrapped_predicate` rejects any module whose last dim isn't divisible by the **global** `group_size` *before* consulting the per-module `quant_predicate`. But a smaller per-module group size is exactly what a predicate would request for such a module — so the predicate never runs, and the module silently stays in full precision.

Concrete case: Qwen3.8-Flash-Next's 51B-param PLE n-gram table has dims not divisible by 64. A "4-bit" conversion silently leaves it in BF16, producing a 162 GB output instead of 97 GB, with no warning.

## Fix

- **`quant_utils.py`**: evaluate the per-module predicate first, then apply the divisibility check against the *effective* group size it returns (falling back to the global one).
- **`qwen4_exp/language.py`**: add a `quant_predicate` quantizing the n-gram embedding at group 32 / 4-bit, which the fixed guard now allows.

## Verified

Converted `Qwen3.8-Flash-Next` to 4-bit with this patch: output is 97 GB (n-gram table quantized at 4-bit/g32) vs 162 GB before, and the quantized model serves correctly under mlx_vlm generate/server on an M5 Max.


