### PR TITLE
Add SAM 3.1 multiplex video tracking port

### DIFF
--- a/mlx_vlm/models/sam3/sam_components.py
+++ b/mlx_vlm/models/sam3/sam_components.py
@@ -199,8 +199,10 @@ class TwoWayAttentionBlock(nn.Module):
         num_heads: int,
         mlp_dim: int = 2048,
         attention_downsample_rate: int = 2,
+        skip_first_layer_pe: bool = False,
     ):
         super().__init__()
+        self.skip_first_layer_pe = skip_first_layer_pe
         self.self_attn = SAMAttention(hidden_size, num_heads)
         self.layer_norm1 = nn.LayerNorm(hidden_size)
 
@@ -225,9 +227,13 @@ class TwoWayAttentionBlock(nn.Module):
         key_pe: mx.array,
     ) -> Tuple[mx.array, mx.array]:
         # Self-attention on queries
-        q = queries + query_pe
-        attn_out = self.self_attn(q, q, queries)
-        queries = queries + attn_out
+        if self.skip_first_layer_pe:
+            # First layer: no query PE, and the output replaces the queries
+            queries = self.self_attn(queries, queries, queries)
+        else:
+            q = queries + query_pe
+            attn_out = self.self_attn(q, q, queries)
+            queries = queries + attn_out
         queries = self.layer_norm1(queries)
 
         # Cross-attention: tokens to image
