### PR TITLE
fix: stop generation on the tokenizer's EOS when the config omits it

### DIFF
--- a/mlx_vlm/server/generation.py
+++ b/mlx_vlm/server/generation.py
@@ -43,7 +43,7 @@ from ..sample_utils import (
 from ..speculative.utils import speculative_stats_since, speculative_stats_snapshot
 from ..structured import ThinkingAwareLogitsProcessor
 from ..tokenizer_utils import _ServerTokenStreamer, make_streaming_detokenizer
-from ..utils import ThinkingBudgetCriteria, load, prepare_inputs
+from ..utils import ThinkingBudgetCriteria, load, prepare_inputs, resolve_eos_token_ids
 from .runtime import runtime
 
 logger = logging.getLogger("mlx_vlm.server")
@@ -1079,12 +1079,12 @@ class ResponseGenerator:
             self.model_path, self.adapter_path
         )
 
-        stop_tokens = set()
-        if hasattr(config, "eos_token_id"):
-            if isinstance(config.eos_token_id, list):
-                stop_tokens.update(config.eos_token_id)
-            elif config.eos_token_id is not None:
-                stop_tokens.add(config.eos_token_id)
+        stop_tokens = set(
+            resolve_eos_token_ids(
+                getattr(config, "eos_token_id", None),
+                getattr(processor, "tokenizer", processor),
+            )
+        )
         stop_tokens.update(getattr(processor, "additional_eos_token_ids", ()))
 
         draft_model = None

--- a/mlx_vlm/tests/test_server.py
+++ b/mlx_vlm/tests/test_server.py
@@ -847,6 +847,25 @@ def test_server_includes_processor_specific_stop_tokens(monkeypatch):
     assert gen.stop_tokens == {2, 3}
 
 
+def test_server_includes_tokenizer_eos_in_stop_tokens(monkeypatch):
+    config = SimpleNamespace(eos_token_id=248044)
+    model = SimpleNamespace(language_model=SimpleNamespace(config=config))
+    processor = SimpleNamespace(tokenizer=SimpleNamespace(eos_token_id=248046))
+    gen = _unstarted_response_generator()
+
+    monkeypatch.delenv("MLX_VLM_DRAFT_MODEL", raising=False)
+    monkeypatch.delenv("MLX_VLM_DRAFT_KIND", raising=False)
+    monkeypatch.setattr(
+        server_generation,
+        "load_model_resources",
+        lambda *_args, **_kwargs: (model, processor, config),
+    )
+
+    gen._initialize_model()
+
+    assert gen.stop_tokens == {248044, 248046}
+
+
 def test_server_caches_apc_mode_when_model_initializes(monkeypatch):
     config = SimpleNamespace(eos_token_id=[])
     language_model = SimpleNamespace()

--- a/mlx_vlm/tests/test_utils.py
+++ b/mlx_vlm/tests/test_utils.py
@@ -729,7 +729,33 @@ def test_load_processor_preserves_additional_eos_tokens_on_reset():
     criteria = loaded.tokenizer.stopping_criteria
     assert criteria.eos_token_ids == [2, 3]
     criteria.reset([5])
-    assert criteria.eos_token_ids == [5, 3]
+    assert criteria.eos_token_ids == [5, 2, 3]
+
+
+def test_load_processor_keeps_tokenizer_eos_when_config_eos_differs():
+    # Chandra OCR 2 configures <|endoftext|> (248044) but ends turns with
+    # <|im_end|> (248046), so dropping either token never stops generation.
+    processor = SimpleNamespace(tokenizer=SimpleNamespace(eos_token_id=248046))
+
+    class Detokenizer:
+        def __init__(self, tokenizer):
+            self.tokenizer = tokenizer
+
+    with (
+        patch(
+            "mlx_vlm.utils.AutoProcessor.from_pretrained",
+            return_value=processor,
+        ),
+        patch("mlx_vlm.utils.load_tokenizer", return_value=Detokenizer),
+    ):
+        loaded = load_processor("unused-model-path", eos_token_ids=248044)
+
+    criteria = loaded.tokenizer.stopping_criteria
+    assert criteria.eos_token_ids == [248044, 248046]
+
+    # generate() resets to the config EOS on every call.
+    criteria.reset(248044)
+    assert criteria.eos_token_ids == [248044, 248046]
 
 
 def test_load_passes_revision():

