### PR TITLE
Cancel individual rows during chunked prefill

### DIFF
--- a/mlx_vlm/generate/ar.py
+++ b/mlx_vlm/generate/ar.py
@@ -1803,6 +1803,7 @@ class PromptProcessingBatch:
 
         # Declare per-row right-padding on each cache so finalize() can roll
         # it into left-padding once the prefill forward pass is complete.
+        self._needs_cache_finalization = False
         if right_pad_per_row is not None and any(right_pad_per_row):
             for c in self.prompt_cache:
                 prepare = getattr(c, "prepare", None)
@@ -1813,6 +1814,7 @@ class PromptProcessingBatch:
                         "APC mixed prefill requires a prompt cache with prepare()"
                     )
                 prepare(right_padding=right_pad_per_row, lengths=self._suffix_lens)
+            self._needs_cache_finalization = True
 
         self.prefill_step_size = _default_prefill_step_size_for_offload(
             self.model, self.prefill_step_size, draft_model, DEFAULT_PREFILL_STEP_SIZE
@@ -1878,6 +1880,7 @@ class PromptProcessingBatch:
             self._inputs_embeds = None
             self._prompt_kwargs = {}
             self._prompt_length_aware_keys = []
+            self._needs_cache_finalization = False
 
         if self._apc_manager is not None:
             keep_set = set(keep)
@@ -2126,8 +2129,9 @@ class PromptProcessingBatch:
         mx.async_eval(first_tokens)
 
         # Roll any right-padding into left-padding so the cache decoded by
-        # GenerationBatch sees a canonical layout.
-        if self._right_pad_per_row is not None and any(self._right_pad_per_row):
+        # GenerationBatch sees a canonical layout. Prepared caches still need
+        # finalization if cancellation removed every right-padded row.
+        if self._needs_cache_finalization:
             for c in self.prompt_cache:
                 finalize = getattr(c, "finalize", None)
                 if not callable(finalize):
@@ -2137,6 +2141,7 @@ class PromptProcessingBatch:
                         "APC mixed prefill requires a prompt cache with finalize()"
                     )
                 finalize()
+            self._needs_cache_finalization = False
         if logger.isEnabledFor(logging.DEBUG) and os.environ.get("APC_DEBUG"):
             c0 = self.prompt_cache[0] if self.prompt_cache else None
             if c0 is not None:

--- a/mlx_vlm/generate/ar.py
+++ b/mlx_vlm/generate/ar.py
@@ -1837,6 +1837,74 @@ class PromptProcessingBatch:
     def __len__(self):
         return len(self.uids)
 
+    def filter(self, keep: List[int]) -> None:
+        """Keep prompt rows without changing their in-flight token positions."""
+        batch_size = len(self.uids)
+        if keep == list(range(batch_size)):
+            return
+
+        # Materialize the submitted chunk before mutating or releasing its
+        # cache state (including any borrowed APC blocks).
+        states = []
+        for c in self.prompt_cache:
+            try:
+                states.append(c.state)
+            except (AttributeError, TypeError):
+                pass
+        mx.eval(states)
+
+        if keep:
+            keep_arr = mx.array(keep, dtype=mx.int32)
+            for c in self.prompt_cache:
+                # Decode filters may compact common left padding. During
+                # prefill some of that padding still belongs to future chunks.
+                c.filter(keep_arr, compact=False)
+            self._input_ids = self._input_ids[keep_arr]
+            if self._inputs_embeds is not None:
+                self._inputs_embeds = self._inputs_embeds[keep_arr]
+            for key, value in self._prompt_kwargs.items():
+                if (
+                    isinstance(value, mx.array)
+                    and _prompt_kwarg_batch_size(key, value) == batch_size
+                ):
+                    self._prompt_kwargs[key] = (
+                        value[:, keep_arr, :]
+                        if _is_mrope_position_ids_prompt_kwarg(key, value)
+                        else value[keep_arr]
+                    )
+        else:
+            self.prompt_cache = []
+            self._input_ids = mx.zeros((0, 0), dtype=self._input_ids.dtype)
+            self._inputs_embeds = None
+            self._prompt_kwargs = {}
+            self._prompt_length_aware_keys = []
+
+        if self._apc_manager is not None:
+            keep_set = set(keep)
+            for idx, meta in enumerate(self._apc_meta):
+                if idx not in keep_set and meta is not None:
+                    self._apc_manager.release(meta.get("apc_blocks", []))
+        if self._apc_meta:
+            self._apc_meta = [self._apc_meta[idx] for idx in keep]
+        self.uids = [self.uids[idx] for idx in keep]
+        self._prompt_uids = [self._prompt_uids[idx] for idx in keep]
+        self.max_tokens = [self.max_tokens[idx] for idx in keep]
+        self._left_padding_per_row = [self._left_padding_per_row[idx] for idx in keep]
+        if self._right_pad_per_row is not None:
+            self._right_pad_per_row = [self._right_pad_per_row[idx] for idx in keep]
+        self._suffix_lens = [self._suffix_lens[idx] for idx in keep]
+        self._prompt_tokens_per_row = [self._prompt_tokens_per_row[idx] for idx in keep]
+        self._cached_tokens_per_row = [self._cached_tokens_per_row[idx] for idx in keep]
+        self._total_prompt_tokens = sum(self._suffix_lens)
+        if self.logits_processors:
+            self.logits_processors = [self.logits_processors[idx] for idx in keep]
+        if self.thinking_budget_criteria:
+            self.thinking_budget_criteria = [
+                self.thinking_budget_criteria[idx] for idx in keep
+            ]
+        if self._token_context:
+            self._token_context = [self._token_context[idx] for idx in keep]
+
     def _release_apc_meta_blocks(self):
         if self._apc_manager is None:
             return
@@ -2743,12 +2811,16 @@ class BatchGenerator:
 
             # Being prefilled
             if self._prompt_batch is not None and uid in self._prompt_batch.uids:
-                if len(self._prompt_batch.uids) == 1:
-                    self._prompt_batch.uids = []
-                    self._prompt_batch.prompt_cache = []
+                keep = [
+                    idx
+                    for idx, prompt_uid in enumerate(self._prompt_batch.uids)
+                    if prompt_uid != uid
+                ]
+                self._prompt_batch.filter(keep)
+                if not keep:
                     self._prompt_batch = None
-                    mx.clear_cache()
-                    return True
+                mx.clear_cache()
+                return True
 
             # Already decoding.
             if uid in self._generation_batch.uids:

--- a/mlx_vlm/models/cache.py
+++ b/mlx_vlm/models/cache.py
@@ -795,7 +795,7 @@ class ArraysCache(_BaseCache):
     def state(self, v):
         self.cache = v
 
-    def filter(self, batch_indices):
+    def filter(self, batch_indices, *, compact=True):
         """
         In-place filter to keep just the given indices in the cache.
         """
@@ -1023,12 +1023,15 @@ class CacheList(_BaseCache):
         for c, m in zip(self.caches, v[1]):
             c.meta_state = m
 
