### PR TITLE
fix(deepseek_v4): cast hyper-connection kernel inputs to float32

### DIFF
--- a/mlx_vlm/models/deepseek_v4/hyper_connection.py
+++ b/mlx_vlm/models/deepseek_v4/hyper_connection.py
@@ -163,14 +163,7 @@ _hc_sinkhorn_collapse_kernel = _make_hc_sinkhorn_collapse_kernel()
 def _hc_kernel(x, y, mixes, scale, base, hc_mult, sinkhorn_iters, eps):
     B, L, H, D = x.shape
 
-    # The kernel reads mixes/scale/base as float32: it type-puns them through
-    # `*(const device float4*)` and indexes `scale[0]` / `base[llane]`.
-    # HyperConnection allocates all three as float32, so that holds for a freshly
-    # constructed module -- but load_weights replaces them with whatever dtype
-    # the checkpoint stores, which is bfloat16 in every GLM-5.3-Flash and
-    # DeepSeek-V4 release. The kernel then reinterprets those bytes as float32.
-    # Sinkhorn still normalises the result into a plausible doubly-stochastic
-    # matrix, so nothing raises and the model silently emits garbage.
+
     return _hc_sinkhorn_collapse_kernel(
         inputs=[
             x,

--- a/mlx_vlm/models/deepseek_v4/hyper_connection.py
+++ b/mlx_vlm/models/deepseek_v4/hyper_connection.py
@@ -163,8 +163,21 @@ _hc_sinkhorn_collapse_kernel = _make_hc_sinkhorn_collapse_kernel()
 def _hc_kernel(x, y, mixes, scale, base, hc_mult, sinkhorn_iters, eps):
     B, L, H, D = x.shape
 
+    # The kernel reads mixes/scale/base as float32: it type-puns them through
+    # `*(const device float4*)` and indexes `scale[0]` / `base[llane]`.
+    # HyperConnection allocates all three as float32, so that holds for a freshly
+    # constructed module -- but load_weights replaces them with whatever dtype
+    # the checkpoint stores, which is bfloat16 in every GLM-5.3-Flash and
+    # DeepSeek-V4 release. The kernel then reinterprets those bytes as float32.
+    # Sinkhorn still normalises the result into a plausible doubly-stochastic
+    # matrix, so nothing raises and the model silently emits garbage.
     return _hc_sinkhorn_collapse_kernel(
-        inputs=[x, mixes, scale, base],
+        inputs=[
+            x,
+            mixes.astype(mx.float32),
+            scale.astype(mx.float32),
+            base.astype(mx.float32),
+        ],
         template=[
             ("T", x.dtype),
             ("U", x.dtype),


### PR DESCRIPTION
## Summary

The fused sinkhorn/collapse Metal kernel in `deepseek_v4/hyper_connection.py` reads `mixes`, `scale` and `base` as **float32** — it type-puns them through `*(const device float4*)` and indexes `scale[0]` / `base[llane]`:

```metal
const device float* mix = (const device float*)mixes + row * MIX;
const float pre_scale = scale[0];
float4 v = (*(const device float4*)(mix  + BASE_OFF + llane * HC) * comb_scale
          + *(const device float4*)(base + BASE_OFF + llane * HC)) * active;
```

`HyperConnection.__init__` allocates all three as float32, so the assumption holds for a freshly constructed module:

```python
self.fn    = mx.zeros((mix, self.hc_mult * config.hidden_size), dtype=mx.float32)
self.base  = mx.zeros((mix,), dtype=mx.float32)
self.scale = mx.ones((3,), dtype=mx.float32)
```

It stops holding after `load_weights()`. The arrays are replaced by whatever dtype the checkpoint stores, and **every GLM-5.3-Flash and DeepSeek-V4 release on the Hub stores them as bfloat16**. The kernel then reinterprets bfloat16 bytes as float32.

`_hc_ops` is unaffected, because `_hc_split_sinkhorn_ops` casts explicitly — so the bug only shows on Metal with a module in `eval()` mode, i.e. exactly the inference path.

## Why this is easy to miss

Nothing raises, and the corruption does not look like corruption. Sinkhorn renormalises the bad logits into a matrix that is still doubly stochastic — column sums come out exactly 1.0 — so the residual stream stays finite and well scaled through all 45 layers with no NaN or inf. The model runs at full speed and emits fluent-looking tokens with no semantics.

Two things also mask it in a naive test:
- `nn.Module.training` defaults to `True`, so a freshly built `HyperConnection` takes the `_hc_ops` path. A test that never calls `.eval()` never exercises the kernel at all.
- Feeding independent random streams looks the same as feeding the broadcast (all-identical) streams the first layer actually sees — both are wrong, so a side-by-side of two ops runs looks perfect.

## Measurement

GLM-5.3-Flash layer 0 (`attn_hc`), real weights, compared against a float64 reference implementation of the same sinkhorn:

| path | relative error vs float64 ref |
| --- | --- |
| `_hc_ops` | **0.00000** |
| `_hc_kernel` (this bug) | **1.97656** |

Maximum element-wise difference between the two is **0.999** on a matrix whose entries are bounded by 1. With the three inputs cast, kernel and ops agree exactly:

```
cast_to_f32=False   ops-vs-kernel max_abs=0.999160
cast_to_f32=True    ops-vs-kernel max_abs=0.000000
```

## End-to-end

GLM-5.3-Flash (`Vontra/GLM-5.3-Flash-MLX-oQ2-MTP`) on 3 Mac Studios, pipeline-sharded:

**Before**
```
'</think></think></think>The</think></think>Paris</think></think>'
```

**After**
```
'The user is asking a simple factual question: what is the capital of France?
 ... The capital of France is Paris. This is a well-established fact.'

'391 divided by 17. 17 x 23 = 391 (17 x 20 = 340, 17 x 3 = 51, 340 + 51 = 391).
 So the answer is 23.'   -> 23
```

Throughput also improves (4.09 tok/s with the fixed kernel vs 2.39 forcing `_hc_ops`), so the fix keeps the kernel's speed rather than trading it away.

## Scope

Affects any hyper-connection model whose checkpoint stores `fn` / `base` / `scale` in a dtype other than float32 — in practice all current GLM-5.3-Flash and DeepSeek-V4 conversions. The casts are no-ops when the arrays are already float32.

Marked draft: happy to add a regression test asserting `_hc_kernel` and `_hc_ops` agree with bf16 parameters if you'd like one, or to instead coerce the dtype at load time in `HyperConnection` if you prefer the fix there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)