### PR TITLE
qwen4_exp: opt-in disk offload for the n-gram PLE table

### DIFF
--- a/mlx_vlm/generate/dispatch.py
+++ b/mlx_vlm/generate/dispatch.py
@@ -509,6 +509,13 @@ def parse_arguments():
         "working set). Ignored for a normal, non-offloaded checkpoint.",
     )
     parser.add_argument(
+        "--ple-on-disk",
+        action="store_true",
+        help="Keep a model's n-gram PLE table (qwen4_exp) on disk and read rows "
+        "on demand instead of holding it resident. Ignored for models without "
+        "a PLE table.",
+    )
+    parser.add_argument(
         "--processor-kwargs",
         type=json.loads,
         default={},
@@ -1271,6 +1278,7 @@ def main():
         trust_remote_code=args.trust_remote_code,
         quantize_activations=args.quantize_activations,
         expert_cache_gb=args.expert_cache_gb,
+        ple_on_disk=args.ple_on_disk,
         max_kv_size=args.max_kv_size,
     )
     config = model.config

--- a/mlx_vlm/models/qwen4_exp/config.py
+++ b/mlx_vlm/models/qwen4_exp/config.py
@@ -67,6 +67,11 @@ class TextConfig(BaseModelConfig):
     eos_token_id: Optional[Union[int, List[int]]] = None
     tie_word_embeddings: bool = False
     attention_bias: bool = False
