### PR TITLE
honor cache limits across single and batched generation

### DIFF
--- a/mlx_vlm/apc_adapters.py
+++ b/mlx_vlm/apc_adapters.py
@@ -222,7 +222,12 @@ def register_default_capabilities() -> None:
         c.SimpleKVCache,
     ):
         register_capability(cls, Capability.PAGEABLE)
-    for cls in (c.RotatingKVCache, c.BatchRotatingKVCache, c.ChunkedKVCache):
+    for cls in (
+        c.RotatingKVCache,
+        c.BatchRotatingKVCache,
+        c.BatchPrefixKVCache,
+        c.ChunkedKVCache,
+    ):
         register_capability(cls, Capability.WINDOWED)
     for cls in (
         c.ArraysCache,
@@ -322,6 +327,7 @@ def _apc_type_tables():
             c.KVCache,
             c.BatchKVCache,
             c.BatchRotatingKVCache,
+            c.BatchPrefixKVCache,
             c.BatchQuantizedKVCache,
             c.RotatingKVCache,
             c.ChunkedKVCache,
@@ -408,7 +414,7 @@ class RotatingKVCacheCloneAdapter:
     def merge_rows(self, caches, prefix_lens):
         from .models import cache as lm
 
-        return lm.BatchRotatingKVCache.merge(caches)
+        return lm.RotatingKVCache.merge(caches)
 
 
 class ChunkedKVCacheCloneAdapter:
@@ -575,6 +581,8 @@ def clone_cache_entry(c, *, min_capacity_tokens, eval_targets):
         if not c.is_single_row():
             return None
         if c.empty():
+            if isinstance(c, lm.BatchPrefixKVCache):
+                return lm.RotatingKVCache(max_size=int(c.max_size), keep=c.keep)
             if isinstance(c, lm.BatchRotatingKVCache):
                 return lm.RotatingKVCache(max_size=int(c.max_size))
             return lm.KVCache()

--- a/mlx_vlm/apc_coordinator.py
+++ b/mlx_vlm/apc_coordinator.py
@@ -10,7 +10,11 @@ from __future__ import annotations
 
 from typing import Any, Callable, List, Optional, Sequence, Tuple
 
-from .apc_adapters import PrefixCachePlan, build_prefix_cache_plan
+from .apc_adapters import (
+    PrefixCachePlan,
+    build_prefix_cache_plan,
+    build_prefix_cache_plan_from_caches,
+)
 
 
 class APCCoordinator:
@@ -21,10 +25,24 @@ class APCCoordinator:
     boundary.  The distinction is deliberately private to this class.
     """
 
-    def __init__(self, manager: Any, model: Any):
+    def __init__(self, manager: Any, model: Any, *, max_kv_size: Optional[int] = None):
         self.manager = manager
         self.model = model
-        self.plan: PrefixCachePlan = build_prefix_cache_plan(model)
+        self.max_kv_size = max_kv_size
+        self.plan: PrefixCachePlan = (
+            build_prefix_cache_plan(model)
+            if max_kv_size is None
+            else build_prefix_cache_plan_from_caches(self.fresh_cache())
+        )
+
+    def scope_hash(self, extra_hash: int) -> int:
+        if self.max_kv_size is None:
+            return extra_hash
+        from .apc import semantic_extra_hash
+
+        return semantic_extra_hash(
+            image_hash=extra_hash, media={"max_kv_size": self.max_kv_size}
+        )
 
     def prepare_prefill(self, token_count: int) -> None:
         if self.enabled:
@@ -48,6 +66,10 @@ class APCCoordinator:
 
     def fresh_cache(self) -> List[Any]:
         language_model = getattr(self.model, "language_model", self.model)
+        if self.max_kv_size is not None:
+            from .models.cache import make_prompt_cache
+
+            return list(make_prompt_cache(language_model, max_kv_size=self.max_kv_size))
         make_cache = getattr(language_model, "make_cache", None) or getattr(
             self.model, "make_cache", None
         )

--- a/mlx_vlm/generate/ar.py
+++ b/mlx_vlm/generate/ar.py
@@ -880,6 +880,7 @@ def _make_cache(
     kv_quant_scheme=DEFAULT_KV_QUANT_SCHEME,
     quantized_kv_start=0,
     prefill_length=0,
+    max_kv_size=None,
 ):
     """
     Convert a list of regular caches into their corresponding
@@ -960,7 +961,7 @@ def _make_cache(
             return cache.BatchPoolingCache(c.ratio, left_padding)
         elif isinstance(c, cache.RotatingKVCache):
             if c.keep > 0:
-                raise ValueError("RotatingKVCache with keep tokens is not supported.")
+                return cache.BatchPrefixKVCache(c.max_size, left_padding, c.keep)
             return cache.BatchRotatingKVCache(c.max_size, left_padding)
         elif isinstance(c, cache.CacheList):
             return cache.CacheList(*(to_batch_cache(sub_c) for sub_c in c.caches))
@@ -969,25 +970,18 @@ def _make_cache(
         else:
             raise ValueError(f"{type(c)} does not yet support batching")
 
-    if hasattr(model, "make_cache"):
-        model_cache = model.make_cache()
-        n = len(model_cache)
-        return [
-            to_batch_cache(c, quantize=cache.should_quantize_kv_layer(i, n))
-            for i, c in enumerate(model_cache)
-        ]
-    else:
-        if kv_bits is not None:
-            n = len(model.layers)
-            return [
-                (
-                    _make_quant_cache(left_padding)
-                    if cache.should_quantize_kv_layer(i, n)
-                    else cache.BatchKVCache(left_padding)
-                )
-                for i in range(n)
-            ]
-        return [cache.BatchKVCache(left_padding) for _ in model.layers]
+    if max_kv_size is not None and any(
+        bits is not None for bits in (kv_bits, kv_key_bits, kv_value_bits)
+    ):
+        raise NotImplementedError(
+            "max_kv_size with quantized batching is not supported"
+        )
+    model_cache = cache.make_prompt_cache(model, max_kv_size=max_kv_size)
+    n = len(model_cache)
+    return [
+        to_batch_cache(c, quantize=cache.should_quantize_kv_layer(i, n))
+        for i, c in enumerate(model_cache)
+    ]
 
 
 @dataclass
@@ -1749,6 +1743,7 @@ class PromptProcessingBatch:
         draft_kind: Optional[str] = None,
         draft_block_size: Optional[int] = None,
         greedy_sampling: bool = False,
+        max_kv_size: Optional[int] = None,
     ):
         self.model = model
         self.uids = uids
@@ -1845,6 +1840,7 @@ class PromptProcessingBatch:
                     kv_quant_scheme=kv_quant_scheme,
                     quantized_kv_start=quantized_kv_start,
                     prefill_length=max_length,
+                    max_kv_size=max_kv_size,
                 ),
             )
         elif (
@@ -1853,7 +1849,7 @@ class PromptProcessingBatch:
             and kv_bits is None
             and hasattr(model, "make_cache")
         ):
-            self.prompt_cache = cache.make_prompt_cache(model)
+            self.prompt_cache = cache.make_prompt_cache(model, max_kv_size=max_kv_size)
         else:
             self.prompt_cache = _make_cache(
                 model,
@@ -1867,6 +1863,7 @@ class PromptProcessingBatch:
                 kv_quant_scheme=kv_quant_scheme,
                 quantized_kv_start=quantized_kv_start,
                 prefill_length=max_length,
+                max_kv_size=max_kv_size,
             )
 
         # Declare per-row right-padding on each cache so finalize() can roll
@@ -2421,8 +2418,17 @@ class BatchGenerator:
         draft_kind: Optional[str] = None,
         draft_block_size: Optional[int] = None,
         greedy_sampling: bool = False,
