### PR TITLE
glm5_next: speed up multi-token steps in MLA and the sparse indexer

### DIFF
--- a/mlx_vlm/models/glm5_next/language.py
+++ b/mlx_vlm/models/glm5_next/language.py
@@ -347,20 +347,30 @@ class Glm5NextIndexer(nn.Module):
         kv_len = T
         kv_pos = mx.arange(T)
 
-        # Incremental pooling at decode: complete pools are stable across steps, so
-        # recompute only the suffix (last partial pool + any new pool) and reuse the
-        # cached complete pools -- turns the per-step pool cost from O(T) to O(kpool).
-        # Exact; falls back to full pooling on prefill, when padding is present, or when
-        # the cached pool's batch axis no longer matches the current batch. That last
-        # guard matters under continuous batching: BatchGenerator grows/shrinks the
-        # batch (extend/filter) on the batch axis but does not carry this per-cache
-        # _pool along, so a stale _pool must be discarded and rebuilt for one step.
+        # Incremental pooling: complete pools are stable across steps, so recompute
+        # only the suffix (last partial pool + the new tokens) and reuse the cached
+        # complete pools -- turns the per-step pool cost from O(T) to O(kpool + S).
+        # Exact for any S: pools completed before s0 cannot change, because s0 is a
+        # multiple of index_kpool and new tokens only ever append. Falls back to full
+        # pooling on the first pass, when padding is present, or when the cached
+        # pool's batch axis no longer matches the current batch. That last guard
+        # matters under continuous batching: BatchGenerator grows/shrinks the batch
+        # (extend/filter) on the batch axis but does not carry this per-cache _pool
+        # along, so a stale _pool must be discarded and rebuilt for one step.
+        #
+        # The length check matters for speculative decoding: a rejection trims the
+        # KV cache, so a pool built at the pre-trim length would still describe the
+        # rejected tokens. Requiring it to match the cache length before this step's
+        # new tokens forces a rebuild after any trim. And `_no_pad` only records
+        # whether padding was present at the last full rebuild, so the new tokens are
+        # checked separately -- single-stream decode passes no mask and short-circuits.
         if (
-            S == 1
-            and cache is not None
+            cache is not None
             and getattr(cache, "_pool", None) is not None
             and getattr(cache, "_no_pad", False)
             and cache._pool[0].shape[0] == B
+            and cache._pool[3] == T - S
+            and (mask is None or bool(mx.all(valid_cur)))
         ):
             ck, ci, cv, t_prev = cache._pool
             n_stable = t_prev // self.index_kpool

--- a/mlx_vlm/models/glm5_next/language.py
+++ b/mlx_vlm/models/glm5_next/language.py
@@ -14,7 +14,7 @@ from ..deepseek_v4.hyper_connection import HyperConnection, hc_expand
 from ..deepseek_v32.language import DeepseekV32MoE
 from ..deepseek_v32.language import Model as DSV32Model
 from ..gated_delta import gated_delta_update
-from ..mla import MultiLinear
+from ..mla import MultiLinear, max_absorbed_queries
 from ..mlp import DeepseekMLP
 from .config import ModelConfig, TextConfig
 
@@ -458,6 +458,9 @@ class Glm5NextSparseAttention(nn.Module):
                 "mla_use_nope=False is not supported."
             )
         self.q_head_dim = config.qk_nope_head_dim
+        self._max_absorbed = max_absorbed_queries(
+            self.kv_lora_rank, self.qk_nope_head_dim, self.v_head_dim
+        )
         self.scale = self.q_head_dim**-0.5
 
         self.q_a_proj = nn.Linear(
@@ -554,7 +557,7 @@ class Glm5NextSparseAttention(nn.Module):
         ):
             cache[0].keys = mx.depends(cache[0].keys, (cache[1].keys, cache[1].values))
 
-        if L == 1:
+        if L <= self._max_absorbed:
             q = self.embed_q(q)
             k = v = kv_latent
         else:
@@ -564,7 +567,7 @@ class Glm5NextSparseAttention(nn.Module):
         output = scaled_dot_product_attention(
             q, k, v, cache=cache, scale=self.scale, mask=attn_mask
         )
-        if L == 1:
+        if L <= self._max_absorbed:
             output = self.unembed_out(output)
 
         output = output.transpose(0, 2, 1, 3).reshape(B, L, -1)

--- a/mlx_vlm/models/mla.py
+++ b/mlx_vlm/models/mla.py
@@ -4,6 +4,20 @@ import mlx.core as mx
 import mlx.nn as nn
 
 
+def max_absorbed_queries(
+    kv_lora_rank: int, qk_nope_head_dim: int, v_head_dim: int
+) -> int:
+    """Query count below which folding into the query beats materializing K/V.
+
+    Absorbed cost scales with the number of new queries; materializing scales
+    with the cached length, so the crossover does not depend on context size.
+    """
+    denom = 2 * kv_lora_rank - qk_nope_head_dim - v_head_dim
+    if denom <= 0:
+        return 1
+    return max(1, int(kv_lora_rank * (qk_nope_head_dim + v_head_dim) / denom))
+
+
 class MultiLinear(nn.Module):
     def __init__(self, input_dims: int, output_dims: int, num_heads: int) -> None:
         super().__init__()


### PR DESCRIPTION
Two related performance fixes (specific to glm5_next):

**Absorbed MLA path** — same change as ml-explore/mlx-lm#1817, scoped to `glm5_next`, the only model here with an absorbed path. It was gated on `L == 1`, so wider steps expanded the whole cached latent instead. The crossover is a fixed query count per model, `kv_lora_rank * (nope + value) / (2 * kv_lora_rank - nope - value)`, which is 512 here. `models/mla.py` gains `max_absorbed_queries()`. This model is sparse (`index_topk = 2048`), so the win is below that budget only: 3.4× on the verify step at cache 512, 0.99–1.02× above it. The dense-MLA models in the linked PR are where it matters. The sparse top-k gather stays at `L == 1` — correctness, not speed.

**Indexer pooling** — incremental pooling was gated on `S == 1`, so every verify fell back to full O(T) pooling. The suffix recompute is exact for any S: pools completed before `s0` cannot change, as `s0` is a multiple of `index_kpool` and tokens only append. Cost per sparse layer, stock → patched (medians of 3 runs, M3 Max):

| context | S=1 (control) | S=2 | S=4 |
|---:|---:|---:|---:|
| 8,192 | 0.692 / 0.679 | 1.215 → 0.830 | 1.215 → 0.780 |
| 32,768 | 0.685 / 0.696 | 1.993 → 0.861 | 1.980 → 0.857 |
| 131,072 | 1.007 / 1.006 | 5.729 → **1.117** | 5.906 → **1.390** |

Stock grows with context, patched is flat — 5.1× at 128K for S=2, or ~63 ms → ~12 ms across this model's 11 sparse layers. S=1 unchanged.

Reuse needs two checks that `S == 1` was masking: the pool must have been built at the current cache length minus this step's tokens, or a speculative rejection that trims the cache leaves pools describing rejected tokens (without it, 0.97 error on a scale of 2.5; with it, 2.4e-07); and padding on new tokens is checked directly, since `_no_pad` only records the last full rebuild.

Verified a wide step pools identically to the same tokens one at a time, for S = 2/3/4/8 at aligned and misaligned prefills — indices, cache length and top-k match exactly, pooled keys to a few float32 ULP. `pytest ./tests` gives 2699 passed / 5 skipped on both arms.