+    # Runtime-only, not part of the checkpoint. Set by load_model() when the
+    # caller passes ``ple_on_disk=True`` so the n-gram PLE table is read row by
+    # row off disk instead of held resident. Default off => no behavior change.
+    ple_on_disk: bool = False
+    ple_disk_path: Optional[str] = None
     rope_parameters: Optional[Dict[str, Union[float, str, bool, List[int]]]] = field(
         default_factory=lambda: {
             "type": "default",

--- a/mlx_vlm/models/qwen4_exp/language.py
+++ b/mlx_vlm/models/qwen4_exp/language.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import math
+import re
 from bisect import bisect_right
 from types import SimpleNamespace
 from typing import Any, Optional
@@ -938,10 +939,115 @@ def _find_nth_prime_after(start: int, count: int) -> int:
     return prime
 
 
-class ShardedEmbedding(nn.Module):
-    """Embedding kept in checkpoint-sized row shards to avoid a 100 GB join."""
+# Matches a PLE n-gram shard tensor under EITHER checkpoint naming convention
+# and captures the shard index: the ``.ngram_embedding.shard_N.`` (underscore)
+# layout that ``sanitize`` remaps to ``.ngram_embedding.shards.N.`` (dot), plus
+# checkpoints that already ship the dot layout. The disk index reads raw tensor
+# names straight from the safetensors index, so it must accept both.
+_DISK_SHARD_RE = re.compile(r"\.ngram_embedding\.shards?[._](\d+)")
 
-    def __init__(self, num_embeddings: int, dims: int, num_shards: int):
+
+class _PLEDiskIndex:
+    """Row-granular reads of the quantized n-gram table straight off the
+    safetensors files via numpy memmap.
+
+    The n-gram PLE table dominates the qwen4_exp parameter count, yet only a
+    handful of its rows are read per token. This keeps the table on disk and
+    dequantizes just the requested rows on the host, matching ``mx.dequantize``
+    for affine group quantization exactly (bit-identical to the resident path).
+    Rows are a few hundred bytes; only touched pages enter the OS page cache.
+    """
+
+    def __init__(self, model_dir):
+        import json as _json
+        import os as _os
+        import struct as _struct
+
+        import numpy as _np
+
+        self.np = _np
+        with open(_os.path.join(model_dir, "model.safetensors.index.json")) as fh:
+            idx = _json.load(fh)
+        files = {}
+        self.tensors = {}
+        for name, fname in idx["weight_map"].items():
+            match = _DISK_SHARD_RE.search(name)
+            if match is None:
+                continue
+            path = _os.path.join(model_dir, fname)
+            if fname not in files:
+                with open(path, "rb") as fh:
+                    header_len = _struct.unpack("<Q", fh.read(8))[0]
+                    header = _json.loads(fh.read(header_len))
+                files[fname] = (
+                    header,
+                    8 + header_len,
+                    _np.memmap(path, dtype=_np.uint8, mode="r"),
+                )
+            header, base, mm = files[fname]
+            info = header[name]
+            shard_no = int(match.group(1))
+            kind = (
+                name.rsplit(".", 1)[-1]
+                if name.endswith(("weight", "scales", "biases"))
+                else None
+            )
+            self.tensors.setdefault(shard_no, {})[kind] = (
+                mm,
+                base + info["data_offsets"][0],
+                info["shape"],
+                info["dtype"],
+            )
+
+    @staticmethod
+    def _bf16(raw_u8):
+        import numpy as _np
+
+        u16 = raw_u8.view(_np.uint16)
+        return (u16.astype(_np.uint32) << 16).view(_np.float32)
+
+    def rows(self, shard_no, local_rows, dims, group_size=32, bits=4):
+        """Dequantize ``local_rows`` of the given shard to float32 ``[R, dims]``.
+
+        Reproduces ``mx.dequantize`` for affine quantization on the host: each
+        packed uint32 word holds ``32 // bits`` values, unpacked little-endian
+        and scaled/biased per group with the bf16 scales and biases.
+        """
+        _np = self.np
+        tensors = self.tensors[shard_no]
+        out = _np.empty((len(local_rows), dims), dtype=_np.float32)
+        mm_w, off_w, shape_w, _ = tensors["weight"]
+        mm_s, off_s, shape_s, _ = tensors["scales"]
+        mm_b, off_b, _, _ = tensors["biases"]
+        wrow = shape_w[1] * 4  # uint32 words per row -> bytes
+        srow = shape_s[1] * 2  # bf16 groups per row -> bytes
+        vals_per_word = 32 // bits
+        shifts = _np.arange(vals_per_word, dtype=_np.uint32) * bits
+        for i, row in enumerate(local_rows):
+            packed = mm_w[off_w + row * wrow : off_w + (row + 1) * wrow].view(
+                _np.uint32
+            )
+            scales = self._bf16(
+                mm_s[off_s + row * srow : off_s + (row + 1) * srow].copy()
+            )
+            biases = self._bf16(
+                mm_b[off_b + row * srow : off_b + (row + 1) * srow].copy()
+            )
+            unpacked = (packed[:, None] >> shifts[None, :]) & ((1 << bits) - 1)
+            quantized = unpacked.reshape(-1)[:dims].astype(_np.float32)
+            groups = quantized.reshape(-1, group_size)
+            out[i] = (groups * scales[:, None] + biases[:, None]).reshape(-1)
+        return out
+
+
+class ShardedEmbedding(nn.Module):
+    """Embedding kept in checkpoint-sized row shards to avoid a 100 GB join.
+
+    When ``disk_dir`` is set the shards are never held resident: the table stays
+    on disk and rows are read and dequantized on demand (see ``_PLEDiskIndex``).
+    """
+
+    def __init__(self, num_embeddings: int, dims: int, num_shards: int, disk_dir=None):
         super().__init__()
         if num_shards <= 0 or num_shards > num_embeddings:
             raise ValueError("num_shards must be in [1, num_embeddings]")
@@ -949,7 +1055,11 @@ class ShardedEmbedding(nn.Module):
         self.shard_sizes = tuple(
             base + (1 if index < remainder else 0) for index in range(num_shards)
         )
-        self.shards = [nn.Embedding(size, dims) for size in self.shard_sizes]
+        self._disk_dir = disk_dir
+        self._disk_index = None
+        self.shards = (
+            [] if disk_dir else [nn.Embedding(size, dims) for size in self.shard_sizes]
+        )
         offsets = [0]
         for size in self.shard_sizes:
             offsets.append(offsets[-1] + size)
@@ -963,6 +1073,8 @@ class ShardedEmbedding(nn.Module):
         mx.eval(flat)
         host_indices = [int(index) for index in flat.tolist()]
         if not host_indices:
+            if self._disk_dir:
+                return mx.zeros((*indices.shape, self.dims), dtype=mx.bfloat16)
             return self.shards[0](flat).reshape(*indices.shape, self.dims)
         if any(index < 0 or index >= self.shard_offsets[-1] for index in host_indices):
             raise IndexError("embedding index is outside the sharded vocabulary")
@@ -970,6 +1082,10 @@ class ShardedEmbedding(nn.Module):
         shard_indices = [
             bisect_right(self.shard_offsets, index) - 1 for index in host_indices
         ]
+        if self._disk_dir:
+            return self._disk_gather(host_indices, shard_indices).reshape(
+                *indices.shape, self.dims
+            )
         result = None
         for shard_index in sorted(set(shard_indices)):
             positions_list = [
@@ -987,6 +1103,26 @@ class ShardedEmbedding(nn.Module):
                 result = mx.zeros((len(host_indices), self.dims), dtype=values.dtype)
             result = result.at[positions].add(values)
         return result.reshape(*indices.shape, self.dims)
+
+    def _disk_gather(self, host_indices, shard_indices) -> mx.array:
+        """Read dequantized rows for the given global indices off disk."""
+        import numpy as np
+
+        if self._disk_index is None:
+            self._disk_index = _PLEDiskIndex(self._disk_dir)
+        out = np.empty((len(host_indices), self.dims), dtype=np.float32)
+        per_shard = {}
+        for position, (shard_index, global_index) in enumerate(
+            zip(shard_indices, host_indices)
+        ):
+            local = global_index - self.shard_offsets[shard_index]
+            per_shard.setdefault(shard_index, []).append((position, local))
+        for shard_index, items in per_shard.items():
+            positions, local_rows = zip(*items)
+            out[list(positions)] = self._disk_index.rows(
+                shard_index, list(local_rows), self.dims
+            )
+        return mx.array(out).astype(mx.bfloat16)
 
 
 class Qwen4ExpNGramEmbedding(nn.Module):
@@ -1031,10 +1167,12 @@ class Qwen4ExpNGramEmbedding(nn.Module):
         self.ngram_heads_offsets = mx.array(head_offsets, dtype=mx.int64)
         divisor = config.make_ngram_vocab_size_divisible_by
         padded_vocab_size = math.ceil(total_vocab_size / divisor) * divisor
+        disk_dir = config.ple_disk_path if config.ple_on_disk else None
         self.ngram_embedding = ShardedEmbedding(
             padded_vocab_size,
             embedding_dim // self.ngram_heads,
             config.split_ngram_parts,
+            disk_dir=disk_dir,
         )
 
     def _shift_right_ignore_eos(self, token_ids: mx.array, shift: int):

--- a/mlx_vlm/models/qwen4_exp/qwen4_exp.py
+++ b/mlx_vlm/models/qwen4_exp/qwen4_exp.py
@@ -10,6 +10,10 @@ from .language import LanguageModel
 from .vision import VisionModel
 
 _NGRAM_SHARD_RE = re.compile(r"\.ngram_embedding\.shard_(\d+)(?=\.)")
+# Matches an n-gram shard tensor under either naming convention (underscore
+# ``.shard_N.`` or dot ``.shards.N.``); used to drop them in ple_on_disk mode,
+# where the table lives on disk and the ShardedEmbedding holds no shards.
+_NGRAM_SHARD_DROP_RE = re.compile(r"\.ngram_embedding\.shards?[._]\d+")
 
 
 class Model(Qwen3_5Model):
@@ -46,10 +50,17 @@ class Model(Qwen3_5Model):
                     f"{prefix}.experts.down_proj"
                 )
 
+        # In ple_on_disk mode the n-gram table is served row by row off disk, so
+        # the ShardedEmbedding holds no shards; drop the shard tensors before
+        # load_weights, or they collide with the empty module.
+        drop_ngram_shards = self.config.text_config.ple_on_disk
+
         sanitized = {}
         for key, value in weights.items():
             key = sanitize_key(key)
             key = _NGRAM_SHARD_RE.sub(r".ngram_embedding.shards.\1", key)
+            if drop_ngram_shards and _NGRAM_SHARD_DROP_RE.search(key):
+                continue
             if "conv1d.weight" in key and value.shape[-1] != 1:
                 value = value.moveaxis(2, 1)
             sanitized[key] = value

--- a/mlx_vlm/server/cli.py
+++ b/mlx_vlm/server/cli.py
@@ -217,6 +217,13 @@ def main():
         "working set). Ignored for a normal, non-offloaded checkpoint.",
     )
     parser.add_argument(
+        "--ple-on-disk",
+        action="store_true",
+        help="Keep a model's n-gram PLE table (qwen4_exp) on disk and read rows "
+        "on demand instead of holding it resident, freeing the table's RAM. "
+        "Ignored for models without a PLE table.",
+    )
+    parser.add_argument(
         "--draft-model",
         type=str,
         default=None,
@@ -335,6 +342,8 @@ def main():
     os.environ["QUANTIZED_KV_START"] = str(args.quantized_kv_start)
     if args.expert_cache_gb is not None:
         os.environ["EXPERT_CACHE_GB"] = str(args.expert_cache_gb)
+    if args.ple_on_disk:
+        os.environ["PLE_ON_DISK"] = "1"
     if args.top_logprobs_k is not None:
         os.environ["TOP_LOGPROBS_K"] = str(args.top_logprobs_k)
     if args.api_key:

--- a/mlx_vlm/server/generation.py
+++ b/mlx_vlm/server/generation.py
@@ -242,6 +242,10 @@ def get_expert_cache_gb():
         return None
 
 
+def get_ple_on_disk():
+    return os.environ.get("PLE_ON_DISK", "").lower() in ("1", "true", "yes")
+
+
 def get_quantized_kv_bits():
     kv_bits = float(os.environ.get("KV_BITS", 0))
     return kv_bits or None
@@ -589,6 +593,7 @@ def load_model_resources(model_path: str, adapter_path: Optional[str]):
             adapter_path,
             trust_remote_code=trust_remote_code,
             expert_cache_gb=get_expert_cache_gb(),
+            ple_on_disk=get_ple_on_disk(),
             max_kv_size=get_configured_context_limit(),
         )
         config = model.config

--- a/mlx_vlm/tests/test_qwen4_exp.py
+++ b/mlx_vlm/tests/test_qwen4_exp.py
@@ -8,13 +8,16 @@ from mlx_vlm.generate.ar import _make_cache
 from mlx_vlm.models import qwen4_exp
 from mlx_vlm.models.cache import ArraysCache
 from mlx_vlm.models.qwen4_exp.language import (
+    _DISK_SHARD_RE,
     BatchQSAKVCache,
     QSAKVCache,
     QSAQuantizedKVCache,
     Qwen4ExpGatedDeltaNet,
     Qwen4ExpNGramEmbedding,
     ShardedEmbedding,
+    _PLEDiskIndex,
 )
+from mlx_vlm.models.qwen4_exp.qwen4_exp import _NGRAM_SHARD_DROP_RE
 from mlx_vlm.prompt_utils import MessageFormat, MessageFormatter
 
 
@@ -624,6 +627,143 @@ class Qwen4ExpTests(unittest.TestCase):
         mapped = "language_model.model.layers.0.mlp.experts.0.gate_proj.weight"
         self.assertIn(mapped, sanitized)
         self.assertEqual(sanitized[mapped].dtype, mx.bfloat16)
+
+
+class Qwen4ExpPLEOnDiskTests(unittest.TestCase):
+    """Opt-in disk offload of the n-gram PLE table (ple_on_disk)."""
+
+    GROUP_SIZE = 32
+    BITS = 4
+
+    def _write_single_shard_checkpoint(self, directory, rows, dims):
+        """Quantize a random row table and write it as a one-shard PLE
+        checkpoint (safetensors + index.json), the layout _PLEDiskIndex reads.
+
+        Returns the quantized (weight, scales, biases) arrays so the resident
+        path can be built from the exact same bytes.
+        """
+        import json
+        import os
+
+        mx.random.seed(0)
+        table = mx.random.normal((rows, dims)).astype(mx.bfloat16)
+        weight, scales, biases = mx.quantize(
+            table, group_size=self.GROUP_SIZE, bits=self.BITS
+        )
+        prefix = "language_model.model.layers.1.ple.ple_embedding.ngram_embedding"
+        tensors = {
+            f"{prefix}.shards.0.weight": weight,
+            f"{prefix}.shards.0.scales": scales,
+            f"{prefix}.shards.0.biases": biases,
+        }
+        shard_file = "model.safetensors"
+        mx.save_safetensors(os.path.join(directory, shard_file), tensors)
+        with open(os.path.join(directory, "model.safetensors.index.json"), "w") as fh:
+            json.dump({"weight_map": {name: shard_file for name in tensors}}, fh)
+        return weight, scales, biases
+
+    def test_disk_shard_regex_handles_both_namings(self):
+        prefix = "language_model.model.layers.1.ple.ple_embedding.ngram_embedding"
+        for key in (f"{prefix}.shards.7.weight", f"{prefix}.shard_7.weight"):
+            match = _DISK_SHARD_RE.search(key)
+            self.assertIsNotNone(match, key)
+            self.assertEqual(int(match.group(1)), 7)
+            self.assertIsNotNone(_NGRAM_SHARD_DROP_RE.search(key))
+        # Non-shard PLE tensors must survive both filters.
+        heads = f"{prefix}.ngram_heads_offsets"
+        self.assertIsNone(_DISK_SHARD_RE.search(heads))
+        self.assertIsNone(_NGRAM_SHARD_DROP_RE.search(heads))
+
+    def test_ple_on_disk_defaults_off(self):
+        config = tiny_config().text_config
+        self.assertFalse(config.ple_on_disk)
+        self.assertIsNone(config.ple_disk_path)
+        # A shard-free embedding is only built when disk mode is requested.
+        resident = ShardedEmbedding(num_embeddings=10, dims=4, num_shards=2)
+        self.assertEqual(len(resident.shards), 2)
+        disk = ShardedEmbedding(num_embeddings=10, dims=4, num_shards=2, disk_dir="/x")
+        self.assertEqual(disk.shards, [])
+
+    def test_sanitize_drops_ngram_shards_in_disk_mode(self):
+        config = tiny_config()
+        config.text_config.ple_on_disk = True
+        model = qwen4_exp.Model(config)
+        prefix = "model.language_model.layers.0.ple.ple_embedding.ngram_embedding"
+        weights = {
+            f"{prefix}.shard_0.weight": mx.zeros((4, 8)),
+            f"{prefix}.shards.1.weight": mx.zeros((4, 8)),
+            f"{prefix}.ngram_heads_offsets": mx.zeros((4,)),
+        }
+        sanitized = model.sanitize(weights)
+        self.assertFalse(
+            any("ngram_embedding.shard" in key for key in sanitized),
+            "shard tensors must be dropped in disk mode",
+        )
+        # Non-shard PLE tensors are still kept.
+        self.assertTrue(any("ngram_heads_offsets" in key for key in sanitized))
+
+    def test_disk_dequant_matches_mx_dequantize_bit_identical(self):
+        import tempfile
+
+        import numpy as np
+
+        rows, dims = 12, 64
+        with tempfile.TemporaryDirectory() as directory:
+            weight, scales, biases = self._write_single_shard_checkpoint(
+                directory, rows, dims
+            )
+            index = _PLEDiskIndex(directory)
+            wanted = [11, 0, 5, 5, 8]
+            disk_rows = index.rows(
+                0, wanted, dims, group_size=self.GROUP_SIZE, bits=self.BITS
+            )
+
+        reference = mx.dequantize(
+            weight[mx.array(wanted)],
+            scales=scales[mx.array(wanted)],
+            biases=biases[mx.array(wanted)],
+            group_size=self.GROUP_SIZE,
+            bits=self.BITS,
+        )
+        # _PLEDiskIndex dequantizes on the host in float32; the runtime embeds
+        # in bf16, so compare after the same bf16 rounding the module applies.
+        disk_bf16 = mx.array(disk_rows).astype(mx.bfloat16).astype(mx.float32)
+        reference_f32 = reference.astype(mx.float32)
+        mx.eval(disk_bf16, reference_f32)
+        max_abs = mx.max(mx.abs(disk_bf16 - reference_f32)).item()
+        self.assertEqual(max_abs, 0.0, f"disk dequant diverged: max abs {max_abs}")
+
+    def test_disk_mode_embedding_matches_resident(self):
+        import tempfile
+
+        rows, dims = 12, 64
+        with tempfile.TemporaryDirectory() as directory:
+            weight, scales, biases = self._write_single_shard_checkpoint(
+                directory, rows, dims
+            )
+
+            resident = ShardedEmbedding(rows, dims, num_shards=1)
+            quantized = nn.QuantizedEmbedding(
+                rows, dims, group_size=self.GROUP_SIZE, bits=self.BITS
+            )
+            quantized.weight, quantized.scales, quantized.biases = (
+                weight,
+                scales,
+                biases,
+            )
+            resident.shards = [quantized]
+
+            disk = ShardedEmbedding(rows, dims, num_shards=1, disk_dir=directory)
+
+            indices = mx.array([[11, 0, 5], [8, 1, 5]], dtype=mx.int32)
+            resident_out = resident(indices)
+            disk_out = disk(indices)
+            mx.eval(resident_out, disk_out)
+
+        self.assertEqual(disk_out.shape, resident_out.shape)
+        self.assertEqual(disk_out.dtype, resident_out.dtype)
+        max_abs = mx.max(mx.abs(disk_out - resident_out)).item()
+        self.assertEqual(max_abs, 0.0, f"disk vs resident diverged: max abs {max_abs}")
 
 
 if __name__ == "__main__":

--- a/mlx_vlm/utils.py
+++ b/mlx_vlm/utils.py
@@ -798,6 +798,9 @@ def load_model(model_path: Path, lazy: bool = False, **kwargs) -> nn.Module:
         quantize_activations (bool, optional): If True, convert QuantizedLinear layers
             to QQLinear layers for activation quantization. Only supported for models
             quantized with 'nvfp4' or 'mxfp8' modes. Default: ``False``.
+        ple_on_disk (bool, optional): If True, keep a model's n-gram PLE table
+            (qwen4_exp) on disk and read rows on demand instead of holding it
+            resident. No effect on models without a PLE table. Default: ``False``.
 
     Returns:
         nn.Module: The loaded and initialized model.
@@ -807,6 +810,7 @@ def load_model(model_path: Path, lazy: bool = False, **kwargs) -> nn.Module:
         ValueError: If the model class or args class are not found or cannot be instantiated.
     """
     strict = kwargs.pop("strict", True)
+    ple_on_disk = kwargs.pop("ple_on_disk", False)
     # An expert-offload dir (mlx_vlm.moe_offload) is missing routed-expert
     # keys by design; defer eval until patch_model swaps those modules, or
     # their random-init resident weights get eagerly materialized -- the OOM
@@ -880,6 +884,20 @@ python -m mlx_vlm.convert --hf-path <local_dir> --mlx-path <mlx_dir>
     modules = ["text", "vision", "perceiver", "projector", "audio"]
     model_config = update_module_configs(model_config, model_class, config, modules)
     model_config = apply_generation_config_defaults(model_config, config)
+
+    # Opt-in disk offload of a model's n-gram PLE table (qwen4_exp). The table
+    # is read row by row off ``model_path`` instead of held resident; the model
+    # constructs its ShardedEmbedding shard-free when this is set.
+    if ple_on_disk:
+        text_config = getattr(model_config, "text_config", None)
+        if text_config is not None and hasattr(text_config, "ple_on_disk"):
+            text_config.ple_on_disk = True
+            text_config.ple_disk_path = str(model_path)
+        else:
+            logging.warning(
+                "ple_on_disk=True ignored: %s has no PLE table to offload.",
+                config.get("model_type"),
+            )
 
     model = model_class.Model(model_config)
 
@@ -1187,6 +1205,9 @@ def load(
         quantize_activations (bool, optional): If True, convert QuantizedLinear layers
             to QQLinear layers for activation quantization. Only supported for models
             quantized with 'nvfp4' or 'mxfp8' modes. Default: ``False``.
+        ple_on_disk (bool, optional): If True, keep a model's n-gram PLE table
+            (qwen4_exp) on disk and read rows on demand instead of holding it
+            resident. No effect on models without a PLE table. Default: ``False``.
 
     Returns:
         Tuple[nn.Module, TokenizerWrapper]: A tuple containing the loaded model and tokenizer.


### PR DESCRIPTION
# qwen4_exp: opt-in disk offload for the n-gram PLE table

## What this does

Adds an opt-in `ple_on_disk` mode for `qwen4_exp` models. When enabled, the
per-layer n-gram PLE (Per-Layer Embedding) table is left on disk and its rows
are read and dequantized on demand instead of being held resident in memory.

It is exposed three ways, all defaulting to **off** with zero behavior change:

- `load_model(..., ple_on_disk=True)` / `load(..., ple_on_disk=True)` kwarg
- `mlx_vlm.server --ple-on-disk`
- `mlx_vlm.generate --ple-on-disk`

This mirrors the existing `--expert-cache-gb` MoE-offload flag: a load-time
option for running a family whose weights are dominated by a structure that is
mostly cold on any given token.

## Why it's useful

In `qwen4_exp` the n-gram PLE table dominates the parameter count — on the
order of ~51B parameters, roughly ~29 GB once quantized to 4-bit — yet only a
few hundred bytes of it are read per token (a handful of rows per n-gram head).
Keeping the whole table resident spends tens of GB of RAM to serve byte-sized
reads.

Reading rows from disk instead drops resident memory by ~29 GB on any
`qwen4_exp` checkpoint. Measured active memory, last-position logits path,
one process per mode (never co-resident):

- Stock 4-bit conversion: ~97 GB resident → ~68 GB with `ple_on_disk`.
- An expert-reduced 4-bit conversion
  ([`sh0wie/Qwen3.8-Flash-Next-REAP-288-MLX-4bit`](https://huggingface.co/sh0wie/Qwen3.8-Flash-Next-REAP-288-MLX-4bit)):
  68.17 GB → 38.37 GB (−29.8 GB).

That is the difference between "needs a 96 GB+ machine" and "runs on a 64 GB
machine" for this family. The table rows are a few hundred bytes each and are
mmap'd, so only touched pages enter the OS page cache; the rest never loads.

## Correctness

The on-disk path is **bit-identical** to the resident path. The disk reader
dequantizes rows on the host in float32 and reproduces `mx.dequantize` for
affine group quantization exactly (little-endian bit unpack, per-group
scale/bias in bf16), then embeds in bf16 as the resident module does.

- On the REAP-288 checkpoint above, disk-vs-RAM last-position logits are
  identical (max abs 0.0; same argmax) — the difference is purely I/O, not math.
- Included unit tests (`mlx_vlm/tests/test_qwen4_exp.py`) assert max abs 0.0
  on a synthetic single-shard checkpoint, both for the row dequant vs
  `mx.dequantize` and for the disk-mode `ShardedEmbedding` vs a resident
  `QuantizedEmbedding` built from the same bytes. They are CPU-light: they
  quantize and read a tiny table, never a full model.

The disk reader accepts **both** n-gram shard naming conventions —
`.ngram_embedding.shard_N.` (underscore) and `.ngram_embedding.shards.N.`
(dot) — because it reads raw tensor names straight from the safetensors index,
and different conversions of this family ship one or the other. A regression
test covers both namings and confirms non-shard PLE tensors are untouched.

## How it works

- `ShardedEmbedding` gains a `disk_dir` mode: it constructs with no resident
  shards and serves lookups via `_PLEDiskIndex`, a numpy-memmap, row-granular
  reader over the quantized shard tensors in the checkpoint's safetensors.
- `Model.sanitize` drops the n-gram shard tensors in disk mode so they don't
  collide with the now shard-free module at `load_weights`.
- `TextConfig` carries runtime `ple_on_disk` / `ple_disk_path` fields (default
  off); `load_model` sets them from the `ple_on_disk` kwarg (recording the
  model path) before constructing the model, so the embedding is built
  shard-free from the start rather than allocated and then freed.

Models without a PLE table are unaffected: the kwarg is a no-op for them, and a
non-`qwen4_exp` model logs a warning and ignores it.

## Usage

```bash
# Server
python -m mlx_vlm.server --model sh0wie/Qwen3.8-Flash-Next-REAP-288-MLX-4bit --ple-on-disk

# One-shot generate
python -m mlx_vlm.generate --model sh0wie/Qwen3.8-Flash-Next-REAP-288-MLX-4bit --ple-on-disk \
    --prompt "Write a Python function that merges two sorted lists."
```

```python
from mlx_vlm import load

model, processor = load("sh0wie/Qwen3.8-Flash-Next-REAP-288-MLX-4bit", ple_on_disk=True)
```

## Notes / scope

- The disk reader assumes the PLE table is affine-quantized at group size 32,
  4-bit — the layout every published `qwen4_exp` conversion ships. Non-disk
  (resident) loading is unchanged and derives quant params from the checkpoint
  as before.
- Trades a small per-token host read for the RAM. On fast NVMe the cost is in
  the noise for interactive use; the point is fitting the model at all on
  memory-constrained machines.
