### PR TITLE
Add Nemotron-H speculative decoding support

### DIFF
--- a/docs/speculative-decoding.md
+++ b/docs/speculative-decoding.md
@@ -1,0 +1,107 @@
+# Implementing speculative decoding
+
+Speculative decoding is a lossless decode optimization. A small drafter proposes
+several tokens, the target verifies the whole block, and MLX-VLM accepts the
+matching prefix plus one target token. Rejected cache entries are then removed
+before the next round.
+
+```text
+target prefill and hidden capture
+              ↓
+draft block → target block verification → accept prefix + target token
+     ↑                                      ↓
+     └──────────── cache rollback ──────────┘
+```
+
+## Code ownership
+
+| Area | Responsibility |
+|---|---|
+| `generate/ar.py` | Prefill, target cache creation, and speculative dispatch |
+| `speculative/drafters/` | Checkpoint loading, drafter architecture, and target compatibility |
+| `speculative/dflash.py` | DFlash, DFlash2, and DSpark round loops |
+| `speculative/mtp.py` | Native and assistant MTP round loops |
+| `speculative/eagle3.py` | EAGLE-3 round loops |
+| `speculative/common.py` | Acceptance, sampling state, statistics, and batch safeguards |
+| `models/<family>/language.py` | Target hidden-state capture and rollback contract |
+| `models/<family>/speculative_verifier.py` | Exact model-specific block verification and Metal kernels |
+
+`draft_kind` selects the round loop, not the checkpoint architecture. Drafter
+`model_type` values are mapped to `dflash`, `mtp`, or `eagle3` in
+`speculative/drafters/__init__.py`.
+
+## Adding a model
+
+1. Inspect the real `config.json` and tensor names. Define the target layers,
+   hidden-state inputs, block-size meaning, cache ownership, and quantization
+   before writing the adapter.
+2. Add or reuse a drafter under `speculative/drafters/<family>/`. Implement its
+   config normalization, checkpoint sanitization, `draft_block`, cache reset,
+   and target compatibility checks.
+3. Register its `model_type` with the correct `draft_kind`. Prefer architecture
+   and config fields over repository-name checks.
+4. Make target prefill return the hidden states the drafter consumes. DFlash and
+   EAGLE-3 normally capture configured layers; MTP normally consumes final
+   hidden state and may share target K/V.
+5. Implement target verification and rollback. Keep `language.py` as the thin
+   public contract and put model-specific verification kernels in
+   `speculative_verifier.py`.
+6. Add synthetic contract tests, then validate the real target and drafter
+   checkpoints before reporting support.
+
+The target hooks used by the round loops are:
+
+- `speculative_verify_hidden(inputs, cache)` returns verified hidden state,
+  shared K/V state, and optional rollback state.
+- `speculative_verify_logits(inputs, cache, sampler)` may additionally return
+  target tokens when hidden-only verification is unavailable.
+- `speculative_verify_dflash_hidden(inputs, cache, capture_layer_ids)` returns
+  captured drafter inputs, final hidden state, and rollback state.
+- `speculative_argmax_from_hidden(hidden)` is an optional greedy fast path that
+  must match sampling from full target logits.
+- `rollback_speculative_cache(caches, rollback_state, accepted, block_size)`
+  commits the accepted prefix and target correction token.
+
+Only implement the hooks a model needs; the shared loops retain generic
+fallbacks where they are safe.
+
+## Exact verification
+
+A normal multi-token target forward is not automatically equivalent to repeated
+one-token decoding. Kernel dispatch can change floating-point order, while
+Mamba, gated-delta, convolution, or rotating caches need an explicit state for
+the accepted position. Near an argmax tie, a small numerical change can alter
+the generated sequence.
+
+Use the nearest existing `speculative_verifier.py` as the structural reference,
+but follow the new model's layer order and cache semantics exactly. The verifier
+must:
+
+- produce the same greedy target tokens as autoregressive decoding;
+- advance every cache through the verification block;
+- restore stateful caches at `accepted + 1` tokens;
+- handle zero, partial, and full acceptance;
+- either support per-row batch rollback or require uniform acceptance;
+- preserve the full required prompt hidden state through chunked prefill; and
+- match every supported weight format, including quantized output heads.
+
+Fused argmax and custom Metal kernels are optimizations, not correctness
+shortcuts. Keep the full-logit fallback until parity is proven.
+
+## Validation and maintenance
+
+Start with cheap tests for config normalization, strict weight loading, capture
+layer order, block sizing, sampling state, and cache rollback. Compare cache
+state and the next target token after zero, partial, and full acceptance for
+single and batched generation.
+
+Then run real-checkpoint greedy generation against the same autoregressive
+baseline. Require token-for-token equality across several prompts and context
+lengths before benchmarking. Measure all variants against one shared baseline
+in the same process, report median decode throughput and acceptance, and reject
+changes that improve an isolated kernel but not end-to-end decoding.
+
+When changing target layers, caches, quantization, sampling, batching, or
+chunked prefill, rerun both synthetic rollback tests and real-model exactness.
+Treat a new checkpoint layout or architecture tag as a compatibility change,
+not as proof that an existing adapter applies.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -85,6 +85,7 @@ nav:
     - Installation: installation.md
     - CLI Reference: cli_reference.md
     - Examples: examples.md
+    - Speculative Decoding: speculative-decoding.md
     - Contributing: contributing.md
     - Community Projects: community_projects.md
     - Report Issues: report_issues.md

--- a/mlx_vlm/models/nemotron_h/language.py
+++ b/mlx_vlm/models/nemotron_h/language.py
@@ -14,6 +14,9 @@ from ..cache import ArraysCache, KVCache
 from ..ssm import ssm_update
 from ..switch_layers import SwitchMLP
 from .config import ModelConfig
+from .speculative_verifier import NemotronHExactSpeculativeVerifier
+
+_EXACT_SPECULATIVE_VERIFIER = NemotronHExactSpeculativeVerifier()
 
 
 class MambaRMSNormGated(nn.Module):
@@ -441,6 +444,8 @@ class NemotronHModel(nn.Module):
         inputs=None,
         cache: Optional[Any] = None,
         inputs_embeds: Optional[mx.array] = None,
+        capture_layer_ids: Optional[list[int]] = None,
+        hidden_sink: Optional[list[mx.array]] = None,
     ):
         if inputs is None and inputs_embeds is None:
             raise ValueError("Provide either inputs or inputs_embeds")
@@ -460,8 +465,9 @@ class NemotronHModel(nn.Module):
         attn_mask = create_attention_mask(hidden_states, attn_cache)
         ssm_mask = create_ssm_mask(hidden_states, ssm_cache)
 
+        capture_set = set(capture_layer_ids) if capture_layer_ids else set()
         cache_counter = 0
-        for layer in self.layers:
+        for index, layer in enumerate(self.layers):
             if layer.block_type == "M" or layer.block_type == "*":
                 c = cache[cache_counter]
                 cache_counter += 1
@@ -473,6 +479,8 @@ class NemotronHModel(nn.Module):
             else:
                 mask = ssm_mask
             hidden_states = layer(hidden_states, mask=mask, cache=c)
+            if hidden_sink is not None and index in capture_set:
+                hidden_sink.append(hidden_states)
 
         return self.norm_f(hidden_states)
 
@@ -515,12 +523,15 @@ class Model(nn.Module):
         for layer_idx in range(self.args.num_hidden_layers):
             prefix = f"backbone.layers.{layer_idx}.mixer"
             for m, n in [("down_proj", "fc2"), ("up_proj", "fc1")]:
-                if f"{prefix}.experts.0.{m}.weight" in weights:
+                for suffix in ("weight", "scales", "biases"):
+                    first_key = f"{prefix}.experts.0.{m}.{suffix}"
+                    if first_key not in weights:
+                        continue
                     to_join = [
-                        weights.pop(f"{prefix}.experts.{e}.{m}.weight")
+                        weights.pop(f"{prefix}.experts.{e}.{m}.{suffix}")
                         for e in range(self.args.n_routed_experts)
                     ]
-                    weights[f"{prefix}.switch_mlp.{n}.weight"] = mx.stack(to_join)
+                    weights[f"{prefix}.switch_mlp.{n}.{suffix}"] = mx.stack(to_join)
 
         return weights
 
@@ -533,6 +544,8 @@ class Model(nn.Module):
 
 
 class LanguageModel(nn.Module):
+    requires_uniform_batch_acceptance = True
+
     def __init__(self, args: ModelConfig):
         super().__init__()
         self.args = args
@@ -550,8 +563,174 @@ class LanguageModel(nn.Module):
     ) -> LanguageModelOutput:
         if inputs is None:
             inputs = kwargs.get("input_ids")
-        out = self.backbone(inputs, cache=cache, inputs_embeds=inputs_embeds)
-        return LanguageModelOutput(logits=self.lm_head(out))
+        capture_layer_ids = kwargs.pop("capture_layer_ids", None)
+        speculative_verify = bool(kwargs.pop("speculative_verify", False))
+        return_hidden = kwargs.pop("return_hidden", False)
+        return_shared_kv = kwargs.pop("return_shared_kv", False)
+        skip_logits = kwargs.pop("skip_logits", False)
+
+        if speculative_verify:
+            return _EXACT_SPECULATIVE_VERIFIER(
+                self,
+                inputs,
+                cache=cache,
+                inputs_embeds=inputs_embeds,
+                capture_layer_ids=capture_layer_ids,
+                return_hidden=return_hidden,
+                return_shared_kv=return_shared_kv,
+                skip_logits=skip_logits,
+            )
+
+        hidden_sink = [] if capture_layer_ids is not None else None
+        out = self.backbone(
+            inputs,
+            cache=cache,
+            inputs_embeds=inputs_embeds,
+            capture_layer_ids=capture_layer_ids,
+            hidden_sink=hidden_sink,
+        )
+        if return_hidden:
+            if hidden_sink is None:
+                hidden_sink = []
+            hidden_sink.append(out)
+        return LanguageModelOutput(
+            logits=None if skip_logits else self.lm_head(out),
+            hidden_states=hidden_sink,
+            shared_kv_states={} if return_shared_kv else None,
+        )
+
+    def chunked_prefill_policy(
+        self,
+        *,
+        input_ids=None,
+        inputs_embeds=None,
+        prompt_cache=None,
+        draft_model=None,
+        draft_kind=None,
+        prefill_kwargs=None,
+    ) -> bool:
+        del input_ids, inputs_embeds, prompt_cache
+        if draft_model is None:
+            return True
+        prefill_kwargs = prefill_kwargs or {}
+        if draft_kind in ("dflash", "dspark"):
+            return prefill_kwargs.get("capture_layer_ids") is not None
+        return False
+
+    def speculative_draft_hidden(self, hidden: mx.array) -> mx.array:
+        return hidden
+
+    def speculative_logits_from_hidden(self, hidden: mx.array) -> mx.array:
+        return _EXACT_SPECULATIVE_VERIFIER.linear(self.lm_head, hidden)
+
+    def speculative_argmax_from_hidden(self, hidden: mx.array) -> mx.array:
+        output = _EXACT_SPECULATIVE_VERIFIER.quantized_argmax(self.lm_head, hidden)
+        if output is not None:
+            return output
+        return mx.argmax(self.speculative_logits_from_hidden(hidden), axis=-1)
+
+    def speculative_verify_hidden(self, inputs: mx.array, cache):
+        out = self(
+            inputs,
+            cache=cache,
+            capture_layer_ids=[],
+            speculative_verify=True,
+            return_hidden=True,
+            return_shared_kv=True,
+            skip_logits=True,
+        )
+        return out.hidden_states[-1], out.shared_kv_states, out.gdn_states
+
+    def speculative_verify_dflash_hidden(
+        self, inputs: mx.array, cache, capture_layer_ids: list[int]
+    ):
+        out = self(
+            inputs,
+            cache=cache,
+            capture_layer_ids=capture_layer_ids,
+            speculative_verify=True,
+            return_hidden=True,
+            skip_logits=True,
+        )
+        return out.hidden_states[:-1], out.hidden_states[-1], out.gdn_states
+
+    def speculative_verify_logits(self, inputs: mx.array, cache, sampler):
+        out = self(
+            inputs,
+            cache=cache,
+            capture_layer_ids=[],
+            speculative_verify=True,
+            return_hidden=True,
+            return_shared_kv=True,
+        )
+        return (
+            out.hidden_states[-1],
+            out.shared_kv_states,
+            out.gdn_states,
+            sampler(out.logits),
+        )
+
+    def rollback_speculative_cache(
+        self,
+        caches: list[Any],
+        gdn_states: Any,
+        accepted: Any,
+        block_size: int,
+    ) -> int:
+        if isinstance(accepted, int):
+            accepted_values = [accepted]
+        elif isinstance(accepted, mx.array):
+            accepted_values = [int(value) for value in accepted.reshape(-1).tolist()]
+        else:
+            accepted_values = [int(value) for value in accepted]
+        if len(set(accepted_values)) != 1:
+            raise ValueError(
+                "Nemotron-H speculative rollback requires uniform acceptance."
+            )
+        if gdn_states is None:
+            raise RuntimeError(
+                "Nemotron-H speculative rollback requires verifier Mamba states."
+            )
+
+        max_accepted = accepted_values[0]
+        if max_accepted < 0:
+            raise ValueError("Accepted tokens must be non-negative.")
+        retained = max_accepted + 1
+        if retained > int(block_size):
+            raise ValueError("Accepted tokens exceed the speculative block size.")
+        trim = int(block_size) - retained
+        state_index = 0
+        for cache in caches:
+            if cache is None:
+                continue
+            if isinstance(cache, ArraysCache):
+                if state_index >= len(gdn_states):
+                    raise RuntimeError(
+                        "Nemotron-H verifier did not return every Mamba state."
+                    )
+                state_history, conv_input, kernel_size = gdn_states[state_index]
+                state_index += 1
+                if isinstance(state_history, dict):
+                    from .speculative_verifier import replay_mamba_state
+
+                    cache[1] = replay_mamba_state(state_history, retained)
+                else:
+                    cache[1] = state_history[:, max_accepted]
+                cache[0] = conv_input[:, retained : retained + int(kernel_size) - 1]
+                if cache._lengths is not None:
+                    cache._lengths_advance -= trim
+                if cache._left_padding is not None:
+                    cache._left_padding_advance -= trim
+                continue
+            if not cache.is_trimmable():
+                raise NotImplementedError(
+                    "Nemotron-H speculative rollback requires trimmable attention caches."
+                )
+            if trim:
+                cache.trim(trim)
+        if state_index != len(gdn_states):
+            raise RuntimeError("Nemotron-H verifier returned extra Mamba states.")
+        return max_accepted
 
     def sanitize(self, weights):
         return Model.sanitize(self, weights)

