### PR TITLE
Dflash2 support for GLM5.3-flash

### DIFF
--- a/mlx_vlm/models/glm5_next/README.md
+++ b/mlx_vlm/models/glm5_next/README.md
@@ -58,6 +58,26 @@ proposes one token from the target's hidden state and the target verifies the
 See [`mlx_vlm/speculative/drafters/glm5_next_mtp/README.md`](../../speculative/drafters/glm5_next_mtp/README.md)
 for the split tool and usage.
 
+## Speculative decoding (DFlash2)
+
+GLM-5.3-Flash can also be driven by a **DFlash2** drafter -- a separate,
+multi-token block drafter (block size 8) trained against the target and published
+as `incoai/GLM-5.3-Flash-DFlash2`. Unlike the single-token nextn head it proposes
+a whole block per round, so acceptance clears the verify overhead by a wide
+margin.
+
+Each round the drafter reads the target's hidden state at the checkpoint's
+`target_layer_ids` and proposes a block; the target verifies the block in one
+forward and, on a partial accept, rolls the KDA recurrent state and the
+MLA/indexer caches back to the accepted prefix (the same rollback MTP uses).
+Output is bit-identical to plain decode.
+
+Target-side support is small: the model captures the per-layer hidden at
+`target_layer_ids` and returns it (with the KDA states) from the verify forward;
+the drafter, its round loop, and the converter are shared across DFlash targets.
+The drafter runs in bf16 as published -- it does not need quantizing to pair with
+a quantized target.
+
 ## Continuous batching
 
 Runs the batched `BatchGenerator` path unmodified. The lightning indexer's incremental

--- a/mlx_vlm/models/glm5_next/language.py
+++ b/mlx_vlm/models/glm5_next/language.py
@@ -795,6 +795,7 @@ class Glm5NextModel(nn.Module):
         inputs_embeds: Optional[mx.array] = None,
         gdn_sink: Optional[list] = None,
         hidden_sink: Optional[list] = None,
+        capture_layer_ids: Optional[list] = None,
     ) -> mx.array:
         h = self.embed_tokens(inputs) if inputs_embeds is None else inputs_embeds
 
@@ -812,12 +813,15 @@ class Glm5NextModel(nn.Module):
         )
         h = mx.contiguous(h)
 
-        for layer, c in zip(self.layers, cache):
+        capture_set = set(capture_layer_ids) if capture_layer_ids else set()
+        for i, (layer, c) in enumerate(zip(self.layers, cache)):
             mask = ssm_mask if layer.is_linear else fa_mask
             h = layer(h, mask=mask, cache=c, gdn_sink=gdn_sink)
+            if i in capture_set and hidden_sink is not None:
+                hidden_sink.append(h.mean(axis=2))
 
         h = h.mean(axis=2)
-        if hidden_sink is not None:
+        if hidden_sink is not None and not capture_set:
             hidden_sink.append(h)  # pre-final-norm hidden for the nextn drafter
         return self.norm(h)
 
@@ -846,12 +850,18 @@ class LanguageModel(nn.Module):
         return_shared_kv = kwargs.pop("return_shared_kv", False)
         skip_logits = kwargs.pop("skip_logits", False)
         capture_layer_ids = kwargs.pop("capture_layer_ids", None)
-        # Speculative verify runs when a capture list is supplied: collect each KDA
+        # glm5_next verifies with a plain capturing forward (no exact kernel), so
+        # speculative_verify only needs to be consumed here.
+        kwargs.pop("speculative_verify", False)
+        # A capture list is supplied whenever a drafter is attached: collect each KDA
         # layer's per-step recurrent state so a round can be rolled back on rejection.
         gdn_sink: Optional[list] = [] if capture_layer_ids is not None else None
-        # Capture the pre-final-norm hidden for the nextn (MTP) drafter, which applies
-        # its own norm -- the DeepSeek-derived convention.
-        hidden_sink: Optional[list] = [] if return_hidden else None
+        # With a non-empty capture list the DFlash drafter reads the per-layer hidden;
+        # with an empty list (MTP) or return_hidden the nextn drafter reads the
+        # pre-final-norm hidden, applying its own norm (the DeepSeek-derived convention).
+        hidden_sink: Optional[list] = (
+            [] if (capture_layer_ids is not None or return_hidden) else None
+        )
 
         out = self.model(
             inputs,
@@ -859,6 +869,7 @@ class LanguageModel(nn.Module):
             inputs_embeds=inputs_embeds,
             gdn_sink=gdn_sink,
             hidden_sink=hidden_sink,
+            capture_layer_ids=capture_layer_ids,
         )
         # Only the last few positions' logits are ever needed for generation; slicing
         # before the (vocab-wide) projection skips it on discarded prefill positions.

