### PR TITLE
Add MoGe-3 monocular geometry estimation model

### DIFF
--- a/mlx_vlm/models/dinov2/README.md
+++ b/mlx_vlm/models/dinov2/README.md
@@ -1,0 +1,15 @@
+# DINOv2 (MLX)
+
+Channel-last MLX port of the [DINOv2](https://github.com/facebookresearch/dinov2)
+vision transformer. This package currently holds only the shared backbone and
+its architecture presets. The standalone model is not ported yet: there is no
+`Model` class, so `facebook/dinov2-*` checkpoints cannot be loaded through
+`mlx_vlm.load`, and register tokens, masking and the DINO heads are not
+implemented.
+
+## Used by
+
+| Model | Backbones |
+| --- | --- |
+| `video_depth_anything` | ViT-S/14, ViT-B/14, ViT-L/14 |
+| `moge3` | ViT-L/14, ViT-g/14 |

--- a/mlx_vlm/models/dinov2/__init__.py
+++ b/mlx_vlm/models/dinov2/__init__.py
@@ -1,0 +1,9 @@
+"""DINOv2 for MLX.
+
+Channel-last port of the DINOv2 vision transformer, shared as the backbone of
+dense-prediction models (Video Depth Anything, MoGe-3). Only the backbone and
+its architecture presets are ported; there is no standalone ``Model`` yet.
+"""
+
+from .config import DINOV2_PRESETS
+from .dinov2 import DINOv2, DINOv2Encoder

--- a/mlx_vlm/models/dinov2/config.py
+++ b/mlx_vlm/models/dinov2/config.py
@@ -1,0 +1,8 @@
+"""DINOv2 architecture presets for the official ViT-*/14 (LVD-142M) checkpoints."""
+
+DINOV2_PRESETS = {
+    "vits14": dict(embed_dim=384, depth=12, num_heads=6, ffn="mlp"),
+    "vitb14": dict(embed_dim=768, depth=12, num_heads=12, ffn="mlp"),
+    "vitl14": dict(embed_dim=1024, depth=24, num_heads=16, ffn="mlp"),
+    "vitg14": dict(embed_dim=1536, depth=40, num_heads=24, ffn="swiglu"),
+}

--- a/mlx_vlm/models/dinov2/dinov2.py
+++ b/mlx_vlm/models/dinov2/dinov2.py
@@ -1,4 +1,4 @@
-"""DINOv2 vision backbone for Video Depth Anything (channel-last MLX port)."""
+"""DINOv2 vision transformer (channel-last MLX port)."""
 
 import math
 from typing import List, Tuple
@@ -6,44 +6,7 @@ from typing import List, Tuple
 import mlx.core as mx
 import mlx.nn as nn
 
-from .config import ModelConfig
-
-
-def _cubic_weight(t, a=-0.75):
-    at = mx.abs(t)
-    at2 = at * at
-    at3 = at2 * at
-    w1 = (a + 2) * at3 - (a + 3) * at2 + 1.0
-    w2 = a * at3 - 5 * a * at2 + 8 * a * at - 4 * a
-    return mx.where(at <= 1.0, w1, mx.where(at < 2.0, w2, mx.zeros_like(t)))
-
-
-def bicubic_scale_factor(x, scale_h, scale_w):
-    """Match ``F.interpolate(scale_factor=..., mode='bicubic')`` exactly.
-
-    Differs from the generic helper: PyTorch samples with the given
-    (fractional) scale, floors the output size, and clamps border taps
-    without renormalizing the weights.
-    """
-    B, C, in_h, in_w = x.shape
-    out_h = int(in_h * scale_h)
-    out_w = int(in_w * scale_w)
-
-    def axis_weights(in_size, out_size, scale):
-        src = (mx.arange(out_size, dtype=mx.float32) + 0.5) / scale - 0.5
-        base = mx.floor(src)
-        taps = base[:, None] + mx.arange(-1, 3, dtype=mx.float32)[None, :]
-        w = _cubic_weight(src[:, None] - taps)
-        idx = mx.clip(taps.astype(mx.int32), 0, in_size - 1)
-        return idx, w
-
-    iy, wy = axis_weights(in_h, out_h, scale_h)
-    ix, wx = axis_weights(in_w, out_w, scale_w)
-
-    g = x[:, :, iy.reshape(-1), :].reshape(B, C, out_h, 4, in_w)
-    t = mx.sum(g * wy[None, None, :, :, None], axis=3)
-    g = t[:, :, :, ix.reshape(-1)].reshape(B, C, out_h, out_w, 4)
-    return mx.sum(g * wx[None, None, None, :, :], axis=4)
+from ..interpolate import resize_bicubic_nhwc, resize_bilinear_nhwc
 
 
 class PatchEmbed(nn.Module):
@@ -61,7 +24,7 @@ class PatchEmbed(nn.Module):
     def __call__(self, x: mx.array) -> mx.array:
         B, H, W, _ = x.shape
         assert H % self.patch_size == 0 and W % self.patch_size == 0
-        x = self.proj(x)  # (B, H/14, W/14, D)
+        x = self.proj(x)  # (B, H/p, W/p, D)
         return x.reshape(B, -1, x.shape[-1])
 
 
@@ -94,6 +57,23 @@ class Mlp(nn.Module):
         return self.fc2(nn.gelu(self.fc1(x)))
 
 
+class SwiGLUFFN(nn.Module):
+    """Fused SwiGLU FFN (dinov2 vit-g): hidden dim rounded up to a multiple of 8."""
+
+    def __init__(self, dim: int, hidden_dim: int):
+        super().__init__()
+        hidden_dim = (int(hidden_dim * 2 / 3) + 7) // 8 * 8
+        self.w12 = nn.Linear(dim, 2 * hidden_dim, bias=True)
+        self.w3 = nn.Linear(hidden_dim, dim, bias=True)
+
+    def __call__(self, x: mx.array) -> mx.array:
+        x1, x2 = mx.split(self.w12(x), 2, axis=-1)
+        return self.w3(nn.silu(x1) * x2)
+
+
+_FFN_LAYERS = {"mlp": Mlp, "swiglu": SwiGLUFFN}
+
+
 class LayerScale(nn.Module):
     def __init__(self, dim: int):
         super().__init__()
@@ -104,14 +84,20 @@ class LayerScale(nn.Module):
 
 
 class Block(nn.Module):
-    def __init__(self, config: ModelConfig):
+    def __init__(self, config):
         super().__init__()
         dim = config.embed_dim
+        hidden = int(dim * config.mlp_ratio)
         self.norm1 = nn.LayerNorm(dim, eps=config.layer_norm_eps)
         self.attn = Attention(dim, config.num_heads)
         self.ls1 = LayerScale(dim)
         self.norm2 = nn.LayerNorm(dim, eps=config.layer_norm_eps)
-        self.mlp = Mlp(dim, int(dim * config.mlp_ratio))
+        ffn = getattr(config, "ffn", None) or "mlp"
+        if ffn not in _FFN_LAYERS:
+            raise ValueError(
+                f"Unknown DINOv2 ffn {ffn!r}; expected one of {list(_FFN_LAYERS)}"
+            )
+        self.mlp = _FFN_LAYERS[ffn](dim, hidden)
         self.ls2 = LayerScale(dim)
 
     def __call__(self, x: mx.array) -> mx.array:
@@ -121,7 +107,7 @@ class Block(nn.Module):
 
 
 class DINOv2(nn.Module):
-    def __init__(self, config: ModelConfig):
+    def __init__(self, config):
         super().__init__()
         self.config = config
         self.embed_dim = config.embed_dim
@@ -149,16 +135,14 @@ class DINOv2(nn.Module):
         w0 = w // self.patch_size + self.config.interpolate_offset
         h0 = h // self.patch_size + self.config.interpolate_offset
         sqrt_N = math.sqrt(N)
+        # (sy, sx) because the reference derives w0 from the pixel height and
+        # applies it to the W axis.
         sx, sy = float(w0) / sqrt_N, float(h0) / sqrt_N
-        # (B, C, H, W) for the interpolation; (sy, sx) because the reference
-        # derives w0 from the pixel height and applies it to the W axis
-        patch_pos_embed = patch_pos_embed.reshape(
-            1, int(sqrt_N), int(sqrt_N), dim
-        ).transpose(0, 3, 1, 2)
-        patch_pos_embed = bicubic_scale_factor(
-            patch_pos_embed.astype(mx.float32), sy, sx
+        patch_pos_embed = patch_pos_embed.reshape(1, int(sqrt_N), int(sqrt_N), dim)
+        patch_pos_embed = resize_bicubic_nhwc(
+            patch_pos_embed.astype(mx.float32), scale_factor=(sy, sx)
         )
-        patch_pos_embed = patch_pos_embed.transpose(0, 2, 3, 1).reshape(1, -1, dim)
+        patch_pos_embed = patch_pos_embed.reshape(1, -1, dim)
         return mx.concatenate([class_pos_embed, patch_pos_embed], axis=1).astype(
             x.dtype
         )
@@ -183,3 +167,31 @@ class DINOv2(nn.Module):
                 outputs.append((out[:, 1:], out[:, 0]))
         assert len(outputs) == len(indices)
         return outputs
+
+
+class DINOv2Encoder(nn.Module):
+    """Resize [0, 1] RGB images to a token grid, normalize, return per-layer grids."""
+
+    def __init__(self, config):
+        super().__init__()
+        self.config = config
+        self.backbone = DINOv2(config)
+        self.image_mean = mx.array([0.485, 0.456, 0.406]).reshape(1, 1, 1, 3)
+        self.image_std = mx.array([0.229, 0.224, 0.225]).reshape(1, 1, 1, 3)
+
+    def __call__(
+        self, image: mx.array, token_rows: int, token_cols: int
+    ) -> List[Tuple[mx.array, mx.array]]:
+        """image: (B, H, W, 3) in [0, 1] -> [((B, rows, cols, D), (B, D) cls), ...]."""
+        p = self.config.patch_size
+        x = resize_bilinear_nhwc(
+            image, (token_rows * p, token_cols * p), antialias=True
+        )
+        x = (x - self.image_mean) / self.image_std
+        B = x.shape[0]
+        return [
+            (tokens.reshape(B, token_rows, token_cols, -1), cls)
+            for tokens, cls in self.backbone.get_intermediate_layers(
+                x, self.config.intermediate_layers
+            )
+        ]

--- a/mlx_vlm/models/interpolate.py
+++ b/mlx_vlm/models/interpolate.py
@@ -1,5 +1,10 @@
+import math
+from functools import lru_cache
+
 import mlx.core as mx
 import numpy as np
+
+from .kernels import _cubic_weight, separable_interpolate
 
 
 def gaussian_blur_axis(image, sigma, axis):
@@ -179,3 +184,71 @@ def resize_bilinear(image, new_size, align_corners=False, antialias=True):
 
     else:
         raise ValueError("Unsupported image dimensions.")
+
+
+@lru_cache(maxsize=64)
+def _bilinear_weights_1d(in_size, out_size, align_corners=False, antialias=False):
+    """(out, taps) indices and weights matching ATen ``upsample_bilinear2d``
+    and, for antialiased downscales, ``_upsample_bilinear2d_aa``."""
+    if align_corners:
+        scale = (in_size - 1) / (out_size - 1) if out_size > 1 else 0.0
+        src = mx.arange(out_size, dtype=mx.float32) * scale
+    else:
+        scale = in_size / out_size
+        src = (mx.arange(out_size, dtype=mx.float32) + 0.5) * scale - 0.5
+    if antialias and scale > 1.0:
+        lo = mx.maximum(mx.floor(src - scale + 1), 0)
+        hi = mx.minimum(mx.floor(src + scale), in_size - 1)
+        # hi - lo + 1 <= ceil(2 * scale) for every pixel, so the tap count is static
+        n_taps = math.ceil(2 * scale)
+        pos = lo[:, None] + mx.arange(n_taps, dtype=mx.float32)[None, :]
+        w = mx.maximum(0.0, 1.0 - mx.abs(pos - src[:, None]) / scale)
+        w = mx.where(pos <= hi[:, None], w, 0.0)
+        w = w / w.sum(axis=1, keepdims=True)
+        # Zero-weight taps past hi are clamped so the gather stays in bounds
+        idx = mx.minimum(pos, in_size - 1).astype(mx.int32)
+    else:
+        src = mx.maximum(src, 0.0)
+        base = mx.floor(src)
+        frac = src - base
+        pos = base[:, None] + mx.arange(2, dtype=mx.float32)[None, :]
+        idx = mx.clip(pos.astype(mx.int32), 0, in_size - 1)
+        w = mx.stack([1.0 - frac, frac], axis=1)
+    return idx, w
+
+
+@lru_cache(maxsize=64)
+def _bicubic_weights_1d(in_size, out_size, scale):
+    """(out, 4) indices and a=-0.75 cubic weights sampled at the given scale,
+    with border taps clamped and not renormalized, as in ATen ``upsample_bicubic2d``."""
+    src = (mx.arange(out_size, dtype=mx.float32) + 0.5) / scale - 0.5
+    taps = mx.floor(src)[:, None] + mx.arange(-1, 3, dtype=mx.float32)[None, :]
+    w = _cubic_weight(src[:, None] - taps)
+    idx = mx.clip(taps.astype(mx.int32), 0, in_size - 1)
+    return idx, w
+
+
+def resize_bilinear_nhwc(x, new_size, align_corners=False, antialias=False):
+    """Channel-last bilinear resize matching ``F.interpolate``; ``antialias``
+    is PyTorch's triangle filter rather than ``resize_bilinear``'s Gaussian blur."""
+    _, H, W, _ = x.shape
+    new_height, new_width = new_size
+    if (H, W) == (new_height, new_width):
+        return x
+    iy, wy = _bilinear_weights_1d(H, new_height, align_corners, antialias)
+    ix, wx = _bilinear_weights_1d(W, new_width, align_corners, antialias)
+    return separable_interpolate(x, iy, wy, ix, wx)
+
+
+def resize_bicubic_nhwc(x, new_size=None, scale_factor=None):
+    """Channel-last ``F.interpolate(mode="bicubic")``; with ``scale_factor`` the
+    output size is floored and sampling uses the given scale, not the effective one."""
+    _, in_h, in_w, _ = x.shape
+    if scale_factor is not None:
+        scale_h, scale_w = scale_factor
+        new_size = (int(in_h * scale_h), int(in_w * scale_w))
+    else:
+        scale_h, scale_w = new_size[0] / in_h, new_size[1] / in_w
+    iy, wy = _bicubic_weights_1d(in_h, new_size[0], scale_h)
+    ix, wx = _bicubic_weights_1d(in_w, new_size[1], scale_w)
+    return separable_interpolate(x, iy, wy, ix, wx)

--- a/mlx_vlm/models/kernels.py
+++ b/mlx_vlm/models/kernels.py
@@ -561,6 +561,104 @@ def grid_sample(x, grid):
     return outputs[0]
 
 
+def _separable_interpolate_axis(x, idx, w):
+    N, _, M = x.shape
+    out, taps = idx.shape
+    g = mx.take(x, idx.reshape(-1), axis=1).reshape(N, out, taps, M)
+    return mx.sum(g * w[None, :, :, None], axis=2)
+
+
+def _separable_interpolate_mlx(x, iy, wy, ix, wx):
+    """Pure-MLX separable interpolation (no Metal kernel)."""
+    N, H, W, C = x.shape
+    out_h, taps_y = iy.shape
+    out_w, taps_x = ix.shape
+    # Both axes are gathered along axis 1 so the tap reduction keeps a long inner axis
+    h_first_cost = out_h * W * (taps_y + 1) + out_h * out_w * (taps_x + 1)
+    w_first_cost = H * W + H * out_w * (taps_x + 1) + out_h * out_w * taps_y
+    if h_first_cost <= w_first_cost:
+        y = _separable_interpolate_axis(x.reshape(N, H, W * C), iy, wy)
+        y = y.reshape(N, out_h, W, C).transpose(0, 2, 1, 3).reshape(N, W, out_h * C)
+        out = _separable_interpolate_axis(y, ix, wx).reshape(N, out_w, out_h, C)
+        return out.transpose(0, 2, 1, 3)
+    y = x.transpose(0, 2, 1, 3).reshape(N, W, H * C)
+    y = _separable_interpolate_axis(y, ix, wx)
+    y = y.reshape(N, out_w, H, C).transpose(0, 2, 1, 3).reshape(N, H, out_w * C)
+    return _separable_interpolate_axis(y, iy, wy).reshape(N, out_h, out_w, C)
+
+
+def separable_interpolate(x, iy, wy, ix, wx):
+    """
+    Separable interpolation of a channel-last tensor from per-axis tap tables.
+
+    Args:
+        x: MLX tensor of shape [B, H, W, C]
+        iy, ix: int32 source indices of shape [out_h, taps_y] and [out_w, taps_x]
+        wy, wx: float32 weights with the same shapes as iy and ix
+
+    Returns:
+        float32 tensor of shape [B, out_h, out_w, C]
+    """
+    if not _HAS_METAL:
+        return _separable_interpolate_mlx(x, iy, wy, ix, wx)
+
+    batch_size, _, _, channels = x.shape
+    out_h = iy.shape[0]
+    out_w = ix.shape[0]
+
+    source = """
+        uint gx = thread_position_in_grid.x;
+        uint y_out = thread_position_in_grid.y;
+        uint b = thread_position_in_grid.z;
+
+        int in_h = x_shape[1];
+        int in_w = x_shape[2];
+        int channels = x_shape[3];
+        int out_h = iy_shape[0];
+        int taps_y = iy_shape[1];
+        int out_w = ix_shape[0];
+        int taps_x = ix_shape[1];
+
+        if (gx >= (uint)(out_w * channels) || y_out >= (uint)out_h)
+            return;
+
+        int x_out = gx / channels;
+        size_t y_tap = (size_t)y_out * taps_y;
+        size_t x_tap = (size_t)x_out * taps_x;
+        size_t input_base = (size_t)b * in_h * in_w * channels + (gx % channels);
+
+        // W taps are contracted inside the H loop to match ATen's summation order
+        float result = 0.0f;
+        for (int a = 0; a < taps_y; a++) {
+            size_t row = input_base + (size_t)iy[y_tap + a] * in_w * channels;
+            float row_result = 0.0f;
+            for (int c = 0; c < taps_x; c++) {
+                row_result += x[row + (size_t)ix[x_tap + c] * channels] * wx[x_tap + c];
+            }
+            result += row_result * wy[y_tap + a];
+        }
+
+        out[((size_t)b * out_h + y_out) * out_w * channels + gx] = result;
+    """
+
+    kernel = mx.fast.metal_kernel(
+        name="separable_interpolate",
+        input_names=["x", "iy", "wy", "ix", "wx"],
+        output_names=["out"],
+        source=source,
+    )
+
+    outputs = kernel(
+        inputs=[x.astype(mx.float32), iy, wy, ix, wx],
+        grid=(out_w * channels, out_h, batch_size),
+        threadgroup=(min(256, out_w * channels), 1, 1),
+        output_shapes=[(batch_size, out_h, out_w, channels)],
+        output_dtypes=[mx.float32],
+    )
+
+    return outputs[0]
+
+
 def get_optimal_threadgroup(out_w, out_h):
     # Calculate optimal threadgroup dimensions based on output dimensions
 

--- a/mlx_vlm/models/moge3/README.md
+++ b/mlx_vlm/models/moge3/README.md
@@ -1,0 +1,63 @@
+# MoGe-3 (MLX)
+
+Port of [MoGe-3](https://github.com/microsoft/MoGe): fine-detail monocular
+geometry estimation with self-guided sparse volumetric refinement. Given a
+single RGB image, the model predicts a metric point map, depth map, normal
+map, valid-pixel mask, and camera intrinsics in one forward pass.
+
+Unlike standard VLMs, this model outputs dense geometry instead of text.
+
+## Supported checkpoints
+
+| HF repo (MLX) | Source checkpoint | Backbone |
+| --- | --- | --- |
+| `mlx-community/moge-3-vitl-mlx-fp32` | `Ruicheng/moge-3-vitl` | DINOv2 ViT-L/14 |
+| `mlx-community/moge-3-vitg-mlx-fp32` | `Ruicheng/moge-3-vitg` | DINOv2 ViT-g/14 |
+
+The MLX repos are produced from the official `model.pt` checkpoints with
+`python -m mlx_vlm.models.moge3.convert`.
+
+## Usage
+
+```python
+from mlx_vlm import load
+from mlx_vlm.models.moge3.generate import MoGe3Predictor, read_image
+
+model, processor = load("mlx-community/moge-3-vitl-mlx-fp32")
+predictor = MoGe3Predictor(model, processor)
+
+output = predictor.infer(read_image("image.jpg"), resolution_level=9)
+points = output["points"]      # (H, W, 3) metric camera-space point map
+depth = output["depth"]        # (H, W) metric depth map
+mask = output["mask"]          # (H, W) valid-pixel mask
+normal = output["normal"]      # (H, W, 3) normal map
+intrinsics = output["intrinsics"]  # (3, 3) normalized camera intrinsics
+```
+
+Useful options: `num_tokens` / `resolution_level` (0-9) control the
+inference resolution, `fov_x` pins the horizontal field of view in degrees,
+`refine_steps` sets the number of sparse 3D refinement updates (default 3),
+and `return_per_step=True` additionally returns the initial estimate and
+every refinement step.
+
+## Implementation notes
+
+- The sparse 3D UNet refiner normally depends on FlexGEMM (Triton,
+  CUDA-only). Here the submanifold convolution, mean pooling, and nearest
+  upsample are re-implemented in pure MLX with sort + binary-search +
+  gather, so the model runs on Apple silicon.
+- Conv weights are stored channel-last. ``Model.sanitize`` relayouts
+  ``ConvTranspose2d`` weights that are still in the torch ``(in, out, 2, 2)``
+  layout (as in the first published MLX checkpoints) by comparing against
+  the module's parameter shape, so both layouts load.
+- The processor accepts ``(H, W, 3)`` or ``(B, H, W, 3)`` images. Integer
+  images are scaled by their dtype range; float images must be in [0, 1].
+- All image/feature resizes match `torch.nn.functional.interpolate`
+  (`align_corners=False`), including the antialiased bilinear downscale in
+  the encoder and the scale-factor bicubic position-embedding interpolation
+  in DINOv2.
+- On GPUs with matrix units (Apple M5 and later), MLX runs float32
+  matmuls, convolutions, and attention at TF32 precision by default, which
+  is roughly 3e-3 relative error. For full float32 geometry, set
+  `MLX_ENABLE_TF32=0` in the environment before the first MLX matmul runs
+  (the setting is latched on first use).

--- a/mlx_vlm/models/moge3/__init__.py
+++ b/mlx_vlm/models/moge3/__init__.py
@@ -1,0 +1,18 @@
+"""MoGe-3 for MLX.
+
+Monocular geometry estimation: metric point maps, depth maps, normal maps,
+and camera intrinsics from a single image. Unlike standard VLMs, this model
+outputs dense geometry instead of text.
+
+Usage:
+    from mlx_vlm import load
+    from mlx_vlm.models.moge3.generate import MoGe3Predictor
+
+    model, processor = load("mlx-community/moge-3-vitl-mlx-fp32")
+    predictor = MoGe3Predictor(model, processor)
+    output = predictor.infer(image)  # image: (H, W, 3) uint8 RGB
+"""
+
+from . import processing_moge3  # Install processor patch
+from .config import ModelConfig
+from .moge3 import Model

--- a/mlx_vlm/models/moge3/config.py
+++ b/mlx_vlm/models/moge3/config.py
@@ -1,0 +1,143 @@
+"""MoGe-3 configuration.
+
+Mirrors the ``model_config`` dict stored in the official ``model.pt``
+checkpoints. Defaults reproduce the released MoGe-3 ViT-L model.
+"""
+
+from dataclasses import dataclass, field
+from typing import List, Optional, Union
+
+from ..base import BaseModelConfig
+from ..dinov2.config import DINOV2_PRESETS
+
+# MoGe names backbones after the torch.hub entry points (``dinov2_vitl14``).
+_BACKBONE_PREFIX = "dinov2_"
+
+
+@dataclass
+class EncoderConfig(BaseModelConfig):
+    backbone: str = "dinov2_vitl14"
+    intermediate_layers: List[int] = field(default_factory=lambda: [5, 11, 17, 23])
+    dim_out: int = 1024
+    img_size: int = 518
+    patch_size: int = 14
+    mlp_ratio: float = 4.0
+    interpolate_offset: float = 0.1
+    layer_norm_eps: float = 1e-6
+    # Filled from the backbone preset when None; override to shrink for tests.
+    embed_dim: Optional[int] = None
+    depth: Optional[int] = None
+    num_heads: Optional[int] = None
+    ffn: Optional[str] = None
+
+    def __post_init__(self):
+        preset = DINOV2_PRESETS.get(self.backbone.removeprefix(_BACKBONE_PREFIX))
+        if preset is None:
+            raise ValueError(
+                f"Unknown backbone {self.backbone!r}; expected one of "
+                f"{[_BACKBONE_PREFIX + name for name in DINOV2_PRESETS]}"
+            )
+        for key, value in preset.items():
+            if getattr(self, key) is None:
+                setattr(self, key, value)
+
+
+@dataclass
+class ConvStackConfig(BaseModelConfig):
+    dim_in: List[Optional[int]] = None
+    dim_res_blocks: List[int] = None
+    dim_out: Optional[List[Optional[int]]] = None
+    resamplers: Union[str, List[str]] = "bilinear"
+    dim_times_res_block_hidden: int = 1
+    num_res_blocks: Union[int, List[int]] = 1
+    res_block_in_norm: str = "layer_norm"
+    res_block_hidden_norm: str = "group_norm"
+    activation: str = "relu"
+
+
+@dataclass
+class ScaleHeadConfig(BaseModelConfig):
+    dims: List[int] = field(default_factory=lambda: [1024, 1024, 1024, 1])
+
+
+@dataclass
+class RefinerConfig(BaseModelConfig):
+    in_channels: int = 3
+    out_channels: int = 1
+    encoder_channels: int = 1026
+    model_channels: List[int] = field(default_factory=lambda: [32, 64, 128, 256, 512])
+    encoder_blocks_per_level: Union[int, List[int]] = 1
+    decoder_blocks_per_level: Union[int, List[int]] = 1
+    bottleneck_blocks: int = 1
+    downsample_factors: List[int] = field(default_factory=lambda: [2, 2, 2, 2])
+    encoder_downsample: int = 16
+
+
+# Default pyramid shared by the neck and the three decoder heads.
+_DEFAULT_DIM_RES_BLOCKS = [1024, 256, 128, 64, 32]
+_DEFAULT_RESAMPLERS = ["conv_transpose", "conv_transpose", "conv_transpose", "bilinear"]
+
+
+def _default_neck() -> ConvStackConfig:
+    return ConvStackConfig(
+        dim_in=[1026, 2, 2, 2, 2],
+        dim_res_blocks=list(_DEFAULT_DIM_RES_BLOCKS),
+        dim_out=None,
+        num_res_blocks=[0, 2, 2, 2, 0],
+        res_block_in_norm="none",
+        res_block_hidden_norm="none",
+        resamplers=list(_DEFAULT_RESAMPLERS),
+    )
+
+
+def _default_head(dim_out_last: int) -> ConvStackConfig:
+    return ConvStackConfig(
+        dim_in=list(_DEFAULT_DIM_RES_BLOCKS),
+        dim_res_blocks=list(_DEFAULT_DIM_RES_BLOCKS),
+        dim_out=[None, None, None, None, dim_out_last],
+        num_res_blocks=[0, 1, 1, 1, 0],
+        res_block_in_norm="none",
+        res_block_hidden_norm="none",
+        resamplers=list(_DEFAULT_RESAMPLERS),
+    )
+
+
+_SUB_CONFIGS = {
+    "encoder": EncoderConfig,
+    "neck": ConvStackConfig,
+    "points_head": ConvStackConfig,
+    "mask_head": ConvStackConfig,
+    "normal_head": ConvStackConfig,
+    "scale_head": ScaleHeadConfig,
+    "refiner": RefinerConfig,
+}
+
+
+@dataclass
+class ModelConfig(BaseModelConfig):
+    model_type: str = "moge3"
+    encoder: EncoderConfig = field(default_factory=EncoderConfig)
+    neck: ConvStackConfig = field(default_factory=_default_neck)
+    points_head: Optional[ConvStackConfig] = field(
+        default_factory=lambda: _default_head(3)
+    )
+    mask_head: Optional[ConvStackConfig] = field(
+        default_factory=lambda: _default_head(1)
+    )
+    normal_head: Optional[ConvStackConfig] = field(
+        default_factory=lambda: _default_head(3)
+    )
+    scale_head: Optional[ScaleHeadConfig] = field(default_factory=ScaleHeadConfig)
+    num_tokens_range: List[int] = field(default_factory=lambda: [1200, 3600])
+    refiner: Optional[RefinerConfig] = field(default_factory=RefinerConfig)
+    refiner_depth_resolution: int = 256
+
+    @classmethod
+    def from_dict(cls, params):
+        if not params:
+            return cls()
+        params = dict(params)
+        for key, sub_cls in _SUB_CONFIGS.items():
+            if isinstance(params.get(key), dict):
+                params[key] = sub_cls.from_dict(params[key])
+        return super().from_dict(params)

--- a/mlx_vlm/models/moge3/conv_stack.py
+++ b/mlx_vlm/models/moge3/conv_stack.py
@@ -1,0 +1,196 @@
+"""Convolutional stacks (neck and decoder heads) for MoGe-3.
+
+Ports ``moge.model.modules.conv_stack`` and ``moge.model.modules.mlp`` to
+channel-last MLX. Submodules are plain lists so parameter names match the
+reference checkpoints exactly (``res_blocks.1.0.layers.2.weight``, ...).
+"""
+
+from typing import List
+
+import mlx.core as mx
+import mlx.nn as nn
+
+from .config import ConvStackConfig, ScaleHeadConfig
+
+
+def run_sequential(modules, x):
+    for module in modules:
+        x = module(x)
+    return x
+
+
+def _per_level(value, num_levels: int) -> list:
+    """Broadcast a scalar config entry to one value per pyramid level."""
+    if isinstance(value, (list, tuple)):
+        return list(value)
+    return [value] * num_levels
+
+
+_ACTIVATIONS = {
+    "relu": nn.ReLU,
+    "leaky_relu": lambda: nn.LeakyReLU(negative_slope=0.2),
+    "silu": nn.SiLU,
+    "elu": nn.ELU,
+}
+
+
+def _make_norm(kind: str, channels: int) -> nn.Module:
+    if kind == "group_norm":
+        return nn.GroupNorm(max(1, channels // 32), channels, pytorch_compatible=True)
+    if kind == "layer_norm":
+        return nn.GroupNorm(1, channels, pytorch_compatible=True)
+    if kind == "instance_norm":
+        return nn.InstanceNorm(channels)
+    if kind == "none":
+        return nn.Identity()
+    raise ValueError(f"Unsupported norm type: {kind}")
+
+
+def _replicate_pad_indices(height: int, width: int, padding: int) -> mx.array:
+    """Flat int32 gather indices that replicate-pad an (H*W) plane by ``padding``.
+
+    ``mx.pad(mode="edge")`` lowers to several full copies of the activation;
+    a single clamped gather is bit-identical and 3-4x cheaper.
+    """
+    rows = mx.clip(mx.arange(-padding, height + padding), 0, height - 1)
+    cols = mx.clip(mx.arange(-padding, width + padding), 0, width - 1)
+    return (rows[:, None] * width + cols[None, :]).reshape(-1)
+
+
+class Conv2dReplicate(nn.Module):
+    """Conv2d with replicate (edge) padding, matching torch padding_mode.
+
+    Stores the weight itself (MLX layout: out, kh, kw, in) so parameter names
+    match the reference checkpoint.
+    """
+
+    def __init__(self, in_channels: int, out_channels: int, kernel_size: int = 3):
+        super().__init__()
+        self.padding = kernel_size // 2
+        k = kernel_size
+        scale = 1.0 / (in_channels * k * k) ** 0.5
+        self.weight = mx.random.uniform(
+            -scale, scale, (out_channels, k, k, in_channels)
+        )
+        self.bias = mx.zeros((out_channels,))
+
+    def __call__(self, x):
+        p = self.padding
+        if p:
+            N, H, W, C = x.shape
+            flat = _replicate_pad_indices(H, W, p)
+            x = mx.take(x.reshape(N, H * W, C), flat, axis=1)
+            x = x.reshape(N, H + 2 * p, W + 2 * p, C)
+        return mx.conv2d(x, self.weight) + self.bias
+
+
+class ResidualConvBlock(nn.Module):
+    def __init__(
+        self,
+        in_channels: int,
+        out_channels: int = None,
+        hidden_channels: int = None,
+        kernel_size: int = 3,
+        activation: str = "relu",
+        in_norm: str = "layer_norm",
+        hidden_norm: str = "group_norm",
+    ):
+        super().__init__()
+        out_channels = out_channels or in_channels
+        hidden_channels = hidden_channels or in_channels
+        act = _ACTIVATIONS[activation]
+        self.layers = [
+            _make_norm(in_norm, in_channels),
+            act(),
+            Conv2dReplicate(in_channels, hidden_channels, kernel_size),
+            _make_norm(hidden_norm, hidden_channels),
+            act(),
+            Conv2dReplicate(hidden_channels, out_channels, kernel_size),
+        ]
+        self.skip_connection = (
+            nn.Conv2d(in_channels, out_channels, kernel_size=1)
+            if in_channels != out_channels
+            else nn.Identity()
+        )
+
+    def __call__(self, x):
+        return run_sequential(self.layers, x) + self.skip_connection(x)
+
+
+def make_resampler(in_channels: int, out_channels: int, type_: str):
+    """Return the 2x resampler as a plain module list (names ``0``, ``1``)."""
+    if type_ == "conv_transpose":
+        return [
+            nn.ConvTranspose2d(in_channels, out_channels, kernel_size=2, stride=2),
+            Conv2dReplicate(out_channels, out_channels, 3),
+        ]
+    if type_ == "bilinear":
+        upsample = nn.Upsample(scale_factor=2, mode="linear", align_corners=False)
+    elif type_ == "nearest":
+        upsample = nn.Upsample(scale_factor=2, mode="nearest")
+    else:
+        raise NotImplementedError(f"Unsupported resampler type: {type_}")
+    return [upsample, Conv2dReplicate(in_channels, out_channels, 3)]
+
+
+class ConvStack(nn.Module):
+    def __init__(self, config: ConvStackConfig):
+        super().__init__()
+        dim_res = config.dim_res_blocks
+        num_levels = len(dim_res)
+        dim_in = _per_level(config.dim_in, num_levels)
+        dim_out = _per_level(config.dim_out, num_levels)
+        resamplers = _per_level(config.resamplers, num_levels - 1)
+        num_res_blocks = _per_level(config.num_res_blocks, num_levels)
+
+        self.input_blocks = [
+            nn.Conv2d(d, r, kernel_size=1) if d is not None else nn.Identity()
+            for d, r in zip(dim_in, dim_res)
+        ]
+        self.resamplers = [
+            make_resampler(dim_prev, dim_succ, resampler)
+            for dim_prev, dim_succ, resampler in zip(
+                dim_res[:-1], dim_res[1:], resamplers
+            )
+        ]
+        self.res_blocks = [
+            [
+                ResidualConvBlock(
+                    d,
+                    d,
+                    config.dim_times_res_block_hidden * d,
+                    activation=config.activation,
+                    in_norm=config.res_block_in_norm,
+                    hidden_norm=config.res_block_hidden_norm,
+                )
+                for _ in range(n)
+            ]
+            for d, n in zip(dim_res, num_res_blocks)
+        ]
+        self.output_blocks = [
+            nn.Conv2d(r, d, kernel_size=1) if d is not None else nn.Identity()
+            for d, r in zip(dim_out, dim_res)
+        ]
+
+    def __call__(self, in_features: List[mx.array]) -> List[mx.array]:
+        out_features = []
+        for i in range(len(self.res_blocks)):
+            feature = self.input_blocks[i](in_features[i])
+            x = feature if i == 0 else x + feature
+            x = run_sequential(self.res_blocks[i], x)
+            out_features.append(self.output_blocks[i](x))
+            if i < len(self.res_blocks) - 1:
+                x = run_sequential(self.resamplers[i], x)
+        return out_features
+
+
+def make_scale_head(config: ScaleHeadConfig) -> list:
+    """MLP as a plain module list: Linear-ReLU pairs, then the final Linear."""
+    dims = config.dims
+    modules = [
+        m
+        for d_in, d_out in zip(dims[:-2], dims[1:-1])
+        for m in (nn.Linear(d_in, d_out), nn.ReLU())
+    ]
+    modules.append(nn.Linear(dims[-2], dims[-1]))
+    return modules

--- a/mlx_vlm/models/moge3/convert.py
+++ b/mlx_vlm/models/moge3/convert.py
@@ -1,0 +1,87 @@
+"""Convert an official MoGe-3 ``model.pt`` checkpoint to an MLX model repo.
+
+The official checkpoints (e.g. ``Ruicheng/moge-3-vitl``) store a torch pickle
+with ``model_config`` + ``model`` state dict. This script writes the standard
+MLX layout: ``config.json`` + ``model.safetensors`` (+ optional Hub upload).
+
+Usage:
+    python -m mlx_vlm.models.moge3.convert \
+        --torch-ckpt /path/to/model.pt \
+        --mlx-path /path/to/out \
+        --dtype float32 \
+        [--upload-repo mlx-community/moge-3-vitl-mlx-fp32]
+"""
+
+import argparse
+import json
+from pathlib import Path
+
+import mlx.core as mx
+
+from ...utils import MODEL_CONVERSION_DTYPES
+from .moge3 import _CONV_TRANSPOSE_KEY
+
+
+def convert_weights(state_dict):
+    """Torch state dict -> MLX weights (channel-last conv layouts)."""
+    weights = {}
+    for key, tensor in state_dict.items():
+        arr = tensor.detach().cpu().numpy()
+        if key in ("encoder.image_mean", "encoder.image_std"):
+            arr = arr.reshape(1, 1, 1, 3)
+        elif arr.ndim == 4 and _CONV_TRANSPOSE_KEY.search(key):
+            arr = arr.transpose(1, 2, 3, 0)  # ConvTranspose2d: (in, out, kh, kw)
+        elif arr.ndim == 4:
+            arr = arr.transpose(0, 2, 3, 1)  # Conv2d: (out, in, kh, kw)
+        weights[key] = mx.array(arr)
+    return weights
+
+
+def convert(
+    torch_ckpt: str, mlx_path: str, dtype: str = "float32", upload_repo: str = None
+):
+    import torch
+
+    checkpoint = torch.load(torch_ckpt, map_location="cpu", weights_only=True)
+    model_config = checkpoint["model_config"]
+
+    weights = convert_weights(checkpoint["model"])
+    if dtype != "float32":
+        cast = getattr(mx, dtype)
+        weights = {
+            k: (v.astype(cast) if mx.issubdtype(v.dtype, mx.floating) else v)
+            for k, v in weights.items()
+        }
+
+    out = Path(mlx_path)
+    out.mkdir(parents=True, exist_ok=True)
+    mx.save_safetensors(str(out / "model.safetensors"), weights)
+    (out / "config.json").write_text(
+        json.dumps({"model_type": "moge3", **model_config}, indent=2)
+    )
+    (out / "preprocessor_config.json").write_text(
+        json.dumps({"resize_to": None}, indent=2)
+    )
+    print(f"Saved {len(weights)} tensors to {out}")
+
+    if upload_repo:
+        from huggingface_hub import HfApi
+
+        api = HfApi()
+        api.create_repo(upload_repo, exist_ok=True)
+        api.upload_folder(repo_id=upload_repo, folder_path=str(out))
+        print(f"Uploaded to https://huggingface.co/{upload_repo}")
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--torch-ckpt", required=True, help="Path to model.pt")
+    parser.add_argument("--mlx-path", required=True, help="Output directory")
+    parser.add_argument("--dtype", default="float32", choices=MODEL_CONVERSION_DTYPES)
+    parser.add_argument("--upload-repo", default=None, help="HF repo id to upload to")
+    args = parser.parse_args()
+    convert(args.torch_ckpt, args.mlx_path, args.dtype, args.upload_repo)
+
+
+if __name__ == "__main__":
+    main()

--- a/mlx_vlm/models/moge3/generate.py
+++ b/mlx_vlm/models/moge3/generate.py
@@ -1,0 +1,56 @@
+"""Single-image geometry prediction for MoGe-3.
+
+Usage:
+    from mlx_vlm import load
+    from mlx_vlm.models.moge3.generate import MoGe3Predictor, read_image
+
+    model, processor = load("mlx-community/moge-3-vitl-mlx-fp32")
+    predictor = MoGe3Predictor(model, processor)
+    output = predictor.infer(read_image("image.jpg"))
+    points, depth, mask = output["points"], output["depth"], output["mask"]
+"""
+
+from typing import Dict
+
+import mlx.core as mx
+import numpy as np
+
+
+def read_image(image_source) -> np.ndarray:
+    """Read an image (path, URL, data URI, BytesIO or PIL) as RGB uint8 (H, W, 3)."""
+    from ...utils import load_image
+
+    return np.asarray(load_image(image_source))
+
+
+class MoGe3Predictor:
+    def __init__(self, model, processor=None):
+        self.model = model
+        if processor is None:
+            from .processing_moge3 import MogeProcessor
+
+            processor = MogeProcessor()
+        self.processor = processor
+
+    def infer(self, image: np.ndarray, **kwargs) -> Dict[str, np.ndarray]:
+        """Predict geometry for an (H, W, 3) uint8/float RGB image or (B, H, W, 3) batch.
+
+        Keyword arguments (``num_tokens``, ``resolution_level``,
+        ``force_projection``, ``apply_mask``, ``fov_x``, ``refine_steps``,
+        ``return_per_step``) are forwarded to :meth:`Model.infer`.
+
+        Returns:
+            Dict of numpy arrays with keys ``points`` (H, W, 3),
+            ``intrinsics`` (3, 3), ``depth`` (H, W), ``mask`` (H, W),
+            ``normal`` (H, W, 3) (batched forms carry a leading B).
+        """
+        image = self.processor.preprocess_image(image)
+        output = self.model.infer(mx.array(image), **kwargs)
+        return {
+            key: (
+                [np.array(v) for v in value]
+                if isinstance(value, list)
+                else np.array(value)
+            )
+            for key, value in output.items()
+        }

--- a/mlx_vlm/models/moge3/geometry.py
+++ b/mlx_vlm/models/moge3/geometry.py
@@ -1,0 +1,181 @@
+"""Geometry helpers for MoGe-3 (ports of moge.utils.geometry_torch / utils3d)."""
+
+from typing import Optional, Tuple
+
+import mlx.core as mx
+
+
+def _view_plane_axes(
+    width: int, height: int, aspect_ratio: float = None
+) -> Tuple[mx.array, mx.array]:
+    """Per-axis view-plane coordinates ``u`` (W,) and ``v`` (H,).
+
+    Pixel centers span ``[-w/diag, w/diag]`` x ``[-h/diag, h/diag]``.
+    """
+    if aspect_ratio is None:
+        aspect_ratio = width / height
+    span_x = aspect_ratio / (1 + aspect_ratio**2) ** 0.5
+    span_y = 1 / (1 + aspect_ratio**2) ** 0.5
+    u = mx.linspace(-span_x * (width - 1) / width, span_x * (width - 1) / width, width)
+    v = mx.linspace(
+        -span_y * (height - 1) / height, span_y * (height - 1) / height, height
+    )
+    return u.astype(mx.float32), v.astype(mx.float32)
+
+
+def normalized_view_plane_uv(
+    width: int, height: int, aspect_ratio: float = None
+) -> mx.array:
+    """UV (H, W, 2) with left-top (-w/diag, -h/diag) and right-bottom (w/diag, h/diag)."""
+    u, v = _view_plane_axes(width, height, aspect_ratio)
+    u, v = mx.meshgrid(u, v, indexing="xy")
+    return mx.stack([u, v], axis=-1)
+
+
+def _lm_evaluate(shift, uv, xy, z, fixed):
+    """Cost, gradient, Gauss-Newton Hessian and focal at ``shift`` (all (B,))."""
+    inv_depth = 1.0 / (z + shift)
+    p = xy * inv_depth[..., None]  # xy / (z + s)
+    q = -p * inv_depth[..., None]  # d p / d s
+    if fixed is None:
+        a = (p * uv).sum(axis=(-2, -1), keepdims=True)
+        b = mx.maximum((p * p).sum(axis=(-2, -1), keepdims=True), 1e-12)
+        f = a / b
+        da = (q * uv).sum(axis=(-2, -1), keepdims=True)
+        db = 2.0 * (p * q).sum(axis=(-2, -1), keepdims=True)
+        df = (da * b - a * db) / (b * b)
+    else:
+        f = fixed[..., None]
+        df = mx.zeros_like(f)
+    r = f * p - uv
+    j = df * p + f * q
+    cost = (r * r).sum(axis=(-2, -1))
+    g = (j * r).sum(axis=(-2, -1))
+    h = (j * j).sum(axis=(-2, -1))
+    return cost, g, h, f.reshape(-1)
+
+
+@mx.compile
+def _lm_step(state, uv, xy, z, fixed, ftol):
+    """One damped Gauss-Newton trial per image; acceptance via ``mx.where``."""
+    shift, lam, done, cost, g, h, f = state
+    step = -g / mx.maximum(h * (1.0 + lam), 1e-30)
+    trial = shift + step[:, None]
+    cost_t, g_t, h_t, f_t = _lm_evaluate(trial, uv, xy, z, fixed)
+    accept = (cost_t < cost) & ~done
+    converged = accept & ((cost - cost_t) <= ftol * cost_t)
+    tiny = mx.abs(step) < 1e-8 * mx.maximum(mx.abs(shift[:, 0]), 1.0)
+    shift = mx.where(accept[:, None], trial, shift)
+    cost, g, h, f = (
+        mx.where(accept, new, old)
+        for new, old in ((cost_t, cost), (g_t, g), (h_t, h), (f_t, f))
+    )
+    lam = mx.where(done, lam, mx.where(accept, lam / 3.0, lam * 5.0))
+    return shift, lam, done | converged | tiny, cost, g, h, f
+
+
+def _solve_focal_shift(
+    uv: mx.array,
+    xyz: mx.array,
+    focal: Optional[mx.array] = None,
+    ftol: float = 1e-3,
+    max_iter: int = 30,
+) -> Tuple[mx.array, mx.array]:
+    xy, z = xyz[..., :2], xyz[..., 2]
+    fixed = None if focal is None else focal.reshape(-1, 1)
+    ftol = mx.array(ftol, dtype=mx.float32)
+
+    batch = xyz.shape[0]
+    shift = mx.zeros((batch, 1), dtype=mx.float32)
+    lam = mx.full((batch,), 1e-3, dtype=mx.float32)
+    done = mx.zeros((batch,), dtype=mx.bool_)
+    state = (shift, lam, done, *_lm_evaluate(shift, uv, xy, z, fixed))
+    for _ in range(max_iter):
+        state = _lm_step(state, uv, xy, z, fixed, ftol)
+    shift, f = state[0], state[-1]
+    return shift.reshape(-1), f
+
+
+def _nearest_indices(in_size: int, out_size: int) -> mx.array:
+    """Torch ``F.interpolate(mode='nearest')`` source indices."""
+    return mx.floor(mx.arange(out_size) * (in_size / out_size)).astype(mx.int32)
+
+
+def recover_focal_shift(
+    points: mx.array,
+    mask: Optional[mx.array] = None,
+    focal: Optional[mx.array] = None,
+    downsample_size: Tuple[int, int] = (64, 64),
+):
+    """Recover focal (rel. to half diagonal) and z-shift from a point map.
+
+    - ``points``: (..., H, W, 3); ``mask``: (..., H, W) bool; ``focal``: (...).
+    - Returns ``(focal, shift)``, each (...) float32.
+    """
+    shape = points.shape
+    height, width = shape[-3], shape[-2]
+    batch_shape = shape[:-3]
+
+    # The solver only needs a 64x64 grid, so build the UV map at that size
+    # directly instead of subsampling a full-resolution grid.
+    ii = _nearest_indices(height, downsample_size[0])
+    jj = _nearest_indices(width, downsample_size[1])
+    points = points.reshape(-1, height, width, 3)[:, ii][:, :, jj]
+    batch = points.shape[0]
+    n = downsample_size[0] * downsample_size[1]
+    xyz = points.reshape(batch, n, 3).astype(mx.float32)
+    u, v = _view_plane_axes(width, height)
+    u, v = mx.meshgrid(u[jj], v[ii], indexing="xy")
+    uv = mx.broadcast_to(mx.stack([u, v], axis=-1).reshape(1, n, 2), (batch, n, 2))
+
+    if mask is None:
+        valid_count = mx.full((batch,), n)
+    else:
+        valid = mask.reshape(-1, height, width)[:, ii][:, :, jj].reshape(batch, n, 1)
+        valid_count = valid.sum(axis=(-2, -1))
+        # Zero invalid samples (and put them at unit depth) so they contribute
+        # nothing to the residual and never divide by zero.
+        uv = mx.where(valid, uv, 0.0)
+        xyz = mx.where(valid, xyz, mx.array([0.0, 0.0, 1.0]))
+
+    focal_flat = None if focal is None else focal.astype(mx.float32).reshape(-1)
+    shift, optim_focal = _solve_focal_shift(uv, xyz, focal_flat)
+
+    degenerate = valid_count < 2
+    shift = mx.where(degenerate, 0.0, shift).reshape(batch_shape)
+    if focal is None:
+        focal = mx.where(degenerate, 1.0, optim_focal)
+    return focal.reshape(batch_shape), shift
+
+
+def intrinsics_from_focal_center(fx, fy, cx, cy) -> mx.array:
+    """OpenCV intrinsics matrix (..., 3, 3) from focal lengths and center."""
+    zeros, ones = mx.zeros_like(fx), mx.ones_like(fx)
+    rows = [
+        mx.stack([fx, zeros, cx], axis=-1),
+        mx.stack([zeros, fy, cy], axis=-1),
+        mx.stack([zeros, zeros, ones], axis=-1),
+    ]
+    return mx.stack(rows, axis=-2)
+
+
+def _inverse_3x3(m: mx.array) -> mx.array:
+    """Closed-form inverse of (..., 3, 3) via the adjugate; runs on the GPU."""
+    c0, c1, c2 = m[..., :, 0], m[..., :, 1], m[..., :, 2]
+    r0 = mx.linalg.cross(c1, c2)
+    r1 = mx.linalg.cross(c2, c0)
+    r2 = mx.linalg.cross(c0, c1)
+    det = (c0 * r0).sum(axis=-1, keepdims=True)[..., None]
+    return mx.stack([r0, r1, r2], axis=-2) / det
+
+
+def depth_map_to_point_map(depth: mx.array, intrinsics: mx.array) -> mx.array:
+    """Unproject depth (..., H, W) to camera-space points (..., H, W, 3)."""
+    height, width = depth.shape[-2], depth.shape[-1]
+    # (H, W, 3) pixel-center coordinates (u, v, 1) normalized to [0, 1].
+    u = (mx.arange(width, dtype=mx.float32) + 0.5) / width
+    v = (mx.arange(height, dtype=mx.float32) + 0.5) / height
+    u, v = mx.meshgrid(u, v, indexing="xy")
+    hom = mx.stack([u, v, mx.ones_like(u)], axis=-1)
+    rays = mx.einsum("...ij,hwj->...hwi", _inverse_3x3(intrinsics), hom)
+    return rays * depth[..., None]

--- a/mlx_vlm/models/moge3/moge3.py
+++ b/mlx_vlm/models/moge3/moge3.py
@@ -1,0 +1,371 @@
+"""MoGe-3 model (MLX port of moge.model.v3.MoGeModel).
+
+Monocular geometry estimation: DINOv2 encoder + convolutional neck and
+heads + sparse 3D UNet refiner. Inputs are channel-last RGB images in
+[0, 1]; outputs are point maps, depth maps, masks, normals, and camera
+intrinsics.
+"""
+
+import math
+import re
+from typing import Dict, List, Optional, Union
+
+import mlx.core as mx
+import mlx.nn as nn
+from mlx.utils import tree_flatten
+
+from ..interpolate import resize_bilinear_nhwc
+from .config import ModelConfig
+from .conv_stack import ConvStack, make_scale_head, run_sequential
+from .geometry import (
+    depth_map_to_point_map,
+    intrinsics_from_focal_center,
+    normalized_view_plane_uv,
+    recover_focal_shift,
+)
+from .refiner import Sparse3DUNet
+from .vision import MoGe3Encoder
+
+DEFAULT_REFINE_STEPS = 3
+
+
+def resize(x: mx.array, size) -> mx.array:
+    """Channel-last bilinear resize matching ``F.interpolate`` (no antialias)."""
+    return resize_bilinear_nhwc(x, size)
+
+
+# ``<stack>.resamplers.<i>.0.weight`` is always the ConvTranspose2d of a
+# "conv_transpose" resampler (bilinear/nearest resamplers have no ``.0`` weight).
+_CONV_TRANSPOSE_KEY = re.compile(r"\.resamplers\.\d+\.0\.weight$")
+
+
+class Model(nn.Module):
+    def __init__(self, config: ModelConfig):
+        super().__init__()
+        self.config = config
+
+        self.encoder = MoGe3Encoder(config.encoder)
+        self.neck = ConvStack(config.neck)
+        if config.points_head is not None:
+            self.points_head = ConvStack(config.points_head)
+        if config.mask_head is not None:
+            self.mask_head = ConvStack(config.mask_head)
+        if config.normal_head is not None:
+            self.normal_head = ConvStack(config.normal_head)
+        if config.scale_head is not None:
+            self.scale_head = make_scale_head(config.scale_head)
+        if config.refiner is not None:
+            self.refiner = Sparse3DUNet(config.refiner)
+
+    def sanitize(self, weights: Dict[str, mx.array]) -> Dict[str, mx.array]:
+        """Relayout ConvTranspose2d weights from torch (in, out, 2, 2) to MLX
+        (out, 2, 2, in). Idempotent: a weight whose shape already matches the
+        module's parameter is left alone (shape sniffing alone cannot tell the
+        two layouts apart when a channel count equals the kernel size)."""
+        targets = {
+            k: v.shape
+            for k, v in tree_flatten(self.parameters())
+            if _CONV_TRANSPOSE_KEY.search(k)
+        }
+        sanitized = {}
+        for k, v in weights.items():
+            target = targets.get(k)
+            if target is not None and v.ndim == 4 and v.shape != target:
+                v = v.transpose(1, 2, 3, 0)
+            sanitized[k] = v
+        return sanitized
+
+    def _has(self, name: str) -> bool:
+        """Whether an optional submodule exists and was not disabled by the
+        loader (which sets modules without checkpoint weights to ``None``)."""
+        return getattr(self, name, None) is not None
+
+    # ---- refiner helpers -------------------------------------------------
+
+    def _voxelize(self, point_coord: mx.array):
+        """Dense (B, H, W, 3) (x/z, y/z, logz) -> sparse feats/coords/shape/logz.
+
+        Binning is quantized at 1/refiner_depth_resolution and done in fp32.
+        Coords come out in raster order (b, i, j), one voxel per pixel, which
+        the sparse ops rely on. The depth extent of ``shape`` is a lazy 0-d
+        array so voxelization does not force a host sync.
+        """
+        if point_coord.ndim != 4 or point_coord.shape[-1] != 3:
+            raise ValueError(
+                f"point_coord must be [B, H, W, 3], got {point_coord.shape}"
+            )
+        point_coord = point_coord.astype(mx.float32)
+        bsz, height, width, _ = point_coord.shape
+
+        logz = point_coord[..., 2]
+        zq = mx.round(logz * self.config.refiner_depth_resolution).astype(mx.int64)
+        z_offset = mx.min(zq, axis=(1, 2), keepdims=True)
+        z_idx = (zq - z_offset).astype(mx.int32)
+        z_extent = z_idx.max() + 1
+
+        b, i, j = mx.meshgrid(
+            mx.arange(bsz, dtype=mx.int32),
+            mx.arange(height, dtype=mx.int32),
+            mx.arange(width, dtype=mx.int32),
+            indexing="ij",
+        )
+        coords = mx.stack([b, i, j, z_idx], axis=-1).reshape(-1, 4)
+        feats = point_coord.reshape(-1, 3)
+        shape = (bsz, height, width, z_extent)
+        return feats, coords, shape, logz
+
+    def _refine_logz(
+        self, point_coord: mx.array, encoder_feature: mx.array
+    ) -> mx.array:
+        bsz, height, width, _ = point_coord.shape
+        feats, coords, shape, logz = self._voxelize(point_coord)
+        out = self.refiner(feats, coords, shape, encoder_feature)
+        return logz + out.astype(mx.float32).reshape(bsz, height, width)
+
+    # ---- forward ----------------------------------------------------------
+
+    def _remap_points(self, points: mx.array) -> mx.array:
+        xy, z = mx.split(points, [2], axis=-1)
+        z = mx.exp(z)
+        return mx.concatenate([xy * z, z], axis=-1)
+
+    def __call__(
+        self,
+        image: mx.array,
+        num_tokens: int,
+        refine_steps: int = DEFAULT_REFINE_STEPS,
+        return_per_step: bool = False,
+    ) -> Dict[str, mx.array]:
+        """image: (B, H, W, 3) float in [0, 1]."""
+        if refine_steps > 0 and not self._has("refiner"):
+            raise ValueError("Refiner is not enabled but refine_steps > 0.")
+
+        batch_size, img_h, img_w, _ = image.shape
+
+        aspect_ratio = img_w / img_h
+        base_h = round((num_tokens / aspect_ratio) ** 0.5)
+        base_w = round((num_tokens * aspect_ratio) ** 0.5)
+
+        # Backbone encoding
+        features, cls_token = self.encoder(image, base_h, base_w)
+
+        # Each pyramid level gets a UV map for the aspect ratio; the first
+        # level concatenates it to the backbone features.
+        uvs = [
+            mx.broadcast_to(uv[None], (batch_size, *uv.shape))
+            for uv in (
+                normalized_view_plane_uv(
+                    base_w * 2**level, base_h * 2**level, aspect_ratio
+                )
+                for level in range(len(self.neck.res_blocks))
+            )
+        ]
+        features = [mx.concatenate([features, uvs[0]], axis=-1), *uvs[1:]]
+
+        # Shared neck
+        neck_features = self.neck(features)
+
+        # Heads decoding
+        raw_coord = (
+            self.points_head(neck_features)[-1] if self._has("points_head") else None
+        )
+        normal = (
+            self.normal_head(neck_features)[-1] if self._has("normal_head") else None
+        )
+        mask = self.mask_head(neck_features)[-1] if self._has("mask_head") else None
+        metric_scale = (
+            run_sequential(self.scale_head, cls_token)
+            if self._has("scale_head")
+            else None
+        )
+
+        # Refine the point map in factorized coordinate space (x/z, y/z, logz)
+        points: Optional[mx.array] = None
+        points_per_step: Optional[List[mx.array]] = None
+        if raw_coord is not None:
+            current_coord = raw_coord.astype(mx.float32)
+            coord_per_step = [current_coord]
+            refiner_feature = features[0]
+            for _ in range(refine_steps):
+                refined_logz = self._refine_logz(
+                    mx.stop_gradient(current_coord),
+                    mx.stop_gradient(refiner_feature),
+                )
+                current_coord = mx.concatenate(
+                    [current_coord[..., :2], refined_logz[..., None]], axis=-1
+                )
+                coord_per_step.append(current_coord)
+            if not return_per_step:
+                coord_per_step = coord_per_step[-1:]
+
+            num_point_steps = len(coord_per_step)
+            coords = resize(mx.concatenate(coord_per_step, axis=0), (img_h, img_w))
+            points_all = self._remap_points(
+                coords.reshape(num_point_steps, batch_size, img_h, img_w, 3)
+            )
+            points = points_all[-1]
+            if return_per_step:
+                points_per_step = list(points_all)
+
+        if normal is not None:
+            normal = resize(normal, (img_h, img_w))
+            normal = normal / mx.maximum(
+                mx.linalg.norm(normal, axis=-1, keepdims=True), 1e-12
+            )
+        if mask is not None:
+            mask = mx.sigmoid(resize(mask, (img_h, img_w)).squeeze(-1))
+        if metric_scale is not None:
+            metric_scale = mx.exp(metric_scale.squeeze(-1))
+
+        return_dict = {
+            "points": points,
+            "points_per_step": points_per_step,
+            "normal": normal,
+            "mask": mask,
+            "metric_scale": metric_scale,
+        }
+        return {k: v for k, v in return_dict.items() if v is not None}
+
+    # ---- user-facing inference ---------------------------------------------
+
+    def infer(
+        self,
+        image: mx.array,
+        num_tokens: int = None,
+        resolution_level: int = 9,
+        force_projection: bool = True,
+        apply_mask: bool = True,
+        fov_x: Optional[Union[float, mx.array]] = None,
+        refine_steps: int = DEFAULT_REFINE_STEPS,
+        return_per_step: bool = False,
+    ) -> Dict[str, mx.array]:
+        """Run the full inference pipeline.
+
+        - ``image``: (B, H, W, 3) or (H, W, 3) RGB float in [0, 1].
+        - ``num_tokens``: base ViT token count; derived from
+          ``resolution_level`` (0-9) when None.
+        - ``force_projection``: recompute the point map from depth and
+          intrinsics.
+        - ``apply_mask``: mask invalid points/depths with the predicted mask.
+        - ``fov_x``: horizontal field of view in degrees, or None to infer.
+        - ``refine_steps``: number of sparse 3D refinement updates.
+
+        Returns a dict with ``points`` (B, H, W, 3), ``intrinsics`` (B, 3, 3),
+        ``depth`` (B, H, W), ``mask`` (B, H, W), ``normal`` (B, H, W, 3) and
+        per-step variants when ``return_per_step`` is True.
+        """
+        omit_batch_dim = image.ndim == 3
+        if omit_batch_dim:
+            image = image[None]
+
+        batch_size, original_height, original_width, _ = image.shape
+        aspect_ratio = original_width / original_height
+
+        if num_tokens is None:
+            min_tokens, max_tokens = self.config.num_tokens_range
+            num_tokens = int(
+                min_tokens + (resolution_level / 9) * (max_tokens - min_tokens)
+            )
+
+        output = self(
+            image,
+            num_tokens=num_tokens,
+            refine_steps=refine_steps,
+            return_per_step=return_per_step,
+        )
+        affine_points_per_step = output.get("points_per_step")
+        if affine_points_per_step is None and "points" in output:
+            affine_points_per_step = [output["points"]]
+
+        # Post-process in fp32
+        normal, mask, metric_scale = (
+            output[k].astype(mx.float32) if k in output else None
+            for k in ("normal", "mask", "metric_scale")
+        )
+        mask_binary = mask > 0.5 if mask is not None else None
+
+        points = depth = intrinsics = None
+        points_per_step = depth_per_step = intrinsics_per_step = mask_per_step = None
+        if affine_points_per_step is not None:
+            # Per-step (focal, shift) recovery: refinement modifies logz which
+            # changes the 3D shape, so each step gets its own alignment.
+            focal_fixed = None
+            if fov_x is not None:
+                fov = mx.array(fov_x, dtype=mx.float32)
+                focal_fixed = mx.broadcast_to(
+                    aspect_ratio
+                    / (1 + aspect_ratio**2) ** 0.5
+                    / mx.tan(fov * (math.pi / 360)),
+                    (batch_size,),
+                )
+
+            points_per_step, depth_per_step, intrinsics_per_step = [], [], []
+            for affine_points in affine_points_per_step:
+                affine_points = affine_points.astype(mx.float32)
+                focal_i, shift_i = recover_focal_shift(
+                    affine_points, mask_binary, focal=focal_fixed
+                )
+                fx_i = focal_i / 2 * (1 + aspect_ratio**2) ** 0.5 / aspect_ratio
+                fy_i = focal_i / 2 * (1 + aspect_ratio**2) ** 0.5
+                half = mx.full(focal_i.shape, 0.5)
+                intrinsics_i = intrinsics_from_focal_center(fx_i, fy_i, half, half)
+
+                depth_i = affine_points[..., 2] + shift_i[..., None, None]
+                if force_projection:
+                    points_i = depth_map_to_point_map(depth_i, intrinsics=intrinsics_i)
+                else:
+                    points_i = mx.concatenate(
+                        [affine_points[..., :2], depth_i[..., None]], axis=-1
+                    )
+
+                if metric_scale is not None:
+                    points_i = points_i * metric_scale[:, None, None, None]
+                    depth_i = depth_i * metric_scale[:, None, None]
+
+                points_per_step.append(points_i)
+                depth_per_step.append(depth_i)
+                intrinsics_per_step.append(intrinsics_i)
+
+            intrinsics = intrinsics_per_step[-1]
+
+            if mask_binary is not None:
+                mask_per_step = [mask_binary & (d > 0) for d in depth_per_step]
+                mask_binary = mask_per_step[-1]
+
+            points, depth = points_per_step[-1], depth_per_step[-1]
+
+        if apply_mask:
+            if mask_per_step is not None:
+                inf = mx.array(float("inf"), mx.float32)
+                points_per_step = [
+                    mx.where(m[..., None], p, inf)
+                    for p, m in zip(points_per_step, mask_per_step)
+                ]
+                depth_per_step = [
+                    mx.where(m, d, inf) for d, m in zip(depth_per_step, mask_per_step)
+                ]
+                points, depth = points_per_step[-1], depth_per_step[-1]
+            if mask_binary is not None and normal is not None:
+                normal = mx.where(mask_binary[..., None], normal, mx.zeros_like(normal))
+
+        if not return_per_step:
+            points_per_step = depth_per_step = intrinsics_per_step = None
+
+        return_dict = {
+            "points": points,
+            "intrinsics": intrinsics,
+            "depth": depth,
+            "mask": mask_binary,
+            "normal": normal,
+            "points_per_step": points_per_step,
+            "intrinsics_per_step": intrinsics_per_step,
+            "depth_per_step": depth_per_step,
+        }
+        return_dict = {k: v for k, v in return_dict.items() if v is not None}
+
+        if omit_batch_dim:
+            return_dict = {
+                k: [item[0] for item in v] if isinstance(v, list) else v[0]
+                for k, v in return_dict.items()
+            }
+        return return_dict

--- a/mlx_vlm/models/moge3/processing_moge3.py
+++ b/mlx_vlm/models/moge3/processing_moge3.py
@@ -1,0 +1,81 @@
+"""MoGe-3 image processor.
+
+MoGe works on the native image resolution, so preprocessing is only an
+optional downscale plus a [0, 1] rescale. ImageNet normalization happens
+inside the model.
+"""
+
+from typing import Dict, Optional
+
+import mlx.core as mx
+import numpy as np
+
+from ..base import install_auto_processor_patch
+
+
+class MogeProcessor:
+    """Preprocess RGB images (H, W, 3) or (B, H, W, 3) for MoGe-3."""
+
+    def __init__(self, resize_to: Optional[int] = None):
+        # Optional longest-side cap; downscaled with INTER_AREA as in the
+        # reference CLI.
+        self.resize_to = resize_to
+
+    @classmethod
+    def from_pretrained(cls, path, **kwargs):
+        import json
+        from pathlib import Path
+
+        cfg_path = Path(path) / "preprocessor_config.json"
+        config = {}
+        if cfg_path.exists():
+            config = json.loads(cfg_path.read_text())
+        config.update(kwargs)
+        return cls(**{k: v for k, v in config.items() if k in ("resize_to",)})
+
+    def preprocess_image(self, image: np.ndarray) -> np.ndarray:
+        """RGB (H, W, 3) or (B, H, W, 3) -> float32 in [0, 1] (optionally downscaled).
+
+        Integer images are scaled by their dtype range (uint8 -> /255,
+        uint16 -> /65535). Float images must already be in [0, 1].
+        """
+        image = np.asarray(image)
+        if np.issubdtype(image.dtype, np.integer):
+            image = image.astype(np.float32) / np.iinfo(image.dtype).max
+        else:
+            image = image.astype(np.float32)
+            if image.size and (image.min() < 0.0 or image.max() > 1.0):
+                raise ValueError(
+                    "Float images must be in [0, 1]; pass integer images "
+                    "(uint8/uint16) or scale the array first."
+                )
+        if self.resize_to is not None:
+            image = self._downscale(image)
+        return image
+
+    def _downscale(self, image: np.ndarray) -> np.ndarray:
+        import cv2
+
+        height, width = image.shape[-3:-1]
+        limit = self.resize_to
+        height, width = (
+            min(limit, int(limit * height / width)),
+            min(limit, int(limit * width / height)),
+        )
+        if image.ndim == 3:
+            return cv2.resize(image, (width, height), interpolation=cv2.INTER_AREA)
+        return np.stack(
+            [
+                cv2.resize(frame, (width, height), interpolation=cv2.INTER_AREA)
+                for frame in image
+            ]
+        )
+
+    def preprocess(self, image: np.ndarray) -> Dict[str, mx.array]:
+        return {"pixel_values": mx.array(self.preprocess_image(image))}
+
+    def __call__(self, image: np.ndarray) -> Dict[str, mx.array]:
+        return self.preprocess(image)
+
+
+install_auto_processor_patch(["moge3"], MogeProcessor)

--- a/mlx_vlm/models/moge3/refiner.py
+++ b/mlx_vlm/models/moge3/refiner.py
@@ -1,0 +1,198 @@
+"""Sparse 3D UNet refiner for MoGe-3 (pure-MLX port).
+
+Ports ``moge.model.modules.sparse_unet.Sparse3DUNet`` and the FlexGEMM-based
+blocks in ``flex_sparse_blocks``. Operates purely on sparse features; the
+caller builds the voxelization and interprets the output.
+"""
+
+import math
+from typing import List, Optional
+
+import mlx.core as mx
+import mlx.nn as nn
+
+from .config import RefinerConfig
+from .conv_stack import run_sequential
+from .sparse import SubmanifoldConv3d, sparse_pool2x_mean, sparse_upsample2x_nearest
+
+
+class SparseResBlock3d(nn.Module):
+    def __init__(self, channels: int, out_channels: int = None):
+        super().__init__()
+        out_channels = out_channels or channels
+        self.norm1 = nn.LayerNorm(channels, eps=1e-6)
+        self.conv1 = SubmanifoldConv3d(channels, out_channels)
+        self.conv2 = SubmanifoldConv3d(out_channels, out_channels)
+        self.skip_connection = (
+            nn.Linear(channels, out_channels) if channels != out_channels else None
+        )
+
+    def __call__(self, feats, coords, shape, neighbor_map=None):
+        h = nn.silu(self.norm1(feats))
+        h, neighbor_map = self.conv1(h, coords, shape, neighbor_map=neighbor_map)
+        h = nn.silu(h)
+        h, neighbor_map = self.conv2(h, coords, shape, neighbor_map=neighbor_map)
+        skip = (
+            self.skip_connection(feats) if self.skip_connection is not None else feats
+        )
+        return h + skip, neighbor_map
+
+
+class PoolDown(nn.Module):
+    """2x mean pool followed by a channel projection."""
+
+    def __init__(self, in_ch: int, out_ch: int):
+        super().__init__()
+        self.linear = nn.Linear(in_ch, out_ch)
+
+    def __call__(self, feats, coords, shape):
+        feats, coords, shape, parent_idx = sparse_pool2x_mean(feats, coords, shape)
+        return self.linear(feats), coords, shape, parent_idx
+
+
+class NearestUp(nn.Module):
+    """Channel projection followed by a 2x nearest upsample onto target coords."""
+
+    def __init__(self, in_ch: int, out_ch: int):
+        super().__init__()
+        self.linear = nn.Linear(in_ch, out_ch)
+
+    def __call__(self, feats, parent_idx, target_coords, target_shape):
+        return sparse_upsample2x_nearest(
+            self.linear(feats), parent_idx, target_coords, target_shape
+        )
+
+
+class Sparse3DUNet(nn.Module):
+    """Sparse 3D UNet with separated resampling and residual refinement.
+
+    forward(feats, coords, shape, encoder_feature):
+    - feats: (M, in_channels) raw input features.
+    - coords: (M, 4) int32, columns (batch, i, j, z_bin), raster-sorted.
+    - shape: spatial extent (B, H, W, Z).
+    - encoder_feature: (B, H/s, W/s, C_enc) dense conditioning map sampled at
+      the bottleneck coords, with s = ``encoder_downsample``.
+    Returns: (M, out_channels).
+    """
+
+    def __init__(self, config: RefinerConfig):
+        super().__init__()
+        model_channels = config.model_channels
+        num_levels = len(model_channels)
+        if num_levels < 2:
+            raise ValueError("model_channels must have at least 2 levels")
+        downsample_factors = config.downsample_factors or [2] * (num_levels - 1)
+        if len(downsample_factors) != num_levels - 1:
+            raise ValueError(
+                "downsample_factors must have len(model_channels) - 1 entries"
+            )
+        if any(f != 2 for f in downsample_factors):
+            raise ValueError("MoGe refiner only supports downsample factor 2")
+        self.encoder_downsample = config.encoder_downsample
+        if self.encoder_downsample != math.prod(downsample_factors):
+            raise ValueError("encoder_downsample must equal prod(downsample_factors)")
+
+        def resolve(value, n, name):
+            value = [value] * n if isinstance(value, int) else list(value)
+            if len(value) != n:
+                raise ValueError(f"{name} must have length {n}, got {value}")
+            return value
+
+        encoder_block_counts = resolve(
+            config.encoder_blocks_per_level, num_levels, "encoder_blocks_per_level"
+        )
+        decoder_block_counts = resolve(
+            config.decoder_blocks_per_level,
+            num_levels - 1,
+            "decoder_blocks_per_level",
+        )
+
+        self.input_proj = nn.Linear(config.in_channels, model_channels[0])
+        self.encoder_fuse = nn.Linear(config.encoder_channels, model_channels[-1])
+        bottleneck_channels = model_channels[-1]
+        self.fuse_proj = [
+            nn.Linear(bottleneck_channels * 2, bottleneck_channels),
+            nn.SiLU(),
+            nn.Linear(bottleneck_channels, bottleneck_channels),
+        ]
+
+        self.down_stages = [
+            [SparseResBlock3d(ch) for _ in range(encoder_block_counts[i])]
+            for i, ch in enumerate(model_channels)
+        ]
+        self.downsample_blocks = [
+            PoolDown(model_channels[i], model_channels[i + 1])
+            for i in range(num_levels - 1)
+        ]
+        self.bottleneck_stage = [
+            SparseResBlock3d(model_channels[-1])
+            for _ in range(config.bottleneck_blocks)
+        ]
+        # Decoder runs from the deepest level up: transition i goes from
+        # level (num_levels - 1 - i) to level (num_levels - 2 - i).
+        self.upsample_blocks = [
+            NearestUp(model_channels[level], model_channels[level - 1])
+            for level in range(num_levels - 1, 0, -1)
+        ]
+        self.up_stages = [
+            [SparseResBlock3d(model_channels[level - 1]) for _ in range(n)]
+            for level, n in zip(range(num_levels - 1, 0, -1), decoder_block_counts)
+        ]
+
+        self.out_proj = nn.Linear(model_channels[0], config.out_channels)
+
+    def __call__(self, feats, coords, shape, encoder_feature):
+        point_cloud_h, point_cloud_w = shape[1], shape[2]
+        encoder_h, encoder_w = encoder_feature.shape[1], encoder_feature.shape[2]
+        assert (
+            point_cloud_h == encoder_h * self.encoder_downsample
+            and point_cloud_w == encoder_w * self.encoder_downsample
+        ), "point cloud and encoder feature resolutions are inconsistent"
+
+        feats = self.input_proj(feats)
+
+        num_levels = len(self.down_stages)
+        num_transitions = len(self.downsample_blocks)
+        # Per-level conv neighbor maps, built on the down pass and reused by
+        # the bottleneck and the symmetric up pass.
+        level_conv_maps: List[Optional[mx.array]] = [None] * num_levels
+        # Per-transition parent indices, reused by the symmetric upsample.
+        level_parent_idx: List[Optional[mx.array]] = [None] * num_transitions
+        skip_features: List = [None] * num_transitions
+
+        for i, stage in enumerate(self.down_stages):
+            conv_map = None
+            for block in stage:
+                feats, conv_map = block(feats, coords, shape, neighbor_map=conv_map)
+            level_conv_maps[i] = conv_map
+            if i < num_transitions:
+                skip_features[i] = (feats, coords, shape)
+                feats, coords, shape, parent_idx = self.downsample_blocks[i](
+                    feats, coords, shape
+                )
+                level_parent_idx[i] = parent_idx
+
+        enc_feat = encoder_feature[coords[:, 0], coords[:, 1], coords[:, 2]]
+        enc_feat = self.encoder_fuse(enc_feat)
+        feats = run_sequential(
+            self.fuse_proj, mx.concatenate([feats, enc_feat], axis=-1)
+        )
+
+        conv_map = level_conv_maps[num_levels - 1]
+        for block in self.bottleneck_stage:
+            feats, conv_map = block(feats, coords, shape, neighbor_map=conv_map)
+
+        for i, (upsample_block, stage) in enumerate(
+            zip(self.upsample_blocks, self.up_stages)
+        ):
+            target_level = num_levels - 2 - i
+            skip_feats, coords, shape = skip_features[target_level]
+            feats, coords, shape = upsample_block(
+                feats, level_parent_idx[target_level], coords, shape
+            )
+            feats = feats + skip_feats
+            conv_map = level_conv_maps[target_level]
+            for block in stage:
+                feats, conv_map = block(feats, coords, shape, neighbor_map=conv_map)
+
+        return self.out_proj(feats)

--- a/mlx_vlm/models/moge3/sparse.py
+++ b/mlx_vlm/models/moge3/sparse.py
@@ -1,0 +1,142 @@
+"""Pure-MLX sparse 3D ops matching FlexGEMM's explicit-GEMM semantics.
+
+MoGe-3's refiner is a sparse 3D UNet over voxels addressed by integer
+coords ``(batch, i, j, z)``. The reference implementation uses FlexGEMM
+(Triton, CUDA-only); here the same ops are expressed with binary search +
+gather, which run on any MLX backend.
+
+Conventions (identical to the reference):
+- ``coords``: (M, 4) int32, columns ``(batch, i, j, z)``, in ascending
+  raster order (see :func:`_coords_to_keys`). The voxelizer emits coords in
+  this order and :func:`sparse_pool2x_mean` preserves it, so neighbor
+  lookups can binary-search the keys without sorting.
+- ``shape``: the spatial extent ``(B, H, W, Z)``. Entries may be Python
+  ints or 0-d MLX integer arrays (the voxelizer's ``Z`` is a lazy scalar).
+- Submanifold conv weight: ``(Co, K0, K1, K2, Ci)``; kernel slot order is
+  ``di``-major, ``dz``-minor. Missing neighbors contribute zero; the bias
+  is always added.
+"""
+
+import mlx.core as mx
+import mlx.nn as nn
+
+# Kernel offsets (di, dj, dz) in product order, matching FlexGEMM.
+_KERNEL_OFFSETS = mx.array(
+    [(di, dj, dz) for di in (-1, 0, 1) for dj in (-1, 0, 1) for dz in (-1, 0, 1)],
+    dtype=mx.int32,
+)
+
+# Target size of the (rows, 27, Ci) im2col gather in the submanifold conv.
+_GATHER_CHUNK_BYTES = 16 << 20
+
+
+def _coords_to_keys(coords, shape):
+    """Raster-scan int64 keys for coords (..., 4) over spatial shape (B, H, W, Z)."""
+    _, H, W, Z = shape
+    c = coords.astype(mx.int64)
+    return ((c[..., 0] * H + c[..., 1]) * W + c[..., 2]) * Z + c[..., 3]
+
+
+def _axis_in_bounds(c, d, size):
+    """(M, 27) bool: ``c + d`` in ``[0, size)`` for ``c`` (M, 1), ``d`` (27,) in {-1, 0, 1}."""
+    return ((d >= 0) | (c > 0)) & ((d <= 0) | (c < size - 1))
+
+
+def submanifold_conv3d_neighbor_map(coords, shape):
+    """(M, 27) int32 map: voxel index at each kernel offset, -1 if missing.
+
+    ``coords`` must be in ascending raster order (see module docstring).
+    """
+    _, H, W, Z = shape
+    keys = _coords_to_keys(coords, shape)
+    di, dj, dz = (_KERNEL_OFFSETS[:, a] for a in range(3))
+    key_offsets = (di.astype(mx.int64) * W + dj) * Z + dz
+    nkeys = keys[:, None] + key_offsets[None]
+    valid = (
+        _axis_in_bounds(coords[:, 1:2], di, H)
+        & _axis_in_bounds(coords[:, 2:3], dj, W)
+        & _axis_in_bounds(coords[:, 3:4], dz, Z)
+    )
+    idx = mx.minimum(mx.searchsorted(keys, nkeys.reshape(-1)), keys.shape[0] - 1)
+    idx = idx.reshape(nkeys.shape)
+    found = (keys[idx] == nkeys) & valid
+    return mx.where(found, idx.astype(mx.int32), -1)
+
+
+class SubmanifoldConv3d(nn.Module):
+    """3x3x3 submanifold sparse convolution; weight layout (Co, 3, 3, 3, Ci)."""
+
+    def __init__(self, in_channels: int, out_channels: int):
+        super().__init__()
+        self.weight = mx.zeros((out_channels, 3, 3, 3, in_channels))
+        self.bias = mx.zeros((out_channels,))
+
+    def __call__(self, feats, coords, shape, neighbor_map=None):
+        if neighbor_map is None:
+            neighbor_map = submanifold_conv3d_neighbor_map(coords, shape)
+        M, Ci = feats.shape
+        Co = self.weight.shape[0]
+        # Missing neighbors gather an appended zero row instead of being masked.
+        feats_pad = mx.concatenate([feats, mx.zeros((1, Ci), dtype=feats.dtype)])
+        idx = mx.where(neighbor_map >= 0, neighbor_map, M)
+        w = self.weight.reshape(Co, 27 * Ci).T
+        rows = max(1, _GATHER_CHUNK_BYTES // (27 * Ci * feats.dtype.size))
+        out = [
+            mx.addmm(self.bias, feats_pad[idx[s : s + rows]].reshape(-1, 27 * Ci), w)
+            for s in range(0, M, rows)
+        ]
+        return (out[0] if len(out) == 1 else mx.concatenate(out)), neighbor_map
+
+
+def _ceil_div(a, b):
+    return (a + b - 1) // b
+
+
+def sparse_pool2x_mean(feats, coords, shape):
+    """Mean pool with kernel=stride=2 over (i, j, z).
+
+    Returns (out_feats, out_coords, out_shape, parent_idx) where
+    ``parent_idx[m]`` is the output segment of input voxel ``m`` (aligned
+    with the input order). Output coords are in ascending raster order, and
+    the segment ids double as the gather indices for the symmetric nearest
+    upsample.
+    """
+    B, H, W, Z = shape
+    out_shape = (B, _ceil_div(H, 2), _ceil_div(W, 2), _ceil_div(Z, 2))
+    tcoords = coords // mx.array([1, 2, 2, 2], dtype=mx.int32)
+    tkeys = _coords_to_keys(tcoords, out_shape)
+    order = mx.argsort(tkeys)
+    sorted_keys = tkeys[order]
+    is_new = mx.concatenate(
+        [mx.array([True]), sorted_keys[1:] != sorted_keys[:-1]], axis=0
+    )
+    seg_sorted = mx.cumsum(is_new.astype(mx.int32)) - 1
+    num_segments = int(is_new.sum().item())
+
+    parent_idx = mx.zeros(coords.shape[0], dtype=mx.int32)
+    parent_idx = parent_idx.at[order].add(seg_sorted)
+
+    sorted_feats = feats[order]
+    C = feats.shape[-1]
+    sums = mx.zeros((num_segments, C), dtype=feats.dtype)
+    sums = sums.at[seg_sorted].add(sorted_feats)
+    counts = mx.zeros((num_segments, 1), dtype=feats.dtype)
+    counts = counts.at[seg_sorted].add(
+        mx.ones(coords.shape[0], dtype=feats.dtype)[:, None]
+    )
+    out_feats = sums / counts
+
+    M = coords.shape[0]
+    first_pos = mx.full((num_segments,), M, dtype=mx.int32)
+    first_pos = first_pos.at[seg_sorted].minimum(mx.arange(M, dtype=mx.int32))
+    out_coords = tcoords[order[first_pos]]
+    return out_feats, out_coords, out_shape, parent_idx
+
+
+def sparse_upsample2x_nearest(feats, parent_idx, target_coords, target_shape):
+    """Nearest 2x upsample: each target voxel copies its parent input voxel.
+
+    ``parent_idx`` comes from the matching :func:`sparse_pool2x_mean` call
+    whose input coords are ``target_coords``.
+    """
+    return feats[parent_idx], target_coords, target_shape

--- a/mlx_vlm/models/moge3/vision.py
+++ b/mlx_vlm/models/moge3/vision.py
@@ -1,0 +1,30 @@
+"""DINOv2 encoder for MoGe-3 (channel-last MLX port).å"""
+
+from typing import Tuple
+
+import mlx.core as mx
+import mlx.nn as nn
+
+from ..dinov2.dinov2 import DINOv2Encoder
+from .config import EncoderConfig
+
+
+class MoGe3Encoder(DINOv2Encoder):
+    """DINOv2 encoder plus per-layer 1x1 projections summed to dim_out."""
+
+    def __init__(self, config: EncoderConfig):
+        super().__init__(config)
+        self.output_projections = [
+            nn.Conv2d(config.embed_dim, config.dim_out, kernel_size=1)
+            for _ in config.intermediate_layers
+        ]
+
+    def __call__(
+        self, image: mx.array, token_rows: int, token_cols: int
+    ) -> Tuple[mx.array, mx.array]:
+        """image: (B, H, W, 3) in [0, 1] -> features (B, rows, cols, dim_out), cls."""
+        features = super().__call__(image, token_rows, token_cols)
+        projected = [
+            proj(grid) for proj, (grid, _) in zip(self.output_projections, features)
+        ]
+        return sum(projected[1:], projected[0]), features[-1][1]

--- a/mlx_vlm/models/video_depth_anything/config.py
+++ b/mlx_vlm/models/video_depth_anything/config.py
@@ -4,29 +4,24 @@ from dataclasses import dataclass
 from typing import List, Optional
 
 from ..base import BaseModelConfig
+from ..dinov2.config import DINOV2_PRESETS
 
-# DINOv2 backbone presets per encoder variant.
+# DPT head presets per encoder variant, on top of the shared DINOv2 dims.
 ENCODER_PRESETS = {
     "vits": {
-        "embed_dim": 384,
-        "depth": 12,
-        "num_heads": 6,
+        **DINOV2_PRESETS["vits14"],
         "features": 64,
         "out_channels": [48, 96, 192, 384],
         "intermediate_layer_idx": [2, 5, 8, 11],
     },
     "vitb": {
-        "embed_dim": 768,
-        "depth": 12,
-        "num_heads": 12,
+        **DINOV2_PRESETS["vitb14"],
         "features": 128,
         "out_channels": [96, 192, 384, 768],
         "intermediate_layer_idx": [2, 5, 8, 11],
     },
     "vitl": {
-        "embed_dim": 1024,
-        "depth": 24,
-        "num_heads": 16,
+        **DINOV2_PRESETS["vitl14"],
         "features": 256,
         "out_channels": [256, 512, 1024, 1024],
         "intermediate_layer_idx": [4, 11, 17, 23],
@@ -58,6 +53,7 @@ class ModelConfig(BaseModelConfig):
     embed_dim: Optional[int] = None
     depth: Optional[int] = None
     num_heads: Optional[int] = None
+    ffn: Optional[str] = None  # "mlp" or "swiglu"
     intermediate_layer_idx: Optional[List[int]] = None
     img_size: int = 518
     patch_size: int = 14

--- a/mlx_vlm/models/video_depth_anything/video_depth_anything.py
+++ b/mlx_vlm/models/video_depth_anything/video_depth_anything.py
@@ -9,9 +9,9 @@ from typing import Dict
 import mlx.core as mx
 import mlx.nn as nn
 
+from ..dinov2.dinov2 import DINOv2
 from .config import ModelConfig
 from .dpt import DPTHeadTemporal, upsample_bilinear
-from .vision import DINOv2
 
 
 class Model(nn.Module):

--- a/mlx_vlm/tests/test_models.py
+++ b/mlx_vlm/tests/test_models.py
@@ -18343,6 +18343,33 @@ class TestMTPSplit(unittest.TestCase):
         self.assertEqual(config["quantization"]["bits"], 4)
 
 
+class TestDinov2(unittest.TestCase):
+    def test_encoder_feature_grids(self):
+        """Encoder resizes to the token grid and returns per-layer grids and cls tokens."""
+        from types import SimpleNamespace
+
+        from mlx_vlm.models.dinov2.dinov2 import DINOv2Encoder
+
+        config = SimpleNamespace(
+            embed_dim=32,
+            depth=4,
+            num_heads=4,
+            img_size=518,
+            patch_size=14,
+            mlp_ratio=4.0,
+            layer_norm_eps=1e-6,
+            interpolate_offset=0.1,
+            ffn="mlp",
+            intermediate_layers=[1, 3],
+        )
+        encoder = DINOv2Encoder(config)
+        features = encoder(mx.random.uniform(shape=(2, 60, 90, 3)), 5, 7)
+        self.assertEqual(len(features), 2)
+        for grid, cls in features:
+            self.assertEqual(grid.shape, (2, 5, 7, 32))
+            self.assertEqual(cls.shape, (2, 32))
+
+
 class TestVideoDepthAnything(unittest.TestCase):
     # ─── Video Depth Anything Tests ────────────────────────────
 
@@ -18380,7 +18407,7 @@ class TestVideoDepthAnything(unittest.TestCase):
 
     def test_vision_backbone(self):
         """DINOv2 backbone returns patch/cls tokens per requested layer."""
-        from mlx_vlm.models.video_depth_anything.vision import DINOv2
+        from mlx_vlm.models.dinov2.dinov2 import DINOv2
 
         config = self._tiny_config()
         backbone = DINOv2(config)
@@ -18793,3 +18820,407 @@ class TestK2HorizonModel(unittest.TestCase):
         model = k2_horizon.Model(self._config(rope_scaling=yarn.rope_scaling))
         out = model(mx.array([[1, 2, 3, 4]])).logits
         self.assertEqual(out.shape, (1, 4, 128))
+
+
+class TestMoge3(unittest.TestCase):
+    # ─── MoGe-3 Tests ──────────────────────────────────────────
+
+    def _tiny_config(self, **overrides):
+        from mlx_vlm.models.moge3.config import (
+            ConvStackConfig,
+            EncoderConfig,
+            ModelConfig,
+            RefinerConfig,
+            ScaleHeadConfig,
+        )
+
+        dim_res = [16, 8, 4]
+
+        def stack(dim_in, dim_out=None):
+            return ConvStackConfig(
+                dim_in=dim_in,
+                dim_res_blocks=list(dim_res),
+                dim_out=dim_out,
+                num_res_blocks=[0, 1, 0],
+                res_block_in_norm="none",
+                res_block_hidden_norm="none",
+                resamplers=["conv_transpose", "bilinear"],
+            )
+
+        args = dict(
+            encoder=EncoderConfig(
+                backbone="dinov2_vits14",
+                intermediate_layers=[0, 1],
+                dim_out=16,
+                depth=2,
+                embed_dim=32,
+                num_heads=4,
+            ),
+            neck=stack([18, 2, 2]),
+            points_head=stack(list(dim_res), [None, None, 3]),
+            mask_head=stack(list(dim_res), [None, None, 1]),
+            normal_head=None,
+            scale_head=ScaleHeadConfig(dims=[32, 16, 1]),
+            refiner=RefinerConfig(
+                encoder_channels=18,
+                model_channels=[8, 16, 32],
+                downsample_factors=[2, 2],
+                encoder_downsample=4,
+            ),
+        )
+        args.update(overrides)
+        return ModelConfig(**args)
+
+    def test_registry_exposes_model(self):
+        """The package resolves through the shared loader like other models."""
+        import dataclasses
+
+        from mlx_vlm.utils import get_model_and_args
+
+        model_module, model_type = get_model_and_args({"model_type": "moge3"})
+        self.assertEqual(model_type, "moge3")
+        config = model_module.ModelConfig.from_dict(
+            dataclasses.asdict(self._tiny_config())
+        )
+        self.assertIsNone(config.normal_head)
+        self.assertEqual(config.encoder.embed_dim, 32)
+        self.assertIsInstance(model_module.Model(config), model_module.Model)
+
+    def test_config_defaults(self):
+        """Default config reproduces the released MoGe-3 ViT-L model."""
+        from mlx_vlm.models.moge3.config import ModelConfig
+
+        config = ModelConfig()
+        self.assertEqual(config.model_type, "moge3")
+        self.assertEqual(config.encoder.backbone, "dinov2_vitl14")
+        self.assertEqual(config.encoder.embed_dim, 1024)
+        self.assertEqual(config.encoder.depth, 24)
+        self.assertEqual(config.encoder.intermediate_layers, [5, 11, 17, 23])
+        self.assertEqual(config.neck.dim_in, [1026, 2, 2, 2, 2])
+        self.assertEqual(config.refiner.model_channels, [32, 64, 128, 256, 512])
+        self.assertEqual(config.refiner_depth_resolution, 256)
+
+    def test_config_from_dict_nested(self):
+        """from_dict parses nested sub-configs like the checkpoint JSON."""
+        from mlx_vlm.models.moge3.config import ModelConfig
+
+        config = ModelConfig.from_dict(
+            {
+                "model_type": "moge3",
+                "encoder": {"backbone": "dinov2_vitg14", "unknown_key": 1},
+                "refiner": None,
+                "points_head": None,
+                "mask_head": None,
+                "normal_head": None,
+                "scale_head": None,
+            }
+        )
+        self.assertEqual(config.encoder.embed_dim, 1536)
+        self.assertEqual(config.encoder.ffn, "swiglu")
+        self.assertIsNone(config.refiner)
+        self.assertIsNone(config.points_head)
+
+    def test_encoder_shapes(self):
+        """Encoder returns (B, rows, cols, dim_out) features and a cls token."""
+        from mlx_vlm.models.moge3.vision import MoGe3Encoder
+
+        config = self._tiny_config()
+        encoder = MoGe3Encoder(config.encoder)
+        x = mx.random.normal((2, 70, 98, 3))
+        features, cls = encoder(x, 5, 7)
+        self.assertEqual(features.shape, (2, 5, 7, 16))
+        self.assertEqual(cls.shape, (2, 32))
+
+    def test_conv_stack_shapes(self):
+        """ConvStack upsamples x2 per level and emits per-level outputs."""
+        from mlx_vlm.models.moge3.conv_stack import ConvStack
+
+        config = self._tiny_config()
+        stack = ConvStack(config.neck)
+        inputs = [
+            mx.random.normal((1, 5, 7, 18)),
+            mx.random.normal((1, 10, 14, 2)),
+            mx.random.normal((1, 20, 28, 2)),
+        ]
+        outputs = stack(inputs)
+        self.assertEqual(len(outputs), 3)
+        self.assertEqual(outputs[0].shape, (1, 5, 7, 16))
+        self.assertEqual(outputs[1].shape, (1, 10, 14, 8))
+        self.assertEqual(outputs[2].shape, (1, 20, 28, 4))
+
+    def test_sanitize_conv_transpose_layout(self):
+        """Torch-layout ConvTranspose2d weights are relaid out; MLX layout is untouched."""
+        from mlx_vlm.models.moge3.moge3 import Model
+
+        model = Model(self._tiny_config())
+        narrow = self._tiny_config()
+        narrow.neck.dim_res_blocks = [16, 2, 4]
+        narrow_model = Model(narrow)
+        torch_w = mx.random.normal((16, 2, 2, 2))
+        sanitized = narrow_model.sanitize({"neck.resamplers.0.0.weight": torch_w})
+        self.assertEqual(sanitized["neck.resamplers.0.0.weight"].shape, (2, 2, 2, 16))
+        assert_sanitize_idempotent(
+            narrow_model, {"neck.resamplers.0.0.weight": torch_w}
+        )
+
+        mlx_weights = dict(tree_flatten(model.parameters()))
+        torch_layout = {
+            k: v.transpose(3, 0, 1, 2) if k.endswith("resamplers.0.0.weight") else v
+            for k, v in mlx_weights.items()
+        }
+        self.assertEqual(
+            torch_layout["neck.resamplers.0.0.weight"].shape, (16, 8, 2, 2)
+        )
+        sanitized = assert_sanitize_idempotent(model, torch_layout)
+        self.assertEqual(sanitized["neck.resamplers.0.0.weight"].shape, (8, 2, 2, 16))
+        for k in mlx_weights:
+            self.assertTrue(mx.array_equal(sanitized[k], mlx_weights[k]), k)
+        model.load_weights(list(sanitized.items()), strict=True)
+
+    def test_submanifold_conv_single_voxel(self):
+        """Degenerate case: one voxel -> bias + center-tap @ feat only."""
+        import numpy as np
+
+        from mlx_vlm.models.moge3.sparse import SubmanifoldConv3d
+
+        conv = SubmanifoldConv3d(3, 4)
+        conv.weight = mx.random.normal((4, 3, 3, 3, 3))
+        conv.bias = mx.random.normal((4,))
+        feats = mx.random.normal((1, 3))
+        coords = mx.array([[0, 2, 3, 1]], dtype=mx.int32)
+        shape = (1, 6, 7, 5)
+        out, _ = conv(feats, coords, shape)
+        want = feats[0] @ conv.weight[:, 1, 1, 1, :].T + conv.bias
+        self.assertTrue(np.allclose(np.array(out[0]), np.array(want), atol=1e-5))
+
+    @staticmethod
+    def _random_sparse_coords(rng, shape, density=0.5):
+        """Raster-ordered (M, 4) int32 coords over ``shape`` (B, H, W, Z)."""
+        import numpy as np
+
+        B, H, W, Z = shape
+        grid = np.stack(np.meshgrid(*(np.arange(n) for n in shape), indexing="ij"))
+        coords = grid.reshape(4, -1).T
+        keep = rng.random(len(coords)) < density
+        return mx.array(coords[keep].astype(np.int32))
+
+    def test_neighbor_map_matches_brute_force(self):
+        """Key-offset neighbor lookup equals an explicit coordinate search."""
+        import numpy as np
+
+        from mlx_vlm.models.moge3.sparse import submanifold_conv3d_neighbor_map
+
+        rng = np.random.default_rng(0)
+        # Z of 1 and W of 2 make edge offsets alias onto neighbouring rows.
+        for shape in [(2, 5, 4, 3), (1, 3, 2, 1), (1, 4, 4, 4)]:
+            coords = self._random_sparse_coords(rng, shape)
+            got = np.array(submanifold_conv3d_neighbor_map(coords, shape))
+            c = np.array(coords)
+            lookup = {tuple(row): m for m, row in enumerate(c.tolist())}
+            offsets = [
+                (0, di, dj, dz)
+                for di in (-1, 0, 1)
+                for dj in (-1, 0, 1)
+                for dz in (-1, 0, 1)
+            ]
+            want = np.array(
+                [[lookup.get(tuple(row + off), -1) for off in offsets] for row in c]
+            )
+            self.assertTrue(np.array_equal(got, want), shape)
+
+    def test_submanifold_conv_chunked_gemm_matches_reference(self):
+        """Chunked im2col GEMM equals the per-tap gather + matmul sum."""
+        from unittest import mock
+
+        import numpy as np
+
+        from mlx_vlm.models.moge3 import sparse
+        from mlx_vlm.models.moge3.sparse import SubmanifoldConv3d
+
+        rng = np.random.default_rng(1)
+        shape = (2, 6, 5, 4)
+        coords = self._random_sparse_coords(rng, shape, density=0.7)
+        M, Ci, Co = coords.shape[0], 6, 5
+        conv = SubmanifoldConv3d(Ci, Co)
+        conv.weight = mx.random.normal((Co, 3, 3, 3, Ci))
+        conv.bias = mx.random.normal((Co,))
+        feats = mx.random.normal((M, Ci))
+
+        nmap = sparse.submanifold_conv3d_neighbor_map(coords, shape)
+        feats_pad = mx.concatenate([feats, mx.zeros((1, Ci))])
+        idx = mx.where(nmap >= 0, nmap, M)
+        w = conv.weight.reshape(Co, 27, Ci)
+        want = mx.broadcast_to(conv.bias, (M, Co))
+        for v in range(27):
+            want = want + feats_pad[idx[:, v]] @ w[:, v, :].T
+
+        # Force several gather chunks (4 rows each) to exercise the split.
+        with mock.patch.object(sparse, "_GATHER_CHUNK_BYTES", 27 * Ci * 4 * 4):
+            out, _ = conv(feats, coords, shape, neighbor_map=nmap)
+        self.assertTrue(np.allclose(np.array(out), np.array(want), atol=1e-5))
+
+    def test_lazy_depth_extent_in_shape(self):
+        """The voxelizer's Z extent may be a lazy scalar; sparse ops accept it."""
+        import numpy as np
+
+        from mlx_vlm.models.moge3.sparse import (
+            sparse_pool2x_mean,
+            submanifold_conv3d_neighbor_map,
+        )
+
+        rng = np.random.default_rng(2)
+        shape = (1, 4, 4, 5)
+        coords = self._random_sparse_coords(rng, shape)
+        lazy_shape = (1, 4, 4, coords[:, 3].max() + 1)
+        self.assertTrue(
+            mx.array_equal(
+                submanifold_conv3d_neighbor_map(coords, shape),
+                submanifold_conv3d_neighbor_map(coords, lazy_shape),
+            )
+        )
+        feats = mx.random.normal((coords.shape[0], 3))
+        out, out_coords, _, _ = sparse_pool2x_mean(feats, coords, shape)
+        out_lazy, out_coords_lazy, _, _ = sparse_pool2x_mean(feats, coords, lazy_shape)
+        self.assertTrue(mx.array_equal(out, out_lazy))
+        self.assertTrue(mx.array_equal(out_coords, out_coords_lazy))
+
+    def test_replicate_padding_matches_edge_pad(self):
+        """Gather-based replicate padding is bit-identical to mx.pad(mode="edge")."""
+        from mlx_vlm.models.moge3.conv_stack import Conv2dReplicate
+
+        conv = Conv2dReplicate(3, 4, kernel_size=3)
+        x = mx.random.normal((2, 7, 5, 3))
+        want = mx.conv2d(
+            mx.pad(x, [(0, 0), (1, 1), (1, 1), (0, 0)], mode="edge"), conv.weight
+        )
+        self.assertTrue(mx.array_equal(conv(x), want + conv.bias))
+
+    def test_processor_resize_and_scaling(self):
+        """resize_to caps the long side, keeps aspect, and handles batches."""
+        import numpy as np
+
+        from mlx_vlm.models.moge3.processing_moge3 import MogeProcessor
+
+        processor = MogeProcessor(resize_to=800)
+        portrait = np.zeros((1000, 500, 3), dtype=np.uint8)
+        self.assertEqual(processor.preprocess_image(portrait).shape, (800, 400, 3))
+        landscape = np.zeros((1080, 1920, 3), dtype=np.uint8)
+        self.assertEqual(processor.preprocess_image(landscape).shape, (450, 800, 3))
+        batch = np.zeros((2, 500, 1000, 3), dtype=np.uint8)
+        self.assertEqual(processor.preprocess_image(batch).shape, (2, 400, 800, 3))
+
+        processor = MogeProcessor()
+        out = processor.preprocess_image(np.full((4, 6, 3), 255, dtype=np.uint8))
+        self.assertEqual(out.dtype, np.float32)
+        self.assertTrue(np.allclose(out, 1.0))
+        out = processor.preprocess_image(np.full((4, 6, 3), 65535, dtype=np.uint16))
+        self.assertTrue(np.allclose(out, 1.0))
+        with self.assertRaises(ValueError):
+            processor.preprocess_image(np.full((4, 6, 3), 255.0, dtype=np.float32))
+
+    def test_loader_disabled_modules_are_skipped(self):
+        """Modules the loader nulls out (no checkpoint weights) are not called."""
+        from mlx_vlm.models.moge3.moge3 import Model
+
+        model = Model(self._tiny_config())
+        model.mask_head = None
+        model.refiner = None
+        image = mx.random.uniform(0, 1, (1, 96, 128, 3))
+        out = model(image, num_tokens=35, refine_steps=0)
+        self.assertNotIn("mask", out)
+        self.assertIn("points", out)
+        with self.assertRaises(ValueError):
+            model(image, num_tokens=35, refine_steps=1)
+
+    def test_focal_shift_uv_grid_matches_subsampled_full_grid(self):
+        """The 64x64 solver grid equals nearest-subsampling the full UV map."""
+        from mlx_vlm.models.moge3.geometry import (
+            _nearest_indices,
+            _view_plane_axes,
+            normalized_view_plane_uv,
+        )
+
+        for height, width in [(1080, 1920), (97, 131), (64, 64), (50, 70)]:
+            ii = _nearest_indices(height, 64)
+            jj = _nearest_indices(width, 64)
+            want = normalized_view_plane_uv(width, height)[ii][:, jj]
+            u, v = _view_plane_axes(width, height)
+            u, v = mx.meshgrid(u[jj], v[ii], indexing="xy")
+            self.assertTrue(mx.array_equal(mx.stack([u, v], axis=-1), want))
+
+    def test_sparse_pool_upsample_roundtrip(self):
+        """Nearest upsample of a 2x2x2 mean pool reproduces parent values."""
+        import numpy as np
+
+        from mlx_vlm.models.moge3.sparse import (
+            sparse_pool2x_mean,
+            sparse_upsample2x_nearest,
+        )
+
+        # Two voxels in the same 2x2x2 block and one outside it.
+        coords = mx.array([[0, 0, 0, 0], [0, 1, 1, 1], [0, 2, 2, 3]], dtype=mx.int32)
+        feats = mx.array([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]])
+        shape = (1, 4, 4, 4)
+        out, out_coords, out_shape, parent_idx = sparse_pool2x_mean(
+            feats, coords, shape
+        )
+        self.assertEqual(out.shape[0], 2)
+        self.assertTrue(np.allclose(np.array(out[0]), [2.0, 3.0]))
+        self.assertTrue(np.allclose(np.array(out[1]), [5.0, 6.0]))
+        self.assertEqual(np.array(out_coords).tolist(), [[0, 0, 0, 0], [0, 1, 1, 1]])
+
+        up, up_coords, _ = sparse_upsample2x_nearest(out, parent_idx, coords, shape)
+        want = np.array([[2.0, 3.0], [2.0, 3.0], [5.0, 6.0]])
+        self.assertTrue(np.allclose(np.array(up), want, atol=1e-6))
+
+    def test_forward_and_infer_shapes(self):
+        """Full forward + infer on a tiny random-weight model."""
+        config = self._tiny_config()
+        from mlx_vlm.models.moge3.moge3 import Model
+
+        model = Model(config)
+        image = mx.random.uniform(0, 1, (1, 96, 128, 3))
+        out = model(image, num_tokens=35, refine_steps=1)
+        self.assertEqual(out["points"].shape, (1, 96, 128, 3))
+        self.assertEqual(out["mask"].shape, (1, 96, 128))
+        self.assertEqual(out["metric_scale"].shape, (1,))
+        self.assertNotIn("normal", out)
+
+        out = model.infer(image[0], num_tokens=35, refine_steps=1)
+        self.assertEqual(out["points"].shape, (96, 128, 3))
+        self.assertEqual(out["depth"].shape, (96, 128))
+        self.assertEqual(out["intrinsics"].shape, (3, 3))
+        self.assertEqual(out["mask"].shape, (96, 128))
+        self.assertNotIn("points_per_step", out)
+
+    def test_zero_refiner_is_identity(self):
+        """With a zeroed out_proj the refiner leaves the point map unchanged."""
+        import numpy as np
+
+        from mlx_vlm.models.moge3.moge3 import Model
+
+        config = self._tiny_config()
+        model = Model(config)
+        model.refiner.out_proj.weight = mx.zeros_like(model.refiner.out_proj.weight)
+        model.refiner.out_proj.bias = mx.zeros_like(model.refiner.out_proj.bias)
+
+        image = mx.random.uniform(0, 1, (1, 96, 128, 3))
+        coarse = model(image, num_tokens=35, refine_steps=0)
+        refined = model(image, num_tokens=35, refine_steps=2, return_per_step=True)
+        self.assertTrue(
+            np.allclose(
+                np.array(coarse["points"]), np.array(refined["points"]), atol=1e-5
+            )
+        )
+        self.assertEqual(len(refined["points_per_step"]), 3)
+
+    def test_per_step_outputs(self):
+        """return_per_step yields initial + one map per refinement step."""
+        from mlx_vlm.models.moge3.moge3 import Model
+
+        model = Model(self._tiny_config())
+        image = mx.random.uniform(0, 1, (1, 96, 128, 3))
+        out = model.infer(image, num_tokens=35, refine_steps=2, return_per_step=True)
+        self.assertEqual(len(out["points_per_step"]), 3)
+        self.assertEqual(len(out["depth_per_step"]), 3)
+        self.assertEqual(out["points_per_step"][-1].shape, (1, 96, 128, 3))


### PR DESCRIPTION
Port MoGe-3 (moge.model.v3) to MLX: DINOv2 encoder with output projections, convolutional neck + points/mask/normal/scale heads, and the sparse 3D UNet refiner.

The refiner normally depends on FlexGEMM (Triton, CUDA-only); here the submanifold convolution, mean pooling, and nearest upsample are re-implemented in pure MLX with sort + binary-search + gather, so the model runs on Apple silicon. Transposed convolutions are computed as exact per-pixel GEMMs followed by a 2x2 pixel shuffle, and all resizes match torch F.interpolate (including antialiased bilinear and the scale-factor bicubic position-embedding path).

Adds moge3 model package (config, vision, conv_stack, sparse, refiner, geometry, generate, processor, checkpoint converter, README) and a TestMoge3 test class.

Converted checkpoints uploaded to mlx-community/moge-3-vitl-mlx-fp32 and mlx-community/moge-3-vitg-mlx-fp32. Validated against the torch reference (CPU, fp32, pure-torch FlexGEMM shim): identical valid-pixel masks, <0.1% median relative depth error at default settings, ~2.1s per 800x547 image on GPU.