### PR TITLE
granite4_vision: align deepstack injection with chunked prefill via c…

### DIFF
--- a/mlx_vlm/models/granite4_vision/language.py
+++ b/mlx_vlm/models/granite4_vision/language.py
@@ -159,8 +159,9 @@ class Granite(nn.Module):
                 h, cache[0] if cache and cache[0] is not None else cache
             )
 
+        prefill_offset = cache[0].offset if cache and cache[0] is not None else 0
+
         for layer_idx, (layer, c) in enumerate(zip(self.layers, cache)):
-            # Inject deepstack features at target layers
             if (
                 deepstack_visual_embeds is not None
                 and deepstack_target_layers is not None
@@ -168,13 +169,14 @@ class Granite(nn.Module):
             ):
                 for feat_idx, target_layer in enumerate(deepstack_target_layers):
                     if layer_idx == target_layer:
-                        features = deepstack_visual_embeds[feat_idx]
-                        # Add features at image positions
-                        h = mx.where(
-                            visual_pos_masks[..., None],
-                            h + features,
-                            h,
-                        )
+                        seq_len = h.shape[1]
+                        pos_mask = visual_pos_masks[
+                            ..., prefill_offset : prefill_offset + seq_len
+                        ]
+                        features = deepstack_visual_embeds[feat_idx][
+                            prefill_offset : prefill_offset + seq_len
+                        ]
+                        h = mx.where(pos_mask[..., None], h + features, h)
 
             h = layer(h, mask, c)
 

--- a/mlx_vlm/tests/test_models.py
+++ b/mlx_vlm/tests/test_models.py
@@ -9598,6 +9598,61 @@ class TestModels(unittest.TestCase):
             config.text_config.num_hidden_layers,
         )
 
+    def test_granite4_vision_chunked_prefill_aligns_deepstack(self):
+        from mlx_vlm.models import granite4_vision
+
+        text_config = granite4_vision.TextConfig(
+            model_type="granitemoehybrid",
+            hidden_size=64,
+            intermediate_size=128,
+            shared_intermediate_size=128,
+            num_hidden_layers=2,
+            num_attention_heads=4,
+            num_key_value_heads=2,
+            vocab_size=1000,
+            rms_norm_eps=1e-5,
+            rope_theta=10000000.0,
+            embedding_multiplier=12.0,
+            attention_multiplier=0.015625,
+            residual_multiplier=0.22,
+            logits_scaling=10.0,
+        )
+        vision_config = granite4_vision.VisionConfig(
+            model_type="siglip_vision_model",
+            hidden_size=64,
+            intermediate_size=128,
+            num_hidden_layers=2,
+            num_attention_heads=4,
+            image_size=48,
+            patch_size=16,
+        )
+        config = granite4_vision.ModelConfig(
+            text_config=text_config,
+            vision_config=vision_config,
+            model_type="granite4_vision",
+            deepstack_layer_map=[[-1, 0]],
+            use_spatial_sampling=False,
+            downsample_rate="3/3",
+            use_image_newline_parameter=False,
+        )
+        inner = granite4_vision.Model(config).language_model.model
+        inner._deepstack_target_layers = [0]
+
+        full_len = 6
+        hidden = text_config.hidden_size
+        visual_pos_masks = mx.array([[True, True, False, False, False, False]])
+        deepstack_visual_embeds = [mx.ones((full_len, hidden))]
+
+        chunk_len = full_len - 1
+        out = inner(
+            mx.zeros((1, chunk_len), dtype=mx.int32),
+            inputs_embeds=mx.zeros((1, chunk_len, hidden)),
+            cache=None,
+            visual_pos_masks=visual_pos_masks,
+            deepstack_visual_embeds=deepstack_visual_embeds,
+        )
+        self.assertEqual(out.shape, (1, chunk_len, hidden))
+
     def test_granite4_1_vision(self):
         from mlx_vlm.models import granite4_vision
 


### PR DESCRIPTION
granite4_vision was crashing on any image prompt since chunked prefill (#2119) landed for an issue upstream in nativ, the chunk loop holds back the last token, so the hidden state comes in one token shorter than the full-length deepstack visual features, and the injection broadcast blew up:

ValueError: [broadcast_shapes] Shapes (1,626,2560) and (627,2560) cannot be broadcast.

Repro now works:
```
python -m mlx_vlm.generate --model mlx-community/granite-4.0-3b-vision-4bit \
  --image cats.jpg --prompt "Describe this image in one sentence." \
  --max-tokens 40 --temperature 0.0 --trust-remote-code
```


Added a unit test that runs the LM forward with a chunk shorter than the visual tensors (would've broadcast-crashed before). Only granite4_vision needed it — swept the other deepstack models and they're fine (qwen3-vl family scatters by index, zaya1_vl already offset-slices).

Closes https://github.com/Blaizzy/mlx-vlm/issues/2134