### PR TITLE
Add Spark-X2.5 (spark2_5 hybrid-attention text model)

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Some models have detailed documentation with prompt formats, examples, and best 
 | LLaVA-OneVision | [Docs](https://github.com/Blaizzy/mlx-vlm/blob/main/mlx_vlm/models/llava_onevision/README.md) |
 | K2-Horizon | [Docs](https://github.com/Blaizzy/mlx-vlm/blob/main/mlx_vlm/models/k2_horizon/README.md) |
 | Z1T-0 | [Docs](https://github.com/Blaizzy/mlx-vlm/blob/main/mlx_vlm/models/z1t/README.md) |
+| Spark-X2.5 | [Docs](https://github.com/Blaizzy/mlx-vlm/blob/main/mlx_vlm/models/spark2_5/README.md) |
 
 ## Installation
 

--- a/mlx_vlm/models/spark2_5/README.md
+++ b/mlx_vlm/models/spark2_5/README.md
@@ -1,0 +1,53 @@
+# Spark-X2.5
+
+Spark-X2.5 (`Spark2_5ForCausalLM`) is a dense, decoder-only text model with a
+hybrid attention stack. Each block uses a fused `q_k_v` projection, grouped-query
+attention (16 Q / 4 KV heads, head dim 256), and a per-head sigmoid gate applied
+to the attention output. Layers alternate between **sliding-window attention**
+(window 512) and **full attention** in a `[S, S, S, F]` pattern (27 sliding, 9
+full), each layer type carrying its own partial-rotary RoPE. The MLP is GeGLU,
+normalization is RMSNorm, and the `lm_head` is tied to the token embedding.
+
+## Supported Models
+
+| Model ID | Notes |
+|---|---|
+| `XHToken/Spark-X2.5-4B` | 4B instruct |
+| `XHToken/Spark-X2.5-4B-Base` | 4B base pretrain |
+| `XHToken/Spark-X2.5-1.7B` | 1.7B instruct |
+| `XHToken/Spark-X2.5-1.7B-Base` | 1.7B base pretrain |
+
+All four share the `spark2_5` architecture, tied embeddings, a 128k vocab, and a
+512-token sliding window; the two sizes differ only in width/depth.
+
+## Model
+
+| Size | Hidden | Layers (S / F) | Heads (Q / KV) | Head dim | Vocab | Window |
+|---|--:|:--:|--:|--:|--:|--:|
+| 4B | 2560 | 36 (27 / 9) | 16 / 4 | 256 | 131072 | 512 |
+| 1.7B | 2048 | 28 (21 / 7) | 8 / 2 | 256 | 131072 | 512 |
+
+Both use the same RoPE layout: full-attention layers apply a partial rotary
+factor of 0.25 (64 of 256 dims) with `θ = 5e6`, while sliding layers rotate all
+256 dims with `θ = 1e4`. Sliding layers are served from a rotating KV cache
+bounded to the 512-token window, so decode throughput and memory stay flat as
+context grows.
+
+## CLI Usage
+
+```bash
+python -m mlx_vlm.generate \
+    --model XHToken/Spark-X2.5-4B \
+    --prompt "The capital of France is" \
+    --max-tokens 64
+```
+
+With greedy decoding:
+
+```bash
+python -m mlx_vlm.generate \
+    --model XHToken/Spark-X2.5-4B \
+    --prompt "The capital of France is" \
+    --max-tokens 64 \
+    --temp 0.0
+```

--- a/mlx_vlm/models/spark2_5/__init__.py
+++ b/mlx_vlm/models/spark2_5/__init__.py
@@ -1,0 +1,4 @@
+from .config import ModelConfig
+from .spark2_5 import Model
+
+__all__ = ["Model", "ModelConfig"]

--- a/mlx_vlm/models/spark2_5/config.py
+++ b/mlx_vlm/models/spark2_5/config.py
@@ -1,0 +1,44 @@
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+from ..base import BaseModelConfig
+
+
+@dataclass
+class ModelConfig(BaseModelConfig):
+    model_type: str = "spark2_5"
+    hidden_size: int = 2560
+    num_hidden_layers: int = 36
+    intermediate_size: int = 10240
+    num_attention_heads: int = 16
+    num_key_value_heads: int = 4
+    head_dim: int = 256
+    vocab_size: int = 131072
+    rms_norm_eps: float = 1e-6
+    max_position_embeddings: int = 1048576
+    sliding_window: int = 512
+    tie_word_embeddings: bool = True
+    attention_bias: bool = False
+    mlp_bias: bool = False
+    headwise_attn_output_gate: bool = True
+    gate_attn_act_mode: str = "sigmoid"
+    hidden_act: str = "gelu"
+    layer_types: Optional[List[str]] = None
+    rope_parameters: Dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self):
+        if self.layer_types is None:
+            self.layer_types = ["full_attention"] * self.num_hidden_layers
+
+    def rope_for(self, layer_type: str):
+        """(rotary_dims, theta) for a layer type. Spark uses a partial rotary
+        factor + a distinct theta per full/sliding layer."""
+        params = (
+            self.rope_parameters.get(layer_type)
+            or self.rope_parameters.get("full_attention")
+            or {}
+        )
+        prf = params.get("partial_rotary_factor", 1.0)
+        theta = params.get("rope_theta", 10000.0)
+        dims = max(2, int(self.head_dim * prf))
+        return dims, float(theta)

--- a/mlx_vlm/models/spark2_5/language.py
+++ b/mlx_vlm/models/spark2_5/language.py
@@ -1,0 +1,201 @@
+import mlx.core as mx
+import mlx.nn as nn
+
+from ..base import (
+    LanguageModelOutput,
+    create_attention_mask,
+    scaled_dot_product_attention,
+)
+from ..cache import KVCache, RotatingKVCache
+from .config import ModelConfig
+
+
+class Attention(nn.Module):
+    def __init__(self, config: ModelConfig, layer_idx: int):
+        super().__init__()
+        dim = config.hidden_size
+        self.n_heads = config.num_attention_heads
+        self.n_kv_heads = config.num_key_value_heads
+        self.head_dim = config.head_dim
+        self.scale = self.head_dim**-0.5
+        self.q_dim = self.n_heads * self.head_dim
+        self.kv_dim = self.n_kv_heads * self.head_dim
+
+        # Spark fuses q/k/v into one projection and gates the attention output
+        # per head with a sigmoid produced from a separate small projection.
+        self.q_k_v_proj = nn.Linear(
+            dim, self.q_dim + 2 * self.kv_dim, bias=config.attention_bias
+        )
+        self.out_proj = nn.Linear(self.q_dim, dim, bias=config.attention_bias)
+        self.headwise_gate = config.headwise_attn_output_gate
+        self.gate_mode = config.gate_attn_act_mode
+        if self.headwise_gate:
+            self.g_proj = nn.Linear(dim, self.n_heads, bias=config.attention_bias)
+
+        layer_type = config.layer_types[layer_idx]
+        self.sliding_window = (
+            config.sliding_window if layer_type == "sliding_attention" else None
+        )
+        rope_dims, rope_base = config.rope_for(layer_type)
+        self.rope = nn.RoPE(rope_dims, traditional=False, base=rope_base)
+
+    def __call__(self, x: mx.array, mask=None, cache=None) -> mx.array:
+        B, L, _ = x.shape
+
+        qkv = self.q_k_v_proj(x)
+        q = qkv[..., : self.q_dim]
+        k = qkv[..., self.q_dim : self.q_dim + self.kv_dim]
+        v = qkv[..., self.q_dim + self.kv_dim :]
+
+        q = q.reshape(B, L, self.n_heads, self.head_dim).transpose(0, 2, 1, 3)
+        k = k.reshape(B, L, self.n_kv_heads, self.head_dim).transpose(0, 2, 1, 3)
+        v = v.reshape(B, L, self.n_kv_heads, self.head_dim).transpose(0, 2, 1, 3)
+
+        if cache is not None:
+            q = self.rope(q, offset=cache.offset)
+            k = self.rope(k, offset=cache.offset)
+            k, v = cache.update_and_fetch(k, v)
+        else:
+            q = self.rope(q)
+            k = self.rope(k)
+
+        out = scaled_dot_product_attention(
+            q, k, v, cache=cache, scale=self.scale, mask=mask
+        )
+
+        if self.headwise_gate:
+            gate = self.g_proj(x).reshape(B, L, self.n_heads, 1).transpose(0, 2, 1, 3)
+            gate = gate.astype(mx.float32)
+            gate = mx.sigmoid(gate) if self.gate_mode == "sigmoid" else nn.silu(gate)
+            out = out * gate.astype(out.dtype)
+
+        out = out.transpose(0, 2, 1, 3).reshape(B, L, -1)
+        return self.out_proj(out)
+
+
+class MLP(nn.Module):
+    def __init__(self, config: ModelConfig):
+        super().__init__()
+        self.gate_proj = nn.Linear(
+            config.hidden_size, config.intermediate_size, bias=config.mlp_bias
+        )
+        self.up_proj = nn.Linear(
+            config.hidden_size, config.intermediate_size, bias=config.mlp_bias
+        )
+        self.down_proj = nn.Linear(
+            config.intermediate_size, config.hidden_size, bias=config.mlp_bias
+        )
+
+    def __call__(self, x: mx.array) -> mx.array:
+        return self.down_proj(nn.gelu(self.gate_proj(x)) * self.up_proj(x))
+
+
+class DecoderLayer(nn.Module):
+    def __init__(self, config: ModelConfig, layer_idx: int):
+        super().__init__()
+        self.self_attn = Attention(config, layer_idx)
+        self.mlp = MLP(config)
+        self.input_layernorm = nn.RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.post_attention_layernorm = nn.RMSNorm(
+            config.hidden_size, eps=config.rms_norm_eps
+        )
+
+    def __call__(self, x: mx.array, mask=None, cache=None) -> mx.array:
+        h = x + self.self_attn(self.input_layernorm(x), mask, cache)
+        return h + self.mlp(self.post_attention_layernorm(h))
+
+
+class Spark2_5Model(nn.Module):
+    def __init__(self, config: ModelConfig):
+        super().__init__()
+        self.config = config
+        self.embedding = nn.Embedding(config.vocab_size, config.hidden_size)
+        self.layers = [DecoderLayer(config, i) for i in range(config.num_hidden_layers)]
+        self.norm = nn.RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.window_size = config.sliding_window
+        # Masks are built from a representative cache of each kind; sliding and
+        # full layers hold different cache types with different offsets.
+        lt = config.layer_types
+        self._swa_idx = (
+            lt.index("sliding_attention") if "sliding_attention" in lt else 0
+        )
+        self._full_idx = lt.index("full_attention") if "full_attention" in lt else 0
+
+    def __call__(self, inputs=None, cache=None, input_embeddings=None):
+        h = input_embeddings if input_embeddings is not None else self.embedding(inputs)
+
+        if cache is None:
+            cache = [None] * len(self.layers)
+
+        full_mask = create_attention_mask(h, cache[self._full_idx])
+        swa_mask = create_attention_mask(
+            h, cache[self._swa_idx], window_size=self.window_size
+        )
+
+        for i, (layer, c) in enumerate(zip(self.layers, cache)):
+            is_sliding = self.config.layer_types[i] == "sliding_attention"
+            h = layer(h, swa_mask if is_sliding else full_mask, c)
+
+        return self.norm(h)
+
+
+class LanguageModel(nn.Module):
+    def __init__(self, config: ModelConfig):
+        super().__init__()
+        self.args = config
+        self.config = config
+        self.model_type = config.model_type
+        self.model = Spark2_5Model(config)
+        if not config.tie_word_embeddings:
+            self.lm_head = nn.Linear(config.hidden_size, config.vocab_size, bias=False)
+
+    def __call__(
+        self,
+        inputs=None,
+        cache=None,
+        input_embeddings=None,
+        inputs_embeds=None,
+        **kwargs,
+    ) -> LanguageModelOutput:
+        if inputs is None:
+            inputs = kwargs.get("input_ids")
+        if inputs_embeds is None:
+            inputs_embeds = input_embeddings
+
+        out = self.model(inputs, cache, inputs_embeds)
+        if self.config.tie_word_embeddings:
+            out = self.model.embedding.as_linear(out)
+        else:
+            out = self.lm_head(out)
+        return LanguageModelOutput(logits=out)
+
+    def sanitize(self, weights):
+        if self.config.tie_word_embeddings:
+            weights.pop("lm_head.weight", None)
+        return weights
+
+    def make_cache(self):
+        # Sliding layers only ever attend to the last `sliding_window` tokens,
+        # so bound their cache with a rotating buffer instead of growing it to
+        # full context. Full-attention layers keep an unbounded cache.
+        caches = []
+        for layer_type in self.config.layer_types:
+            if layer_type == "sliding_attention":
+                caches.append(
+                    RotatingKVCache(max_size=self.config.sliding_window, keep=0)
+                )
+            else:
+                caches.append(KVCache())
+        return caches
+
+    @property
+    def layers(self):
+        return self.model.layers
+
+    @property
+    def head_dim(self):
+        return self.args.head_dim
+
+    @property
+    def n_kv_heads(self):
+        return self.args.num_key_value_heads

--- a/mlx_vlm/models/spark2_5/spark2_5.py
+++ b/mlx_vlm/models/spark2_5/spark2_5.py
@@ -1,0 +1,49 @@
+from typing import Optional
+
+import mlx.core as mx
+import mlx.nn as nn
+
+from ..base import InputEmbeddingsFeatures, LanguageModelOutput
+from .config import ModelConfig
+from .language import LanguageModel
+
+
+class Model(nn.Module):
+    def __init__(self, config: ModelConfig):
+        super().__init__()
+        self.config = config
+        self.model_type = config.model_type
+        self.language_model = LanguageModel(config)
+
+    def get_input_embeddings(
+        self,
+        input_ids: Optional[mx.array] = None,
+        pixel_values: Optional[mx.array] = None,
+        **kwargs,
+    ) -> InputEmbeddingsFeatures:
+        return InputEmbeddingsFeatures(
+            inputs_embeds=self.language_model.model.embedding(input_ids)
+        )
+
+    def __call__(
+        self,
+        input_ids: mx.array,
+        pixel_values: mx.array = None,
+        mask: mx.array = None,
+        cache=None,
+        **kwargs,
+    ) -> LanguageModelOutput:
+        return self.language_model(input_ids, cache=cache, **kwargs)
+
+    def sanitize(self, weights):
+        if any(k.startswith("language_model.") for k in weights):
+            return weights
+        weights = self.language_model.sanitize(weights)
+        return {f"language_model.{k}": v for k, v in weights.items()}
+
+    def make_cache(self):
+        return self.language_model.make_cache()
+
+    @property
+    def layers(self):
+        return self.language_model.layers

--- a/mlx_vlm/tests/test_models.py
+++ b/mlx_vlm/tests/test_models.py
@@ -19277,3 +19277,70 @@ class TestMoge3(unittest.TestCase):
         self.assertEqual(len(out["points_per_step"]), 3)
         self.assertEqual(len(out["depth_per_step"]), 3)
         self.assertEqual(out["points_per_step"][-1].shape, (1, 96, 128, 3))
+
+
+class TestSpark2_5Model(unittest.TestCase):
+    def _config(self, **overrides):
+        from mlx_vlm.models import spark2_5
+
+        params = dict(
+            model_type="spark2_5",
+            hidden_size=64,
+            num_hidden_layers=4,
+            intermediate_size=128,
+            num_attention_heads=4,
+            num_key_value_heads=2,
+            head_dim=16,
+            vocab_size=128,
+            sliding_window=8,
+            max_position_embeddings=512,
+            layer_types=[
+                "sliding_attention",
+                "sliding_attention",
+                "sliding_attention",
+                "full_attention",
+            ],
+            rope_parameters={
+                "full_attention": {"partial_rotary_factor": 0.25, "rope_theta": 5e6},
+                "sliding_attention": {"partial_rotary_factor": 1.0, "rope_theta": 1e4},
+            },
+        )
+        params.update(overrides)
+        return spark2_5.ModelConfig.from_dict(params)
+
+    def test_dense_forward_and_cached_decode(self):
+        from mlx_vlm.models import spark2_5
+        from mlx_vlm.utils import get_model_and_args
+
+        cfg = self._config()
+        model = spark2_5.Model(cfg)
+
+        full_logits, _ = assert_cached_forward_matches_full(model)
+        self.assertEqual(full_logits.shape[0], 1)
+        self.assertEqual(full_logits.shape[-1], cfg.vocab_size)
+        self.assertEqual(len(model.layers), cfg.num_hidden_layers)
+
+        module, model_type = get_model_and_args({"model_type": "spark2_5"})
+        self.assertIs(module, spark2_5)
+        self.assertEqual(model_type, "spark2_5")
+
+    def test_partial_rope_and_headwise_gate(self):
+        from mlx_vlm.models import spark2_5
+
+        cfg = self._config()
+        # full-attention layers use a 0.25 partial rotary; sliding use full.
+        self.assertEqual(cfg.rope_for("full_attention"), (4, 5e6))
+        self.assertEqual(cfg.rope_for("sliding_attention"), (16, 1e4))
+
+        attn = spark2_5.Model(cfg).language_model.model.layers[0].self_attn
+        self.assertTrue(attn.headwise_gate)
+        self.assertEqual(attn.g_proj.weight.shape[0], cfg.num_attention_heads)
+        self.assertEqual(attn.sliding_window, cfg.sliding_window)
+
+    def test_sanitize_adds_language_model_prefix(self):
+        from mlx_vlm.models import spark2_5
+
+        model = spark2_5.Model(self._config())
+        weights = {"model.embedding.weight": mx.zeros((128, 64))}
+        sanitized = model.sanitize(weights)
+        self.assertIn("language_model.model.embedding.weight", sanitized)


### PR DESCRIPTION
Ports XHToken's Spark-X2.5 family (`spark2_5`) — a dense, hybrid sliding/full-attention text model. Covers both sizes in instruct and base variants. Sliding layers are served from a rotating KV cache bounded to the 512-token window, so decode throughput and memory stay flat as context grows.

decode tok/s (Apple M5 Max · bf16 · batch 1)

**Spark-X2.5-4B**

| ctx | tok/s |
|--:|--:|
| 512 | 54 |
| 4,096 | 53 |
| 16,384 | 51 |
| 32,768 | 48 |

**Spark-X2.5-1.7B**

| ctx | tok/s |
|--:|--:|
| 512 | 119 |
| 4,096 | 118 |
| 16,384 | 106 |
| 32,768 | 100 |

**Spark-X2.5-4B-Base**

| ctx | tok/s |
|--:|--:|
| 512 | 54 |
| 4,096 | 52 |
| 16,384 | 50 |
| 32,768 | 46 |

**Spark-X2.5-1.7B-Base**

| ctx | tok/s |
|--:|--:|
| 512 | 120 |
| 4,096 | 118 |
| 16,384 | 110 |
| 32,768 | 101 |

[Model](https://huggingface.co/XHToken/Spark-X2.5-4B)
