### PR TITLE
Configure APC through live server settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -913,6 +913,44 @@ curl http://localhost:8080/v1/cache/stats
 curl -X POST http://localhost:8080/v1/cache/reset
 ```
 
+Configure APC on a running server with `PATCH /v1/settings`. Use
+`GET /v1/settings` to discover supported settings and read their current values:
+
+```sh
+curl http://localhost:8080/v1/settings
+
+curl -X PATCH http://localhost:8080/v1/settings \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "apc_enabled": true,
+    "apc_disk_enabled": true,
+    "apc_memory_max_gb": 2,
+    "apc_disk_max_gb": 20,
+    "apc_checkpoint_interval_tokens": 1024
+  }'
+```
+
+The endpoint also accepts `apc_memory_reserve_gb`, `apc_disk_queue_max_gb`,
+`apc_disk_path`, `apc_disk_shard_max_blocks`, `apc_block_size`, `apc_num_blocks`,
+`apc_checkpoint_entries`, and `apc_checkpoint_guard_tokens`. When
+`MLX_VLM_SERVER_API_KEY` is configured, include `Authorization: Bearer <key>`.
+
+Settings apply on the next text-generation request through the existing model
+reload path; the server process stays running. Reloading clears resident caches
+and retires the previous disk writer after its generation worker finishes.
+Existing disk files remain available. Updating APC options while APC is disabled
+stages them for the next enable. The response reports `applied`, `rejected`,
+`reload_kinds`, and the resulting settings; invalid sizes are rejected without
+changing those values. Unchanged settings do not trigger a reload.
+
+Use `null` for automatic memory budgets or the default disk path/cap. Zero has
+specific meanings: `apc_memory_max_gb: 0` retains caches only on disk,
+`apc_disk_max_gb: 0` removes the disk cap, and `apc_disk_queue_max_gb: 0` writes
+synchronously. An empty `apc_disk_path` or `apc_disk_enabled: false` disables
+persistence. PATCH merges with current settings; the optional
+`{"op": "replace", "values": {...}}` form first restores startup environment
+defaults. `/v1/cache/stats` shows the active manager after the next request.
+
 Common APC environment variables:
 
 | Variable | Default | Description |

--- a/mlx_vlm/apc.py
+++ b/mlx_vlm/apc.py
@@ -84,6 +84,15 @@ def default_disk_path() -> Path:
     return root / "mlx-vlm" / "apc"
 
 
+def _setting(overrides: Optional[dict], key: str, env: str, default: Any) -> Any:
+    # Explicit null restores the built-in/automatic default. An absent key
+    # inherits the environment; zero and an empty disk path remain meaningful.
+    if overrides is not None and key in overrides:
+        value = overrides[key]
+        return default if value is None else value
+    return os.environ.get(env, default)
+
+
 def _cache_nbytes(value: Any, seen: Optional[set[int]] = None) -> int:
     """Account cache buffers without evaluating or cloning their contents."""
     if value is None:
@@ -1147,6 +1156,8 @@ class DiskBlockStore:
         namespace: str = "default",
         num_workers: int = 1,
         max_bytes: Optional[int] = None,
+        *,
+        overrides: Optional[dict] = None,
     ):
         self.dir = Path(root) / _safe_namespace(namespace)
         self.dir.mkdir(parents=True, exist_ok=True)
@@ -1154,7 +1165,13 @@ class DiskBlockStore:
         self.evictions = 0  # cumulative shard deletions by _maybe_evict
         self._q: queue.Queue = queue.Queue(maxsize=4096)
         self.queue_max_bytes = max(
-            0, int(float(os.environ.get("APC_DISK_QUEUE_MAX_GB", "1")) * (1 << 30))
+            0,
+            int(
+                float(
+                    _setting(overrides, "disk_queue_max_gb", "APC_DISK_QUEUE_MAX_GB", 1)
+                )
+                * (1 << 30)
+            ),
         )
         self._pending_bytes = 0
         self._pending_lock = threading.Lock()
@@ -1180,7 +1197,12 @@ class DiskBlockStore:
         # is ~2.25 MiB, so 256 blocks is roughly a 576 MiB shard before the
         # small KV step padding.
         self._shard_max_blocks = max(
-            1, int(os.environ.get("APC_DISK_SHARD_MAX_BLOCKS", "256"))
+            1,
+            int(
+                _setting(
+                    overrides, "disk_shard_max_blocks", "APC_DISK_SHARD_MAX_BLOCKS", 256
+                )
+            ),
         )
         # Layer-major warm-disk restore concatenates segment shards one layer
         # at a time. Clearing MLX's allocator cache after each layer keeps the
@@ -3051,6 +3073,8 @@ class APCManager:
         num_blocks: int = DEFAULT_NUM_BLOCKS,
         block_size: int = DEFAULT_BLOCK_SIZE,
         disk: Optional["DiskBlockStore"] = None,
+        *,
+        overrides: Optional[dict] = None,
     ):
         self.block_size = block_size
         self.num_blocks = num_blocks
@@ -3072,7 +3096,9 @@ class APCManager:
         self._exact_cache_max = max(
             0,
             int(
-                os.environ.get(
+                _setting(
+                    overrides,
+                    "checkpoint_entries",
                     "APC_CHECKPOINT_ENTRIES",
                     os.environ.get("APC_EXACT_CACHE_ENTRIES", "2"),
                 )
@@ -3081,7 +3107,9 @@ class APCManager:
         self.exact_cache_guard_tokens = max(
             1,
             int(
-                os.environ.get(
+                _setting(
+                    overrides,
+                    "checkpoint_guard_tokens",
                     "APC_CHECKPOINT_GUARD_TOKENS",
                     os.environ.get("APC_EXACT_PREFIX_GUARD_TOKENS", "1"),
                 )
@@ -3091,7 +3119,15 @@ class APCManager:
             1, int(os.environ.get("APC_EXACT_MIN_TOKENS", "16"))
         )
         self.checkpoint_interval_tokens = max(
-            0, int(os.environ.get("APC_CHECKPOINT_INTERVAL_TOKENS", "2048"))
+            0,
+            int(
+                _setting(
+                    overrides,
+                    "checkpoint_interval_tokens",
+                    "APC_CHECKPOINT_INTERVAL_TOKENS",
+                    2048,
+                )
+            ),
         )
         # If free RAM (best-effort reading) drops below this, skip disk
         # promotion this turn and fall back to memory-only matching. The
@@ -3122,7 +3158,14 @@ class APCManager:
         self.memory_max_bytes = max(
             0,
             int(
-                float(os.environ.get("APC_MEMORY_MAX_GB", automatic_budget / (1 << 30)))
+                float(
+                    _setting(
+                        overrides,
+                        "memory_max_gb",
+                        "APC_MEMORY_MAX_GB",
+                        automatic_budget / (1 << 30),
+                    )
+                )
                 * (1 << 30)
             ),
         )
@@ -3130,8 +3173,11 @@ class APCManager:
             0,
             int(
                 float(
-                    os.environ.get(
-                        "APC_MEMORY_RESERVE_GB", automatic_reserve / (1 << 30)
+                    _setting(
+                        overrides,
+                        "memory_reserve_gb",
+                        "APC_MEMORY_RESERVE_GB",
+                        automatic_reserve / (1 << 30),
                     )
                 )
                 * (1 << 30)
@@ -4878,9 +4924,11 @@ def from_env(
     model_namespace: Optional[str] = None,
     overrides: Optional[dict] = None,
 ) -> Optional[APCManager]:
-    """Build an APCManager when enabled; read knobs from env (default) or
-    ``overrides`` (keys: enabled, disk_path, block_size, num_blocks,
-    disk_max_gb) so live settings can drive APC without env mutation."""
+    """Build APC from env or live settings, without mutating the environment.
+
+    Override keys are server APC setting names without the ``apc_`` prefix.
+    Explicit null selects the built-in/automatic default; omitted keys use env.
+    """
     if overrides is not None and "enabled" in overrides:
         enabled = bool(overrides["enabled"])
     else:
@@ -4893,30 +4941,25 @@ def from_env(
         return None
 
     def _ov_int(override_key: str, env_name: str, default: int) -> int:
-        if (
-            overrides is not None
-            and override_key in overrides
-            and overrides[override_key] is not None
-        ):
-            return int(overrides[override_key])
-        return int(os.environ.get(env_name, default))
+        return int(_setting(overrides, override_key, env_name, default))
 
     block_size = _ov_int("block_size", "APC_BLOCK_SIZE", DEFAULT_BLOCK_SIZE)
     num_blocks = _ov_int("num_blocks", "APC_NUM_BLOCKS", DEFAULT_NUM_BLOCKS)
 
     disk: Optional[DiskBlockStore] = None
-    if overrides is not None and overrides.get("disk_path") is not None:
-        disk_path = overrides["disk_path"]
-    else:
-        disk_path = os.environ.get("APC_DISK_PATH", str(default_disk_path()))
-    if not _env_truthy("APC_DISK_ENABLED", "1"):
+    disk_path = _setting(
+        overrides, "disk_path", "APC_DISK_PATH", str(default_disk_path())
+    )
+    disk_enabled = str(
+        _setting(overrides, "disk_enabled", "APC_DISK_ENABLED", True)
+    ).lower() in ("1", "true", "yes")
+    if not disk_enabled:
         disk_path = None
     if disk_path:
         ns = model_namespace or os.environ.get("APC_DISK_NAMESPACE", "default")
-        if overrides is not None and overrides.get("disk_max_gb") is not None:
-            max_gb = float(overrides["disk_max_gb"])
-        else:
-            max_gb = float(os.environ.get("APC_DISK_MAX_GB", DEFAULT_DISK_MAX_GB))
+        max_gb = float(
+            _setting(overrides, "disk_max_gb", "APC_DISK_MAX_GB", DEFAULT_DISK_MAX_GB)
+        )
         max_bytes = int(max_gb * (1 << 30)) if max_gb > 0 else None
         workers = int(os.environ.get("APC_DISK_WORKERS", "1"))
         try:
@@ -4925,6 +4968,7 @@ def from_env(
                 namespace=ns,
                 num_workers=workers,
                 max_bytes=max_bytes,
+                overrides=overrides,
             )
             cap_str = f"{max_gb:.1f} GB" if max_bytes else "unbounded"
             logger.info(
@@ -4943,4 +4987,6 @@ def from_env(
         "sha256" if _hash_use_sha256() else "fast",
         bool(disk),
     )
-    return APCManager(num_blocks=num_blocks, block_size=block_size, disk=disk)
+    return APCManager(
+        num_blocks=num_blocks, block_size=block_size, disk=disk, overrides=overrides
+    )

--- a/mlx_vlm/server/app.py
+++ b/mlx_vlm/server/app.py
@@ -868,13 +868,7 @@ def get_cached_model(
             kv_quant_scheme=kv_quant_scheme,
             quantized_kv_start=quantized_kv_start,
         ),
-        overrides={
-            "enabled": cfg.apc_enabled,
-            "disk_path": cfg.apc_disk_path,
-            "block_size": cfg.apc_block_size,
-            "num_blocks": cfg.apc_num_blocks,
-            "disk_max_gb": cfg.apc_disk_max_gb,
-        },
+        overrides=cfg.apc_overrides(),
     )
 
     response_generator = ResponseGenerator(
@@ -1153,14 +1147,17 @@ async def update_runtime_settings(request: Request):
     if not isinstance(payload, dict):
         raise HTTPException(status_code=400, detail="body must be a JSON object")
     op, values = _settings_operation(payload)
+    before = runtime.config.current()
     applied, rejected = runtime.config.apply_changes(values, op=op)
+    current = runtime.config.current()
+    changed = {name: value for name, value in current.items() if before[name] != value}
     return {
         "op": op,
         "applied": applied,
         "rejected": rejected,
-        "reload_kinds": sorted(runtime.config.reload_kinds(applied)),
+        "reload_kinds": sorted(runtime.config.reload_kinds(changed)),
         "fingerprint": runtime.config.fingerprint(),
-        "current": runtime.config.current(),
+        "current": current,
     }
 
 

--- a/mlx_vlm/server/generation.py
+++ b/mlx_vlm/server/generation.py
@@ -1662,7 +1662,16 @@ class ResponseGenerator:
         try:
             self._run_impl()
         finally:
-            clear_mlx_streams()
+            try:
+                # The worker can outlive stop_and_join's timeout. Retire its
+                # disk writer only after its final request/store has finished.
+                manager = getattr(self, "apc_manager", None)
+                if manager is not None:
+                    manager.close()
+            except Exception:
+                logger.exception("Error closing APC after generation worker shutdown")
+            finally:
+                clear_mlx_streams()
 
     def _run_impl(self):
         """Single GPU thread: owns BatchGenerator, runs tight next() loop."""

--- a/mlx_vlm/server/runtime_config.py
+++ b/mlx_vlm/server/runtime_config.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import hashlib
 import json
 import logging
+import math
 import os
 import threading
 from dataclasses import dataclass, field
@@ -74,15 +75,30 @@ KNOBS: Tuple[
     ),
     ("apc_enabled", "bool", False, TEXT_KINDS, None, "Prefix caching on/off."),
     (
+        "apc_disk_enabled",
+        "bool",
+        True,
+        TEXT_KINDS,
+        None,
+        "APC disk persistence on/off.",
+    ),
+    (
         "apc_disk_path",
         "str_or_none",
         None,
         TEXT_KINDS,
         None,
-        "APC disk tier directory; None uses the default mlx-vlm cache directory.",
+        "APC disk directory; null uses the default cache directory, empty disables disk.",
     ),
     ("apc_block_size", "int", 16, TEXT_KINDS, None, "APC block size (tokens)."),
-    ("apc_num_blocks", "int", 2048, TEXT_KINDS, None, "APC block pool capacity."),
+    (
+        "apc_num_blocks",
+        "int",
+        2048,
+        TEXT_KINDS,
+        None,
+        "APC block pool capacity; 0 disables block retention.",
+    ),
     (
         "apc_disk_max_gb",
         "float_or_none",
@@ -90,6 +106,62 @@ KNOBS: Tuple[
         TEXT_KINDS,
         None,
         "APC disk tier cap (GiB); None defaults to 20, 0 is uncapped.",
+    ),
+    (
+        "apc_memory_max_gb",
+        "float_or_none",
+        None,
+        TEXT_KINDS,
+        None,
+        "Resident APC budget (GiB); null = automatic, 0 = disk-only retention.",
+    ),
+    (
+        "apc_memory_reserve_gb",
+        "float_or_none",
+        None,
+        TEXT_KINDS,
+        None,
+        "Additional prefill headroom (GiB); null = automatic, 0 = no fixed reserve.",
+    ),
+    (
+        "apc_disk_queue_max_gb",
+        "float_or_none",
+        1.0,
+        TEXT_KINDS,
+        None,
+        "Queued disk tensor budget (GiB); null = 1 GiB, 0 = synchronous writes.",
+    ),
+    (
+        "apc_disk_shard_max_blocks",
+        "int",
+        256,
+        TEXT_KINDS,
+        None,
+        "Maximum blocks per disk shard.",
+    ),
+    (
+        "apc_checkpoint_entries",
+        "int",
+        2,
+        TEXT_KINDS,
+        None,
+        "Resident checkpoint entries and hybrid capture bound; 0 = disk-only checkpoints.",
+    ),
+    (
+        "apc_checkpoint_interval_tokens",
+        "int",
+        2048,
+        TEXT_KINDS,
+        None,
+        "Intermediate hybrid checkpoint spacing; 0 = final checkpoint only.",
+    ),
+    (
+        "apc_checkpoint_guard_tokens",
+        "int",
+        1,
+        TEXT_KINDS,
+        None,
+        "Tokens retained after the final reusable checkpoint.",
     ),
     (
         "max_kv_size",
@@ -149,12 +221,49 @@ _KNOB_SPEC: Dict[str, Dict[str, Any]] = {
 _LIVE_KNOBS: Tuple[str, ...] = ("max_kv_size", "token_queue_timeout")
 
 
-def _env_float(name: str, default: Optional[float]) -> Optional[float]:
+def _env_float(
+    name: str, default: Optional[float], *, zero_is_none: bool = True
+) -> Optional[float]:
     raw = os.environ.get(name)
     if raw is None or raw == "":
         return default
     value = float(raw)
-    return default if value == 0 else value
+    return default if zero_is_none and value == 0 else value
+
+
+def _coerce_apc(name: str, spec: Dict[str, Any], raw: Any) -> Any:
+    """APC zero/empty values have meaning; reject invalid sizes before reload."""
+    kind = spec["type"]
+    if kind == "bool":
+        return _coerce(kind, raw)
+    if kind == "str_or_none":
+        if raw is not None and not isinstance(raw, str):
+            raise ValueError("expected a string or null")
+        return raw
+    if kind == "float_or_none" and (raw is None or raw == ""):
+        return None
+    if isinstance(raw, bool):
+        raise ValueError("expected a number, got a boolean")
+    value = int(raw) if kind == "int" else float(raw)
+    if kind == "int" and isinstance(raw, float) and raw != value:
+        raise ValueError("expected a whole number")
+    minimum = (
+        1
+        if name
+        in (
+            "apc_block_size",
+            "apc_disk_shard_max_blocks",
+            "apc_checkpoint_guard_tokens",
+        )
+        else 0
+    )
+    if (
+        not math.isfinite(value)
+        or value < minimum
+        or (name.endswith("_gb") and not math.isfinite(value * (1 << 30)))
+    ):
+        raise ValueError(f"expected a finite number >= {minimum}")
+    return value
 
 
 def _env_int(name: str, default: Optional[int]) -> Optional[int]:
@@ -189,10 +298,18 @@ class RuntimeConfig:
     kv_value_scheme: Optional[str] = None
     quantized_kv_start: Optional[int] = None
     apc_enabled: bool = False
+    apc_disk_enabled: bool = True
     apc_disk_path: Optional[str] = None
     apc_block_size: int = 16
     apc_num_blocks: int = 2048
     apc_disk_max_gb: Optional[float] = None
+    apc_memory_max_gb: Optional[float] = None
+    apc_memory_reserve_gb: Optional[float] = None
+    apc_disk_queue_max_gb: Optional[float] = 1.0
+    apc_disk_shard_max_blocks: int = 256
+    apc_checkpoint_entries: int = 2
+    apc_checkpoint_interval_tokens: int = 2048
+    apc_checkpoint_guard_tokens: int = 1
     max_kv_size: Optional[int] = None
     token_queue_timeout: Optional[float] = DEFAULT_TOKEN_QUEUE_TIMEOUT
     spec_draft_model: Optional[str] = None
@@ -219,10 +336,37 @@ class RuntimeConfig:
             quantized_kv_start=_env_int("QUANTIZED_KV_START", None),
             apc_enabled=os.environ.get("APC_ENABLED", "0").lower()
             in ("1", "true", "yes"),
-            apc_disk_path=os.environ.get("APC_DISK_PATH") or None,
+            apc_disk_enabled=os.environ.get("APC_DISK_ENABLED", "1").lower()
+            in ("1", "true", "yes"),
+            apc_disk_path=os.environ.get("APC_DISK_PATH"),
             apc_block_size=int(os.environ.get("APC_BLOCK_SIZE", "16")),
             apc_num_blocks=int(os.environ.get("APC_NUM_BLOCKS", "2048")),
-            apc_disk_max_gb=_env_float("APC_DISK_MAX_GB", None),
+            apc_disk_max_gb=_env_float("APC_DISK_MAX_GB", None, zero_is_none=False),
+            apc_memory_max_gb=_env_float("APC_MEMORY_MAX_GB", None, zero_is_none=False),
+            apc_memory_reserve_gb=_env_float(
+                "APC_MEMORY_RESERVE_GB", None, zero_is_none=False
+            ),
+            apc_disk_queue_max_gb=_env_float(
+                "APC_DISK_QUEUE_MAX_GB", 1.0, zero_is_none=False
+            ),
+            apc_disk_shard_max_blocks=int(
+                os.environ.get("APC_DISK_SHARD_MAX_BLOCKS", "256")
+            ),
+            apc_checkpoint_entries=int(
+                os.environ.get(
+                    "APC_CHECKPOINT_ENTRIES",
+                    os.environ.get("APC_EXACT_CACHE_ENTRIES", "2"),
+                )
+            ),
+            apc_checkpoint_interval_tokens=int(
+                os.environ.get("APC_CHECKPOINT_INTERVAL_TOKENS", "2048")
+            ),
+            apc_checkpoint_guard_tokens=int(
+                os.environ.get(
+                    "APC_CHECKPOINT_GUARD_TOKENS",
+                    os.environ.get("APC_EXACT_PREFIX_GUARD_TOKENS", "1"),
+                )
+            ),
             max_kv_size=_env_int("MAX_KV_SIZE", None),
             token_queue_timeout=_env_token_queue_timeout(),
             spec_draft_model=os.environ.get("MLX_VLM_DRAFT_MODEL") or None,
@@ -249,6 +393,15 @@ class RuntimeConfig:
         with self._lock:
             return {name: getattr(self, name) for name in _KNOB_SPEC}
 
+    def apc_overrides(self) -> Dict[str, Any]:
+        """Snapshot all APC settings for manager creation without changing env."""
+        with self._lock:
+            return {
+                name.removeprefix("apc_"): getattr(self, name)
+                for name in _KNOB_SPEC
+                if name.startswith("apc_")
+            }
+
     def apply_changes(
         self, payload: Dict[str, Any], op: str = "merge"
     ) -> Tuple[Dict[str, Any], List[Dict[str, Any]]]:
@@ -273,14 +426,18 @@ class RuntimeConfig:
                     continue
                 spec = _KNOB_SPEC[name]
                 try:
-                    value = _coerce(spec["type"], raw, spec.get("allowed"))
+                    value = (
+                        _coerce_apc(name, spec, raw)
+                        if name.startswith("apc_")
+                        else _coerce(spec["type"], raw, spec.get("allowed"))
+                    )
                     if (
                         name == "token_queue_timeout"
                         and value is not None
                         and value < 0
                     ):
                         value = None
-                except (TypeError, ValueError) as exc:
+                except (TypeError, ValueError, OverflowError) as exc:
                     rejected.append({"name": name, "reason": str(exc)})
                     continue
                 setattr(self, name, value)
@@ -307,7 +464,7 @@ class RuntimeConfig:
 
     def fingerprint(self, kinds: Optional[Iterable[str]] = None) -> str:
         kind_set = set(kinds) if kinds is not None else None
-        items: List[Tuple[str, str]] = []
+        items: List[Tuple[str, Any]] = []
         with self._lock:
             for name in _KNOB_SPEC:
                 if not self._in_cache_key(name):
@@ -316,7 +473,7 @@ class RuntimeConfig:
                 if kind_set is not None and not (set(spec["reload_kinds"]) & kind_set):
                     continue
                 value = getattr(self, name)
-                items.append((name, "" if value is None else str(value)))
+                items.append((name, value))
         blob = json.dumps(sorted(items), sort_keys=True).encode()
         return hashlib.sha256(blob).hexdigest()
 

--- a/mlx_vlm/tests/test_apc_settings.py
+++ b/mlx_vlm/tests/test_apc_settings.py
@@ -1,0 +1,342 @@
+"""Live APC settings: endpoint validation, reloads, and manager configuration."""
+
+import os
+from threading import Thread
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import mlx.core as mx
+import pytest
+from fastapi.testclient import TestClient
+
+import mlx_vlm.server as server
+from mlx_vlm import apc
+from mlx_vlm.models.cache import KVCache
+from mlx_vlm.server.runtime_config import RuntimeConfig
+
+
+@pytest.fixture
+def settings_client(monkeypatch, tmp_path):
+    for name in list(os.environ):
+        if name.startswith("APC_"):
+            monkeypatch.delenv(name)
+    monkeypatch.delenv("MLX_VLM_SERVER_API_KEY", raising=False)
+    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path / "cache"))
+    monkeypatch.setattr(server.runtime, "config", RuntimeConfig.from_env())
+    monkeypatch.setattr(server.runtime, "model_cache", server.ModelCacheRegistry())
+    monkeypatch.setattr(server.runtime, "response_generator", None)
+    monkeypatch.setattr(server.runtime, "apc_manager", None)
+    monkeypatch.setattr(
+        server._app_module, "is_image_generation_model", lambda _: False
+    )
+
+    # Exercise the real cache factory / APC manager while avoiding model downloads.
+    generators = []
+
+    class FakeGenerator:
+        def __init__(self, **kwargs):
+            self.model = SimpleNamespace(make_cache=lambda: [KVCache()])
+            self.processor = SimpleNamespace()
+            self.config = SimpleNamespace(model_type="test")
+            self.apc_manager = kwargs["apc_manager"]
+            self.stopped = False
+            generators.append(self)
+
+        def wait_until_ready(self):
+            return self.model, self.processor, self.config
+
+        def stop_and_join(self):
+            self.stopped = True
+            if self.apc_manager is not None:
+                self.apc_manager.close()
+
+    monkeypatch.setattr(server._app_module, "ResponseGenerator", FakeGenerator)
+    client = TestClient(server.app)
+    yield client, generators
+    for generator in generators:
+        if not generator.stopped:
+            generator.stop_and_join()
+    client.close()
+
+
+def test_apc_patch_reaches_next_model_request(settings_client, tmp_path):
+    client, generators = settings_client
+    server.get_cached_model("demo")
+    assert server.runtime.apc_manager is None
+    settings = {
+        "apc_enabled": True,
+        "apc_disk_enabled": True,
+        "apc_disk_path": str(tmp_path / "live"),
+        "apc_block_size": 32,
+        "apc_num_blocks": 8,
+        "apc_disk_max_gb": 0,
+        "apc_memory_max_gb": 1,
+        "apc_memory_reserve_gb": 0.25,
+        "apc_disk_queue_max_gb": 0,
+        "apc_disk_shard_max_blocks": 64,
+        "apc_checkpoint_entries": 3,
+        "apc_checkpoint_interval_tokens": 128,
+        "apc_checkpoint_guard_tokens": 2,
+    }
+    response = client.patch("/v1/settings", json=settings)
+    assert response.status_code == 200
+    assert response.json()["applied"] == settings
+    assert response.json()["rejected"] == []
+    assert response.json()["reload_kinds"] == ["text_generation"]
+    assert len(generators) == 1  # Configuration changes apply at the next load.
+
+    body = client.get("/v1/settings").json()
+    assert settings.keys() <= {knob["name"] for knob in body["schema"]}
+    assert {name: body["current"][name] for name in settings} == settings
+    server.get_cached_model("demo")
+    assert len(generators) == 2 and generators[0].stopped
+    manager = server.runtime.apc_manager
+    assert manager is generators[-1].apc_manager
+    assert (manager.block_size, manager.num_blocks) == (32, 8)
+    assert manager.memory_max_bytes == 1 << 30
+    assert manager.memory_reserve_bytes == 1 << 28
+    assert manager._exact_cache_max == 3
+    assert manager.checkpoint_interval_tokens == 128
+    assert manager.exact_cache_guard_tokens == 2
+    assert manager.disk.dir.parent == tmp_path / "live"
+    assert manager.disk.max_bytes is None
+    assert manager.disk.queue_max_bytes == 0
+    assert manager.disk._shard_max_blocks == 64
+    assert client.get("/v1/cache/stats").json()["memory_max_bytes"] == 1 << 30
+
+    response = client.patch("/v1/settings", json=settings)
+    assert response.json()["reload_kinds"] == []  # A no-op retains the model/cache.
+    server.get_cached_model("demo")
+    assert len(generators) == 2
+
+    client.patch("/v1/settings", json={"apc_memory_max_gb": 0})
+    server.get_cached_model("demo")
+    assert server.runtime.apc_manager.memory_max_bytes == 0
+    assert all(not thread.is_alive() for thread in manager.disk._workers)
+
+    client.patch("/v1/settings", json={"apc_enabled": False})
+    server.get_cached_model("demo")
+    assert server.runtime.apc_manager is None
+    assert client.get("/v1/cache/stats").json() == {"enabled": False}
+
+
+def test_apc_empty_path_and_null_have_distinct_fingerprints(settings_client):
+    client, _ = settings_client
+    client.patch("/v1/settings", json={"apc_enabled": True})
+    original = client.get("/v1/settings").json()["fingerprint"]
+    response = client.patch("/v1/settings", json={"apc_disk_path": ""})
+    assert response.json()["fingerprint"] != original
+    assert response.json()["current"]["apc_disk_path"] == ""
+    server.get_cached_model("demo")
+    assert server.runtime.apc_manager.disk is None
+
+    response = client.patch("/v1/settings", json={"apc_disk_path": None})
+    assert response.json()["fingerprint"] == original
+    server.get_cached_model("demo")
+    assert server.runtime.apc_manager.disk is not None
+
+    client.patch("/v1/settings", json={"apc_disk_enabled": False})
+    server.get_cached_model("demo")
+    assert server.runtime.apc_manager.disk is None
+
+
+def test_apc_zero_null_and_replace_override_environment(
+    settings_client, monkeypatch, tmp_path
+):
+    client, _ = settings_client
+    monkeypatch.setattr(apc, "_metal_working_set_bytes", lambda: 40 << 30)
+    monkeypatch.setenv("APC_ENABLED", "1")
+    monkeypatch.setenv("APC_DISK_ENABLED", "0")
+    monkeypatch.setenv("APC_DISK_PATH", str(tmp_path / "environment"))
+    for name in (
+        "APC_DISK_MAX_GB",
+        "APC_MEMORY_MAX_GB",
+        "APC_MEMORY_RESERVE_GB",
+        "APC_DISK_QUEUE_MAX_GB",
+    ):
+        monkeypatch.setenv(name, "2")
+    monkeypatch.setattr(server.runtime, "config", RuntimeConfig.from_env())
+    before_env = dict(os.environ)
+    zero_values = {
+        "apc_memory_max_gb": 0,
+        "apc_memory_reserve_gb": 0,
+        "apc_disk_max_gb": 0,
+        "apc_disk_queue_max_gb": 0,
+    }
+    body = client.patch(
+        "/v1/settings", json={**zero_values, "apc_disk_enabled": True}
+    ).json()
+    assert all(body["current"][name] == 0 for name in zero_values)
+    server.get_cached_model("demo")
+    manager = server.runtime.apc_manager
+    assert manager.memory_max_bytes == manager.memory_reserve_bytes == 0
+    assert manager.disk.max_bytes is None
+    assert manager.disk.queue_max_bytes == 0
+
+    client.patch(
+        "/v1/settings",
+        json={**{name: None for name in zero_values}, "apc_disk_path": None},
+    )
+    server.get_cached_model("demo")
+    manager = server.runtime.apc_manager
+    assert manager.memory_max_bytes == manager.memory_reserve_bytes == 4 << 30
+    assert manager.disk.max_bytes == 20 << 30
+    assert manager.disk.queue_max_bytes == 1 << 30
+    assert manager.disk.dir.parent == apc.default_disk_path()
+
+    body = client.patch("/v1/settings", json={"op": "replace", "values": {}}).json()
+    assert body["reload_kinds"] == ["text_generation"]
+    server.get_cached_model("demo")
+    assert server.runtime.apc_manager.memory_max_bytes == 2 << 30
+    assert server.runtime.apc_manager.disk is None
+    assert dict(os.environ) == before_env
+
+
+def test_apc_environment_preserves_zero_and_legacy_checkpoint_values(monkeypatch):
+    for name in (
+        "APC_DISK_MAX_GB",
+        "APC_MEMORY_MAX_GB",
+        "APC_MEMORY_RESERVE_GB",
+        "APC_DISK_QUEUE_MAX_GB",
+    ):
+        monkeypatch.setenv(name, "0")
+    monkeypatch.setenv("APC_DISK_PATH", "")
+    monkeypatch.delenv("APC_CHECKPOINT_ENTRIES", raising=False)
+    monkeypatch.delenv("APC_CHECKPOINT_GUARD_TOKENS", raising=False)
+    monkeypatch.setenv("APC_EXACT_CACHE_ENTRIES", "0")
+    monkeypatch.setenv("APC_EXACT_PREFIX_GUARD_TOKENS", "2")
+    values = RuntimeConfig.from_env().apc_overrides()
+    assert (
+        values["disk_max_gb"]
+        == values["memory_max_gb"]
+        == values["memory_reserve_gb"]
+        == values["disk_queue_max_gb"]
+        == 0
+    )
+    assert values["disk_path"] == ""
+    assert values["checkpoint_entries"] == 0
+    assert values["checkpoint_guard_tokens"] == 2
+
+
+@pytest.mark.parametrize(
+    "name,value",
+    [
+        ("apc_block_size", 0),
+        ("apc_num_blocks", -1),
+        ("apc_checkpoint_entries", -1),
+        ("apc_checkpoint_entries", 1.5),
+        ("apc_checkpoint_guard_tokens", 0),
+        ("apc_checkpoint_interval_tokens", -1),
+        ("apc_disk_shard_max_blocks", 0),
+        ("apc_memory_max_gb", -1),
+        ("apc_memory_max_gb", "NaN"),
+        ("apc_memory_reserve_gb", "inf"),
+        ("apc_disk_queue_max_gb", 1e308),
+        ("apc_disk_max_gb", -1),
+        ("apc_num_blocks", True),
+        ("apc_disk_path", []),
+        ("apc_disk_enabled", None),
+    ],
+)
+def test_invalid_apc_values_are_rejected_without_reload(settings_client, name, value):
+    client, _ = settings_client
+    client.patch("/v1/settings", json={"apc_enabled": True})
+    before = client.get("/v1/settings").json()
+    response = client.patch("/v1/settings", json={name: value})
+    assert response.status_code == 200
+    body = response.json()
+    assert body["applied"] == {} and body["rejected"][0]["name"] == name
+    assert body["reload_kinds"] == []
+    assert body["current"] == before["current"]
+    assert body["fingerprint"] == before["fingerprint"]
+
+
+def test_disabled_apc_settings_are_staged_until_enabled(settings_client):
+    client, _ = settings_client
+    cfg = server.runtime.config
+    text_before = cfg.fingerprint(kinds={"text_generation"})
+    image_before = cfg.fingerprint(kinds={"image_generation"})
+    body = client.patch(
+        "/v1/settings",
+        json={
+            "apc_checkpoint_entries": "0",
+            "apc_checkpoint_interval_tokens": 0,
+            "apc_num_blocks": 0,
+            "apc_memory_max_gb": "0.5",
+        },
+    ).json()
+    assert body["rejected"] == [] and body["reload_kinds"] == []
+    assert cfg.fingerprint(kinds={"text_generation"}) == text_before
+    client.patch("/v1/settings", json={"apc_enabled": True})
+    assert cfg.fingerprint(kinds={"image_generation"}) == image_before
+    server.get_cached_model("demo")
+    manager = server.runtime.apc_manager
+    assert manager.num_blocks == 0
+    assert manager._exact_cache_max == manager.checkpoint_interval_tokens == 0
+    assert manager.memory_max_bytes == 1 << 29
+
+
+def test_apc_settings_require_management_key(settings_client, monkeypatch):
+    client, _ = settings_client
+    monkeypatch.setenv("MLX_VLM_SERVER_API_KEY", "secret")
+    for headers in ({}, {"Authorization": "Bearer wrong"}):
+        assert client.get("/v1/settings", headers=headers).status_code == 401
+        assert (
+            client.patch(
+                "/v1/settings", headers=headers, json={"apc_enabled": True}
+            ).status_code
+            == 401
+        )
+    assert server.runtime.config.apc_enabled is False
+    headers = {"Authorization": "Bearer secret"}
+    assert (
+        client.patch(
+            "/v1/settings", headers=headers, json={"apc_enabled": True}
+        ).status_code
+        == 200
+    )
+    assert (
+        client.get("/v1/settings", headers=headers).json()["current"]["apc_enabled"]
+        is True
+    )
+
+
+@pytest.mark.parametrize("fail", [False, True])
+def test_generation_worker_closes_disk_after_final_store(tmp_path, fail):
+    disk = apc.DiskBlockStore(tmp_path)
+    manager = apc.APCManager(num_blocks=1, disk=disk)
+    generator = server.ResponseGenerator.__new__(server.ResponseGenerator)
+    generator.apc_manager = manager
+
+    def finish_request():
+        cache = KVCache()
+        cache.keys = cache.values = mx.ones((1, 1, 32, 4))
+        cache.offset = 32
+        manager.store_exact_cache(list(range(32)), [cache])
+        if fail:
+            raise RuntimeError("worker failed")
+
+    generator._run_impl = MagicMock(side_effect=finish_request)
+    errors = []
+
+    def run_worker():
+        try:
+            generator._run()
+        except Exception as exc:
+            errors.append(exc)
+
+    worker = Thread(target=run_worker, daemon=True)
+    try:
+        worker.start()
+        worker.join(5)
+        assert not worker.is_alive()
+        if fail:
+            assert len(errors) == 1 and str(errors[0]) == "worker failed"
+        else:
+            assert errors == []
+        assert disk.num_exact_indexed == 1
+        assert disk.pending_bytes == 0
+        assert all(not thread.is_alive() for thread in disk._workers)
+    finally:
+        if any(thread.is_alive() for thread in disk._workers):
+            manager.close()

--- a/mlx_vlm/tests/test_server.py
+++ b/mlx_vlm/tests/test_server.py
@@ -5533,7 +5533,7 @@ class TestResponseGenerator:
         gen.kv_quant_scheme = server.DEFAULT_KV_QUANT_SCHEME
         gen.quantized_kv_start = server.DEFAULT_QUANTIZED_KV_START
         gen.top_logprobs_k = 0
-        apc_manager = SimpleNamespace(prepare_prefill=MagicMock())
+        apc_manager = SimpleNamespace(prepare_prefill=MagicMock(), close=MagicMock())
         gen.apc_manager = apc_manager
         gen.prefill_step_size = 3072
         gen.tokenizer = SimpleNamespace()
@@ -5597,6 +5597,7 @@ class TestResponseGenerator:
         assert kwargs["apc_manager"] is apc_manager
         assert apc_manager.prepare_prefill.call_count == 2
         apc_manager.prepare_prefill.assert_called_with(1)
+        apc_manager.close.assert_called_once_with()
         assert batch_state["instance"].next_active_sizes == [2]
 
     @pytest.mark.parametrize("draft_kind", ["dflash", "eagle3", "mtp"])


### PR DESCRIPTION
Expose APC memory, disk, and checkpoint controls through the running server's existing `GET` / `PATCH /v1/settings` endpoints. Changes take effect on the next text-generation request through the model reload path, without restarting the server process.

Stacked on #2182, which provides shared-prefix reuse, memory budgets, and default disk persistence. This PR contains only the live-configuration changes.

```sh
curl -X PATCH http://localhost:8080/v1/settings \
  -H 'Content-Type: application/json' \
  -d '{"apc_enabled":true,"apc_disk_enabled":true,"apc_memory_max_gb":2,"apc_disk_max_gb":20,"apc_checkpoint_interval_tokens":1024}'
```

- Add settings for memory budget/reserve, disk enablement and queue/shard limits, and checkpoint entries/interval/guard. Pass an APC configuration snapshot into manager creation without mutating the process environment.
- Preserve meaningful zero values, distinguish empty disk paths from `null`, and allow explicit `null` to restore automatic defaults even when environment overrides were set. Reject invalid and non-finite sizes before reload.
- Keep no-op updates from requesting reloads, report changes caused by `replace` operations, and stage APC options while APC is disabled.
- Close the old disk writer after its generation worker's final store, including when requests drain beyond the shutdown timeout. Reloads clear resident caches; existing disk files remain available.
- Document endpoint usage, authentication, defaults, and reset semantics.

Validation on this unchanged commit: **1,056 passed, 2 skipped** across all `test_apc*.py` modules, `test_generate.py`, `test_server.py`, and `test_diffusion_gemma.py`. Formatting, import, lint, and whitespace checks passed. The 23 added cases cover endpoint discovery, next-request configuration, enable/disable, no-op updates, environment precedence, zero/null/empty values, validation, authentication, and disk-writer shutdown on success/failure.
