### PR TITLE
Strip Muse Glimmer channel scaffolding from generated output

### DIFF
--- a/mlx_vlm/models/muse_glimmer/processing_muse_glimmer.py
+++ b/mlx_vlm/models/muse_glimmer/processing_muse_glimmer.py
@@ -1,6 +1,7 @@
 import itertools
 import json
 import math
+import re
 from pathlib import Path
 from typing import List, Optional, Union
 
@@ -12,6 +13,20 @@ from transformers.processing_utils import ProcessorMixin
 
 from ..base import install_auto_processor_patch, load_chat_template, to_mlx
 from .config import ModelConfig
+
+_USER_CHANNEL_RE = re.compile(r"to\s*=\s*user\s*<\|message\|>")
+_CHANNEL_END_RE = re.compile(r"<\|(?:eom|return|end)\|>")
+_CHANNEL_MARKER_RE = re.compile(r"<\|[^>]*\|>")
+
+
+def _extract_final_channel(text: str) -> str:
+    matches = list(_USER_CHANNEL_RE.finditer(text))
+    if not matches:
+        return text
+    body = text[matches[-1].end() :]
+    body = _CHANNEL_END_RE.split(body, maxsplit=1)[0]
+    body = _CHANNEL_MARKER_RE.sub("", body)
+    return body.strip()
 
 
 def smart_resize(height: int, width: int, patch_size: int, max_tokens: int):
@@ -194,6 +209,15 @@ class MuseGlimmerProcessor(ProcessorMixin):
 
     def decode(self, *args, **kwargs):
         return self.tokenizer.decode(*args, **kwargs)
+
+    def clean_output(self, text: str) -> str:
+        """Return only the final ``to=user`` channel body.
+
+        Muse Glimmer emits a Harmony-style channel transcript (a ``to=self``
+        reasoning channel followed by the ``to=user`` answer) whose markers are
+        non-special and leak into decoded text, so keep just the answer.
+        """
+        return _extract_final_channel(text)
 
     @property
     def model_input_names(self):

--- a/mlx_vlm/tests/test_processors.py
+++ b/mlx_vlm/tests/test_processors.py
@@ -4056,3 +4056,31 @@ class TestVideoFrameCaps(unittest.TestCase):
             processor.video_sampling_defaults(),
             {"max_frames": processor.max_num_frames},
         )
+
+
+class TestMuseGlimmerCleanOutput(unittest.TestCase):
+    def _clean(self, text):
+        from mlx_vlm.models.muse_glimmer.processing_muse_glimmer import (
+            _extract_final_channel,
+        )
+
+        return _extract_final_channel(text)
+
+    def test_returns_only_final_user_channel(self):
+        raw = (
+            " to=self<|message|>Describe this image in one sentence.\n"
+            "Probably: two cats.\nLet's produce.<|eom|>"
+            "<|start|>assistant to=user<|message|>Two tabby cats sleep on a pink couch."
+        )
+        cleaned = self._clean(raw)
+        self.assertEqual(cleaned, "Two tabby cats sleep on a pink couch.")
+        self.assertNotIn("to=self", cleaned)
+        self.assertNotIn("<|message|>", cleaned)
+
+    def test_strips_trailing_channel_end_marker(self):
+        raw = "to=user<|message|>Final answer.<|return|>"
+        self.assertEqual(self._clean(raw), "Final answer.")
+
+    def test_noop_without_channels(self):
+        plain = "Two tabby cats sleep on a pink couch."
+        self.assertEqual(self._clean(plain), plain)


### PR DESCRIPTION
Closes #2121. Adds a `clean_output` hook to `MuseGlimmerProcessor` that strips the Harmony-style channel scaffolding (the `to=self` reasoning channel and `<|start|>`/`<|message|>`/`<|eom|>` markers) and returns only the final `to=user` answer.

Verified on checkpoints this addresses issue