### PR TITLE
Add DeepSeek-V4 DSpark speculative drafter

### DIFF
--- a/mlx_vlm/models/deepseek_v4/language.py
+++ b/mlx_vlm/models/deepseek_v4/language.py
@@ -1016,6 +1016,8 @@ class DeepseekV4Model(PipelineMixin, nn.Module):
         inputs_embeds: Optional[mx.array] = None,
         hidden_sink: Optional[list] = None,
         skip_final_norm: bool = False,
+        capture_layer_ids: Optional[List[int]] = None,
+        capture_sink: Optional[list] = None,
     ) -> mx.array:
         h = self.embed_tokens(inputs) if inputs_embeds is None else inputs_embeds
         h = mx.broadcast_to(
@@ -1044,8 +1046,14 @@ class DeepseekV4Model(PipelineMixin, nn.Module):
         if pipeline_rank < pipeline_size - 1:
             h = mx.distributed.recv_like(h, (pipeline_rank + 1))
 
-        for layer, layer_cache in zip(self.pipeline_layers, cache):
+        capture_set = set(capture_layer_ids) if capture_layer_ids else None
+        for local_idx, (layer, layer_cache) in enumerate(
+            zip(self.pipeline_layers, cache)
+        ):
             h = layer(h, mask, layer_cache, inputs)
+            if capture_set is not None and (self.start_idx + local_idx) in capture_set:
+                # DSpark taps the mean over the hyper-connection copies.
+                capture_sink.append(h.mean(axis=2))
 
         if pipeline_rank != 0:
             h = mx.distributed.send(h, (pipeline_rank - 1) % pipeline_size)
@@ -1261,8 +1269,10 @@ class LanguageModel(nn.Module):
         skip_logits = kwargs.pop("skip_logits", False)
         skip_final_norm = kwargs.pop("skip_final_norm", False)
         hidden_sink = kwargs.pop("hidden_sink", None)
+        capture_layer_ids = kwargs.pop("capture_layer_ids", None)
         if return_hidden and hidden_sink is None:
             hidden_sink = []
+        capture_sink = [] if capture_layer_ids else None
 
         out = self.model(
             inputs,
@@ -1270,11 +1280,13 @@ class LanguageModel(nn.Module):
             inputs_embeds=inputs_embeds,
             hidden_sink=hidden_sink,
             skip_final_norm=skip_final_norm,
+            capture_layer_ids=capture_layer_ids,
+            capture_sink=capture_sink,
         )
         logits = None if skip_logits else self.lm_head(out)
         return LanguageModelOutput(
             logits=logits,
-            hidden_states=hidden_sink,
+            hidden_states=capture_sink if capture_sink is not None else hidden_sink,
             shared_kv_states={} if return_shared_kv else None,
         )
 

--- a/mlx_vlm/speculative/drafters/__init__.py
+++ b/mlx_vlm/speculative/drafters/__init__.py
@@ -14,6 +14,7 @@ KNOWN_DRAFTER_KINDS = {"dflash", "mtp", "eagle3"}
 # here falls back to ``DEFAULT_DRAFTER_KIND`` when the caller didn't pass one.
 DRAFTER_KIND_BY_MODEL_TYPE = {
     "deepseek_v4_mtp": "mtp",
+    "deepseek_v4_dspark": "dflash",
     "dspark": "dflash",
     "eagle3": "eagle3",
     "gemma4_assistant": "mtp",

--- a/mlx_vlm/speculative/drafters/deepseek_v4_dspark/README.md
+++ b/mlx_vlm/speculative/drafters/deepseek_v4_dspark/README.md
@@ -1,0 +1,44 @@
+# DeepSeek-V4 DSpark drafter
+
+`deepseek_v4_dspark` is the native DSpark speculative head shipped inside
+`deepseek-ai/DeepSeek-V4-Flash-0731`. It is a **DeepSeek-V4-backbone variant of
+the model-agnostic `dspark` drafter**: it reuses the shared DSpark machinery —
+`VanillaMarkov` block sampling and the `dflash` round loop with its target-hidden
+tap — and only swaps the Qwen-style draft layers for DeepSeek-V4 blocks (MLA
+attention, MoE, Hyper-Connections). It is distinct from `deepseek_v4_mtp`, which
+serves the single-block MTP of the base `deepseek-ai/DeepSeek-V4-Flash`.
+
+## Architecture
+
+Like the base `dspark` drafter, it conforms to the DFlash drafter contract
+(`reset` / `_hidden` / `_logits` / `draft_block`) and maps to `draft_kind="dflash"`:
+
+- A stack of `n_mtp_layers` DeepSeek-V4 HC transformer stages. **Stage 0** owns
+  `main_proj` (`hidden_size * len(target_layer_ids) -> hidden_size`) + `main_norm`,
+  which mix the concatenated hidden states of the target's `target_layer_ids`
+  (the `dflash` capture tap, mean-pooled over the hyper-connection copies) into
+  the attention context. **The last stage** owns `hc_head` + `norm`.
+- The block attention reads that projected context (cached) and denoises a block
+  of `block_size - 1` proposals seeded with `mask_token_id`.
+- A model-level `markov_head` (`VanillaMarkov`, reused from `..dspark`) applies a
+  low-rank bigram bias while sampling the block.
+
+The confidence head shipped in the checkpoint is unused by the `dflash` loop and
+is dropped during `sanitize`.
+
+## Building a drafter
+
+```python
+from mlx_vlm.speculative.drafters.deepseek_v4_dspark.split import (
+    split_deepseek_v4_dspark,
+)
+
+split_deepseek_v4_dspark(
+    "deepseek-ai/DeepSeek-V4-Flash-0731",
+    "DS-V4-DSpark-drafter",
+)
+```
+
+The written config carries `n_mtp_layers`, `block_size`, `target_layer_ids`,
+`mask_token_id` and `markov_rank`, so `load_drafter` resolves it to
+`draft_kind="dflash"`.

--- a/mlx_vlm/speculative/drafters/deepseek_v4_dspark/__init__.py
+++ b/mlx_vlm/speculative/drafters/deepseek_v4_dspark/__init__.py
@@ -1,0 +1,6 @@
+from .config import DeepseekV4DsparkConfig as ModelConfig
+from .config import TextConfig
+from .deepseek_v4_dspark import DeepseekV4DsparkDraftModel
+from .deepseek_v4_dspark import DeepseekV4DsparkDraftModel as Model
+
+__all__ = ["DeepseekV4DsparkDraftModel", "Model", "ModelConfig", "TextConfig"]

--- a/mlx_vlm/speculative/drafters/deepseek_v4_dspark/config.py
+++ b/mlx_vlm/speculative/drafters/deepseek_v4_dspark/config.py
@@ -1,0 +1,87 @@
+import inspect
+from dataclasses import dataclass, field
+from typing import List, Optional
+
+from ....models.base import BaseModelConfig
+from ....models.deepseek_v4.config import ModelConfig as DeepseekV4Config
+
+
+class TextConfig:
+    @classmethod
+    def from_dict(cls, params: dict):
+        return DeepseekV4Config.from_dict(params)
+
+
+@dataclass
+class DeepseekV4DsparkConfig(BaseModelConfig):
+    """DeepSeek-V4 DSpark speculative head.
+
+    A DeepSeek-V4-backbone variant of the model-agnostic DSpark drafter: it
+    shares the DSpark proposal machinery (``VanillaMarkov`` block sampling, the
+    ``dflash`` round loop and its target-hidden tap) but swaps the Qwen-style
+    draft layers for DeepSeek-V4 blocks (MLA attention, MoE, Hyper-Connections).
+    Field names mirror ``DSparkConfig`` so the shared ``dflash`` dispatch and
+    proposal code apply unchanged.
+    """
+
+    model_type: str = "deepseek_v4_dspark"
+    text_config: Optional[TextConfig] = None
+    n_mtp_layers: int = 1
+
+    # DSpark / dflash proposal contract (mirrors DSparkConfig)
+    target_layer_ids: List[int] = field(default_factory=list)
+    mask_token_id: int = -1
+    markov_rank: int = 256
+    block_size: int = 0
+    runtime_block_size: Optional[int] = None
+    block_size_policy: str = "fixed"
+    dflash_initial_block_size: Optional[int] = None
+    draft_window_size: Optional[int] = None
+    tie_word_embeddings: bool = False
+
+    def __post_init__(self):
+        if isinstance(self.text_config, dict):
+            self.text_config = TextConfig.from_dict(self.text_config)
+        self.target_layer_ids = list(self.target_layer_ids or [])
+        self._sync_from_text_config()
+        if not self.block_size:
+            self.block_size = self.proposal_length + 1
+        if self.runtime_block_size is None:
+            self.runtime_block_size = self.block_size
+
+    def _sync_from_text_config(self):
+        text = self.text_config
+        if text is None:
+            return
+        if self.mask_token_id < 0:
+            self.mask_token_id = int(getattr(text, "dspark_noise_token_id", 0) or 0)
+        if not self.markov_rank:
+            self.markov_rank = int(getattr(text, "dspark_markov_rank", 256) or 256)
+        if not self.target_layer_ids:
+            self.target_layer_ids = list(
+                getattr(text, "dspark_target_layer_ids", []) or []
+            )
+        if not self.block_size:
+            block = int(getattr(text, "dspark_block_size", 0) or 0)
+            if block:
+                self.block_size = block + 1
+
+    @property
+    def proposal_length(self) -> int:
+        return max(int(self.block_size) - 1, 0)
+
+    @property
+    def hidden_size(self) -> int:
+        return self.text_config.hidden_size
+
+    @property
+    def vocab_size(self) -> int:
+        return self.text_config.vocab_size
+
+    @classmethod
+    def from_dict(cls, params: dict) -> "DeepseekV4DsparkConfig":
+        flat = dict(params)
+        sig = inspect.signature(cls).parameters
+        return cls(**{k: v for k, v in flat.items() if k in sig})
+
+    from_hf_dict = from_dict

--- a/mlx_vlm/speculative/drafters/deepseek_v4_dspark/deepseek_v4_dspark.py
+++ b/mlx_vlm/speculative/drafters/deepseek_v4_dspark/deepseek_v4_dspark.py
@@ -1,0 +1,291 @@
+"""DeepSeek-V4 DSpark speculative drafter.
+
+A DeepSeek-V4-backbone variant of the model-agnostic DSpark drafter (``..dspark``).
+It reuses the shared DSpark proposal machinery — ``VanillaMarkov`` block sampling
+and the ``dflash`` round loop with its target-hidden tap — and only swaps the
+Qwen-style draft layers for DeepSeek-V4 blocks (MLA attention, MoE,
+Hyper-Connections), mirroring DeepSeek-V4-Flash-0731's native DSpark head.
+
+Like the base DSpark drafter, it conforms to the DFlash drafter contract
+(``reset`` / ``_hidden`` / ``_logits`` / ``draft_block``): the projected target
+hidden (``main_proj`` over the concatenated ``target_layer_ids`` hiddens) is the
+accumulating attention context, and the drafted block — seeded with
+``mask_token_id`` — supplies the queries.
+"""
+
+import re
+from dataclasses import replace
+from types import SimpleNamespace
+from typing import Callable, List
+
+import mlx.core as mx
+import mlx.nn as nn
+
+from ....models.base import scaled_dot_product_attention
+from ....models.cache import RotatingKVCache
+from ....models.deepseek_v4.hyper_connection import (
+    HyperConnection,
+    HyperHead,
+    hc_expand,
+)
+from ....models.deepseek_v4.language import DeepseekV4MoE, LocalAttention
+from ..dspark.dspark import VanillaMarkov
+from .config import DeepseekV4DsparkConfig
+
+
+class DSparkMLACrossAttention(LocalAttention):
+    """DeepSeek-V4 MLA attention in the DFlash cross-attention layout.
+
+    The accumulating KV context is the projected target hidden ``x_ctx``
+    (cached); the drafted block supplies the queries and a transient block KV.
+    Block self-attention is non-causal (the whole block is denoised at once).
+    """
+
+    def __call__(
+        self, x: mx.array, x_ctx: mx.array, cache: RotatingKVCache
+    ) -> mx.array:
+        B, L, _ = x.shape
+        S = x_ctx.shape[1]
+        eps = self.config.rms_norm_eps
+        offset = cache.offset
+
+        q = self.wq_b(self.q_norm(self.wq_a(x)))
+        q = q.reshape(B, L, self.n_heads, self.head_dim)
+        q = mx.fast.rms_norm(q, None, eps).transpose(0, 2, 1, 3)
+        q = self.rope(q, offset + S)
+
+        ctx_kv = self.kv_norm(self.wkv(x_ctx)).reshape(B, 1, S, self.head_dim)
+        ctx_kv = self.rope(ctx_kv, offset)
+        block_kv = self.kv_norm(self.wkv(x)).reshape(B, 1, L, self.head_dim)
+        block_kv = self.rope(block_kv, offset + S)
+
+        kv, _ = cache.update_and_fetch(ctx_kv, mx.zeros((B, 1, S, 0)))
+        kv = mx.concatenate([kv, block_kv], axis=2)
+
+        out = scaled_dot_product_attention(
+            q,
+            kv,
+            kv,
+            cache=None,
+            scale=self.scale,
+            mask=None,
+            sinks=self.attn_sink.astype(q.dtype),
+        )
+        out = self.rope(out, offset + S, inverse=True)
+
+        out = out.reshape(B, self.o_groups, -1, L, self.head_dim)
+        out = out.transpose(0, 1, 3, 2, 4).flatten(-2)
+        out = self.wo_a(out)
+        out = out.transpose(0, 2, 1, 3).flatten(-2)
+        return self.wo_b(out)
+
+
+class DSparkStage(nn.Module):
+    """One DSpark transformer stage: a DeepSeek-V4 HC block whose attention reads
+    the projected target hidden. Same parameter names as ``DeepseekV4Block`` so
+    the checkpoint maps straight in, plus the stage-specific input/output modules."""
+
+    def __init__(self, config: DeepseekV4DsparkConfig, stage_id: int):
+        super().__init__()
+        text_config = config.text_config
+        layer_config = replace(
+            text_config,
+            num_hidden_layers=1,
+            compress_ratios=[0],
+            num_hash_layers=0,
+        )
+        self.is_first = stage_id == 0
+        self.is_last = stage_id == config.n_mtp_layers - 1
+
+        self.attn = DSparkMLACrossAttention(layer_config, layer_idx=0)
+        self.ffn = DeepseekV4MoE(layer_config, layer_idx=0)
+        self.attn_norm = nn.RMSNorm(
+            text_config.hidden_size, eps=text_config.rms_norm_eps
+        )
+        self.ffn_norm = nn.RMSNorm(
+            text_config.hidden_size, eps=text_config.rms_norm_eps
+        )
+        self.attn_hc = HyperConnection(layer_config)
+        self.ffn_hc = HyperConnection(layer_config)
+
+        if self.is_first:
+            n_targets = max(len(config.target_layer_ids), 1)
+            self.main_proj = nn.Linear(
+                text_config.hidden_size * n_targets,
+                text_config.hidden_size,
+                bias=False,
+            )
+            self.main_norm = nn.RMSNorm(
+                text_config.hidden_size, eps=text_config.rms_norm_eps
+            )
+        if self.is_last:
+            self.hc_head = HyperHead(layer_config)
+            self.norm = nn.RMSNorm(
+                text_config.hidden_size, eps=text_config.rms_norm_eps
+            )
+
+    def __call__(
+        self, h: mx.array, main_x: mx.array, cache: RotatingKVCache
+    ) -> mx.array:
+        residual = h
+        x, post, comb = self.attn_hc(h)
+        x = self.attn(self.attn_norm(x), main_x, cache)
+        h = hc_expand(x, residual, post, comb)
+
+        residual = h
+        x, post, comb = self.ffn_hc(h)
+        x = self.ffn(self.ffn_norm(x), None)
+        return hc_expand(x, residual, post, comb)
+
+
+class DeepseekV4DsparkDraftModel(nn.Module):
+    def __init__(self, config: DeepseekV4DsparkConfig):
+        super().__init__()
+        self.config = config
+        text_config = config.text_config
+        if text_config is None:
+            raise ValueError("DeepseekV4DsparkConfig.text_config must be set")
+        self.args = text_config
+        self.hc_mult = text_config.hc_mult
+
+        self.stages = [
+            DSparkStage(config, stage_id) for stage_id in range(config.n_mtp_layers)
+        ]
+        self.markov_head = VanillaMarkov(config.vocab_size, config.markov_rank)
+
+        self.prefer_requested_block_size = config.block_size_policy == "fixed"
+        self.dflash_initial_block_size = config.dflash_initial_block_size
+        self._input_embed = None
+        self._lm_head_fn = None
+        self.accept_lens: List[int] = []
+        self.draft_lens: List[int] = []
+
+    def bind(self, target_model) -> "DeepseekV4DsparkDraftModel":
+        inner = None
+        if hasattr(target_model, "embed_tokens"):
+            inner = target_model
+        elif hasattr(target_model, "model") and hasattr(
+            target_model.model, "embed_tokens"
+        ):
+            inner = target_model.model
+        elif (
+            hasattr(target_model, "language_model")
+            and hasattr(target_model.language_model, "model")
+            and hasattr(target_model.language_model.model, "embed_tokens")
+        ):
+            inner = target_model.language_model.model
+        if inner is None:
+            raise AttributeError(
+                f"Cannot find embed_tokens in {type(target_model).__name__}"
+            )
+        self._input_embed = inner.embed_tokens
+        lm = getattr(target_model, "language_model", target_model)
+        self._lm_head_fn = (
+            getattr(target_model, "lm_head", None)
+            or getattr(lm, "lm_head", None)
+            or self._input_embed.as_linear
+        )
+        return self
+
+    def make_cache(self) -> List[RotatingKVCache]:
+        return [RotatingKVCache(max_size=self.args.sliding_window) for _ in self.stages]
+
+    def reset(self, target_model) -> List[RotatingKVCache]:
+        self.bind(target_model)
+        self.accept_lens = []
+        self.draft_lens = []
+        return self.make_cache()
+
+    def _hidden(
+        self,
+        inputs: mx.array,
+        target_hidden: mx.array,
+        cache: List[RotatingKVCache],
+    ) -> mx.array:
+        first = self.stages[0]
+        main_x = first.main_norm(first.main_proj(target_hidden))
+
+        h = self._input_embed(inputs)
+        h = mx.broadcast_to(
+            h[:, :, None, :], (h.shape[0], h.shape[1], self.hc_mult, h.shape[-1])
+        )
+        h = mx.contiguous(h)
+        for stage, stage_cache in zip(self.stages, cache):
+            h = stage(h, main_x, stage_cache)
+
+        last = self.stages[-1]
+        return last.norm(last.hc_head(h))
+
+    def _logits(self, hidden: mx.array) -> mx.array:
+        return self._lm_head_fn(hidden)
+
+    def draft_block(
+        self,
+        last_bonus,
+        hidden: mx.array,
+        cache: List[RotatingKVCache],
+        block_size: int,
+        sampler: Callable[[mx.array], mx.array],
+        token_dtype: mx.Dtype = mx.int32,
+    ) -> mx.array:
+        if self._input_embed is None or self._lm_head_fn is None:
+            raise RuntimeError(
+                "bind(target_model) must be called before draft_block()."
+            )
+
+        proposal_length = int(block_size) - 1
+        if proposal_length <= 0:
+            batch = 1 if isinstance(last_bonus, int) else int(last_bonus.shape[0])
+            return mx.zeros((batch, 0), dtype=token_dtype)
+
+        anchor = (
+            mx.array([last_bonus], dtype=token_dtype)
+            if isinstance(last_bonus, int)
+            else last_bonus.reshape(-1).astype(token_dtype)
+        )
+        masks = mx.full(
+            (anchor.shape[0], proposal_length - 1),
+            int(self.config.mask_token_id),
+            dtype=token_dtype,
+        )
+        draft_inputs = mx.concatenate([anchor[:, None], masks], axis=1)
+        base_logits = self._logits(self._hidden(draft_inputs, hidden, cache))
+        return self.markov_head.sample_block(
+            base_logits,
+            first_prev_tokens=anchor,
+            sampler=sampler,
+        ).astype(token_dtype)
+
+    def sanitize(self, weights: dict) -> dict:
+        """Map the ``mtp.<stage>.*`` checkpoint layout onto the drafter.
+
+        Reuses the proven ``deepseek_v4_mtp`` block sanitizer per stage, then
+        reprefixes to ``stages.<i>.*``. The markov head is model-level, and the
+        confidence head (unused by the ``dflash`` loop) is dropped.
+        """
+        from ..deepseek_v4_mtp.deepseek_v4_mtp import DeepseekV4MTPDraftModel
+
+        context = SimpleNamespace(args=self.args)
+        by_stage: dict = {}
+        out: dict = {}
+        for key, value in weights.items():
+            match = re.match(r"mtp\.(\d+)\.", key)
+            if match:
+                by_stage.setdefault(int(match.group(1)), {})[key] = value
+            else:
+                out[key] = value
+
+        for stage_id, stage_weights in by_stage.items():
+            mapped = DeepseekV4MTPDraftModel.sanitize(context, stage_weights)
+            for key, value in mapped.items():
+                body = key[len("decoder.") :] if key.startswith("decoder.") else key
+                if body.startswith("confidence_head."):
+                    continue
+                if body.startswith("markov_head."):
+                    out[body] = value
+                else:
+                    out[f"stages.{stage_id}.{body}"] = value
+        return out
+
+
+Model = DeepseekV4DsparkDraftModel

--- a/mlx_vlm/speculative/drafters/deepseek_v4_dspark/split.py
+++ b/mlx_vlm/speculative/drafters/deepseek_v4_dspark/split.py
@@ -1,0 +1,126 @@
+import argparse
+import re
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Dict, Optional
+
+import mlx.core as mx
+
+from ....models.deepseek_v4.config import ModelConfig as DeepseekV4Config
+from ..mtp_split import MTPSplitter
+from .deepseek_v4_dspark import DeepseekV4DsparkDraftModel
+
+
+def _quantization_from_weights(weights: Dict[str, mx.array]) -> Optional[dict]:
+    """Per-module quantization config for the sanitized DSpark layout."""
+    mxfp4 = {"group_size": 32, "bits": 4, "mode": "mxfp4"}
+    mxfp8 = {"group_size": 32, "bits": 8, "mode": "mxfp8"}
+    quantization = {"group_size": 64, "bits": 8, "mode": "affine"}
+
+    for key in weights:
+        if not key.endswith(".scales"):
+            continue
+        module = key[: -len(".scales")]
+        if "ffn.switch_mlp." in module and module.endswith("_proj"):
+            quantization[module] = mxfp4
+        elif (
+            module.endswith("main_proj")
+            or "ffn.shared_experts." in module
+            or ".attn.w" in module
+        ):
+            quantization[module] = mxfp8
+
+    return quantization if len(quantization) > 3 else None
+
+
+class DeepseekV4DsparkSplitter(MTPSplitter):
+    """Extract DeepSeek-V4's native DSpark head (``mtp.<stage>.*``, stages 0..N)
+    into a standalone ``deepseek_v4_dspark`` drafter."""
+
+    output_model_type = "deepseek_v4_dspark"
+    draft_model_cls = DeepseekV4DsparkDraftModel
+    require_text_config = False
+    tie_word_embeddings_default = False
+    depth_field = "num_nextn_predict_layers"
+    block_size_extra = 1
+    tokenizer_files = (
+        "tokenizer.json",
+        "tokenizer_config.json",
+        "vocab.json",
+        "merges.txt",
+        "special_tokens_map.json",
+        "generation_config.json",
+        "chat_template.jinja",
+    )
+
+    def __init__(self):
+        self._n_mtp_layers = 1
+
+    def select_keys(self, key: str, text_config: dict) -> bool:
+        return key.startswith("mtp.")
+
+    def sanitize_ctx(self, text_config: dict):
+        return SimpleNamespace(args=DeepseekV4Config.from_dict(text_config))
+
+    def postprocess(self, tensors: Dict[str, mx.array], text_config: dict) -> None:
+        stages = {
+            int(match.group(1))
+            for key in tensors
+            if (match := re.match(r"stages\.(\d+)\.", key))
+        }
+        self._n_mtp_layers = (max(stages) + 1) if stages else 1
+
+    def quantization_from_source(self, tensors, source_config):
+        return _quantization_from_weights(tensors)
+
+    def extra_config(self, text_config: dict) -> dict:
+        dspark_block = int(text_config.get("dspark_block_size", 0) or 0)
+        return {
+            "n_mtp_layers": self._n_mtp_layers,
+            "target_layer_ids": list(
+                text_config.get("dspark_target_layer_ids", []) or []
+            ),
+            "mask_token_id": int(text_config.get("dspark_noise_token_id", 0) or 0),
+            "markov_rank": int(text_config.get("dspark_markov_rank", 256) or 256),
+            "block_size": (dspark_block + 1) if dspark_block else 0,
+        }
+
+
+def split_deepseek_v4_dspark(
+    source: str,
+    output: str,
+    *,
+    revision: Optional[str] = None,
+    block_size: Optional[int] = None,
+    force_download: bool = False,
+) -> Path:
+    """Write DeepSeek-V4 DSpark MTP tensors into a standalone drafter folder."""
+    return DeepseekV4DsparkSplitter().split(
+        source,
+        output,
+        revision=revision,
+        block_size=block_size,
+        force_download=force_download,
+    )
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Split DeepSeek-V4 DSpark MTP tensors into a standalone MLX drafter."
+    )
+    parser.add_argument("--model", "--source", dest="source", required=True)
+    parser.add_argument("--output", required=True)
+    parser.add_argument("--revision", default=None)
+    parser.add_argument("--block-size", type=int, default=None)
+    parser.add_argument("--force-download", action="store_true")
+    return parser
+
+
+def main():
+    args = build_parser().parse_args()
+    output = split_deepseek_v4_dspark(**vars(args))
+    print(f"Wrote DeepSeek-V4 DSpark drafter to {output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/mlx_vlm/speculative/drafters/deepseek_v4_mtp/deepseek_v4_mtp.py
+++ b/mlx_vlm/speculative/drafters/deepseek_v4_mtp/deepseek_v4_mtp.py
@@ -1,3 +1,4 @@
+import re
 from dataclasses import replace
 from typing import Any, Dict, List, Optional, Tuple
 
@@ -446,10 +447,12 @@ class DeepseekV4MTPDraftModel(nn.Module):
         weights = dict(weights)
         new_weights = {}
         for k, v in weights.items():
-            if k.startswith("mtp.0."):
-                k = k[len("mtp.0.") :]
-            elif k.startswith("mtp."):
-                k = k[len("mtp.") :]
+            # The single MTP block lives under `mtp.<layer_idx>.` (index 1 for
+            # DeepSeek-V4-Flash, 0 for others) or bare `mtp.` — strip any of them
+            # so the block's tensors land at the drafter's top level.
+            m = re.match(r"mtp\.(?:\d+\.)?", k)
+            if m:
+                k = k[m.end() :]
             new_weights[k] = v
         weights = new_weights
 

--- a/mlx_vlm/tests/test_speculative.py
+++ b/mlx_vlm/tests/test_speculative.py
@@ -6,6 +6,7 @@ and Qwen3.5 DFlash cache rollback coverage in one place.
 
 import importlib
 import json
+import re
 from pathlib import Path
 from types import MethodType, SimpleNamespace
 from unittest.mock import patch
@@ -41,6 +42,13 @@ from mlx_vlm.speculative.drafters import (
     KNOWN_DRAFTER_KINDS,
     resolve_drafter_kind,
     validate_drafter_compatibility,
+)
+from mlx_vlm.speculative.drafters.deepseek_v4_dspark import DeepseekV4DsparkDraftModel
+from mlx_vlm.speculative.drafters.deepseek_v4_dspark.config import (
+    DeepseekV4DsparkConfig,
+)
+from mlx_vlm.speculative.drafters.deepseek_v4_dspark.split import (
+    split_deepseek_v4_dspark,
 )
 from mlx_vlm.speculative.drafters.deepseek_v4_mtp import DeepseekV4MTPDraftModel
 from mlx_vlm.speculative.drafters.deepseek_v4_mtp.config import DeepseekV4MTPConfig
@@ -3746,6 +3754,255 @@ def test_deepseek_v4_mtp_sanitize_maps_embedded_weights():
         cfg.n_routed_experts
     )
     assert out["decoder.attn.wo_a.weight"].shape == (1, cfg.o_lora_rank, 4)
+
+
+def test_deepseek_v4_mtp_sanitize_strips_nonzero_layer_index():
+    # DeepSeek-V4-Flash-0731 stores its MTP blocks at layer indices 1/2/…, not
+    # 0. The prefix strip must drop any `mtp.<idx>.` so the tensors land at the
+    # drafter's top level instead of keeping a stray `1.`.
+    cfg = _tiny_deepseek_v4_config()
+    context = SimpleNamespace(args=cfg)
+    weights = {
+        "mtp.1.enorm.weight": mx.ones((cfg.hidden_size,)),
+        "mtp.1.attn.wkv.weight": mx.ones((4, 4)),
+        "mtp.1.hc_head_scale": mx.ones((1,)),
+        "mtp.1.attn.wo_a.weight": mx.ones((cfg.o_lora_rank, 4)),
+    }
+    for expert in range(cfg.n_routed_experts):
+        weights[f"mtp.1.ffn.experts.{expert}.w1.weight"] = mx.zeros((4, 16))
+
+    out = DeepseekV4MTPDraftModel.sanitize(context, weights)
+
+    assert not any(re.match(r"\d+\.", key) for key in out)
+    assert "enorm.weight" in out
+    assert "decoder.attn.wkv.weight" in out
+    assert "hc_head.scale" in out
+    assert out["decoder.ffn.switch_mlp.gate_proj.weight"].shape[0] == (
+        cfg.n_routed_experts
+    )
+
+
+def _tiny_deepseek_v4_dspark_config():
+    return DeepseekV4DsparkConfig(
+        text_config=_tiny_deepseek_v4_config(),
+        n_mtp_layers=3,
+        target_layer_ids=[0, 1, 2],
+        mask_token_id=1,
+        markov_rank=8,
+        block_size=5,
+    )
+
+
+def _forge_dspark_source(model, cfg):
+    """Reconstruct the ``mtp.<stage>.*`` checkpoint tensors from the drafter's
+    own params, so the split->load round-trip can be exercised without the real
+    (multi-GB) DeepSeek-V4-Flash-0731 checkpoint."""
+    params = dict(tree_flatten(model.parameters()))
+    text = cfg.text_config
+    n_experts, o_groups, o_lora_rank = (
+        text.n_routed_experts,
+        text.o_groups,
+        text.o_lora_rank,
+    )
+    last_stage = cfg.n_mtp_layers - 1
+    proj_to_w = {"gate_proj": "w1", "down_proj": "w2", "up_proj": "w3"}
+    hc = {"attn_hc": "hc_attn", "ffn_hc": "hc_ffn"}
+    src = {}
+    for key, value in params.items():
+        if key.startswith("markov_head."):
+            # the model-level markov head lives under the last stage on disk
+            src[f"mtp.{last_stage}.{key}"] = value
+            continue
+        _, stage, body = key.split(".", 2)
+        prefix = f"mtp.{stage}."
+        if body.startswith("ffn.switch_mlp."):
+            w = proj_to_w[body.split(".")[-2]]
+            for expert in range(n_experts):
+                src[f"{prefix}ffn.experts.{expert}.{w}.weight"] = value[expert]
+        elif body.startswith("ffn.shared_experts."):
+            w = proj_to_w[body.split(".")[-2]]
+            src[f"{prefix}ffn.shared_experts.{w}.weight"] = value
+        elif body == "ffn.gate.e_score_correction_bias":
+            src[f"{prefix}ffn.gate.bias"] = value
+        elif body == "attn.wo_a.weight":
+            src[f"{prefix}attn.wo_a.weight"] = (
+                value.reshape(o_groups * o_lora_rank, -1) if value.ndim == 3 else value
+            )
+        elif body.startswith("attn_hc.") or body.startswith("ffn_hc."):
+            module, param = body.split(".")
+            src[f"{prefix}{hc[module]}_{param}"] = value
+        elif body.startswith("hc_head."):
+            src[f"{prefix}hc_head_{body.split('.')[-1]}"] = value
+        else:
+            src[f"{prefix}{body}"] = value
+    return src
+
+
+def test_deepseek_v4_dspark_sanitize_round_trips_three_stage_layout():
+    cfg = _tiny_deepseek_v4_dspark_config()
+    model = DeepseekV4DsparkDraftModel(cfg)
+    mx.eval(model.parameters())
+    src = _forge_dspark_source(model, cfg)
+    # a trained checkpoint also ships an (unused) confidence head -> dropped
+    src["mtp.2.confidence_head.proj.weight"] = mx.zeros(
+        (1, cfg.hidden_size + cfg.markov_rank)
+    )
+
+    written = DeepseekV4DsparkDraftModel.sanitize(
+        SimpleNamespace(args=cfg.text_config), dict(src)
+    )
+    fresh = DeepseekV4DsparkDraftModel(cfg)
+    mx.eval(fresh.parameters())
+    sanitized = fresh.sanitize(dict(written))
+    fresh.load_weights(list(sanitized.items()), strict=True)
+
+    assert not any(key.startswith("mtp.") for key in sanitized)
+    assert not any("confidence_head" in key for key in sanitized)
+    assert any(key.startswith("stages.0.main_proj") for key in sanitized)
+    assert any(key.startswith("markov_head.") for key in sanitized)
+
+
+def test_deepseek_v4_dspark_draft_block_emits_proposal_tokens():
+    cfg = _tiny_deepseek_v4_dspark_config()
+    model = DeepseekV4DsparkDraftModel(cfg)
+    mx.eval(model.parameters())
+    text = cfg.text_config
+    target = SimpleNamespace(
+        embed_tokens=nn.Embedding(text.vocab_size, text.hidden_size),
+        lm_head=nn.Linear(text.hidden_size, text.vocab_size, bias=False),
+    )
+    mx.eval(target.embed_tokens.parameters(), target.lm_head.parameters())
+    draft_cache = model.reset(target)
+
+    ctx = 5
+    n_targets = len(cfg.target_layer_ids)
+    hidden = mx.random.normal((1, ctx, text.hidden_size * n_targets))
+    drafts = model.draft_block(
+        3,
+        hidden,
+        draft_cache,
+        cfg.block_size,
+        lambda logits: mx.argmax(logits, axis=-1),
+    )
+    assert drafts.shape == (1, cfg.block_size - 1)
+
+
+def test_deepseek_v4_capture_layer_ids_taps_mean_over_hc():
+    base = _tiny_deepseek_v4_config()
+    cfg = deepseek_language.ModelConfig(
+        **{
+            **base.to_dict(),
+            "num_hidden_layers": 3,
+            "compress_ratios": [0, 0, 0],
+        }
+    )
+    lm = deepseek_language.LanguageModel(cfg)
+    mx.eval(lm.parameters())
+
+    out = lm(mx.array([[1, 2, 3, 4]]), capture_layer_ids=[0, 2])
+
+    assert isinstance(out.hidden_states, list)
+    assert len(out.hidden_states) == 2
+    for hidden in out.hidden_states:
+        assert hidden.shape == (1, 4, cfg.hidden_size)
+
+
+def test_split_deepseek_v4_dspark_writes_dspark_config(tmp_path):
+    cfg = _tiny_deepseek_v4_dspark_config()
+    model = DeepseekV4DsparkDraftModel(cfg)
+    mx.eval(model.parameters())
+    src_weights = _forge_dspark_source(model, cfg)
+
+    source = tmp_path / "source"
+    source.mkdir()
+    text = cfg.text_config
+    (source / "config.json").write_text(
+        json.dumps(
+            {
+                "model_type": "deepseek_v4",
+                **text.to_dict(),
+                "dspark_block_size": cfg.block_size - 1,
+                "dspark_noise_token_id": cfg.mask_token_id,
+                "dspark_target_layer_ids": cfg.target_layer_ids,
+                "dspark_markov_rank": cfg.markov_rank,
+            }
+        )
+    )
+    mx.save_safetensors(str(source / "mtp.safetensors"), src_weights, metadata={})
+    (source / "model.safetensors.index.json").write_text(
+        json.dumps({"weight_map": {"model.foo": "model.safetensors"}})
+    )
+
+    output = tmp_path / "dspark"
+    split_deepseek_v4_dspark(str(source), str(output))
+
+    written_cfg = json.loads((output / "config.json").read_text())
+    weights = mx.load(str(output / "model.safetensors"))
+    assert written_cfg["model_type"] == "deepseek_v4_dspark"
+    assert written_cfg["n_mtp_layers"] == 3
+    assert written_cfg["target_layer_ids"] == cfg.target_layer_ids
+    assert written_cfg["mask_token_id"] == cfg.mask_token_id
+    assert any(key.startswith("stages.0.main_proj") for key in weights)
+    assert any(key.startswith("markov_head.") for key in weights)
+
+
+def test_deepseek_v4_dspark_uses_dflash_rounds_losslessly():
+    # deepseek_v4_dspark maps to the dflash kind. Losslessness comes from
+    # verification, not drafter quality: with a random (untrained) drafter every
+    # proposal is rejected, so speculative decoding must reproduce the target's
+    # plain-greedy trajectory exactly.
+    from mlx_vlm.speculative.dflash import _dflash_rounds
+
+    base = _tiny_deepseek_v4_config()
+    tgt_cfg = deepseek_language.ModelConfig(
+        **{**base.to_dict(), "num_hidden_layers": 4, "compress_ratios": [0, 0, 0, 0]}
+    )
+    target = deepseek_language.LanguageModel(tgt_cfg)
+    mx.eval(target.parameters())
+
+    dcfg = DeepseekV4DsparkConfig(
+        text_config=tgt_cfg,
+        n_mtp_layers=3,
+        target_layer_ids=[1, 2, 3],
+        mask_token_id=1,
+        markov_rank=8,
+        block_size=5,
+    )
+    drafter = DeepseekV4DsparkDraftModel(dcfg)
+    mx.eval(drafter.parameters())
+
+    prompt = mx.array([[5, 6, 7, 8, 9]])
+    n_new = 12
+
+    def argmax_last(logits):
+        return int(mx.argmax(logits[:, -1, :], axis=-1).item())
+
+    cache_ref = target.make_cache()
+    tok = argmax_last(target(prompt, cache=cache_ref).logits)
+    ref = [tok]
+    for _ in range(n_new - 1):
+        tok = argmax_last(target(mx.array([[tok]]), cache=cache_ref).logits)
+        ref.append(tok)
+
+    cache_spec = target.make_cache()
+    out = target(prompt, cache=cache_spec, capture_layer_ids=[1, 2, 3])
+    hidden = mx.concatenate([h[:, -1:, :] for h in out.hidden_states], axis=-1)
+    first_bonus = argmax_last(out.logits)
+    spec = [first_bonus]
+    for tok, _ in _dflash_rounds(
+        target,
+        drafter,
+        cache_spec,
+        hidden,
+        first_bonus=first_bonus,
+        max_tokens=n_new,
+        sampler=lambda logits: mx.argmax(logits, axis=-1),
+        greedy_sampling=True,
+    ):
+        spec.append(tok)
+
+    n = min(len(ref), len(spec))
+    assert spec[:n] == ref[:n]
 
 
 def test_split_deepseek_v4_mtp_writes_sidecar_without_index_mtp_entries(tmp_path):


### PR DESCRIPTION
Adds a native `deepseek_v4_dspark` speculative drafter for DeepSeek-V4-Flash-0731's DSpark head as a **DeepSeek-V4 (MLA / Hyper-Connection / MoE) backbone variant of the existing `dspark` drafter** — reusing `VanillaMarkov` and the `dflash` round loop + capture tap rather than adding a new kind or loop — which also fixes #2095 by giving `-0731` a drafter that matches its architecture instead of the base `deepseek_v4_mtp` head it silently fails to load into.