### PR TITLE
fix(video): forward the frame-count kwargs to load_video instead of the processor (#2050)

### DIFF
--- a/mlx_vlm/tests/test_utils.py
+++ b/mlx_vlm/tests/test_utils.py
@@ -508,6 +508,48 @@ def test_prepare_inputs_preserves_mlx_attention_mask_for_thread_handoff():
     assert consumed == [[[1, 1]]]
 
 
+def test_prepare_inputs_forwards_video_sampling_kwargs_to_load_video():
+    """nframes/min_frames/max_frames clamp load_video's frame count.
+
+    load_video is what samples the clip here, so these have to reach it. Left
+    in kwargs they go to the processor, which only sees the frames load_video
+    already chose, and the caller's cap silently does nothing.
+    """
+    tok_result = MagicMock()
+    tok_result.input_ids = [[1, 2, 3]]
+    tok_result.attention_mask = [7, 8, 9]
+    processor = MockProcessor(tokenizer_return_value=tok_result)
+
+    seen = {}
+    frames = object()
+
+    def fake_load_video(path, **kw):
+        seen.update(kw)
+        return frames, 1.5
+
+    with (
+        patch("mlx_vlm.utils.load_video", side_effect=fake_load_video),
+        patch("mlx_vlm.utils.process_inputs_with_fallback") as fallback,
+    ):
+        fallback.return_value = {"input_ids": mx.array([[1, 2, 3]])}
+        prepare_inputs(
+            processor,
+            prompts="describe the clip",
+            videos=["clip.mp4"],
+            fps=0.5,
+            max_frames=20,
+            min_frames=8,
+        )
+
+    assert seen == {"fps": 0.5, "max_frames": 20, "min_frames": 8}
+
+    forwarded = fallback.call_args.kwargs
+    assert forwarded["videos"] == [frames]
+    assert forwarded["fps"] == [1.5]
+    for name in ("nframes", "min_frames", "max_frames"):
+        assert name not in forwarded
+
+
 def test_process_inputs_with_fallback():
 
     processor = MockProcessor()

--- a/mlx_vlm/utils.py
+++ b/mlx_vlm/utils.py
@@ -2116,10 +2116,19 @@ def prepare_inputs(
         if not isinstance(videos, list):
             videos = [videos]
         fps_hint = kwargs.pop("fps", 2.0)
+        # The frame-count controls belong to load_video, which is what samples
+        # here. Left in kwargs they reach the processor instead, which only
+        # ever sees the frames load_video already picked, so they read as
+        # silently ignored.
+        sampling = {
+            name: kwargs.pop(name)
+            for name in ("nframes", "min_frames", "max_frames")
+            if name in kwargs
+        }
         loaded, video_fps = [], []
         for v in videos:
             arr, s_fps = (
-                load_video(str(v), fps=fps_hint)
+                load_video(str(v), fps=fps_hint, **sampling)
                 if isinstance(v, (str, bytes))
                 else (v, fps_hint)
             )


### PR DESCRIPTION
Fixes #2050

### What

`prepare_inputs()` pops `fps` out of `kwargs` and passes it to `load_video()`, but leaves `nframes` / `min_frames` / `max_frames` in `kwargs`, where they are forwarded to the processor instead. This pops them next to `fps` and passes them through.

### Why

For a native-video processor (Qwen3-VL and friends) `mlx_vlm` decodes the clip itself, in `prepare_inputs`:

```python
fps_hint = kwargs.pop("fps", 2.0)
...
arr, s_fps = load_video(str(v), fps=fps_hint) if isinstance(v, (str, bytes)) else (v, fps_hint)
```

`load_video()` is what picks the frames, and its signature is `(video_path, fps=2.0, nframes=None, min_frames=4, max_frames=768, frame_factor=2)`. Only `fps` ever reaches it. Everything else the caller passes falls through to

```python
inputs = process_inputs_with_fallback(processor, ..., **extra, **kwargs)
```

so the processor receives `max_frames=...` — after `load_video` has already chosen the frames. It has no effect there, and nothing warns.

The consequence is that `load_video`'s built-in `max_frames=768` is the only cap that ever applies, and the caller cannot lower it. In #2050 that cap is exactly what binds: on a clip long enough that `total_frames / video_fps * fps` exceeds 768, `n` clamps to 768 for every `fps` at or above the one that first saturates it, so raising `--fps` changes nothing, and `max_frames=20` vs `max_frames=200` are indistinguishable — both are dropped. Mutating `processor.video_processor.max_frames` does nothing for the same reason: that object is not what samples the clip.

Note the sibling path already honours the knob — when `processor_handles_video()` is false, `dispatch.py` routes through `resolve_video_inputs(..., max_frames=max_frames)` and `subsample_evenly()` applies it. This only closes the gap on the native-video path; `--video-max-frames` keeps its documented fallback-only meaning, and this PR does not touch the CLI.

### Scope

`kwargs.pop(name)` only fires when the caller actually supplied the name, so `load_video`'s defaults (`nframes=None`, `min_frames=4`, `max_frames=768`) are unchanged for every existing call. No behaviour changes unless a caller passes one of these, which today is silently ignored.

### Verification

No Apple silicon here, so this was checked by extracting `prepare_inputs` with `ast` and running it against stubbed `load_video` / `process_inputs_with_fallback` on both `main` and this branch:

```
--- UNPATCHED (main @ 8adff01)
    load_video kwargs  : {'fps': 0.5}
    leaked to processor: ['max_frames', 'min_frames']
--- PATCHED
    load_video kwargs  : {'fps': 0.5, 'min_frames': 8, 'max_frames': 20}
    leaked to processor: []
```

`tests/test_utils.py::test_prepare_inputs_forwards_video_sampling_kwargs_to_load_video` encodes the same thing as a regression test, asserting both halves: the kwargs reach `load_video`, and they no longer reach the processor. Formatted with the pinned `black==26.3.1` and `isort==5.13.2 --profile=black`; leaving the rest to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
