### PR TITLE
qwen4_exp: load checkpoints with pre-shifted RMSNorm gains

### DIFF
--- a/mlx_vlm/models/qwen4_exp/README.md
+++ b/mlx_vlm/models/qwen4_exp/README.md
@@ -137,3 +137,10 @@ python -m mlx_vlm.split_mtp \
   requesting both raises an explicit error to preserve the QSA indexer state.
 - Long image or video prompts may benefit from a smaller
   `--prefill-step-size` to reduce peak memory.
+- MLX conversions published before #2032 folded `Qwen4ExpRMSNorm`'s `1 + w`
+  offset into their saved norm gains, so loading one would apply the offset
+  twice and generate noise. Such a checkpoint is now detected and the offset
+  subtracted back out, with a warning. Re-converting from
+  `Qwen/Qwen3.8-Flash-Next` avoids relying on that fixup, which cannot restore
+  gains the conversion rounded away. Set `text_config.preshifted_norm_weights`
+  to `true` or `false` to override the detection.

--- a/mlx_vlm/models/qwen4_exp/config.py
+++ b/mlx_vlm/models/qwen4_exp/config.py
@@ -54,6 +54,7 @@ class TextConfig(BaseModelConfig):
     split_ngram_parts: int = 128
     seed: int = 1234
     ple_storage: Optional[Dict] = None
+    preshifted_norm_weights: Optional[bool] = None
     indexer_n_heads: int = 4
     indexer_kv_heads: int = 1
     indexer_head_dim: int = 128

--- a/mlx_vlm/models/qwen4_exp/qwen4_exp.py
+++ b/mlx_vlm/models/qwen4_exp/qwen4_exp.py
@@ -1,5 +1,7 @@
+import logging
 import re
 
+import mlx.core as mx
 import mlx.nn as nn
 
 from ..qwen3_5 import Model as Qwen3_5Model
@@ -10,6 +12,99 @@ from .language import LanguageModel
 from .vision import VisionModel
 
 _NGRAM_SHARD_RE = re.compile(r"\.ngram_embedding\.shard_(\d+)(?=\.)")