+        max_kv_size: Optional[int] = None,
     ):
         self.model = model
+        self._wire_stack = contextlib.ExitStack()
+        if max_kv_size is not None and any(
+            bits is not None for bits in (kv_bits, kv_key_bits, kv_value_bits)
+        ):
+            raise NotImplementedError(
+                "max_kv_size with quantized batching is not supported"
+            )
+        self.max_kv_size = max_kv_size
         self.max_tokens = max_tokens
         self.processor = processor
         self.kv_bits = kv_bits
@@ -2446,7 +2452,9 @@ class BatchGenerator:
             self.compute_logprobs = False
             self.top_logprobs_k = 0
         self.apc = (
-            _apc.APCCoordinator(apc_manager, model) if apc_manager is not None else None
+            _apc.APCCoordinator(apc_manager, model, max_kv_size=max_kv_size)
+            if apc_manager is not None
+            else None
         )
         if self.apc is not None and not self.apc.enabled:
             self.apc = None
@@ -2484,7 +2492,6 @@ class BatchGenerator:
         self._steps_counter = 0
         self._cache_eval_interval = _get_batch_cache_eval_interval()
 
-        self._wire_stack = contextlib.ExitStack()
         self._wire_stack.enter_context(wired_limit(model, [self._stream]))
 
     # ---------------- APC integration helpers ----------------
@@ -2500,13 +2507,18 @@ class BatchGenerator:
             prompt_kwargs = {}
         precomputed = prompt_kwargs.get("_apc_semantic_hash")
         if precomputed is not None:
-            return int(precomputed)
+            coordinator = getattr(self, "apc", None)
+            return (
+                coordinator.scope_hash(int(precomputed))
+                if coordinator
+                else int(precomputed)
+            )
         img = prompt_kwargs.get("_apc_image_hash")
         if img is None:
             pixel_values = prompt_kwargs.get("pixel_values")
             img = _apc.hash_image_payload(pixel_values=pixel_values, image_ref=None)
         tenant = prompt_kwargs.get("_apc_tenant")
-        return _apc.semantic_extra_hash(
+        extra_hash = _apc.semantic_extra_hash(
             tenant=tenant,
             image_hash=img,
             media={
@@ -2518,6 +2530,8 @@ class BatchGenerator:
             model=getattr(self, "model", None),
             processor=getattr(self, "processor", None),
         )
+        coordinator = getattr(self, "apc", None)
+        return coordinator.scope_hash(extra_hash) if coordinator else extra_hash
 
     def _apc_media_token_ids(self) -> set[int]:
         config = getattr(self.model, "config", None)
@@ -2755,6 +2769,7 @@ class BatchGenerator:
             logits_processors=logits_processors,
             thinking_budget_criteria=thinking_budget_criteria,
             prefill_step_size=self.prefill_step_size,
+            max_kv_size=self.max_kv_size,
             kv_bits=self.kv_bits,
             kv_key_bits=getattr(self, "kv_key_bits", None),
             kv_value_bits=getattr(self, "kv_value_bits", None),
@@ -3084,6 +3099,7 @@ class BatchGenerator:
                 logits_processors=logits_processors,
                 thinking_budget_criteria=thinking_budget_criteria,
                 prefill_step_size=self.prefill_step_size,
+                max_kv_size=self.max_kv_size,
                 kv_bits=self.kv_bits,
                 kv_key_bits=getattr(self, "kv_key_bits", None),
                 kv_value_bits=getattr(self, "kv_value_bits", None),

--- a/mlx_vlm/generate/common.py
+++ b/mlx_vlm/generate/common.py
@@ -277,6 +277,7 @@ class PromptCacheState:
     def __init__(self):
         self.cache: Optional[List[Any]] = None
         self.token_ids: Optional[List[int]] = None
+        self.max_kv_size: Optional[int] = None
 
     def find_prefix_length(self, new_ids: list) -> int:
         """Return the number of leading tokens that match the cached ids."""
@@ -288,7 +289,10 @@ class PromptCacheState:
                 return i
         return max_len
 
-    def update(self, token_ids: list, kv_cache: list):
+    def update(
+        self, token_ids: list, kv_cache: list, *, max_kv_size: Optional[int] = None
+    ):
         """Store the full token sequence and corresponding KV cache."""
         self.token_ids = list(token_ids)
         self.cache = kv_cache
+        self.max_kv_size = max_kv_size

--- a/mlx_vlm/generate/dispatch.py
+++ b/mlx_vlm/generate/dispatch.py
@@ -906,7 +906,9 @@ def stream_generate(
         )
 
     if apc_manager is not None:
-        apc_coordinator = _apc.APCCoordinator(apc_manager, model.language_model)
+        apc_coordinator = _apc.APCCoordinator(
+            apc_manager, model.language_model, max_kv_size=kwargs.get("max_kv_size")
+        )
         if not apc_coordinator.enabled:
             apc_coordinator = None
             apc_manager = None
@@ -930,7 +932,13 @@ def stream_generate(
             processor=processor,
         )
 
-    if prompt_cache_state is not None and prompt_cache_state.cache is not None:
+        apc_extra_hash = apc_coordinator.scope_hash(apc_extra_hash)
+
+    if (
+        prompt_cache_state is not None
+        and prompt_cache_state.cache is not None
+        and prompt_cache_state.max_kv_size == kwargs.get("max_kv_size")
+    ):
         prefix_len = prompt_cache_state.find_prefix_length(full_input_ids_list)
         kv_cache = prompt_cache_state.cache
         # None => a cache can't be trimmed back to the shared prefix (wrapped
@@ -1137,7 +1145,9 @@ def stream_generate(
             all_ids = full_input_ids_list + [
                 t.item() if hasattr(t, "item") else t for t in generated_tokens
             ]
-            prompt_cache_state.update(all_ids, tracked_cache)
+            prompt_cache_state.update(
+                all_ids, tracked_cache, max_kv_size=kwargs.get("max_kv_size")
+            )
 
         # APC: harvest new blocks from the post-generation KV state.
         if apc_coordinator is not None and not apc_coordinator.is_checkpoint:

--- a/mlx_vlm/models/cache.py
+++ b/mlx_vlm/models/cache.py
@@ -743,7 +743,7 @@ class RotatingKVCache(_BaseCache):
                 (positions < self.keep) | (queries < positions + recent)
             )
         if N > 1:
-            window_size = window_size or self.max_size
+            window_size = min(window_size or self.max_size, self.max_size)
             offset = min(self.max_size - 1, self.offset)
             if offset + N > window_size or return_array:
                 return create_causal_mask(N, offset, window_size=window_size)
@@ -1523,12 +1523,15 @@ class BatchRotatingKVCache(_BaseCache):
             )
         return self.keys, self.values
 
+    def _uses_in_place_update(self, N):
+        return N == 1 and self._lengths is None
+
     def update_and_fetch(self, keys, values):
         # Single-token updates normally use the in-place decode path. While
         # right-padding bookkeeping is active (_lengths set by prepare()), the
         # last prefill step may still be S=1; that must go through concat so
         # pad tokens are tracked until finalize() rolls them out.
-        if keys.shape[2] == 1 and self._lengths is None:
+        if self._uses_in_place_update(keys.shape[2]):
             return self._update_in_place(keys, values)
         return self._update_concat(keys, values)
 
@@ -1595,7 +1598,8 @@ class BatchRotatingKVCache(_BaseCache):
         self, N: int, window_size: Optional[int] = None, return_array: bool = False
     ):
         left_padding = self.left_padding
-        window_size = window_size or self.max_size
+        window_size = min(window_size or self.max_size, self.max_size)
+        in_place = self._uses_in_place_update(N)
         offset = min(self.max_size - 1, self._offset)
         rinds = mx.arange(offset + N)
         linds = mx.arange(offset, offset + N) if offset else rinds
