### PR TITLE
Optimize exact Qwen verifier QMV unrolling

### DIFF
--- a/mlx_vlm/models/qwen3_5/speculative_verifier.py
+++ b/mlx_vlm/models/qwen3_5/speculative_verifier.py
@@ -188,6 +188,7 @@ _TARGET_VERIFY_QMV_SOURCE = r"""
         sums[t] = load_vector_exact<T>(xk + t * K_SIZE, x_thread[t]);
       }
 
+#pragma clang loop unroll_count(2)
       for (int row = 0; row < RESULTS_PER_SIMDGROUP; ++row) {
         const device uint8_t* wl = ws + row * in_vec_size_w;
         const device T* sl = sc + row * in_vec_size_g;
@@ -259,6 +260,7 @@ _TARGET_VERIFY_QARGMAX_SOURCE = r"""
         sums[t] = load_vector_exact<T>(xk + t * K_SIZE, x_thread[t]);
       }
 
+#pragma clang loop unroll_count(2)
       for (int row = 0; row < RESULTS_PER_SIMDGROUP; ++row) {
         const device uint8_t* wl = ws + row * in_vec_size_w;
         const device T* sl = sc + row * in_vec_size_g;


### PR DESCRIPTION
## Summary

- pair-unroll the row loop in the exact Qwen verifier QMV kernel
- apply the same optimization to the fused exact QARGMAX path
- preserve the singleton accumulation order and exact token parity

## Performance

Apple M5 Max, 48 GB, warmed 200-token runs:

| Metric | Before | After |
|---|---:|---:|
| Exact speculative throughput (paired mean) | 59.31 tok/s | 61.32 tok/s |
| Improvement | — | +3.39% |

Fresh end-to-end parity runs reached 63.33 tok/s on coding and 60.74 tok/s on math, with 200/200 token IDs matching the autoregressive baseline in both cases.

Selected verifier microbenchmarks improved by 2.9–5.8%, including a 5.2% reduction in fused vocabulary QARGMAX latency.

## Validation

- `uv run --with pre-commit pre-commit run --all-files`
- `.venv/bin/pytest -q mlx_vlm/tests/test_speculative.py` — 203 passed
- exact coding parity — 200/200 token IDs
- exact math parity — 200/200 token IDs