--- a/mlx_vlm/models/nemotron_h/speculative_verifier.py
+++ b/mlx_vlm/models/nemotron_h/speculative_verifier.py
@@ -1,0 +1,779 @@
+from functools import lru_cache
+from typing import Any, Optional
+
+import mlx.core as mx
+import mlx.nn as nn
+
+from ..base import (
+    LanguageModelOutput,
+    create_attention_mask,
+    create_ssm_mask,
+    scaled_dot_product_attention,
+)
+from ..exact_speculative_verify import exact_speculative_verify_weight
+from ..qwen3_5.speculative_verifier import Qwen3_5ExactSpeculativeVerifier
+from ..ssm import compute_dt, ssm_update
+
+_MAMBA_VERIFY_SOURCE = r"""
+    uint lane = thread_position_in_grid.x;
+    uint d_idx = thread_position_in_grid.y;
+    uint n = thread_position_in_grid.z;
+    uint batch_idx = n / H;
+    uint head_idx = n % H;
+    uint group_idx = head_idx / HEADS_PER_GROUP;
+    uint state_idx = ((batch_idx * H + head_idx) * DH + d_idx) * DS;
+    constexpr int N_PER_THREAD = DS / 32;
+
+    U local_state[N_PER_THREAD];
+    for (int i = 0; i < N_PER_THREAD; ++i) {
+        uint s_idx = N_PER_THREAD * lane + i;
+        local_state[i] = state_in[state_idx + s_idx];
+    }
+
+    float A = -fast::exp(static_cast<float>(A_log[head_idx]));
+    for (int token = 0; token < VERIFY_T; ++token) {
+        uint x_idx = ((batch_idx * VERIFY_T + token) * H + head_idx) * DH + d_idx;
+        uint bc_idx = ((batch_idx * VERIFY_T + token) * GROUPS + group_idx) * DS;
+        uint dt_idx = (batch_idx * VERIFY_T + token) * H + head_idx;
+        float dt_value = static_cast<float>(dt[dt_idx]);
+        float decay = fast::exp(A * dt_value);
+        float x_value = static_cast<float>(X[x_idx]);
+        float acc = 0.0f;
+
+        for (int i = 0; i < N_PER_THREAD; ++i) {
+            uint s_idx = N_PER_THREAD * lane + i;
+            float next_state =
+                decay * static_cast<float>(local_state[i]) +
+                x_value * dt_value * static_cast<float>(B[bc_idx + s_idx]);
+            local_state[i] = static_cast<U>(next_state);
+            acc += next_state * static_cast<float>(C[bc_idx + s_idx]);
+        }
+
+        acc = simd_sum(acc);
+        if (lane == 0) {
+            out[x_idx] = static_cast<T>(
+                acc + x_value * static_cast<float>(D[head_idx])
+            );
+        }
+    }
+
+    for (int i = 0; i < N_PER_THREAD; ++i) {
+        uint s_idx = N_PER_THREAD * lane + i;
+        state_out[state_idx + s_idx] = local_state[i];
+    }
+"""
+
+_MAMBA_STATE_SOURCE = r"""
+    uint lane = thread_position_in_grid.x;
+    uint d_idx = thread_position_in_grid.y;
+    uint n = thread_position_in_grid.z;
+    uint batch_idx = n / H;
+    uint head_idx = n % H;
+    uint group_idx = head_idx / HEADS_PER_GROUP;
+    uint state_idx = ((batch_idx * H + head_idx) * DH + d_idx) * DS;
+    constexpr int N_PER_THREAD = DS / 32;
+
+    U local_state[N_PER_THREAD];
+    for (int i = 0; i < N_PER_THREAD; ++i) {
+        uint s_idx = N_PER_THREAD * lane + i;
+        local_state[i] = state_in[state_idx + s_idx];
+    }
+
+    float A = -fast::exp(static_cast<float>(A_log[head_idx]));
+    for (int token = 0; token < VERIFY_T; ++token) {
+        uint x_idx = ((batch_idx * VERIFY_T + token) * H + head_idx) * DH + d_idx;
+        uint b_idx = ((batch_idx * VERIFY_T + token) * GROUPS + group_idx) * DS;
+        uint dt_idx = (batch_idx * VERIFY_T + token) * H + head_idx;
+        float dt_value = static_cast<float>(dt[dt_idx]);
+        float decay = fast::exp(A * dt_value);
+        float x_value = static_cast<float>(X[x_idx]);
+
+        for (int i = 0; i < N_PER_THREAD; ++i) {
+            uint s_idx = N_PER_THREAD * lane + i;
+            float next_state =
+                decay * static_cast<float>(local_state[i]) +
+                x_value * dt_value * static_cast<float>(B[b_idx + s_idx]);
+            local_state[i] = static_cast<U>(next_state);
+        }
+    }
+
+    for (int i = 0; i < N_PER_THREAD; ++i) {
+        uint s_idx = N_PER_THREAD * lane + i;
+        state_out[state_idx + s_idx] = local_state[i];
+    }
+"""
+
+_NVFP4_ARGMAX_HEADER = r"""
+    using namespace metal;
+
+    constant constexpr int SIMD_SIZE = 32;
+    constant constexpr int VALUES_PER_THREAD = 8;
+    constant constexpr int BLOCK_SIZE = SIMD_SIZE * VALUES_PER_THREAD;
+    constant constexpr int RESULTS_PER_SIMDGROUP = 4;
+    constant constexpr int NUM_SIMDGROUPS = 2;
+    constant constexpr int ROWS_PER_THREADGROUP =
+        RESULTS_PER_SIMDGROUP * NUM_SIMDGROUPS;
+
+    inline float decode_e2m1(uint value) {
+        half decoded = as_type<half>(ushort((value & 7) << 9));
+        decoded *= 16384.0h;
+        return float(value & 8 ? -decoded : decoded);
+    }
+
+    inline float decode_e4m3(uint8_t value) {
+        half decoded = as_type<half>(ushort((value & 127) << 7));
+        decoded *= 256.0h;
+        return float(value & 128 ? -decoded : decoded);
+    }
+
+    inline float nvfp4_dot(
+        const device uint8_t* weight,
+        const thread float* values,
+        float scale) {
+        const device uint16_t* packed =
+            reinterpret_cast<const device uint16_t*>(weight);
+        float result = 0.0f;
+        for (int index = 0; index < 2; ++index) {
+            uint word = packed[index];
+            result +=
+                values[4 * index] * decode_e2m1(word) +
+                values[4 * index + 1] * decode_e2m1(word >> 4) +
+                values[4 * index + 2] * decode_e2m1(word >> 8) +
+                values[4 * index + 3] * decode_e2m1(word >> 12);
+        }
+        return scale * result;
+    }
+"""
+
+_NVFP4_ARGMAX_SOURCE = r"""
+    uint output_tile = threadgroup_position_in_grid.y;
+    uint batch_index = threadgroup_position_in_grid.z;
+    uint simd_group = simdgroup_index_in_threadgroup;
+    uint lane = thread_index_in_simdgroup;
+    uint output_row =
+        output_tile * ROWS_PER_THREADGROUP +
+        simd_group * RESULTS_PER_SIMDGROUP;
+
+    threadgroup float group_values[VERIFY_T][NUM_SIMDGROUPS];
+    threadgroup int group_indices[VERIFY_T][NUM_SIMDGROUPS];
+    float results[VERIFY_T][RESULTS_PER_SIMDGROUP];
+    float values[VERIFY_T][VALUES_PER_THREAD];
+    for (int token = 0; token < VERIFY_T; ++token) {
+        for (int row = 0; row < RESULTS_PER_SIMDGROUP; ++row) {
+            results[token][row] = 0.0f;
+        }
+    }
+
+    const device uint8_t* weight_bytes =
+        reinterpret_cast<const device uint8_t*>(w);
+    for (int k = 0; k < K_SIZE; k += BLOCK_SIZE) {
+        int lane_start = k + int(lane) * VALUES_PER_THREAD;
+        if (lane_start < K_SIZE) {
+            for (int token = 0; token < VERIFY_T; ++token) {
+                const device T* input =
+                    x + (int(batch_index) * VERIFY_T + token) * K_SIZE + lane_start;
+                for (int index = 0; index < VALUES_PER_THREAD; ++index) {
+                    values[token][index] = float(input[index]);
+                }
+            }
+
+            for (int row = 0; row < RESULTS_PER_SIMDGROUP; ++row) {
+                int n = int(output_row) + row;
+                const device uint8_t* weight =
+                    weight_bytes + n * (K_SIZE / 2) + lane_start / 2;
+                float scale = decode_e4m3(
+                    scales[n * (K_SIZE / 16) + lane_start / 16]
+                );
+                for (int token = 0; token < VERIFY_T; ++token) {
+                    results[token][row] += nvfp4_dot(weight, values[token], scale);
+                }
+            }
+        }
+    }
+
+    for (int token = 0; token < VERIFY_T; ++token) {
+        float best_value = -3.4028234663852886e38f;
+        int best_index = 0;
+        for (int row = 0; row < RESULTS_PER_SIMDGROUP; ++row) {
+            int n = int(output_row) + row;
+            float value = float(T(simd_sum(results[token][row])));
+            if (value > best_value) {
+                best_value = value;
+                best_index = n;
+            }
+        }
+        if (lane == 0) {
+            group_values[token][simd_group] = best_value;
+            group_indices[token][simd_group] = best_index;
+        }
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    if (simd_group == 0 && lane == 0) {
+        for (int token = 0; token < VERIFY_T; ++token) {
+            float best_value = group_values[token][0];
+            int best_index = group_indices[token][0];
+            for (int group = 1; group < NUM_SIMDGROUPS; ++group) {
+                float value = group_values[token][group];
+                if (value > best_value) {
+                    best_value = value;
+                    best_index = group_indices[token][group];
+                }
+            }
+            int offset =
+                (int(batch_index) * VERIFY_T + token) * NUM_TILES +
+                int(output_tile);
+            tile_values[offset] = T(best_value);
+            tile_indices[offset] = best_index;
+        }
+    }
+"""
+
+
+@lru_cache(maxsize=None)
+def _nvfp4_argmax_kernel(dtype, verify_length, input_size, output_size):
+    dtype_name = {mx.bfloat16: "bf16", mx.float16: "fp16"}.get(dtype, "unk")
+    return mx.fast.metal_kernel(
+        name=(
+            "nemotron_h_nvfp4_argmax_"
+            f"t{verify_length}_k{input_size}_n{output_size}_{dtype_name}"
+        ),
+        input_names=["x", "w", "scales"],
+        output_names=["tile_values", "tile_indices"],
+        header=_NVFP4_ARGMAX_HEADER,
+        source=_NVFP4_ARGMAX_SOURCE,
+    )
+
+
+def _nvfp4_argmax(linear, hidden: mx.array) -> Optional[mx.array]:
+    if (
+        not isinstance(linear, nn.QuantizedLinear)
+        or linear.mode != "nvfp4"
+        or linear.bits != 4
+        or linear.group_size != 16
+        or "bias" in linear
+        or hidden.ndim != 3
+        or hidden.dtype not in (mx.bfloat16, mx.float16)
+        or not mx.metal.is_available()
+        or mx.default_device() != mx.gpu
+    ):
+        return None
+
+    batch, length, input_size = hidden.shape
+    expected_input_size = linear.weight.shape[1] * 8
+    output_size = linear.weight.shape[0]
+    if input_size != expected_input_size or input_size % 16 or output_size % 8:
+        return None
+
+    tile_count = output_size // 8
+    kernel = _nvfp4_argmax_kernel(hidden.dtype, length, input_size, output_size)
+    tile_values, tile_indices = kernel(
+        inputs=[mx.contiguous(hidden), linear.weight, linear.scales],
+        template=[
+            ("T", hidden.dtype),
+            ("VERIFY_T", int(length)),
+            ("K_SIZE", int(input_size)),
+            ("N_SIZE", int(output_size)),
+            ("NUM_TILES", int(tile_count)),
+        ],
+        grid=(32, 2 * tile_count, batch),
+        threadgroup=(32, 2, 1),
+        output_shapes=[
+            (batch, length, tile_count),
+            (batch, length, tile_count),
+        ],
+        output_dtypes=[hidden.dtype, mx.int32],
+    )
+    best_tile = mx.argmax(tile_values, axis=-1)
+    return mx.take_along_axis(tile_indices, best_tile[..., None], axis=-1).squeeze(-1)
+
+
+@lru_cache(maxsize=None)
+def _mamba_verify_kernel(
+    input_dtype,
+    state_dtype,
+    verify_length,
+    num_heads,
+    head_dim,
+    state_size,
+    num_groups,
+):
+    input_name = {mx.bfloat16: "bf16", mx.float16: "fp16", mx.float32: "fp32"}.get(
+        input_dtype, "unk"
+    )
+    state_name = {
+        mx.bfloat16: "bf16",
+        mx.float16: "fp16",
+        mx.float32: "fp32",
+    }.get(state_dtype, "unk")
+    return mx.fast.metal_kernel(
+        name=(
+            "nemotron_h_target_verify_mamba_"
+            f"t{verify_length}_h{num_heads}_dh{head_dim}_ds{state_size}_"
+            f"g{num_groups}_{input_name}_{state_name}"
+        ),
+        input_names=["X", "A_log", "B", "C", "D", "dt", "state_in"],
+        output_names=["out", "state_out"],
+        source=_MAMBA_VERIFY_SOURCE,
+    )
+
+
+@lru_cache(maxsize=None)
+def _mamba_state_kernel(
+    input_dtype,
+    state_dtype,
+    verify_length,
+    num_heads,
+    head_dim,
+    state_size,
+    num_groups,
+):
+    input_name = {mx.bfloat16: "bf16", mx.float16: "fp16", mx.float32: "fp32"}.get(
+        input_dtype, "unk"
+    )
+    state_name = {
+        mx.bfloat16: "bf16",
+        mx.float16: "fp16",
+        mx.float32: "fp32",
+    }.get(state_dtype, "unk")
+    return mx.fast.metal_kernel(
+        name=(
+            "nemotron_h_target_replay_mamba_"
+            f"t{verify_length}_h{num_heads}_dh{head_dim}_ds{state_size}_"
+            f"g{num_groups}_{input_name}_{state_name}"
+        ),
+        input_names=["X", "A_log", "B", "dt", "state_in"],
+        output_names=["state_out"],
+        source=_MAMBA_STATE_SOURCE,
+    )
+
+
+def replay_mamba_state(rollback_state: dict[str, mx.array], length: int) -> mx.array:
+    hidden_states = rollback_state["hidden_states"][:, :length]
+    B = rollback_state["B"][:, :length]
+    dt = rollback_state["dt"][:, :length]
+    state = rollback_state["state"]
+    A_log = rollback_state["A_log"]
+    batch, _, num_heads, head_dim = hidden_states.shape
+    num_groups, state_size = B.shape[-2:]
+    kernel = _mamba_state_kernel(
+        hidden_states.dtype,
+        state.dtype,
+        length,
+        num_heads,
+        head_dim,
+        state_size,
+        num_groups,
+    )
+    return kernel(
+        inputs=[hidden_states, A_log, B, dt, state],
+        template=[
+            ("T", hidden_states.dtype),
+            ("U", state.dtype),
+            ("VERIFY_T", int(length)),
+            ("H", int(num_heads)),
+            ("DH", int(head_dim)),
+            ("DS", int(state_size)),
+            ("GROUPS", int(num_groups)),
+            ("HEADS_PER_GROUP", int(num_heads // num_groups)),
+        ],
+        grid=(32, head_dim, batch * num_heads),
+        threadgroup=(32, min(8, head_dim), 1),
+        output_shapes=[state.shape],
+        output_dtypes=[state.dtype],
+    )[0]
+
+
+def _mamba_update_timewise(
+    hidden_states,
+    A_log,
+    B,
+    C,
+    D,
+    dt,
+    dt_bias,
+    state,
+    time_step_limit,
+    mask,
+):
+    outputs = []
+    states = []
+    for position in range(hidden_states.shape[1]):
+        output, state = ssm_update(
+            hidden_states[:, position : position + 1],
+            A_log,
+            B[:, position : position + 1],
+            C[:, position : position + 1],
+            D,
+            dt[:, position : position + 1],
+            dt_bias,
+            state,
+            time_step_limit,
+            None if mask is None else mask[:, position : position + 1],
+        )
+        outputs.append(output)
+        states.append(state[:, None])
+    return mx.concatenate(outputs, axis=1), state, mx.concatenate(states, axis=1)
+
+
+def _mamba_update_exact(
+    hidden_states,
+    A_log,
+    B,
+    C,
+    D,
+    dt,
+    dt_bias,
+    state,
+    time_step_limit,
+    mask,
+):
+    batch, length, num_heads, head_dim = hidden_states.shape
+    num_groups, state_size = B.shape[-2:]
+    if (
+        state is None
+        or mask is not None
+        or not mx.metal.is_available()
+        or mx.default_device() != mx.gpu
+        or state_size % 32
+        or hidden_states.dtype not in (mx.bfloat16, mx.float16, mx.float32)
+        or state.dtype not in (mx.bfloat16, mx.float16, mx.float32)
+    ):
+        return _mamba_update_timewise(
+            hidden_states,
+            A_log,
+            B,
+            C,
+            D,
+            dt,
+            dt_bias,
+            state,
+            time_step_limit,
+            mask,
+        )
+
+    dt = compute_dt(dt, dt_bias, time_step_limit)
+    kernel = _mamba_verify_kernel(
+        hidden_states.dtype,
+        state.dtype,
+        length,
+        num_heads,
+        head_dim,
+        state_size,
+        num_groups,
+    )
+    output, final_state = kernel(
+        inputs=[hidden_states, A_log, B, C, D, dt, state],
+        template=[
+            ("T", hidden_states.dtype),
+            ("U", state.dtype),
+            ("VERIFY_T", int(length)),
+            ("H", int(num_heads)),
+            ("DH", int(head_dim)),
+            ("DS", int(state_size)),
+            ("GROUPS", int(num_groups)),
+            ("HEADS_PER_GROUP", int(num_heads // num_groups)),
+        ],
+        grid=(32, head_dim, batch * num_heads),
+        threadgroup=(32, min(8, head_dim), 1),
+        output_shapes=[
+            hidden_states.shape,
+            state.shape,
+        ],
+        output_dtypes=[hidden_states.dtype, state.dtype],
+    )
+    rollback_state = {
+        "hidden_states": hidden_states,
+        "A_log": A_log,
+        "B": B,
+        "dt": dt,
+        "state": state,
+    }
+    return output, final_state, rollback_state
+
+
+class NemotronHExactSpeculativeVerifier(Qwen3_5ExactSpeculativeVerifier):
+    """Run Nemotron-H verification with singleton-equivalent Metal kernels."""
+
+    def quantized_argmax(
+        self,
+        linear,
+        hidden: mx.array,
+        token_mask: Optional[mx.array] = None,
+    ) -> Optional[mx.array]:
+        output = super().quantized_argmax(linear, hidden, token_mask=token_mask)
+        if output is not None or token_mask is not None:
+            return output
+        return _nvfp4_argmax(linear, hidden)
+
+    def _linear(self, linear, hidden: mx.array) -> mx.array:
+        if hidden.ndim == 3 and hidden.shape[1] > 1 and hidden.dtype == mx.float32:
+            return mx.concatenate(
+                [
+                    linear(hidden[:, position : position + 1])
+                    for position in range(hidden.shape[1])
+                ],
+                axis=1,
+            )
+        return super()._linear(linear, hidden)
+
+    def _linears(self, linears, hidden: mx.array):
+        if hidden.ndim == 3 and hidden.shape[1] > 1 and hidden.dtype == mx.float32:
+            return tuple(self._linear(linear, hidden) for linear in linears)
+        return super()._linears(linears, hidden)
+
+    def linear(self, linear, hidden: mx.array) -> mx.array:
+        return self._linear(linear, hidden)
+
+    def _attention(self, attention, hidden, mask, cache):
+        batch, length, _ = hidden.shape
+        queries, keys, values = self._linears(
+            (attention.q_proj, attention.k_proj, attention.v_proj), hidden
+        )
+        queries = queries.reshape(
+            batch, length, attention.num_heads, attention.head_dim
+        ).transpose(0, 2, 1, 3)
+        keys = keys.reshape(
+            batch, length, attention.num_key_value_heads, attention.head_dim
+        ).transpose(0, 2, 1, 3)
+        values = values.reshape(
+            batch, length, attention.num_key_value_heads, attention.head_dim
+        ).transpose(0, 2, 1, 3)
+        if cache is not None:
+            keys, values = cache.update_and_fetch(keys, values)
+
+        if length > 1:
+            prefix_length = keys.shape[-2] - length
+            output = mx.concatenate(
+                [
+                    scaled_dot_product_attention(
+                        queries[:, :, position : position + 1],
+                        keys[:, :, : prefix_length + position + 1],
+                        values[:, :, : prefix_length + position + 1],
+                        cache=cache,
+                        scale=attention.scale,
+                        mask=(
+                            mask[
+                                ...,
+                                position : position + 1,
+                                : prefix_length + position + 1,
+                            ]
+                            if isinstance(mask, mx.array) and mask.ndim >= 4
+                            else None
+                        ),
+                    )
+                    for position in range(length)
+                ],
+                axis=2,
+            )
+        else:
+            output = scaled_dot_product_attention(
+                queries,
+                keys,
+                values,
+                cache=cache,
+                scale=attention.scale,
+                mask=mask,
+            )
+        output = output.transpose(0, 2, 1, 3).reshape(batch, length, -1)
+        return self._linear(attention.o_proj, output)
+
+    def _mamba(self, mixer, hidden, mask, cache, state_sink):
+        projected = self._linear(mixer.in_proj, hidden)
+        gate, conv_input, dt = mixer._split_projected_states(projected)
+        if mask is not None:
+            conv_input = mx.where(mask[..., None], conv_input, 0)
+
+        if cache is not None and cache[0] is not None:
+            conv_state = cache[0]
+        else:
+            conv_state = mx.zeros(
+                (hidden.shape[0], mixer.conv_kernel_size - 1, mixer.conv_dim),
+                dtype=hidden.dtype,
+            )
+        padded_input = mx.concatenate([conv_state, conv_input], axis=1)
+        if cache is not None:
+            keep = mixer.conv_kernel_size - 1
+            if cache.lengths is not None:
+                total = padded_input.shape[1]
+                ends = mx.clip(cache.lengths, 0, total - keep)
+                positions = (ends[:, None] + mx.arange(keep))[..., None]
+                cache[0] = mx.take_along_axis(padded_input, positions, axis=1)
+            else:
+                cache[0] = mx.contiguous(padded_input[:, -keep:])
+
+        conv_output = nn.silu(mixer.conv1d(padded_input))
+        hidden_ssm, B, C = mx.split(
+            conv_output,
+            [
+                mixer.intermediate_size,
+                mixer.intermediate_size + mixer.n_groups * mixer.ssm_state_size,
+            ],
+            axis=-1,
+        )
+        batch, length, _ = hidden_ssm.shape
+        hidden_ssm = hidden_ssm.reshape(batch, length, mixer.num_heads, mixer.head_dim)
+        B = B.reshape(batch, length, mixer.n_groups, mixer.ssm_state_size)
+        C = C.reshape(batch, length, mixer.n_groups, mixer.ssm_state_size)
+        state = cache[1] if cache is not None else None
+        output, state, rollback_state = _mamba_update_exact(
+            hidden_ssm,
+            mixer.A_log,
+            B,
+            C,
+            mixer.D.astype(hidden_ssm.dtype),
+            dt,
+            mixer.dt_bias,
+            state,
+            mixer.time_step_limit,
+            mask,
+        )
+        if cache is not None:
+            cache[1] = state
+            cache.advance(length)
+        state_sink.append((rollback_state, padded_input, mixer.conv_kernel_size))
+        output = output.reshape(batch, length, mixer.intermediate_size)
+        output = mixer.norm(output, gate)
+        return self._linear(mixer.out_proj, output)
+
+    def _mlp(self, mlp, hidden):
+        return self._linear(mlp.down_proj, nn.relu2(self._linear(mlp.up_proj, hidden)))
+
+    def _switch_mlp(self, switch_mlp, hidden, indices):
+        if hidden.ndim != 3 or hidden.shape[1] <= 1:
+            return switch_mlp(hidden, indices)
+        batch, length, width = hidden.shape
+        top_k = indices.shape[-1]
+        hidden = hidden.reshape(batch * length, width)
+        indices = indices.reshape(batch * length, top_k)
+        hidden = mx.expand_dims(hidden, (-2, -3))
+        hidden = switch_mlp.fc1(hidden, indices, sorted_indices=False)
+        hidden = switch_mlp.activation(hidden)
+        hidden = switch_mlp.fc2(hidden, indices, sorted_indices=False)
+        return hidden.squeeze(-2).reshape(batch, length, top_k, -1)
+
+    def _moe(self, moe, hidden):
+        from .language import group_expert_select
+
+        gate_logits = (
+            None
+            if hidden.dtype == mx.float32
+            else exact_speculative_verify_weight(moe.gate.weight, hidden)
+        )
+        if gate_logits is None:
+            gate_logits = mx.concatenate(
+                [
+                    hidden[:, position : position + 1] @ moe.gate.weight.T
+                    for position in range(hidden.shape[1])
+                ],
+                axis=1,
+            )
+        indices, scores = group_expert_select(
+            gate_logits,
+            moe.gate.e_score_correction_bias,
+            moe.gate.top_k,
+            moe.gate.n_group,
+            moe.gate.topk_group,
+            moe.gate.routed_scaling_factor,
+            moe.gate.norm_topk_prob,
+        )
+        residual = hidden
+        if moe.moe_latent_size is not None:
+            hidden = self._linear(moe.fc1_latent_proj, hidden)
+        output = self._switch_mlp(moe.switch_mlp, hidden, indices)
+        output = (output * scores[..., None]).sum(axis=-2).astype(output.dtype)
+        if moe.moe_latent_size is not None:
+            output = self._linear(moe.fc2_latent_proj, output)
+        if moe.config.n_shared_experts is not None:
+            output = output + self._mlp(moe.shared_experts, residual)
+        return output
+
+    def _layer(self, layer, hidden, mask, cache, state_sink):
+        normed = layer.norm(hidden)
+        if layer.block_type == "M":
+            output = self._mamba(layer.mixer, normed, mask, cache, state_sink)
+        elif layer.block_type == "*":
+            output = self._attention(layer.mixer, normed, mask, cache)
+        elif layer.block_type == "-":
+            output = self._mlp(layer.mixer, normed)
+        else:
+            output = self._moe(layer.mixer, normed)
+        return hidden + output
+
+    def _model(
+        self,
+        model,
+        inputs,
+        cache,
+        inputs_embeds,
+        capture_layer_ids,
+        hidden_sink,
+        state_sink,
+    ):
+        if inputs_embeds is not None:
+            hidden = inputs_embeds
+        elif model.with_embeddings:
+            hidden = model.embeddings(inputs)
+        else:
+            raise ValueError("This Nemotron-H backbone has no token embedding table")
+
+        stateful_layers = sum(layer.block_type in {"M", "*"} for layer in model.layers)
+        if cache is None:
+            cache = [None] * stateful_layers
+        has_attention = any(layer.block_type == "*" for layer in model.layers)
+        has_mamba = any(layer.block_type == "M" for layer in model.layers)
+        attention_cache = cache[model.fa_idx] if has_attention else None
+        mamba_cache = cache[model.ssm_idx] if has_mamba else None
+        attention_mask = create_attention_mask(hidden, attention_cache)
+        mamba_mask = create_ssm_mask(hidden, mamba_cache)
+        capture_set = set(capture_layer_ids) if capture_layer_ids else set()
+        cache_index = 0
+        for index, layer in enumerate(model.layers):
+            layer_cache = cache[cache_index] if layer.block_type in {"M", "*"} else None
+            if layer.block_type in {"M", "*"}:
+                cache_index += 1
+            mask = attention_mask if layer.block_type == "*" else mamba_mask
+            hidden = self._layer(layer, hidden, mask, layer_cache, state_sink)
+            if hidden_sink is not None and index in capture_set:
+                hidden_sink.append(hidden)
+        return model.norm_f(hidden)
+
+    def __call__(
+        self,
+        language_model,
+        inputs: Optional[mx.array],
+        *,
+        cache: Optional[list[Any]] = None,
+        inputs_embeds: Optional[mx.array] = None,
+        capture_layer_ids: Optional[list[int]] = None,
+        return_hidden: bool = False,
+        return_shared_kv: bool = False,
+        skip_logits: bool = False,
+    ) -> LanguageModelOutput:
+        if inputs is None and inputs_embeds is None:
+            raise ValueError("Provide either inputs or inputs_embeds")
+        hidden_sink = [] if capture_layer_ids is not None else None
+        state_sink = []
+        hidden = self._model(
+            language_model.backbone,
+            inputs,
+            cache,
+            inputs_embeds,
+            capture_layer_ids,
+            hidden_sink,
+            state_sink,
+        )
+        if return_hidden:
+            if hidden_sink is None:
+                hidden_sink = []
+            hidden_sink.append(hidden)
+        logits = None if skip_logits else self._linear(language_model.lm_head, hidden)
+        return LanguageModelOutput(
+            logits=logits,
+            hidden_states=hidden_sink,
+            gdn_states=state_sink,
+            shared_kv_states={} if return_shared_kv else None,
+        )
+
+
+__all__ = ["NemotronHExactSpeculativeVerifier", "replay_mamba_state"]

--- a/mlx_vlm/speculative/dflash.py
+++ b/mlx_vlm/speculative/dflash.py
@@ -80,6 +80,47 @@ def _dflash_committed_hidden_segments(
     ]
 
 
+def _reserve_dflash_target_cache(prompt_cache: List[Any], block_size: int) -> None:
+    pending = []
+    for entry in prompt_cache:
+        reserve = getattr(entry, "prefix_cache_reserve", None)
+        offset = getattr(entry, "offset", None)
+        if not callable(reserve) or not isinstance(offset, int):
+            continue
+        pending.extend(reserve(offset + block_size))
+    if pending:
+        mx.async_eval(*pending)
+
+
+def _dflash_verify_greedy(
+    lm: nn.Module,
+    verify_input: mx.array,
+    prompt_cache: List[Any],
+    target_layer_ids: List[int],
+    sampler: Callable[[mx.array], mx.array],
+):
+    verify_hidden = getattr(lm, "speculative_verify_dflash_hidden", None)
+    argmax_from_hidden = getattr(lm, "speculative_argmax_from_hidden", None)
+    if callable(verify_hidden) and callable(argmax_from_hidden):
+        captured, final_hidden, gdn_states = verify_hidden(
+            verify_input, prompt_cache, target_layer_ids
+        )
+        target_tokens = argmax_from_hidden(final_hidden)
+        if target_tokens is None:
+            raise RuntimeError(
+                "speculative_argmax_from_hidden returned no greedy target tokens"
+            )
+        return captured, gdn_states, target_tokens
+
+    verify_out = lm(
+        verify_input,
+        cache=prompt_cache,
+        capture_layer_ids=target_layer_ids,
+        speculative_verify=True,
+    )
+    return verify_out.hidden_states, verify_out.gdn_states, sampler(verify_out.logits)
+
+
 def _supports_positioned_target_sampling(sampler: Callable) -> bool:
     return callable(getattr(sampler, "sample_target", None))
 
@@ -255,7 +296,18 @@ def _dflash_rounds(
 
     target_layer_ids = list(draft_model.config.target_layer_ids)
     block_total = _dflash_block_total(draft_model, draft_block_size)
+    choose_block_ceiling = getattr(draft_model, "choose_block_ceiling", None)
+    if callable(choose_block_ceiling):
+        block_total = choose_block_ceiling(int(hidden.shape[1]), block_total)
+    initial_block_size = getattr(draft_model, "dflash_initial_block_size", None)
+    choose_initial_block_size = getattr(draft_model, "choose_initial_block_size", None)
+    if use_model_initial_block_size and callable(choose_initial_block_size):
+        initial_block_size = choose_initial_block_size(
+            int(hidden.shape[1]), block_total
+        )
     draft_cache = draft_model.reset(model)
+    with mx.stream(generation_stream):
+        _reserve_dflash_target_cache(prompt_cache, block_total)
     positioned_sampling = _supports_positioned_target_sampling(sampler)
     sampler_rng = _SpeculativeSamplerRNG(
         draft_model,
@@ -275,11 +327,7 @@ def _dflash_rounds(
             draft_model,
             block_total,
             max_tokens - emitted + 1,
-            (
-                getattr(draft_model, "dflash_initial_block_size", None)
-                if use_model_initial_block_size
-                else None
-            ),
+            (initial_block_size if use_model_initial_block_size else None),
         )
         if bs <= 1:
             break
@@ -294,8 +342,13 @@ def _dflash_rounds(
             if not greedy_sampling and positioned_sampling
             else sampler
         )
+        draft_fn = (
+            getattr(draft_model, "draft_block_greedy", draft_model.draft_block)
+            if greedy_sampling
+            else draft_model.draft_block
+        )
         draft_tokens = sampler_rng.draft_tokens(
-            draft_model.draft_block,
+            draft_fn,
             b,
             hidden,
             draft_cache,
@@ -311,15 +364,24 @@ def _dflash_rounds(
                 [mx.array([[b]], dtype=token_dtype), draft_tokens],
                 axis=1,
             )
-            verify_out = lm(
-                verify_input,
-                cache=prompt_cache,
-                capture_layer_ids=target_layer_ids,
-                speculative_verify=True,
-            )
-            hidden = mx.concatenate(verify_out.hidden_states, axis=-1)
             if greedy_sampling:
-                target_tokens = sampler(verify_out.logits)
+                captured, gdn_states, target_tokens = _dflash_verify_greedy(
+                    lm,
+                    verify_input,
+                    prompt_cache,
+                    target_layer_ids,
+                    sampler,
+                )
+                hidden = mx.concatenate(captured, axis=-1)
+            else:
+                verify_out = lm(
+                    verify_input,
+                    cache=prompt_cache,
+                    capture_layer_ids=target_layer_ids,
+                    speculative_verify=True,
+                )
+                gdn_states = verify_out.gdn_states
+                hidden = mx.concatenate(verify_out.hidden_states, axis=-1)
         if greedy_sampling:
             mx.async_eval(target_tokens, hidden)
         else:
@@ -349,9 +411,7 @@ def _dflash_rounds(
 
         if accepted < bs - 1:
             with mx.stream(generation_stream):
-                lm.rollback_speculative_cache(
-                    prompt_cache, verify_out.gdn_states, accepted, bs
-                )
+                lm.rollback_speculative_cache(prompt_cache, gdn_states, accepted, bs)
 
         if hidden_is_prepared and emitted + len(new_tokens) < max_tokens:
             hidden = prepare_target_hidden(hidden)
@@ -406,7 +466,18 @@ def _dflash_rounds_batch(
     row_ids = list(range(B)) if row_ids is None else list(row_ids)
     target_layer_ids = list(draft_model.config.target_layer_ids)
     block_total = _dflash_block_total(draft_model, draft_block_size)
+    choose_block_ceiling = getattr(draft_model, "choose_block_ceiling", None)
+    if callable(choose_block_ceiling):
+        block_total = choose_block_ceiling(int(hidden.shape[1]), block_total)
+    initial_block_size = getattr(draft_model, "dflash_initial_block_size", None)
+    choose_initial_block_size = getattr(draft_model, "choose_initial_block_size", None)
+    if callable(choose_initial_block_size):
+        initial_block_size = choose_initial_block_size(
+            int(hidden.shape[1]), block_total
+        )
     draft_model.reset(model)
+    with mx.stream(generation_stream):
+        _reserve_dflash_target_cache(prompt_cache, block_total)
     positioned_sampling = _supports_positioned_target_sampling(sampler)
     sampler_rng = _SpeculativeSamplerRNG(
         draft_model,
@@ -429,7 +500,12 @@ def _dflash_rounds_batch(
             max(1, max_tokens - emitted[active_idx[j]] + 1)
             for j in range(len(active_idx))
         ]
-        bs = _dflash_next_block_size(draft_model, block_total, min(remaining))
+        bs = _dflash_next_block_size(
+            draft_model,
+            block_total,
+            min(remaining),
+            initial_block_size,
+        )
         if bs <= 1:
             break
 
@@ -443,7 +519,15 @@ def _dflash_rounds_batch(
         def draft_active_rows():
             return mx.concatenate(
                 [
-                    draft_model.draft_block(
+                    (
+                        getattr(
+                            draft_model,
+                            "draft_block_greedy",
+                            draft_model.draft_block,
+                        )
+                        if greedy_sampling
+                        else draft_model.draft_block
+                    )(
                         int(b_active[j]),
                         hidden_by_orig[active_idx[j]],
                         draft_caches[active_idx[j]],
@@ -470,15 +554,24 @@ def _dflash_rounds_batch(
 
         with mx.stream(generation_stream):
             verify_input = mx.concatenate([b_arr[:, None], draft_tokens], axis=1)
-            verify_out = lm(
-                verify_input,
-                cache=prompt_cache,
-                capture_layer_ids=target_layer_ids,
-                speculative_verify=True,
-            )
-            hidden_full = mx.concatenate(verify_out.hidden_states, axis=-1)
             if greedy_sampling:
-                target_tokens = sampler(verify_out.logits)
+                captured, gdn_states, target_tokens = _dflash_verify_greedy(
+                    lm,
+                    verify_input,
+                    prompt_cache,
+                    target_layer_ids,
+                    sampler,
+                )
+                hidden_full = mx.concatenate(captured, axis=-1)
+            else:
+                verify_out = lm(
+                    verify_input,
+                    cache=prompt_cache,
+                    capture_layer_ids=target_layer_ids,
+                    speculative_verify=True,
+                )
+                gdn_states = verify_out.gdn_states
+                hidden_full = mx.concatenate(verify_out.hidden_states, axis=-1)
         if greedy_sampling:
             mx.async_eval(target_tokens, hidden_full)
         else:
@@ -548,7 +641,7 @@ def _dflash_rounds_batch(
         if min_accepted < bs - 1:
             with mx.stream(generation_stream):
                 lm.rollback_speculative_cache(
-                    prompt_cache, verify_out.gdn_states, accepted_arr, bs
+                    prompt_cache, gdn_states, accepted_arr, bs
                 )
 
         # --- Continuous batching: filter out finished sequences ---

--- a/mlx_vlm/speculative/drafters/dflash2/dflash2.py
+++ b/mlx_vlm/speculative/drafters/dflash2/dflash2.py
@@ -72,11 +72,11 @@ class DFlash2DecoderLayer(DFlashDecoderLayer):
             config.hidden_size, config.conv_kernel_size, config.conv_group_size
         )
 
-    def __call__(self, x, x_ctx, rope, cache):
+    def __call__(self, x, x_ctx, rope, cache, projected_context=None):
         residual = x
         x, kernel = self.attention_conv.prepare(self.input_layernorm(x))
         x = residual + self.attention_conv.finish(
-            self.self_attn(x, x_ctx, rope, cache), kernel
+            self.self_attn(x, x_ctx, rope, cache, projected_context), kernel
         )
         residual = x
         x, kernel = self.mlp_conv.prepare(self.post_attention_layernorm(x))

--- a/mlx_vlm/speculative/drafters/dspark/config.py
+++ b/mlx_vlm/speculative/drafters/dspark/config.py
@@ -17,9 +17,8 @@ def _is_strictly_increasing_ints(values: list[int]) -> bool:
 class DSparkConfig(BaseModelConfig):
     """Model-agnostic configuration for a DSpark drafter.
 
-    Checkpoints publish ``block_size`` as the number of proposals (gamma),
-    while mlx-vlm's DFlash loop uses the verification width (anchor plus
-    proposals). ``from_dict`` normalizes that boundary once.
+    ``from_dict`` normalizes checkpoint block semantics to mlx-vlm's
+    verification width, which includes the anchor token.
     """
 
     model_type: str = "dspark"
@@ -43,6 +42,9 @@ class DSparkConfig(BaseModelConfig):
     final_logit_softcapping: float | None = None
     layer_types: list[str] = field(default_factory=list)
     sliding_window: int | None = None
+    is_causal: bool = False
+    attention_sink_bias: bool = False
+    sample_from_anchor: bool = True
 
     # mlx-vlm verification width (anchor + proposals).
     block_size: int = 0
@@ -59,7 +61,7 @@ class DSparkConfig(BaseModelConfig):
 
     markov_rank: int = 256
     markov_head_type: str = "vanilla"
-    enable_confidence_head: bool = True
+    enable_confidence_head: bool = False
     confidence_head_with_markov: bool = True
 
     def __post_init__(self) -> None:
@@ -111,10 +113,6 @@ class DSparkConfig(BaseModelConfig):
             raise ValueError(
                 "DSpark dflash_initial_block_size must be between 2 and block_size."
             )
-        if self.hidden_size != self.num_attention_heads * self.head_dim:
-            raise ValueError(
-                "DSpark hidden_size must equal attention heads * head_dim."
-            )
         if self.num_attention_heads % self.num_key_value_heads:
             raise ValueError("DSpark attention heads must be divisible by KV heads.")
         if self.hidden_act != "silu":
@@ -126,9 +124,12 @@ class DSparkConfig(BaseModelConfig):
         if not 0 <= self.mask_token_id < self.vocab_size:
             raise ValueError("DSpark mask_token_id must be inside the vocabulary.")
         if len(self.layer_types) != self.num_hidden_layers or any(
-            layer_type != "full_attention" for layer_type in self.layer_types
+            layer_type not in {"full_attention", "sliding_attention"}
+            for layer_type in self.layer_types
         ):
-            raise ValueError("DSpark requires one full_attention type per draft layer.")
+            raise ValueError("DSpark requires one supported type per draft layer.")
+        if "sliding_attention" in self.layer_types and self.sliding_window is None:
+            raise ValueError("DSpark requires sliding_window for sliding layers.")
         if (
             not self.target_layer_ids
             or not _is_strictly_increasing_ints(self.target_layer_ids)
@@ -156,6 +157,9 @@ class DSparkConfig(BaseModelConfig):
                 f"{projector_type!r}."
             )
 
+        architectures = flat.get("architectures") or []
+        uses_qwen3_dspark_runtime = "Qwen3DSparkModel" in architectures
+
         flat["backbone_model_type"] = str(flat.pop("model_type", "qwen3"))
         flat["model_type"] = "dspark"
 
@@ -175,6 +179,19 @@ class DSparkConfig(BaseModelConfig):
             if key in dflash:
                 flat[key] = dflash[key]
 
+        if "num_target_layers" not in flat and flat.get("target_layer_ids"):
+            flat["num_target_layers"] = max(flat["target_layer_ids"]) + 1
+        if "causal" in dflash:
+            flat["is_causal"] = bool(dflash["causal"])
+        elif "dflash_query_causal" in flat:
+            flat["is_causal"] = bool(flat.pop("dflash_query_causal"))
+        if "attention_sink_bias" in dflash:
+            flat["attention_sink_bias"] = bool(dflash["attention_sink_bias"])
+        if "sample_from_anchor" in dflash:
+            flat["sample_from_anchor"] = bool(dflash["sample_from_anchor"])
+        if "swa_window_size" in dflash:
+            flat["sliding_window"] = int(dflash["swa_window_size"])
+
         rope_parameters = flat.pop("rope_parameters", None)
         if isinstance(rope_parameters, Mapping):
             rope_parameters = dict(rope_parameters)
@@ -185,8 +202,9 @@ class DSparkConfig(BaseModelConfig):
         raw_block_size = dflash.get("block_size", flat.get("block_size"))
         if raw_block_size is None:
             raise ValueError("DSpark requires a checkpoint block_size.")
-        flat["proposal_length"] = int(raw_block_size)
-        flat["block_size"] = int(raw_block_size) + 1
+        includes_anchor = bool(flat.pop("dspark_bonus_anchor", False))
+        flat["block_size"] = int(raw_block_size) + (0 if includes_anchor else 1)
+        flat["proposal_length"] = flat["block_size"] - 1
 
         if "runtime_block_size" not in flat:
             flat["runtime_block_size"] = min(8, flat["block_size"])
@@ -204,7 +222,9 @@ class DSparkConfig(BaseModelConfig):
                 )
             else:
                 flat["block_size_policy"] = (
-                    "adaptive" if projector_type == "dspark" else "fixed"
+                    "adaptive"
+                    if projector_type == "dspark" or uses_qwen3_dspark_runtime
+                    else "fixed"
                 )
 
         if (

--- a/mlx_vlm/speculative/drafters/dspark/dspark.py
+++ b/mlx_vlm/speculative/drafters/dspark/dspark.py
@@ -98,6 +98,24 @@ class DSparkDraftModel(DFlashDraftModel):
     def validate_target_compatibility(self, target_model) -> None:
         validate_dspark_target(self.config, target_model)
 
+    def choose_initial_block_size(
+        self, context_length: int, requested_block_size: int
+    ) -> int | None:
+        window = self.config.sliding_window
+        if window is not None and context_length <= window:
+            return min(6, requested_block_size)
+        return self.dflash_initial_block_size
+
+    def choose_block_ceiling(
+        self, context_length: int, requested_block_size: int
+    ) -> int:
+        window = self.config.sliding_window
+        if window is not None and context_length <= window:
+            return min(6, requested_block_size)
+        if window is not None:
+            return min(4, requested_block_size)
+        return requested_block_size
+
     def bind(self, target_model) -> "DSparkDraftModel":
         self.validate_target_compatibility(target_model)
         super().bind(target_model)
@@ -136,19 +154,40 @@ class DSparkDraftModel(DFlashDraftModel):
             if isinstance(last_bonus, int)
             else last_bonus.reshape(-1).astype(token_dtype)
         )
+        mask_count = proposal_length - int(self.config.sample_from_anchor)
         masks = mx.full(
-            (anchor.shape[0], proposal_length - 1),
+            (anchor.shape[0], mask_count),
             int(self.config.mask_token_id),
             dtype=token_dtype,
         )
         draft_inputs = mx.concatenate([anchor[:, None], masks], axis=1)
         draft_hidden = self._hidden(draft_inputs, hidden, cache)
+        if not self.config.sample_from_anchor:
+            draft_hidden = draft_hidden[:, 1:]
         base_logits = self._logits(draft_hidden)
         return self.markov_head.sample_block(
             base_logits,
             first_prev_tokens=anchor,
             sampler=sampler,
         ).astype(token_dtype)
+
+    def draft_block_greedy(
+        self,
+        last_bonus,
+        hidden: mx.array,
+        cache,
+        block_size: int,
+        sampler: Callable[[mx.array], mx.array],
+        token_dtype: mx.Dtype = mx.int32,
+    ) -> mx.array:
+        return self.draft_block(
+            last_bonus,
+            hidden,
+            cache,
+            block_size,
+            sampler,
+            token_dtype,
+        )
 
     def sanitize(self, weights: Mapping[str, mx.array]) -> dict[str, mx.array]:
         normalized = {}
@@ -159,6 +198,10 @@ class DSparkDraftModel(DFlashDraftModel):
                     f"Duplicate DSpark weight key after sanitization: {key}"
                 )
             normalized[key] = value
+        if "embed_tokens.weight" in normalized and self.embed_tokens is None:
+            self.embed_tokens = nn.Embedding(
+                self.config.vocab_size, self.config.hidden_size
+            )
         return normalized
 
 

--- a/mlx_vlm/speculative/drafters/gemma4_dspark/gemma4_dspark.py
+++ b/mlx_vlm/speculative/drafters/gemma4_dspark/gemma4_dspark.py
@@ -97,9 +97,13 @@ class Gemma4DSparkDecoderLayer(nn.Module):
         self.post_feedforward_layernorm = RMSNorm(config.hidden_size, eps=eps)
         self.layer_scalar = mx.ones((1,))
 
-    def __call__(self, x: mx.array, x_ctx: mx.array, rope, cache) -> mx.array:
+    def __call__(
+        self, x: mx.array, x_ctx: mx.array, rope, cache, projected_context=None
+    ) -> mx.array:
         residual = x
-        h = self.self_attn(self.input_layernorm(x), x_ctx, rope, cache)
+        h = self.self_attn(
+            self.input_layernorm(x), x_ctx, rope, cache, projected_context
+        )
         h = residual + self.post_attention_layernorm(h)
 
         residual = h

--- a/mlx_vlm/speculative/drafters/qwen3_dflash/config.py
+++ b/mlx_vlm/speculative/drafters/qwen3_dflash/config.py
@@ -1,4 +1,5 @@
 import inspect
+from collections.abc import Mapping
 from dataclasses import dataclass, field
 from typing import Any, List, Optional
 
@@ -29,6 +30,8 @@ class DFlashConfig(BaseModelConfig):
     final_logit_softcapping: Optional[float] = None
     runtime_block_size: int | None = None
     draft_window_size: int | None = None
+    is_causal: bool = False
+    attention_sink_bias: bool = False
 
     @classmethod
     def from_dict(cls, params: dict) -> "DFlashConfig":
@@ -38,10 +41,26 @@ class DFlashConfig(BaseModelConfig):
             flat["mask_token_id"] = dflash_cfg["mask_token_id"]
         if "target_layer_ids" in dflash_cfg:
             flat["target_layer_ids"] = list(dflash_cfg["target_layer_ids"])
+        if "num_target_layers" in dflash_cfg:
+            flat["num_target_layers"] = dflash_cfg["num_target_layers"]
         if "runtime_block_size" in dflash_cfg:
             flat["runtime_block_size"] = dflash_cfg["runtime_block_size"]
         if "draft_window_size" in dflash_cfg:
             flat["draft_window_size"] = dflash_cfg["draft_window_size"]
+        if "causal" in dflash_cfg:
+            flat["is_causal"] = bool(dflash_cfg["causal"])
+        elif "dflash_query_causal" in flat:
+            flat["is_causal"] = bool(flat.pop("dflash_query_causal"))
+        if "attention_sink_bias" in dflash_cfg:
+            flat["attention_sink_bias"] = bool(dflash_cfg["attention_sink_bias"])
+        if "num_target_layers" not in flat and flat.get("target_layer_ids"):
+            flat["num_target_layers"] = max(flat["target_layer_ids"]) + 1
+        rope_parameters = flat.pop("rope_parameters", None)
+        if isinstance(rope_parameters, Mapping):
+            rope_parameters = dict(rope_parameters)
+            if "rope_theta" in rope_parameters:
+                flat["rope_theta"] = rope_parameters.pop("rope_theta")
+            flat["rope_scaling"] = rope_parameters
         sig = inspect.signature(cls).parameters
         return cls(**{k: v for k, v in flat.items() if k in sig})
 

--- a/mlx_vlm/speculative/drafters/qwen3_dflash/dflash.py
+++ b/mlx_vlm/speculative/drafters/qwen3_dflash/dflash.py
@@ -4,7 +4,12 @@ import mlx.core as mx
 import mlx.nn as nn
 
 from ....models.activations import swiglu
-from ....models.cache import BufferedRotatingKVCache, KVCache, RotatingKVCache
+from ....models.cache import (
+    BufferedRotatingKVCache,
+    KVCache,
+    RotatingKVCache,
+    create_causal_mask,
+)
 from ....models.rope_utils import initialize_rope
 from .config import DFlashConfig
 
@@ -36,6 +41,12 @@ class DFlashAttention(nn.Module):
         )
         self.is_sliding = layer_types[layer_idx] == "sliding_attention"
         self.sliding_window = config.sliding_window if self.is_sliding else None
+        self.is_causal = bool(getattr(config, "is_causal", self.is_sliding))
+        self.attention_sink_bias = (
+            mx.zeros((self.n_heads,))
+            if getattr(config, "attention_sink_bias", False)
+            else None
+        )
         self.q_proj = nn.Linear(dim, self.n_heads * self.head_dim, bias=False)
         self.k_proj = nn.Linear(dim, self.n_kv_heads * self.head_dim, bias=False)
         self.v_proj = nn.Linear(dim, self.n_kv_heads * self.head_dim, bias=False)
@@ -47,7 +58,14 @@ class DFlashAttention(nn.Module):
         """Project keys and values. Subclasses may share one projection."""
         return self.k_proj(x), self.v_proj(x)
 
-    def __call__(self, x: mx.array, x_ctx: mx.array, rope, cache: KVCache):
+    def __call__(
+        self,
+        x: mx.array,
+        x_ctx: mx.array,
+        rope,
+        cache: KVCache,
+        projected_context=None,
+    ):
         B, L, _ = x.shape
         S = x_ctx.shape[1]
         if self.is_sliding:
@@ -59,12 +77,18 @@ class DFlashAttention(nn.Module):
             if S > keep_ctx:
                 skip = S - keep_ctx
                 x_ctx = x_ctx[:, skip:]
+                if projected_context is not None:
+                    projected_context = tuple(
+                        value[:, skip:] for value in projected_context
+                    )
                 S = x_ctx.shape[1]
                 cache.offset += skip
 
         # Project context and proposal separately so only context KV
         queries = self.q_proj(x)
-        ctx_keys, ctx_values = self._project_kv(x_ctx)
+        ctx_keys, ctx_values = (
+            self._project_kv(x_ctx) if projected_context is None else projected_context
+        )
         prop_keys, prop_values = self._project_kv(x)
         queries = self.q_norm(queries.reshape(B, L, self.n_heads, -1)).transpose(
             0, 2, 1, 3
@@ -85,12 +109,22 @@ class DFlashAttention(nn.Module):
         keys, values = cache.update_and_fetch(ctx_keys, ctx_values)
         keys = mx.concatenate([keys, prop_keys], axis=2)
         values = mx.concatenate([values, prop_values], axis=2)
-        # DFlash denoises the whole proposed block at once, so draft-block
-        # self-attention is intentionally non-causal. Sliding layers already
-        # limit resident prefix context through the rotating cache above.
-        mask = None
+        mask = (
+            create_causal_mask(
+                L,
+                offset=keys.shape[2] - L,
+                window_size=self.sliding_window,
+            )
+            if self.is_causal
+            else None
+        )
         o = mx.fast.scaled_dot_product_attention(
-            queries, keys, values, scale=self.scale, mask=mask
+            queries,
+            keys,
+            values,
+            scale=self.scale,
+            mask=mask,
+            sinks=self.attention_sink_bias,
         )
         return self.o_proj(o.transpose(0, 2, 1, 3).reshape(B, L, -1))
 
@@ -118,8 +152,14 @@ class DFlashDecoderLayer(nn.Module):
             config.hidden_size, eps=config.rms_norm_eps
         )
 
-    def __call__(self, x, x_ctx, rope, cache):
-        h = x + self.self_attn(self.input_layernorm(x), x_ctx, rope, cache)
+    def __call__(self, x, x_ctx, rope, cache, projected_context=None):
+        h = x + self.self_attn(
+            self.input_layernorm(x),
+            x_ctx,
+            rope,
+            cache,
+            projected_context,
+        )
         return h + self.mlp(self.post_attention_layernorm(h))
 
 
@@ -142,36 +182,50 @@ class DFlashDraftModel(nn.Module):
         self.embed_tokens = None
         self.embed_scale = 1.0
         self.lm_head = None
+        self.argmax_from_hidden = None
+        self._fused_context_kv_weight = None
         self.accept_lens: List[int] = []
         self.draft_lens: List[int] = []
 
     def bind(self, target_model) -> "DFlashDraftModel":
-        if hasattr(target_model, "embed_tokens"):
-            inner = target_model
-        elif hasattr(target_model, "model") and hasattr(
-            target_model.model, "embed_tokens"
-        ):
-            inner = target_model.model
-        elif (
-            hasattr(target_model, "language_model")
-            and hasattr(target_model.language_model, "model")
-            and hasattr(target_model.language_model.model, "embed_tokens")
-        ):
-            inner = target_model.language_model.model
-        else:
-            raise AttributeError(
-                f"Cannot find embed_tokens in {type(target_model).__name__}"
+        if self.embed_tokens is None:
+            if hasattr(target_model, "embed_tokens"):
+                inner = target_model
+            elif hasattr(target_model, "model") and hasattr(
+                target_model.model, "embed_tokens"
+            ):
+                inner = target_model.model
+            elif (
+                hasattr(target_model, "language_model")
+                and hasattr(target_model.language_model, "model")
+                and hasattr(target_model.language_model.model, "embed_tokens")
+            ):
+                inner = target_model.language_model.model
+            elif (
+                hasattr(target_model, "language_model")
+                and hasattr(target_model.language_model, "backbone")
+                and hasattr(target_model.language_model.backbone, "embeddings")
+            ):
+                inner = target_model.language_model.backbone
+            else:
+                raise AttributeError(
+                    f"Cannot find embed_tokens in {type(target_model).__name__}"
+                )
+            self.embed_tokens = (
+                inner.embed_tokens
+                if hasattr(inner, "embed_tokens")
+                else inner.embeddings
             )
-        self.embed_tokens = inner.embed_tokens
-        self.embed_scale = getattr(
-            self.embed_tokens, "embed_scale", getattr(inner, "embed_scale", 1.0)
-        )
+            self.embed_scale = getattr(
+                self.embed_tokens, "embed_scale", getattr(inner, "embed_scale", 1.0)
+            )
         lm = getattr(target_model, "language_model", target_model)
         self.lm_head = (
             getattr(target_model, "lm_head", None)
             or getattr(lm, "lm_head", None)
             or self.embed_tokens.as_linear
         )
+        self.argmax_from_hidden = getattr(lm, "speculative_argmax_from_hidden", None)
         return self
 
     def make_cache(self) -> List[KVCache]:
@@ -226,6 +280,39 @@ class DFlashDraftModel(nn.Module):
         draft_logits = self._logits(draft_hidden[:, 1:])
         return sampler(draft_logits)
 
+    def draft_block_greedy(
+        self,
+        last_bonus,
+        hidden: mx.array,
+        cache: List[KVCache],
+        block_size: int,
+        sampler,
+        token_dtype: mx.Dtype = mx.int32,
+    ) -> mx.array:
+        if not callable(self.argmax_from_hidden):
+            return self.draft_block(
+                last_bonus,
+                hidden,
+                cache,
+                block_size,
+                sampler,
+                token_dtype,
+            )
+        mask_id = int(self.config.mask_token_id)
+        if isinstance(last_bonus, int):
+            block = mx.array(
+                [[last_bonus] + [mask_id] * (block_size - 1)],
+                dtype=token_dtype,
+            )
+        else:
+            batch = last_bonus.shape[0]
+            masks = mx.full((batch, block_size - 1), mask_id, dtype=token_dtype)
+            block = mx.concatenate(
+                [last_bonus[:, None].astype(token_dtype), masks], axis=1
+            )
+        draft_hidden = self._hidden(block, hidden, cache)
+        return self.argmax_from_hidden(draft_hidden[:, 1:]).astype(token_dtype)
+
     def _hidden(
         self,
         inputs: mx.array,
@@ -234,9 +321,32 @@ class DFlashDraftModel(nn.Module):
     ) -> mx.array:
         h = self._embed_input_tokens(inputs)
         h_ctx = self.hidden_norm(self.fc(target_hidden))
-        for layer, c in zip(self.layers, cache):
-            h = layer(h, h_ctx, self.rope, c)
+        projected_context = self._project_context_kv(h_ctx)
+        for index, (layer, c) in enumerate(zip(self.layers, cache)):
+            layer_context = (
+                None if projected_context is None else projected_context[index]
+            )
+            h = layer(h, h_ctx, self.rope, c, layer_context)
         return self.norm(h)
+
+    def _project_context_kv(self, hidden: mx.array):
+        projections = [
+            projection
+            for layer in self.layers
+            for projection in (
+                layer.self_attn.k_proj,
+                layer.self_attn.v_proj,
+            )
+        ]
+        if not all(isinstance(projection, nn.Linear) for projection in projections):
+            return None
+        if self._fused_context_kv_weight is None:
+            self._fused_context_kv_weight = mx.concatenate(
+                [projection.weight for projection in projections], axis=0
+            )
+        projected = hidden @ self._fused_context_kv_weight.T
+        chunks = mx.split(projected, len(projections), axis=-1)
+        return list(zip(chunks[::2], chunks[1::2]))
 
     def _embed_input_tokens(self, inputs: mx.array) -> mx.array:
         return self.embed_tokens(inputs) * self.embed_scale
@@ -262,6 +372,10 @@ class DFlashDraftModel(nn.Module):
             if k.startswith("model."):
                 k = k[len("model.") :]
             out[k] = v
+        if "embed_tokens.weight" in out and self.embed_tokens is None:
+            self.embed_tokens = nn.Embedding(
+                self.config.vocab_size, self.config.hidden_size
+            )
         return out
 
 

--- a/mlx_vlm/speculative/utils.py
+++ b/mlx_vlm/speculative/utils.py
@@ -17,6 +17,7 @@ from .dflash import (
     _dflash_next_block_size,
     _dflash_rounds,
     _dflash_rounds_batch,
+    _reserve_dflash_target_cache,
 )
 from .eagle3 import _eagle3_capture_layer_ids, _eagle3_rounds, _eagle3_rounds_batch
 from .mtp import (
@@ -39,6 +40,7 @@ __all__ = [
     "_dflash_block_total",
     "_dflash_committed_hidden_segments",
     "_dflash_next_block_size",
+    "_reserve_dflash_target_cache",
     "_dflash_rounds",
     "_dflash_rounds_batch",
     "_effective_mtp_block_size",

--- a/mlx_vlm/tests/test_models.py
+++ b/mlx_vlm/tests/test_models.py
@@ -18400,3 +18400,255 @@ class TestVideoDepthAnything(unittest.TestCase):
         self.assertEqual((h % 14, w % 14), (0, 0))
         self.assertGreaterEqual(min(h, w), 294)
         self.assertAlmostEqual(h / w, 1080 / 1920, places=1)
+
+
+class TestNemotronHSpeculativeVerifier(unittest.TestCase):
+    @staticmethod
+    def _language_model():
+        from mlx_vlm.models import nemotron_h
+
+        config = nemotron_h.ModelConfig(
+            model_type="nemotron_h",
+            vocab_size=64,
+            hidden_size=32,
+            intermediate_size=64,
+            num_hidden_layers=4,
+            max_position_embeddings=64,
+            num_attention_heads=4,
+            num_key_value_heads=2,
+            attention_bias=False,
+            mamba_num_heads=4,
+            mamba_head_dim=8,
+            mamba_proj_bias=False,
+            ssm_state_size=32,
+            conv_kernel=3,
+            n_groups=2,
+            mlp_bias=False,
+            layer_norm_epsilon=1e-5,
+            use_bias=False,
+            use_conv_bias=True,
+            hybrid_override_pattern=["M", "*", "-", "E"],
+            moe_intermediate_size=16,
+            n_group=1,
+            n_routed_experts=4,
+            n_shared_experts=1,
+            moe_shared_expert_intermediate_size=16,
+            topk_group=1,
+            num_experts_per_tok=2,
+            norm_topk_prob=True,
+            routed_scaling_factor=1.0,
+        )
+        mx.random.seed(7)
+        model = nemotron_h.Model(config).language_model
+        model.set_dtype(mx.bfloat16)
+        model.eval()
+        mx.eval(model.parameters())
+        return model
+
+    def test_sanitize_stacks_quantized_expert_parameters(self):
+        model = self._language_model()
+        weights = {}
+        for expert in range(model.args.n_routed_experts):
+            for source in ("down_proj", "up_proj"):
+                prefix = f"backbone.layers.3.mixer.experts.{expert}.{source}"
+                weights[f"{prefix}.weight"] = mx.full((2, 3), expert)
+                weights[f"{prefix}.scales"] = mx.full((2, 1), expert + 4)
+
+        sanitized = model.sanitize(weights)
+
+        for target in ("fc2", "fc1"):
+            prefix = f"backbone.layers.3.mixer.switch_mlp.{target}"
+            self.assertEqual(sanitized[f"{prefix}.weight"].shape, (4, 2, 3))
+            self.assertEqual(sanitized[f"{prefix}.scales"].shape, (4, 2, 1))
+        self.assertFalse(any(".experts." in key for key in sanitized))
+
+    def test_verifier_matches_singleton_mamba_moe_and_captures(self):
+        from mlx_vlm.models.nemotron_h import speculative_verifier
+
+        speculative_verifier._mamba_verify_kernel.cache_clear()
+        model = self._language_model()
+        prompt = mx.array([[1, 2, 3]])
+        verify = mx.array([[4, 5, 6, 7]])
+        verifier_cache = model.make_cache()
+        reference_cache = model.make_cache()
+        model(prompt, cache=verifier_cache)
+        model(prompt, cache=reference_cache)
+
+        actual = model(
+            verify,
+            cache=verifier_cache,
+            capture_layer_ids=[0, 3],
+            speculative_verify=True,
+        )
+        logits = []
+        captures = [[], []]
+        for position in range(verify.shape[1]):
+            output = model(
+                verify[:, position : position + 1],
+                cache=reference_cache,
+                capture_layer_ids=[0, 3],
+            )
+            logits.append(output.logits)
+            for index, hidden in enumerate(output.hidden_states):
+                captures[index].append(hidden)
+
+        expected_logits = mx.concatenate(logits, axis=1)
+        expected_captures = [
+            mx.concatenate(layer_tokens, axis=1) for layer_tokens in captures
+        ]
+        mx.eval(actual.logits, expected_logits, actual.hidden_states, expected_captures)
+        self.assertTrue(mx.array_equal(actual.logits, expected_logits).item())
+        for actual_hidden, expected_hidden in zip(
+            actual.hidden_states, expected_captures
+        ):
+            self.assertTrue(mx.array_equal(actual_hidden, expected_hidden).item())
+        if mx.metal.is_available():
+            self.assertGreater(
+                speculative_verifier._mamba_verify_kernel.cache_info().misses, 0
+            )
+
+    def test_verifier_uses_masked_mamba_fallback_for_left_padding(self):
+        from mlx_vlm.models.nemotron_h import speculative_verifier
+
+        speculative_verifier._mamba_verify_kernel.cache_clear()
+        model = self._language_model()
+        inputs = mx.array([[0, 4, 5, 6], [1, 2, 3, 4]])
+        verifier_cache = model.make_cache()
+        reference_cache = model.make_cache()
+        verifier_cache[0].left_padding = mx.array([1, 0])
+        reference_cache[0].left_padding = mx.array([1, 0])
+
+        actual = model(inputs, cache=verifier_cache, speculative_verify=True)
+        expected = model(inputs, cache=reference_cache)
+        mx.eval(actual.logits, expected.logits)
+
+        self.assertTrue(mx.array_equal(actual.logits, expected.logits).item())
+        self.assertEqual(
+            speculative_verifier._mamba_verify_kernel.cache_info().misses, 0
+        )
+
+    def test_nvfp4_argmax_matches_singleton_qmv_with_tail(self):
+        if not mx.metal.is_available():
+            self.skipTest("NVFP4 argmax requires Metal")
+        from mlx_vlm.models.nemotron_h.speculative_verifier import _nvfp4_argmax
+
+        mx.random.seed(19)
+        linear = nn.QuantizedLinear.from_linear(
+            nn.Linear(272, 64, bias=False),
+            group_size=16,
+            bits=4,
+            mode="nvfp4",
+        )
+        hidden = mx.random.normal((2, 6, 272)).astype(mx.bfloat16)
+        expected = mx.concatenate(
+            [linear(hidden[:, index : index + 1]) for index in range(6)], axis=1
+        ).argmax(axis=-1)
+        actual = _nvfp4_argmax(linear, hidden)
+        mx.eval(expected, actual)
+
+        self.assertTrue(mx.array_equal(actual, expected).item())
+
+    def test_rollback_restores_mamba_and_attention_to_accepted_prefix(self):
+        model = self._language_model()
+        prompt = mx.array([[1, 2, 3]])
+        verify = mx.array([[4, 5, 6, 7]])
+        actual_cache = model.make_cache()
+        expected_cache = model.make_cache()
+        model(prompt, cache=actual_cache)
+        model(prompt, cache=expected_cache)
+
+        _, _, rollback_state = model.speculative_verify_hidden(verify, actual_cache)
+        model(verify[:, :2], cache=expected_cache, speculative_verify=True)
+        accepted = model.rollback_speculative_cache(
+            actual_cache,
+            rollback_state,
+            accepted=1,
+            block_size=verify.shape[1],
+        )
+        self.assertEqual(accepted, 1)
+
+        for actual_state, expected_state in zip(
+            actual_cache[0].state, expected_cache[0].state
+        ):
+            mx.eval(actual_state, expected_state)
+            self.assertTrue(mx.array_equal(actual_state, expected_state).item())
+        self.assertEqual(actual_cache[1].offset, expected_cache[1].offset)
+        for actual_state, expected_state in zip(
+            actual_cache[1].state, expected_cache[1].state
+        ):
+            mx.eval(actual_state, expected_state)
+            self.assertTrue(mx.array_equal(actual_state, expected_state).item())
+
+    def test_rollback_rejects_ragged_batch_acceptance(self):
+        model = self._language_model()
+        cache = model.make_cache()
+        verify = mx.array([[1, 2], [3, 4]])
+        _, _, rollback_state = model.speculative_verify_hidden(verify, cache)
+        with self.assertRaisesRegex(ValueError, "uniform acceptance"):
+            model.rollback_speculative_cache(
+                cache,
+                rollback_state,
+                accepted=[0, 1],
+                block_size=2,
+            )
+
+    def test_verifier_supports_embeds_hidden_only_and_shared_kv_contract(self):
+        model = self._language_model()
+        inputs = mx.array([[1, 2, 3]])
+        inputs_embeds = model.backbone.embeddings(inputs)
+        cache = model.make_cache()
+
+        output = model(
+            None,
+            inputs_embeds=inputs_embeds,
+            cache=cache,
+            capture_layer_ids=[],
+            speculative_verify=True,
+            return_hidden=True,
+            return_shared_kv=True,
+            skip_logits=True,
+        )
+        mx.eval(output.hidden_states)
+
+        self.assertIsNone(output.logits)
+        self.assertEqual(len(output.hidden_states), 1)
+        self.assertEqual(output.hidden_states[0].shape, (1, 3, 32))
+        self.assertEqual(output.shared_kv_states, {})
+        self.assertIsNotNone(output.gdn_states)
+
+    def test_dflash_hidden_verification_returns_captures_and_final_hidden(self):
+        model = self._language_model()
+        cache = model.make_cache()
+        model(mx.array([[1, 2, 3]]), cache=cache)
+
+        captured, final_hidden, gdn_states = model.speculative_verify_dflash_hidden(
+            mx.array([[4, 5, 6]]), cache, [0, 3]
+        )
+        mx.eval(captured, final_hidden, gdn_states)
+
+        self.assertEqual(len(captured), 2)
+        self.assertEqual(captured[0].shape, (1, 3, model.args.hidden_size))
+        self.assertEqual(captured[1].shape, (1, 3, model.args.hidden_size))
+        self.assertEqual(final_hidden.shape, (1, 3, model.args.hidden_size))
+        self.assertEqual(len(gdn_states), 1)
+
+    def test_rollback_rejects_invalid_acceptance(self):
+        model = self._language_model()
+        cache = model.make_cache()
+        verify = mx.array([[1, 2]])
+        _, _, rollback_state = model.speculative_verify_hidden(verify, cache)
+
+        with self.assertRaisesRegex(ValueError, "non-negative"):
+            model.rollback_speculative_cache(
+                cache,
+                rollback_state,
+                accepted=-1,
+                block_size=2,
+            )
+        with self.assertRaisesRegex(ValueError, "exceed"):
+            model.rollback_speculative_cache(
+                cache,
+                rollback_state,
+                accepted=2,
+                block_size=2,
+            )

--- a/mlx_vlm/tests/test_models_dspark.py
+++ b/mlx_vlm/tests/test_models_dspark.py
@@ -98,6 +98,41 @@ def _published_qwen38_config():
     }
 
 
+def _published_nemotron_config():
+    return {
+        "architectures": ["Qwen3DSparkModel"],
+        "model_type": "qwen3",
+        "hidden_size": 2688,
+        "intermediate_size": 6144,
+        "num_hidden_layers": 6,
+        "num_attention_heads": 32,
+        "num_key_value_heads": 2,
+        "head_dim": 128,
+        "hidden_act": "silu",
+        "rms_norm_eps": 1e-6,
+        "vocab_size": 131072,
+        "max_position_embeddings": 1048576,
+        "rope_theta": 10000,
+        "layer_types": ["sliding_attention"] * 6,
+        "sliding_window": 1024,
+        "block_size": 8,
+        "dspark_bonus_anchor": True,
+        "dflash_query_causal": True,
+        "attention_sink_bias": True,
+        "markov_rank": 512,
+        "markov_head_type": "vanilla",
+        "dflash_config": {
+            "attention_sink_bias": True,
+            "causal": True,
+            "mask_token_id": 990,
+            "swa_window_size": 1024,
+            "target_layer_ids": [1, 5, 19, 29, 41, 51],
+            "use_swa": True,
+            "sample_from_anchor": False,
+        },
+    }
+
+
 def _tiny_draft_config():
     return ModelConfig.from_dict(
         {
@@ -357,6 +392,100 @@ def test_published_qwen38_config_normalizes_dspark_contract_and_yarn():
     assert config.dflash_initial_block_size == 4
     assert drafter.prefer_requested_block_size is False
     assert drafter.rope.traditional is False
+
+
+def test_published_nemotron_config_normalizes_dspark_contract():
+    config = ModelConfig.from_dict(_published_nemotron_config())
+    drafter = DSparkDraftModel(config)
+
+    assert config.proposal_length == 7
+    assert config.block_size == 8
+    assert config.runtime_block_size == 8
+    assert config.target_layer_ids == [1, 5, 19, 29, 41, 51]
+    assert config.num_target_layers == 52
+    assert config.sliding_window == 1024
+    assert config.is_causal is True
+    assert config.attention_sink_bias is True
+    assert config.sample_from_anchor is False
+    assert config.enable_confidence_head is False
+    assert config.block_size_policy == "adaptive"
+    assert config.dflash_initial_block_size == 4
+    assert drafter.prefer_requested_block_size is False
+    assert drafter.choose_initial_block_size(512, 8) == 6
+    assert drafter.choose_initial_block_size(1024, 8) == 6
+    assert drafter.choose_initial_block_size(1025, 8) == 4
+    assert drafter.choose_block_ceiling(512, 8) == 6
+    assert drafter.choose_block_ceiling(1024, 8) == 6
+    assert drafter.choose_block_ceiling(1025, 8) == 4
+    assert drafter.confidence_head is None
+    assert all(layer.self_attn.is_causal for layer in drafter.layers)
+    assert all(
+        layer.self_attn.attention_sink_bias is not None for layer in drafter.layers
+    )
+
+
+def test_nemotron_dspark_sanitize_installs_checkpoint_embedding():
+    config_dict = _published_nemotron_config()
+    config_dict["hidden_size"] = 8
+    config_dict["intermediate_size"] = 16
+    config_dict["num_hidden_layers"] = 1
+    config_dict["num_attention_heads"] = 2
+    config_dict["num_key_value_heads"] = 1
+    config_dict["head_dim"] = 4
+    config_dict["vocab_size"] = 32
+    config_dict["layer_types"] = ["sliding_attention"]
+    config_dict["markov_rank"] = 4
+    config_dict["dflash_config"]["mask_token_id"] = 31
+    config_dict["dflash_config"]["target_layer_ids"] = [0]
+    config = ModelConfig.from_dict(config_dict)
+    drafter = DSparkDraftModel(config)
+    weight = mx.zeros((32, 8))
+
+    sanitized = drafter.sanitize({"model.embed_tokens.weight": weight})
+
+    assert sanitized["embed_tokens.weight"] is weight
+    assert drafter.embed_tokens is not None
+
+
+def test_dspark_bonus_anchor_uses_mask_position_logits():
+    config_dict = _published_nemotron_config()
+    config_dict["hidden_size"] = 8
+    config_dict["intermediate_size"] = 16
+    config_dict["num_hidden_layers"] = 1
+    config_dict["num_attention_heads"] = 2
+    config_dict["num_key_value_heads"] = 1
+    config_dict["head_dim"] = 4
+    config_dict["vocab_size"] = 32
+    config_dict["layer_types"] = ["sliding_attention"]
+    config_dict["markov_rank"] = 4
+    config_dict["dflash_config"]["mask_token_id"] = 31
+    config_dict["dflash_config"]["target_layer_ids"] = [0]
+    config = ModelConfig.from_dict(config_dict)
+    drafter = DSparkDraftModel(config)
+    seen = {}
+
+    def hidden(inputs, target_hidden, cache):
+        seen["inputs"] = inputs
+        return mx.zeros((1, inputs.shape[1], config.hidden_size))
+
+    def logits(states):
+        seen["states"] = states
+        return mx.zeros((1, states.shape[1], config.vocab_size))
+
+    drafter._hidden = hidden
+    drafter._logits = logits
+    drafter.draft_block(
+        3,
+        mx.zeros((1, 1, config.hidden_size)),
+        [],
+        config.block_size,
+        lambda values: mx.argmax(values, axis=-1),
+    )
+
+    assert seen["inputs"].shape[1] == config.block_size
+    assert seen["inputs"][0, 0].item() == 3
+    assert seen["inputs"][0, 1:].tolist() == [31] * config.proposal_length
+    assert seen["states"].shape[1] == config.proposal_length
 
 
 def test_dspark_config_uses_explicit_rope_capability_not_architecture_name():

--- a/mlx_vlm/tests/test_speculative.py
+++ b/mlx_vlm/tests/test_speculative.py
@@ -36,6 +36,7 @@ from mlx_vlm.models.cache import (
 )
 from mlx_vlm.quantization.one_bit import OneBitLinear
 from mlx_vlm.speculative.common import _SpeculativeSamplerRNG
+from mlx_vlm.speculative.dflash import _dflash_verify_greedy
 from mlx_vlm.speculative.drafters import (
     DEFAULT_DRAFTER_KIND,
     DRAFTER_KIND_BY_MODEL_TYPE,
@@ -2320,6 +2321,53 @@ def test_dflash_committed_hidden_segments_keep_per_row_lengths():
     assert segments[1].tolist() == [[[6.0, 7.0]]]
 
 
+def test_dflash_target_cache_reserves_one_verification_block():
+    calls = []
+
+    class Cache:
+        offset = 512
+
+        def prefix_cache_reserve(self, capacity):
+            calls.append(capacity)
+            return ()
+
+    speculative_utils._reserve_dflash_target_cache([Cache()], 8)
+
+    assert calls == [520]
+
+
+def test_dflash_greedy_verify_prefers_hidden_argmax_hook():
+    captured = [mx.ones((1, 3, 2))]
+    final_hidden = mx.zeros((1, 3, 2))
+    target_tokens = mx.array([[4, 5, 6]])
+
+    class LM:
+        def speculative_verify_dflash_hidden(self, inputs, cache, layer_ids):
+            assert inputs.shape == (1, 3)
+            assert cache == ["cache"]
+            assert layer_ids == [1]
+            return captured, final_hidden, ["gdn"]
+
+        def speculative_argmax_from_hidden(self, hidden):
+            assert hidden is final_hidden
+            return target_tokens
+
+        def __call__(self, *args, **kwargs):
+            raise AssertionError("full target logits should not be materialized")
+
+    actual_captured, gdn_states, actual_tokens = _dflash_verify_greedy(
+        LM(),
+        mx.array([[1, 2, 3]]),
+        ["cache"],
+        [1],
+        lambda logits: mx.argmax(logits, axis=-1),
+    )
+
+    assert actual_captured is captured
+    assert gdn_states == ["gdn"]
+    assert actual_tokens is target_tokens
+
+
 def test_gemma4_26b_dflash_config_preserves_capture_layers():
     config = Gemma4DFlashConfig.from_dict(
         {
@@ -2402,6 +2450,56 @@ def test_generic_dflash_config_parses_gemma4_metadata_without_runtime_cap():
     assert config.runtime_block_size is None
 
 
+def test_generic_dflash_config_infers_target_depth_and_parses_rope_parameters():
+    config = ModelConfig.from_dict(
+        {
+            "hidden_size": 4,
+            "intermediate_size": 8,
+            "num_hidden_layers": 2,
+            "num_attention_heads": 1,
+            "num_key_value_heads": 1,
+            "head_dim": 4,
+            "vocab_size": 8,
+            "rope_parameters": {
+                "rope_theta": 10000.0,
+                "rope_type": "yarn",
+                "factor": 8.0,
+            },
+            "dflash_config": {
+                "target_layer_ids": [1, 5],
+                "mask_token_id": 4,
+            },
+        }
+    )
+
+    assert config.num_target_layers == 6
+    assert config.rope_theta == 10000.0
+    assert config.rope_scaling == {"rope_type": "yarn", "factor": 8.0}
+
+
+def test_dflash_sanitize_installs_checkpoint_embedding():
+    config = ModelConfig(
+        hidden_size=4,
+        intermediate_size=8,
+        num_hidden_layers=0,
+        num_attention_heads=1,
+        num_key_value_heads=1,
+        head_dim=4,
+        vocab_size=8,
+        target_layer_ids=[0],
+    )
+    drafter = DFlashDraftModel(config)
+    weight = mx.zeros((8, 4))
+
+    sanitized = drafter.sanitize(
+        {"model.embed_tokens.weight": weight, "model.norm.weight": mx.ones((4,))}
+    )
+
+    assert sanitized["embed_tokens.weight"] is weight
+    assert drafter.embed_tokens is not None
+    assert sanitized["norm.weight"] is not None
+
+
 def test_dflash_drafter_uses_bound_target_embedding_scale():
     class Embed:
         def __call__(self, inputs):
@@ -2429,6 +2527,31 @@ def test_dflash_drafter_uses_bound_target_embedding_scale():
 
     embedded = drafter._embed_input_tokens(mx.array([[1, 2]], dtype=mx.int32))
     assert embedded.tolist() == [[[2.0] * 4, [2.0] * 4]]
+
+
+def test_dflash_drafter_binds_backbone_embeddings():
+    config = ModelConfig(
+        hidden_size=4,
+        intermediate_size=8,
+        num_hidden_layers=0,
+        num_attention_heads=1,
+        num_key_value_heads=1,
+        head_dim=4,
+        vocab_size=8,
+        target_layer_ids=[0],
+    )
+    drafter = DFlashDraftModel(config)
+    embeddings = nn.Embedding(8, 4)
+    target = SimpleNamespace(
+        language_model=SimpleNamespace(
+            backbone=SimpleNamespace(embeddings=embeddings),
+            lm_head=nn.Linear(4, 8, bias=False),
+        )
+    )
+
+    drafter.bind(target)
+
+    assert drafter.embed_tokens is embeddings
 
 
 def test_dflash_config_parses_sliding_attention_metadata():

--- a/mlx_vlm/tests/test_utils.py
+++ b/mlx_vlm/tests/test_utils.py
@@ -44,8 +44,15 @@ from mlx_vlm.utils import (
 )
 
 
-@pytest.mark.parametrize("quant_method", ["modelopt", "modelopt_mixed"])
-def test_transform_modelopt_nvfp4_weights(quant_method):
+@pytest.mark.parametrize(
+    ("quant_method", "quant_algo"),
+    [
+        ("modelopt", "NVFP4"),
+        ("modelopt", "W4A16_NVFP4"),
+        ("modelopt_mixed", "NVFP4"),
+    ],
+)
+def test_transform_modelopt_nvfp4_weights(quant_method, quant_algo):
     packed = mx.arange(32, dtype=mx.uint8).reshape(2, 16)
     weights = {
         "layer.weight": packed,
@@ -57,7 +64,7 @@ def test_transform_modelopt_nvfp4_weights(quant_method):
 
     transformed, quantization = _transform_modelopt_nvfp4_weights(
         weights,
-        {"quant_method": quant_method, "quant_algo": "NVFP4"},
+        {"quant_method": quant_method, "quant_algo": quant_algo},
     )
 
     assert transformed["layer.weight"].dtype == mx.uint32

--- a/mlx_vlm/utils.py
+++ b/mlx_vlm/utils.py
@@ -184,7 +184,11 @@ def _transform_modelopt_nvfp4_weights(
     if quantization_config.get("quant_method") not in {
         "modelopt",
         "modelopt_mixed",
-    } or quantization_config.get("quant_algo") not in {"NVFP4", "MIXED_PRECISION"}:
+    } or quantization_config.get("quant_algo") not in {
+        "NVFP4",
+        "W4A16_NVFP4",
+        "MIXED_PRECISION",
+    }:
         return weights, None
 
     scale_2_suffix = ".weight_scale_2"


### PR DESCRIPTION
Adds exact Nemotron-H DFlash and DSpark speculative decoding with optimized Metal verification and rollback.

Models: [target (`NemotronHForCausalLM`, ModelOpt NVFP4)](https://huggingface.co/nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-NVFP4) · [DFlash (`DFlashDraftModel`, ModelOpt NVFP4)](https://huggingface.co/nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-NVFP4-DFlash) · [DSpark (`Qwen3DSparkModel`, ModelOpt NVFP4)](https://huggingface.co/nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-NVFP4-DSpark)

M5 Max, median of five 64-token greedy runs:

| Context | Baseline (AR) | DFlash | DSpark |
|---:|---:|---:|---:|
| 512 | 112.77 tok/s | 204.27 tok/s | 251.92 tok/s |
| 1K | 111.34 tok/s | 181.88 tok/s | 209.86 tok/s |
| 2K | 109.62 tok/s | 167.48 tok/s | 172.07 tok/s |
| 4K | 105.31 tok/s | 140.31 tok/s | 159.76 tok/s |
| 8K | 102.80 tok/s | 122.70 tok/s | 131.59 tok/s |

All speculative outputs matched baseline token-for-token.

I also included a doc on how to do spec decode support since this was something repeated for each agent, worth having for docs