### PR TITLE
fix(qwen3_5): transpose Qwen3.8 Conv3d patch embed to NDHWC

### DIFF
--- a/mlx_vlm/models/qwen3_5/qwen3_5.py
+++ b/mlx_vlm/models/qwen3_5/qwen3_5.py
@@ -159,6 +159,13 @@ class Model(Qwen3VLModel):
 
             if "conv1d.weight" in key and value.shape[-1] != 1:
                 value = value.moveaxis(2, 1)
+            # Qwen3.8 ships the Conv3d patch embed in PyTorch NCDHW order,
+            # while MLX convolutions expect NDHWC. Guard on the trailing axis
+            # so re-sanitizing already-converted weights is a no-op.
+            if key.endswith("patch_embed.proj.weight") and value.ndim == 5:
+                in_ch = self.config.vision_config.in_channels
+                if value.shape[-1] != in_ch and value.shape[1] == in_ch:
+                    value = value.transpose(0, 2, 3, 4, 1)
             if any(key.endswith(sfx) for sfx in NORM_WEIGHT_SUFFIXES):
                 if value.ndim == 1 and should_offset_norm_weight(
                     original_key, shift_norm_weights

--- a/mlx_vlm/tests/test_qwen3_5_patch_embed.py
+++ b/mlx_vlm/tests/test_qwen3_5_patch_embed.py
@@ -1,0 +1,101 @@
+import mlx.core as mx
+
+from mlx_vlm.models.qwen3_5.config import ModelConfig, TextConfig, VisionConfig
+from mlx_vlm.models.qwen3_5.qwen3_5 import Model
+
+PATCH_EMBED_KEY = "model.visual.patch_embed.proj.weight"
+SANITIZED_KEY = "vision_tower.patch_embed.proj.weight"
+
+
+def _tiny_model(in_channels=3, temporal_patch_size=2, patch_size=4, hidden_size=8):
+    text_config = TextConfig(
+        model_type="qwen3_5_text",
+        hidden_size=32,
+        intermediate_size=64,
+        linear_num_value_heads=4,
+        linear_num_key_heads=2,
+        linear_key_head_dim=8,
+        linear_value_head_dim=8,
+        linear_conv_kernel_dim=4,
+        num_hidden_layers=2,
+        num_attention_heads=2,
+        rms_norm_eps=1e-6,
+        vocab_size=64,
+        num_key_value_heads=1,
+        max_position_embeddings=128,
+        full_attention_interval=2,
+        head_dim=16,
+    )
+    vision_config = VisionConfig(
+        model_type="qwen3_5",
+        depth=1,
+        hidden_size=hidden_size,
+        intermediate_size=16,
+        out_hidden_size=32,
+        num_heads=1,
+        in_channels=in_channels,
+        patch_size=patch_size,
+        temporal_patch_size=temporal_patch_size,
+        spatial_merge_size=1,
+        num_position_embeddings=4,
+    )
+    config = ModelConfig(
+        text_config=text_config, vision_config=vision_config, model_type="qwen3_5"
+    )
+    return Model(config), vision_config
+
+
+def test_patch_embed_is_transposed_from_ncdhw_to_ndhwc():
+    """Qwen3.8 stores the Conv3d patch embed as NCDHW; MLX expects NDHWC."""
+    model, vision_config = _tiny_model()
+    expected = model.vision_tower.patch_embed.proj.weight.shape
+
+    ncdhw = mx.zeros(
+        (
+            vision_config.hidden_size,
+            vision_config.in_channels,
+            vision_config.temporal_patch_size,
+            vision_config.patch_size,
+            vision_config.patch_size,
+        ),
+        dtype=mx.bfloat16,
+    )
+    sanitized = model.sanitize({PATCH_EMBED_KEY: ncdhw})
+
+    assert sanitized[SANITIZED_KEY].shape == expected
+
+
+def test_patch_embed_transpose_is_idempotent():
+    """Weights already in NDHWC order must pass through untouched."""
+    model, _ = _tiny_model()
+    ndhwc = mx.zeros(
+        model.vision_tower.patch_embed.proj.weight.shape, dtype=mx.bfloat16
+    )
+
+    once = model.sanitize({PATCH_EMBED_KEY: ndhwc})[SANITIZED_KEY]
+    twice = model.sanitize({SANITIZED_KEY: once})[SANITIZED_KEY]
+
+    assert once.shape == ndhwc.shape
+    assert twice.shape == ndhwc.shape
+
+
+def test_sanitized_patch_embed_loads_strictly():
+    """The whole point: a strict load must accept the sanitized weight."""
+    model, vision_config = _tiny_model()
+    ncdhw = mx.zeros(
+        (
+            vision_config.hidden_size,
+            vision_config.in_channels,
+            vision_config.temporal_patch_size,
+            vision_config.patch_size,
+            vision_config.patch_size,
+        ),
+        dtype=mx.bfloat16,
+    )
+    sanitized = model.sanitize({PATCH_EMBED_KEY: ncdhw})[SANITIZED_KEY]
+
+    bias = model.vision_tower.patch_embed.proj.bias
+    model.vision_tower.patch_embed.load_weights(
+        [("proj.weight", sanitized), ("proj.bias", bias)], strict=True
+    )
+    assert model.vision_tower.patch_embed.proj.weight.shape == sanitized.shape


### PR DESCRIPTION
## Summary

Qwen3.8-27B (which declares `model_type: qwen3_5` / `Qwen3_5ForConditionalGeneration`) currently cannot be loaded or converted. It ships `visual.patch_embed.proj.weight` in PyTorch NCDHW order while MLX convolutions expect NDHWC, and `sanitize()` — which already rewrites `conv1d` weights — leaves this tensor untouched. `load_model` uses `strict=True`, so the load aborts:

```
ValueError: Expected shape (1152, 2, 16, 16, 3) but received shape (1152, 3, 2, 16, 16)
             for parameter patch_embed.proj.weight
```

This is the *only* blocker. Diffing the instantiated model's parameter tree against all 1199 checkpoint tensors post-`sanitize`:

```
model params 1184 | ckpt 1199 | after sanitize 1184
MISSING 0 | EXTRA 0 | SHAPE MISMATCH 1   <- patch_embed.proj.weight
```

Every linear-attention, full-attention, MLP, embedding and vision-block tensor already binds correctly. (The 15 unbound checkpoint tensors are the `mtp.*` draft head, dropped deliberately at `qwen3_5.py` sanitize.)

## Change

One transpose in `Model.sanitize`, alongside the existing `conv1d` case. The guard compares the trailing axis against `vision_config.in_channels`, so re-sanitizing weights already in NDHWC is a no-op rather than a second transpose.

## Verification

With the fix, the same structural diff reports `MISSING 0 | EXTRA 0 | SHAPE MISMATCH 0`, and Qwen3.8-27B converts and runs. Image-conditioned generation from the converted model returns an accurate description of the input, so the axis order is right and not merely shape-compatible.

Three regression tests added in `mlx_vlm/tests/test_qwen3_5_patch_embed.py`, built on a tiny synthetic config (no checkpoint download). Two fail without the fix; the idempotence test passes either way by design, guarding against a future over-eager transpose.

## Test plan

- [x] `pytest mlx_vlm/tests/test_qwen3_5_patch_embed.py` — 3 passed
- [x] Same file against unpatched `sanitize` — 2 failed, confirming the tests bite
- [x] `pytest mlx_vlm/tests/ -k qwen3_5` — 72 passed, no regressions
- [x] `pre-commit run --files ...` — black, isort, autoflake all pass
- [x] End-to-end: converted Qwen3.8-27B at mixed precision and generated from an image

🤖 Generated with [Claude Code](https://claude.com/claude-code)