@@ -269,9 +275,13 @@ class TwoWayTransformer(nn.Module):
         super().__init__()
         self.layers = [
             TwoWayAttentionBlock(
-                hidden_size, num_heads, mlp_dim, attention_downsample_rate
+                hidden_size,
+                num_heads,
+                mlp_dim,
+                attention_downsample_rate,
+                skip_first_layer_pe=(i == 0),
             )
-            for _ in range(num_layers)
+            for i in range(num_layers)
         ]
 
         self.final_attn_token_to_image = SAMAttention(

--- a/mlx_vlm/models/sam3_1/README.md
+++ b/mlx_vlm/models/sam3_1/README.md
@@ -182,11 +182,44 @@ mlx_vlm/models/sam3_1/
 ├── config.py             # Configs (extends SAM 3 with multiplex_count, 3 scales)
 ├── vision.py             # TriViTDetNeck (imports ViT backbone from sam3)
 ├── sam_components.py     # MultiplexMaskDecoder, DecoupledMemoryAttention, SimpleRoPEAttention
-├── tracker.py            # MultiplexTrackerModel (dual decoder, multiplex embeddings)
+├── multiplex.py          # MultiplexState/Controller (bucket mux/demux) + MultiplexTrackerState
+├── tracker.py            # MultiplexTrackerModel — full video_tracking_multiplex port
 ├── sam3_1.py             # Main Model + sanitize
 ├── processing_sam3_1.py  # Processor (same as SAM 3)
 ├── generate.py           # Inference pipeline (optimized realtime with backbone caching + tracker)
 └── convert_weights.py    # Meta .pt → MLX safetensors converter
+```
+
+## Video Tracking (multiplex)
+
+`tracker.py` ports Meta's `video_tracking_multiplex.py` to MLX (inference):
+
+- **Mask-as-output init** — detection masks on a conditioning frame become the
+  output directly; the interactive decoder only produces object pointers
+- **Memory-conditioned propagation** — the decoupled memory attention reads
+  spatial mask memories, per-frame image features, and object pointer tokens
+  (with temporal pos enc) from up to 7 past frames + 4 conditioning frames
+- **Multiplex batching** — up to 16 objects per bucket share one decoder pass;
+  `MultiplexState` converts between per-object (data) and bucket (mux) space
+- **Interactive refinement** — point/mask prompts on any frame via the
+  interactive SAM head (propagation-and-interaction merge)
+- **Dynamic objects** — `add_new_masks_to_existing_state` /
+  `recondition_masks_in_existing_state` add or re-condition objects mid-video
+
+```python
+from mlx_vlm.utils import load_model, get_model_path
+from mlx_vlm.models.sam3_1.processing_sam3_1 import Sam31Processor
+
+model = load_model(get_model_path("mlx-community/sam3.1-bf16"))
+processor = Sam31Processor.from_pretrained(...)
+
+# Initialize a session from detection masks on frame 0
+state, out = model.track_init(backbone_features, detection_masks)  # (N, H, W)
+
+# Propagate all objects to the next frame
+out = model.track_step(state, backbone_features_t, frame_idx=1)
+masks = out["pred_masks_high_res"]  # (N, 1, 1008, 1008) logits
+scores = out["object_score_logits"]  # (N, 1)
 ```
 
 ### Code Reuse from SAM 3

--- a/mlx_vlm/models/sam3_1/config.py
+++ b/mlx_vlm/models/sam3_1/config.py
@@ -48,15 +48,16 @@ class TrackerMaskDecoderConfig(BaseModelConfig):
     num_attention_heads: int = 8
     attention_downsample_rate: int = 2
     num_multimask_outputs: int = 3
-    iou_head_depth: int = 3
-    iou_head_hidden_dim: int = 256
     mlp_dim: int = 2048
-    hidden_act: str = "gelu"
     dynamic_multimask_via_stability: bool = True
     dynamic_multimask_stability_delta: float = 0.05
     dynamic_multimask_stability_thresh: float = 0.98
     # SAM 3.1 multiplex
     multiplex_count: int = 16
+    # Propagation decoder has no single-mask token (multimask tokens only)
+    multimask_outputs_only: bool = False
+    # Use multimask tokens (not the single-mask token) for object pointers
+    use_multimask_token_for_obj_ptr: bool = True
 
 
 @dataclass
@@ -73,59 +74,76 @@ class TrackerConfig(BaseModelConfig):
     multiplex_count: int = 16
 
     # Memory attention (decoupled)
-    memory_attention_hidden_size: int = 256
-    memory_attention_num_layers: int = 4
-    memory_attention_num_attention_heads: int = 8
     memory_attention_feed_forward_hidden_size: int = 2048
-    memory_attention_feed_forward_hidden_act: str = "relu"
-    memory_attention_dropout: float = 0.1
-    memory_attention_rope_dropout: float = 0.1
-    memory_attention_rope_theta: float = 10000.0
+    memory_attention_hidden_size: int = 256
+    memory_attention_num_attention_heads: int = 8
+    memory_attention_num_layers: int = 4
     memory_attention_rope_feat_sizes: List[int] = field(
         default_factory=lambda: [72, 72]
     )
-    memory_attention_downsample_rate: int = 1
+    memory_attention_rope_theta: float = 10000.0
 
-    # Memory encoder
-    memory_encoder_hidden_size: int = 256
-    memory_encoder_output_channels: int = 256  # SAM 3.1: 256 (was 64 in SAM 3)
-
-    # Mask downsampler — first channels from checkpoint: 16
+    # Memory encoder — mask downsampler (SAM 3.1: dim = out_dim = 256)
     mask_downsampler_embed_dim: int = 256
-    mask_downsampler_kernel_size: int = 3
-    mask_downsampler_stride: int = 2
-    mask_downsampler_padding: int = 1
-    mask_downsampler_total_stride: int = 16
-    mask_downsampler_hidden_act: str = "gelu"
     mask_downsampler_first_channels: int = 16  # actual from checkpoint
+    mask_downsampler_input_size: int = 1152  # resize masks to this pre-convs
+    mask_downsampler_kernel_size: int = 3
+    mask_downsampler_padding: int = 1
+    mask_downsampler_stride: int = 2
+    memory_encoder_hidden_size: int = 256
 
     # Memory fuser (CXBlock)
     memory_fuser_embed_dim: int = 256
-    memory_fuser_kernel_size: int = 7
-    memory_fuser_padding: int = 3
-    memory_fuser_num_layers: int = 2
     memory_fuser_intermediate_dim: int = 1024
+    memory_fuser_kernel_size: int = 7
     memory_fuser_layer_scale_init_value: float = 1e-6
-    memory_fuser_hidden_act: str = "gelu"
+    memory_fuser_num_layers: int = 2
+    memory_fuser_padding: int = 3
 
-    # Tracker settings
-    num_maskmem: int = 7
+    # Memory retrieval over past frames
     max_cond_frame_num: int = 4
     max_object_pointers_in_encoder: int = 16
-    multimask_output_in_sam: bool = True
-    multimask_output_for_tracking: bool = True
-    multimask_min_pt_num: int = 0
+    memory_temporal_stride_for_eval: int = 1
+    num_maskmem: int = 7
+    save_image_features: bool = True
+    use_maskmem_tpos_v2: bool = True
+
+    # Memory encoding: mask -> memory (SAM 3.1: sigmoid(logits) * 2.0 - 1.0)
+    apply_sigmoid_to_mask_logits_for_mem_enc: bool = True
+    sigmoid_bias_for_mem_enc: float = -1.0
+    sigmoid_scale_for_mem_enc: float = 2.0
+    # Extra per-object channel marking conditioning objects
+    condition_as_mask_input: bool = True
+    condition_as_mask_input_bg: float = 0.0
+    condition_as_mask_input_fg: float = 1.0
+
+    # SAM head behavior (multimask, mask-as-output)
+    directly_add_no_mem_embed: bool = True
     multimask_max_pt_num: int = 1
+    multimask_min_pt_num: int = 0
+    multimask_output_for_tracking: bool = True
+    multimask_output_in_sam: bool = True
+    num_multimask_outputs: int = 3
+    use_mask_input_as_output_without_sam: bool = True
 
-    # Memory encoding params
-    sigmoid_bias_for_mem_enc: float = -10.0
-    sigmoid_scale_for_mem_enc: float = 20.0
-
-    # Occlusion / temporal
-    enable_occlusion_spatial_embedding: bool = True
-    enable_temporal_pos_encoding_for_object_pointers: bool = True
+    # Object presence scores and pointers
+    add_output_suppression_embeddings: bool = True
+    fixed_no_obj_ptr: bool = True
+    object_score_logit_threshold: float = 0.0
+    pred_obj_scores: bool = True
+    use_linear_no_obj_ptr: bool = True
+    use_no_obj_ptr: bool = True
+    use_obj_ptrs_in_encoder: bool = True
 
     def __post_init__(self):
+        # The facebook/sam3.1 HF config carries a stale SAM 3 (non-multiplex)
+        # tracker_config. Re-pin the SAM 3.1 multiplex architectural constants
+        # (see build_sam3_multiplex_video_model in the SAM 3 repo).
+        if self.model_type == "sam3_tracker_video":
+            self.memory_attention_num_attention_heads = 8
+            self.sigmoid_scale_for_mem_enc = 2.0
+            self.sigmoid_bias_for_mem_enc = -1.0
+
         if isinstance(self.vision_config, dict):
             self.vision_config = VisionEncoderConfig.from_dict(self.vision_config)
         elif self.vision_config is None:
@@ -135,8 +153,12 @@ class TrackerConfig(BaseModelConfig):
             self.mask_decoder_config = TrackerMaskDecoderConfig.from_dict(
                 self.mask_decoder_config
             )
+            # Propagation decoder: multimask tokens only (no single-mask token)
+            self.mask_decoder_config.multimask_outputs_only = True
         elif self.mask_decoder_config is None:
-            self.mask_decoder_config = TrackerMaskDecoderConfig()
+            self.mask_decoder_config = TrackerMaskDecoderConfig(
+                multimask_outputs_only=True
+            )
 
         if isinstance(self.prompt_encoder_config, dict):
             self.prompt_encoder_config = PromptEncoderConfig.from_dict(

--- a/mlx_vlm/models/sam3_1/generate.py
+++ b/mlx_vlm/models/sam3_1/generate.py
@@ -352,106 +352,52 @@ def _detect_with_backbone(
     )
 
 
-def _init_tracker_memory(
+def _init_tracker_state(
     model,
     backbone_features: mx.array,
     detection_masks: List[np.ndarray],
-) -> List[mx.array]:
-    """Initialize tracker memory bank from detection masks."""
-    prop_fpn = model._get_tracker_features(backbone_features)
-    track_features = prop_fpn[2]  # 1x scale
-    feat_H, feat_W = track_features.shape[1], track_features.shape[2]
-
-    multiplex_count = model.config.tracker_config.multiplex_count
-    n_ch = multiplex_count * 2
-    # Mask downsampler has stride 16 total, so input must be feat_size * 16
-    target = feat_H * 16
-
-    # Build combined multiplex mask in MLX
-    N = min(len(detection_masks), multiplex_count)
-    # Stack masks → (N, H_mask, W_mask), resize once
-    masks_mx = mx.array(
-        np.stack(detection_masks[:N]).astype(np.float32)
-    )  # single conversion
-    mask_h, mask_w = masks_mx.shape[1], masks_mx.shape[2]
-    if mask_h != target or mask_w != target:
-        up = nn.Upsample(
-            scale_factor=(target / mask_h, target / mask_w), mode="nearest"
+):
+    """Initialize a multiplex tracking session from detection masks."""
+    # The tracker operates at the model's image_size (1008x1008)
+    target = model.config.tracker_config.image_size
+    masks = np.stack(detection_masks).astype(np.float32)  # (N, H, W)
+    if masks.shape[1] != target or masks.shape[2] != target:
+        masks = np.stack(
+            [
+                np.array(Image.fromarray(m).resize((target, target), Image.BILINEAR))
+                for m in masks
+            ]
         )
-        masks_mx = up(masks_mx[:, :, :, None])[:, :, :, 0]  # (N, target, target)
-
-    # Pack into multiplex channels in MLX
-    channels = []
-    for ch in range(n_ch):
-        slot = ch // 2
-        if slot < N:
-            if ch % 2 == 0:
-                channels.append(masks_mx[slot : slot + 1, :, :, None])  # mask
-            else:
-                channels.append(1.0 - masks_mx[slot : slot + 1, :, :, None])  # inverse
-        else:
-            channels.append(mx.zeros((1, target, target, 1)))
-    # (multiplex*2, target, target, 1) → (1, target, target, n_ch)
-    mask_mx = mx.concatenate(channels, axis=0)  # (n_ch, target, target, 1)
-    mask_mx = mask_mx[:, :, :, 0].transpose(1, 2, 0)[None]  # (1, target, target, n_ch)
-    memory = model.tracker_model.memory_encoder(track_features, mask_mx)
-    mx.eval(memory)
-    _, H_m, W_m, C = memory.shape
-    return [memory.reshape(1, H_m * W_m, C)]
+    state, _ = model.track_init(backbone_features, mx.array(masks))
+    return state
 
 
-def _propagate_tracker(
-    model,
-    backbone_features: mx.array,
-    memory_bank: List[mx.array],
-    n_objects: int,
-    image_size,
-) -> tuple:
-    """Run tracker propagation. Returns (DetectionResult, updated_memory_bank)."""
-    prop_fpn = model._get_tracker_features(backbone_features)
-    track_features = prop_fpn[2]
-    high_res = [prop_fpn[0], prop_fpn[1]] if len(prop_fpn) > 1 else None
-
-    result = model.tracker_model.track_step(
-        current_features=track_features,
-        memory_bank=memory_bank,
-        multimask_output=False,
-        high_res_features=high_res,
-    )
-    mx.eval(result)
-
-    # Convert tracker output to DetectionResult — stay in MLX as long as possible
-    pred_masks = result["pred_masks"]  # (B, M, num_masks, H, W) or (B, num_masks, H, W)
-    iou_scores = result["iou_scores"]
+def _masks_to_detection(
+    out: Dict[str, mx.array], n_objects: int, image_size
+) -> DetectionResult:
+    """Convert a tracker frame output to a DetectionResult."""
+    pred_masks = out["pred_masks_high_res"][:, 0]  # (N, H_t, W_t) logits
+    obj_scores = mx.sigmoid(out["object_score_logits"][:, 0])  # (N,)
 
     W, H = (
         image_size if isinstance(image_size, tuple) else (image_size[1], image_size[0])
     )
-    N = min(n_objects, 16)
+    N = min(n_objects, pred_masks.shape[0])
+    obj_masks = pred_masks[:N]
+    obj_scores = obj_scores[:N]
 
-    # Extract per-object masks and scores in MLX (batched, no per-object np.array)
-    if pred_masks.ndim == 5:
-        # (B, M, num_masks, H_out, W_out) → take best mask per object
-        obj_masks = pred_masks[0, :N, 0]  # (N, H_out, W_out) — still MLX
-        obj_scores = iou_scores[0, :N, 0]  # (N,)
-    else:
-        obj_masks = mx.broadcast_to(pred_masks[0, 0:1], (N,) + pred_masks.shape[2:])
-        obj_scores = mx.broadcast_to(iou_scores[0, 0:1], (N,))
-
-    # Resize masks in MLX using Upsample (batched, no per-object PIL)
+    # Resize masks in MLX (batched)
     mask_h, mask_w = obj_masks.shape[1], obj_masks.shape[2]
     if mask_h != H or mask_w != W:
         up = nn.Upsample(scale_factor=(H / mask_h, W / mask_w), mode="nearest")
-        obj_masks_up = up(obj_masks[:, :, :, None])[:, :, :, 0]  # (N, H, W)
-    else:
-        obj_masks_up = obj_masks
+        obj_masks = up(obj_masks[:, :, :, None])[:, :, :, 0]  # (N, H, W)
 
     # Single eval + conversion
-    mx.eval(obj_masks_up, obj_scores)
-    masks_np = (np.array(obj_masks_up) > 0).astype(np.uint8)
+    mx.eval(obj_masks, obj_scores)
+    masks_np = (np.array(obj_masks) > 0).astype(np.uint8)
     scores_np = np.array(obj_scores)
 
-    # Derive boxes from masks (numpy — needed for contour-based boxes)
+    # Derive boxes from masks
     boxes_list = []
     for i in range(N):
         ys, xs = np.where(masks_np[i])
@@ -460,49 +406,28 @@ def _propagate_tracker(
         else:
             boxes_list.append([0, 0, 0, 0])
 
-    det_result = DetectionResult(
+    return DetectionResult(
         boxes=np.array(boxes_list, dtype=np.float32),
         masks=masks_np,
         scores=scores_np,
         labels=[],
     )
 
-    # Update memory bank
-    multiplex_count = model.config.tracker_config.multiplex_count
-    n_ch = multiplex_count * 2
-    feat_H = track_features.shape[1]
-    target = feat_H * 16  # mask_downsampler has stride 16
 
-    channels = []
-    for ch in range(n_ch):
-        slot = ch // 2
-        is_inv = ch % 2 == 1
-        if slot < n_objects and pred_masks.ndim == 5:
-            slot_mask = pred_masks[:, slot, 0]  # (B, H_out, W_out)
-            up = nn.Upsample(
-                scale_factor=(target / slot_mask.shape[1], target / slot_mask.shape[2]),
-                mode="nearest",
-            )
-            sig = mx.sigmoid(up(slot_mask[:, :, :, None])[:, :, :, 0] * 20.0 - 10.0)
-            if is_inv:
-                channels.append((1.0 - sig)[:, :, :, None])
-            else:
-                channels.append(sig[:, :, :, None])
-        else:
-            channels.append(mx.zeros((1, target, target, 1)))
-
-    mask_for_mem = mx.concatenate(channels, axis=-1)
-    memory = model.tracker_model.memory_encoder(track_features, mask_for_mem)
-    mx.eval(memory)
-    B_m, H_m, W_m, C_m = memory.shape
-    new_mem = memory.reshape(1, H_m * W_m, C_m)
-
-    max_mem = model.config.tracker_config.num_maskmem
-    updated_bank = memory_bank + [new_mem]
-    if len(updated_bank) > max_mem:
-        updated_bank = updated_bank[-max_mem:]
-
-    return det_result, updated_bank
+def _propagate_tracker(
+    model,
+    state,
+    backbone_features: mx.array,
+    frame_idx: int,
+    n_objects: int,
+    image_size,
+    run_mem_encoder: bool = True,
+) -> DetectionResult:
+    """Propagate tracked objects to the next frame (memory-conditioned)."""
+    out = model.track_step(
+        state, backbone_features, frame_idx, run_mem_encoder=run_mem_encoder
+    )
+    return _masks_to_detection(out, n_objects, image_size)
 
 
 def track_video(
@@ -803,7 +728,12 @@ def track_video_realtime(
     def inference_loop_impl():
         backbone_cache = {"features": None}
         encoder_cache = {}
-        tracker_state = {"memory_bank": [], "n_objects": 0, "labels": []}
+        tracker_state = {
+            "session": None,
+            "n_objects": 0,
+            "labels": [],
+            "frame_idx": 0,
+        }
         inference_count = 0
         prop_count = 0
         id_tracker = SimpleTracker()
@@ -833,12 +763,12 @@ def track_video_realtime(
             # Step 2: Detect or propagate
             can_track = (
                 resolution >= 1008
-                and tracker_state["memory_bank"]
+                and tracker_state["session"] is not None
                 and tracker_state["n_objects"] > 0
             )
             need_detect = (
                 inference_count % detect_every == 0
-                or not tracker_state["memory_bank"]
+                or tracker_state["session"] is None
                 or not can_track  # always detect at non-native resolutions
             )
 
@@ -857,12 +787,13 @@ def track_video_realtime(
 
                 mode = "detect"
 
-                # Initialize tracker memory from detections (only at native res)
+                # Initialize tracker session from detections (only at native res)
                 if len(result.scores) > 0 and resolution >= 1008:
-                    tracker_state["memory_bank"] = _init_tracker_memory(
+                    tracker_state["session"] = _init_tracker_state(
                         model, backbone_features, list(result.masks)
                     )
                     tracker_state["n_objects"] = len(result.scores)
+                    tracker_state["frame_idx"] = 0
                     tracker_state["labels"] = (
                         result.labels
                         if result.labels
@@ -878,19 +809,20 @@ def track_video_realtime(
                     )
             else:
                 # Tracker propagation (fast path — native resolution only)
-                result, updated_bank = _propagate_tracker(
+                next_frame = tracker_state["frame_idx"] + 1
+                run_mem = (prop_count + 1) % update_memory_every == 0
+                result = _propagate_tracker(
                     model,
+                    tracker_state["session"],
                     backbone_features,
-                    tracker_state["memory_bank"],
+                    next_frame,
                     tracker_state["n_objects"],
                     image_size,
+                    run_mem_encoder=run_mem,
                 )
                 result.labels = tracker_state["labels"]
-
-                # Update memory periodically
+                tracker_state["frame_idx"] = next_frame
                 prop_count += 1
-                if prop_count % update_memory_every == 0:
-                    tracker_state["memory_bank"] = updated_bank
 
                 mode = "track"
 

--- a/mlx_vlm/models/sam3_1/multiplex.py
+++ b/mlx_vlm/models/sam3_1/multiplex.py
@@ -1,0 +1,295 @@
+"""Multiplex state management for SAM 3.1 video tracking.
+
+Port of sam3/model/multiplex_utils.py (inference subset).
+
+A multiplex state maps objects (data space, batch dim) to slots in buckets
+(multiplex space, num_buckets x multiplex_count). The mask decoder runs on
+whole buckets at once; mux/demux convert between the two spaces via
+precomputed gather/scatter indices (exact copies, unlike permutation matmuls).
+"""
+
+import math
+from typing import Dict, List, Optional
+
+import mlx.core as mx
+
+# Special values for object tracking
+PADDING_NUM = -1  # Marks empty slots in buckets
+REMOVED_NUM = -1116  # Marks objects that have been removed
+
+
+class MultiplexState:
+    """Records the assignment of each object to a (bucket, slot) pair.
+
+    Supports:
+        mux:   (total_valid_entries, ...) -> (num_buckets, multiplex_count, ...)
+        demux: (num_buckets, multiplex_count, ...) -> (total_valid_entries, ...)
+        add_objects / remove_objects for dynamic object management
+    """
+
+    def __init__(
+        self,
+        assignments: List[List[int]],
+        allowed_bucket_capacity: int,
+        *,
+        object_ids: Optional[List[int]] = None,
+    ):
+        """
+        Args:
+            assignments: list of buckets; each bucket is a list of object indices
+                (0..total_valid-1), PADDING_NUM for empty slots, or REMOVED_NUM
+                for removed objects.
+            allowed_bucket_capacity: max non-padding entries per bucket.
+            object_ids: optional bookkeeping of global object IDs.
+        """
+        self.allowed_bucket_capacity = allowed_bucket_capacity
+        self._initialize_assignments(assignments, object_ids=object_ids)
+
+    def _initialize_assignments(self, assignments, *, object_ids=None):
+        self.assignments = [list(b) for b in assignments]
+        self.num_buckets = len(self.assignments)
+        if self.num_buckets == 0:
+            raise ValueError("No buckets found in the state")
+        self.multiplex_count = len(self.assignments[0])
+        assert all(len(b) == self.multiplex_count for b in self.assignments)
+
+        flat = [x for bucket in self.assignments for x in bucket]
+        self.total_valid_entries = sum(x >= 0 for x in flat)
+        self.total_non_padding_entries = sum(x != PADDING_NUM for x in flat)
+
+        self.object_ids = object_ids
+        if self.object_ids is not None:
+            assert len(self.object_ids) == self.total_valid_entries
+
+        # Precompute the slot<->object index maps for mux/demux. Gather
+        # indices are used instead of permutation matrices so the operations
+        # are exact copies (GPU matmul is not bit-exact).
+        slot_to_obj = [max(x, PADDING_NUM) for x in flat]
+        obj_to_slot = [0] * self.total_valid_entries
+        for slot, obj_idx in enumerate(slot_to_obj):
+            if obj_idx >= 0:
+                obj_to_slot[obj_idx] = slot
+        self._slot_to_obj = mx.array(slot_to_obj)
+        self._slot_gather_idx = mx.maximum(self._slot_to_obj, 0)
+        self._slot_is_valid = self._slot_to_obj >= 0
+        self._obj_to_slot = mx.array(obj_to_slot)
+
+    @property
+    def available_slots(self) -> int:
+        return (
+            self.num_buckets * self.allowed_bucket_capacity
+            - self.total_non_padding_entries
+        )
+
+    def find_next_batch_of_available_indices(
+        self,
+        num_objects: int,
+        *,
+        allow_new_buckets: bool = False,
+        prefer_new_buckets: bool = False,
+    ) -> List[int]:
+        """Return the next consecutive object indices available in the state."""
+        assert num_objects > 0
+        if not allow_new_buckets:
+            assert (
+                self.available_slots >= num_objects
+            ), f"not enough available slots {self.available_slots} < {num_objects}"
+        return list(
+            range(self.total_valid_entries, self.total_valid_entries + num_objects)
+        )
+
+    def add_objects(
+        self,
+        object_indices: List[int],
+        *,
+        object_ids: Optional[List[int]] = None,
+        allow_new_buckets: bool = False,
+        prefer_new_buckets: bool = False,
+    ):
+        """Add new objects, filling empty slots first, then new buckets."""
+        num_new_objects = len(object_indices)
+        if num_new_objects == 0:
+            return
+        assert object_indices == sorted(object_indices)
+        assert (object_ids is None) == (self.object_ids is None)
+        if object_ids is not None:
+            assert len(object_ids) == num_new_objects
+        if prefer_new_buckets:
+            assert allow_new_buckets
+
+        pending = list(zip(object_indices, object_ids or [None] * num_new_objects))
+
+        def _place(bucket, i):
+            obj_idx, obj_id = pending.pop(0)
+            bucket[i] = obj_idx
+            if object_ids is not None:
+                self.object_ids.append(obj_id)
+
+        if not prefer_new_buckets:
+            # Fill empty slots in existing buckets first
+            for bucket in self.assignments:
+                for i in range(self.allowed_bucket_capacity):
+                    if pending and bucket[i] == PADDING_NUM:
+                        _place(bucket, i)
+                if not pending:
+                    break
+
+        if pending and not allow_new_buckets:
+            raise ValueError(
+                f"Cannot place objects {[p[0] for p in pending]} "
+                "without creating new buckets"
+            )
+
+        # Create new buckets for remaining objects
+        while pending:
+            new_bucket = [PADDING_NUM] * self.multiplex_count
+            for i in range(self.allowed_bucket_capacity):
+                if not pending:
+                    break
+                _place(new_bucket, i)
+            self.assignments.append(new_bucket)
+
+        original_num_entries = self.total_valid_entries
+        self._initialize_assignments(self.assignments, object_ids=self.object_ids)
+        assert self.total_valid_entries == original_num_entries + num_new_objects
+
+    def remove_objects(self, object_indices: List[int], strict: bool = True):
+        """Mark objects as removed; drop buckets that become empty.
+
+        Returns the list of bucket indices that are kept.
+        """
+        remaining = set(object_indices)
+        for bucket in self.assignments:
+            for slot_idx, obj_id in enumerate(bucket):
+                if obj_id in remaining:
+                    bucket[slot_idx] = REMOVED_NUM
+                    remaining.discard(obj_id)
+        if strict:
+            assert not remaining, f"Failed to remove objects: {sorted(remaining)}"
+
+        # A bucket is dead once it holds no valid (non-negative) objects
+        buckets_to_keep = [
+            i
+            for i, bucket in enumerate(self.assignments)
+            if any(obj_id >= 0 for obj_id in bucket)
+        ]
+        self.assignments = [self.assignments[i] for i in buckets_to_keep]
+
+        if not buckets_to_keep:
+            self.assignments = None
+            if self.object_ids is not None:
+                self.object_ids = []
+            return buckets_to_keep
+
+        # Remap remaining object indices to be sequential
+        all_positive_ids = sorted(
+            {x for bucket in self.assignments for x in bucket if x >= 0}
+        )
+        id_mapping = {old: new for new, old in enumerate(all_positive_ids)}
+        for bucket in self.assignments:
+            for i, obj_id in enumerate(bucket):
+                if obj_id >= 0:
+                    bucket[i] = id_mapping[obj_id]
+
+        if self.object_ids is not None:
+            self.object_ids = [self.object_ids[old] for old in all_positive_ids]
+
+        self._initialize_assignments(self.assignments, object_ids=self.object_ids)
+        return buckets_to_keep
+
+    def mux(self, x: mx.array) -> mx.array:
+        """(total_valid_entries, ...) -> (num_buckets, multiplex_count, ...).
+
+        Padding slots are filled with zeros."""
+        num_valid = x.shape[0]
+        assert (
+            num_valid == self.total_valid_entries
+        ), f"{num_valid=} != {self.total_valid_entries=}"
+        result = mx.take(x.reshape(num_valid, -1), self._slot_gather_idx, axis=0)
+        result = mx.where(self._slot_is_valid[:, None], result, 0)
+        return result.reshape(self.num_buckets, self.multiplex_count, *x.shape[1:])
+
+    def demux(self, x: mx.array) -> mx.array:
+        """(num_buckets, multiplex_count, ...) -> (total_valid_entries, ...)."""
+        num_buckets, multiplex_count = x.shape[:2]
+        assert num_buckets == self.num_buckets
+        assert multiplex_count == self.multiplex_count
+        x_flat = x.reshape(num_buckets * multiplex_count, -1)
+        result = mx.take(x_flat, self._obj_to_slot, axis=0)
+        return result.reshape(self.total_valid_entries, *x.shape[2:])
+
+    def get_valid_object_mask(self) -> mx.array:
+        """(num_buckets, multiplex_count) bool mask of valid (non-padding) slots."""
+        return self._slot_is_valid.reshape(self.num_buckets, self.multiplex_count)
+
+    def get_all_valid_object_idx(self) -> set:
+        """All valid internal object indices in the state."""
+        return {
+            obj_idx for bucket in self.assignments for obj_idx in bucket if obj_idx >= 0
+        }
+
+
+class MultiplexController:
+    """Creates multiplex states by bucketing objects (inference: no shuffle)."""
+
+    def __init__(self, multiplex_count: int, eval_multiplex_count: int = -1):
+        assert multiplex_count >= 1
+        self.multiplex_count = multiplex_count
+        self.eval_multiplex_count = (
+            multiplex_count if eval_multiplex_count < 0 else eval_multiplex_count
+        )
+
+    @property
+    def allowed_bucket_capacity(self) -> int:
+        # inference only (eval capacity)
+        return self.eval_multiplex_count
+
+    def get_state(
+        self,
+        num_valid_entries: int,
+        random: bool = False,
+        *,
+        object_ids: Optional[List[int]] = None,
+    ) -> MultiplexState:
+        """Map `num_valid_entries` objects into buckets of size multiplex_count."""
+        capacity = self.allowed_bucket_capacity
+        num_buckets = math.ceil(num_valid_entries / capacity)
+
+        ids = (
+            mx.random.permutation(num_valid_entries).tolist()
+            if random
+            else list(range(num_valid_entries))
+        )
+        ids += [PADDING_NUM] * (num_buckets * capacity - len(ids))
+        assignments = [
+            ids[i * capacity : (i + 1) * capacity]
+            + [PADDING_NUM] * (self.multiplex_count - capacity)
+            for i in range(num_buckets)
+        ]
+        return MultiplexState(
+            assignments, allowed_bucket_capacity=capacity, object_ids=object_ids
+        )
+
+
+class MultiplexTrackerState:
+    """Inference state for a multiplex video tracking session.
+
+    Holds the multiplex assignment (buckets) and the per-frame outputs that
+    serve as memory for future frames.
+    """
+
+    def __init__(self, multiplex_state: MultiplexState):
+        self.multiplex_state = multiplex_state
+        self.cond_frame_outputs: Dict[int, dict] = {}
+        self.non_cond_frame_outputs: Dict[int, dict] = {}
+
+    @property
+    def output_dict(self) -> dict:
+        return {
+            "cond_frame_outputs": self.cond_frame_outputs,
+            "non_cond_frame_outputs": self.non_cond_frame_outputs,
+        }
+
+    @property
+    def num_objects(self) -> int:
+        return self.multiplex_state.total_valid_entries

--- a/mlx_vlm/models/sam3_1/sam3_1.py
+++ b/mlx_vlm/models/sam3_1/sam3_1.py
@@ -159,61 +159,74 @@ class Model(nn.Module):
         self.detector_model = DetectorModel(config)
         self.tracker_model = MultiplexTrackerModel(config.tracker_config)
 
-    def _get_tracker_features(self, backbone_features: mx.array):
-        """Get propagation FPN features from TriViTDetNeck for tracking."""
-        _, _, prop_features = self.detector_model.vision_encoder.neck(
+    def tracker_frame_features(
+        self,
+        backbone_features: mx.array,
+        need_interactive: bool = True,
+        need_propagation: bool = True,
+    ) -> dict:
+        """Run the interactive/propagation FPN heads and prepare the frame
+        features for the multiplex tracker (mirrors forward_image)."""
+        _, interactive_fpn, propagation_fpn = self.detector_model.vision_encoder.neck(
             backbone_features,
             need_det=False,
-            need_interactive=False,
-            need_propagation=True,
+            need_interactive=need_interactive,
+            need_propagation=need_propagation,
         )
-        return prop_features
+        frame_features = self.tracker_model.prepare_frame_features(
+            interactive_fpn if need_interactive else None,
+            propagation_fpn if need_propagation else None,
+        )
+        mx.eval(frame_features)
+        return frame_features
 
-    def tracker_neck(self, backbone_features: mx.array):
-        """Compat shim for Sam3VideoPredictor — returns propagation FPN features."""
-        return self._get_tracker_features(backbone_features)
+    def tracker_init_state(
+        self, num_objects: int, object_ids: Optional[List[int]] = None
+    ):
+        """Create a fresh multiplex tracking session state."""
+        return self.tracker_model.init_state(num_objects, object_ids=object_ids)
 
     def track_init(
         self,
         backbone_features: mx.array,
         detection_masks: mx.array,
-    ) -> Dict[str, mx.array]:
-        """Initialize tracker with detection results."""
-        prop_fpn = self._get_tracker_features(backbone_features)
-        features = prop_fpn[2]  # 1x scale (72x72)
-        B, H, W, D = features.shape
+        state=None,
+    ):
+        """Initialize a tracking session from detection masks on frame 0.
 
-        mask_input = detection_masks[:, :1].transpose(0, 2, 3, 1)  # (B, H, W, 1)
-        memory = self.tracker_model.memory_encoder(features, mask_input)
-
-        return {
-            "memory": memory.reshape(B, -1, memory.shape[-1]),
-            "features": features,
-        }
+        Returns (state, frame_output). frame_output["pred_masks_high_res"] holds
+        the (N, 1, H, W) per-object mask logits.
+        """
+        if detection_masks.ndim == 3:
+            detection_masks = detection_masks[:, None]
+        if state is None:
+            state = self.tracker_init_state(detection_masks.shape[0])
+        frame_features = self.tracker_frame_features(backbone_features)
+        out = self.tracker_model.add_mask_prompt(
+            state, 0, frame_features, detection_masks
+        )
+        mx.eval(out)
+        return state, out
 
     def track_step(
         self,
+        state,
         backbone_features: mx.array,
-        memory_bank: Optional[List[mx.array]] = None,
-        prompt_points=None,
-        prompt_boxes=None,
-        prompt_masks=None,
-        multimask_output: bool = False,
+        frame_idx: int,
+        run_mem_encoder: bool = True,
     ) -> Dict[str, mx.array]:
-        """Run one tracking step using propagation FPN."""
-        prop_fpn = self._get_tracker_features(backbone_features)
-        features = prop_fpn[2]
-        high_res = [prop_fpn[0], prop_fpn[1]] if len(prop_fpn) > 1 else None
-
-        return self.tracker_model.track_step(
-            current_features=features,
-            memory_bank=memory_bank,
-            prompt_points=prompt_points,
-            prompt_boxes=prompt_boxes,
-            prompt_masks=prompt_masks,
-            multimask_output=multimask_output,
-            high_res_features=high_res,
+        """Propagate all tracked objects to the next frame."""
+        frame_features = self.tracker_frame_features(
+            backbone_features, need_interactive=False
         )
+        out = self.tracker_model.propagate(
+            state,
+            frame_idx,
+            frame_features,
+            run_mem_encoder=run_mem_encoder,
+        )
+        mx.eval(out)
+        return out
 
     def detect(
         self,

--- a/mlx_vlm/models/sam3_1/sam_components.py
+++ b/mlx_vlm/models/sam3_1/sam_components.py
@@ -22,13 +22,15 @@ from .config import TrackerMaskDecoderConfig
 class MultiplexMaskDecoder(nn.Module):
     """SAM mask decoder that processes multiplex_count objects simultaneously.
 
-    Key differences from SAMMaskDecoder:
-    - iou_token: (multiplex_count, D) instead of (1, D)
-    - mask_tokens: (multiplex_count * num_masks, D) instead of (num_masks, D)
-    - obj_score_token: (multiplex_count, D) instead of (1, D)
-    - Output: (B, multiplex_count, num_masks, H, W)
+    Port of sam3/model/multiplex_mask_decoder.py. Also covers the interactive
+    (single-slot) MaskDecoder when multiplex_count=1 with sparse/dense prompts.
 
-    Weight keys: tracker_model.sam_mask_decoder.*
+    - Token layout: [obj_score(M), iou(M), mask(M * num_per_object), sparse...]
+    - multimask_outputs_only: no extra single-mask token (propagation decoder)
+    - extra_per_object_embeddings: (B, M, D) added to every mask token
+      (used by the output-suppression embeddings)
+
+    Weight keys: tracker_model.sam_mask_decoder.* / tracker_model.interactive_sam_mask_decoder.*
     """
 
     def __init__(self, config: TrackerMaskDecoderConfig):
@@ -36,14 +38,20 @@ class MultiplexMaskDecoder(nn.Module):
         d = config.hidden_size
         self.multiplex_count = config.multiplex_count
         self.num_multimask_outputs = config.num_multimask_outputs
-        self.num_mask_tokens = config.num_multimask_outputs  # 3
+        self.multimask_outputs_only = config.multimask_outputs_only
+        self.use_multimask_token_for_obj_ptr = config.use_multimask_token_for_obj_ptr
+
+        if self.multimask_outputs_only:
+            self.num_mask_output_per_object = self.num_multimask_outputs
+        else:
+            # +1 for the single (best) mask token
+            self.num_mask_output_per_object = self.num_multimask_outputs + 1
+        self.num_mask_tokens = self.multiplex_count * self.num_mask_output_per_object
 
         # Tokens sized for multiplex
-        self.iou_token = nn.Embedding(config.multiplex_count, d)  # (16, 256)
-        self.mask_tokens = nn.Embedding(
-            config.multiplex_count * self.num_mask_tokens, d
-        )  # (48, 256)
-        self.obj_score_token = nn.Embedding(config.multiplex_count, d)  # (16, 256)
+        self.iou_token = nn.Embedding(self.multiplex_count, d)
+        self.mask_tokens = nn.Embedding(self.num_mask_tokens, d)
+        self.obj_score_token = nn.Embedding(self.multiplex_count, d)
 
         # TwoWayTransformer (same architecture as SAM 3)
         self.transformer = TwoWayTransformer(
@@ -54,11 +62,11 @@ class MultiplexMaskDecoder(nn.Module):
             attention_downsample_rate=config.attention_downsample_rate,
         )
 
-        # Output MLPs — shared across multiplex slots (only num_mask_tokens MLPs)
+        # Output MLPs — one per mask token of an object (shared across slots)
         self.output_hypernetworks_mlps = [
-            OutputMLP(d, d, d // 8) for _ in range(self.num_mask_tokens)
+            OutputMLP(d, d, d // 8) for _ in range(self.num_mask_output_per_object)
         ]
-        self.iou_prediction_head = OutputMLP(d, d, self.num_mask_tokens)
+        self.iou_prediction_head = OutputMLP(d, d, self.num_mask_output_per_object)
         self.pred_obj_score_head = OutputMLP(d, d, 1)
 
         # Upscaling
@@ -66,110 +74,222 @@ class MultiplexMaskDecoder(nn.Module):
         self.upscale_conv2 = nn.ConvTranspose2d(d // 4, d // 8, kernel_size=2, stride=2)
         self.upscale_layer_norm = LayerNorm2d(d // 4)
 
-        # High-res skip connections
+        # 1x1 projections of the high-res FPN levels; applied by the caller
+        # before decoding (as in the reference forward_image)
         self.conv_s0 = nn.Conv2d(d, d // 8, kernel_size=1, bias=True)
         self.conv_s1 = nn.Conv2d(d, d // 4, kernel_size=1, bias=True)
+
+        self.dynamic_multimask_via_stability = config.dynamic_multimask_via_stability
+        self.dynamic_multimask_stability_delta = (
+            config.dynamic_multimask_stability_delta
+        )
+        self.dynamic_multimask_stability_thresh = (
+            config.dynamic_multimask_stability_thresh
+        )
 
     def __call__(
         self,
         image_embeddings: mx.array,
         image_pe: mx.array,
-        sparse_prompt_embeddings: mx.array,
-        dense_prompt_embeddings: mx.array,
-        multimask_output: bool = True,
+        multimask_output: bool,
         high_res_features: Optional[List[mx.array]] = None,
-    ) -> Tuple[mx.array, mx.array, mx.array, mx.array]:
+        extra_per_object_embeddings: Optional[mx.array] = None,
+        sparse_prompt_embeddings: Optional[mx.array] = None,
+        dense_prompt_embeddings: Optional[mx.array] = None,
+    ) -> dict:
         """
+        Args:
+            image_embeddings: (B, HW, D) memory-conditioned image features
+            image_pe: (1, HW, D) dense positional encoding
+            multimask_output: return all mask tokens (else best/single token)
+            high_res_features: [feat_s0, feat_s1] pre-projected by conv_s0/conv_s1
+            extra_per_object_embeddings: (B, M, D) added to the mask tokens
+            sparse/dense_prompt_embeddings: interactive prompts (multiplex_count=1)
+
         Returns:
-            masks, iou_pred, sam_tokens, obj_score
+            dict with masks (B, M, K, H, W), iou_pred (B, M, K),
+            sam_tokens_out (B, M, K, D), object_score_logits (B, M, 1)
         """
-        B = image_embeddings.shape[0]
-        d = image_embeddings.shape[-1]
+        if self.multimask_outputs_only:
+            assert (
+                multimask_output
+            ), "multimask_output must be True with multimask_outputs_only"
 
-        # Build token sequence: iou + mask + obj_score + sparse prompts
-        tokens = mx.concatenate(
-            [
-                mx.broadcast_to(
-                    self.iou_token.weight[None], (B, self.multiplex_count, d)
-                ),
-                mx.broadcast_to(
-                    self.mask_tokens.weight[None],
-                    (B, self.multiplex_count * self.num_mask_tokens, d),
-                ),
-                mx.broadcast_to(
-                    self.obj_score_token.weight[None], (B, self.multiplex_count, d)
-                ),
-            ],
-            axis=1,
+        out = self.predict_masks(
+            image_embeddings=image_embeddings,
+            image_pe=image_pe,
+            high_res_features=high_res_features,
+            extra_per_object_embeddings=extra_per_object_embeddings,
+            sparse_prompt_embeddings=sparse_prompt_embeddings,
+            dense_prompt_embeddings=dense_prompt_embeddings,
         )
-        tokens = mx.concatenate([tokens, sparse_prompt_embeddings], axis=1)
 
-        src = image_embeddings + dense_prompt_embeddings
+        masks = out["masks"]  # (B, M, P, H, W)
+        iou_pred = out["iou_pred"]  # (B, M, P)
+        mask_tokens_out = out["mask_tokens_out"]  # (B, M, P, D)
+
+        # Select the correct mask or masks for output
+        if multimask_output:
+            if not self.multimask_outputs_only:
+                # drop the single-mask token, keep the multimask tokens
+                masks = masks[:, :, 1:]
+                iou_pred = iou_pred[:, :, 1:]
+        elif self.dynamic_multimask_via_stability:
+            masks, iou_pred = self._dynamic_multimask_via_stability(masks, iou_pred)
+        else:
+            masks = masks[:, :, 0:1]
+            iou_pred = iou_pred[:, :, 0:1]
+
+        if multimask_output and self.use_multimask_token_for_obj_ptr:
+            if self.multimask_outputs_only:
+                sam_tokens_out = mask_tokens_out
+            else:
+                sam_tokens_out = mask_tokens_out[:, :, 1:]
+        else:
+            # Always take the single-mask token for the object pointer
+            sam_tokens_out = mask_tokens_out[:, :, 0:1]
+
+        return {
+            "masks": masks,
+            "iou_pred": iou_pred,
+            "sam_tokens_out": sam_tokens_out,
+            "object_score_logits": out["object_score_logits"],
+        }
+
+    def predict_masks(
+        self,
+        image_embeddings: mx.array,
+        image_pe: mx.array,
+        high_res_features: Optional[List[mx.array]] = None,
+        extra_per_object_embeddings: Optional[mx.array] = None,
+        sparse_prompt_embeddings: Optional[mx.array] = None,
+        dense_prompt_embeddings: Optional[mx.array] = None,
+    ) -> dict:
+        B_img, HW, d = image_embeddings.shape
+        M = self.multiplex_count
+        P = self.num_mask_output_per_object
+
+        if sparse_prompt_embeddings is not None:
+            B = sparse_prompt_embeddings.shape[0]
+        else:
+            B = B_img
+
+        # Repeat the image embeddings to the token batch size if needed
+        if B_img != B:
+            assert B_img == 1
+            src = mx.broadcast_to(image_embeddings, (B, HW, d))
+        else:
+            src = image_embeddings
+        if dense_prompt_embeddings is not None:
+            src = src + dense_prompt_embeddings
+
+        # Token layout: [obj_score(M), iou(M), mask(M * P), sparse...]
+        tokens = [
+            mx.broadcast_to(self.obj_score_token.weight[None], (B, M, d)),
+            mx.broadcast_to(self.iou_token.weight[None], (B, M, d)),
+        ]
+        mask_tokens = self.mask_tokens.weight.reshape(1, M, P, d)
+        if extra_per_object_embeddings is not None:
+            mask_tokens = mask_tokens + extra_per_object_embeddings[:, :, None, :]
+        else:
+            mask_tokens = mx.broadcast_to(mask_tokens, (B, M, P, d))
+        tokens.append(mask_tokens.reshape(B, M * P, d))
+        if sparse_prompt_embeddings is not None:
+            tokens.append(sparse_prompt_embeddings)
+        tokens = mx.concatenate(tokens, axis=1)
+
+        image_pe = mx.broadcast_to(image_pe, (B, HW, d))
         hs, src = self.transformer(src, image_pe, tokens)
 
-        # Extract outputs
-        M = self.multiplex_count
-        N_mask = self.num_mask_tokens
-        iou_out = hs[:, :M]
-        mask_out = hs[:, M : M + M * N_mask]
-        obj_out = hs[:, M + M * N_mask : 2 * M + M * N_mask]
+        obj_score_token_out = hs[:, :M]  # (B, M, D)
+        iou_token_out = hs[:, M : 2 * M]  # (B, M, D)
+        mask_tokens_out = hs[:, 2 * M : 2 * M + M * P]  # (B, M * P, D)
 
-        # Upscale
-        HW = src.shape[1]
+        # Upscale image features (72 -> 144 -> 288) with high-res skip fusion
         H = W = int(HW**0.5)
         src = src.reshape(B, H, W, d)
 
         upscaled = self.upscale_conv1(src)
+        if high_res_features is not None:
+            feat_s0, feat_s1 = high_res_features
+            upscaled = upscaled + feat_s1
         upscaled = self.upscale_layer_norm(upscaled)
         upscaled = nn.gelu(upscaled)
 
-        if high_res_features is not None and len(high_res_features) >= 1:
-            s1_feat = self.conv_s1(high_res_features[0])
-            if s1_feat.shape[1:3] == upscaled.shape[1:3]:
-                upscaled = upscaled + s1_feat
-
         upscaled = self.upscale_conv2(upscaled)
+        if high_res_features is not None:
+            upscaled = upscaled + feat_s0
         upscaled = nn.gelu(upscaled)
-
-        if high_res_features is not None and len(high_res_features) >= 2:
-            s0_feat = self.conv_s0(high_res_features[1])
-            if s0_feat.shape[1:3] == upscaled.shape[1:3]:
-                upscaled = upscaled + s0_feat
 
         B, H_up, W_up, C_up = upscaled.shape
         upscaled_flat = upscaled.reshape(B, H_up * W_up, C_up)
 
-        # Generate masks — MLPs are shared across multiplex slots
-        masks = []
-        for obj_i in range(M):
-            for mask_j in range(N_mask):
-                token_idx = obj_i * N_mask + mask_j
-                hyper_out = self.output_hypernetworks_mlps[mask_j](
-                    mask_out[:, token_idx]
-                )
-                mask = (upscaled_flat * hyper_out[:, None, :]).sum(axis=-1)
-                masks.append(mask.reshape(B, 1, H_up, W_up))
-        masks = mx.concatenate(masks, axis=1)  # (B, M*N_mask, H, W)
-        masks = masks.reshape(B, M, N_mask, H_up, W_up)
+        # Hypernetwork projections of the mask tokens: (B, M, P, C_up)
+        mask_tokens_out = mask_tokens_out.reshape(B, M, P, d)
+        hyper_in = mx.stack(
+            [
+                self.output_hypernetworks_mlps[i](mask_tokens_out[:, :, i])
+                for i in range(P)
+            ],
+            axis=2,
+        )
 
-        # IoU prediction — per multiplex slot
-        iou_pred = mx.stack(
-            [self.iou_prediction_head(iou_out[:, i]) for i in range(M)], axis=1
-        )  # (B, M, N_mask)
+        # Generate masks: (B, M*P, C) @ (B, C, HW) -> (B, M, P, H, W)
+        masks = (
+            hyper_in.reshape(B, M * P, C_up) @ upscaled_flat.transpose(0, 2, 1)
+        ).reshape(B, M, P, H_up, W_up)
 
-        # Object score
-        obj_score = mx.stack(
-            [self.pred_obj_score_head(obj_out[:, i]) for i in range(M)], axis=1
-        )  # (B, M, 1)
+        # Per-slot mask quality and object existence predictions
+        iou_pred = self.iou_prediction_head(iou_token_out)  # (B, M, P)
+        object_score_logits = self.pred_obj_score_head(obj_score_token_out)  # (B, M, 1)
 
-        if multimask_output:
-            out_masks = masks
-            out_iou = iou_pred
-        else:
-            out_masks = masks[:, :, 0:1]
-            out_iou = iou_pred[:, :, 0:1]
+        return {
+            "masks": masks,
+            "iou_pred": iou_pred,
+            "mask_tokens_out": mask_tokens_out,
+            "object_score_logits": object_score_logits,
+        }
 
-        return out_masks, out_iou, hs, obj_score
+    def _get_stability_scores(self, mask_logits: mx.array) -> mx.array:
+        """IoU between upper/lower thresholded masks, per mask."""
+        mask_logits = mask_logits.reshape(*mask_logits.shape[:-2], -1)
+        delta = self.dynamic_multimask_stability_delta
+        area_i = (mask_logits > delta).sum(axis=-1).astype(mx.float32)
+        area_u = (mask_logits > -delta).sum(axis=-1).astype(mx.float32)
+        return mx.where(area_u > 0, area_i / area_u, mx.array(1.0, mx.float32))
+
+    def _dynamic_multimask_via_stability(self, all_mask_logits, all_iou_scores):
+        """Fall back to the best multimask output when the single-mask output
+        has a low stability score."""
+        B, M = all_mask_logits.shape[:2]
+        all_mask_logits = all_mask_logits.reshape(-1, *all_mask_logits.shape[2:])
+        all_iou_scores = all_iou_scores.reshape(-1, all_iou_scores.shape[-1])
+
+        # Best mask among multimask output tokens (1..P-1)
+        multimask_logits = all_mask_logits[:, 1:]
+        multimask_iou = all_iou_scores[:, 1:]
+        best_inds = mx.argmax(multimask_iou, axis=-1)  # (B*M,)
+        best_multimask_logits = mx.take_along_axis(
+            multimask_logits, best_inds[:, None, None, None], axis=1
+        )
+        best_multimask_iou = mx.take_along_axis(
+            multimask_iou, best_inds[:, None], axis=1
+        )
+
+        # Single-mask output token 0 and its stability score
+        singlemask_logits = all_mask_logits[:, 0:1]
+        singlemask_iou = all_iou_scores[:, 0:1]
+        stability = self._get_stability_scores(singlemask_logits)[:, :, None, None]
+        is_stable = stability >= self.dynamic_multimask_stability_thresh
+
+        mask_logits_out = mx.where(is_stable, singlemask_logits, best_multimask_logits)
+        iou_scores_out = mx.where(
+            is_stable[:, :, 0, 0], singlemask_iou, best_multimask_iou
+        )
+
+        mask_logits_out = mask_logits_out.reshape(B, M, *mask_logits_out.shape[1:])
+        iou_scores_out = iou_scores_out.reshape(B, M, -1)
+        return mask_logits_out, iou_scores_out
 
 
 class SimpleRoPEAttention(nn.Module):
@@ -298,17 +418,25 @@ class DecoupledMemoryAttentionLayer(nn.Module):
 
     def __call__(
         self,
+        image: mx.array,
         src: mx.array,
+        memory_image: mx.array,
         memory: mx.array,
+        memory_image_pos: Optional[mx.array] = None,
         num_k_exclude_rope: int = 0,
     ) -> mx.array:
         """
+        Pre-norm decoupled layer (DecoupledTransformerDecoderLayerv2 port).
+
         Args:
-            src: (B, HW, D) current frame features
-            memory: (B, N_mem, D) memory features
-            num_k_exclude_rope: keys to exclude from RoPE
+            image: (1, HW, D) raw current-frame image features (not normed)
+            src: (B, HW, D) current frame features (self-attention)
+            memory_image: (1, N, D) image features of the memory frames
+            memory: (B, N, D) mask-memory features (+ object pointers)
+            memory_image_pos: (1, N, D) positional encodings for the memory keys
+            num_k_exclude_rope: trailing keys excluded from RoPE (obj pointers)
         """
-        # 1. Self-attention with RoPE (pre-norm)
+        # 1. Self-attention with RoPE (pre-norm, no pos enc at attention)
         residual = src
         src_normed = self.norm1(src)
         q = self.self_attn_q_proj(src_normed)
@@ -319,23 +447,23 @@ class DecoupledMemoryAttentionLayer(nn.Module):
         src = residual + src2
 
         # 2. Cross-attention to memory with RoPE (pre-norm)
+        # q/k get additional projections of the (raw) image features
         residual = src
         src_normed = self.norm2(src)
-        q = self.cross_attn_q_proj(src_normed)
-        k = self.cross_attn_k_proj(memory)
+        q = self.image_cross_attn_q_proj(image) + self.cross_attn_q_proj(src_normed)
+        k = self.image_cross_attn_k_proj(memory_image) + self.cross_attn_k_proj(memory)
+        if memory_image_pos is not None:
+            # pos enc at cross-attention keys only
+            k = k + memory_image_pos
         v = self.cross_attn_v_proj(memory)
-
-        # Add image cross-attention projections
-        q = q + self.image_cross_attn_q_proj(src_normed)
-        k = k + self.image_cross_attn_k_proj(memory)
 
         src2 = self.cross_attention_rope(q, k, v, num_k_exclude_rope=num_k_exclude_rope)
         src2 = self.cross_attn_out_proj(src2)
         src = residual + src2
 
-        # 3. FFN (pre-norm)
+        # 3. FFN (pre-norm, gelu)
         residual = src
-        src2 = self.linear2(nn.relu(self.linear1(self.norm3(src))))
+        src2 = self.linear2(nn.gelu(self.linear1(self.norm3(src))))
         src = residual + src2
 
         mx.eval(src)  # Free attention intermediates
@@ -377,10 +505,56 @@ class DecoupledMemoryAttention(nn.Module):
 
     def __call__(
         self,
+        image: mx.array,
         src: mx.array,
+        memory_image: mx.array,
         memory: mx.array,
+        src_pos: Optional[mx.array] = None,
+        memory_pos: Optional[mx.array] = None,
+        memory_image_pos: Optional[mx.array] = None,
         num_k_exclude_rope: int = 0,
     ) -> mx.array:
+        """TransformerEncoderDecoupledCrossAttention port (batch-first).
+
+        Args:
+            image: (1, HW, D) raw current-frame image features
+            src: (B, HW, D) current-frame features
+            memory_image: (1, N_img, D) image features of memory frames
+            memory: (B, N_mem, D) mask memories + object pointer tokens
+            src_pos: (B, HW, D) pos enc added to src at input (scaled by 0.1)
+            memory_pos: (B, N_mem, D) pos enc; only its object-pointer tail is
+                used (to extend memory_image_pos)
+            memory_image_pos: (1, N_img, D) pos enc for the memory image keys
+            num_k_exclude_rope: number of trailing object-pointer tokens
+        """
+        # pos enc at input (scaled by 0.1 as in the reference)
+        if src_pos is not None:
+            src = src + 0.1 * src_pos
+
+        # Pad the image memories with zeros for the object pointer tokens
+        if memory_image.shape[1] != memory.shape[1]:
+            pad = memory.shape[1] - memory_image.shape[1]
+            assert pad == num_k_exclude_rope
+            memory_image = mx.concatenate(
+                [
+                    memory_image,
+                    mx.zeros((memory_image.shape[0], pad, memory_image.shape[2])),
+                ],
+                axis=1,
+            )
+            if memory_image_pos is not None and memory_pos is not None:
+                memory_image_pos = mx.concatenate(
+                    [memory_image_pos, memory_pos[0:1, -pad:]], axis=1
+                )
+
         for layer in self.layers:
-            src = layer(src, memory, num_k_exclude_rope=num_k_exclude_rope)
+            src = layer(
+                image,
+                src,
+                memory_image,
+                memory,
+                memory_image_pos=memory_image_pos,
+                num_k_exclude_rope=num_k_exclude_rope,
+            )
+        # use_image_in_output=False: norm the output only
         return self.layer_norm(src)

--- a/mlx_vlm/models/sam3_1/tracker.py
+++ b/mlx_vlm/models/sam3_1/tracker.py
@@ -964,9 +964,7 @@ class MultiplexTrackerModel(nn.Module):
                         == len(objects_to_interact)
                     )
 
-                multimask_output = self._use_multimask(
-                    is_init_cond_frame, point_inputs
-                )
+                multimask_output = self._use_multimask(is_init_cond_frame, point_inputs)
                 interaction_out = self._forward_sam_heads(
                     backbone_features=interactive_pix_feat,
                     point_inputs=point_inputs,
@@ -1165,9 +1163,7 @@ class MultiplexTrackerModel(nn.Module):
                 prev_output["pred_masks_high_res"].shape[0]
                 == multiplex_state.total_valid_entries
             )
-            self._reencode_memory(
-                prev_output, propagation_vision_feat, multiplex_state
-            )
+            self._reencode_memory(prev_output, propagation_vision_feat, multiplex_state)
 
     def recondition_masks_in_existing_state(
         self,
@@ -1206,9 +1202,7 @@ class MultiplexTrackerModel(nn.Module):
 
         # Step 3: re-encode the spatial memory
         if add_mask_to_memory:
-            self._reencode_memory(
-                prev_output, propagation_vision_feat, multiplex_state
-            )
+            self._reencode_memory(prev_output, propagation_vision_feat, multiplex_state)
 
     # ------------------------------------------------------------------
     # Convenience session API

--- a/mlx_vlm/models/sam3_1/tracker.py
+++ b/mlx_vlm/models/sam3_1/tracker.py
@@ -1,4 +1,12 @@
-"""SAM 3.1 Multiplex Tracker: dual decoder, multiplex embeddings.
+"""SAM 3.1 multiplex video tracker.
+
+Port of sam3/model/video_tracking_multiplex.py (inference subset; the training
+branches sampling correction points from ground-truth masks are omitted).
+
+Covers mask-as-output initialization (mask prompts bypass the SAM decoder),
+memory-conditioned propagation (spatial mask memories, image features, object
+pointer tokens), interactive point/mask refinement, and dynamic object
+addition / reconditioning, plus the mask downsampler / memory encoder.
 
 Weight keys: tracker_model.*
 """
@@ -8,14 +16,20 @@ from typing import Dict, List, Optional, Tuple
 import mlx.core as mx
 import mlx.nn as nn
 
+from ..interpolate import resize_bilinear_nhwc
+from ..sam3.position import PositionEmbeddingSine
 from ..sam3.tracker import DownsampleConvBlock, MemoryFuser
-from .config import TrackerConfig
+from .config import TrackerConfig, TrackerMaskDecoderConfig
+from .multiplex import MultiplexController, MultiplexState, MultiplexTrackerState
 from .sam_components import (
     DecoupledMemoryAttention,
     MultiplexMaskDecoder,
     PositionalEmbedding,
     SAMPromptEncoder,
 )
+
+# A large negative value as a placeholder score for missing objects
+NO_OBJ_SCORE = -1024.0
 
 
 class MultiplexMaskDownSampler(nn.Module):
@@ -27,29 +41,36 @@ class MultiplexMaskDownSampler(nn.Module):
     def __init__(self, config: TrackerConfig):
         super().__init__()
         first_ch = config.mask_downsampler_first_channels  # 16
-        kernel_size = config.mask_downsampler_kernel_size
-        stride = config.mask_downsampler_stride
-        padding = config.mask_downsampler_padding
-        embed_dim = config.mask_downsampler_embed_dim
+        self.input_size = config.mask_downsampler_input_size  # 1152
 
-        # Progressive: 16 -> 64 -> 256 -> 1024 (from checkpoint)
-        # Input channels = multiplex_count * 2 = 32
-        channels = [first_ch, first_ch * 4, first_ch * 16, first_ch * 64]
-        self.layers = []
-        in_ch = first_ch * 2  # 32 input channels
-        for out_ch in channels:
-            self.layers.append(
-                DownsampleConvBlock(in_ch, out_ch, kernel_size, stride, padding)
-            )
-            in_ch = out_ch
-
-        self.final_conv = nn.Conv2d(channels[-1], embed_dim, kernel_size=1, bias=True)
+        # Progressive: 32 -> 16 -> 64 -> 256 -> 1024 (from checkpoint)
+        channels = [
+            first_ch * 2,
+            first_ch,
+            first_ch * 4,
+            first_ch * 16,
+            first_ch * 64,
+        ]
+        conv_args = (
+            config.mask_downsampler_kernel_size,
+            config.mask_downsampler_stride,
+            config.mask_downsampler_padding,
+        )
+        self.layers = [
+            DownsampleConvBlock(in_ch, out_ch, *conv_args)
+            for in_ch, out_ch in zip(channels, channels[1:])
+        ]
+        self.final_conv = nn.Conv2d(
+            channels[-1], config.mask_downsampler_embed_dim, kernel_size=1, bias=True
+        )
 
     def __call__(self, masks: mx.array) -> mx.array:
-        x = masks
+        """masks: (B, H, W, 2*multiplex_count) muxed mask channels."""
+        if masks.shape[1:3] != (self.input_size, self.input_size):
+            masks = resize_bilinear_nhwc(masks, (self.input_size, self.input_size))
         for layer in self.layers:
-            x = layer(x)
-        return self.final_conv(x)
+            masks = layer(masks)
+        return self.final_conv(masks)
 
 
 class MultiplexMemoryEncoder(nn.Module):
@@ -66,38 +87,90 @@ class MultiplexMemoryEncoder(nn.Module):
         self.mask_downsampler = MultiplexMaskDownSampler(config)
         self.memory_fuser = MemoryFuser(config)
         self.feature_projection = nn.Conv2d(dim, dim, kernel_size=1, bias=True)
+        # Parameter-free sinusoidal 2D pos enc (256-dim output)
+        self.position_encoding = PositionEmbeddingSine(dim // 2)
 
-    def __call__(self, features: mx.array, masks: mx.array) -> mx.array:
-        mask_features = self.mask_downsampler(masks)
-        features = self.feature_projection(features)
-        fused = features + mask_features
-        return self.memory_fuser(fused)
+    def __call__(
+        self, features: mx.array, masks: mx.array
+    ) -> Tuple[mx.array, mx.array]:
+        """features: (1, H, W, D); masks: (B, H_m, W_m, 2M) muxed channels.
+
+        Returns (memory, pos_enc), each (B, H, W, D).
+        """
+        fused = self.feature_projection(features) + self.mask_downsampler(masks)
+        memory = self.memory_fuser(fused)
+        return memory, self.position_encoding(memory)
 
 
 class ObjectPointerMLP(nn.Module):
     """Projects SAM output tokens to object pointers.
 
-    Weight keys: tracker_model.obj_ptr_proj.* or tracker_model.interactive_obj_ptr_proj.*
+    Weight keys: tracker_model.(interactive_)obj_ptr_proj.*
     """
 
     def __init__(self, hidden_size: int):
         super().__init__()
-        self.layers = [
-            nn.Linear(hidden_size, hidden_size),
-            nn.Linear(hidden_size, hidden_size),
-            nn.Linear(hidden_size, hidden_size),
-        ]
+        self.layers = [nn.Linear(hidden_size, hidden_size) for _ in range(3)]
 
     def __call__(self, x: mx.array) -> mx.array:
-        for i, layer in enumerate(self.layers):
-            x = layer(x)
-            if i < len(self.layers) - 1:
-                x = nn.relu(x)
-        return x
+        for layer in self.layers[:-1]:
+            x = nn.relu(layer(x))
+        return self.layers[-1](x)
+
+
+def get_1d_sine_pe(pos_inds: mx.array, dim: int, temperature: float = 10000.0):
+    """1D sine positional embedding as in the original Transformer paper."""
+    pe_dim = dim // 2
+    dim_t = mx.arange(pe_dim, dtype=mx.float32)
+    dim_t = temperature ** (2 * (dim_t // 2) / pe_dim)
+    pos_embed = pos_inds[..., None] / dim_t
+    return mx.concatenate([mx.sin(pos_embed), mx.cos(pos_embed)], axis=-1)
+
+
+def select_closest_cond_frames(
+    frame_idx: int,
+    cond_frame_outputs: Dict[int, dict],
+    max_cond_frame_num: int,
+) -> Tuple[Dict[int, dict], Dict[int, dict]]:
+    """Select up to `max_cond_frame_num` temporally closest conditioning frames."""
+    if max_cond_frame_num == -1 or len(cond_frame_outputs) <= max_cond_frame_num:
+        return dict(cond_frame_outputs), {}
+
+    assert max_cond_frame_num >= 2
+    selected = {}
+    # closest conditioning frame before and after `frame_idx`
+    idx_before = max((t for t in cond_frame_outputs if t < frame_idx), default=None)
+    if idx_before is not None:
+        selected[idx_before] = cond_frame_outputs[idx_before]
+    idx_after = min((t for t in cond_frame_outputs if t >= frame_idx), default=None)
+    if idx_after is not None:
+        selected[idx_after] = cond_frame_outputs[idx_after]
+    # fill up with the temporally closest remaining frames
+    num_remain = max_cond_frame_num - len(selected)
+    inds_remain = sorted(
+        (t for t in cond_frame_outputs if t not in selected),
+        key=lambda x: abs(x - frame_idx),
+    )[:num_remain]
+    selected.update({t: cond_frame_outputs[t] for t in inds_remain})
+    unselected = {t: v for t, v in cond_frame_outputs.items() if t not in selected}
+    return selected, unselected
+
+
+def _resize_masks(
+    masks: mx.array, out_h: int, out_w: int, antialias: bool = False
+) -> mx.array:
+    """Bilinear-resize the last two dims of (N, K, H, W) mask logits."""
+    n, k, h, w = masks.shape
+    if (h, w) == (out_h, out_w):
+        return masks
+    out = resize_bilinear_nhwc(
+        masks.reshape(n * k, h, w, 1), (out_h, out_w), antialias=antialias
+    )
+    return out.reshape(n, k, out_h, out_w)
 
 
 class MultiplexTrackerModel(nn.Module):
-    """SAM 3.1 multiplex tracker with dual decoder.
+    """SAM 3.1 multiplex tracker (VideoTrackingMultiplex port).
 
     Weight keys: tracker_model.*
     """
@@ -106,12 +179,44 @@ class MultiplexTrackerModel(nn.Module):
         super().__init__()
         self.config = config
         d = config.memory_attention_hidden_size
-        mem_dim = config.memory_encoder_output_channels
         M = config.multiplex_count
+        self.multiplex_count = M
+        self.hidden_dim = d
+        self.num_maskmem = config.num_maskmem
+        self.max_cond_frames_in_attn = config.max_cond_frame_num
+        self.max_obj_ptrs_in_encoder = config.max_object_pointers_in_encoder
+        self.memory_temporal_stride_for_eval = config.memory_temporal_stride_for_eval
+        self.object_score_logit_threshold = config.object_score_logit_threshold
 
-        # Interactive SAM components (for point/box prompts — single object, 4 mask outputs)
-        from .config import TrackerMaskDecoderConfig
+        # Tracking behavior flags (SAM 3.1 build_sam3_multiplex_video_model)
+        for name in (
+            "use_obj_ptrs_in_encoder",
+            "pred_obj_scores",
+            "use_no_obj_ptr",
+            "use_linear_no_obj_ptr",
+            "fixed_no_obj_ptr",
+            "add_output_suppression_embeddings",
+            "condition_as_mask_input",
+            "condition_as_mask_input_fg",
+            "condition_as_mask_input_bg",
+            "use_maskmem_tpos_v2",
+            "save_image_features",
+            "directly_add_no_mem_embed",
+            "use_mask_input_as_output_without_sam",
+            "apply_sigmoid_to_mask_logits_for_mem_enc",
+            "sigmoid_scale_for_mem_enc",
+            "sigmoid_bias_for_mem_enc",
+            "multimask_output_in_sam",
+            "multimask_output_for_tracking",
+            "multimask_min_pt_num",
+            "multimask_max_pt_num",
+            "num_multimask_outputs",
+        ):
+            setattr(self, name, getattr(config, name))
 
+        self.multiplex_controller = MultiplexController(M)
+
+        # Interactive SAM components (point/box prompts, single object slot)
         self.interactive_sam_prompt_encoder = SAMPromptEncoder(
             config.prompt_encoder_config
         )
@@ -119,8 +224,10 @@ class MultiplexTrackerModel(nn.Module):
             **{
                 **config.mask_decoder_config.__dict__,
                 "multiplex_count": 1,
-                "num_multimask_outputs": 4,
-            }  # interactive uses 4 mask outputs
+                "num_multimask_outputs": config.num_multimask_outputs,
+                "multimask_outputs_only": False,
+                "dynamic_multimask_via_stability": False,
+            }
         )
         self.interactive_sam_mask_decoder = MultiplexMaskDecoder(interactive_cfg)
 
@@ -150,78 +257,1029 @@ class MultiplexTrackerModel(nn.Module):
 
         # Image positional encoding
         self.image_pe_layer = PositionalEmbedding(d // 2)
+        # Present in converted checkpoints for weight-load compatibility;
+        # the reference model has no such module (it is unused)
         self.shared_image_embedding = PositionalEmbedding(d // 2)
+        # Sinusoidal 2D pos enc for FPN features (parameter-free)
+        self._pos_enc = PositionEmbeddingSine(d // 2)
 
         # Interactive mask downsample
         self.interactive_mask_downsample = nn.Conv2d(
             1, 1, kernel_size=4, stride=4, bias=True
         )
 
-    def track_step(
+    # ------------------------------------------------------------------
+    # State management
+    # ------------------------------------------------------------------
+
+    def init_state(
+        self, num_objects: int, object_ids: Optional[List[int]] = None
+    ) -> MultiplexTrackerState:
+        """Create a fresh tracking session state for `num_objects` objects."""
+        mux = self.multiplex_controller.get_state(
+            num_objects, random=False, object_ids=object_ids
+        )
+        return MultiplexTrackerState(mux)
+
+    # ------------------------------------------------------------------
+    # Frame feature preparation (called by the Model wrapper)
+    # ------------------------------------------------------------------
+
+    def prepare_frame_features(
         self,
-        current_features: mx.array,
-        memory_bank: Optional[List[mx.array]] = None,
-        prompt_points: Optional[Tuple[mx.array, mx.array]] = None,
-        prompt_boxes: Optional[mx.array] = None,
-        prompt_masks: Optional[mx.array] = None,
-        multimask_output: bool = False,
-        high_res_features: Optional[List[mx.array]] = None,
-    ) -> Dict[str, mx.array]:
-        """Run one tracking step."""
-        B, H, W, D = current_features.shape
-        src = current_features.reshape(B, H * W, D)
+        interactive_fpn: Optional[List[mx.array]],
+        propagation_fpn: Optional[List[mx.array]],
+    ) -> dict:
+        """Prepare per-frame backbone features (mirrors forward_image).
 
-        # Memory attention
-        if memory_bank and len(memory_bank) > 0:
-            memory = mx.concatenate(memory_bank, axis=1)
-            src = self.memory_attention(src, memory)
+        Pre-applies the conv_s0/conv_s1 high-res projections so they are not
+        recomputed on every decoder call, and computes the sine pos encs.
+        Each fpn is [f0 (288), f1 (144), f2 (72)] or None.
+        """
 
-        # Image positional encoding (resize if resolution differs from training)
-        image_pe = self.interactive_sam_prompt_encoder.get_dense_pe()
-        pe_len = image_pe.shape[1]
-        if pe_len != H * W:
-            pe_side = int(pe_len**0.5)
-            image_pe = image_pe.reshape(1, pe_side, pe_side, D)
-            image_pe = (
-                mx.broadcast_to(image_pe[:, :H, :W, :], (B, H, W, D))
-                if H <= pe_side
-                else nn.Upsample(
-                    scale_factor=(H / pe_side, W / pe_side), mode="nearest"
-                )(image_pe)
+        def prep(fpn, decoder):
+            return {
+                "vision_feat": fpn[-1],
+                "high_res": [decoder.conv_s0(fpn[0]), decoder.conv_s1(fpn[1])],
+            }
+
+        out = {}
+        if interactive_fpn is not None:
+            out["interactive"] = prep(
+                interactive_fpn, self.interactive_sam_mask_decoder
             )
-            image_pe = image_pe.reshape(B, H * W, D)
+        if propagation_fpn is not None:
+            out["propagation"] = prep(propagation_fpn, self.sam_mask_decoder)
+            out["propagation"]["vision_pos"] = self._pos_enc(propagation_fpn[-1])
+        return out
+
+    # ------------------------------------------------------------------
+    # SAM heads
+    # ------------------------------------------------------------------
+
+    def get_propagation_dense_pe(self) -> mx.array:
+        """Dense positional encoding for the propagation mask decoder.
+
+        Cached across frames (hidden from Module.parameters); keyed on the
+        embedding weight so reloading weights invalidates the cache.
+        """
+        w = self.image_pe_layer.positional_embedding
+        cached = self.__dict__.get("_prop_dense_pe")
+        if cached is None or cached[0] is not w:
+            side = self.config.mask_downsampler_input_size // 16  # 72
+            pe = self.image_pe_layer((side, side))[None]  # (1, HW, D)
+            object.__setattr__(self, "_prop_dense_pe", (w, pe))
+            return pe
+        return cached[1]
+
+    def _get_interactive_pix_mem(self, vision_feat: mx.array) -> mx.array:
+        """(1, H, W, D) -> (1, HW, D) with the no-memory embedding added."""
+        assert self.directly_add_no_mem_embed
+        B, H, W, D = vision_feat.shape
+        return (vision_feat + self.interactivity_no_mem_embed).reshape(B, H * W, D)
+
+    def _apply_no_obj_ptr(self, obj_ptr: mx.array, is_obj_appearing: mx.array):
+        """Blend the learned no-object pointer into absent objects' pointers."""
+        if not (self.pred_obj_scores and self.use_no_obj_ptr):
+            return obj_ptr
+        lam = is_obj_appearing.astype(mx.float32)
+        if self.use_linear_no_obj_ptr:
+            return lam * obj_ptr + (1 - lam) * self.no_obj_ptr_linear(obj_ptr)
+        return lam * obj_ptr if self.fixed_no_obj_ptr else obj_ptr
+
+    def _forward_sam_heads(
+        self,
+        backbone_features: mx.array,
+        *,
+        point_inputs: Optional[dict] = None,
+        mask_inputs: Optional[mx.array] = None,
+        interactive_high_res_features: Optional[List[mx.array]] = None,
+        propagation_high_res_features: Optional[List[mx.array]] = None,
+        multimask_output: bool = False,
+        multiplex_state: MultiplexState,
+    ) -> dict:
+        """Forward the SAM prompt encoder + mask heads (interactive and/or
+        multiplexed propagation path).
+
+        Args:
+            backbone_features: (B, HW, D) image features for the decoder
+            point_inputs: point_coords (N, P, 2) absolute pixels, point_labels
+                (N, P) with 1=positive, 0=negative, -1=padding
+            mask_inputs: (N, 1, H_im, W_im) mask prompt
+            multimask_output: output multiple candidate masks + IoU estimates
+        Returns:
+            dict with low/high-res (multi)masks, ious, object_score_logits
+            (all (N, ...)) and obj_ptr (N, C)
+        """
+        is_interactive = point_inputs is not None or mask_inputs is not None
+
+        if is_interactive:
+            # Image-level, per-object interactive path
+            assert interactive_high_res_features is not None
+
+            if point_inputs is not None:
+                sam_point_coords = point_inputs["point_coords"]
+                sam_point_labels = point_inputs["point_labels"]
+            else:
+                # Pad with an empty point (label -1) when only masks are given
+                sam_point_coords = mx.zeros((mask_inputs.shape[0], 1, 2))
+                sam_point_labels = -mx.ones((mask_inputs.shape[0], 1), mx.int32)
+
+            sam_mask_prompt = None
+            if mask_inputs is not None:
+                assert mask_inputs.ndim == 4
+                # Downsize into the prompt encoder's mask input size (4x72=288)
+                mask_size = (
+                    4 * self.interactive_sam_prompt_encoder.image_embedding_size[0]
+                )
+                sam_mask_prompt = _resize_masks(
+                    mask_inputs, mask_size, mask_size, antialias=True
+                )
+
+            # The prompt encoder pads with a not-a-point token when no boxes
+            # are given (boxes are never used in the tracker)
+            pad_coord = mx.zeros((sam_point_coords.shape[0], 1, 2))
+            pad_label = -mx.ones((sam_point_labels.shape[0], 1), mx.int32)
+            sam_point_coords = mx.concatenate([sam_point_coords, pad_coord], axis=1)
+            sam_point_labels = mx.concatenate([sam_point_labels, pad_label], axis=1)
+
+            # The MLX prompt encoder expects coords in embedding-grid units
+            grid_scale = (
+                self.interactive_sam_prompt_encoder.image_embedding_size[0]
+                / self.config.image_size
+            )
+            sparse_embeddings, dense_embeddings = self.interactive_sam_prompt_encoder(
+                points=(sam_point_coords * grid_scale, sam_point_labels),
+                masks=(
+                    None
+                    if sam_mask_prompt is None
+                    else sam_mask_prompt.transpose(0, 2, 3, 1)
+                ),
+            )
+
+            out = self.interactive_sam_mask_decoder(
+                image_embeddings=backbone_features,
+                image_pe=self.interactive_sam_prompt_encoder.get_dense_pe(),
+                multimask_output=multimask_output,
+                high_res_features=interactive_high_res_features,
+                sparse_prompt_embeddings=sparse_embeddings,
+                dense_prompt_embeddings=dense_embeddings,
+            )
+            # Squeeze the singleton multiplex dim of the interactive decoder
+            low_res_multimasks = out["masks"][:, 0]  # (N, K, h, w)
+            ious = out["iou_pred"][:, 0]  # (N, K)
+            sam_output_tokens = out["sam_tokens_out"][:, 0]  # (N, K', C)
+            object_score_logits = out["object_score_logits"][:, 0]  # (N, 1)
+
         else:
-            image_pe = mx.broadcast_to(image_pe, (B, H * W, D))
+            # Multiplexed propagation path
+            assert propagation_high_res_features is not None
 
-        # Encode prompts
-        sparse_emb, dense_emb = self.interactive_sam_prompt_encoder(
-            points=prompt_points,
-            boxes=prompt_boxes,
-            masks=prompt_masks,
-        )
+            output_merged_embed = None
+            if self.add_output_suppression_embeddings:
+                # Inform the mask decoder which slots hold valid objects
+                valid_f = multiplex_state.get_valid_object_mask().astype(mx.float32)
+                valid_f = valid_f[..., None]
+                output_merged_embed = (
+                    valid_f * self.output_valid_embed[None]
+                    + (1 - valid_f) * self.output_invalid_embed[None]
+                )
 
-        # Predict masks
-        masks, iou_pred, sam_tokens, obj_score = self.sam_mask_decoder(
-            image_embeddings=src,
-            image_pe=image_pe,
-            sparse_prompt_embeddings=sparse_emb,
-            dense_prompt_embeddings=dense_emb,
-            multimask_output=multimask_output,
-            high_res_features=high_res_features,
-        )
+            out = self.sam_mask_decoder(
+                image_embeddings=backbone_features,
+                image_pe=self.get_propagation_dense_pe(),
+                multimask_output=multimask_output,
+                high_res_features=propagation_high_res_features,
+                extra_per_object_embeddings=output_merged_embed,
+            )
+            low_res_multimasks = multiplex_state.demux(out["masks"])
+            ious = multiplex_state.demux(out["iou_pred"])
+            object_score_logits = multiplex_state.demux(out["object_score_logits"])
+            sam_output_tokens = multiplex_state.demux(out["sam_tokens_out"])
 
-        # Object pointer
-        obj_ptr = self.obj_ptr_proj(sam_tokens[:, 0])
+        # The interactive and propagation paths converge here
+        if self.pred_obj_scores:
+            is_obj_appearing = object_score_logits > self.object_score_logit_threshold
+            # Hard choice between obj and no-obj for the spatial memories
+            low_res_multimasks = mx.where(
+                is_obj_appearing[:, None, None],
+                low_res_multimasks,
+                NO_OBJ_SCORE,
+            )
 
-        # Simplified: return first multiplex slot for single-object tracking
-        if masks.ndim == 5:
-            masks = masks[:, 0]  # (B, num_masks, H, W)
-            iou_pred = iou_pred[:, 0]
-            obj_score = obj_score[:, 0]
+        image_size = self.config.image_size
+        high_res_multimasks = _resize_masks(low_res_multimasks, image_size, image_size)
+
+        sam_output_token = sam_output_tokens[:, 0]
+        if multimask_output:
+            # Take the best mask prediction (highest estimated IoU)
+            best_iou_inds = mx.argmax(ious, axis=-1)  # (N,)
+            low_res_masks = mx.take_along_axis(
+                low_res_multimasks, best_iou_inds[:, None, None, None], axis=1
+            )
+            high_res_masks = mx.take_along_axis(
+                high_res_multimasks, best_iou_inds[:, None, None, None], axis=1
+            )
+            if sam_output_tokens.shape[1] > 1:
+                sam_output_token = mx.take_along_axis(
+                    sam_output_tokens, best_iou_inds[:, None, None], axis=1
+                )[:, 0]
+        else:
+            low_res_masks = low_res_multimasks[:, 0:1]
+            high_res_masks = high_res_multimasks[:, 0:1]
+
+        # Object pointer from the SAM output token
+        proj = self.interactive_obj_ptr_proj if is_interactive else self.obj_ptr_proj
+        obj_ptr = proj(sam_output_token)
+        if self.pred_obj_scores:
+            obj_ptr = self._apply_no_obj_ptr(obj_ptr, is_obj_appearing)
 
         return {
-            "pred_masks": masks,
-            "iou_scores": iou_pred,
-            "obj_scores": obj_score,
-            "object_pointer": obj_ptr,
+            "low_res_multimasks": low_res_multimasks,
+            "high_res_multimasks": high_res_multimasks,
+            "ious": ious,
+            "low_res_masks": low_res_masks,
+            "high_res_masks": high_res_masks,
+            "object_score_logits": object_score_logits,
+            "obj_ptr": obj_ptr,  # (N, C), in data space
         }
+
+    def _use_mask_as_output(
+        self,
+        backbone_features: mx.array,
+        high_res_features: List[mx.array],
+        mask_inputs: mx.array,
+        multiplex_state: MultiplexState,
+    ) -> dict:
+        """Turn binary `mask_inputs` directly into output mask logits (no SAM)."""
+        # -10/+10 logits for neg/pos pixels (~0/1 after sigmoid)
+        out_scale, out_bias = 20.0, -10.0
+        mask_inputs_float = mask_inputs.astype(mx.float32)
+        high_res_masks = mask_inputs_float * out_scale + out_bias
+        h, w = high_res_masks.shape[-2:]
+        low_res_masks = _resize_masks(high_res_masks, h // 4, w // 4, antialias=True)
+
+        # Produce an object pointer using the SAM decoder from the mask input
+        mask_prompt = self.interactive_mask_downsample(
+            mask_inputs_float.transpose(0, 2, 3, 1)
+        ).transpose(0, 3, 1, 2)
+        sam_outputs = self._forward_sam_heads(
+            backbone_features=backbone_features,
+            mask_inputs=mask_prompt,
+            interactive_high_res_features=high_res_features,
+            multiplex_state=multiplex_state,
+        )
+
+        # The mask input itself decides if the object appears
+        is_obj_appearing = (
+            (mask_inputs.reshape(mask_inputs.shape[0], -1) > 0.0)
+            .any(axis=1)[:, None]
+            .astype(mx.float32)
+        )
+        obj_ptr = self._apply_no_obj_ptr(sam_outputs["obj_ptr"], is_obj_appearing)
+
+        return {
+            "low_res_multimasks": low_res_masks,
+            "high_res_multimasks": high_res_masks,
+            # A dummy IoU prediction of all 1's under mask input
+            "ious": mx.ones((mask_inputs.shape[0], 1)),
+            "low_res_masks": low_res_masks,
+            "high_res_masks": high_res_masks,
+            "object_score_logits": out_scale * is_obj_appearing + out_bias,
+            "obj_ptr": obj_ptr,
+        }
+
+    # ------------------------------------------------------------------
+    # Memory conditioning / encoding
+    # ------------------------------------------------------------------
+
+    def _get_tpos_enc(self, rel_pos_list: List[int], max_abs_pos: int) -> mx.array:
+        """Temporal positional encoding for object pointers."""
+        pos = mx.array(rel_pos_list, dtype=mx.float32) / (max_abs_pos - 1)
+        pos_enc = get_1d_sine_pe(pos, dim=self.hidden_dim)
+        return self.temporal_positional_encoding_projection_layer(pos_enc)
+
+    def _prepare_memory_conditioned_features(
+        self,
+        *,
+        frame_idx: int,
+        current_vision_feat: mx.array,
+        current_vision_pos: mx.array,
+        output_dict: dict,
+        num_frames: int,
+        multiplex_state: MultiplexState,
+        track_in_reverse: bool = False,
+    ) -> mx.array:
+        """Fuse current (1, H, W, C) features/pos encs with past memories.
+
+        Returns (B=num_buckets, H, W, C) memory-conditioned features.
+        """
+        B = multiplex_state.num_buckets
+        _, H, W, C = current_vision_feat.shape
+        HW = H * W
+        vision_feat = mx.broadcast_to(current_vision_feat.reshape(1, HW, C), (B, HW, C))
+        src_pos = mx.broadcast_to(current_vision_pos.reshape(1, HW, C), (B, HW, C))
+
+        # Gather spatial mask memories, their pos encs, and image features
+        to_cat_prompt, to_cat_prompt_pos = [], []
+        to_cat_image, to_cat_image_pos = [], []
+
+        selected_cond, unselected_cond = select_closest_cond_frames(
+            frame_idx,
+            output_dict["cond_frame_outputs"],
+            self.max_cond_frames_in_attn,
+        )
+
+        tpos_sign_mul = -1 if track_in_reverse else 1
+        t_pos_and_prevs = [
+            ((frame_idx - t) * tpos_sign_mul, out, True)
+            for t, out in selected_cond.items()
+        ]
+
+        # Last (num_maskmem - 1) frames as non-conditioning memory
+        r = self.memory_temporal_stride_for_eval
+        for t_pos in range(1, self.num_maskmem):
+            t_rel = self.num_maskmem - t_pos
+            if t_rel == 1:
+                # the frame immediately before/after this frame
+                prev_frame_idx = (
+                    frame_idx - t_rel if not track_in_reverse else frame_idx + t_rel
+                )
+            elif not track_in_reverse:
+                prev_frame_idx = ((frame_idx - 2) // r) * r - (t_rel - 2) * r
+            else:
+                prev_frame_idx = -(-(frame_idx + 2) // r) * r + (t_rel - 2) * r
+            out = output_dict["non_cond_frame_outputs"].get(prev_frame_idx)
+            if out is None:
+                out = unselected_cond.get(prev_frame_idx)
+            t_pos_and_prevs.append((t_pos, out, False))
+
+        for t_pos, prev, is_cond in t_pos_and_prevs:
+            if prev is None or prev.get("maskmem_features") is None:
+                continue
+            to_cat_prompt.append(prev["maskmem_features"].reshape(B, HW, C))
+            mem_pos = prev["maskmem_pos_enc"].reshape(B, HW, C)
+
+            if self.use_maskmem_tpos_v2:
+                # out-of-range t_pos maps to the last ("out-of-range") slot
+                t_idx = (
+                    self.num_maskmem - t_pos - 1
+                    if 0 < t_pos < self.num_maskmem
+                    else self.num_maskmem - 1
+                )
+            else:
+                t_idx = self.num_maskmem - (0 if is_cond else t_pos) - 1
+            tpos = self.memory_temporal_positional_encoding[t_idx]
+            to_cat_prompt_pos.append(mem_pos + tpos.reshape(1, 1, C))
+
+            if self.save_image_features:
+                to_cat_image.append(prev["image_features"].reshape(1, HW, C))
+                to_cat_image_pos.append(
+                    prev["image_pos_enc"].reshape(1, HW, C) + tpos.reshape(1, 1, C)
+                )
+
+        # Object pointers from past frames
+        num_obj_ptr_tokens = 0
+        if self.use_obj_ptrs_in_encoder:
+            max_obj_ptrs = min(num_frames, self.max_obj_ptrs_in_encoder)
+            pos_and_outs = [
+                (abs(frame_idx - t), out) for t, out in selected_cond.items()
+            ]
+            for t_diff in range(1, max_obj_ptrs):
+                t = frame_idx + t_diff if track_in_reverse else frame_idx - t_diff
+                if t < 0 or t >= num_frames:
+                    break
+                out = output_dict["non_cond_frame_outputs"].get(
+                    t, unselected_cond.get(t)
+                )
+                if out is not None:
+                    pos_and_outs.append((t_diff, out))
+
+            filtered = [(p, o) for p, o in pos_and_outs if "obj_ptr" in o]
+            if filtered:
+                pos_list, out_list = zip(*filtered)
+                # muxed ptrs per frame: (B, M, C) -> (B, T*M, C)
+                obj_ptrs = mx.concatenate([out["obj_ptr"] for out in out_list], axis=1)
+                obj_pos = self._get_tpos_enc(
+                    list(pos_list), max_abs_pos=max_obj_ptrs
+                )  # (T, C)
+                # Each frame contributes multiplex_count pointers
+                obj_pos = mx.repeat(obj_pos, self.multiplex_count, axis=0)
+                obj_pos = mx.broadcast_to(obj_pos[None], (B, *obj_pos.shape))
+
+                to_cat_prompt.append(obj_ptrs)
+                to_cat_prompt_pos.append(obj_pos)
+                num_obj_ptr_tokens = obj_ptrs.shape[1]
+
+        if not to_cat_prompt:
+            # No available memories; propagate from current features only
+            return vision_feat.reshape(B, H, W, C)
+
+        memory = mx.concatenate(to_cat_prompt, axis=1)
+        memory_pos = mx.concatenate(to_cat_prompt_pos, axis=1)
+
+        if self.save_image_features:
+            if not to_cat_image:
+                return vision_feat.reshape(B, H, W, C)
+            memory_image = mx.concatenate(to_cat_image, axis=1)
+            memory_image_pos = mx.concatenate(to_cat_image_pos, axis=1)
+        else:
+            memory_image, memory_image_pos = memory, memory_pos
+
+        pix_feat_with_mem = self.memory_attention(
+            image=current_vision_feat.reshape(1, HW, C),
+            src=vision_feat,
+            memory_image=memory_image,
+            memory=memory,
+            src_pos=src_pos,
+            memory_pos=memory_pos,
+            memory_image_pos=memory_image_pos,
+            num_k_exclude_rope=num_obj_ptr_tokens,
+        )
+        return pix_feat_with_mem.reshape(B, H, W, C)
+
+    def _encode_new_memory(
+        self,
+        *,
+        current_vision_feat: mx.array,
+        pred_masks_high_res: mx.array,
+        object_score_logits: mx.array,
+        conditioning_objects,
+        multiplex_state: MultiplexState,
+    ) -> Tuple[mx.array, mx.array]:
+        """Encode the current frame's predictions into a memory feature.
+
+        pred_masks_high_res: (N, 1, H_im, W_im); object_score_logits: (N, 1).
+        Returns (maskmem_features, maskmem_pos_enc), each (B, H, W, C).
+        """
+        mask_for_mem = pred_masks_high_res
+        if self.apply_sigmoid_to_mask_logits_for_mem_enc:
+            mask_for_mem = (
+                mx.sigmoid(pred_masks_high_res) * self.sigmoid_scale_for_mem_enc
+                + self.sigmoid_bias_for_mem_enc
+            )
+
+        # (the reference also computes unconditioned objects here, only used by
+        # the object-conditional embeddings that SAM 3.1 disables)
+        conditioning_objects = sorted(conditioning_objects or ())
+
+        # (N, 1, H, W) -> mux -> (B, M, H, W)
+        mux_mask = multiplex_state.mux(mask_for_mem[:, 0])
+
+        if self.condition_as_mask_input:
+            # Extra per-object channel marking conditioning objects
+            cond_values = mx.full(
+                (mask_for_mem.shape[0],), self.condition_as_mask_input_bg, mx.float32
+            )
+            if conditioning_objects:
+                cond_values[conditioning_objects] = self.condition_as_mask_input_fg
+            embedded = mx.broadcast_to(
+                cond_values[:, None, None], mask_for_mem[:, 0].shape
+            )
+            mux_mask = mx.concatenate([mux_mask, multiplex_state.mux(embedded)], axis=1)
+
+        # (B, 2M, H, W) -> (B, H, W, 2M) channel-last for the convs
+        mux_mask = mux_mask.transpose(0, 2, 3, 1)
+        maskmem_features, maskmem_pos_enc = self.memory_encoder(
+            current_vision_feat, mux_mask
+        )
+
+        # Add a projected embedding for each empty object slot
+        obj_logits = object_score_logits
+        num_missing = multiplex_state.total_valid_entries - obj_logits.shape[0]
+        if num_missing > 0:
+            pad = mx.zeros((num_missing, *obj_logits.shape[1:]))
+            obj_logits = mx.concatenate([obj_logits, pad], axis=0)
+        elif num_missing < 0:
+            obj_logits = obj_logits[: multiplex_state.total_valid_entries]
+        appearing = multiplex_state.mux(obj_logits)
+        is_obj_appearing = (appearing > self.object_score_logit_threshold).astype(
+            mx.float32
+        )  # (B, M, 1)
+        no_obj_embed = ((1 - is_obj_appearing) * self.no_obj_embed_spatial[None]).sum(
+            axis=1
+        )  # (B, C)
+        maskmem_features = maskmem_features + no_obj_embed[:, None, None, :]
+
+        return maskmem_features, maskmem_pos_enc
+
+    # ------------------------------------------------------------------
+    # Track step
+    # ------------------------------------------------------------------
+
+    def _use_multimask(self, is_init_cond_frame: bool, point_inputs) -> bool:
+        """Whether to use multimask output in the SAM head."""
+        num_pts = 0 if point_inputs is None else point_inputs["point_labels"].shape[1]
+        return (
+            self.multimask_output_in_sam
+            and (is_init_cond_frame or self.multimask_output_for_tracking)
+            and (self.multimask_min_pt_num <= num_pts <= self.multimask_max_pt_num)
+            and self.num_multimask_outputs > 0
+        )
+
+    def track_step(
+        self,
+        state: MultiplexTrackerState,
+        *,
+        frame_idx: int,
+        is_init_cond_frame: bool,
+        frame_features: dict,
+        point_inputs: Optional[dict] = None,
+        mask_inputs: Optional[mx.array] = None,
+        num_frames: Optional[int] = None,
+        track_in_reverse: bool = False,
+        run_mem_encoder: bool = True,
+        prev_sam_mask_logits: Optional[mx.array] = None,
+        objects_to_interact: Optional[List[int]] = None,
+        new_object_masks: Optional[mx.array] = None,
+        new_object_idxs: Optional[List[int]] = None,
+        new_object_ids: Optional[List[int]] = None,
+        are_new_masks_from_pts: bool = False,
+    ) -> dict:
+        """Run one tracking step on a frame.
+
+        Four modes, selected from the inputs: mask-as-output (mask_inputs
+        given), propagation-only (no prompts), interaction-only (points on a
+        conditioning frame, or refinement with prev_sam_mask_logits), and
+        propagation-and-interaction (points on a non-conditioning frame).
+
+        Args:
+            frame_features: dict from prepare_frame_features
+            num_frames: total video length (for object-pointer range limiting)
+        Returns:
+            the frame's StageOutput dict (also stored into `state`)
+        """
+        if num_frames is None:
+            num_frames = frame_idx + 1
+
+        current_out, aux_out = self._track_step_aux(
+            state,
+            frame_idx=frame_idx,
+            is_init_cond_frame=is_init_cond_frame,
+            frame_features=frame_features,
+            point_inputs=point_inputs,
+            mask_inputs=mask_inputs,
+            num_frames=num_frames,
+            track_in_reverse=track_in_reverse,
+            run_mem_encoder=(run_mem_encoder and new_object_masks is None),
+            prev_sam_mask_logits=prev_sam_mask_logits,
+            objects_to_interact=objects_to_interact,
+            need_aux_output=(new_object_masks is not None),
+        )
+
+        if new_object_masks is not None:
+            assert new_object_idxs is not None
+            self.add_new_masks_to_existing_state(
+                interactive_pix_feat=aux_out["interactive_pix_feat"],
+                interactive_high_res_features=aux_out["interactive_high_res_features"],
+                propagation_vision_feat=aux_out["propagation_vision_feat"],
+                new_masks=new_object_masks,
+                obj_idxs_in_mask=new_object_idxs,
+                obj_ids_in_mask=new_object_ids,
+                prev_output=current_out,
+                state=state,
+                add_mask_to_memory=run_mem_encoder,
+                are_masks_from_pts=are_new_masks_from_pts,
+            )
+
+        if is_init_cond_frame:
+            state.cond_frame_outputs[frame_idx] = current_out
+        else:
+            state.non_cond_frame_outputs[frame_idx] = current_out
+
+        # Prune stale non-conditioning outputs that can no longer be
+        # referenced by the memory attention (bounds session memory)
+        max_lookback = max(
+            self.max_obj_ptrs_in_encoder,
+            2 + (self.num_maskmem - 2) * self.memory_temporal_stride_for_eval,
+        )
+        cutoff = frame_idx - max_lookback
+        for t in [t for t in state.non_cond_frame_outputs if t < cutoff]:
+            del state.non_cond_frame_outputs[t]
+
+        return current_out
+
+    def _track_step_aux(
+        self,
+        state: MultiplexTrackerState,
+        *,
+        frame_idx: int,
+        is_init_cond_frame: bool,
+        frame_features: dict,
+        point_inputs: Optional[dict],
+        mask_inputs: Optional[mx.array],
+        num_frames: int,
+        track_in_reverse: bool,
+        run_mem_encoder: bool,
+        prev_sam_mask_logits: Optional[mx.array],
+        objects_to_interact: Optional[List[int]],
+        need_aux_output: bool,
+    ) -> Tuple[dict, dict]:
+        multiplex_state = state.multiplex_state
+        interactive = frame_features.get("interactive")
+        propagation = frame_features.get("propagation")
+
+        current_out = {
+            "conditioning_objects": set(),
+            "point_inputs": point_inputs,
+            "mask_inputs": mask_inputs,
+        }
+
+        # Determine the tracking mode
+        if mask_inputs is not None:
+            mode = "mask_as_output"
+        elif point_inputs is None:
+            mode = "propagation_only"
+        elif prev_sam_mask_logits is not None or is_init_cond_frame:
+            mode = "interaction_only"
+        elif objects_to_interact is not None:
+            mode = "propagation_and_interaction"
+        else:
+            raise ValueError(
+                "Unable to determine tracking mode: "
+                f"mask_inputs={mask_inputs is not None}, "
+                f"point_inputs={point_inputs is not None}, "
+                f"prev_sam_mask_logits={prev_sam_mask_logits is not None}, "
+                f"{objects_to_interact=}, {is_init_cond_frame=}"
+            )
+
+        if mode in ("interaction_only", "propagation_and_interaction"):
+            assert interactive is not None
+        if mode in ("propagation_only", "propagation_and_interaction"):
+            assert propagation is not None
+
+        interactive_pix_feat = None
+        if mode == "mask_as_output":
+            assert self.use_mask_input_as_output_without_sam
+            assert interactive is not None
+            interactive_pix_feat = self._get_interactive_pix_mem(
+                interactive["vision_feat"]
+            )
+            sam_outputs = self._use_mask_as_output(
+                backbone_features=interactive_pix_feat,
+                high_res_features=interactive["high_res"],
+                mask_inputs=mask_inputs,
+                multiplex_state=multiplex_state,
+            )
+            current_out["conditioning_objects"].update(range(mask_inputs.shape[0]))
+        else:
+            propagation_out = None
+            if mode in ("propagation_only", "propagation_and_interaction"):
+                pix_feat_with_mem = self._prepare_memory_conditioned_features(
+                    frame_idx=frame_idx,
+                    current_vision_feat=propagation["vision_feat"],
+                    current_vision_pos=propagation["vision_pos"],
+                    output_dict=state.output_dict,
+                    num_frames=num_frames,
+                    multiplex_state=multiplex_state,
+                    track_in_reverse=track_in_reverse,
+                )
+                B, H, W, C = pix_feat_with_mem.shape
+                multimask_output = self._use_multimask(is_init_cond_frame, None)
+                propagation_out = self._forward_sam_heads(
+                    backbone_features=pix_feat_with_mem.reshape(B, H * W, C),
+                    propagation_high_res_features=propagation["high_res"],
+                    multimask_output=multimask_output,
+                    multiplex_state=multiplex_state,
+                )
+
+            interaction_out = None
+            if mode in ("interaction_only", "propagation_and_interaction"):
+                interactive_pix_feat = self._get_interactive_pix_mem(
+                    interactive["vision_feat"]
+                )
+                assert mask_inputs is None and point_inputs is not None
+                if prev_sam_mask_logits is not None:
+                    assert objects_to_interact is not None
+                    assert mode != "propagation_and_interaction"
+                    mask_inputs = prev_sam_mask_logits[objects_to_interact]
+                elif mode == "propagation_and_interaction":
+                    # Use the propagated masks as mask input
+                    mask_inputs = propagation_out["low_res_masks"][objects_to_interact]
+
+                if objects_to_interact is not None:
+                    assert (
+                        point_inputs["point_coords"].shape[0]
+                        == point_inputs["point_labels"].shape[0]
+                        == len(objects_to_interact)
+                    )
+
+                multimask_output = self._use_multimask(
+                    is_init_cond_frame, point_inputs
+                )
+                interaction_out = self._forward_sam_heads(
+                    backbone_features=interactive_pix_feat,
+                    point_inputs=point_inputs,
+                    mask_inputs=mask_inputs,
+                    interactive_high_res_features=interactive["high_res"],
+                    multimask_output=multimask_output,
+                    multiplex_state=multiplex_state,
+                )
+                current_out["conditioning_objects"].update(
+                    objects_to_interact
+                    if objects_to_interact is not None
+                    else multiplex_state.get_all_valid_object_idx()
+                )
+
+            if propagation_out is None:
+                sam_outputs = interaction_out
+            elif interaction_out is None:
+                sam_outputs = propagation_out
+            else:
+                # Merge: replace the interacted objects in the propagated output
+                for k in (
+                    "low_res_multimasks",
+                    "high_res_multimasks",
+                    "low_res_masks",
+                    "high_res_masks",
+                    "ious",
+                    "object_score_logits",
+                    "obj_ptr",
+                ):
+                    propagation_out[k][objects_to_interact] = interaction_out[k]
+                sam_outputs = propagation_out
+
+        current_out["pred_masks"] = sam_outputs["low_res_masks"]
+        current_out["pred_masks_high_res"] = sam_outputs["high_res_masks"]
+        current_out["object_score_logits"] = sam_outputs["object_score_logits"]
+        if self.use_obj_ptrs_in_encoder:
+            # Object pointers are stored in the multiplex space
+            current_out["obj_ptr"] = multiplex_state.mux(sam_outputs["obj_ptr"])
+
+        # Encode the predicted masks into a new memory for future frames
+        if run_mem_encoder and self.num_maskmem > 0:
+            features, pos_enc = self._encode_new_memory(
+                current_vision_feat=propagation["vision_feat"],
+                pred_masks_high_res=current_out["pred_masks_high_res"],
+                object_score_logits=current_out["object_score_logits"],
+                conditioning_objects=current_out["conditioning_objects"],
+                multiplex_state=multiplex_state,
+            )
+            current_out["maskmem_features"] = features
+            current_out["maskmem_pos_enc"] = pos_enc
+
+        if self.save_image_features:
+            current_out["image_features"] = propagation["vision_feat"]
+            current_out["image_pos_enc"] = propagation["vision_pos"]
+
+        aux_output = {}
+        if need_aux_output:
+            if interactive_pix_feat is None:
+                interactive_pix_feat = self._get_interactive_pix_mem(
+                    interactive["vision_feat"]
+                )
+            aux_output["interactive_pix_feat"] = interactive_pix_feat
+            aux_output["interactive_high_res_features"] = interactive["high_res"]
+            aux_output["propagation_vision_feat"] = (
+                propagation["vision_feat"] if propagation is not None else None
+            )
+
+        return current_out, aux_output
+
+    # ------------------------------------------------------------------
+    # Dynamic object management
+    # ------------------------------------------------------------------
+
+    def _merge_mask_output(
+        self,
+        prev_output: dict,
+        mask_output: dict,
+        multiplex_state: MultiplexState,
+        *,
+        conditioned: List[int],
+        obj_idxs: Optional[List[int]] = None,
+        existing_pointers: Optional[mx.array] = None,
+    ):
+        """Merge mask-encoded objects into `prev_output` (in place).
+
+        Appends the new rows, or replaces the `obj_idxs` rows when given
+        (reconditioning); `conditioned` objects condition on this frame.
+        """
+        h, w = prev_output["pred_masks"].shape[-2:]
+        new_values = (
+            _resize_masks(mask_output["low_res_masks"], h, w, antialias=True),
+            mask_output["high_res_masks"],
+            mask_output["object_score_logits"],
+        )
+        for key, val in zip(
+            ("pred_masks", "pred_masks_high_res", "object_score_logits"), new_values
+        ):
+            if key not in prev_output:
+                continue
+            if obj_idxs is None:
+                prev_output[key] = mx.concatenate([prev_output[key], val], axis=0)
+            else:
+                prev_output[key][obj_idxs] = val
+
+        if self.use_obj_ptrs_in_encoder:
+            if obj_idxs is None:
+                pointers = mx.concatenate(
+                    [existing_pointers, mask_output["obj_ptr"]], axis=0
+                )
+            else:
+                pointers = multiplex_state.demux(prev_output["obj_ptr"])
+                pointers[obj_idxs] = mask_output["obj_ptr"]
+            prev_output["obj_ptr"] = multiplex_state.mux(pointers)
+
+        prev_output["conditioning_objects"].update(conditioned)
+
+    def _reencode_memory(
+        self,
+        prev_output: dict,
+        propagation_vision_feat: Optional[mx.array],
+        multiplex_state: MultiplexState,
+    ):
+        """Re-encode the spatial memory from the merged predictions."""
+        features, pos_enc = self._encode_new_memory(
+            current_vision_feat=propagation_vision_feat,
+            pred_masks_high_res=prev_output["pred_masks_high_res"],
+            object_score_logits=prev_output["object_score_logits"],
+            conditioning_objects=prev_output["conditioning_objects"],
+            multiplex_state=multiplex_state,
+        )
+        prev_output["maskmem_features"] = features
+        prev_output["maskmem_pos_enc"] = pos_enc
+
+    def add_new_masks_to_existing_state(
+        self,
+        *,
+        interactive_pix_feat: mx.array,
+        interactive_high_res_features: List[mx.array],
+        propagation_vision_feat: Optional[mx.array],
+        new_masks: mx.array,
+        obj_idxs_in_mask: List[int],
+        obj_ids_in_mask: Optional[List[int]],
+        prev_output: dict,
+        state: MultiplexTrackerState,
+        add_mask_to_memory: bool = True,
+        are_masks_from_pts: bool = False,
+        allow_new_buckets: bool = False,
+        prefer_new_buckets: bool = False,
+    ):
+        """Append new objects to an existing output/multiplex state (in-place)."""
+        assert self.use_mask_input_as_output_without_sam
+        multiplex_state = state.multiplex_state
+        num_new_objects = new_masks.shape[0]
+        assert num_new_objects == len(obj_idxs_in_mask)
+
+        existing_pointers = multiplex_state.demux(prev_output["obj_ptr"])
+
+        # Step 1: extend the multiplex state
+        new_object_idx = multiplex_state.find_next_batch_of_available_indices(
+            num_objects=num_new_objects,
+            allow_new_buckets=allow_new_buckets,
+            prefer_new_buckets=prefer_new_buckets,
+        )
+        multiplex_state.add_objects(
+            object_indices=new_object_idx,
+            object_ids=obj_ids_in_mask,
+            allow_new_buckets=allow_new_buckets,
+            prefer_new_buckets=prefer_new_buckets,
+        )
+
+        # Step 2: encode the incoming masks
+        mask_output = self._use_mask_as_output(
+            backbone_features=interactive_pix_feat,
+            high_res_features=interactive_high_res_features,
+            mask_inputs=new_masks,
+            multiplex_state=multiplex_state,
+        )
+
+        # Step 3: match the high-res resolutions, then append the new objects
+        if "pred_masks_high_res" in prev_output:
+            res = mask_output["high_res_masks"].shape[-1]
+            prev_output["pred_masks_high_res"] = _resize_masks(
+                prev_output["pred_masks_high_res"], res, res
+            )
+        self._merge_mask_output(
+            prev_output,
+            mask_output,
+            multiplex_state,
+            conditioned=new_object_idx,
+            existing_pointers=existing_pointers,
+        )
+
+        # Step 4: re-encode the spatial memory
+        if add_mask_to_memory:
+            assert (
+                prev_output["pred_masks_high_res"].shape[0]
+                == multiplex_state.total_valid_entries
+            )
+            self._reencode_memory(
+                prev_output, propagation_vision_feat, multiplex_state
+            )
+
+    def recondition_masks_in_existing_state(
+        self,
+        *,
+        interactive_pix_feat: mx.array,
+        interactive_high_res_features: List[mx.array],
+        propagation_vision_feat: Optional[mx.array],
+        new_masks: mx.array,
+        obj_idxs_in_mask: List[int],
+        obj_ids_in_mask: Optional[List[int]],
+        prev_output: dict,
+        state: MultiplexTrackerState,
+        add_mask_to_memory: bool = True,
+    ):
+        """Recondition existing objects with new masks (in-place)."""
+        assert self.use_mask_input_as_output_without_sam
+        multiplex_state = state.multiplex_state
+        assert new_masks.shape[0] == len(obj_idxs_in_mask)
+
+        # Step 1: encode the incoming masks
+        mask_output = self._use_mask_as_output(
+            backbone_features=interactive_pix_feat,
+            high_res_features=interactive_high_res_features,
+            mask_inputs=new_masks,
+            multiplex_state=multiplex_state,
+        )
+
+        # Step 2: replace the reconditioned objects in the existing state
+        self._merge_mask_output(
+            prev_output,
+            mask_output,
+            multiplex_state,
+            conditioned=obj_idxs_in_mask,
+            obj_idxs=obj_idxs_in_mask,
+        )
+
+        # Step 3: re-encode the spatial memory
+        if add_mask_to_memory:
+            self._reencode_memory(
+                prev_output, propagation_vision_feat, multiplex_state
+            )
+
+    # ------------------------------------------------------------------
+    # Convenience session API
+    # ------------------------------------------------------------------
+
+    def add_mask_prompt(
+        self,
+        state: MultiplexTrackerState,
+        frame_idx: int,
+        frame_features: dict,
+        masks: mx.array,
+        object_ids: Optional[List[int]] = None,
+    ) -> dict:
+        """Initialize (or extend) a session with mask prompts on a frame.
+
+        masks: (N, H_im, W_im) binary/float masks at image resolution.
+        Returns the frame's output dict.
+        """
+        if masks.ndim == 3:
+            masks = masks[:, None]
+
+        prev_output = state.cond_frame_outputs.get(
+            frame_idx, state.non_cond_frame_outputs.get(frame_idx)
+        )
+        if prev_output is None:
+            # Fresh frame: the masks are the conditioning input (mask-as-output)
+            return self.track_step(
+                state,
+                frame_idx=frame_idx,
+                is_init_cond_frame=True,
+                frame_features=frame_features,
+                mask_inputs=masks,
+                num_frames=frame_idx + 1,
+            )
+
+        # Frame already tracked: merge the masks as new objects
+        new_idxs = state.multiplex_state.find_next_batch_of_available_indices(
+            masks.shape[0], allow_new_buckets=True
+        )
+        self.add_new_masks_to_existing_state(
+            interactive_pix_feat=self._get_interactive_pix_mem(
+                frame_features["interactive"]["vision_feat"]
+            ),
+            interactive_high_res_features=frame_features["interactive"]["high_res"],
+            propagation_vision_feat=frame_features["propagation"]["vision_feat"],
+            new_masks=masks,
+            obj_idxs_in_mask=new_idxs,
+            obj_ids_in_mask=object_ids,
+            prev_output=prev_output,
+            state=state,
+        )
+        return prev_output
+
+    def propagate(
+        self,
+        state: MultiplexTrackerState,
+        frame_idx: int,
+        frame_features: dict,
+        num_frames: Optional[int] = None,
+        run_mem_encoder: bool = True,
+    ) -> dict:
+        """Propagate all tracked objects to a new frame.
+
+        Returns the frame's output dict; per-object masks are
+        out["pred_masks"] (N, 1, h, w) and out["pred_masks_high_res"].
+        """
+        return self.track_step(
+            state,
+            frame_idx=frame_idx,
+            is_init_cond_frame=False,
+            frame_features=frame_features,
+            num_frames=num_frames,
+            run_mem_encoder=run_mem_encoder,
+        )

--- a/mlx_vlm/tests/test_models.py
+++ b/mlx_vlm/tests/test_models.py
@@ -10900,6 +10900,216 @@ class TestModels(unittest.TestCase):
         np.testing.assert_allclose(embedded, normalized, rtol=1e-5, atol=1e-7)
 
 
+class TestSam31MultiplexTracker(unittest.TestCase):
+    """SAM 3.1 multiplex video tracker (video_tracking_multiplex port)."""
+
+    def _make_tracker(self):
+        from mlx_vlm.models.sam3_1.config import (
+            PromptEncoderConfig,
+            TrackerConfig,
+            TrackerMaskDecoderConfig,
+        )
+        from mlx_vlm.models.sam3_1.tracker import MultiplexTrackerModel
+
+        config = TrackerConfig(
+            image_size=112,
+            multiplex_count=2,
+            memory_attention_hidden_size=32,
+            memory_attention_num_layers=2,
+            memory_attention_num_attention_heads=2,
+            memory_attention_feed_forward_hidden_size=64,
+            memory_attention_rope_feat_sizes=[8, 8],
+            memory_encoder_hidden_size=32,
+            mask_downsampler_embed_dim=32,
+            mask_downsampler_first_channels=2,
+            mask_downsampler_input_size=128,
+            memory_fuser_embed_dim=32,
+            memory_fuser_intermediate_dim=64,
+            mask_decoder_config=TrackerMaskDecoderConfig(
+                hidden_size=32,
+                num_hidden_layers=2,
+                num_attention_heads=2,
+                mlp_dim=64,
+                multiplex_count=2,
+                multimask_outputs_only=True,
+            ),
+            prompt_encoder_config=PromptEncoderConfig(
+                hidden_size=32, image_size=112, patch_size=14, mask_input_channels=16
+            ),
+        )
+        return MultiplexTrackerModel(config)
+
+    def _fake_frame(self, tracker, seed):
+        mx.random.seed(seed)
+        fpn_i = [
+            mx.random.normal((1, 32, 32, 32)),
+            mx.random.normal((1, 16, 16, 32)),
+            mx.random.normal((1, 8, 8, 32)),
+        ]
+        mx.random.seed(seed + 1)
+        fpn_p = [
+            mx.random.normal((1, 32, 32, 32)),
+            mx.random.normal((1, 16, 16, 32)),
+            mx.random.normal((1, 8, 8, 32)),
+        ]
+        return tracker.prepare_frame_features(fpn_i, fpn_p)
+
+    def test_multiplex_state_mux_demux(self):
+        from mlx_vlm.models.sam3_1.multiplex import MultiplexController
+
+        controller = MultiplexController(multiplex_count=4)
+        state = controller.get_state(7, random=False)
+        self.assertEqual(state.num_buckets, 2)
+        self.assertEqual(state.total_valid_entries, 7)
+
+        x = mx.random.normal((7, 3, 5))
+        muxed = state.mux(x)
+        self.assertEqual(muxed.shape, (2, 4, 3, 5))
+        # padding slot is zero-filled
+        np.testing.assert_array_equal(np.array(muxed[1, 3]), np.zeros((3, 5)))
+        # demux is the exact inverse on valid entries
+        np.testing.assert_array_equal(np.array(state.demux(muxed)), np.array(x))
+
+        valid = np.array(state.get_valid_object_mask())
+        self.assertEqual(valid.sum(), 7)
+
+        # add / remove objects
+        state.add_objects([7], allow_new_buckets=False)
+        self.assertEqual(state.total_valid_entries, 8)
+        state.remove_objects([2])
+        self.assertEqual(state.total_valid_entries, 7)
+
+    def test_multiplex_mask_decoder_shapes(self):
+        from mlx_vlm.models.sam3_1.config import TrackerMaskDecoderConfig
+        from mlx_vlm.models.sam3_1.sam_components import MultiplexMaskDecoder
+
+        # propagation decoder: multimask tokens only, 2 slots per bucket
+        dec = MultiplexMaskDecoder(
+            TrackerMaskDecoderConfig(
+                hidden_size=32,
+                num_hidden_layers=2,
+                num_attention_heads=2,
+                mlp_dim=64,
+                multiplex_count=2,
+                num_multimask_outputs=3,
+                multimask_outputs_only=True,
+            )
+        )
+        image_embeddings = mx.random.normal((2, 64, 32))
+        image_pe = mx.random.normal((1, 64, 32))
+        extra = mx.random.normal((2, 2, 32))
+        out = dec(
+            image_embeddings=image_embeddings,
+            image_pe=image_pe,
+            multimask_output=True,
+            extra_per_object_embeddings=extra,
+        )
+        self.assertEqual(out["masks"].shape, (2, 2, 3, 32, 32))
+        self.assertEqual(out["iou_pred"].shape, (2, 2, 3))
+        self.assertEqual(out["sam_tokens_out"].shape, (2, 2, 3, 32))
+        self.assertEqual(out["object_score_logits"].shape, (2, 2, 1))
+
+        # interactive decoder: one slot, single-mask token + 3 multimask tokens
+        dec_i = MultiplexMaskDecoder(
+            TrackerMaskDecoderConfig(
+                hidden_size=32,
+                num_hidden_layers=2,
+                num_attention_heads=2,
+                mlp_dim=64,
+                multiplex_count=1,
+                num_multimask_outputs=3,
+                multimask_outputs_only=False,
+                dynamic_multimask_via_stability=False,
+            )
+        )
+        out_i = dec_i(
+            image_embeddings=mx.random.normal((1, 64, 32)),
+            image_pe=image_pe,
+            multimask_output=True,
+            sparse_prompt_embeddings=mx.random.normal((3, 2, 32)),
+            dense_prompt_embeddings=mx.random.normal((3, 64, 32)),
+        )
+        self.assertEqual(out_i["masks"].shape, (3, 1, 3, 32, 32))
+        out_i1 = dec_i(
+            image_embeddings=mx.random.normal((1, 64, 32)),
+            image_pe=image_pe,
+            multimask_output=False,
+            sparse_prompt_embeddings=mx.random.normal((3, 2, 32)),
+            dense_prompt_embeddings=mx.random.normal((3, 64, 32)),
+        )
+        self.assertEqual(out_i1["masks"].shape, (3, 1, 1, 32, 32))
+
+    def test_track_step_modes(self):
+        """Mask-as-output init, propagation, interaction, object addition."""
+        tracker = self._make_tracker()
+        state = tracker.init_state(3, object_ids=[10, 11, 12])
+        self.assertEqual(state.multiplex_state.assignments, [[0, 1], [2, -1]])
+
+        # frame 0: mask prompts (mask-as-output)
+        masks = mx.zeros((3, 112, 112))
+        masks[0, 20:60, 20:60] = 1.0
+        masks[1, 40:80, 40:90] = 1.0
+        masks[2, 10:30, 60:100] = 1.0
+        out0 = tracker.add_mask_prompt(state, 0, self._fake_frame(tracker, 0), masks)
+        mx.eval(out0)
+        # mask-as-output: low-res is image_size / 4, high-res is image_size
+        self.assertEqual(out0["pred_masks"].shape, (3, 1, 28, 28))
+        self.assertEqual(out0["pred_masks_high_res"].shape, (3, 1, 112, 112))
+        # mask-as-output passes the input masks through as +-10 logits
+        np.testing.assert_allclose(
+            np.array(out0["pred_masks_high_res"][0, 0, 30, 30]), 10.0, atol=1e-4
+        )
+        self.assertEqual(out0["maskmem_features"].shape, (2, 8, 8, 32))
+        self.assertEqual(out0["obj_ptr"].shape, (2, 2, 32))  # muxed
+        self.assertIn(0, state.cond_frame_outputs)
+
+        # frames 1-2: memory-conditioned propagation
+        for t in (1, 2):
+            out = tracker.propagate(state, t, self._fake_frame(tracker, 10 + t))
+            mx.eval(out)
+            # decoder low-res is 4x the 8x8 feature grid
+            self.assertEqual(out["pred_masks"].shape, (3, 1, 32, 32))
+            self.assertEqual(out["pred_masks_high_res"].shape, (3, 1, 112, 112))
+            self.assertEqual(out["object_score_logits"].shape, (3, 1))
+            self.assertIn(t, state.non_cond_frame_outputs)
+
+        # frame 3: add a new object mid-video
+        ff = self._fake_frame(tracker, 13)
+        new_mask = mx.zeros((1, 112, 112))
+        new_mask[0, 5:25, 5:25] = 1.0
+        out3 = tracker.track_step(
+            state,
+            frame_idx=3,
+            is_init_cond_frame=False,
+            frame_features=ff,
+            new_object_masks=new_mask[:, None],
+            new_object_idxs=[3],
+            new_object_ids=[13],
+        )
+        mx.eval(out3)
+        self.assertEqual(state.num_objects, 4)
+        self.assertEqual(out3["pred_masks"].shape[0], 4)
+        self.assertEqual(state.multiplex_state.object_ids, [10, 11, 12, 13])
+
+        # frame 4: point interaction on top of propagation
+        pts = {
+            "point_coords": mx.array(
+                [[[40.0, 40.0]], [[60.0, 60.0]], [[80.0, 15.0]], [[15.0, 15.0]]]
+            ),
+            "point_labels": mx.ones((4, 1), mx.int32),
+        }
+        out4 = tracker.track_step(
+            state,
+            frame_idx=4,
+            is_init_cond_frame=False,
+            frame_features=self._fake_frame(tracker, 14),
+            point_inputs=pts,
+            objects_to_interact=[0, 1, 2, 3],
+        )
+        mx.eval(out4)
+        self.assertEqual(out4["pred_masks"].shape[0], 4)
+
+
 class TestGetInputEmbeddings(unittest.TestCase):
     """Test that all models with get_input_embeddings return InputEmbeddingsFeatures."""
 


### PR DESCRIPTION
Port Meta's video_tracking_multiplex to MLX for sam3_1:

- multiplex.py: MultiplexState/Controller for bucket mux/demux via gather/scatter indices, with dynamic object add/remove
- tracker.py: full MultiplexTrackerModel — mask-as-output init, memory-conditioned propagation (spatial mask memories, per-frame image features, temporal-pos-encoded object pointers over 7 past + 4 conditioning frames), interactive point/mask refinement, and dynamic add/recondition of objects mid-video
- config.py: re-pin SAM 3.1 multiplex tracker constants, add multimask_outputs_only and mask/memory-encoding options
- sam3_1.py: session-based track_init/track_step APIs on Model
- generate.py: realtime pipeline now drives the multiplex tracker session instead of a manual memory bank
- sam3: add skip_first_layer_pe to TwoWayAttentionBlock
- tests: TestSam31MultiplexTracker (mux/demux exactness, decoder shapes, tracker forward)