@@ -1603,10 +1607,11 @@ class BatchRotatingKVCache(_BaseCache):
         rinds = rinds[None]
         mask = linds >= rinds
         mask &= linds < rinds + window_size
-        if (trim_size := self._idx - self.max_size + int(N > 1)) > 0:
+        idx = self.keys.shape[2] if self.rotated and not in_place else self._idx
+        if (trim_size := idx - self.max_size + int(not in_place)) > 0:
             left_padding = left_padding - trim_size
 
-        rotated = N == 1 and (self.rotated or self._idx >= self.max_size)
+        rotated = in_place and (self.rotated or self._idx >= self.max_size)
         if rotated:
             left_padding = left_padding - 1
 
@@ -1834,7 +1839,9 @@ class BatchPrefixKVCache(_BaseCache):
         prefix_mask = queries[..., None] >= mx.arange(self.keep)
         positions = self.offset[:, None] - retained + mx.arange(retained + N)
         tail_valid = positions >= self.keep
-        if N == 1 and (self.tail.rotated or self.tail._idx >= self.tail.max_size):
+        if self.tail._uses_in_place_update(N) and (
+            self.tail.rotated or self.tail._idx >= self.tail.max_size
+        ):
             idx = self.tail._idx if self.tail._idx < self.tail.max_size else 0
             tail_valid = mx.roll(tail_valid, idx + 1, axis=-1)
         tail_mask = tail_mask & tail_valid[:, None, None, :]

