### PR TITLE
Add Ornith 1.5 (Qwen3.5 VL) support and verify qwen3_5_moe MTP

### DIFF
--- a/mlx_vlm/models/qwen3_5/README.md
+++ b/mlx_vlm/models/qwen3_5/README.md
@@ -11,9 +11,10 @@ changes.
 
 | Model | Repository | Variant | Notes |
 |---|---|---|---|
+| Qwen3.6 35B-A3B | `Qwen/Qwen3.6-35B-A3B` | MoE (`qwen3_5_moe`) | Same architecture and MTP head |
 | Ornith 1.5 9B | `ornith-ai/Ornith-1.5-9B` | dense (`qwen3_5`) | Vision-language, image and video |
 | Ornith 1.5 35B-A3B | `ornith-ai/Ornith-1.5-35B-A3B` | MoE (`qwen3_5_moe`) | 256 experts, 8 active (~3B active) |
-| Qwen3.6 35B-A3B | `Qwen/Qwen3.6-35B-A3B` | MoE (`qwen3_5_moe`) | Same architecture and MTP head |
+
 
 ## Details
 

--- a/mlx_vlm/models/qwen3_5/README.md
+++ b/mlx_vlm/models/qwen3_5/README.md
@@ -1,0 +1,97 @@
+# Qwen3.5 VL
+
+`qwen3_5` (dense) and `qwen3_5_moe` (mixture-of-experts) implement the Qwen3.5
+vision-language architecture: a hybrid Qwen3.5 text backbone that interleaves
+gated-delta linear attention with full attention, paired with a Qwen3-VL vision
+tower and spatial-merge connector. The same architecture backs several published
+checkpoints, including Ornith 1.5, so third-party fine-tunes load without model
+changes.
+
+## Models
+
+| Model | Repository | Variant | Notes |
+|---|---|---|---|
+| Ornith 1.5 9B | `ornith-ai/Ornith-1.5-9B` | dense (`qwen3_5`) | Vision-language, image and video |
+| Ornith 1.5 35B-A3B | `ornith-ai/Ornith-1.5-35B-A3B` | MoE (`qwen3_5_moe`) | 256 experts, 8 active (~3B active) |
+| Qwen3.6 35B-A3B | `Qwen/Qwen3.6-35B-A3B` | MoE (`qwen3_5_moe`) | Same architecture and MTP head |
+
+## Details
+
+| | |
+|---|---|
+| **Architecture** | Hybrid Qwen3.5 text (gated-delta + full attention) + Qwen3-VL vision tower |
+| **Modalities** | Text, image, video |
+| **Vocabulary** | 248320 |
+| **Speculative decoding** | Single-layer MTP head (`mtp` drafter), dense and MoE |
+| **Official Cards** | [Ornith 1.5 9B](https://huggingface.co/ornith-ai/Ornith-1.5-9B), [Ornith 1.5 35B-A3B](https://huggingface.co/ornith-ai/Ornith-1.5-35B-A3B) |
+
+## CLI Usage
+
+```bash
+python -m mlx_vlm.generate \
+    --model ornith-ai/Ornith-1.5-9B \
+    --image path/to/image.jpg \
+    --prompt "Describe this image." \
+    --max-tokens 200 \
+    --temperature 0.0
+```
+
+## Python Usage
+
+```python
+from mlx_vlm import generate, load
+from mlx_vlm.prompt_utils import apply_chat_template
+
+model_path = "ornith-ai/Ornith-1.5-9B"
+model, processor = load(model_path)
+
+image = "path/to/image.jpg"
+prompt = "Describe this image."
+
+formatted_prompt = apply_chat_template(
+    processor,
+    model.config,
+    prompt,
+    num_images=1,
+)
+
+result = generate(
+    model,
+    processor,
+    formatted_prompt,
+    image=image,
+    max_tokens=200,
+    temperature=0.0,
+)
+print(result.text)
+```
+
+## Speculative Decoding
+
+These checkpoints ship a single-layer MTP head. Extract it into a standalone
+drafter and run speculative decoding with the `qwen3_5_mtp` drafter, which
+supports both the dense and mixture-of-experts variants:
+
+```bash
+python -m mlx_vlm.speculative.drafters.qwen3_5_mtp.split \
+    --model ornith-ai/Ornith-1.5-9B \
+    --output ornith-1.5-9b-mtp
+
+python -m mlx_vlm.generate \
+    --model ornith-ai/Ornith-1.5-9B \
+    --draft-model ornith-1.5-9b-mtp \
+    --image path/to/image.jpg \
+    --prompt "Describe this image." \
+    --max-tokens 200 \
+    --temperature 0.0
+```
+
+## Architecture
+
+- **Vision**: Qwen3-VL vision tower with patch embedding and a spatial-merge
+  connector that projects merged patches into the text hidden size.
+- **Language**: Hybrid Qwen3.5 backbone alternating gated-delta linear-attention
+  layers with full-attention layers; the MoE variant replaces the MLP with a
+  routed expert block plus a shared expert.
+- **Processor**: Reuses the Qwen3-VL processor and prompt format; image, video,
+  and vision-start token ids are read from the model config.

--- a/mlx_vlm/speculative/drafters/qwen3_5_mtp/qwen3_5_mtp.py
+++ b/mlx_vlm/speculative/drafters/qwen3_5_mtp/qwen3_5_mtp.py
@@ -51,6 +51,7 @@ class Qwen3_5MTPDraftModel(nn.Module):
         self._input_embed = None
         self._input_embed_scale: float = 1.0
         self._lm_head_fn = None
+        self._greedy_argmax_fn = None
         self._cache: List[KVCache] = []
         self._seed_token: Optional[mx.array] = None
         self._seed_hidden: Optional[mx.array] = None
@@ -91,6 +92,7 @@ class Qwen3_5MTPDraftModel(nn.Module):
             or getattr(lm, "lm_head", None)
             or self._input_embed.as_linear
         )
