### PR TITLE
mla: use the absorbed path for multi-token steps

### DIFF
--- a/mlx_vlm/models/deepseek_v3/language.py
+++ b/mlx_vlm/models/deepseek_v3/language.py
@@ -10,7 +10,7 @@ from ..base import (
     create_attention_mask,
     scaled_dot_product_attention,
 )
-from ..mla import MultiLinear
+from ..mla import MultiLinear, latent_length, max_absorbed_queries
 from ..mlp import DeepseekMLP as DeepseekV3MLP
 from ..pipeline import PipelineMixin
 from ..rope_utils import initialize_rope
@@ -59,6 +59,11 @@ class DeepseekV3Attention(nn.Module):
         )
         self.unembed_out = MultiLinear(
             self.kv_lora_rank, self.v_head_dim, self.num_heads
+        )
+        self._absorbed_dims = (
+            self.kv_lora_rank,
+            self.qk_nope_head_dim,
+            self.v_head_dim,
         )
 
         self.o_proj = nn.Linear(
@@ -120,7 +125,10 @@ class DeepseekV3Attention(nn.Module):
                 mx.array(mx.finfo(pe_scores.dtype).min, pe_scores.dtype),
             )
 
-        if L == 1:
+        absorbed = L == 1 or L <= max_absorbed_queries(
+            *self._absorbed_dims, latent_length(kv_latent)
+        )
+        if absorbed:
             q_nope = self.embed_q(q_nope)
             k = v = kv_latent
         else:
@@ -130,7 +138,7 @@ class DeepseekV3Attention(nn.Module):
         output = scaled_dot_product_attention(
             q_nope, k, v, cache=cache, scale=self.scale, mask=pe_scores
         )
-        if L == 1:
+        if absorbed:
             output = self.unembed_out(output)
 
         output = output.transpose(0, 2, 1, 3).reshape(B, L, -1)

--- a/mlx_vlm/models/deepseek_v32/language.py
+++ b/mlx_vlm/models/deepseek_v32/language.py
@@ -11,7 +11,7 @@ from ..base import (
     scaled_dot_product_attention,
 )
 from ..cache import CacheList, KVCache
-from ..mla import MultiLinear
+from ..mla import MultiLinear, latent_length, max_absorbed_queries
 from ..mlp import DeepseekMLP as DeepseekV32MLP
 from ..rope_utils import initialize_rope
 from ..switch_layers import SwitchGLU
@@ -115,6 +115,11 @@ class DeepseekV32Attention(nn.Module):
         self.unembed_out = MultiLinear(
             self.kv_lora_rank, self.v_head_dim, self.num_heads
         )
+        self._absorbed_dims = (
+            self.kv_lora_rank,
+            self.qk_nope_head_dim,
+            self.v_head_dim,
+        )
 
         self.o_proj = nn.Linear(
             self.num_heads * self.v_head_dim,
@@ -205,7 +210,10 @@ class DeepseekV32Attention(nn.Module):
                 mx.array(mx.finfo(pe_scores.dtype).min, pe_scores.dtype),
             )
 
-        if L == 1:
+        absorbed = L == 1 or L <= max_absorbed_queries(
+            *self._absorbed_dims, latent_length(kv_latent)
+        )
+        if absorbed:
             q_nope = self.embed_q(q_nope)
             k = v = kv_latent
         else:
@@ -215,7 +223,7 @@ class DeepseekV32Attention(nn.Module):
         output = scaled_dot_product_attention(
             q_nope, k, v, cache=cache, scale=self.scale, mask=pe_scores
         )
-        if L == 1:
+        if absorbed:
             output = self.unembed_out(output)
 
         output = output.transpose(0, 2, 1, 3).reshape(B, L, -1)

--- a/mlx_vlm/models/glm4_moe_lite/language.py
+++ b/mlx_vlm/models/glm4_moe_lite/language.py
@@ -13,7 +13,7 @@ from ..base import (
     scaled_dot_product_attention,
 )
 from ..cache import KVCache
