### PR TITLE
qwen3_vl: render per-group video timestamps like the reference processor

### DIFF
--- a/mlx_vlm/models/qwen3_5/language.py
+++ b/mlx_vlm/models/qwen3_5/language.py
@@ -1744,6 +1744,14 @@ class LanguageModel(nn.Module):
         video_token_id = self.config.video_token_id
         vision_start_token_id = self.config.vision_start_token_id
         mrope_position_deltas = []
+        # The processor emits one vision block per temporal patch group, so
+        # expand each video grid (t, h, w) into t rows of (1, h, w) — the same
+        # split the reference implementation performs before indexing.
+        if video_grid_thw is not None:
+            rows = []
+            for thw in video_grid_thw.tolist():
+                rows.extend([[1, thw[1], thw[2]]] * int(thw[0]))
+            video_grid_thw = mx.array(rows, dtype=mx.int32)
         if input_ids is not None and (
             image_grid_thw is not None or video_grid_thw is not None
         ):

--- a/mlx_vlm/models/qwen3_vl/language.py
+++ b/mlx_vlm/models/qwen3_vl/language.py
@@ -312,6 +312,14 @@ class LanguageModel(nn.Module):
         video_token_id = self.config.video_token_id
         vision_start_token_id = self.config.vision_start_token_id
         mrope_position_deltas = []
+        # The processor emits one vision block per temporal patch group, so
+        # expand each video grid (t, h, w) into t rows of (1, h, w) — the same
+        # split the reference implementation performs before indexing.
+        if video_grid_thw is not None:
+            rows = []
+            for thw in video_grid_thw.tolist():
+                rows.extend([[1, thw[1], thw[2]]] * int(thw[0]))
+            video_grid_thw = mx.array(rows, dtype=mx.int32)
         if input_ids is not None and (
             image_grid_thw is not None or video_grid_thw is not None
         ):