--- a/mlx_vlm/tests/test_models_dflash2.py
+++ b/mlx_vlm/tests/test_models_dflash2.py
@@ -289,3 +289,189 @@ def test_dflash2_generation_has_exact_target_parity(temperature, seed):
 
     assert speculative == baseline
     assert drafter.draft_lens
+
+
+def _tiny_glm5_next_target():
+    from mlx_vlm.models import glm5_next
+    from mlx_vlm.models.glm5_next.language import LanguageModel
+
+    config = glm5_next.TextConfig(
+        model_type="glm5_next_text",
+        vocab_size=32,
+        hidden_size=16,
+        intermediate_size=32,
+        moe_intermediate_size=16,
+        num_hidden_layers=2,
+        num_attention_heads=2,
+        num_key_value_heads=2,
+        n_shared_experts=1,
+        n_routed_experts=8,
+        routed_scaling_factor=2.5,
+        kv_lora_rank=16,
+        q_lora_rank=32,
+        qk_rope_head_dim=0,
+        v_head_dim=8,
+        qk_nope_head_dim=8,
+        qk_head_dim=8,
+        num_experts_per_tok=4,
+        first_k_dense_replace=1,
+        max_position_embeddings=128,
+        rms_norm_eps=1e-5,
+        index_topk=6,
+        index_head_dim=8,
+        index_n_heads=2,
+        index_kpool=3,
+        layer_types=["linear_attention", "deepseek_sparse_attention"],
+        mlp_layer_types=["dense", "sparse"],
+        linear_attn_config={
+            "num_heads": 2,
+            "head_dim": 8,
+            "short_conv_kernel_size": 2,
+            "gate_lower_bound": -5.0,
+        },
+        hc_mult=4,
+        num_nextn_predict_layers=1,
+        pad_token_id=0,
+        eos_token_id=1,
+    )
+    model = LanguageModel(config)
+    model.set_dtype(mx.bfloat16)
+    return model
+
+
+def _tiny_glm5_next_drafter_config():
+    config = _published_config()
+    config.update(
+        hidden_size=16,
+        intermediate_size=32,
+        num_hidden_layers=1,
+        num_attention_heads=2,
+        num_key_value_heads=1,
+        head_dim=8,
+        vocab_size=32,
+        max_position_embeddings=128,
+        num_target_layers=2,
+        layer_types=["full_attention"],
+        sliding_window=None,
+        rope_parameters={"rope_type": "default", "rope_theta": 10000},
+    )
+    config["dflash_config"] = {
+        "block_size": 3,
+        "runtime_block_size": 3,
+        "conv_group_size": 4,
+        "conv_kernel_size": 2,
+        "mask_token_id": 31,
+        "selector_rank": 4,
+        "selector_top_k": 4,
+        "target_layer_ids": [0],
+    }
+    return ModelConfig.from_dict(config)
+
+
+def _glm5_next_generated_tokens(target, prompt, drafter=None, temperature=0, seed=None):
+    def get_input_embeddings(input_ids, pixel_values=None, mask=None, **kwargs):
+        del pixel_values, mask, kwargs
+        return InputEmbeddingsFeatures(
+            inputs_embeds=target.model.embed_tokens(input_ids)
+        )
+
+    generation_target = SimpleNamespace(
+        language_model=target,
+        get_input_embeddings=get_input_embeddings,
+    )
+    kwargs = (
+        {"draft_model": drafter, "draft_kind": "dflash"} if drafter is not None else {}
+    )
+    return [
+        int(token.item()) if hasattr(token, "item") else int(token)
+        for token, _ in generate_step(
+            prompt,
+            generation_target,
+            None,
+            None,
+            max_tokens=10,
+            temperature=temperature,
+            seed=seed,
+            prefill_step_size=None,
+            **kwargs,
+        )
+    ]
+
+
+def test_dflash2_glm5_next_generation_has_exact_target_parity():
+    mx.random.seed(7)
+    target = _tiny_glm5_next_target()
+    drafter = DFlash2DraftModel(_tiny_glm5_next_drafter_config())
+    mx.eval(target.parameters(), drafter.parameters())
+    prompt = mx.array([[2, 4, 6, 8]], dtype=mx.int32)
+
+    baseline = _glm5_next_generated_tokens(target, prompt)
+    speculative = _glm5_next_generated_tokens(target, prompt, drafter)
+
+    assert speculative == baseline
+    assert drafter.draft_lens
+
+
+def test_dflash2_glm5_next_batch_generation_matches_target():
+    from mlx_vlm.generate import BatchGenerator
+
+    class NeverStop:
+        def __call__(self, _token):
+            return False
+
+        def add_eos_token_ids(self, _tokens):
+            return None
+
+    def generate(target, prompts, max_tokens, drafter=None):
+        processor = SimpleNamespace(
+            tokenizer=SimpleNamespace(stopping_criteria=NeverStop())
+        )
+        generator = BatchGenerator(
+            target,
+            processor,
+            prefill_batch_size=2,
+            completion_batch_size=2,
+            prefill_step_size=None,
+            draft_model=drafter,
+            draft_kind="dflash" if drafter is not None else None,
+            draft_block_size=3,
+            greedy_sampling=True,
+        )
+        prompt_kwargs = [
+            {
+                "inputs_embeds": target.model.embed_tokens(
+                    mx.array([prompt], dtype=mx.int32)
+                )
+            }
+            for prompt in prompts
+        ]
+        uids = generator.insert(
+            prompts, max_tokens=max_tokens, prompt_kwargs=prompt_kwargs
+        )
+        tokens = {uid: [] for uid in uids}
+        try:
+            for _ in range(32):
+                if not generator.has_work:
+                    break
+                _, responses = generator.next()
+                for response in responses:
+                    if response.token is not None:
+                        tokens[response.uid].append(int(response.token))
+            assert not generator.has_work
+        finally:
+            generator.close()
+        return [tokens[uid] for uid in uids]
+
+    mx.random.seed(0)
+    target = _tiny_glm5_next_target()
+    mx.eval(target.parameters())
+    prompts = [[2, 4, 6], [3, 5, 7, 9, 11]]
+    max_tokens = [3, 5]
+
+    expected = generate(target, prompts, max_tokens)
+    drafter = DFlash2DraftModel(_tiny_glm5_next_drafter_config())
+    mx.eval(drafter.parameters())
+    actual = generate(target, prompts, max_tokens, drafter=drafter)
+
+    assert actual == expected
+    assert [len(row) for row in actual] == max_tokens