-from ..mla import MultiLinear
+from ..mla import MultiLinear, latent_length, max_absorbed_queries
 from ..pipeline import PipelineMixin
 from ..rope_utils import initialize_rope
 from ..switch_layers import SwitchGLU
@@ -63,6 +63,11 @@ class Glm4MoeLiteAttention(nn.Module):
         )
         self.unembed_out = MultiLinear(
             self.kv_lora_rank, self.v_head_dim, self.num_heads
+        )
+        self._absorbed_dims = (
+            self.kv_lora_rank,
+            self.qk_nope_head_dim,
+            self.v_head_dim,
         )
 
         self.o_proj = nn.Linear(
@@ -130,7 +135,10 @@ class Glm4MoeLiteAttention(nn.Module):
                 mx.array(mx.finfo(pe_scores.dtype).min, pe_scores.dtype),
             )
 
-        if L == 1:
+        absorbed = L == 1 or L <= max_absorbed_queries(
+            *self._absorbed_dims, latent_length(kv_latent)
+        )
+        if absorbed:
             q_nope = self.embed_q(q_nope)
             k = v = kv_latent
         else:
@@ -139,7 +147,7 @@ class Glm4MoeLiteAttention(nn.Module):
         output = scaled_dot_product_attention(
             q_nope, k, v, cache=attention_cache, scale=self.scale, mask=pe_scores
         )
-        if L == 1:
+        if absorbed:
             output = self.unembed_out(output)
 
         output = output.transpose(0, 2, 1, 3).reshape(B, L, -1)

--- a/mlx_vlm/models/glm5_next/language.py
+++ b/mlx_vlm/models/glm5_next/language.py
@@ -14,7 +14,7 @@ from ..deepseek_v4.hyper_connection import HyperConnection, hc_expand
 from ..deepseek_v32.language import DeepseekV32MoE
 from ..deepseek_v32.language import Model as DSV32Model
 from ..gated_delta import gated_delta_update
-from ..mla import MultiLinear
+from ..mla import MultiLinear, latent_length, max_absorbed_queries
 from ..mlp import DeepseekMLP
 from .config import ModelConfig, TextConfig
 
@@ -477,6 +477,11 @@ class Glm5NextSparseAttention(nn.Module):
         self.unembed_out = MultiLinear(
             self.kv_lora_rank, self.v_head_dim, self.num_heads
         )
+        self._absorbed_dims = (
+            self.kv_lora_rank,
+            self.qk_nope_head_dim,
+            self.v_head_dim,
+        )
         self.o_proj = nn.Linear(
             self.num_heads * self.v_head_dim,
             self.hidden_size,
@@ -554,7 +559,10 @@ class Glm5NextSparseAttention(nn.Module):
         ):
             cache[0].keys = mx.depends(cache[0].keys, (cache[1].keys, cache[1].values))
 
-        if L == 1:
+        absorbed = L == 1 or L <= max_absorbed_queries(
+            *self._absorbed_dims, latent_length(kv_latent)
+        )
+        if absorbed:
             q = self.embed_q(q)
             k = v = kv_latent
         else:
@@ -564,7 +572,7 @@ class Glm5NextSparseAttention(nn.Module):
         output = scaled_dot_product_attention(
             q, k, v, cache=cache, scale=self.scale, mask=attn_mask
         )
-        if L == 1:
+        if absorbed:
             output = self.unembed_out(output)
 
         output = output.transpose(0, 2, 1, 3).reshape(B, L, -1)

--- a/mlx_vlm/models/glm_moe_dsa/language.py
+++ b/mlx_vlm/models/glm_moe_dsa/language.py
@@ -16,6 +16,7 @@ from ..deepseek_v32.language import (
     DeepseekV32MoE,
 )
 from ..deepseek_v32.language import Model as DSV32Model
+from ..mla import latent_length, max_absorbed_queries
 from .config import ModelConfig
 from .speculative_verifier import GlmMoeDsaExactSpeculativeVerifier, verify_logits
 
@@ -109,7 +110,10 @@ class GlmMoeDsaAttention(DeepseekV32Attention):
                 mx.array(mx.finfo(pe_scores.dtype).min, pe_scores.dtype),
             )
 
