### PR TITLE
Add TTS support for MiniCPM-o

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,11 +130,14 @@ mlx_vlm.generate --model mlx-community/Qwen2-VL-2B-Instruct-4bit --max-tokens 10
 # Image generation
 mlx_vlm.generate --model mlx-community/Qwen2-VL-2B-Instruct-4bit --max-tokens 100 --temperature 0.0 --image http://images.cocodataset.org/val2017/000000039769.jpg
 
-# Audio generation (New)
+# Audio understanding
 mlx_vlm.generate --model mlx-community/gemma-3n-E2B-it-4bit --max-tokens 100 --prompt "Describe what you hear" --audio /path/to/audio.wav
 
-# Multi-modal generation (Image + Audio)
+# Multi-modal understanding (Image + Audio)
 mlx_vlm.generate --model mlx-community/gemma-3n-E2B-it-4bit --max-tokens 100 --prompt "Describe what you see and hear" --image /path/to/image.jpg --audio /path/to/audio.wav
+
+# Speech generation
+mlx_vlm.generate --model openbmb/MiniCPM-o-4_5 --output-modality audio --prompt "Say hello." --ref-audio /path/to/voice.wav --output speech.wav --max-tokens 256
 ```
 
 #### Thinking Budget

--- a/mlx_vlm/__init__.py
+++ b/mlx_vlm/__init__.py
@@ -7,12 +7,15 @@ os.environ["TRANSFORMERS_VERBOSITY"] = "error"
 from ._stream_cleanup import clear_mlx_streams
 from .convert import convert
 from .generate import (
+    AudioGenerationResult,
     BatchResponse,
     BatchStats,
     GenerationResult,
     PromptCacheState,
     batch_generate,
     generate,
+    generate_audio,
+    save_audio,
     stream_generate,
 )
 from .prompt_utils import apply_chat_template, get_message_json

--- a/mlx_vlm/__main__.py
+++ b/mlx_vlm/__main__.py
@@ -9,6 +9,7 @@ if __name__ == "__main__":
         "generate",
         "generate_image",
         "generate_video",
+        "generate_audio",
         "convert",
         "chat",
         "chat_ui",
@@ -21,7 +22,7 @@ if __name__ == "__main__":
     subcommand = sys.argv.pop(1)
     if subcommand not in subcommands:
         raise ValueError(f"CLI requires a subcommand in {subcommands}")
-    if subcommand in {"generate_image", "generate_video"}:
+    if subcommand in {"generate_image", "generate_video", "generate_audio"}:
         output_modality = subcommand.removeprefix("generate_")
         sys.argv[1:1] = ["--output-modality", output_modality]
         subcommand = "generate"

--- a/mlx_vlm/generate/__init__.py
+++ b/mlx_vlm/generate/__init__.py
@@ -8,6 +8,12 @@ from .ar import (
     batch_generate,
     generate_step,
 )
+from .audio import (
+    AudioGenerationResult,
+    generate_audio,
+    is_audio_generation_model,
+    save_audio,
+)
 from .cli import main, parse_arguments
 from .common import (
     GenerationResult,
@@ -55,6 +61,7 @@ from .video_generation import (
 )
 
 __all__ = [
+    "AudioGenerationResult",
     "BatchGenerator",
     "BatchResponse",
     "BatchStats",
@@ -79,6 +86,7 @@ __all__ = [
     "batch_generate",
     "edit_image",
     "generate",
+    "generate_audio",
     "generate_image",
     "generate_step",
     "generate_video",
@@ -88,6 +96,7 @@ __all__ = [
     "image_to_b64_json",
     "image_to_png_bytes",
     "is_image_edit_model",
+    "is_audio_generation_model",
     "is_image_generation_model",
     "is_video_generation_model",
     "load_image_edit_model",
@@ -97,6 +106,7 @@ __all__ = [
     "main",
     "maybe_quantize_kv_cache",
     "parse_arguments",
+    "save_audio",
     "save_video",
     "stream_generate",
     "video_generation_model_class",

--- a/mlx_vlm/generate/audio.py
+++ b/mlx_vlm/generate/audio.py
@@ -1,0 +1,153 @@
+"""Speech output for omni models, using the shared text generation path."""
+
+from dataclasses import dataclass, fields, replace
+from io import BytesIO
+from pathlib import Path
+from typing import List, Optional, Union
+
+import mlx.core as mx
+import mlx.nn as nn
+import numpy as np
+
+from .common import GenerationResult, generation_stream, wired_limit
+from .types import ProcessorLike
+
+
+@dataclass
+class AudioGenerationResult(GenerationResult):
+    """Generated speech as a mono waveform and its sample rate in Hz."""
+
+    audio: Optional[mx.array] = None
+    sample_rate: int = 24000
+    audio_tokens: Optional[mx.array] = None
+    path: Optional[Path] = None
+
+    def to_wav_bytes(self) -> bytes:
+        from mlx_audio.audio_io import write
+
+        if self.audio is None or self.audio.size == 0:
+            raise ValueError("No audio was generated.")
+        buffer = BytesIO()
+        write(
+            buffer,
+            np.asarray(self.audio, dtype=np.float32),
+            samplerate=self.sample_rate,
+            format="wav",
+        )
+        return buffer.getvalue()
+
+
+def save_audio(result: AudioGenerationResult, path: Union[str, Path]) -> Path:
+    """Save generated speech as a WAV file and record its path on the result."""
+    path = Path(path)
+    if path.suffix.lower() != ".wav":
+        raise ValueError("Audio output must use a .wav extension.")
+    data = result.to_wav_bytes()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(data)
+    result.path = path
+    return path
+
+
+def is_audio_generation_model(model: nn.Module) -> bool:
+    """Check local model capabilities without downloading any metadata."""
+    return callable(getattr(model, "generate_audio", None)) and getattr(
+        model, "supports_audio_generation", True
+    )
+
+
+def generate_audio(
+    model: nn.Module,
+    processor: ProcessorLike,
+    prompt: str,
+    image: Union[str, List[str], None] = None,
+    audio: Union[str, List[str], None] = None,
+    video: Union[str, List[str], None] = None,
+    verbose: bool = False,
+    output_audio_path: Union[str, Path, None] = None,
+    ref_audio_path: Optional[str] = None,
+    **kwargs,
+) -> AudioGenerationResult:
+    """Generate a spoken response to a formatted chat prompt.
+
+    Load the omni model with :func:`mlx_vlm.load` and format its prompt with
+    ``apply_chat_template(..., use_tts_template=True)``. Text sampling options
+    are shared with ``generate``; options prefixed with ``tts_`` go only to
+    the speech model. ``audio`` is an input to understand; ``ref_audio_path``
+    supplies the reference voice to both the model's prompt and its codec.
+    The waveform is returned even without a file path. MiniCPM-o currently
+    requires a reference WAV (or audio input).
+    """
+    from .dispatch import _prepare_generation_inputs, generate
+
+    if not is_audio_generation_model(model):
+        raise ValueError(
+            f"{type(model).__name__} does not support audio generation with these "
+            "weights. Use a checkpoint containing the TTS module."
+        )
+    if (
+        output_audio_path is not None
+        and Path(output_audio_path).suffix.lower() != ".wav"
+    ):
+        raise ValueError("Audio output must use a .wav extension.")
+    validate = getattr(model, "validate_audio_generation", None)
+    if callable(validate):
+        validate(audio=audio, ref_audio_path=ref_audio_path)
+
+    prepare_reference = getattr(processor, "prepare_audio_generation", None)
+    if callable(prepare_reference):
+        if kwargs.get("input_ids") is not None:
+            raise ValueError(
+                "Automatic reference-voice conditioning requires a formatted "
+                "prompt, not precomputed input_ids."
+            )
+        prompt, audio = prepare_reference(
+            prompt, audio=audio, ref_audio_path=ref_audio_path
+        )
+
+    speech_kwargs = {
+        key: kwargs.pop(key) for key in list(kwargs) if key.startswith("tts_")
+    }
+    input_ids, pixel_values, mask, data_kwargs = _prepare_generation_inputs(
+        model, processor, prompt, image, audio, video, kwargs
+    )
+    text_result = generate(
+        model,
+        processor,
+        prompt,
+        image,
+        audio,
+        video,
+        verbose=verbose,
+        input_ids=input_ids,
+        pixel_values=pixel_values,
+        mask=mask,
+        **kwargs,
+    )
+    tokenizer = getattr(processor, "tokenizer", processor)
+    with wired_limit(model, [generation_stream]), mx.stream(generation_stream):
+        result = model.generate_audio(
+            input_ids=input_ids,
+            generated_tokens=text_result.token_ids or [],
+            tokenizer=tokenizer,
+            pixel_values=pixel_values,
+            mask=mask,
+            audio=audio,
+            ref_audio_path=ref_audio_path,
+            **data_kwargs,
+            **speech_kwargs,
+        )
+        mx.eval(result.audio, result.audio_tokens)
+    spoken_text = result.text or text_result.text
+    result = replace(
+        result,
+        **{
+            field.name: getattr(text_result, field.name)
+            for field in fields(GenerationResult)
+        },
+    )
+    result.text = spoken_text
+    result.peak_memory = mx.get_peak_memory() / 1e9
+    if output_audio_path is not None:
+        save_audio(result, output_audio_path)
+    return result

--- a/mlx_vlm/generate/common.py
+++ b/mlx_vlm/generate/common.py
@@ -269,6 +269,7 @@ class GenerationResult:
     diffusion_total_steps: int = 0
     diffusion_canvas_index: int = 0
     diffusion_block_complete: bool = False
+    token_ids: Optional[List[int]] = None
 
 
 class PromptCacheState:

--- a/mlx_vlm/generate/dispatch.py
+++ b/mlx_vlm/generate/dispatch.py
@@ -24,6 +24,7 @@ from ..utils import (
     prepare_inputs,
     should_add_special_tokens,
 )
+from .audio import generate_audio
 from .common import (
     DEFAULT_DIFFUSION_MAX_DENOISING_STEPS,
     DEFAULT_DIFFUSION_MIN_CANVAS_LENGTH,
@@ -97,7 +98,7 @@ DEFAULT_THINKING_END_TOKEN = "</think>"
 
 def parse_arguments():
     parser = argparse.ArgumentParser(
-        description="Generate text, an image, or a video with a supported model."
+        description="Generate text, an image, a video, or audio with a supported model."
     )
     parser.add_argument(
         "--model",
@@ -108,18 +109,24 @@ def parse_arguments():
     parser.add_argument(
         "--output-modality",
         type=str,
-        choices=("text", "image", "video"),
+        choices=("text", "image", "video", "audio"),
         default="text",
         help=(
             "Generate text with a VLM, an image with a supported image model, "
-            "or a video with a supported video model."
+            "a video with a supported video model, or speech with an omni model."
         ),
     )
     parser.add_argument(
         "--output",
         type=str,
         default=None,
-        help="Output path for image or video generation.",
+        help="Output path for image, video, or audio generation (.wav for audio).",
+    )
+    parser.add_argument(
+        "--ref-audio",
+        type=str,
+        default=None,
+        help="Reference voice audio for --output-modality audio.",
     )
     parser.add_argument(
         "--task",
@@ -656,13 +663,48 @@ def normalize_resize_shape(
 
 from .diffusion import (
     DEFAULT_DIFFUSION_CONFIDENCE_THRESHOLD,
-    DEFAULT_DIFFUSION_MIN_CANVAS_LENGTH,
     DiffusionOutputHandler,
     diffusion_kwargs_from_args,
     is_diffusion_model,
     stream_diffusion_generate_from_kwargs,
 )
 from .types import GenerateKwargs, ProcessorLike, Unpack
+
+
+def _prepare_generation_inputs(model, processor, prompt, image, audio, video, kwargs):
+    """Prepare multimodal inputs once, or consume caller-prepared tensors."""
+    resize_shape = normalize_resize_shape(kwargs.pop("resize_shape", None))
+    if kwargs.get("input_ids") is not None:
+        input_ids = kwargs.pop("input_ids")
+        pixel_values = kwargs.pop("pixel_values", None)
+        mask = kwargs.pop("mask", None)
+        return input_ids, pixel_values, mask, dict(kwargs)
+
+    inputs = prepare_inputs(
+        processor,
+        images=image or None,
+        audio=audio or None,
+        videos=video or None,
+        prompts=prompt,
+        image_token_index=getattr(model.config, "image_token_index", None),
+        resize_shape=resize_shape,
+        add_special_tokens=should_add_special_tokens(
+            model.config.model_type, processor
+        ),
+        **kwargs,
+    )
+    data_kwargs = {
+        key: value
+        for key, value in inputs.items()
+        if key not in ("input_ids", "pixel_values", "attention_mask")
+    }
+    kwargs.update(data_kwargs)
+    return (
+        inputs.get("input_ids"),
+        inputs.get("pixel_values"),
+        inputs.get("attention_mask"),
+        data_kwargs,
+    )
 
 
 def _prime_cached_prefix_rope_state(
@@ -808,10 +850,6 @@ def stream_generate(
         else []
     )
 
-    add_special_tokens = should_add_special_tokens(model.config.model_type, processor)
-
-    resize_shape = normalize_resize_shape(kwargs.pop("resize_shape", None))
-    image_token_index = getattr(model.config, "image_token_index", None)
     vision_cache = kwargs.pop("vision_cache", None)
     prompt_cache_state = kwargs.pop("prompt_cache_state", None)
     apc_manager: Optional[_apc.APCManager] = kwargs.pop("apc_manager", None)
@@ -820,31 +858,9 @@ def stream_generate(
     audio = audio or None
     video = video or None
 
-    if kwargs.get("input_ids", None) is not None:
-        input_ids = kwargs.pop("input_ids")
-        pixel_values = kwargs.pop("pixel_values", None)
-        mask = kwargs.pop("mask", None)
-    else:
-        inputs = prepare_inputs(
-            processor,
-            images=image,
-            audio=audio,
-            videos=video,
-            prompts=prompt,
-            image_token_index=image_token_index,
-            resize_shape=resize_shape,
-            add_special_tokens=add_special_tokens,
-            **kwargs,
-        )
-        input_ids = inputs.get("input_ids", None)
-        pixel_values = inputs.get("pixel_values", None)
-        mask = inputs.get("attention_mask", None)
-        data_kwargs = {
-            k: v
-            for k, v in inputs.items()
-            if k not in ["input_ids", "pixel_values", "attention_mask"]
-        }
-        kwargs.update(data_kwargs)
+    input_ids, pixel_values, mask, _ = _prepare_generation_inputs(
+        model, processor, prompt, image, audio, video, kwargs
+    )
 
     if is_diffusion_model(model, kwargs):
         yield from stream_diffusion_generate_from_kwargs(
@@ -1113,6 +1129,7 @@ def stream_generate(
                 peak_memory=mx.get_peak_memory() / 1e9,
                 cached_tokens=reused_prefix_len,
                 finish_reason="length",
+                token_ids=[],
             )
             return
 
@@ -1129,6 +1146,10 @@ def stream_generate(
             peak_memory=mx.get_peak_memory() / 1e9,
             cached_tokens=reused_prefix_len,
             finish_reason=finish_reason,
+            token_ids=[
+                int(t.item()) if hasattr(t, "item") else int(t)
+                for t in generated_tokens
+            ],
         )
 
         # Save cache state for potential reuse on next turn
@@ -1271,6 +1292,7 @@ def generate(
     return GenerationResult(
         text=text,
         token=last_response.token,
+        token_ids=last_response.token_ids,
         logprobs=last_response.logprobs,
         prompt_tokens=last_response.prompt_tokens,
         generation_tokens=last_response.generation_tokens,
@@ -1290,13 +1312,21 @@ def generate(
 
 def main():
     args = parse_arguments()
+    output_modality = getattr(args, "output_modality", "text")
 
-    if getattr(args, "output_modality", "text") == "image":
+    if output_modality == "image":
         run_image_generation_cli(args)
         return
-    if getattr(args, "output_modality", "text") == "video":
+    if output_modality == "video":
         run_video_generation_cli(args)
         return
+    if output_modality == "audio":
+        if getattr(args, "output", None) is None:
+            raise ValueError(
+                "--output is required when --output-modality audio is selected"
+            )
+        if args.chat:
+            raise ValueError("--output-modality audio does not support --chat")
 
     if getattr(args, "seed", None) is not None:
         mx.random.seed(args.seed)
@@ -1442,6 +1472,8 @@ def main():
     num_audios = len(args.audio) if args.audio is not None else 0
 
     chat_template_kwargs = {"enable_thinking": args.enable_thinking}
+    if output_modality == "audio":
+        chat_template_kwargs["use_tts_template"] = True
     if args.thinking_mode is not None:
         chat_template_kwargs["thinking_mode"] = args.thinking_mode
     if args.video:
@@ -1602,7 +1634,12 @@ def main():
         if args.verbose:
             _enable_verbose_logging()
 
-        result = generate(
+        generate_fn = generate
+        if output_modality == "audio":
+            generate_fn = generate_audio
+            gen_kwargs["output_audio_path"] = args.output
+            gen_kwargs["ref_audio_path"] = args.ref_audio
+        result = generate_fn(
             model,
             processor,
             prompt,
@@ -1610,6 +1647,8 @@ def main():
         )
         if not args.verbose:
             print(result.text)
+        if output_modality == "audio":
+            print(f"Audio written to {result.path}")
 
         if draft_model is not None:
             stats = format_speculative_stats(draft_model)

--- a/mlx_vlm/models/minicpmo/README.md
+++ b/mlx_vlm/models/minicpmo/README.md
@@ -54,14 +54,16 @@ uv run mlx_vlm.generate \
   --temperature 0
 ```
 
