### PR TITLE
Prime speculative drafters from the whole prompt during chunked prefill

### DIFF
--- a/mlx_vlm/generate/ar.py
+++ b/mlx_vlm/generate/ar.py
@@ -26,11 +26,14 @@ from ..sample_utils import (
     top_p_sampling,
 )
 from ..speculative.utils import (
+    drafter_consumes_prompt_hidden,
     make_speculative_prompt_cache,
+    prompt_chunk_capture_kwargs,
     run_speculative_rounds,
     run_speculative_server_rounds,
     speculative_hidden_state,
     speculative_prefill_kwargs,
+    splice_prompt_hidden,
 )
 from ..turboquant import BatchTurboQuantKVCache, turboquant_enabled
 from ..utils import group_images_by_shape, prepare_inputs, should_add_special_tokens
@@ -345,7 +348,10 @@ def generate_step(
 
     # Speculative decoding setup
     last_outputs = None
+    speculative_prompt_ids = input_ids
+    prompt_hidden_chunks: List[Optional[List[mx.array]]] = []
     speculative_prefill_capture_kwargs = {}
+    capture_prompt_hidden_per_chunk = False
     if draft_model is not None:
         from ..speculative.drafters import validate_drafter_compatibility
 
@@ -353,6 +359,10 @@ def generate_step(
         speculative_prefill_capture_kwargs = speculative_prefill_kwargs(
             draft_kind, draft_model
         )
+        capture_prompt_hidden_per_chunk = drafter_consumes_prompt_hidden(
+            draft_kind, draft_model
+        )
+        chunk_capture_kwargs = prompt_chunk_capture_kwargs(draft_kind, draft_model)
         # Reset stale mRoPE state from any previous generation.
         lm = model.language_model if hasattr(model, "language_model") else model
         if hasattr(lm, "_position_ids"):
@@ -470,6 +480,9 @@ def generate_step(
         ) or (
             checkpoint_len is not None and 0 < checkpoint_len < inputs_embeds.shape[1]
         )
+        # Drafters are primed from the whole prompt, which the chunk loop below
+        # consumes token by token; snapshot the ids before that happens.
+        speculative_prompt_ids = input_ids
         if prefill_step_size is not None and should_chunk:
             # Chunked prefill with embeddings
             total_tokens = inputs_embeds.shape[1]
@@ -489,13 +502,26 @@ def generate_step(
                     chunk_kwargs = kwargs
                     if getattr(model.language_model, "supports_logits_to_keep", False):
                         chunk_kwargs = {**kwargs, "logits_to_keep": 1}
-                    model.language_model(
+                    if capture_prompt_hidden_per_chunk:
+                        chunk_kwargs = {
+                            **chunk_kwargs,
+                            **chunk_capture_kwargs,
+                        }
+                    chunk_outputs = model.language_model(
                         inputs=input_ids[:, :n_to_process],
                         inputs_embeds=inputs_embeds[:, :n_to_process],
                         cache=prompt_cache,
                         n_to_process=n_to_process,
                         **chunk_kwargs,
                     )
+                    if capture_prompt_hidden_per_chunk:
+                        chunk_hidden = getattr(chunk_outputs, "hidden_states", None)
+                        # Eval now: an unevaluated capture pins the whole chunk's
+                        # activation graph until the drafter is primed.
+                        if chunk_hidden:
+                            mx.eval(chunk_hidden)
+                        prompt_hidden_chunks.append(chunk_hidden)
+                    chunk_outputs = None
                     quantize_cache_fn(prompt_cache)
                     mx.eval([c.state for c in prompt_cache])
                     processed_tokens += n_to_process
@@ -519,11 +545,12 @@ def generate_step(
 
     # Speculative decoding
     if draft_model is not None:
+        last_outputs = splice_prompt_hidden(prompt_hidden_chunks, last_outputs)
         yield from run_speculative_rounds(
             model,
             draft_model,
             prompt_cache,
-            input_ids,
+            speculative_prompt_ids,
             y,
             logprobs,
             last_outputs,
@@ -1682,6 +1709,12 @@ class PromptProcessingBatch:
         self.draft_kind = draft_kind
         self.draft_block_size = draft_block_size
         self.greedy_sampling = greedy_sampling
+        self._capture_prompt_hidden_per_chunk = (
+            draft_model is not None
+            and draft_kind is not None
+            and drafter_consumes_prompt_hidden(draft_kind, draft_model)
+        )
+        self._prompt_hidden_chunks: List[Optional[List[mx.array]]] = []
 
         lengths = [len(ids) for ids in input_ids]
         max_length = max(lengths)
@@ -1710,6 +1743,9 @@ class PromptProcessingBatch:
         self._left_padding_per_row = list(left_padding)
         self._total_prompt_tokens = sum(lengths)
         self._processed_prompt_columns = 0
+        # ``prompt_step`` walks ``_input_ids`` forward chunk by chunk; drafters
+        # are primed from the whole prompt, so keep the unconsumed ids.
+        self._speculative_prompt_ids = self._input_ids
 
         self.logits_processors = logits_processors or []
         self.thinking_budget_criteria = thinking_budget_criteria or []
@@ -1961,13 +1997,26 @@ class PromptProcessingBatch:
         if n <= 0:
             return 0
         prompt_kwargs = self._prompt_kwargs_for_step(n)
-        self.model(
+        if self._capture_prompt_hidden_per_chunk:
+            prompt_kwargs = {
+                **prompt_kwargs,
+                **prompt_chunk_capture_kwargs(self.draft_kind, self.draft_model),
+            }
+        chunk_outputs = self.model(
             self._input_ids[:, :n],
             cache=self.prompt_cache,
             inputs_embeds=self._inputs_embeds[:, :n],
             n_to_process=n,
             **prompt_kwargs,
         )
+        if self._capture_prompt_hidden_per_chunk:
+            chunk_hidden = getattr(chunk_outputs, "hidden_states", None)
+            # Eval now: an unevaluated capture pins the whole chunk's
+            # activation graph until the drafter is primed.
+            if chunk_hidden:
+                mx.eval(chunk_hidden)
+            self._prompt_hidden_chunks.append(chunk_hidden)
+        chunk_outputs = None
         mx.async_eval([c.state for c in self.prompt_cache])
         self._processed_prompt_columns += n
         self._store_apc_exact_checkpoints()
@@ -2018,6 +2067,9 @@ class PromptProcessingBatch:
             **call_kwargs,
         )
         logits = output.logits if hasattr(output, "logits") else output
+        if self._prompt_hidden_chunks:
+            output = splice_prompt_hidden(self._prompt_hidden_chunks, output)
+            self._prompt_hidden_chunks = []
         if self._right_pad_per_row is not None and any(self._right_pad_per_row):
             # Per-row last *real* token sits at index (seq - 1 - right_pad[i]).
             seq = logits.shape[1]
@@ -2091,7 +2143,7 @@ class PromptProcessingBatch:
                 shared_kv_states=(
                     output.shared_kv_states if self.draft_kind == "mtp" else None
                 ),
-                prompt_tokens=self._input_ids,
+                prompt_tokens=self._speculative_prompt_ids,
                 draft_block_size=self.draft_block_size,
                 token_dtype=self._input_ids.dtype,
                 greedy_sampling=self.greedy_sampling,

--- a/mlx_vlm/generate/common.py
+++ b/mlx_vlm/generate/common.py
@@ -96,9 +96,18 @@ def _chunked_prefill_enabled(
     if any(getattr(candidate, "no_chunked_prefill", False) for candidate in candidates):
         return False
 
-    # Hidden-state speculative prefill is model-contract dependent. Keep unknown
-    # target models conservative unless they expose a chunked_prefill_policy.
-    return draft_model is None
+    if draft_model is None:
+        return True
+
+    # Chunked prefill re-joins the per-chunk hidden captures before handing
+    # them to the drafter, so the speculative contract is the same one an
+    # unchunked prefill already has to satisfy. Requiring the target to
+    # implement the round loops' rollback hook keeps models that cannot
+    # speculate at all from silently opting in here.
+    return any(
+        callable(getattr(candidate, "rollback_speculative_cache", None))
+        for candidate in candidates
+    )
 
 
 def maybe_quantize_kv_cache(

--- a/mlx_vlm/models/cohere_compass/cohere_compass.py
+++ b/mlx_vlm/models/cohere_compass/cohere_compass.py
@@ -94,19 +94,6 @@ class Model(nn.Module):
     def layers(self):
         return self.language_model.model.layers
 
-    def chunked_prefill_policy(
-        self,
-        *,
-        input_ids=None,
-        inputs_embeds=None,
-        prompt_cache=None,
-        draft_model=None,
-        draft_kind=None,
-        prefill_kwargs=None,
-    ):
-        del input_ids, inputs_embeds, prompt_cache, draft_kind, prefill_kwargs
-        return draft_model is None
-
     def __call__(
         self,
         input_ids: mx.array,

--- a/mlx_vlm/models/gemma4/language.py
+++ b/mlx_vlm/models/gemma4/language.py
@@ -681,7 +681,7 @@ class LanguageModel(nn.Module):
         draft_kind=None,
         prefill_kwargs=None,
     ) -> bool:
-        del input_ids, inputs_embeds, prompt_cache
+        del input_ids, inputs_embeds, prompt_cache, draft_model, draft_kind
         prefill_kwargs = prefill_kwargs or {}
         if getattr(self, "no_chunked_prefill", False):
             return False
@@ -697,13 +697,6 @@ class LanguageModel(nn.Module):
             has_audio = int(mx.sum(token_types == 3).item()) > 0
             if has_visual and not has_audio:
                 return False
-
-        if draft_model is not None:
-            return (
-                draft_kind == "mtp"
-                and bool(prefill_kwargs.get("return_hidden", False))
-                and bool(prefill_kwargs.get("return_shared_kv", False))
-            )
 
         return True
 

--- a/mlx_vlm/models/gemma4_unified/gemma4_unified.py
+++ b/mlx_vlm/models/gemma4_unified/gemma4_unified.py
@@ -144,17 +144,10 @@ class Model(nn.Module):
         draft_kind=None,
         prefill_kwargs=None,
     ) -> bool:
-        del inputs_embeds, prompt_cache
+        del inputs_embeds, prompt_cache, draft_model, draft_kind
         prefill_kwargs = prefill_kwargs or {}
         if self._should_disable_chunked_prefill(input_ids, **prefill_kwargs):
             return False
-
-        if draft_model is not None:
-            return (
-                draft_kind == "mtp"
-                and bool(prefill_kwargs.get("return_hidden", False))
-                and bool(prefill_kwargs.get("return_shared_kv", False))
-            )
 
         return True
 

--- a/mlx_vlm/models/lfm2/language.py
+++ b/mlx_vlm/models/lfm2/language.py
@@ -393,24 +393,6 @@ class LanguageModel(nn.Module):
             gdn_states=None,
         )
 
-    def chunked_prefill_policy(
-        self,
-        *,
-        input_ids=None,
-        inputs_embeds=None,
-        prompt_cache=None,
-        draft_model=None,
-        draft_kind=None,
-        prefill_kwargs=None,
-    ) -> bool:
-        del input_ids, inputs_embeds, prompt_cache
-        if draft_model is None:
-            return True
-        prefill_kwargs = prefill_kwargs or {}
-        if draft_kind == "dflash":
-            return prefill_kwargs.get("capture_layer_ids") is not None
-        return False
-
     @staticmethod
     def _restore_conv_cache(
         cache: ArraysCache,

--- a/mlx_vlm/models/muse_glimmer/language.py
+++ b/mlx_vlm/models/muse_glimmer/language.py
@@ -277,24 +277,6 @@ class LanguageModel(nn.Module):
         self.final_logit_softcapping = args.final_logit_softcapping
         self.output_multiplier = args.output_multiplier
 
-    def chunked_prefill_policy(
-        self,
-        *,
-        input_ids=None,
-        inputs_embeds=None,
-        prompt_cache=None,
-        draft_model=None,
-        draft_kind=None,
-        prefill_kwargs=None,
-    ) -> bool:
-        del input_ids, inputs_embeds, prompt_cache
-        if draft_model is None:
-            return True
-        prefill_kwargs = prefill_kwargs or {}
-        if draft_kind in ("dflash", "eagle3"):
-            return prefill_kwargs.get("capture_layer_ids") is not None
-        return False
-
     def __call__(
         self,
         inputs: Optional[mx.array] = None,

--- a/mlx_vlm/models/qwen3_5/language.py
+++ b/mlx_vlm/models/qwen3_5/language.py
@@ -1421,28 +1421,6 @@ class LanguageModel(nn.Module):
         if not args.tie_word_embeddings:
             self.lm_head = nn.Linear(args.hidden_size, args.vocab_size, bias=False)
 
-    def chunked_prefill_policy(
-        self,
-        *,
-        input_ids=None,
-        inputs_embeds=None,
-        prompt_cache=None,
-        draft_model=None,
-        draft_kind=None,
-        prefill_kwargs=None,
-    ) -> bool:
-        del input_ids, inputs_embeds, prompt_cache
-        prefill_kwargs = prefill_kwargs or {}
-        if draft_model is None:
-            return True
-        if draft_kind == "mtp":
-            return bool(prefill_kwargs.get("return_hidden", False)) and bool(
-                prefill_kwargs.get("return_shared_kv", False)
-            )
-        if draft_kind in ("dflash", "eagle3"):
-            return prefill_kwargs.get("capture_layer_ids") is not None
-        return draft_kind is None
-
     def rollback_speculative_cache(
         self,
         caches: List[Any],

--- a/mlx_vlm/speculative/utils.py
+++ b/mlx_vlm/speculative/utils.py
@@ -1,3 +1,6 @@
+import logging
+from copy import copy
+from dataclasses import is_dataclass, replace
 from typing import Any, Callable, Generator, List, Optional, Tuple
 
 import mlx.core as mx
@@ -56,16 +59,21 @@ __all__ = [
     "_speculative_walk_batch_deferred_greedy",
     "_speculative_walk_batch_uniform_acceptance",
     "_speculative_walk_deferred_greedy",
+    "drafter_consumes_prompt_hidden",
     "format_speculative_stats",
     "get_speculative_rounds_batch",
     "make_speculative_prompt_cache",
     "run_speculative_rounds",
     "run_speculative_server_rounds",
     "speculative_hidden_state",
+    "prompt_chunk_capture_kwargs",
     "speculative_prefill_kwargs",
     "speculative_stats_since",
     "speculative_stats_snapshot",
+    "splice_prompt_hidden",
 ]
+
+logger = logging.getLogger(__name__)
 
 
 def format_speculative_stats(draft_model: nn.Module) -> Optional[str]:
@@ -112,6 +120,70 @@ def speculative_hidden_state(draft_kind: str, outputs):
     raise ValueError(
         f"Unknown draft_kind {draft_kind!r}. Supported: ['dflash', 'eagle3', 'mtp']"
     )
+
+
+def prompt_chunk_capture_kwargs(draft_kind: str, drafter) -> dict:
+    """Capture kwargs for an intermediate chunk of a chunked prefill.
+
+    Only the hidden-state capture has to span the whole prompt. Shared-KV
+    state is read off the completed target cache by the final prefill call,
+    so asking for it per chunk would materialize a full per-layer K/V dict
+    each time for nothing.
+    """
+    return {
+        key: value
+        for key, value in speculative_prefill_kwargs(draft_kind, drafter).items()
+        if key != "return_shared_kv"
+    }
+
+
+def drafter_consumes_prompt_hidden(draft_kind: str, drafter) -> bool:
+    """Whether a drafter reads target hidden past the last prompt position.
+
+    MTP drafters that borrow the target KV cache (``set_shared_kv`` with no
+    priming hook) only ever look at the final position, so capturing hidden on
+    the last prefill call is enough. Everything else needs the whole prompt:
+    own-cache MTP and EAGLE3 prime a persistent drafter cache via
+    ``prefill_from_target_hidden``, and DFlash cross-attends its first draft
+    block over the full prompt hidden as context.
+    """
+    if drafter is not None and callable(
+        getattr(drafter, "prefill_from_target_hidden", None)
+    ):
+        return True
+    return draft_kind != "mtp"
+
+
+def splice_prompt_hidden(chunk_hidden_states: List[List[mx.array]], outputs):
+    """Rejoin per-chunk captured hidden with the final prefill call's hidden.
+
+    Chunked prefill splits the prompt across several forward passes, so a
+    drafter primed only from the last call would see a one-token prompt.
+    Returns ``outputs`` with ``hidden_states`` spanning the whole prompt, or
+    unchanged when the captures cannot be lined up.
+    """
+    if not chunk_hidden_states or outputs is None:
+        return outputs
+    tail = getattr(outputs, "hidden_states", None)
+    if not tail:
+        return outputs
+    if any(not chunk or len(chunk) != len(tail) for chunk in chunk_hidden_states):
+        logger.warning(
+            "Chunked prefill captured %d hidden slot(s) but the final prefill "
+            "call returned %d; leaving the drafter primed from the prompt tail.",
+            max(len(chunk) if chunk else 0 for chunk in chunk_hidden_states),
+            len(tail),
+        )
+        return outputs
+    merged = [
+        mx.concatenate([chunk[i] for chunk in chunk_hidden_states] + [tail[i]], axis=1)
+        for i in range(len(tail))
+    ]
+    if is_dataclass(outputs):
+        return replace(outputs, hidden_states=merged)
+    spliced = copy(outputs)
+    spliced.hidden_states = merged
+    return spliced
 
 
 def make_speculative_prompt_cache(

--- a/mlx_vlm/tests/test_generate.py
+++ b/mlx_vlm/tests/test_generate.py
@@ -2151,6 +2151,125 @@ def test_chunked_prefill_policy_defaults_conservative_for_speculation():
     )
 
 
+def test_chunked_prefill_allows_speculation_for_rollback_capable_targets():
+    model = SimpleNamespace(
+        no_chunked_prefill=False,
+        language_model=SimpleNamespace(rollback_speculative_cache=lambda *a, **k: 0),
+    )
+
+    assert ar_module._chunked_prefill_enabled(
+        model,
+        draft_model=SimpleNamespace(config=SimpleNamespace(target_layer_ids=[])),
+        draft_kind="mtp",
+        prefill_kwargs={"return_hidden": True, "return_shared_kv": True},
+    )
+
+
+@pytest.mark.parametrize(
+    "draft_kind,has_prefill_hook,expected_hidden_len",
+    [
+        # Own-cache MTP (DeepSeek-V4 / Qwen3.5 / Inkling), EAGLE3 and DFlash all
+        # read target hidden past the last prompt position, so a chunked prefill
+        # has to hand the drafter the whole prompt.
+        ("mtp", True, 9),
+        ("eagle3", True, 9),
+        ("dflash", False, 9),
+        # Shared-KV MTP (Gemma 4) only ever looks at the final position.
+        ("mtp", False, 1),
+    ],
+)
+def test_chunked_prefill_primes_drafter_from_whole_prompt(
+    draft_kind, has_prefill_hook, expected_hidden_len
+):
+    model = MagicMock()
+    model.no_chunked_prefill = False
+    del model.chunked_prefill_policy
+    model.language_model.rollback_speculative_cache = lambda *a, **k: 0
+    model.language_model.supports_logits_to_keep = False
+
+    def language_model_call(*args, **kwargs):
+        embeds = kwargs.get("inputs_embeds")
+        n = embeds.shape[1] if embeds is not None else 1
+        captured = kwargs.get("return_hidden") or kwargs.get("capture_layer_ids")
+        return SimpleNamespace(
+            logits=mx.zeros((1, n, 4)),
+            hidden_states=[mx.zeros((1, n, 4))] if captured else None,
+            shared_kv_states={} if kwargs.get("return_shared_kv") else None,
+            cross_attention_states=None,
+            encoder_outputs=None,
+            gdn_states=None,
+        )
+
+    model.language_model.side_effect = language_model_call
+
+    embedding_output = MagicMock()
+    embedding_output.inputs_embeds = mx.zeros((1, 9, 4))
+    embedding_output.to_dict.return_value = {}
+    model.get_input_embeddings.return_value = embedding_output
+
+    draft_model = SimpleNamespace(config=SimpleNamespace(target_layer_ids=[0]))
+    if has_prefill_hook:
+        draft_model.prefill_from_target_hidden = lambda *a, **k: None
+
+    seen = {}
+
+    def record_rounds(m, d, c, input_ids, first_token, logprobs, last_outputs, **kw):
+        seen["prompt_tokens"] = int(input_ids.shape[1])
+        hidden_states = getattr(last_outputs, "hidden_states", None)
+        seen["hidden_len"] = int(hidden_states[-1].shape[1]) if hidden_states else None
+        return iter(())
+
+    with (
+        patch("mlx_vlm.speculative.drafters.validate_drafter_compatibility"),
+        patch.object(generate_module.cache, "make_prompt_cache", return_value=[]),
+        patch.object(generate_module, "make_logits_processors", return_value=[]),
+        patch.object(
+            generate_module, "make_sampler", return_value=lambda _: mx.array([0])
+        ),
+        patch.object(ar_module, "run_speculative_rounds", side_effect=record_rounds),
+    ):
+        list(
+            generate_module.generate_step(
+                input_ids=mx.array([[1, 2, 3, 4, 5, 6, 7, 8, 9]], dtype=mx.int32),
+                model=model,
+                pixel_values=None,
+                mask=None,
+                max_tokens=1,
+                prefill_step_size=2,
+                draft_model=draft_model,
+                draft_kind=draft_kind,
+            )
+        )
+
+    assert seen["prompt_tokens"] == 9
+    assert seen["hidden_len"] == expected_hidden_len
+
+
+def test_splice_prompt_hidden_keeps_tail_when_captures_do_not_line_up():
+    from mlx_vlm.speculative.utils import splice_prompt_hidden
+
+    outputs = SimpleNamespace(hidden_states=[mx.zeros((1, 1, 4))])
+
+    assert splice_prompt_hidden([], outputs) is outputs
+    assert splice_prompt_hidden([None], outputs) is outputs
+    assert splice_prompt_hidden([[mx.zeros((1, 2, 4))] * 2], outputs) is outputs
+
+    spliced = splice_prompt_hidden([[mx.zeros((1, 2, 4))]], outputs)
+    assert spliced.hidden_states[0].shape == (1, 3, 4)
+
+
+def test_drafter_consumes_prompt_hidden_matches_drafter_family():
+    from mlx_vlm.speculative.utils import drafter_consumes_prompt_hidden
+
+    shared_kv_drafter = SimpleNamespace()
+    own_cache_drafter = SimpleNamespace(prefill_from_target_hidden=lambda *a, **k: None)
+
+    assert not drafter_consumes_prompt_hidden("mtp", shared_kv_drafter)
+    assert drafter_consumes_prompt_hidden("mtp", own_cache_drafter)
+    assert drafter_consumes_prompt_hidden("eagle3", own_cache_drafter)
+    assert drafter_consumes_prompt_hidden("dflash", shared_kv_drafter)
+
+
 def test_stream_generate_forwards_verbose_to_generate_step():
     captured = {}
 

--- a/mlx_vlm/tests/test_models.py
+++ b/mlx_vlm/tests/test_models.py
@@ -16668,11 +16668,20 @@ class TestCohereCompass(unittest.TestCase):
         )
 
     def test_visual_deepstack_allows_chunked_prefill(self):
+        from mlx_vlm.generate.common import _chunked_prefill_enabled
+
         model = self._tiny_model()
-        self.assertTrue(model.chunked_prefill_policy(prefill_kwargs={}))
+        self.assertTrue(_chunked_prefill_enabled(model, prefill_kwargs={}))
         self.assertTrue(
-            model.chunked_prefill_policy(
-                prefill_kwargs={"deepstack_visual_embeds": [mx.zeros((4, 32))]}
+            _chunked_prefill_enabled(
+                model,
+                prefill_kwargs={"deepstack_visual_embeds": [mx.zeros((4, 32))]},
+            )
+        )
+        # No rollback_speculative_cache hook, so speculation stays unchunked.
+        self.assertFalse(
+            _chunked_prefill_enabled(
+                model, draft_model=object(), draft_kind="dflash", prefill_kwargs={}
             )
         )
 


### PR DESCRIPTION
Fixes #2022

## Summary

Chunked prefill requested the speculative capture kwargs only on the final
prefill call. Drafters that read target hidden states past the last prompt
position were therefore primed from a one-token prompt.

Three drafter families are affected: own-cache MTP (`deepseek_v4_mtp`,
`qwen3_5_mtp`, `inkling_mtp`) and EAGLE3 prime a persistent drafter cache
through `prefill_from_target_hidden`; DFlash cross-attends its first draft
block over the prompt hidden. Shared-KV MTP (`gemma4_assistant`) only reads
the final position and is unaffected.

This passes the hidden capture on every chunk, rejoins the captures, and
hands the round loops the full prompt ids. Applied to `generate_step` and to
the batch path in `PromptBatch`, which had the same gap.

The per-model `chunked_prefill_policy` speculative branches were four copies
of the same predicate, checking capture flags the caller had already set.
They are replaced by a capability check on `rollback_speculative_cache`, the
hook the round loops already require. That also enables chunked prefill for
DeepSeek-V4 MTP. Model-specific media and padding rules are unchanged.

Only the hidden capture is requested per chunk. Shared-KV state still comes
from the final call, which reads the completed target cache.

## Benchmarks

Qwen3.5-9B-4bit + its MTP drafter, both built locally from `Qwen/Qwen3.5-9B`.
128 new tokens, greedy, `prefill_step_size=512`.

| prompt | metric | unchunked | chunked (main) | chunked (this PR) |
|---|---|--:|--:|--:|
| 2048 | % of drafted accepted | 82.3% | 57.1% | 82.3% |
| 2048 | accepted tokens/round | 2.65 | 2.13 | 2.65 |
| 4096 | % of drafted accepted | 64.9% | 55.4% | 82.3% |
| 4096 | accepted tokens/round | 2.29 | 2.10 | 2.65 |
| 8192 | % of drafted accepted | 69.8% | 68.5% | 70.8% |
| 8192 | accepted tokens/round | 2.40 | 2.37 | 2.42 |

At 2048 the chunked run reproduces the unchunked counters exactly, which
means an identical decode trajectory. The 4096 row where this PR exceeds the
unchunked baseline is trajectory divergence, not a gain: chunked prefill
accumulates KV in a different order, so greedy decoding can diverge. The
claim is parity, not improvement.

Qwen3.5-27B-4bit + `z-lab/Qwen3.5-27B-DFlash`, same settings. DFlash only
loses its first round, so the delta is small.

| prefill | % of drafted accepted | accepted tokens/round |
|---|--:|--:|
| unchunked | 46.4% | 2.54 |
| chunked (main) | 45.0% | 2.49 |
| chunked (this PR) | 49.4% | 2.65 |

Peak memory at 8192 tokens goes from 7.6 GB to 10.2 GB for the chunked run,
against 17.4 GB unchunked. The cost is non-linear in prompt length (+0.0 GB
at 2048, +0.3 GB at 4096, +2.6 GB at 8192), consistent with the drafter's
own prefill forward now running over the whole prompt instead of one token.

No EAGLE3 drafter was available locally, so that family is covered by unit
tests only.

## Reproducing

```sh
git clone https://github.com/Blaizzy/mlx-vlm && cd mlx-vlm
uv venv && uv pip install -e .

# target + MTP drafter, no checkpoint download beyond the base model
uv run mlx_vlm convert --hf-path Qwen/Qwen3.5-9B --mlx-path ./q35-9b-4bit \
  -q --q-bits 4 --q-group-size 64 --mtp

# acceptance is printed at the end of a verbose CLI run
uv run mlx_vlm generate --model ./q35-9b-4bit --draft-model ./q35-9b-4bit-mtp \
  --draft-kind mtp --prompt "$(python -c 'print("the harbour ledger " * 900)')" \
  --max-tokens 128 --temperature 0 --verbose
uv run mlx_vlm generate --model ./q35-9b-4bit --draft-model ./q35-9b-4bit-mtp \
  --draft-kind mtp --prompt "$(python -c 'print("the harbour ledger " * 900)')" \
  --max-tokens 128 --temperature 0 --prefill-step-size 512 --verbose
```

## Tests

`test_chunked_prefill_primes_drafter_from_whole_prompt` is parametrized over
the four drafter families and fails on `main` for all four. Added coverage
for `splice_prompt_hidden`, `drafter_consumes_prompt_hidden`, and the new
gate. `TestCohereCompass::test_visual_deepstack_allows_chunked_prefill` now
asserts through `_chunked_prefill_enabled` instead of the deleted method.

```
pytest ./tests --ignore=tests/test_smoke.py
2897 passed
```

## Notes

`_mtp_rounds_batch` never calls `prefill_from_target_hidden`, so own-cache
MTP drafters run unprimed at batch size > 1 regardless of chunking. This PR
carries the correct hidden through the batch path but does not change that
round loop. Worth a separate issue.

Separately, `convert --mtp -q` cannot extract a drafter: `--q-group-size`
defaults to `None` and `convert.py` passes it straight to the splitter while
the main quantize path guards with `q_group_size or 64`. Passing
`--q-group-size 64` works around it.
