### PR TITLE
feat(speculative): declare drafter batch lifecycle

### DIFF
--- a/mlx_vlm/speculative/drafters/deepseek_v4_mtp/deepseek_v4_mtp.py
+++ b/mlx_vlm/speculative/drafters/deepseek_v4_mtp/deepseek_v4_mtp.py
@@ -43,6 +43,7 @@ class DeepseekV4MTPDraftModel(nn.Module):
     supports_greedy_draft_argmax = True
     prefer_requested_block_size = True
     requires_uniform_batch_acceptance = True
+    requires_verified_token_reconciliation = True
 
     def __init__(self, config: DeepseekV4MTPConfig):
         super().__init__()

--- a/mlx_vlm/speculative/drafters/gemma4_assistant/gemma4_assistant.py
+++ b/mlx_vlm/speculative/drafters/gemma4_assistant/gemma4_assistant.py
@@ -30,6 +30,7 @@ class Gemma4AssistantDraftModel(nn.Module):
     supports_greedy_draft_argmax = True
     # The drafter owns no cache; batched target KV is normalized per call.
     supports_continuous_batching = True
+    requires_verified_token_reconciliation = False
 
     def __init__(self, config: Gemma4AssistantConfig):
         super().__init__()

--- a/mlx_vlm/speculative/drafters/gemma4_assistant/gemma4_assistant.py
+++ b/mlx_vlm/speculative/drafters/gemma4_assistant/gemma4_assistant.py
@@ -28,6 +28,8 @@ class _DraftInner(nn.Module):
 
 class Gemma4AssistantDraftModel(nn.Module):
     supports_greedy_draft_argmax = True
+    # The drafter owns no cache; batched target KV is normalized per call.
+    supports_continuous_batching = True
 
     def __init__(self, config: Gemma4AssistantConfig):
         super().__init__()

--- a/mlx_vlm/speculative/drafters/qwen4_exp_mtp/qwen4_exp_mtp.py
+++ b/mlx_vlm/speculative/drafters/qwen4_exp_mtp/qwen4_exp_mtp.py
@@ -23,6 +23,8 @@ class Qwen4ExpMTPDraftModel(DeepseekV4MTPDraftModel):
     """
 
     supports_greedy_draft_argmax = True
+    # filter_batch keeps owned KV and per-row speculative state aligned.
+    supports_continuous_batching = True
     # A caller-provided block size is an adaptive ceiling. Longer
     # autoregressive tails are useful only after the native one-token prefix
     # has demonstrated enough acceptance to amortize them.

--- a/mlx_vlm/speculative/drafters/qwen4_exp_mtp/qwen4_exp_mtp.py
+++ b/mlx_vlm/speculative/drafters/qwen4_exp_mtp/qwen4_exp_mtp.py
@@ -25,6 +25,10 @@ class Qwen4ExpMTPDraftModel(DeepseekV4MTPDraftModel):
     supports_greedy_draft_argmax = True
     # filter_batch keeps owned KV and per-row speculative state aligned.
     supports_continuous_batching = True
+    # Unlike shared-KV-only assistants, this drafter owns speculative KV and
+    # seed state. External serving loops must reconcile every verified round
+    # and apply the same row filters as the target batch.
+    requires_verified_token_reconciliation = True
     # A caller-provided block size is an adaptive ceiling. Longer
     # autoregressive tails are useful only after the native one-token prefix
     # has demonstrated enough acceptance to amortize them.

--- a/mlx_vlm/tests/test_qwen4_mtp.py
+++ b/mlx_vlm/tests/test_qwen4_mtp.py
@@ -73,6 +73,10 @@ def test_qwen4_decoder_layers_expose_normalized_layer_types_for_mtp():
     assert Qwen4ExpDecoderLayer(config, 1).layer_type == "qwen_sparse_attention"
 
 
+def test_qwen4_mtp_declares_continuous_batching_support():
+    assert Qwen4ExpMTPDraftModel.supports_continuous_batching is True
+
+
 def test_qwen4_mtp_fusion_matches_released_equations():
     config = _tiny_text_config()
     drafter = Qwen4ExpMTPDraftModel(ModelConfig(text_config=config))

--- a/mlx_vlm/tests/test_qwen4_mtp.py
+++ b/mlx_vlm/tests/test_qwen4_mtp.py
@@ -75,6 +75,9 @@ def test_qwen4_decoder_layers_expose_normalized_layer_types_for_mtp():
 
 def test_qwen4_mtp_declares_continuous_batching_support():
     assert Qwen4ExpMTPDraftModel.supports_continuous_batching is True
+    assert Qwen4ExpMTPDraftModel.requires_verified_token_reconciliation is True
+    assert callable(getattr(Qwen4ExpMTPDraftModel, "accept_verified_tokens_batch"))
+    assert callable(getattr(Qwen4ExpMTPDraftModel, "filter_batch"))
 
 
 def test_qwen4_mtp_fusion_matches_released_equations():

--- a/mlx_vlm/tests/test_speculative.py
+++ b/mlx_vlm/tests/test_speculative.py
@@ -2632,6 +2632,10 @@ def test_gemma4_assistant_overrides_dflash_to_mtp(tmp_path, caplog):
     assert any("requires --draft-kind='mtp'" in r.getMessage() for r in caplog.records)
 
 
+def test_gemma4_assistant_declares_continuous_batching_support():
+    assert Gemma4AssistantDraftModel.supports_continuous_batching is True
+
+
 def test_explicit_mtp_kept_for_gemma4_assistant(tmp_path, caplog):
     path = _make_drafter_dir(tmp_path, "gemma4_assistant")
     with caplog.at_level("WARNING"):

--- a/mlx_vlm/tests/test_speculative.py
+++ b/mlx_vlm/tests/test_speculative.py
@@ -2634,6 +2634,11 @@ def test_gemma4_assistant_overrides_dflash_to_mtp(tmp_path, caplog):
 
 def test_gemma4_assistant_declares_continuous_batching_support():
     assert Gemma4AssistantDraftModel.supports_continuous_batching is True
+    assert Gemma4AssistantDraftModel.requires_verified_token_reconciliation is False
+
+
+def test_deepseek_v4_mtp_declares_owned_state_reconciliation():
+    assert DeepseekV4MTPDraftModel.requires_verified_token_reconciliation is True
 
 
 def test_explicit_mtp_kept_for_gemma4_assistant(tmp_path, caplog):


### PR DESCRIPTION
## Summary

- declare whether each registered MTP drafter supports continuous batching
- distinguish stateful drafters that require verified-token reconciliation from stateless assistants
- bind the public capability contract for Qwen3.8/DeepSeek V4 MTP and Gemma 4 assistants

This lets serving integrations reject unknown batch behavior instead of assuming it is safe.

## Validation

- full mlx-vlm suite: `2956 passed, 6 skipped, 75 subtests passed`
- Qwen3.8 Flash-Next composed serving qualification: exact and ragged continuous batching at 64K
- 128K MTP replay: 129,998 prompt tokens; 55 attempted, 42 accepted, 0 errors
- full Runtime promotion and installed-source verification passed

