### PR TITLE
Add DSpark support for Gemma 4

### DIFF
--- a/mlx_vlm/models/gemma4/config.py
+++ b/mlx_vlm/models/gemma4/config.py
@@ -90,6 +90,7 @@ class TextConfig(BaseModelConfig):
     use_double_wide_mlp: bool = True
     enable_moe_block: bool = False
     use_second_mlp_block: bool = False
+    exact_speculative_verify: bool = False
     num_experts: Optional[int] = None
     top_k_experts: Optional[int] = None
     moe_intermediate_size: Optional[int] = None

--- a/mlx_vlm/models/gemma4/language.py
+++ b/mlx_vlm/models/gemma4/language.py
@@ -14,6 +14,9 @@ from ..base import (
 from ..cache import KVCache, RotatingKVCache
 from ..rope_utils import initialize_rope
 from .config import TextConfig
+from .speculative_verifier import Gemma4ExactSpeculativeVerifier
+
+_EXACT_SPECULATIVE_VERIFIER = Gemma4ExactSpeculativeVerifier()
 
 
 @partial(mx.compile, shapeless=True)
@@ -718,6 +721,17 @@ class LanguageModel(nn.Module):
         capture_layer_ids: Optional[List[int]] = None,
         **kwargs,
     ):
+        if kwargs.pop("speculative_verify", False) and getattr(
+            self.config, "exact_speculative_verify", False
+        ):
+            return _EXACT_SPECULATIVE_VERIFIER(
+                self,
+                inputs,
+                cache=cache,
+                input_embeddings=inputs_embeds,
+                capture_layer_ids=capture_layer_ids,
+            )
+
         hidden_sink: Optional[list] = (
             []
             if capture_layer_ids is not None or kwargs.pop("return_hidden", False)

--- a/mlx_vlm/models/gemma4/speculative_verifier.py
+++ b/mlx_vlm/models/gemma4/speculative_verifier.py
@@ -1,0 +1,190 @@
+from typing import Any, List, Optional
+
+import mlx.core as mx
+
+from ..base import LanguageModelOutput, scaled_dot_product_attention
+from ..qwen3_5.speculative_verifier import Qwen3_5ExactSpeculativeVerifier
+
+
+class Gemma4ExactSpeculativeVerifier(Qwen3_5ExactSpeculativeVerifier):
+    """Run Gemma 4 block verification with singleton-equivalent numerics.
+
+    Verifying a block as one ``(1, K, D)`` matmul takes a different kernel path
+    than the ``K`` singleton steps base decoding performs, and the last-bit
+    difference is enough to move an argmax. The dense and quantized linear
+    primitives are inherited; only the Gemma 4 forward is reimplemented here.
+
+    Sliding layers are bounded by their RotatingKVCache, so the resident
+    prefix already carries at most ``sliding_window`` keys.
+    """
+
+    def _attention(self, attention, x, mask, cache, shared_kv=None, offset=None):
+        batch, length, _ = x.shape
+        n_heads, n_kv_heads = attention.n_heads, attention.n_kv_heads
+        head_dim = attention.head_dim
+
+        queries = self._linear(attention.q_proj, x).reshape(
+            batch, length, n_heads, head_dim
+        )
+        queries = attention.q_norm(queries)
+
+        if shared_kv is not None:
+            keys, values = shared_kv
+        else:
+            # k_eq_v layers publish no v_proj: keys and values share the
+            # projection, and values take it before k_norm.
+            keys = self._linear(attention.k_proj, x).reshape(
+                batch, length, n_kv_heads, head_dim
+            )
+            if attention.use_k_eq_v:
+                values = keys
+            else:
+                values = self._linear(attention.v_proj, x).reshape(
+                    batch, length, n_kv_heads, head_dim
+                )
+
+            offset = mx.array(cache.offset) if cache is not None else 0
+
+            keys = attention.k_norm(keys).transpose(0, 2, 1, 3)
+            keys = attention.rope(keys, offset=offset)
+            values = attention.v_norm(values).transpose(0, 2, 1, 3)
+
+            if cache is not None:
+                keys, values = cache.update_and_fetch(keys, values)
+
+        queries = queries.transpose(0, 2, 1, 3)
+        queries = attention.rope(queries, offset=offset)
+
+        if length > 1:
+            # Sliding layers are already bounded by RotatingKVCache, so the
+            # resident prefix needs no extra windowing here.
+            prefix_length = keys.shape[-2] - length
+            output = mx.concatenate(
+                [
+                    scaled_dot_product_attention(
+                        queries[:, :, index : index + 1, :],
+                        keys[..., : prefix_length + index + 1, :],
+                        values[..., : prefix_length + index + 1, :],
+                        cache=cache,
+                        scale=attention.scale,
+                        mask=(
+                            mask[..., index : index + 1, : prefix_length + index + 1]
+                            if isinstance(mask, mx.array) and mask.ndim >= 4
+                            else None
+                        ),
+                    )
+                    for index in range(length)
+                ],
+                axis=2,
+            )
+        else:
+            output = scaled_dot_product_attention(
+                queries, keys, values, cache=cache, scale=attention.scale, mask=mask
+            )
+
+        output = output.transpose(0, 2, 1, 3).reshape(batch, length, -1)
+        return self._linear(attention.o_proj, output), (keys, values), offset
+
+    def _feed_forward(self, mlp, x):
+        from .language import geglu
+
+        gate = self._linear(mlp.gate_proj, x)
+        up = self._linear(mlp.up_proj, x)
+        return self._linear(mlp.down_proj, geglu(gate, up))
+
+    def _layer(self, layer, x, mask, cache, per_layer_input, shared_kv, offset):
+        residual = x
+        hidden, kvs, offset = self._attention(
+            layer.self_attn, layer.input_layernorm(x), mask, cache, shared_kv, offset
+        )
+        hidden = residual + layer.post_attention_layernorm(hidden)
+
+        residual = hidden
+        if getattr(layer, "enable_moe", False):
+            inner = layer.mlp(layer.pre_feedforward_layernorm(hidden))
+        else:
+            inner = self._feed_forward(
+                mlp=layer.mlp, x=layer.pre_feedforward_layernorm(hidden)
+            )
+        hidden = residual + layer.post_feedforward_layernorm(inner)
+
+        if (
+            getattr(layer, "per_layer_input_gate", None) is not None
+            and getattr(layer, "per_layer_projection", None) is not None
+            and getattr(layer, "post_per_layer_input_norm", None) is not None
+            and per_layer_input is not None
+        ):
+            hidden = layer(
+                hidden, mask, cache, per_layer_input=per_layer_input, offset=offset
+            )[0]
+        elif layer.layer_scalar is not None:
+            hidden = hidden * layer.layer_scalar
+
+        return hidden, kvs, offset
+
+    def _model(self, model, inputs, cache, input_embeddings, capture_layer_ids, sink):
+        hidden = (
+            input_embeddings
+            if input_embeddings is not None
+            else model.embed_tokens(inputs) * model.embed_scale
+        )
+        if cache is None:
+            cache = [None] * len(model.layers)
+
+        masks = model._make_masks(hidden, cache, None)
+        capture_set = set(capture_layer_ids) if capture_layer_ids else set()
+        intermediates: List[Any] = [(None, None)] * len(model.layers)
+
+        for index, (layer, layer_cache, mask, prev_index) in enumerate(
+            zip(model.layers, cache, masks, model.previous_kvs)
+        ):
+            kvs, offset = intermediates[prev_index]
+            hidden, kvs, offset = self._layer(
+                layer, hidden, mask, layer_cache, None, kvs, offset
+            )
+            intermediates[index] = (kvs, offset)
+            if sink is not None and index in capture_set:
+                sink.append(hidden)
+
+        if sink is not None and not capture_set:
+            sink.append(hidden)
+
+        return model.norm(hidden)
+
+    def __call__(
+        self,
+        language_model,
+        inputs,
+        *,
+        cache: Any = None,
+        input_embeddings: Optional[mx.array] = None,
+        capture_layer_ids: Optional[List[int]] = None,
+    ) -> LanguageModelOutput:
+        sink: Optional[List[mx.array]] = [] if capture_layer_ids is not None else None
+        hidden = self._model(
+            language_model.model,
+            inputs,
+            cache,
+            input_embeddings,
+            capture_layer_ids,
+            sink,
+        )
+
+        head = getattr(language_model, "lm_head", None)
+        if head is None:
+            logits = self._embedding_as_linear(
+                language_model.model.embed_tokens, hidden
+            )
+        else:
+            logits = self._linear(head, hidden)
+
+        softcap = getattr(language_model, "final_logit_softcapping", None)
+        if softcap is not None:
+            from .language import logit_softcap
+
+            logits = logit_softcap(softcap, logits)
+
+        return LanguageModelOutput(logits=logits, hidden_states=sink)
+
+
+__all__ = ["Gemma4ExactSpeculativeVerifier"]

--- a/mlx_vlm/speculative/drafters/__init__.py
+++ b/mlx_vlm/speculative/drafters/__init__.py
@@ -16,6 +16,7 @@ DRAFTER_KIND_BY_MODEL_TYPE = {
     "deepseek_v4_mtp": "mtp",
     "deepseek_v4_dspark": "dflash",
     "dspark": "dflash",
+    "gemma4_dspark": "dflash",
     "eagle3": "eagle3",
     "gemma4_assistant": "mtp",
     "gemma4_unified_assistant": "mtp",
@@ -26,6 +27,7 @@ DRAFTER_KIND_BY_MODEL_TYPE = {
     "qwen4_exp_mtp": "mtp",
     "laguna": "dflash",
     "muse_glimmer_assistant": "dflash",
+    "qwen3_dspark": "dflash",
 }
 
 DEFAULT_DRAFTER_KIND = "dflash"

--- a/mlx_vlm/speculative/drafters/gemma4_dspark/README.md
+++ b/mlx_vlm/speculative/drafters/gemma4_dspark/README.md
@@ -1,0 +1,130 @@
+# Gemma 4 DSpark drafter
+
+`gemma4_dspark` runs DeepSeek's DSpark self-speculative decoding against Gemma 4
+targets. Like `deepseek_v4_dspark`, it is a **backbone variant of the
+model-agnostic `dspark` drafter**: it reuses the shared DSpark machinery —
+`VanillaMarkov` block sampling, the confidence head, and the `dflash` round loop
+with its target-hidden tap — and swaps only the Qwen-style draft layers for
+Gemma 4 blocks.
+
+Unlike `deepseek_v4_dspark`, the drafter is published as a standalone repository
+rather than inside the base checkpoint's `mtp.*` namespace, so there is no
+`split.py`.
+
+- Drafter: `deepseek-ai/dspark_gemma4_12b_block7`
+- Target: any `gemma4` / `gemma4_unified` checkpoint with 48 text layers
+
+## Reuse over reimplementation
+
+The draft layers compose `models.gemma4.language` rather than restating Gemma 4:
+`MLP` supplies the GeGLU feed-forward, and the projection geometry follows
+`gemma4.language.Attention`. Only two pieces are genuinely drafter-specific.
+
+`Gemma4DSparkAttention` subclasses `DFlashAttention` to keep the context /
+proposal split, overriding the projections for Gemma 4 geometry:
+`global_head_dim` (512) on full-attention layers instead of `head_dim`, a unit
+softmax scale, `num_global_key_value_heads` (1) for MQA, and `attention_k_eq_v`,
+under which keys and values share one projection so the checkpoint ships no
+`v_proj`. That last case is what the `_project_kv` hook on `DFlashAttention`
+exists for.
+
+`Gemma4DSparkDecoderLayer` applies Gemma 4's sandwich norms — input,
+post-attention, pre-feedforward, post-feedforward — plus the per-layer
+`layer_scalar`, where the generic DFlash layer has only two norms.
+
+## Checkpoint contract
+
+Two details differ from the Qwen-style DSpark checkpoints:
+
+The config declares the generic `model_type: gemma4_text` and identifies itself
+through the `Gemma4DSparkModel` architecture tag, so `get_model_and_args` routes
+on the tag. It also publishes the DSpark fields flat rather than under
+`dflash_config`, which `Gemma4DsparkConfig.from_dict` reads either way.
+
+RoPE follows Gemma 4's per-layer-type parameters — `partial_rotary_factor` 0.25
+at theta 1e6 for full attention — and rotates `global_head_dim`. The generic
+DFlash helper would instead use `head_dim` and a flat `rope_theta`.
+
+The drafter also carries untied `embed_tokens` and `lm_head`, so `bind()` keeps
+its own rather than adopting the target's as DFlash does.
+
+## Drafter precision
+
+The drafter is published in bf16 (6.9 GB) and is worth quantizing: the target
+block pass dominates a round, but the drafter still reads its whole 262144-row
+`lm_head` every round, and it keeps its own untied head rather than the
+target's. At 8-bit it moves 3.6 GB instead of 6.9 GB per round, and the
+proposals do not change -- mean acceptance and the generated tokens are
+identical to bf16 at every context measured.
+
+`mlx_vlm.convert` cannot be used here: the drafter repo ships no tokenizer or
+processor, so processor loading fails. Quantize the weights directly instead:
+
+```python
+import json, pathlib
+import mlx.core as mx, mlx.nn as nn
+from mlx.utils import tree_flatten
+from mlx_vlm.utils import load_model, get_model_path
+
+src = get_model_path("deepseek-ai/dspark_gemma4_12b_block7")
+out = pathlib.Path("./dspark_gemma4_12b_block7-8bit")
+out.mkdir(parents=True, exist_ok=True)
+
+drafter = load_model(src)
+nn.quantize(drafter, group_size=64, bits=8)
+mx.eval(drafter.parameters())
+
+mx.save_safetensors(
+    str(out / "model.safetensors"), dict(tree_flatten(drafter.parameters()))
+)
+config = json.load(open(src / "config.json"))
+config["quantization"] = {"group_size": 64, "bits": 8}
+json.dump(config, open(out / "config.json", "w"), indent=2)
+```
+
+4-bit is not faster than 8-bit and costs acceptance (5.40 to 5.10 at 2k), so
+8-bit is the recommended setting.
+
+## Exactness
+
+Speculation does not reproduce base decoding token-for-token on every prompt.
+Measured over six chat prompts at 256 tokens, greedy:
+
+| prompt | base vs base | vs dspark | vs dspark, exact verify |
+| --- | --- | --- | --- |
+| reasoning | 0/256 | 208/256 | 208/256 |
+| code | 0/256 | 141/256 | 0/256 |
+| factual | 0/256 | 0/256 | 0/256 |
+| summarize | 0/256 | 159/256 | 159/256 |
+| creative | 0/256 | 0/256 | 108/256 |
+| longform | 0/256 | 49/256 | 57/256 |
+
+The cause is the target's own block forward, not the drafter. The divergence is
+unchanged across block sizes 2, 4 and 8; unchanged when acceptance is forced to
+zero so that every emitted token is one the target produced itself; and
+identical for bf16 and 8-bit drafters down to the first-divergence index. What
+is left is that block verification evaluates the target over `L >= 2` positions
+where base decoding evaluates it over one, and the model sits near enough to an
+argmax tie on these prompts that the last-bit difference flips tokens.
+
+`models/gemma4/speculative_verifier.py` narrows this but does not close it -- it
+removes the divergence on one prompt and introduces it on another -- because it
+restores singleton numerics for the linear projections and attention but not for
+every op in the block. It stays **opt-in** via
+`text_config.exact_speculative_verify`: its per-position attention loop costs
+roughly half of decode throughput (30.5 vs 77.4 tok/s at 2k), and on this
+architecture most projections cannot reach the singleton-equivalent Metal
+kernels at all, since Gemma 4's hidden size of 3840 fails their `K % 512 == 0`
+precondition and q/k/v/gate/up fall back to a per-token loop.
+
+## Known limitation
+
+Speculative gain is 1.7-2.4x except for prompts near `sliding_window` (1024),
+where it drops to ~0.5x. Sliding layers hold a `RotatingKVCache`, and
+`update_and_fetch` routes any multi-token write to `_update_concat`, which
+rebuilds the whole cache to keep it in the temporal order the positional causal
+mask requires. That is O(window) per verification round instead of O(block),
+and it bites hardest once the ring saturates but total model work is still
+small. The cost is shared infrastructure: it applies to every block-speculative
+path — `dflash`, `eagle3`, `mtp` — on any sliding-window target, not just this
+drafter. Fixing it needs ring-aware masking rather than a change here.

--- a/mlx_vlm/speculative/drafters/gemma4_dspark/__init__.py
+++ b/mlx_vlm/speculative/drafters/gemma4_dspark/__init__.py
@@ -1,0 +1,11 @@
+from .config import Gemma4DsparkConfig
+from .config import Gemma4DsparkConfig as ModelConfig
+from .gemma4_dspark import Gemma4DSparkDraftModel
+from .gemma4_dspark import Gemma4DSparkDraftModel as Model
+
+__all__ = [
+    "Gemma4DSparkDraftModel",
+    "Gemma4DsparkConfig",
+    "Model",
+    "ModelConfig",
+]

--- a/mlx_vlm/speculative/drafters/gemma4_dspark/config.py
+++ b/mlx_vlm/speculative/drafters/gemma4_dspark/config.py
@@ -1,0 +1,133 @@
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from typing import Any
+
+from ..dspark.config import DSparkConfig, _is_strictly_increasing_ints
+
+
+@dataclass
+class Gemma4DsparkConfig(DSparkConfig):
+    """DSpark drafter over a Gemma 4 draft backbone.
+
+    Published checkpoints declare the generic ``gemma4_text`` model type and
+    identify themselves through the ``Gemma4DSparkModel`` architecture tag. They
+    also publish the DSpark fields flat rather than under ``dflash_config``, so
+    ``from_dict`` reads either layout. The remaining fields mirror the Gemma 4
+    text config that the reused ``models.gemma4.language`` layers read.
+    """
+
+    model_type: str = "gemma4_dspark"
+    backbone_model_type: str = "gemma4"
+    hidden_size: int = 3840
+    intermediate_size: int = 15360
+    num_hidden_layers: int = 5
+    num_attention_heads: int = 16
+    num_key_value_heads: int = 8
+    head_dim: int = 256
+    global_head_dim: int | None = 512
+    num_global_key_value_heads: int | None = 1
+    attention_k_eq_v: bool = True
+    num_kv_shared_layers: int = 0
+    use_double_wide_mlp: bool = False
+    enable_moe_block: bool = False
+    hidden_activation: str = "gelu_pytorch_tanh"
+    hidden_size_per_layer_input: int = 0
+    rms_norm_eps: float = 1e-6
+    vocab_size: int = 262144
+    final_logit_softcapping: float | None = 30.0
+    tie_word_embeddings: bool = False
+    sliding_window: int | None = 1024
+    rope_parameters: dict[str, Any] = field(default_factory=dict)
+    rope_traditional: bool = False
+    num_anchors: int = 512
+
+    def validate(self) -> None:
+        """Validate the model-agnostic DSpark invariants.
+
+        The base checks additionally assert Qwen3 backbone properties that
+        Gemma 4 does not share: ``hidden_size`` is independent of
+        ``num_attention_heads * head_dim`` because full-attention layers project
+        to ``global_head_dim``, and the activation is GeGLU rather than SiLU.
+        """
+        if self.model_type != "gemma4_dspark":
+            raise ValueError(
+                "Gemma 4 DSpark requires normalized model_type='gemma4_dspark', "
+                f"got {self.model_type!r}."
+            )
+        for key in (
+            "hidden_size",
+            "intermediate_size",
+            "num_hidden_layers",
+            "num_attention_heads",
+            "num_key_value_heads",
+            "head_dim",
+            "vocab_size",
+            "max_position_embeddings",
+            "block_size",
+            "proposal_length",
+            "num_target_layers",
+            "markov_rank",
+        ):
+            value = getattr(self, key)
+            if not isinstance(value, int) or value <= 0:
+                raise ValueError(f"DSpark requires a positive integer {key}.")
+        if self.block_size != self.proposal_length + 1:
+            raise ValueError(
+                "DSpark verification block_size must equal proposal_length + 1."
+            )
+        if self.markov_head_type != "vanilla":
+            raise ValueError(
+                "DSpark currently supports only markov_head_type='vanilla'."
+            )
+        if not 0 <= self.mask_token_id < self.vocab_size:
+            raise ValueError("DSpark mask_token_id must be inside the vocabulary.")
+        if len(self.layer_types) != self.num_hidden_layers:
+            raise ValueError("DSpark requires one layer type per draft layer.")
+        if (
+            not self.target_layer_ids
+            or not _is_strictly_increasing_ints(self.target_layer_ids)
+            or any(
+                layer_id < 0 or layer_id >= self.num_target_layers
+                for layer_id in self.target_layer_ids
+            )
+        ):
+            raise ValueError(
+                "DSpark target_layer_ids must be unique, increasing indices "
+                "inside the target layer range."
+            )
+
+    @classmethod
+    def from_dict(cls, params: dict) -> "Gemma4DsparkConfig":
+        flat = dict(params)
+        nested = flat.pop("dflash_config", None)
+        source: Mapping[str, Any] = nested if isinstance(nested, Mapping) else flat
+
+        flat["backbone_model_type"] = str(flat.get("model_type", "gemma4"))
+        flat["model_type"] = "gemma4_dspark"
+
+        for key in (
+            "mask_token_id",
+            "target_layer_ids",
+            "num_target_layers",
+            "runtime_block_size",
+            "draft_window_size",
+            "block_size_policy",
+            "dflash_initial_block_size",
+            "markov_rank",
+            "markov_head_type",
+            "enable_confidence_head",
+            "confidence_head_with_markov",
+        ):
+            if key in source:
+                flat[key] = source[key]
+
+        raw_block_size = source.get("block_size", flat.get("block_size"))
+        if raw_block_size is None:
+            raise ValueError("DSpark requires a checkpoint block_size.")
+        flat["proposal_length"] = int(raw_block_size)
+        flat["block_size"] = int(raw_block_size) + 1
+        flat.setdefault("runtime_block_size", min(8, flat["block_size"]))
+        flat.setdefault("block_size_policy", "fixed")
+
+        known = {f.name for f in cls.__dataclass_fields__.values()}
+        return cls(**{k: v for k, v in flat.items() if k in known})

--- a/mlx_vlm/speculative/drafters/gemma4_dspark/gemma4_dspark.py
+++ b/mlx_vlm/speculative/drafters/gemma4_dspark/gemma4_dspark.py
@@ -1,0 +1,157 @@
+from collections.abc import Mapping
+
+import mlx.core as mx
+import mlx.nn as nn
+from mlx.nn import RMSNorm
+
+from ....models.gemma4.language import MLP as Gemma4MLP
+from ....models.rope_utils import initialize_rope
+from ..dspark.dspark import DSparkDraftModel
+from ..qwen3_dflash.dflash import DFlashAttention
+from .config import Gemma4DsparkConfig
+
+
+def _build_gemma4_rope(config: Gemma4DsparkConfig):
+    """Build RoPE with Gemma 4's per-layer-type parameters.
+
+    The generic DFlash helper keys off ``head_dim`` and a flat ``rope_theta``.
+    Gemma 4 publishes theta and ``partial_rotary_factor`` per layer type and
+    rotates ``global_head_dim`` on full-attention layers, which is what every
+    draft layer here is.
+    """
+    layer_types = config.layer_types or ["full_attention"] * config.num_hidden_layers
+    layer_key = (
+        "sliding_attention"
+        if layer_types[0] == "sliding_attention"
+        else "full_attention"
+    )
+    params = dict(config.rope_parameters.get(layer_key) or {})
+    dims = (
+        config.global_head_dim
+        if layer_key == "full_attention" and config.global_head_dim
+        else config.head_dim
+    )
+    return initialize_rope(
+        dims=dims,
+        traditional=config.rope_traditional,
+        base=params.get("rope_theta", 10000.0),
+        scaling_config=params,
+        max_position_embeddings=config.max_position_embeddings,
+    )
+
+
+class Gemma4DSparkAttention(DFlashAttention):
+    """DFlash context/proposal attention with Gemma 4 projection geometry.
+
+    Gemma 4 full-attention layers use ``global_head_dim`` rather than
+    ``head_dim``, a unit softmax scale, and share one projection between keys
+    and values, so the draft checkpoint carries no ``v_proj``.
+    """
+
+    def __init__(self, config: Gemma4DsparkConfig, layer_idx: int):
+        nn.Module.__init__(self)
+        layer_types = (
+            config.layer_types or ["full_attention"] * config.num_hidden_layers
+        )
+        self.is_sliding = layer_types[layer_idx] == "sliding_attention"
+        self.sliding_window = config.sliding_window if self.is_sliding else None
+
+        self.head_dim = (
+            config.global_head_dim
+            if not self.is_sliding and config.global_head_dim
+            else config.head_dim
+        )
+        self.use_k_eq_v = bool(config.attention_k_eq_v) and not self.is_sliding
+        self.n_heads = config.num_attention_heads
+        if self.use_k_eq_v and config.num_global_key_value_heads is not None:
+            self.n_kv_heads = config.num_global_key_value_heads
+        else:
+            self.n_kv_heads = config.num_key_value_heads
+        self.scale = 1.0
+
+        dim = config.hidden_size
+        self.q_proj = nn.Linear(dim, self.n_heads * self.head_dim, bias=False)
+        self.k_proj = nn.Linear(dim, self.n_kv_heads * self.head_dim, bias=False)
+        if not self.use_k_eq_v:
+            self.v_proj = nn.Linear(dim, self.n_kv_heads * self.head_dim, bias=False)
+        self.o_proj = nn.Linear(self.n_heads * self.head_dim, dim, bias=False)
+        self.q_norm = RMSNorm(self.head_dim, eps=config.rms_norm_eps)
+        self.k_norm = RMSNorm(self.head_dim, eps=config.rms_norm_eps)
+
+    def _project_kv(self, x: mx.array):
+        keys = self.k_proj(x)
+        return (keys, keys) if self.use_k_eq_v else (keys, self.v_proj(x))
+
+
+class Gemma4DSparkDecoderLayer(nn.Module):
+    """Gemma 4 sandwich-norm block driven by the DFlash context split."""
+
+    def __init__(self, config: Gemma4DsparkConfig, layer_idx: int):
+        super().__init__()
+        eps = config.rms_norm_eps
+        self.self_attn = Gemma4DSparkAttention(config, layer_idx)
+        self.mlp = Gemma4MLP(config, layer_idx)
+        self.input_layernorm = RMSNorm(config.hidden_size, eps=eps)
+        self.post_attention_layernorm = RMSNorm(config.hidden_size, eps=eps)
+        self.pre_feedforward_layernorm = RMSNorm(config.hidden_size, eps=eps)
+        self.post_feedforward_layernorm = RMSNorm(config.hidden_size, eps=eps)
+        self.layer_scalar = mx.ones((1,))
+
+    def __call__(self, x: mx.array, x_ctx: mx.array, rope, cache) -> mx.array:
+        residual = x
+        h = self.self_attn(self.input_layernorm(x), x_ctx, rope, cache)
+        h = residual + self.post_attention_layernorm(h)
+
+        residual = h
+        h = self.post_feedforward_layernorm(self.mlp(self.pre_feedforward_layernorm(h)))
+        h = residual + h
+        return h * self.layer_scalar
+
+
+class Gemma4DSparkDraftModel(DSparkDraftModel):
+    """DSpark drafter for Gemma 4 targets.
+
+    Unlike DFlash, the published checkpoint ships untied ``embed_tokens`` and
+    ``lm_head``, so binding to a target must not replace them.
+    """
+
+    layer_class = Gemma4DSparkDecoderLayer
+
+    def __init__(self, config: Gemma4DsparkConfig):
+        super().__init__(config)
+        self.embed_tokens = nn.Embedding(config.vocab_size, config.hidden_size)
+        self.lm_head = nn.Linear(config.hidden_size, config.vocab_size, bias=False)
+        self.embed_scale = config.hidden_size**0.5
+        self.rope = _build_gemma4_rope(config)
+
+    def bind(self, target_model) -> "Gemma4DSparkDraftModel":
+        embed_tokens, lm_head, embed_scale = (
+            self.embed_tokens,
+            self.lm_head,
+            self.embed_scale,
+        )
+        super().bind(target_model)
+        self.embed_tokens, self.lm_head, self.embed_scale = (
+            embed_tokens,
+            lm_head,
+            embed_scale,
+        )
+        return self
+
+    def sanitize(self, weights: Mapping[str, mx.array]) -> dict[str, mx.array]:
+        return super().sanitize(
+            {key.removeprefix("model."): value for key, value in weights.items()}
+        )
+
+
+Model = Gemma4DSparkDraftModel
+ModelConfig = Gemma4DsparkConfig
+
+
+__all__ = [
+    "Gemma4DSparkAttention",
+    "Gemma4DSparkDecoderLayer",
+    "Gemma4DSparkDraftModel",
+    "Model",
+    "ModelConfig",
+]

--- a/mlx_vlm/speculative/drafters/qwen3_dflash/dflash.py
+++ b/mlx_vlm/speculative/drafters/qwen3_dflash/dflash.py
@@ -43,6 +43,10 @@ class DFlashAttention(nn.Module):
         self.q_norm = nn.RMSNorm(self.head_dim, eps=config.rms_norm_eps)
         self.k_norm = nn.RMSNorm(self.head_dim, eps=config.rms_norm_eps)
 
+    def _project_kv(self, x: mx.array):
+        """Project keys and values. Subclasses may share one projection."""
+        return self.k_proj(x), self.v_proj(x)
+
     def __call__(self, x: mx.array, x_ctx: mx.array, rope, cache: KVCache):
         B, L, _ = x.shape
         S = x_ctx.shape[1]
@@ -60,10 +64,8 @@ class DFlashAttention(nn.Module):
 
         # Project context and proposal separately so only context KV
         queries = self.q_proj(x)
-        ctx_keys = self.k_proj(x_ctx)
-        ctx_values = self.v_proj(x_ctx)
-        prop_keys = self.k_proj(x)
-        prop_values = self.v_proj(x)
+        ctx_keys, ctx_values = self._project_kv(x_ctx)
+        prop_keys, prop_values = self._project_kv(x)
         queries = self.q_norm(queries.reshape(B, L, self.n_heads, -1)).transpose(
             0, 2, 1, 3
         )

--- a/mlx_vlm/tests/test_models_dspark.py
+++ b/mlx_vlm/tests/test_models_dspark.py
@@ -948,3 +948,151 @@ def test_target_compatibility_rejects_wrong_size():
 
     with pytest.raises(ValueError, match="hidden-size mismatch"):
         validate_drafter_compatibility(target, drafter, "dflash")
+
+
+def _published_gemma4_dspark_config():
+    """Fields the published deepseek-ai/dspark_gemma4_12b_block7 config carries."""
+    return {
+        "architectures": ["Gemma4DSparkModel"],
+        "model_type": "gemma4_text",
+        "attention_k_eq_v": True,
+        "block_size": 7,
+        "confidence_head_with_markov": True,
+        "enable_confidence_head": True,
+        "final_logit_softcapping": 30.0,
+        "global_head_dim": 512,
+        "head_dim": 256,
+        "hidden_activation": "gelu_pytorch_tanh",
+        "hidden_size": 3840,
+        "intermediate_size": 15360,
+        "layer_types": ["full_attention"] * 5,
+        "markov_head_type": "vanilla",
+        "markov_rank": 256,
+        "mask_token_id": 4,
+        "max_position_embeddings": 262144,
+        "num_attention_heads": 16,
+        "num_global_key_value_heads": 1,
+        "num_hidden_layers": 5,
+        "num_key_value_heads": 8,
+        "num_target_layers": 48,
+        "rms_norm_eps": 1e-06,
+        "rope_parameters": {
+            "full_attention": {
+                "partial_rotary_factor": 0.25,
+                "rope_theta": 1000000.0,
+                "rope_type": "proportional",
+            },
+            "sliding_attention": {"rope_theta": 10000.0, "rope_type": "default"},
+        },
+        "sliding_window": 1024,
+        "target_layer_ids": [5, 17, 29, 41, 46],
+        "tie_word_embeddings": False,
+        "vocab_size": 262144,
+    }
+
+
+def test_published_gemma4_dspark_config_reads_flat_contract():
+    """The Gemma 4 checkpoint publishes DSpark fields flat, not under dflash_config."""
+    from mlx_vlm.speculative.drafters.gemma4_dspark import ModelConfig as G4Config
+
+    config = G4Config.from_dict(_published_gemma4_dspark_config())
+
+    assert config.model_type == "gemma4_dspark"
+    assert config.backbone_model_type == "gemma4_text"
+    assert config.proposal_length == 7
+    assert config.block_size == 8
+    assert config.target_layer_ids == [5, 17, 29, 41, 46]
+    assert config.num_target_layers == 48
+    assert config.attention_k_eq_v is True
+    assert config.global_head_dim == 512
+    assert config.final_logit_softcapping == 30.0
+
+
+def test_gemma4_dspark_rope_uses_full_attention_parameters():
+    """RoPE must follow Gemma 4's per-layer-type theta and rotate global_head_dim.
+
+    The generic DFlash helper would key off head_dim and a flat rope_theta,
+    which for this checkpoint means 256 dims at 1e7 instead of 512 at 1e6.
+    """
+    from mlx_vlm.speculative.drafters.gemma4_dspark import Model as G4Model
+    from mlx_vlm.speculative.drafters.gemma4_dspark import ModelConfig as G4Config
+
+    config = G4Config.from_dict(_published_gemma4_dspark_config())
+    drafter = G4Model(config)
+
+    assert drafter.rope.dims == 512
+    assert type(drafter.rope).__name__ == "ProportionalRoPE"
+
+
+def test_gemma4_dspark_attention_shares_key_and_value_projection():
+    """attention_k_eq_v layers publish no v_proj; values reuse the key projection."""
+    from mlx_vlm.speculative.drafters.gemma4_dspark import ModelConfig as G4Config
+    from mlx_vlm.speculative.drafters.gemma4_dspark.gemma4_dspark import (
+        Gemma4DSparkAttention,
+    )
+
+    config = G4Config.from_dict(_published_gemma4_dspark_config())
+    attention = Gemma4DSparkAttention(config, 0)
+
+    assert attention.use_k_eq_v is True
+    assert "v_proj" not in attention
+    assert attention.head_dim == 512
+    assert attention.n_kv_heads == 1
+    assert attention.scale == 1.0
+
+    x = mx.zeros((1, 3, config.hidden_size))
+    keys, values = attention._project_kv(x)
+    assert keys.shape == values.shape == (1, 3, 512)
+
+
+def test_generic_loader_routes_gemma4_dspark_checkpoint(tmp_path):
+    """The checkpoint declares gemma4_text, so routing keys off the architecture tag."""
+    from mlx_vlm.speculative.drafters.gemma4_dspark import Model as G4Model
+
+    published = _published_gemma4_dspark_config()
+    architecture, model_type = get_model_and_args(published)
+
+    assert model_type == "gemma4_dspark"
+    assert architecture.Model is G4Model
+
+    (tmp_path / "config.json").write_text(json.dumps(published))
+    assert resolve_drafter_kind(tmp_path) == "dflash"
+
+
+def test_gemma4_exact_verifier_is_opt_in():
+    """Exact block verification is off unless the checkpoint asks for it.
+
+    Singleton-equivalent numerics roughly halve decode throughput, and the
+    other DSpark targets verify with the plain path, so Gemma 4 matches them
+    by default and exposes the trade as a config flag.
+    """
+    from mlx_vlm.models.gemma4.config import TextConfig
+
+    assert TextConfig().exact_speculative_verify is False
+    assert TextConfig(exact_speculative_verify=True).exact_speculative_verify is True
+
+    routed = []
+
+    class _Spy:
+        def __call__(self, *a, **kw):
+            routed.append(True)
+            return "verified"
+
+    import mlx_vlm.models.gemma4.language as g4
+
+    real = g4._EXACT_SPECULATIVE_VERIFIER
+    g4._EXACT_SPECULATIVE_VERIFIER = _Spy()
+    try:
+        model = g4.LanguageModel(TextConfig(exact_speculative_verify=True))
+        assert model(mx.array([[1]]), speculative_verify=True) == "verified"
+        assert routed == [True]
+
+        routed.clear()
+        off = g4.LanguageModel(TextConfig(exact_speculative_verify=False))
+        try:
+            off(mx.array([[1]]), speculative_verify=True)
+        except Exception:
+            pass
+        assert routed == []
+    finally:
+        g4._EXACT_SPECULATIVE_VERIFIER = real

--- a/mlx_vlm/utils.py
+++ b/mlx_vlm/utils.py
@@ -744,6 +744,8 @@ def get_model_and_args(config: dict, model_path: Optional[Path] = None):
         model_type = "gliner2_5"
     elif "DFlash2DraftModel" in architectures:
         model_type = "dflash2"
+    elif "Gemma4DSparkModel" in architectures:
+        model_type = "gemma4_dspark"
     elif dflash_config is not None:
         is_dspark = (
             dflash_config.get("projector_type") == "dspark"


### PR DESCRIPTION
adds dspark support for gemma

Drafter `deepseek-ai/dspark_gemma4_12b_block7`, target `mlx-community/gemma-4-12B-it-8bit`, greedy, 128 tokens.

| ctx | baseline tok/s | dspark tok/s | speedup |
| --- | --- | --- | --- |
| 512 | 38.65 | 92.62 | 2.40x |
| 2048 | 37.13 | 72.38 | 1.95x |
| 4096 | 35.58 | 65.74 | 1.85x |
| 8192 | 26.18 | 44.44 | 1.70x |
| 16384 | 27.73 | 58.22 | 2.10x |

WIP trying to optimize

