### PR TITLE
fix: declare jinja2 as a runtime dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 mlx>=0.32.2
 transformers>=5.14.0
+jinja2>=3.1.0
 sentencepiece>=0.2.0
 miniaudio>=1.59
 tqdm>=4.66.2


### PR DESCRIPTION
`jinja2` is required at runtime but is not declared in `requirements.txt`, which `pyproject.toml` reads via `dependencies = {file = ["requirements.txt"]}`.

It is not pulled in transitively: `transformers` does not depend on `jinja2`, and the only package in `uv.lock` that does is `gradio` — which lives in the optional `ui` extra. So `pip install mlx-vlm` (no extras) gives an environment without jinja2, while anyone who installed `[ui]` never sees the failure.

That breaks a core path, not one model. `prompt_utils.apply_chat_template()` calls `processor.apply_chat_template()`, which raises:

```
ImportError: apply_chat_template requires jinja2 to be installed.
             Please install it using `pip install jinja2`.
```

It is on the path of `generate`, `chat`, `convert`, the FastAPI server (openai/anthropic/reranking) and `trainer/datasets.py`. Six processors also import jinja2 directly — `molmo` and `molmo2` unguarded, `kimi_vl`, `phi3_v`, `ernie4_5_moe_vl` and `locateanything` behind a `raise ImportError(...)`.

The `>=3.1.0` bound matches the version transformers enforces in `_cached_compile_jinja_template`.

Note: `uv.lock` still mirrors the old `requirements.txt` and needs a `uv lock` refresh. No workflow runs `uv lock --check`/`--locked`, so it is not blocking, and I left it out to keep the diff to one line — happy to add it if you prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)