+
+ZERO_CENTERED_NORM_MODULES = frozenset(
+    {
+        "hc_norm",
+        "k_layernorm",
+        "k_norm",
+        "norm_conv",
+        "norm_key",
+        "norm_query",
+        "pre_fc_norm_embedding",
+        "pre_fc_norm_hidden",
+        "q_layernorm",
+        "q_norm",
+    }
+)
+
+_PRESHIFTED_GAIN_THRESHOLD = 0.5
+
+
+def zero_centered_norm_keys(weights):
+    """Keys whose values Qwen4ExpRMSNorm reads as ``1 + w``.
+
+    These are the gains the checkpoint stores centered at zero, matching
+    upstream ``Qwen4ExpTextRMSNorm``. ``norm`` is excluded on purpose: it belongs
+    to ``Qwen4ExpRMSNormGated``, whose gains are already centered at one and must
+    be left alone. Matching is on the owning module's name rather than a dotted
+    suffix so that the MTP head's unprefixed ``pre_fc_norm_*`` keys also match.
+    """
+    keys = []
+    for key, value in weights.items():
+        parts = key.split(".")
+        if (
+            len(parts) >= 2
+            and parts[-1] == "weight"
+            and parts[-2] in ZERO_CENTERED_NORM_MODULES
+            and getattr(value, "ndim", 0) == 1
+        ):
+            keys.append(key)
+    return keys
+
+
+def norm_weights_are_preshifted(weights, keys=None):
+    """Whether a checkpoint already folded Qwen4ExpRMSNorm's ``+1`` into its gains.
+
+    Conversions produced before #2032 applied the offset at convert time, so
+    applying it again at load time doubles it and inflates every gain (~2.6x on
+    the hyper-connection norms), which degenerates generation into noise. Such a
+    checkpoint carries the same keys, shapes and dtypes as a correct one, so only
+    the values tell them apart: the released gains average ~0.15 and pre-shifted
+    ones ~1.15, so the two are separated by the midpoint with a wide margin
+    either side. Per-tensor sign is not usable -- a quarter of the pre-shifted
+    tensors still contain negative values.
+    """
+    keys = zero_centered_norm_keys(weights) if keys is None else keys
+    if not keys:
+        return False
+    total = sum(weights[key].size for key in keys)
+    sums = mx.stack([mx.sum(weights[key].astype(mx.float32)) for key in keys])
+    return mx.sum(sums).item() / total > _PRESHIFTED_GAIN_THRESHOLD
+
+
+def unshift_preshifted_norm_weights(weights, preshifted=None):
+    """Subtract a ``+1`` that a checkpoint already folded into its norm gains.
+
+    ``preshifted`` overrides the value-based detection when it is not ``None``.
+    Correcting a checkpoint moves it into the untouched class, so running this
+    over its own output is a no-op and ``sanitize`` stays idempotent.
+
+    Recovery is only as good as the precision the sum was stored at: a bf16
+    checkpoint rounds ``w + 1`` to the coarser exponent around one, so gains
+    within an ulp of zero come back as zero. The error is bounded by one ulp of
+    the stored value, which re-converting from the released weights avoids.
+    """
+    keys = zero_centered_norm_keys(weights)
+    if not keys:
+        return weights
+    if preshifted is None:
+        preshifted = norm_weights_are_preshifted(weights, keys)
+    if not preshifted:
+        return weights
+
+    logging.warning(
+        "qwen4_exp: this checkpoint's RMSNorm gains are centered at one, so "
+        "Qwen4ExpRMSNorm's +1 offset is already folded in -- the signature of a "
+        "conversion made before #2032. Subtracting it back out of %d tensors; "
+        "re-convert from Qwen/Qwen3.8-Flash-Next to avoid relying on this "
+        "fixup, or set text_config.preshifted_norm_weights to override the "
+        "detection.",
+        len(keys),
+    )
+    for key in keys:
+        weights[key] = weights[key] - 1.0
+    return weights
 
 
 class Model(Qwen3_5Model):
@@ -35,6 +130,10 @@ class Model(Qwen3_5Model):
 
         if self.config.text_config.tie_word_embeddings:
             weights.pop("lm_head.weight", None)
+
+        weights = unshift_preshifted_norm_weights(
+            weights, self.config.text_config.preshifted_norm_weights
+        )
 
         for layer_idx in range(self.config.text_config.num_hidden_layers):
             prefix = f"model.language_model.layers.{layer_idx}.mlp"

--- a/mlx_vlm/speculative/drafters/qwen4_exp_mtp/qwen4_exp_mtp.py
+++ b/mlx_vlm/speculative/drafters/qwen4_exp_mtp/qwen4_exp_mtp.py
@@ -11,6 +11,7 @@ from ....models.qwen4_exp.language import (
     Qwen4ExpGatedResidual,
     Qwen4ExpRMSNorm,
 )
+from ....models.qwen4_exp.qwen4_exp import unshift_preshifted_norm_weights
 from ..deepseek_v4_mtp.deepseek_v4_mtp import DeepseekV4MTPDraftModel
 from .config import Qwen4ExpMTPConfig
 
@@ -181,4 +182,6 @@ class Qwen4ExpMTPDraftModel(DeepseekV4MTPDraftModel):
             stripped["layers.0.mlp.switch_mlp.down_proj.weight"] = stripped.pop(
                 down_key
             )
-        return stripped
+        return unshift_preshifted_norm_weights(
+            stripped, self.config.text_config.preshifted_norm_weights
+        )

--- a/mlx_vlm/speculative/drafters/qwen4_exp_mtp/split.py
+++ b/mlx_vlm/speculative/drafters/qwen4_exp_mtp/split.py
@@ -1,7 +1,9 @@
+from types import SimpleNamespace
 from typing import Dict
 
 import mlx.core as mx
 
