### PR TITLE
Add OpenAI Privacy Filter model support

### DIFF
--- a/mlx_vlm/models/openai_privacy_filter/README.md
+++ b/mlx_vlm/models/openai_privacy_filter/README.md
@@ -1,0 +1,82 @@
+# OpenAI Privacy Filter
+
+`openai/privacy-filter` is a bidirectional, sparse-MoE token classifier for
+detecting and masking personally identifiable information. The MLX port loads
+the original Hugging Face safetensors directly and includes the model's
+constrained BIOES Viterbi decoder.
+
+## Supported Models
+
+| Source | Repository ID |
+| --- | --- |
+| Official | [`openai/privacy-filter`](https://huggingface.co/openai/privacy-filter) |
+| MLX BF16 | [`mlx-community/openai-privacy-filter-bf16`](https://huggingface.co/mlx-community/openai-privacy-filter-bf16) |
+| MLX 4-bit | [`mlx-community/openai-privacy-filter-4bit`](https://huggingface.co/mlx-community/openai-privacy-filter-4bit) |
+| MLX 5-bit | [`mlx-community/openai-privacy-filter-5bit`](https://huggingface.co/mlx-community/openai-privacy-filter-5bit) |
+| MLX 6-bit | [`mlx-community/openai-privacy-filter-6bit`](https://huggingface.co/mlx-community/openai-privacy-filter-6bit) |
+| MLX 8-bit | [`mlx-community/openai-privacy-filter-8bit`](https://huggingface.co/mlx-community/openai-privacy-filter-8bit) |
+| MLX MXFP4 | [`mlx-community/openai-privacy-filter-mxfp4`](https://huggingface.co/mlx-community/openai-privacy-filter-mxfp4) |
+| MLX NVFP4 | [`mlx-community/openai-privacy-filter-nvfp4`](https://huggingface.co/mlx-community/openai-privacy-filter-nvfp4) |
+| MLX MXFP8 | [`mlx-community/openai-privacy-filter-mxfp8`](https://huggingface.co/mlx-community/openai-privacy-filter-mxfp8) |
+
+## Python
+
+```python
+from mlx_vlm.privacy_filter import load_privacy_filter
+
+detector = load_privacy_filter("openai/privacy-filter")
+result = detector(
+    "Alice Smith can be reached at alice@example.com.",
+)
+
+print(result.spans)
+print(result.redacted_text)
+```
+
+The result contains character offsets, typed labels, source text for each
+span, and redacted text. Pass `replacement="[REDACTED]"` to use a single
+replacement string instead of typed placeholders such as `<PRIVATE_EMAIL>`.
+
+Use independent per-token decoding only when explicitly needed:
+
+```python
+result = detector(text, decode="argmax")
+```
+
+The default Viterbi decoder enforces coherent BIOES spans and reads
+`viterbi_calibration.json` from the checkpoint. Transition biases can be
+overridden when loading the model.
+
+## Command line
+
+```sh
+python -m mlx_vlm.privacy_filter \
+  --model openai/privacy-filter \
+  "Alice Smith can be reached at alice@example.com."
+```
+
+## Quantization
+
+The MLX conversions listed above load directly. Their split expert projections
+and the original checkpoint's fused expert projections are both supported:
+
+```python
+detector = load_privacy_filter("mlx-community/openai-privacy-filter-8bit")
+```
+
+The standard converter can produce an MLX-native quantized checkpoint:
+
+```sh
+mlx_vlm.convert \
+  --hf-path openai/privacy-filter \
+  --mlx-path privacy-filter-4bit \
+  --quantize \
+  --q-bits 4
+```
+
+The attention sink tensors remain FP32, and router projections default to
+8-bit during mixed model quantization.
+
+Privacy Filter is a redaction aid, not an anonymization or compliance
+guarantee. Evaluate it on the target domain and retain review paths for
+high-sensitivity workflows.

--- a/mlx_vlm/models/openai_privacy_filter/__init__.py
+++ b/mlx_vlm/models/openai_privacy_filter/__init__.py
@@ -1,0 +1,4 @@
+from .config import ModelConfig
+from .openai_privacy_filter import Model, TokenClassifierOutput
+
+__all__ = ["Model", "ModelConfig", "TokenClassifierOutput"]

--- a/mlx_vlm/models/openai_privacy_filter/config.py
+++ b/mlx_vlm/models/openai_privacy_filter/config.py
@@ -1,0 +1,87 @@
+from dataclasses import dataclass, field
+from typing import Any, Dict, Optional
+
+from ..base import BaseModelConfig
+
+SPAN_LABELS = (
+    "account_number",
+    "private_address",
+    "private_date",
+    "private_email",
+    "private_person",
+    "private_phone",
+    "private_url",
+    "secret",
+)
+
+TOKEN_LABELS = ("O",) + tuple(
+    f"{boundary}-{label}" for label in SPAN_LABELS for boundary in ("B", "I", "E", "S")
+)
+
+
+def _default_rope_parameters() -> Dict[str, Any]:
+    return {
+        "rope_type": "yarn",
+        "rope_theta": 150000.0,
+        "factor": 32.0,
+        "beta_fast": 32.0,
+        "beta_slow": 1.0,
+        "truncate": False,
+        "original_max_position_embeddings": 4096,
+    }
+
+
+@dataclass
+class ModelConfig(BaseModelConfig):
+    model_type: str = "openai_privacy_filter"
+    vocab_size: int = 200064
+    hidden_size: int = 640
+    intermediate_size: int = 640
+    num_hidden_layers: int = 8
+    num_local_experts: int = 128
+    num_experts_per_tok: int = 4
+    head_dim: int = 64
+    num_attention_heads: int = 14
+    num_key_value_heads: int = 2
+    sliding_window: int = 128
+    max_position_embeddings: int = 131072
+    default_n_ctx: int = 128000
+    initial_context_length: int = 4096
+    rms_norm_eps: float = 1e-5
+    attention_bias: bool = True
+    attention_dropout: float = 0.0
+    classifier_dropout: float = 0.0
+    num_labels: int = len(TOKEN_LABELS)
+    pad_token_id: int = 199999
+    eos_token_id: int = 199999
+    bos_token_id: Optional[int] = None
+    rope_parameters: Dict[str, Any] = field(default_factory=_default_rope_parameters)
+    id2label: Optional[Dict[Any, str]] = None
+    label2id: Optional[Dict[str, int]] = None
+    quantization: Optional[Dict[str, Any]] = None
+    quantization_config: Optional[Dict[str, Any]] = None
+    attention_chunk_size: int = 4096
+    moe_chunk_size: int = 2048
+
+    def __post_init__(self):
+        rope = _default_rope_parameters()
+        rope.update(self.rope_parameters or {})
+        self.rope_parameters = rope
+
+        if self.id2label is None:
+            self.id2label = dict(enumerate(TOKEN_LABELS))
+        else:
+            self.id2label = {int(key): value for key, value in self.id2label.items()}
+            self.num_labels = len(self.id2label)
+
+        if self.label2id is None:
+            self.label2id = {label: idx for idx, label in self.id2label.items()}
+
+        if self.num_attention_heads % self.num_key_value_heads:
+            raise ValueError(
+                "num_attention_heads must be divisible by num_key_value_heads"
+            )
+        if self.attention_chunk_size <= 0:
+            raise ValueError("attention_chunk_size must be positive")
+        if self.moe_chunk_size <= 0:
+            raise ValueError("moe_chunk_size must be positive")

--- a/mlx_vlm/models/openai_privacy_filter/openai_privacy_filter.py
+++ b/mlx_vlm/models/openai_privacy_filter/openai_privacy_filter.py
@@ -1,0 +1,420 @@
+import math
+from dataclasses import dataclass
+from typing import Optional
+
+import mlx.core as mx
+import mlx.nn as nn
+
+from ..switch_layers import SwitchLinear, _gather_sort, _scatter_unsort
+from .config import ModelConfig
+
+
+@dataclass
+class TokenClassifierOutput:
+    logits: mx.array
+
+
+class RMSNorm(nn.Module):
+    """RMSNorm matching the upstream model's explicit FP32 normalization."""
+
+    def __init__(self, hidden_size: int, eps: float):
+        super().__init__()
+        self.weight = mx.ones((hidden_size,))
+        self.eps = eps
+
+    def __call__(self, x: mx.array) -> mx.array:
+        dtype = x.dtype
+        x = x.astype(mx.float32)
+        x = x * mx.rsqrt(mx.mean(mx.square(x), axis=-1, keepdims=True) + self.eps)
+        return (x * self.weight.astype(mx.float32)).astype(dtype)
+
+
+class PrivacyFilterRoPE(nn.Module):
+    """Interleaved YaRN RoPE used by OpenAI Privacy Filter."""
+
+    def __init__(self, config: ModelConfig):
+        super().__init__()
+        params = config.rope_parameters
+        if params.get("rope_type", "yarn") != "yarn":
+            raise ValueError("OpenAI Privacy Filter currently requires YaRN RoPE")
+
+        dims = config.head_dim
+        base = float(params.get("rope_theta", 150000.0))
+        factor = float(params.get("factor", 32.0))
+        original_context = int(params.get("original_max_position_embeddings", 4096))
+        beta_fast = float(params.get("beta_fast", 32.0))
+        beta_slow = float(params.get("beta_slow", 1.0))
+
+        def correction_dim(rotations: float) -> float:
+            return (
+                dims
+                * math.log(original_context / (rotations * 2 * math.pi))
+                / (2 * math.log(base))
+            )
+
+        low = correction_dim(beta_fast)
+        high = correction_dim(beta_slow)
+        if params.get("truncate", True):
+            low = math.floor(low)
+            high = math.ceil(high)
+        low = max(low, 0.0)
+        high = min(high, dims - 1.0)
+        if low == high:
+            high += 0.001
+
+        pos_freqs = base ** (mx.arange(0, dims, 2, dtype=mx.float32) / float(dims))
+        ramp = mx.clip(
+            (mx.arange(dims // 2, dtype=mx.float32) - low) / (high - low),
+            0.0,
+            1.0,
+        )
+        extrapolation = 1.0 - ramp
+        inv_freq = (1.0 / (factor * pos_freqs)) * (1.0 - extrapolation)
+        inv_freq = inv_freq + (1.0 / pos_freqs) * extrapolation
+
+        # mx.fast.rope takes wavelength-like denominators rather than inverse
+        # frequencies. Prefixing the name with '_' keeps it out of checkpoints.
+        self._freqs = 1.0 / inv_freq
+        self._dims = dims
+        self._attention_factor = 1.0 + 0.1 * math.log(factor) if factor > 1 else 1.0
+
+    def __call__(self, x: mx.array) -> mx.array:
+        if self._attention_factor != 1.0:
+            x = x * mx.array(self._attention_factor, dtype=x.dtype)
+        return mx.fast.rope(
+            x,
+            self._dims,
+            traditional=True,
+            base=None,
+            scale=1.0,
+            offset=0,
+            freqs=self._freqs,
+        )
+
+
+def _bidirectional_local_attention(
+    q: mx.array,
+    k: mx.array,
+    v: mx.array,
+    *,
+    sinks: mx.array,
+    radius: int,
+    attention_mask: Optional[mx.array],
+    chunk_size: int,
+) -> mx.array:
+    """Run symmetric local attention without materializing a full T x T mask."""
+
+    seq_len = q.shape[2]
+    chunks = []
+    for query_start in range(0, seq_len, chunk_size):
+        query_end = min(query_start + chunk_size, seq_len)
+        key_start = max(0, query_start - radius)
+        key_end = min(seq_len, query_end + radius)
+
+        query_positions = mx.arange(query_start, query_end)[:, None]
+        key_positions = mx.arange(key_start, key_end)[None, :]
+        local_mask = mx.abs(query_positions - key_positions) <= radius
+        local_mask = local_mask[None, None, :, :]
+        if attention_mask is not None:
+            key_mask = attention_mask[:, None, None, key_start:key_end].astype(mx.bool_)
+            local_mask = local_mask & key_mask
+
+        chunks.append(
+            mx.fast.scaled_dot_product_attention(
+                q[:, :, query_start:query_end],
+                k[:, :, key_start:key_end],
+                v[:, :, key_start:key_end],
+                scale=1.0,
+                mask=local_mask,
+                # MLX SDPA requires sinks to match the attention output type.
+                # Keep checkpoint storage FP32 and narrow only at the kernel.
+                sinks=sinks.astype(q.dtype),
+            )
+        )
+    return chunks[0] if len(chunks) == 1 else mx.concatenate(chunks, axis=2)
+
+
+class Attention(nn.Module):
+    def __init__(self, config: ModelConfig):
+        super().__init__()
+        self.head_dim = config.head_dim
+        self.num_attention_heads = config.num_attention_heads
+        self.num_key_value_heads = config.num_key_value_heads
+        self.sliding_window = config.sliding_window
+        self.chunk_size = config.attention_chunk_size
+        self.qk_scale = config.head_dim**-0.25
+
+        self.q_proj = nn.Linear(
+            config.hidden_size,
+            config.num_attention_heads * config.head_dim,
+            bias=config.attention_bias,
+        )
+        self.k_proj = nn.Linear(
+            config.hidden_size,
+            config.num_key_value_heads * config.head_dim,
+            bias=config.attention_bias,
+        )
+        self.v_proj = nn.Linear(
+            config.hidden_size,
+            config.num_key_value_heads * config.head_dim,
+            bias=config.attention_bias,
+        )
+        self.o_proj = nn.Linear(
+            config.num_attention_heads * config.head_dim,
+            config.hidden_size,
+            bias=config.attention_bias,
+        )
+        self.sinks = mx.zeros((config.num_attention_heads,), dtype=mx.float32)
+        self.rope = PrivacyFilterRoPE(config)
+
+    def __call__(
+        self, hidden_states: mx.array, attention_mask: Optional[mx.array] = None
+    ) -> mx.array:
+        batch, seq_len, _ = hidden_states.shape
+        q = self.q_proj(hidden_states).reshape(
+            batch, seq_len, self.num_attention_heads, self.head_dim
+        )
+        k = self.k_proj(hidden_states).reshape(
+            batch, seq_len, self.num_key_value_heads, self.head_dim
+        )
+        v = self.v_proj(hidden_states).reshape(
+            batch, seq_len, self.num_key_value_heads, self.head_dim
+        )
+        q = q.transpose(0, 2, 1, 3)
+        k = k.transpose(0, 2, 1, 3)
+        v = v.transpose(0, 2, 1, 3)
+
+        q = (self.rope(q) * self.qk_scale).astype(q.dtype)
+        k = (self.rope(k) * self.qk_scale).astype(k.dtype)
+        output = _bidirectional_local_attention(
+            q,
+            k,
+            v,
+            sinks=self.sinks,
+            radius=self.sliding_window,
+            attention_mask=attention_mask,
+            chunk_size=self.chunk_size,
+        )
+        output = output.transpose(0, 2, 1, 3).reshape(batch, seq_len, -1)
+        return self.o_proj(output)
+
+
+def _swiglu(gate: mx.array, up: mx.array) -> mx.array:
+    gate = mx.clip(gate, a_min=None, a_max=7.0)
+    up = mx.clip(up, a_min=-7.0, a_max=7.0)
+    return (up + 1.0) * gate * mx.sigmoid(1.702 * gate)
+
+
+class Experts(nn.Module):
+    def __init__(self, config: ModelConfig):
+        super().__init__()
+        # Keep the projections split to match existing mlx-community
+        # checkpoints. The Hugging Face checkpoint's fused gate/up tensors are
+        # split by Model.sanitize before loading.
+        self.gate_proj = SwitchLinear(
+            config.hidden_size,
+            config.intermediate_size,
+            config.num_local_experts,
+            bias=True,
+        )
+        self.up_proj = SwitchLinear(
+            config.hidden_size,
+            config.intermediate_size,
+            config.num_local_experts,
+            bias=True,
+        )
+        self.down_proj = SwitchLinear(
+            config.intermediate_size,
+            config.hidden_size,
+            config.num_local_experts,
+            bias=True,
+        )
+
+    def __call__(self, x: mx.array, indices: mx.array) -> mx.array:
+        # The reference implementation performs selected-expert projections and
+        # accumulation in FP32. Mixed BF16/FP32 gather_mm preserves that contract
+        # without expanding all 1.4B expert parameters to FP32 in memory.
+        x = mx.expand_dims(x.astype(mx.float32), (-2, -3))
+        do_sort = indices.size >= 64
+        sorted_indices = indices
+        inverse_order = None
+        if do_sort:
+            x, sorted_indices, inverse_order = _gather_sort(x, indices)
+        if self.training:
+            sorted_indices = mx.stop_gradient(sorted_indices)
+
+        gate = self.gate_proj(x, sorted_indices, sorted_indices=do_sort).astype(
+            mx.float32
+        )
+        up = self.up_proj(x, sorted_indices, sorted_indices=do_sort).astype(mx.float32)
+        output = self.down_proj(
+            _swiglu(gate, up),
+            sorted_indices,
+            sorted_indices=do_sort,
+        ).astype(mx.float32)
+
+        if do_sort:
+            output = _scatter_unsort(output, inverse_order, indices.shape)
+        return output.squeeze(-2)
+
+
+class MLP(nn.Module):
+    def __init__(self, config: ModelConfig):
+        super().__init__()
+        self.top_k = config.num_experts_per_tok
+        self.chunk_size = config.moe_chunk_size
+        self.router = nn.Linear(config.hidden_size, config.num_local_experts, bias=True)
+        self.experts = Experts(config)
+
+    def _route(self, x: mx.array) -> tuple[mx.array, mx.array]:
+        if hasattr(self.router, "scales"):
+            logits = self.router(x.astype(mx.float32)).astype(mx.float32)
+        else:
+            logits = x.astype(mx.float32) @ self.router.weight.astype(mx.float32).T
+            logits = logits + self.router.bias.astype(mx.float32)
+
+        indices = mx.argpartition(-logits, kth=self.top_k - 1, axis=-1)[
+            ..., : self.top_k
+        ]
+        top_logits = mx.take_along_axis(logits, indices, axis=-1)
+        order = mx.argsort(-top_logits, axis=-1)
+        indices = mx.take_along_axis(indices, order, axis=-1)
+        top_logits = mx.take_along_axis(top_logits, order, axis=-1)
+        weights = mx.softmax(top_logits, axis=-1, precise=True) / self.top_k
+        return mx.stop_gradient(indices), weights
+
+    def _forward_chunk(self, x: mx.array, output_dtype) -> mx.array:
+        indices, weights = self._route(x)
+        expert_outputs = self.experts(x, indices)
+        output = mx.sum(expert_outputs * weights[..., None], axis=-2)
+        return (output * self.top_k).astype(output_dtype)
+
+    def __call__(self, hidden_states: mx.array) -> mx.array:
+        original_shape = hidden_states.shape
+        flat = hidden_states.reshape(-1, original_shape[-1])
+        chunks = [
+            self._forward_chunk(
+                flat[start : start + self.chunk_size], hidden_states.dtype
+            )
+            for start in range(0, flat.shape[0], self.chunk_size)
+        ]
+        output = chunks[0] if len(chunks) == 1 else mx.concatenate(chunks, axis=0)
+        return output.reshape(original_shape)
+
+
+class EncoderLayer(nn.Module):
+    def __init__(self, config: ModelConfig):
+        super().__init__()
+        self.self_attn = Attention(config)
+        self.mlp = MLP(config)
+        self.input_layernorm = RMSNorm(config.hidden_size, config.rms_norm_eps)
+        self.post_attention_layernorm = RMSNorm(config.hidden_size, config.rms_norm_eps)
+
+    def __call__(
+        self, hidden_states: mx.array, attention_mask: Optional[mx.array] = None
+    ) -> mx.array:
+        hidden_states = hidden_states + self.self_attn(
+            self.input_layernorm(hidden_states), attention_mask
+        )
+        hidden_states = hidden_states + self.mlp(
+            self.post_attention_layernorm(hidden_states)
+        )
+        return hidden_states
+
+
+class Encoder(nn.Module):
+    def __init__(self, config: ModelConfig):
+        super().__init__()
+        self.embed_tokens = nn.Embedding(config.vocab_size, config.hidden_size)
+        self.layers = [EncoderLayer(config) for _ in range(config.num_hidden_layers)]
+        self.norm = RMSNorm(config.hidden_size, config.rms_norm_eps)
+
+    def __call__(
+        self,
+        input_ids: mx.array,
+        attention_mask: Optional[mx.array] = None,
+        inputs_embeds: Optional[mx.array] = None,
+    ) -> mx.array:
+        hidden_states = (
+            self.embed_tokens(input_ids) if inputs_embeds is None else inputs_embeds
+        )
+        for layer in self.layers:
+            hidden_states = layer(hidden_states, attention_mask)
+        return self.norm(hidden_states)
+
+
+class Model(nn.Module):
+    def __init__(self, config: ModelConfig):
+        super().__init__()
+        self.config = config
+        self.model_type = config.model_type
+        self.model = Encoder(config)
+        self.score = nn.Linear(config.hidden_size, config.num_labels, bias=True)
+
+    def __call__(
+        self,
+        input_ids: mx.array,
+        attention_mask: Optional[mx.array] = None,
+        inputs_embeds: Optional[mx.array] = None,
+        mask: Optional[mx.array] = None,
+        **kwargs,
+    ) -> TokenClassifierOutput:
+        if attention_mask is None:
+            attention_mask = mask
+        if input_ids.ndim != 2:
+            raise ValueError("input_ids must have shape [batch, tokens]")
+        if attention_mask is not None and attention_mask.shape != input_ids.shape:
+            raise ValueError("attention_mask must have the same shape as input_ids")
+        hidden_states = self.model(input_ids, attention_mask, inputs_embeds)
+        return TokenClassifierOutput(logits=self.score(hidden_states))
+
+    def sanitize(self, weights):
+        sanitized = {}
+        for key, value in weights.items():
+            if key.endswith(".mlp.experts.gate_up_proj"):
+                value = mx.contiguous(value.swapaxes(-1, -2))
+                prefix = key.removesuffix("gate_up_proj")
+                gate, up = mx.split(value, 2, axis=-2)
+                sanitized[f"{prefix}gate_proj.weight"] = gate
+                sanitized[f"{prefix}up_proj.weight"] = up
+                continue
+            elif key.endswith(".mlp.experts.gate_up_proj_bias"):
+                prefix = key.removesuffix("gate_up_proj_bias")
+                gate, up = mx.split(value, 2, axis=-1)
+                sanitized[f"{prefix}gate_proj.bias"] = gate
+                sanitized[f"{prefix}up_proj.bias"] = up
+                continue
+            elif ".mlp.experts.gate_up_proj." in key:
+                # Accept MLX checkpoints produced with the earlier fused
+                # runtime layout as well as the published split layout. This
+                # applies to dense weights and every quantization companion.
+                prefix, suffix = key.split("gate_up_proj.", 1)
+                output_axis = -1 if suffix == "bias" else -2
+                gate, up = mx.split(value, 2, axis=output_axis)
+                sanitized[f"{prefix}gate_proj.{suffix}"] = gate
+                sanitized[f"{prefix}up_proj.{suffix}"] = up
+                continue
+            elif key.endswith(".mlp.experts.down_proj"):
+                key = f"{key}.weight"
+                value = mx.contiguous(value.swapaxes(-1, -2))
+            elif key.endswith(".mlp.experts.down_proj_bias"):
+                key = key.replace("down_proj_bias", "down_proj.bias")
+            sanitized[key] = value
+        return sanitized
+
+    @property
+    def cast_predicate(self):
+        return lambda path: not path.endswith(".sinks")
+
+    @property
+    def quant_predicate(self):
+        def predicate(path, _module):
+            if path.endswith(".mlp.router"):
+                return {"group_size": 64, "bits": 8}
+            return True
+
+        return predicate
+
+    @property
+    def layers(self):
+        return self.model.layers

--- a/mlx_vlm/privacy_filter.py
+++ b/mlx_vlm/privacy_filter.py
@@ -1,0 +1,469 @@
+"""High-level MLX inference and span decoding for OpenAI Privacy Filter."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Mapping, Optional, Sequence
+
+import mlx.core as mx
+import numpy as np
+from transformers import AutoTokenizer
+
+from .utils import get_model_path, load_model
+
+VITERBI_BIAS_KEYS = (
+    "transition_bias_background_stay",
+    "transition_bias_background_to_start",
+    "transition_bias_inside_to_continue",
+    "transition_bias_inside_to_end",
+    "transition_bias_end_to_background",
+    "transition_bias_end_to_start",
+)
+
+
+@dataclass(frozen=True)
+class PrivacySpan:
+    label: str
+    start: int
+    end: int
+    text: str
+    placeholder: str
+
+
+@dataclass(frozen=True)
+class PrivacyFilterResult:
+    text: str
+    spans: tuple[PrivacySpan, ...]
+    redacted_text: str
+
+    def to_dict(self) -> dict:
+        return {
+            "text": self.text,
+            "spans": [asdict(span) for span in self.spans],
+            "redacted_text": self.redacted_text,
+        }
+
+
+@dataclass(frozen=True)
+class _LabelInfo:
+    labels: tuple[str, ...]
+    background: int
+    span_names: tuple[str, ...]
+    span_index: Mapping[str, int]
+    token_to_span: Mapping[int, int]
+    boundaries: Mapping[int, Optional[str]]
+    states_by_span: Mapping[str, Mapping[str, int]]
+
+
+def _build_label_info(labels: Sequence[str]) -> _LabelInfo:
+    background = None
+    span_names = ["O"]
+    span_index = {"O": 0}
+    token_to_span = {}
+    boundaries = {}
+    states_by_span: dict[str, dict[str, int]] = {}
+
+    for index, label in enumerate(labels):
+        if label == "O":
+            background = index
+            token_to_span[index] = 0
+            boundaries[index] = None
+            continue
+        if "-" not in label:
+            raise ValueError(f"Invalid token label {label!r}; expected BIOES labels")
+        boundary, span_name = label.split("-", 1)
+        if boundary not in {"B", "I", "E", "S"} or not span_name:
+            raise ValueError(f"Invalid token label {label!r}; expected BIOES labels")
+        if span_name not in span_index:
+            span_index[span_name] = len(span_names)
+            span_names.append(span_name)
+        token_to_span[index] = span_index[span_name]
+        boundaries[index] = boundary
+        states_by_span.setdefault(span_name, {})[boundary] = index
+
+    if background is None:
+        raise ValueError("Privacy Filter labels must include the background label 'O'")
+    for span_name, states in states_by_span.items():
+        missing = {"B", "I", "E", "S"} - set(states)
+        if missing:
+            raise ValueError(
+                f"Privacy Filter labels for {span_name!r} are missing {sorted(missing)}"
+            )
+    return _LabelInfo(
+        labels=tuple(labels),
+        background=background,
+        span_names=tuple(span_names),
+        span_index=span_index,
+        token_to_span=token_to_span,
+        boundaries=boundaries,
+        states_by_span=states_by_span,
+    )
+
+
+class ViterbiDecoder:
+    """Linear-time constrained BIOES decoder used by Privacy Filter."""
+
+    def __init__(
+        self,
+        labels: Sequence[str],
+        transition_biases: Optional[Mapping[str, float]] = None,
+    ):
+        self.label_info = _build_label_info(labels)
+        supplied = dict(transition_biases or {})
+        unknown = set(supplied) - set(VITERBI_BIAS_KEYS)
+        if unknown:
+            raise ValueError(f"Unknown Viterbi transition biases: {sorted(unknown)}")
+        self.biases = {key: float(supplied.get(key, 0.0)) for key in VITERBI_BIAS_KEYS}
+
+        states = self.label_info.states_by_span
+        self._b = np.asarray([value["B"] for value in states.values()], dtype=np.int32)
+        self._i = np.asarray([value["I"] for value in states.values()], dtype=np.int32)
+        self._e = np.asarray([value["E"] for value in states.values()], dtype=np.int32)
+        self._s = np.asarray([value["S"] for value in states.values()], dtype=np.int32)
+        self._start_states = np.concatenate(
+            (np.asarray([self.label_info.background], dtype=np.int32), self._b, self._s)
+        )
+        self._end_states = np.concatenate(
+            (np.asarray([self.label_info.background], dtype=np.int32), self._e, self._s)
+        )
+        self._closed_states = np.concatenate((self._e, self._s))
+
+    def decode(self, emissions: np.ndarray) -> list[int]:
+        emissions = np.asarray(emissions, dtype=np.float32)
+        if emissions.ndim != 2:
+            raise ValueError("emissions must have shape [tokens, labels]")
+        length, num_labels = emissions.shape
+        if num_labels != len(self.label_info.labels):
+            raise ValueError(
+                f"Expected {len(self.label_info.labels)} labels, got {num_labels}"
+            )
+        if length == 0:
+            return []
+
+        negative_infinity = np.float32(-1e9)
+        scores = np.full((num_labels,), negative_infinity, dtype=np.float32)
+        scores[self._start_states] = emissions[0, self._start_states]
+        backpointers = np.full((length - 1, num_labels), -1, dtype=np.int16)
+        background = self.label_info.background
+        biases = self.biases
+
+        for step in range(1, length):
+            next_scores = np.full_like(scores, negative_infinity)
+            pointers = backpointers[step - 1]
+
+            closed_values = scores[self._closed_states]
+            closed_offset = int(np.argmax(closed_values))
+            best_closed = float(closed_values[closed_offset])
+            best_closed_state = int(self._closed_states[closed_offset])
+
+            background_options = (
+                float(scores[background]) + biases["transition_bias_background_stay"],
+                best_closed + biases["transition_bias_end_to_background"],
+            )
+            if background_options[0] >= background_options[1]:
+                background_score, background_prev = background_options[0], background
+            else:
+                background_score, background_prev = (
+                    background_options[1],
+                    best_closed_state,
+                )
+            next_scores[background] = background_score + emissions[step, background]
+            pointers[background] = background_prev
+
+            start_options = (
+                float(scores[background])
+                + biases["transition_bias_background_to_start"],
+                best_closed + biases["transition_bias_end_to_start"],
+            )
+            if start_options[0] >= start_options[1]:
+                start_score, start_prev = start_options[0], background
+            else:
+                start_score, start_prev = start_options[1], best_closed_state
+            next_scores[self._b] = start_score + emissions[step, self._b]
+            next_scores[self._s] = start_score + emissions[step, self._s]
+            pointers[self._b] = start_prev
+            pointers[self._s] = start_prev
+
+            open_scores = np.stack((scores[self._b], scores[self._i]), axis=1)
+            choose_inside = open_scores[:, 1] > open_scores[:, 0]
+            best_open = np.where(choose_inside, open_scores[:, 1], open_scores[:, 0])
+            best_open_state = np.where(choose_inside, self._i, self._b)
+            next_scores[self._i] = (
+                best_open
+                + biases["transition_bias_inside_to_continue"]
+                + emissions[step, self._i]
+            )
+            next_scores[self._e] = (
+                best_open
+                + biases["transition_bias_inside_to_end"]
+                + emissions[step, self._e]
+            )
+            pointers[self._i] = best_open_state
+            pointers[self._e] = best_open_state
+            scores = next_scores
+
+        end_scores = scores[self._end_states]
+        last_label = int(self._end_states[int(np.argmax(end_scores))])
+        path = np.empty((length,), dtype=np.int32)
+        path[-1] = last_label
+        for step in range(length - 2, -1, -1):
+            last_label = int(backpointers[step, last_label])
+            path[step] = last_label
+        return path.tolist()
+
+
+def _load_transition_biases(model_path: Path, operating_point: str) -> dict[str, float]:
+    calibration_path = model_path / "viterbi_calibration.json"
+    if not calibration_path.is_file():
+        return {key: 0.0 for key in VITERBI_BIAS_KEYS}
+    with calibration_path.open(encoding="utf-8") as handle:
+        payload = json.load(handle)
+    try:
+        raw_biases = payload["operating_points"][operating_point]["biases"]
+    except (KeyError, TypeError) as exc:
+        raise ValueError(
+            f"Unknown Privacy Filter operating point {operating_point!r}"
+        ) from exc
+    missing = set(VITERBI_BIAS_KEYS) - set(raw_biases)
+    if missing:
+        raise ValueError(f"Viterbi calibration is missing biases: {sorted(missing)}")
+    return {key: float(raw_biases[key]) for key in VITERBI_BIAS_KEYS}
+
+
+def _placeholder(label: str) -> str:
+    normalized = re.sub(r"[^A-Za-z0-9]+", "_", label.upper()).strip("_")
+    return f"<{normalized or 'REDACTED'}>"
+
+
+def _token_spans(path: Sequence[int], labels: _LabelInfo):
+    spans = []
+    current_span = None
+    current_start = None
+    for token_index, token_label in enumerate(path):
+        span_index = labels.token_to_span[token_label]
+        boundary = labels.boundaries[token_label]
+        if token_label == labels.background:
+            if current_span is not None:
+                spans.append((current_span, current_start, token_index))
+            current_span = current_start = None
+        elif boundary == "S":
+            if current_span is not None:
+                spans.append((current_span, current_start, token_index))
+            spans.append((span_index, token_index, token_index + 1))
+            current_span = current_start = None
+        elif boundary == "B":
+            if current_span is not None:
+                spans.append((current_span, current_start, token_index))
+            current_span, current_start = span_index, token_index
+        elif boundary == "I":
+            if current_span != span_index:
+                if current_span is not None:
+                    spans.append((current_span, current_start, token_index))
+                current_span, current_start = span_index, token_index
+        elif boundary == "E":
+            if current_span == span_index:
+                spans.append((span_index, current_start, token_index + 1))
+            else:
+                if current_span is not None:
+                    spans.append((current_span, current_start, token_index))
+                spans.append((span_index, token_index, token_index + 1))
+            current_span = current_start = None
+    if current_span is not None:
+        spans.append((current_span, current_start, len(path)))
+    return spans
+
+
+def _redact(text: str, spans: Sequence[PrivacySpan], replacement: Optional[str]) -> str:
+    output = text
+    for span in reversed(spans):
+        value = replacement if replacement is not None else span.placeholder
+        output = output[: span.start] + value + output[span.end :]
+    return output
+
+
+class PrivacyFilter:
+    """Tokenize text, run the MLX model, and return coherent privacy spans."""
+
+    def __init__(
+        self,
+        model,
+        tokenizer,
+        *,
+        transition_biases: Optional[Mapping[str, float]] = None,
+        context_size: Optional[int] = None,
+    ):
+        self.model = model
+        self.tokenizer = tokenizer
+        id2label = model.config.id2label
+        labels = tuple(id2label[index] for index in range(model.config.num_labels))
+        self.decoder = ViterbiDecoder(labels, transition_biases)
+        self.label_info = self.decoder.label_info
+        self.context_size = int(
+            context_size
+            or getattr(model.config, "default_n_ctx", None)
+            or getattr(model.config, "max_position_embeddings", 4096)
+        )
+        if self.context_size <= 0:
+            raise ValueError("context_size must be positive")
+        self.model.eval()
+
+    def _tokenize(self, text: str) -> tuple[list[int], list[tuple[int, int]]]:
+        encoded = self.tokenizer(
+            text,
+            add_special_tokens=False,
+            return_attention_mask=False,
+            return_offsets_mapping=True,
+            truncation=False,
+        )
+        if "offset_mapping" not in encoded:
+            raise ValueError("Privacy Filter requires a fast tokenizer with offsets")
+        return list(encoded["input_ids"]), [
+            tuple(item) for item in encoded["offset_mapping"]
+        ]
+
+    def __call__(
+        self,
+        text: str,
+        *,
+        decode: str = "viterbi",
+        replacement: Optional[str] = None,
+        trim_whitespace: bool = True,
+    ) -> PrivacyFilterResult:
+        if not isinstance(text, str):
+            raise TypeError("text must be a string")
+        if decode not in {"viterbi", "argmax"}:
+            raise ValueError("decode must be 'viterbi' or 'argmax'")
+        input_ids, offsets = self._tokenize(text)
+        if not input_ids:
+            return PrivacyFilterResult(text=text, spans=(), redacted_text=text)
+
+        score_chunks = []
+        for start in range(0, len(input_ids), self.context_size):
+            token_chunk = input_ids[start : start + self.context_size]
+            ids = mx.array([token_chunk], dtype=mx.int32)
+            attention_mask = mx.ones(ids.shape, dtype=mx.bool_)
+            logits = self.model(ids, attention_mask=attention_mask).logits
+            log_probs = logits.astype(mx.float32)
+            log_probs = log_probs - mx.logsumexp(log_probs, axis=-1, keepdims=True)
+            log_probs = log_probs[0]
+            mx.eval(log_probs)
+            score_chunks.append(np.asarray(log_probs))
+        scores = np.concatenate(score_chunks, axis=0)
+
+        if decode == "viterbi":
+            path = self.decoder.decode(scores)
+        else:
+            path = np.argmax(scores, axis=-1).tolist()
+
+        detected = []
+        for span_index, token_start, token_end in _token_spans(path, self.label_info):
+            char_start = int(offsets[token_start][0])
+            char_end = int(offsets[token_end - 1][1])
+            if trim_whitespace:
+                while char_start < char_end and text[char_start].isspace():
+                    char_start += 1
+                while char_end > char_start and text[char_end - 1].isspace():
+                    char_end -= 1
+            if char_end <= char_start:
+                continue
+            label = self.label_info.span_names[span_index]
+            detected.append(
+                PrivacySpan(
+                    label=label,
+                    start=char_start,
+                    end=char_end,
+                    text=text[char_start:char_end],
+                    placeholder=_placeholder(label),
+                )
+            )
+
+        # Byte-level tokenizers can give several tokens the same character
+        # range. Keep one deterministic, globally non-overlapping span set.
+        detected.sort(
+            key=lambda span: (span.start, -(span.end - span.start), span.label)
+        )
+        non_overlapping = []
+        cursor = 0
+        for span in detected:
+            if span.start < cursor:
+                continue
+            non_overlapping.append(span)
+            cursor = span.end
+        spans = tuple(non_overlapping)
+        return PrivacyFilterResult(
+            text=text,
+            spans=spans,
+            redacted_text=_redact(text, spans, replacement),
+        )
+
+
+def load_privacy_filter(
+    path_or_hf_repo: str = "openai/privacy-filter",
+    *,
+    revision: Optional[str] = None,
+    force_download: bool = False,
+    lazy: bool = False,
+    strict: bool = True,
+    operating_point: str = "default",
+    transition_biases: Optional[Mapping[str, float]] = None,
+    context_size: Optional[int] = None,
+) -> PrivacyFilter:
+    """Load a local or Hugging Face Privacy Filter checkpoint."""
+
+    model_path = get_model_path(
+        path_or_hf_repo,
+        revision=revision,
+        force_download=force_download,
+        allow_patterns=[
+            "config.json",
+            "model.safetensors",
+            "model-*.safetensors",
+            "model.safetensors.index.json",
+            "tokenizer.json",
+            "tokenizer_config.json",
+            "special_tokens_map.json",
+            "viterbi_calibration.json",
+        ],
+    )
+    model = load_model(model_path, lazy=lazy, strict=strict)
+    if model.model_type != "openai_privacy_filter":
+        raise ValueError(
+            f"Expected an OpenAI Privacy Filter checkpoint, got {model.model_type!r}"
+        )
+    tokenizer = AutoTokenizer.from_pretrained(model_path, use_fast=True)
+    biases = (
+        dict(transition_biases)
+        if transition_biases is not None
+        else _load_transition_biases(model_path, operating_point)
+    )
+    return PrivacyFilter(
+        model,
+        tokenizer,
+        transition_biases=biases,
+        context_size=context_size,
+    )
+
+
+def main(argv: Optional[Sequence[str]] = None) -> None:
+    parser = argparse.ArgumentParser(description="Detect and redact PII with MLX")
+    parser.add_argument("text", help="Text to inspect")
+    parser.add_argument("--model", default="openai/privacy-filter")
+    parser.add_argument("--argmax", action="store_true")
+    parser.add_argument("--replacement", default=None)
+    args = parser.parse_args(argv)
+
+    detector = load_privacy_filter(args.model)
+    result = detector(
+        args.text,
+        decode="argmax" if args.argmax else "viterbi",
+        replacement=args.replacement,
+    )
+    print(json.dumps(result.to_dict(), ensure_ascii=False, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/mlx_vlm/tests/test_privacy_filter.py
+++ b/mlx_vlm/tests/test_privacy_filter.py
@@ -1,0 +1,225 @@
+from types import SimpleNamespace
+
+import mlx.core as mx
+import mlx.nn as nn
+import numpy as np
+import pytest
+
+from mlx_vlm.models.openai_privacy_filter import Model, ModelConfig
+from mlx_vlm.privacy_filter import PrivacyFilter, ViterbiDecoder
+from mlx_vlm.utils import get_model_and_args
+
+LABELS = {0: "O", 1: "B-x", 2: "I-x", 3: "E-x", 4: "S-x"}
+
+
+def _tiny_config(**overrides):
+    values = {
+        "vocab_size": 32,
+        "hidden_size": 8,
+        "intermediate_size": 8,
+        "num_hidden_layers": 1,
+        "num_local_experts": 4,
+        "num_experts_per_tok": 2,
+        "head_dim": 4,
+        "num_attention_heads": 2,
+        "num_key_value_heads": 1,
+        "sliding_window": 2,
+        "max_position_embeddings": 32,
+        "default_n_ctx": 32,
+        "pad_token_id": 31,
+        "eos_token_id": 31,
+        "num_labels": 5,
+        "id2label": LABELS,
+        "attention_chunk_size": 3,
+        "moe_chunk_size": 3,
+    }
+    values.update(overrides)
+    return ModelConfig(**values)
+
+
+def test_model_type_resolves_to_privacy_filter_package():
+    module, model_type = get_model_and_args({"model_type": "openai_privacy_filter"})
+
+    assert model_type == "openai_privacy_filter"
+    assert module.Model is Model
+
+
+def test_config_normalizes_json_label_keys():
+    config = _tiny_config(id2label={str(key): value for key, value in LABELS.items()})
+
+    assert config.id2label == LABELS
+    assert config.label2id["S-x"] == 4
+    assert config.num_labels == 5
+
+
+def test_checkpoint_expert_layout_sanitization():
+    gate_up = mx.arange(2 * 3 * 8).reshape(2, 3, 8)
+    down = mx.arange(2 * 4 * 3).reshape(2, 4, 3)
+    weights = {
+        "model.layers.0.mlp.experts.gate_up_proj": gate_up,
+        "model.layers.0.mlp.experts.gate_up_proj_bias": mx.zeros((2, 8)),
+        "model.layers.0.mlp.experts.down_proj": down,
+        "model.layers.0.mlp.experts.down_proj_bias": mx.zeros((2, 3)),
+        "score.weight": mx.zeros((5, 3)),
+    }
+
+    sanitized = Model.sanitize(None, weights)
+
+    gate_key = "model.layers.0.mlp.experts.gate_proj.weight"
+    up_key = "model.layers.0.mlp.experts.up_proj.weight"
+    down_key = "model.layers.0.mlp.experts.down_proj.weight"
+    transposed = gate_up.swapaxes(-1, -2)
+    assert sanitized[gate_key].shape == (2, 4, 3)
+    assert sanitized[up_key].shape == (2, 4, 3)
+    assert sanitized[down_key].shape == (2, 3, 4)
+    assert mx.array_equal(sanitized[gate_key], transposed[:, :4]).item()
+    assert mx.array_equal(sanitized[up_key], transposed[:, 4:]).item()
+    assert mx.array_equal(sanitized[down_key], down.swapaxes(-1, -2)).item()
+    assert "model.layers.0.mlp.experts.gate_proj.bias" in sanitized
+    assert "model.layers.0.mlp.experts.up_proj.bias" in sanitized
+    assert "model.layers.0.mlp.experts.down_proj.bias" in sanitized
+    assert "score.weight" in sanitized
+
+
+def test_existing_split_quantized_expert_layout_is_preserved():
+    weights = {
+        "model.layers.0.mlp.experts.gate_proj.weight": mx.zeros((4, 8, 2)),
+        "model.layers.0.mlp.experts.gate_proj.scales": mx.ones((4, 8, 1)),
+        "model.layers.0.mlp.experts.gate_proj.biases": mx.zeros((4, 8, 1)),
+        "model.layers.0.mlp.experts.up_proj.weight": mx.zeros((4, 8, 2)),
+        "model.layers.0.mlp.experts.up_proj.scales": mx.ones((4, 8, 1)),
+        "model.layers.0.mlp.experts.up_proj.biases": mx.zeros((4, 8, 1)),
+    }
+
+    sanitized = Model.sanitize(None, weights)
+
+    assert sanitized.keys() == weights.keys()
+    for key in weights:
+        assert mx.array_equal(sanitized[key], weights[key]).item()
+
+
+@pytest.mark.parametrize(
+    ("group_size", "bits", "mode"),
+    [
+        (64, 4, "affine"),
+        (64, 5, "affine"),
+        (64, 6, "affine"),
+        (64, 8, "affine"),
+        (32, 4, "mxfp4"),
+        (16, 4, "nvfp4"),
+        (32, 8, "mxfp8"),
+    ],
+)
+def test_published_quantization_modes_run_end_to_end(group_size, bits, mode):
+    model = Model(
+        _tiny_config(
+            hidden_size=64,
+            intermediate_size=64,
+            head_dim=16,
+            num_attention_heads=4,
+        )
+    )
+    nn.quantize(
+        model,
+        group_size=group_size,
+        bits=bits,
+        mode=mode,
+    )
+    input_ids = mx.array([[1, 2, 3, 4, 5]], dtype=mx.int32)
+
+    logits = model(input_ids, attention_mask=mx.ones_like(input_ids)).logits
+    mx.eval(logits)
+
+    assert logits.shape == (1, 5, 5)
+    assert mx.all(mx.isfinite(logits)).item()
+
+
+def test_tiny_forward_supports_attention_and_moe_chunk_boundaries():
+    model = Model(_tiny_config())
+    input_ids = mx.array([[1, 2, 3, 4, 5]], dtype=mx.int32)
+
+    logits = model(input_ids, attention_mask=mx.ones_like(input_ids)).logits
+    mx.eval(logits)
+
+    assert logits.shape == (1, 5, 5)
+    assert mx.all(mx.isfinite(logits)).item()
+
+
+def test_viterbi_rejects_invalid_inside_start():
+    # Independent argmax gives I-x, E-x. The constrained path must begin with B/S.
+    emissions = np.array(
+        [
+            [0.0, 8.0, 10.0, 0.0, 1.0],
+            [0.0, 0.0, 1.0, 10.0, 2.0],
+        ],
+        dtype=np.float32,
+    )
+
+    path = ViterbiDecoder(tuple(LABELS.values())).decode(emissions)
+
+    assert path == [1, 3]
+
+
+def test_viterbi_biases_change_background_operating_point():
+    emissions = np.zeros((2, 5), dtype=np.float32)
+    default_path = ViterbiDecoder(tuple(LABELS.values())).decode(emissions)
+    recall_path = ViterbiDecoder(
+        tuple(LABELS.values()),
+        {"transition_bias_background_to_start": 3.0},
+    ).decode(emissions)
+
+    assert default_path == [0, 0]
+    assert recall_path != default_path
+    assert recall_path[-1] == 4
+
+
+class _FakeTokenizer:
+    def __call__(self, text, **kwargs):
+        assert text == "Alice emailed bob@example.com"
+        return {
+            "input_ids": [1, 2, 3],
+            "offset_mapping": [(0, 5), (5, 13), (13, 29)],
+        }
+
+
+class _FakeModel:
+    def __init__(self):
+        labels = {
+            0: "O",
+            1: "B-private_person",
+            2: "I-private_person",
+            3: "E-private_person",
+            4: "S-private_person",
+            5: "B-private_email",
+            6: "I-private_email",
+            7: "E-private_email",
+            8: "S-private_email",
+        }
+        self.config = SimpleNamespace(
+            id2label=labels,
+            num_labels=len(labels),
+            default_n_ctx=16,
+        )
+
+    def eval(self):
+        return self
+
+    def __call__(self, input_ids, attention_mask=None):
+        logits = mx.full((1, input_ids.shape[1], 9), -10.0)
+        logits[0, 0, 4] = 10.0
+        logits[0, 1, 0] = 10.0
+        logits[0, 2, 8] = 10.0
+        return SimpleNamespace(logits=logits)
+
+
+def test_high_level_api_returns_offsets_and_redacted_text():
+    detector = PrivacyFilter(_FakeModel(), _FakeTokenizer())
+
+    result = detector("Alice emailed bob@example.com")
+
+    assert [(span.label, span.start, span.end) for span in result.spans] == [
+        ("private_person", 0, 5),
+        ("private_email", 14, 29),
+    ]
+    assert result.redacted_text == ("<PRIVATE_PERSON> emailed <PRIVATE_EMAIL>")
+    assert result.to_dict()["spans"][0]["text"] == "Alice"


### PR DESCRIPTION
This was previously supported in `mlx-embeddings` and makes sense to pull in now since we've added the other embedding models. This port supports both the official safetensors weights and the `mlx-community` quantizations.