### PR TITLE
diffusion_gemma: strip channel scaffolding from decoded output

### DIFF
--- a/mlx_vlm/generate/dispatch.py
+++ b/mlx_vlm/generate/dispatch.py
@@ -1186,6 +1186,10 @@ def generate(
         text += response.text
         last_response = response
 
+    clean_output = getattr(processor, "clean_output", None)
+    if callable(clean_output):
+        text = clean_output(text)
+
     if last_response is None:
         return GenerationResult(text=text, peak_memory=mx.get_peak_memory() / 1e9)
 

--- a/mlx_vlm/models/diffusion_gemma/processing_diffusion_gemma.py
+++ b/mlx_vlm/models/diffusion_gemma/processing_diffusion_gemma.py
@@ -6,6 +6,7 @@ token expansion + ``mm_token_type_ids``), so no torch/torchvision is pulled in.
 Audio inputs are rejected: this model port supports text, images, and videos.
 """
 
+import re
 from typing import List, Optional, Union
 
 import mlx.core as mx
@@ -55,6 +56,27 @@ def _make_tool_parser_tokens_non_special(tokenizer):
     ]
 
 
+_CHANNEL_OPEN = "<|channel>"
+_CHANNEL_CLOSE = "<channel|>"
+# Header scaffolding the model emits around a response channel:
+#   <|channel>{name}<channel|>{message}
+# These markers are non-special (see _make_tool_parser_tokens_non_special) so
+# the tool parser can read them from text, which means they leak verbatim into
+# ordinary output. Drop the header span, keep the message body.
+_CHANNEL_HEADER_RE = re.compile(
+    re.escape(_CHANNEL_OPEN) + r".*?" + re.escape(_CHANNEL_CLOSE),
+    re.DOTALL,
+)
+
+
+def _strip_channel_scaffolding(text: str) -> str:
+    if _CHANNEL_OPEN not in text and _CHANNEL_CLOSE not in text:
+        return text
+    cleaned = _CHANNEL_HEADER_RE.sub("", text)
+    cleaned = cleaned.replace(_CHANNEL_OPEN, "").replace(_CHANNEL_CLOSE, "")
+    return cleaned.lstrip()
+
+
 def _materialize_mx_arrays(inputs: BatchFeature) -> BatchFeature:
     arrays = [
         value for _, value in tree_flatten(inputs.data) if isinstance(value, mx.array)
@@ -73,6 +95,10 @@ class DiffusionGemma4Processor(Gemma4Processor):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         _make_tool_parser_tokens_non_special(self.tokenizer)
+
+    def clean_output(self, text: str) -> str:
+        """Strip response-channel scaffolding the model emits as plain text."""
+        return _strip_channel_scaffolding(text)
 
     @staticmethod
     def _flatten_visual_items(values):

--- a/mlx_vlm/tests/test_diffusion_gemma.py
+++ b/mlx_vlm/tests/test_diffusion_gemma.py
@@ -1559,6 +1559,70 @@ class TestDiffusionGemma4(unittest.TestCase):
                 tokenizer.convert_tokens_to_ids(token), tokenizer.unk_token_id
             )
 
+    def test_strip_channel_scaffolding_removes_leaked_header(self):
+        from mlx_vlm.models.diffusion_gemma.processing_diffusion_gemma import (
+            _strip_channel_scaffolding,
+        )
+
+        raw = (
+            "<|channel>thought\n"
+            "<channel|>Title: White motor cruiser Wavey Katey II cruising on a river\n"
+            "Description: A white cabin motor cruiser named Wavey Katey II cruises "
+            "along a calm waterway.\n"
+            "Keywords: Boat, cabin cruiser, motorboat, river"
+        )
+
+        cleaned = _strip_channel_scaffolding(raw)
+
+        self.assertNotIn("<|channel>", cleaned)
+        self.assertNotIn("<channel|>", cleaned)
+        self.assertNotIn("thought", cleaned)
+        self.assertTrue(cleaned.startswith("Title: White motor cruiser"))
+        self.assertIn("Keywords: Boat, cabin cruiser, motorboat, river", cleaned)
+
+    def test_strip_channel_scaffolding_is_noop_without_markers(self):
+        from mlx_vlm.models.diffusion_gemma.processing_diffusion_gemma import (
+            _strip_channel_scaffolding,
+        )
+
+        plain = "Title: A calm river cruise\nKeywords: boat, river"
+        self.assertEqual(_strip_channel_scaffolding(plain), plain)
+
+    def test_generate_strips_diffusion_channel_scaffolding(self):
+        dispatch_module = importlib.import_module("mlx_vlm.generate.dispatch")
+        from mlx_vlm.generate import GenerationResult, generate
+
+        class Config:
+            model_type = "diffusion_gemma"
+            eos_token_id = 999999
+
+        class Model:
+            config = Config()
+
+        processor = tiny_diffusion_gemma_processor()
+        processor.tokenizer.stopping_criteria = StoppingCriteria(
+            [999999], processor.tokenizer
+        )
+
+        chunks = [
+            GenerationResult(
+                text="<|channel>thought\n<channel|>Title: A calm river cruise",
+                token=1,
+                prompt_tokens=3,
+                generation_tokens=8,
+                total_tokens=11,
+                prompt_tps=10.0,
+                generation_tps=5.0,
+            )
+        ]
+
+        with patch.object(
+            dispatch_module, "stream_generate", return_value=iter(chunks)
+        ):
+            result = generate(Model(), processor, "")
+
+        self.assertEqual(result.text, "Title: A calm river cruise")
+
     def test_processor_returns_video_frames_as_pixel_values(self):
         processor = tiny_diffusion_gemma_processor()
 


### PR DESCRIPTION
Closes #2098.

DiffusionGemma leaked `<|channel>` response-channel scaffolding into plain output. The fix strips the header on decode, leaving other models unaffected.