+from ....models.qwen4_exp.config import TextConfig
 from ....models.qwen4_exp.fp8 import convert_qwen4_exp_fp8_weights
 from ..mtp_split import MTPSplitter
 from .qwen4_exp_mtp import Qwen4ExpMTPDraftModel
@@ -28,6 +30,11 @@ class Qwen4ExpMTPSplitter(MTPSplitter):
     ) -> Dict[str, mx.array]:
         del text_config
         return convert_qwen4_exp_fp8_weights(tensors)
+
+    def sanitize_ctx(self, text_config: dict):
+        return SimpleNamespace(
+            config=SimpleNamespace(text_config=TextConfig.from_dict(text_config))
+        )
 
 
 def split_qwen4_exp_mtp(source: str, output: str, **kwargs):

--- a/mlx_vlm/tests/test_qwen4_exp.py
+++ b/mlx_vlm/tests/test_qwen4_exp.py
@@ -2,6 +2,7 @@ import unittest
 
 import mlx.core as mx
 import mlx.nn as nn
+from mlx.utils import tree_flatten
 
 from mlx_vlm.generate import maybe_quantize_kv_cache
 from mlx_vlm.generate.ar import _make_cache
@@ -13,9 +14,16 @@ from mlx_vlm.models.qwen4_exp.language import (
     QSAQuantizedKVCache,
     Qwen4ExpGatedDeltaNet,
     Qwen4ExpNGramEmbedding,
+    Qwen4ExpRMSNorm,
+    Qwen4ExpRMSNormGated,
     ShardedEmbedding,
 )
+from mlx_vlm.models.qwen4_exp.qwen4_exp import (
+    norm_weights_are_preshifted,
+    zero_centered_norm_keys,
+)
 from mlx_vlm.prompt_utils import MessageFormat, MessageFormatter
+from mlx_vlm.tests.sanitize_invariants import assert_sanitize_idempotent
 
 
 def tiny_config():
@@ -636,6 +644,127 @@ class Qwen4ExpTests(unittest.TestCase):
             predicate(path, None),
             {"fallback_group_size": 32},
         )