-        if L == 1:
+        absorbed = L == 1 or L <= max_absorbed_queries(
+            *self._absorbed_dims, latent_length(kv_latent)
+        )
+        if absorbed:
             q_nope = self.embed_q(q_nope)
             k = v = kv_latent
         else:
@@ -119,7 +123,7 @@ class GlmMoeDsaAttention(DeepseekV32Attention):
         output = scaled_dot_product_attention(
             q_nope, k, v, cache=cache, scale=self.scale, mask=pe_scores
         )
-        if L == 1:
+        if absorbed:
             output = self.unembed_out(output)
 
         output = output.transpose(0, 2, 1, 3).reshape(B, L, -1)

--- a/mlx_vlm/models/kimi_k3/language.py
+++ b/mlx_vlm/models/kimi_k3/language.py
@@ -14,7 +14,7 @@ from ..base import (
 )
 from ..cache import ArraysCache, KVCache
 from ..gated_delta import gated_delta_update
-from ..mla import MultiLinear
+from ..mla import MultiLinear, latent_length, max_absorbed_queries
 from ..switch_layers import SwitchGLU
 from .config import TextConfig
 
@@ -549,6 +549,11 @@ class KimiK3MLAAttention(nn.Module):
         self.unembed_out = MultiLinear(
             self.kv_lora_rank, self.v_head_dim, self.num_heads
         )
+        self._absorbed_dims = (
+            self.kv_lora_rank,
+            self.qk_nope_head_dim,
+            self.v_head_dim,
+        )
         self.o_proj = nn.Linear(self.num_heads * self.v_head_dim, hidden, bias=False)
         if self.use_gate:
             self.g_proj = nn.Linear(
@@ -588,7 +593,10 @@ class KimiK3MLAAttention(nn.Module):
                 mx.array(mx.finfo(pe_scores.dtype).min, pe_scores.dtype),
             )
 
-        if L == 1:
+        absorbed = L == 1 or L <= max_absorbed_queries(
+            *self._absorbed_dims, latent_length(kv_latent)
+        )
+        if absorbed:
             q_nope = self.embed_q(q_nope)
             k = v = kv_latent
         else:
@@ -599,7 +607,7 @@ class KimiK3MLAAttention(nn.Module):
             q_nope, k, v, cache=cache, scale=self.scale, mask=pe_scores
         )
 
-        if L == 1:
+        if absorbed:
             output = self.unembed_out(output)
 
         output = output.transpose(0, 2, 1, 3).reshape(B, L, -1)

--- a/mlx_vlm/models/kimi_linear/language.py
+++ b/mlx_vlm/models/kimi_linear/language.py
@@ -12,7 +12,7 @@ from ..base import (
 )
 from ..cache import ArraysCache, KVCache
 from ..gated_delta import gated_delta_update
-from ..mla import MultiLinear
+from ..mla import MultiLinear, latent_length, max_absorbed_queries
 from ..switch_layers import SwitchGLU
 from .config import ModelConfig
 
@@ -145,6 +145,11 @@ class KimiMLAAttention(nn.Module):
         self.unembed_out = MultiLinear(
             args.kv_lora_rank, self.v_head_dim, self.num_heads
         )
+        self._absorbed_dims = (
+            args.kv_lora_rank,
+            self.qk_nope_head_dim,
+            self.v_head_dim,
+        )
         self.o_proj = nn.Linear(self.num_heads * self.v_head_dim, hidden, bias=False)
 
     def __call__(
@@ -177,7 +182,10 @@ class KimiMLAAttention(nn.Module):
                 mx.array(mx.finfo(pe_scores.dtype).min, pe_scores.dtype),
             )
 
-        if L == 1:
+        absorbed = L == 1 or L <= max_absorbed_queries(
+            *self._absorbed_dims, latent_length(kv_latent)
+        )
+        if absorbed:
             q_nope = self.embed_q(q_nope)
             k = v = kv_latent
         else:
