### PR TITLE
fix(qwen4_exp): use standard RMSNorm gamma convention

### DIFF
--- a/mlx_vlm/models/qwen4_exp/language.py
+++ b/mlx_vlm/models/qwen4_exp/language.py
@@ -574,7 +574,7 @@ class QSAQuantizedKVCache(QuantizedKVCache):
 
 
 class Qwen4ExpRMSNorm(nn.Module):
-    """Qwen4 RMSNorm, whose checkpoint weights are centered at zero."""
+    """Qwen4 RMSNorm over standard gamma centered at one, matching qwen3_5."""
 
     def __init__(self, dim: int, group_size: int | None = None, eps: float = 1e-6):
         super().__init__()
@@ -582,7 +582,7 @@ class Qwen4ExpRMSNorm(nn.Module):
         self.group_size = group_size
         if group_size is not None and dim % group_size:
             raise ValueError(f"{dim=} must be divisible by {group_size=}")
-        self.weight = mx.zeros(dim)
+        self.weight = mx.ones(dim)
 
     def __call__(self, x: mx.array) -> mx.array:
         dtype = x.dtype
@@ -593,7 +593,7 @@ class Qwen4ExpRMSNorm(nn.Module):
         else:
             weight = self.weight
         y = y * mx.rsqrt(mx.mean(mx.square(y), axis=-1, keepdims=True) + self.eps)
-        y = y * (1.0 + weight.astype(mx.float32))
+        y = y * weight.astype(mx.float32)
         return y.reshape(x.shape).astype(dtype)
 
 

--- a/mlx_vlm/models/qwen4_exp/qwen4_exp.py
+++ b/mlx_vlm/models/qwen4_exp/qwen4_exp.py
@@ -3,13 +3,28 @@ import re
 import mlx.nn as nn
 
 from ..qwen3_5 import Model as Qwen3_5Model
-from ..qwen3_5.qwen3_5 import sanitize_key
+from ..qwen3_5.qwen3_5 import (
+    sanitize_key,
+    should_offset_norm_weight,
+    should_shift_norm_weights,
+)
 from .config import ModelConfig
 from .fp8 import convert_qwen4_exp_fp8_weights
 from .language import LanguageModel
 from .vision import VisionModel
 
 _NGRAM_SHARD_RE = re.compile(r"\.ngram_embedding\.shard_(\d+)(?=\.)")
+
+NORM_WEIGHT_SUFFIXES = (
+    ".q_norm.weight",
+    ".k_norm.weight",
+    ".q_layernorm.weight",
+    ".k_layernorm.weight",
+    ".hc_norm.weight",
+    ".norm_key.weight",
+    ".norm_query.weight",
+    ".norm_conv.weight",
+)
 
 
 class Model(Qwen3_5Model):
@@ -26,6 +41,7 @@ class Model(Qwen3_5Model):
             key: value for key, value in weights.items() if not key.startswith("mtp.")
         }
         weights = convert_qwen4_exp_fp8_weights(weights)
+        shift_norm_weights = should_shift_norm_weights(weights)
         if self.config.text_config.ple_storage:
             weights = {
                 key: value
@@ -54,10 +70,17 @@ class Model(Qwen3_5Model):
 
         sanitized = {}
         for key, value in weights.items():
+            original_key = key
             key = sanitize_key(key)
             key = _NGRAM_SHARD_RE.sub(r".ngram_embedding.shards.\1", key)
             if "conv1d.weight" in key and value.shape[-1] != 1:
                 value = value.moveaxis(2, 1)
+            if (
+                value.ndim == 1
+                and key.endswith(NORM_WEIGHT_SUFFIXES)
+                and should_offset_norm_weight(original_key, shift_norm_weights)
+            ):
+                value += 1.0
             sanitized[key] = value
         return sanitized
 

--- a/mlx_vlm/tests/test_qwen4_exp.py
+++ b/mlx_vlm/tests/test_qwen4_exp.py
@@ -13,6 +13,7 @@ from mlx_vlm.models.qwen4_exp.language import (
     QSAQuantizedKVCache,
     Qwen4ExpGatedDeltaNet,
     Qwen4ExpNGramEmbedding,
+    Qwen4ExpRMSNorm,
     ShardedEmbedding,
 )
 from mlx_vlm.prompt_utils import MessageFormat, MessageFormatter
@@ -636,6 +637,75 @@ class Qwen4ExpTests(unittest.TestCase):
             predicate(path, None),
             {"fallback_group_size": 32},
         )
