### PR TITLE
fix(video): resolve frame sampling in one place (#2050)

### DIFF
--- a/mlx_vlm/generate/dispatch.py
+++ b/mlx_vlm/generate/dispatch.py
@@ -2,6 +2,7 @@ import argparse
 import codecs
 import json
 import logging
+import sys
 import time
 from collections.abc import Sequence
 from typing import Any, Dict, Generator, List, Optional, Tuple, Union
@@ -49,6 +50,40 @@ from .image import (
 from .video_generation import DEFAULT_VIDEO_STEPS, run_video_generation_cli
 
 logger = logging.getLogger("mlx_vlm.generate")
+
+
+def _video_sampling(args):
+    """The frame-sampling overrides the user actually set."""
+    from ..utils import VideoSampling
+
+    return VideoSampling(
+        fps=args.fps,
+        nframes=getattr(args, "video_num_frames", None),
+        min_frames=getattr(args, "video_min_frames", None),
+        max_frames=getattr(args, "video_max_frames", None),
+    )
+
+
+def _video_sampling_kwargs(args) -> dict:
+    """``_video_sampling`` flattened for generate()'s keyword interface."""
+    from dataclasses import asdict
+
+    return {k: v for k, v in asdict(_video_sampling(args)).items() if v is not None}
+
+
+def _enable_verbose_logging() -> None:
+    """Surface mlx_vlm's INFO records, such as how a video got sampled."""
+    package_logger = logging.getLogger("mlx_vlm")
+    if not any(
+        getattr(handler, "_mlx_vlm_verbose", False)
+        for handler in package_logger.handlers
+    ):
+        handler = logging.StreamHandler(sys.stdout)
+        handler.setFormatter(logging.Formatter("%(message)s"))
+        handler._mlx_vlm_verbose = True
+        package_logger.addHandler(handler)
+    package_logger.setLevel(logging.INFO)
+
 
 DEFAULT_MODEL_PATH = "mlx-community/nanoLLaVA-1.5-8bit"
 DEFAULT_IMAGE = None
@@ -201,11 +236,24 @@ def parse_arguments():
         help="Frames-per-second to sample from --video.",
     )
     parser.add_argument(
+        "--video-num-frames",
+        type=int,
+        default=None,
+        help="Exact number of frames to sample from --video, overriding --fps.",
+    )
+    parser.add_argument(
+        "--video-min-frames",
+        type=int,
+        default=None,
+        help="Lower bound on the frames sampled from --video.",
+    )
+    parser.add_argument(
         "--video-max-frames",
         type=int,
-        default=16,
-        help="Cap on frames sent when video falls back to ordered images "
-        "(long clips are re-sampled evenly to this count).",
+        default=None,
+        help="Upper bound on the frames taken from --video. Falls back to 16 "
+        "for processors without native video support, which are sent evenly "
+        "re-sampled stills instead.",
     )
     parser.add_argument(
         "--resize-shape",
@@ -1327,7 +1375,9 @@ def main():
             max_frames = max(2, getattr(args, "video_max_frames", 16) or 16)
             pair_hook = getattr(model, "prepare_video_frame_pairs", None)
             if pair_hook is not None:
-                frames, frame_fps = sample_video_frames(args.video, args.fps or 2.0)
+                frames, frame_fps = sample_video_frames(
+                    args.video, args.fps or 2.0, _video_sampling(args)
+                )
                 anchors, first_frames, second_frames = pair_adjacent_frames(
                     frames, max_frames
                 )
@@ -1361,6 +1411,7 @@ def main():
                     images=args.image,
                     fps=args.fps or 2.0,
                     max_frames=max_frames,
+                    sampling=_video_sampling(args),
                 )
                 print(
                     f"{processor.__class__.__name__} has no native video "
@@ -1425,6 +1476,9 @@ def main():
             kwargs["thinking_start_token"] = args.thinking_start_token
 
     if args.chat:
+        if args.verbose:
+            _enable_verbose_logging()
+
         from ..vision_cache import VisionFeatureCache
 
         vision_cache = VisionFeatureCache()
@@ -1456,6 +1510,7 @@ def main():
                 "frequency_penalty": args.frequency_penalty,
                 "frequency_context_size": args.frequency_context_size,
                 "vision_cache": vision_cache,
+                **_video_sampling_kwargs(args),
                 **kwargs,
             }
             if args.resize_shape is not None:
@@ -1491,7 +1546,7 @@ def main():
             "image": args.image,
             "audio": args.audio,
             "video": args.video,
-            "fps": args.fps,
+            **_video_sampling_kwargs(args),
             "temperature": args.temperature,
             "top_p": args.top_p,
             "top_k": args.top_k,
@@ -1527,6 +1582,9 @@ def main():
             gen_kwargs["draft_kind"] = args.draft_kind
             if args.draft_block_size is not None:
                 gen_kwargs["draft_block_size"] = args.draft_block_size
+
+        if args.verbose:
+            _enable_verbose_logging()
 
         result = generate(
             model,

--- a/mlx_vlm/generate/video.py
+++ b/mlx_vlm/generate/video.py
@@ -48,16 +48,18 @@ def processor_handles_video(processor) -> bool:
     return "videos" in params and has_component
 
 
-def sample_video_frames(videos, fps=2.0):
-    """Decode ``videos`` at ``fps`` into one chronological list of PIL frames,
-    returned alongside the sampling fps actually used."""
-    from ..utils import load_video
+def sample_video_frames(videos, fps=2.0, sampling=None):
+    """Decode ``videos`` into one chronological list of PIL frames, returned
+    alongside the sampling fps actually used. ``sampling`` carries the
+    caller's frame-count overrides and wins over ``fps``."""
+    from ..utils import VideoSampling, load_video
 
+    resolved = (sampling or VideoSampling()).merge(VideoSampling(fps=fps))
     frames = []
     frame_fps = fps
     for video in videos:
-        arr, sampled_fps = load_video(str(video), fps=fps)
-        frame_fps = sampled_fps or frame_fps
+        arr, metadata = load_video(str(video), resolved)
+        frame_fps = metadata.sampled_fps or frame_fps
         for frame in arr:
             frames.append(Image.fromarray(np.transpose(frame, (1, 2, 0))))
     return frames, frame_fps
@@ -81,6 +83,7 @@ def resolve_video_inputs(
     images=None,
     fps=2.0,
     max_frames=16,
+    sampling=None,
 ) -> VideoInputResolution:
     """Resolve unsupported videos into a globally capped list of still images.
 
@@ -98,7 +101,7 @@ def resolve_video_inputs(
         )
 
     max_frames = max(2, int(max_frames or 16))
-    frames, frame_fps = sample_video_frames(resolved_videos, fps or 2.0)
+    frames, frame_fps = sample_video_frames(resolved_videos, fps or 2.0, sampling)
     sampled_count = len(frames)
     if not sampled_count:
         raise ValueError("Video frame fallback decoded no frames.")

--- a/mlx_vlm/models/gemma4/processing_gemma4.py
+++ b/mlx_vlm/models/gemma4/processing_gemma4.py
@@ -306,6 +306,11 @@ class Gemma4VideoProcessor(BaseVideoProcessor):
         self.image_std = image_std or [1.0, 1.0, 1.0]
         self.default_fps = default_fps
 
+    def video_sampling_defaults(self) -> dict:
+        """Cap decoding at the frame count this processor keeps, so the
+        decoder stops reading frames ``_sample_frames`` would discard."""
+        return {"max_frames": self.num_frames}
+
     def _sample_frames(self, video: np.ndarray, num_frames: int) -> np.ndarray:
         """Uniformly sample ``num_frames`` frames from ``video`` (T, C, H, W)."""
         T = video.shape[0]

--- a/mlx_vlm/models/minicpmv4_6/processing_minicpmv4_6.py
+++ b/mlx_vlm/models/minicpmv4_6/processing_minicpmv4_6.py
@@ -488,6 +488,11 @@ class MiniCPMVVideoProcessor(MiniCPMVImageProcessor):
         self.max_num_frames = int(max_num_frames)
         self.stack_frames = int(stack_frames)
 
+    def video_sampling_defaults(self) -> dict:
+        """Cap decoding at the frame count this processor keeps, so the
+        decoder stops reading frames ``_select_frames`` would discard."""
+        return {"max_frames": self.max_num_frames}
+
     @classmethod
     def from_pretrained(cls, pretrained_model_name_or_path: Union[str, Path], **kwargs):
         model_dir = Path(pretrained_model_name_or_path)

--- a/mlx_vlm/tests/test_generate.py
+++ b/mlx_vlm/tests/test_generate.py
@@ -2614,7 +2614,7 @@ def test_resolve_video_inputs_uses_one_global_frame_budget():
     assert resolution.frame_fps == pytest.approx(1.5)
     assert images == [still]
     assert videos == ["first.mp4", "second.mp4"]
-    mock_sample.assert_called_once_with(videos, 1.5)
+    mock_sample.assert_called_once_with(videos, 1.5, None)
 
 
 def test_resolve_video_inputs_does_not_partially_mutate_on_decode_failure():

--- a/mlx_vlm/tests/test_processors.py
+++ b/mlx_vlm/tests/test_processors.py
@@ -3902,3 +3902,37 @@ class TestTrustRemoteCodePassthrough(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TestVideoFrameCaps(unittest.TestCase):
+    """Processors that re-subsample declare their cap so the decoder can stop
+    reading frames that are about to be thrown away."""
+
+    def test_gemma4_declares_its_frame_count(self):
+        from mlx_vlm.models.gemma4.processing_gemma4 import Gemma4VideoProcessor
+
+        processor = Gemma4VideoProcessor()
+        self.assertEqual(
+            processor.video_sampling_defaults(), {"max_frames": processor.num_frames}
+        )
+
+    def test_gemma4_unified_inherits_the_declaration(self):
+        from mlx_vlm.models.gemma4_unified.processing_gemma4_unified import (
+            Gemma4UnifiedVideoProcessor,
+        )
+
+        processor = Gemma4UnifiedVideoProcessor()
+        self.assertEqual(
+            processor.video_sampling_defaults(), {"max_frames": processor.num_frames}
+        )
+
+    def test_minicpmv_declares_its_frame_count(self):
+        from mlx_vlm.models.minicpmv4_6.processing_minicpmv4_6 import (
+            MiniCPMVVideoProcessor,
+        )
+
+        processor = MiniCPMVVideoProcessor()
+        self.assertEqual(
+            processor.video_sampling_defaults(),
+            {"max_frames": processor.max_num_frames},
+        )

--- a/mlx_vlm/tests/test_server.py
+++ b/mlx_vlm/tests/test_server.py
@@ -3595,7 +3595,7 @@ def test_chat_completions_endpoint_falls_back_from_video_to_images(client):
     assert mock_template.call_args.kwargs["video"] is None
     assert mock_generate.call_args.kwargs["image"] == frames
     assert mock_generate.call_args.kwargs["video"] == []
-    mock_sample.assert_called_once_with(["clip.mp4"], 2.0)
+    mock_sample.assert_called_once_with(["clip.mp4"], 2.0, None)
 
 
 def test_chat_completions_endpoint_preserves_assistant_reasoning_content(client):

--- a/mlx_vlm/tests/test_utils.py
+++ b/mlx_vlm/tests/test_utils.py
@@ -10,11 +10,14 @@ from unittest.mock import MagicMock, patch
 
 import mlx.core as mx
 import mlx.nn as nn
+import numpy as np
 import pytest
 
 from mlx_vlm.convert import _preserve_existing_deepseek_v4_quantization
 from mlx_vlm.utils import (
+    DEFAULT_VIDEO_SAMPLING,
     StoppingCriteria,
+    VideoSampling,
     _drop_modules_without_weights,
     _load_safetensors,
     _quantization_for_module_path,
@@ -29,9 +32,12 @@ from mlx_vlm.utils import (
     load_image,
     load_model,
     load_processor,
+    load_video,
     prepare_inputs,
     process_image,
     process_inputs_with_fallback,
+    processor_video_sampling,
+    resolve_video_sampling,
     sanitize_weights,
     update_module_configs,
 )
@@ -1526,3 +1532,152 @@ def test_modelopt_mixed_folds_many_tensors_without_exhausting_buffers():
 
     assert len(transformed) == 2 * count
     assert transformed[f"l.{count - 1}.scales"].dtype == mx.uint8
+
+
+@pytest.fixture(scope="module")
+def synthetic_video(tmp_path_factory):
+    """A deterministic 600-frame 64x64 clip at 30 fps, i.e. 20 seconds."""
+    cv2 = pytest.importorskip("cv2")
+    path = tmp_path_factory.mktemp("video") / "clip.mp4"
+    writer = cv2.VideoWriter(str(path), cv2.VideoWriter_fourcc(*"mp4v"), 30.0, (64, 64))
+    for i in range(600):
+        writer.write(np.full((64, 64, 3), i % 256, np.uint8))
+    writer.release()
+    return str(path)
+
+
+class _AttributeVideoProcessor:
+    """A video processor naming its knobs the way load_video does."""
+
+    fps = 1.0
+    min_frames = 8
+    max_frames = 100
+
+
+class _HookVideoProcessor:
+    """A video processor whose cap is named something else entirely."""
+
+    num_frames = 32
+
+    def video_sampling_defaults(self):
+        return {"max_frames": self.num_frames}
+
+
+class TestVideoSampling:
+    def test_merge_fills_only_unset_fields(self):
+        merged = VideoSampling(fps=3.0).merge(VideoSampling(fps=1.0, max_frames=99))
+        assert merged.fps == 3.0
+        assert merged.max_frames == 99
+
+    def test_library_defaults_match_the_historical_load_video_signature(self):
+        assert DEFAULT_VIDEO_SAMPLING == VideoSampling(
+            fps=2.0, nframes=None, min_frames=4, max_frames=768, frame_factor=2
+        )
+
+
+class TestLoadVideo:
+    @pytest.mark.parametrize(
+        "kwargs,frames,sampled_fps",
+        [
+            ({}, 40, 2.0),
+            ({"fps": 0.5}, 10, 0.5),
+            ({"fps": 1.0}, 20, 1.0),
+            ({"fps": 8.0}, 160, 8.0),
+            ({"nframes": 12}, 12, 0.6),
+            ({"nframes": 7}, 8, 0.4),
+            ({"fps": 0.1, "min_frames": 30}, 30, 1.5),
+        ],
+    )
+    def test_frame_count_and_effective_fps(
+        self, synthetic_video, kwargs, frames, sampled_fps
+    ):
+        video, metadata = load_video(synthetic_video, **kwargs)
+        assert video.shape[0] == frames
+        assert metadata.sampled_fps == pytest.approx(sampled_fps)
+
+    @pytest.mark.parametrize(
+        "max_frames,frames,sampled_fps", [(8, 8, 0.4), (40, 40, 2.0), (768, 160, 8.0)]
+    )
+    def test_max_frames_clamps_the_requested_rate(
+        self, synthetic_video, max_frames, frames, sampled_fps
+    ):
+        """A cap below what ``fps`` asks for drags the effective rate well
+        under the requested one, which is what callers need reported back."""
+        video, metadata = load_video(synthetic_video, fps=8.0, max_frames=max_frames)
+        assert video.shape[0] == frames
+        assert metadata.sampled_fps == pytest.approx(sampled_fps)
+
+    def test_struct_and_keyword_forms_agree(self, synthetic_video):
+        by_struct = load_video(synthetic_video, VideoSampling(fps=8.0, max_frames=8))
+        by_kwargs = load_video(synthetic_video, fps=8.0, max_frames=8)
+        assert np.array_equal(by_struct[0], by_kwargs[0])
+        assert by_struct[1] == by_kwargs[1]
+
+    def test_struct_takes_precedence_over_keywords(self, synthetic_video):
+        _, metadata = load_video(synthetic_video, VideoSampling(fps=1.0), fps=8.0)
+        assert metadata.sampled_fps == pytest.approx(1.0)
+
+    def test_unknown_keyword_is_rejected(self, synthetic_video):
+        with pytest.raises(TypeError, match="fpss"):
+            load_video(synthetic_video, fpss=1.0)
+
+    def test_metadata_describes_the_source_clip(self, synthetic_video):
+        video, metadata = load_video(synthetic_video, fps=1.0)
+        assert metadata.total_num_frames == 600
+        assert metadata.fps == pytest.approx(30.0)
+        assert metadata.duration == pytest.approx(20.0)
+        assert (metadata.width, metadata.height) == (64, 64)
+        assert len(metadata.frames_indices) == video.shape[0]
+
+    def test_timestamps_span_the_clip_at_the_source_frame_rate(self, synthetic_video):
+        _, metadata = load_video(synthetic_video, fps=1.0)
+        assert metadata.timestamps[0] == pytest.approx(0.0)
+        assert metadata.timestamps[-1] == pytest.approx(20.0, abs=0.05)
+
+
+class TestProcessorVideoSampling:
+    def test_processor_without_a_video_component_declares_nothing(self):
+        assert processor_video_sampling(SimpleNamespace()) == VideoSampling()
+
+    def test_matching_attributes_are_picked_up(self):
+        processor = SimpleNamespace(video_processor=_AttributeVideoProcessor())
+        assert processor_video_sampling(processor) == VideoSampling(
+            fps=1.0, min_frames=8, max_frames=100
+        )
+
+    def test_hook_declares_a_differently_named_cap(self):
+        processor = SimpleNamespace(video_processor=_HookVideoProcessor())
+        assert processor_video_sampling(processor) == VideoSampling(max_frames=32)
+
+
+class TestResolveVideoSampling:
+    def test_falls_back_to_library_defaults(self):
+        assert resolve_video_sampling(SimpleNamespace(), {}) == DEFAULT_VIDEO_SAMPLING
+
+    def test_processor_beats_defaults(self):
+        processor = SimpleNamespace(video_processor=_AttributeVideoProcessor())
+        resolved = resolve_video_sampling(processor, {})
+        assert (resolved.fps, resolved.min_frames, resolved.max_frames) == (1.0, 8, 100)
+
+    def test_caller_beats_processor(self):
+        processor = SimpleNamespace(video_processor=_AttributeVideoProcessor())
+        resolved = resolve_video_sampling(processor, {"fps": 4.0, "max_frames": 20})
+        assert (resolved.fps, resolved.max_frames) == (4.0, 20)
+        assert resolved.min_frames == 8
+
+    def test_caller_beats_a_hook_declared_cap(self):
+        processor = SimpleNamespace(video_processor=_HookVideoProcessor())
+        assert resolve_video_sampling(processor, {"max_frames": 5}).max_frames == 5
+
+    def test_sampling_keys_do_not_travel_on_to_the_processor(self):
+        """The processor only ever sees frames that were already chosen, so
+        leaving these in kwargs would read as silently ignored."""
+        kwargs = {
+            "fps": 1.0,
+            "nframes": 4,
+            "min_frames": 6,
+            "max_frames": 20,
+            "temperature": 0.7,
+        }
+        resolve_video_sampling(SimpleNamespace(), kwargs)
+        assert kwargs == {"temperature": 0.7}

--- a/mlx_vlm/utils.py
+++ b/mlx_vlm/utils.py
@@ -7,6 +7,7 @@ import logging
 import math
 import struct
 import warnings
+from dataclasses import dataclass, fields
 from io import BytesIO
 from pathlib import Path
 from textwrap import dedent
@@ -26,6 +27,8 @@ from .models.base import BaseImageProcessor
 from .quantization.one_bit import _quantization_for_path, replace_one_bit_modules
 from .tokenizer_utils import load_tokenizer
 from .trainer.utils import apply_lora_layers
+
+logger = logging.getLogger(__name__)
 
 # Modes that support activation quantization
 ACTIVATION_QUANTIZATION_MODES = {"nvfp4", "mxfp8"}
@@ -1895,21 +1898,95 @@ def load_audio(
     return audio.mean(axis=1) if audio.ndim > 1 else audio
 
 
+@dataclass(frozen=True)
+class VideoSampling:
+    """How many frames to take from a clip, and at what rate.
+
+    Every field is optional so an unset one can be filled from a
+    lower-precedence source via :meth:`merge`, with
+    :data:`DEFAULT_VIDEO_SAMPLING` terminating the chain.
+    """
+
+    fps: Optional[float] = None
+    nframes: Optional[int] = None
+    min_frames: Optional[int] = None
+    max_frames: Optional[int] = None
+    frame_factor: Optional[int] = None
+
+    def merge(self, fallback: "VideoSampling") -> "VideoSampling":
+        """Return a copy with every unset field taken from ``fallback``."""
+        return VideoSampling(
+            **{
+                f.name: (
+                    getattr(self, f.name)
+                    if getattr(self, f.name) is not None
+                    else getattr(fallback, f.name)
+                )
+                for f in fields(self)
+            }
+        )
+
+
+DEFAULT_VIDEO_SAMPLING = VideoSampling(
+    fps=2.0, min_frames=4, max_frames=768, frame_factor=2
+)
+
+
+@dataclass
+class VideoMetadata:
+    """What the decode step knew about a clip, carried alongside its frames.
+
+    Field names mirror ``transformers.video_utils.VideoMetadata`` so a
+    processor ported from upstream can consume this unchanged.
+    """
+
+    total_num_frames: int
+    fps: float
+    frames_indices: List[int]
+    width: Optional[int] = None
+    height: Optional[int] = None
+    duration: Optional[float] = None
+
+    @property
+    def timestamps(self) -> List[float]:
+        """Seconds into the clip for each sampled frame."""
+        return [idx / self.fps for idx in self.frames_indices]
+
+    @property
+    def sampled_fps(self) -> float:
+        """Frame rate actually achieved, which clamping can push well below
+        the requested ``fps``."""
+        return len(self.frames_indices) / max(self.total_num_frames, 1e-6) * self.fps
+
+
 def load_video(
     video_path: str,
-    fps: float = 2.0,
-    nframes: Optional[int] = None,
-    min_frames: int = 4,
-    max_frames: int = 768,
-    frame_factor: int = 2,
-) -> Tuple[np.ndarray, float]:
+    sampling: Optional[VideoSampling] = None,
+    **sampling_kwargs,
+) -> Tuple[np.ndarray, "VideoMetadata"]:
     """Read a video file as a (T, C, H, W) numpy array.
 
-    Uniformly samples ``nframes`` frames — either a fixed count or derived
-    from ``fps`` — and returns the sampled frames alongside the effective
-    sampling fps.
+    Uniformly samples frames — either a fixed ``nframes`` or a count derived
+    from ``fps`` — and returns them alongside the :class:`VideoMetadata`
+    describing what was read. Sampling fields may be given either as a
+    :class:`VideoSampling` or as loose keyword arguments; the former wins
+    where both set the same field.
     """
     import cv2
+
+    if sampling_kwargs:
+        unknown = set(sampling_kwargs) - {f.name for f in fields(VideoSampling)}
+        if unknown:
+            raise TypeError(
+                f"load_video() got unexpected keyword arguments: {sorted(unknown)}"
+            )
+        sampling = (sampling or VideoSampling()).merge(VideoSampling(**sampling_kwargs))
+    resolved = (sampling or VideoSampling()).merge(DEFAULT_VIDEO_SAMPLING)
+    fps = resolved.fps
+    nframes = resolved.nframes
+    min_frames = resolved.min_frames
+    max_frames = resolved.max_frames
+    frame_factor = resolved.frame_factor
 
     if video_path.startswith("file://"):
         video_path = video_path[7:]
@@ -1956,8 +2033,70 @@ def load_video(
         raise ValueError("No frames read from the video.")
 
     video_np = np.transpose(np.stack(frames, axis=0), (0, 3, 1, 2))
-    sample_fps = n / max(total_frames, 1e-6) * video_fps
-    return video_np, sample_fps
+    metadata = VideoMetadata(
+        total_num_frames=total_frames,
+        fps=video_fps,
+        # Truncated where a read failed part-way, so this tracks the frames
+        # actually returned rather than the ones asked for.
+        frames_indices=indices[: len(frames)].tolist(),
+        height=int(video_np.shape[2]),
+        width=int(video_np.shape[3]),
+        duration=total_frames / video_fps,
+    )
+    return video_np, metadata
+
+
+_VIDEO_SAMPLING_FIELDS = tuple(f.name for f in fields(VideoSampling))
+
+
+def processor_video_sampling(processor) -> VideoSampling:
+    """The frame sampling a processor asks for, if it declares any.
+
+    A processor opts in either by exposing a ``video_sampling_defaults()``
+    hook — the way to declare a cap whose attribute is named something else,
+    such as Gemma 4's ``num_frames`` — or by carrying matching attributes on
+    its video processor component.
+    """
+    component = getattr(processor, "video_processor", None)
+    if component is None:
+        return VideoSampling()
+
+    for owner in (component, processor):
+        hook = getattr(owner, "video_sampling_defaults", None)
+        if callable(hook):
+            declared = hook()
+            return (
+                declared
+                if isinstance(declared, VideoSampling)
+                else VideoSampling(**declared)
+            )
+
+    return VideoSampling(
+        **{
+            name: getattr(component, name, None)
+            for name in ("fps", "min_frames", "max_frames")
+        }
+    )
+
+
+def resolve_video_sampling(processor, overrides: Dict[str, Any]) -> VideoSampling:
+    """Settle how a clip gets sampled.
+
+    Caller wins, then whatever the processor declares, then the library
+    defaults. Consumes the sampling keys from ``overrides`` so they do not
+    travel on to the processor, which only ever sees frames that were already
+    chosen here.
+    """
+    explicit = VideoSampling(
+        **{
+            name: overrides.pop(name)
+            for name in _VIDEO_SAMPLING_FIELDS
+            if name in overrides
+        }
+    )
+    return explicit.merge(processor_video_sampling(processor)).merge(
+        DEFAULT_VIDEO_SAMPLING
+    )
 
 
 def process_inputs(
@@ -2163,16 +2302,32 @@ def prepare_inputs(
     if has_videos:
         if not isinstance(videos, list):
             videos = [videos]
-        fps_hint = kwargs.pop("fps", 2.0)
+        sampling = resolve_video_sampling(processor, kwargs)
         loaded, video_fps = [], []
         for v in videos:
-            arr, s_fps = (
-                load_video(str(v), fps=fps_hint)
-                if isinstance(v, (str, bytes))
-                else (v, fps_hint)
-            )
+            if isinstance(v, (str, bytes)):
+                arr, metadata = load_video(str(v), sampling)
+                logger.info(
+                    "video %s: sampled %d of %d frames at %.2f fps "
+                    "(source %.2f fps, %.1fs)",
+                    v,
+                    len(metadata.frames_indices),
+                    metadata.total_num_frames,
+                    metadata.sampled_fps,
+                    metadata.fps,
+                    metadata.duration,
+                )
+            else:
+                # Already-decoded frames: nothing was sampled here, so report
+                # the requested rate and describe what we were handed.
+                arr = v
+                metadata = VideoMetadata(
+                    total_num_frames=len(v),
+                    fps=sampling.fps,
+                    frames_indices=list(range(len(v))),
+                )
             loaded.append(arr)
-            video_fps.append(s_fps)
+            video_fps.append(metadata.sampled_fps)
         videos = loaded
 
     model_inputs = {}


### PR DESCRIPTION
`nframes`, `min_frames` and `max_frames` never reached `load_video`, and the video processor's own values were never read. Sampling is now settled once — caller, then processor, then library default — and the keys are consumed so they never reach a processor that only sees frames already chosen. `--verbose` reports what was actually sampled.

Closes #2050.