### PR TITLE
Add Z1T-0 (Extropic attention-free sparse LM)

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Some models have detailed documentation with prompt formats, examples, and best 
 | GLiNER2.5 | [Docs](https://github.com/Blaizzy/mlx-vlm/blob/main/mlx_vlm/models/gliner2_5/README.md) |
 | LLaVA-OneVision | [Docs](https://github.com/Blaizzy/mlx-vlm/blob/main/mlx_vlm/models/llava_onevision/README.md) |
 | K2-Horizon | [Docs](https://github.com/Blaizzy/mlx-vlm/blob/main/mlx_vlm/models/k2_horizon/README.md) |
+| Z1T-0 | [Docs](https://github.com/Blaizzy/mlx-vlm/blob/main/mlx_vlm/models/z1t/README.md) |
 
 ## Installation
 

--- a/mlx_vlm/models/z1t/README.md
+++ b/mlx_vlm/models/z1t/README.md
@@ -1,0 +1,37 @@
+# Z1T-0
+
+Z1T-0 is Extropic's open-weight, **attention-free** decoder LM, ported from JAX/Equinox
+([extropic-ai/sparse-transformers](https://github.com/extropic-ai/sparse-transformers),
+[writeup](https://extropic.ai/writing/z1t)). It has no softmax attention: each block mixes
+tokens with AFT-conv — a causal depthwise conv plus a causal cumulative pool. Dynamic-Tanh
+(DyT) is the only normalization, and every internal projection is a fixed fan-in-`k` sparse
+`tanh`-linear. Decoding is O(1) per token via a small per-layer streaming cache (running pool
+sums + conv window). Tokenizer is GPT-2 BPE.
+
+## Supported Models
+
+| Model ID | Notes |
+|---|---|
+| `AlazarM/Z1T-0-mlx` | MLX conversion of the open weights (fp32) |
+| `Extropic-AI/Z1T-0` | Original JAX/Equinox `.eqx` checkpoint — convert to MLX first |
+
+## Model
+
+| Vocab | Hidden | Layers | AFT heads | Conv ksize | Fan-in | Max pos |
+|--:|--:|--:|--:|--:|--:|--:|
+| 50257 | 12288 | 4 | 4 | 4 | 4 | 256 |
+
+The published checkpoint ships a numerically-zero positional table (AFT-conv already carries
+local position), so absolute position is effectively unused.
+
+## CLI Usage
+
+```bash
+python -m mlx_vlm.generate \
+    --model AlazarM/Z1T-0-mlx \
+    --prompt "The meaning of life is" \
+    --max-tokens 64 \
+    --temp 0.0
+```
+
+This is a small research model (4 layers); generations are short and repetitive by design.

--- a/mlx_vlm/models/z1t/__init__.py
+++ b/mlx_vlm/models/z1t/__init__.py
@@ -1,0 +1,4 @@
+from .config import ModelConfig
+from .z1t import Model
+
+__all__ = ["Model", "ModelConfig"]

--- a/mlx_vlm/models/z1t/config.py
+++ b/mlx_vlm/models/z1t/config.py
@@ -1,0 +1,31 @@
+from dataclasses import dataclass
+from typing import List, Optional, Union
+
+from ..base import BaseModelConfig
+
+
+@dataclass
+class ModelConfig(BaseModelConfig):
+    model_type: str = "z1t"
+    vocab_size: int = 50257
+    hidden_size: int = 12288
+    num_hidden_layers: int = 4
+    max_position_embeddings: int = 256
+    aft_kind: str = "conv"
+    aft_heads: int = 4
+    aft_ksize: int = 4
+    dyt_alpha: float = 0.5
+    linear_fan_in: Optional[int] = None  # shared fixed sparse fan-in; None = dense
+    attn_fan_in: Optional[int] = None  # per-site override for attention linears
+    mlp_fan_in: Optional[int] = None  # per-site override for MLP linears
+    tanh_linear: bool = (
+        False  # wrap every internal linear as tanh(Wx + b); lm_head exempt
+    )
+    tanh_mlp: bool = False  # MLP activation is tanh instead of silu
+    tie_word_embeddings: bool = False
+    bos_token_id: Optional[int] = None
+    eos_token_id: Optional[Union[int, List[int]]] = None
+
+    def fan_in(self, site: str) -> Optional[int]:
+        override = getattr(self, f"{site}_fan_in")
+        return override if override is not None else self.linear_fan_in

--- a/mlx_vlm/models/z1t/language.py
+++ b/mlx_vlm/models/z1t/language.py
@@ -93,6 +93,32 @@ class Z1TCache:
         self.win_eKV = None
         self.win_eK = None
 
+    # APC prefix-cache contract: snapshot/restore the streaming state so a
+    # reused prefix restores the pool sums and conv window (auto-detected as a
+    # CHECKPOINT cache; see mlx_vlm.apc_adapters).
+    @property
+    def state(self):
+        return (self.cum_eKV, self.cum_eK, self.win_eKV, self.win_eK)
+
+    @state.setter
+    def state(self, value):
+        self.cum_eKV, self.cum_eK, self.win_eKV, self.win_eK = value
+
+    @property
+    def meta_state(self):
+        return str(self.offset)
+
+    @meta_state.setter
+    def meta_state(self, value):
+        self.offset = int(value) if value else 0
+
+    @classmethod
+    def from_state(cls, state, meta_state):
+        cache = cls.__new__(cls)
+        cache.state = state
+        cache.meta_state = meta_state
+        return cache
+
 
 class AFTConv(nn.Module):
     """AFT-conv (causal): depthwise conv stencil + causal cumulative pool.

--- a/mlx_vlm/models/z1t/language.py
+++ b/mlx_vlm/models/z1t/language.py
@@ -1,0 +1,331 @@
+"""Z1T: attention-free (AFT-conv), DyT-normed, fixed-sparsity decoder LM.
+
+Port of Extropic's `z1t` (github.com/extropic-ai/sparse-transformers) into the
+mlx-vlm text-model interface. Each block mixes tokens with a causal depthwise
+conv plus a causal cumulative pool (no softmax / no q.k). This has no key/value
+tensors, so it does not use `KVCache`; instead each layer keeps a `Z1TCache`
+holding its running pool sums and its `ksize-1` conv window, giving O(1)/step
+decode that is exact vs the flat forward (window-prepend == same conv;
+prior-sum + cumsum(chunk) == same pool).
+"""
+
+import math
+from typing import Optional
+
+import mlx.core as mx
+import mlx.nn as nn
+
+from ..base import LanguageModelOutput
+from .config import ModelConfig
+
+
+def _sparse_count(fan_in: Optional[int], dim: int) -> int:
+    if fan_in is None:
+        return dim
+    return max(1, min(fan_in, dim))
+
+
+# Cap the transient (B, chunk, out, k) gather so a long prefill stays in memory;
+# the gather is split along the sequence axis, which is exact.
+_SPARSE_CHUNK_ELEMS = 8_000_000
+
+
+class SparseLinear(nn.Module):
+    """y = sum_k weight * x[indices] + bias. `indices` is a fixed, non-trained
+    (out, k) fan-in table stored as an int param so it loads from the checkpoint."""
+
+    def __init__(self, in_features: int, out_features: int, k: int):
+        super().__init__()
+        self.weight = mx.zeros((out_features, k))
+        self.bias = mx.zeros((out_features,))
+        self.indices = mx.zeros((out_features, k), dtype=mx.int32)
+
+    def _gather(self, x: mx.array, idx: mx.array) -> mx.array:
+        return (mx.take(x, idx, axis=-1) * self.weight).sum(axis=-1) + self.bias
+
+    def __call__(self, x: mx.array) -> mx.array:
+        idx = self.indices
+        if idx.dtype not in (mx.int32, mx.int64, mx.uint32):
+            idx = idx.astype(mx.int32)
+        out_features = self.weight.shape[0]
+        if x.ndim == 3 and x.shape[1] * out_features > _SPARSE_CHUNK_ELEMS:
+            step = max(1, _SPARSE_CHUNK_ELEMS // out_features)
+            parts = [
+                self._gather(x[:, s : s + step], idx)
+                for s in range(0, x.shape[1], step)
+            ]
+            return mx.concatenate(parts, axis=1)
+        return self._gather(x, idx)
+
+
+def _make_linear(in_features: int, out_features: int, fan_in: Optional[int]):
+    k = _sparse_count(fan_in, in_features)
+    if k >= in_features:
+        return nn.Linear(in_features, out_features)
+    return SparseLinear(in_features, out_features, k)
+
+
+class DyT(nn.Module):
+    """Dynamic Tanh: weight * tanh(alpha * x) + bias over the last axis."""
+
+    def __init__(self, dim: int, alpha_init: float = 0.5):
+        super().__init__()
+        self.alpha = mx.array([alpha_init])
+        self.weight = mx.ones((dim,))
+        self.bias = mx.zeros((dim,))
+
+    def __call__(self, x: mx.array) -> mx.array:
+        return self.weight * mx.tanh(self.alpha * x) + self.bias
+
+
+class Z1TCache:
+    """Per-layer streaming state for AFT-conv decode.
+
+    Holds the running pool sums (`cum_eKV`, `cum_eK`) and the last `ksize-1`
+    conv-window values (`win_eKV`, `win_eK`). Empty state == zeros == the flat
+    forward's left-padding, so a fresh cache reproduces the full-sequence result.
+    """
+
+    def __init__(self):
+        self.offset = 0
+        self.cum_eKV = None
+        self.cum_eK = None
+        self.win_eKV = None
+        self.win_eK = None
+
+
+class AFTConv(nn.Module):
+    """AFT-conv (causal): depthwise conv stencil + causal cumulative pool.
+
+    Threads an optional `Z1TCache`: prepends the prior conv window and continues
+    the pool from the prior running sums, so decoding one token is O(1) in the
+    context length while matching the flat forward.
+    """
+
+    def __init__(self, config: ModelConfig):
+        super().__init__()
+        dim, heads = config.hidden_size, config.aft_heads
+        assert dim % heads == 0, "hidden_size must be divisible by aft_heads"
+        self.dim = dim
+        self.heads = heads
+        self.ksize = config.aft_ksize
+        self.tanh_linear = config.tanh_linear
+        fan = config.fan_in("attn")
+        self.qkv_proj = _make_linear(dim, 2 * dim + heads, fan)
+        self.out_proj = _make_linear(dim, dim, fan)
+        self.w_conv = mx.zeros((heads, self.ksize))
+
+    def __call__(self, x: mx.array, cache: Optional[Z1TCache] = None) -> mx.array:
+        if cache is not None and x.shape[1] == 1:
+            return self._decode_step(x, cache)
+
+        B, Ln, dim = x.shape
+        h, hd, s = self.heads, dim // self.heads, self.ksize
+
+        qkv = self.qkv_proj(x)
+        if self.tanh_linear:
+            qkv = mx.tanh(qkv)
+        Q = qkv[..., :dim]
+        V = qkv[..., dim : 2 * dim]
+        K = qkv[..., 2 * dim :]
+        Qh = Q.reshape(B, Ln, h, hd)
+        Vh = V.reshape(B, Ln, h, hd)
+
+        eK = mx.exp(mx.tanh(K))  # (B, Ln, h)
+        kernel = mx.exp(self.w_conv) - 1.0  # (h, s)
+        eKV = eK[..., None] * Vh  # (B, Ln, h, hd)
+
+        if cache is not None and cache.cum_eKV is not None:
+            cum_eKV, cum_eK = cache.cum_eKV, cache.cum_eK
+            win_eKV, win_eK = cache.win_eKV, cache.win_eK
+        else:
+            cum_eKV = mx.zeros((B, h, hd), x.dtype)
+            cum_eK = mx.zeros((B, h), x.dtype)
+            win_eKV = mx.zeros((B, s - 1, h, hd), x.dtype)
+            win_eK = mx.zeros((B, s - 1, h), x.dtype)
+
+        # depthwise causal conv over [window ++ new]: output[t] = sum_j k_j * ext[t+j]
+        eKV_ext = mx.concatenate([win_eKV, eKV], axis=1)  # (B, s-1+Ln, h, hd)
+        eK_ext = mx.concatenate([win_eK, eK], axis=1)  # (B, s-1+Ln, h)
+        num_conv = mx.zeros((B, Ln, h, hd), x.dtype)
+        den_conv = mx.zeros((B, Ln, h), x.dtype)
+        for j in range(s):
+            num_conv = (
+                num_conv + kernel[:, j].reshape(1, 1, h, 1) * eKV_ext[:, j : j + Ln]
+            )
+            den_conv = den_conv + kernel[:, j].reshape(1, 1, h) * eK_ext[:, j : j + Ln]
+
+        # global pool: prior running sum + inclusive cumsum within the new chunk
+        run_eKV = cum_eKV[:, None] + mx.cumsum(eKV, axis=1)
+        run_eK = cum_eK[:, None] + mx.cumsum(eK, axis=1)
+        num = num_conv + run_eKV
+        den = den_conv + run_eK
+        ctx = num / (den[..., None] + 1e-6)
+        Y = (mx.tanh(Qh) * ctx).reshape(B, Ln, dim)
+
+        out = self.out_proj(Y)
+        if self.tanh_linear:
+            out = mx.tanh(out)
+
+        if cache is not None:
+            cache.cum_eKV = cum_eKV + eKV.sum(axis=1)
+            cache.cum_eK = cum_eK + eK.sum(axis=1)
+            if s > 1:
+                cache.win_eKV = eKV_ext[:, -(s - 1) :]
+                cache.win_eK = eK_ext[:, -(s - 1) :]
+            cache.offset += Ln
+            mx.eval(cache.cum_eKV, cache.cum_eK, cache.win_eKV, cache.win_eK)
+        return out
+
+    def _decode_step(self, x: mx.array, cache: Z1TCache) -> mx.array:
+        """O(1) single-token decode. Works on time-axis-free (B, h, hd) tensors:
+        MLX (0.31) miscompiles fused kernels over a length-1 sequence axis, so
+        keeping no size-1 time dim here is load-bearing, not just an optimization.
+        """
+        B, _, dim = x.shape
+        h, hd, s = self.heads, dim // self.heads, self.ksize
+
+        qkv = self.qkv_proj(x[:, 0])
+        if self.tanh_linear:
+            qkv = mx.tanh(qkv)
+        Qh = qkv[:, :dim].reshape(B, h, hd)
+        Vh = qkv[:, dim : 2 * dim].reshape(B, h, hd)
+        eK = mx.exp(mx.tanh(qkv[:, 2 * dim :]))  # (B, h)
+        eKV = eK[..., None] * Vh  # (B, h, hd)
+        kernel = mx.exp(self.w_conv) - 1.0  # (h, s)
+
+        if cache.cum_eKV is not None:
+            cum_eKV, cum_eK = cache.cum_eKV, cache.cum_eK
+            win_eKV, win_eK = cache.win_eKV, cache.win_eK
+        else:
+            cum_eKV = mx.zeros((B, h, hd), x.dtype)
+            cum_eK = mx.zeros((B, h), x.dtype)
+            win_eKV = mx.zeros((B, s - 1, h, hd), x.dtype)
+            win_eK = mx.zeros((B, s - 1, h), x.dtype)
+
+        taps_eKV = [win_eKV[:, j] for j in range(s - 1)] + [eKV]
+        taps_eK = [win_eK[:, j] for j in range(s - 1)] + [eK]
+        num = cum_eKV + eKV
+        den = cum_eK + eK
+        for j in range(s):
+            num = num + kernel[:, j].reshape(1, h, 1) * taps_eKV[j]
+            den = den + kernel[:, j].reshape(1, h) * taps_eK[j]
+        ctx = num / (den[..., None] + 1e-6)
+        Y = (mx.tanh(Qh) * ctx).reshape(B, dim)
+        out = self.out_proj(Y)
+        if self.tanh_linear:
+            out = mx.tanh(out)
+
+        cache.cum_eKV = cum_eKV + eKV
+        cache.cum_eK = cum_eK + eK
+        if s > 1:
+            cache.win_eKV = mx.concatenate([win_eKV[:, 1:], eKV[:, None]], axis=1)
+            cache.win_eK = mx.concatenate([win_eK[:, 1:], eK[:, None]], axis=1)
+        cache.offset += 1
+        mx.eval(cache.cum_eKV, cache.cum_eK, cache.win_eKV, cache.win_eK)
+        return out[:, None]
+
+
+class MLP(nn.Module):
+    def __init__(self, config: ModelConfig):
+        super().__init__()
+        dim = config.hidden_size
+        hidden = int(dim * 4.0)
+        fan = config.fan_in("mlp")
+        self.proj1 = _make_linear(dim, hidden, fan)
+        self.proj2 = _make_linear(hidden, dim, fan)
+        self.tanh_linear = config.tanh_linear
+        self.tanh_mlp = config.tanh_mlp
+
+    def __call__(self, x: mx.array) -> mx.array:
+        h = self.proj1(x)
+        if self.tanh_linear:
+            h = mx.tanh(h)
+        h = mx.tanh(h) if self.tanh_mlp else nn.silu(h)
+        o = self.proj2(h)
+        if self.tanh_linear:
+            o = mx.tanh(o)
+        return o
+
+
+class Block(nn.Module):
+    def __init__(self, config: ModelConfig):
+        super().__init__()
+        self.norm1 = DyT(config.hidden_size, config.dyt_alpha)
+        self.attn = AFTConv(config)
+        self.norm2 = DyT(config.hidden_size, config.dyt_alpha)
+        self.mlp = MLP(config)
+
+    def __call__(self, x: mx.array, cache: Optional[Z1TCache] = None) -> mx.array:
+        x = x + self.attn(self.norm1(x), cache=cache)
+        x = x + self.mlp(self.norm2(x))
+        return x
+
+
+def _build_pe(dim: int, max_seq: int, omega: float = 1e4) -> mx.array:
+    d = dim // 2
+    freq = mx.exp(-math.log(omega) * mx.arange(d) / d)
+    angle = mx.arange(max_seq)[:, None] * freq[None, :]
+    pe = mx.stack([mx.sin(angle), mx.cos(angle)], axis=-1)  # (max_seq, d, 2)
+    return pe.reshape(max_seq, dim)
+
+
+class Z1TModel(nn.Module):
+    def __init__(self, config: ModelConfig):
+        super().__init__()
+        self.config = config
+        self.embed_tokens = nn.Embedding(config.vocab_size, config.hidden_size)
+        self.layers = [Block(config) for _ in range(config.num_hidden_layers)]
+        self.norm = DyT(config.hidden_size, config.dyt_alpha)
+        # additive positional table, loaded from the checkpoint (Z1T-0 ships it ~0)
+        self.pe = _build_pe(config.hidden_size, config.max_position_embeddings)
+
+    def _pos(self, offset: int, length: int, dtype) -> mx.array:
+        pos = self.pe[offset : offset + length]
+        if pos.shape[0] < length:  # past the table (out-of-distribution): zero-extend
+            pad = mx.zeros((length - pos.shape[0], self.pe.shape[1]), self.pe.dtype)
+            pos = mx.concatenate([pos, pad], axis=0)
+        return pos.astype(dtype)
+
+    def __call__(
+        self,
+        inputs: mx.array,
+        inputs_embeds: Optional[mx.array] = None,
+        cache=None,
+        **kwargs,
+    ) -> mx.array:
+        x = self.embed_tokens(inputs) if inputs_embeds is None else inputs_embeds
+        offset = cache[0].offset if (cache is not None and cache[0] is not None) else 0
+        x = x + self._pos(offset, x.shape[1], x.dtype)
+
+        caches = cache if cache is not None else [None] * len(self.layers)
+        for layer, layer_cache in zip(self.layers, caches):
+            x = layer(x, cache=layer_cache)
+        return self.norm(x)
+
+
+class LanguageModel(nn.Module):
+    def __init__(self, config: ModelConfig):
+        super().__init__()
+        self.config = config
+        self.model_type = config.model_type
+        self.model = Z1TModel(config)
+        self.lm_head = nn.Linear(config.hidden_size, config.vocab_size)
+
+    @property
+    def layers(self):
+        return self.model.layers
+
+    def make_cache(self):
+        return [Z1TCache() for _ in range(self.config.num_hidden_layers)]
+
+    def __call__(
+        self,
+        inputs: mx.array,
+        inputs_embeds: Optional[mx.array] = None,
+        cache=None,
+        mask: Optional[mx.array] = None,
+        **kwargs,
+    ) -> LanguageModelOutput:
+        out = self.model(inputs, inputs_embeds=inputs_embeds, cache=cache)
+        return LanguageModelOutput(logits=self.lm_head(out))

--- a/mlx_vlm/models/z1t/z1t.py
+++ b/mlx_vlm/models/z1t/z1t.py
@@ -1,0 +1,73 @@
+from typing import Optional
+
+import mlx.core as mx
+import mlx.nn as nn
+
+from ..base import InputEmbeddingsFeatures, LanguageModelOutput
+from .config import ModelConfig
+from .language import LanguageModel
+
+
+class Model(nn.Module):
+    def __init__(self, config: ModelConfig):
+        super().__init__()
+        self.config = config
+        self.model_type = config.model_type
+        self.language_model = LanguageModel(config)
+
+    def get_input_embeddings(
+        self,
+        input_ids: Optional[mx.array] = None,
+        pixel_values: Optional[mx.array] = None,
+        **kwargs,
+    ) -> InputEmbeddingsFeatures:
+        if pixel_values is not None:
+            raise ValueError("Z1T is a text-only model.")
+        if input_ids is None:
+            raise ValueError("input_ids are required for Z1T.")
+        return InputEmbeddingsFeatures(
+            inputs_embeds=self.language_model.model.embed_tokens(input_ids)
+        )
+
+    def __call__(
+        self,
+        input_ids: mx.array,
+        pixel_values: mx.array = None,
+        mask: mx.array = None,
+        cache=None,
+        **kwargs,
+    ) -> LanguageModelOutput:
+        embeds = self.get_input_embeddings(input_ids, pixel_values).inputs_embeds
+        return self.language_model(
+            input_ids, cache=cache, mask=mask, inputs_embeds=embeds, **kwargs
+        )
+
+    def sanitize(self, weights):
+        def transform_key(key: str) -> Optional[str]:
+            if key.startswith("language_model."):
+                return key
+            if key == "pe.pe":
+                return "language_model.model.pe"
+            if key.startswith("embedding."):
+                return "language_model.model.embed_tokens." + key[len("embedding.") :]
+            if key.startswith("blocks."):
+                return "language_model.model.layers." + key[len("blocks.") :]
+            if key.startswith("norm."):
+                return "language_model.model.norm." + key[len("norm.") :]
+            if key.startswith("clf."):
+                return "language_model.lm_head." + key[len("clf.") :]
+            return key
+
+        sanitized = {}
+        for key, value in weights.items():
+            new_key = transform_key(key)
+            if new_key is not None:
+                sanitized[new_key] = value
+        return sanitized
+
+    @property
+    def layers(self):
+        return self.language_model.layers
+
+    def make_cache(self):
+        return self.language_model.make_cache()

--- a/mlx_vlm/tests/test_apc_all_models.py
+++ b/mlx_vlm/tests/test_apc_all_models.py
@@ -39,6 +39,7 @@ from mlx_vlm.models.cache import (
 from mlx_vlm.models.minimax_m3_vl.language import MiniMaxM3KVCache
 from mlx_vlm.models.qwen4_exp.language import QSAKVCache
 from mlx_vlm.models.unlimited_ocr.language import RingSlidingKVCache
+from mlx_vlm.models.z1t.language import Z1TCache
 
 
 def _model_source_root() -> Path:
@@ -89,6 +90,7 @@ def _cache_samples():
         "RotatingKVCache": RotatingKVCache(max_size=16),
         "SimpleKVCache": SimpleKVCache(),
         "StaticPrefixKVCache": StaticPrefixKVCache(max_size=16),
+        "Z1TCache": Z1TCache(),
     }
 
 
@@ -235,6 +237,14 @@ def _populated_cache(name: str, token_count: int):
             _populated_cache("KVCache", token_count),
             _populated_cache("ArraysCache", token_count),
         )
+    if name == "Z1TCache":
+        cache = Z1TCache()
+        cache.offset = token_count
+        cache.cum_eKV = mx.ones((1, 4))
+        cache.cum_eK = mx.ones((1, 4)) * 2
+        cache.win_eKV = mx.ones((1, 3, 4)) * 3
+        cache.win_eK = mx.ones((1, 3, 4)) * 4
+        return cache
     raise AssertionError(f"No populated APC sample for {name}")
 
 

--- a/mlx_vlm/tests/test_models.py
+++ b/mlx_vlm/tests/test_models.py
@@ -2223,6 +2223,59 @@ class TestModels(unittest.TestCase):
         self.assertNotIn(f"{prefix}.gate_proj.weight", sanitized)
         self.assertNotIn(f"{prefix}.up_proj.weight", sanitized)
 
+    def test_z1t_language_model(self):
+        from mlx_vlm.models import z1t
+
+        mx.random.seed(0)
+        config = z1t.ModelConfig(
+            model_type="z1t",
+            vocab_size=97,
+            hidden_size=32,
+            num_hidden_layers=2,
+            max_position_embeddings=64,
+            aft_kind="conv",
+            aft_heads=4,
+            aft_ksize=4,
+            dyt_alpha=0.5,
+            linear_fan_in=4,
+            tanh_linear=True,
+            tanh_mlp=True,
+        )
+        model = z1t.Model(config)
+
+        inputs = mx.array([[1, 2, 3]])
+        embeddings = model.get_input_embeddings(inputs)
+        self.assertEqual(embeddings.inputs_embeds.shape, (1, 3, config.hidden_size))
+
+        cache = model.make_cache()
+        self.assertEqual(len(cache), config.num_hidden_layers)
+        self.assertEqual(type(cache[0]).__name__, "Z1TCache")
+
+        # O(1) streaming decode matches the flat forward on the clean fp32 model
+        # (run before language_test_runner, which recasts params to fp16).
+        ids = mx.array([[3, 1, 4, 1, 5, 9, 2, 6]])
+        flat = model(ids).logits
+        cache = model.make_cache()
+        model(ids[:, :5], cache=cache)
+        for t in range(5, 8):
+            step = model(ids[:, t : t + 1], cache=cache).logits
+            self.assertEqual(step.shape, (1, 1, config.vocab_size))
+            self.assertLess(float(mx.abs(step[0, 0] - flat[0, t]).max()), 2e-3)
+
+        self.language_test_runner(
+            model.language_model,
+            config.model_type,
+            config.vocab_size,
+            config.num_hidden_layers,
+        )
+
+        # sanitize maps the flat checkpoint scheme onto the module tree
+        sanitized = model.sanitize(
+            {"clf.weight": mx.zeros((97, 32)), "pe.pe": mx.zeros((64, 32))}
+        )
+        self.assertIn("language_model.lm_head.weight", sanitized)
+        self.assertIn("language_model.model.pe", sanitized)
+
     def test_hrm_text_language_model(self):
         from mlx_vlm.models import hrm_text
 


### PR DESCRIPTION
## Z1T-0

decode tok/s (M5 Max · fp32 · batch 1)

| ctx | tok/s |
|--:|--:|
| 256 | 159 |
| 4,096 | 148 |
| 16,384 | 131 |
| 32,768 | 92 |

[Blog](https://extropic.ai/writing/z1t) · [Model](https://huggingface.co/AlazarM/Z1T-0-mlx)
