### PR TITLE
Support float-quantized compressed-tensors checkpoints

### DIFF
--- a/mlx_vlm/tests/test_models.py
+++ b/mlx_vlm/tests/test_models.py
@@ -1951,6 +1951,80 @@ class TestModels(unittest.TestCase):
         self.assertFalse(any(".weight_global_scale" in key for key in sanitized))
         self.assertFalse(any(".input_global_scale" in key for key in sanitized))
 
+    def test_laguna_stacks_pure_fp8_experts_after_dequantization(self):
+        from mlx_vlm.models import laguna
+        from mlx_vlm.utils import _transform_compressed_tensors_weights
+
+        config = laguna.ModelConfig(
+            model_type="laguna",
+            vocab_size=128,
+            hidden_size=16,
+            intermediate_size=32,
+            num_hidden_layers=2,
+            num_attention_heads=2,
+            num_key_value_heads=1,
+            head_dim=8,
+            max_position_embeddings=128,
+            mlp_layer_types=["dense", "sparse"],
+            num_attention_heads_per_layer=[2, 2],
+            num_experts=3,
+            num_experts_per_tok=1,
+            moe_intermediate_size=16,
+            shared_expert_intermediate_size=16,
+        )
+        model = laguna.Model(config)
+        weights = {}
+        for expert_idx in range(config.num_experts):
+            for proj in ["gate_proj", "up_proj", "down_proj"]:
+                prefix = f"model.layers.1.mlp.experts.{expert_idx}.{proj}"
+                weights[f"{prefix}.weight"] = mx.full(
+                    (16, 16), 56 + expert_idx, dtype=mx.uint8
+                )
+                weights[f"{prefix}.weight_scale"] = mx.full(
+                    (2, 2), 0.5, dtype=mx.bfloat16
+                )
+        for proj in ["gate_proj", "up_proj", "down_proj"]:
+            prefix = f"model.layers.1.mlp.shared_expert.{proj}"
+            weights[f"{prefix}.weight"] = mx.full((16, 16), 56, dtype=mx.uint8)
+            weights[f"{prefix}.weight_scale"] = mx.full((2, 2), 0.5, dtype=mx.bfloat16)
+
+        transformed, quantization = _transform_compressed_tensors_weights(
+            weights,
+            {
+                "quant_method": "compressed-tensors",
+                "format": "float-quantized",
+                "config_groups": {
+                    "group_0": {
+                        "format": "float-quantized",
+                        "weights": {
+                            "block_structure": [8, 8],
+                            "num_bits": 8,
+                            "strategy": "block",
+                            "type": "float",
+                        },
+                    }
+                },
+            },
+        )
+        sanitized = model.language_model.sanitize(transformed)
+
+        prefix = "model.layers.1.mlp"
+        assert sanitized[f"{prefix}.switch_mlp.gate_up_proj.weight"].shape == (
+            3,
+            32,
+            16,
+        )
+        assert sanitized[f"{prefix}.switch_mlp.down_proj.weight"].shape == (
+            3,
+            16,
+            16,
+        )
+        assert sanitized[f"{prefix}.shared_expert.gate_proj.weight"].dtype == (
+            mx.bfloat16
+        )
+        assert not any(key.endswith(".weight_scale") for key in sanitized)
+        assert quantization is None
+
     def test_laguna_folds_nvfp4_shared_experts(self):
         from unittest.mock import patch
 