--- a/mlx_vlm/utils.py
+++ b/mlx_vlm/utils.py
@@ -1446,16 +1446,9 @@ def load_processor(
         # Instantiate the detokenizer
         processor.detokenizer = detokenizer_class(tokenizer_obj)
 
-        # Determine the EOS token IDs, prioritizing the function argument
-        final_eos_token_ids = (
-            eos_token_ids
-            or getattr(tokenizer_obj, "eos_token_ids", None)
-            or getattr(tokenizer_obj, "eos_token_id", None)
-        )
-
         # Create and assign the StoppingCriteria
         criteria = StoppingCriteria(
-            final_eos_token_ids,
+            eos_token_ids,
             tokenizer_obj,
             additional_eos_token_ids=getattr(processor, "additional_eos_token_ids", ()),
         )
@@ -2531,6 +2524,29 @@ def group_images_by_shape(
     return grouped_images, grouped_indices
 
 
+def resolve_eos_token_ids(eos_token_ids, tokenizer) -> List[int]:
+    """Union configured EOS token ids with the tokenizer's own EOS.
+
+    A checkpoint's ``eos_token_id`` can disagree with the token its chat template
+    ends turns on -- Chandra OCR 2 configures ``<|endoftext|>`` but emits
+    ``<|im_end|>`` -- so neither source alone is enough to stop generation.
+    """
+    resolved: List[int] = []
+    for source in (
+        eos_token_ids,
+        getattr(tokenizer, "eos_token_ids", None),
+        getattr(tokenizer, "eos_token_id", None),
+    ):
+        if isinstance(source, int):
+            source = [source]
+        if not isinstance(source, (list, tuple, set)):
+            continue
+        for token_id in source:
+            if isinstance(token_id, int) and token_id not in resolved:
+                resolved.append(token_id)
+    return resolved
+
+
 class StoppingCriteria:
     def __init__(
         self,
@@ -2572,14 +2588,7 @@ class StoppingCriteria:
             self.eos_token_ids.extend(resolved)
 
     def reset(self, eos_token_ids: List[int] = None):
-        eos_token_ids = (
-            eos_token_ids if eos_token_ids is not None else self.tokenizer.eos_token_ids
-        )
-
-        if isinstance(eos_token_ids, int):
-            eos_token_ids = [eos_token_ids]
-
-        resolved = list(eos_token_ids)
+        resolved = resolve_eos_token_ids(eos_token_ids, self.tokenizer)
         resolved.extend(
             token_id
             for token_id in self.additional_eos_token_ids


### PR DESCRIPTION
Reported in https://github.com/Blaizzy/mlx-vlm/issues/39#issuecomment-5264660498: `datalab-to/chandra-ocr-2` generates forever and leaks `<think>` tags. Its `generation_config.json` lists only `<|endoftext|>` while the model ends turns with `<|im_end|>`, and we let the configured EOS *replace* the tokenizer's own instead of unioning them — so the stop set was `[248044]`, generation ran to `max_tokens`, and the model opened a second assistant turn (where the stray think tags come from). `resolve_eos_token_ids` now unions both sources everywhere the stop set is built, including the `reset()` `generate()` performs on every call and the server's continuous-batching path.

Verified on `jwindle47/chandra-ocr-2-8bit-mlx` with `examples/images/password.jpg`, 900-token cap: before — 900 tokens, `finish_reason=length`, `<|im_end|>` emitted at token 460 and ignored, think tags present; after — 461 tokens, `finish_reason=stop`, clean output, no think tags. `mlx-community/gemma-3-4b-it-4bit` output is bit-identical (control), and `pytest ./tests --ignore=tests/test_smoke.py` is green (2956 passed).