-### Disable thinking in chat template
+### Enable thinking in chat template
+
+Thinking is disabled by default. To enable it:
 
 ```sh
 uv run mlx_vlm.generate \
   --model openbmb/MiniCPM-o-4_5 \
   --audio /path/to/audio.wav \
   --prompt "Describe this audio briefly." \
-  --chat-template-kwargs '{"enable_thinking": false}' \
+  --enable-thinking \
   --max-tokens 256 \
   --temperature 0
 ```
@@ -86,7 +88,7 @@ formatted_prompt = apply_chat_template(
     prompt,
     num_images=len(image),
     num_audios=len(audio),
-    chat_template_kwargs={"enable_thinking": False},
+    enable_thinking=False,
 )
 
 result = generate(
@@ -104,4 +106,83 @@ print(result.text)
 ## Notes
 
 - You usually should not manually add `<image>` or `<audio>` markers when using `apply_chat_template`.
-- For CLI, `--audio` currently behaves as a single-audio path in template counting.
+- Multiple `--audio` inputs are processed in the order supplied.
+
+## Speech output
+
+MiniCPM-o 4.5 can generate a spoken response using `--output-modality audio`.
+The CLI formats the TTS prompt, generates the response text, and synthesizes a
+24 kHz mono WAV file.
+
+```sh
+python -m mlx_vlm generate \
+  --model openbmb/MiniCPM-o-4_5 \
+  --output-modality audio \
+  --prompt "Say hello in one short sentence." \
+  --ref-audio /path/to/reference.wav \
+  --output speech.wav \
+  --max-tokens 256 \
+  --temperature 0 \
+  --seed 7
+```
+
+`python -m mlx_vlm generate_audio` is an alias for the same path. Supply a short,
+clean voice recording with `--ref-audio`. If it is omitted, the first `--audio`
+input supplies the reference voice. The reference conditions both the speech
+codec and a voice-cloning system prompt, following the upstream MiniCPM-o
+recipe. This lets the language-model hidden states used by TTS carry the
+reference voice and style. Existing system instructions and separate image or
+audio inputs are preserved. Pass a formatted prompt to `generate_audio()` so
+it can insert the reference before tokenization; precomputed `input_ids` are
+not supported by this automatic conditioning path.
+
+The first synthesis loads the separate `mlx-community/Step-Audio-2-token2wav`
+codec and its S3 tokenizer. Decoding runs in MLX, without PyTorch or remote
+Python code. This path currently supports a single response at a time, with
+non-streaming waveform output; `--chat` is not supported.
+
+Text generation uses the usual sampling arguments. Speech sampling can be tuned
+independently with `--gen-kwargs`, for example:
+
+```sh
+--gen-kwargs '{"tts_max_tokens": 1024, "tts_temperature": 0.8}'
+```
+
+The supported speech options are `tts_max_tokens` (2048), `tts_temperature` (0.8),
+`tts_top_p` (0.85), `tts_top_k` (25), and `tts_repetition_penalty` (1.05).
+Parenthesized values are the defaults for MiniCPM-o 4.5. The text budget must be
+large enough to finish the spoken response and generate its `<|tts_eos|>` marker.
+
+### Python speech API
+
+```python
+from mlx_vlm import apply_chat_template, generate_audio, load, save_audio
+
+model, processor = load("openbmb/MiniCPM-o-4_5")
+prompt = apply_chat_template(
+    processor,
+    model.config,
+    "Say hello in one short sentence.",
+    enable_thinking=False,
+    use_tts_template=True,
+)
+result = generate_audio(
+    model,
+    processor,
+    prompt,
+    ref_audio_path="/path/to/reference.wav",
+    max_tokens=256,
+    temperature=0,
+)
+print(result.text)          # Spoken response, without TTS control tokens
+print(result.audio.shape)  # MLX mono waveform, available without writing a file
+print(result.sample_rate)  # 24000
+save_audio(result, "speech.wav")
+# result.to_wav_bytes() returns an in-memory WAV.
+```
+
+`AudioGenerationResult` includes the text generation statistics and token IDs,
+the speech codec tokens, the waveform, sample rate, and saved `path` (if any).
+Text throughput statistics describe the text stage; `peak_memory` includes
+speech synthesis. `generate_audio(..., output_audio_path="speech.wav")` saves
+the waveform directly.

--- a/mlx_vlm/models/minicpmo/__init__.py
+++ b/mlx_vlm/models/minicpmo/__init__.py
@@ -1,15 +1,19 @@
 from ..qwen3_vl.language import LanguageModel
 from .audio import AudioModel
-from .config import AudioConfig, ModelConfig, TextConfig, VisionConfig
+from .config import AudioConfig, MiniCPMTTSConfig, ModelConfig, TextConfig, VisionConfig
 from .minicpmo import Model
+from .tts import MiniCPMTTS, TTSSamplingParams
 from .vision import VisionModel
 
 __all__ = [
     "AudioConfig",
     "AudioModel",
     "LanguageModel",
+    "MiniCPMTTS",
+    "MiniCPMTTSConfig",
     "Model",
     "ModelConfig",
+    "TTSSamplingParams",
     "TextConfig",
     "VisionConfig",
     "VisionModel",

--- a/mlx_vlm/models/minicpmo/config.py
+++ b/mlx_vlm/models/minicpmo/config.py
@@ -80,10 +80,45 @@ class AudioConfig(BaseModelConfig):
 
 
 @dataclass
+class MiniCPMTTSConfig(BaseModelConfig):
+    model_type: str = "minicpmtts"
+    llm_dim: int = 4096
+    llm_hidden_size: Optional[int] = None
+    llm_intermediate_size: int = 768
+    projector_type: str = "mlp"
+    hidden_size: int = 768
+    intermediate_size: int = 3072
+    num_attention_heads: int = 12
+    num_hidden_layers: int = 20
+    num_key_value_heads: int = 12
+    max_position_embeddings: int = 4096
+    num_audio_tokens: int = 6562
+    num_text_tokens: int = 152064
+    num_vq: int = 1
+    audio_bos_token_id: int = 151687
+    text_eos_token_id: int = 151692
+    condition_type: str = "hidden_text_merge"
+    backbone_model: str = "llama"
+    backbone_vocab_size: int = 32000
+    normalize_projected_hidden: bool = False
+    top_p: float = 0.85
+    top_k: int = 25
+    repetition_penalty: float = 1.05
+    temperature: float = 0.8
+    rms_norm_eps: float = 1e-6
+    rope_theta: float = 10000.0
+
+    def __post_init__(self):
+        if self.llm_hidden_size is None:
+            self.llm_hidden_size = self.llm_dim
+
+
+@dataclass
 class ModelConfig(BaseModelConfig):
     text_config: TextConfig
     vision_config: VisionConfig
     audio_config: Optional[AudioConfig] = None
+    tts_config: Optional[MiniCPMTTSConfig] = None
     model_type: str = "minicpmo"
     query_num: int = 64
     image_size: int = 448
@@ -145,6 +180,13 @@ class ModelConfig(BaseModelConfig):
             AudioConfig.from_dict(audio_params) if len(audio_params) > 0 else None
         )
 
+        tts_params = dict(params.pop("tts_config", {}))
+        if source_params is not None:
+            source_params["tts_config"] = dict(tts_params)
+        tts_config = (
+            MiniCPMTTSConfig.from_dict(tts_params) if len(tts_params) > 0 else None
+        )
+
         slice_params = params.pop("slice_config", None)
         slice_config = (
             SliceConfig.from_dict(slice_params)
@@ -156,6 +198,7 @@ class ModelConfig(BaseModelConfig):
             text_config=text_config,
             vision_config=vision_config,
             audio_config=audio_config,
+            tts_config=tts_config,
             slice_config=slice_config,
             **{
                 k: v

--- a/mlx_vlm/models/minicpmo/minicpmo.py
+++ b/mlx_vlm/models/minicpmo/minicpmo.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from typing import Optional
 
 import mlx.core as mx
@@ -9,6 +10,7 @@ from ..qwen3_vl.language import LanguageModel
 from .audio import AudioModel, AudioProjector, check_conv1d_weight_shape
 from .config import ModelConfig
 from .processing_minicpmo import MiniCPMOProcessor  # noqa: F401
+from .tts import MiniCPMTTS, TTSSamplingParams, sanitize_tts_weights
 from .vision import VisionModel, check_array_shape
 
 
@@ -234,10 +236,18 @@ class Model(nn.Module):
         else:
             self.audio_tower = None
             self.audio_projection_layer = None
+        if config.init_tts and config.tts_config is not None:
+            self.tts = MiniCPMTTS(config.tts_config)
+        else:
+            self.tts = None
 
     @property
     def layers(self):
         return self.language_model.model.layers
+
+    @property
+    def supports_audio_generation(self):
+        return self.tts is not None
 
     def _set_position_state(self, input_ids: mx.array):
         batch_size, seq_len = input_ids.shape
@@ -501,13 +511,287 @@ class Model(nn.Module):
             cache=cache,
         )
 
+    def get_hidden_states(
+        self,
+        input_ids: mx.array,
+        pixel_values: Optional[list] = None,
+        mask: Optional[mx.array] = None,
+        **kwargs,
+    ):
+        """Recompute final hidden states without a vocabulary projection.
+
+        The normal text loop remains cache-compatible and does not retain
+        intermediate activations for every layer and every generated token.
+        """
+        input_embeddings_features = self.get_input_embeddings(
+            input_ids=input_ids,
+            pixel_values=pixel_values,
+            **kwargs,
+        )
+        attention_mask = None
+        if mask is not None:
+            if mask.shape != input_ids.shape:
+                raise ValueError(
+                    "Speech conditioning requires a 2D attention mask matching input_ids"
+                )
+            if not mx.all(mask).item():
+                causal = mx.tril(
+                    mx.ones((input_ids.shape[1], input_ids.shape[1]), dtype=mx.bool_)
+                )
+                attention_mask = causal[None, None] & mask[:, None, None, :].astype(
+                    mx.bool_
+                )
+        return self.language_model.model(
+            input_ids,
+            inputs_embeds=input_embeddings_features.inputs_embeds,
+            mask=attention_mask,
+            cache=None,
+            position_ids=self.language_model._position_ids,
+        )
+
+    def find_tts_bound(
+        self,
+        input_ids: mx.array,
+        tts_start_id: int,
+        tts_end_id: int,
+    ) -> tuple[int, int]:
+        ids = _to_numpy(input_ids).reshape(-1)
+        start_positions = np.where(ids == tts_start_id)[0]
+        end_positions = np.where(ids == tts_end_id)[0]
+        if len(start_positions) == 0:
+            raise ValueError(
+                "Could not find <|tts_bos|> in the generated "
+                "sequence. Make sure the prompt was built with use_tts_template=True."
+            )
+
+        start = start_positions[-1]
+        valid_ends = end_positions[end_positions > start]
+        if len(valid_ends) == 0:
+            raise ValueError(
+                "The spoken response is incomplete; increase max_tokens to generate <|tts_eos|>."
+            )
+        end = valid_ends[0]
+        if end == start + 1:
+            raise ValueError("The model generated an empty spoken response.")
+        return int(start + 1), int(end)
+
+    def build_tts_input_embeddings(
+        self,
+        full_input_ids: mx.array,
+        hidden_states: mx.array,
+        tts_bound: tuple[int, int],
+    ) -> mx.array:
+        if self.tts is None:
+            raise ValueError("MiniCPM-o TTS module is not initialized.")
+        if self.tts.condition_type != "hidden_text_merge":
+            raise NotImplementedError(
+                f"Unsupported MiniCPM-o TTS condition type: {self.tts.condition_type}"
+            )
+
+        start, end = tts_bound
+        llm_tokens = full_input_ids[:, start:end]
+        llm_embeds = self.tts.emb_text(llm_tokens)
+        hidden_embeds = self.tts.projector_semantic(hidden_states[:, start:end, :])
+        if self.tts.config.normalize_projected_hidden:
+            normalized = hidden_embeds.astype(mx.float32)
+            denom = mx.linalg.norm(normalized, ord=2, axis=-1, keepdims=True)
+            hidden_embeds = (normalized / mx.maximum(denom, 1e-12)).astype(
+                hidden_embeds.dtype
+            )
+
+        tts_embeds = llm_embeds + hidden_embeds
+        text_eos = mx.array([[self.tts.config.text_eos_token_id]], dtype=mx.int32)
+        audio_bos = mx.array([[self.tts.audio_bos_token_id]], dtype=mx.int32)
+        text_eos_embed = self.tts.emb_text(text_eos).astype(tts_embeds.dtype)
+        audio_bos_embed = self.tts.emb_text(audio_bos).astype(tts_embeds.dtype)
+        return mx.concatenate([tts_embeds, text_eos_embed, audio_bos_embed], axis=1)
+
+    def generate_speech_tokens(
+        self,
+        full_input_ids: mx.array,
+        pixel_values: Optional[list] = None,
+        mask: Optional[mx.array] = None,
+        tts_start_id: Optional[int] = None,
+        tts_end_id: Optional[int] = None,
+        tts_bound: Optional[tuple[int, int]] = None,
+        tts_sampling_params: Optional[TTSSamplingParams] = None,
+        tts_max_new_token: int = 2048,
+        **kwargs,
+    ) -> mx.array:
+        if self.tts is None:
+            raise ValueError("MiniCPM-o TTS module is not initialized.")
+        if full_input_ids.shape[0] != 1:
+            raise ValueError(
+                "MiniCPM-o audio generation currently supports batch size 1"
+            )
+
+        if tts_bound is None:
+            if tts_start_id is None or tts_end_id is None:
+                raise ValueError("tts_start_id and tts_end_id are required.")
+            tts_bound = self.find_tts_bound(full_input_ids, tts_start_id, tts_end_id)
+
+        hidden_states = self.get_hidden_states(
+            full_input_ids,
+            pixel_values=pixel_values,
+            mask=mask,
+            **kwargs,
+        )
+        inputs_embeds = self.build_tts_input_embeddings(
+            full_input_ids,
+            hidden_states,
+            tts_bound,
+        )
+        outputs = self.tts.generate(
+            inputs_embeds=inputs_embeds,
+            eos_token=self.tts.config.num_audio_tokens - 1,
+            # Suppress early EOS, while respecting a smaller generation budget.
+            min_new_token=min(50, tts_max_new_token),
+            max_new_token=tts_max_new_token,
+            sampling_params=tts_sampling_params,
+        )
+        return outputs.new_ids
+
+    @staticmethod
+    def _token_id(tokenizer, attr: str, token: str) -> int:
+        token_id = getattr(tokenizer, attr, None)
+        if token_id is None:
+            token_id = tokenizer.convert_tokens_to_ids(token)
+        if token_id is None or token_id < 0:
+            raise ValueError(f"Could not resolve MiniCPM-o speech token {token!r}.")
+        return int(token_id)
+
+    @staticmethod
+    def _ref_audio_path(audio, ref_audio_path: Optional[str]) -> Optional[str]:
+        if ref_audio_path is not None:
+            return ref_audio_path
+        if isinstance(audio, list) and len(audio) > 0 and isinstance(audio[0], str):
+            return audio[0]
+        if isinstance(audio, str):
+            return audio
+        return None
+
+    def validate_audio_generation(self, *, audio=None, ref_audio_path=None):
+        if not self.supports_audio_generation:
+            raise ValueError(
+                "This MiniCPM-o checkpoint has no TTS weights. Convert openbmb/MiniCPM-o-4_5 with the current converter."
+            )
+        reference = self._ref_audio_path(audio, ref_audio_path)
+        if reference is None:
+            raise ValueError(
+                "MiniCPM-o speech requires ref_audio_path (--ref-audio), or an audio input, for the reference voice."
+            )
+        if not Path(reference).is_file():
+            raise FileNotFoundError(f"Reference audio does not exist: {reference}")
+
+    def generate_audio(
+        self,
+        *,
+        input_ids: mx.array,
+        generated_tokens: list[int],
+        tokenizer,
+        pixel_values: Optional[list] = None,
+        mask: Optional[mx.array] = None,
+        audio=None,
+        ref_audio_path: Optional[str] = None,
+        **kwargs,
+    ):
+        from ...generate.audio import AudioGenerationResult
+        from .vocoder import StepAudio2Vocoder
+
+        self.validate_audio_generation(audio=audio, ref_audio_path=ref_audio_path)
+        if input_ids.shape[0] != 1:
+            raise ValueError(
+                "MiniCPM-o audio generation currently supports batch size 1"
+            )
+
+        if mask is not None:
+            if mask.shape != input_ids.shape:
+                raise ValueError(
+                    "Speech conditioning requires a 2D attention mask matching input_ids"
+                )
+            mask = mx.concatenate(
+                [mask, mx.ones((1, len(generated_tokens)), dtype=mask.dtype)], axis=1
+            )
+
+        if len(generated_tokens) == 0:
+            full_input_ids = input_ids
+        else:
+            full_input_ids = mx.concatenate(
+                [
+                    input_ids,
+                    mx.array(generated_tokens, dtype=input_ids.dtype)[None, :],
+                ],
+                axis=1,
+            )
+
+        tts_max_tokens = kwargs.pop("tts_max_tokens", 2048)
+        sampling_params = TTSSamplingParams(
+            top_p=kwargs.pop("tts_top_p", self.tts.config.top_p),
+            top_k=kwargs.pop("tts_top_k", self.tts.config.top_k),
+            repetition_penalty=kwargs.pop(
+                "tts_repetition_penalty", self.tts.config.repetition_penalty
+            ),
+            temperature=kwargs.pop("tts_temperature", self.tts.config.temperature),
+        )
+        tts_bound = self.find_tts_bound(
+            full_input_ids,
+            self._token_id(tokenizer, "tts_start_id", "<|tts_bos|>"),
+            self._token_id(tokenizer, "tts_end_id", "<|tts_eos|>"),
+        )
+        if tts_bound[0] < input_ids.shape[1]:
+            raise ValueError(
+                "The new response has no TTS start marker. Format the prompt "
+                "with use_tts_template=True."
+            )
+        audio_tokens = self.generate_speech_tokens(
+            full_input_ids,
+            pixel_values=pixel_values,
+            mask=mask,
+            tts_bound=tts_bound,
+            tts_sampling_params=sampling_params,
+            tts_max_new_token=tts_max_tokens,
+            **kwargs,
+        )
+
+        # Keep the codec outside nn.Module's parameter tree: it is a separate
+        # pretrained component, not part of MiniCPM-o conversion/quantization.
+        vocoder = getattr(self, "_speech_vocoder", None)
+        if vocoder is None:
+            vocoder = StepAudio2Vocoder()
+            object.__setattr__(self, "_speech_vocoder", vocoder)
+        waveform = vocoder.decode(
+            audio_tokens,
+            prompt_wav_path=self._ref_audio_path(audio, ref_audio_path),
+        )
+        return AudioGenerationResult(
+            text=tokenizer.decode(
+                full_input_ids[0, tts_bound[0] : tts_bound[1]].tolist(),
+                skip_special_tokens=True,
+            ),
+            audio_tokens=audio_tokens,
+            audio=waveform,
+            sample_rate=vocoder.sample_rate,
+        )
+
     def sanitize(self, weights):
         sanitized_weights = {}
         in_proj_weight = None
         in_proj_bias = None
+        tts_weights = {}
+
+        # Older conversions retained tts_config but discarded all speech
+        # tensors. Keep text inference working without random speech weights.
+        if self.tts is not None and not any(key.startswith("tts.") for key in weights):
+            self.tts = None
+            self.config.init_tts = False
 
         for key, value in weights.items():
-            if key.startswith(("tts.", "audio_avg_pooler.")):
+            if key.startswith("audio_avg_pooler."):
+                continue
+
+            if key.startswith("tts."):
+                if self.tts is not None:
+                    tts_weights[key] = value
                 continue
 
             if key.startswith("llm."):
@@ -520,7 +804,12 @@ class Model(nn.Module):
                 pass
             elif key.startswith("resampler."):
                 pass
+            elif key.startswith(("language_model.", "vision_tower.", "audio_tower.")):
+                pass
             else:
+                continue
+
+            if "rotary_emb.inv_freq" in key:
                 continue
 
             if key == "resampler.attn.in_proj_weight":
@@ -558,6 +847,8 @@ class Model(nn.Module):
             sanitized_weights["resampler.attn.q_proj.bias"] = q_b
             sanitized_weights["resampler.attn.k_proj.bias"] = k_b
             sanitized_weights["resampler.attn.v_proj.bias"] = v_b
+
+        sanitized_weights.update(sanitize_tts_weights(tts_weights))
 
         if self.config.text_config.tie_word_embeddings:
             sanitized_weights.pop("language_model.lm_head.weight", None)

--- a/mlx_vlm/models/minicpmo/processing_minicpmo.py
+++ b/mlx_vlm/models/minicpmo/processing_minicpmo.py
@@ -255,6 +255,7 @@ class MiniCPMOProcessor(ProcessorMixin):
     audio_processor_class = "AutoFeatureExtractor"
     tokenizer_class = "AutoTokenizer"
     valid_kwargs = ["chat_template"]
+    supports_multiple_audio = True
 
     _IMAGE_MARKER_PATTERN = re.compile(r"<image>\./</image>|<image>")
     _AUDIO_MARKER_PATTERN = re.compile(r"<audio>\./</audio>|<audio>")
@@ -295,6 +296,8 @@ class MiniCPMOProcessor(ProcessorMixin):
             "audio_end": "<|audio_end|>",
             "spk_start": "<|spk_bos|>",
             "spk_end": "<|spk_eos|>",
+            "tts_start": "<|tts_bos|>",
+            "tts_end": "<|tts_eos|>",
         }
 
         for attr, token in token_map.items():
@@ -324,6 +327,48 @@ class MiniCPMOProcessor(ProcessorMixin):
     @classmethod
     def _count_audio_markers(cls, text: str) -> int:
         return len(cls._AUDIO_MARKER_PATTERN.findall(text or ""))
+
+    def prepare_audio_generation(self, prompt, *, audio=None, ref_audio_path=None):
+        """Condition the LLM on the reference voice, as in upstream get_sys_prompt.
+
+        TTS uses the LLM's hidden states in addition to text. Passing a reference
+        only to the waveform decoder leaves those states unconditioned.
+        """
+        if audio is None:
+            audio_inputs = []
+        elif isinstance(audio, list):
+            audio_inputs = list(audio)
+        else:
+            audio_inputs = [audio]
+        reference = ref_audio_path or (audio_inputs[0] if audio_inputs else None)
+        if reference is None:
+            raise ValueError("MiniCPM-o speech requires a reference audio file.")
+
+        # Preserve user-audio placement before introducing a system-audio marker.
+        prompt = self._inject_audio_placeholders(
+            prompt, ["<audio>"] * len(audio_inputs)
+        )
+        system_tag = "<|im_start|>system\n"
+        has_system = prompt.startswith(system_tag)
+        if has_system:
+            system_content = prompt[len(system_tag) :].split("<|im_end|>", 1)[0]
+            if (
+                self._count_audio_markers(system_content)
+                and audio_inputs
+                and Path(audio_inputs[0]).resolve() == Path(reference).resolve()
+            ):
+                # Respect a caller-supplied voice-conditioning system prompt.
+                return prompt, audio_inputs
+
+        voice_instruction = (
+            "Clone the voice in the provided audio prompt.\n<audio>\n"
+            "As an assistant, you will speak using this voice style."
+        )
+        if has_system:
+            prompt = system_tag + voice_instruction + "\n\n" + prompt[len(system_tag) :]
+        else:
+            prompt = system_tag + voice_instruction + "<|im_end|>\n" + prompt
+        return prompt, [reference, *audio_inputs]
 
     def _normalize_images(
         self,
@@ -508,6 +553,14 @@ class MiniCPMOProcessor(ProcessorMixin):
             return np.zeros((0, 2), dtype=np.int32)
         return np.stack([start_idx[:n], end_idx[:n]], axis=1).astype(np.int32)
 
+    def _compute_spk_bounds(self, input_ids: np.ndarray) -> np.ndarray:
+        start_idx = np.where(input_ids == self.tokenizer.spk_start_id)[0] + 1
+        end_idx = np.where(input_ids == self.tokenizer.spk_end_id)[0]
+        n = min(len(start_idx), len(end_idx))
+        if n == 0:
+            return np.zeros((0, 2), dtype=np.int32)
+        return np.stack([start_idx[:n], end_idx[:n]], axis=1).astype(np.int32)
+
     def _extract_audio_inputs(
         self,
         batched_audios: List[List[np.ndarray]],
@@ -624,6 +677,7 @@ class MiniCPMOProcessor(ProcessorMixin):
         input_ids_list: List[np.ndarray] = []
         image_bounds_list: List[np.ndarray] = []
         audio_bounds_list: List[np.ndarray] = []
+        spk_bounds_list: List[np.ndarray] = []
 
         for i, prompt in enumerate(texts):
             prompt = self._inject_image_placeholders(prompt, len(batched_images[i]))
@@ -638,6 +692,7 @@ class MiniCPMOProcessor(ProcessorMixin):
             input_ids_list.append(ids_array)
             image_bounds_list.append(self._compute_image_bounds(ids_array))
             audio_bounds_list.append(self._compute_audio_bounds(ids_array))
+            spk_bounds_list.append(self._compute_spk_bounds(ids_array))
 
         if not padding and len(input_ids_list) == 1:
             padded_input_ids = np.expand_dims(input_ids_list[0], axis=0)
@@ -655,6 +710,8 @@ class MiniCPMOProcessor(ProcessorMixin):
                 image_bounds_list[i] = image_bounds_list[i] + offset
             if offset > 0 and audio_bounds_list[i].size > 0:
                 audio_bounds_list[i] = audio_bounds_list[i] + offset
+            if offset > 0 and spk_bounds_list[i].size > 0:
+                spk_bounds_list[i] = spk_bounds_list[i] + offset
 
         return {
             "input_ids": padded_input_ids,
@@ -666,7 +723,7 @@ class MiniCPMOProcessor(ProcessorMixin):
             "audio_features": audio_features,
             "audio_feature_lens": audio_feature_lens,
             "audio_bounds": audio_bounds_list,
-            "spk_bounds": [np.zeros((0, 2), dtype=np.int32) for _ in range(batch_size)],
+            "spk_bounds": spk_bounds_list,
         }
 
     def apply_chat_template(self, *args, **kwargs):

--- a/mlx_vlm/models/minicpmo/processing_minicpmo.py
+++ b/mlx_vlm/models/minicpmo/processing_minicpmo.py
@@ -329,11 +329,7 @@ class MiniCPMOProcessor(ProcessorMixin):
         return len(cls._AUDIO_MARKER_PATTERN.findall(text or ""))
 
     def prepare_audio_generation(self, prompt, *, audio=None, ref_audio_path=None):
-        """Condition the LLM on the reference voice, as in upstream get_sys_prompt.
-
-        TTS uses the LLM's hidden states in addition to text. Passing a reference
-        only to the waveform decoder leaves those states unconditioned.
-        """
+        """Condition the LLM on the reference voice."""
         if audio is None:
             audio_inputs = []
         elif isinstance(audio, list):

--- a/mlx_vlm/models/minicpmo/tts.py
+++ b/mlx_vlm/models/minicpmo/tts.py
@@ -1,0 +1,260 @@
+from dataclasses import dataclass
+from typing import Optional
+
+import mlx.core as mx
+import mlx.nn as nn
+from mlx_lm.models.cache import KVCache
+from mlx_lm.models.llama import LlamaModel, ModelArgs
+from mlx_lm.sample_utils import apply_top_k, apply_top_p
+
+from .config import MiniCPMTTSConfig
+
+
+def materialize_weight_norm(g: mx.array, v: mx.array) -> mx.array:
+    if g.ndim == 1:
+        g = g[:, None]
+    v_float = v.astype(mx.float32)
+    denom = mx.sqrt(mx.sum(v_float * v_float, axis=1, keepdims=True))
+    denom = mx.maximum(denom, 1e-12)
+    return (v_float * (g.astype(mx.float32) / denom)).astype(v.dtype)
+
+
+def sanitize_tts_weights(weights: dict[str, mx.array]) -> dict[str, mx.array]:
+    sanitized = {}
+    head_g = {}
+    head_v = {}
+
+    for key, value in weights.items():
+        if key.startswith("tts.head_code.") and ".parametrizations.weight." in key:
+            parts = key.split(".")
+            if len(parts) >= 6:
+                head_idx = parts[2]
+                original = parts[-1]
+                if original == "original0":
+                    head_g[head_idx] = value
+                elif original == "original1":
+                    head_v[head_idx] = value
+            continue
+        if "rotary_emb.inv_freq" in key:
+            continue
+        if key.startswith("tts."):
+            sanitized[key] = value
+
+    for head_idx, v in head_v.items():
+        g = head_g.get(head_idx)
+        if g is None:
+            raise ValueError(f"Missing weight-norm scale for TTS head {head_idx}")
+        sanitized[f"tts.head_code.{head_idx}.weight"] = materialize_weight_norm(g, v)
+
+    if head_g.keys() != head_v.keys():
+        raise ValueError("Incomplete weight-norm tensors for a TTS head")
+
+    return sanitized
+
+
+@dataclass
+class TTSSamplingParams:
+    top_p: Optional[float] = 0.85
+    top_k: Optional[int] = 25
+    repetition_penalty: Optional[float] = 1.05
+    temperature: float = 0.8
+    repetition_context_size: int = 16
+
+
+@dataclass
+class MiniCPMTTSGenerationOutput:
+    new_ids: mx.array
+    finished: bool
+
+
+class MultiModalProjector(nn.Module):
+    def __init__(self, in_dim: int, out_dim: int):
+        super().__init__()
+        self.linear1 = nn.Linear(in_dim, out_dim, bias=True)
+        self.linear2 = nn.Linear(out_dim, out_dim, bias=True)
+
+    def __call__(self, x: mx.array) -> mx.array:
+        return self.linear2(nn.relu(self.linear1(x)))
+
+
+class MiniCPMMLP(nn.Module):
+    def __init__(self, config: MiniCPMTTSConfig):
+        super().__init__()
+        self.gate_proj = nn.Linear(config.llm_hidden_size, config.llm_intermediate_size)
+        self.up_proj = nn.Linear(config.llm_hidden_size, config.llm_intermediate_size)
+        self.down_proj = nn.Linear(config.llm_intermediate_size, config.hidden_size)
+
+    def __call__(self, x: mx.array) -> mx.array:
+        return self.down_proj(nn.silu(self.gate_proj(x)) * self.up_proj(x))
+
+
+class MiniCPMTTS(nn.Module):
+    def __init__(self, config: MiniCPMTTSConfig):
+        super().__init__()
+        self.config = config
+        self.audio_bos_token_id = config.audio_bos_token_id
+        self.num_vq = config.num_vq
+        self.num_audio_tokens = config.num_audio_tokens
+        self.top_p = config.top_p
+        self.top_k = config.top_k
+        self.repetition_penalty = config.repetition_penalty
+        self.condition_type = config.condition_type
+
+        if config.backbone_model != "llama":
+            raise ValueError(
+                f"Unsupported MiniCPM-o TTS backbone: {config.backbone_model}"
+            )
+
+        llama_args = ModelArgs(
+            model_type="llama",
+            hidden_size=config.hidden_size,
+            intermediate_size=config.intermediate_size,
+            num_attention_heads=config.num_attention_heads,
+            num_hidden_layers=config.num_hidden_layers,
+            num_key_value_heads=config.num_key_value_heads,
+            rms_norm_eps=config.rms_norm_eps,
+            vocab_size=config.backbone_vocab_size,
+            max_position_embeddings=config.max_position_embeddings,
+            rope_theta=config.rope_theta,
+            tie_word_embeddings=True,
+        )
+        self.emb_text = nn.Embedding(config.num_text_tokens, config.hidden_size)
+        self.model = LlamaModel(llama_args)
+        self.projector_spk = self.create_projector(config)
+        self.projector_semantic = self.create_projector(config)
+        self.emb_code = [
+            nn.Embedding(config.num_audio_tokens, config.hidden_size)
+            for _ in range(config.num_vq)
+        ]
+        self.head_code = [
+            nn.Linear(config.hidden_size, config.num_audio_tokens, bias=False)
+            for _ in range(config.num_vq)
+        ]
+
+    @staticmethod
+    def create_projector(config: MiniCPMTTSConfig):
+        if config.projector_type == "mlp":
+            return MultiModalProjector(config.llm_dim, config.hidden_size)
+        if config.projector_type == "minicpm":
+            return MiniCPMMLP(config)
+        if config.projector_type == "default":
+            return nn.Linear(config.llm_dim, config.hidden_size, bias=False)
+        raise ValueError(
+            f"Unsupported MiniCPM-o TTS projector: {config.projector_type}"
+        )
+
+    @staticmethod
+    def _apply_repetition_penalty(
+        logits: mx.array,
+        generated: list[int],
+        penalty: Optional[float],
+        context_size: int,
+    ) -> mx.array:
+        if penalty is None or penalty == 1 or not generated:
+            return logits
+
+        recent = mx.array(generated[-context_size:], dtype=mx.int32)
+        counts = mx.zeros((logits.shape[-1],), dtype=logits.dtype).at[recent].add(1)
+        alpha = mx.power(penalty, counts)
+        return mx.where(logits < 0, logits * alpha, logits / alpha)
+
+    @staticmethod
+    def _sample(logits: mx.array, params: TTSSamplingParams) -> mx.array:
+        if params.temperature == 0:
+            return mx.argmax(logits, axis=-1)
+
+        logits = logits / params.temperature
+        logprobs = logits - mx.logsumexp(logits, axis=-1, keepdims=True)
+        if params.top_p is not None and 0 < params.top_p < 1.0:
+            logprobs = apply_top_p(logprobs, params.top_p)
+        if params.top_k is not None and params.top_k > 0:
+            top_k = min(int(params.top_k), logprobs.shape[-1])
+            if top_k < logprobs.shape[-1]:
+                logprobs = apply_top_k(logprobs, top_k)
+        return mx.random.categorical(logprobs)
+
+    def generate(
+        self,
+        inputs_embeds: mx.array,
+        eos_token: Optional[int] = None,
+        force_no_stop: bool = False,
+        min_new_token: int = 50,
+        max_new_token: int = 2048,
+        sampling_params: Optional[TTSSamplingParams] = None,
+    ) -> MiniCPMTTSGenerationOutput:
+        if inputs_embeds.shape[0] != 1:
+            raise ValueError("MiniCPM-o TTS generation currently supports batch size 1")
+        if max_new_token <= 0 or not 0 <= min_new_token <= max_new_token:
+            raise ValueError(
+                "Require 0 <= min_new_token <= max_new_token and max_new_token > 0"
+            )
+
+        if sampling_params is None:
+            sampling_params = TTSSamplingParams(
+                top_p=self.top_p,
+                top_k=self.top_k,
+                repetition_penalty=self.repetition_penalty,
+                temperature=self.config.temperature,
+            )
+        if eos_token is None:
+            eos_token = self.config.num_audio_tokens - 1
+        if sampling_params.temperature < 0:
+            raise ValueError("tts_temperature must be non-negative")
+        if (
+            sampling_params.repetition_penalty is not None
+            and sampling_params.repetition_penalty <= 0
+        ):
+            raise ValueError("tts_repetition_penalty must be positive")
+
+        cache = [KVCache() for _ in self.model.layers]
+        generated: list[list[int]] = [[] for _ in range(self.num_vq)]
+        new_tokens = []
+        finished = False
+        current_embeds = inputs_embeds
+
+        for step in range(max_new_token):
+            if step > 0:
+                code_embeds = []
+                for q in range(self.num_vq):
+                    prev = mx.array([[generated[q][-1]]], dtype=mx.int32)
+                    code_embeds.append(self.emb_code[q](prev))
+                current_embeds = mx.stack(code_embeds, axis=-1).sum(axis=-1)
+
+            hidden = self.model(
+                mx.zeros(current_embeds.shape[:2], dtype=mx.int32),
+                cache=cache,
+                input_embeddings=current_embeds,
+            )
+
+            logits_per_vq = []
+            for q in range(self.num_vq):
+                logits = self.head_code[q](hidden[:, -1:, :])[:, 0, :].astype(
+                    mx.float32
+                )
+                if step > 0:
+                    logits = self._apply_repetition_penalty(
+                        logits,
+                        generated[q],
+                        sampling_params.repetition_penalty,
+                        sampling_params.repetition_context_size,
+                    )
+                if step < min_new_token or force_no_stop:
+                    logits[:, eos_token] = -mx.inf
+                logits_per_vq.append(logits)
+
+            next_codes = mx.stack(
+                [self._sample(logits, sampling_params) for logits in logits_per_vq],
+                axis=-1,
+            )[0].tolist()
+            if eos_token in next_codes:
+                finished = True
+                break
+            for q, token_id in enumerate(next_codes):
+                generated[q].append(token_id)
+            new_tokens.append(next_codes)
+
+        if len(new_tokens) == 0:
+            ids = mx.zeros((1, 0, self.num_vq), dtype=mx.int32)
+        else:
+            ids = mx.array(new_tokens, dtype=mx.int32)[None, :, :]
+        return MiniCPMTTSGenerationOutput(new_ids=ids, finished=finished)

--- a/mlx_vlm/models/minicpmo/tts.py
+++ b/mlx_vlm/models/minicpmo/tts.py
@@ -3,10 +3,11 @@ from typing import Optional
 
 import mlx.core as mx
 import mlx.nn as nn
-from mlx_lm.models.cache import KVCache
-from mlx_lm.models.llama import LlamaModel, ModelArgs
-from mlx_lm.sample_utils import apply_top_k, apply_top_p
 
+from ...sample_utils import apply_top_k, apply_top_p
+from ..cache import KVCache
+from ..llama.config import ModelConfig as LlamaConfig
+from ..llama.language import LlamaModel
 from .config import MiniCPMTTSConfig
 
 
@@ -105,7 +106,7 @@ class MiniCPMTTS(nn.Module):
                 f"Unsupported MiniCPM-o TTS backbone: {config.backbone_model}"
             )
 
-        llama_args = ModelArgs(
+        llama_args = LlamaConfig(
             model_type="llama",
             hidden_size=config.hidden_size,
             intermediate_size=config.intermediate_size,

--- a/mlx_vlm/models/minicpmo/vocoder.py
+++ b/mlx_vlm/models/minicpmo/vocoder.py
@@ -1,0 +1,42 @@
+from pathlib import Path
+
+import mlx.core as mx
+
+
+class StepAudio2Vocoder:
+    """Lazy, MLX-native waveform decoding using the mlx-audio speech codec."""
+
+    sample_rate = 24000
+
+    def __init__(self, *, n_timesteps: int = 10):
+        try:
+            from mlx_audio.codec.models.stepaudio2 import StepAudio2Token2Wav
+        except ImportError as exc:
+            raise ImportError(
+                "MiniCPM-o waveform decoding requires mlx-audio with the "
+                "StepAudio2 codec. Install mlx-audio>=0.4.8."
+            ) from exc
+
+        self.n_timesteps = n_timesteps
+        self._codec = StepAudio2Token2Wav.from_pretrained()
+
+    def decode(self, audio_tokens: mx.array, *, prompt_wav_path: str) -> mx.array:
+        if prompt_wav_path is None or not Path(prompt_wav_path).is_file():
+            raise ValueError("The StepAudio2 codec requires a reference audio file.")
+        if (
+            audio_tokens.ndim != 3
+            or audio_tokens.shape[0] != 1
+            or audio_tokens.shape[2] != 1
+        ):
+            raise ValueError("StepAudio2 expects audio tokens with shape (1, time, 1).")
+        if audio_tokens.shape[1] == 0:
+            raise ValueError("No speech tokens were generated.")
+        wav = self._codec(
+            audio_tokens[0, :, 0],
+            prompt_wav_path,
+            n_timesteps=self.n_timesteps,
+            # mlx-audio's prompt cache is not keyed by voice. Reusing the codec
+            # must not reuse another request's reference speaker.
+            use_cache=False,
+        )
+        return wav.reshape(-1).astype(mx.float32)

--- a/mlx_vlm/tests/test_audio_generation.py
+++ b/mlx_vlm/tests/test_audio_generation.py
@@ -1,0 +1,267 @@
+"""Audio output routing, token fidelity, and waveform serialization."""
+
+import contextlib
+import sys
+import wave
+from io import BytesIO
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import mlx.core as mx
+import numpy as np
+import pytest
+
+from mlx_vlm.generate import AudioGenerationResult
+from mlx_vlm.generate import audio as audio_module
+from mlx_vlm.generate import dispatch, generate_audio, save_audio
+from mlx_vlm.generate.common import GenerationResult
+from mlx_vlm.tests.test_generate import MockDetokenizer, MockModel, MockProcessor
+
+
+def test_reference_conditions_both_generation_stages(monkeypatch):
+    from mlx_vlm.models.minicpmo.processing_minicpmo import MiniCPMOProcessor
+
+    processor = MiniCPMOProcessor.__new__(MiniCPMOProcessor)
+    processor.tokenizer = object()
+    model = SimpleNamespace(
+        config=SimpleNamespace(model_type="minicpmo"),
+        generate_audio=Mock(return_value=AudioGenerationResult(audio=mx.zeros(10))),
+    )
+    features = [mx.ones((1, 80, 12))]
+    prepare = Mock(
+        return_value=dict(
+            input_ids=mx.array([[1, 2, 3, 4]]),
+            attention_mask=mx.ones((1, 4)),
+            audio_features=features,
+            audio_bounds=[[(1, 2), (2, 3)]],
+        )
+    )
+    text_generate = Mock(return_value=GenerationResult(token_ids=[5]))
+    monkeypatch.setattr(dispatch, "prepare_inputs", prepare)
+    monkeypatch.setattr(dispatch, "generate", text_generate)
+    monkeypatch.setattr(
+        audio_module, "wired_limit", lambda *a: contextlib.nullcontext()
+    )
+    generate_audio(
+        model,
+        processor,
+        "<|im_start|>user\nDescribe this audio.<|im_end|>\n<|im_start|>assistant\n<|tts_bos|>",
+        audio=["input.wav"],
+        ref_audio_path="voice.wav",
+    )
+    assert prepare.call_args.kwargs["audio"] == ["voice.wav", "input.wav"]
+    prompt = prepare.call_args.kwargs["prompts"]
+    assert prompt.startswith("<|im_start|>system\nClone the voice")
+    assert "<|im_start|>user\n<audio>Describe this audio." in prompt
+    for call in (text_generate.call_args, model.generate_audio.call_args):
+        assert call.kwargs["audio_features"] is features
+        assert call.kwargs["audio_bounds"] == [[(1, 2), (2, 3)]]
+    assert model.generate_audio.call_args.kwargs["ref_audio_path"] == "voice.wav"
+
+
+def test_precomputed_inputs_cannot_silently_skip_reference_conditioning(monkeypatch):
+    processor = SimpleNamespace(prepare_audio_generation=Mock())
+    model = SimpleNamespace(generate_audio=Mock())
+    text_generate = Mock()
+    monkeypatch.setattr(dispatch, "generate", text_generate)
+    with pytest.raises(ValueError, match="not precomputed input_ids"):
+        generate_audio(model, processor, "prompt", input_ids=mx.array([[1]]))
+    processor.prepare_audio_generation.assert_not_called()
+    text_generate.assert_not_called()
+
+
+@pytest.mark.parametrize("multiple_audio", [False, True])
+def test_prepare_inputs_preserves_audio_for_capable_processors(
+    monkeypatch, multiple_audio
+):
+    from mlx_vlm import utils
+
+    processor = SimpleNamespace(supports_multiple_audio=multiple_audio)
+    load = Mock(
+        side_effect=lambda path, sr: (
+            np.ones(16) if path == "voice.wav" else np.zeros(16)
+        )
+    )
+    process = Mock(return_value={"input_ids": mx.array([[1]])})
+    monkeypatch.setattr(utils, "load_audio", load)
+    monkeypatch.setattr(utils, "process_inputs_with_fallback", process)
+    utils.prepare_inputs(processor, prompts="prompt", audio=["voice.wav", "input.wav"])
+    audios = process.call_args.kwargs["audio"]
+    assert len(audios) == (2 if multiple_audio else 1)
+    np.testing.assert_array_equal(audios[0], np.ones(16))
+    if multiple_audio:
+        np.testing.assert_array_equal(audios[1], np.zeros(16))
+
+
+@pytest.mark.parametrize("tokens", [[], [7], [7, 8], [7, 2], [2]])
+def test_final_token_ids_preserve_eos_without_duplicate_flush(monkeypatch, tokens):
+    model, processor = MockModel(), MockProcessor()
+    monkeypatch.setattr(
+        dispatch,
+        "generate_step",
+        lambda *a, **kw: iter((t, mx.zeros(4)) for t in tokens),
+    )
+    monkeypatch.setattr(
+        dispatch, "make_streaming_detokenizer", lambda p: MockDetokenizer()
+    )
+    monkeypatch.setattr(dispatch, "wired_limit", lambda *a: contextlib.nullcontext())
+    results = list(
+        dispatch.stream_generate(
+            model, processor, "prompt", input_ids=mx.array([[1, 3]])
+        )
+    )
+    assert results[-1].token_ids == tokens
+    assert results[-1].generation_tokens == len(tokens)
+    assert all(r.token_ids is None for r in results[:-1])
+
+
+@pytest.mark.parametrize("precomputed", [False, True])
+def test_audio_uses_shared_text_generation_and_prepares_once(
+    monkeypatch, precomputed, tmp_path
+):
+    model = SimpleNamespace(config=SimpleNamespace(model_type="minicpmo"))
+    model.generate_audio = Mock(
+        return_value=AudioGenerationResult(
+            audio=mx.zeros(240), audio_tokens=mx.array([[[5]]])
+        )
+    )
+    processor = SimpleNamespace(tokenizer=object())
+    inputs = dict(
+        input_ids=mx.array([[1, 2]]),
+        pixel_values=["image"],
+        attention_mask=mx.ones((1, 2)),
+        audio_bounds=[(1, 2)],
+    )
+    prepare = Mock(return_value=inputs)
+    monkeypatch.setattr(dispatch, "prepare_inputs", prepare)
+    text_generate = Mock(
+        return_value=GenerationResult(
+            text="hello",
+            token_ids=[3, 4],
+            prompt_tokens=2,
+            generation_tokens=2,
+            finish_reason="stop",
+        )
+    )
+    monkeypatch.setattr(dispatch, "generate", text_generate)
+    monkeypatch.setattr(
+        audio_module, "wired_limit", lambda *a: contextlib.nullcontext()
+    )
+    kwargs = dict(temperature=0.1, tts_temperature=0.8, tts_max_tokens=20)
+    if precomputed:
+        kwargs.update(
+            input_ids=inputs["input_ids"],
+            pixel_values=inputs["pixel_values"],
+            mask=inputs["attention_mask"],
+            audio_bounds=inputs["audio_bounds"],
+        )
+    result = generate_audio(
+        model,
+        processor,
+        "prompt",
+        image=["image.png"],
+        audio=["input.wav"],
+        ref_audio_path="voice.wav",
+        output_audio_path=tmp_path / "out.wav",
+        **kwargs,
+    )
+    assert prepare.call_count == (0 if precomputed else 1)
+    assert result.text == "hello"
+    assert result.token_ids == [3, 4]
+    assert result.prompt_tokens == 2
+    assert result.finish_reason == "stop"
+    assert result.path.is_file()
+    text_kwargs = text_generate.call_args.kwargs
+    assert text_kwargs["temperature"] == 0.1
+    assert "tts_temperature" not in text_kwargs
+    speech_kwargs = model.generate_audio.call_args.kwargs
+    assert speech_kwargs["generated_tokens"] == [3, 4]
+    assert speech_kwargs["tts_temperature"] == 0.8
+    assert speech_kwargs["tts_max_tokens"] == 20
+    assert speech_kwargs["audio_bounds"] == [(1, 2)]
+    assert speech_kwargs["ref_audio_path"] == "voice.wav"
+
+
+def test_audio_returns_waveform_without_file(monkeypatch):
+    model = SimpleNamespace(
+        config=SimpleNamespace(model_type="test"),
+        generate_audio=Mock(return_value=AudioGenerationResult(audio=mx.zeros(10))),
+    )
+    monkeypatch.setattr(
+        dispatch, "generate", Mock(return_value=GenerationResult(token_ids=[3]))
+    )
+    monkeypatch.setattr(
+        audio_module, "wired_limit", lambda *a: contextlib.nullcontext()
+    )
+    result = generate_audio(
+        model, SimpleNamespace(tokenizer=None), "prompt", input_ids=mx.array([[1]])
+    )
+    assert result.audio.shape == (10,)
+    assert result.path is None
+
+
+def test_unsupported_audio_fails_before_text_generation(monkeypatch):
+    text_generate = Mock()
+    monkeypatch.setattr(dispatch, "generate", text_generate)
+    with pytest.raises(ValueError, match="TTS module"):
+        generate_audio(SimpleNamespace(), None, "prompt")
+    text_generate.assert_not_called()
+
+
+def test_save_audio_writes_valid_wav(tmp_path):
+    result = AudioGenerationResult(audio=mx.sin(mx.arange(2400) * 0.1) * 0.1)
+    path = save_audio(result, tmp_path / "nested" / "speech.wav")
+    with wave.open(BytesIO(path.read_bytes())) as wav:
+        assert wav.getnchannels() == 1
+        assert wav.getframerate() == result.sample_rate
+        assert wav.getnframes() == 2400
+    with pytest.raises(ValueError, match=".wav"):
+        save_audio(result, tmp_path / "speech.mp3")
+
+
+def test_audio_cli_uses_tts_template_and_shared_loader(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "mlx_vlm.generate",
+            "--output-modality",
+            "audio",
+            "--output",
+            str(tmp_path / "out.wav"),
+            "--ref-audio",
+            "voice.wav",
+            "--prompt",
+            "Say hello.",
+        ],
+    )
+    model = SimpleNamespace(config=SimpleNamespace(model_type="minicpmo"))
+    monkeypatch.setattr(dispatch, "load", Mock(return_value=(model, object())))
+    template = Mock(return_value="formatted")
+    monkeypatch.setattr(dispatch, "apply_chat_template", template)
+    speech = Mock(
+        return_value=AudioGenerationResult(text="Hello.", path=tmp_path / "out.wav")
+    )
+    monkeypatch.setattr(dispatch, "generate_audio", speech)
+    dispatch.main()
+    assert template.call_args.kwargs["use_tts_template"] is True
+    assert speech.call_args.args[2] == "formatted"
+    assert speech.call_args.kwargs["ref_audio_path"] == "voice.wav"
+
+
+@pytest.mark.parametrize(
+    "flags, message",
+    [
+        ([], "--output is required"),
+        (["--output", "out.wav", "--chat"], "does not support --chat"),
+    ],
+)
+def test_invalid_audio_cli_fails_before_loading(monkeypatch, flags, message):
+    monkeypatch.setattr(
+        sys, "argv", ["mlx_vlm.generate", "--output-modality", "audio", *flags]
+    )
+    loader = Mock()
+    monkeypatch.setattr(dispatch, "load", loader)
+    with pytest.raises(ValueError, match=message):
+        dispatch.main()
+    loader.assert_not_called()

--- a/mlx_vlm/tests/test_minicpmo_tts.py
+++ b/mlx_vlm/tests/test_minicpmo_tts.py
@@ -1,0 +1,538 @@
+import sys
+import types
+import unittest
+from unittest.mock import patch
+
+import mlx.core as mx
+import numpy as np
+
+
+class TestMiniCPMOTTS(unittest.TestCase):
+    def test_reference_voice_prompt_preserves_messages_and_audio_order(self):
+        from mlx_vlm.models.minicpmo.processing_minicpmo import MiniCPMOProcessor
+
+        processor = MiniCPMOProcessor.__new__(MiniCPMOProcessor)
+        user = (
+            "<|im_start|>user\nSay hello.<|im_end|>\n<|im_start|>assistant\n<|tts_bos|>"
+        )
+        custom_system = "<|im_start|>system\nBe concise.<|im_end|>\n"
+        for system in ("", custom_system):
+            for input_audio in (None, "input.wav", ["input.wav"]):
+                with self.subTest(system=system, audio=input_audio):
+                    prompt, paths = processor.prepare_audio_generation(
+                        system + user, audio=input_audio, ref_audio_path="voice.wav"
+                    )
+                    self.assertTrue(
+                        prompt.startswith("<|im_start|>system\nClone the voice")
+                    )
+                    self.assertTrue(prompt.endswith("<|tts_bos|>"))
+                    self.assertEqual(prompt.count("<|im_start|>system"), 1)
+                    self.assertEqual(processor._count_audio_markers(prompt), len(paths))
+                    if system:
+                        self.assertIn("Be concise.<|im_end|>", prompt)
+                    if input_audio:
+                        self.assertEqual(paths, ["voice.wav", "input.wav"])
+                        self.assertIn("<|im_start|>user\n<audio>Say hello.", prompt)
+                    else:
+                        self.assertEqual(paths, ["voice.wav"])
+                        self.assertTrue(prompt.endswith(user))
+                    if isinstance(input_audio, list):
+                        self.assertEqual(input_audio, ["input.wav"])
+                    # A caller-supplied system reference must not be duplicated.
+                    again = processor.prepare_audio_generation(
+                        prompt, audio=paths, ref_audio_path="./voice.wav"
+                    )
+                    self.assertEqual(again, (prompt, paths))
+
+    def test_audio_input_can_also_supply_reference_voice(self):
+        from mlx_vlm.models.minicpmo.processing_minicpmo import MiniCPMOProcessor
+
+        processor = MiniCPMOProcessor.__new__(MiniCPMOProcessor)
+        prompt, paths = processor.prepare_audio_generation(
+            "<|im_start|>user\n<audio>./</audio>Respond.<|im_end|>\n",
+            audio=["input.wav"],
+        )
+        self.assertEqual(paths, ["input.wav", "input.wav"])
+        self.assertEqual(processor._count_audio_markers(prompt), 2)
+        self.assertIn("<|im_start|>user\n<audio>Respond.", prompt)
+
+    def test_tts_config_parses(self):
+        from mlx_vlm.models.minicpmo.config import ModelConfig
+
+        cfg = ModelConfig.from_dict(
+            {
+                "model_type": "minicpmo",
+                "hidden_size": 8,
+                "intermediate_size": 16,
+                "num_hidden_layers": 1,
+                "num_attention_heads": 2,
+                "num_key_value_heads": 2,
+                "rms_norm_eps": 1e-6,
+                "vocab_size": 32,
+                "head_dim": 4,
+                "rope_theta": 10000.0,
+                "max_position_embeddings": 64,
+                "vision_config": {
+                    "hidden_size": 8,
+                    "intermediate_size": 16,
+                    "num_hidden_layers": 1,
+                    "num_attention_heads": 2,
+                },
+                "tts_config": {
+                    "hidden_size": 16,
+                    "intermediate_size": 32,
+                    "num_hidden_layers": 1,
+                    "num_attention_heads": 4,
+                    "num_key_value_heads": 4,
+                    "num_text_tokens": 64,
+                    "num_audio_tokens": 32,
+                    "llm_dim": 8,
+                    "condition_type": "hidden_text_merge",
+                    "normalize_projected_hidden": True,
+                },
+            }
+        )
+
+        self.assertEqual(cfg.tts_config.hidden_size, 16)
+        self.assertEqual(cfg.tts_config.num_audio_tokens, 32)
+        self.assertEqual(cfg.tts_config.condition_type, "hidden_text_merge")
+        self.assertTrue(cfg.tts_config.normalize_projected_hidden)
+
+    def test_tiny_tts_generates_audio_tokens(self):
+        from mlx_vlm.models.minicpmo.config import MiniCPMTTSConfig
+        from mlx_vlm.models.minicpmo.tts import MiniCPMTTS, TTSSamplingParams
+
+        cfg = MiniCPMTTSConfig(
+            hidden_size=16,
+            intermediate_size=32,
+            num_attention_heads=4,
+            num_key_value_heads=4,
+            num_hidden_layers=1,
+            num_text_tokens=32,
+            num_audio_tokens=16,
+            llm_dim=8,
+        )
+        model = MiniCPMTTS(cfg)
+        out = model.generate(
+            mx.zeros((1, 3, 16)),
+            max_new_token=2,
+            min_new_token=2,
+            sampling_params=TTSSamplingParams(
+                temperature=0.0,
+                top_p=None,
+                top_k=None,
+                repetition_penalty=None,
+            ),
+        )
+        mx.eval(out.new_ids)
+        self.assertEqual(out.new_ids.shape, (1, 2, 1))
+
+    def test_sanitize_materializes_tts_weight_norm(self):
+        from mlx_vlm.models.minicpmo.config import (
+            MiniCPMTTSConfig,
+            ModelConfig,
+            TextConfig,
+            VisionConfig,
+        )
+        from mlx_vlm.models.minicpmo.minicpmo import Model
+
+        text = TextConfig(
+            model_type="qwen3",
+            hidden_size=8,
+            intermediate_size=16,
+            num_hidden_layers=1,
+            num_attention_heads=2,
+            rms_norm_eps=1e-6,
+            vocab_size=20,
+            num_key_value_heads=2,
+            head_dim=4,
+            rope_theta=10000,
+            max_position_embeddings=64,
+        )
+        vision = VisionConfig(
+            hidden_size=8,
+            intermediate_size=16,
+            num_hidden_layers=1,
+            num_attention_heads=2,
+        )
+        tts = MiniCPMTTSConfig(
+            hidden_size=8,
+            intermediate_size=16,
+            num_attention_heads=2,
+            num_key_value_heads=2,
+            num_hidden_layers=1,
+            num_text_tokens=20,
+            num_audio_tokens=12,
+            llm_dim=8,
+        )
+        model = Model(
+            ModelConfig(
+                text_config=text,
+                vision_config=vision,
+                tts_config=tts,
+                init_audio=False,
+                init_tts=True,
+            )
+        )
+        weights = {
+            "tts.head_code.0.parametrizations.weight.original0": mx.ones((12, 1)),
+            "tts.head_code.0.parametrizations.weight.original1": mx.ones((12, 8)),
+        }
+        sanitized = model.sanitize(weights)
+
+        self.assertIn("tts.head_code.0.weight", sanitized)
+        self.assertEqual(sanitized["tts.head_code.0.weight"].shape, (12, 8))
+
+    def test_processor_exposes_tts_and_spk_tokens(self):
+        from mlx_vlm.models.minicpmo.processing_minicpmo import MiniCPMOProcessor
+
+        class Tokenizer:
+            eos_token = "<eos>"
+            pad_token = None
+            pad_token_id = 0
+
+            def __init__(self):
+                self.vocab = {
+                    "<|spk_bos|>": 10,
+                    "<|spk_eos|>": 11,
+                    "<|tts_bos|>": 12,
+                    "<|tts_eos|>": 13,
+                    "<|listen|>": 14,
+                    "<image>": 20,
+                    "</image>": 21,
+                    "<slice>": 22,
+                    "</slice>": 23,
+                    "<|audio_start|>": 30,
+                    "<|audio_end|>": 31,
+                }
+
+            def convert_tokens_to_ids(self, token):
+                return self.vocab.get(token, -1)
+
+        processor = MiniCPMOProcessor.__new__(MiniCPMOProcessor)
+        processor.tokenizer = Tokenizer()
+        processor._ensure_tokenizer_attrs()
+
+        self.assertEqual(processor.tokenizer.tts_start_id, 12)
+        self.assertEqual(processor.tokenizer.tts_end_id, 13)
+
+        ids = np.array([1, 10, 2, 3, 11, 4], dtype=np.int32)
+        np.testing.assert_array_equal(
+            processor._compute_spk_bounds(ids),
+            np.array([[2, 4]], dtype=np.int32),
+        )
+
+    def test_model_generate_audio_consumes_tts_kwargs(self):
+        from mlx_vlm.models.minicpmo.minicpmo import Model
+
+        class Tokenizer:
+            tts_start_id = 10
+            tts_end_id = 11
+
+            def decode(self, tokens, **kwargs):
+                return "speech"
+
+            def convert_tokens_to_ids(self, token):
+                return {
+                    "<|tts_bos|>": self.tts_start_id,
+                    "<|tts_eos|>": self.tts_end_id,
+                }.get(token, -1)
+
+        model = Model.__new__(Model)
+        from mlx_vlm.models.minicpmo.config import MiniCPMTTSConfig
+
+        model.tts = types.SimpleNamespace(config=MiniCPMTTSConfig())
+        model.validate_audio_generation = lambda **kwargs: None
+        object.__setattr__(
+            model,
+            "_speech_vocoder",
+            types.SimpleNamespace(
+                sample_rate=24000, decode=lambda *args, **kwargs: mx.zeros(24)
+            ),
+        )
+        captured = {}
+
+        def generate_speech_tokens(full_input_ids, **kwargs):
+            captured["full_input_ids"] = full_input_ids
+            captured.update(kwargs)
+            return mx.zeros((1, 1, 1), dtype=mx.int32)
+
+        model.generate_speech_tokens = generate_speech_tokens
+        model.find_tts_bound = lambda *args: (2, 3)
+        output = Model.generate_audio(
+            model,
+            input_ids=mx.array([[1, 2]], dtype=mx.int32),
+            generated_tokens=[3],
+            mask=mx.ones((1, 2), dtype=mx.int32),
+            tokenizer=Tokenizer(),
+            tts_max_tokens=5,
+            tts_temperature=0.2,
+            tts_top_p=0.3,
+            tts_top_k=6,
+            tts_repetition_penalty=1.2,
+            max_tokens=99,
+        )
+
+        mx.eval(output.audio_tokens)
+        self.assertEqual(output.audio_tokens.shape, (1, 1, 1))
+        self.assertEqual(captured["tts_max_new_token"], 5)
+        self.assertEqual(captured["tts_bound"], (2, 3))
+        self.assertEqual(captured["mask"].shape, (1, 3))
+        self.assertEqual(captured["max_tokens"], 99)
+        params = captured["tts_sampling_params"]
+        self.assertEqual(params.temperature, 0.2)
+        self.assertEqual(params.top_p, 0.3)
+        self.assertEqual(params.top_k, 6)
+        self.assertEqual(params.repetition_penalty, 1.2)
+
+    def test_stepaudio2_vocoder_uses_codec_default_repo(self):
+        from mlx_vlm.models.minicpmo.vocoder import StepAudio2Vocoder
+
+        calls = []
+
+        class Codec:
+            @classmethod
+            def from_pretrained(cls, *args, **kwargs):
+                calls.append((args, kwargs))
+                return cls()
+
+        stepaudio2 = types.ModuleType("mlx_audio.codec.models.stepaudio2")
+        stepaudio2.StepAudio2Token2Wav = Codec
+
+        with patch.dict(
+            sys.modules,
+            {
+                "mlx_audio": types.ModuleType("mlx_audio"),
+                "mlx_audio.codec": types.ModuleType("mlx_audio.codec"),
+                "mlx_audio.codec.models": types.ModuleType("mlx_audio.codec.models"),
+                "mlx_audio.codec.models.stepaudio2": stepaudio2,
+            },
+        ):
+            StepAudio2Vocoder()
+
+        self.assertEqual(calls, [((), {})])
+
+
+def _tiny_speech_model():
+    from mlx_vlm.models.minicpmo import (
+        MiniCPMTTSConfig,
+        Model,
+        ModelConfig,
+        TextConfig,
+        VisionConfig,
+    )
+
+    return Model(
+        ModelConfig(
+            text_config=TextConfig(
+                model_type="qwen3",
+                hidden_size=16,
+                intermediate_size=32,
+                num_hidden_layers=2,
+                num_attention_heads=2,
+                num_key_value_heads=2,
+                rms_norm_eps=1e-6,
+                vocab_size=32,
+                head_dim=8,
+                rope_theta=10000.0,
+                max_position_embeddings=64,
+                rope_scaling={"type": "default", "mrope_section": [1, 1, 2]},
+            ),
+            vision_config=VisionConfig(
+                hidden_size=16,
+                intermediate_size=32,
+                num_hidden_layers=1,
+                num_attention_heads=2,
+                image_size=28,
+            ),
+            tts_config=MiniCPMTTSConfig(
+                hidden_size=16,
+                intermediate_size=32,
+                num_hidden_layers=1,
+                num_attention_heads=2,
+                num_key_value_heads=2,
+                num_text_tokens=32,
+                num_audio_tokens=16,
+                llm_dim=16,
+                backbone_vocab_size=32,
+                audio_bos_token_id=28,
+                text_eos_token_id=29,
+                normalize_projected_hidden=True,
+            ),
+            init_audio=False,
+            query_num=4,
+        )
+    )
+
+
+def test_speech_hidden_states_match_cached_forward():
+    from mlx_lm.models.cache import KVCache
+
+    model = _tiny_speech_model()
+    ids = mx.array([[1, 2, 3, 4]])
+    full = model.get_hidden_states(ids)
+    cache = [KVCache() for _ in model.layers]
+    parts = []
+    for i in range(ids.shape[1]):
+        positions = mx.full((3, 1, 1), i, dtype=mx.int32)
+        parts.append(
+            model.language_model.model(
+                ids[:, i : i + 1], cache=cache, position_ids=positions
+            )
+        )
+    np.testing.assert_allclose(
+        np.array(full), np.array(mx.concatenate(parts, axis=1)), atol=1e-5
+    )
+
+
+def test_speech_tokens_run_with_tiny_model():
+    from mlx_vlm.models.minicpmo import TTSSamplingParams
+
+    model = _tiny_speech_model()
+    ids = mx.array([[1, 10, 3, 4, 11]])
+    tokens = model.generate_speech_tokens(
+        ids,
+        tts_start_id=10,
+        tts_end_id=11,
+        tts_max_new_token=2,
+        tts_sampling_params=TTSSamplingParams(temperature=0),
+    )
+    assert tokens.shape == (1, 2, 1)
+    assert mx.all(tokens < 15).item()
+
+
+def test_tts_eos_is_never_sent_to_codec():
+    from mlx_vlm.models.minicpmo import TTSSamplingParams
+
+    tts = _tiny_speech_model().tts
+    with patch.object(tts, "_sample", side_effect=[mx.array([4]), mx.array([15])]):
+        result = tts.generate(
+            mx.zeros((1, 2, 16)),
+            min_new_token=0,
+            max_new_token=4,
+            sampling_params=TTSSamplingParams(temperature=0),
+        )
+    assert result.finished
+    assert result.new_ids.tolist() == [[[4]]]
+
+
+def test_tts_bound_rejects_incomplete_latest_turn():
+    import pytest
+
+    model = _tiny_speech_model()
+    with pytest.raises(ValueError, match="incomplete"):
+        model.find_tts_bound(mx.array([[10, 3, 11, 10, 4]]), 10, 11)
+    with pytest.raises(ValueError, match="empty"):
+        model.find_tts_bound(mx.array([[10, 11]]), 10, 11)
+
+
+def test_sanitizer_preserves_converted_weights_and_disables_missing_tts(tmp_path):
+    import json
+    from dataclasses import asdict
+
+    from mlx.utils import tree_flatten
+
+    from mlx_vlm.utils import load_model
+
+    model = _tiny_speech_model()
+    config = asdict(model.config)
+    config.pop("audio_config")
+    weights = dict(tree_flatten(model.parameters()))
+    sanitized = model.sanitize(weights)
+    assert set(sanitized) == set(weights)
+    mx.save_safetensors(str(tmp_path / "model.safetensors"), sanitized)
+    (tmp_path / "config.json").write_text(json.dumps(config))
+    loaded = load_model(tmp_path)
+    assert loaded.supports_audio_generation
+    ids = mx.array([[1, 2, 3]])
+    np.testing.assert_allclose(
+        np.array(loaded.get_hidden_states(ids)),
+        np.array(model.get_hidden_states(ids)),
+        atol=1e-6,
+    )
+
+    # Old 4-bit artifacts still carry init_tts=True, but lack all TTS tensors.
+    mx.save_safetensors(
+        str(tmp_path / "model.safetensors"),
+        {k: v for k, v in weights.items() if not k.startswith("tts.")},
+    )
+    loaded = load_model(tmp_path)
+    assert not loaded.supports_audio_generation
+    assert loaded.config.init_tts is False
+    assert loaded.get_hidden_states(ids).shape == (1, 3, 16)
+
+
+def test_partial_tts_checkpoint_fails_strict_loading(tmp_path):
+    import json
+    from dataclasses import asdict
+
+    import pytest
+    from mlx.utils import tree_flatten
+
+    from mlx_vlm.utils import load_model
+
+    model = _tiny_speech_model()
+    config = asdict(model.config)
+    config.pop("audio_config")
+    weights = dict(tree_flatten(model.parameters()))
+    del weights["tts.head_code.0.weight"]
+    mx.save_safetensors(str(tmp_path / "model.safetensors"), weights)
+    (tmp_path / "config.json").write_text(json.dumps(config))
+    with pytest.raises(ValueError, match="Missing"):
+        load_model(tmp_path)
+
+
+def test_vocoder_keeps_tokens_on_device_and_refreshes_reference(tmp_path):
+    from unittest.mock import Mock
+
+    from mlx_vlm.models.minicpmo.vocoder import StepAudio2Vocoder
+
+    voice_a, voice_b = tmp_path / "a.wav", tmp_path / "b.wav"
+    voice_a.touch()
+    voice_b.touch()
+    vocoder = StepAudio2Vocoder.__new__(StepAudio2Vocoder)
+    vocoder.n_timesteps = 10
+    vocoder._codec = Mock(return_value=mx.zeros((1, 24)))
+    tokens = mx.array([[[1], [2]]])
+    for voice in (voice_a, voice_b):
+        wav = vocoder.decode(tokens, prompt_wav_path=str(voice))
+        assert wav.shape == (24,)
+        assert vocoder._codec.call_args.kwargs["use_cache"] is False
+        assert isinstance(vocoder._codec.call_args.args[0], mx.array)
+        assert vocoder._codec.call_args.args[0].tolist() == [1, 2]
+        assert vocoder._codec.call_args.args[1] == str(voice)
+
+
+def test_missing_reference_fails_before_text_generation(monkeypatch):
+    from unittest.mock import Mock
+
+    import pytest
+
+    from mlx_vlm import generate_audio
+    from mlx_vlm.generate import dispatch
+
+    text = Mock()
+    monkeypatch.setattr(dispatch, "generate", text)
+    with pytest.raises(ValueError, match="ref_audio_path"):
+        generate_audio(_tiny_speech_model(), None, "prompt")
+    text.assert_not_called()
+
+
+def test_old_tts_turn_cannot_supply_new_response_audio(tmp_path):
+    from unittest.mock import Mock
+
+    import pytest
+
+    model = _tiny_speech_model()
+    ref = tmp_path / "voice.wav"
+    ref.touch()
+    tokenizer = types.SimpleNamespace(tts_start_id=10, tts_end_id=11)
+    with patch.object(model, "generate_speech_tokens", Mock()) as generate_tokens:
+        with pytest.raises(ValueError, match="new response"):
+            model.generate_audio(
+                input_ids=mx.array([[10, 3, 11, 2]]),
+                generated_tokens=[4],
+                tokenizer=tokenizer,
+                ref_audio_path=str(ref),
+            )
+    generate_tokens.assert_not_called()

--- a/mlx_vlm/tests/test_minicpmo_tts.py
+++ b/mlx_vlm/tests/test_minicpmo_tts.py
@@ -1,3 +1,4 @@
+import subprocess
 import sys
 import types
 import unittest
@@ -366,7 +367,7 @@ def _tiny_speech_model():
 
 
 def test_speech_hidden_states_match_cached_forward():
-    from mlx_lm.models.cache import KVCache
+    from mlx_vlm.models.cache import KVCache
 
     model = _tiny_speech_model()
     ids = mx.array([[1, 2, 3, 4]])
@@ -399,6 +400,35 @@ def test_speech_tokens_run_with_tiny_model():
     )
     assert tokens.shape == (1, 2, 1)
     assert mx.all(tokens < 15).item()
+
+
+def test_speech_generation_without_mlx_lm():
+    # Use a fresh interpreter so an installed or already-imported mlx-lm cannot
+    # hide an undeclared dependency, as it did in the original local test run.
+    script = """
+import sys
+sys.modules["mlx_lm"] = None
+
+import mlx.core as mx
+from mlx_vlm.models.minicpmo import TTSSamplingParams
+from mlx_vlm.tests.test_minicpmo_tts import _tiny_speech_model
+
+model = _tiny_speech_model()
+tokens = model.generate_speech_tokens(
+    mx.array([[1, 10, 3, 4, 11]]),
+    tts_start_id=10,
+    tts_end_id=11,
+    tts_max_new_token=2,
+    tts_sampling_params=TTSSamplingParams(temperature=0.8, top_p=0.85, top_k=5),
+)
+mx.eval(tokens)
+assert tokens.shape == (1, 2, 1)
+assert mx.all(tokens < 15).item()
+"""
+    result = subprocess.run(
+        [sys.executable, "-c", script], capture_output=True, text=True, timeout=60
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
 
 
 def test_tts_eos_is_never_sent_to_codec():

--- a/mlx_vlm/utils.py
+++ b/mlx_vlm/utils.py
@@ -2359,7 +2359,7 @@ def prepare_inputs(
         if not isinstance(audio, list):
             audio = [audio]
 
-        if len(audio) > 1:
+        if len(audio) > 1 and not getattr(processor, "supports_multiple_audio", False):
             print(
                 "\033[33mWarning\033[0m: Single prompt with multiple audio files is not supported yet. Using the first audio file.\n"
             )


### PR DESCRIPTION
This is a rework of https://github.com/Blaizzy/mlx-vlm/pull/1148 that allows generating assistant speech responses from MiniCPM-o. it also adds support for `--output-modality audio` and `generate_audio` as a supported generation modality.

```sh
python -m mlx_vlm generate_audio --model openbmb/MiniCPM-o-4_5 \
--prompt "What's a fun thing to do in Paris?" \
--ref-audio /path/to/voice.wav --output speech.wav
```

[Example](https://s3.amazonaws.com/lucasnewman.datasets/minicpm-o/example.wav)