--- a/mlx_vlm/models/cache.py
+++ b/mlx_vlm/models/cache.py
@@ -49,25 +49,39 @@ def make_prompt_cache(
     """
     Construct the model's cache for use in generation.
 
-    This function will defer the cache construction to the model if it has a
-    ``make_cache`` method, otherwise it will make a default KV cache.
+    Models choose their cache layout. Each cache owns whether and how that
+    layout can retain a bounded token history.
 
     Args:
         model (nn.Module): The language model.
-        max_kv_size (Optional[int]): If provided and the model does not have a
-            ``make_cache`` method, a ``RotatingKVCache`` is used with a maximum
-            size of ``max_kv_size``
+        max_kv_size (Optional[int]): Maximum retained token history. Unsupported
+            cache layouts raise rather than silently ignoring this limit.
     """
-    if hasattr(model, "make_cache"):
-        return model.make_cache()
+    if max_kv_size is not None and (
+        isinstance(max_kv_size, bool)
+        or not isinstance(max_kv_size, int)
+        or max_kv_size <= 0
+    ):
+        raise ValueError("max_kv_size must be a positive integer")
+    caches = (
+        model.make_cache()
+        if hasattr(model, "make_cache")
+        else [KVCache() for _ in model.layers]
+    )
+    if max_kv_size is None:
+        return caches
+    return [_bounded_cache(entry, max_kv_size) for entry in caches]
 
-    num_layers = len(model.layers)
-    if max_kv_size is not None:
-        return [
-            RotatingKVCache(max_size=max_kv_size, keep=4) for _ in range(num_layers)
-        ]
-    else:
-        return [KVCache() for _ in range(num_layers)]
+
+def _bounded_cache(entry, max_size):
+    if isinstance(entry, tuple):
+        return tuple(_bounded_cache(child, max_size) for child in entry)
+    bound = getattr(entry, "with_max_size", None)
+    if bound is None:
+        raise NotImplementedError(
+            f"{type(entry).__name__} does not support max_kv_size"
+        )
+    return bound(max_size)
 
 
 def create_attention_mask(
@@ -84,6 +98,14 @@ def create_attention_mask(
 
 
 class _BaseCache:
+    def with_max_size(self, max_size):
+        """Build an empty cache with bounded history and the same semantics.
+
+        Specialized caches must opt in: bounding only their K/V arrays can
+        leave auxiliary sequence state unbounded or misaligned.
+        """
+        raise NotImplementedError(f"{type(self).__name__} does not support max_kv_size")
+
     @property
     def state(self):
         return []
@@ -410,6 +432,13 @@ class QuantizedKVCache(_BaseCache):
 
 
 class KVCache(_BaseCache):
+    def with_max_size(self, max_size):
+        if type(self) is not KVCache:
+            return super().with_max_size(max_size)
+        if not self.empty():
+            raise ValueError("Cannot change the limit of a populated KVCache")
+        return RotatingKVCache(max_size, keep=min(4, max_size - 1))
+
     step = 256
 
     def __init__(self):
@@ -546,6 +575,16 @@ class KVCache(_BaseCache):
 
 
 class RotatingKVCache(_BaseCache):
+    def with_max_size(self, max_size):
+        if type(self) is not RotatingKVCache:
+            return super().with_max_size(max_size)
+        if not self.empty():
+            raise ValueError("Cannot change the limit of a populated RotatingKVCache")
+        max_size = min(self.max_size, max_size)
+        if max_size <= self.keep:
+            raise ValueError("max_kv_size must exceed the preserved prefix length")
+        return RotatingKVCache(max_size, keep=self.keep)
+
     step = 256
 
     def __init__(self, max_size, keep=0):
@@ -692,6 +731,17 @@ class RotatingKVCache(_BaseCache):
     def make_mask(
         self, N: int, window_size: Optional[int] = None, return_array: bool = False
     ):
+        if self.keep and N > 1:
+            retained = min(self.max_size - 1, self.offset)
+            positions = mx.arange(retained + N)
+            positions = mx.where(
+                positions < self.keep, positions, positions + self.offset - retained
+            )
+            queries = mx.arange(self.offset, self.offset + N)[:, None]
+            recent = min(window_size or self.max_size, self.max_size - self.keep)
+            return (queries >= positions) & (
+                (positions < self.keep) | (queries < positions + recent)
+            )
         if N > 1:
             window_size = window_size or self.max_size
             offset = min(self.max_size - 1, self.offset)
@@ -702,6 +752,14 @@ class RotatingKVCache(_BaseCache):
         else:
             if window_size is None:
                 return None
+            if self.keep:
+                if self.offset < self.keep:
+                    return None
+                mask_size = min(self.offset + 1, self.max_size)
+                idx = self._idx if self._idx < self.max_size else self.keep
+                positions = mx.arange(mask_size)
+                age = (idx - positions) % (mask_size - self.keep)
+                return (positions < self.keep) | (age < window_size)
             # May need a mask for when window_size < max_size
             if self.offset >= window_size and self.max_size > window_size:
                 idx = self._idx
@@ -717,6 +775,8 @@ class RotatingKVCache(_BaseCache):
 
     @classmethod
     def merge(_, caches):
+        if caches[0].keep:
+            return BatchPrefixKVCache.merge(caches)
         return BatchRotatingKVCache.merge(caches)
 
     def empty(self):
@@ -730,6 +790,11 @@ class RotatingKVCache(_BaseCache):
 
 
 class ArraysCache(_BaseCache):
+    def with_max_size(self, max_size):
+        if type(self) is not ArraysCache:
+            return super().with_max_size(max_size)
+        return self
+
     def __new__(cls, *args, **kwargs):
         instance = super().__new__(cls)
         instance._left_padding = None
@@ -988,6 +1053,11 @@ class ChunkedKVCache(_BaseCache):
 
 
 class CacheList(_BaseCache):
+    def with_max_size(self, max_size):
+        if type(self) is not CacheList:
+            return super().with_max_size(max_size)
+        return CacheList(*(_bounded_cache(c, max_size) for c in self.caches))
+
     def __init__(self, *caches):
         self.caches = caches
 
@@ -1257,6 +1327,8 @@ class BatchKVCache(_BaseCache):
 
     def extract(self, idx):
         cache = KVCache()
+        if self.empty():
+            return cache
         padding = self.left_padding[idx].item()
         cache.keys = mx.contiguous(self.keys[idx : idx + 1, :, padding : self._idx])
         cache.values = mx.contiguous(self.values[idx : idx + 1, :, padding : self._idx])
@@ -1485,7 +1557,7 @@ class BatchRotatingKVCache(_BaseCache):
     @property
     def state(self):
         k, v = self.keys, self.values
-        if self._offset < k.shape[2]:
+        if k is not None and self._offset < k.shape[2]:
             k, v = k[..., : self._offset, :], v[..., : self._offset, :]
         return k, v, self.offset, self.left_padding
 
@@ -1503,7 +1575,8 @@ class BatchRotatingKVCache(_BaseCache):
             int,
             v[:3],
         )
-        self.rotated = bool(v[3])
+        self.rotated = str(v[3]) == "True"
+        self._lengths = None
 
     def is_trimmable(self):
         return self._offset < self.max_size
@@ -1608,6 +1681,8 @@ class BatchRotatingKVCache(_BaseCache):
         self._offset = max(self._offset, other._offset)
 
     def extract(self, idx):
+        if self.empty():
+            return RotatingKVCache(self.max_size)
         mx.eval(self.left_padding, self.offset)
         cache = RotatingKVCache(self.max_size)
         padding = max(0, self.left_padding.tolist()[idx])
@@ -1627,6 +1702,8 @@ class BatchRotatingKVCache(_BaseCache):
 
     @classmethod
     def merge(cls, caches):
+        if any(c.keep for c in caches):
+            return BatchPrefixKVCache.merge(caches)
         if not all(c.max_size == caches[0].max_size for c in caches):
             raise ValueError(
                 "BatchRotatingKVCache can only merge caches with the same maximum size"
@@ -1688,6 +1765,228 @@ class BatchRotatingKVCache(_BaseCache):
         if self.keys is None:
             return 0
         return self.keys.nbytes + self.values.nbytes
+
+
+class BatchPrefixKVCache(_BaseCache):
+    """A per-sequence fixed prefix plus a rotating recent-token window."""
+
+    def __init__(self, max_size, left_padding, keep=4):
+        if not 0 < keep < max_size:
+            raise ValueError("keep must be positive and smaller than max_size")
+        self.max_size = max_size
+        self.keep = keep
+        self.tail = BatchRotatingKVCache(max_size - keep, left_padding)
+        self.prefix_keys = None
+        self.prefix_values = None
+
+    @property
+    def offset(self):
+        return self.tail.offset
+
+    @offset.setter
+    def offset(self, value):
+        self.tail.offset = value
+
+    @property
+    def left_padding(self):
+        return self.tail.left_padding
+
+    @left_padding.setter
+    def left_padding(self, value):
+        self.tail.left_padding = value
+
+    @property
+    def _idx(self):
+        return self.tail._idx
+
+    @property
+    def batch_size(self):
+        return self.tail.batch_size
+
+    def is_single_row(self):
+        return self.batch_size == 1
+
+    def update_and_fetch(self, keys, values):
+        positions = mx.arange(self.keep)[None]
+        source = positions - self.offset[:, None]
+        valid = (source >= 0) & (source < keys.shape[2])
+        if self.tail._lengths is not None:
+            valid &= positions < self.tail._lengths[:, None]
+        source = mx.clip(source, 0, keys.shape[2] - 1)[:, None, :, None]
+        valid = valid[:, None, :, None]
+        prefix = []
+        for old, incoming in ((self.prefix_keys, keys), (self.prefix_values, values)):
+            selected = mx.take_along_axis(incoming, source, axis=2)
+            if old is None:
+                old = mx.zeros_like(selected)
+            prefix.append(mx.where(valid, selected, old))
+        self.prefix_keys, self.prefix_values = prefix
+        tail_keys, tail_values = self.tail.update_and_fetch(keys, values)
+        return (
+            mx.concatenate([self.prefix_keys, tail_keys], axis=2),
+            mx.concatenate([self.prefix_values, tail_values], axis=2),
+        )
+
+    def make_mask(self, N, window_size=None, return_array=False):
+        tail_mask = self.tail.make_mask(N, window_size, return_array=True)
+        retained = min(self.tail.max_size - 1, self.tail._offset)
+        queries = self.offset[:, None] + mx.arange(N)[None]
+        prefix_mask = queries[..., None] >= mx.arange(self.keep)
+        positions = self.offset[:, None] - retained + mx.arange(retained + N)
+        tail_valid = positions >= self.keep
+        if N == 1 and (self.tail.rotated or self.tail._idx >= self.tail.max_size):
+            idx = self.tail._idx if self.tail._idx < self.tail.max_size else 0
+            tail_valid = mx.roll(tail_valid, idx + 1, axis=-1)
+        tail_mask = tail_mask & tail_valid[:, None, None, :]
+        return mx.concatenate([prefix_mask[:, None], tail_mask], axis=-1)
+
+    def prepare(self, **kwargs):
+        self.tail.prepare(**kwargs)
+
+    def finalize(self):
+        self.tail.finalize()
+
+    def is_trimmable(self):
+        return self.tail.is_trimmable()
+
+    def trim(self, n):
+        return self.tail.trim(n)
+
+    def filter(self, batch_indices):
+        self.tail.filter(batch_indices)
+        if self.prefix_keys is not None:
+            self.prefix_keys = self.prefix_keys[batch_indices]
+            self.prefix_values = self.prefix_values[batch_indices]
+
+    def extend(self, other):
+        if self.max_size != other.max_size or self.keep != other.keep:
+            raise ValueError("Cannot extend prefix caches with different limits")
+        prefix = []
+        for a, b in (
+            (self.prefix_keys, other.prefix_keys),
+            (self.prefix_values, other.prefix_values),
+        ):
+            if a is None and b is None:
+                prefix.append(None)
+                continue
+            template = a if a is not None else b
+            if a is None:
+                a = mx.zeros(
+                    (self.batch_size, *template.shape[1:]), dtype=template.dtype
+                )
+            if b is None:
+                b = mx.zeros(
+                    (other.batch_size, *template.shape[1:]), dtype=template.dtype
+                )
+            prefix.append(mx.concatenate([a, b], axis=0))
+        self.tail.extend(other.tail)
+        self.prefix_keys, self.prefix_values = prefix
+
+    def extract(self, idx):
+        if self.empty():
+            return RotatingKVCache(self.max_size, self.keep)
+        tail = self.tail.extract(idx)
+        cache = RotatingKVCache(self.max_size, self.keep)
+        cache.offset = max(0, tail.offset)
+        prefix_length = min(self.keep, max(0, tail.offset))
+        tail_length = min(max(0, tail.offset - self.keep), self.tail.max_size)
+        for attr, prefix in (
+            ("keys", self.prefix_keys),
+            ("values", self.prefix_values),
+        ):
+            values = getattr(tail, attr)
+            recent = (
+                values[..., -tail_length:, :] if tail_length else values[..., :0, :]
+            )
+            setattr(
+                cache,
+                attr,
+                mx.concatenate(
+                    [prefix[idx : idx + 1, :, :prefix_length], recent], axis=2
+                ),
+            )
+        cache._idx = cache.keys.shape[2]
+        return cache
+
+    @classmethod
+    def merge(cls, caches):
+        max_size, keep = caches[0].max_size, caches[0].keep
+        if any(c.max_size != max_size or c.keep != keep for c in caches):
+            raise ValueError("Cannot merge prefix caches with different limits")
+        result = cls(max_size, [0] * len(caches), keep)
+        if all(c.empty() for c in caches):
+            return result
+        tails = []
+        prefixes = [[], []]
+        exemplar = next(c for c in caches if not c.empty())
+        for cache in caches:
+            tail = RotatingKVCache(max_size - keep)
+            tail.offset = cache.offset
+            for i, attr in enumerate(("keys", "values")):
+                template = getattr(exemplar, attr)
+                prefix = mx.zeros(
+                    (1, template.shape[1], keep, template.shape[-1]),
+                    dtype=template.dtype,
+                )
+                if not cache.empty():
+                    temporal = cache._temporal_order(getattr(cache, attr))
+                    count = min(keep, max(0, cache.offset))
+                    prefix[..., :count, :] = temporal[..., :count, :]
+                    length = min(max(0, cache.offset), tail.max_size)
+                    recent = (
+                        temporal[..., -length:, :] if length else temporal[..., :0, :]
+                    )
+                    setattr(tail, attr, recent)
+                    tail._idx = recent.shape[2]
+                prefixes[i].append(prefix)
+            tails.append(tail)
+        result.tail = BatchRotatingKVCache.merge(tails)
+        result.tail._offset = max(c.offset for c in caches)
+        result.prefix_keys, result.prefix_values = [
+            mx.concatenate(p, axis=0) for p in prefixes
+        ]
+        return result
+
+    @property
+    def state(self):
+        return self.tail.state, self.prefix_keys, self.prefix_values
+
+    @state.setter
+    def state(self, value):
+        self.tail.state, self.prefix_keys, self.prefix_values = value
+
+    @property
+    def meta_state(self):
+        return self.max_size, self.keep, self.tail.meta_state
+
+    @meta_state.setter
+    def meta_state(self, value):
+        self.max_size, self.keep, tail_meta = value
+        self.tail.meta_state = tail_meta
+
+    @classmethod
+    def from_state(cls, state, meta_state):
+        max_size, keep, tail_meta = meta_state
+        result = cls(max_size, [], keep)
+        result.tail.state = state[0]
+        result.tail.meta_state = tail_meta
+        result.prefix_keys, result.prefix_values = state[1:]
+        return result
+
+    def size(self):
+        return min(self.tail._offset, self.max_size)
+
+    def empty(self):
+        return self.tail.empty()
+
+    @property
+    def nbytes(self):
+        prefix = (
+            0
+            if self.prefix_keys is None
+            else self.prefix_keys.nbytes + self.prefix_values.nbytes
+        )
+        return self.tail.nbytes + prefix
 
 
 # MLX-VLM cache extensions.
@@ -2742,6 +3041,15 @@ class BatchPoolingCache(_BaseCache):
 
 
 class SimpleKVCache:
+    def with_max_size(self, max_size):
+        if type(self) is not SimpleKVCache:
+            raise NotImplementedError(
+                f"{type(self).__name__} does not support max_kv_size"
+            )
+        if not self.empty():
+            raise ValueError("Cannot change the limit of a populated SimpleKVCache")
+        return RotatingKVCache(max_size, keep=min(4, max_size - 1))
+
     """A simple key-value cache for transformer attention layers.
 
     Stores and concatenates key/value tensors along sequence dimension.

--- a/mlx_vlm/models/qwen3_5/language.py
+++ b/mlx_vlm/models/qwen3_5/language.py
@@ -139,7 +139,7 @@ def _extract_row_cache(cache_entry, row: int):
             row_cache.lengths = lengths[row : row + 1]
         return row_cache
 
-    if hasattr(cache_entry, "extract") and not cache_entry.empty():
+    if hasattr(cache_entry, "extract"):
         return cache_entry.extract(row)
 
     if hasattr(cache_entry, "left_padding"):
@@ -282,6 +282,9 @@ def _create_qwen3_5_attention_mask(h: mx.array, cache):
 
     if hasattr(cache, "_qwen3_5_decode_left_padding"):
         delattr(cache, "_qwen3_5_decode_left_padding")
+
+    if getattr(cache, "max_size", None) is not None:
+        return create_attention_mask(h, cache)
 
     left_padding = getattr(cache, "left_padding", None)
     if h.shape[1] == 1 and isinstance(left_padding, mx.array) and left_padding.ndim > 0:
@@ -1017,7 +1020,7 @@ class Qwen3_5Attention(nn.Module):
             cos, sin = position_embeddings
             queries, keys = apply_multimodal_rotary_pos_emb(queries, keys, cos, sin)
 
-        if mask is not None and isinstance(mask, mx.array):
+        if isinstance(mask, mx.array) and getattr(cache, "max_size", None) is None:
             if (
                 cache is not None
                 and hasattr(cache, "_idx")
@@ -1958,6 +1961,12 @@ class LanguageModel(nn.Module):
                 and c0.offset.size > 1
             ):
                 cache_offsets = mx.maximum(c0.offset, 0)
+            elif getattr(c0, "max_size", None) is not None:
+                cache_offset = (
+                    int(c0.offset.item())
+                    if isinstance(c0.offset, mx.array)
+                    else c0.offset
+                )
 
         if position_ids is not None and cache_offsets is None:
             seq_length = inputs.shape[-1]

--- a/mlx_vlm/tests/test_generate.py
+++ b/mlx_vlm/tests/test_generate.py
@@ -2251,6 +2251,7 @@ def test_stream_generate_stores_checkpoint_only_before_decode(reused_prefix):
             pass
 
     coordinator = MagicMock()
+    coordinator.scope_hash.side_effect = lambda value: value
     coordinator.enabled = True
     coordinator.is_checkpoint = True
     coordinator.lookup.return_value = (
@@ -3152,6 +3153,7 @@ def test_cold_batch_left_pads_sequence_aligned_prompt_kwargs():
             return 0
 
     bg = object.__new__(BatchGenerator)
+    bg.max_kv_size = None
     bg._generation_batch = EmptyGenerationBatch()
     bg._prompt_batch = None
     bg._prompt_tokens_counter = 0
@@ -3260,6 +3262,7 @@ def test_prompt_processing_batch_slices_native_mrope_position_ids():
 
 def test_mixed_apc_batch_strips_private_kwargs_before_prefill():
     bg = object.__new__(BatchGenerator)
+    bg.max_kv_size = None
     bg.apc_manager = object()
     bg.model = SimpleNamespace(layers=[object()])
     bg.prefill_step_size = None

--- a/mlx_vlm/tests/test_models.py
+++ b/mlx_vlm/tests/test_models.py
@@ -15094,6 +15094,439 @@ class TestDeepseekV4HISA(unittest.TestCase):
         self.assertTrue(bool(mx.array_equal(mx.sort(out, -1), mx.sort(ftk, -1))))
 
 
+class TestCacheCapacity(unittest.TestCase):
+    def test_quantized_limit_is_rejected_before_warm_cache_lookup(self):
+        from mlx_vlm.generate.ar import BatchGenerator, _make_cache
+
+        for kwargs in ({"kv_bits": 4}, {"kv_key_bits": 4, "kv_value_bits": 4}):
+            with self.assertRaisesRegex(NotImplementedError, "quantized batching"):
+                BatchGenerator(None, None, max_kv_size=8, **kwargs)
+            with self.assertRaisesRegex(NotImplementedError, "quantized batching"):
+                _make_cache(None, [0, 0], max_kv_size=8, **kwargs)
+
+    def test_conversation_cache_is_not_reused_after_limit_changes(self):
+        import contextlib
+        from unittest.mock import patch
+
+        from mlx_vlm.generate import dispatch
+        from mlx_vlm.generate.common import PromptCacheState
+        from mlx_vlm.models.cache import KVCache, RotatingKVCache
+        from mlx_vlm.tests.test_generate import MockProcessor
+
+        model = SimpleNamespace(
+            config=SimpleNamespace(model_type="test", eos_token_id=[]),
+            language_model=SimpleNamespace(layers=[None]),
+        )
+        state = PromptCacheState()
+        state.update([1, 2], [KVCache()])
+
+        def generate(*args, **kwargs):
+            self.assertEqual(args[0].tolist(), [[1, 2, 3]])
+            self.assertIsInstance(kwargs["prompt_cache"][0], RotatingKVCache)
+            self.assertEqual(kwargs["prompt_cache"][0].max_size, 8)
+            yield 7, mx.zeros(8)
+
+        with (
+            patch.object(
+                dispatch, "wired_limit", return_value=contextlib.nullcontext()
+            ),
+            patch.object(dispatch, "generate_step", side_effect=generate),
+            patch.object(
+                state, "find_prefix_length", side_effect=AssertionError("stale policy")
+            ),
+        ):
+            list(
+                dispatch.stream_generate(
+                    model,
+                    MockProcessor(),
+                    "",
+                    input_ids=mx.array([[1, 2, 3]]),
+                    prompt_cache_state=state,
+                    max_kv_size=8,
+                    max_tokens=1,
+                )
+            )
+        self.assertEqual(state.max_kv_size, 8)
+
+    def test_cache_owners_apply_limit_without_losing_layout(self):
+        from mlx_vlm.models.cache import (
+            ArraysCache,
+            CacheList,
+            KVCache,
+            RotatingKVCache,
+            make_prompt_cache,
+        )
+
+        recurrent = ArraysCache(size=2)
+        model = SimpleNamespace(
+            make_cache=lambda: [CacheList(KVCache(), recurrent), RotatingKVCache(5)]
+        )
+        caches = make_prompt_cache(model, max_kv_size=8)
+        self.assertEqual(caches[0][0].max_size, 8)
+        self.assertEqual(caches[0][0].keep, 4)
+        self.assertIs(caches[0][1], recurrent)
+        self.assertEqual(caches[1].max_size, 5)
+        self.assertEqual(
+            make_prompt_cache(SimpleNamespace(layers=[None]), max_kv_size=1)[0].keep, 0
+        )
+
+    def test_limit_cannot_partially_succeed(self):
+        from mlx_vlm.models.cache import KVCache, PoolingCache, make_prompt_cache
+
+        class AuxiliaryCache(KVCache):
+            pass
+
+        for unsupported in (PoolingCache(4), AuxiliaryCache()):
+            ordinary = KVCache()
+            model = SimpleNamespace(make_cache=lambda: [ordinary, unsupported])
+            with self.assertRaisesRegex(
+                NotImplementedError, type(unsupported).__name__
+            ):
+                make_prompt_cache(model, max_kv_size=8)
+            self.assertIsNone(ordinary.keys)
+
+    def test_invalid_limit_fails_before_cache_construction(self):
+        from mlx_vlm.models.cache import make_prompt_cache
+
+        for limit in (0, -1, True, 1.5):
+            with (
+                self.subTest(limit=limit),
+                self.assertRaisesRegex(ValueError, "positive integer"),
+            ):
+                make_prompt_cache(object(), max_kv_size=limit)
+
+    def assert_visible_tokens(self, cache, chunks, positions=None, window_size=None):
+        if positions is None:
+            positions = np.array(cache.offset).reshape(-1)
+        for length in chunks:
+            p = positions[:, None] + np.arange(length)
+            data = mx.array(p[:, None, :, None], dtype=mx.float32)
+            mask = cache.make_mask(length, window_size=window_size)
+            keys, values = cache.update_and_fetch(data, data)
+            mx.eval(mask, keys, values)
+            keys = np.array(keys)
+            masks = (
+                np.ones((length, keys.shape[2]), dtype=bool)
+                if mask is None
+                else np.array(mask)
+            )
+            masks = np.broadcast_to(masks, (len(positions), 1, length, keys.shape[2]))
+            for row in range(len(positions)):
+                for col in range(length):
+                    position = int(p[row, col])
+                    if position < 0:
+                        continue
+                    expected = set(range(min(position + 1, cache.keep)))
+                    expected.update(
+                        range(
+                            max(
+                                cache.keep,
+                                position
+                                - min(
+                                    window_size or cache.max_size,
+                                    cache.max_size - cache.keep,
+                                )
+                                + 1,
+                            ),
+                            position + 1,
+                        )
+                    )
+                    visible = keys[row, 0, :, 0][masks[row, 0, col]]
+                    self.assertEqual(len(visible), len(expected))
+                    self.assertEqual(set(visible), expected)
+            positions += length
+        return positions
+
+    def test_batched_prefix_survives_chunking_and_cache_lifecycle(self):
+        from mlx_vlm.models.cache import BatchPrefixKVCache
+
+        for padding in ([0, 0], [0, 3], [0, 9]):
+            for chunks in ([1] * 25, [5, 3, 2, 15], [20, 1, 4]):
+                with self.subTest(padding=padding, chunks=chunks):
+                    cache = BatchPrefixKVCache(8, padding, keep=2)
+                    positions = self.assert_visible_tokens(cache, chunks)
+                    restored = BatchPrefixKVCache.from_state(
+                        cache.state, cache.meta_state
+                    )
+                    self.assert_visible_tokens(restored, [1, 3], positions.copy())
+                    merged = BatchPrefixKVCache.merge(
+                        [cache.extract(i) for i in range(2)]
+                    )
+                    self.assert_visible_tokens(merged, [1, 3], positions.copy())
+                    cache.filter([1, 0])
+                    self.assert_visible_tokens(cache, [1, 3], positions[::-1].copy())
+
+    def test_explicit_attention_window_keeps_the_fixed_prefix(self):
+        from mlx_vlm.models.cache import BatchPrefixKVCache, RotatingKVCache
+
+        for chunks in ([1] * 25, [3, 5, 17]):
+            for cache in (
+                RotatingKVCache(8, keep=4),
+                BatchPrefixKVCache(8, [0], keep=4),
+            ):
+                self.assert_visible_tokens(cache, chunks, window_size=2)
+
+    def test_batch_generation_receives_the_requested_limit(self):
+        from mlx_vlm.generate.ar import BatchGenerator
+        from mlx_vlm.models.gemma3.config import TextConfig
+        from mlx_vlm.models.gemma3.language import LanguageModel
+        from mlx_vlm.tests.test_generate import MockTokenizer
+
+        class RecordingModel(LanguageModel):
+            def __call__(self, *args, cache=None, **kwargs):
+                self.seen_cache = cache
+                return super().__call__(*args, cache=cache, **kwargs)
+
+        config = TextConfig(
+            model_type="gemma3_text",
+            hidden_size=32,
+            num_hidden_layers=2,
+            intermediate_size=64,
+            num_attention_heads=4,
+            num_key_value_heads=2,
+            head_dim=8,
+            vocab_size=64,
+            sliding_window_pattern=1,
+        )
+        model = RecordingModel(config)
+        model.eval()
+        for batch_size in (1, 2):
+            with self.subTest(batch_size=batch_size):
+                generator = BatchGenerator(
+                    model,
+                    MockTokenizer(),
+                    max_kv_size=8,
+                    prefill_batch_size=batch_size,
+                    completion_batch_size=batch_size,
+                    prefill_step_size=5,
+                )
+                try:
+                    prompts = [list(range(3, 23 - i)) for i in range(batch_size)]
+                    prompt_kwargs = [
+                        {"inputs_embeds": model.model.embed_tokens(mx.array([ids]))}
+                        for ids in prompts
+                    ]
+                    generator.insert(prompts, max_tokens=3, prompt_kwargs=prompt_kwargs)
+                    while generator.has_work:
+                        generator.next()
+                    for cache in model.seen_cache:
+                        self.assertEqual(cache.max_size, 8)
+                        self.assertEqual(cache.keep, 4)
+                        self.assertLessEqual(cache.size(), 8)
+                finally:
+                    generator.close()
+
+    def test_right_padding_and_new_rows_preserve_prefix_tokens(self):
+        from mlx_vlm.models.cache import BatchPrefixKVCache
+
+        for chunks in ([12], [4, 4, 4], [5, 3, 3, 1]):
+            cache = BatchPrefixKVCache(8, [0, 0], keep=2)
+            cache.prepare(lengths=[4, 12], right_padding=[8, 0])
+            processed = 0
+            for length in chunks:
+                data = np.broadcast_to(
+                    np.arange(processed, processed + length)[None], (2, length)
+                ).copy()
+                data[0, data[0] >= 4] = -100
+                values = mx.array(data[:, None, :, None], dtype=mx.float32)
+                mx.eval(cache.update_and_fetch(values, values))
+                processed += length
+            cache.finalize()
+            self.assert_visible_tokens(cache, [1, 3], np.array([4, 12]))
+        first = BatchPrefixKVCache(8, [0], keep=2)
+        second = BatchPrefixKVCache(8, [0], keep=2)
+        a = self.assert_visible_tokens(first, [12])
+        b = self.assert_visible_tokens(second, [3])
+        first.extend(second)
+        self.assert_visible_tokens(first, [1, 3], np.concatenate([a, b]))
+
+    def test_single_and_batched_bounded_attention_agree(self):
+        from mlx_vlm.generate.ar import _make_cache
+        from mlx_vlm.models.cache import make_prompt_cache
+        from mlx_vlm.models.gemma3.config import TextConfig
+        from mlx_vlm.models.gemma3.language import LanguageModel
+
+        mx.random.seed(42)
+        config = TextConfig(
+            model_type="gemma3_text",
+            hidden_size=32,
+            num_hidden_layers=2,
+            intermediate_size=64,
+            num_attention_heads=4,
+            num_key_value_heads=2,
+            head_dim=8,
+            vocab_size=64,
+            sliding_window_pattern=1,
+        )
+        model = LanguageModel(config)
+        model.eval()
+        ids = mx.array([list(range(3, 28)), list(range(5, 30))])
+        refs = []
+        for row in range(2):
+            cache = make_prompt_cache(model, max_kv_size=8)
+            refs.append(
+                mx.concatenate(
+                    [
+                        model(ids[row : row + 1, t : t + 1], cache=cache).logits
+                        for t in range(25)
+                    ],
+                    axis=1,
+                )
+            )
+        expected = mx.concatenate(refs, axis=0)
+        mx.eval(expected)
+        for chunks in ([25], [5, 7, 13], [1] * 25):
+            with self.subTest(chunks=chunks):
+                cache = _make_cache(model, [0, 0], max_kv_size=8)
+                actual = []
+                offset = 0
+                for length in chunks:
+                    actual.append(
+                        model(ids[:, offset : offset + length], cache=cache).logits
+                    )
+                    offset += length
+                actual = mx.concatenate(actual, axis=1)
+                mx.eval(actual)
+                np.testing.assert_allclose(
+                    np.array(actual), np.array(expected), atol=2e-3, rtol=2e-3
+                )
+
+    def test_apc_uses_bounded_layout_and_separates_limit_policies(self):
+        from mlx_vlm.apc import APCManager, snapshot_prompt_cache_row
+        from mlx_vlm.apc_coordinator import APCCoordinator
+        from mlx_vlm.models.cache import BatchPrefixKVCache, KVCache
+
+        model = SimpleNamespace(make_cache=lambda: [KVCache()])
+        manager = APCManager(num_blocks=8, block_size=4)
+        bounded = APCCoordinator(manager, model, max_kv_size=8)
+        other = APCCoordinator(manager, model, max_kv_size=16)
+        default = APCCoordinator(manager, model)
+        self.assertTrue(bounded.is_checkpoint)
+        self.assertEqual(bounded.fresh_cache()[0].max_size, 8)
+        self.assertEqual(default.scope_hash(7), 7)
+        self.assertNotEqual(bounded.scope_hash(7), other.scope_hash(7))
+        cache = BatchPrefixKVCache(8, [0, 0], keep=4)
+        positions = self.assert_visible_tokens(cache, [20, 1])
+        rows = [snapshot_prompt_cache_row([cache], batch_idx=i) for i in range(2)]
+        self.assertTrue(all(row is not None for row in rows))
+        merged, _ = bounded.merge_rows([{"warm_cache": row} for row in rows], [21, 21])
+        self.assertIsInstance(merged[0], BatchPrefixKVCache)
+        self.assert_visible_tokens(merged[0], [1, 3], positions)
+
+    def test_prefix_cache_restores_empty_partial_and_rotated_states(self):
+        from mlx_vlm.models.cache import BatchPrefixKVCache, BatchRotatingKVCache
+
+        for length in (0, 1, 3, 7, 8, 9):
+            with self.subTest(length=length):
+                cache = BatchPrefixKVCache(8, [0, 2], keep=4)
+                positions = self.assert_visible_tokens(cache, [1] * length)
+                restored = BatchPrefixKVCache.from_state(cache.state, cache.meta_state)
+                self.assertEqual(restored.tail.rotated, cache.tail.rotated)
+                self.assert_visible_tokens(restored, [1, 4], positions.copy())
+        cache = BatchPrefixKVCache(8, [0, 0], keep=4)
+        positions = self.assert_visible_tokens(cache, [3])
+        merged = BatchRotatingKVCache.merge([cache.extract(i) for i in range(2)])
+        self.assertIsInstance(merged, BatchPrefixKVCache)
+        self.assert_visible_tokens(merged, [1, 8], positions)
+
+    def test_qwen35_ragged_prefill_respects_bounded_mask_and_cache_type(self):
+        from unittest.mock import patch
+
+        from mlx_vlm.generate.ar import _make_cache
+        from mlx_vlm.models.cache import BatchPrefixKVCache, make_prompt_cache
+        from mlx_vlm.models.qwen3_5.config import TextConfig
+        from mlx_vlm.models.qwen3_5.language import LanguageModel
+
+        mx.random.seed(7)
+        model = LanguageModel(
+            TextConfig(
+                model_type="qwen3_5_text",
+                hidden_size=32,
+                intermediate_size=64,
+                linear_num_value_heads=2,
+                linear_num_key_heads=2,
+                linear_key_head_dim=32,
+                linear_value_head_dim=32,
+                linear_conv_kernel_dim=4,
+                num_hidden_layers=4,
+                num_attention_heads=2,
+                num_key_value_heads=2,
+                head_dim=32,
+                rms_norm_eps=1e-5,
+                vocab_size=64,
+                max_position_embeddings=256,
+                rope_parameters={
+                    "type": "default",
+                    "mrope_section": [1, 1, 2],
+                    "rope_theta": 100000,
+                    "partial_rotary_factor": 0.25,
+                },
+            )
+        )
+        model.eval()
+        for padding in (3, 11):
+            ids = mx.array([list(range(3, 35)), list(range(4, 36))])
+            cache = _make_cache(model, [padding, 0], max_kv_size=8)
+            for start in range(0, 32, 8):
+                actual = model.model(ids[:, start : start + 8], cache=cache)
+                mx.eval(actual)
+            references = []
+            for row, pad in enumerate((padding, 0)):
+                row_cache = make_prompt_cache(model, max_kv_size=8)
+                for start in range(pad, 32):
+                    expected = model.model(
+                        ids[row : row + 1, start : start + 1], cache=row_cache
+                    )
+                    mx.eval(expected)
+                references.append(expected)
+            np.testing.assert_allclose(
+                np.array(actual[:, -1:]),
+                np.array(mx.concatenate(references)),
+                atol=2e-3,
+                rtol=2e-3,
+            )
+            self.assertIsInstance(cache[3], BatchPrefixKVCache)
+            self.assertEqual(cache[3].offset.tolist(), [32 - padding, 32])
+            model._rope_deltas = mx.zeros((1, 1), dtype=mx.int32)
+            with patch.object(
+                type(model.model), "__call__", return_value=mx.zeros((1, 1, 32))
+            ) as forward:
+                model(ids[:1, :1], cache=row_cache)
+            np.testing.assert_array_equal(
+                np.array(forward.call_args.kwargs["position_ids"]), [[32]]
+            )
+
+    def test_apc_checkpoint_reuse_preserves_the_requested_history(self):
+        from mlx_vlm.apc import APCManager
+        from mlx_vlm.apc_coordinator import APCCoordinator
+        from mlx_vlm.models.cache import KVCache
+
+        model = SimpleNamespace(make_cache=lambda: [KVCache()])
+        manager = APCManager(num_blocks=8, block_size=4)
+        coordinator = APCCoordinator(manager, model, max_kv_size=8)
+        cache = coordinator.fresh_cache()
+        positions = self.assert_visible_tokens(cache[0], [20], np.array([0]))
+        scope = coordinator.scope_hash(0)
+        self.assertTrue(
+            coordinator.store_checkpoint(list(range(20)), cache, extra_hash=scope)
+        )
+        lookup_kwargs = dict(
+            safe_lookup_min=0,
+            suffix_is_text_only=lambda _: True,
+            prefix_has_media=lambda _: False,
+        )
+        hit = coordinator.lookup(list(range(23)), extra_hash=scope, **lookup_kwargs)
+        self.assertIsNotNone(hit)
+        restored = coordinator.materialize_single(hit, min_capacity_tokens=24)
+        self.assert_visible_tokens(restored[0], [1, 3], positions)
+        other = APCCoordinator(manager, model, max_kv_size=16)
+        self.assertIsNone(
+            other.lookup(
+                list(range(23)), extra_hash=other.scope_hash(0), **lookup_kwargs
+            )
+        )
+
+
 class TestQuantizedKVCacheMask(unittest.TestCase):
     """Mask-length checks must handle quantized KV caches, whose
     ``update_and_fetch`` returns packed tuples instead of arrays (#1481)."""

--- a/mlx_vlm/tests/test_models.py
+++ b/mlx_vlm/tests/test_models.py
@@ -15195,13 +15195,16 @@ class TestCacheCapacity(unittest.TestCase):
             ):
                 make_prompt_cache(object(), max_kv_size=limit)
 
-    def assert_visible_tokens(self, cache, chunks, positions=None, window_size=None):
+    def assert_visible_tokens(
+        self, cache, chunks, positions=None, window_size=None, lengths=None
+    ):
         if positions is None:
             positions = np.array(cache.offset).reshape(-1)
+        keep = getattr(cache, "keep", 0)
         for length in chunks:
             p = positions[:, None] + np.arange(length)
             data = mx.array(p[:, None, :, None], dtype=mx.float32)
-            mask = cache.make_mask(length, window_size=window_size)
+            mask = cache.make_mask(length, window_size=window_size, return_array=True)
             keys, values = cache.update_and_fetch(data, data)
             mx.eval(mask, keys, values)
             keys = np.array(keys)
@@ -15216,15 +15219,17 @@ class TestCacheCapacity(unittest.TestCase):
                     position = int(p[row, col])
                     if position < 0:
                         continue
-                    expected = set(range(min(position + 1, cache.keep)))
+                    if lengths is not None and position >= lengths[row]:
+                        continue
+                    expected = set(range(min(position + 1, keep)))
                     expected.update(
                         range(
                             max(
-                                cache.keep,
+                                keep,
                                 position
                                 - min(
                                     window_size or cache.max_size,
-                                    cache.max_size - cache.keep,
+                                    cache.max_size - keep,
                                 )
                                 + 1,
                             ),
@@ -15245,9 +15250,13 @@ class TestCacheCapacity(unittest.TestCase):
                 with self.subTest(padding=padding, chunks=chunks):
                     cache = BatchPrefixKVCache(8, padding, keep=2)
                     positions = self.assert_visible_tokens(cache, chunks)
-                    restored = BatchPrefixKVCache.from_state(
-                        cache.state, cache.meta_state
+                    snapshot = tree_map(
+                        lambda x: (
+                            mx.array(np.array(x)) if isinstance(x, mx.array) else x
+                        ),
+                        cache.state,
                     )
+                    restored = BatchPrefixKVCache.from_state(snapshot, cache.meta_state)
                     self.assert_visible_tokens(restored, [1, 3], positions.copy())
                     merged = BatchPrefixKVCache.merge(
                         [cache.extract(i) for i in range(2)]
@@ -15265,6 +15274,64 @@ class TestCacheCapacity(unittest.TestCase):
                 BatchPrefixKVCache(8, [0], keep=4),
             ):
                 self.assert_visible_tokens(cache, chunks, window_size=2)
+
+    def test_attention_window_cannot_exceed_retained_history(self):
+        from mlx_vlm.models.cache import (
+            BatchPrefixKVCache,
+            BatchRotatingKVCache,
+            RotatingKVCache,
+        )
+
+        for capacity, keep in ((2, 0), (2, 1), (8, 0), (8, 4)):
+            for chunks in ([1] * 25, [4, 7, 14]):
+                for window in (1, capacity, capacity * 2):
+                    with self.subTest(
+                        capacity=capacity, keep=keep, chunks=chunks, window=window
+                    ):
+                        batched = (
+                            BatchPrefixKVCache(capacity, [0], keep)
+                            if keep
+                            else BatchRotatingKVCache(capacity, [0])
+                        )
+                        for cache in (RotatingKVCache(capacity, keep), batched):
+                            self.assert_visible_tokens(
+                                cache, chunks, window_size=window
+                            )
+
+    def test_padded_prefill_mask_matches_concat_layout(self):
+        from mlx_vlm.models.cache import BatchPrefixKVCache, BatchRotatingKVCache
+
+        for keep in (0, 2, 4):
+            for window in (None, 2, 16):
+                for warm_chunks in ([], [11, 1]):
+                    for chunks in ([1] * 20, [5, 7, 7, 1]):
+                        with self.subTest(
+                            keep=keep, window=window, warm=warm_chunks, chunks=chunks
+                        ):
+                            cache = (
+                                BatchPrefixKVCache(8, [0, 0], keep)
+                                if keep
+                                else BatchRotatingKVCache(8, [0, 0])
+                            )
+                            positions = self.assert_visible_tokens(
+                                cache, warm_chunks, window_size=window
+                            )
+                            lengths = positions + np.array([5, 20])
+                            cache.prepare(lengths=[5, 20], right_padding=[15, 0])
+                            self.assert_visible_tokens(
+                                cache,
+                                chunks,
+                                positions.copy(),
+                                window_size=window,
+                                lengths=lengths,
+                            )
+                            cache.finalize()
+                            np.testing.assert_array_equal(
+                                np.array(cache.offset), lengths
+                            )
+                            self.assert_visible_tokens(
+                                cache, [1, 3], lengths.copy(), window_size=window
+                            )
 
     def test_batch_generation_receives_the_requested_limit(self):
         from mlx_vlm.generate.ar import BatchGenerator
@@ -15356,7 +15423,8 @@ class TestCacheCapacity(unittest.TestCase):
             num_key_value_heads=2,
             head_dim=8,
             vocab_size=64,
-            sliding_window_pattern=1,
+            sliding_window=16,
+            sliding_window_pattern=2,
         )
         model = LanguageModel(config)
         model.eval()


### PR DESCRIPTION
replaces #1995 by making each cache type explicitly support or reject max_kv_size and applying the limit to both single and batched generation. preserves fixed prefixes and prevents reuse of caches built with a different limit.