### PR TITLE
Add compact proposal-only heads for Qwen MTP

### DIFF
--- a/mlx_vlm/server/app.py
+++ b/mlx_vlm/server/app.py
@@ -893,6 +893,7 @@ def get_cached_model(
         apc_manager=runtime.apc_manager,
         draft_model_path=cfg.spec_draft_model,
         draft_kind=cfg.spec_draft_kind,
+        draft_compact_head_path=cfg.spec_draft_compact_head,
     )
     try:
         model, processor, config = response_generator.wait_until_ready()

--- a/mlx_vlm/server/cli.py
+++ b/mlx_vlm/server/cli.py
@@ -18,7 +18,8 @@ from .generation import (
     get_server_thinking_end_token,
     get_server_thinking_start_token,
 )
-from .runtime import MODEL_DISCOVERY_ENV, MODEL_DISCOVERY_MODES
+from .runtime import MODEL_DISCOVERY_ENV, MODEL_DISCOVERY_MODES, runtime
+from .runtime_config import RuntimeConfig
 
 DEFAULT_SERVER_HOST = "0.0.0.0"
 DEFAULT_SERVER_PORT = 8080
@@ -237,6 +238,12 @@ def main():
         ),
     )
     parser.add_argument(
+        "--draft-compact-head",
+        type=str,
+        default=None,
+        help="Optional local compact proposal-only head for an MTP drafter.",
+    )
+    parser.add_argument(
         "--draft-kind",
         type=str,
         default=None,
@@ -314,6 +321,8 @@ def main():
     os.environ["MLX_VLM_VISION_CACHE_SIZE"] = str(args.vision_cache_size)
     if args.draft_model:
         os.environ["MLX_VLM_DRAFT_MODEL"] = args.draft_model
+    if args.draft_compact_head:
+        os.environ["MLX_VLM_DRAFT_COMPACT_HEAD"] = args.draft_compact_head
     if args.draft_kind is not None:
         os.environ["MLX_VLM_DRAFT_KIND"] = args.draft_kind
     if args.draft_block_size is not None:
@@ -352,6 +361,11 @@ def main():
         os.environ["TOP_LOGPROBS_K"] = str(args.top_logprobs_k)
     if args.api_key:
         os.environ["MLX_VLM_SERVER_API_KEY"] = args.api_key
+
+    # ``runtime`` is imported before CLI arguments are parsed. Re-read all
+    # boot-time environment defaults so cache identity and settings reset
+    # semantics match the command line that will start the server.
+    runtime.config = RuntimeConfig.from_env()
 
     log_level = getattr(logging, args.log_level.upper(), logging.INFO)
     logging.basicConfig(

--- a/mlx_vlm/server/generation.py
+++ b/mlx_vlm/server/generation.py
@@ -51,6 +51,7 @@ logger = logging.getLogger("mlx_vlm.server")
 DEFAULT_SPECULATIVE_BATCH_COALESCE_MS = 5.0
 DEFAULT_LOG_PROGRESS_INTERVAL = 10
 DEFAULT_ENABLE_THINKING = False
+_UNSET = object()
 METRICS_HISTORY_LIMIT = 100
 METRICS_RECENT_LIMIT = 32
 
@@ -1001,6 +1002,7 @@ class ResponseGenerator:
         apc_manager: Optional["_apc.APCManager"] = None,
         draft_model_path: Optional[str] = None,
         draft_kind: Optional[str] = None,
+        draft_compact_head_path=_UNSET,
         prefill_step_size: Optional[int] = None,
     ):
         self.model_path = model_path
@@ -1012,6 +1014,11 @@ class ResponseGenerator:
         self.vision_cache = vision_cache
         self.draft_model_path = draft_model_path
         self.draft_kind_override = draft_kind
+        self.draft_compact_head_path = (
+            os.environ.get("MLX_VLM_DRAFT_COMPACT_HEAD")
+            if draft_compact_head_path is _UNSET
+            else draft_compact_head_path
+        )
         self.draft_model = None
         self.kv_bits = kv_bits
         self.kv_key_bits = kv_key_bits
@@ -1092,6 +1099,9 @@ class ResponseGenerator:
         draft_model_path = self.draft_model_path or os.environ.get(
             "MLX_VLM_DRAFT_MODEL"
         )
+        compact_head_path = self.draft_compact_head_path
+        if compact_head_path and not draft_model_path:
+            raise ValueError("a compact proposal head requires a draft model")
         if draft_model_path:
             from ..speculative.drafters import (
                 load_drafter,
@@ -1116,6 +1126,11 @@ class ResponseGenerator:
             try:
                 validate_drafter_compatibility(model, draft_model, draft_kind)
             except ValueError as e:
+                if compact_head_path:
+                    raise ValueError(
+                        "compact proposal head cannot be used with an incompatible "
+                        "drafter"
+                    ) from e
                 logger.warning(
                     "Speculative drafter is incompatible with the target model; "
                     "falling back to autoregressive generation: %s",
@@ -1124,6 +1139,36 @@ class ResponseGenerator:
                 draft_model = None
                 draft_kind = None
             else:
+                if compact_head_path:
+                    if draft_kind != "mtp":
+                        raise ValueError(
+                            "a compact proposal head requires an MTP drafter"
+                        )
+                    from ..speculative.drafters.qwen3_5_mtp import (
+                        load_compact_proposal_head,
+                    )
+
+                    binder = getattr(draft_model, "set_compact_proposal_head", None)
+                    if not callable(binder):
+                        raise ValueError(
+                            "selected MTP drafter does not support a compact "
+                            "proposal head"
+                        )
+                    target_tokenizer = getattr(processor, "tokenizer", processor)
+                    target_text_config = getattr(config, "text_config", None)
+                    if target_text_config is None:
+                        language_model = getattr(model, "language_model", model)
+                        target_text_config = getattr(language_model, "args", config)
+                    compact_head = load_compact_proposal_head(
+                        compact_head_path,
+                        target_config=target_text_config,
+                        tokenizer=target_tokenizer,
+                    )
+                    binder(compact_head)
+                    logger.info(
+                        "Compact proposal head enabled: %s",
+                        compact_head_path,
+                    )
                 logger.info("Drafter ready; speculative decoding enabled.")
 
         self.model = model
@@ -1424,8 +1469,7 @@ class ResponseGenerator:
             )
         elif crossed_interval and not debug_enabled:
             logger.info(
-                "Decode progress: request=%s generated_tokens=%d elapsed=%.3fs "
-                "rate=%s",
+                "Decode progress: request=%s generated_tokens=%d elapsed=%.3fs rate=%s",
                 request_id,
                 generated_tokens,
                 elapsed,

--- a/mlx_vlm/server/runtime_config.py
+++ b/mlx_vlm/server/runtime_config.py
@@ -124,6 +124,14 @@ KNOBS: Tuple[
         "Speculative draft kind (auto if unset).",
     ),
     (
+        "spec_draft_compact_head",
+        "str_or_none",
+        None,
+        TEXT_KINDS,
+        None,
+        "Compact proposal-head path for a Qwen MTP drafter.",
+    ),
+    (
         "vision_cache_size",
         "int",
         20,
@@ -197,6 +205,7 @@ class RuntimeConfig:
     token_queue_timeout: Optional[float] = DEFAULT_TOKEN_QUEUE_TIMEOUT
     spec_draft_model: Optional[str] = None
     spec_draft_kind: Optional[str] = None
+    spec_draft_compact_head: Optional[str] = None
     vision_cache_size: int = 20
 
     _lock: threading.Lock = field(
@@ -227,6 +236,9 @@ class RuntimeConfig:
             token_queue_timeout=_env_token_queue_timeout(),
             spec_draft_model=os.environ.get("MLX_VLM_DRAFT_MODEL") or None,
             spec_draft_kind=os.environ.get("MLX_VLM_DRAFT_KIND") or None,
+            spec_draft_compact_head=(
+                os.environ.get("MLX_VLM_DRAFT_COMPACT_HEAD") or None
+            ),
             vision_cache_size=int(os.environ.get("MLX_VLM_VISION_CACHE_SIZE", "20")),
         )
         cfg._env_defaults = {name: getattr(cfg, name) for name in _KNOB_SPEC}

--- a/mlx_vlm/speculative/drafters/qwen3_5_mtp/README.md
+++ b/mlx_vlm/speculative/drafters/qwen3_5_mtp/README.md
@@ -41,6 +41,91 @@ split_qwen3_5_mtp(
 )
 ```
 
+## Optional compact proposal head
+
+A Qwen MTP checkpoint does not contain an LM head. By default, the drafter uses
+the target model's full LM head each time it proposes a token. For greedy
+decoding, an optional compact head can reduce that work by projecting only a
+selected subset of vocabulary rows.
+
+The compact head only proposes tokens. The unchanged full target model still
+verifies every proposal and decides which tokens are emitted. Sampled decoding
+does not use the compact head.
+
+### Build one
+
+The builder copies packed affine rows directly from an existing quantized Qwen
+LM head. It does not train, dequantize, or requantize them.
+
+This command reproduces the selection used for the Qwen3.8 27B measurements
+below. Pin the source revision so the result can be audited:
+
+```bash
+uv run python -m mlx_vlm.speculative.drafters.qwen3_5_mtp.build_compact_head \
+  --model orcarouter/Qwen3.8-27B-Uncensored-MLX \
+  --revision b4603df5fd2a51e7fed2560ee7090caa4e13e4b7 \
+  --subdir 4-bit \
+  --vocab-prefix 98303 \
+  --output ./Qwen3.8-27B-compact-head
+```
+
+With `--vocab-prefix`, tokenizer-added IDs are included by default and the row
+count is padded with unused real IDs to a multiple of 32. This produced 98,336
+rows for the checkpoint above. The selection is a model-specific performance
+choice, not a recommended default for every language or workload. To use a
+fully explicit selection instead, pass `--vocab-ids path/to/ids.json`, where
+the file is a JSON array of real token IDs.
+
+The output contains:
+
+- `compact_head.safetensors`: packed `weight`, `scales`, affine `biases`, and
+  the `vocab_ids` mapping;
+- `config.json`: shape, quantization, target-model, tokenizer, source, and
+  selection identity;
+- `manifest.json`: hashes of the two required runtime files.
+
+No model tensors are included in mlx-vlm. The person creating or distributing
+a sidecar is responsible for the source model's license terms.
+
+### Use it
+
+```bash
+uv run mlx_vlm.server \
+  --model /path/to/Qwen3.8-27B-8bit \
+  --draft-model /path/to/Qwen3.8-27B-mtp \
+  --draft-kind mtp \
+  --draft-compact-head ./Qwen3.8-27B-compact-head \
+  --draft-block-size 4
+```
+
+For sidecars created by this builder, loading checks the model family, hidden
+width, vocabulary size, tokenizer vocabulary, tensor shapes, and token-ID
+mapping before attaching the compact head. Older sidecars without the `target`
+metadata remain loadable, but only their shape and token range can be checked.
+Rebuild them with this tool to enable the full checks.
+
+### Performance measured on Qwen3.8 27B
+
+A four-prompt, 1,024-token greedy screen on an M5 Max measured:
+
+| Proposal projection | Pooled throughput | Change |
+| --- | ---: | ---: |
+| Full 8-bit head, 248,320 rows | 27.14 tok/s | baseline |
+| Compact 8-bit head, 98,336 rows | 28.12 tok/s | +3.58% |
+| Compact 4-bit head, 98,336 rows | 29.27 tok/s | +7.82% |
+
+The compact 4-bit path was faster on all four prompts, added about 0.26 GiB of
+peak MLX memory, and emitted the same 1,024 token IDs as the serial reference.
+This was a directional screen on predecessor code, with one observation per
+prompt and a production model resident. It is not a controlled result for this
+PR head. A current-head compact-off/compact-on result should be reported before
+using these percentages as the final performance claim.
+
+The proposal-only compact-vocabulary approach and the 98,336-row physical shape
+were informed by [MLX.fast challenge PR 59](https://github.com/Layr-Labs/qwen-3.8-mtp-challenge/pull/59).
+The builder above uses the selected source checkpoint's own rows and tokenizer
+mapping. It does not use challenge model tensors or its exact token mapping.
+
 ## Generate
 
 ```bash

--- a/mlx_vlm/speculative/drafters/qwen3_5_mtp/__init__.py
+++ b/mlx_vlm/speculative/drafters/qwen3_5_mtp/__init__.py
@@ -1,3 +1,4 @@
+from .compact_head import CompactProposalHead, load_compact_proposal_head
 from .config import Qwen3_5MTPConfig as ModelConfig
 from .config import TextConfig
 from .qwen3_5_mtp import Qwen3_5MTPDraftModel
@@ -7,5 +8,7 @@ __all__ = [
     "Model",
     "ModelConfig",
     "TextConfig",
+    "CompactProposalHead",
+    "load_compact_proposal_head",
     "Qwen3_5MTPDraftModel",
 ]

--- a/mlx_vlm/speculative/drafters/qwen3_5_mtp/build_compact_head.py
+++ b/mlx_vlm/speculative/drafters/qwen3_5_mtp/build_compact_head.py
@@ -1,0 +1,431 @@
+"""Build a proposal-only compact head from a quantized Qwen LM head."""
+
+import argparse
+import hashlib
+import json
+import shutil
+import tempfile
+from pathlib import Path
+from typing import Dict, List, Optional, Sequence, Tuple
+
+import mlx.core as mx
+from safetensors import safe_open
+
+from ....utils import get_model_path
+from .compact_head import (
+    COMPACT_HEAD_MODEL_TYPE,
+    COMPACT_HEAD_SCHEMA_VERSION,
+    CompactProposalHead,
+    tokenizer_vocab_sha256,
+    vocab_ids_sha256,
+)
+
+_TENSOR_NAMES = ("weight", "scales", "biases")
+
+
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _write_json(path: Path, value) -> None:
+    path.write_text(
+        json.dumps(value, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _checkpoint_files(model_path: Path) -> List[Path]:
+    return sorted(
+        path.resolve()
+        for path in model_path.glob("*.safetensors")
+        if path.name != "consolidated.safetensors"
+    )
+
+
+def _tensor_file_map(model_path: Path) -> Dict[str, Path]:
+    index_path = model_path / "model.safetensors.index.json"
+    if index_path.is_file():
+        index = json.loads(index_path.read_text(encoding="utf-8"))
+        weight_map = index.get("weight_map")
+        if not isinstance(weight_map, dict):
+            raise ValueError("model.safetensors.index.json has no weight_map")
+        root = model_path.resolve()
+        result = {}
+        for key, value in weight_map.items():
+            if not isinstance(value, str) or Path(value).is_absolute():
+                raise ValueError("checkpoint index contains an invalid shard path")
+            path = (root / value).resolve()
+            if not path.is_relative_to(root):
+                raise ValueError("checkpoint index shard escapes the model directory")
+            if not path.is_file():
+                raise FileNotFoundError(f"checkpoint shard does not exist: {path}")
+            result[key] = path
+        return result
+
+    result: Dict[str, Path] = {}
+    for path in _checkpoint_files(model_path):
+        with safe_open(path, framework="mlx") as handle:
+            for key in handle.keys():
+                if key in result:
+                    raise ValueError(f"checkpoint tensor appears more than once: {key}")
+                result[key] = path
+    return result
+
+
+def _find_affine_lm_head(tensor_files: Dict[str, Path]) -> Dict[str, Tuple[str, Path]]:
+    candidates = []
+    for key in tensor_files:
+        if key != "lm_head.weight" and not key.endswith(".lm_head.weight"):
+            continue
+        prefix = key[: -len("weight")]
+        keys = {name: prefix + name for name in _TENSOR_NAMES}
+        if all(name in tensor_files for name in keys.values()):
+            candidates.append(keys)
+    if len(candidates) != 1:
+        raise ValueError(
+            "expected exactly one affine LM head with weight, scales, and biases"
+        )
+    keys = candidates[0]
+    return {name: (key, tensor_files[key]) for name, key in keys.items()}
+
+
+def _load_head_tensors(
+    head_tensors: Dict[str, Tuple[str, Path]],
+) -> Dict[str, mx.array]:
+    by_file: Dict[Path, List[Tuple[str, str]]] = {}
+    for name, (key, path) in head_tensors.items():
+        by_file.setdefault(path, []).append((name, key))
+
+    loaded: Dict[str, mx.array] = {}
+    for path, items in by_file.items():
+        try:
+            with safe_open(path, framework="mlx") as handle:
+                loaded.update(
+                    {name: mx.array(handle.get_tensor(key)) for name, key in items}
+                )
+        except (AttributeError, RuntimeError, TypeError):
+            shard = mx.load(str(path))
+            loaded.update({name: shard[key] for name, key in items})
+    return loaded
+
+
+def _validate_vocab_ids(vocab_ids: Sequence[int], vocab_size: int) -> List[int]:
+    values = list(vocab_ids)
+    if not values:
+        raise ValueError("compact vocabulary must not be empty")
+    if any(isinstance(value, bool) or not isinstance(value, int) for value in values):
+        raise ValueError("compact vocabulary IDs must be integers")
+    if len(values) != len(set(values)):
+        raise ValueError("compact vocabulary IDs must be unique")
+    values.sort()
+    if values[0] < 0 or values[-1] >= vocab_size:
+        raise ValueError("compact vocabulary ID exceeds target vocabulary")
+    return values
+
+
+def select_vocab_ids(
+    *,
+    prefix_size: int,
+    added_token_ids: Sequence[int],
+    vocab_size: int,
+    row_multiple: int = 32,
+) -> List[int]:
+    """Select a low-ID prefix plus added tokens and shape-alignment rows."""
+    if prefix_size <= 0 or prefix_size >= vocab_size:
+        raise ValueError("vocabulary prefix must be between zero and vocab size")
+    if row_multiple <= 0:
+        raise ValueError("row multiple must be positive")
+    selected = list(range(prefix_size))
+    selected.extend(
+        sorted({token_id for token_id in added_token_ids if token_id >= prefix_size})
+    )
+    selected_set = set(selected)
+    next_id = prefix_size
+    while len(selected) % row_multiple:
+        while next_id in selected_set:
+            next_id += 1
+        if next_id >= vocab_size:
+            raise ValueError("cannot align compact rows within target vocabulary")
+        selected.append(next_id)
+        selected_set.add(next_id)
+    return _validate_vocab_ids(selected, vocab_size)
+
+
+def _resolved_revision(model_path: Path) -> Optional[str]:
+    parts = model_path.parts
+    if "snapshots" not in parts:
+        return None
+    index = parts.index("snapshots")
+    if index + 1 >= len(parts):
+        return None
+    return parts[index + 1]
+
+
+def _load_tokenizer(model_path: Path):
+    from transformers import AutoTokenizer
+
+    return AutoTokenizer.from_pretrained(
+        model_path,
+        local_files_only=True,
+        trust_remote_code=False,
+    )
+
+
+def _resolve_model_path(
+    source: str,
+    *,
+    revision: Optional[str],
+    subdir: Optional[str],
+    force_download: bool,
+) -> Tuple[Path, Path]:
+    allow_patterns = None
+    if subdir:
+        allow_patterns = [
+            f"{subdir}/*.json",
+            f"{subdir}/*.safetensors",
+            f"{subdir}/*.model",
+            f"{subdir}/*.tiktoken",
+        ]
+    source_root = get_model_path(
+        source,
+        revision=revision,
+        force_download=force_download,
+        allow_patterns=allow_patterns,
+    )
+    return source_root, source_root / subdir if subdir else source_root
+
+
+def build_compact_proposal_head(
+    source: str | Path,
+    output: str | Path,
+    *,
+    vocab_ids: Sequence[int],
+    revision: Optional[str] = None,
+    subdir: Optional[str] = None,
+    force_download: bool = False,
+    tokenizer=None,
+) -> Path:
+    """Copy selected packed affine rows into a compact proposal-head sidecar."""
+    source_string = str(source)
+    source_is_local = Path(source_string).exists()
+    source_root, model_path = _resolve_model_path(
+        source_string,
+        revision=revision,
+        subdir=subdir,
+        force_download=force_download,
+    )
+    config_path = model_path / "config.json"
+    if not config_path.is_file():
+        raise FileNotFoundError(f"source model has no config.json: {model_path}")
+
+    output_path = Path(output).expanduser().resolve()
+    if output_path.exists():
+        raise FileExistsError(f"output already exists: {output_path}")
+
+    config = json.loads(config_path.read_text(encoding="utf-8"))
+    text_config = config.get("text_config") or config
+    model_type = text_config.get("model_type") or config.get("model_type")
+    if not model_type or not str(model_type).startswith(("qwen3_5", "qwen3_next")):
+        raise ValueError("compact proposal builder supports Qwen3.5-family models")
+    hidden_size = int(text_config["hidden_size"])
+    vocab_size = int(text_config["vocab_size"])
+    selected = _validate_vocab_ids(vocab_ids, vocab_size)
+
+    tensor_files = _tensor_file_map(model_path)
+    head_tensors = _find_affine_lm_head(tensor_files)
+    source_tensors = _load_head_tensors(head_tensors)
+    weight = source_tensors["weight"]
+    scales = source_tensors["scales"]
+    biases = source_tensors["biases"]
+    if weight.ndim != 2 or scales.ndim != 2 or biases.ndim != 2:
+        raise ValueError("source affine LM-head tensors must be rank 2")
+    if weight.dtype != mx.uint32:
+        raise ValueError("source affine LM-head weight must use packed uint32 values")
+    if scales.shape != biases.shape or int(scales.shape[0]) != int(weight.shape[0]):
+        raise ValueError("source affine LM-head tensor shapes do not match")
+    if int(weight.shape[0]) < vocab_size:
+        raise ValueError("source LM head has fewer rows than the configured vocabulary")
+
+    packed_bits = int(weight.shape[1]) * 32
+    if packed_bits % hidden_size:
+        raise ValueError("cannot infer source LM-head bit width")
+    bits = packed_bits // hidden_size
+    if bits not in (2, 3, 4, 5, 6, 8):
+        raise ValueError(f"unsupported source LM-head bit width: {bits}")
+    if int(scales.shape[1]) <= 0 or hidden_size % int(scales.shape[1]):
+        raise ValueError("cannot infer source LM-head group size")
+    group_size = hidden_size // int(scales.shape[1])
+    quantization = config.get("quantization") or text_config.get("quantization") or {}
+    if quantization.get("mode", "affine") != "affine":
+        raise ValueError("source LM head must use affine quantization")
+    if "bits" in quantization and int(quantization["bits"]) != bits:
+        raise ValueError("source LM-head bit width differs from config")
+    if "group_size" in quantization and int(quantization["group_size"]) != group_size:
+        raise ValueError("source LM-head group size differs from config")
+
+    selected_array = mx.array(selected, dtype=mx.int32)
+    compact = {
+        "weight": mx.take(weight, selected_array, axis=0),
+        "scales": mx.take(scales, selected_array, axis=0),
+        "biases": mx.take(biases, selected_array, axis=0),
+        "vocab_ids": selected_array,
+    }
+    mx.eval(*compact.values())
+
+    if tokenizer is None:
+        tokenizer = _load_tokenizer(model_path)
+    tokenizer_hash = tokenizer_vocab_sha256(tokenizer)
+    CompactProposalHead(
+        **compact,
+        group_size=group_size,
+        bits=bits,
+        mode="affine",
+        full_vocab_size=vocab_size,
+        target_model_type=str(model_type),
+        target_tokenizer_sha256=tokenizer_hash,
+    )
+
+    source_paths = sorted({path for _, path in head_tensors.values()})
+    source_kind = "local" if source_is_local else "huggingface"
+    sidecar_config = {
+        "bits": bits,
+        "group_size": group_size,
+        "hidden_size": hidden_size,
+        "mode": "affine",
+        "model_type": COMPACT_HEAD_MODEL_TYPE,
+        "purpose": "proposal-only greedy MTP projection; never target verification",
+        "rows": len(selected),
+        "schema_version": COMPACT_HEAD_SCHEMA_VERSION,
+        "selection": {
+            "mapping_sha256": vocab_ids_sha256(selected),
+            "maximum_token_id": selected[-1],
+            "minimum_token_id": selected[0],
+            "ordering": "ascending_token_id",
+        },
+        "source": {
+            "config_sha256": _sha256_file(config_path),
+            "kind": source_kind,
+            "model": None if source_is_local else source_string,
+            "requested_revision": revision,
+            "resolved_revision": _resolved_revision(source_root),
+            "subdir": subdir,
+            "tensor_files": [
+                {
+                    "path": path.relative_to(model_path.resolve()).as_posix(),
+                    "sha256": _sha256_file(path),
+                }
+                for path in source_paths
+            ],
+            "tensor_keys": {name: key for name, (key, _) in head_tensors.items()},
+        },
+        "target": {
+            "model_type": str(model_type),
+            "tokenizer_vocab_sha256": tokenizer_hash,
+            "vocab_size": vocab_size,
+        },
+    }
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = Path(
+        tempfile.mkdtemp(prefix=f".{output_path.name}.", dir=output_path.parent)
+    )
+    try:
+        weights_path = temporary / "compact_head.safetensors"
+        mx.save_safetensors(
+            str(weights_path),
+            compact,
+            metadata={
+                "format": "mlx",
+                "purpose": "proposal-only",
+            },
+        )
+        _write_json(temporary / "config.json", sidecar_config)
+        _write_json(
+            temporary / "manifest.json",
+            [
+                {
+                    "bytes": (temporary / name).stat().st_size,
+                    "path": name,
+                    "sha256": _sha256_file(temporary / name),
+                }
+                for name in ("compact_head.safetensors", "config.json")
+            ],
+        )
+        temporary.rename(output_path)
+    except Exception:
+        shutil.rmtree(temporary, ignore_errors=True)
+        raise
+    return output_path
+
+
+def _read_vocab_ids(path: Path) -> List[int]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, list):
+        raise ValueError("--vocab-ids must contain a JSON array")
+    return payload
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--model", "--source", dest="source", required=True)
+    parser.add_argument("--output", required=True)
+    parser.add_argument("--revision")
+    parser.add_argument("--subdir")
+    parser.add_argument("--force-download", action="store_true")
+    selection = parser.add_mutually_exclusive_group(required=True)
+    selection.add_argument("--vocab-ids", type=Path)
+    selection.add_argument("--vocab-prefix", type=int)
+    parser.add_argument("--row-multiple", type=int, default=32)
+    parser.add_argument(
+        "--include-added-tokens",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Include tokenizer-added IDs with --vocab-prefix (default: true).",
+    )
+    return parser
+
+
+def main() -> None:
+    args = build_parser().parse_args()
+    _, model_path = _resolve_model_path(
+        args.source,
+        revision=args.revision,
+        subdir=args.subdir,
+        force_download=args.force_download,
+    )
+    tokenizer = _load_tokenizer(model_path)
+    config = json.loads((model_path / "config.json").read_text(encoding="utf-8"))
+    text_config = config.get("text_config") or config
+    vocab_size = int(text_config["vocab_size"])
+    if args.vocab_ids is not None:
+        vocab_ids = _read_vocab_ids(args.vocab_ids)
+    else:
+        added_ids = (
+            list(tokenizer.get_added_vocab().values())
+            if args.include_added_tokens
+            else []
+        )
+        vocab_ids = select_vocab_ids(
+            prefix_size=args.vocab_prefix,
+            added_token_ids=added_ids,
+            vocab_size=vocab_size,
+            row_multiple=args.row_multiple,
+        )
+    output = build_compact_proposal_head(
+        args.source,
+        args.output,
+        vocab_ids=vocab_ids,
+        revision=args.revision,
+        subdir=args.subdir,
+        force_download=False,
+        tokenizer=tokenizer,
+    )
+    print(f"Wrote compact Qwen proposal head to {output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/mlx_vlm/speculative/drafters/qwen3_5_mtp/compact_head.py
+++ b/mlx_vlm/speculative/drafters/qwen3_5_mtp/compact_head.py
@@ -1,0 +1,276 @@
+import hashlib
+import json
+import logging
+import struct
+from pathlib import Path
+from typing import Any, Mapping, Optional
+
+import mlx.core as mx
+
+COMPACT_HEAD_MODEL_TYPE = "qwen3_5_compact_proposal_head"
+COMPACT_HEAD_SCHEMA_VERSION = 1
+_SUPPORTED_BITS = (2, 3, 4, 5, 6, 8)
+logger = logging.getLogger(__name__)
+
+
+def vocab_ids_sha256(vocab_ids) -> str:
+    """Hash real token IDs using an explicit little-endian int32 encoding."""
+    digest = hashlib.sha256()
+    for value in vocab_ids:
+        digest.update(struct.pack("<I", int(value)))
+    return digest.hexdigest()
+
+
+def tokenizer_vocab_sha256(tokenizer) -> str:
+    """Return a stable digest of a tokenizer's token-to-ID mapping."""
+    tokenizer = getattr(tokenizer, "tokenizer", tokenizer)
+    get_vocab = getattr(tokenizer, "get_vocab", None)
+    if not callable(get_vocab):
+        raise ValueError("target tokenizer does not provide get_vocab()")
+    vocab = get_vocab()
+    if not isinstance(vocab, Mapping):
+        raise ValueError("target tokenizer vocabulary must be a mapping")
+    items = sorted((str(token), int(token_id)) for token, token_id in vocab.items())
+    payload = json.dumps(items, ensure_ascii=False, separators=(",", ":")).encode(
+        "utf-8"
+    )
+    return hashlib.sha256(payload).hexdigest()
+
+
+def _config_value(config: Any, name: str):
+    if isinstance(config, Mapping):
+        return config.get(name)
+    return getattr(config, name, None)
+
+
+class CompactProposalHead:
+    """Proposal-only quantized LM-head rows with real-vocabulary remapping.
+
+    This intentionally is not an ``nn.Module``. The drafter owns it as opaque
+    runtime state, so loading MTP checkpoint weights cannot traverse or mutate
+    the separately-derived proposal tensors.
+    """
+
+    def __init__(
+        self,
+        *,
+        weight: mx.array,
+        scales: mx.array,
+        biases: mx.array,
+        vocab_ids: mx.array,
+        group_size: int,
+        bits: int,
+        mode: str = "affine",
+        full_vocab_size: Optional[int] = None,
+        target_model_type: Optional[str] = None,
+        target_tokenizer_sha256: Optional[str] = None,
+    ):
+        if mode != "affine":
+            raise ValueError("compact proposal head must use affine quantization")
+        if bits not in _SUPPORTED_BITS:
+            raise ValueError(f"unsupported compact proposal bit width: {bits}")
+        if group_size <= 0:
+            raise ValueError("compact proposal group size must be positive")
+        if weight.ndim != 2 or scales.ndim != 2 or biases.ndim != 2:
+            raise ValueError("compact proposal tensors must be rank 2")
+        if weight.dtype != mx.uint32:
+            raise ValueError("compact proposal weight must use packed uint32 values")
+        if not mx.issubdtype(scales.dtype, mx.floating):
+            raise ValueError("compact proposal scales must be floating point")
+        if not mx.issubdtype(biases.dtype, mx.floating):
+            raise ValueError("compact proposal biases must be floating point")
+        if scales.dtype != biases.dtype or scales.shape != biases.shape:
+            raise ValueError("compact proposal scales/biases shape or dtype mismatch")
+
+        rows = int(weight.shape[0])
+        if rows <= 0:
+            raise ValueError("compact proposal head must contain at least one row")
+        if int(scales.shape[0]) != rows:
+            raise ValueError("compact proposal weight/scales row mismatch")
+        if vocab_ids.ndim != 1 or int(vocab_ids.shape[0]) != rows:
+            raise ValueError("compact proposal vocab mapping row mismatch")
+        if not mx.issubdtype(vocab_ids.dtype, mx.integer):
+            raise ValueError("compact proposal vocab IDs must be integers")
+
+        packed_bits = int(weight.shape[1]) * 32
+        if packed_bits % bits:
+            raise ValueError("compact proposal packed weight width is invalid")
+        input_dims = packed_bits // bits
+        if input_dims % group_size:
+            raise ValueError(
+                "compact proposal hidden size must be divisible by group size"
+            )
+        expected_groups = input_dims // group_size
+        if int(scales.shape[1]) != expected_groups:
+            raise ValueError(
+                "compact proposal scales/biases width differs from quantization"
+            )
+
+        ids = [int(value) for value in vocab_ids.tolist()]
+        if any(value < 0 for value in ids):
+            raise ValueError("compact proposal vocab IDs must be non-negative")
+        if any(left >= right for left, right in zip(ids, ids[1:])):
+            raise ValueError(
+                "compact proposal vocab IDs must be unique and strictly increasing"
+            )
+        if full_vocab_size is not None:
+            full_vocab_size = int(full_vocab_size)
+            if full_vocab_size <= 0:
+                raise ValueError("target vocabulary size must be positive")
+            if ids[-1] >= full_vocab_size:
+                raise ValueError("compact proposal vocab ID exceeds target vocabulary")
+
+        self.weight = weight
+        self.scales = scales
+        self.biases = biases
+        self.vocab_ids = vocab_ids.astype(mx.int32)
+        self.group_size = int(group_size)
+        self.bits = int(bits)
+        self.mode = str(mode)
+        self.full_vocab_size = full_vocab_size
+        self.target_model_type = target_model_type
+        self.target_tokenizer_sha256 = target_tokenizer_sha256
+        self._input_dims = input_dims
+        self._maximum_vocab_id = ids[-1]
+        self.last_proposal_implementation = "not_run"
+
+    @property
+    def output_dims(self) -> int:
+        return int(self.weight.shape[0])
+
+    @property
+    def input_dims(self) -> int:
+        return self._input_dims
+
+    def validate_target(self, target_config, tokenizer=None) -> None:
+        """Reject a sidecar that cannot match the selected target model."""
+        hidden_size = _config_value(target_config, "hidden_size")
+        vocab_size = _config_value(target_config, "vocab_size")
+        model_type = _config_value(target_config, "model_type")
+        if hidden_size is None or vocab_size is None:
+            raise ValueError("target config must provide hidden_size and vocab_size")
+        if int(hidden_size) != self.input_dims:
+            raise ValueError(
+                f"compact proposal hidden size {self.input_dims} does not match "
+                f"target hidden size {hidden_size}"
+            )
+        if self.full_vocab_size is not None and int(vocab_size) != self.full_vocab_size:
+            raise ValueError(
+                f"compact proposal vocabulary size {self.full_vocab_size} does not "
+                f"match target vocabulary size {vocab_size}"
+            )
+        if self._maximum_vocab_id >= int(vocab_size):
+            raise ValueError("compact proposal vocab ID exceeds target vocabulary")
+        if (
+            self.target_model_type is not None
+            and model_type is not None
+            and str(model_type) != self.target_model_type
+        ):
+            raise ValueError(
+                f"compact proposal target type {self.target_model_type} does not "
+                f"match selected target type {model_type}"
+            )
+        if tokenizer is not None and self.target_tokenizer_sha256 is not None:
+            observed = tokenizer_vocab_sha256(tokenizer)
+            if observed != self.target_tokenizer_sha256:
+                raise ValueError(
+                    "compact proposal tokenizer vocabulary does not match target"
+                )
+
+    def logits(self, hidden: mx.array) -> mx.array:
+        if int(hidden.shape[-1]) != self.input_dims:
+            raise ValueError(
+                f"compact proposal hidden size {hidden.shape[-1]} != {self.input_dims}"
+            )
+        return mx.quantized_matmul(
+            hidden,
+            self.weight,
+            scales=self.scales,
+            biases=self.biases,
+            transpose=True,
+            group_size=self.group_size,
+            bits=self.bits,
+            mode=self.mode,
+        )
+
+    def propose(self, hidden: mx.array) -> mx.array:
+        compact_ids = mx.argmax(self.logits(hidden), axis=-1)
+        self.last_proposal_implementation = "quantized_matmul_argmax"
+        return self.vocab_ids[compact_ids]
+
+
+def load_compact_proposal_head(
+    path: str | Path,
+    *,
+    target_config=None,
+    tokenizer=None,
+) -> CompactProposalHead:
+    root = Path(path).expanduser().resolve()
+    config_path = root / "config.json"
+    weights_path = root / "compact_head.safetensors"
+    if not config_path.is_file() or not weights_path.is_file():
+        raise FileNotFoundError(
+            "compact proposal sidecar requires config.json and "
+            f"compact_head.safetensors: {root}"
+        )
+
+    try:
+        config = json.loads(config_path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError) as error:
+        raise ValueError(f"invalid compact proposal config: {config_path}") from error
+    if not isinstance(config, dict):
+        raise ValueError("compact proposal config must be a JSON object")
+    if config.get("schema_version") != COMPACT_HEAD_SCHEMA_VERSION:
+        raise ValueError("unsupported compact proposal schema version")
+    if config.get("model_type") != COMPACT_HEAD_MODEL_TYPE:
+        raise ValueError("unsupported compact proposal model type")
+
+    tensors = mx.load(str(weights_path))
+    required = {"weight", "scales", "biases", "vocab_ids"}
+    if set(tensors) != required:
+        missing = sorted(required.difference(tensors))
+        extra = sorted(set(tensors).difference(required))
+        raise ValueError(
+            f"compact proposal tensor keys differ: missing={missing}, extra={extra}"
+        )
+
+    try:
+        target = config.get("target") or {}
+        selection = config.get("selection") or {}
+        group_size = int(config["group_size"])
+        bits = int(config["bits"])
+        expected_rows = int(config["rows"])
+        expected_hidden = int(config["hidden_size"])
+    except (KeyError, TypeError, ValueError) as error:
+        raise ValueError("invalid compact proposal config values") from error
+    if not isinstance(target, dict) or not isinstance(selection, dict):
+        raise ValueError("compact proposal target and selection must be objects")
+
+    head = CompactProposalHead(
+        weight=tensors["weight"],
+        scales=tensors["scales"],
+        biases=tensors["biases"],
+        vocab_ids=tensors["vocab_ids"],
+        group_size=group_size,
+        bits=bits,
+        mode=config.get("mode", "affine"),
+        full_vocab_size=target.get("vocab_size"),
+        target_model_type=target.get("model_type"),
+        target_tokenizer_sha256=target.get("tokenizer_vocab_sha256"),
+    )
+
+    if head.output_dims != expected_rows or head.input_dims != expected_hidden:
+        raise ValueError("compact proposal sidecar shape differs from config")
+    expected_mapping_hash = selection.get("mapping_sha256")
+    if expected_mapping_hash is not None:
+        observed_mapping_hash = vocab_ids_sha256(head.vocab_ids.tolist())
+        if observed_mapping_hash != expected_mapping_hash:
+            raise ValueError("compact proposal vocabulary mapping hash differs")
+    if target_config is not None:
+        head.validate_target(target_config, tokenizer=tokenizer)
+        if not target:
+            logger.warning(
+                "Compact proposal sidecar has no target identity metadata; "
+                "only shape and token-range compatibility were checked."
+            )
+    return head

--- a/mlx_vlm/speculative/drafters/qwen3_5_mtp/qwen3_5_mtp.py
+++ b/mlx_vlm/speculative/drafters/qwen3_5_mtp/qwen3_5_mtp.py
@@ -10,11 +10,13 @@ from ....models.cache import BatchKVCache, KVCache
 from ....models.qwen3_5.fp8 import convert_qwen_fp8_weights
 from ....models.qwen3_5.language import Qwen3_5DecoderLayer
 from ....models.qwen3_5_moe.language import Qwen3_5MoeDecoderLayer
+from .compact_head import CompactProposalHead
 from .config import Qwen3_5MTPConfig
 
 
 class Qwen3_5MTPDraftModel(nn.Module):
     supports_greedy_draft_argmax = True
+    supports_compact_proposal_head = True
     prefer_requested_block_size = True
     requires_uniform_batch_acceptance = False
     supports_ragged_batch_acceptance = True
@@ -52,6 +54,7 @@ class Qwen3_5MTPDraftModel(nn.Module):
         self._input_embed_scale: float = 1.0
         self._lm_head_fn = None
         self._greedy_argmax_fn = None
+        self._compact_proposal_head: Optional[CompactProposalHead] = None
         self._cache: List[KVCache] = []
         self._seed_token: Optional[mx.array] = None
         self._seed_hidden: Optional[mx.array] = None
@@ -94,6 +97,30 @@ class Qwen3_5MTPDraftModel(nn.Module):
         )
         self._greedy_argmax_fn = getattr(lm, "speculative_argmax_from_hidden", None)
         return self
+
+    def set_compact_proposal_head(self, head: Optional[CompactProposalHead]) -> None:
+        if head is not None:
+            if not isinstance(head, CompactProposalHead):
+                raise TypeError("compact proposal head has an unsupported type")
+            head.validate_target(self.config.text_config)
+        self._compact_proposal_head = head
+
+    def _propose_token(
+        self,
+        hidden: mx.array,
+        sampler,
+        greedy: bool,
+        compact_proposals: Optional[bool] = None,
+    ) -> mx.array:
+        use_compact = greedy if compact_proposals is None else compact_proposals
+        if self._compact_proposal_head is not None and greedy and use_compact:
+            return self._compact_proposal_head.propose(hidden)
+        # Compact heads are proposal-only argmax accelerators. Sampled target
+        # requests keep the original full-head proposal path rather than
+        # applying a truncated vocabulary.
+        if greedy:
+            return self._greedy_token(hidden)
+        return sampler(self._lm_head_fn(hidden))
 
     def make_cache(self, left_padding: Optional[List[int]] = None) -> List[KVCache]:
         if left_padding is not None:
@@ -211,11 +238,16 @@ class Qwen3_5MTPDraftModel(nn.Module):
                 return token
         return mx.argmax(self._lm_head_fn(hidden), axis=-1)
 
-    def _set_seed_from_hidden(self, hidden: mx.array, sampler, greedy: bool) -> None:
-        if greedy:
-            self._seed_token = self._greedy_token(hidden)
-        else:
-            self._seed_token = sampler(self._lm_head_fn(hidden))
+    def _set_seed_from_hidden(
+        self,
+        hidden: mx.array,
+        sampler,
+        greedy: bool,
+        compact_proposals: Optional[bool] = None,
+    ) -> None:
+        self._seed_token = self._propose_token(
+            hidden, sampler, greedy, compact_proposals
+        )
         self._seed_hidden = hidden
 
     def prefill_from_target_hidden(
@@ -226,6 +258,7 @@ class Qwen3_5MTPDraftModel(nn.Module):
         sampler,
         token_dtype: mx.Dtype = mx.int32,
         greedy: bool = False,
+        compact_proposals: Optional[bool] = None,
     ) -> None:
         if input_ids.shape[1] == 0:
             return
@@ -241,7 +274,7 @@ class Qwen3_5MTPDraftModel(nn.Module):
             hidden[:, : shifted.shape[1], :],
             token_dtype,
         )
-        self._set_seed_from_hidden(h[:, -1:, :], sampler, greedy)
+        self._set_seed_from_hidden(h[:, -1:, :], sampler, greedy, compact_proposals)
 
     def accept_verified_tokens(
         self,
@@ -252,6 +285,7 @@ class Qwen3_5MTPDraftModel(nn.Module):
         sampler,
         token_dtype: mx.Dtype = mx.int32,
         greedy: bool = False,
+        compact_proposals: Optional[bool] = None,
     ) -> None:
         keep_appended = min(int(accepted), self._round_appended)
         trim = self._round_appended - keep_appended
@@ -278,7 +312,7 @@ class Qwen3_5MTPDraftModel(nn.Module):
             tokens = mx.concatenate(token_chunks, axis=1).astype(token_dtype)
             hiddens = mx.concatenate(hidden_chunks, axis=1)
             h = self._forward_tokens(tokens, hiddens, token_dtype)
-            self._set_seed_from_hidden(h[:, -1:, :], sampler, greedy)
+            self._set_seed_from_hidden(h[:, -1:, :], sampler, greedy, compact_proposals)
         self._round_appended = 0
 
     def accept_verified_tokens_batch(
@@ -290,6 +324,7 @@ class Qwen3_5MTPDraftModel(nn.Module):
         sampler,
         token_dtype: mx.Dtype = mx.int32,
         greedy: bool = False,
+        compact_proposals: Optional[bool] = None,
     ) -> None:
         """Extend the Qwen MTP drafter cache after a batched verify step."""
         if len(accepted) <= 1:
@@ -301,6 +336,7 @@ class Qwen3_5MTPDraftModel(nn.Module):
                 sampler,
                 token_dtype,
                 greedy,
+                compact_proposals,
             )
             return
 
@@ -410,7 +446,7 @@ class Qwen3_5MTPDraftModel(nn.Module):
 
             last_idx = mx.array([length - 1 for length in lengths], dtype=mx.int32)
             last_hidden = mx.take_along_axis(h, last_idx[:, None, None], axis=1)
-            self._set_seed_from_hidden(last_hidden, sampler, greedy)
+            self._set_seed_from_hidden(last_hidden, sampler, greedy, compact_proposals)
         self._round_appended = 0
 
     def filter_batch(self, keep) -> None:
@@ -445,6 +481,7 @@ class Qwen3_5MTPDraftModel(nn.Module):
         sampler,
         token_dtype: mx.Dtype = mx.int32,
         greedy: bool = False,
+        compact_proposals: Optional[bool] = None,
     ) -> mx.array:
         del cache
         if self._input_embed is None or self._lm_head_fn is None:
@@ -472,10 +509,7 @@ class Qwen3_5MTPDraftModel(nn.Module):
         while len(tokens) < block_size - 1:
             h_prev = self._forward_token(tok, h_prev, token_dtype)
             self._round_appended += 1
-            if greedy:
-                tok = self._greedy_token(h_prev)
-            else:
-                tok = sampler(self._lm_head_fn(h_prev))
+            tok = self._propose_token(h_prev, sampler, greedy, compact_proposals)
             tokens.append(tok)
 
         self._draft_round += 1

--- a/mlx_vlm/speculative/mtp.py
+++ b/mlx_vlm/speculative/mtp.py
@@ -727,9 +727,14 @@ def _mtp_draft_kwargs(
     sampler: Optional[Callable[[mx.array], mx.array]] = None,
 ) -> Dict[str, bool]:
     greedy_draft = greedy_sampling or _sampler_supports_positioned_target(sampler)
+    kwargs = {}
     if greedy_draft and getattr(draft_model, "supports_greedy_draft_argmax", False):
-        return {"greedy": True}
-    return {}
+        kwargs["greedy"] = True
+    if getattr(draft_model, "supports_compact_proposal_head", False):
+        # Positioned target sampling may use greedy proposals without making the
+        # request itself greedy. Keep compact vocabularies disabled there.
+        kwargs["compact_proposals"] = greedy_sampling
+    return kwargs
 
 
 def _mtp_draft_block_active(

--- a/mlx_vlm/tests/test_qwen3_5_compact_head.py
+++ b/mlx_vlm/tests/test_qwen3_5_compact_head.py
@@ -1,0 +1,309 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import mlx.core as mx
+
+from mlx_vlm.speculative.drafters.qwen3_5_mtp.build_compact_head import (
+    build_compact_proposal_head,
+    select_vocab_ids,
+)
+from mlx_vlm.speculative.drafters.qwen3_5_mtp.compact_head import (
+    CompactProposalHead,
+    load_compact_proposal_head,
+    tokenizer_vocab_sha256,
+)
+from mlx_vlm.speculative.drafters.qwen3_5_mtp.qwen3_5_mtp import Qwen3_5MTPDraftModel
+
+
+class _FakeTokenizer:
+    def __init__(self, vocab_size=96, added_ids=(90, 91)):
+        self._vocab = {f"token-{index}": index for index in range(vocab_size)}
+        self._added = {f"added-{index}": index for index in added_ids}
+        self._vocab.update(self._added)
+
+    def get_vocab(self):
+        return dict(self._vocab)
+
+    def get_added_vocab(self):
+        return dict(self._added)
+
+
+class CompactHeadTests(unittest.TestCase):
+    def _source_checkpoint(self, root: Path):
+        source = root / "source"
+        source.mkdir()
+        dense = mx.arange(96 * 64, dtype=mx.float32).reshape(96, 64) / 1000
+        weight, scales, biases = mx.quantize(dense, group_size=32, bits=4)
+        scales = scales.astype(mx.bfloat16)
+        biases = biases.astype(mx.bfloat16)
+        tensor_key = "language_model.lm_head.{}"
+        tensors = {
+            tensor_key.format("weight"): weight,
+            tensor_key.format("scales"): scales,
+            tensor_key.format("biases"): biases,
+        }
+        mx.save_safetensors(
+            str(source / "model.safetensors"),
+            tensors,
+            metadata={"format": "mlx"},
+        )
+        config = {
+            "model_type": "qwen3_5",
+            "hidden_size": 64,
+            "vocab_size": 96,
+            "quantization": {"bits": 4, "group_size": 32, "mode": "affine"},
+        }
+        (source / "config.json").write_text(json.dumps(config), encoding="utf-8")
+        index = {"weight_map": {key: "model.safetensors" for key in tensors}}
+        (source / "model.safetensors.index.json").write_text(
+            json.dumps(index), encoding="utf-8"
+        )
+        return source, tensors
+
+    def test_builder_copies_exact_rows_and_loads_with_target_checks(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            source, tensors = self._source_checkpoint(root)
+            tokenizer = _FakeTokenizer()
+            output = build_compact_proposal_head(
+                source,
+                root / "compact",
+                vocab_ids=[90, 1, 7],
+                tokenizer=tokenizer,
+            )
+            head = load_compact_proposal_head(
+                output,
+                target_config={
+                    "hidden_size": 64,
+                    "vocab_size": 96,
+                    "model_type": "qwen3_5",
+                },
+                tokenizer=tokenizer,
+            )
+
+            expected_ids = mx.array([1, 7, 90], dtype=mx.int32)
+            self.assertEqual(head.vocab_ids.tolist(), expected_ids.tolist())
+            for name in ("weight", "scales", "biases"):
+                expected = mx.take(
+                    tensors[f"language_model.lm_head.{name}"], expected_ids, axis=0
+                )
+                self.assertTrue(mx.array_equal(getattr(head, name), expected).item())
+            self.assertTrue((output / "manifest.json").is_file())
+
+    def test_builder_is_reproducible_and_supports_single_file_checkpoints(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            source, _ = self._source_checkpoint(root)
+            (source / "model.safetensors.index.json").unlink()
+            tokenizer = _FakeTokenizer()
+            outputs = []
+            for name in ("first", "second"):
+                output = build_compact_proposal_head(
+                    source,
+                    root / name,
+                    vocab_ids=[1, 7, 90],
+                    tokenizer=tokenizer,
+                )
+                outputs.append(output)
+
+            self.assertEqual(
+                (outputs[0] / "config.json").read_bytes(),
+                (outputs[1] / "config.json").read_bytes(),
+            )
+            self.assertEqual(
+                json.loads((outputs[0] / "manifest.json").read_text()),
+                json.loads((outputs[1] / "manifest.json").read_text()),
+            )
+
+    def test_prefix_selection_includes_added_ids_and_alignment_rows(self):
+        selected = select_vocab_ids(
+            prefix_size=7,
+            added_token_ids=[91, 90],
+            vocab_size=96,
+            row_multiple=8,
+        )
+
+        self.assertEqual(selected, list(range(14)) + [90, 91])
+
+    def test_loader_rejects_changed_mapping_and_unknown_schema(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            source, _ = self._source_checkpoint(root)
+            output = build_compact_proposal_head(
+                source,
+                root / "compact",
+                vocab_ids=[1, 7, 90],
+                tokenizer=_FakeTokenizer(),
+            )
+            config_path = output / "config.json"
+            config = json.loads(config_path.read_text(encoding="utf-8"))
+
+            config["selection"]["mapping_sha256"] = "0" * 64
+            config_path.write_text(json.dumps(config), encoding="utf-8")
+            with self.assertRaisesRegex(ValueError, "mapping hash"):
+                load_compact_proposal_head(output)
+
+            config["selection"]["mapping_sha256"] = None
+            config["schema_version"] = 2
+            config_path.write_text(json.dumps(config), encoding="utf-8")
+            with self.assertRaisesRegex(ValueError, "schema version"):
+                load_compact_proposal_head(output)
+
+    def test_builder_rejects_index_paths_outside_model_directory(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            source, _ = self._source_checkpoint(root)
+            index_path = source / "model.safetensors.index.json"
+            index = json.loads(index_path.read_text(encoding="utf-8"))
+            first_key = next(iter(index["weight_map"]))
+            index["weight_map"][first_key] = "../outside.safetensors"
+            index_path.write_text(json.dumps(index), encoding="utf-8")
+
+            with self.assertRaisesRegex(ValueError, "escapes"):
+                build_compact_proposal_head(
+                    source,
+                    root / "compact",
+                    vocab_ids=[1, 7, 90],
+                    tokenizer=_FakeTokenizer(),
+                )
+
+    def test_builder_rejects_invalid_vocab_ids(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            source, _ = self._source_checkpoint(root)
+            tokenizer = _FakeTokenizer()
+            invalid = ([], [1, 1], [True], [1.5], [-1], [96])
+            for index, values in enumerate(invalid):
+                with self.subTest(values=values):
+                    with self.assertRaises(ValueError):
+                        build_compact_proposal_head(
+                            source,
+                            root / f"invalid-{index}",
+                            vocab_ids=values,
+                            tokenizer=tokenizer,
+                        )
+
+    def test_head_rejects_invalid_geometry_and_mapping(self):
+        dense = mx.zeros((4, 64), dtype=mx.float32)
+        weight, scales, biases = mx.quantize(dense, group_size=32, bits=4)
+        cases = (
+            {"vocab_ids": mx.array([0, 2, 1, 3])},
+            {"vocab_ids": mx.array([0, 1, 1, 3])},
+            {"vocab_ids": mx.array([0.0, 1.0, 2.0, 3.0])},
+            {"scales": scales[:, :1]},
+            {"biases": biases[:, :1]},
+            {"weight": weight.astype(mx.int32)},
+        )
+        base = {
+            "weight": weight,
+            "scales": scales,
+            "biases": biases,
+            "vocab_ids": mx.arange(4, dtype=mx.int32),
+            "group_size": 32,
+            "bits": 4,
+        }
+        for change in cases:
+            with self.subTest(change=tuple(change)):
+                with self.assertRaises(ValueError):
+                    CompactProposalHead(**(base | change))
+
+    def test_target_validation_checks_shape_vocab_model_and_tokenizer(self):
+        dense = mx.zeros((4, 64), dtype=mx.float32)
+        weight, scales, biases = mx.quantize(dense, group_size=32, bits=4)
+        tokenizer = _FakeTokenizer()
+        head = CompactProposalHead(
+            weight=weight,
+            scales=scales,
+            biases=biases,
+            vocab_ids=mx.array([0, 1, 2, 90], dtype=mx.int32),
+            group_size=32,
+            bits=4,
+            full_vocab_size=96,
+            target_model_type="qwen3_5",
+            target_tokenizer_sha256=tokenizer_vocab_sha256(tokenizer),
+        )
+        valid = {
+            "hidden_size": 64,
+            "vocab_size": 96,
+            "model_type": "qwen3_5",
+            "quantization": {"bits": 8, "group_size": 32, "mode": "affine"},
+        }
+        head.validate_target(valid, tokenizer=tokenizer)
+
+        invalid = (
+            ({**valid, "hidden_size": 32}, tokenizer),
+            ({**valid, "vocab_size": 95}, tokenizer),
+            ({**valid, "model_type": "qwen3_next"}, tokenizer),
+            (valid, _FakeTokenizer(96, added_ids=(89, 91))),
+        )
+        for config, selected_tokenizer in invalid:
+            with self.subTest(config=config):
+                with self.assertRaises(ValueError):
+                    head.validate_target(config, tokenizer=selected_tokenizer)
+
+    def test_drafter_validates_attachment_and_can_restore_full_head(self):
+        dense = mx.zeros((4, 64), dtype=mx.float32)
+        weight, scales, biases = mx.quantize(dense, group_size=32, bits=4)
+        head = CompactProposalHead(
+            weight=weight,
+            scales=scales,
+            biases=biases,
+            vocab_ids=mx.arange(4, dtype=mx.int32),
+            group_size=32,
+            bits=4,
+            full_vocab_size=96,
+            target_model_type="qwen3_5",
+        )
+        draft = SimpleNamespace(
+            config=SimpleNamespace(
+                text_config=SimpleNamespace(
+                    hidden_size=64,
+                    vocab_size=96,
+                    model_type="qwen3_5",
+                )
+            )
+        )
+
+        Qwen3_5MTPDraftModel.set_compact_proposal_head(draft, head)
+        self.assertIs(draft._compact_proposal_head, head)
+        Qwen3_5MTPDraftModel.set_compact_proposal_head(draft, None)
+        self.assertIsNone(draft._compact_proposal_head)
+        with self.assertRaises(TypeError):
+            Qwen3_5MTPDraftModel.set_compact_proposal_head(draft, object())
+
+    def test_full_head_keeps_target_greedy_shortcut_after_compact_attachment(self):
+        hidden = mx.zeros((1, 1, 64))
+        greedy_token = Mock(return_value=mx.array([[11]]))
+        full_head = Mock(return_value=mx.array([[[0.0, 1.0]]]))
+        sampler = Mock(return_value=mx.array([[1]]))
+        compact_head = SimpleNamespace(propose=Mock(return_value=mx.array([[7]])))
+        draft = SimpleNamespace(
+            _compact_proposal_head=None,
+            _greedy_token=greedy_token,
+            _lm_head_fn=full_head,
+        )
+
+        token = Qwen3_5MTPDraftModel._propose_token(draft, hidden, sampler, greedy=True)
+        self.assertEqual(token.item(), 11)
+        greedy_token.assert_called_once_with(hidden)
+        full_head.assert_not_called()
+
+        draft._compact_proposal_head = compact_head
+        token = Qwen3_5MTPDraftModel._propose_token(draft, hidden, sampler, greedy=True)
+        self.assertEqual(token.item(), 7)
+        compact_head.propose.assert_called_once_with(hidden)
+
+        token = Qwen3_5MTPDraftModel._propose_token(
+            draft, hidden, sampler, greedy=False, compact_proposals=False
+        )
+        self.assertEqual(token.item(), 1)
+        full_head.assert_called_once_with(hidden)
+        sampler.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/mlx_vlm/tests/test_server.py
+++ b/mlx_vlm/tests/test_server.py
@@ -46,16 +46,20 @@ def test_response_generator_prefill_step_override_wins_over_environment(monkeypa
             pass
 
     monkeypatch.setenv("PREFILL_STEP_SIZE", "2048")
+    monkeypatch.setenv("MLX_VLM_DRAFT_COMPACT_HEAD", "/proposal/from-env")
     monkeypatch.setattr(server_generation, "Thread", DormantThread)
 
     default_generator = server.ResponseGenerator(model_path="default")
     overridden_generator = server.ResponseGenerator(
         model_path="overridden",
+        draft_compact_head_path=None,
         prefill_step_size=3072,
     )
 
     assert default_generator.prefill_step_size == 2048
+    assert default_generator.draft_compact_head_path == "/proposal/from-env"
     assert overridden_generator.prefill_step_size == 3072
+    assert overridden_generator.draft_compact_head_path is None
 
 
 def test_response_generator_clears_worker_streams(monkeypatch):
@@ -752,6 +756,7 @@ def _unstarted_response_generator():
     gen.draft_kind = None
     gen.draft_model_path = None
     gen.draft_kind_override = None
+    gen.draft_compact_head_path = None
     gen.kv_bits = None
     gen.kv_group_size = server.DEFAULT_KV_GROUP_SIZE
     gen.kv_quant_scheme = server.DEFAULT_KV_QUANT_SCHEME
@@ -803,6 +808,105 @@ def test_server_demotes_incompatible_mtp_drafter_to_ar(monkeypatch):
     assert gen.processor is processor
     assert gen.draft_model is None
     assert gen.draft_kind is None
+
+
+def test_server_loads_compact_mtp_proposal_head(monkeypatch):
+    target_text_config = SimpleNamespace(
+        hidden_size=16, vocab_size=32, model_type="qwen3_5"
+    )
+    target_config = SimpleNamespace(eos_token_id=[], text_config=target_text_config)
+    model = SimpleNamespace(language_model=SimpleNamespace(config=target_config))
+    target_tokenizer = SimpleNamespace()
+    processor = SimpleNamespace(tokenizer=target_tokenizer)
+    draft_text_config = SimpleNamespace(
+        hidden_size=16, vocab_size=32, model_type="qwen3_5"
+    )
+    drafter = SimpleNamespace(
+        config=SimpleNamespace(block_size=4, text_config=draft_text_config)
+    )
+    drafter.set_compact_proposal_head = MagicMock()
+    compact_head = object()
+    gen = _unstarted_response_generator()
+
+    monkeypatch.setenv("MLX_VLM_DRAFT_MODEL", "assistant")
+    monkeypatch.setenv("MLX_VLM_DRAFT_KIND", "mtp")
+    monkeypatch.setenv("MLX_VLM_DRAFT_COMPACT_HEAD", "/proposal/compact")
+    monkeypatch.setattr(
+        server_generation,
+        "load_model_resources",
+        lambda *_args, **_kwargs: (model, processor, target_config),
+    )
+    monkeypatch.setattr(
+        "mlx_vlm.speculative.drafters.load_drafter",
+        lambda *_args, **_kwargs: (drafter, "mtp"),
+    )
+    monkeypatch.setattr(
+        "mlx_vlm.speculative.drafters.validate_drafter_compatibility",
+        lambda *_args, **_kwargs: None,
+    )
+    load_compact = MagicMock(return_value=compact_head)
+    monkeypatch.setattr(
+        "mlx_vlm.speculative.drafters.qwen3_5_mtp.load_compact_proposal_head",
+        load_compact,
+    )
+
+    gen._initialize_model()
+
+    load_compact.assert_called_once_with(
+        "/proposal/compact",
+        target_config=target_text_config,
+        tokenizer=target_tokenizer,
+    )
+    drafter.set_compact_proposal_head.assert_called_once_with(compact_head)
+    assert gen.draft_model is drafter
+    assert gen.draft_kind == "mtp"
+
+
+def test_server_rejects_compact_head_without_drafter(monkeypatch):
+    target_config = SimpleNamespace(eos_token_id=[])
+    model = SimpleNamespace(language_model=SimpleNamespace(config=target_config))
+    processor = SimpleNamespace(tokenizer=SimpleNamespace())
+    gen = _unstarted_response_generator()
+
+    monkeypatch.delenv("MLX_VLM_DRAFT_MODEL", raising=False)
+    monkeypatch.delenv("MLX_VLM_DRAFT_KIND", raising=False)
+    monkeypatch.setenv("MLX_VLM_DRAFT_COMPACT_HEAD", "/proposal/compact")
+    monkeypatch.setattr(
+        server_generation,
+        "load_model_resources",
+        lambda *_args, **_kwargs: (model, processor, target_config),
+    )
+
+    with pytest.raises(ValueError, match="requires a draft model"):
+        gen._initialize_model()
+
+
+def test_server_rejects_compact_head_for_non_mtp_drafter(monkeypatch):
+    target_config = SimpleNamespace(eos_token_id=[])
+    model = SimpleNamespace(language_model=SimpleNamespace(config=target_config))
+    processor = SimpleNamespace(tokenizer=SimpleNamespace())
+    drafter = SimpleNamespace(config=SimpleNamespace(block_size=4))
+    gen = _unstarted_response_generator()
+
+    monkeypatch.setenv("MLX_VLM_DRAFT_MODEL", "assistant")
+    monkeypatch.setenv("MLX_VLM_DRAFT_KIND", "eagle3")
+    monkeypatch.setenv("MLX_VLM_DRAFT_COMPACT_HEAD", "/proposal/compact")
+    monkeypatch.setattr(
+        server_generation,
+        "load_model_resources",
+        lambda *_args, **_kwargs: (model, processor, target_config),
+    )
+    monkeypatch.setattr(
+        "mlx_vlm.speculative.drafters.load_drafter",
+        lambda *_args, **_kwargs: (drafter, "eagle3"),
+    )
+    monkeypatch.setattr(
+        "mlx_vlm.speculative.drafters.validate_drafter_compatibility",
+        lambda *_args, **_kwargs: None,
+    )
+
+    with pytest.raises(ValueError, match="requires an MTP drafter"):
+        gen._initialize_model()
 
 
 def test_server_includes_processor_specific_stop_tokens(monkeypatch):
@@ -6427,6 +6531,7 @@ class TestResponseGenerator:
             "MLX_VLM_PRELOAD_RERANKER_MODEL",
             "MLX_VLM_MODEL_DISCOVERY",
             "MLX_VLM_VISION_CACHE_SIZE",
+            "MLX_VLM_DRAFT_COMPACT_HEAD",
             "MLX_VLM_MAX_TOKENS",
             "MLX_VLM_THINKING_BUDGET",
             "MLX_VLM_THINKING_START_TOKEN",
@@ -6459,6 +6564,8 @@ class TestResponseGenerator:
                 "reranker-demo",
                 "--model-discovery",
                 "served",
+                "--draft-compact-head",
+                "/proposal/compact",
                 "--enable-thinking",
                 "--thinking-budget",
                 "128",
@@ -6471,6 +6578,11 @@ class TestResponseGenerator:
             ],
         )
         run_calls = []
+        monkeypatch.setattr(
+            server_cli.runtime,
+            "config",
+            RuntimeConfig.from_env(),
+        )
         monkeypatch.setattr(
             server_cli.uvicorn,
             "run",
@@ -6490,6 +6602,16 @@ class TestResponseGenerator:
             assert os.environ["MLX_VLM_PRELOAD_STT_MODEL"] == "stt-demo"
             assert os.environ["MLX_VLM_PRELOAD_RERANKER_MODEL"] == "reranker-demo"
             assert os.environ["MLX_VLM_MODEL_DISCOVERY"] == "served"
+            assert os.environ["MLX_VLM_DRAFT_COMPACT_HEAD"] == "/proposal/compact"
+            assert (
+                server_cli.runtime.config.spec_draft_compact_head == "/proposal/compact"
+            )
+            server_cli.runtime.config.apply_changes({"spec_draft_compact_head": None})
+            assert server_cli.runtime.config.spec_draft_compact_head is None
+            server_cli.runtime.config.apply_changes({}, op="replace")
+            assert (
+                server_cli.runtime.config.spec_draft_compact_head == "/proposal/compact"
+            )
             assert os.environ["MLX_VLM_SERVER_API_KEY"] == "admin-token"
             assert run_calls[0][1]["host"] == "127.0.0.1"
         finally:
@@ -6503,6 +6625,7 @@ class TestResponseGenerator:
                 "MLX_VLM_PRELOAD_RERANKER_MODEL",
                 "MLX_VLM_MODEL_DISCOVERY",
                 "MLX_VLM_VISION_CACHE_SIZE",
+                "MLX_VLM_DRAFT_COMPACT_HEAD",
                 "MLX_VLM_MAX_TOKENS",
                 "MLX_VLM_THINKING_BUDGET",
                 "MLX_VLM_THINKING_START_TOKEN",
@@ -7387,9 +7510,19 @@ class TestRuntimeConfigAdditions:
             "token_queue_timeout",
             "spec_draft_model",
             "spec_draft_kind",
+            "spec_draft_compact_head",
         ):
             assert name in spec
             assert spec[name]["reload_kinds"] == ["text_generation"]
+
+    def test_compact_head_env_is_part_of_runtime_identity(self, monkeypatch):
+        monkeypatch.delenv("MLX_VLM_DRAFT_COMPACT_HEAD", raising=False)
+        without_compact = RuntimeConfig.from_env()
+        monkeypatch.setenv("MLX_VLM_DRAFT_COMPACT_HEAD", "/proposal/compact")
+        with_compact = RuntimeConfig.from_env()
+
+        assert with_compact.spec_draft_compact_head == "/proposal/compact"
+        assert with_compact.fingerprint() != without_compact.fingerprint()
 
     def test_token_queue_timeout_is_live(self, client, monkeypatch):
         monkeypatch.delenv("MLX_VLM_TOKEN_QUEUE_TIMEOUT", raising=False)
@@ -7444,10 +7577,18 @@ class TestRuntimeConfigAdditions:
         monkeypatch.setattr(server.runtime, "apc_manager", None)
         monkeypatch.setattr(server.runtime.config, "spec_draft_model", "draft-x")
         monkeypatch.setattr(server.runtime.config, "spec_draft_kind", "auto")
+        monkeypatch.setattr(
+            server.runtime.config,
+            "spec_draft_compact_head",
+            "compact-x",
+        )
 
         server.get_cached_model("demo-model")
         assert FakeResponseGenerator.last_kwargs["draft_model_path"] == "draft-x"
         assert FakeResponseGenerator.last_kwargs["draft_kind"] == "auto"
+        assert (
+            FakeResponseGenerator.last_kwargs["draft_compact_head_path"] == "compact-x"
+        )
 
     def test_settings_patch_replace_semantics(self, client, monkeypatch):
         monkeypatch.setattr(server.runtime, "config", RuntimeConfig.from_env())

--- a/mlx_vlm/tests/test_speculative.py
+++ b/mlx_vlm/tests/test_speculative.py
@@ -66,6 +66,7 @@ from mlx_vlm.speculative.drafters.gemma4_assistant.masks import (
 )
 from mlx_vlm.speculative.drafters.gemma4_dflash import ModelConfig as Gemma4DFlashConfig
 from mlx_vlm.speculative.drafters.glm4_moe_lite_mtp.split import split_glm4_moe_lite_mtp
+from mlx_vlm.speculative.drafters.qwen3_5_mtp import CompactProposalHead
 from mlx_vlm.speculative.drafters.qwen3_5_mtp import ModelConfig as Qwen3_5MTPConfig
 from mlx_vlm.speculative.drafters.qwen3_5_mtp import Qwen3_5MTPDraftModel
 from mlx_vlm.speculative.drafters.qwen3_5_mtp.split import split_qwen3_5_mtp
@@ -1657,6 +1658,19 @@ def test_mtp_draft_kwargs_uses_greedy_for_positioned_sampler():
     assert mtp_utils._mtp_draft_kwargs(draft_model, False) == {}
     assert mtp_utils._mtp_draft_kwargs(draft_model, False, PositionedSampler()) == {
         "greedy": True
+    }
+
+    compact_model = SimpleNamespace(
+        supports_greedy_draft_argmax=True,
+        supports_compact_proposal_head=True,
+    )
+    assert mtp_utils._mtp_draft_kwargs(compact_model, True) == {
+        "greedy": True,
+        "compact_proposals": True,
+    }
+    assert mtp_utils._mtp_draft_kwargs(compact_model, False, PositionedSampler()) == {
+        "greedy": True,
+        "compact_proposals": False,
     }
 
 
@@ -3517,6 +3531,83 @@ def test_qwen3_5_mtp_batch_accept_updates_ragged_cache():
     assert drafter._cache[0].offset.tolist() == [2, 1]
     assert drafter._cache[0].left_padding.tolist() == [1, 2]
     assert drafter._next_position.tolist() == [6, 5]
+
+
+def test_compact_qwen_proposal_head_maps_argmax_to_real_vocab():
+    dense = mx.random.uniform(shape=(16, 64), dtype=mx.float16)
+    weight, scales, biases = mx.quantize(dense, group_size=32, bits=4)
+    vocab_ids = mx.array([1, 3, 5, 7, 9, 11, 13, 15], dtype=mx.int32)
+    head = CompactProposalHead(
+        weight=weight[vocab_ids],
+        scales=scales[vocab_ids],
+        biases=biases[vocab_ids],
+        vocab_ids=vocab_ids,
+        group_size=32,
+        bits=4,
+    )
+    hidden = mx.random.uniform(shape=(2, 1, 64), dtype=mx.float16)
+    full_logits = mx.quantized_matmul(
+        hidden,
+        weight,
+        scales=scales,
+        biases=biases,
+        transpose=True,
+        group_size=32,
+        bits=4,
+    )
+    expected = vocab_ids[mx.argmax(full_logits[..., vocab_ids], axis=-1)]
+
+    assert mx.array_equal(head.propose(hidden), expected).item()
+
+
+def test_qwen_compact_proposal_falls_back_to_full_head_for_stochastic_drafting():
+    compact_calls = []
+    sampler_calls = []
+    compact = SimpleNamespace(
+        propose=lambda hidden: (
+            compact_calls.append(hidden) or mx.zeros(hidden.shape[:-1])
+        )
+    )
+    draft = SimpleNamespace(
+        _compact_proposal_head=compact,
+        _lm_head_fn=lambda hidden: hidden + mx.array([[[0.0, 1.0]]]),
+    )
+
+    def sampler(logits):
+        sampler_calls.append(logits)
+        return mx.argmax(logits, axis=-1)
+
+    token = Qwen3_5MTPDraftModel._propose_token(
+        draft,
+        mx.zeros((1, 1, 2)),
+        sampler,
+        False,
+    )
+
+    assert token.item() == 1
+    assert compact_calls == []
+    assert len(sampler_calls) == 1
+
+    positioned_token = Qwen3_5MTPDraftModel._propose_token(
+        draft,
+        mx.zeros((1, 1, 2)),
+        sampler,
+        True,
+        compact_proposals=False,
+    )
+    assert positioned_token.item() == 1
+    assert compact_calls == []
+    assert len(sampler_calls) == 1
+
+    compact_token = Qwen3_5MTPDraftModel._propose_token(
+        draft,
+        mx.zeros((1, 1, 2)),
+        sampler,
+        True,
+        compact_proposals=True,
+    )
+    assert compact_token.item() == 0
+    assert len(compact_calls) == 1
 
 
 def test_qwen3_5_rollback_speculative_cache_trims_batch_rows_ragged():


### PR DESCRIPTION
## Summary

Add an opt-in compact, quantized proposal-only LM head for Qwen 3.5 MTP drafters.

- loads a local `config.json` + `compact_head.safetensors` sidecar
- maps compact-row argmax results back to real vocabulary IDs
- keeps the full target model/head as the sole commit authority
- uses the compact head only for greedy drafting
- falls back to the original full proposal head and sampler for stochastic drafting, preserving the independent drafter RNG stream
- exposes the feature through `--draft-compact-head`

No model tensors, vocabulary mapping, or checkpoint-specific artifact is included in this PR.

## Why

Large-vocabulary proposal projection can be a material fraction of MTP draft cost. A proposal-only row subset can reduce that cost without changing target verification. A missing compact row can reduce acceptance, but cannot change committed output under exact verification.

The compact head is deliberately opaque runtime state rather than an `nn.Module`, so loading MTP checkpoint weights cannot traverse or mutate the separate sidecar.

## Correctness

Tests cover:

- sidecar shape and vocabulary-map validation
- exact affine quantized projection/argmax remapping
- greedy compact proposal dispatch
- stochastic fallback to the full head/sampler without invoking the compact head
- server loading and binding
- CLI environment propagation

Local real-checkpoint screens on current `main` (`09a987a`) used an affine-8/group-64 Qwen 3.8 27B target and Qwen MTP drafter:

- greedy compact MTP: 128/128 emitted IDs matched serial
- seeded `temperature=1`, `top_k=40` compact-configured MTP: 128/128 emitted IDs matched serial through full-head stochastic fallback

Both arm orders were exercised across the two cases. These are correctness screens, not benchmark claims.

## Operational notes

The feature is off by default. Existing drafters and generation paths are unchanged unless a compact sidecar is explicitly configured.
