### PR TITLE
Fix Gemma4DSparkAttention AttributeError on first forward

### DIFF
--- a/mlx_vlm/speculative/drafters/gemma4_dspark/gemma4_dspark.py
+++ b/mlx_vlm/speculative/drafters/gemma4_dspark/gemma4_dspark.py
@@ -68,6 +68,14 @@ class Gemma4DSparkAttention(DFlashAttention):
         else:
             self.n_kv_heads = config.num_key_value_heads
         self.scale = 1.0
+        # Set here too: this __init__ bypasses DFlashAttention.__init__ for Gemma 4's
+        # geometry, but the inherited __call__ still reads both of these.
+        self.is_causal = bool(getattr(config, "is_causal", self.is_sliding))
+        self.attention_sink_bias = (
+            mx.zeros((self.n_heads,))
+            if getattr(config, "attention_sink_bias", False)
+            else None
+        )
 
         dim = config.hidden_size
         self.q_proj = nn.Linear(dim, self.n_heads * self.head_dim, bias=False)

--- a/mlx_vlm/speculative/drafters/gemma4_dspark/gemma4_dspark.py
+++ b/mlx_vlm/speculative/drafters/gemma4_dspark/gemma4_dspark.py
@@ -68,8 +68,7 @@ class Gemma4DSparkAttention(DFlashAttention):
         else:
             self.n_kv_heads = config.num_key_value_heads
         self.scale = 1.0
-        # Set here too: this __init__ bypasses DFlashAttention.__init__ for Gemma 4's
-        # geometry, but the inherited __call__ still reads both of these.
+
         self.is_causal = bool(getattr(config, "is_causal", self.is_sliding))
         self.attention_sink_bias = (
             mx.zeros((self.n_heads,))

--- a/mlx_vlm/tests/test_models_dspark.py
+++ b/mlx_vlm/tests/test_models_dspark.py
@@ -1174,6 +1174,28 @@ def test_gemma4_dspark_attention_shares_key_and_value_projection():
     assert keys.shape == values.shape == (1, 3, 512)
 
 
+def test_gemma4_dspark_attention_forward_runs():
+    """A forward must not raise: the custom __init__ still has to set is_causal and
+    attention_sink_bias, which the inherited DFlashAttention.__call__ reads."""
+    from mlx_vlm.models.cache import KVCache
+    from mlx_vlm.speculative.drafters.gemma4_dspark import Model as G4Model
+    from mlx_vlm.speculative.drafters.gemma4_dspark import ModelConfig as G4Config
+    from mlx_vlm.speculative.drafters.gemma4_dspark.gemma4_dspark import (
+        Gemma4DSparkAttention,
+    )
+
+    config = G4Config.from_dict(_published_gemma4_dspark_config())
+    rope = G4Model(config).rope
+    attention = Gemma4DSparkAttention(config, 0)
+    x = mx.zeros((1, 2, config.hidden_size))
+    x_ctx = mx.zeros((1, 3, config.hidden_size))
+
+    out = attention(x, x_ctx, rope, KVCache())
+    mx.eval(out)
+
+    assert out.shape == (1, 2, config.hidden_size)
+
+
 def test_generic_loader_routes_gemma4_dspark_checkpoint(tmp_path):
     """The checkpoint declares gemma4_text, so routing keys off the architecture tag."""
     from mlx_vlm.speculative.drafters.gemma4_dspark import Model as G4Model


### PR DESCRIPTION
Gemma4DSparkAttention skips DFlashAttention.__init__ for Gemma 4's geometry but never set the `is_causal` / `attention_sink_bias` its inherited `__call__` reads, so it crashed on the first forward — this sets both and adds a forward smoke test.