+
+
+class Qwen4ExpPreshiftedNormTests(unittest.TestCase):
+    """Guards against loading a checkpoint that already applied ``1 + w``."""
+
+    def released_checkpoint(self, config=None):
+        mx.random.seed(0)
+        config = config or tiny_config()
+        model = qwen4_exp.Model(config)
+        weights = dict(tree_flatten(model.parameters()))
+        keys = zero_centered_norm_keys(weights)
+        for key in keys:
+            weights[key] = mx.random.normal(weights[key].shape) * 0.4 + 0.15
+        mx.eval(weights)
+        return model, weights, keys
+
+    def preshift(self, released, keys):
+        preshifted = dict(released)
+        for key in keys:
+            preshifted[key] = released[key] + 1.0
+        mx.eval(preshifted)
+        return preshifted
+
+    def test_suffixes_cover_exactly_the_zero_centered_norms(self):
+        model = qwen4_exp.Model(tiny_config())
+        zero_centered = {
+            f"{name}.weight"
+            for name, module in model.named_modules()
+            if isinstance(module, Qwen4ExpRMSNorm)
+        }
+        gated = {
+            f"{name}.weight"
+            for name, module in model.named_modules()
+            if isinstance(module, Qwen4ExpRMSNormGated)
+        }
+        matched = set(zero_centered_norm_keys(dict(tree_flatten(model.parameters()))))
+
+        self.assertTrue(zero_centered)
+        self.assertTrue(gated)
+        self.assertEqual(matched, zero_centered)
+        self.assertEqual(matched & gated, set())
+
+    def test_detects_only_the_preshifted_checkpoint(self):
+        _, released, keys = self.released_checkpoint()
+        self.assertTrue(keys)
+        self.assertFalse(norm_weights_are_preshifted(released, keys))
+        self.assertTrue(
+            norm_weights_are_preshifted(self.preshift(released, keys), keys)
+        )
+        self.assertFalse(norm_weights_are_preshifted({}))
+
+    def test_preshifted_gains_are_restored(self):
+        model, released, keys = self.released_checkpoint()
+        preshifted = self.preshift(released, keys)
+        restored = model.sanitize(dict(preshifted))
+        for key in keys:
+            self.assertTrue(
+                mx.allclose(restored[key], released[key], atol=1e-6).item(), key
+            )
+
+    def test_gated_norm_is_never_shifted(self):
+        model, released, keys = self.released_checkpoint()
+        gated = [
+            f"{name}.weight"
+            for name, module in model.named_modules()
+            if isinstance(module, Qwen4ExpRMSNormGated)
+        ]
+        preshifted = self.preshift(released, keys)
+        restored = model.sanitize(dict(preshifted))
+        self.assertTrue(gated)
+        for key in gated:
+            self.assertTrue(mx.array_equal(restored[key], preshifted[key]).item(), key)
+
+    def test_released_checkpoint_is_left_alone(self):
+        model, released, keys = self.released_checkpoint()
+        sanitized = model.sanitize(dict(released))
+        for key in keys:
+            self.assertTrue(mx.array_equal(sanitized[key], released[key]).item(), key)
+
+    def test_sanitize_stays_idempotent(self):
+        model, released, keys = self.released_checkpoint()
+        assert_sanitize_idempotent(model, self.preshift(released, keys))
+        assert_sanitize_idempotent(model, dict(released))
+
+    def test_config_flag_overrides_detection(self):
+        config = tiny_config()
+        config.text_config.preshifted_norm_weights = False
+        model, released, keys = self.released_checkpoint(config)
+        preshifted = self.preshift(released, keys)
+        left_alone = model.sanitize(dict(preshifted))
+        for key in keys:
+            self.assertTrue(
+                mx.array_equal(left_alone[key], preshifted[key]).item(), key
+            )
+
+        config.text_config.preshifted_norm_weights = True
+        forced = model.sanitize(dict(released))
+        for key in keys:
+            self.assertTrue(
+                mx.allclose(forced[key], released[key] - 1.0, atol=1e-6).item(), key
+            )
+
+    def test_forward_pass_matches_the_released_checkpoint(self):
+        config = tiny_config()
+        config.text_config.layer_types = [
+            "qwen_sparse_attention",
+            "qwen_sparse_attention",
+        ]
+        model, released, keys = self.released_checkpoint(config)
+        tokens = mx.array([[2, 5, 9, 13, 21, 34, 40, 7]])
+
+        def logits(weights):
+            candidate = qwen4_exp.Model(config)
+            candidate.load_weights(list(model.sanitize(dict(weights)).items()))
+            candidate.eval()
+            return candidate.language_model(tokens, cache=None).logits
+
+        expected = logits(released)
+        actual = logits(self.preshift(released, keys))
+        mx.eval(expected, actual)
+        self.assertTrue(mx.allclose(expected, actual, atol=1e-4).item())
 
 
 if __name__ == "__main__":

--- a/mlx_vlm/tests/test_qwen4_mtp.py
+++ b/mlx_vlm/tests/test_qwen4_mtp.py
@@ -4,9 +4,18 @@ from types import SimpleNamespace
 import mlx.core as mx
 import mlx.nn as nn
 import pytest
+from mlx.utils import tree_flatten
 
 from mlx_vlm.models.qwen4_exp.config import TextConfig
