### PR TITLE
Enable speculative decoding for Laguna

### DIFF
--- a/mlx_vlm/models/laguna/language.py
+++ b/mlx_vlm/models/laguna/language.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Optional, Union
+from typing import Any, Dict, List, Optional, Union
 
 import mlx.core as mx
 import mlx.nn as nn
@@ -274,6 +274,8 @@ class LagunaModel(nn.Module):
         inputs: mx.array,
         cache=None,
         inputs_embeds: Optional[mx.array] = None,
+        capture_layer_ids: Optional[List[int]] = None,
+        hidden_sink: Optional[list] = None,
     ) -> mx.array:
         if inputs_embeds is not None:
             h = inputs_embeds
@@ -289,13 +291,16 @@ class LagunaModel(nn.Module):
                 h, cache[self.swa_idx], window_size=self.args.sliding_window
             )
 
-        for layer, c in zip(self.layers, cache):
+        capture_set = set(capture_layer_ids) if capture_layer_ids else set()
+        for index, (layer, c) in enumerate(zip(self.layers, cache)):
             mask = (
                 sliding_mask
                 if layer.attention_type == "sliding_attention"
                 else full_mask
             )
             h = layer(h, mask, c)
+            if hidden_sink is not None and index in capture_set:
+                hidden_sink.append(h)
         return self.norm(h)
 
 
@@ -315,18 +320,27 @@ class LanguageModel(nn.Module):
         cache=None,
         input_embeddings: Optional[mx.array] = None,
         inputs_embeds: Optional[mx.array] = None,
+        capture_layer_ids: Optional[List[int]] = None,
         **kwargs,
     ) -> LanguageModelOutput:
         if inputs is None:
             inputs = kwargs.get("input_ids")
         if inputs_embeds is None:
             inputs_embeds = input_embeddings
-        out = self.model(inputs, cache, inputs_embeds)
+        kwargs.pop("speculative_verify", None)
+        hidden_sink: Optional[list] = [] if capture_layer_ids is not None else None
+        out = self.model(
+            inputs,
+            cache,
+            inputs_embeds,
+            capture_layer_ids=capture_layer_ids,
+            hidden_sink=hidden_sink,
+        )
         if self.args.tie_word_embeddings:
             out = self.model.embed_tokens.as_linear(out)
         else:
             out = self.lm_head(out)
-        return LanguageModelOutput(logits=out)
+        return LanguageModelOutput(logits=out, hidden_states=hidden_sink)
 
     def sanitize(self, weights):
         if self.args.tie_word_embeddings:
@@ -553,6 +567,41 @@ class LanguageModel(nn.Module):
     @property
     def n_kv_heads(self):
         return self.args.num_key_value_heads