-    def filter(self, batch_indices):
+    def filter(self, batch_indices, *, compact=True):
         """
         In-place filter to keep just the given indices in the cache.
         """
         for c in self.caches:
-            c.filter(batch_indices)
+            if compact:
+                c.filter(batch_indices)
+            else:
+                c.filter(batch_indices, compact=False)
 
     def extend(self, other):
         """
@@ -1165,7 +1168,7 @@ class BatchKVCache(_BaseCache):
     @property
     def state(self):
         k, v = self.keys, self.values
-        if self._idx < k.shape[2]:
+        if k is not None and self._idx < k.shape[2]:
             k = k[..., : self._idx, :]
             v = v[..., : self._idx, :]
         return k, v, self.offset, self.left_padding
@@ -1173,7 +1176,7 @@ class BatchKVCache(_BaseCache):
     @state.setter
     def state(self, v):
         self.keys, self.values, self.offset, self.left_padding = v
-        self._idx = self.keys.shape[2]
+        self._idx = 0 if self.keys is None else self.keys.shape[2]
 
     def is_trimmable(self):
         return True
@@ -1189,9 +1192,12 @@ class BatchKVCache(_BaseCache):
             N, offset=self._idx, left_padding=self.left_padding, **kwargs
         )
 
-    def filter(self, batch_indices):
+    def filter(self, batch_indices, *, compact=True):
         """
         In-place filter to keep just the given indices in the cache.
