### PR TITLE
Fix GLM and Kimi output control tokens

### DIFF
--- a/mlx_vlm/models/glm4v/processing.py
+++ b/mlx_vlm/models/glm4v/processing.py
@@ -4,6 +4,14 @@ import numpy as np
 from transformers.feature_extraction_utils import BatchFeature
 from transformers.processing_utils import ProcessorMixin
 
+_BOX_TOKENS = ("<|begin_of_box|>", "<|end_of_box|>")
+
+
+def _strip_box_markers(text: str) -> str:
+    for token in _BOX_TOKENS:
+        text = text.replace(token, "")
+    return text
+
 
 class Glm46VProcessor(ProcessorMixin):
     """
@@ -34,6 +42,7 @@ class Glm46VProcessor(ProcessorMixin):
         self.video_token = "<|video|>"
 
         if tokenizer is not None:
+            tokenizer.add_special_tokens({"additional_special_tokens": _BOX_TOKENS})
             self.image_token = getattr(tokenizer, "image_token", "<|image|>")
             self.video_token = getattr(tokenizer, "video_token", "<|video|>")
 
@@ -50,6 +59,9 @@ class Glm46VProcessor(ProcessorMixin):
             self.video_token_id = None
 
         super().__init__(image_processor, tokenizer, chat_template=chat_template)
+
+    def clean_output(self, text: str) -> str:
+        return _strip_box_markers(text)
 
     def __call__(
         self,

--- a/mlx_vlm/models/kimi_vl/processing_kimi_vl.py
+++ b/mlx_vlm/models/kimi_vl/processing_kimi_vl.py
@@ -327,6 +327,13 @@ class KimiVLProcessor(ProcessorMixin):
     image_processor_class = "KimiVLImageProcessor"
     tokenizer_class = "AutoTokenizer"
 
+    @property
+    def additional_eos_token_ids(self):
+        token_id = self.tokenizer.convert_tokens_to_ids("<|im_assistant|>")
+        if token_id == getattr(self.tokenizer, "unk_token_id", None):
+            return []
+        return [token_id]
+
     def __init__(
         self,
         image_processor=None,

--- a/mlx_vlm/tests/test_processors.py
+++ b/mlx_vlm/tests/test_processors.py
@@ -87,6 +87,28 @@ def _mock_ip(**extra):
     )()
 
 
+class TestOutputControlTokens(unittest.TestCase):
+    def test_glm46v_strips_box_markers(self):
+        from mlx_vlm.models.glm4v.processing import _strip_box_markers
+
+        self.assertEqual(
+            _strip_box_markers("<|begin_of_box|>answer<|end_of_box|>"), "answer"
+        )
+
+    def test_kimi_vl_stops_on_assistant_marker(self):
+        from mlx_vlm.models.kimi_vl.processing_kimi_vl import KimiVLProcessor
+
+        processor = object.__new__(KimiVLProcessor)
+        processor.tokenizer = SimpleNamespace(
+            unk_token_id=0,
+            convert_tokens_to_ids=lambda token: (
+                163586 if token == "<|im_assistant|>" else 0
+            ),
+        )
+
+        self.assertEqual(processor.additional_eos_token_ids, [163586])
+
+
 class TestGemma4UnifiedProcessor(unittest.TestCase):
     # Test fixtures
 


### PR DESCRIPTION
fixes #2159. strips glm box markers and stops kimi output at the assistant marker.

these were the actual reproducible model issues from the report on 0.6.17