### PR TITLE
Fix phantom KV in ragged batched speculative rollback

### DIFF
--- a/mlx_vlm/models/deepseek_v4/language.py
+++ b/mlx_vlm/models/deepseek_v4/language.py
@@ -1241,6 +1241,8 @@ def _iter_leaf_caches(caches):
 
 
 class LanguageModel(nn.Module):
+    requires_uniform_batch_acceptance = True
+
     def __init__(self, config: ModelConfig):
         super().__init__()
         self.args = config
@@ -1371,15 +1373,18 @@ class LanguageModel(nn.Module):
                     continue
                 kv_len = cache._idx
                 verify_start = kv_len - n
-                for bi, valid_end in enumerate(valid_ends.tolist()):
-                    start = verify_start + int(valid_end)
-                    if start < kv_len:
-                        zero_row_tail = getattr(cache, "zero_row_tail", None)
-                        if callable(zero_row_tail):
-                            zero_row_tail(bi, start, kv_len)
-                        else:
-                            cache.keys[bi, :, start:kv_len, :] = 0
-                            cache.values[bi, :, start:kv_len, :] = 0
+                if any(
+                    verify_start + int(valid_end) < kv_len
+                    for valid_end in valid_ends.tolist()
+                ):
+                    raise RuntimeError(
+                        "DeepSeek-V4 batched speculative rollback requires uniform "
+                        f"per-row acceptance; got ragged accepts {accepted.tolist()}. "
+                        "Zeroing a rejected row's KV tail leaves phantom keys "
+                        "attended (issue #1962); set "
+                        "requires_uniform_batch_acceptance on the drafter or target "
+                        "so accepts are clamped before rollback."
+                    )
 
         return max_a
 

--- a/mlx_vlm/models/gemma4/language.py
+++ b/mlx_vlm/models/gemma4/language.py
@@ -651,6 +651,7 @@ class Gemma4TextModel(nn.Module):
 
 class LanguageModel(nn.Module):
     supports_logits_to_keep = True
+    requires_uniform_batch_acceptance = True
 
     def __init__(self, config: TextConfig):
         super().__init__()
@@ -785,15 +786,18 @@ class LanguageModel(nn.Module):
                 kv_len = c._idx
                 ve = valid_ends.tolist()
                 verify_start = kv_len - n
-                for bi in range(accepted.shape[0]):
-                    start = verify_start + int(ve[bi])
-                    if start < kv_len:
-                        zero_row_tail = getattr(c, "zero_row_tail", None)
-                        if callable(zero_row_tail):
-                            zero_row_tail(bi, start, kv_len)
-                        else:
-                            c.keys[bi, :, start:kv_len, :] = 0
-                            c.values[bi, :, start:kv_len, :] = 0
+                if any(
+                    verify_start + int(ve[bi]) < kv_len
+                    for bi in range(accepted.shape[0])
+                ):
+                    raise RuntimeError(
+                        "Gemma 4 batched speculative rollback requires uniform "
+                        f"per-row acceptance; got ragged accepts {accepted.tolist()}. "
+                        "Zeroing a rejected row's KV tail leaves phantom keys "
+                        "attended (issue #1962); set "
+                        "requires_uniform_batch_acceptance on the drafter or target "
+                        "so accepts are clamped before rollback."
+                    )
         return max_a
 
     def sanitize(self, weights):

--- a/mlx_vlm/models/minimax_m3_vl/language.py
+++ b/mlx_vlm/models/minimax_m3_vl/language.py
@@ -1899,6 +1899,8 @@ class MiniMaxM3Model(nn.Module):
 
 
 class LanguageModel(nn.Module):
+    requires_uniform_batch_acceptance = True
+
     def __init__(self, args: TextConfig, config: Optional[ModelConfig] = None):
         super().__init__()
         self.args = args
@@ -2166,24 +2168,15 @@ class LanguageModel(nn.Module):
                 continue
             valid_ends_list = [int(v) for v in valid_ends.tolist()]
 
