### PR TITLE
glm5_next: O(1)-per-step DSA indexer decode path + fix a stale-pool reuse

### DIFF
--- a/mlx_vlm/models/glm5_next/language.py
+++ b/mlx_vlm/models/glm5_next/language.py
@@ -1,3 +1,4 @@
+import os  # noqa: E402  (kept next to the toggle it serves)
 from typing import Any, Optional
 
 import mlx.core as mx
@@ -17,6 +18,31 @@ from ..gated_delta import gated_delta_update
 from ..mla import MultiLinear
 from ..mlp import DeepseekMLP
 from .config import ModelConfig, TextConfig
+
+_IDX_FAST_ENV = None
+
+# Pools per growth step for the incremental indexer pool buffers (one pool is
+# ``index_kpool`` tokens, so 512 pools = 2048 tokens of headroom per growth).
+_IDX_POOL_STEP = 512
+
+
+def _idx_fast_enabled() -> bool:
+    # Opt-in fast decode path for the DSA indexer's *active* regime
+    # (T > index_topk).  The eager path redoes O(T) work every step -- a
+    # full-context ``visible`` mask, an O(T) reduction inside ``_visible_tail``
+    # and an O(P) re-concatenation of the pool cache -- none of which can change
+    # between steps when the sequence is unpadded and single-stream.  Off by
+    # default until it has live mileage; the bypass regime and prefill are
+    # untouched.
+    global _IDX_FAST_ENV
+    if _IDX_FAST_ENV is None:
+        _IDX_FAST_ENV = os.environ.get("MLX_VLM_GLM5_IDX_FAST", "0").lower() in (
+            "1",
+            "true",
+            "yes",
+            "on",
+        )
+    return _IDX_FAST_ENV
 
 
 class Glm5NextRMSNormGated(nn.Module):
@@ -310,6 +336,169 @@ class Glm5NextIndexer(nn.Module):
         tail_indices = mx.where(tail_valid & tail_vis, tail_indices, -1)
         return tail_indices
 