@@ -188,7 +196,7 @@ class KimiMLAAttention(nn.Module):
             q_nope, k, v, cache=cache, scale=self.scale, mask=pe_scores
         )
 
-        if L == 1:
+        if absorbed:
             output = self.unembed_out(output)
 
         output = output.transpose(0, 2, 1, 3).reshape(B, L, -1)

--- a/mlx_vlm/models/longcat_flash/language.py
+++ b/mlx_vlm/models/longcat_flash/language.py
@@ -12,7 +12,7 @@ from ..base import (
     scaled_dot_product_attention,
 )
 from ..cache import CacheList, KVCache
-from ..mla import MultiLinear
+from ..mla import MultiLinear, latent_length, max_absorbed_queries
 from ..rope_utils import initialize_rope
 from ..switch_layers import SwitchGLU
 from .config import ModelConfig
@@ -59,6 +59,11 @@ class LongcatFlashMLA(nn.Module):
         )
         self.unembed_out = MultiLinear(
             self.kv_lora_rank, self.v_head_dim, self.num_attention_heads
+        )
+        self._absorbed_dims = (
+            self.kv_lora_rank,
+            self.qk_nope_head_dim,
+            self.v_head_dim,
         )
 
         self.o_proj = nn.Linear(
@@ -137,7 +142,10 @@ class LongcatFlashMLA(nn.Module):
                 mx.array(mx.finfo(pe_scores.dtype).min, pe_scores.dtype),
             )
 
-        if L == 1:
+        absorbed = L == 1 or L <= max_absorbed_queries(
+            *self._absorbed_dims, latent_length(kv_latent)
+        )
+        if absorbed:
             q_nope = self.embed_q(q_nope)
             k = v = kv_latent
         else:
@@ -147,7 +155,7 @@ class LongcatFlashMLA(nn.Module):
         output = scaled_dot_product_attention(
             q_nope, k, v, cache=cache, scale=self.scale, mask=pe_scores
         )
-        if L == 1:
+        if absorbed:
             output = self.unembed_out(output)
 
         output = output.transpose(0, 2, 1, 3).reshape(B, L, -1)

--- a/mlx_vlm/models/longcat_flash_sparse/language.py
+++ b/mlx_vlm/models/longcat_flash_sparse/language.py
@@ -12,7 +12,7 @@ from ..base import (
     scaled_dot_product_attention,
 )
 from ..cache import ArraysCache, CacheList, KVCache
-from ..mla import MultiLinear
+from ..mla import MultiLinear, latent_length, max_absorbed_queries
 from ..rope_utils import initialize_rope
 from ..switch_layers import SwitchGLU
 from .config import ModelConfig
@@ -229,6 +229,11 @@ class LongcatFlashMLA(nn.Module):
         self.unembed_out = MultiLinear(
             self.kv_lora_rank, self.v_head_dim, self.num_attention_heads
         )
+        self._absorbed_dims = (
+            self.kv_lora_rank,
+            self.qk_nope_head_dim,
+            self.v_head_dim,
+        )
 
         self.o_proj = nn.Linear(
             self.num_attention_heads * args.v_head_dim,
@@ -340,7 +345,10 @@ class LongcatFlashMLA(nn.Module):
                 mx.array(mx.finfo(pe_scores.dtype).min, pe_scores.dtype),
             )
 
-        if L == 1:
+        absorbed = L == 1 or L <= max_absorbed_queries(
+            *self._absorbed_dims, latent_length(kv_latent)
+        )
+        if absorbed:
             q_nope = self.embed_q(q_nope)
             k = v = kv_latent
         else:
@@ -350,7 +358,7 @@ class LongcatFlashMLA(nn.Module):
         output = scaled_dot_product_attention(
             q_nope, k, v, cache=latent_cache, scale=self.scale, mask=pe_scores
         )
-        if L == 1:
+        if absorbed:
             output = self.unembed_out(output)
 
         output = output.transpose(0, 2, 1, 3).reshape(B, L, -1)

--- a/mlx_vlm/models/mla.py
+++ b/mlx_vlm/models/mla.py
@@ -1,7 +1,44 @@
 import math
