### PR TITLE
Add standalone DINOv2 model with register tokens and mask support

### DIFF
--- a/mlx_vlm/models/dinov2/README.md
+++ b/mlx_vlm/models/dinov2/README.md
@@ -1,11 +1,39 @@
 # DINOv2 (MLX)
 
 Channel-last MLX port of the [DINOv2](https://github.com/facebookresearch/dinov2)
-vision transformer. This package currently holds only the shared backbone and
-its architecture presets. The standalone model is not ported yet: there is no
-`Model` class, so `facebook/dinov2-*` checkpoints cannot be loaded through
-`mlx_vlm.load`, and register tokens, masking and the DINO heads are not
-implemented.
+vision transformer. The package holds:
+
+- `Model` — the standalone image encoder. Loads the Hugging Face
+  `facebook/dinov2-{small,base,large,giant}` and
+  `facebook/dinov2-with-registers-{small,base,large,giant}` checkpoints
+  directly (`dinov2_with_registers` configs are remapped to this package).
+  Register tokens, patch masks (`bool_masked_pos`), `forward_features` and
+  `get_intermediate_layers` are supported.
+- `DINOv2` / `DINOv2Encoder` — the shared backbone used by dense-prediction
+  models (see below).
+
+The training-time DINO heads and stochastic depth (drop path) are not ported.
+
+## Example
+
+```python
+import mlx.core as mx
+from mlx_vlm import load
+
+model, processor = load("facebook/dinov2-with-registers-base")
+
+# processor returns channel-first pixel values; the model takes (B, H, W, C)
+pixel_values = processor(images=[image], return_tensors="np")["pixel_values"]
+out = model(mx.array(pixel_values).transpose(0, 2, 3, 1))
+out["last_hidden_state"]      # (B, 1 + registers + patches, D), normed
+out["pooler_output"]          # (B, D) — normed cls token
+out["hidden_patch_tokens"]    # (B, patches, D)
+```
+
+Positional-embedding interpolation follows the Hugging Face reference
+(size-based, antialiased when the config sets `interpolate_antialias`). Set
+`interpolate_offset: 0.1` in the config for the original repo's scale-factor
+behavior (used by the MoGe-3 and Video Depth Anything backbones below).
 
 ## Used by
 

--- a/mlx_vlm/models/dinov2/__init__.py
+++ b/mlx_vlm/models/dinov2/__init__.py
@@ -1,9 +1,13 @@
 """DINOv2 for MLX.
 
-Channel-last port of the DINOv2 vision transformer, shared as the backbone of
-dense-prediction models (Video Depth Anything, MoGe-3). Only the backbone and
-its architecture presets are ported; there is no standalone ``Model`` yet.
+Channel-last port of the DINOv2 vision transformer: a standalone image
+encoder (``Model``) for the ``facebook/dinov2-*`` and
+``facebook/dinov2-with-registers-*`` checkpoints, plus the shared backbone
+used by dense-prediction models (Video Depth Anything, MoGe-3). The
+training-time DINO heads are not ported.
 """
 
-from .config import DINOV2_PRESETS
-from .dinov2 import DINOv2, DINOv2Encoder
+from .config import DINOV2_PRESETS, ModelConfig
+from .dinov2 import DINOv2, DINOv2Encoder, Model
+
+__all__ = ["DINOV2_PRESETS", "DINOv2", "DINOv2Encoder", "Model", "ModelConfig"]

--- a/mlx_vlm/models/dinov2/config.py
+++ b/mlx_vlm/models/dinov2/config.py
@@ -1,4 +1,9 @@
-"""DINOv2 architecture presets for the official ViT-*/14 (LVD-142M) checkpoints."""
+"""DINOv2 architecture presets and standalone model configuration."""
+
+from dataclasses import dataclass
+from typing import List, Union
+
+from ..base import BaseModelConfig
 
 DINOV2_PRESETS = {
     "vits14": dict(embed_dim=384, depth=12, num_heads=6, ffn="mlp"),
@@ -6,3 +11,55 @@ DINOV2_PRESETS = {
     "vitl14": dict(embed_dim=1024, depth=24, num_heads=16, ffn="mlp"),
     "vitg14": dict(embed_dim=1536, depth=40, num_heads=24, ffn="swiglu"),
 }
+
+
+@dataclass
+class ModelConfig(BaseModelConfig):
+    """Standalone DINOv2 model configuration.
+
+    Field names follow the Hugging Face ``dinov2`` and
+    ``dinov2_with_registers`` configs so Hub checkpoints load unchanged.
+    """
+
+    model_type: str = "dinov2"
+    hidden_size: int = 768
+    num_hidden_layers: int = 12
+    num_attention_heads: int = 12
+    mlp_ratio: float = 4.0
+    layer_norm_eps: float = 1e-6
+    image_size: Union[int, List[int]] = 224
+    patch_size: int = 14
+    num_channels: int = 3
+    qkv_bias: bool = True
+    layerscale_value: float = 1.0
+    use_swiglu_ffn: bool = False
+    num_register_tokens: int = 0
+    # Pos-embed interpolation follows the HF reference (size-based) by default;
+    # set interpolate_offset=0.1 for the original repo's scale-factor behavior.
+    interpolate_offset: float = 0.0
+    interpolate_antialias: bool = False
+
+    def __post_init__(self):
+        if isinstance(self.image_size, (list, tuple)):
+            self.image_size = self.image_size[0]
+
+    # Aliases used by the shared backbone (DINOv2 / DINOv2Encoder).
+    @property
+    def embed_dim(self) -> int:
+        return self.hidden_size
+
+    @property
+    def depth(self) -> int:
+        return self.num_hidden_layers
+
+    @property
+    def num_heads(self) -> int:
+        return self.num_attention_heads
+
+    @property
+    def img_size(self) -> int:
+        return self.image_size
+
+    @property
+    def ffn(self) -> str:
+        return "swiglu" if self.use_swiglu_ffn else "mlp"

--- a/mlx_vlm/models/dinov2/dinov2.py
+++ b/mlx_vlm/models/dinov2/dinov2.py
@@ -1,7 +1,8 @@
 """DINOv2 vision transformer (channel-last MLX port)."""
 
 import math
-from typing import List, Tuple
+import re
+from typing import Dict, List, Optional, Tuple
 
 import mlx.core as mx
 import mlx.nn as nn
@@ -29,12 +30,12 @@ class PatchEmbed(nn.Module):
 
 
 class Attention(nn.Module):
-    def __init__(self, dim: int, num_heads: int):
+    def __init__(self, dim: int, num_heads: int, qkv_bias: bool = True):
         super().__init__()
         self.num_heads = num_heads
         self.head_dim = dim // num_heads
         self.scale = self.head_dim**-0.5
-        self.qkv = nn.Linear(dim, dim * 3, bias=True)
+        self.qkv = nn.Linear(dim, dim * 3, bias=qkv_bias)
         self.proj = nn.Linear(dim, dim, bias=True)
 
     def __call__(self, x: mx.array) -> mx.array:
@@ -89,7 +90,9 @@ class Block(nn.Module):
         dim = config.embed_dim
         hidden = int(dim * config.mlp_ratio)
         self.norm1 = nn.LayerNorm(dim, eps=config.layer_norm_eps)
-        self.attn = Attention(dim, config.num_heads)
+        self.attn = Attention(
+            dim, config.num_heads, qkv_bias=getattr(config, "qkv_bias", True)
+        )
         self.ls1 = LayerScale(dim)
         self.norm2 = nn.LayerNorm(dim, eps=config.layer_norm_eps)
         ffn = getattr(config, "ffn", None) or "mlp"
@@ -112,6 +115,7 @@ class DINOv2(nn.Module):
         self.config = config
         self.embed_dim = config.embed_dim
         self.patch_size = config.patch_size
+        self.num_register_tokens = getattr(config, "num_register_tokens", 0) or 0
         self.patch_embed = PatchEmbed(
             config.img_size, config.patch_size, 3, config.embed_dim
         )
@@ -120,6 +124,11 @@ class DINOv2(nn.Module):
             (1, self.patch_embed.num_patches + 1, config.embed_dim)
         )
         self.mask_token = mx.zeros((1, config.embed_dim))
+        self.register_tokens = (
+            mx.zeros((1, self.num_register_tokens, config.embed_dim))
+            if self.num_register_tokens
+            else None
+        )
         self.blocks = [Block(config) for _ in range(config.depth)]
         self.norm = nn.LayerNorm(config.embed_dim, eps=config.layer_norm_eps)
 
@@ -131,28 +140,74 @@ class DINOv2(nn.Module):
         dim = x.shape[-1]
         class_pos_embed = self.pos_embed[:, :1]
         patch_pos_embed = self.pos_embed[:, 1:]
-        # Small offset to avoid floating point error in the interpolation
-        w0 = w // self.patch_size + self.config.interpolate_offset
-        h0 = h // self.patch_size + self.config.interpolate_offset
         sqrt_N = math.sqrt(N)
-        # (sy, sx) because the reference derives w0 from the pixel height and
-        # applies it to the W axis.
-        sx, sy = float(w0) / sqrt_N, float(h0) / sqrt_N
         patch_pos_embed = patch_pos_embed.reshape(1, int(sqrt_N), int(sqrt_N), dim)
-        patch_pos_embed = resize_bicubic_nhwc(
-            patch_pos_embed.astype(mx.float32), scale_factor=(sy, sx)
-        )
+        offset = getattr(self.config, "interpolate_offset", 0.1)
+        if offset:
+            # Small offset to avoid floating point error in the interpolation
+            w0 = w // self.patch_size + offset
+            h0 = h // self.patch_size + offset
+            # (sy, sx) because the reference derives w0 from the pixel height
+            # and applies it to the W axis.
+            sx, sy = float(w0) / sqrt_N, float(h0) / sqrt_N
+            patch_pos_embed = resize_bicubic_nhwc(
+                patch_pos_embed.astype(mx.float32), scale_factor=(sy, sx)
+            )
+        else:
+            # HF style: explicit output size instead of a scale factor
+            size = (h // self.patch_size, w // self.patch_size)
+            patch_pos_embed = resize_bicubic_nhwc(
+                patch_pos_embed.astype(mx.float32),
+                size,
+                antialias=getattr(self.config, "interpolate_antialias", False),
+            )
         patch_pos_embed = patch_pos_embed.reshape(1, -1, dim)
         return mx.concatenate([class_pos_embed, patch_pos_embed], axis=1).astype(
             x.dtype
         )
 
-    def prepare_tokens(self, x: mx.array) -> mx.array:
+    def prepare_tokens(self, x: mx.array, masks: Optional[mx.array] = None) -> mx.array:
+        """Patch embed, then add cls token, position and register tokens.
+
+        ``masks`` is an optional (B, N) bool array; masked patches are replaced
+        by the mask token before the cls token is prepended.
+        """
         B, H, W, _ = x.shape
         x = self.patch_embed(x)
+        if masks is not None:
+            x = mx.where(masks[..., None], self.mask_token.astype(x.dtype), x)
         cls = mx.broadcast_to(self.cls_token, (B, 1, self.embed_dim))
         x = mx.concatenate([cls, x], axis=1)
-        return x + self.interpolate_pos_encoding(x, H, W)
+        x = x + self.interpolate_pos_encoding(x, H, W)
+        if self.register_tokens is not None:
+            registers = mx.broadcast_to(
+                self.register_tokens, (B, self.num_register_tokens, self.embed_dim)
+            )
+            x = mx.concatenate([x[:, :1], registers, x[:, 1:]], axis=1)
+        return x
+
+    def _encode(
+        self, x: mx.array, masks: Optional[mx.array] = None
+    ) -> Tuple[mx.array, mx.array]:
+        """Run the full backbone; return (prenorm, normed) token sequences."""
+        x = self.prepare_tokens(x, masks)
+        for blk in self.blocks:
+            x = blk(x)
+        return x, self.norm(x)
+
+    def forward_features(
+        self, x: mx.array, masks: Optional[mx.array] = None
+    ) -> Dict[str, mx.array]:
+        """Full forward pass; returns the reference implementation's feature dict."""
+        x, x_norm = self._encode(x, masks)
+        r = self.num_register_tokens
+        return {
+            "x_norm_clstoken": x_norm[:, 0],
+            "x_norm_regtokens": x_norm[:, 1 : r + 1],
+            "x_norm_patchtokens": x_norm[:, r + 1 :],
+            "x_prenorm": x,
+            "masks": masks,
+        }
 
     def get_intermediate_layers(
         self, x: mx.array, indices: List[int]
@@ -164,9 +219,99 @@ class DINOv2(nn.Module):
             x = blk(x)
             if i in indices:
                 out = self.norm(x)
-                outputs.append((out[:, 1:], out[:, 0]))
+                outputs.append((out[:, 1 + self.num_register_tokens :], out[:, 0]))
         assert len(outputs) == len(indices)
         return outputs
+
+
+_HF_EMBED_KEYS = {
+    "embeddings.cls_token": "cls_token",
+    "embeddings.mask_token": "mask_token",
+    "embeddings.register_tokens": "register_tokens",
+    "embeddings.position_embeddings": "pos_embed",
+    "embeddings.patch_embeddings.projection.weight": "patch_embed.proj.weight",
+    "embeddings.patch_embeddings.projection.bias": "patch_embed.proj.bias",
+    "layernorm.weight": "norm.weight",
+    "layernorm.bias": "norm.bias",
+}
+
+_HF_BLOCK_KEYS = {
+    "attention.output.dense.weight": "attn.proj.weight",
+    "attention.output.dense.bias": "attn.proj.bias",
+    "layer_scale1.lambda1": "ls1.gamma",
+    "layer_scale2.lambda1": "ls2.gamma",
+    "norm1.weight": "norm1.weight",
+    "norm1.bias": "norm1.bias",
+    "norm2.weight": "norm2.weight",
+    "norm2.bias": "norm2.bias",
+    "mlp.fc1.weight": "mlp.fc1.weight",
+    "mlp.fc1.bias": "mlp.fc1.bias",
+    "mlp.fc2.weight": "mlp.fc2.weight",
+    "mlp.fc2.bias": "mlp.fc2.bias",
+    "mlp.weights_in.weight": "mlp.w12.weight",
+    "mlp.weights_in.bias": "mlp.w12.bias",
+    "mlp.weights_out.weight": "mlp.w3.weight",
+    "mlp.weights_out.bias": "mlp.w3.bias",
+}
+
+_HF_BLOCK_KEY = re.compile(r"encoder\.layer\.(\d+)\.(.+)")
+_HF_QKV_KEY = re.compile(r"attention\.attention\.(query|key|value)\.(weight|bias)")
+
+
+class Model(DINOv2):
+    """Standalone DINOv2 image encoder.
+
+    Loads the Hugging Face ``facebook/dinov2-*`` and
+    ``facebook/dinov2-with-registers-*`` checkpoints (HF key layout) as well
+    as checkpoints already in the original DINOv2 layout.
+    """
+
+    def __call__(
+        self, pixel_values: mx.array, bool_masked_pos: Optional[mx.array] = None
+    ) -> Dict[str, mx.array]:
+        """pixel_values: (B, H, W, C) -> dict with the normed token sequence
+        (``last_hidden_state``), the cls token (``pooler_output``), the patch
+        tokens without cls/registers, and the pre-norm sequence."""
+        x, x_norm = self._encode(pixel_values, bool_masked_pos)
+        r = self.num_register_tokens
+        return {
+            "last_hidden_state": x_norm,
+            "pooler_output": x_norm[:, 0],
+            "hidden_patch_tokens": x_norm[:, r + 1 :],
+            "x_prenorm": x,
+        }
+
+    def sanitize(self, weights: Dict[str, mx.array]) -> Dict[str, mx.array]:
+        """Rename HF ``dinov2``/``dinov2_with_registers`` keys to the backbone
+        layout. Checkpoints already in the original DINOv2 layout pass through
+        unchanged."""
+        out, qkv = {}, {}
+        for key, value in weights.items():
+            key = key.removeprefix("dinov2.")
+            if key.startswith("classifier."):
+                continue  # classification head is not part of the encoder
+            if key in _HF_EMBED_KEYS:
+                key = _HF_EMBED_KEYS[key]
+                if key == "patch_embed.proj.weight":
+                    value = value.transpose(0, 2, 3, 1)  # (O, I, H, W) -> (O, H, W, I)
+                out[key] = value
+                continue
+            match = _HF_BLOCK_KEY.fullmatch(key)
+            if match is None:
+                out[key] = value
+                continue
+            idx, rest = match.groups()
+            proj = _HF_QKV_KEY.fullmatch(rest)
+            if proj is not None:
+                name, kind = proj.groups()
+                qkv.setdefault(f"blocks.{idx}.attn.qkv.{kind}", {})[name] = value
+            else:
+                out[f"blocks.{idx}.{_HF_BLOCK_KEYS.get(rest, rest)}"] = value
+        for key, parts in qkv.items():
+            out[key] = mx.concatenate(
+                [parts["query"], parts["key"], parts["value"]], axis=0
+            )
+        return out
 
 
 class DINOv2Encoder(nn.Module):

--- a/mlx_vlm/models/interpolate.py
+++ b/mlx_vlm/models/interpolate.py
@@ -240,7 +240,28 @@ def resize_bilinear_nhwc(x, new_size, align_corners=False, antialias=False):
     return separable_interpolate(x, iy, wy, ix, wx)
 
 
-def resize_bicubic_nhwc(x, new_size=None, scale_factor=None):
+@lru_cache(maxsize=64)
+def _bicubic_aa_weights_1d(in_size, out_size):
+    """(out, taps) indices and a=-0.5 cubic weights matching ATen
+    ``_upsample_bicubic2d_aa``: stretched kernel, normalized per output pixel."""
+    scale = in_size / out_size
+    support = 2.0 * scale if scale >= 1.0 else 2.0
+    max_taps = math.ceil(support) * 2 + 1
+    invscale = 1.0 / scale if scale >= 1.0 else 1.0
+    center = scale * (mx.arange(out_size, dtype=mx.float32) + 0.5)
+    xmin = mx.maximum(mx.floor(center - support + 0.5), 0.0)
+    xmax = mx.minimum(mx.floor(center + support + 0.5), float(in_size))
+    xsize = mx.clip(xmax - xmin, 0, max_taps)
+    pos = xmin[:, None] + mx.arange(max_taps, dtype=mx.float32)[None, :]
+    w = _cubic_weight((pos - center[:, None] + 0.5) * invscale, a=-0.5)
+    w = mx.where(pos - xmin[:, None] < xsize[:, None], w, 0.0)
+    total = w.sum(axis=1, keepdims=True)
+    w = mx.where(total > 0, w / mx.maximum(total, 1e-30), w)
+    idx = mx.minimum(pos, in_size - 1).astype(mx.int32)
+    return idx, w
+
+
+def resize_bicubic_nhwc(x, new_size=None, scale_factor=None, antialias=False):
     """Channel-last ``F.interpolate(mode="bicubic")``; with ``scale_factor`` the
     output size is floored and sampling uses the given scale, not the effective one."""
     _, in_h, in_w, _ = x.shape
@@ -249,6 +270,12 @@ def resize_bicubic_nhwc(x, new_size=None, scale_factor=None):
         new_size = (int(in_h * scale_h), int(in_w * scale_w))
     else:
         scale_h, scale_w = new_size[0] / in_h, new_size[1] / in_w
-    iy, wy = _bicubic_weights_1d(in_h, new_size[0], scale_h)
-    ix, wx = _bicubic_weights_1d(in_w, new_size[1], scale_w)
+    if (in_h, in_w) == tuple(new_size):
+        return x
+    if antialias:
+        iy, wy = _bicubic_aa_weights_1d(in_h, new_size[0])
+        ix, wx = _bicubic_aa_weights_1d(in_w, new_size[1])
+    else:
+        iy, wy = _bicubic_weights_1d(in_h, new_size[0], scale_h)
+        ix, wx = _bicubic_weights_1d(in_w, new_size[1], scale_w)
     return separable_interpolate(x, iy, wy, ix, wx)

--- a/mlx_vlm/tests/test_models.py
+++ b/mlx_vlm/tests/test_models.py
@@ -18422,6 +18422,198 @@ class TestDinov2(unittest.TestCase):
             self.assertEqual(grid.shape, (2, 5, 7, 32))
             self.assertEqual(cls.shape, (2, 32))
 
+    def _tiny_config(self, **overrides):
+        from mlx_vlm.models.dinov2.config import ModelConfig
+
+        args = dict(
+            hidden_size=32,
+            num_hidden_layers=2,
+            num_attention_heads=4,
+            image_size=28,
+            patch_size=14,
+        )
+        args.update(overrides)
+        return ModelConfig(**args)
+
+    def _tiny_hf_state_dict(self, config):
+        d = config.hidden_size
+        p = config.patch_size
+        num_patches = (config.image_size // p) ** 2
+        weights = {
+            "embeddings.cls_token": mx.zeros((1, 1, d)),
+            "embeddings.mask_token": mx.zeros((1, d)),
+            "embeddings.position_embeddings": mx.zeros((1, num_patches + 1, d)),
+            "embeddings.patch_embeddings.projection.weight": mx.zeros((d, 3, p, p)),
+            "embeddings.patch_embeddings.projection.bias": mx.zeros((d,)),
+            "layernorm.weight": mx.ones((d,)),
+            "layernorm.bias": mx.zeros((d,)),
+        }
+        if config.num_register_tokens:
+            weights["embeddings.register_tokens"] = mx.zeros(
+                (1, config.num_register_tokens, d)
+            )
+        for i in range(config.num_hidden_layers):
+            prefix = f"encoder.layer.{i}."
+            weights.update(
+                {
+                    prefix + "attention.attention.query.weight": mx.full((d, d), 1.0),
+                    prefix + "attention.attention.key.weight": mx.full((d, d), 2.0),
+                    prefix + "attention.attention.value.weight": mx.full((d, d), 3.0),
+                    prefix + "attention.attention.query.bias": mx.zeros((d,)),
+                    prefix + "attention.attention.key.bias": mx.zeros((d,)),
+                    prefix + "attention.attention.value.bias": mx.zeros((d,)),
+                    prefix + "attention.output.dense.weight": mx.zeros((d, d)),
+                    prefix + "attention.output.dense.bias": mx.zeros((d,)),
+                    prefix + "layer_scale1.lambda1": mx.ones((d,)),
+                    prefix + "layer_scale2.lambda1": mx.ones((d,)),
+                    prefix + "norm1.weight": mx.ones((d,)),
+                    prefix + "norm1.bias": mx.zeros((d,)),
+                    prefix + "norm2.weight": mx.ones((d,)),
+                    prefix + "norm2.bias": mx.zeros((d,)),
+                }
+            )
+            if config.use_swiglu_ffn:
+                h = (int(d * config.mlp_ratio * 2 / 3) + 7) // 8 * 8
+                weights.update(
+                    {
+                        prefix + "mlp.weights_in.weight": mx.zeros((2 * h, d)),
+                        prefix + "mlp.weights_in.bias": mx.zeros((2 * h,)),
+                        prefix + "mlp.weights_out.weight": mx.zeros((d, h)),
+                        prefix + "mlp.weights_out.bias": mx.zeros((d,)),
+                    }
+                )
+            else:
+                hidden = int(d * config.mlp_ratio)
+                weights.update(
+                    {
+                        prefix + "mlp.fc1.weight": mx.zeros((hidden, d)),
+                        prefix + "mlp.fc1.bias": mx.zeros((hidden,)),
+                        prefix + "mlp.fc2.weight": mx.zeros((d, hidden)),
+                        prefix + "mlp.fc2.bias": mx.zeros((d,)),
+                    }
+                )
+        return weights
+
+    def test_config_aliases(self):
+        """HF-style config fields map to the shared backbone's field names."""
+        from mlx_vlm.models.dinov2.config import ModelConfig
+
+        config = self._tiny_config()
+        self.assertEqual(config.embed_dim, 32)
+        self.assertEqual(config.depth, 2)
+        self.assertEqual(config.num_heads, 4)
+        self.assertEqual(config.img_size, 28)
+        self.assertEqual(config.ffn, "mlp")
+        self.assertEqual(ModelConfig(use_swiglu_ffn=True).ffn, "swiglu")
+        self.assertEqual(ModelConfig(image_size=[518, 518]).img_size, 518)
+
+        # A dinov2_with_registers Hub config loads; unknown keys are dropped.
+        config = ModelConfig.from_dict(
+            {
+                "model_type": "dinov2_with_registers",
+                "hidden_size": 16,
+                "num_hidden_layers": 1,
+                "num_attention_heads": 2,
+                "num_register_tokens": 4,
+                "out_features": ["stage1"],
+                "stage_names": ["stem", "stage1"],
+            }
+        )
+        self.assertEqual(config.model_type, "dinov2_with_registers")
+        self.assertEqual(config.num_register_tokens, 4)
+
+    def test_forward_features_registers(self):
+        """Register tokens go after the cls token; patch tokens exclude them."""
+        from mlx_vlm.models.dinov2 import Model
+
+        model = Model(self._tiny_config(num_register_tokens=2))
+        x = mx.random.normal((2, 28, 28, 3))
+        features = model.forward_features(x)
+        self.assertEqual(features["x_norm_clstoken"].shape, (2, 32))
+        self.assertEqual(features["x_norm_regtokens"].shape, (2, 2, 32))
+        self.assertEqual(features["x_norm_patchtokens"].shape, (2, 4, 32))
+        self.assertEqual(features["x_prenorm"].shape, (2, 1 + 2 + 4, 32))
+
+        for patches, cls in model.get_intermediate_layers(x, [0, 1]):
+            self.assertEqual(patches.shape, (2, 4, 32))
+            self.assertEqual(cls.shape, (2, 32))
+
+    def test_prepare_tokens_masks(self):
+        """Masked patch embeddings are replaced by the mask token."""
+        from mlx_vlm.models.dinov2 import Model
+
+        model = Model(self._tiny_config())
+        model.load_weights(
+            [
+                ("mask_token", mx.full((1, 32), 2.0)),
+                ("pos_embed", mx.random.normal((1, 5, 32))),
+            ],
+            strict=False,
+        )
+        x = mx.random.normal((2, 28, 28, 3))
+        masks = mx.array([[True, False, True, False], [False, True, False, True]])
+        tokens = model.prepare_tokens(x, masks)
+        patches = tokens[:, 1:]  # after the cls token
+        for b, j in [(0, 0), (0, 2), (1, 1), (1, 3)]:
+            expected = model.mask_token[0] + model.pos_embed[0, j + 1]
+            self.assertTrue(mx.allclose(patches[b, j], expected))
+        # Unmasked positions keep their patch embedding.
+        for b, j in [(0, 1), (1, 0)]:
+            unexpected = model.mask_token[0] + model.pos_embed[0, j + 1]
+            self.assertFalse(bool(mx.allclose(patches[b, j], unexpected)))
+
+    def test_model_call_output(self):
+        """The standalone model returns HF-style pooled and sequence outputs."""
+        from mlx_vlm.models.dinov2 import Model
+
+        model = Model(self._tiny_config())
+        out = model(mx.random.normal((2, 28, 28, 3)))
+        self.assertEqual(out["last_hidden_state"].shape, (2, 5, 32))
+        self.assertEqual(out["pooler_output"].shape, (2, 32))
+        self.assertTrue(
+            mx.allclose(out["pooler_output"], out["last_hidden_state"][:, 0])
+        )
+        self.assertEqual(out["hidden_patch_tokens"].shape, (2, 4, 32))
+
+    def test_sanitize_hf_checkpoint(self):
+        """HF keys are renamed (and qkv fused) to the exact model parameters."""
+        from mlx.utils import tree_flatten
+
+        from mlx_vlm.models.dinov2 import Model
+
+        for overrides in ({"num_register_tokens": 2}, {"use_swiglu_ffn": True}):
+            config = self._tiny_config(**overrides)
+            model = Model(config)
+            weights = model.sanitize(self._tiny_hf_state_dict(config))
+            self.assertEqual(
+                set(weights), {k for k, _ in tree_flatten(model.parameters())}
+            )
+            model.load_weights(list(weights.items()), strict=True)
+            d = config.hidden_size
+            qkv_w = model.blocks[0].attn.qkv.weight
+            self.assertTrue(bool(mx.all(qkv_w[:d] == 1.0)))
+            self.assertTrue(bool(mx.all(qkv_w[d : 2 * d] == 2.0)))
+            self.assertTrue(bool(mx.all(qkv_w[2 * d :] == 3.0)))
+            self.assertEqual(model.patch_embed.proj.weight.shape, (d, 14, 14, 3))
+
+    def test_sanitize_strips_prefix_and_classifier(self):
+        """A ``dinov2.`` prefix is stripped and classifier weights dropped."""
+        from mlx_vlm.models.dinov2 import Model
+
+        config = self._tiny_config()
+        model = Model(config)
+        weights = {
+            f"dinov2.{k}": v for k, v in self._tiny_hf_state_dict(config).items()
+        }
+        weights["dinov2.classifier.weight"] = mx.zeros((10, config.hidden_size))
+        sanitized = model.sanitize(weights)
+        self.assertNotIn("dinov2.classifier.weight", sanitized)
+        self.assertNotIn("classifier.weight", sanitized)
+        self.assertIn("blocks.0.attn.qkv.weight", sanitized)
+        # Original-layout checkpoints pass through unchanged.
+        original = {"blocks.0.attn.qkv.weight": mx.zeros((96, 32))}
+        self.assertEqual(model.sanitize(original), original)
+
 
 class TestVideoDepthAnything(unittest.TestCase):
     # ─── Video Depth Anything Tests ────────────────────────────

--- a/mlx_vlm/utils.py
+++ b/mlx_vlm/utils.py
@@ -48,6 +48,7 @@ MODEL_REMAPPING = {
     "granite4-vision": "granite4_vision",
     "granite4_vision": "granite4_vision",
     "rf-detr": "rfdetr",
+    "dinov2_with_registers": "dinov2",
     "falcon-perception": "falcon_perception",
     "nemotronh_nano_omni_reasoning_v3": "nemotron_h_nano_omni",
     "cohere2moe": "cohere2_moe",


### PR DESCRIPTION
Finish the DINOv2 port: a Model class that loads the HF facebook/dinov2-* and facebook/dinov2-with-registers-* checkpoints directly (sanitize maps HF keys, fuses qkv, transposes the patch conv), register tokens, patch masking (bool_masked_pos), forward_features, and a ModelConfig following the HF dinov2/dinov2_with_registers fields.

Pos-embed interpolation gains the HF size-based branch with antialiased bicubic (matches ATen _upsample_bicubic2d_aa); the original repo scale-factor + offset path is kept for the MoGe-3/VDA backbones.

Validated against transformers on facebook/dinov2-small and facebook/dinov2-with-registers-small at several resolutions (~1e-4 fp32 noise), including masked inputs and the SwiGLU FFN.