+    # ------------------------------------------------------------------ fast
+    # Incremental decode path for the ACTIVE indexer regime (T > index_topk).
+    #
+    # The eager path recomputes, every step and for every one of the 11 DSA
+    # layers, three things that provably cannot change:
+    #   (a) ``valid`` / ``kv_pos`` / ``visible`` / ``pool_visible`` -- with a
+    #       single unpadded stream every cached position is valid and every
+    #       position is <= the current query position, so ``visible`` is all-True
+    #       and ``valid_candidates`` collapses to ``pool_valid``;
+    #   (b) ``_visible_tail`` -- an O(T) reduction whose result, once (a) holds,
+    #       is a closed form in T alone;
+    #   (c) ``mx.concatenate`` of the stable pool prefix -- pools are append-only
+    #       during decode, so this is an O(P) copy of data that is already there.
+    # This path keeps (per step) only the work that genuinely depends on the new
+    # token: repooling the one incomplete pool, the query-dependent pool scoring,
+    # and the top-k.  It is written to be bit-identical to the eager path.
+
+    def _pool_buffers(self, cache):
+        """Preallocated append-only pool store; seeded from ``cache._pool``."""
+        kp = self.index_kpool
+        buf = getattr(cache, "_fpool", None)
+        if buf is not None:
+            return buf
+        ck, ci, cv, t_prev = cache._pool
+        B, n = ck.shape[0], ck.shape[1]
+        cap = ((n + _IDX_POOL_STEP - 1) // _IDX_POOL_STEP + 1) * _IDX_POOL_STEP
+        pk = mx.zeros((B, cap, self.head_dim), dtype=ck.dtype)
+        pi = mx.zeros((B, cap, kp), dtype=ci.dtype)
+        pv = mx.zeros((B, cap), dtype=cv.dtype)
+        pk[:, :n] = ck
+        pi[:, :n] = ci
+        pv[:, :n] = cv
+        buf = [pk, pi, pv, t_prev, cap]
+        cache._fpool = buf
+        # The eager incremental path keys off ``_pool``; drop it so that if this
+        # path ever becomes ineligible mid-stream the fallback is a correct full
+        # rebuild rather than a stale prefix.
+        cache._pool = None
+        return buf
+
+    def _decode_fast(self, x, q, packed_full, cache, T):
+        kp, hd = self.index_kpool, self.head_dim
+        B = packed_full.shape[0]
+        buf = self._pool_buffers(cache)
+        pk, pi, pv, t_prev, cap = buf
+
+        # --- (c) repool only the trailing incomplete pool, in place ----------
+        n_stable = t_prev // kp
+        s0 = n_stable * kp
+        tail = packed_full[:, s0:]
+        pk_s, pi_s, pv_s = self._pool_tail(tail, s0, T - s0)
+        P = n_stable + 1
+        if P > cap:
+            cap += _IDX_POOL_STEP
+            grow = [
+                mx.zeros((B, cap) + a.shape[2:], dtype=a.dtype) for a in (pk, pi, pv)
+            ]
+            for g, a in zip(grow, (pk, pi, pv)):
+                g[:, : a.shape[1]] = a
+            pk, pi, pv = grow
+        pk[:, n_stable:P] = pk_s
+        pi[:, n_stable:P] = pi_s
+        pv[:, n_stable:P] = pv_s
+        buf[:] = [pk, pi, pv, T, cap]
+
+        # `pool_end` is never needed here: it exists only to gather `visible`,
+        # which is all-True on this path, so no buffer is kept for it.
+        pool_keys, pool_indices, pool_valid = pk[:, :P], pi[:, :P], pv[:, :P]
+
+        # --- scoring: genuinely query-dependent, recomputed in full ----------
+        select_k = min(self.index_topk // kp, P)
+        scores = q @ pool_keys[:, None].swapaxes(-1, -2)
+        scores = mx.maximum(scores * self.softmax_scale, 0.0)
+        weights = self.weights_proj(x) * (self.n_heads**-0.5)
+        index_scores = mx.sum(weights[..., None] * scores, axis=2)
+        # (a) valid_candidates == pool_valid: `visible` is all-True here.
+        valid_candidates = mx.broadcast_to(pool_valid[:, None], (B, 1, P))
+        index_scores = mx.where(valid_candidates, index_scores, -1e30)
+
+        order = mx.argsort(-index_scores, axis=-1)
+        selected = order[..., :select_k]
+        selected_valid = mx.take_along_axis(valid_candidates, selected, axis=-1)
+        sel_exp = mx.broadcast_to(selected[..., None], (B, 1, select_k, kp))
+        topk = mx.take_along_axis(
+            mx.broadcast_to(pool_indices[:, None], (B, 1, P, kp)), sel_exp, axis=2
+        ).reshape(B, 1, select_k * kp)
+        sv = mx.broadcast_to(selected_valid[..., None], (B, 1, select_k, kp)).reshape(
+            B, 1, select_k * kp
+        )
+        topk = mx.where(sv, topk, -1)
+
+        # --- (b) closed-form _visible_tail ----------------------------------
+        if self.index_kpool_always_select_tail and kp > 1:
+            topk = mx.concatenate([topk, self._tail_fast(B, T, topk.dtype)], axis=-1)
+        width = self.index_topk + (
+            kp - 1 if (self.index_kpool_always_select_tail and kp > 1) else 0
+        )
+        if topk.shape[-1] < width:
+            topk = mx.concatenate(
+                [topk, mx.full((B, 1, width - topk.shape[-1]), -1, dtype=topk.dtype)],
+                axis=-1,
+            )
+        # `valid_cur` is all-True on this path, so the final mask is the identity.
+        return topk[:, None, ..., :width].astype(mx.int32)
+
+    def _pool_tail(self, tail, s0, n):
+        """`_pooled_states` specialised to the one trailing pool at decode.
+
+        With `n = T - s0` in [1, kpool] and every cached position valid, the
+        whole index apparatus of `_pooled_states` -- any/argmax/where for
+        `first_key`, the arange, the clip, three `take_along_axis` calls and the
+        validity reductions -- collapses to constants known on the host:
+            first_key    = 0
+            safe[j]      = min(j, n-1)
+            grouped_valid[j] = (j < n)
+            pool_valid   = (n == kpool)
+            pool_indices[j]  = s0 + j  if j < n else -1
+        Only the gather, the gate softmax and the weighted sum remain, and each
+        is left byte-for-byte as the eager path performs it.
+        """
+        kp, hd = self.index_kpool, self.head_dim
+        B = tail.shape[0]
+        # Load-bearing: the caller's `t_prev == T - 1` guard is what bounds the
+        # tail to a single pool (n = (t_prev % kp) + 1).  Fail loudly rather than
+        # silently pool only the first kp tokens if that ever stops holding.
+        if not 1 <= n <= kp:
+            raise ValueError(f"indexer fast tail expects 1..{kp} tokens, got {n}")
+        key = (kp, n, s0)
+        cached = getattr(self, "_ptc", None)
+        if cached is None or cached[0] != key:
+            idx = mx.array([min(j, n - 1) for j in range(kp)], dtype=mx.int32)
+            gv = mx.array([[j < n] for j in range(kp)], dtype=mx.bool_)
+            pi = mx.array(
+                [[[s0 + j if j < n else -1 for j in range(kp)]]], dtype=mx.int32
+            )
+            pv = mx.array([[n == kp]], dtype=mx.bool_)
+            self._ptc = cached = (key, idx, gv, pi, pv)
+        _, idx, gv, pi, pv = cached
+
+        gk = mx.take(tail[..., :hd], idx, axis=1)[:, None]
+        gg = mx.take(tail[..., hd : 2 * hd], idx, axis=1)[:, None]
+        logits = gg + self.index_kpool_compress_ape[None, None]
+        logits = mx.where(gv, logits, -1e30)
+        probs = mx.softmax(logits, axis=2)
+        probs = mx.where(mx.isnan(probs), 0.0, probs)
+        pool_keys = mx.sum(probs * gk, axis=2)
+        return (
+            pool_keys,
+            mx.broadcast_to(pi, (B, 1, kp)),
+            mx.broadcast_to(pv, (B, 1)),
+        )
+
+    def _tail_fast(self, B, T, dtype):
+        # With every position visible and valid, _visible_tail collapses to a
+        # closed form: first_key = 0, visible_count = T, tail_count = T % kp,
+        # tail_start = T - tail_count, tail_vis all-True, so
+        #   tail_valid[o] = (o < tail_count) & (tail_start + o < T) = o < tail_count.
+        # Built host-side: 3 int32s, no GPU reduction over T.
+        kp = self.index_kpool
+        c = T % kp
+        vals = [(T - c + o) if o < c else -1 for o in range(kp - 1)]
+        return mx.broadcast_to(mx.array(vals, dtype=dtype), (B, 1, kp - 1))
+
     def __call__(self, x, qr, mask, cache=None):
         B, S, _ = x.shape
         q = self.wq_b(qr).reshape(B, S, self.n_heads, self.head_dim)
@@ -338,6 +527,35 @@ class Glm5NextIndexer(nn.Module):
         # stays consistent; the full pool is rebuilt once when T first exceeds index_topk.
         if getattr(self, "bypass_short", True) and T <= self.index_topk:
             return None
+        # Fast incremental decode: single unpadded stream, exactly one new token
+        # since the pool cache was last built, and a pool state to build on.
+        # Anything else (prefill, S>1 verify block, batched or left-padded
+        # decode, a rollback that shortened the cache) takes the eager path.
+        if (
+            _idx_fast_enabled()
+            and S == 1
+            and B == 1
+            and cache is not None
+            and mask is None
+            and getattr(cache, "_no_pad", False)
+            and (
+                getattr(cache, "_fpool", None) is not None
+                or getattr(cache, "_pool", None) is not None
+            )
+            and (
+                cache._fpool[3]
+                if getattr(cache, "_fpool", None) is not None
+                else cache._pool[3]
+            )
+            == T - 1
+            and (
+                cache._fpool[0]
+                if getattr(cache, "_fpool", None) is not None
+                else cache._pool[0]
+            ).shape[0]
+            == B
+        ):
+            return self._decode_fast(x, q, packed_full, cache, T)
         k_full, gate_full, valid_ch = mx.split(
             packed_full, [self.head_dim, 2 * self.head_dim], axis=-1
         )
@@ -361,6 +579,11 @@ class Glm5NextIndexer(nn.Module):
             and getattr(cache, "_pool", None) is not None
             and getattr(cache, "_no_pad", False)
             and cache._pool[0].shape[0] == B
+            # The cached prefix describes a cache of t_prev tokens; if anything
+            # shortened the cache since (APC prefix reuse trims the DSA caches
+            # via dispatch.py's c.trim(n_drop) without touching _pool), reusing
+            # it would splice stale pools onto a shorter sequence.
+            and cache._pool[3] == T - S
         ):
             ck, ci, cv, t_prev = cache._pool
             n_stable = t_prev // self.index_kpool
@@ -380,6 +603,7 @@ class Glm5NextIndexer(nn.Module):
                 cache._no_pad = bool(mx.all(valid))
         if cache is not None:
             cache._pool = (pool_keys, pool_indices, pool_valid, T)
+            cache._fpool = None
         P = pool_keys.shape[1]
         select_k = min(self.index_topk // self.index_kpool, P)
         pool_end = mx.clip(pool_indices[..., -1], 0, kv_len - 1)

--- a/mlx_vlm/tests/test_glm5_next_idx_fast.py
+++ b/mlx_vlm/tests/test_glm5_next_idx_fast.py
@@ -1,0 +1,310 @@
+"""Eager vs fast equivalence for the GLM-5-Next DSA indexer decode path.
+
+``MLX_VLM_GLM5_IDX_FAST=1`` replaces the indexer's *active* decode path (the
+regime ``T > index_topk``, where the short-context bypass no longer applies)
+with one that does only the work a new token actually creates.
+
+The eager path recomputes, every step and in every DSA layer:
+  * ``kv_pos`` / ``visible`` / ``pool_visible`` -- O(T) tensors that, for a
+    single unpadded stream, are all-True by construction;
+  * ``_visible_tail`` -- an O(T) reduction whose result is then a closed form
+    in ``T`` alone;
+  * ``mx.concatenate`` of the stable pool prefix -- an O(P) copy of pool state
+    that is append-only during decode;
+  * the whole index apparatus of ``_pooled_states`` (argmax/arange/clip/three
+    gathers/validity reductions) for a tail of at most ``index_kpool`` tokens,
+    where every one of those indices is known on the host.
+
+None of that changes the selection, so the fast path is expected to be
+*bit-identical*: the returned top-k index tensor must match element for
+element across carried steps.  These tests pin that at three context lengths,
+pin the pool-buffer growth path, and pin that anything the path is not written
+for (prefill, S>1 verify blocks, batching, left-padding, a rollback that
+shortened the cache) falls back to the eager path.
+"""
+
+import mlx.core as mx
+import pytest
+
+import mlx_vlm.models.glm5_next.language as glm5
+from mlx_vlm.models.cache import KVCache
+from mlx_vlm.models.glm5_next.config import TextConfig
+
+# GLM-5.3-Flash text_config, restricted to what the indexer reads.
+_CFG = dict(
+    model_type="glm5_next_text",
+    vocab_size=1024,
+    hidden_size=4096,
+    intermediate_size=12288,
+    moe_intermediate_size=2048,
+    num_hidden_layers=1,
+    num_attention_heads=64,
+    num_key_value_heads=64,
+    n_shared_experts=1,
+    n_routed_experts=288,
+    routed_scaling_factor=2.5,
+    kv_lora_rank=512,
+    q_lora_rank=1536,
+    qk_rope_head_dim=0,
+    v_head_dim=256,
+    qk_nope_head_dim=256,
+    num_experts_per_tok=8,
+    first_k_dense_replace=3,
+    max_position_embeddings=1048576,
+    rms_norm_eps=1e-05,
+    index_topk=2048,
+    index_head_dim=128,
+    index_n_heads=32,
+    layer_types=["deepseek_sparse_attention"],
+    mlp_layer_types=["dense"],
+    linear_attn_config={
+        "num_heads": 64,
+        "gate_lower_bound": -5.0,
+        "head_dim": 128,
+        "short_conv_kernel_size": 4,
+    },
+)
+
+
+def _config():
+    return TextConfig.from_dict(dict(_CFG))
+
+
+def _indexer(config, seed=0):
+    mx.random.seed(seed)
+    ix = glm5.Glm5NextIndexer(config)
+
+    def rand(tree):
+        if isinstance(tree, dict):
+            return {k: rand(v) for k, v in tree.items()}
+        if isinstance(tree, list):
+            return [rand(v) for v in tree]
+        return (mx.random.normal(tree.shape) * 0.05).astype(mx.bfloat16)
+
+    ix.update(rand(ix.parameters()))
+    return ix
+
+
+def _prefill(ix, config, T, seed=1, batch=1):
+    """Eager prefill, so `_pool` / `_no_pad` are built by the reference path."""
+    mx.random.seed(seed)
+    cache = KVCache()
+    x = (mx.random.normal((batch, T, config.hidden_size)) * 0.4).astype(mx.bfloat16)
+    qr = (mx.random.normal((batch, T, config.q_lora_rank)) * 0.4).astype(mx.bfloat16)
+    glm5._IDX_FAST_ENV = False
+    mx.eval(ix(x, qr, None, cache=cache), cache.keys)
+    return cache
+
+
+def _clone(cache):
+    out = KVCache()
+    out.keys = mx.array(cache.keys)
+    out.values = cache.values
+    out.offset = cache.offset
+    out._pool = tuple(
+        mx.array(a) if isinstance(a, mx.array) else a for a in cache._pool
+    )
+    out._no_pad = cache._no_pad
+    out._fpool = None
+    mx.eval(out.keys, out._pool[0], out._pool[1], out._pool[2])
+    return out
+
+
+def _steps(config, n, batch=1, seed=99):
+    mx.random.seed(seed)
+    out = []
+    for _ in range(n):
+        out.append(
+            (
+                (mx.random.normal((batch, 1, config.hidden_size)) * 0.4).astype(
+                    mx.bfloat16
+                ),
+                (mx.random.normal((batch, 1, config.q_lora_rank)) * 0.4).astype(
+                    mx.bfloat16
+                ),
+            )
+        )
+    mx.eval(out)
+    return out
+
+
+@pytest.fixture(autouse=True)
+def _reset_toggle():
+    saved = (glm5._IDX_FAST_ENV, glm5._IDX_POOL_STEP)
+    yield
+    glm5._IDX_FAST_ENV, glm5._IDX_POOL_STEP = saved
+
+
+def _carry(ix, config, ctx, n_steps, seed=1):
+    """Run n_steps eager and fast from the same prefill; return worst mismatch.
+
+    Counts fast-path entries as well: if the eligibility guard ever stopped
+    firing this comparison would quietly become eager-vs-eager and pass for the
+    wrong reason, so the count is asserted rather than assumed.
+    """
+    eager_cache = _prefill(ix, config, ctx, seed=seed)
+    fast_cache = _clone(eager_cache)
+    worst = 0
+    entered = {"n": 0}
+    original = type(ix)._decode_fast
+
+    def counting(self, *args, **kwargs):
+        entered["n"] += 1
+        return original(self, *args, **kwargs)
+
+    type(ix)._decode_fast = counting
+    try:
+        worst = _carry_inner(ix, config, eager_cache, fast_cache, n_steps, worst)
+    finally:
+        type(ix)._decode_fast = original
+    assert entered["n"] == n_steps, (
+        f"fast path ran {entered['n']}/{n_steps} steps -- the comparison would "
+        "have been eager-vs-eager"
+    )
+    return worst
+
+
+def _carry_inner(ix, config, eager_cache, fast_cache, n_steps, worst):
+    for x, qr in _steps(config, n_steps):
+        glm5._IDX_FAST_ENV = False
+        ref = ix(x, qr, None, cache=eager_cache)
+        glm5._IDX_FAST_ENV = True
+        got = ix(x, qr, None, cache=fast_cache)
+        mx.eval(ref, got)
+        assert ref is not None and got is not None
+        assert ref.shape == got.shape and ref.dtype == got.dtype
+        worst = max(worst, int(mx.sum((ref != got).astype(mx.int32))))
+    return worst
+
+
+@pytest.mark.parametrize("ctx", [4096, 16384])
+def test_idx_fast_matches_eager_over_32_decode_steps(ctx):
+    if not mx.metal.is_available():
+        pytest.skip("Metal kernels are unavailable on this host")
+    config = _config()
+    ix = _indexer(config)
+    # The selection is the same selection, reached with less arithmetic, so this
+    # is exact rather than merely close.
+    assert _carry(ix, config, ctx, 32) == 0
+
+
+def test_idx_fast_survives_pool_buffer_growth():
+    if not mx.metal.is_available():
+        pytest.skip("Metal kernels are unavailable on this host")
+    config = _config()
+    ix = _indexer(config)
+    # Shrink the growth step so the preallocated pool buffers must be grown
+    # several times inside the run instead of once every 2048 tokens.
+    glm5._IDX_POOL_STEP = 2
+    assert _carry(ix, config, 4096, 40) == 0
+
+
+def test_idx_fast_survives_interleaved_verify_blocks():
+    """Speculative decoding interleaves S>1 verify blocks with S=1 decode.
+
+    The fast path owns the pool state in `_fpool` and clears `_pool`; a verify
+    block is ineligible, so it must fall back to a full rebuild, restore
+    `_pool`, and let the next single-token step re-seed `_fpool` from it.  Run
+    the identical mixed sequence eager and fast and require the selections to
+    stay bit-identical the whole way through.
+    """
+    if not mx.metal.is_available():
+        pytest.skip("Metal kernels are unavailable on this host")
+    config = _config()
+    ix = _indexer(config)
+    eager_cache = _prefill(ix, config, 4096)
+    fast_cache = _clone(eager_cache)
+
+    mx.random.seed(1234)
+    plan = []
+    for i in range(4):
+        for _ in range(3):
+            plan.append(1)
+        plan.append(4)  # a draft-block verify
+    for n in plan:
+        x = (mx.random.normal((1, n, config.hidden_size)) * 0.4).astype(mx.bfloat16)
+        qr = (mx.random.normal((1, n, config.q_lora_rank)) * 0.4).astype(mx.bfloat16)
+        mx.eval(x, qr)
+        glm5._IDX_FAST_ENV = False
+        ref = ix(x, qr, None, cache=eager_cache)
+        glm5._IDX_FAST_ENV = True
+        got = ix(x, qr, None, cache=fast_cache)
+        mx.eval(ref, got)
+        assert ref.shape == got.shape
+        assert int(mx.sum((ref != got).astype(mx.int32))) == 0, f"diverged at S={n}"
+
+
+def test_idx_fast_declines_ineligible_shapes():
+    if not mx.metal.is_available():
+        pytest.skip("Metal kernels are unavailable on this host")
+    config = _config()
+    ix = _indexer(config)
+
+    def _boom(*a, **k):
+        raise AssertionError("fast path taken for an ineligible step")
+
+    real = glm5.Glm5NextIndexer._decode_fast
+    glm5.Glm5NextIndexer._decode_fast = _boom
+    try:
+        glm5._IDX_FAST_ENV = True
+        # prefill (S = T) -- no pool state yet
+        cache = _prefill(ix, config, 4096)
+        # S > 1 speculative-verify block
+        glm5._IDX_FAST_ENV = True
+        mx.random.seed(3)
+        x = (mx.random.normal((1, 4, config.hidden_size)) * 0.4).astype(mx.bfloat16)
+        qr = (mx.random.normal((1, 4, config.q_lora_rank)) * 0.4).astype(mx.bfloat16)
+        mx.eval(ix(x, qr, None, cache=_clone(cache)))
+        # left-padded decode: a bool mask is supplied
+        c2 = _clone(cache)
+        x1, qr1 = _steps(config, 1)[0]
+        mx.eval(ix(x1, qr1, mx.ones((1, 1), dtype=mx.bool_), cache=c2))
+        # padded sequence: _no_pad is False
+        c3 = _clone(cache)
+        c3._no_pad = False
+        mx.eval(ix(x1, qr1, None, cache=c3))
+        # rollback: the cache was trimmed, so `_pool` is stale by > 1 token
+        c4 = _clone(cache)
+        c4._pool = c4._pool[:3] + (c4._pool[3] - 4,)
+        mx.eval(ix(x1, qr1, None, cache=c4))
+        # batched decode
+        cb = _prefill(ix, config, 4096, batch=2)
+        xb, qrb = _steps(config, 1, batch=2)[0]
+        mx.eval(ix(xb, qrb, None, cache=cb))
+    finally:
+        glm5.Glm5NextIndexer._decode_fast = real
+
+
+def test_idx_fast_bypass_regime_returns_none():
+    if not mx.metal.is_available():
+        pytest.skip("Metal kernels are unavailable on this host")
+    config = _config()
+    ix = _indexer(config)
+    for flag in (False, True):
+        glm5._IDX_FAST_ENV = flag
+        cache = KVCache()
+        mx.random.seed(5)
+        x = (mx.random.normal((1, 512, config.hidden_size)) * 0.4).astype(mx.bfloat16)
+        qr = (mx.random.normal((1, 512, config.q_lora_rank)) * 0.4).astype(mx.bfloat16)
+        # T = 512 <= index_topk = 2048 -> short-context bypass, no selection
+        assert ix(x, qr, None, cache=cache) is None
+
+
+def test_toggle_off_uses_eager_path():
+    if not mx.metal.is_available():
+        pytest.skip("Metal kernels are unavailable on this host")
+    config = _config()
+    ix = _indexer(config)
+
+    def _boom(*a, **k):
+        raise AssertionError("fast path taken with the toggle off")
+
+    real = glm5.Glm5NextIndexer._decode_fast
+    glm5.Glm5NextIndexer._decode_fast = _boom
+    try:
+        glm5._IDX_FAST_ENV = False
+        cache = _prefill(ix, config, 4096)
+        x, qr = _steps(config, 1)[0]
+        mx.eval(ix(x, qr, None, cache=cache))
+    finally:
+        glm5.Glm5NextIndexer._decode_fast = real


### PR DESCRIPTION
Two changes to `Glm5NextIndexer`: one fix, one opt-in fast path.

**Fix.** The incremental-pooling branch reuses `cache._pool`'s stable prefix without checking that the prefix still describes the current cache. Anything that shortens the KV cache invalidates it — APC prefix reuse does exactly that, via `dispatch.py`'s `for c in kv_cache: c.trim(n_drop)`, which trims the DSA caches but leaves the indexer's `_pool` attribute untouched. If the suffix after the shared prefix is a single token, the next call takes the incremental branch with `t_prev` describing the longer, pre-trim sequence and splices stale pools onto a shorter one. Guarding on `cache._pool[3] == T - S` sends that case to the full rebuild it needs. Narrow, but silent when it hits.

**Fast path** (`MLX_VLM_GLM5_IDX_FAST=1`, default off). Once context passes `index_topk` the short-context bypass stops firing and the indexer runs full selection every step in all 11 DSA layers. Almost none of that work depends on the new token. For a single unpadded stream every cached position is valid and <= the query position, so `visible` is all-True, `valid_candidates` collapses to `pool_valid`, and the O(T) `kv_pos`/`visible`/`pool_visible` tensors are dead weight; `_visible_tail` becomes a closed form in `T`; pools are append-only during decode, so re-concatenating the stable prefix is an O(P) copy of data already in place; and `_pooled_states` runs on a tail of <= `index_kpool` tokens whose entire index apparatus (argmax/arange/clip/three gathers/validity reductions) is host-computable. The fast path keeps only what a new token creates: repooling the one incomplete pool, the query-dependent scoring, and the top-k. Pool state moves to preallocated append-only buffers, grown 512 pools at a time.

Measured on GLM-5.3-Flash (M3 Ultra, decode step, medians over 8 trials; eager spread <=0.5 ms):

| context | eager | fast | recovered |
|---|---|---|---|
| 4k | 29.56 ms | 29.14 ms | **0.42 ms/step** |
| 16k | 29.96 ms | 29.12 ms | **0.84 ms/step** |
| 64k | 30.62 ms | 29.59 ms | **1.03 ms/step** |

The gain grows with context, which is the point: the step's context slope over 4k->64k falls from 1.06 ms to 0.45 ms, **-58%**.

It is the same selection with less arithmetic, so it is bit-identical rather than close — the returned top-k matches element for element over 32 carried steps at 4k and 16k, including across pool-buffer growth and interleaved S>1 verify blocks. The tests assert the fast path actually ran, so they cannot pass by falling back. Prefill, S>1 blocks, batched or left-padded decode, and a rollback that shortened the cache all fall back to the eager path, which is otherwise untouched, as is the short-context bypass.

Note for anyone tempted by `mx.argpartition` here: on Metal, `ArgPartition` and `ArgSort` both dispatch `gpu_merge_sort`, so it buys nothing.