+
+        Set compact=False during prefill to preserve the token-axis layout,
+        including left padding that has not been processed yet.
         """
         if self.keys is not None:
             self.keys = self.keys[batch_indices]
@@ -1202,7 +1208,7 @@ class BatchKVCache(_BaseCache):
             self._right_padding = self._right_padding[batch_indices]
 
         # Shift left to reduce padding
-        min_left_pad = self.left_padding.min().item()
+        min_left_pad = self.left_padding.min().item() if compact else 0
         if min_left_pad > 0:
             if self.keys is not None:
                 self.keys = self.keys[..., min_left_pad:, :]
@@ -1547,7 +1553,7 @@ class BatchRotatingKVCache(_BaseCache):
 
         return mask
 
-    def filter(self, batch_indices):
+    def filter(self, batch_indices, *, compact=True):
         """
         In-place filter to keep just the given indices in the cache.
         """
@@ -1999,7 +2005,7 @@ class BatchQuantizedKVCache(_BaseCache):
         cache.offset = int(cache.keys[0].shape[2])
         return cache
 
-    def filter(self, batch_indices: mx.array):
+    def filter(self, batch_indices: mx.array, *, compact=True):
         """Keep only the sequences at *batch_indices*."""
         if self.keys is not None:
             self.keys = tuple(k[batch_indices] for k in self.keys)
@@ -2009,7 +2015,7 @@ class BatchQuantizedKVCache(_BaseCache):
         if self._right_padding is not None:
             self._right_padding = self._right_padding[batch_indices]
 
-        min_lp = self.left_padding.min().item()
+        min_lp = self.left_padding.min().item() if compact else 0
         if min_lp > 0:
             if self.keys is not None:
                 self.keys = tuple(k[..., min_lp:, :] for k in self.keys)
@@ -2579,7 +2585,7 @@ class BatchPoolingCache(_BaseCache):
             total += self.pooled.nbytes
         return total
 
-    def filter(self, batch_indices):
+    def filter(self, batch_indices, *, compact=True):
         if isinstance(batch_indices, mx.array):
             idx_list = batch_indices.tolist()
         else:

--- a/mlx_vlm/models/minimax_m3_vl/language.py
+++ b/mlx_vlm/models/minimax_m3_vl/language.py
@@ -760,9 +760,9 @@ class MiniMaxM3BatchKVCache:
             return None
         return self.kv_cache.make_mask(*args, **kwargs)
 
-    def filter(self, batch_indices):
-        min_left_pad = self.left_padding[batch_indices].min().item()
-        self.kv_cache.filter(batch_indices)
+    def filter(self, batch_indices, *, compact=True):
+        min_left_pad = self.left_padding[batch_indices].min().item() if compact else 0
+        self.kv_cache.filter(batch_indices, compact=compact)
         if self.index_keys is not None:
             self.index_keys = self.index_keys[batch_indices]
             if min_left_pad > 0:

--- a/mlx_vlm/models/qwen3_5/language.py
+++ b/mlx_vlm/models/qwen3_5/language.py
@@ -1259,6 +1259,7 @@ class Qwen3_5Model(nn.Module):
         position_ids: Optional[mx.array] = None,
         capture_layer_ids: Optional[List[int]] = None,
         hidden_sink: Optional[list] = None,
+        n_to_process: Optional[int] = None,
     ):
         if inputs_embeds is None:
             h = self.embed_tokens(inputs)
@@ -1269,37 +1270,11 @@ class Qwen3_5Model(nn.Module):
             cache = [None] * len(self.layers)
 
         fa_cache = cache[self.fa_idx]
+        # A cancelled prefill peer can leave a singleton whose next chunk is
+        # still partly (or entirely) left padding. Handle it before the
+        # singleton decode shortcut, including one-token prefill chunks.
         if (
-            h.shape[0] == 1
-            and hidden_sink is None
-            and fa_cache is not None
-            and _is_single_row_batch_cache(fa_cache)
-        ):
-            row_cache = []
-            for cache_entry in cache:
-                if cache_entry is None:
-                    row_cache.append(None)
-                elif _is_single_row_batch_cache(cache_entry):
-                    row_cache.append(_extract_row_cache(cache_entry, 0))
-                else:
-                    row_cache.append(cache_entry)
-
-            row_out = self(
-                inputs,
-                inputs_embeds=h,
-                cache=row_cache,
-                position_ids=position_ids,
-            )
-            for i, cache_entry in enumerate(row_cache):
-                if cache[i] is None or cache_entry is None:
-                    continue
-                if hasattr(cache[i].__class__, "merge"):
-                    cache[i] = cache[i].__class__.merge([cache_entry])
-            return row_out
-
-        if (
-            h.shape[0] > 1
-            and h.shape[1] > 1
+            (h.shape[1] > 1 or n_to_process is not None)
             and hidden_sink is None
             and fa_cache is not None
             and hasattr(fa_cache, "extract")
@@ -1372,6 +1347,34 @@ class Qwen3_5Model(nn.Module):
                             h.shape[1],
                         )
                 return mx.concatenate(row_outputs, axis=0)
+
+        if (
+            h.shape[0] == 1
+            and hidden_sink is None
+            and fa_cache is not None
+            and _is_single_row_batch_cache(fa_cache)
+        ):
+            row_cache = []
+            for cache_entry in cache:
+                if cache_entry is None:
+                    row_cache.append(None)
+                elif _is_single_row_batch_cache(cache_entry):
+                    row_cache.append(_extract_row_cache(cache_entry, 0))
+                else:
+                    row_cache.append(cache_entry)
+
+            row_out = self(
+                inputs,
+                inputs_embeds=h,
+                cache=row_cache,
+                position_ids=position_ids,
+            )
+            for i, cache_entry in enumerate(row_cache):
+                if cache[i] is None or cache_entry is None:
+                    continue
+                if hasattr(cache[i].__class__, "merge"):
+                    cache[i] = cache[i].__class__.merge([cache_entry])
+            return row_out
 
         fa_mask = _create_qwen3_5_attention_mask(h, cache[self.fa_idx])
         ssm_mask = _create_qwen3_5_ssm_mask(h, cache[self.ssm_idx])
@@ -2087,6 +2090,7 @@ class LanguageModel(nn.Module):
             position_ids=position_ids,
             capture_layer_ids=capture_layer_ids,
             hidden_sink=hidden_sink,
+            n_to_process=kwargs.get("n_to_process"),
         )
         if return_hidden:
             if hidden_sink is None:

--- a/mlx_vlm/models/qwen4_exp/language.py
+++ b/mlx_vlm/models/qwen4_exp/language.py
@@ -1273,6 +1273,7 @@ class Qwen4ExpModel(nn.Module):
         position_ids: Optional[mx.array] = None,
         capture_layer_ids=None,
         hidden_sink=None,
+        n_to_process: Optional[int] = None,
         **kwargs,
     ):
         del kwargs
@@ -1284,11 +1285,11 @@ class Qwen4ExpModel(nn.Module):
 
         # Ragged prefill has row-specific recurrent, PLE, RoPE, and QSA
         # semantics. Process each row through the singleton-equivalent path,
-        # merge the resulting caches, and continue decode as a batch.
+        # including a padded singleton left by cancellation and one-token
+        # prefill chunks, then merge the caches for subsequent steps.
         fa_cache = cache[self.fa_idx]
         if (
-            hidden_states.shape[0] > 1
-            and hidden_states.shape[1] > 1
+            (hidden_states.shape[1] > 1 or n_to_process is not None)
             and hidden_sink is None
             and fa_cache is not None
             and hasattr(fa_cache, "extract")

--- a/mlx_vlm/models/qwen4_exp/language.py
+++ b/mlx_vlm/models/qwen4_exp/language.py
@@ -259,9 +259,9 @@ class BatchQSAKVCache:
     def make_mask(self, *args, **kwargs):
         return self.kv_cache.make_mask(*args, **kwargs)
 
-    def filter(self, batch_indices):
-        min_left = int(self.left_padding[batch_indices].min().item())
-        self.kv_cache.filter(batch_indices)
+    def filter(self, batch_indices, *, compact=True):
+        min_left = int(self.left_padding[batch_indices].min().item()) if compact else 0
+        self.kv_cache.filter(batch_indices, compact=compact)
         if self.index_keys is None:
             return
         self.index_keys = self.index_keys[batch_indices]

--- a/mlx_vlm/server/generation.py
+++ b/mlx_vlm/server/generation.py
@@ -1074,6 +1074,28 @@ class ResponseGenerator:
             pending, self._cancelled = self._cancelled, set()
             return pending
 
+    def _cancel_active_requests(self, batch_gen, active):
+        cancelled = self._drain_cancellations()
+        if batch_gen is None:
+            return
+        for uid in cancelled:
+            if uid not in active:
+                continue
+            if not batch_gen.remove(uid):
+                # Let the generation loop's error handler notify callers and
+                # discard the inconsistent batch, rather than hiding GPU work.
+                raise RuntimeError(f"Failed to remove cancelled active request {uid}")
+            info = active.pop(uid)
+            logger.info(
+                "Generation cancelled: request=%s generated_tokens=%d",
+                info.get("request_id", uid),
+                int(info.get("generated_tokens", 0) or 0),
+            )
+            try:
+                info["rqueue"].put(None)
+            except Exception:
+                pass
+
     def _initialize_model(self):
         model, processor, config = load_model_resources(
             self.model_path, self.adapter_path
@@ -1711,21 +1733,7 @@ class ResponseGenerator:
                     break
 
                 # Drop abandoned requests before doing more work.
-                cancelled = self._drain_cancellations()
-                if cancelled and batch_gen is not None:
-                    for uid in cancelled:
-                        if uid in active:
-                            batch_gen.remove(uid)
-                            info = active.pop(uid)
-                            logger.info(
-                                "Generation cancelled: request=%s generated_tokens=%d",
-                                info.get("request_id", uid),
-                                int(info.get("generated_tokens", 0) or 0),
-                            )
-                            try:
-                                info["rqueue"].put(None)
-                            except Exception:
-                                pass
+                self._cancel_active_requests(batch_gen, active)
 
                 if new_items and batch_gen is not None and not active:
                     if not batch_gen.has_work:

--- a/mlx_vlm/tests/test_apc_adapters.py
+++ b/mlx_vlm/tests/test_apc_adapters.py
@@ -7,6 +7,8 @@ dequant-aware block harvest. Uses real cache types with small dimensions.
 from __future__ import annotations
 
 import mlx.core as mx
+import pytest
+from mlx.utils import tree_flatten
 
 from mlx_vlm.apc import (
     APCManager,
@@ -596,6 +598,99 @@ def _fill_batch_turbo(left_padding, seq_len, bits=4.0):
     cache.update_and_fetch(k, v)
     mx.eval(cache.keys)
     return cache, k, v
+
+
+@pytest.mark.parametrize(
+    "kind", ["kv", "quantized", "turbo", "rotating", "qsa", "minimax"]
+)
+@pytest.mark.parametrize("processed", [0, 3])
+def test_prefill_filter_preserves_unprocessed_left_padding(kind, processed):
+    from mlx_vlm.models.minimax_m3_vl.language import MiniMaxM3BatchKVCache
+    from mlx_vlm.models.qwen4_exp.language import BatchQSAKVCache
+    from mlx_vlm.turboquant import BatchTurboQuantKVCache
+
+    factories = {
+        "kv": lambda: BatchKVCache([8, 0]),
+        "quantized": lambda: BatchQuantizedKVCache([8, 0], group_size=32, bits=8),
+        "turbo": lambda: BatchTurboQuantKVCache([8, 0], bits=4.0),
+        "rotating": lambda: BatchRotatingKVCache(32, [8, 0]),
+        "qsa": lambda: BatchQSAKVCache([8, 0]),
+        "minimax": lambda: MiniMaxM3BatchKVCache([8, 0]),
+    }
+    cache = factories[kind]()
+    backend = getattr(cache, "kv_cache", cache)
+
+    def update(batch, length):
+        k, v = _rand_kv(batch=batch, seq_len=length, dim=64)
+        cache.update_and_fetch(k, v)
+        if kind == "qsa":
+            positions = mx.broadcast_to(
+                mx.arange(length)[None, None], (3, batch, length)
+            )
+            cache.update_indexer(k[:, 0], positions)
+        elif kind == "minimax":
+            cache.update_index_and_fetch(k)
+
+    if processed:
+        update(2, processed)
+        before = [v for _, v in tree_flatten((backend.keys, backend.values))]
+        if kind in ("qsa", "minimax"):
+            index_before = cache.index_keys
+    cache.filter(mx.array([0], dtype=mx.int32), compact=False)
+
+    assert cache._idx == processed
+    assert cache.left_padding.tolist() == [8]
+    assert cache.offset.tolist() == [processed - 8]
+    if processed:
+        after = [v for _, v in tree_flatten((backend.keys, backend.values))]
+        for expected, actual in zip(before, after):
+            assert mx.array_equal(actual, expected[:1]).item()
+        if kind in ("qsa", "minimax"):
+            assert cache.index_offset == processed
+            assert mx.array_equal(cache.index_keys, index_before[:1]).item()
+        if kind == "qsa":
+            assert cache.index_position_ids.shape == (3, 1, processed)
+
+    # Consume the remaining padding and real tokens, then retain the existing
+    # default decode behavior: compact only once prefill has finished.
+    update(1, 10 - processed)
+    assert cache._idx == 10
+    assert cache.offset.tolist() == [2]
+    cache.filter(mx.array([0], dtype=mx.int32))
+    assert cache._idx == (10 if kind == "rotating" else 2)
+    assert cache.left_padding.tolist() == ([8] if kind == "rotating" else [0])
+    if kind in ("qsa", "minimax"):
+        assert cache.index_offset == 2
+
+
+def test_prefill_filter_propagates_through_nested_and_recurrent_caches():
+    kv = BatchKVCache([8, 0])
+    recurrent = ArraysCache(2, left_padding=[8, 0])
+    recurrent[0] = mx.arange(8).reshape(2, 4)
+    recurrent[1] = mx.arange(12).reshape(2, 2, 3)
+    recurrent.prepare(lengths=[10, 10])
+    recurrent.advance(3)
+    pooling = BatchPoolingCache(4, [8, 0])
+    pooling.prepare(lengths=[10, 10])
+    pooling.accumulate_windows(
+        mx.ones((2, 3, 4)), mx.ones((2, 3, 4)), mx.array([-8, 0])
+    )
+    k, v = _rand_kv(batch=2, seq_len=3)
+    kv.update_and_fetch(k, v)
+    caches = CacheList(kv, CacheList(recurrent, pooling))
+
+    caches.filter(mx.array([0], dtype=mx.int32), compact=False)
+
+    assert kv._idx == 3
+    assert kv.left_padding.tolist() == [8]
+    assert recurrent.left_padding.tolist() == [5]
+    assert recurrent.lengths.tolist() == [7]
+    assert recurrent[0].tolist() == [[0, 1, 2, 3]]
+    assert recurrent[1].shape == (1, 2, 3)
+    assert pooling.left_padding == [5]
+    assert pooling.remainder == [0]
+    assert pooling._processed == [0]
+    assert pooling.buf_kv.shape[0] == 1
 
 
 class TestBatchRightPadPrefill:

--- a/mlx_vlm/tests/test_generate.py
+++ b/mlx_vlm/tests/test_generate.py
@@ -1455,6 +1455,65 @@ class TestBatchGenerator:
         ]
         assert warm_cache._idx == 10
 
+    @pytest.mark.parametrize(
+        "right_padding, keep",
+        [
+            ([2, 0], [1]),
+            ([2, 0], [0]),
+            ([2, 0, 0], [1, 2]),
+            ([1, 2, 0], [0, 2]),
+            ([0, 0], [1]),
+            (None, [1]),
+        ],
+    )
+    def test_cancel_prefill_finalizes_prepared_caches(self, right_padding, keep):
+        from mlx_vlm.models.cache import ArraysCache
+
+        def model(ids, *, cache, inputs_embeds=None, **kwargs):
+            if inputs_embeds is None:
+                inputs_embeds = mx.ones((*ids.shape, 4))
+            kv = inputs_embeds[:, None]
+            cache[0].update_and_fetch(kv, kv)
+            cache[1].advance(ids.shape[1])
+            return SimpleNamespace(logits=mx.zeros((*ids.shape, 16)))
+
+        padding = right_padding or [0, 0]
+        caches = [BatchKVCache([0] * len(padding)), ArraysCache(1)]
+        caches[1][0] = mx.zeros((len(padding), 4))
+        batch = PromptProcessingBatch(
+            model=model,
+            uids=list(range(len(padding))),
+            input_ids=[list(range(1, 6 - pad)) for pad in padding],
+            max_tokens=[5] * len(padding),
+            inputs_embeds=mx.ones((len(padding), 5, 4)),
+            prompt_kwargs={},
+            warm_cache=caches,
+            right_pad_per_row=right_padding,
+            prefill_step_size=1,
+        )
+        batch.prompt_step()
+        batch.filter(keep)
+        while batch.needs_processing():
+            batch.prompt_step()
+
+        with contextlib.ExitStack() as stack:
+            finalizers = [
+                stack.enter_context(patch.object(c, "finalize", wraps=c.finalize))
+                for c in caches
+            ]
+            generation = batch.generate(
+                lambda logits: mx.argmax(logits, axis=-1), lambda _: False
+            )
+            for finalize in finalizers:
+                assert finalize.call_count == int(any(padding))
+
+        assert generation.prompt_cache[0]._right_padding is None
+        recurrent = generation.prompt_cache[1]
+        assert recurrent.lengths is None
+        assert recurrent.make_mask(1) is None
+        generation.next()
+        assert recurrent.lengths is None
+
     def test_prefill_filter_keeps_mrope_and_request_metadata_aligned(self, mock_model):
         positions = mx.arange(3 * 3 * 6).reshape(3, 3, 6)
         embeddings = mx.arange(3 * 6 * 4).reshape(3, 6, 4)

--- a/mlx_vlm/tests/test_generate.py
+++ b/mlx_vlm/tests/test_generate.py
@@ -176,6 +176,57 @@ def mock_processor():
     return MockProcessor()
 
 
+@pytest.fixture(params=["dense", "moe"])
+def tiny_cancellation_model(request):
+    from mlx_vlm.models import qwen3_5, qwen3_5_moe
+
+    mx.random.seed(17)
+    module = qwen3_5 if request.param == "dense" else qwen3_5_moe
+    model_type = "qwen3_5" if request.param == "dense" else "qwen3_5_moe"
+    mlp_config = (
+        {"intermediate_size": 64}
+        if request.param == "dense"
+        else {
+            "num_experts": 4,
+            "num_experts_per_tok": 2,
+            "shared_expert_intermediate_size": 64,
+            "moe_intermediate_size": 64,
+        }
+    )
+    config = module.TextConfig(
+        model_type=model_type,
+        hidden_size=32,
+        linear_num_value_heads=2,
+        linear_num_key_heads=2,
+        linear_key_head_dim=16,
+        linear_value_head_dim=16,
+        linear_conv_kernel_dim=3,
+        num_hidden_layers=2,
+        num_attention_heads=2,
+        rms_norm_eps=1e-5,
+        vocab_size=32,
+        num_key_value_heads=2,
+        max_position_embeddings=128,
+        head_dim=16,
+        full_attention_interval=2,
+        rope_parameters={
+            "type": "default",
+            "mrope_section": [1, 1, 0],
+            "rope_theta": 10000,
+            "partial_rotary_factor": 0.25,
+        },
+        **mlp_config,
+    )
+    return module.LanguageModel(
+        config,
+        module.ModelConfig(
+            text_config=config,
+            vision_config=module.VisionConfig(),
+            model_type=model_type,
+        ),
+    )
+
+
 def test_batch_generator_apc_media_token_ids_handles_text_only_model(mock_processor):
     model = SimpleNamespace(
         language_model=MockLanguageModel(),
@@ -1171,10 +1222,13 @@ class TestBatchGenerator:
             processor=mock_processor,
             max_tokens=50,
         )
-        prompt_batch = SimpleNamespace(
+        prompt_batch = PromptProcessingBatch(
+            model=mock_model.language_model,
             uids=[7],
-            prompt_cache=[MagicMock()],
-            input_ids=mx.array([[1, mock_model.config.image_token_index, 2]]),
+            input_ids=[[1, mock_model.config.image_token_index, 2]],
+            max_tokens=[50],
+            inputs_embeds=mx.zeros((1, 3, 768)),
+            prompt_kwargs={},
         )
         gen._prompt_batch = prompt_batch
 
@@ -1182,6 +1236,264 @@ class TestBatchGenerator:
         assert prompt_batch.uids == []
         assert prompt_batch.prompt_cache == []
         assert gen._prompt_batch is None
+
+    @pytest.mark.parametrize("cancel_row", [0, 1])
+    @pytest.mark.parametrize("chunks", [1, 3])
+    @pytest.mark.parametrize("step_size", [1, 3])
+    def test_cancel_prefill_row_preserves_survivor_logits(
+        self, mock_processor, tiny_cancellation_model, cancel_row, chunks, step_size
+    ):
+        model = tiny_cancellation_model
+        prompts = [[1, 2, 3, 4], list(range(1, 14))]
+        kwargs = [
+            {
+                "inputs_embeds": model.model.embed_tokens(mx.array([ids])),
+                "position_ids": mx.broadcast_to(
+                    mx.arange(len(ids))[None, None], (3, 1, len(ids))
+                ),
+                "rope_deltas": mx.zeros((1, 1), dtype=mx.int32),
+            }
+            for ids in prompts
+        ]
+        gen = BatchGenerator(
+            model,
+            mock_processor,
+            prefill_batch_size=2,
+            prefill_step_size=step_size,
+            max_tokens=5,
+        )
+        try:
+            uids = gen.insert(prompts, prompt_kwargs=kwargs)
+            for _ in range(chunks):
+                gen.next()
+            batch = gen._prompt_batch
+            assert batch is not None
+            processed = batch._processed_prompt_columns
+            remaining = batch._input_ids.shape[1]
+            assert gen.remove(uids[cancel_row]) is True
+            assert gen._prompt_batch is batch
+            assert batch._processed_prompt_columns == processed
+            assert batch._input_ids.shape == (1, remaining)
+            assert batch.uids == [uids[1 - cancel_row]]
+            assert not gen.unprocessed_prompts
+
+            # Compare final-prefill logits and several decode steps with a
+            # standalone survivor; no generated prose or full weights needed.
+            while batch.needs_processing():
+                batch.prompt_step()
+            output = model(
+                batch._input_ids,
+                inputs_embeds=batch._inputs_embeds,
+                cache=batch.prompt_cache,
+                **batch._prompt_kwargs,
+            ).logits[:, -1:]
+            baseline_cache = model.make_cache()
+            baseline = model(
+                mx.array([prompts[1 - cancel_row]]), cache=baseline_cache
+            ).logits[:, -1:]
+            for _ in range(4):
+                assert mx.allclose(output, baseline, atol=1e-4, rtol=1e-4).item()
+                token = mx.argmax(baseline[:, -1], axis=-1)[:, None]
+                output = model(token, cache=batch.prompt_cache).logits
+                baseline = model(token, cache=baseline_cache).logits
+        finally:
+            gen.close()
+
+    @pytest.mark.parametrize("cancel_row", [0, 1])
+    @pytest.mark.parametrize("speculative", [False, True])
+    def test_cancel_prefill_then_decode_matches_standalone(
+        self, mock_processor, tiny_cancellation_model, cancel_row, speculative
+    ):
+        from mlx_vlm.speculative.drafters.qwen3_5_mtp.config import Qwen3_5MTPConfig
+        from mlx_vlm.speculative.drafters.qwen3_5_mtp.qwen3_5_mtp import (
+            Qwen3_5MTPDraftModel,
+        )
+
+        model = tiny_cancellation_model
+        drafter = (
+            Qwen3_5MTPDraftModel(Qwen3_5MTPConfig(text_config=model.args))
+            if speculative
+            else None
+        )
+        prompts = [[1, 2, 3, 4], list(range(1, 14))]
+        mock_processor.tokenizer.stopping_criteria = MockStoppingCriteria([-1])
+        gen = BatchGenerator(
+            model,
+            mock_processor,
+            prefill_batch_size=2,
+            prefill_step_size=3,
+            max_tokens=5,
+            draft_model=drafter,
+            draft_kind="mtp" if speculative else None,
+            draft_block_size=3 if speculative else None,
+        )
+        try:
+            uids = gen.insert(
+                prompts,
+                prompt_kwargs=[
+                    {
+                        "inputs_embeds": model.model.embed_tokens(mx.array([ids])),
+                        "position_ids": mx.broadcast_to(
+                            mx.arange(len(ids))[None, None], (3, 1, len(ids))
+                        ),
+                        "rope_deltas": mx.zeros((1, 1), dtype=mx.int32),
+                    }
+                    for ids in prompts
+                ],
+            )
+            gen.next()
+            assert gen.remove(uids[cancel_row]) is True
+            tokens = []
+            for _ in range(30):
+                if not gen.has_work:
+                    break
+                progress, responses = gen.next()
+                assert all(p.uid == uids[1 - cancel_row] for p in progress)
+                assert all(r.uid == uids[1 - cancel_row] for r in responses)
+                tokens.extend(r.token for r in responses)
+            assert not gen.has_work
+
+            expected = []
+            baseline_cache = model.make_cache()
+            inputs = mx.array([prompts[1 - cancel_row]])
+            for _ in range(5):
+                output = model(inputs, cache=baseline_cache)
+                inputs = mx.argmax(output.logits[:, -1], axis=-1)[:, None]
+                expected.append(inputs.item())
+            assert tokens == expected
+        finally:
+            gen.close()
+
+    def test_cancel_all_prefill_rows_releases_apc_without_requeue(
+        self, mock_model, mock_processor
+    ):
+        manager = MagicMock()
+        meta = [
+            {"apc_blocks": [11], "full_input_ids": [1, 2, 3]},
+            {"apc_blocks": [22], "full_input_ids": [4, 5, 6]},
+        ]
+        gen = BatchGenerator(mock_model.language_model, mock_processor)
+        batch = PromptProcessingBatch(
+            model=mock_model.language_model,
+            uids=[7, 8],
+            input_ids=[[1, 2, 3], [4, 5, 6]],
+            max_tokens=[5, 5],
+            inputs_embeds=mx.zeros((2, 3, 768)),
+            prompt_kwargs={},
+            apc_meta=meta,
+            apc_manager=manager,
+        )
+        gen._prompt_batch = batch
+        try:
+            assert gen.remove(7) is True
+            manager.release.assert_called_once_with([11])
+            assert batch._apc_meta == [meta[1]]
+            assert gen.remove(8) is True
+            assert manager.release.call_args_list == [
+                (([11],), {}),
+                (([22],), {}),
+            ]
+            assert gen.remove(8) is False
+            assert gen._prompt_batch is None
+            assert not gen.has_work
+            assert batch.prompt_cache == []
+            assert batch._apc_meta == []
+            assert batch._inputs_embeds is None
+        finally:
+            gen.close()
+
+    @pytest.mark.parametrize("keep_row", [0, 1])
+    def test_prefill_filter_preserves_mixed_apc_suffix_metadata(self, keep_row):
+        calls = []
+
+        def model(ids, *, cache, inputs_embeds, **kwargs):
+            calls.append(ids.tolist())
+            kv = inputs_embeds[:, None]
+            cache[0].update_and_fetch(kv, kv)
+            return SimpleNamespace(logits=mx.zeros((*ids.shape, 16)))
+
+        manager = MagicMock()
+        meta = [
+            {"full_input_ids": list(range(10)), "prefix_len": 4, "apc_blocks": [11]},
+            {"full_input_ids": list(range(8)), "prefix_len": 0, "apc_blocks": []},
+        ]
+        warm_cache = BatchKVCache([0, 4])
+        warm_cache.update_and_fetch(mx.ones((2, 1, 4, 4)), mx.ones((2, 1, 4, 4)))
+        batch = PromptProcessingBatch(
+            model=model,
+            uids=[7, 8],
+            input_ids=[list(range(4, 10)), list(range(8))],
+            max_tokens=[5, 5],
+            inputs_embeds=mx.ones((2, 8, 4)),
+            prompt_kwargs={},
+            warm_cache=[warm_cache],
+            prefill_step_size=3,
+            apc_meta=meta,
+            apc_manager=manager,
+            apc_mode="exact",
+            right_pad_per_row=[2, 0],
+            suffix_lens=[6, 8],
+        )
+        batch.prompt_step()
+        batch.filter([keep_row])
+        assert warm_cache._idx == 7
+        assert warm_cache.left_padding.tolist() == [[0], [4]][keep_row]
+        assert warm_cache._right_padding.tolist() == [[2], [0]][keep_row]
+        assert batch._right_pad_per_row == [[2], [0]][keep_row]
+        assert batch._suffix_lens == [[6], [8]][keep_row]
+        assert batch._cached_tokens_per_row == [[4], [0]][keep_row]
+        assert batch._prompt_tokens_per_row == [[10], [8]][keep_row]
+        assert batch._row_real_tokens_processed(0) == [7, 3][keep_row]
+        assert batch._apc_meta == [meta[keep_row]]
+        manager.release.assert_called_once_with(meta[1 - keep_row]["apc_blocks"])
+
+        batch.prompt_step()
+        assert batch._processed_prompt_columns == 6
+        assert calls == [
+            [[4, 5, 6], [0, 1, 2]],
+            [[[7, 8, 9]], [[3, 4, 5]]][keep_row],
+        ]
+        assert warm_cache._idx == 10
+
+    def test_prefill_filter_keeps_mrope_and_request_metadata_aligned(self, mock_model):
+        positions = mx.arange(3 * 3 * 6).reshape(3, 3, 6)
+        embeddings = mx.arange(3 * 6 * 4).reshape(3, 6, 4)
+        processors = [[MagicMock()] for _ in range(3)]
+        criteria = [MagicMock() for _ in range(3)]
+        batch = PromptProcessingBatch(
+            model=mock_model.language_model,
+            uids=[7, 8, 9],
+            input_ids=[[1, 2], [3, 4, 5, 6], [7, 8, 9, 10, 11, 12]],
+            max_tokens=[5, 6, 7],
+            inputs_embeds=embeddings,
+            prompt_kwargs={
+                "position_ids": positions,
+                "rope_deltas": mx.array([[10], [20], [30]]),
+                "attention_mask": mx.ones((3, 6)),
+                "shared_scalar": mx.array(42),
+            },
+            logits_processors=processors,
+            thinking_budget_criteria=criteria,
+        )
+        batch.record_prompt_time(1.0)
+        batch.filter([2, 0])
+        batch.filter([1])
+
+        assert batch.uids == [7]
+        assert batch.max_tokens == [5]
+        assert batch._left_padding_per_row == [4]
+        assert batch.logits_processors == [processors[0]]
+        assert batch.thinking_budget_criteria == [criteria[0]]
+        assert batch._token_context == [[1, 2]]
+        assert batch.total_prompt_tokens == 2
+        assert [p.uid for p in batch.prompt_progress()] == [7]
+        assert mx.array_equal(batch._inputs_embeds, embeddings[:1]).item()
+        assert mx.array_equal(
+            batch._prompt_kwargs["position_ids"], positions[:, :1]
+        ).item()
+        assert batch._prompt_kwargs["rope_deltas"].tolist() == [[10]]
+        assert batch._prompt_kwargs["attention_mask"].shape == (1, 6)
+        assert batch._prompt_kwargs["shared_scalar"].item() == 42
 
 
 # ============================================================================

--- a/mlx_vlm/tests/test_qwen4_exp.py
+++ b/mlx_vlm/tests/test_qwen4_exp.py
@@ -1,9 +1,14 @@
 import unittest
+from types import SimpleNamespace
 
 import mlx.core as mx
 import mlx.nn as nn
 
-from mlx_vlm.generate import maybe_quantize_kv_cache
+from mlx_vlm.generate import (
+    BatchGenerator,
+    PromptProcessingBatch,
+    maybe_quantize_kv_cache,
+)
 from mlx_vlm.generate.ar import _make_cache
 from mlx_vlm.models import qwen4_exp
 from mlx_vlm.models.cache import ArraysCache
@@ -16,6 +21,7 @@ from mlx_vlm.models.qwen4_exp.language import (
     ShardedEmbedding,
 )
 from mlx_vlm.prompt_utils import MessageFormat, MessageFormatter
+from mlx_vlm.utils import StoppingCriteria
 
 
 def tiny_config():
@@ -89,6 +95,17 @@ def tiny_config():
 
 
 class Qwen4ExpTests(unittest.TestCase):
+    @staticmethod
+    def _cancellation_model():
+        mx.random.seed(17)
+        config = tiny_config()
+        # Exercise inference kernels, which require at least 32 key dimensions.
+        config.text_config.linear_key_head_dim = 32
+        config.text_config.linear_value_head_dim = 32
+        model = qwen4_exp.Model(config).language_model
+        model.eval()
+        return model
+
     def test_config_normalizes_reference_layer_type(self):
         config = tiny_config()
         self.assertEqual(
@@ -372,6 +389,114 @@ class Qwen4ExpTests(unittest.TestCase):
                 mx.argmax(row_logits, axis=-1),
             ).item()
         )
+
+    def test_cancel_prefill_preserves_survivor_logits(self):
+        prompts = [[1, 2, 3, 4], list(range(1, 14))]
+        for step_size in (1, 3):
+            for chunks in (1, 3):
+                for cancel_row in (0, 1):
+                    with self.subTest(
+                        step_size=step_size, chunks=chunks, cancel_row=cancel_row
+                    ):
+                        model = self._cancellation_model()
+                        processor = SimpleNamespace(
+                            stopping_criteria=StoppingCriteria([-1])
+                        )
+                        gen = BatchGenerator(
+                            model,
+                            processor,
+                            max_tokens=5,
+                            prefill_batch_size=2,
+                            prefill_step_size=step_size,
+                        )
+                        try:
+                            uids = gen.insert(
+                                prompts,
+                                prompt_kwargs=[
+                                    {
+                                        "inputs_embeds": model.model.embed_tokens(
+                                            mx.array([ids])
+                                        ),
+                                        "position_ids": mx.broadcast_to(
+                                            mx.arange(len(ids))[None, None],
+                                            (3, 1, len(ids)),
+                                        ),
+                                        "rope_deltas": mx.zeros((1, 1), dtype=mx.int32),
+                                    }
+                                    for ids in prompts
+                                ],
+                            )
+                            for _ in range(chunks):
+                                gen.next()
+                            batch = gen._prompt_batch
+                            processed = batch._processed_prompt_columns
+                            self.assertTrue(gen.remove(uids[cancel_row]))
+                            self.assertIs(gen._prompt_batch, batch)
+                            self.assertEqual(batch._processed_prompt_columns, processed)
+                            self.assertEqual(batch.uids, [uids[1 - cancel_row]])
+                            self.assertFalse(gen.unprocessed_prompts)
+                            while batch.needs_processing():
+                                batch.prompt_step()
+                            actual = model(
+                                batch._input_ids,
+                                inputs_embeds=batch._inputs_embeds,
+                                cache=batch.prompt_cache,
+                                **batch._prompt_kwargs,
+                            ).logits[:, -1:]
+
+                            # Match real-token chunk boundaries in the standalone
+                            # reference, then compare several decode steps too.
+                            ids = mx.array([prompts[1 - cancel_row]])
+                            reference_cache = model.make_cache()
+                            for offset in range(0, ids.shape[1], step_size):
+                                chunk = ids[:, offset : offset + step_size]
+                                expected = model(
+                                    chunk,
+                                    cache=reference_cache,
+                                    position_ids=mx.broadcast_to(
+                                        mx.arange(offset, offset + chunk.shape[1])[
+                                            None, None
+                                        ],
+                                        (3, 1, chunk.shape[1]),
+                                    ),
+                                ).logits[:, -1:]
+                            for _ in range(4):
+                                self.assertTrue(
+                                    mx.allclose(
+                                        actual, expected, atol=1e-4, rtol=1e-4
+                                    ).item()
+                                )
+                                token = mx.argmax(expected[:, -1], axis=-1)[:, None]
+                                actual = model(token, cache=batch.prompt_cache).logits
+                                expected = model(token, cache=reference_cache).logits
+                        finally:
+                            gen.close()
+
+    def test_cancel_prefill_padding_preserves_ngram_history(self):
+        for step_size in (1, 3):
+            with self.subTest(step_size=step_size):
+                model = self._cancellation_model()
+                batch = PromptProcessingBatch(
+                    model=model,
+                    uids=[0, 1],
+                    input_ids=[[1, 2, 3, 4], list(range(1, 14))],
+                    max_tokens=[5, 5],
+                    inputs_embeds=mx.zeros((2, 13, 32)),
+                    prompt_kwargs={
+                        "position_ids": mx.broadcast_to(
+                            mx.arange(13)[None, None], (3, 2, 13)
+                        )
+                    },
+                    prefill_step_size=step_size,
+                )
+                batch.prompt_step()
+                batch.filter([0])
+                history = batch.prompt_cache[0][3]
+                # The next chunk is still entirely padding for the survivor.
+                batch.prompt_step()
+                self.assertTrue(
+                    mx.array_equal(history, batch.prompt_cache[0][3]).item()
+                )
 
     def test_multimodal_forward_uses_qwen3_vision_encoder(self):
         model = qwen4_exp.Model(tiny_config())

--- a/mlx_vlm/tests/test_server.py
+++ b/mlx_vlm/tests/test_server.py
@@ -58,6 +58,43 @@ def test_response_generator_prefill_step_override_wins_over_environment(monkeypa
     assert overridden_generator.prefill_step_size == 3072
 
 
+def test_response_generator_cancels_only_the_matching_active_request():
+    gen = server.ResponseGenerator.__new__(server.ResponseGenerator)
+    gen._cancelled = {7, 99}
+    gen._cancel_lock = Lock()
+    queues = [Queue(), Queue()]
+    active = {7: {"rqueue": queues[0]}, 8: {"rqueue": queues[1]}}
+    batch_gen = MagicMock()
+    batch_gen.remove.return_value = True
+
+    gen._cancel_active_requests(batch_gen, active)
+
+    batch_gen.remove.assert_called_once_with(7)
+    assert list(active) == [8]
+    assert queues[0].get_nowait() is None
+    assert queues[1].empty()
+    assert gen._drain_cancellations() == set()
+
+
+def test_response_generator_does_not_hide_failed_cancellation():
+    gen = server.ResponseGenerator.__new__(server.ResponseGenerator)
+    gen._cancelled = {7}
+    gen._cancel_lock = Lock()
+    rqueue = Queue()
+    active = {7: {"rqueue": rqueue}}
+    batch_gen = MagicMock()
+    batch_gen.remove.return_value = False
+
+    with pytest.raises(
+        RuntimeError, match="Failed to remove cancelled active request 7"
+    ):
+        gen._cancel_active_requests(batch_gen, active)
+
+    # The outer error handler still has the queue it must notify on failure.
+    assert 7 in active
+    assert rqueue.empty()
+
+
 def test_response_generator_clears_worker_streams(monkeypatch):
     gen = server.ResponseGenerator.__new__(server.ResponseGenerator)
     error = RuntimeError("worker failed")

--- a/mlx_vlm/turboquant.py
+++ b/mlx_vlm/turboquant.py
@@ -6664,14 +6664,14 @@ class BatchTurboQuantKVCache(_TurboQuantAttentionMixin, _BaseCache):
     # Batch operations for Batch.filter / Batch.extend
     # ------------------------------------------------------------------
 
-    def filter(self, batch_indices: mx.array):
+    def filter(self, batch_indices: mx.array, *, compact=True):
         if self.keys is not None:
             self.keys = _filter_state(self.keys, batch_indices)
             self.values = _filter_state(self.values, batch_indices)
         self.offset = self.offset[batch_indices]
         self.left_padding = self.left_padding[batch_indices]
 
-        min_lp = self.left_padding.min().item()
+        min_lp = self.left_padding.min().item() if compact else 0
         if min_lp > 0:
             if self.keys is not None:
                 # Trim leading padding tokens


### PR DESCRIPTION
Fixes #2147

## Summary

Allow a request to be removed from a multi-row prompt batch without restarting the surviving requests. Their processed prefix, cache state, and remaining prompt position are retained, so cancellation does not trigger re-prefill.

Previously, `BatchGenerator.remove()` only cancelled an active prefill when it contained one row. The mlx-vlm server's `ResponseGenerator` still closed the cancelled request's queue when removal returned `False`, leaving the row in the prompt batch.

Cancellation remains cooperative: the current GPU chunk completes before the cancelled row is removed from subsequent work.

## Changes

- Add `PromptProcessingBatch.filter()` to remove cancelled rows while keeping the survivors' cache state, remaining inputs, embeddings, positional arguments, and request metadata aligned. Preserve their processed-column count without requeueing prompts.
- Add `compact=False` to the affected batch cache filters, including nested, recurrent, quantized, TurboQuant, Qwen4, and MiniMax caches. Row selection during prefill preserves the token axis; existing decode-time compaction remains the default.
- Keep Qwen3.5/3.6 and Qwen4 prefill padding-aware when cancellation leaves a single row, including one-token chunks. Preserve Qwen4's n-gram history across all-padding chunks.
- Finalize prepared caches even when cancellation removes every right-padded row, clearing prefill-only length metadata before decode.
- Materialize submitted cache work before filtering and release only the removed rows' borrowed APC references. Clear the prompt batch when no rows remain.
- Require successful removal before `ResponseGenerator` closes the cancelled request's queue. Failed removal reaches the existing generation-loop error handler.

## Why prefill cannot use the existing decode filter unchanged

Decode-time cache filtering can remove padding shared by all surviving rows. During prefill, a surviving short prompt may still have unprocessed padding: after three processed columns, it can still carry eight columns of initial left padding. Compacting all eight at that point can make the cache write index negative and misalign subsequent inputs.

The new row-only mode preserves the token axis, padding, and offsets until normal prefill processing consumes them. This also avoids losing already-computed work for surviving requests.

## Regression coverage

- Cancel either row at different chunk boundaries and compare survivor logits and subsequent tokens with standalone execution, including MTP decoding in the small-model tests.
- Cancel all rows and repeat cancellation; verify batch cleanup and exactly-once release of APC references.
- Preserve padding, cached/uncached suffix metadata, embeddings, MRoPE positions, and per-request generation settings when rows are filtered.
- Verify prefill filtering preserves cache positions while normal decode compaction remains unchanged.
- Check finalization with one or multiple surviving rows and compare Qwen4 survivor logits through repeated decode in inference mode.
- Check that server cancellation closes only the matching request and does not hide failed removal.

## Validation

### Repro script: before and after

The same self-contained script included in the issue was run against the affected revision `346ebc95` and the working tree with this fix. It uses a tiny, locally initialized Qwen3.5 model and cancels the longer of two prompts after one prefill chunk; no checkpoint download is required.

Before the fix (exit code 1; traceback shortened):

```text
before cancellation: [0, 1]
processed prompt columns: 3
remove returned: False
prompt uids after removal: [0, 1]
...
AssertionError: BUG: cancellation did not remove the active prefill row
```

After the fix (exit code 0):

```text
before cancellation: [0, 1]
processed prompt columns: 3
remove returned: True
prompt uids after removal: [0]
PASS: survivor resumed without re-prefill and matches standalone decode
```

The passing run checks that the surviving row keeps its processed-column count and remaining prompt position, is not requeued, and produces the same five greedy tokens as standalone generation.

### Full-checkpoint validation

Tested directly through `BatchGenerator` with `lmstudio-community/Qwen3.5-9B-MLX-4bit` on an M5 Pro, using MLX 0.32.2 and Transformers 5.16.1. The run used prompts of 131 and 1,271 tokens, 64-token prefill chunks, and 16 greedy output tokens.

- On the pre-fix revision `346ebc95`, cancelling the short row after the first chunk failed to remove it.
- With the fix, cancelling either row after chunk 1 or chunk 18 succeeded in all four cases. The survivor retained its cache objects, processed-column count, and remaining prompt position without being requeued or re-prefilled.
- Repeated cancellation correctly reported that the request was no longer present. Cancelling both rows cleared the prompt batch and left no scheduled work.
- All four cases matched the standalone survivor's 16 output tokens when the real-token prefill chunk boundaries were aligned.

The parity comparison requires matching chunk boundaries: without alignment, two cases differed at token 15 and the strict comparison exited with code 1. The same difference was reproduced by changing standalone chunk boundaries without cancellation on the pre-fix revision. The aligned comparisons validate survivor continuity, not identical tokens across different chunk layouts.

### Test suites

The following targeted runs completed locally with MLX 0.32.2 and Transformers 5.16.1: **957 tests and 18 subtests passed**.

Run the cancellation, cache, and server coverage:

```bash
python -m pytest \
  mlx_vlm/tests/test_generate.py \
  mlx_vlm/tests/test_apc_adapters.py \
  mlx_vlm/tests/test_batch_quantized_cache.py \
  mlx_vlm/tests/test_server.py \
  -q
```

Result: 616 passed.

Run the speculative decoding and model-specific cache regressions:

```bash
python -m pytest \
  mlx_vlm/tests/test_speculative.py \
  mlx_vlm/tests/test_qwen4_exp.py \
  mlx_vlm/tests/test_minimax_m3.py \
  -q
```

Result: 314 passed, 10 subtests passed.

Run the affected Qwen and inherited-model regressions:

```bash
python -m pytest mlx_vlm/tests/test_models.py \
  -k 'qwen3_5 or Qwen35 or MiniCPMV4_6 or QwenMRoPE' \
  -q
```

Result: 27 passed, 386 deselected, 8 subtests passed.

For a quicker run restricted to the cancellation and prefill-filter regressions:

```bash
python -m pytest \
  mlx_vlm/tests/test_generate.py \
  mlx_vlm/tests/test_apc_adapters.py \
  mlx_vlm/tests/test_server.py \
  mlx_vlm/tests/test_qwen4_exp.py \
  -k 'cancel or prefill_filter' \
  -q
```

These automated test suites use small locally initialized models and synthetic cache state; no pretrained checkpoint download is required. The separate full-checkpoint validation is described above.