### PR TITLE
Add LLaVA-OneVision

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Some models have detailed documentation with prompt formats, examples, and best 
 | Granite 4.0 Vision | [Docs](https://github.com/Blaizzy/mlx-vlm/blob/main/mlx_vlm/models/granite4_vision/README.md) |
 | MiniCPM-V 4.6 | [Docs](https://github.com/Blaizzy/mlx-vlm/blob/main/mlx_vlm/models/minicpmv4_6/README.md) |
 | GLiNER2.5 | [Docs](https://github.com/Blaizzy/mlx-vlm/blob/main/mlx_vlm/models/gliner2_5/README.md) |
+| LLaVA-OneVision | [Docs](https://github.com/Blaizzy/mlx-vlm/blob/main/mlx_vlm/models/llava_onevision/README.md) |
 
 ## Installation
 
@@ -1437,6 +1438,7 @@ The following models support video chat:
 3. Idefics3
 4. LLaVA
 5. MiniMax M3
+6. LLaVA-OneVision
 
 With more coming soon.
 

--- a/mlx_vlm/models/llava_onevision/README.md
+++ b/mlx_vlm/models/llava_onevision/README.md
@@ -1,0 +1,52 @@
+# LLaVA-OneVision
+
+SigLIP vision tower + Qwen2 language model, supporting single images, multiple
+images, and video in one checkpoint.
+
+## Checkpoints
+
+| Model | Notes |
+|-------|-------|
+| `llava-hf/llava-onevision-qwen2-0.5b-ov-hf` | image + multi-image + video |
+| `llava-hf/llava-onevision-qwen2-0.5b-si-hf` | single-image tuned |
+| `llava-hf/llava-onevision-qwen2-7b-ov-hf` | image + multi-image + video |
+| `llava-hf/llava-onevision-qwen2-7b-si-hf` | single-image tuned |
+| `llava-hf/llava-onevision-qwen2-7b-ov-chat-hf` | chat-tuned |
+| `llava-hf/llava-onevision-qwen2-72b-ov-hf` | quantize before loading |
+
+`lmms-lab/LLaVA-OneVision-1.5-*` is a different architecture (RICE-ViT vision
+tower) and is not handled by this implementation.
+
+## Usage
+
+```sh
+mlx_vlm.generate --model llava-hf/llava-onevision-qwen2-0.5b-ov-hf \
+  --prompt "What is in this image?" --image image.jpg --max-tokens 100
+
+mlx_vlm.generate --model llava-hf/llava-onevision-qwen2-0.5b-ov-hf \
+  --prompt "What is happening in this video?" --video video.mp4 --fps 1.0
+```
+
+```python
+from mlx_vlm import load, generate
+from mlx_vlm.prompt_utils import apply_chat_template
+
+model, processor = load("llava-hf/llava-onevision-qwen2-0.5b-ov-hf")
+prompt = apply_chat_template(processor, model.config, "Compare these images.", num_images=2)
+print(generate(model, processor, prompt, image=["a.jpg", "b.jpg"], max_tokens=100).text)
+```
+
+## Token budget
+
+Images are tiled with AnyRes and packed as `base + unpadded grid + newlines`,
+capped by `vision_aspect_ratio` (`anyres_max_9`). A 384px tower with patch 14
+gives 729 base features, so a full-resolution image costs up to ~7.3k tokens; a
+video costs `frames * 196 + 1`. Prefill dominates runtime for both.
+
+## Preprocessing
+
+The image processor `AutoImageProcessor` resolves for this model type is
+torchvision-backed, so this implementation uses the PIL backend directly and
+handles video frames with numpy — mlx-vlm needs no torch install. Resampling
+differs slightly from the torchvision path (~1e-2 on normalized pixels), which
+does not change greedy output.

--- a/mlx_vlm/models/llava_onevision/__init__.py
+++ b/mlx_vlm/models/llava_onevision/__init__.py
@@ -1,0 +1,4 @@
+import mlx_vlm.models.llava_onevision.processing_llava_onevision  # noqa: F401 (installs processor patch)
+
+from .config import ModelConfig, TextConfig, VisionConfig
+from .llava_onevision import LanguageModel, Model, VisionModel

--- a/mlx_vlm/models/llava_onevision/config.py
+++ b/mlx_vlm/models/llava_onevision/config.py
@@ -1,0 +1,58 @@
+from dataclasses import dataclass
+from typing import Dict, List, Optional, Union
+
+from ..base import BaseModelConfig
+
+
+@dataclass
+class TextConfig(BaseModelConfig):
+    model_type: str = "qwen2"
+    hidden_size: int = 896
+    num_hidden_layers: int = 24
+    intermediate_size: int = 4864
+    num_attention_heads: int = 14
+    rms_norm_eps: float = 1e-6
+    vocab_size: int = 151936
+    num_key_value_heads: int = 2
+    rope_theta: float = 1000000.0
+    rope_traditional: bool = False
+    rope_scaling: Optional[Dict[str, Union[float, str]]] = None
+    max_position_embeddings: int = 32768
+    # Qwen2's own default: the 0.5b checkpoints opt in explicitly, the 7b/72b do not
+    tie_word_embeddings: bool = False
+
+    def __post_init__(self):
+        if self.num_key_value_heads is None:
+            self.num_key_value_heads = self.num_attention_heads
+
+
+@dataclass
+class VisionConfig(BaseModelConfig):
+    model_type: str = "siglip_vision_model"
+    num_hidden_layers: int = 26
+    hidden_size: int = 1152
+    intermediate_size: int = 4304
+    num_attention_heads: int = 16
+    image_size: int = 384
+    patch_size: int = 14
+    num_channels: int = 3
+    layer_norm_eps: float = 1e-6
+    vision_use_head: bool = False  # onevision checkpoints ship no pooling head
+
+
+@dataclass
+class ModelConfig(BaseModelConfig):
+    text_config: TextConfig
+    vision_config: VisionConfig
+    model_type: str = "llava_onevision"
+    image_token_index: int = 151646
+    video_token_index: int = 151647
+    image_grid_pinpoints: Optional[List[List[int]]] = None
+    vision_aspect_ratio: str = "anyres_max_9"
+    vision_feature_select_strategy: str = "full"
+    vision_feature_layer: Union[int, List[int]] = -1
+    use_image_newline_parameter: bool = True
+    projector_hidden_act: str = "gelu"
+    ignore_index: int = -100
+    vocab_size: int = 151936
+    eos_token_id: Optional[List[int]] = None

--- a/mlx_vlm/models/llava_onevision/language.py
+++ b/mlx_vlm/models/llava_onevision/language.py
@@ -1,0 +1,44 @@
+from typing import Optional
+
+import mlx.core as mx
+import mlx.nn as nn
+
+from ..base import LanguageModelOutput
+from ..qwen2.language import Qwen2Model
+from .config import TextConfig
+
+
+class LanguageModel(nn.Module):
+    def __init__(self, config: TextConfig):
+        super().__init__()
+        self.config = config
+        self.model_type = config.model_type
+        self.model = Qwen2Model(config)
+        if not config.tie_word_embeddings:
+            self.lm_head = nn.Linear(config.hidden_size, config.vocab_size, bias=False)
+
+    def __call__(
+        self,
+        inputs: mx.array,
+        mask: mx.array = None,
+        cache=None,
+        inputs_embeds: Optional[mx.array] = None,
+        **kwargs,
+    ):
+        out = self.model(inputs, cache=cache, input_embeddings=inputs_embeds)
+        if self.config.tie_word_embeddings:
+            out = self.model.embed_tokens.as_linear(out)
+        else:
+            out = self.lm_head(out)
+        return LanguageModelOutput(out)
+
+    def sanitize(self, weights):
+        if self.config.tie_word_embeddings:
+            weights.pop("language_model.lm_head.weight", None)
+        return {
+            k: v for k, v in weights.items() if "self_attn.rotary_emb.inv_freq" not in k
+        }
+
+    @property
+    def layers(self):
+        return self.model.layers

--- a/mlx_vlm/models/llava_onevision/llava_onevision.py
+++ b/mlx_vlm/models/llava_onevision/llava_onevision.py
@@ -1,0 +1,364 @@
+import math
+from typing import List, Optional
+
+import mlx.core as mx
+import mlx.nn as nn
+import numpy as np
+
+from ..base import InputEmbeddingsFeatures
+from ..interpolate import resize_bilinear
+from . import processing_llava_onevision  # noqa: F401
+from .config import ModelConfig
+from .language import LanguageModel
+from .vision import VisionModel
+
+
+def get_anyres_image_grid_shape(image_size, grid_pinpoints, patch_size):
+    """Return the (rows, cols) tile grid AnyRes picked for ``image_size``."""
+    from transformers.image_processing_utils import select_best_resolution
+
+    if not isinstance(image_size, (list, tuple)):
+        image_size = image_size.tolist()
+    height, width = select_best_resolution(image_size, grid_pinpoints)
+    return height // patch_size, width // patch_size
+
+
+def image_size_to_num_patches(image_size, grid_pinpoints, patch_size):
+    """Number of tiles AnyRes produces for ``image_size``, including the base tile."""
+    num_patch_height, num_patch_width = get_anyres_image_grid_shape(
+        image_size, grid_pinpoints, patch_size
+    )
+    return num_patch_height * num_patch_width + 1
+
+
+def unpad_image(tensor, original_size):
+    """Strip the AnyRes padding from a (C, H, W) feature map."""
+    original_height, original_width = original_size
+    current_height, current_width = tensor.shape[1], tensor.shape[2]
+
+    original_aspect_ratio = original_width / original_height
+    current_aspect_ratio = current_width / current_height
+
+    if original_aspect_ratio > current_aspect_ratio:
+        scale_factor = current_width / original_width
+        new_height = int(original_height * scale_factor)
+        padding = (current_height - new_height) // 2
+        return tensor[:, padding : current_height - padding, :]
+
+    scale_factor = current_height / original_height
+    new_width = int(original_width * scale_factor)
+    padding = (current_width - new_width) // 2
+    return tensor[:, :, padding : current_width - padding]
+
+
+class LlavaOnevisionMultiModalProjector(nn.Module):
+    def __init__(self, config: ModelConfig):
+        super().__init__()
+        self.linear_1 = nn.Linear(
+            config.vision_config.hidden_size, config.text_config.hidden_size, bias=True
+        )
+        self.gelu = nn.GELU()
+        self.linear_2 = nn.Linear(
+            config.text_config.hidden_size, config.text_config.hidden_size, bias=True
+        )
+
+    def __call__(self, x: mx.array) -> mx.array:
+        return self.linear_2(self.gelu(self.linear_1(x)))
+
+
+class Model(nn.Module):
+    def __init__(self, config: ModelConfig):
+        super().__init__()
+        self.config = config
+        self.vision_tower = VisionModel(config.vision_config)
+        self.language_model = LanguageModel(config.text_config)
+        self.multi_modal_projector = LlavaOnevisionMultiModalProjector(config)
+
+        self.image_newline = None
+        if config.use_image_newline_parameter:
+            embed_std = 1 / math.sqrt(config.text_config.hidden_size)
+            self.image_newline = (
+                mx.random.normal((config.text_config.hidden_size,)) * embed_std
+            )
+
+    @property
+    def max_num_patches(self) -> int:
+        return int(self.config.vision_aspect_ratio.strip("anyres_max_"))
+
+    @property
+    def patches_per_side(self) -> int:
+        return (
+            self.config.vision_config.image_size // self.config.vision_config.patch_size
+        )
+
+    def _select_features(self, hidden_states) -> mx.array:
+        layer = self.config.vision_feature_layer
+        if isinstance(layer, int):
+            selected = hidden_states[layer]
+        else:
+            selected = mx.concatenate([hidden_states[i] for i in layer], axis=-1)
+        if self.config.vision_feature_select_strategy == "default":
+            selected = selected[:, 1:]
+        return selected
+
+    def pack_image_features(
+        self, image_features: List[mx.array], image_sizes
+    ) -> List[mx.array]:
+        """Unpad, optionally downsample, and append newlines to each image's tiles."""
+        packed = []
+        for image_idx, image_feature in enumerate(image_features):
+            if image_feature.shape[0] > 1:
+                base_image_feature = image_feature[0]
+                tiles = image_feature[1:]
+
+                height = width = self.patches_per_side
+                if height * width != base_image_feature.shape[0]:
+                    raise ValueError(
+                        "The number of patches is not consistent with the image size."
+                    )
+                num_patch_height, num_patch_width = get_anyres_image_grid_shape(
+                    image_sizes[image_idx],
+                    self.config.image_grid_pinpoints,
+                    self.config.vision_config.image_size,
+                )
+
+                tiles = tiles.reshape(
+                    num_patch_height, num_patch_width, height, width, -1
+                )
+                tiles = mx.transpose(tiles, axes=(4, 0, 2, 1, 3))
+                channels = tiles.shape[0]
+                tiles = tiles.reshape(
+                    channels, num_patch_height * height, num_patch_width * width
+                )
+                tiles = unpad_image(tiles, image_sizes[image_idx])
+
+                curr_height, curr_width = tiles.shape[1], tiles.shape[2]
+                ratio = math.sqrt(
+                    curr_height * curr_width / (self.max_num_patches * height**2)
+                )
+                if ratio > 1.1:
+                    tiles = mx.transpose(tiles, axes=(1, 2, 0))
+                    tiles = resize_bilinear(
+                        tiles,
+                        (int(curr_height // ratio), int(curr_width // ratio)),
+                        antialias=False,
+                    )
+                    tiles = mx.transpose(tiles, axes=(2, 0, 1))
+
+                if self.image_newline is not None:
+                    channels, curr_height, _ = tiles.shape
+                    newline = mx.broadcast_to(
+                        self.image_newline[:, None, None].astype(tiles.dtype),
+                        (channels, curr_height, 1),
+                    )
+                    tiles = mx.concatenate([tiles, newline], axis=-1)
+
+                channels = tiles.shape[0]
+                tiles = tiles.reshape(channels, -1).T
+                image_feature = mx.concatenate([base_image_feature, tiles], axis=0)
+            else:
+                image_feature = image_feature[0]
+                if self.image_newline is not None:
+                    image_feature = mx.concatenate(
+                        [
+                            image_feature,
+                            self.image_newline[None].astype(image_feature.dtype),
+                        ],
+                        axis=0,
+                    )
+            packed.append(image_feature)
+        return packed
+
+    def get_image_features(self, pixel_values: mx.array, image_sizes) -> mx.array:
+        """Tower + projector + AnyRes packing, flattened over all images."""
+        if image_sizes is None:
+            raise ValueError(
+                "llava_onevision needs image_sizes to unpad AnyRes image features"
+            )
+        image_sizes = np.array(image_sizes).reshape(-1, 2).tolist()
+
+        if pixel_values.ndim == 5:
+            # The processor pads the tile axis to the batch maximum; drop the padding.
+            num_patches = [
+                image_size_to_num_patches(
+                    size,
+                    self.config.image_grid_pinpoints,
+                    self.config.vision_config.image_size,
+                )
+                for size in image_sizes
+            ]
+            flat_pixel_values = mx.concatenate(
+                [pixel_values[i, :count] for i, count in enumerate(num_patches)],
+                axis=0,
+            )
+        elif pixel_values.ndim == 4:
+            flat_pixel_values = pixel_values
+            num_patches = [pixel_values.shape[0]]
+        else:
+            raise ValueError(
+                f"pixel_values of shape {pixel_values.shape}, expect 4 or 5 dimensions"
+            )
+
+        *_, hidden_states = self.vision_tower(
+            flat_pixel_values.transpose(0, 2, 3, 1), output_hidden_states=True
+        )
+        selected = self._select_features(hidden_states)
+        features = self.multi_modal_projector(selected)
+
+        split, start = [], 0
+        for count in num_patches:
+            split.append(features[start : start + count])
+            start += count
+
+        packed = self.pack_image_features(split, image_sizes)
+        return mx.concatenate(packed, axis=0)
+
+    def apply_pooling(self, features: mx.array) -> mx.array:
+        """Bilinearly pool each frame's patch grid by 2x, as onevision does for video."""
+        batch_frames, _, dim = features.shape
+        side = self.patches_per_side
+        pooled_side = math.ceil(side / 2)
+        features = features.reshape(batch_frames, side, side, dim)
+        features = mx.transpose(features, axes=(0, 3, 1, 2))
+        features = resize_bilinear(
+            features, (pooled_side, pooled_side), antialias=False
+        )
+        features = mx.transpose(features, axes=(0, 2, 3, 1))
+        return features.reshape(batch_frames, pooled_side * pooled_side, dim)
+
+    def get_video_features(self, pixel_values_videos: mx.array) -> mx.array:
+        if pixel_values_videos.ndim == 5:
+            batch_size, frames = pixel_values_videos.shape[:2]
+            flat = pixel_values_videos.reshape(-1, *pixel_values_videos.shape[2:])
+        else:
+            batch_size, frames = 1, pixel_values_videos.shape[0]
+            flat = pixel_values_videos
+
+        *_, hidden_states = self.vision_tower(
+            flat.transpose(0, 2, 3, 1), output_hidden_states=True
+        )
+        selected = self._select_features(hidden_states)
+        features = self.multi_modal_projector(selected)
+        features = self.apply_pooling(features)
+        features = features.reshape(batch_size, frames * features.shape[1], -1)
+
+        if self.image_newline is not None:
+            newline = mx.broadcast_to(
+                self.image_newline[None, None, :].astype(features.dtype),
+                (features.shape[0], 1, features.shape[-1]),
+            )
+            features = mx.concatenate([features, newline], axis=1)
+
+        return features.reshape(-1, features.shape[-1])
+
+    def _scatter_features(
+        self,
+        inputs_embeds: mx.array,
+        input_ids: mx.array,
+        features: mx.array,
+        token_index: int,
+        kind: str,
+    ) -> mx.array:
+        """Replace every ``token_index`` placeholder with the next row of ``features``."""
+        mask = input_ids == token_index
+        num_placeholders = int(mask.sum().item())
+        if num_placeholders != features.shape[0]:
+            raise ValueError(
+                f"{kind} features and {kind} tokens do not match: "
+                f"tokens {num_placeholders}, features {features.shape[0]}"
+            )
+
+        features = features.astype(inputs_embeds.dtype)
+        flat_positions = mx.cumsum(mask.reshape(-1).astype(mx.int32)) - 1
+        positions = flat_positions.reshape(mask.shape)
+        gathered = features[mx.clip(positions, 0, features.shape[0] - 1)]
+        return mx.where(mask[..., None], gathered, inputs_embeds)
+
+    def get_input_embeddings(
+        self,
+        input_ids: Optional[mx.array] = None,
+        pixel_values: Optional[mx.array] = None,
+        **kwargs,
+    ):
+        pixel_values_videos = kwargs.get("pixel_values_videos", None)
+        if pixel_values is None and pixel_values_videos is None:
+            return InputEmbeddingsFeatures(
+                inputs_embeds=self.language_model.model.embed_tokens(input_ids)
+            )
+
+        inputs_embeds = self.language_model.model.embed_tokens(input_ids)
+
+        if pixel_values is not None:
+            cached = kwargs.get("cached_image_features", None)
+            if cached is not None:
+                image_features = cached
+            else:
+                image_features = self.get_image_features(
+                    pixel_values, kwargs.get("image_sizes", None)
+                )
+            inputs_embeds = self._scatter_features(
+                inputs_embeds,
+                input_ids,
+                image_features,
+                self.config.image_token_index,
+                "Image",
+            )
+
+        if pixel_values_videos is not None:
+            video_features = self.get_video_features(pixel_values_videos)
+            inputs_embeds = self._scatter_features(
+                inputs_embeds,
+                input_ids,
+                video_features,
+                self.config.video_token_index,
+                "Video",
+            )
+
+        return InputEmbeddingsFeatures(inputs_embeds=inputs_embeds)
+
+    @staticmethod
+    def sanitize(weights):
+        """Accept both the published key layout and transformers' newer one.
+
+        Hub checkpoints are exported as ``language_model.model.*`` / ``vision_tower.*``;
+        transformers >= 5 nests the same tensors under ``model.*`` with the language
+        model flattened.
+        """
+        renames = (
+            ("model.vision_tower.", "vision_tower."),
+            ("model.multi_modal_projector.", "multi_modal_projector."),
+            ("model.language_model.", "language_model.model."),
+            ("model.image_newline", "image_newline"),
+        )
+        sanitized = {}
+        for key, value in weights.items():
+            for prefix, replacement in renames:
+                if key.startswith(prefix):
+                    key = replacement + key[len(prefix) :]
+                    break
+            else:
+                if key == "lm_head.weight":
+                    key = "language_model.lm_head.weight"
+            if key.startswith("vision_tower.") and not key.startswith(
+                "vision_tower.vision_model."
+            ):
+                key = "vision_tower.vision_model." + key[len("vision_tower.") :]
+            sanitized[key] = value
+        return sanitized
+
+    @property
+    def layers(self):
+        return self.language_model.model.layers
+
+    def __call__(
+        self,
+        input_ids: mx.array,
+        pixel_values: mx.array = None,
+        mask: mx.array = None,
+        cache=None,
+        **kwargs,
+    ):
+        features = self.get_input_embeddings(input_ids, pixel_values, **kwargs)
+        return self.language_model(
+            input_ids, cache=cache, inputs_embeds=features.inputs_embeds
+        )

--- a/mlx_vlm/models/llava_onevision/processing_llava_onevision.py
+++ b/mlx_vlm/models/llava_onevision/processing_llava_onevision.py
@@ -1,0 +1,335 @@
+"""
+Processor class for LLaVA-OneVision.
+
+The image processor that ``AutoImageProcessor`` resolves for this model type is
+torchvision-backed, and the video processor requires torchvision too, so both are
+bypassed here: images go through the PIL backend and video frames are handled with
+numpy, keeping mlx-vlm free of a torch dependency.
+"""
+
+import json
+import math
+from pathlib import Path
+
+import numpy as np
+from transformers.feature_extraction_utils import BatchFeature
+from transformers.image_processing_utils import select_best_resolution
+from transformers.tokenization_utils_base import PreTokenizedInput, TextInput
+
+from ..base import load_chat_template, to_mlx
+
+_IMAGE_MARKER = "<mlx_image_placeholder>"
+_VIDEO_MARKER = "<mlx_video_placeholder>"
+
+
+class LlavaOnevisionVideoProcessor:
+    """Resizes and normalizes video frames to the vision tower's input size.
+
+    Kept independent of the torchvision-backed upstream video processor so that
+    mlx-vlm needs no torch install; ``LlavaOnevisionProcessor`` exposes it as its
+    ``video_processor`` component, which is how callers detect native video
+    support.
+    """
+
+    def __init__(
+        self,
+        size=(384, 384),
+        image_mean=(0.5, 0.5, 0.5),
+        image_std=(0.5, 0.5, 0.5),
+        rescale_factor: float = 1 / 255,
+    ):
+        self.size = tuple(size)
+        self.image_mean = np.array(image_mean, dtype=np.float32)
+        self.image_std = np.array(image_std, dtype=np.float32)
+        self.rescale_factor = rescale_factor
+
+    def __call__(self, videos, **kwargs) -> np.ndarray:
+        from PIL import Image
+
+        if not isinstance(videos, (list, tuple)):
+            videos = [videos]
+
+        height, width = self.size
+        processed = []
+        for video in videos:
+            frames = []
+            for frame in video:
+                if not isinstance(frame, Image.Image):
+                    array = np.asarray(frame)
+                    # load_video yields channels-first frames; PIL needs HWC.
+                    if (
+                        array.ndim == 3
+                        and array.shape[0] in (1, 3, 4)
+                        and array.shape[-1] not in (1, 3, 4)
+                    ):
+                        array = array.transpose(1, 2, 0)
+                    frame = Image.fromarray(array.astype(np.uint8))
+                frame = frame.convert("RGB").resize(
+                    (width, height), Image.Resampling.BICUBIC
+                )
+                array = np.asarray(frame, dtype=np.float32) * self.rescale_factor
+                array = (array - self.image_mean) / self.image_std
+                frames.append(array.transpose(2, 0, 1))
+            processed.append(np.stack(frames))
+        return np.stack(processed)
+
+
+class LlavaOnevisionProcessor:
+    """Pairs the PIL image processor and tokenizer, expanding visual placeholders."""
+
+    def __init__(
+        self,
+        image_processor=None,
+        tokenizer=None,
+        num_image_tokens: int = 729,
+        vision_aspect_ratio: str = "anyres_max_9",
+        vision_feature_select_strategy: str = "full",
+        image_token: str = "<image>",
+        video_token: str = "<video>",
+        video_size=(384, 384),
+        image_mean=(0.5, 0.5, 0.5),
+        image_std=(0.5, 0.5, 0.5),
+        **kwargs,
+    ):
+        self.image_processor = image_processor
+        self.tokenizer = tokenizer
+        self.num_image_tokens = num_image_tokens
+        self.vision_aspect_ratio = vision_aspect_ratio
+        self.vision_feature_select_strategy = vision_feature_select_strategy
+        self.image_token = image_token
+        self.video_token = video_token
+        self.video_processor = LlavaOnevisionVideoProcessor(
+            size=video_size, image_mean=image_mean, image_std=image_std
+        )
+        self.chat_template = getattr(tokenizer, "chat_template", None)
+
+    @classmethod
+    def from_pretrained(cls, pretrained_model_name_or_path, **kwargs):
+        from transformers import AutoTokenizer
+        from transformers.models.llava_onevision.image_processing_pil_llava_onevision import (
+            LlavaOnevisionImageProcessorPil,
+        )
+
+        kwargs.pop("use_fast", None)
+        tokenizer = AutoTokenizer.from_pretrained(
+            pretrained_model_name_or_path, **kwargs
+        )
+        load_chat_template(tokenizer, pretrained_model_name_or_path)
+        image_processor = LlavaOnevisionImageProcessorPil.from_pretrained(
+            pretrained_model_name_or_path, **kwargs
+        )
+
+        proc_kwargs = {}
+        model_dir = Path(pretrained_model_name_or_path)
+        proc_cfg_path = model_dir / "processor_config.json"
+        if proc_cfg_path.exists():
+            with open(proc_cfg_path) as f:
+                proc_cfg = json.load(f)
+            for key in (
+                "num_image_tokens",
+                "vision_feature_select_strategy",
+                "image_token",
+                "video_token",
+            ):
+                if key in proc_cfg:
+                    proc_kwargs[key] = proc_cfg[key]
+
+        video_cfg_path = model_dir / "video_preprocessor_config.json"
+        if video_cfg_path.exists():
+            with open(video_cfg_path) as f:
+                video_cfg = json.load(f)
+            size = video_cfg.get("size") or {}
+            if "height" in size and "width" in size:
+                proc_kwargs["video_size"] = (size["height"], size["width"])
+            for key in ("image_mean", "image_std"):
+                if key in video_cfg:
+                    proc_kwargs[key] = video_cfg[key]
+
+        config_path = model_dir / "config.json"
+        if config_path.exists():
+            with open(config_path) as f:
+                model_cfg = json.load(f)
+            if "vision_aspect_ratio" in model_cfg:
+                proc_kwargs["vision_aspect_ratio"] = model_cfg["vision_aspect_ratio"]
+
+        return cls(image_processor=image_processor, tokenizer=tokenizer, **proc_kwargs)
+
+    def __call__(
+        self,
+        images=None,
+        text: (
+            TextInput | PreTokenizedInput | list[TextInput] | list[PreTokenizedInput]
+        ) = None,
+        videos=None,
+        **kwargs,
+    ) -> BatchFeature:
+        if images is None and videos is None and text is None:
+            raise ValueError("You have to specify at least images, videos or text.")
+
+        kwargs.pop("return_tensors", None)
+        kwargs.pop("fps", None)
+        kwargs.pop("audio", None)
+        padding = kwargs.pop("padding", False)
+
+        image_inputs = {}
+        if images is not None:
+            image_inputs = dict(
+                self.image_processor(images, return_tensors="np", **kwargs)
+            )
+
+        video_inputs = {}
+        if videos is not None:
+            video_inputs = {"pixel_values_videos": self.video_processor(videos)}
+
+        if isinstance(text, str):
+            text = [text]
+        elif text is not None and not isinstance(text, list):
+            raise TypeError(
+                "Invalid input text. Please provide a string, or a list of strings"
+            )
+
+        prompt_strings = text
+        if text is not None:
+            # One iterator per batch, so images and videos are consumed in prompt
+            # order across every sample -- matching the reference processor.
+            image_sizes = iter(
+                np.asarray(image_inputs["image_sizes"]).tolist() if image_inputs else ()
+            )
+            videos = iter(
+                np.asarray(video_inputs["pixel_values_videos"]) if video_inputs else ()
+            )
+            tile_size = (
+                np.asarray(image_inputs["pixel_values"]).shape[-2:]
+                if image_inputs
+                else (0, 0)
+            )
+            prompt_strings = [
+                self._expand_placeholders(sample, image_sizes, videos, tile_size)
+                for sample in text
+            ]
+
+        text_inputs = (
+            self.tokenizer(prompt_strings, padding=padding, **kwargs) if text else {}
+        )
+
+        return BatchFeature(
+            data=to_mlx({**text_inputs, **image_inputs, **video_inputs})
+        )
+
+    def _expand_placeholders(self, sample: str, image_sizes, videos, tile_size) -> str:
+        """Replace each visual token with as many copies as the model will emit rows."""
+        height, width = tile_size
+        while self.image_token in sample:
+            try:
+                orig_height, orig_width = next(image_sizes)
+            except StopIteration:
+                raise ValueError(
+                    "More image placeholders than images were provided."
+                ) from None
+            num_image_tokens = self._get_number_of_features(
+                orig_height, orig_width, height, width
+            )
+            if self.vision_feature_select_strategy == "default":
+                num_image_tokens -= 1
+            sample = sample.replace(
+                self.image_token, _IMAGE_MARKER * num_image_tokens, 1
+            )
+
+        patches_side = int(math.sqrt(self.num_image_tokens))
+        pooled_side = math.ceil(patches_side / 2)
+        while self.video_token in sample:
+            try:
+                video = next(videos)
+            except StopIteration:
+                raise ValueError(
+                    "More video placeholders than videos were provided."
+                ) from None
+            # one trailing newline token closes the whole video
+            num_video_tokens = len(video) * pooled_side * pooled_side + 1
+            sample = sample.replace(
+                self.video_token, _VIDEO_MARKER * num_video_tokens, 1
+            )
+
+        return sample.replace(_IMAGE_MARKER, self.image_token).replace(
+            _VIDEO_MARKER, self.video_token
+        )
+
+    def _get_number_of_features(
+        self, orig_height: int, orig_width: int, height: int, width: int
+    ) -> int:
+        image_grid_pinpoints = self.image_processor.image_grid_pinpoints
+
+        height_best_resolution, width_best_resolution = select_best_resolution(
+            [orig_height, orig_width], image_grid_pinpoints
+        )
+        scale_height = height_best_resolution // height
+        scale_width = width_best_resolution // width
+
+        patches_height = patches_width = int(math.sqrt(self.num_image_tokens))
+        unpadded_features, newline_features = self._get_unpadded_features(
+            orig_height,
+            orig_width,
+            patches_height,
+            patches_width,
+            scale_height,
+            scale_width,
+        )
+        return unpadded_features + newline_features + self.num_image_tokens
+
+    def _get_unpadded_features(
+        self, height, width, patches_height, patches_width, scale_height, scale_width
+    ):
+        current_height = patches_height * scale_height
+        current_width = patches_width * scale_width
+
+        original_aspect_ratio = width / height
+        current_aspect_ratio = current_width / current_height
+        if original_aspect_ratio > current_aspect_ratio:
+            new_height = int(round(height * (current_width / width), 7))
+            padding = (current_height - new_height) // 2
+            current_height -= padding * 2
+        else:
+            new_width = int(round(width * (current_height / height), 7))
+            padding = (current_width - new_width) // 2
+            current_width -= padding * 2
+
+        unpadded_features = current_height * current_width
+        newline_features = current_height
+
+        max_num_patches = int(self.vision_aspect_ratio.strip("anyres_max_"))
+        ratio = math.sqrt(
+            current_height * current_width / (max_num_patches * patches_height**2)
+        )
+        if ratio > 1.1:
+            unpadded_features = int(current_height // ratio) * int(
+                current_width // ratio
+            )
+            newline_features = int(current_height // ratio)
+
+        return (unpadded_features, newline_features)
+
+    def apply_chat_template(self, *args, **kwargs):
+        return self.tokenizer.apply_chat_template(*args, **kwargs)
+
+    def batch_decode(self, *args, **kwargs):
+        return self.tokenizer.batch_decode(*args, **kwargs)
+
+    def decode(self, *args, **kwargs):
+        return self.tokenizer.decode(*args, **kwargs)
+
+    @property
+    def model_input_names(self):
+        tokenizer_input_names = self.tokenizer.model_input_names
+        return list(
+            dict.fromkeys(
+                tokenizer_input_names
+                + ["pixel_values", "image_sizes", "pixel_values_videos"]
+            )
+        )
+
+
+__all__ = ["LlavaOnevisionProcessor"]
+
+from ..base import install_auto_processor_patch
+
+install_auto_processor_patch("llava_onevision", LlavaOnevisionProcessor)

--- a/mlx_vlm/models/llava_onevision/vision.py
+++ b/mlx_vlm/models/llava_onevision/vision.py
@@ -1,0 +1,232 @@
+from typing import Optional
+
+import mlx.core as mx
+import mlx.nn as nn
+import numpy as np
+
+from ..mlp import TanhGELUMLP as MLP
+from .config import VisionConfig
+
+
+def check_array_shape(arr):
+    shape = arr.shape
+    if len(shape) != 4:
+        return False
+    out_channels, kH, KW, _ = shape
+    if (out_channels >= kH) and (out_channels >= KW) and (kH == KW):
+        return True
+    return False
+
+
+class Attention(nn.Module):
+    def __init__(
+        self,
+        dims: int,
+        num_heads: int,
+        bias: bool = True,
+    ):
+        super().__init__()
+        if (dims % num_heads) != 0:
+            raise ValueError(
+                "The input feature dimensions should be divisible by the "
+                f"number of heads ({dims} % {num_heads}) != 0"
+            )
+        self.num_heads = num_heads
+        head_dim = dims // num_heads
+        self.scale = head_dim**-0.5
+        self.q_proj = nn.Linear(dims, dims, bias=bias)
+        self.k_proj = nn.Linear(dims, dims, bias=bias)
+        self.v_proj = nn.Linear(dims, dims, bias=bias)
+        self.out_proj = nn.Linear(dims, dims, bias=bias)
+
+    def __call__(self, queries, keys, values, mask=None):
+        queries = self.q_proj(queries)
+        keys = self.k_proj(keys)
+        values = self.v_proj(values)
+
+        num_heads = self.num_heads
+        B, L, D = queries.shape
+        _, S, _ = keys.shape
+        queries = queries.reshape(B, L, num_heads, -1).transpose(0, 2, 1, 3)
+        keys = keys.reshape(B, S, num_heads, -1).transpose(0, 2, 1, 3)
+        values = values.reshape(B, S, num_heads, -1).transpose(0, 2, 1, 3)
+
+        output = mx.fast.scaled_dot_product_attention(
+            queries, keys, values, scale=self.scale, mask=mask
+        )
+        output = output.transpose(0, 2, 1, 3).reshape(B, L, -1)
+        return self.out_proj(output)
+
+
+class MHA(nn.Module):
+    """Multi-head attention with fused QKV projection (for pooling head)."""
+
+    def __init__(
+        self,
+        dims: int,
+        num_heads: int,
+        bias: bool = True,
+    ):
+        super().__init__()
+        if (dims % num_heads) != 0:
+            raise ValueError(
+                "The input feature dimensions should be divisible by the "
+                f"number of heads ({dims} % {num_heads}) != 0"
+            )
+        self.num_heads = num_heads
+        head_dim = dims // num_heads
+        self.scale = head_dim**-0.5
+        self.in_proj = nn.Linear(dims, dims * 3, bias=bias)
+        self.out_proj = nn.Linear(dims, dims, bias=bias)
+
+    def __call__(self, queries: mx.array, kv: mx.array, mask=None):
+        B, L, D = queries.shape
+
+        qkv = self.in_proj(queries)
+        _, keys, values = mx.split(qkv, 3, axis=-1)
+
+        num_heads = self.num_heads
+        _, S, _ = keys.shape
+        queries = queries.reshape(B, L, num_heads, -1).transpose(0, 2, 1, 3)
+        keys = keys.reshape(B, S, num_heads, -1).transpose(0, 2, 1, 3)
+        values = values.reshape(B, S, num_heads, -1).transpose(0, 2, 1, 3)
+
+        output = mx.fast.scaled_dot_product_attention(
+            queries, keys, values, scale=self.scale, mask=mask
+        )
+        output = output.transpose(0, 2, 1, 3).reshape(B, L, -1)
+        return self.out_proj(output)
+
+
+class EncoderLayer(nn.Module):
+    def __init__(self, config: VisionConfig):
+        super().__init__()
+        self.embed_dim = config.hidden_size
+        self.self_attn = Attention(
+            config.hidden_size, config.num_attention_heads, bias=True
+        )
+        self.layer_norm1 = nn.LayerNorm(self.embed_dim, eps=config.layer_norm_eps)
+        self.mlp = MLP(config)
+        self.layer_norm2 = nn.LayerNorm(self.embed_dim, eps=config.layer_norm_eps)
+
+    def __call__(self, x: mx.array, mask: Optional[mx.array] = None) -> mx.array:
+        y = self.layer_norm1(x)
+        y = self.self_attn(y, y, y, mask)
+        x = x + y
+        y = self.layer_norm2(x)
+        y = self.mlp(y)
+        return x + y
+
+
+class Encoder(nn.Module):
+    def __init__(self, config: VisionConfig):
+        super().__init__()
+        self.layers = [EncoderLayer(config) for _ in range(config.num_hidden_layers)]
+
+
+class VisionEmbeddings(nn.Module):
+    def __init__(self, config: VisionConfig):
+        super().__init__()
+        self.config = config
+        self.embed_dim = config.hidden_size
+        self.image_size = config.image_size
+        self.patch_size = config.patch_size
+
+        self.patch_embedding = nn.Conv2d(
+            in_channels=config.num_channels,
+            out_channels=self.embed_dim,
+            kernel_size=self.patch_size,
+            stride=self.patch_size,
+            bias=True,
+        )
+
+        self.num_patches = (self.image_size // self.patch_size) ** 2
+        self.num_positions = self.num_patches
+        self.position_embedding = nn.Embedding(self.num_positions, self.embed_dim)
+
+    def __call__(self, x: mx.array) -> mx.array:
+        patch_embeddings = self.patch_embedding(x)
+        patch_embeddings = mx.flatten(patch_embeddings, start_axis=1, end_axis=2)
+        position_ids = mx.array(np.arange(self.num_positions)[None, :])
+        embeddings = patch_embeddings + self.position_embedding(position_ids)
+        return embeddings
+
+
+class SigLipMultiheadAttentionPoolingHead(nn.Module):
+    def __init__(self, config: VisionConfig):
+        super().__init__()
+        self.probe = mx.ones((1, 1, config.hidden_size))
+        self.attention = MHA(
+            config.hidden_size, num_heads=config.num_attention_heads, bias=True
+        )
+        self.layernorm = nn.LayerNorm(config.hidden_size, eps=config.layer_norm_eps)
+        self.mlp = MLP(config)
+
+    def __call__(self, x: mx.array):
+        x = self.attention(self.probe, x)[0]
+        residual = x
+        x = self.layernorm(x)
+        x = residual + self.mlp(x)
+        return x[:, 0]
+
+
+class SigLipVisionModel(nn.Module):
+    def __init__(self, config: VisionConfig):
+        super().__init__()
+        self.embeddings = VisionEmbeddings(config)
+        self.encoder = Encoder(config)
+        self.post_layernorm = nn.LayerNorm(
+            config.hidden_size, eps=config.layer_norm_eps
+        )
+        self.use_head = config.vision_use_head
+        if self.use_head:
+            self.head = SigLipMultiheadAttentionPoolingHead(config)
+
+    def __call__(
+        self,
+        x: mx.array,
+        output_hidden_states: Optional[bool] = None,
+    ) -> mx.array:
+        x = self.embeddings(x)
+
+        encoder_states = (x,) if output_hidden_states else None
+
+        for l in self.encoder.layers:
+            x = l(x, mask=None)
+            if output_hidden_states:
+                encoder_states = encoder_states + (x,)
+
+        pooler_output = self.post_layernorm(x)
+        return pooler_output, x, encoder_states
+
+
+class VisionModel(nn.Module):
+    def __init__(self, config: VisionConfig):
+        super().__init__()
+        self.model_type = config.model_type
+        self.vision_model = SigLipVisionModel(config)
+
+    def __call__(
+        self, x: mx.array, output_hidden_states: Optional[bool] = None
+    ) -> mx.array:
+        return self.vision_model(x, output_hidden_states)
+
+    @staticmethod
+    def sanitize(weights):
+        sanitized_weights = {}
+        for k, v in weights.items():
+            if "position_ids" in k:
+                continue
+            elif "patch_embedding.weight" in k:
+                if check_array_shape(v):
+                    sanitized_weights[k] = v
+                else:
+                    sanitized_weights[k] = v.transpose(0, 2, 3, 1)
+            elif "head.attention.in_proj_weight" in k:
+                # PyTorch nn.MultiheadAttention stores as in_proj_weight parameter
+                sanitized_weights[k.replace("in_proj_weight", "in_proj.weight")] = v
+            elif "head.attention.in_proj_bias" in k:
+                sanitized_weights[k.replace("in_proj_bias", "in_proj.bias")] = v
+            else:
+                sanitized_weights[k] = v
+        return sanitized_weights

--- a/mlx_vlm/prompt_utils.py
+++ b/mlx_vlm/prompt_utils.py
@@ -77,6 +77,7 @@ MODEL_CONFIG = {
     "smolvlm": MessageFormat.LIST_WITH_IMAGE_FIRST,
     "llava": MessageFormat.LIST_WITH_IMAGE,
     "llava_next": MessageFormat.LIST_WITH_IMAGE,
+    "llava_onevision": MessageFormat.LIST_WITH_IMAGE,
     "granite_vision": MessageFormat.LIST_WITH_IMAGE,
     "granite4_vision": MessageFormat.LIST_WITH_IMAGE,
     "mllama": MessageFormat.LIST_WITH_IMAGE,
@@ -303,6 +304,7 @@ class MessageFormatter:
             "diffusion_gemma",
             "minicpmv4_6",
             "minimax_m3_vl",
+            "llava_onevision",
         ] and kwargs.get("video"):
             return self._format_video_message(
                 prompt,

--- a/mlx_vlm/tests/test_models.py
+++ b/mlx_vlm/tests/test_models.py
@@ -1,5 +1,6 @@
 import importlib
 import inspect
+import math
 import threading
 import unittest
 from types import SimpleNamespace
@@ -4175,6 +4176,258 @@ class TestModels(unittest.TestCase):
             config.vision_config.num_channels,
             (config.vision_config.image_size, config.vision_config.image_size),
         )
+
+    def test_llava_onevision(self):
+        from mlx_vlm.models import llava_onevision
+
+        text_config = llava_onevision.TextConfig(
+            model_type="qwen2",
+            hidden_size=64,
+            num_hidden_layers=2,
+            intermediate_size=128,
+            num_attention_heads=4,
+            num_key_value_heads=2,
+            rms_norm_eps=1e-6,
+            vocab_size=200,
+            rope_theta=1000000.0,
+            tie_word_embeddings=False,
+        )
+
+        vision_config = llava_onevision.VisionConfig(
+            model_type="siglip_vision_model",
+            num_hidden_layers=3,
+            hidden_size=48,
+            intermediate_size=96,
+            num_attention_heads=4,
+            image_size=56,
+            patch_size=14,
+            num_channels=3,
+            layer_norm_eps=1e-6,
+            vision_use_head=False,
+        )
+
+        config = llava_onevision.ModelConfig(
+            text_config=text_config,
+            vision_config=vision_config,
+            model_type="llava_onevision",
+            image_token_index=190,
+            video_token_index=191,
+            image_grid_pinpoints=[[56, 56], [56, 112], [112, 56], [112, 112]],
+            vocab_size=200,
+        )
+
+        model = llava_onevision.Model(config)
+
+        self.language_test_runner(
+            model.language_model,
+            config.text_config.model_type,
+            config.text_config.vocab_size,
+            config.text_config.num_hidden_layers,
+        )
+
+        self.mm_projector_test_runner(
+            model.multi_modal_projector,
+            config.vision_config.hidden_size,
+            config.text_config.hidden_size,
+        )
+
+        self.vision_test_runner(
+            model.vision_tower,
+            config.vision_config.model_type,
+            config.vision_config.hidden_size,
+            config.vision_config.num_channels,
+            (config.vision_config.image_size, config.vision_config.image_size),
+        )
+
+    def _llava_onevision_test_model(self, **overrides):
+        from mlx_vlm.models import llava_onevision
+
+        config = llava_onevision.ModelConfig(
+            text_config=llava_onevision.TextConfig(
+                model_type="qwen2",
+                hidden_size=32,
+                num_hidden_layers=1,
+                intermediate_size=64,
+                num_attention_heads=4,
+                num_key_value_heads=2,
+                rms_norm_eps=1e-6,
+                vocab_size=200,
+                tie_word_embeddings=False,
+            ),
+            vision_config=llava_onevision.VisionConfig(
+                model_type="siglip_vision_model",
+                num_hidden_layers=1,
+                hidden_size=32,
+                intermediate_size=64,
+                num_attention_heads=4,
+                image_size=56,
+                patch_size=14,
+                num_channels=3,
+                layer_norm_eps=1e-6,
+                vision_use_head=False,
+            ),
+            model_type="llava_onevision",
+            image_token_index=190,
+            video_token_index=191,
+            image_grid_pinpoints=[
+                [56, 56],
+                [56, 112],
+                [112, 56],
+                [112, 112],
+                [224, 224],
+            ],
+            vocab_size=200,
+            **overrides,
+        )
+        return llava_onevision.Model(config)
+
+    def test_llava_onevision_packing_single_tile(self):
+        model = self._llava_onevision_test_model()
+        tokens = model.patches_per_side**2
+
+        features = mx.zeros((1, tokens, 32))
+        packed = model.pack_image_features([features], [[56, 56]])
+
+        # A single tile keeps the base features and appends exactly one newline row.
+        self.assertEqual(packed[0].shape, (tokens + 1, 32))
+
+    def test_llava_onevision_packing_matches_grid_layout(self):
+        model = self._llava_onevision_test_model()
+        side = model.patches_per_side
+        tokens = side**2
+
+        features = mx.random.normal((5, tokens, 32))
+        packed = model.pack_image_features([features], [[112, 112]])[0]
+
+        # 2x2 grid of tiles, no downsampling at this size: base + rows*(cols+newline).
+        expected = tokens + (2 * side) * (2 * side + 1)
+        self.assertEqual(packed.shape, (expected, 32))
+        self.assertTrue(mx.allclose(packed[:tokens], features[0]))
+
+    def test_llava_onevision_packing_downsamples_above_ratio(self):
+        model = self._llava_onevision_test_model()
+        side = model.patches_per_side
+        tokens = side**2
+
+        features = mx.random.normal((17, tokens, 32))
+        packed = model.pack_image_features([features], [[224, 224]])[0]
+
+        # 4x4 grid exceeds anyres_max_9, so the unpadded grid is scaled down.
+        ratio = math.sqrt((4 * side) ** 2 / (model.max_num_patches * side**2))
+        self.assertGreater(ratio, 1.1)
+        scaled = int(4 * side // ratio)
+        self.assertEqual(packed.shape, (tokens + scaled * (scaled + 1), 32))
+
+    def test_llava_onevision_video_pooling(self):
+        model = self._llava_onevision_test_model()
+        side = model.patches_per_side
+        pooled = math.ceil(side / 2)
+
+        frames = 3
+        features = mx.random.normal((frames, side**2, 32))
+        pooled_features = model.apply_pooling(features)
+
+        self.assertEqual(pooled_features.shape, (frames, pooled**2, 32))
+
+    def test_llava_onevision_scatter_rejects_count_mismatch(self):
+        model = self._llava_onevision_test_model()
+
+        input_ids = mx.array([[1, 190, 190, 2]])
+        inputs_embeds = mx.zeros((1, 4, 32))
+        features = mx.zeros((3, 32))
+
+        with self.assertRaises(ValueError):
+            model._scatter_features(inputs_embeds, input_ids, features, 190, "Image")
+
+    def test_llava_onevision_packing_matches_processor_token_count(self):
+        from mlx_vlm.models.llava_onevision.llava_onevision import (
+            get_anyres_image_grid_shape,
+        )
+        from mlx_vlm.models.llava_onevision.processing_llava_onevision import (
+            LlavaOnevisionProcessor,
+        )
+
+        model = self._llava_onevision_test_model()
+        side = model.patches_per_side
+        tile = model.config.vision_config.image_size
+
+        processor = LlavaOnevisionProcessor(
+            image_processor=SimpleNamespace(
+                image_grid_pinpoints=model.config.image_grid_pinpoints
+            ),
+            tokenizer=None,
+            num_image_tokens=side**2,
+            vision_aspect_ratio=model.config.vision_aspect_ratio,
+            vision_feature_select_strategy="full",
+        )
+
+        for image_size in ([56, 56], [112, 112], [56, 112], [224, 224], [112, 224]):
+            with self.subTest(image_size=image_size):
+                num_patch_height, num_patch_width = get_anyres_image_grid_shape(
+                    image_size, model.config.image_grid_pinpoints, tile
+                )
+                tiles = num_patch_height * num_patch_width + 1
+                features = mx.zeros((tiles, side**2, 32))
+
+                packed = model.pack_image_features([features], [image_size])[0]
+                predicted = processor._get_number_of_features(
+                    image_size[0], image_size[1], tile, tile
+                )
+
+                self.assertEqual(packed.shape[0], predicted)
+
+    def test_llava_onevision_keeps_untied_lm_head(self):
+        from mlx_vlm.models import llava_onevision
+        from mlx_vlm.models.llava_onevision.language import LanguageModel
+
+        # The 7b/72b checkpoints omit tie_word_embeddings and ship a real lm_head,
+        # so the default must not tie or their output projection is dropped.
+        self.assertFalse(llava_onevision.TextConfig().tie_word_embeddings)
+
+        def sanitized(tie):
+            config = llava_onevision.TextConfig(
+                hidden_size=16,
+                num_hidden_layers=1,
+                intermediate_size=32,
+                num_attention_heads=2,
+                num_key_value_heads=2,
+                vocab_size=32,
+                tie_word_embeddings=tie,
+            )
+            return LanguageModel(config).sanitize(
+                {"language_model.lm_head.weight": mx.zeros((32, 16))}
+            )
+
+        self.assertIn("language_model.lm_head.weight", sanitized(tie=False))
+        self.assertNotIn("language_model.lm_head.weight", sanitized(tie=True))
+
+    def test_llava_onevision_sanitize_accepts_both_layouts(self):
+        from mlx_vlm.models import llava_onevision
+
+        published = {
+            "language_model.model.embed_tokens.weight": 0,
+            "language_model.lm_head.weight": 1,
+            "vision_tower.vision_model.post_layernorm.weight": 2,
+            "multi_modal_projector.linear_1.weight": 3,
+            "image_newline": 4,
+        }
+        nested = {
+            "model.language_model.embed_tokens.weight": 0,
+            "lm_head.weight": 1,
+            "model.vision_tower.post_layernorm.weight": 2,
+            "model.multi_modal_projector.linear_1.weight": 3,
+            "model.image_newline": 4,
+        }
+
+        self.assertEqual(
+            llava_onevision.Model.sanitize(published),
+            llava_onevision.Model.sanitize(nested),
+        )
+        self.assertEqual(set(llava_onevision.Model.sanitize(nested)), set(published))
+
+        # Sanitizing twice must not rewrite already-normalized keys.
+        once = llava_onevision.Model.sanitize(nested)
+        self.assertEqual(llava_onevision.Model.sanitize(dict(once)), once)
 
     def test_llava(self):
         from mlx_vlm.models import llava
@@ -10287,6 +10540,41 @@ class TestGetInputEmbeddings(unittest.TestCase):
             )
         )
         self._check_returns_input_embeddings_features(model, "llava_next")
+
+    def test_llava_onevision_input_embeddings(self):
+        from mlx_vlm.models import llava_onevision
+
+        model = llava_onevision.Model(
+            llava_onevision.ModelConfig(
+                text_config=llava_onevision.TextConfig(
+                    model_type="qwen2",
+                    hidden_size=16,
+                    num_hidden_layers=1,
+                    intermediate_size=32,
+                    num_attention_heads=2,
+                    num_key_value_heads=2,
+                    vocab_size=32,
+                    rms_norm_eps=1e-6,
+                    tie_word_embeddings=False,
+                ),
+                vision_config=llava_onevision.VisionConfig(
+                    model_type="siglip_vision_model",
+                    num_hidden_layers=1,
+                    hidden_size=16,
+                    intermediate_size=32,
+                    num_attention_heads=2,
+                    image_size=28,
+                    patch_size=14,
+                    num_channels=3,
+                    vision_use_head=False,
+                ),
+                model_type="llava_onevision",
+                image_token_index=31,
+                video_token_index=30,
+                vocab_size=32,
+            )
+        )
+        self._check_returns_input_embeddings_features(model, "llava_onevision")
 
     def test_qwen2_vl_input_embeddings(self):
         from mlx_vlm.models import qwen2_vl

--- a/mlx_vlm/tests/test_processors.py
+++ b/mlx_vlm/tests/test_processors.py
@@ -643,6 +643,126 @@ class TestLlavaNextProcessor(_ProcessorTestBase, unittest.TestCase):
         return {"text": ["<image> Describe"], "images": [_make_image()]}
 
 
+class TestLlavaOnevisionProcessor(_ProcessorTestBase, unittest.TestCase):
+    GRID = [[384, 384], [384, 768], [768, 384], [768, 768], [1536, 1536]]
+
+    def _make_processor(self, tiles=5, image_sizes=((768, 768),)):
+        from mlx_vlm.models.llava_onevision.processing_llava_onevision import (
+            LlavaOnevisionProcessor,
+        )
+
+        image_processor = type(
+            "IP",
+            (),
+            {
+                "model_input_names": ["pixel_values"],
+                "image_grid_pinpoints": self.GRID,
+                "size": {"height": 384, "width": 384},
+                "__call__": lambda self, images=None, **kw: {
+                    "pixel_values": np.random.randn(
+                        len(image_sizes), tiles, 3, 384, 384
+                    ).astype(np.float32),
+                    "image_sizes": [list(size) for size in image_sizes],
+                },
+            },
+        )()
+
+        return LlavaOnevisionProcessor(
+            image_processor=image_processor,
+            tokenizer=_mock_tokenizer(),
+            num_image_tokens=729,
+            vision_aspect_ratio="anyres_max_9",
+            vision_feature_select_strategy="full",
+        )
+
+    def _image_call_args(self):
+        return {"text": ["<image> Describe"], "images": [_make_image()]}
+
+    def test_expands_image_token_to_feature_count(self):
+        processor = self._make_processor()
+        expanded = processor._expand_placeholders(
+            "<image> Describe", iter([[768, 768]]), iter(()), (384, 384)
+        )
+
+        # 2x2 tile grid at 27 patches a side: 729 base + 54 * (54 + 1) newline column.
+        self.assertEqual(expanded.count("<image>"), 729 + 54 * 55)
+
+    def test_expands_video_token_per_frame_plus_newline(self):
+        processor = self._make_processor()
+        frames = 4
+        expanded = processor._expand_placeholders(
+            "<video> Describe",
+            iter(()),
+            iter([np.zeros((frames, 3, 384, 384), dtype=np.float32)]),
+            (384, 384),
+        )
+
+        # 27 patches a side pool to 14, and one newline closes the whole video.
+        self.assertEqual(expanded.count("<video>"), frames * 14 * 14 + 1)
+
+    def test_expands_image_and_video_tokens_in_one_prompt(self):
+        processor = self._make_processor()
+        expanded = processor._expand_placeholders(
+            "<image> and <video>",
+            iter([[384, 384]]),
+            iter([np.zeros((2, 3, 384, 384), dtype=np.float32)]),
+            (384, 384),
+        )
+
+        # A 384x384 image still yields base + one tile: 729 + 27 * (27 + 1).
+        self.assertEqual(expanded.count("<image>"), 729 + 27 * 28)
+        self.assertEqual(expanded.count("<video>"), 2 * 14 * 14 + 1)
+
+    def test_batched_prompts_consume_images_in_order(self):
+        processor = self._make_processor()
+        image_sizes = iter([[768, 768], [384, 384]])
+
+        first = processor._expand_placeholders(
+            "<image> first", image_sizes, iter(()), (384, 384)
+        )
+        second = processor._expand_placeholders(
+            "<image> second", image_sizes, iter(()), (384, 384)
+        )
+
+        # The iterator is shared across the batch, so each prompt gets its own image.
+        self.assertEqual(first.count("<image>"), 729 + 54 * 55)
+        self.assertEqual(second.count("<image>"), 729 + 27 * 28)
+
+    def test_rejects_more_placeholders_than_images(self):
+        processor = self._make_processor()
+        with self.assertRaises(ValueError):
+            processor._expand_placeholders(
+                "<image> <image>", iter([[384, 384]]), iter(()), (384, 384)
+            )
+
+    def test_declares_native_video_support(self):
+        from mlx_vlm.generate.video import processor_handles_video
+
+        self.assertTrue(processor_handles_video(self._make_processor()))
+
+    def test_video_preprocessing_normalizes_frames(self):
+        processor = self._make_processor()
+        frames = np.full((2, 40, 60, 3), 255, dtype=np.uint8)
+
+        pixel_values_videos = processor.video_processor([frames])
+
+        self.assertEqual(pixel_values_videos.shape, (1, 2, 3, 384, 384))
+        # 255 rescales to 1.0 and normalizes to (1 - 0.5) / 0.5 == 1.0
+        self.assertTrue(np.allclose(pixel_values_videos, 1.0, atol=1e-5))
+
+    def test_video_preprocessing_accepts_channels_first_frames(self):
+        processor = self._make_processor()
+        # load_video returns (frames, channels, height, width)
+        frames = np.zeros((2, 3, 40, 60), dtype=np.uint8)
+        frames[:, 0] = 255
+
+        pixel_values_videos = processor.video_processor([frames])
+
+        self.assertEqual(pixel_values_videos.shape, (1, 2, 3, 384, 384))
+        self.assertTrue(np.allclose(pixel_values_videos[:, :, 0], 1.0, atol=1e-5))
+        self.assertTrue(np.allclose(pixel_values_videos[:, :, 1], -1.0, atol=1e-5))
+
+
 class TestPaliGemmaProcessor(_ProcessorTestBase, unittest.TestCase):
     def _make_processor(self):
         from mlx_vlm.models.paligemma.processing_paligemma import PaliGemmaProcessor


### PR DESCRIPTION
Brings support for the LLaVA-OneVision model class (SigLIP vision tower + Qwen2 language model), covering single images, multiple images, and video in one checkpoint — requested in https://github.com/Blaizzy/mlx-vlm/issues/39#issuecomment-5478540596.

Tested against HF transformers on `llava-onevision-qwen2-0.5b-ov-hf`, `0.5b-si-hf`, `7b-ov-hf` and `7b-si-hf`: identical `input_ids` and identical greedy output on 5 images spanning 2.7k–7.3k prompt tokens, with next-token logits matching to ~3e-6 relative; text-only, multi-image, video, multi-turn, batched, 4-bit, CLI and OpenAI server paths all exercised.

`0.5b-ov`, fp16, M5 Max, median of 3:

| prompt tokens | prefill tok/s | decode tok/s |
|--:|--:|--:|
| 513 | 32,055 | 392 |
| 1,024 | 39,747 | 360 |
| 2,048 | 45,853 | 338 |
| 4,096 | 47,018 | 355 |
| 8,193 | 43,614 | 311 |