+from typing import Optional
 
 import mlx.core as mx
 import mlx.nn as nn
+
+
+def max_absorbed_queries(
+    kv_lora_rank: int,
+    qk_nope_head_dim: int,
+    v_head_dim: int,
+    cache_len: Optional[int] = None,
+) -> int:
+    """Query count below which folding into the query beats materializing K/V.
+
+    Per head, with ``r = kv_lora_rank`` and ``d = qk_nope_head_dim +
+    v_head_dim``, the absorbed path costs ``L*r*d + 2*L*T*r`` and materializing
+    costs ``T*r*d + L*T*d``, where ``T`` is the post-update cache length. The
+    absorbed path wins while::
+
+        L < r*d / (r*d/T + 2*r - d)
+
+    With ``cache_len`` omitted this returns the ``T -> inf`` limit,
+    ``r*d / (2*r - d)``, which is the right answer once the cache is much
+    larger than the latent. Pass ``cache_len`` for the exact bound: on a cold
+    cache, where ``T == L``, it correctly falls below ``L``, because
+    materializing K and V is cheaper there for every current model.
+    """
+    d = qk_nope_head_dim + v_head_dim
+    denom = 2 * kv_lora_rank - d
+    if cache_len is not None and cache_len > 0:
+        denom += kv_lora_rank * d / cache_len
+    if denom <= 0:
+        return 1
+    return max(1, int(kv_lora_rank * d / denom))
+
+
+def latent_length(kv_latent) -> int:
+    """Length of the cached latent, tolerating the quantized 3-tuple form."""
+    arr = kv_latent[0] if isinstance(kv_latent, tuple) else kv_latent
+    return arr.shape[-2]
 
 
 class MultiLinear(nn.Module):

--- a/mlx_vlm/models/youtu_vl/language.py
+++ b/mlx_vlm/models/youtu_vl/language.py
@@ -10,7 +10,7 @@ from ..base import (
     create_attention_mask,
     scaled_dot_product_attention,
 )
-from ..mla import MultiLinear
+from ..mla import MultiLinear, latent_length, max_absorbed_queries
 from ..rope_utils import initialize_rope
 from ..switch_layers import SwitchGLU
 from .config import ModelConfig, TextConfig
@@ -66,6 +66,11 @@ class YoutuAttention(nn.Module):
         self.unembed_out = MultiLinear(
             self.kv_lora_rank, self.v_head_dim, self.num_heads
         )
+        self._absorbed_dims = (
+            self.kv_lora_rank,
+            self.qk_nope_head_dim,
+            self.v_head_dim,
+        )
 
         self.o_proj = nn.Linear(
             self.num_heads * self.v_head_dim,
@@ -119,7 +124,10 @@ class YoutuAttention(nn.Module):
                 mx.array(mx.finfo(pe_scores.dtype).min, pe_scores.dtype),
             )
 
-        if L == 1:
+        absorbed = L == 1 or L <= max_absorbed_queries(
+            *self._absorbed_dims, latent_length(kv_latent)
+        )
+        if absorbed:
             q_nope = self.embed_q(q_nope)
             k = v = kv_latent
         else:
@@ -129,7 +137,7 @@ class YoutuAttention(nn.Module):
         output = scaled_dot_product_attention(
             q_nope, k, v, cache=cache, scale=self.scale, mask=pe_scores
         )
-        if L == 1:
+        if absorbed:
             output = self.unembed_out(output)
 
         output = output.transpose(0, 2, 1, 3).reshape(B, L, -1)

