### PR TITLE
Add native affine4 KV cache for Apple M5

### DIFF
--- a/README.md
+++ b/README.md
@@ -1605,6 +1605,32 @@ TurboQuant automatically quantizes `KVCache` layers (global attention). Models w
 
 TurboQuant is supported in both single-request generation and continuous batching on the server. In continuous batching mode, KV states are stored in TurboQuant's compressed format and dequantized at attention time (custom Metal kernels are not yet batch-aware).
 
+### Native Affine4 on M5
+
+Apple M5 GPUs can execute signed 4-bit matrix operands directly through Metal
+Performance Primitives TensorOps. The `affine4` KV scheme uses a native-friendly
+signed-int4 cache format instead of TurboQuant's nonlinear codebook:
+
+```sh
+mlx_vlm generate \
+  --model mlx-community/Qwen3.5-4B-4bit \
+  --kv-bits 4 \
+  --kv-quant-scheme affine4 \
+  --prompt "Your long prompt here..."
+```
+
+Affine4 applies a deterministic orthonormal rotation, stores one FP16 scale per
+KV vector, and keeps two signed values in each byte. On M5, decode attention
+consumes packed K/V directly with `int4b_format` TensorOps. Standard attention
+geometries whose head dimension is divisible by 32 and at most 512 use the
+native path, including grouped-query attention, short causal speculative
+verification, and left-padded batches. Other hardware and unsupported attention
+shapes use the portable affine4 implementation without changing cache semantics.
+
+`affine4` and `turboquant` are distinct formats. Affine4 requires exactly four
+bits for both keys and values; fractional widths and mixed affine4 schemes are
+rejected. Existing `uniform` and `turboquant` defaults are unchanged.
+
 ## Distributed Inference
 
 mlx-vlm supports distributed inference across multiple computers. It works by sharding the language model (not the vision tower), because the LLM is much larger and vision embeddings only need to be computed once.

