### PR TITLE
fix(florence2): load legacy large-ft checkpoints on transformers>=5.14

### DIFF
--- a/mlx_vlm/models/florence2/florence2.py
+++ b/mlx_vlm/models/florence2/florence2.py
@@ -124,6 +124,11 @@ class PositionalEmbeddingCosine1D(nn.Module):
 class Model(nn.Module):
     """Florence-2 model for conditional generation."""
 
+    # Florence-2 is encoder-decoder: the encoder consumes the whole prompt in
+    # one pass, so the decoder-only chunked prefill (which drops the last token
+    # while keeping the full attention mask) must not run.
+    no_chunked_prefill = True
+
     def __init__(self, config: ModelConfig):
         super().__init__()
         self.config = config

--- a/mlx_vlm/models/florence2/processing_florence2.py
+++ b/mlx_vlm/models/florence2/processing_florence2.py
@@ -1,7 +1,22 @@
-from transformers import AddedToken
+from transformers import AddedToken, AutoConfig, BartConfig
 from transformers.models.florence2.processing_florence2 import Florence2Processor
 
 from ..base import install_auto_processor_patch
+
+
+class Florence2LanguageConfig(BartConfig):
+    """BART text config under Florence-2's legacy ``florence2_language`` type.
+
+    Published Florence-2 checkpoints label their (BART) text config with this
+    remote-code model_type, which the native Florence-2 support in
+    transformers>=5.14 does not register, so loading raises ``KeyError``.
+    Registering it lets the config load through the native, torch-free path.
+    """
+
+    model_type = "florence2_language"
+
+
+AutoConfig.register("florence2_language", Florence2LanguageConfig, exist_ok=True)
 
 _ORIGINAL_INIT = Florence2Processor.__init__
 
@@ -102,9 +117,10 @@ def _from_pretrained(cls, pretrained_model_name_or_path, **kwargs):
     import json
     from pathlib import Path
 
-    from transformers import AutoImageProcessor, AutoTokenizer
+    from transformers import AutoImageProcessor, AutoTokenizer, CLIPImageProcessor
 
     kwargs.pop("use_fast", None)
+    kwargs["trust_remote_code"] = False
     tokenizer = AutoTokenizer.from_pretrained(pretrained_model_name_or_path, **kwargs)
 
     proc_cfg_path = Path(pretrained_model_name_or_path) / "processor_config.json"
@@ -130,6 +146,11 @@ def _from_pretrained(cls, pretrained_model_name_or_path, **kwargs):
             pretrained_model_name_or_path,
             **ip_overrides,
             **kwargs,
+        )
+    except ImportError:
+        image_processor = CLIPImageProcessor.from_pretrained(
+            pretrained_model_name_or_path,
+            **ip_overrides,
         )
     return cls(image_processor=image_processor, tokenizer=tokenizer)
 

--- a/mlx_vlm/tests/test_models.py
+++ b/mlx_vlm/tests/test_models.py
@@ -7238,6 +7238,31 @@ class TestModels(unittest.TestCase):
         self.assertLessEqual(fp16_clipped[1], -MAX_FLOAT16_IMAGE_FEATURE + 16)
         self.assertEqual(fp16_clipped[2], 42.0)
 
+    def test_florence2_language_config_registered(self):
+        from transformers import AutoConfig
+
+        from mlx_vlm.models import florence2  # noqa: F401
+
+        self.assertEqual(
+            AutoConfig.for_model("florence2_language").model_type, "florence2_language"
+        )
+
+    def test_florence2_skips_chunked_prefill(self):
+        from mlx_vlm.generate.common import _chunked_prefill_enabled
+        from mlx_vlm.models import florence2
+
+        config = florence2.ModelConfig(
+            text_config=florence2.TextConfig(),
+            vision_config=florence2.VisionConfig(drop_path_rate=0.0),
+        )
+        model = florence2.Model(config)
+        self.assertTrue(model.no_chunked_prefill)
+        self.assertFalse(
+            _chunked_prefill_enabled(
+                model, inputs_embeds=mx.zeros((1, 8, 4)), prefill_kwargs={}
+            )
+        )
+
     def test_florence2(self):
         from mlx_vlm.models import florence2
 


### PR DESCRIPTION
The published `Florence-2-large-ft` checkpoints fail to load on main: transformers>=5.14 ships native Florence-2 that rejects their legacy `florence2_language` text config (`KeyError`) and routes the processor through torch remote code (torch/torchvision `ImportError` in the mlx-only env). This registers the legacy config as a BART config, forces the native torch-free processor path (with a `CLIPImageProcessor` fallback when torchvision is absent), and marks the encoder-decoder model `no_chunked_prefill` so the decoder-only chunked prefill (which trims the prompt but not the encoder mask) does not run.

Refs #1840. With this, the checkpoints load and run torch-free on main and region tasks like `<OD>` produce correct output; the separate `<CAPTION>`/`<OCR>` BOS-only degeneration reproduces once loading works and is a checkpoint-conversion defect (same code path, `<OD>` is fine), not addressed here.