--- a/mlx_vlm/tests/test_absorbed_mla.py
+++ b/mlx_vlm/tests/test_absorbed_mla.py
@@ -1,0 +1,180 @@
+import unittest
+
+import mlx.core as mx
+
+from mlx_vlm.models.cache import KVCache
+from mlx_vlm.models.mla import latent_length, max_absorbed_queries
+
+# Dims chosen only to steer the gate; they do not affect the attention maths.
+FORCE_MATERIALIZED = (1, 1, 1)  # threshold 1
+FORCE_ABSORBED = (512, 511, 511)  # threshold ~261k
+
+
+def _dense_attentions():
+    """Every MLA attention whose __call__ is (x, mask, cache)."""
+    from mlx_vlm.models.deepseek_v3.config import ModelConfig as DSV3Config
+    from mlx_vlm.models.deepseek_v3.language import DeepseekV3Attention
+    from mlx_vlm.models.glm4_moe_lite.config import ModelConfig as GlmConfig
+    from mlx_vlm.models.glm4_moe_lite.language import Glm4MoeLiteAttention
+
+    common = dict(
+        vocab_size=128,
+        hidden_size=256,
+        intermediate_size=256,
+        moe_intermediate_size=128,
+        num_hidden_layers=1,
+        num_attention_heads=4,
+        num_key_value_heads=4,
+        n_shared_experts=1,
+        n_routed_experts=4,
+        num_experts_per_tok=2,
+        max_position_embeddings=512,
+        rms_norm_eps=1e-6,
+    )
+    yield "deepseek_v3", DeepseekV3Attention(
+        DSV3Config(model_type="deepseek_v3", **common)
+    )
+    yield "glm4_moe_lite", Glm4MoeLiteAttention(
+        GlmConfig(model_type="glm4_moe_lite", **common)
+    )
+
+
+class TestMaxAbsorbedQueries(unittest.TestCase):
+    def test_asymptotic_matches_mlx_lm(self):
+        # cache_len omitted -> the T -> inf limit, as in ml-explore/mlx-lm#1817
+        self.assertEqual(max_absorbed_queries(512, 128, 128), 170)
+        self.assertEqual(max_absorbed_queries(512, 192, 256), 398)
+
+    def test_cold_cache_rejects_the_absorbed_path(self):
+        # At T == L materializing is cheaper for every current model, so the
+        # threshold must fall below L rather than admit it.
+        for r, n, v in ((512, 128, 128), (512, 192, 256)):
+            for L in (2, 32, 64, 169, 398):
+                self.assertLess(
+                    max_absorbed_queries(r, n, v, cache_len=L),
+                    L,
+                    f"cold cache admitted L={L} for dims {(r, n, v)}",
+                )
+
+    def test_warm_cache_approaches_the_asymptote(self):
+        r, n, v = 512, 128, 128
+        limit = max_absorbed_queries(r, n, v)
+        self.assertEqual(max_absorbed_queries(r, n, v, cache_len=32768), limit - 1)
+        self.assertLess(max_absorbed_queries(r, n, v, cache_len=1024), limit)
+        # monotonic in cache length
+        seq = [max_absorbed_queries(r, n, v, cache_len=t) for t in (256, 1024, 8192)]
+        self.assertEqual(seq, sorted(seq))
+
+    def test_degenerate_dims_keep_the_decode_path(self):
+        self.assertEqual(max_absorbed_queries(64, 128, 128), 1)
+        self.assertGreaterEqual(max_absorbed_queries(1, 1, 1), 1)
+
+
+class TestLatentLength(unittest.TestCase):
+    def test_plain_array(self):
+        self.assertEqual(latent_length(mx.zeros((1, 1, 37, 8))), 37)
+
+    def test_quantized_tuple(self):
+        # A quantized KV cache hands back a 3-tuple rather than an array.
+        q = (mx.zeros((1, 1, 37, 2)), mx.zeros((1, 1, 37, 1)), mx.zeros((1, 1, 37, 1)))
+        self.assertEqual(latent_length(q), 37)
+
+
+class TestGateWiring(unittest.TestCase):
+    """Run the real __call__ and force each branch, so the gates are executed."""
+
+    def _both_branches(self, attn, L, cache_len):
+        mx.random.seed(0)
+        outs = []
+        for dims in (FORCE_MATERIALIZED, FORCE_ABSORBED):
+            mx.random.seed(0)
+            x = mx.random.normal((1, L, 256))
+            cache = KVCache()
+            if cache_len:
+                warm = mx.random.normal((1, L, 256))
+                mx.random.seed(0)
+                attn._absorbed_dims = dims
+                attn(warm, cache=cache)
+            attn._absorbed_dims = dims
+            outs.append(attn(x, cache=cache))
+        mx.eval(outs)
+        return outs
+
+    def test_branches_agree_through_call(self):
+        for name, attn in _dense_attentions():
+            mx.eval(attn.parameters())
+            with self.subTest(model=name):
+                materialized, absorbed = self._both_branches(attn, L=4, cache_len=8)
+                self.assertTrue(
+                    mx.allclose(materialized, absorbed, atol=1e-4, rtol=1e-4),
+                    f"{name}: absorbed and materialized disagree through __call__",
+                )
+
+
+class TestGatePairing(unittest.TestCase):
+    """The two gates must never disagree: one boolean drives both."""
+
+    MODELS = [
+        "deepseek_v3",
+        "deepseek_v32",
+        "kimi_k3",
+        "kimi_linear",
+        "longcat_flash",
+        "longcat_flash_sparse",
+        "glm4_moe_lite",
+        "glm_moe_dsa",
+        "glm5_next",
+        "youtu_vl",
+    ]
+
+    def test_one_boolean_two_uses(self):
+        import pathlib
+
+        root = pathlib.Path(__file__).resolve().parents[1] / "models"
+        for m in self.MODELS:
+            src = (root / m / "language.py").read_text()
+            with self.subTest(model=m):
+                self.assertEqual(
+                    src.count("absorbed = L == 1 or L <= max_absorbed_queries("),
+                    1,
+                    f"{m}: expected exactly one gate decision",
+                )
+                self.assertEqual(
+                    src.count("if absorbed:"), 2, f"{m}: expected both gates to use it"
+                )
+
+
+class TestIndexerGateUnchanged(unittest.TestCase):
+    """The sparse top-k gather stays at L == 1.
+
+    It selects with ``topk_indices[:, :, 0, :]``, the first query's top-k, so
+    widening it would apply one query's selection to all of them.
+    """
+
+    SPARSE = [
+        "deepseek_v32",
+        "longcat_flash_sparse",
+        "glm5_next",
+        "glm_moe_dsa",
+    ]
+
+    def test_first_query_gather_is_still_gated_on_one_query(self):
+        import pathlib
+        import re
+
+        root = pathlib.Path(__file__).resolve().parents[1] / "models"
+        gate = re.compile(
+            r"if L == 1:\s*\n\s*(?:clamped = mx\.clip\(topk_indices|idx = topk_indices)"
+        )
+        for m in self.SPARSE:
+            src = (root / m / "language.py").read_text()
+            with self.subTest(model=m):
+                self.assertRegex(
+                    src,
+                    gate,
+                    f"{m}: the first-query top-k gather is no longer gated on L == 1",
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The absorbed MLA path is gated on `L == 1`. Any step with more than one query materialises K and V across the whole cached latent instead, and materialising costs O(T) in the cached length regardless of how many queries you have, while the absorbed path costs O(L). The crossover is therefore a fixed query count per model:

```
kv_lora_rank * (nope + v) / (2 * kv_lora_rank - nope - v)
```

For DeepSeek V3 that is 170 queries and for GLM-4 MoE Lite it is 398, against a gate that admits exactly one. So every speculative verify step, and every short continuation on a warm cache, has been taking the expensive branch.

This adds `max_absorbed_queries()` to `models/mla.py` and applies it in the ten models with an absorbed path: `deepseek_v3`, `deepseek_v32`, `kimi_k3`, `kimi_linear`, `longcat_flash`, `longcat_flash_sparse`, `glm4_moe_lite`, `glm_moe_dsa`, `glm5_next` and `youtu_vl`. The helper is byte-identical to the one in ml-explore/mlx-lm#1817, including the attribute name, so the two runtimes pick the same width for a shared model.

It is the same reasoning as my mlx-lm PR ml-explore/mlx-lm#1817, extended here to four models that do not exist in mlx-lm.

## Multi-turn chat, which needs no drafter

`DEFAULT_PREFILL_STEP_SIZE` is 2048, so a long prompt chunks above the crossover and is unaffected. A follow-up turn on a warm cache is not chunked though, it is one step of however many tokens the turn holds, and that is where most people will see this. Moonlight-16B-A3B-Instruct-4-bit at 32K context, full forward pass, M3 Max, medians of 5:

| follow-up turn | stock | patched | speedup |
|---:|---:|---:|---:|
| 16 tokens | 497 ms | 85 ms | 5.8x |
| 32 tokens | 515 ms | 161 ms | 3.2x |
| 64 tokens | 543 ms | 271 ms | 2.0x |

## Speculative verify steps

Same model and setup, at the draft lengths the in-tree MTP drafters use:

| context | L=1 | L=2 | L=4 | L=8 |
|---:|---:|---:|---:|---:|
| 32768 stock | 17.3 ms | 380.8 ms | 394.6 ms | 413.0 ms |
| 32768 patched | 17.3 ms | 22.1 ms | 28.7 ms | 47.8 ms |
| speedup | 1.00x | 17.3x | 13.8x | 8.6x |

At 16384 the same three steps are 10.7x, 8.9x and 5.9x, and at 4096 they are 4.2x, 3.4x and 2.5x. L=1 is unchanged because the gate already picked the absorbed path there, which makes that row a control on the rest of the table.

The stock row is nearly flat across L because the cost is dominated by materialising K and V over the cache, which does not depend on L at all, so one extra token costs 21x more than the first one does at 32K.

## Memory

Materialising also expands the latent into per-head K and V. Peak memory for a single attention call at 32768 context drops from 2478 MB to 462 MB at L=4, and the absorbed path stays lower at every L up to the threshold (2742 MB against 3602 MB at L=144).

## The sparse indexer gate is left alone

`deepseek_v32`, `longcat_flash_sparse`, `glm5_next` and `glm_moe_dsa` have a second `L == 1` gate on the sparse top-k gather. That one selects with `topk_indices[:, :, 0, :]`, the first query's top-k, which is only correct for a single query, so widening it would silently apply one query's selection to all of them. It stays at `L == 1` and there is a test asserting it stays there.

## Numerics

In float32 the two forms agree to a relative 3.4e-06 across L = 1 to 170 at batch 1, 2 and 4, because they are the same linear algebra associated differently. At L = 1 the patch is a no-op and output is bit-identical.

I want to be clear about the quantised case. On 4-bit weights the two forms reorder quantised matmuls, so a wide step is not bit-identical to the other form. Teacher-forced over 1024 positions with token-by-token prefill as the reference, the stock wide chunk agrees on 98.54% of argmaxes and the patched wide chunk on 98.34%. Every disagreement sits at a near-tie, with top-2 margins between 0.00 and 0.30 against a median margin of 0.664, on a logit scale of
23.4. Drift of this size is already present without the patch, because the stock
wide chunk diverges from sequential prefill at the same rate, and in free-running greedy decode at the same token.

## Testing

Unmodified main gives `3131 passed` and this branch gives `3137 passed`, the difference being the six tests added here, with per-file results otherwise identical, so the change moves no existing test either way. `test_smoke.py` fails to collect on this branch and on unmodified main alike, which is unrelated to this change.

`mlx_vlm/tests/test_absorbed_mla.py` covers the threshold formula, wide-step parity against the materialised form, and the preserved indexer gate.

## The glm5_next hunk overlaps #2127

`glm5_next` is one of the ten models changed here, and #2127 adds that file at full length, so this is the one place the two PRs touch the same lines. That overlap is what superseded my earlier #2141, which only changed `glm5_next`. I am happy to wait on #2127 and re-apply this hunk afterwards, or to drop `glm5_next` from this PR entirely if that is easier to review, since the other nine models stand on their own either way. Let me know which you prefer.

## What I did not measure

Moonlight-16B is the only one of the ten models I have local weights for, so the end-to-end numbers above are all from `deepseek_v3` and the other nine are covered by the unit tests and by the block being identical. I also have no cached model that pairs a dense-MLA target with a working MTP drafter, so the speculative numbers are per-step costs rather than a full generation loop with measured acceptance.

