### PR TITLE
fix(speculative): detect native MTP drafters via num_nextn_predict_layers

### DIFF
--- a/mlx_vlm/speculative/drafters/__init__.py
+++ b/mlx_vlm/speculative/drafters/__init__.py
@@ -70,9 +70,7 @@ def validate_drafter_compatibility(
         return
 
     model_type = _cfg_get(draft_cfg, "model_type")
-    expected_kind = DRAFTER_KIND_BY_MODEL_TYPE.get(model_type)
-    if expected_kind is None and "mtp" in str(model_type).lower():
-        expected_kind = "mtp"
+    expected_kind = _expected_drafter_kind(model_type, draft_cfg)
     if expected_kind is not None and draft_kind != expected_kind:
         raise ValueError(
             f"Drafter model_type={model_type!r} requires draft_kind={expected_kind!r}. "
@@ -105,22 +103,53 @@ def validate_drafter_compatibility(
         )
 
 
-def _peek_drafter_model_type(model_path) -> Optional[str]:
-    """Read the drafter's HF ``config.json`` ``model_type`` without loading
-    weights. Returns ``None`` if the config can't be read."""
+def _read_drafter_config(model_path) -> dict:
+    """Read the drafter's HF ``config.json`` without loading weights. Returns an
+    empty dict when the config can't be read."""
     try:
         with open(model_path / "config.json") as f:
-            config = json.load(f)
-            return config.get("model_type") or config.get("speculators_model_type")
+            return json.load(f)
     except (FileNotFoundError, json.JSONDecodeError, OSError):
-        return None
+        return {}
+
+
+def _peek_drafter_model_type(model_path) -> Optional[str]:
+    config = _read_drafter_config(model_path)
+    return config.get("model_type") or config.get("speculators_model_type")
+
+
+def _declares_mtp_layers(config: Any) -> bool:
+    """True when the config declares next-token-prediction layers, the marker of
+    a native checkpoint that carries an embedded ``mtp.*`` head."""
+    for cfg in (config, _cfg_get(config, "text_config")):
+        if cfg is None:
+            continue
+        count = _cfg_get(cfg, "num_nextn_predict_layers")
+        if isinstance(count, int) and count > 0:
+            return True
+    return False
+
+
+def _expected_drafter_kind(model_type: Any, config: Any = None) -> Optional[str]:
+    """Round-loop kind a drafter requires, or ``None`` when it can't be inferred:
+    an explicit ``model_type`` mapping first, then an ``mtp`` model_type name,
+    then a config that declares next-token-prediction layers."""
+    expected = DRAFTER_KIND_BY_MODEL_TYPE.get(model_type)
+    if expected is not None:
+        return expected
+    if "mtp" in str(model_type).lower():
+        return "mtp"
+    if config is not None and _declares_mtp_layers(config):
+        return "mtp"
+    return None
 
 
 def resolve_drafter_kind(model_path, kind: Optional[str] = None) -> str:
     """Reconcile the caller's ``kind`` with the drafter's actual model type.
 
-    When ``kind`` is None, auto-detect from the drafter's HF ``model_type``;
-    if the model_type is unknown, fall back to :data:`DEFAULT_DRAFTER_KIND`.
+    When ``kind`` is None, auto-detect from the drafter's HF ``model_type`` or,
+    for a native checkpoint that declares next-token-prediction layers, ``mtp``;
+    if neither applies, fall back to :data:`DEFAULT_DRAFTER_KIND`.
 
     When the caller passes a ``kind`` that disagrees with the drafter's
     ``model_type``, we override (and warn). This avoids the trap where a
@@ -128,8 +157,9 @@ def resolve_drafter_kind(model_path, kind: Optional[str] = None) -> str:
     but forgets ``--draft-kind mtp``: rather than crashing deep inside
     ``draft_block`` with an opaque error, we pick the right kind for them.
     """
-    model_type = _peek_drafter_model_type(model_path)
-    expected = DRAFTER_KIND_BY_MODEL_TYPE.get(model_type)
+    config = _read_drafter_config(model_path)
+    model_type = config.get("model_type") or config.get("speculators_model_type")
+    expected = _expected_drafter_kind(model_type, config)
 
     if kind is None:
         resolved = expected or DEFAULT_DRAFTER_KIND

--- a/mlx_vlm/tests/test_speculative.py
+++ b/mlx_vlm/tests/test_speculative.py
@@ -238,10 +238,14 @@ def _make_gdn_state(
     )
 
 
-def _make_drafter_dir(tmp_path: Path, model_type: str | None) -> Path:
+def _make_drafter_dir(
+    tmp_path: Path, model_type: str | None, extra: dict | None = None
+) -> Path:
     d = tmp_path / "drafter"
     d.mkdir()
     cfg = {} if model_type is None else {"model_type": model_type}
+    if extra:
+        cfg.update(extra)
     (d / "config.json").write_text(json.dumps(cfg))
     return d
 
@@ -2705,6 +2709,31 @@ def test_kind_none_autodetects_mtp_for_glm4_moe_lite_mtp(tmp_path):
     path = _make_drafter_dir(tmp_path, "glm4_moe_lite_mtp")
     assert resolve_drafter_kind(path, None) == "mtp"
     assert resolve_drafter_kind(path, "dflash") == "mtp"
+
+
+def test_kind_none_autodetects_mtp_for_native_nextn_checkpoint(tmp_path):
+    path = _make_drafter_dir(tmp_path, "deepseek_v4", {"num_nextn_predict_layers": 1})
+    assert resolve_drafter_kind(path, None) == "mtp"
+    assert resolve_drafter_kind(path) == "mtp"
+
+
+def test_native_nextn_overrides_dflash_to_mtp(tmp_path, caplog):
+    path = _make_drafter_dir(tmp_path, "deepseek_v4", {"num_nextn_predict_layers": 1})
+    with caplog.at_level("WARNING"):
+        assert resolve_drafter_kind(path, "dflash") == "mtp"
+    assert any("requires --draft-kind='mtp'" in r.getMessage() for r in caplog.records)
+
+
+def test_mapped_type_wins_over_nextn_heuristic(tmp_path):
+    path = _make_drafter_dir(
+        tmp_path, "deepseek_v4_dspark", {"num_nextn_predict_layers": 1}
+    )
+    assert resolve_drafter_kind(path, None) == "dflash"
+
+
+def test_zero_nextn_falls_back_to_default(tmp_path):
+    path = _make_drafter_dir(tmp_path, "deepseek_v4", {"num_nextn_predict_layers": 0})
+    assert resolve_drafter_kind(path, None) == "dflash"
 
 
 def test_kind_none_autodetects_eagle3_speculators_config(tmp_path):


### PR DESCRIPTION
fixing #2094 by resolving native checkpoints that declare num_nextn_predict_layers to the mtp drafter kind instead of dflash

verified by doing a real-config resolve on DeepSeek-V4-Flash-0731 that now returns mtp, backed by 203 passing speculative tests