### PR TITLE
fix(recurrent_gemma): initialize nn.Module in LanguageModel

### DIFF
--- a/mlx_vlm/models/recurrent_gemma/language.py
+++ b/mlx_vlm/models/recurrent_gemma/language.py
@@ -377,6 +377,7 @@ class Griffin(nn.Module):
 class LanguageModel(nn.Module):
 
     def __init__(self, config):
+        super().__init__()
         self.args = config
         self.model = Griffin(config)
         self.model_type = config.model_type


### PR DESCRIPTION
### Problem

`LanguageModel` in `mlx_vlm/models/recurrent_gemma/language.py` never initializes its base class:

```python
class LanguageModel(nn.Module):

    def __init__(self, config):
        self.args = config            # <-- no super().__init__()
        self.model = Griffin(config)
        self.model_type = config.model_type
        self.lm_head = nn.Linear(config.hidden_size, config.vocab_size, bias=False)
```

`mlx.nn.Module.__init__` is what creates the module's bookkeeping state, and its docstring says so explicitly:

```python
def __init__(self):
    """Should be called by the subclasses of ``Module``."""
    self._no_grad = set()
    self._training = True
```

`Module` subclasses `dict`, and `Module.__getattr__` falls through to `__getattribute__` for any key that is not in the dict — so those two names do not quietly default, they raise:

* `trainable_parameter_filter` reads `key not in module._no_grad`, so **`trainable_parameters()` and `freeze()`/`unfreeze()` raise `AttributeError`** as soon as the traversal reaches this module
* the `training` property returns `self._training`, so **reading `.training` raises `AttributeError`**

That puts the LoRA/SFT paths out of action for this model — `mlx_vlm/trainer/utils.py` and `mlx_vlm/lora.py` both go through `trainable_parameters()`.

### This is the only class that does it

Every other class in the `recurrent_gemma` package initializes its base:

| class | base init |
|---|---|
| `RMSNorm`, `Conv1d`, `RGLRU`, `RecurrentBlock`, `LocalAttentionBlock`, `MLPBlock`, `ResidualBlock`, `Griffin` | ✅ |
| `recurrent_gemma.py::Model` | ✅ |
| `language.py::LanguageModel` | ❌ — this PR |

And repo-wide, of the **166** `LanguageModel` classes under `mlx_vlm/models` that define `__init__`, **165** initialize the base (most via `super().__init__()`, `qwen3_5_moe` and `qwen4_exp` via the equivalent `nn.Module.__init__(self)`). This one is the only exception.

### Fix

```diff
     def __init__(self, config):
+        super().__init__()
         self.args = config
```

### Verification

I do not have mlx on this machine, so rather than hand-writing a stand-in `Module` (which can silently diverge from the real one), I lifted the relevant methods **verbatim out of `mlx/nn/layers/base.py` with the AST** — `__init__`, `__getattr__`, `trainable_parameter_filter`, `valid_parameter_filter` — and re-exec'd them onto a bare `dict` subclass, which is exactly what `mlx.nn.Module` is. The failure path is therefore the real one.

```
UNPATCHED
  recurrent_gemma (as-is)      _no_grad  (trainable_parameters)   AttributeError: 'LanguageModel'
                                                                  object has no attribute '_no_grad'
  recurrent_gemma (as-is)      _training (.training)              AttributeError: 'LanguageModel'
                                                                  object has no attribute '_training'
BASELINE -- the other 165
  super().__init__() called    _no_grad  (trainable_parameters)   OK
  super().__init__() called    _training (.training)              OK
```

With `super().__init__()` in place the module behaves like every other one in the tree.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