-            kv_cache = getattr(cache, "kv_cache", cache)
-            if getattr(kv_cache, "keys", None) is not None:
-                for bi, valid_end in enumerate(valid_ends_list):
-                    start = verify_start + valid_end
-                    if start < kv_len:
-                        kv_cache.keys[bi, :, start:kv_len, :] = 0
-                        kv_cache.values[bi, :, start:kv_len, :] = 0
-
-            index_keys = getattr(cache, "index_keys", None)
-            if index_keys is not None:
-                idx_len = int(getattr(cache, "index_offset", kv_len))
-                idx_verify_start = idx_len - n
-                if idx_verify_start < 0:
-                    continue
-                for bi, valid_end in enumerate(valid_ends_list):
-                    start = idx_verify_start + valid_end
-                    if start < idx_len:
-                        cache.index_keys[bi, :, start:idx_len, :] = 0
+            if any(verify_start + valid_end < kv_len for valid_end in valid_ends_list):
+                raise RuntimeError(
+                    "MiniMax-M3 batched speculative rollback requires uniform "
+                    f"per-row acceptance; got ragged accepts {accepted.tolist()}. "
+                    "Zeroing a rejected row's KV (or indexer) tail leaves phantom "
+                    "keys attended (issue #1962); set "
+                    "requires_uniform_batch_acceptance on the drafter or target so "
+                    "accepts are clamped before rollback."
+                )
         return max_a
 
     @property

--- a/mlx_vlm/models/muse_glimmer/language.py
+++ b/mlx_vlm/models/muse_glimmer/language.py
@@ -267,6 +267,8 @@ class TextModel(nn.Module):
 
 
 class LanguageModel(nn.Module):
+    requires_uniform_batch_acceptance = True
+
     def __init__(self, args: TextConfig):
         super().__init__()
         self.args = args
@@ -354,16 +356,18 @@ class LanguageModel(nn.Module):
             ):
                 cache_length = cache._idx
                 verify_start = cache_length - retained
-                for row, valid_end in enumerate(valid_ends.tolist()):
-                    start = verify_start + int(valid_end)
-                    if start >= cache_length:
-                        continue
-                    zero_row_tail = getattr(cache, "zero_row_tail", None)
-                    if callable(zero_row_tail):
-                        zero_row_tail(row, start, cache_length)
-                    else:
-                        cache.keys[row, :, start:cache_length, :] = 0
-                        cache.values[row, :, start:cache_length, :] = 0
+                if any(
+                    verify_start + int(valid_end) < cache_length
+                    for valid_end in valid_ends.tolist()
+                ):
+                    raise RuntimeError(
+                        "Muse Glimmer batched speculative rollback requires uniform "
+                        f"per-row acceptance; got ragged accepts {accepted.tolist()}. "
+                        "Zeroing a rejected row's KV tail leaves phantom keys "
+                        "attended (issue #1962); set "
+                        "requires_uniform_batch_acceptance on the drafter or target "
+                        "so accepts are clamped before rollback."
+                    )
         return max_accepted
 
     @property

--- a/mlx_vlm/models/qwen3_5/language.py
+++ b/mlx_vlm/models/qwen3_5/language.py
@@ -1409,6 +1409,8 @@ class Qwen3_5Model(nn.Module):
 
 
 class LanguageModel(nn.Module):
+    requires_uniform_batch_acceptance = True
+
     def __init__(self, args: TextConfig, config: ModelConfig = None):
         super().__init__()
         self.args = args
@@ -1508,14 +1510,15 @@ class LanguageModel(nn.Module):
             ):
                 kv_len = c._idx
                 verify_start = kv_len - n
