### PR TITLE
Check native tool calling when adding models

### DIFF
--- a/skills/skills/add-new-model/SKILL.md
+++ b/skills/skills/add-new-model/SKILL.md
@@ -24,8 +24,18 @@ Use this workflow to port a new model to MLX-VLM.
    - reading `model.safetensors.index.json` in the HF repo.
 5. **Wire the forward pass** (embeddings → vision/audio encoder → projector → language model), reusing shared helpers (`prompt_utils.py`, processors) where possible.
 6. **Convert to MLX** to get loadable weights — `Skill("mlx-vlm-skills:convert-quantize")`. Upload them to to `mlx-community` (which is self-add) on HF if there is no usable official repo. If the model is already usable directly from HF, you can skip this step and just use the repo directly.
-7. **Add a test class** in `mlx_vlm/tests/test_models.py` (e.g. `TestMyModel`) — a tiny random-weight config, a shape/forward check, and (if applicable) an exactness check against a reference path in the degenerate limit. Do not create a standalone test file.
-8. **Add a README in the model dir** with a short description of the model, supported HF repos, and example usage.
+7. **Check tool calling for every model.** Inspect the official model card, chat template, and reference parser to establish support, including for models that reuse an existing architecture. If supported, complete [Tool Calling](#tool-calling); otherwise record whether support is absent or still unknown.
+8. **Add a test class** in `mlx_vlm/tests/test_models.py` (e.g. `TestMyModel`) — a tiny random-weight config, a shape/forward check, and (if applicable) an exactness check against a reference path in the degenerate limit. Do not create a standalone test file.
+9. **Add a README in the model dir** with a short description of the model, supported HF repos, and example usage.
+
+## Tool Calling
+
+- Verify `_infer_tool_parser_from_processor` against the model's actual chat template. Reuse a compatible parser in `mlx_vlm/tool_parsers/`; add a parser and register its template markers in `__init__.py` only when needed. Check that existing formats still select the right parser.
+- Match the native protocol and schema types, including its string escaping or CDATA rules where applicable. Exercise `process_tool_calls` in `mlx_vlm/server/responses_state.py`: it strips the start/end markers before invoking the parser. Confirm tools and prior tool results render correctly through the chat template.
+- Keep regressions compact in `TestProcessToolCalls` in `mlx_vlm/tests/test_server.py`, reusing existing streaming tests and fixtures. Avoid a new model-specific test file or duplicated endpoint mocks. Cover a single call, argument types, malformed input, and ordinary text around calls.
+- For models supporting multiple calls per response, check both different functions and repeated calls to the same function with different arguments. Assert independent arguments, unique IDs, and ordered indices. Verify split streaming markers do not leak markup or swallow surrounding text; the client controls concurrent tool execution.
+- Run the focused parser cases and shared streaming tests from the repository root: `uv run --with pytest python -m pytest mlx_vlm/tests/test_server.py mlx_vlm/tests/test_responses_state.py -q -k 'ToolCall or tool_content'`. Include existing tests for any reused parser that changed.
+- With loadable weights, smoke-test tools through the server in streaming and non-streaming modes, plus a normal reply without a call. Report whether validation used actual generation or synthetic output. Include a concrete before/after response example when describing a tool-calling fix in a PR.
 
 ## Determine Layer Names (quick)
 

--- a/skills/skills/server-inference/SKILL.md
+++ b/skills/skills/server-inference/SKILL.md
@@ -76,11 +76,11 @@ Match the model kind to the endpoint (an image endpoint needs a diffusion/image 
 - For OpenAI client issues, reproduce with `curl` before blaming the client SDK.
 - For streaming bugs, save raw event chunks and compare with non-streaming.
 - For structured outputs, isolate the JSON schema and confirm whether the same request works without schema constraints.
-- For tool calls, record the chat template/tool parser inferred by the loaded processor when possible.
+- For tool calls, inspect native support and the parser inferred from the loaded processor's actual chat template. Follow [Tool Calling](../add-new-model/SKILL.md#tool-calling) for parser registration and validation.
 
 ## Validation
 
 - For route/schema changes, run `uv run pytest mlx_vlm/tests/test_server.py -q`.
 - For structured output changes, include `uv run pytest mlx_vlm/tests/test_structured.py -q`.
-- For tool parser changes, include the relevant parser tests under `mlx_vlm/tests/test_*tool_parser.py`.
+- For tool parser changes, add compact regressions to `TestProcessToolCalls` in `mlx_vlm/tests/test_server.py` and run the shared streaming tests in `test_responses_state.py`, plus any existing tests for affected parsers. Reuse consolidated tests instead of creating a new test file.
 - If the result is a user-facing bug report, switch to `Skill("mlx-vlm-skills:reproducible-github-issues")`.


### PR DESCRIPTION
The model-porting workflow did not require checking native tool calling, allowing parser gaps like the MiniCPM5 issue fixed in #2190 to go unnoticed. Update `add-new-model` to check the official model card, actual chat template, and reference parser for every model being added, including those that reuse an existing architecture.

**Before:** A tool-capable model could pass the prescribed forward and generation checks without verifying whether its native tool output became structured API calls.

**After:** The workflow establishes native support, reuses or adds and registers a compatible parser, and validates argument handling and streamed output. For models supporting multiple calls per response, it checks independent arguments, unique IDs, ordered indices, and repeated calls to the same function. It also requires tools and prior tool results to render through the chat template, with server smoke tests when weights are loadable.

Keep regressions compact in the existing `TestProcessToolCalls` class and reuse shared streaming tests. Align `server-inference` with this guidance. Require before/after response examples for tool-calling fixes and distinguish synthetic checks from actual model generation.

Validation:
- Repository skill validator: all 8 skills valid.
- Skill-creator validator: both edited skills valid.
- Documented parser/streaming test selection: 23 passed.
- `git diff --check`: passed.

This updates the workflow for future model work; it does not audit every existing model.