### PR TITLE
Fix qwen3_5 ragged speculative rollback on BatchQSAKVCache

### DIFF
--- a/mlx_vlm/models/qwen3_5/language.py
+++ b/mlx_vlm/models/qwen3_5/language.py
@@ -1497,7 +1497,20 @@ class LanguageModel(nn.Module):
                 if any(extra_trim_list):
                     prepare = getattr(c, "prepare", None)
                     finalize = getattr(c, "finalize", None)
-                    if c.keys is not None and callable(prepare) and callable(finalize):
+                    # BatchQSAKVCache keeps its KV inside a wrapped BatchKVCache and
+                    # exposes no ``keys`` attribute, so a direct ``c.keys`` here raises
+                    # AttributeError before this branch can run -- even though its
+                    # ``prepare``/``finalize`` implement a correct ragged right-padding
+                    # trim (dynamic_roll, not a zero-fill, so it is not affected by the
+                    # phantom-key issue #1962 that the KV-zeroing fallback below guards
+                    # against). Check prepare/finalize first and read ``keys`` via
+                    # getattr so caches with real ``keys`` still gate on it (None-check
+                    # preserved) while wrapper caches take their own correct trim path.
+                    if (
+                        callable(prepare)
+                        and callable(finalize)
+                        and getattr(c, "keys", True) is not None
+                    ):
                         prepare(right_padding=extra_trim_list)
                         finalize()
                         right_trimmed = True


### PR DESCRIPTION
## What

Fix `Qwen3_5` batched speculative rollback so a **ragged per-row accepted count** works on `BatchQSAKVCache`.

In `LanguageModel.rollback_speculative_cache`, the batched right-padding trim is gated on:

```python
if c.keys is not None and callable(prepare) and callable(finalize):
```

`BatchQSAKVCache` keeps its KV inside a wrapped `BatchKVCache` and exposes **no `keys` attribute**, so `c.keys` raises `AttributeError` *before* this branch can run. As a result, a ragged rollback (rows accepting different numbers of drafts) over a `BatchQSAKVCache` crashes — even though that cache implements a **correct** ragged trim via its own `prepare(right_padding=...)` / `finalize()` (which uses `dynamic_roll`, not the KV-zeroing fallback that #1962 warns leaves phantom keys attended).

## Fix

Reorder the guard to check `prepare`/`finalize` first and read `keys` via `getattr`:

```python
if callable(prepare) and callable(finalize) and getattr(c, "keys", True) is not None:
```

- `BatchQSAKVCache` (no `keys` attr) → `getattr` returns the default → takes its own correct `prepare`/`finalize` ragged-trim path, and sets `right_trimmed=True` so it does **not** reach the `#1962` uniform-acceptance `RuntimeError` below.
- Caches with a real `keys` tensor still gate on it (the `is not None` check is preserved).

Only the `is_batch` ragged path is affected; uniform-acceptance and single-row rollback are unchanged.

## Why it matters

This unblocks **fused / batched multi-token speculative decode** where concurrent sequences accept different draft lengths (e.g. native MTP on Qwen3.8-Flash-Next under continuous batching). Without it, any ragged batched rollback on the continuous-batch cache aborts.

## Testing

- Verified live end-to-end: 6–16 concurrent streams, temperature 0, coherent output on every row, no cache corruption across 200-token generations (the `dynamic_roll` trim does not exhibit the phantom-key behavior of the zero-tail fallback).
- `python -m py_compile mlx_vlm/models/qwen3_5/language.py` passes.

15 lines changed (14 insertions, 1 deletion), scoped to the one guard.