+        self._greedy_argmax_fn = getattr(lm, "speculative_argmax_from_hidden", None)
         return self
 
     def make_cache(self, left_padding: Optional[List[int]] = None) -> List[KVCache]:
@@ -202,9 +204,18 @@ class Qwen3_5MTPDraftModel(nn.Module):
     ) -> mx.array:
         return self._forward_tokens(tok, hidden, token_dtype)
 
+    def _greedy_token(self, hidden: mx.array) -> mx.array:
+        if self._greedy_argmax_fn is not None:
+            token = self._greedy_argmax_fn(hidden)
+            if token is not None:
+                return token
+        return mx.argmax(self._lm_head_fn(hidden), axis=-1)
+
     def _set_seed_from_hidden(self, hidden: mx.array, sampler, greedy: bool) -> None:
-        logits = self._lm_head_fn(hidden)
-        self._seed_token = mx.argmax(logits, axis=-1) if greedy else sampler(logits)
+        if greedy:
+            self._seed_token = self._greedy_token(hidden)
+        else:
+            self._seed_token = sampler(self._lm_head_fn(hidden))
         self._seed_hidden = hidden
 
     def prefill_from_target_hidden(
@@ -461,8 +472,10 @@ class Qwen3_5MTPDraftModel(nn.Module):
         while len(tokens) < block_size - 1:
             h_prev = self._forward_token(tok, h_prev, token_dtype)
             self._round_appended += 1
-            logits = self._lm_head_fn(h_prev)
-            tok = mx.argmax(logits, axis=-1) if greedy else sampler(logits)
+            if greedy:
+                tok = self._greedy_token(h_prev)
+            else:
+                tok = sampler(self._lm_head_fn(h_prev))
             tokens.append(tok)
 
         self._draft_round += 1

--- a/mlx_vlm/tests/test_models.py
+++ b/mlx_vlm/tests/test_models.py
@@ -6005,6 +6005,62 @@ class TestModels(unittest.TestCase):
         self.assertEqual(config.vision_end_token_id, 151653)
         self.assertEqual(config.vision_config.patch_size, 16)
 
+    def test_ornith_1_5_configs_route_to_qwen3_5_family(self):
+        from mlx_vlm.models import qwen3_5, qwen3_5_moe
+        from mlx_vlm.utils import get_model_and_args
+
+        common = {
+            "image_token_id": 248056,
+            "video_token_id": 248057,
+            "vision_start_token_id": 248053,
+            "vision_end_token_id": 248054,
+            "tie_word_embeddings": False,
+        }
+        cases = [
+            (
+                qwen3_5,
+                {
+                    "model_type": "qwen3_5",
+                    "architectures": ["Qwen3_5ForConditionalGeneration"],
+                    "text_config": {
+                        "model_type": "qwen3_5_text",
+                        "vocab_size": 248320,
+                    },
+                    "vision_config": {"model_type": "qwen3_5_vision", "patch_size": 16},
+                    **common,
+                },
+            ),
+            (
+                qwen3_5_moe,
+                {
+                    "model_type": "qwen3_5_moe",
+                    "architectures": ["Qwen3_5MoeForConditionalGeneration"],
+                    "text_config": {
+                        "model_type": "qwen3_5_moe_text",
+                        "vocab_size": 248320,
+                        "num_experts": 256,
+                        "num_experts_per_tok": 8,
+                    },
+                    "vision_config": {
+                        "model_type": "qwen3_5_moe_vision",
+                        "patch_size": 16,
+                    },
+                    **common,
+                },
+            ),
+        ]
+        for module, raw in cases:
+            with self.subTest(model_type=raw["model_type"]):
+                model_class, _ = get_model_and_args(config=dict(raw))
+                self.assertIs(model_class, module)
+
+                config = module.ModelConfig.from_dict(dict(raw))
+                self.assertEqual(config.image_token_id, 248056)
+                self.assertEqual(config.video_token_id, 248057)
+                self.assertEqual(config.vision_start_token_id, 248053)
+                self.assertEqual(config.vision_end_token_id, 248054)
+                self.assertEqual(config.vision_config.patch_size, 16)
+
     def test_qwen3_5_decode_uses_rope_deltas_kwarg(self):
         from mlx_vlm.models import qwen3_5
 

--- a/mlx_vlm/tests/test_speculative.py
+++ b/mlx_vlm/tests/test_speculative.py
@@ -2872,6 +2872,38 @@ def _tiny_qwen3_5_text_config():
     )
 
 