-from mlx_vlm.models.qwen4_exp.language import LanguageModel, Qwen4ExpDecoderLayer
+from mlx_vlm.models.qwen4_exp.language import (
+    LanguageModel,
+    Qwen4ExpDecoderLayer,
+    Qwen4ExpRMSNorm,
+)
+from mlx_vlm.models.qwen4_exp.qwen4_exp import (
+    norm_weights_are_preshifted,
+    zero_centered_norm_keys,
+)
 from mlx_vlm.speculative.drafters.mtp_split import detect_mtp_splitter, get_mtp_splitter
 from mlx_vlm.speculative.drafters.qwen4_exp_mtp import (
     ModelConfig,
@@ -308,3 +317,55 @@ def test_qwen4_mtp_splitter_converts_official_fp8_experts(tmp_path):
     assert down.shape == (2, 128, 128)
     assert not any(key.endswith("weight_scale_inv") for key in split_weights)
     assert "quantization" not in config
+
+
+def _released_drafter_checkpoint():
+    mx.random.seed(0)
+    drafter = Qwen4ExpMTPDraftModel(ModelConfig(text_config=_tiny_text_config()))
+    released = dict(tree_flatten(drafter.parameters()))
+    keys = zero_centered_norm_keys(released)
+    for key in keys:
+        released[key] = mx.random.normal(released[key].shape) * 0.4 + 0.15
+    mx.eval(released)
+    return drafter, released, keys
+
+
+def test_drafter_zero_centered_norms_are_all_recognized():
+    drafter = Qwen4ExpMTPDraftModel(ModelConfig(text_config=_tiny_text_config()))
+    expected = {
+        f"{name}.weight"
+        for name, module in drafter.named_modules()
+        if isinstance(module, Qwen4ExpRMSNorm)
+    }
+    matched = set(zero_centered_norm_keys(dict(tree_flatten(drafter.parameters()))))
+
+    assert expected
+    assert "pre_fc_norm_embedding.weight" in expected
+    assert "pre_fc_norm_hidden.weight" in expected
+    assert matched == expected
+
+
+def test_drafter_sanitize_unshifts_preshifted_norm_gains():
+    drafter, released, keys = _released_drafter_checkpoint()
+    shifted_keys = set(keys)
+    preshifted = {
+        key: (value + 1.0 if key in shifted_keys else value)
+        for key, value in released.items()
+    }
+    mx.eval(preshifted)
+
+    assert not norm_weights_are_preshifted(released, keys)
+    assert norm_weights_are_preshifted(preshifted, keys)
+
+    restored = drafter.sanitize(dict(preshifted))
+    for key in keys:
+        assert mx.allclose(restored[key], released[key], atol=1e-6).item(), key
+
+
+def test_drafter_sanitize_leaves_correct_gains_alone():
+    drafter, released, keys = _released_drafter_checkpoint()
+    once = drafter.sanitize(dict(released))
+    twice = drafter.sanitize(dict(once))
+    for key in keys:
+        assert mx.array_equal(once[key], released[key]).item(), key
+        assert mx.array_equal(twice[key], once[key]).item(), key


### PR DESCRIPTION
Fixes #2041.

`Qwen4ExpRMSNorm` applies `1 + w` to gains the released checkpoint stores centered at zero, matching upstream `Qwen4ExpTextRMSNorm`, but MLX conversions published before #2032 folded that `+1` into their saved weights — so loading one applies the offset twice and inflates every gain (~2.6x on the hyper-connection norms), which is the noise reported in the issue. Because such a checkpoint is otherwise identical to a correct one in keys, shapes and dtypes, `sanitize()` now tells them apart by value — released gains average ~+0.22, pre-shifted ones ~+1.15 — and subtracts the offset back out with a warning pointing at re-conversion. The same correction is applied to the MTP draft head, which shares `Qwen4ExpRMSNorm` and had the same defect, and `text_config.preshifted_norm_weights` overrides the detection either way.

Verified end-to-end on `Vontra/Qwen3.8-Flash-Next-MLX-4bit` (gain center +1.22, 148 tensors corrected): `main` stops after 7 tokens of noise, matching the issue exactly, the fix generates coherent text to the full 128-token limit, and forcing the detection off reproduces the 7-token failure.

Surveying the Hub, 8 of 11 published MLX conversions carry the doubled offset, and there was no canonical conversion to point people at — so I made one:

link to correct model: https://huggingface.co/AlazarM/Qwen3.8-Flash-Next-4bit

Converted from `Qwen/Qwen3.8-Flash-Next` with this repo's own converter on `main`, with norm gains verified bit-identical to the source (148/148) and a byte-exact source integrity check.