--- a/mlx_vlm/affine4.py
+++ b/mlx_vlm/affine4.py
@@ -1,0 +1,978 @@
+from __future__ import annotations
+
+import logging
+import math
+from functools import cache, lru_cache
+
+import mlx.core as mx
+
+from .kv_quant import AFFINE4_SCHEME
+from .models.cache import create_causal_mask
+from .turboquant import (
+    DEFAULT_TURBOQUANT_SEED,
+    BatchTurboQuantKVCache,
+    TurboQuantKVCache,
+    TurboQuantMSEState,
+    _pack_lowbit,
+    _rht_forward,
+    _rht_inverse,
+    _rotation_matrix,
+    _slice_state,
+    _state_length,
+    _unpack_lowbit,
+)
+
+logger = logging.getLogger("mlx_vlm.affine4")
+
+__all__ = [
+    "AFFINE4_SCHEME",
+    "Affine4Codec",
+    "Affine4KVCache",
+    "BatchAffine4KVCache",
+]
+
+_BITS = 4
+_MIN_NATIVE_TOKENS = 256
+_MAX_PADDED_ROWS = 32
+_NATIVE_LAUNCHABLE = {}
+_FUSED_QUANTIZE_LAUNCHABLE = {}
+
+
+class Affine4Codec:
+    """Signed int4 codec with deterministic orthonormal rotation."""
+
+    bits = _BITS
+
+    def __init__(self, dim: int, seed: int):
+        if dim <= 0:
+            raise ValueError(f"affine4 requires a positive head dimension, got {dim}")
+        self.dim = int(dim)
+        self.seed = int(seed)
+        self.use_rht = (dim & (dim - 1)) == 0
+        if self.use_rht:
+            from .turboquant import _rht_sign_vector
+
+            self.signs = _rht_sign_vector(dim, seed)
+            self.rotation = None
+            self.rotation_t = None
+        else:
+            self.signs = None
+            self.rotation = _rotation_matrix(dim, seed)
+            self.rotation_t = self.rotation.transpose()
+
+    def _rotate_forward(self, x: mx.array) -> mx.array:
+        x = x.astype(mx.float32)
+        if self.use_rht:
+            return _rht_forward(x, self.signs)
+        return mx.matmul(x, self.rotation_t)
+
+    def _rotate_inverse(self, x: mx.array) -> mx.array:
+        if self.use_rht:
+            return _rht_inverse(x, self.signs)
+        return mx.matmul(x, self.rotation)
+
+    def quantize(self, vectors: mx.array) -> TurboQuantMSEState:
+        rotated = self._rotate_forward(vectors)
+        scales = mx.maximum(
+            mx.max(rotated, axis=-1) / 7.0,
+            -mx.min(rotated, axis=-1) / 8.0,
+        ).astype(mx.float16)
+        codes = mx.clip(mx.round(rotated / (scales[..., None] + 1e-7)), -8, 7).astype(
+            mx.int8
+        )
+        packed = _pack_lowbit(codes.astype(mx.int32) & 15, _BITS)
+        return TurboQuantMSEState(scales, packed)
+
+    def _codes(self, state: TurboQuantMSEState) -> mx.array:
+        nibbles = _unpack_lowbit(state.indices, _BITS, self.dim).astype(mx.int16)
+        return ((nibbles ^ 8) - 8).astype(mx.float32)
+
+    def dequantize(self, state: TurboQuantMSEState) -> mx.array:
+        rotated = self._codes(state) * state.norms.astype(mx.float32)[..., None]
+        return self._rotate_inverse(rotated)
+
+    def prepare_queries(self, queries: mx.array) -> mx.array:
+        return self._rotate_forward(queries)
+
+    def score_prepared(
+        self, prepared_queries: mx.array, state: TurboQuantMSEState
+    ) -> mx.array:
+        scores = mx.einsum("bhmld,bhtd->bhmlt", prepared_queries, self._codes(state))
+        return scores * state.norms.astype(mx.float32)[:, :, None, None, :]
+
+    def score(self, queries: mx.array, state: TurboQuantMSEState) -> mx.array:
+        return self.score_prepared(self.prepare_queries(queries), state)
+
+    def weighted_sum(self, weights: mx.array, state: TurboQuantMSEState) -> mx.array:
+        rotated = self._codes(state)
+        weighted = mx.einsum(
+            "bhmlt,bht,bhtd->bhmld",
+            weights.astype(mx.float32),
+            state.norms.astype(mx.float32),
+            rotated,
+        )
+        return self._rotate_inverse(weighted)
+
+    def weighted_sum_from_scores(
+        self, scores: mx.array, state: TurboQuantMSEState
+    ) -> mx.array:
+        return self.weighted_sum(mx.softmax(scores, axis=-1), state)
+
+    def weighted_sum_stats_from_scores(
+        self, scores: mx.array, state: TurboQuantMSEState
+    ) -> tuple[mx.array, mx.array, mx.array]:
+        maximum = mx.max(scores, axis=-1)
+        weights = mx.exp(scores - maximum[..., None])
+        return (
+            self.weighted_sum(weights, state),
+            mx.sum(weights, axis=-1),
+            maximum,
+        )
+
+
+_FUSED_QUANTIZE_SOURCE = r"""
+    uint d = thread_position_in_threadgroup.x;
+    uint row = threadgroup_position_in_grid.x;
+    uint is_value = threadgroup_position_in_grid.y;
+    uint sg = simdgroup_index_in_threadgroup;
+    uint lane = thread_index_in_simdgroup;
+
+    float input_value = is_value
+        ? static_cast<float>(values[row * Dim + d])
+        : static_cast<float>(keys[row * Dim + d]);
+    float sign = is_value ? value_signs[d] : key_signs[d];
+    threadgroup float rotated[Dim];
+    rotated[d] = sign * input_value;
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    for (int stride = 1; stride < Dim; stride *= 2) {
+        int base = int(d) & ~stride;
+        float low = rotated[base];
+        float high = rotated[base | stride];
+        float transformed = (int(d) & stride) ? low - high : low + high;
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        rotated[d] = transformed;
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+    }
+    float value = rotated[d] * rsqrt(float(Dim));
+
+    float sg_positive = simd_max(value);
+    float sg_negative = simd_max(-value);
+    threadgroup float extrema[2 * SimdGroups];
+    if (lane == 0) {
+        extrema[sg] = sg_positive;
+        extrema[SimdGroups + sg] = sg_negative;
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    float positive = (sg == 0 && lane < SimdGroups) ? extrema[lane] : 0.0f;
+    float negative =
+        (sg == 0 && lane < SimdGroups) ? extrema[SimdGroups + lane] : 0.0f;
+    positive = simd_max(positive);
+    negative = simd_max(negative);
+    if (sg == 0 && lane == 0)
+        extrema[0] = max(positive / 7.0f, negative / 8.0f);
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    half quant_scale = half(extrema[0]);
+    if (d == 0) {
+        if (is_value) value_scales[row] = quant_scale;
+        else key_scales[row] = quant_scale;
+    }
+    float divisor = static_cast<float>(quant_scale) + 1e-7f;
+    int code = divisor > 0.0f
+        ? int(rint(clamp(value / divisor, -8.0f, 7.0f)))
+        : 0;
+    threadgroup uint codes[Dim];
+    codes[d] = uint(code) & 15u;
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    if (d < PackedWidth) {
+        uint word = 0u;
+        for (int i = 0; i < 8; ++i)
+            word |= codes[d * 8 + i] << (i * 4);
+        if (is_value) value_packed[row * PackedWidth + d] = word;
+        else key_packed[row * PackedWidth + d] = word;
+    }
+"""
+
+
+@cache
+def _fused_quantize_kernel(dim: int):
+    if (
+        not hasattr(mx, "metal")
+        or not mx.metal.is_available()
+        or dim < 32
+        or dim > 512
+        or dim % 8
+        or (dim & (dim - 1)) != 0
+    ):
+        return None
+    return mx.fast.metal_kernel(
+        name=f"affine4_fused_kv_quantize_d{dim}",
+        input_names=["keys", "values", "key_signs", "value_signs"],
+        output_names=[
+            "key_scales",
+            "key_packed",
+            "value_scales",
+            "value_packed",
+        ],
+        source=_FUSED_QUANTIZE_SOURCE,
+    )
+
+
+_MPP_HEADER = r"""
+#include <MetalPerformancePrimitives/MetalPerformancePrimitives.h>
+using namespace metal;
+using namespace mpp::tensor_ops;
+
+template <int Dim, int Repeats, int QueryLength, int PaddedRows, int Warps,
+          int NumKvHeads, typename ScalePtr>
+METAL_FUNC void affine4_attention_impl(
+    device uchar* keys,
+    ScalePtr key_scales,
+    device uchar* values,
+    ScalePtr value_scales,
+    device float* partials,
+    device float* sums,
+    device float* maxs,
+    int tokens,
+    int blocks,
+    int valid_start,
+    int valid_end,
+    float attention_scale,
+    uint tid,
+    uint sg,
+    uint3 group,
+    threadgroup half* q_tile,
+    threadgroup float* scores,
+    threadgroup half* probabilities,
+    threadgroup float* row_m,
+    threadgroup float* row_l,
+    threadgroup float* row_factor) {
+    constexpr int ActiveRows = Repeats * QueryLength;
+    constexpr int BK = 64;
+    constexpr int OutDim = Dim / Warps;
+
+    int bh = int(group.y) * NumKvHeads + int(group.x);
+    int block = int(group.z);
+    int ntiles = (tokens + BK - 1) / BK;
+    int tiles_per_block = (ntiles + blocks - 1) / blocks;
+    int tile_begin = block * tiles_per_block;
+    int tile_end = min(ntiles, tile_begin + tiles_per_block);
+
+    if (tile_begin >= tile_end) {
+        for (int i = int(tid); i < ActiveRows * Dim; i += 32 * Warps) {
+            int row = bh * ActiveRows + i / Dim;
+            partials[(row * blocks + block) * Dim + i % Dim] = 0.0f;
+        }
+        for (int row = int(tid); row < ActiveRows; row += 32 * Warps) {
+            int idx = (bh * ActiveRows + row) * blocks + block;
+            sums[idx] = 0.0f;
+            maxs[idx] = 0.0f;
+        }
+        return;
+    }
+
+    for (int row = int(tid); row < PaddedRows; row += 32 * Warps) {
+        row_m[row] = -INFINITY;
+        row_l[row] = 0.0f;
+        row_factor[row] = 0.0f;
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    using QTensor = tensor<threadgroup half, dextents<int, 2>, tensor_inline>;
+    using KVTensor = tensor<device int4b_format, dextents<int, 2>, tensor_inline>;
+    using PTensor = tensor<threadgroup half, dextents<int, 2>, tensor_inline>;
+    QTensor q_tensor(q_tile, dextents<int, 2>{Dim, PaddedRows});
+    KVTensor k_tensor(keys, dextents<int, 2>{Dim, tokens});
+    KVTensor v_tensor(values, dextents<int, 2>{Dim, tokens});
+    PTensor p_tensor(probabilities, dextents<int, 2>{BK, PaddedRows});
+
+    constexpr auto av_desc = matmul2d_descriptor(
+        PaddedRows, OutDim, BK, false, false, false,
+        matmul2d_descriptor::mode::multiply_accumulate);
+    matmul2d<av_desc, execution_simdgroup> av_op;
+    auto v_first = v_tensor.template slice<OutDim, BK>(
+        int(sg) * OutDim, tile_begin * BK);
+    auto output_tile = av_op.template get_destination_cooperative_tensor<
+        decltype(p_tensor), decltype(v_first), half>();
+    for (short i = 0; i < output_tile.get_capacity(); ++i)
+        output_tile[i] = 0.0f;
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    for (int tile_idx = tile_begin; tile_idx < tile_end; ++tile_idx) {
+        int token = tile_idx * BK;
+        int tile_valid_start = max(token, valid_start);
+        int tile_valid_end = min(min(token + BK, tokens), valid_end);
+        if (tile_valid_start >= tile_valid_end)
+            continue;
+
+        if (sg == 0) {
+            constexpr auto qk_desc = matmul2d_descriptor(
+                PaddedRows, BK, Dim, false, true, false);
+            matmul2d<qk_desc, execution_simdgroup> qk_op;
+            auto q_slice = q_tensor.template slice<Dim, PaddedRows>(0, 0);
+            auto k_slice = k_tensor.template slice<Dim, BK>(0, token);
+            auto score_tile = qk_op.template get_destination_cooperative_tensor<
+                decltype(q_slice), decltype(k_slice), float>();
+            qk_op.run(q_slice, k_slice, score_tile);
+            for (short i = 0; i < score_tile.get_capacity(); ++i) {
+                auto coord = score_tile.get_multidimensional_index(i);
+                if (score_tile.is_valid_element(i)) {
+                    int column = coord[0];
+                    int row = coord[1];
+                    int absolute_token = token + column;
+                    int position = row % QueryLength;
+                    int row_valid_end = valid_end - QueryLength + position + 1;
+                    scores[row * BK + column] = row < ActiveRows &&
+                            absolute_token >= tile_valid_start &&
+                            absolute_token < tile_valid_end &&
+                            absolute_token < row_valid_end
+                        ? score_tile[i] * attention_scale *
+                              float(key_scales[absolute_token])
+                        : -INFINITY;
+                }
+            }
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+
+        if (int(tid) < ActiveRows) {
+            int row = int(tid);
+            float tile_m = -INFINITY;
+            for (int column = 0; column < BK; ++column)
+                tile_m = max(tile_m, scores[row * BK + column]);
+            float old_m = row_m[row];
+            if (isinf(tile_m)) {
+                row_factor[row] = 1.0f;
+                for (int column = 0; column < BK; ++column)
+                    probabilities[row * BK + column] = half(0.0f);
+            } else {
+                float new_m = max(old_m, tile_m);
+                float factor = isinf(old_m) ? 0.0f : fast::exp(old_m - new_m);
+                float l = row_l[row] * factor;
+                for (int column = 0; column < BK; ++column) {
+                    int absolute_token = token + column;
+                    bool active = !isinf(scores[row * BK + column]);
+                    float weight = active
+                        ? fast::exp(scores[row * BK + column] - new_m)
+                        : 0.0f;
+                    l += weight;
+                    probabilities[row * BK + column] = half(
+                        weight * (active ? float(value_scales[absolute_token]) : 0.0f));
+                }
+                row_m[row] = new_m;
+                row_l[row] = l;
+                row_factor[row] = factor;
+            }
+        }
+        for (int i = int(tid) + ActiveRows * BK;
+             i < PaddedRows * BK; i += 32 * Warps)
+            probabilities[i] = half(0.0f);
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+
+        for (short i = 0; i < output_tile.get_capacity(); ++i) {
+            auto coord = output_tile.get_multidimensional_index(i);
+            if (output_tile.is_valid_element(i))
+                output_tile[i] *= row_factor[coord[1]];
+        }
+        auto v_slice = v_tensor.template slice<OutDim, BK>(
+            int(sg) * OutDim, token);
+        av_op.run(p_tensor, v_slice, output_tile);
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+    }
+
+    if (int(tid) < ActiveRows) {
+        int idx = (bh * ActiveRows + int(tid)) * blocks + block;
+        sums[idx] = row_l[tid];
+        maxs[idx] = row_m[tid];
+    }
+    for (short i = 0; i < output_tile.get_capacity(); ++i) {
+        auto coord = output_tile.get_multidimensional_index(i);
+        if (output_tile.is_valid_element(i) && coord[1] < ActiveRows) {
+            int row = bh * ActiveRows + coord[1];
+            int dimension = int(sg) * OutDim + coord[0];
+            partials[(row * blocks + block) * Dim + dimension] = output_tile[i];
+        }
+    }
+}
+"""
+
+
+_MPP_ATTENTION_SOURCE = r"""
+    uint tid = thread_index_in_threadgroup;
+    uint3 group = threadgroup_position_in_grid;
+    constexpr int ActiveRows = Repeats * QueryLength;
+    threadgroup half q_tile[PaddedRows * Dim];
+    threadgroup float scores[PaddedRows * 64];
+    threadgroup half probabilities[PaddedRows * 64];
+    threadgroup float row_m[PaddedRows];
+    threadgroup float row_l[PaddedRows];
+    threadgroup float row_factor[PaddedRows];
+
+    int batch = int(group.y);
+    int kv_head = int(group.x);
+    for (int i = int(tid); i < PaddedRows * Dim; i += 32 * Warps) {
+        int row = i / Dim;
+        if (row < ActiveRows) {
+            int head = kv_head * Repeats + row / QueryLength;
+            int position = row % QueryLength;
+            q_tile[i] = half(queries[
+                batch * queries_strides[0] + head * queries_strides[1] +
+                position * queries_strides[2] + i % Dim]);
+        } else {
+            q_tile[i] = half(0.0f);
+        }
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    int tokens = int(params[0]);
+    int blocks = int(params[1]);
+    float attention_scale = as_type<float>(params[2]);
+    int key_word_offset = batch * int(keys_strides[0]) +
+        kv_head * int(keys_strides[1]);
+    int value_word_offset = batch * int(values_strides[0]) +
+        kv_head * int(values_strides[1]);
+    int key_scale_offset = batch * int(key_scales_strides[0]) +
+        kv_head * int(key_scales_strides[1]);
+    int value_scale_offset = batch * int(value_scales_strides[0]) +
+        kv_head * int(value_scales_strides[1]);
+    affine4_attention_impl<
+        Dim, Repeats, QueryLength, PaddedRows, Warps, NumKvHeads>(
+        (device uchar*)(keys + key_word_offset),
+        key_scales + key_scale_offset,
+        (device uchar*)(values + value_word_offset),
+        value_scales + value_scale_offset,
+        partials,
+        sums,
+        maxs,
+        tokens,
+        blocks,
+        int(valid_starts[batch]),
+        int(valid_ends[batch]),
+        attention_scale,
+        tid,
+        simdgroup_index_in_threadgroup,
+        group,
+        q_tile,
+        scores,
+        probabilities,
+        row_m,
+        row_l,
+        row_factor);
+"""
+
+
+_MPP_REDUCE_SOURCE = r"""
+    uint dimension = thread_index_in_threadgroup;
+    uint row = threadgroup_position_in_grid.x;
+    int blocks = int(params[1]);
+    threadgroup float global_m;
+    threadgroup float global_l;
+    if (dimension == 0) {
+        float maximum = -INFINITY;
+        for (int block = 0; block < blocks; ++block) {
+            int idx = int(row) * blocks + block;
+            if (sums[idx] > 0.0f)
+                maximum = max(maximum, maxs[idx]);
+        }
+        float normalizer = 0.0f;
+        for (int block = 0; block < blocks; ++block) {
+            int idx = int(row) * blocks + block;
+            if (sums[idx] > 0.0f)
+                normalizer += sums[idx] * fast::exp(maxs[idx] - maximum);
+        }
+        global_m = maximum;
+        global_l = normalizer;
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    float value = 0.0f;
+    for (int block = 0; block < blocks; ++block) {
+        int idx = int(row) * blocks + block;
+        if (sums[idx] > 0.0f)
+            value += partials[idx * Dim + int(dimension)] *
+                fast::exp(maxs[idx] - global_m);
+    }
+    output[int(row) * Dim + int(dimension)] = value / global_l;
+"""
+
+
+@cache
+def _mpp_attention_kernel(
+    dim: int,
+    repeats: int,
+    query_length: int,
+    padded_rows: int,
+    warps: int,
+    kv_heads: int,
+):
+    return mx.fast.metal_kernel(
+        name=(
+            f"affine4_mpp_d{dim}_r{repeats}_l{query_length}_"
+            f"m{padded_rows}_w{warps}_h{kv_heads}"
+        ),
+        input_names=[
+            "queries",
+            "keys",
+            "key_scales",
+            "values",
+            "value_scales",
+            "valid_starts",
+            "valid_ends",
+            "params",
+        ],
+        output_names=["partials", "sums", "maxs"],
+        header=_MPP_HEADER,
+        source=_MPP_ATTENTION_SOURCE,
+        ensure_row_contiguous=False,
+        compile_options={"math_mode": "fast"},
+    )
+
+
+@cache
+def _mpp_reduce_kernel(dim: int):
+    return mx.fast.metal_kernel(
+        name=f"affine4_mpp_reduce_d{dim}",
+        input_names=["partials", "sums", "maxs", "params"],
+        output_names=["output"],
+        header="using namespace metal;\n",
+        source=_MPP_REDUCE_SOURCE,
+        ensure_row_contiguous=False,
+        compile_options={"math_mode": "fast"},
+    )
+
+
+def _float_bits(value: float) -> int:
+    import struct
+
+    return struct.unpack("I", struct.pack("f", value))[0]
+
+
+@lru_cache(maxsize=1)
+def _m5_mpp_available() -> bool:
+    if not (hasattr(mx, "metal") and mx.metal.is_available()):
+        return False
+    info = mx.device_info() if hasattr(mx, "device_info") else mx.metal.device_info()
+    return str(info.get("architecture", "")).startswith("applegpu_g17")
+
+
+def _padded_rows(active_rows: int) -> int:
+    return max(8, ((active_rows + 7) // 8) * 8)
+
+
+def _attention_blocks(tokens: int, kv_heads: int, dim: int) -> int:
+    token_tiles = (tokens + 63) // 64
+    target_groups = 256 if dim <= 64 else 168
+    return min(token_tiles, max(1, (target_groups + kv_heads - 1) // kv_heads))
+
+
+def _attention_warps(dim: int) -> int:
+    if dim <= 64:
+        return 1
+    if dim == 96:
+        return 2
+    return 4
+
+
+def _native_attention(
+    cache,
+    queries: mx.array,
+    keys_state: TurboQuantMSEState,
+    values_state: TurboQuantMSEState,
+    scale: float,
+    mask,
+) -> mx.array | None:
+    if (
+        not _m5_mpp_available()
+        or queries.ndim != 4
+        or queries.dtype not in (mx.float16, mx.bfloat16)
+    ):
+        return None
+    if (
+        not isinstance(cache.key_codec, Affine4Codec)
+        or not isinstance(cache.value_codec, Affine4Codec)
+        or not isinstance(keys_state, TurboQuantMSEState)
+        or not isinstance(values_state, TurboQuantMSEState)
+        or keys_state.indices.ndim != 4
+        or values_state.indices.ndim != 4
+        or keys_state.norms.ndim != 3
+        or values_state.norms.ndim != 3
+    ):
+        return None
+    batch, query_heads, query_length, dim = queries.shape
+    kv_heads = keys_state.norms.shape[1]
+    if (
+        dim != cache.key_codec.dim
+        or dim != cache.value_codec.dim
+        or kv_heads <= 0
+        or keys_state.norms.shape[:2] != (batch, kv_heads)
+        or values_state.norms.shape != keys_state.norms.shape
+        or keys_state.indices.shape[:3] != keys_state.norms.shape
+        or values_state.indices.shape != keys_state.indices.shape
+        or keys_state.indices.shape[-1] != dim // 8
+        or keys_state.indices.dtype != mx.uint32
+        or values_state.indices.dtype != mx.uint32
+        or keys_state.norms.dtype != mx.float16
+        or values_state.norms.dtype != mx.float16
+        or dim % 32
+        or dim > 512
+        or query_heads % kv_heads
+        or query_length < 1
+        or query_length > 4
+    ):
+        return None
+    repeats = query_heads // kv_heads
+    if query_length > 1 and not (
+        isinstance(mask, str) and mask in ("causal", "left_padded_causal")
+    ):
+        return None
+    padded_rows = _padded_rows(repeats * query_length)
+    warps = _attention_warps(dim)
+    if padded_rows > _MAX_PADDED_ROWS or dim % warps:
+        return None
+    tokens = _state_length(keys_state)
+    if (
+        tokens < _MIN_NATIVE_TOKENS
+        or keys_state.indices.nbytes <= 4096
+        or _state_length(values_state) != tokens
+    ):
+        return None
+
+    is_batch = isinstance(cache, BatchAffine4KVCache)
+    if is_batch:
+        if isinstance(mask, mx.array):
+            return None
+        if isinstance(mask, str) and mask not in (
+            "causal",
+            "left_padded_decode",
+            "left_padded_causal",
+        ):
+            return None
+        valid_starts = cache.left_padding.astype(mx.int32)
+    else:
+        if mask is not None and not (isinstance(mask, str) and mask == "causal"):
+            return None
+        valid_starts = mx.zeros((batch,), dtype=mx.int32)
+    valid_ends = mx.full((batch,), tokens, dtype=mx.int32)
+
+    blocks = _attention_blocks(tokens, kv_heads, dim)
+    params = mx.array([tokens, blocks, _float_bits(float(scale))], dtype=mx.uint32)
+    grouped = queries.reshape(batch, kv_heads, repeats, query_length, dim)
+    rotated = cache.key_codec.prepare_queries(grouped).astype(mx.float16)
+    rows = batch * query_heads * query_length
+    signature = (dim, repeats, query_length, padded_rows, warps, kv_heads)
+    if _NATIVE_LAUNCHABLE.get(signature) is False:
+        return None
+
+    try:
+        pass1 = _mpp_attention_kernel(*signature)
+        partials, sums, maxs = pass1(
+            inputs=[
+                rotated.reshape(batch, query_heads, query_length, dim),
+                keys_state.indices,
+                keys_state.norms,
+                values_state.indices,
+                values_state.norms,
+                valid_starts,
+                valid_ends,
+                params,
+            ],
+            template=[
+                ("Dim", dim),
+                ("Repeats", repeats),
+                ("QueryLength", query_length),
+                ("PaddedRows", padded_rows),
+                ("Warps", warps),
+                ("NumKvHeads", kv_heads),
+            ],
+            output_shapes=[
+                (rows, blocks, dim),
+                (rows, blocks),
+                (rows, blocks),
+            ],
+            output_dtypes=[mx.float32, mx.float32, mx.float32],
+            grid=(kv_heads * 32, batch * warps, blocks),
+            threadgroup=(32, warps, 1),
+        )
+        rotated_output = _mpp_reduce_kernel(dim)(
+            inputs=[partials, sums, maxs, params],
+            template=[("Dim", dim)],
+            output_shapes=[(batch, kv_heads, repeats, query_length, dim)],
+            output_dtypes=[mx.float32],
+            grid=(rows * dim, 1, 1),
+            threadgroup=(dim, 1, 1),
+        )[0]
+        output = cache.value_codec._rotate_inverse(rotated_output)
+        output = output.reshape(batch, query_heads, query_length, dim).astype(
+            queries.dtype
+        )
+        if signature not in _NATIVE_LAUNCHABLE:
+            mx.eval(output)
+            _NATIVE_LAUNCHABLE[signature] = True
+            logger.info(
+                "Affine4 native M5 attention active (d=%d, repeats=%d, rows=%d)",
+                dim,
+                repeats,
+                query_length,
+            )
+        return output
+    except (RuntimeError, ValueError):
+        _NATIVE_LAUNCHABLE[signature] = False
+        logger.warning(
+            "Affine4 M5 kernel rejected geometry d=%d r=%d l=%d; using fallback",
+            dim,
+            repeats,
+            query_length,
+            exc_info=True,
+        )
+        return None
+
+
+class Affine4KVCache(TurboQuantKVCache):
+    def __init__(
+        self,
+        bits: float = 4.0,
+        seed: int = DEFAULT_TURBOQUANT_SEED,
+        key_bits: float | None = None,
+        value_bits: float | None = None,
+    ):
+        widths = (
+            bits,
+            key_bits if key_bits is not None else 4.0,
+            value_bits if value_bits is not None else 4.0,
+        )
+        if any(not math.isclose(float(width), 4.0) for width in widths):
+            raise ValueError(
+                f"affine4 requires exactly 4 bits for keys and values, got {widths}"
+            )
+        super().__init__(bits=4.0, seed=seed, key_bits=4.0, value_bits=4.0)
+
+    def _new_batch_cache(self, left_padding):
+        return BatchAffine4KVCache(left_padding, bits=4.0, seed=self.seed)
+
+    def _ensure_codecs(self, keys: mx.array, values: mx.array):
+        if self.key_codec is None:
+            self.key_codec = Affine4Codec(keys.shape[-1], self.seed)
+        if self.value_codec is None:
+            self.value_codec = Affine4Codec(values.shape[-1], self.seed + 1)
+
+    def _try_fused_kv_quantize(self, keys, values):
+        self._ensure_codecs(keys, values)
+        dim = keys.shape[-1]
+        signature = (dim, keys.dtype, values.dtype)
+        if _FUSED_QUANTIZE_LAUNCHABLE.get(signature) is False:
+            return None, None
+        if values.shape != keys.shape:
+            return None, None
+        try:
+            kernel = _fused_quantize_kernel(dim)
+        except (RuntimeError, ValueError):
+            _FUSED_QUANTIZE_LAUNCHABLE[signature] = False
+            return None, None
+        if kernel is None:
+            return None, None
+        flat_keys = keys.reshape(-1, dim)
+        flat_values = values.reshape(-1, dim)
+        rows = flat_keys.shape[0]
+        packed_width = dim // 8
+        try:
+            outputs = kernel(
+                inputs=[
+                    flat_keys,
+                    flat_values,
+                    self.key_codec.signs,
+                    self.value_codec.signs,
+                ],
+                template=[
+                    ("Dim", dim),
+                    ("SimdGroups", (dim + 31) // 32),
+                    ("PackedWidth", packed_width),
+                ],
+                output_shapes=[
+                    (rows,),
+                    (rows, packed_width),
+                    (rows,),
+                    (rows, packed_width),
+                ],
+                output_dtypes=[
+                    mx.float16,
+                    mx.uint32,
+                    mx.float16,
+                    mx.uint32,
+                ],
+                grid=(dim * rows, 2, 1),
+                threadgroup=(dim, 1, 1),
+            )
+            key_scales, key_packed, value_scales, value_packed = outputs
+            if signature not in _FUSED_QUANTIZE_LAUNCHABLE:
+                mx.eval(*outputs)
+                _FUSED_QUANTIZE_LAUNCHABLE[signature] = True
+            shape = keys.shape[:-1]
+            return (
+                TurboQuantMSEState(
+                    key_scales.reshape(shape),
+                    key_packed.reshape(*shape, packed_width),
+                ),
+                TurboQuantMSEState(
+                    value_scales.reshape(shape),
+                    value_packed.reshape(*shape, packed_width),
+                ),
+            )
+        except (RuntimeError, ValueError):
+            _FUSED_QUANTIZE_LAUNCHABLE[signature] = False
+            return None, None
+
+    def decode_attention(
+        self,
+        queries: mx.array,
+        keys_state=None,
+        values_state=None,
+        scale: float = 1.0,
+        mask=None,
+    ) -> mx.array:
+        if keys_state is None or values_state is None:
+            keys_state, values_state = self._attention_states()
+        keys_state = self._unwrap(keys_state)
+        values_state = self._unwrap(values_state)
+        output = _native_attention(self, queries, keys_state, values_state, scale, mask)
+        if output is not None:
+            return output
+        fallback_mask = mask
+        materialize_mask = getattr(self, "materialize_attention_mask", None)
+        if callable(materialize_mask):
+            fallback_mask = materialize_mask(mask, queries.shape[-2])
+        return super().decode_attention(
+            queries,
+            keys_state=keys_state,
+            values_state=values_state,
+            scale=scale,
+            mask=fallback_mask,
+        )
+
+    def prefill_attention(
+        self,
+        queries: mx.array,
+        keys_state=None,
+        values_state=None,
+        scale: float = 1.0,
+        mask=None,
+    ):
+        if queries.shape[-2] <= 4 and (
+            isinstance(mask, str) and mask in ("causal", "left_padded_causal")
+        ):
+            if keys_state is None or values_state is None:
+                keys_state, values_state = self._attention_states()
+            keys_state = self._unwrap(keys_state)
+            values_state = self._unwrap(values_state)
+            output = _native_attention(
+                self, queries, keys_state, values_state, scale, mask
+            )
+            if output is not None:
+                return output
+        return super().prefill_attention(
+            queries,
+            keys_state=keys_state,
+            values_state=values_state,
+            scale=scale,
+            mask=mask,
+        )
+
+    def prefix_cache_snapshot(self):
+        return {
+            "meta_state": self.meta_state,
+            "keys": _slice_state(self.keys, self.offset),
+            "values": _slice_state(self.values, self.offset),
+            "key_codec": None if self.key_codec is None else self.key_codec.dim,
+            "value_codec": None if self.value_codec is None else self.value_codec.dim,
+        }
+
+    def prefix_cache_restore(self, snapshot):
+        meta = snapshot["meta_state"]
+        self.__init__(bits=float(meta[1]), seed=int(meta[2]))
+        self.meta_state = meta
+        key_dim = snapshot.get("key_codec")
+        value_dim = snapshot.get("value_codec")
+        if key_dim is not None:
+            self.key_codec = Affine4Codec(int(key_dim), self.seed)
+        if value_dim is not None:
+            self.value_codec = Affine4Codec(int(value_dim), self.seed + 1)
+        keys = snapshot["keys"]
+        values = snapshot["values"]
+        self.keys = None if keys is None else TurboQuantMSEState(*keys)
+        self.values = None if values is None else TurboQuantMSEState(*values)
+
+
+class BatchAffine4KVCache(BatchTurboQuantKVCache, Affine4KVCache):
+    def __init__(
+        self,
+        left_padding: list | None = None,
+        bits: float = 4.0,
+        seed: int = DEFAULT_TURBOQUANT_SEED,
+        key_bits: float | None = None,
+        value_bits: float | None = None,
+    ):
+        widths = (
+            float(bits),
+            float(key_bits) if key_bits is not None else 4.0,
+            float(value_bits) if value_bits is not None else 4.0,
+        )
+        if any(not math.isclose(width, 4.0) for width in widths):
+            raise ValueError(
+                f"affine4 requires exactly 4 bits for keys and values, got {widths}"
+            )
+        BatchTurboQuantKVCache.__init__(
+            self,
+            left_padding or [],
+            bits=4.0,
+            seed=seed,
+            key_bits=4.0,
+            value_bits=4.0,
+        )
+        self._affine4_has_padding = any(value > 0 for value in (left_padding or []))
+
+    def _refresh_fused_attention_eligibility(self):
+        BatchTurboQuantKVCache._refresh_fused_attention_eligibility(self)
+        self._affine4_has_padding = bool(mx.any(self.left_padding != 0).item())
+
+    def _ensure_codecs(self, keys: mx.array, values: mx.array):
+        Affine4KVCache._ensure_codecs(self, keys, values)
+
+    def _try_fused_kv_quantize(self, keys, values):
+        return Affine4KVCache._try_fused_kv_quantize(self, keys, values)
+
+    def _quantize_kv(self, keys, values):
+        new_keys, new_values = self._try_fused_kv_quantize(keys, values)
+        if new_keys is not None:
+            return new_keys, new_values
+        return self.key_codec.quantize(keys), self.value_codec.quantize(values)
+
+    def _new_single_cache(self):
+        return Affine4KVCache(bits=4.0, seed=self.seed)
+
+    def quantized_attention_applies(self):
+        return True
+
+    def materialize_attention_mask(self, mask, query_length: int):
+        if isinstance(mask, str) and mask in (
+            "left_padded_decode",
+            "left_padded_causal",
+        ):
+            return create_causal_mask(
+                query_length,
+                offset=self._idx - query_length,
+                left_padding=self.left_padding,
+            )
+        return mask
+
+    def make_mask(self, n: int, return_array: bool = False, **kwargs):
+        if 1 <= n <= 4 and kwargs.get("window_size") is None:
+            if self._affine4_has_padding:
+                return "left_padded_decode" if n == 1 else "left_padded_causal"
+            if n > 1:
+                return "causal"
+        return super().make_mask(n, return_array=return_array, **kwargs)
+
+    def decode_attention(self, *args, **kwargs):
+        return Affine4KVCache.decode_attention(self, *args, **kwargs)
+
+    def prefill_attention(self, *args, **kwargs):
+        return Affine4KVCache.prefill_attention(self, *args, **kwargs)

--- a/mlx_vlm/apc.py
+++ b/mlx_vlm/apc.py
@@ -3537,12 +3537,17 @@ def _fill_stream_layer_cache(
 
     if quantize and kv_quant_config is not None:
         policy = kv_quant_from_config(kv_quant_config)
+        from .affine4 import Affine4KVCache
         from .turboquant import HybridQuantKVCache, TurboQuantKVCache
 
         if not policy.is_homogeneous:
             c = HybridQuantKVCache(policy)
             c.update_and_fetch(merged_k, merged_v)
             c.offset = prefix_len
+            return c
+        if policy.is_affine4:
+            c = Affine4KVCache(bits=policy.bits)
+            c.update_and_fetch(merged_k, merged_v)
             return c
         if policy.is_turboquant:
             c = TurboQuantKVCache(
@@ -3588,16 +3593,21 @@ def _fill_batch_layer_cache(
     """Build one batch-path layer cache matching ``_make_cache`` layout.
 
     When quantizing, select the same backend as live generation:
-    TurboQuant (``BatchTurboQuantKVCache``) if ``turboquant_enabled(bits, scheme)``,
-    otherwise uniform ``BatchQuantizedKVCache`` with integer bits.
+    Packed affine4 and TurboQuant use their batch cache classes; other policies
+    use uniform ``BatchQuantizedKVCache`` with integer bits.
     """
     from .models.cache import BatchKVCache, BatchQuantizedKVCache
 
     if quantize and kv_quant_config is not None:
         policy = kv_quant_from_config(kv_quant_config)
+        from .affine4 import BatchAffine4KVCache
         from .turboquant import BatchTurboQuantKVCache
 
         _reject_mixed_batch_policy(policy)
+        if policy.is_affine4:
+            c = BatchAffine4KVCache(left_padding, bits=policy.bits)
+            c.update_and_fetch(merged_k, merged_v)
+            return c
         if policy.is_turboquant:
             c = BatchTurboQuantKVCache(
                 left_padding,
@@ -3863,9 +3873,12 @@ def _merge_exact_cache_entries(
 def _empty_quant_batch_cache(left_padding: List[int], kv_quant_config: dict) -> Any:
     """Empty quantized batch cache matching live ``_make_cache`` backend."""
     policy = kv_quant_from_config(kv_quant_config)
+    from .affine4 import BatchAffine4KVCache
     from .turboquant import BatchTurboQuantKVCache
 
     _reject_mixed_batch_policy(policy)
+    if policy.is_affine4:
+        return BatchAffine4KVCache(left_padding, bits=policy.bits)
     if policy.is_turboquant:
         return BatchTurboQuantKVCache(
             left_padding,

--- a/mlx_vlm/apc_adapters.py
+++ b/mlx_vlm/apc_adapters.py
@@ -233,10 +233,13 @@ def register_default_capabilities() -> None:
         register_capability(cls, Capability.CHECKPOINT)
     register_capability(c.CacheList, Capability.COMPOSITE)
     try:
+        from .affine4 import Affine4KVCache, BatchAffine4KVCache
         from .turboquant import BatchTurboQuantKVCache, TurboQuantKVCache
 
         register_capability(TurboQuantKVCache, Capability.PAGEABLE)
         register_capability(BatchTurboQuantKVCache, Capability.PAGEABLE)
+        register_capability(Affine4KVCache, Capability.PAGEABLE)
+        register_capability(BatchAffine4KVCache, Capability.PAGEABLE)
     except ImportError:
         # TurboQuant is optional in stripped-down installations.
         pass

--- a/mlx_vlm/chat.py
+++ b/mlx_vlm/chat.py
@@ -252,14 +252,14 @@ def main():
     parser.add_argument(
         "--kv-key-scheme",
         type=str,
-        choices=("uniform", "turboquant"),
+        choices=("uniform", "turboquant", "affine4"),
         default=None,
         help="Override the KV quantization backend for keys only.",
     )
     parser.add_argument(
         "--kv-value-scheme",
         type=str,
-        choices=("uniform", "turboquant"),
+        choices=("uniform", "turboquant", "affine4"),
         default=None,
         help="Override the KV quantization backend for values only.",
     )
@@ -272,7 +272,7 @@ def main():
     parser.add_argument(
         "--kv-quant-scheme",
         type=str,
-        choices=("uniform", "turboquant"),
+        choices=("uniform", "turboquant", "affine4"),
         default=DEFAULT_KV_QUANT_SCHEME,
         help="KV cache quantization backend.",
     )

--- a/mlx_vlm/generate/ar.py
+++ b/mlx_vlm/generate/ar.py
@@ -16,6 +16,7 @@ import mlx.nn as nn
 from tqdm import tqdm
 
 from .. import apc as _apc
+from ..affine4 import BatchAffine4KVCache
 from ..kv_quant import from_legacy as kv_quant_from_legacy
 from ..models import cache
 from ..prompt_utils import apply_chat_template
@@ -32,7 +33,7 @@ from ..speculative.utils import (
     speculative_hidden_state,
     speculative_prefill_kwargs,
 )
-from ..turboquant import BatchTurboQuantKVCache, turboquant_enabled
+from ..turboquant import BatchTurboQuantKVCache
 from ..utils import group_images_by_shape, prepare_inputs, should_add_special_tokens
 from .common import (
     DEFAULT_COMPLETION_BATCH_SIZE,
@@ -898,6 +899,7 @@ def _make_cache(
     *kv_quant_scheme* selects the quantization backend:
     - ``"uniform"`` → ``BatchQuantizedKVCache`` (``mx.quantize``)
     - ``"turboquant"`` or fractional *kv_bits* → ``BatchTurboQuantKVCache``
+    - ``"affine4"`` → ``BatchAffine4KVCache``
 
     Model-specific ``to_batch()`` conversions preserve auxiliary cache state.
     Quantized continuous batching with these caches raises
@@ -919,15 +921,26 @@ def _make_cache(
             "continuous batching"
         )
 
-    use_turbo = kv_bits is not None and turboquant_enabled(kv_bits, kv_quant_scheme)
+    use_turbo = _batch_policy is not None and _batch_policy.is_turboquant
+    use_affine4 = _batch_policy is not None and _batch_policy.is_affine4
+    use_packed = use_turbo or use_affine4
 
-    defer_turbo = (
-        use_turbo and quantized_kv_start > 0 and prefill_length < quantized_kv_start
+    defer_packed = (
+        use_packed and quantized_kv_start > 0 and prefill_length < quantized_kv_start
     )
 
     def _make_quant_cache(lp):
+        if use_affine4:
+            if defer_packed:
+                return cache.BatchKVCache(lp)
+            return BatchAffine4KVCache(
+                lp,
+                bits=kv_bits,
+                key_bits=kv_key_bits,
+                value_bits=kv_value_bits,
+            )
         if use_turbo:
-            if defer_turbo:
+            if defer_packed:
                 return cache.BatchKVCache(lp)
             return BatchTurboQuantKVCache(
                 lp, bits=kv_bits, key_bits=kv_key_bits, value_bits=kv_value_bits

--- a/mlx_vlm/generate/common.py
+++ b/mlx_vlm/generate/common.py
@@ -9,9 +9,10 @@ import mlx.core as mx
 import mlx.nn as nn
 from mlx.utils import tree_reduce
 
+from ..affine4 import Affine4KVCache
 from ..kv_quant import from_legacy as kv_quant_from_legacy
 from ..models import cache
-from ..turboquant import HybridQuantKVCache, TurboQuantKVCache, turboquant_enabled
+from ..turboquant import HybridQuantKVCache, TurboQuantKVCache
 
 DEFAULT_KV_GROUP_SIZE = 64
 DEFAULT_KV_QUANT_SCHEME = "uniform"
@@ -156,11 +157,27 @@ def maybe_quantize_kv_cache(
             prompt_cache[index] = hybridize(layer_cache)
         return
 
-    if turboquant_enabled(kv_bits, kv_quant_scheme):
+    if policy is not None and (policy.is_turboquant or policy.is_affine4):
+        cache_type = Affine4KVCache if policy.is_affine4 else TurboQuantKVCache
 
         def quantize_entry(entry):
-            if isinstance(entry, TurboQuantKVCache):
+            if type(entry) is cache_type:
                 return entry
+            if isinstance(entry, (TurboQuantKVCache, Affine4KVCache)):
+                if entry.empty():
+                    return cache_type(
+                        bits=kv_bits,
+                        key_bits=kv_key_bits,
+                        value_bits=kv_value_bits,
+                    )
+                keys, values = entry.dequantize()
+                converted = cache_type(
+                    bits=kv_bits,
+                    key_bits=kv_key_bits,
+                    value_bits=kv_value_bits,
+                )
+                converted.update_and_fetch(keys, values)
+                return converted
             if isinstance(entry, cache.RotatingKVCache):
                 return entry
             if getattr(entry, "preserve_auxiliary_kv_state", False):
@@ -168,14 +185,14 @@ def maybe_quantize_kv_cache(
             if isinstance(entry, cache.KVCache):
                 if entry.offset == 0:
                     # Empty: replace so update_and_fetch quantizes on the fly
-                    return TurboQuantKVCache(
+                    return cache_type(
                         bits=kv_bits,
                         key_bits=kv_key_bits,
                         value_bits=kv_value_bits,
                     )
                 if entry.offset < quantized_kv_start:
                     return entry
-                return TurboQuantKVCache.from_cache(
+                return cache_type.from_cache(
                     entry,
                     bits=kv_bits,
                     key_bits=kv_key_bits,

--- a/mlx_vlm/generate/dispatch.py
+++ b/mlx_vlm/generate/dispatch.py
@@ -489,21 +489,21 @@ def parse_arguments():
     parser.add_argument(
         "--kv-key-scheme",
         type=str,
-        choices=("uniform", "turboquant"),
+        choices=("uniform", "turboquant", "affine4"),
         default=None,
         help="Override the KV quantization backend for keys only.",
     )
     parser.add_argument(
         "--kv-value-scheme",
         type=str,
-        choices=("uniform", "turboquant"),
+        choices=("uniform", "turboquant", "affine4"),
         default=None,
         help="Override the KV quantization backend for values only.",
     )
     parser.add_argument(
         "--kv-quant-scheme",
         type=str,
-        choices=("uniform", "turboquant"),
+        choices=("uniform", "turboquant", "affine4"),
         default=DEFAULT_KV_QUANT_SCHEME,
         help="KV cache quantization backend. Fractional --kv-bits values use "
         "TurboQuant automatically.",

--- a/mlx_vlm/kv_quant.py
+++ b/mlx_vlm/kv_quant.py
@@ -4,6 +4,7 @@ import math
 from dataclasses import dataclass
 from typing import Any, Dict, Optional
 
+AFFINE4_SCHEME = "affine4"
 TURBOQUANT_SCHEME = "turboquant"
 UNIFORM_SCHEME = "uniform"
 
@@ -17,6 +18,10 @@ class KVQuantSpec:
     @property
     def is_turboquant(self) -> bool:
         return self.scheme == TURBOQUANT_SCHEME
+
+    @property
+    def is_affine4(self) -> bool:
+        return self.scheme == AFFINE4_SCHEME
 
 
 @dataclass(frozen=True)
@@ -32,6 +37,10 @@ class KVQuantPolicy:
     @property
     def is_turboquant(self) -> bool:
         return self.key.is_turboquant and self.value.is_turboquant
+
+    @property
+    def is_affine4(self) -> bool:
+        return self.key.is_affine4 and self.value.is_affine4
 
     @property
     def scheme(self) -> str:
@@ -116,7 +125,12 @@ def from_legacy(
 
     from .turboquant import resolve_kv_bits, turboquant_enabled
 
-    if turboquant_enabled(kv_bits, kv_quant_scheme):
+    if kv_quant_scheme == AFFINE4_SCHEME:
+        bits = float(kv_bits)
+        default_key_bits = float(kv_key_bits) if kv_key_bits is not None else bits
+        default_value_bits = float(kv_value_bits) if kv_value_bits is not None else bits
+        scheme = AFFINE4_SCHEME
+    elif turboquant_enabled(kv_bits, kv_quant_scheme):
         bits, default_key_bits, default_value_bits = resolve_kv_bits(
             kv_bits, kv_key_bits, kv_value_bits
         )
@@ -135,6 +149,11 @@ def from_legacy(
     value_bits = _bits_for_scheme(
         value_scheme, scheme, default_value_bits, kv_value_bits, bits
     )
+    if AFFINE4_SCHEME in (key_scheme, value_scheme):
+        if key_scheme != AFFINE4_SCHEME or value_scheme != AFFINE4_SCHEME:
+            raise ValueError("affine4 requires the same scheme for keys and values")
+        if not math.isclose(key_bits, 4.0) or not math.isclose(value_bits, 4.0):
+            raise ValueError("affine4 requires exactly 4 bits for keys and values")
 
     return KVQuantPolicy(
         bits=bits,
@@ -146,10 +165,10 @@ def from_legacy(
 def _validate_scheme(scheme: Optional[str], fallback: str) -> str:
     if scheme is None:
         return fallback
-    if scheme not in (UNIFORM_SCHEME, TURBOQUANT_SCHEME):
+    if scheme not in (UNIFORM_SCHEME, TURBOQUANT_SCHEME, AFFINE4_SCHEME):
         raise ValueError(
-            f"unknown KV quantization scheme {scheme!r}; "
-            f"expected {UNIFORM_SCHEME!r} or {TURBOQUANT_SCHEME!r}"
+            f"unknown KV quantization scheme {scheme!r}; expected "
+            f"{UNIFORM_SCHEME!r}, {TURBOQUANT_SCHEME!r}, or {AFFINE4_SCHEME!r}"
         )
     return scheme
 

--- a/mlx_vlm/models/base.py
+++ b/mlx_vlm/models/base.py
@@ -354,6 +354,9 @@ def _turboquant_attention_applies(cache) -> bool:
     cache; the batch cache qualifies only while it carries a single row with
     no left padding (padded rows would be attended to as real tokens).
     """
+    applies = getattr(cache, "quantized_attention_applies", None)
+    if callable(applies):
+        return bool(applies())
     if not isinstance(cache, BatchTurboQuantKVCache):
         return True
     if not cache.is_single_row():
@@ -371,9 +374,9 @@ def scaled_dot_product_attention(
     sinks: Optional[mx.array] = None,
 ) -> mx.array:
     if isinstance(cache, (TurboQuantKVCache, BatchTurboQuantKVCache)):
-        # The fused kernels have no sink term, and the batch cache only shares
-        # them when it holds a single unpadded row. Anything else dequantizes,
-        # which is also the only path that can apply sinks.
+        # Packed-cache implementations decide which masks and batch layouts
+        # their direct attention kernels can consume. Sinks always use dense
+        # dequantization because packed kernels do not implement sink terms.
         if sinks is None and _turboquant_attention_applies(cache):
             if queries.shape[-2] == 1:
                 return cache.decode_attention(
@@ -393,6 +396,9 @@ def scaled_dot_product_attention(
             if result is not None:
                 return result
         dequantized_keys, dequantized_values = cache.dequantize(keys, values)
+        materialize_mask = getattr(cache, "materialize_attention_mask", None)
+        if callable(materialize_mask):
+            mask = materialize_mask(mask, queries.shape[-2])
         return mx.fast.scaled_dot_product_attention(
             queries,
             dequantized_keys.astype(queries.dtype),

--- a/mlx_vlm/server/cli.py
+++ b/mlx_vlm/server/cli.py
@@ -183,21 +183,21 @@ def main():
     parser.add_argument(
         "--kv-key-scheme",
         type=str,
-        choices=("uniform", "turboquant"),
+        choices=("uniform", "turboquant", "affine4"),
         default=None,
         help="Override the KV quantization backend for keys only.",
     )
     parser.add_argument(
         "--kv-value-scheme",
         type=str,
-        choices=("uniform", "turboquant"),
+        choices=("uniform", "turboquant", "affine4"),
         default=None,
         help="Override the KV quantization backend for values only.",
     )
     parser.add_argument(
         "--kv-quant-scheme",
         type=str,
-        choices=("uniform", "turboquant"),
+        choices=("uniform", "turboquant", "affine4"),
         default=DEFAULT_KV_QUANT_SCHEME,
         help="KV cache quantization backend.",
     )

--- a/mlx_vlm/server/runtime_config.py
+++ b/mlx_vlm/server/runtime_config.py
@@ -13,7 +13,7 @@ from typing import Any, Dict, Iterable, Iterator, List, Optional, Set, Tuple
 TEXT_KINDS: Tuple[str, ...] = ("text_generation",)
 VISION_KINDS: Tuple[str, ...] = ("image_generation", "image_edit")
 
-KV_SCHEMES: Tuple[str, ...] = ("uniform", "turboquant")
+KV_SCHEMES: Tuple[str, ...] = ("uniform", "turboquant", "affine4")
 DEFAULT_TOKEN_QUEUE_TIMEOUT = 600.0
 
 logger = logging.getLogger("mlx_vlm.server")

--- a/mlx_vlm/tests/test_affine4.py
+++ b/mlx_vlm/tests/test_affine4.py
@@ -1,0 +1,525 @@
+import mlx.core as mx
+import pytest
+
+from mlx_vlm import affine4
+from mlx_vlm.affine4 import Affine4Codec, Affine4KVCache, BatchAffine4KVCache
+from mlx_vlm.generate.ar import _make_cache
+from mlx_vlm.generate.common import maybe_quantize_kv_cache
+from mlx_vlm.kv_quant import from_legacy
+from mlx_vlm.models.cache import KVCache
+from mlx_vlm.turboquant import BatchTurboQuantKVCache, TurboQuantKVCache
+
+
+def _reference(cache, queries, scale, mask=None):
+    keys, values = cache.dequantize()
+    return mx.fast.scaled_dot_product_attention(
+        queries,
+        keys.astype(queries.dtype),
+        values.astype(queries.dtype),
+        scale=scale,
+        mask=mask,
+    )
+
+
+def _cosine(a, b):
+    a = a.astype(mx.float32).reshape(-1)
+    b = b.astype(mx.float32).reshape(-1)
+    return mx.sum(a * b) / (mx.sqrt(mx.sum(a * a)) * mx.sqrt(mx.sum(b * b)))
+
+
+def test_affine4_policy_requires_homogeneous_four_bits():
+    policy = from_legacy(4, "affine4")
+
+    assert policy.is_affine4
+    assert policy.scheme == "affine4"
+    assert policy.key.bits == policy.value.bits == 4
+    with pytest.raises(ValueError, match="exactly 4 bits"):
+        from_legacy(3.5, "affine4")
+    with pytest.raises(ValueError, match="same scheme"):
+        from_legacy(4, "affine4", kv_value_scheme="turboquant")
+
+
+def test_affine4_codec_round_trip_and_layout():
+    mx.random.seed(1)
+    vectors = mx.random.normal((2, 3, 7, 64), dtype=mx.float16)
+    codec = Affine4Codec(64, seed=9)
+
+    state = codec.quantize(vectors)
+    restored = codec.dequantize(state)
+    mx.eval(state.norms, state.indices, restored)
+
+    assert state.norms.shape == vectors.shape[:-1]
+    assert state.indices.shape == (*vectors.shape[:-1], 8)
+    assert state.norms.dtype == mx.float16
+    assert state.indices.dtype == mx.uint32
+    assert restored.shape == vectors.shape
+    assert _cosine(vectors, restored).item() > 0.99
+
+
+def test_fused_affine4_quantizer_matches_portable_codec():
+    if not mx.metal.is_available():
+        pytest.skip("Metal kernel unavailable")
+    mx.random.seed(2)
+    keys = mx.random.normal((1, 2, 1, 256), dtype=mx.bfloat16)
+    values = mx.random.normal((1, 2, 1, 256), dtype=mx.bfloat16)
+    cache = Affine4KVCache()
+    cache._ensure_codecs(keys, values)
+
+    fused_keys, fused_values = cache._try_fused_kv_quantize(keys, values)
+    ref_keys = cache.key_codec.quantize(keys)
+    ref_values = cache.value_codec.quantize(values)
+    mx.eval(
+        fused_keys.norms,
+        fused_keys.indices,
+        fused_values.norms,
+        fused_values.indices,
+        ref_keys.norms,
+        ref_keys.indices,
+        ref_values.norms,
+        ref_values.indices,
+    )
+
+    assert mx.array_equal(fused_keys.norms, ref_keys.norms).item()
+    assert mx.array_equal(fused_keys.indices, ref_keys.indices).item()
+    assert mx.array_equal(fused_values.norms, ref_values.norms).item()
+    assert mx.array_equal(fused_values.indices, ref_values.indices).item()
+
+
+def test_single_cache_conversion_and_prefix_snapshot_round_trip(monkeypatch):
+    monkeypatch.setattr(affine4, "_m5_mpp_available", lambda: False)
+    mx.random.seed(3)
+    keys = mx.random.normal((1, 2, 17, 64), dtype=mx.float16)
+    values = mx.random.normal((1, 2, 17, 64), dtype=mx.float16)
+    source = KVCache()
+    source.update_and_fetch(keys, values)
+    caches = [source, KVCache(), KVCache()]
+
+    maybe_quantize_kv_cache(caches, 0, 64, 4, "affine4")
+    converted = caches[0]
+    snapshot = converted.prefix_cache_snapshot()
+    restored = Affine4KVCache()
+    restored.prefix_cache_restore(snapshot)
+    dk, dv = restored.dequantize()
+    rk, rv = converted.dequantize()
+    mx.eval(dk, dv, rk, rv)
+
+    assert isinstance(converted, Affine4KVCache)
+    assert restored.offset == converted.offset
+    assert mx.array_equal(restored.keys.indices, converted.keys.indices).item()
+    assert mx.array_equal(restored.values.indices, converted.values.indices).item()
+    assert mx.allclose(dk, rk).item()
+    assert mx.allclose(dv, rv).item()
+
+
+def test_cache_conversion_does_not_confuse_affine4_with_turboquant():
+    from mlx_vlm.turboquant import TurboQuantKVCache
+
+    keys = mx.zeros((1, 2, 8, 64), dtype=mx.float16)
+    values = mx.zeros((1, 2, 8, 64), dtype=mx.float16)
+    affine_cache = Affine4KVCache()
+    affine_cache.update_and_fetch(keys, values)
+    caches = [affine_cache, KVCache(), KVCache()]
+
+    maybe_quantize_kv_cache(caches, 0, 64, 4, "turboquant")
+    assert type(caches[0]) is TurboQuantKVCache
+
+    maybe_quantize_kv_cache(caches, 0, 64, 4, "affine4")
+    assert type(caches[0]) is Affine4KVCache
+
+
+def test_batch_factory_and_extract_preserve_affine4_type():
+    class Model:
+        def make_cache(self):
+            return [KVCache(), KVCache(), KVCache()]
+
+    caches = _make_cache(Model(), [0, 0], kv_bits=4, kv_quant_scheme="affine4")
+    cache = caches[0]
+    keys = mx.zeros((2, 2, 5, 64), dtype=mx.float16)
+    values = mx.zeros((2, 2, 5, 64), dtype=mx.float16)
+    cache.update_and_fetch(keys, values)
+
+    extracted = cache.extract(1)
+
+    assert isinstance(cache, BatchAffine4KVCache)
+    assert isinstance(extracted, Affine4KVCache)
+    assert extracted.offset == 5
+
+
+@pytest.mark.parametrize(
+    "cache_type,batch_type",
+    [
+        (TurboQuantKVCache, BatchTurboQuantKVCache),
+        (Affine4KVCache, BatchAffine4KVCache),
+    ],
+)
+def test_prefix_cache_merge_preserves_packed_cache_type(cache_type, batch_type):
+    mx.random.seed(10)
+    rows = []
+    for length in (5, 3):
+        cache = cache_type(bits=4)
+        cache.update_and_fetch(
+            mx.random.normal((1, 2, length, 64), dtype=mx.float16),
+            mx.random.normal((1, 2, length, 64), dtype=mx.float16),
+        )
+        rows.append(cache)
+
+    merged = rows[0].prefix_cache_merge(rows, [5, 3])
+
+    assert type(merged) is batch_type
+    for index, row in enumerate(rows):
+        extracted = merged.extract(index)
+        assert type(extracted) is cache_type
+        actual = extracted.dequantize()
+        expected = row.dequantize()
+        mx.eval(*actual, *expected)
+        assert all(mx.array_equal(a, b).item() for a, b in zip(actual, expected))
+
+
+def test_prefix_cache_merge_rejects_different_packed_scheme():
+    keys = mx.zeros((1, 2, 3, 64), dtype=mx.float16)
+    values = mx.zeros((1, 2, 3, 64), dtype=mx.float16)
+    turbo = TurboQuantKVCache(bits=4)
+    affine = Affine4KVCache()
+    turbo.update_and_fetch(keys, values)
+    affine.update_and_fetch(keys, values)
+
+    assert turbo.prefix_cache_merge([turbo, affine], [3, 3]) is None
+    assert affine.prefix_cache_merge([affine, turbo], [3, 3]) is None
+
+
+@pytest.mark.parametrize(
+    "query_heads,kv_heads,dim",
+    [
+        (4, 1, 32),
+        (8, 2, 64),
+        (12, 2, 96),
+        (8, 2, 192),
+        (16, 2, 256),
+        (24, 4, 256),
+        (8, 2, 512),
+    ],
+)
+def test_native_affine4_decode_matches_dequantized_sdpa(query_heads, kv_heads, dim):
+    if not affine4._m5_mpp_available():
+        pytest.skip("M5 TensorOps unavailable")
+    mx.random.seed(query_heads)
+    tokens = 257
+    keys = mx.random.normal((1, kv_heads, tokens, dim), dtype=mx.float16)
+    values = mx.random.normal((1, kv_heads, tokens, dim), dtype=mx.float16)
+    queries = mx.random.normal((1, query_heads, 1, dim), dtype=mx.bfloat16)
+    cache = Affine4KVCache()
+    cache.update_and_fetch(keys, values)
+
+    output = cache.decode_attention(queries, scale=dim**-0.5)
+    reference = _reference(cache, queries, dim**-0.5)
+    mx.eval(output, reference)
+
+    signature = (
+        dim,
+        query_heads // kv_heads,
+        1,
+        8,
+        affine4._attention_warps(dim),
+        kv_heads,
+    )
+    assert affine4._NATIVE_LAUNCHABLE[signature]
+    assert _cosine(output, reference).item() > 0.999
+    assert mx.max(mx.abs(output - reference)).item() < 0.01
+
+
+@pytest.mark.parametrize("query_length", [2, 3, 4])
+def test_native_affine4_causal_multirow(query_length):
+    if not affine4._m5_mpp_available():
+        pytest.skip("M5 TensorOps unavailable")
+    mx.random.seed(query_length)
+    tokens, dim = 257, 256
+    keys = mx.random.normal((1, 4, tokens, dim), dtype=mx.float16)
+    values = mx.random.normal((1, 4, tokens, dim), dtype=mx.float16)
+    queries = mx.random.normal((1, 24, query_length, dim), dtype=mx.bfloat16)
+    cache = Affine4KVCache()
+    key_state, value_state = cache.update_and_fetch(keys, values)
+
+    output = cache.prefill_attention(
+        queries,
+        key_state,
+        value_state,
+        scale=dim**-0.5,
+        mask="causal",
+    )
+    q_positions = mx.arange(tokens - query_length, tokens)
+    mask = mx.arange(tokens)[None, :] <= q_positions[:, None]
+    reference = _reference(cache, queries, dim**-0.5, mask)
+    mx.eval(output, reference)
+
+    assert _cosine(output, reference).item() > 0.999
+    assert mx.max(mx.abs(output - reference)).item() < 0.01
+
+
+def test_native_failure_is_cached_and_uses_portable_fallback(monkeypatch):
+    mx.random.seed(4)
+    keys = mx.random.normal((1, 2, 256, 64), dtype=mx.float16)
+    values = mx.random.normal((1, 2, 256, 64), dtype=mx.float16)
+    queries = mx.random.normal((1, 8, 1, 64), dtype=mx.float16)
+    cache = Affine4KVCache()
+    cache.update_and_fetch(keys, values)
+    calls = 0
+
+    def rejected(*args, **kwargs):
+        nonlocal calls
+        calls += 1
+
+        def launch(**kwargs):
+            raise RuntimeError("rejected")
+
+        return launch
+
+    monkeypatch.setattr(affine4, "_m5_mpp_available", lambda: True)
+    monkeypatch.setattr(affine4, "_mpp_attention_kernel", rejected)
+    monkeypatch.setattr(affine4, "_NATIVE_LAUNCHABLE", {})
+
+    first = cache.decode_attention(queries, scale=64**-0.5)
+    second = cache.decode_attention(queries, scale=64**-0.5)
+    reference = _reference(cache, queries, 64**-0.5)
+    mx.eval(first, second, reference)
+
+    assert calls == 1
+    assert mx.allclose(first, reference, rtol=1e-3, atol=1e-3).item()
+    assert mx.allclose(second, reference, rtol=1e-3, atol=1e-3).item()
+
+
+def test_arbitrary_mask_declines_native_path(monkeypatch):
+    mx.random.seed(5)
+    keys = mx.random.normal((1, 2, 256, 64), dtype=mx.float16)
+    values = mx.random.normal((1, 2, 256, 64), dtype=mx.float16)
+    queries = mx.random.normal((1, 8, 1, 64), dtype=mx.float16)
+    cache = Affine4KVCache()
+    cache.update_and_fetch(keys, values)
+    called = False
+
+    def unexpected(*args, **kwargs):
+        nonlocal called
+        called = True
+        raise AssertionError("native kernel must not receive an arbitrary mask")
+
+    monkeypatch.setattr(affine4, "_m5_mpp_available", lambda: True)
+    monkeypatch.setattr(affine4, "_mpp_attention_kernel", unexpected)
+    mask = mx.ones((1, 1, 1, 256), dtype=mx.bool_)
+
+    output = cache.decode_attention(queries, scale=64**-0.5, mask=mask)
+    reference = _reference(cache, queries, 64**-0.5, mask)
+    mx.eval(output, reference)
+
+    assert not called
+    assert mx.allclose(output, reference, rtol=1e-3, atol=1e-3).item()
+
+
+def test_left_padded_batch_marker_has_portable_fallback(monkeypatch):
+    from mlx_vlm.models.cache import create_causal_mask
+
+    monkeypatch.setattr(affine4, "_m5_mpp_available", lambda: False)
+    mx.random.seed(6)
+    batch, query_heads, kv_heads, prefix, dim = 2, 8, 2, 256, 64
+    cache = BatchAffine4KVCache([17, 0])
+    cache.update_and_fetch(
+        mx.random.normal((batch, kv_heads, prefix, dim), dtype=mx.float16),
+        mx.random.normal((batch, kv_heads, prefix, dim), dtype=mx.float16),
+    )
+    mask = cache.make_mask(1)
+    keys, values = cache.update_and_fetch(
+        mx.random.normal((batch, kv_heads, 1, dim), dtype=mx.float16),
+        mx.random.normal((batch, kv_heads, 1, dim), dtype=mx.float16),
+    )
+    queries = mx.random.normal((batch, query_heads, 1, dim), dtype=mx.float16)
+
+    output = cache.decode_attention(queries, keys, values, scale=dim**-0.5, mask=mask)
+    dense_mask = create_causal_mask(1, offset=prefix, left_padding=cache.left_padding)
+    reference = _reference(cache, queries, dim**-0.5, dense_mask)
+    mx.eval(output, reference)
+
+    assert mask == "left_padded_decode"
+    assert _cosine(output, reference).item() > 0.999
+
+
+def test_apc_factories_preserve_affine4_cache_types():
+    from mlx_vlm import apc
+    from mlx_vlm.apc_adapters import Capability, resolve_capability
+
+    config = {"bits": 4, "group_size": 64, "scheme": "affine4"}
+    keys = mx.zeros((1, 2, 8, 64), dtype=mx.float16)
+    values = mx.zeros((1, 2, 8, 64), dtype=mx.float16)
+
+    stream = apc._fill_stream_layer_cache(
+        keys,
+        values,
+        8,
+        quantize=True,
+        kv_quant_config=config,
+    )
+    batch = apc._empty_quant_batch_cache([0], config)
+
+    assert isinstance(stream, Affine4KVCache)
+    assert isinstance(batch, BatchAffine4KVCache)
+    assert resolve_capability(stream) is Capability.PAGEABLE
+    assert resolve_capability(batch) is Capability.PAGEABLE
+
+
+def test_native_left_padded_batch_matches_dequantized_sdpa():
+    from mlx_vlm.models.cache import create_causal_mask
+
+    if not affine4._m5_mpp_available():
+        pytest.skip("M5 TensorOps unavailable")
+    mx.random.seed(7)
+    batch, query_heads, kv_heads, prefix, dim = 2, 8, 2, 256, 64
+    cache = BatchAffine4KVCache([13, 0])
+    cache.update_and_fetch(
+        mx.random.normal((batch, kv_heads, prefix, dim), dtype=mx.float16),
+        mx.random.normal((batch, kv_heads, prefix, dim), dtype=mx.float16),
+    )
+    mask = cache.make_mask(1)
+    keys, values = cache.update_and_fetch(
+        mx.random.normal((batch, kv_heads, 1, dim), dtype=mx.float16),
+        mx.random.normal((batch, kv_heads, 1, dim), dtype=mx.float16),
+    )
+    queries = mx.random.normal((batch, query_heads, 1, dim), dtype=mx.bfloat16)
+
+    output = cache.decode_attention(queries, keys, values, scale=dim**-0.5, mask=mask)
+    dense_mask = create_causal_mask(1, offset=prefix, left_padding=cache.left_padding)
+    reference = _reference(cache, queries, dim**-0.5, dense_mask)
+    mx.eval(output, reference)
+
+    signature = (64, 4, 1, 8, 1, 2)
+    assert affine4._NATIVE_LAUNCHABLE[signature]
+    assert _cosine(output, reference).item() > 0.999
+
+
+@pytest.mark.parametrize("query_length", [2, 3, 4])
+@pytest.mark.parametrize(
+    "left_padding,expected_mask",
+    [([13, 0], "left_padded_causal"), ([0, 0], "causal")],
+)
+def test_native_batch_causal_multirow(query_length, left_padding, expected_mask):
+    from mlx_vlm.models.cache import create_causal_mask
+
+    if not affine4._m5_mpp_available():
+        pytest.skip("M5 TensorOps unavailable")
+    mx.random.seed(20 + query_length)
+    batch, query_heads, kv_heads, prefix, dim = 2, 8, 2, 256, 64
+    cache = BatchAffine4KVCache(left_padding)
+    cache.update_and_fetch(
+        mx.random.normal((batch, kv_heads, prefix, dim), dtype=mx.float16),
+        mx.random.normal((batch, kv_heads, prefix, dim), dtype=mx.float16),
+    )
+    mask = cache.make_mask(query_length)
+    keys, values = cache.update_and_fetch(
+        mx.random.normal((batch, kv_heads, query_length, dim), dtype=mx.float16),
+        mx.random.normal((batch, kv_heads, query_length, dim), dtype=mx.float16),
+    )
+    queries = mx.random.normal(
+        (batch, query_heads, query_length, dim), dtype=mx.bfloat16
+    )
+
+    output = cache.prefill_attention(queries, keys, values, scale=dim**-0.5, mask=mask)
+    dense_mask = create_causal_mask(
+        query_length, offset=prefix, left_padding=cache.left_padding
+    )
+    reference = _reference(cache, queries, dim**-0.5, dense_mask)
+    mx.eval(output, reference)
+
+    signature = (
+        dim,
+        query_heads // kv_heads,
+        query_length,
+        ((query_heads // kv_heads) * query_length + 7) // 8 * 8,
+        1,
+        kv_heads,
+    )
+    assert mask == expected_mask
+    assert affine4._NATIVE_LAUNCHABLE[signature]
+    assert _cosine(output, reference).item() > 0.999
+    assert mx.max(mx.abs(output - reference)).item() < 0.01
+
+
+def test_left_padded_multirow_marker_has_portable_fallback(monkeypatch):
+    from mlx_vlm.models.base import scaled_dot_product_attention
+    from mlx_vlm.models.cache import create_causal_mask
+
+    monkeypatch.setattr(affine4, "_m5_mpp_available", lambda: False)
+    mx.random.seed(30)
+    batch, query_heads, kv_heads, prefix, query_length, dim = 2, 8, 2, 17, 3, 64
+    cache = BatchAffine4KVCache([5, 0])
+    cache.update_and_fetch(
+        mx.random.normal((batch, kv_heads, prefix, dim), dtype=mx.float16),
+        mx.random.normal((batch, kv_heads, prefix, dim), dtype=mx.float16),
+    )
+    mask = cache.make_mask(query_length)
+    keys, values = cache.update_and_fetch(
+        mx.random.normal((batch, kv_heads, query_length, dim), dtype=mx.float16),
+        mx.random.normal((batch, kv_heads, query_length, dim), dtype=mx.float16),
+    )
+    queries = mx.random.normal(
+        (batch, query_heads, query_length, dim), dtype=mx.float16
+    )
+
+    output = scaled_dot_product_attention(queries, keys, values, cache, dim**-0.5, mask)
+    dense_mask = create_causal_mask(
+        query_length, offset=prefix, left_padding=cache.left_padding
+    )
+    reference = _reference(cache, queries, dim**-0.5, dense_mask)
+    mx.eval(output, reference)
+
+    assert mask == "left_padded_causal"
+    assert _cosine(output, reference).item() > 0.999
+
+
+def test_unsupported_head_dimension_uses_portable_fallback(monkeypatch):
+    mx.random.seed(8)
+    keys = mx.random.normal((1, 2, 256, 80), dtype=mx.float16)
+    values = mx.random.normal((1, 2, 256, 80), dtype=mx.float16)
+    queries = mx.random.normal((1, 8, 1, 80), dtype=mx.float16)
+    cache = Affine4KVCache()
+    cache.update_and_fetch(keys, values)
+
+    def unexpected(*args, **kwargs):
+        raise AssertionError("unsupported geometry reached native compilation")
+
+    monkeypatch.setattr(affine4, "_m5_mpp_available", lambda: True)
+    monkeypatch.setattr(affine4, "_mpp_attention_kernel", unexpected)
+
+    output = cache.decode_attention(queries, scale=80**-0.5)
+    reference = _reference(cache, queries, 80**-0.5)
+    mx.eval(output, reference)
+
+    assert mx.allclose(output, reference, rtol=1e-3, atol=1e-3).item()
+
+
+@pytest.mark.parametrize("factory_failure", [False, True])
+def test_fused_quantizer_failure_is_cached(monkeypatch, factory_failure):
+    mx.random.seed(9)
+    keys = mx.random.normal((1, 2, 1, 64), dtype=mx.float16)
+    values = mx.random.normal((1, 2, 1, 64), dtype=mx.float16)
+    calls = 0
+
+    def rejected(dim):
+        nonlocal calls
+        calls += 1
+        if factory_failure:
+            raise RuntimeError("rejected")
+
+        def launch(**kwargs):
+            raise RuntimeError("rejected")
+
+        return launch
+
+    monkeypatch.setattr(affine4, "_fused_quantize_kernel", rejected)
+    monkeypatch.setattr(affine4, "_FUSED_QUANTIZE_LAUNCHABLE", {})
+    cache = Affine4KVCache()
+
+    cache.update_and_fetch(keys, values)
+    cache.update_and_fetch(keys, values)
+    restored_keys, restored_values = cache.dequantize()
+    mx.eval(restored_keys, restored_values)
+
+    assert calls == 1
+    assert cache.offset == 2
+    assert restored_keys.shape == (1, 2, 2, 64)
+    assert restored_values.shape == (1, 2, 2, 64)

--- a/mlx_vlm/tests/test_apc_quantized.py
+++ b/mlx_vlm/tests/test_apc_quantized.py
@@ -743,6 +743,53 @@ class TestNativePackedExactCheckpoints:
         mx.eval(updated)
         assert warm[0]._idx == seq_len + 1
 
+    def test_affine4_disk_roundtrip_preserves_packed_state(
+        self, tmp_path, monkeypatch
+    ):
+        from mlx_vlm.affine4 import Affine4KVCache, BatchAffine4KVCache
+
+        monkeypatch.setenv("APC_EXACT_CACHE_ENTRIES", "0")
+        seq_len = 32
+        token_ids = list(range(seq_len))
+        source = BatchAffine4KVCache([0])
+        keys, values = _rand_kv(seq_len=seq_len)
+        source.update_and_fetch(keys, values)
+        mx.eval(source.state)
+
+        def fail(*args, **kwargs):
+            raise AssertionError("affine4 checkpoint must stay packed")
+
+        monkeypatch.setattr(Affine4KVCache, "dequantize_for_apc", fail)
+        snapshot = snapshot_prompt_cache_row([source], batch_idx=0)
+        assert snapshot is not None
+        assert type(snapshot[0]) is Affine4KVCache
+
+        restored, matched = _disk_roundtrip(
+            tmp_path, "native-affine4", token_ids, snapshot
+        )
+        assert matched == seq_len
+        assert restored is not None
+        assert type(restored[0]) is Affine4KVCache
+        _assert_packed_state_equal(restored[0].state, snapshot[0].state)
+
+        warm, _ = make_warm_batch_exact_cache_multi(
+            [restored, [KVCache()]],
+            [seq_len, 0],
+            kv_quant_config={
+                "bits": 4,
+                "group_size": GROUP_SIZE,
+                "scheme": "affine4",
+            },
+        )
+        assert warm is not None
+        assert type(warm[0]) is BatchAffine4KVCache
+        _assert_packed_state_equal(warm[0].extract(0).state, snapshot[0].state)
+
+        next_keys, next_values = _rand_kv(batch=2, seq_len=1)
+        updated = warm[0].update_and_fetch(next_keys, next_values)
+        mx.eval(updated)
+        assert warm[0]._idx == seq_len + 1
+
 
 # ---------------------------------------------------------------------------
 # Test 11: Stored blocks are decoupled from quantized source

--- a/mlx_vlm/turboquant.py
+++ b/mlx_vlm/turboquant.py
@@ -5310,7 +5310,7 @@ class _TurboQuantAttentionMixin:
         return self.keys, self.values
 
     def prefix_cache_merge(self, rows, prefix_lens):
-        """Merge compatible packed rows into ``BatchTurboQuantKVCache``."""
+        """Merge compatible packed rows into matching batch cache."""
         from .models.cache import KVCache
 
         if not rows or len(rows) != len(prefix_lens):
@@ -5321,7 +5321,7 @@ class _TurboQuantAttentionMixin:
 
         populated = []
         for row in rows:
-            if isinstance(row, TurboQuantKVCache):
+            if type(row) is type(self):
                 if (
                     row.bits != self.bits
                     or row.key_bits != self.key_bits
@@ -5337,20 +5337,14 @@ class _TurboQuantAttentionMixin:
         prefix_lens = [int(length) for length in prefix_lens]
         max_prefix = max(prefix_lens, default=0)
         left_padding = [max_prefix - length for length in prefix_lens]
-        out = BatchTurboQuantKVCache(
-            left_padding,
-            bits=self.bits,
-            seed=self.seed,
-            key_bits=self.key_bits,
-            value_bits=self.value_bits,
-        )
+        out = self._new_batch_cache(left_padding)
         if not populated:
             out.offset = mx.array(prefix_lens)
             return out
         if any(
             int(row.offset) != length
             for row, length in zip(rows, prefix_lens)
-            if isinstance(row, TurboQuantKVCache) and row.keys is not None
+            if type(row) is type(self) and row.keys is not None
         ):
             return None
 
@@ -5365,7 +5359,7 @@ class _TurboQuantAttentionMixin:
             reference_state = getattr(reference, attr)
             merged = None
             for row, left in zip(rows, left_padding):
-                if isinstance(row, TurboQuantKVCache) and row.keys is not None:
+                if type(row) is type(self) and row.keys is not None:
                     state = _slice_state(getattr(row, attr), row.offset)
                     state = _pad_state_tokens(
                         state, left, max_prefix - left - _state_length(state)
@@ -6303,6 +6297,15 @@ class _TurboQuantAttentionMixin:
 class TurboQuantKVCache(_TurboQuantAttentionMixin, _BaseCache):
     cache_step = 256
 
+    def _new_batch_cache(self, left_padding):
+        return BatchTurboQuantKVCache(
+            left_padding,
+            bits=self.bits,
+            seed=self.seed,
+            key_bits=self.key_bits,
+            value_bits=self.value_bits,
+        )
+
     def __init__(
         self,
         bits: float,
@@ -6608,12 +6611,14 @@ class BatchTurboQuantKVCache(_TurboQuantAttentionMixin, _BaseCache):
     # Core cache operation
     # ------------------------------------------------------------------
 
+    def _quantize_kv(self, keys, values):
+        return self.key_codec.quantize(keys), self.value_codec.quantize(values)
+
     def update_and_fetch(self, keys: mx.array, values: mx.array):
         self._ensure_codecs(keys, values)
         prev = self._idx
 
-        new_keys = self.key_codec.quantize(keys)
-        new_values = self.value_codec.quantize(values)
+        new_keys, new_values = self._quantize_kv(keys, values)
 
         new_end = prev + keys.shape[2]
         if self.keys is None:
@@ -6771,14 +6776,17 @@ class BatchTurboQuantKVCache(_TurboQuantAttentionMixin, _BaseCache):
             return None, None
         return self.dequantize()
 
-    def extract(self, idx):
-        """Extract one batch row as a single-sequence TurboQuantKVCache."""
-        cache = TurboQuantKVCache(
+    def _new_single_cache(self):
+        return TurboQuantKVCache(
             bits=self.bits,
             seed=self.seed,
             key_bits=self.key_bits,
             value_bits=self.value_bits,
         )
+
+    def extract(self, idx):
+        """Extract one batch row as a single-sequence TurboQuantKVCache."""
+        cache = self._new_single_cache()
         if self.keys is None or self._idx == 0:
             return cache
         cache.key_codec = self.key_codec


### PR DESCRIPTION
## Summary

- add a first-class `affine4` KV-cache format beside `uniform` and `turboquant`
- consume packed signed-int4 K/V directly with Metal Performance Primitives TensorOps on Apple M5 GPUs
- keep the same affine4 representation portable through a dequantized fallback on unsupported hardware and attention shapes
- support single-request generation, continuous batching, left padding, causal verification lengths 2–4, APC snapshots/disk restore, and cache migration
- expose `affine4` through generation, chat, and server configuration without changing existing defaults

TurboQuant stores nonlinear codebook indices, so its packed values cannot be interpreted as native signed-int4 operands. Affine4 is therefore an explicit format rather than a hardware-dependent reinterpretation of TurboQuant snapshots.

The native path is implemented with `mx.fast.metal_kernel`; it JIT-compiles MPP `matmul2d` operations over `metal::int4b_format`. It does not require a C++ extension, bundled metallib, or build-system changes.

## Format and routing

Affine4 applies a deterministic orthonormal rotation, computes one FP16 scale per KV vector, and stores signed codes in `[-8, 7]` as two's-complement nibbles. Key and value rotations use different seeds.

Native routing currently requires:

- Apple GPU architecture `applegpu_g17*`
- FP16 or BF16 queries
- head dimension divisible by 32 and at most 512
- grouped-query geometry with `query_heads % kv_heads == 0`
- query length 1–4
- no attention sinks or arbitrary array mask

Unsupported cases dequantize the same affine4 state and use existing attention paths. Failed JIT signatures are cached so they are not retried on every token.

## End-to-end benchmark

Hardware: Apple M5 Pro, 48 GB unified memory.  
Model: `Qwen3.6-35B-A3B-oQ4e-mtp` (`16q / 2kv / D=256`).  
Protocol: direct `generate_step`, batch 1, greedy, no server or speculative decoding, 2048-token prefill chunks, quantization from token 0, 128 generated tokens. Inputs were fixed across schemes. TurboQuant and affine4 use exactly the same cache bytes.

| Context | Affine4 | TurboQuant 4 | FP16 KV | Affine4 vs TQ4 | Affine4 vs FP16 |
|---:|---:|---:|---:|---:|---:|
| 8K | 80.34 tok/s | 75.19 tok/s | 80.57 tok/s | +6.8% | -0.3% |
| 32K | 74.40 tok/s | 58.67 tok/s | 67.58 tok/s | +26.8% | +10.1% |
| 55K | 70.07 tok/s | 48.88 tok/s | 59.19 tok/s | +43.3% | +18.4% |
| 100K | 60.71 tok/s | 36.75 tok/s | 46.72 tok/s | +65.2% | +29.9% |
| 150K | 54.35 tok/s | 28.37 tok/s | 38.30 tok/s | +91.6% | +41.9% |
| 200K | 49.53 tok/s | 23.33 tok/s | 32.83 tok/s | +112.3% | +50.8% |

The 200K comparison was repeated in reverse order:

- TQ4 first / affine4 second: 23.247 / 49.514 tok/s
- affine4 first / TQ4 second: 49.540 / 23.409 tok/s

Median per-token latency at 200K was 20.08 ms for affine4, 42.67 ms for TQ4, and 30.36 ms for FP16. P10–P90 ranges were 19.97–20.40 ms, 42.06–43.43 ms, and 30.29–30.82 ms respectively.

### Prefill

Regular long-query prefill is intentionally still handled by dequantization plus MLX SDPA; native packed attention is used for decode and short causal verification. Affine4 and TQ4 prefill rates remain close:

| Context | Affine4 | TQ4 | FP16 KV |
|---:|---:|---:|---:|
| 100K | 1276 tok/s | 1262 tok/s | 1368 tok/s |
| 150K | 996 tok/s | 996 tok/s | 1076 tok/s |
| 200K | ~824 tok/s | ~830 tok/s | 894 tok/s |

### Cache memory

| Context | Affine4 / TQ4 | FP16 KV |
|---:|---:|---:|
| 100K | 704 MiB | 2021 MiB |
| 150K | 1025 MiB | 2996 MiB |
| 200K | 1346 MiB | 3971 MiB |

At 200K, measured process peak was 26.3–26.7 GB for affine4/TQ4 and 28.17 GB for FP16 KV. The model keeps its final sensitive attention layer in FP16, matching existing quantized-cache policy.

## Numerical checks

At 100K, affine4, TQ4, and FP16 produced the same 128 greedy tokens. At 150K, affine4 matched FP16 while TQ4 diverged. At 200K all three paths crossed different close token boundaries, so a separate teacher-forced comparison was run after true 200K chunked prefill:

| Metric vs FP16, 64 steps | Affine4 | TQ4 |
|---|---:|---:|
| mean cosine | 0.998593 | 0.998454 |
| minimum cosine | 0.994687 | 0.994621 |
| mean KL | 0.003615 | 0.003837 |
| maximum KL | 0.015028 | 0.009978 |
| top-1 agreement | 61/64 | 59/64 |

Native-kernel tests additionally compare against SDPA over the affine-dequantized cache across dimensions 32–512, dense and MoE GQA geometries, padded batches, and causal lengths 1–4.

## Tests

```text
3216 passed, 8 skipped, 104 subtests passed
```

Full test command excluded three Nemotron voicechat modules because the local optional `mlx-audio` installation does not provide their codec package. Affine4, TurboQuant, generation, batching, speculative KV, APC, server, and model tests all ran in the remaining suite.