### PR DESCRIPTION
## DFlash2 support for GLM-5.3-Flash

Stacked on #2044 — the incremental change here is the DFlash2 target hooks for
`glm5_next` (the DFlash2 drafter, its runtime round-loop, and the converter are
already generic in the tree).

- `Glm5NextModel.__call__` captures the per-layer hidden at the drafter's
  `target_layer_ids`.
- `LanguageModel.__call__` builds the hidden sink for both prefill and verify,
  threads `capture_layer_ids`, and returns the per-layer hidden plus KDA states,
  reusing the existing `rollback_speculative_cache`.

Single- and batch-sequence tests generate with and without the drafter and assert
the output is bit-identical to plain greedy decode.

## Performance

GLM-5.3-Flash (mixed 4-bit MoE / 8-bit) target + the published
`incoai/GLM-5.3-Flash-DFlash2` drafter (bf16, block 8) on an Apple M3 Ultra
(512 GB). Greedy, batch 1, decode throughput (tokens after the first; prefill
excluded), 64 generated tokens. MTP (single nextn head, block 2) shown for
comparison. Every row is bit-identical to plain decode (0 mismatched tokens).

| ctx | baseline tok/s | MTP tok/s | MTP × | DFlash2 tok/s | DFlash2 × | DFlash2 accepted/8 |
|--:|--:|--:|--:|--:|--:|--:|
| 512   | 33.84 | 36.49 | 1.08× | 81.78 | 2.42× | 6.00 |
| 2048  | 29.88 | 35.18 | 1.18× | 76.40 | 2.56× | 6.00 |
| 8192  | 28.94 | 34.83 | 1.20× | 68.45 | 2.37× | 6.00 |
| 16384 | 28.29 | 32.01 | 1.13× | 58.29 | 2.06× | 6.00 |
