### PR TITLE
sam3: fix pred_boxes inflation and offset (RoPE scale, RPB grid, ref_point_head)

### DIFF
--- a/mlx_vlm/models/sam3/decoder.py
+++ b/mlx_vlm/models/sam3/decoder.py
@@ -354,9 +354,8 @@ class DETRDecoder(nn.Module):
         y2 = cy + h / 2
         boxes_xyxy = mx.stack([x1, y1, x2, y2], axis=-1)  # (B, Q, 4)
 
-        # Coordinate grids normalized to [0, 1]
-        coords_h = (mx.arange(height).astype(mx.float32) + 0.5) / height
-        coords_w = (mx.arange(width).astype(mx.float32) + 0.5) / width
+        coords_h = mx.arange(height).astype(mx.float32) / height
+        coords_w = mx.arange(width).astype(mx.float32) / width
 
         # Compute deltas: coords - box boundaries
         # y deltas: (B*Q, HW, 2) = coords_h - [y1, y2]

--- a/mlx_vlm/models/sam3/decoder.py
+++ b/mlx_vlm/models/sam3/decoder.py
@@ -130,7 +130,7 @@ class RefPointHead(nn.Module):
         self.layer2 = nn.Linear(hidden_size, hidden_size)
 
     def __call__(self, x: mx.array) -> mx.array:
-        return nn.relu(self.layer2(nn.relu(self.layer1(x))))
+        return self.layer2(nn.relu(self.layer1(x)))
 
 
 class BoxRPBEmbed(nn.Module):

--- a/mlx_vlm/models/sam3/position.py
+++ b/mlx_vlm/models/sam3/position.py
@@ -67,8 +67,14 @@ def compute_axial_cis(
     end_x: int,
     end_y: int,
     theta: float = 10000.0,
+    scale: float = 1.0,
 ) -> Tuple[mx.array, mx.array]:
     """Compute 2D axial rotary position embeddings matching HF Sam3ViTRotaryEmbedding.
+
+    ``scale`` multiplies the grid coordinates, as HF does via its ``rotary_scale``.
+    Global-attention blocks span the whole feature map but keep the window-sized
+    coordinate stride, so they pass ``window_size / feat_size``; windowed blocks
+    pass 1.0. Omitting it makes global-block positions advance too fast.
 
     Returns:
         cos: (end_x*end_y, dim) cosine embeddings
@@ -79,8 +85,8 @@ def compute_axial_cis(
 
     # Grid positions (row-major: y changes with row, x changes with column)
     flat_idx = mx.arange(end_x * end_y)
-    x_positions = (flat_idx % end_x).astype(mx.float32)
-    y_positions = (flat_idx // end_x).astype(mx.float32)
+    x_positions = (flat_idx % end_x).astype(mx.float32) * scale
+    y_positions = (flat_idx // end_x).astype(mx.float32) * scale
 
     # Outer products: (N, dim//4) each
     freqs_x = x_positions[:, None] * freqs[None, :]

--- a/mlx_vlm/models/sam3/vision.py
+++ b/mlx_vlm/models/sam3/vision.py
@@ -280,6 +280,7 @@ class ViTBackbone(nn.Module):
             feat_size,
             feat_size,
             theta=config.rope_theta,
+            scale=config.window_size / feat_size,
         )
 
     def __call__(self, x: mx.array) -> mx.array:
@@ -312,6 +313,7 @@ class ViTBackbone(nn.Module):
                 H,
                 W,
                 theta=self.config.rope_theta,
+                scale=self.config.window_size / H,
             )
         else:
             global_cos = self._rope_global_cos

--- a/mlx_vlm/tests/test_models.py
+++ b/mlx_vlm/tests/test_models.py
@@ -14249,6 +14249,34 @@ class TestSam3(unittest.TestCase):
         self.assertEqual(cos.shape, (64, 64))
         self.assertEqual(sin.shape, (64, 64))
 
+    def test_sam3_decoder_two_layer_mlps_have_no_output_activation(self):
+        """RefPointHead and BoxRPBEmbed mirror the reference 2-layer MLP.
+
+        The reference applies ReLU only between the layers, so a ReLU on the
+        output would clamp query_pos and the RPB deltas to non-negative values.
+        """
+        from mlx_vlm.models.sam3.decoder import BoxRPBEmbed, RefPointHead
+
+        hidden = 8
+        head = RefPointHead(hidden)
+        head.layer1.weight = mx.zeros((hidden, hidden * 2))
+        head.layer1.bias = mx.ones((hidden,))
+        head.layer2.weight = mx.eye(hidden) * -1.0
+        head.layer2.bias = mx.zeros((hidden,))
+        out = head(mx.zeros((1, 3, hidden * 2)))
+        mx.eval(out)
+        self.assertTrue(float(out.min()) < 0.0)
+        self.assertTrue(mx.allclose(out, -mx.ones_like(out), atol=1e-6).item())
+
+        rpb = BoxRPBEmbed(num_heads=hidden, hidden_size=hidden)
+        rpb.layer1.weight = mx.zeros((hidden, 2))
+        rpb.layer1.bias = mx.ones((hidden,))
+        rpb.layer2.weight = mx.eye(hidden) * -1.0
+        rpb.layer2.bias = mx.zeros((hidden,))
+        out = rpb(mx.zeros((1, 2, 2)))
+        mx.eval(out)
+        self.assertTrue(float(out.min()) < 0.0)
+
     def test_sam3_global_rope_uses_window_scaled_grid(self):
         """Global-attention RoPE keeps the window-sized coordinate stride.
 

