### PR TITLE
Fix Unlimited-OCR prompt suffix

### DIFF
--- a/mlx_vlm/models/unlimited_ocr/processing_unlimitedocr.py
+++ b/mlx_vlm/models/unlimited_ocr/processing_unlimitedocr.py
@@ -15,6 +15,17 @@ from ..deepseekocr.processing_deepseekocr import (
 
 
 class UnlimitedOCRProcessor(DeepseekOCRProcessor):
+    @property
+    def default_chat_template(self):
+        return (
+            "{% for message in messages %}"
+            "{% if message['role'] == 'user' %}"
+            "{% elif message['role'] == 'assistant' %}{% endif %}"
+            "{{message['content']}}{% if not loop.last %} {% endif %}"
+            "{% endfor %}"
+            "{% if add_generation_prompt %}{% endif %}"
+        )
+
     @classmethod
     def from_pretrained(cls, pretrained_model_name_or_path, **kwargs):
         kwargs.pop("trust_remote_code", None)

--- a/mlx_vlm/tests/test_processors.py
+++ b/mlx_vlm/tests/test_processors.py
@@ -87,6 +87,27 @@ def _mock_ip(**extra):
     )()
 
 
+class TestUnlimitedOCRProcessor(unittest.TestCase):
+    def test_default_chat_template_omits_trailing_space(self):
+        from jinja2 import Template
+
+        from mlx_vlm.models.unlimited_ocr.processing_unlimitedocr import (
+            UnlimitedOCRProcessor,
+        )
+
+        processor = object.__new__(UnlimitedOCRProcessor)
+        rendered = Template(processor.default_chat_template).render(
+            messages=[
+                {"role": "user", "content": "<image>document parsing."},
+                {"role": "assistant", "content": "partial"},
+                {"role": "user", "content": "continue"},
+            ],
+            add_generation_prompt=True,
+        )
+
+        self.assertEqual(rendered, "<image>document parsing. partial continue")
+
+
 class TestGemma4UnifiedProcessor(unittest.TestCase):
     # Test fixtures
 

--- a/mlx_vlm/tests/test_processors.py
+++ b/mlx_vlm/tests/test_processors.py
@@ -5,6 +5,7 @@ from types import SimpleNamespace
 from unittest.mock import patch
 
 import numpy as np
+import pytest
 from PIL import Image
 
 # ── Shared mocks ──────────────────────────────────────────────────────────────
@@ -89,7 +90,7 @@ def _mock_ip(**extra):
 
 class TestUnlimitedOCRProcessor(unittest.TestCase):
     def test_default_chat_template_omits_trailing_space(self):
-        from jinja2 import Template
+        Template = pytest.importorskip("jinja2").Template
 
         from mlx_vlm.models.unlimited_ocr.processing_unlimitedocr import (
             UnlimitedOCRProcessor,


### PR DESCRIPTION
fixes #2161. removes the trailing space from unlimited-ocr's default chat template.