-                for bi, ve in enumerate(valid_ends_list):
-                    start = verify_start + ve
-                    if start < kv_len:
-                        if hasattr(c, "zero_row_tail"):
-                            c.zero_row_tail(bi, start, kv_len)
-                        else:
-                            c.keys[bi, :, start:kv_len, :] = 0
-                            c.values[bi, :, start:kv_len, :] = 0
+                if any(verify_start + ve < kv_len for ve in valid_ends_list):
+                    raise RuntimeError(
+                        "Qwen3.5 batched speculative rollback requires uniform "
+                        f"per-row acceptance; got ragged accepts {accepted_list}. "
+                        "Zeroing a rejected row's KV tail leaves phantom keys "
+                        "attended (issue #1962); set "
+                        "requires_uniform_batch_acceptance on the drafter or target "
+                        "so accepts are clamped before rollback."
+                    )
 
         if not ssm_caches:
             return max_a

--- a/mlx_vlm/speculative/common.py
+++ b/mlx_vlm/speculative/common.py
@@ -209,6 +209,22 @@ def _speculative_walk_batch_uniform_acceptance(
     return [accepted] * len(accepted_list), new_tokens_list
 
 
+def _requires_uniform_batch_acceptance(
+    draft_model: nn.Module, target_model: Optional[nn.Module] = None
+) -> bool:
+    """Whether ragged per-row acceptance must be clamped to a uniform count.
+
+    The flag is honored on either the drafter or the target model. A target's
+    dedicated drafter (e.g. qwen3_5 -> qwen3_5_mtp) may not advertise it, yet
+    the target's rectangular batch KV cache (single ``_idx``) cannot represent
+    ragged accepts without leaving phantom zeroed keys attended (issue #1962),
+    so the target may require it independently of the drafter.
+    """
+    if getattr(draft_model, "requires_uniform_batch_acceptance", False):
+        return True
+    return bool(getattr(target_model, "requires_uniform_batch_acceptance", False))
+
+
 def _record_speculative_round(
     draft_model: nn.Module, accepted: float, draft_count: int
 ) -> None:

--- a/mlx_vlm/speculative/dflash.py
+++ b/mlx_vlm/speculative/dflash.py
@@ -6,6 +6,7 @@ import mlx.nn as nn
 from .common import (
     _dflash_block_total,
     _record_speculative_round,
+    _requires_uniform_batch_acceptance,
     _speculative_walk,
     _speculative_walk_batch,
     _SpeculativeSamplerRNG,
@@ -498,6 +499,15 @@ def _dflash_rounds_batch(
                 base_positions=[emitted[active_idx[j]] for j in range(n_active)],
             )
             sampler_rng.target_sampled(sync_draft=not positioned_sampling)
+
+        if (
+            n_active > 1
+            and _requires_uniform_batch_acceptance(draft_model, lm)
+            and len(set(accepted_list)) > 1
+        ):
+            uniform = min(len(nt) - 1 for nt in new_tokens_list)
+            new_tokens_list = [nt[: uniform + 1] for nt in new_tokens_list]
+            accepted_list = [uniform] * n_active
 
         min_accepted = min(accepted_list)
         accepted_arr = mx.array(accepted_list)

--- a/mlx_vlm/speculative/eagle3.py
+++ b/mlx_vlm/speculative/eagle3.py
@@ -6,6 +6,7 @@ import mlx.nn as nn
 from .common import (
     _batch_cache_left_padding,
     _record_speculative_round,
+    _requires_uniform_batch_acceptance,
     _SpeculativeSamplerRNG,
     generation_stream,
 )
@@ -607,7 +608,7 @@ def _eagle3_rounds_batch(
         )
         if (
             n_active > 1
-            and getattr(draft_model, "requires_uniform_batch_acceptance", False)
+            and _requires_uniform_batch_acceptance(draft_model, lm)
             and len(set(accepted_list)) > 1
         ):
             accepted_list, new_tokens_list = _eagle3_walk_batch_uniform_acceptance(

--- a/mlx_vlm/speculative/mtp.py
+++ b/mlx_vlm/speculative/mtp.py
@@ -9,6 +9,7 @@ from .common import (
     _batch_cache_left_padding,
     _dflash_block_total,
     _record_speculative_round,
+    _requires_uniform_batch_acceptance,
     _speculative_walk,
     _speculative_walk_batch,
     _speculative_walk_batch_uniform_acceptance,
@@ -374,11 +375,12 @@ def _mtp_use_uniform_deferred_walk(
     n_active: int,
     greedy_sampling: bool,
     sampler: Callable[[mx.array], mx.array],
+    target_model: Optional[nn.Module] = None,
 ) -> bool:
     if n_active <= 1:
         return False
 
-    if getattr(draft_model, "requires_uniform_batch_acceptance", False):
+    if _requires_uniform_batch_acceptance(draft_model, target_model):
         return True
 
     if _sampler_supports_positioned_target(sampler):
@@ -935,7 +937,7 @@ def _mtp_rounds_batch(
             sampler_rng.sync_draft_to_target()
             if (
                 n_active > 1
-                and getattr(draft_model, "requires_uniform_batch_acceptance", False)
+                and _requires_uniform_batch_acceptance(draft_model, lm)
                 and len(set(accepted_list)) > 1
             ):
                 accepted_list, new_tokens_list = (
@@ -953,6 +955,7 @@ def _mtp_rounds_batch(
                 n_active=n_active,
                 greedy_sampling=greedy_sampling,
                 sampler=sampler,
+                target_model=lm,
             ):
                 accepted_list, new_tokens_list = (
                     _speculative_walk_batch_deferred_uniform(

--- a/mlx_vlm/tests/test_minimax_m3.py
+++ b/mlx_vlm/tests/test_minimax_m3.py
@@ -2,6 +2,7 @@ import math
 
 import mlx.core as mx
 import numpy as np
+import pytest
 
 import mlx_vlm.models.minimax_m3_vl.language as minimax_language
 from mlx_vlm.models.minimax_m3_vl.config import ModelConfig, TextConfig, VisionConfig
@@ -1329,7 +1330,10 @@ def test_minimax_m3_rollback_speculative_cache_trims_index_cache():
     assert cache.index_offset == 3
 
 
-def test_minimax_m3_batch_rollback_zeroes_rejected_index_tails():
+def test_minimax_m3_batch_rollback_raises_on_ragged_accepts():
+    # Ragged accepts on a rectangular batch cache would zero the shorter row's
+    # KV and indexer tails, leaving phantom keys attended (issue #1962). The
+    # rollback must fail loud so callers clamp to uniform acceptance instead.
     lm = LanguageModel(_tiny_minimax_text_config(num_hidden_layers=1))
     cache = MiniMaxM3BatchKVCache([0, 0])
     keys = mx.ones((2, 1, 5, 4), dtype=mx.float32)
@@ -1338,18 +1342,10 @@ def test_minimax_m3_batch_rollback_zeroes_rejected_index_tails():
 
     cache.update_and_fetch(keys, values)
     cache.update_index_and_fetch(index_keys)
-    accepted = lm.rollback_speculative_cache(
-        [cache], None, accepted=mx.array([2, 0], dtype=mx.int32), block_size=4
-    )
-
-    assert accepted == 2
-    assert cache._idx == 4
-    assert cache.index_offset == 4
-    assert cache.kv_cache.keys[0, :, 1:4, :].sum().item() > 0
-    assert cache.index_keys[0, :, 1:4, :].sum().item() > 0
-    assert cache.kv_cache.keys[1, :, 2:4, :].sum().item() == 0
-    assert cache.kv_cache.values[1, :, 2:4, :].sum().item() == 0
-    assert cache.index_keys[1, :, 2:4, :].sum().item() == 0
+    with pytest.raises(RuntimeError, match="uniform"):
+        lm.rollback_speculative_cache(
+            [cache], None, accepted=mx.array([2, 0], dtype=mx.int32), block_size=4
+        )
 
 
 def test_minimax_m3_batch_index_cache_filter_extend_extract():

--- a/mlx_vlm/tests/test_speculative.py
+++ b/mlx_vlm/tests/test_speculative.py
@@ -3306,23 +3306,19 @@ def test_qwen3_5_rollback_speculative_cache_trims_batch_rows_ragged():
     assert cache.left_padding.tolist() == [0, 2]
 
 
-def test_qwen3_5_rollback_speculative_cache_handles_turboquant_batch_kv():
+def test_qwen3_5_rollback_speculative_cache_raises_on_ragged_turboquant_batch_kv():
+    # A rectangular TurboQuant batch cache (single _idx, no prepare/finalize)
+    # cannot represent ragged accepts; zeroing the shorter row's tail would
+    # leave phantom keys attended (issue #1962), so it must fail loud instead.
     cache = BatchTurboQuantKVCache([0, 0], bits=3.5)
     keys = mx.arange(2 * 1 * 7 * 8, dtype=mx.float32).reshape(2, 1, 7, 8)
     values = keys + 100
     cache.update_and_fetch(keys, values)
 
-    qwen_language.LanguageModel.rollback_speculative_cache(
-        None, [cache], [], mx.array([0, 2]), block_size=5
-    )
-
-    mx.eval(cache.keys.norms, cache.keys.indices, cache.values.norms, cache.offset)
-    assert cache._idx == 5
-    assert cache.offset.tolist() == [5, 5]
-    assert mx.all(cache.keys.norms[0, :, 3:5] == 0).item()
-    assert mx.all(cache.keys.indices[0, :, 3:5, :] == 0).item()
-    assert mx.all(cache.values.norms[0, :, 3:5] == 0).item()
-    assert mx.any(cache.keys.norms[1, :, 3:5] != 0).item()
+    with pytest.raises(RuntimeError, match="uniform"):
+        qwen_language.LanguageModel.rollback_speculative_cache(
+            None, [cache], [], mx.array([0, 2]), block_size=5
+        )
 
 
 def test_qwen3_5_rollback_speculative_cache_handles_native_quantized_batch_kv():
@@ -3341,38 +3337,75 @@ def test_qwen3_5_rollback_speculative_cache_handles_native_quantized_batch_kv():
     assert cache.left_padding.tolist() == [2, 0]
 
 
-def test_gemma4_rollback_speculative_cache_handles_turboquant_batch_tail_zero():
+def test_gemma4_rollback_speculative_cache_raises_on_ragged_turboquant_batch():
     cache = BatchTurboQuantKVCache([0, 0], bits=3.5)
     keys = mx.arange(2 * 1 * 5 * 8, dtype=mx.float32).reshape(2, 1, 5, 8)
     values = keys + 100
     cache.update_and_fetch(keys, values)
 
-    gemma4_language.LanguageModel.rollback_speculative_cache(
-        None, [cache], [], mx.array([0, 2]), block_size=3
-    )
-
-    mx.eval(cache.keys.norms, cache.keys.indices, cache.values.norms)
-    assert mx.all(cache.keys.norms[0, :, 3:5] == 0).item()
-    assert mx.all(cache.keys.indices[0, :, 3:5, :] == 0).item()
-    assert mx.all(cache.values.norms[0, :, 3:5] == 0).item()
-    assert mx.any(cache.keys.norms[1, :, 3:5] != 0).item()
+    with pytest.raises(RuntimeError, match="uniform"):
+        gemma4_language.LanguageModel.rollback_speculative_cache(
+            None, [cache], [], mx.array([0, 2]), block_size=3
+        )
 
 
-def test_deepseek_v4_rollback_speculative_cache_handles_turboquant_batch_tail_zero():
+def test_deepseek_v4_rollback_speculative_cache_raises_on_ragged_turboquant_batch():
     cache = BatchTurboQuantKVCache([0, 0], bits=3.5)
     keys = mx.arange(2 * 1 * 5 * 8, dtype=mx.float32).reshape(2, 1, 5, 8)
     values = keys + 100
     cache.update_and_fetch(keys, values)
 
-    deepseek_language.LanguageModel.rollback_speculative_cache(
-        None, [cache], [], mx.array([0, 2]), block_size=3
-    )
+    with pytest.raises(RuntimeError, match="uniform"):
+        deepseek_language.LanguageModel.rollback_speculative_cache(
+            None, [cache], [], mx.array([0, 2]), block_size=3
+        )
 
-    mx.eval(cache.keys.norms, cache.keys.indices, cache.values.norms)
-    assert mx.all(cache.keys.norms[0, :, 3:5] == 0).item()
-    assert mx.all(cache.keys.indices[0, :, 3:5, :] == 0).item()
-    assert mx.all(cache.values.norms[0, :, 3:5] == 0).item()
-    assert mx.any(cache.keys.norms[1, :, 3:5] != 0).item()
+
+def test_uniform_turboquant_batch_rollback_trims_without_raising():
+    # With uniform per-row acceptance there is no ragged tail: rollback is a
+    # plain uniform trim, no phantom keys, no raise (issue #1962 fix).
+    for lm_cls, block in (
+        (qwen_language.LanguageModel, 5),
+        (gemma4_language.LanguageModel, 5),
+        (deepseek_language.LanguageModel, 5),
+    ):
+        cache = BatchTurboQuantKVCache([0, 0], bits=3.5)
+        keys = mx.arange(2 * 1 * 7 * 8, dtype=mx.float32).reshape(2, 1, 7, 8)
+        cache.update_and_fetch(keys, keys + 100)
+
+        max_a = lm_cls.rollback_speculative_cache(
+            None, [cache], [], mx.array([2, 2]), block_size=block
+        )
+        mx.eval(cache.offset)
+        assert max_a == 2
+        assert cache._idx == 5
+
+
+def test_uniform_batch_acceptance_flag_advertised_on_affected_models():
+    import mlx_vlm.models.minimax_m3_vl.language as minimax_language
+    import mlx_vlm.models.muse_glimmer.language as muse_glimmer_language
+
+    for module in (
+        gemma4_language,
+        deepseek_language,
+        qwen_language,
+        muse_glimmer_language,
+        minimax_language,
+    ):
+        assert module.LanguageModel.requires_uniform_batch_acceptance is True
+
+
+def test_requires_uniform_batch_acceptance_honors_drafter_or_target():
+    from mlx_vlm.speculative.common import _requires_uniform_batch_acceptance
+
+    plain = SimpleNamespace()
+    flagged = SimpleNamespace(requires_uniform_batch_acceptance=True)
+
+    assert _requires_uniform_batch_acceptance(plain) is False
+    assert _requires_uniform_batch_acceptance(flagged) is True
+    assert _requires_uniform_batch_acceptance(plain, flagged) is True
+    assert _requires_uniform_batch_acceptance(flagged, plain) is True
+    assert _requires_uniform_batch_acceptance(plain, plain) is False
 
 
 def test_qwen3_5_mtp_filter_batch_keeps_drafter_state_aligned():


### PR DESCRIPTION
Fixes #1962. When batch rows accept a different number of drafted tokens, speculative rollback zeroed the rejected KV tail of the shorter rows — but a zeroed key still adds `e^0` to the softmax denominator, silently diluting those rows' attention. This clamps per-row acceptance to a uniform count before rollback, and fails loud if a ragged batch ever reaches a rectangular batch cache.

Verified: 290 speculative + minimax unit tests pass. On a real checkpoint (Qwen3.5-4B-MLX-4bit, batched B=2 DFlash), probing the live rollback confirms it now receives uniform accepts every round with the attention KV cache staying healthy (`offset=[40,34] left_pad=[0,6]`), versus ragged accepts zeroing phantom KV tails before the fix.