--- a/mlx_vlm/tests/test_models.py
+++ b/mlx_vlm/tests/test_models.py
@@ -14249,6 +14249,42 @@ class TestSam3(unittest.TestCase):
         self.assertEqual(cos.shape, (64, 64))
         self.assertEqual(sin.shape, (64, 64))
 
+    def test_sam3_global_rope_uses_window_scaled_grid(self):
+        """Global-attention RoPE keeps the window-sized coordinate stride.
+
+        HF derives ``rotary_scale = window_size / rotary_input_size[0]``, which is
+        1.0 for windowed blocks and ``window_size / feat_size`` for global ones.
+        Dropping it makes global-block positions advance too fast.
+        """
+        from mlx_vlm.models.sam3.position import compute_axial_cis
+
+        dim, feat_size, window_size = 64, 6, 2
+        scale = window_size / feat_size
+
+        scaled_cos, scaled_sin = compute_axial_cis(
+            dim, feat_size, feat_size, scale=scale
+        )
+        unit_cos, unit_sin = compute_axial_cis(dim, feat_size, feat_size)
+
+        default_cos, default_sin = compute_axial_cis(
+            dim, feat_size, feat_size, scale=1.0
+        )
+        self.assertTrue(mx.array_equal(default_cos, unit_cos).item())
+        self.assertTrue(mx.array_equal(default_sin, unit_sin).item())
+
+        self.assertFalse(mx.allclose(scaled_cos, unit_cos, atol=1e-6).item())
+
+        freqs = 1.0 / (10000.0 ** (mx.arange(0, dim, 4).astype(mx.float32) / dim))
+        flat = mx.arange(feat_size * feat_size)
+        xs = (flat % feat_size).astype(mx.float32) * scale
+        ys = (flat // feat_size).astype(mx.float32) * scale
+        angles = mx.concatenate(
+            [xs[:, None] * freqs[None, :], ys[:, None] * freqs[None, :]], axis=-1
+        )
+        angles = mx.stack([angles, angles], axis=-1).reshape(angles.shape[0], -1)
+        self.assertTrue(mx.allclose(scaled_cos, mx.cos(angles), atol=1e-6).item())
+        self.assertTrue(mx.allclose(scaled_sin, mx.sin(angles), atol=1e-6).item())
+
 
 class TestRTDetrV2(unittest.TestCase):
     def test_config_from_dict(self):


### PR DESCRIPTION
Fixes #2103.

Three spots in the SAM3 vision/decoder path diverged from the reference: `compute_axial_cis` had no `rotary_scale` so global-attention blocks advanced RoPE positions 3x too fast, the box RPB coordinate grid added a half-cell offset where the reference uses cell corners, and `ref_point_head` applied a ReLU to its output where the reference 2-layer MLP activates only between layers, clamping `query_pos` and inflating every box.

Verified against `transformers` on identical weights: `pred_boxes` error on the issue's synthetic cases drops from -17..+29 px to ~1 px, matching HF to within 0.1 px, and objects that were previously missed entirely are detected again.