+def _tiny_qwen3_5_moe_text_config(num_experts=4, moe_intermediate_size=8):
+    from mlx_vlm.models.qwen3_5_moe.config import TextConfig as MoeTextConfig
+
+    return MoeTextConfig(
+        model_type="qwen3_5_moe_text",
+        hidden_size=16,
+        num_hidden_layers=1,
+        num_attention_heads=2,
+        linear_num_value_heads=2,
+        linear_num_key_heads=2,
+        linear_key_head_dim=4,
+        linear_value_head_dim=4,
+        linear_conv_kernel_dim=4,
+        num_experts=num_experts,
+        num_experts_per_tok=2,
+        shared_expert_intermediate_size=moe_intermediate_size,
+        moe_intermediate_size=moe_intermediate_size,
+        rms_norm_eps=1e-6,
+        vocab_size=32,
+        num_key_value_heads=1,
+        max_position_embeddings=128,
+        head_dim=8,
+        full_attention_interval=1,
+        rope_parameters={
+            "type": "default",
+            "mrope_section": [1, 0, 0],
+            "rope_theta": 10000,
+            "partial_rotary_factor": 0.25,
+        },
+    )
+
+
 def _tiny_deepseek_v4_config():
     return deepseek_language.ModelConfig(
         vocab_size=32,
@@ -3196,6 +3228,44 @@ def test_eagle3_draft_vocab_mapping_uses_d2t_offsets():
     mapped = model._draft_to_target(mx.array([[0, 1, 3]], dtype=mx.int32), mx.int32)
 
     assert mapped.tolist() == [[0, 5, 15]]
+
+
+def test_qwen3_5_moe_mtp_builds_moe_layer_and_sanitizes_both_expert_layouts():
+    num_experts, moe_inter, hidden = 4, 8, 16
+    drafter = Qwen3_5MTPDraftModel(
+        Qwen3_5MTPConfig(
+            text_config=_tiny_qwen3_5_moe_text_config(
+                num_experts=num_experts, moe_intermediate_size=moe_inter
+            ),
+            block_size=3,
+        )
+    )
+    from mlx_vlm.models.qwen3_5_moe.language import Qwen3_5MoeSparseMoeBlock
+
+    self_mlp = drafter.layers[0].mlp
+    assert isinstance(self_mlp, Qwen3_5MoeSparseMoeBlock)
+    assert hasattr(self_mlp, "switch_mlp")
+
+    p = "mtp.layers.0.mlp"
+    split = {}
+    for e in range(num_experts):
+        split[f"{p}.experts.{e}.gate_proj.weight"] = mx.ones((moe_inter, hidden))
+        split[f"{p}.experts.{e}.up_proj.weight"] = mx.ones((moe_inter, hidden))
+        split[f"{p}.experts.{e}.down_proj.weight"] = mx.ones((hidden, moe_inter))
+    fused = {
+        f"{p}.experts.gate_up_proj": mx.ones((num_experts, 2 * moe_inter, hidden)),
+        f"{p}.experts.down_proj": mx.ones((num_experts, hidden, moe_inter)),
+    }
+
+    for label, weights in (("split", split), ("fused", fused)):
+        out = drafter.sanitize(dict(weights))
+        for proj in ("gate_proj", "up_proj", "down_proj"):
+            key = f"layers.0.mlp.switch_mlp.{proj}.weight"
+            assert key in out, f"[{label}] missing {key}"
+            assert out[key].shape[0] == num_experts, f"[{label}] {key} not stacked"
+        assert not any(
+            ".experts." in k and "switch_mlp" not in k for k in out
+        ), f"[{label}] raw expert keys leaked"
 
 
 def test_qwen3_5_mtp_draft_block_smoke():


### PR DESCRIPTION
Adds Ornith 1.5 (9B dense and 35B-A3B MoE) vision-language support on the existing Qwen3.5 (`qwen3_5`/`qwen3_5_moe`) implementation with a model README, and verifies + tests Qwen3.5-family MoE MTP speculative decoding so the `qwen3_5_mtp` drafter works for any `qwen3_5_moe` checkpoint (Ornith, Qwen3.6, …), not just dense.

MTP speedup vs context (Ornith-1.5-9B, greedy, lossless):

| ctx | plain tok/s | spec tok/s | speedup |
|---:|---:|---:|---:|
| 512 | 33.7 | 40.5 | 1.20× |
| 1024 | 33.3 | 43.4 | 1.30× |
| 2048 | 33.8 | 39.6 | 1.17× |
| 4096 | 33.5 | 38.7 | 1.16× |
| 8192 | 30.5 | 40.0 | 1.31× |
| 16384 | 27.7 | 37.1 | 1.34× |