+
+    def rollback_speculative_cache(
+        self,
+        caches: List[Any],
+        gdn_states: Any,
+        accepted: Any,
+        block_size: int,
+    ) -> int:
+        """Commit the accepted speculative prefix and drop rejected entries.
+
+        Laguna holds only KV and RotatingKV caches, so committing is a trim.
+        ``gdn_states`` is accepted and ignored, for parity with the targets
+        that carry recurrent state.
+        """
+        del gdn_states
+        if isinstance(accepted, int):
+            accepted = mx.array([accepted], dtype=mx.int32)
+        elif not isinstance(accepted, mx.array):
+            accepted = mx.array(accepted, dtype=mx.int32)
+
+        max_accepted = int(accepted.max().item())
+        if accepted.size > 1 and int(accepted.min().item()) != max_accepted:
+            raise RuntimeError(
+                "Laguna batched speculative rollback requires uniform per-row "
+                f"acceptance; got ragged accepts {accepted.tolist()}. Set "
+                "requires_uniform_batch_acceptance on the drafter or target so "
+                "accepts are clamped before rollback."
+            )
+
+        trim = block_size - max_accepted - 1
+        if trim > 0:
+            for cache in caches:
+                if cache is not None and hasattr(cache, "trim"):
+                    cache.trim(trim)
+        return max_accepted
 
     def make_cache(self):
         return [

--- a/mlx_vlm/speculative/drafters/laguna_dflash/config.py
+++ b/mlx_vlm/speculative/drafters/laguna_dflash/config.py
@@ -17,7 +17,6 @@ _REQUIRED_CHECKPOINT_FIELDS = {
     "max_position_embeddings",
     "rope_theta",
     "layer_types",
-    "sliding_windows",
     "sliding_window",
     "gating",
     "eagle_aux_hidden_state_layer_ids",
@@ -65,8 +64,17 @@ def validate_laguna_dflash_target(
     target_model_config: Any = None,
     target_model_layer_count: Optional[int] = None,
     target_tokenizer_length: Optional[int] = None,
+    target_language_model: Any = None,
 ) -> None:
     """Validate target-model identity before binding shared target tensors."""
+    if target_language_model is not None and not hasattr(
+        target_language_model, "rollback_speculative_cache"
+    ):
+        raise ValueError(
+            "Laguna DFlash target "
+            f"{type(target_language_model).__name__} does not expose speculative "
+            "cache rollback support."
+        )
     if target_model_layer_count is None and target_model_config is not None:
         target_model_layer_count = _target_layer_count(target_model_config)
     if target_model_layer_count is None:
@@ -230,6 +238,10 @@ class DFlashConfig(BaseModelConfig):
             merged["aux_hidden_state_layer_ids"] = raw[
                 "eagle_aux_hidden_state_layer_ids"
             ]
+        if not merged.get("sliding_windows"):
+            merged["sliding_windows"] = [merged["sliding_window"]] * int(
+                merged["num_hidden_layers"]
+            )
 
         signature = inspect.signature(cls).parameters
         config = cls(**{k: v for k, v in merged.items() if k in signature})

--- a/mlx_vlm/speculative/drafters/laguna_dflash/dflash.py
+++ b/mlx_vlm/speculative/drafters/laguna_dflash/dflash.py
@@ -275,15 +275,16 @@ class LagunaDFlashDraftModel(nn.Module):
         tokenizer_length = len(tokenizer) if tokenizer is not None else None
         if tokenizer_length is None and target_config is not None:
             tokenizer_length = getattr(target_config, "vocab_size", None)
+        lm = getattr(target_model, "language_model", target_model)
         validate_laguna_dflash_target(
             self.config,
             target_model_config=target_config,
             target_model_layer_count=target_layer_count,
             target_tokenizer_length=tokenizer_length,
+            target_language_model=lm,
         )
         self.embed_tokens = inner.embed_tokens
         self.embed_scale = getattr(self.embed_tokens, "embed_scale", 1.0)
-        lm = getattr(target_model, "language_model", target_model)
         self.lm_head = getattr(lm, "lm_head", None) or self.embed_tokens.as_linear
         return self
 
@@ -297,6 +298,7 @@ class LagunaDFlashDraftModel(nn.Module):
             target_model_layer_count=(
                 len(target_layers) if target_layers is not None else None
             ),
+            target_language_model=target,
         )
 
     def make_cache(self) -> List[KVCache]:

--- a/mlx_vlm/tests/test_laguna_dflash_drafter.py
+++ b/mlx_vlm/tests/test_laguna_dflash_drafter.py
@@ -154,6 +154,7 @@ def test_generic_drafter_gate_invokes_laguna_target_validation():
     target = SimpleNamespace(
         config=SimpleNamespace(num_hidden_layers=48, vocab_size=100352),
         model=SimpleNamespace(layers=[object()] * 48),
+        rollback_speculative_cache=lambda *args: 0,
     )
 
     validate_drafter_compatibility(target, draft, "dflash")
@@ -203,3 +204,17 @@ def test_weight_key_drift_is_rejected():
 
     with pytest.raises(ValueError, match="weight keys"):
         validate_laguna_dflash_weights(weights, config)
+
+
+def test_target_without_rollback_support_is_rejected():
+    config = ModelConfig.from_dict(_config_dict())
+
+    with pytest.raises(ValueError, match="rollback"):
+        validate_laguna_dflash_target(
+            config,
+            target_model_config=SimpleNamespace(
+                num_hidden_layers=48, vocab_size=100352
+            ),
+            target_tokenizer_length=100352,
+            target_language_model=SimpleNamespace(),
+        )

--- a/mlx_vlm/tests/test_speculative.py
+++ b/mlx_vlm/tests/test_speculative.py
@@ -19,6 +19,7 @@ from mlx.utils import tree_flatten, tree_map
 
 import mlx_vlm.models.deepseek_v4.language as deepseek_language
 import mlx_vlm.models.gemma4.language as gemma4_language
+import mlx_vlm.models.laguna.language as laguna_language
 import mlx_vlm.models.qwen3_5.language as qwen_language
 import mlx_vlm.models.qwen3_5.speculative_verifier as qwen_verifier
 import mlx_vlm.models.qwen3_5_moe.language as qwen_moe_language
@@ -4184,3 +4185,148 @@ def test_split_glm4_moe_lite_mtp_flattens_nextn_layer(tmp_path):
     assert out["model.mtp_block.mlp.gate.e_score_correction_bias"].dtype == mx.float32
     # non-parameter buffers are dropped
     assert not any(k.endswith("rotary_emb.inv_freq") for k in out)
+
+
+def _laguna_language_model(num_hidden_layers=4):
+    from mlx_vlm.models.laguna.config import ModelConfig
+
+    config = ModelConfig(
+        model_type="laguna",
+        vocab_size=256,
+        hidden_size=64,
+        intermediate_size=128,
+        num_hidden_layers=num_hidden_layers,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        head_dim=16,
+        max_position_embeddings=512,
+        sliding_window=32,
+        layer_types=["sliding_attention", "full_attention"] * (num_hidden_layers // 2),
+    )
+    model = laguna_language.LanguageModel(config)
+    mx.eval(model.parameters())
+    return model
+
+
+def test_laguna_exposes_speculative_cache_rollback():
+    assert hasattr(laguna_language.LanguageModel, "rollback_speculative_cache")
+
+
+def test_laguna_rollback_trims_rejected_speculative_tail():
+    class DummyCache:
+        def __init__(self):
+            self.trims = []
+
+        def trim(self, n):
+            self.trims.append(n)
+
+    cache = DummyCache()
+    max_accepted = laguna_language.LanguageModel.rollback_speculative_cache(
+        SimpleNamespace(), [cache], None, 1, block_size=4
+    )
+
+    assert max_accepted == 1
+    assert cache.trims == [2]
+
+
+def test_laguna_rollback_skips_trim_when_block_fully_accepted():
+    class DummyCache:
+        def __init__(self):
+            self.trims = []
+
+        def trim(self, n):
+            self.trims.append(n)
+
+    cache = DummyCache()
+    laguna_language.LanguageModel.rollback_speculative_cache(
+        SimpleNamespace(), [cache], None, 3, block_size=4
+    )
+
+    assert cache.trims == []
+
+
+def test_laguna_rollback_rejects_ragged_batch_acceptance():
+    with pytest.raises(RuntimeError, match="uniform per-row"):
+        laguna_language.LanguageModel.rollback_speculative_cache(
+            SimpleNamespace(), [None], None, [0, 2], block_size=4
+        )
+
+
+def test_laguna_rollback_advances_real_cache_offsets():
+    model = _laguna_language_model()
+    cache = model.make_cache()
+    model(mx.array([[1, 2, 3, 4]]), cache=cache)
+    assert [c.offset for c in cache] == [4, 4, 4, 4]
+
+    model.rollback_speculative_cache(cache, None, 1, block_size=4)
+
+    assert [c.offset for c in cache] == [2, 2, 2, 2]
+
+
+def test_laguna_captures_target_hidden_states_for_dflash():
+    model = _laguna_language_model()
+    out = model(
+        mx.array([[1, 2, 3, 4]]),
+        cache=model.make_cache(),
+        capture_layer_ids=[1, 2],
+        speculative_verify=True,
+    )
+
+    assert out.hidden_states is not None
+    assert [h.shape for h in out.hidden_states] == [(1, 4, 64), (1, 4, 64)]
+    assert mx.concatenate(out.hidden_states, axis=-1).shape == (1, 4, 128)
+
+
+def test_laguna_omits_hidden_states_without_capture_request():
+    model = _laguna_language_model()
+    out = model(mx.array([[1, 2, 3, 4]]), cache=model.make_cache())
+
+    assert out.hidden_states is None
+
+
+def test_laguna_dflash_binding_requires_target_rollback_hook():
+    from mlx_vlm.speculative.drafters.laguna_dflash.config import (
+        validate_laguna_dflash_target,
+    )
+
+    config = SimpleNamespace(num_target_layers=4, vocab_size=256)
+    with pytest.raises(ValueError, match="rollback"):
+        validate_laguna_dflash_target(
+            config,
+            target_model_layer_count=4,
+            target_tokenizer_length=256,
+            target_language_model=SimpleNamespace(),
+        )
+
+
+def test_laguna_dflash_config_derives_sliding_windows_when_absent():
+    from mlx_vlm.speculative.drafters.laguna_dflash.config import DFlashConfig
+
+    params = {
+        "model_type": "laguna",
+        "hidden_size": 64,
+        "intermediate_size": 128,
+        "num_hidden_layers": 2,
+        "num_attention_heads": 4,
+        "num_key_value_heads": 2,
+        "head_dim": 16,
+        "vocab_size": 256,
+        "draft_vocab_size": 256,
+        "max_position_embeddings": 512,
+        "rope_theta": 500000.0,
+        "layer_types": ["sliding_attention"] * 2,
+        "sliding_window": 512,
+        "gating": "per-head",
+        "eagle_aux_hidden_state_layer_ids": [2, 4],
+        "dflash_config": {
+            "block_size": 16,
+            "mask_token_id": 3,
+            "target_layer_ids": [1, 3],
+            "num_target_layers": 4,
+            "causal": True,
+        },
+    }
+
+    config = DFlashConfig.from_dict(params)
+
+    assert config.sliding_windows == [512, 512]


### PR DESCRIPTION
The Laguna DFlash drafter is registered but speculative decoding could not run: the target model exposed no `rollback_speculative_cache` and silently dropped `capture_layer_ids`, so the dflash round loop refused to start. The drafter config also rejected the published XS checkpoints over a missing `sliding_windows` field, which is redundant with `sliding_window` and is now derived when absent.

| ctx | baseline | dflash | speedup | mean accept |
| --- | --- | --- | --- | --- |
| 512 | 84.70 | 304.27 | 3.59x | 10.64 |
| 2048 | 83.48 | 313.96 | 3.76x | 11.80 |
| 4096 | 81.32 | 343.29 | 4.22x | 13.22 |

Decode-only tok/s, 128 tokens greedy, target `poolside/Laguna-XS-2.1-NVFP4-mlx` with drafter `poolside/Laguna-XS-2.1-DFlash`. Output is token-identical to base decoding at every context.