--- a/mlx_vlm/tests/test_utils.py
+++ b/mlx_vlm/tests/test_utils.py
@@ -19,6 +19,7 @@ from mlx_vlm.utils import (
     _load_safetensors,
     _quantization_for_module_path,
     _quantization_path_aliases,
+    _transform_compressed_tensors_weights,
     _transform_modelopt_nvfp4_weights,
     apply_generation_config_defaults,
     estimate_num_image_tokens,
@@ -85,6 +86,50 @@ def test_transform_modelopt_mixed_nvfp4_fp8_weights():
     assert transformed["attention.weight"].tolist() == [[0.5, 1.0], [0.75, 1.0]]
     assert not any("weight_scale" in key or "input_scale" in key for key in transformed)
     assert quantization == {"group_size": 16, "bits": 4, "mode": "nvfp4"}
+
+
+def test_transform_compressed_tensors_pure_fp8_weights():
+    weights = {
+        "linear.weight": mx.array(
+            [
+                [56, 64, 56, 64],
+                [68, 72, 68, 72],
+                [56, 64, 56, 64],
+                [68, 72, 68, 72],
+            ],
+            dtype=mx.uint8,
+        ),
+        "linear.weight_scale": mx.array([[0.5, 0.25], [0.125, 1.0]], dtype=mx.bfloat16),
+        "linear.input_scale": mx.array(0.125, dtype=mx.float32),
+    }
+    config = {
+        "quant_method": "compressed-tensors",
+        "format": "float-quantized",
+        "config_groups": {
+            "group_0": {
+                "format": "float-quantized",
+                "weights": {
+                    "block_structure": [2, 2],
+                    "num_bits": 8,
+                    "strategy": "block",
+                    "type": "float",
+                },
+            }
+        },
+    }
+
+    transformed, quantization = _transform_compressed_tensors_weights(weights, config)
+
+    assert transformed["linear.weight"].dtype == mx.bfloat16
+    assert transformed["linear.weight"].tolist() == [
+        [0.5, 1.0, 0.25, 0.5],
+        [1.5, 2.0, 0.75, 1.0],
+        [0.125, 0.25, 1.0, 2.0],
+        [0.375, 0.5, 3.0, 4.0],
+    ]
+    assert "linear.weight_scale" not in transformed
+    assert "linear.input_scale" not in transformed
+    assert quantization is None
 
 
 class MockTensor:

--- a/mlx_vlm/utils.py
+++ b/mlx_vlm/utils.py
@@ -404,37 +404,84 @@ def _compressed_tensors_group_weights(
 
 
 def _dequantize_compressed_tensors_fp8_weight(
-    weight: mx.array, scale: mx.array
+    weight: mx.array,
+    scale: mx.array,
+    block_structure: Optional[List[int]] = None,
 ) -> mx.array:
-    """Dequantize a channel-wise fp8 ``float-quantized`` weight to dense.
+    """Dequantize an fp8 ``float-quantized`` weight to dense.
 
-    ``float-quantized`` (``num_bits: 8``, ``strategy: channel``) stores the
-    weight as ``float8_e4m3fn`` -- which ``mx.load`` surfaces as raw ``uint8``
-    E4M3 bytes -- plus a per-output-channel ``weight_scale``. MLX has no
-    per-channel fp8 quantization mode, so we decode the E4M3 codes with the
-    shared LUT and rescale into a dense tensor: ``w = E4M3(byte) * weight_scale``.
-    The dense weight is emitted in ``weight_scale``'s dtype (the checkpoint's
-    compute dtype, typically ``bfloat16``).
+    ``float-quantized`` stores the weight as ``float8_e4m3fn`` -- which
+    ``mx.load`` surfaces as raw ``uint8`` E4M3 bytes -- plus either a
+    per-output-channel or blockwise ``weight_scale``. MLX has no matching FP8
+    mode, so decode the E4M3 codes and rescale into a dense tensor. The dense
+    weight is emitted in ``weight_scale``'s dtype (typically ``bfloat16``).
     """
+    if weight.dtype != mx.uint8 or weight.ndim < 2:
+        raise ValueError(
+            "Compressed-tensors FP8 weights must be E4M3 byte matrices; "
+            f"got dtype={weight.dtype}, shape={weight.shape}."
+        )
+
     out_dtype = scale.dtype if scale.dtype != mx.float32 else mx.bfloat16
     decoded = _E4M3_DECODE_LUT[weight.astype(mx.uint32)]  # float32 [out, in]
     scale = scale.astype(mx.float32)
-    if scale.ndim == 1:
-        scale = scale[:, None]
-    return (decoded * scale).astype(out_dtype)
+    if block_structure is None:
+        if scale.ndim == 1:
+            scale = scale[:, None]
+        return (decoded * scale).astype(out_dtype)
+
+    if len(block_structure) != 2 or any(size <= 0 for size in block_structure):
+        raise ValueError(
+            "Compressed-tensors FP8 block_structure must contain two positive "
+            f"dimensions; got {block_structure}."
+        )
+    block_rows, block_cols = block_structure
+    *batch_shape, rows, cols = weight.shape
+    row_blocks = (rows + block_rows - 1) // block_rows
+    col_blocks = (cols + block_cols - 1) // block_cols
+    expected_scale_shape = (*batch_shape, row_blocks, col_blocks)
+    if scale.shape != expected_scale_shape:
+        raise ValueError(
+            "Compressed-tensors FP8 scale shape does not match its weight: "
+            f"weight={weight.shape}, scales={scale.shape}, "
+            f"block_structure={block_structure}, expected={expected_scale_shape}."
+        )
+
+    pad_rows = row_blocks * block_rows - rows
+    pad_cols = col_blocks * block_cols - cols
+    if pad_rows or pad_cols:
+        decoded = mx.pad(
+            decoded,
+            [(0, 0)] * len(batch_shape) + [(0, pad_rows), (0, pad_cols)],
+        )
+    decoded = decoded.reshape(
+        *batch_shape,
+        row_blocks,
+        block_rows,
+        col_blocks,
+        block_cols,
+    )
+    decoded = (decoded * scale[..., :, None, :, None]).reshape(
+        *batch_shape,
+        rows + pad_rows,
+        cols + pad_cols,
+    )
+    return decoded[..., :rows, :cols].astype(out_dtype)
 
 
 def _transform_compressed_tensors_mixed_weights(
     weights: Dict[str, mx.array],
     quantization_config: Dict[str, Any],
 ) -> Tuple[Dict[str, mx.array], Optional[Dict[str, Any]]]:
-    """Route a compressed-tensors ``mixed-precision`` checkpoint per group.
+    """Route compressed-tensors mixed-precision or pure FP8 weights.
 
     A ``mixed-precision`` export keeps a single top-level ``format`` and puts
-    the real formats in per-group ``config_groups``. Rather than match each
-    group's regex ``targets``/``ignore`` against module paths (fragile -- the
-    HF names differ from MLX's), we route every quantized Linear by the tensors
-    it actually carries, which is exactly what the group assignment produced:
+    the real formats in per-group ``config_groups``. A pure ``float-quantized``
+    export uses the same FP8 tensor layout without any packed weights. Rather
+    than match each group's regex ``targets``/``ignore`` against module paths
+    (fragile -- the HF names differ from MLX's), route every quantized Linear
+    by the tensors it actually carries, which is exactly what the group
+    assignment produced:
 
     - ``.weight_packed`` + ``.weight_global_scale`` -> NVFP4
       (folded to MLX-native ``nvfp4``, as ``_transform_..._nvfp4_weights`` does)
@@ -465,11 +512,22 @@ def _transform_compressed_tensors_mixed_weights(
     int4_cfg = _compressed_tensors_group_weights(quantization_config, "pack-quantized")
     int4_bits = int4_cfg.get("num_bits", 4)
     int4_group_size = int4_cfg.get("group_size", 32)
+    fp8_cfg = _compressed_tensors_group_weights(quantization_config, "float-quantized")
+    fp8_block_structure = fp8_cfg.get("block_structure")
 
     new_weights: Dict[str, mx.array] = {}
     native_quant: Dict[str, Dict[str, Any]] = {}
+    pending: List[mx.array] = []
 
-    for key, value in weights.items():
+    def flush(force: bool = False) -> None:
+        if pending and (force or len(pending) >= 256):
+            mx.eval(pending)
+            pending.clear()
+
+    for key in list(weights):
+        if key not in weights:
+            continue
+        value = weights[key]
         if key.endswith(".weight_packed"):
             prefix = key[: -len(".weight_packed")]
             scale = weights[f"{prefix}.weight_scale"]
@@ -493,11 +551,18 @@ def _transform_compressed_tensors_mixed_weights(
         if key.endswith(".weight_scale"):
             prefix = key[: -len(".weight_scale")]
             if prefix in fp8_prefixes:
+                weight_key = f"{prefix}.weight"
+                source_weight = weights.pop(weight_key)
+                source_scale = weights.pop(key)
                 new_weights[f"{prefix}.weight"] = (
                     _dequantize_compressed_tensors_fp8_weight(
-                        weights[f"{prefix}.weight"], value
+                        source_weight,
+                        source_scale,
+                        fp8_block_structure,
                     )
                 )
+                pending.append(new_weights[f"{prefix}.weight"])
+                flush()
             # NVFP4 / INT4 scales are consumed with their ``.weight_packed``.
             continue
         if key.endswith(".weight") and key[: -len(".weight")] in fp8_prefixes:
@@ -505,6 +570,8 @@ def _transform_compressed_tensors_mixed_weights(
         if any(key.endswith(suffix) for suffix in _COMPRESSED_TENSORS_DROP_SUFFIXES):
             continue
         new_weights[key] = value
+
+    flush(force=True)
 
     if not native_quant:
         return new_weights, None
@@ -531,9 +598,14 @@ def _transform_compressed_tensors_weights(
     if quantization_config.get("quant_method") != "compressed-tensors":
         return weights, None
 
-    # ``mixed-precision`` puts the real formats in per-group ``config_groups``;
-    # route per group (some groups may be dense fp8 with no ``.weight_packed``).
-    if quantization_config.get("format") == "mixed-precision":
+    # Mixed-precision and pure float-quantized exports both use
+    # ``.weight``/``.weight_scale`` for FP8 tensors. Route these before the
+    # packed-weight guard because a pure FP8 checkpoint has no
+    # ``.weight_packed`` tensors at all.
+    if quantization_config.get("format") in {
+        "mixed-precision",
+        "float-quantized",
+    }:
         return _transform_compressed_tensors_mixed_weights(weights, quantization_config)
 
     if not any(key.endswith(".weight_packed") for key in weights):


### PR DESCRIPTION
Fixes [#422](https://github.com/Blaizzy/nativ/issues/422) by converting pure float-quantized compressed-tensors FP8 weights to BF16. Adds block-scale handling and Laguna regression coverage for strict model loading.

I put this in utils.py so can be a reusable componenet