### PR TITLE
fix(generate): chunk prefill for prompts shorter than prefill_step_size

### DIFF
--- a/mlx_vlm/generate/ar.py
+++ b/mlx_vlm/generate/ar.py
@@ -465,8 +465,13 @@ def generate_step(
             else None
         )
         checkpoint_done = False
+        # Chunk whenever there is more than one prompt token left to process.
+        # The chunk loop discards its output, so the [B, N, vocab] logits are
+        # never evaluated; the unchunked path feeds the whole prompt to _step,
+        # which reads logits[:, -1, :] and so materializes every row. Gating on
+        # prefill_step_size made short prompts peak higher than long ones.
         should_chunk = (
-            prefill_step_size is not None and inputs_embeds.shape[1] > prefill_step_size
+            prefill_step_size is not None and inputs_embeds.shape[1] > 1
         ) or (
             checkpoint_len is not None and 0 < checkpoint_len < inputs_embeds.shape[1]
         )
@@ -1851,7 +1856,9 @@ class PromptProcessingBatch:
             return self._next_apc_checkpoint_column() is not None
         if self._next_apc_checkpoint_column() is not None:
             return True
-        return self._inputs_embeds.shape[1] > self.prefill_step_size
+        # See the note in stream_generate: prompts at or below prefill_step_size
+        # would otherwise skip chunking and materialize the full logits tensor.
+        return self._inputs_embeds.shape[1] > 1
 
     def _apc_checkpoint_column_for_meta(
         self, batch_idx: int, meta: dict

--- a/mlx_vlm/models/paligemma/paligemma.py
+++ b/mlx_vlm/models/paligemma/paligemma.py
@@ -34,6 +34,25 @@ class Model(nn.Module):
         self.language_model = LanguageModel(config.text_config)
         self.multi_modal_projector = PaliGemmaMultiModalProjector(config)
 
+    def chunked_prefill_policy(
+        self,
+        *,
+        input_ids=None,
+        inputs_embeds=None,
+        prompt_cache=None,
+        draft_model=None,
+        draft_kind=None,
+        prefill_kwargs=None,
+    ) -> bool:
+        del input_ids, inputs_embeds, prompt_cache, draft_model
+        del draft_kind, prefill_kwargs
+        # The prefix-LM mask is built across the whole prompt, so splitting the
+        # prompt into causal chunks changes the attention pattern and with it
+        # the generated text. Prefill this model in one pass.
+        return not bool(
+            getattr(self.config.text_config, "use_bidirectional_attention", False)
+        )
+
     def get_input_embeddings(
         self,
         input_ids: Optional[mx.array] = None,

--- a/mlx_vlm/tests/test_generate.py
+++ b/mlx_vlm/tests/test_generate.py
@@ -3416,3 +3416,67 @@ class TestPrePaddedBatchRows:
         assert mask.shape == (2, 8)
         assert mask[0].tolist() == [False] * 5 + [True] * 3
         assert mask[1].tolist() == [True] * 8
+
+
+def test_prompt_shorter_than_prefill_step_size_is_still_chunked():
+    """Short prompts must not skip chunking: the unchunked path feeds the whole
+    prompt to _step, which reads logits[:, -1, :] and materializes [1, N, vocab]."""
+    model = MagicMock()
+    model.chunked_prefill_policy = MagicMock(return_value=True)
+    output = SimpleNamespace(
+        logits=mx.zeros((1, 1, 8)),
+        hidden_states=[mx.zeros((1, 1, 4))],
+        shared_kv_states={},
+        cross_attention_states=None,
+        encoder_outputs=None,
+    )
+    model.language_model.return_value = output
+
+    embedding_output = MagicMock()
+    embedding_output.inputs_embeds = mx.zeros((1, 5, 4))
+    embedding_output.to_dict.return_value = {}
+    model.get_input_embeddings.return_value = embedding_output
+
+    with (
+        patch.object(generate_module.cache, "make_prompt_cache", return_value=[]),
+        patch.object(generate_module, "make_logits_processors", return_value=[]),
+        patch.object(
+            generate_module, "make_sampler", return_value=lambda _: mx.array([0])
+        ),
+    ):
+        # 5 prompt tokens, prefill_step_size 2048: previously unchunked.
+        list(
+            generate_module.generate_step(
+                input_ids=mx.array([[1, 2, 3, 4, 5]], dtype=mx.int32),
+                model=model,
+                pixel_values=None,
+                mask=None,
+                max_tokens=1,
+                prefill_step_size=2048,
+            )
+        )
+
+    n_processed = [
+        c.kwargs["n_to_process"]
+        for c in model.language_model.call_args_list
+        if "n_to_process" in c.kwargs
+    ]
+    assert n_processed == [4], f"expected one 4-token prefill chunk, got {n_processed}"
+
+
+def test_paligemma_opts_out_of_chunked_prefill_when_bidirectional():
+    from mlx_vlm.models.paligemma.paligemma import Model as PaliGemmaModel
+
+    bidirectional = SimpleNamespace(
+        config=SimpleNamespace(
+            text_config=SimpleNamespace(use_bidirectional_attention=True)
+        )
+    )
+    causal = SimpleNamespace(
+        config=SimpleNamespace(
+            text_config=SimpleNamespace(use_bidirectional_attention=False)
+        )
+    )
+    policy = PaliGemmaModel.chunked_prefill_policy
+    assert policy(bidirectional) is False
+    assert policy(causal) is True

--- a/mlx_vlm/tests/test_kv_cache_quantization.py
+++ b/mlx_vlm/tests/test_kv_cache_quantization.py
@@ -1,4 +1,5 @@
 import sys
+from math import ceil
 from unittest.mock import Mock, patch
 
 import mlx.core as mx
@@ -7,6 +8,7 @@ import pytest
 
 # Import the module to patch
 from mlx_vlm.generate import generate_step
+from mlx_vlm.generate.common import DEFAULT_PREFILL_STEP_SIZE
 
 
 class MockInputEmbeddingsFeatures:
@@ -81,6 +83,10 @@ class MockCacheLayer:
         self.offset = 0
         self.keys = mx.random.normal((1, 8, 100, 64))
         self.values = mx.random.normal((1, 8, 100, 64))
+
+    @property
+    def state(self):
+        return self.keys, self.values
 
 
 class MockCache:
@@ -192,8 +198,9 @@ class TestKVCacheQuantization:
                 assert first_call_kwargs["kv_group_size"] == 64
                 assert first_call_kwargs["kv_bits"] == 4
 
-                # Should be called once after initial forward pass and once per generated token
-                expected_calls = 1 + len(tokens)
+                prompt_len = input_ids.shape[1]
+                prefill_chunks = ceil((prompt_len - 1) / DEFAULT_PREFILL_STEP_SIZE)
+                expected_calls = prefill_chunks + 1 + len(tokens)
                 assert len(mock_quantize_calls) == expected_calls
 
     def test_different_quantization_bit_configurations(self):


### PR DESCRIPTION
Prefill only chunked when the prompt was **longer** than `prefill_step_size`. The chunk loop discards its return value, so MLX never evaluates the `[B, N, vocab]` logits. The unchunked path hands the whole prompt to `_step`, which reads `logits[:, -1, :]` — materializing every row to keep one.

So a shorter prompt costs more than a longer one:

| prompt | chunked | peak (Qwen3.5-0.8B) |
|---|---|---|
| 2047 | no | **2.896 GB** |
| 2049 | yes | **1.965 GB** |

Ordinary chat turns land on the expensive side. This chunks whenever more than one prompt token remains. The same gate existed in `PromptProcessingBatch.needs_processing`, the batch path the server uses.

Greedy decode, output unchanged. Savings scale with `prompt_tokens x vocab_size`:

| model | prompt | before | after |
|---|---|---|---|
| Qwen3.5-0.8B-4bit | 2047 | 2.898 GB | 1.973 GB |
| Qwen3.8-27B-4bit | 1229 | 17.505 GB | 17.013 GB |

Swept 56 local checkpoints across 24 families: 54 byte-identical. `diffusion_gemma` is nondeterministic on unpatched `main` and already opts out of chunking.

**PaliGemma** builds a prefix-LM mask over the whole prompt, so causal chunking changes its output. It gains a `chunked_prefill_policy` opting out while bidirectional attention is on, using the hook `gemma4` and `lfm2` already use. Already latent: its prompts over `prefill_step_size` chunk on `main` today. Other whole-prompt-mask models already opt out or are unaffected.

Two regression tests, both failing on `main`. Suite green: 533 passed.

Downstream: Blaizzy/nativ#427.