+
+
+class Qwen4ExpNormConventionTests(unittest.TestCase):
+    def test_rms_norm_applies_standard_gamma(self):
+        dim = 8
+        norm = Qwen4ExpRMSNorm(dim, eps=1e-6)
+        gamma = mx.array([1.3, 0.7, 1.1, 0.9, 1.5, 0.5, 1.2, 0.8])
+        norm.weight = gamma
+        x = mx.random.normal((2, 3, dim))
+        normalized = mx.fast.rms_norm(x, mx.ones(dim), 1e-6)
+        out = norm(x)
+        self.assertTrue(mx.allclose(out, normalized * gamma, atol=1e-4).item())
+        self.assertFalse(mx.allclose(out, normalized * (1.0 + gamma), atol=1e-3).item())
+
+    def test_default_gamma_is_plain_rms_norm(self):
+        dim = 8
+        norm = Qwen4ExpRMSNorm(dim, eps=1e-6)
+        x = mx.random.normal((2, dim))
+        self.assertTrue(
+            mx.allclose(
+                norm(x), mx.fast.rms_norm(x, mx.ones(dim), 1e-6), atol=1e-4
+            ).item()
+        )
+
+    def test_sanitize_keeps_converted_norm_weights(self):
+        model = qwen4_exp.Model(tiny_config())
+        key = "language_model.model.layers.1.self_attn.q_norm.weight"
+        gamma = mx.array([1.3, 0.7, 1.1, 0.9])
+        out = model.sanitize({key: gamma})
+        self.assertTrue(mx.array_equal(out[key], gamma).item())
+
+    def test_sanitize_shifts_raw_norm_weights(self):
+        model = qwen4_exp.Model(tiny_config())
+        norm_key = "language_model.model.layers.1.self_attn.q_norm.weight"
+        raw = [0.3, -0.3, 0.1, -0.1]
+        out = model.sanitize(
+            {
+                norm_key: mx.array(raw),
+                "language_model.model.layers.0.linear_attn.conv1d.weight": mx.zeros(
+                    (6, 1, 3)
+                ),
+            }
+        )
+        expected = mx.array([v + 1.0 for v in raw])
+        self.assertTrue(mx.allclose(out[norm_key], expected, atol=1e-6).item())
+
+    def test_sanitize_shifts_raw_prefixed_norm_weights(self):
+        model = qwen4_exp.Model(tiny_config())
+        raw = [0.3, -0.3, 0.1, -0.1]
+        out = model.sanitize(
+            {"model.language_model.layers.1.self_attn.q_norm.weight": mx.array(raw)}
+        )
+        key = "language_model.model.layers.1.self_attn.q_norm.weight"
+        expected = mx.array([v + 1.0 for v in raw])
+        self.assertTrue(mx.allclose(out[key], expected, atol=1e-6).item())
+
+    def test_sanitize_leaves_gated_delta_norm_unshifted(self):
+        model = qwen4_exp.Model(tiny_config())
+        key = "language_model.model.layers.0.linear_attn.norm.weight"
+        gamma = mx.array([0.9, 1.1, 0.8, 1.2, 0.7, 1.3, 0.6, 1.4])
+        out = model.sanitize(
+            {
+                key: gamma,
+                "language_model.model.layers.0.linear_attn.conv1d.weight": mx.zeros(
+                    (6, 1, 3)
+                ),
+            }
+        )
+        self.assertTrue(mx.array_equal(out[key], gamma).item())
 
 
 if __name__ == "__main__":

--- a/mlx_vlm/tests/test_qwen4_mtp.py
+++ b/mlx_vlm/tests/test_qwen4_mtp.py
@@ -78,10 +78,10 @@ def test_qwen4_mtp_fusion_matches_released_equations():
     drafter = Qwen4ExpMTPDraftModel(ModelConfig(text_config=config))
     drafter.fc_embedding.weight = mx.eye(config.hidden_size)
     drafter.fc_hidden.weight = mx.eye(config.hidden_size)
-    embedding_weight = mx.linspace(-0.8, -0.2, config.hidden_size)
-    hidden_weight = mx.linspace(-0.6, 0.3, config.hc_count * config.hidden_size)
-    drafter.pre_fc_norm_embedding.weight = embedding_weight
-    drafter.pre_fc_norm_hidden.weight = hidden_weight
+    released_embedding_gain = mx.linspace(-0.8, -0.2, config.hidden_size)
+    released_hidden_gain = mx.linspace(-0.6, 0.3, config.hc_count * config.hidden_size)
+    drafter.pre_fc_norm_embedding.weight = 1 + released_embedding_gain
+    drafter.pre_fc_norm_hidden.weight = 1 + released_hidden_gain
     embedding = mx.arange(1, 33, dtype=mx.float32).reshape(1, 1, 32)
     hidden = mx.arange(1, 65, dtype=mx.float32).reshape(1, 1, 64)
 
@@ -89,11 +89,11 @@ def test_qwen4_mtp_fusion_matches_released_equations():
     expected_embedding = embedding * mx.rsqrt(
         mx.mean(embedding * embedding, axis=-1, keepdims=True) + config.rms_norm_eps
     )
-    expected_embedding = expected_embedding * (1 + embedding_weight)
+    expected_embedding = expected_embedding * (1 + released_embedding_gain)
     expected_hidden = hidden * mx.rsqrt(
         mx.mean(hidden * hidden, axis=-1, keepdims=True) + config.rms_norm_eps
     )
-    expected_hidden = expected_hidden * (1 + hidden_weight)
+    expected_hidden = expected_hidden * (1 + released_hidden_gain)
     expected_hidden = expected_hidden.reshape(1, 1, config.hc_count, 32)
     expected = (expected_embedding[..., None, :] + expected_hidden).reshape(1, 1, 64)
 


### PR DESCRIPTION
Qwen4ExpRMSNorm scaled by (1 + gamma), but the MLX-converted checkpoints store standard gamma centered at 1.0, so every norm was double-shifted and generation was deterministic garbage (#2041). This makes it a plain rms_norm(x) * gamma and offsets raw-HF checkpoints at load time via should_offset_norm_weight, matching qwen3_5 and the rest of the family. The MTP drafter shares the module and its checkpoints follow the same convention, so its released-equations test is updated to match.