--- a/mlx_vlm/models/qwen3_vl/processing_qwen3_vl.py
+++ b/mlx_vlm/models/qwen3_vl/processing_qwen3_vl.py
@@ -64,6 +64,32 @@ def _drop_surplus_image_tokens(
     return text
 
 
+def _timestamped_video_placeholder(
+    grid_t: int,
+    frame_seqlen: int,
+    temporal_patch_size: int,
+    fps: float,
+    vision_start_token: str,
+    vision_end_token: str,
+) -> str:
+    """Render one ``<t.t seconds>`` marker plus vision block per temporal group.
+
+    The timestamp is the mean of the first and last frame of each group, the
+    convention used by the reference Qwen3-VL processor.
+    """
+    parts = []
+    for group in range(grid_t):
+        first = group * temporal_patch_size
+        seconds = (first + first + temporal_patch_size - 1) / 2 / fps
+        parts.append(
+            f"<{seconds:.1f} seconds>"
+            + vision_start_token
+            + "<|placeholder|>" * frame_seqlen
+            + vision_end_token
+        )
+    return "".join(parts)
+
+
 def _flatten_images(images):
     """Flatten grouped and array-batched images while retaining path support."""
     if isinstance(images, (list, tuple)):
@@ -810,18 +836,48 @@ class Qwen3VLProcessor(ProcessorMixin):
                     index += 1
                 text[i] = text[i].replace("<|placeholder|>", self.image_token)
 
+        # Qwen3-VL prompts carry one "<t.t seconds>" marker followed by its own
+        # vision_start/vision_end block per temporal patch group, exactly as the
+        # reference processor renders videos. Without the markers the model sees
+        # one timeless block of frames and describes motion as a spatial collage.
+        fps_list = kwargs.pop("fps", None)
         if video_grid_thw is not None:
             _video_proc = self.video_processor or self.image_processor
             merge_length = _video_proc.merge_size**2
+            temporal_patch_size = getattr(_video_proc, "temporal_patch_size", 2)
             index = 0
             for i in range(len(text)):
                 while self.video_token in text[i]:
-                    num_video_tokens = video_grid_thw[index].prod() // merge_length
-                    text[i] = text[i].replace(
-                        self.video_token,
-                        "<|placeholder|>" * num_video_tokens,
-                        1,
+                    grid_t = int(video_grid_thw[index][0])
+                    frame_seqlen = int(video_grid_thw[index][1:].prod() // merge_length)
+                    fps = (
+                        fps_list[index]
+                        if isinstance(fps_list, (list, tuple))
+                        else fps_list
                     )
+                    # Same fallback idea as the reference processor: use the
+                    # configured sampling rate when no per-video fps was given.
+                    fps = fps or getattr(_video_proc, "fps", None) or 2.0
+                    wrapped = f"{self.vision_start_token}{self.video_token}{self.vision_end_token}"
+                    if wrapped in text[i]:
+                        text[i] = text[i].replace(
+                            wrapped,
+                            _timestamped_video_placeholder(
+                                grid_t,
+                                frame_seqlen,
+                                temporal_patch_size,
+                                float(fps),
+                                self.vision_start_token,
+                                self.vision_end_token,
+                            ),
+                            1,
+                        )
+                    else:
+                        text[i] = text[i].replace(
+                            self.video_token,
+                            "<|placeholder|>" * (grid_t * frame_seqlen),
+                            1,
+                        )
                     index += 1
                 text[i] = text[i].replace("<|placeholder|>", self.video_token)
 

--- a/mlx_vlm/models/qwen3_vl_moe/language.py
+++ b/mlx_vlm/models/qwen3_vl_moe/language.py
@@ -335,6 +335,14 @@ class LanguageModel(nn.Module):
         video_token_id = self.config.video_token_id
         vision_start_token_id = self.config.vision_start_token_id
         mrope_position_deltas = []
+        # The processor emits one vision block per temporal patch group, so
+        # expand each video grid (t, h, w) into t rows of (1, h, w) — the same
+        # split the reference implementation performs before indexing.
+        if video_grid_thw is not None:
+            rows = []
+            for thw in video_grid_thw.tolist():
+                rows.extend([[1, thw[1], thw[2]]] * int(thw[0]))
+            video_grid_thw = mx.array(rows, dtype=mx.int32)
         if input_ids is not None and (
             image_grid_thw is not None or video_grid_thw is not None
         ):

--- a/mlx_vlm/tests/test_processors.py
+++ b/mlx_vlm/tests/test_processors.py
@@ -4084,3 +4084,95 @@ class TestMuseGlimmerCleanOutput(unittest.TestCase):
     def test_noop_without_channels(self):
         plain = "Two tabby cats sleep on a pink couch."
         self.assertEqual(self._clean(plain), plain)
+
+
+class Qwen3VLVideoTimestampTests(unittest.TestCase):
+    """The processor renders one timestamped vision block per temporal group."""
+
+    class _Tokenizer:
+        video_token = "<|video_pad|>"
+        video_token_id = 102
+        pad_token = "<pad>"
+        pad_token_id = 0
+
+        def __init__(self):
+            self.last_text = None
+
+        def __call__(self, text, **kwargs):
+            self.last_text = text
+            texts = [text] if isinstance(text, str) else text
+            ids = []
+            for item in texts:
+                row = []
+                remaining = item
+                while remaining:
+                    if remaining.startswith(self.video_token):
+                        row.append(self.video_token_id)
+                        remaining = remaining[len(self.video_token) :]
+                    else:
+                        row.append(1)
+                        remaining = remaining[1:]
+                ids.append(row)
+            return {"input_ids": ids, "attention_mask": [[1] * len(r) for r in ids]}
+
+    def _make_processor(self, grid_thw):
+        from mlx_vlm.models.qwen3_vl.processing_qwen3_vl import Qwen3VLProcessor
+
+        tokenizer = self._Tokenizer()
+        video_processor = SimpleNamespace(
+            merge_size=2,
+            temporal_patch_size=2,
+            fps=2.0,
+            __call__=None,
+        )
+        video_processor = type(
+            "StubVideoProcessor",
+            (),
+            {
+                "merge_size": 2,
+                "temporal_patch_size": 2,
+                "fps": 2.0,
+                "__call__": lambda self, videos=None, **kw: {
+                    "pixel_values_videos": np.zeros((1, 4), dtype=np.float32),
+                    "video_grid_thw": np.array([grid_thw], dtype=np.int64),
+                },
+            },
+        )()
+        processor = Qwen3VLProcessor.__new__(Qwen3VLProcessor)
+        processor.tokenizer = tokenizer
+        processor.image_processor = None
+        processor.video_processor = video_processor
+        processor.image_token = "<|image_pad|>"
+        processor.image_token_id = 100
+        processor.video_token = tokenizer.video_token
+        processor.video_token_id = tokenizer.video_token_id
+        processor.vision_start_token = "<|vision_start|>"
+        processor.vision_end_token = "<|vision_end|>"
+        processor.vision_start_token_id = 58
+        processor.vision_end_token_id = 59
+        return processor, tokenizer
+
+    def test_video_prompt_gets_one_timestamped_block_per_temporal_group(self):
+        processor, tokenizer = self._make_processor(grid_thw=[4, 2, 2])
+        prompt = "<|vision_start|><|video_pad|><|vision_end|>Describe the clip."
+
+        out = processor(text=[prompt], videos=["clip.mp4"], fps=[2.0])
+
+        rendered = tokenizer.last_text[0]
+        self.assertEqual(rendered.count(" seconds>"), 4)
+        self.assertIn("<0.2 seconds><|vision_start|>", rendered)
+        self.assertIn("<3.2 seconds><|vision_start|>", rendered)
+        self.assertEqual(rendered.count("<|vision_start|>"), 4)
+        ids = np.array(out["input_ids"])[0].tolist()
+        self.assertEqual(ids.count(tokenizer.video_token_id), 4)  # 4 groups x 1 token
+
+    def test_video_prompt_falls_back_to_processor_fps(self):
+        processor, tokenizer = self._make_processor(grid_thw=[2, 2, 2])
+        prompt = "<|vision_start|><|video_pad|><|vision_end|>Describe the clip."
+
+        processor(text=[prompt], videos=["clip.mp4"])
+
+        rendered = tokenizer.last_text[0]
+        self.assertEqual(rendered.count(" seconds>"), 2)
+        self.assertIn("<0.2 seconds>", rendered)
+        self.assertIn("<1.2 seconds>", rendered)


### PR DESCRIPTION
## Problem
The reference Qwen3-VL processor renders a video as one `<t.t seconds>` marker followed by its own `<|vision_start|>…<|vision_end|>` block **per temporal patch group**. mlx-vlm rendered a single block of `<|video_pad|>` tokens with no time information, so the model saw a timeless stack of frames.

Symptom (Qwen3.8-27B-MLX-4bit, synthetic 8 s clip: red square moves left→right, blue phase, then the text "42"): the model described the moving square as *several simultaneous squares in different areas* and never mentioned the "42" — the same frames passed as separate images were described correctly.

## Fix
- `processing_qwen3_vl.py`: expand each video into `grid_t` timestamped blocks. Timestamp = mean of the first and last frame of the group (reference formula), from the per-video `fps` that `prepare_inputs` already passes; falls back to the video processor's configured sampling rate (the reference falls back to a fixed fps as well).
- `get_rope_index` in `qwen3_5`, `qwen3_vl`, `qwen3_vl_moe` (used by `qwen3_5_moe` and `qwen4_exp` through inheritance): expand each video grid `(t, h, w)` into `t` rows of `(1, h, w)` — the split the reference performs — so position ids line up with the per-group blocks.

## Validation
- New `Qwen3VLVideoTimestampTests` in `mlx_vlm/tests/test_processors.py` (marker count, timestamps, token count, fps fallback).
- Real-world, same clip and model: prompt grows from 1792 to 1854 tokens (8 markers) and the description is now correct and ordered: "square appears → moves right → background turns blue → white again → the number 42 appears".
