### PR TITLE
fix(aya_vision): reference patch_embeddings in the spatial_shapes branch

### DIFF
--- a/mlx_vlm/models/aya_vision/vision.py
+++ b/mlx_vlm/models/aya_vision/vision.py
@@ -209,7 +209,7 @@ class VisionEmbeddings(nn.Module):
             )
 
             # Add positional embeddings to patch embeddings
-            embeddings = patch_embeds + resized_positional_embeddings
+            embeddings = patch_embeddings + resized_positional_embeddings
         return embeddings
 
 


### PR DESCRIPTION
### Problem

In `mlx_vlm/models/aya_vision/vision.py`, `VisionEmbeddings.__call__` has two branches:

```python
patch_embeddings = self.patch_embedding(x)
patch_embeddings = mx.flatten(patch_embeddings, start_axis=1, end_axis=2)
if spatial_shapes is None:
    ...
    embeddings = patch_embeddings          # ok
else:
    ...
    embeddings = patch_embeds + resized_positional_embeddings   # NameError
```

The `else` branch references `patch_embeds`, which is never defined — the local is `patch_embeddings`. `SigLipVisionModel.__call__` passes `spatial_shapes` through as a required argument, and `AyaVisionModel.get_input_embeddings` forwards the processor's `spatial_shapes`, so the variable-resolution path is the normal one for Aya Vision. Any forward pass that supplies `spatial_shapes` raises:

```
NameError: name 'patch_embeds' is not defined
```

### Fix

Rename the reference to `patch_embeddings`, matching the surrounding code and the `spatial_shapes is None` branch. One character; behavior in the `None` branch is unchanged.

### Verification

- `python -m pyflakes` on the file: the `undefined name 'patch_embeds'` warning is gone.
- Minimal repro of the `else` arithmetic: before → `NameError: name 'patch_embeds' is not defined`; after → returns the summed embeddings tensor with the expected shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
