### PR TITLE
Support multiple tool call invocations at once

### DIFF
--- a/mlx_vlm/server/responses_state.py
+++ b/mlx_vlm/server/responses_state.py
@@ -374,8 +374,8 @@ def process_tool_calls(model_output: str, tool_module, tools):
                                 },
                             },
                         )
-                except Exception:
-                    logger.warning("Invalid tool call: %s", call)
+                except Exception as exc:
+                    logger.warning("Invalid tool call %r: %s", call, exc)
     return dict(calls=called_tools, remaining_text=remaining)
 
 

--- a/mlx_vlm/tests/test_pythonic_tool_parser.py
+++ b/mlx_vlm/tests/test_pythonic_tool_parser.py
@@ -45,6 +45,37 @@ def test_lfm_tool_call_output_parses_for_server_response():
     }
 
 
+def test_multiple_tool_calls_are_parsed():
+    result = parse_tool_call(
+        "[read_file(path='brick.html'), read_file(path='game.html')]"
+    )
+
+    assert result == [
+        {"name": "read_file", "arguments": {"path": "brick.html"}},
+        {"name": "read_file", "arguments": {"path": "game.html"}},
+    ]
+
+
+def test_multiple_tool_calls_parse_for_server_response():
+    parser = load_tool_module("pythonic")
+    result = process_tool_calls(
+        "<|tool_call_start|>[read_file(path='brick.html'), "
+        "read_file(path='game.html')]<|tool_call_end|>",
+        parser,
+        tools=[{"type": "function", "function": {"name": "read_file"}}],
+    )
+
+    assert result["remaining_text"] == ""
+    assert [call["function"]["name"] for call in result["calls"]] == [
+        "read_file",
+        "read_file",
+    ]
+    assert [json.loads(call["function"]["arguments"]) for call in result["calls"]] == [
+        {"path": "brick.html"},
+        {"path": "game.html"},
+    ]
+
+
 def test_single_quoted_string_preserves_embedded_commas():
     result = parse_tool_call(
         "[write_file(path='game.js', content='const player = { x: 0, y: 1 };')]"

--- a/mlx_vlm/tool_parsers/pythonic.py
+++ b/mlx_vlm/tool_parsers/pythonic.py
@@ -103,19 +103,7 @@ def _parse_tolerant_tool_call(text: str) -> dict[str, Any]:
     }
 
 
-def parse_tool_call(text: str, tools: Any | None = None):
-    try:
-        expression = ast.parse(text.strip(), mode="eval").body
-    except SyntaxError as exc:
-        try:
-            return _parse_tolerant_tool_call(text)
-        except ValueError as fallback_exc:
-            raise fallback_exc from exc
-
-    if not isinstance(expression, ast.List) or len(expression.elts) != 1:
-        raise ValueError("Expected a single tool call inside a list.")
-
-    call = expression.elts[0]
+def _parse_call(call: ast.expr) -> dict[str, Any]:
     if not isinstance(call, ast.Call) or not isinstance(call.func, ast.Name):
         raise TypeError("Expected a named function call.")
     if call.args:
@@ -135,6 +123,22 @@ def parse_tool_call(text: str, tools: Any | None = None):
             ) from exc
 
     return {"name": call.func.id, "arguments": arguments}
+
+
+def parse_tool_call(text: str, tools: Any | None = None):
+    try:
+        expression = ast.parse(text.strip(), mode="eval").body
+    except SyntaxError as exc:
+        try:
+            return _parse_tolerant_tool_call(text)
+        except ValueError as fallback_exc:
+            raise fallback_exc from exc
+
+    if not isinstance(expression, ast.List) or not expression.elts:
+        raise ValueError("Expected one or more tool calls inside a list.")
+
+    calls = [_parse_call(call) for call in expression.elts]
+    return calls[0] if len(calls) == 1 else calls
 
 
 tool_call_start = "<|tool_call_start|>"


### PR DESCRIPTION
Many models emit a list of tool calls to be executed consecutively, and we were dropping all tool calls when the list didn't contain exactly one element. This updates the tool call parser to resolve all of the calls.