### PR TITLE
Fix MiniCPM5 function-call parsing

### DIFF
--- a/mlx_vlm/tests/test_server.py
+++ b/mlx_vlm/tests/test_server.py
@@ -35,6 +35,7 @@ from mlx_vlm.generate.image import ImageGenerationResult
 from mlx_vlm.prompt_utils import apply_chat_template
 from mlx_vlm.server.runtime_config import RuntimeConfig
 from mlx_vlm.tokenizer_utils import SPMStreamingDetokenizer, _ServerTokenStreamer
+from mlx_vlm.tool_parsers import _infer_tool_parser, minicpm5
 
 
 def test_response_generator_prefill_step_override_wins_over_environment(monkeypatch):
@@ -7201,6 +7202,69 @@ class TestProcessToolCalls:
         assert json.loads(result["calls"][1]["function"]["arguments"]) == {
             "path": "file.py"
         }
+
+    minicpm5_call = (
+        '<function name="write_file"><param name="content">'
+        "<![CDATA[  <html>\nA & B\n</html>  ]]></param>"
+        '<param name="version">123</param><param name="count">3</param>'
+        '<param name="enabled">True</param></function>'
+    )
+
+    def test_detects_minicpm5_chat_template(self):
+        template = """{{ '<function name="' ~ tool_call.name ~ '">' }}
+    {{ '<param name="' ~ param_name ~ '">' }}"""
+        assert server.load_tool_module(_infer_tool_parser(template)) is minicpm5
+
+    def test_minicpm5_cdata_and_argument_types(self):
+        tools = [
+            {
+                "function": {
+                    "name": "write_file",
+                    "parameters": {"properties": {"version": {"type": "string"}}},
+                }
+            }
+        ]
+        result = minicpm5.parse_tool_call(self.minicpm5_call, tools)
+
+        assert result == {
+            "name": "write_file",
+            "arguments": {
+                "content": "  <html>\nA & B\n</html>  ",
+                "version": "123",
+                "count": 3,
+                "enabled": True,
+            },
+        }
+
+    def test_minicpm5_multiple_calls_and_streamed_markup(self):
+        text = f'Before{self.minicpm5_call}Between<function name="get_time"></function>After'
+        result = server.process_tool_calls(text, minicpm5, tools=None)
+
+        assert result["remaining_text"] == "Before Between After"
+        assert [call["function"]["name"] for call in result["calls"]] == [
+            "write_file",
+            "get_time",
+        ]
+        assert json.loads(result["calls"][1]["function"]["arguments"]) == {}
+
+        state = server.ToolCallStreamState(
+            minicpm5.tool_call_start, minicpm5.tool_call_end
+        )
+        visible = "".join(state.feed(char) or "" for char in text)
+        visible += state.feed("", last=True) or ""
+        assert visible == "BeforeBetweenAfter"
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            '<function name="lookup"><param name="value">unfinished',
+            '<function name=""></function>',
+            '<function name="lookup"><param>3</param></function>',
+        ],
+    )
+    def test_minicpm5_rejects_malformed_calls(self, text):
+        with pytest.raises(ValueError):
+            minicpm5.parse_tool_call(text)
 
 
 class TestCountThinkingTagTokens:

--- a/mlx_vlm/tool_parsers/__init__.py
+++ b/mlx_vlm/tool_parsers/__init__.py
@@ -15,6 +15,7 @@ _TEMPLATE_MARKERS = [
     (("<mm:think>",), "minimax_m3"),
     (("<minimax:tool_call>",), "minimax_m2"),
     (("<start_function_call>",), "function_gemma"),
+    (("<function name=", "<param name="), "minicpm5"),
     (("<longcat_tool_call>",), "longcat"),
     (("<arg_key>",), "glm47"),
     (("<|tool_call_start|>", "<|tool_call_end|>"), "pythonic"),

--- a/mlx_vlm/tool_parsers/minicpm5.py
+++ b/mlx_vlm/tool_parsers/minicpm5.py
@@ -1,0 +1,66 @@
+"""Parse native XML tool calls from MiniCPM5 models.
+
+Format: https://huggingface.co/openbmb/MiniCPM5-2B/blob/main/chat_template.jinja
+"""
+
+import ast
+import json
+import xml.etree.ElementTree as ET
+
+tool_call_start = "<function"
+tool_call_end = "</function>"
+
+
+def _argument_properties(name, tools):
+    for tool in tools or []:
+        function = tool.get("function") or {}
+        if function.get("name") == name:
+            return (function.get("parameters") or {}).get("properties", {})
+    return {}
+
+
+def _parse_value(value, schema):
+    param_type = schema.get("type")
+    if param_type == "string" or (
+        isinstance(param_type, list) and "string" in param_type
+    ):
+        return value
+
+    try:
+        return json.loads(value)
+    except json.JSONDecodeError:
+        pass
+
+    # The chat template also renders Python literals for non-string arguments.
+    try:
+        return ast.literal_eval(value)
+    except (ValueError, SyntaxError):
+        return value
+
+
+def parse_tool_call(text: str, tools=None):
+    """Parse a complete function element or the shared server's stripped body."""
+    text = text.strip()
+    if not text.startswith(tool_call_start):
+        # process_tool_calls removes both markers, leaving name="...">...</param>.
+        text = f"{tool_call_start} {text}{tool_call_end}"
+
+    try:
+        function = ET.fromstring(text)
+    except ET.ParseError as exc:
+        raise ValueError("Invalid MiniCPM5 function call XML.") from exc
+
+    name = (function.get("name") or "").strip()
+    if function.tag != "function" or not name:
+        raise ValueError("No MiniCPM5 function name provided.")
+
+    properties = _argument_properties(name, tools)
+    arguments = {}
+    for param in function:
+        key = param.get("name")
+        if param.tag != "param" or not key or key in arguments or len(param):
+            raise ValueError("Invalid MiniCPM5 function parameter.")
+        # ElementTree decodes entities and CDATA without stripping text spaces.
+        arguments[key] = _parse_value(param.text or "", properties.get(key, {}))
+
+    return {"name": name, "arguments": arguments}


### PR DESCRIPTION
MiniCPM5-2B's native XML function calls were not detected, so tool requests appeared as assistant text without structured `tool_calls`. Detect its chat-template markers and load a MiniCPM5 parser that handles CDATA, XML entities, and schema-aware argument values.

For a `get_weather` call with `city="Warsaw"`, the assistant message changes as follows (response excerpts; generated call IDs and indices omitted):

**Before**
```json
{
  "content": "<function name=\"get_weather\"><param name=\"city\">Warsaw</param></function>",
  "tool_calls": null
}
```

**After**
```json
{
  "content": null,
  "tool_calls": [
    {
      "type": "function",
      "function": {
        "name": "get_weather",
        "arguments": "{\"city\": \"Warsaw\"}"
      }
    }
  ]
}
```

Multiple calls are extracted, and the shared stream filter suppresses XML markup while preserving surrounding assistant text.

Validation: **415 tests passed** across the tool-parser, response-state, and server suites. Compact regressions live in the existing `TestProcessToolCalls` class in `test_server.py`, covering detection, CDATA/types, malformed input, multiple calls, and split streaming markers. Also verified parser detection against the published [MiniCPM5-2B chat template](https://huggingface.co/openbmb/MiniCPM5-2B/blob/main/chat_template.jinja).