### PR TITLE
Preserve Qwen assistant reasoning through prompt normalization

### DIFF
--- a/mlx_vlm/prompt_utils.py
+++ b/mlx_vlm/prompt_utils.py
@@ -932,6 +932,12 @@ def apply_chat_template(
                     **kwargs,
                 )
             )
+            if (
+                model_type in ("qwen3_5", "qwen3_5_moe")
+                and role == "assistant"
+                and "reasoning_content" in prompt
+            ):
+                messages[-1]["reasoning_content"] = prompt["reasoning_content"]
     elif isinstance(prompt, list):
         # Preserve explicit media markers on their originating user message.
         # Any legacy side-channel media without markers remains attached to the
@@ -1010,6 +1016,13 @@ def apply_chat_template(
                             **kwargs,
                         )
                     )
+                    if (
+                        model_type in ("qwen3_5", "qwen3_5_moe")
+                        and role == "assistant"
+                        and isinstance(p, dict)
+                        and "reasoning_content" in p
+                    ):
+                        messages[-1]["reasoning_content"] = p["reasoning_content"]
 
     if return_messages:
         return messages

--- a/mlx_vlm/tests/test_prompt_utils.py
+++ b/mlx_vlm/tests/test_prompt_utils.py
@@ -1,5 +1,9 @@
 """Tests for prompt_utils module, specifically multimodal content handling."""
 
+from copy import deepcopy
+
+import pytest
+
 from mlx_vlm.prompt_utils import apply_chat_template, extract_text_from_content
 
 
@@ -146,6 +150,136 @@ class TestExtractTextFromContent:
         ]
         result = extract_text_from_content(content)
         assert result == "이미지에서 상품명, 가격, 설명을 추출해주세요."
+
+
+class TestQwenAssistantReasoning:
+    @pytest.mark.parametrize("model_type", ["qwen3_5", "qwen3_5_moe"])
+    @pytest.mark.parametrize("as_list", [False, True])
+    @pytest.mark.parametrize(
+        "reasoning_fields",
+        [
+            {},
+            {"reasoning_content": None},
+            {"reasoning_content": ""},
+            {"reasoning_content": "Prior thought"},
+        ],
+    )
+    @pytest.mark.parametrize(
+        ("content", "expected_text"),
+        [
+            ("Answer", "Answer"),
+            (None, ""),
+            ([{"type": "text", "text": "Answer"}], "Answer"),
+            ([{"type": "input_text", "text": "Answer"}], "Answer"),
+            ([{"type": "text", "content": "Answer"}], "Answer"),
+            (
+                [
+                    {"type": "text", "text": "First"},
+                    {"type": "input_text", "text": "", "content": "second"},
+                ],
+                "First second",
+            ),
+        ],
+    )
+    def test_preserves_reasoning_after_content_normalization(
+        self, model_type, as_list, reasoning_fields, content, expected_text
+    ):
+        message = {"role": "assistant", "content": content, **reasoning_fields}
+        prompt = [message] if as_list else message
+        original = deepcopy(prompt)
+
+        result = apply_chat_template(
+            None, {"model_type": model_type}, prompt, return_messages=True
+        )
+
+        assert result == [
+            {
+                "role": "assistant",
+                "content": [
+                    {"type": "text", "text": expected_text, "content": expected_text}
+                ],
+                **reasoning_fields,
+            }
+        ]
+        assert prompt == original
+
+    @pytest.mark.parametrize("model_type", ["qwen3_5", "qwen3_5_moe"])
+    def test_preserves_reasoning_through_tool_continuation(self, model_type):
+        tool_call = _assistant_tool_call(None)
+        tool_call["reasoning_content"] = "Check the weather"
+        tool_call["tool_calls"][0]["function"]["arguments"] = '{"city":"Paris"}'
+        prompt = [
+            {"role": "user", "content": "Check the weather."},
+            {"role": "assistant", "content": "Checking", "reasoning_content": "Plan"},
+            tool_call,
+            {"role": "tool", "tool_call_id": "call_1", "content": "Sunny"},
+            {"role": "assistant", "content": "Sunny", "reasoning_content": "Done"},
+        ]
+        original = deepcopy(prompt)
+
+        result = apply_chat_template(
+            None, {"model_type": model_type}, prompt, return_messages=True
+        )
+
+        assert result[1]["reasoning_content"] == "Plan"
+        assert result[2]["reasoning_content"] == "Check the weather"
+        assert result[2]["content"] == ""
+        assert result[2]["tool_calls"][0]["function"]["arguments"] == {"city": "Paris"}
+        assert result[3] == prompt[3]
+        assert result[4]["reasoning_content"] == "Done"
+        assert prompt == original
+
+    @pytest.mark.parametrize("model_type", ["qwen3_5", "qwen3_5_moe"])
+    @pytest.mark.parametrize("role", ["system", "user"])
+    @pytest.mark.parametrize("as_list", [False, True])
+    def test_does_not_add_reasoning_to_other_roles(self, model_type, role, as_list):
+        message = {"role": role, "content": "Hello", "reasoning_content": "Ignored"}
+        prompt = [message] if as_list else message
+
+        result = apply_chat_template(
+            None, {"model_type": model_type}, prompt, return_messages=True
+        )
+
+        assert result == [
+            {
+                "role": role,
+                "content": [{"type": "text", "text": "Hello", "content": "Hello"}],
+            }
+        ]
+
+    @pytest.mark.parametrize("model_type", ["qwen3_5", "qwen3_5_moe"])
+    @pytest.mark.parametrize("prompt", ["Hello", ["Hello"]])
+    def test_string_prompts_are_unchanged(self, model_type, prompt):
+        assert apply_chat_template(
+            None, {"model_type": model_type}, prompt, return_messages=True
+        ) == [
+            {
+                "role": "user",
+                "content": [{"type": "text", "text": "Hello", "content": "Hello"}],
+            }
+        ]
+
+    @pytest.mark.parametrize("model_type", ["qwen2_vl", "qwen3_vl", "gemma3"])
+    @pytest.mark.parametrize("as_list", [False, True])
+    def test_other_model_families_are_unchanged(self, model_type, as_list):
+        message = {"role": "assistant", "content": "Answer"}
+        with_reasoning = {**message, "reasoning_content": "Prior thought"}
+        expected = apply_chat_template(
+            None,
+            {"model_type": model_type},
+            [message] if as_list else message,
+            return_messages=True,
+        )
+
+        assert (
+            apply_chat_template(
+                None,
+                {"model_type": model_type},
+                [with_reasoning] if as_list else with_reasoning,
+                return_messages=True,
+            )
+            == expected
+        )
 
 
 class TestApplyChatTemplateIntegration:

--- a/mlx_vlm/tests/test_server.py
+++ b/mlx_vlm/tests/test_server.py
@@ -3647,6 +3647,70 @@ def test_chat_completions_endpoint_preserves_assistant_reasoning_content(client)
     }
 
 
+@pytest.mark.parametrize("model_type", ["qwen3_5", "qwen3_5_moe"])
+def test_chat_completions_renders_assistant_reasoning_content(client, model_type):
+    from jinja2 import Template
+
+    # A synthetic template checks field propagation through the real normalizer.
+    # The official Qwen3.5-4B template reads the same reasoning_content field:
+    # https://huggingface.co/Qwen/Qwen3.5-4B/blob/851bf6e806efd8d0a36b00ddf55e13ccb7b8cd0a/chat_template.jinja
+    template = """{%- for message in messages %}
+{%- if message.role == 'assistant' %}
+{%- if message.reasoning_content is string %}
+{{- '<think>' + message.reasoning_content + '</think>' }}
+{%- endif %}
+{%- for part in message.content %}{{ part.text }}{% endfor %}
+{%- endif %}
+{%- endfor %}"""
+    processor = SimpleNamespace(
+        chat_template=template,
+        apply_chat_template=lambda messages, **kwargs: Template(template).render(
+            messages=messages
+        ),
+    )
+    result = GenerationResult(
+        text="done",
+        prompt_tokens=8,
+        generation_tokens=4,
+        total_tokens=12,
+        prompt_tps=10.0,
+        generation_tps=5.0,
+        peak_memory=0.1,
+    )
+
+    with (
+        patch.object(
+            server,
+            "get_cached_model",
+            return_value=(
+                SimpleNamespace(),
+                processor,
+                SimpleNamespace(model_type=model_type),
+            ),
+        ),
+        patch.object(server, "generate", return_value=result) as mock_generate,
+    ):
+        response = client.post(
+            "/chat/completions",
+            json={
+                "model": "demo",
+                "messages": [
+                    {"role": "user", "content": "Hi"},
+                    {
+                        "role": "assistant",
+                        "content": [{"type": "text", "text": "Hello"}],
+                        "reasoning_content": "Prior thought",
+                    },
+                ],
+            },
+        )
+
+    assert response.status_code == 200
+    assert (
+        mock_generate.call_args.kwargs["prompt"] == "<think>Prior thought</think>Hello"
+    )
+
+
 def test_anthropic_messages_endpoint_maps_text_and_images(client, monkeypatch):
     monkeypatch.setattr(server.runtime, "response_generator", None)
     model = SimpleNamespace()


### PR DESCRIPTION
Assistant `reasoning_content` reaches the server's processed messages after #1411, but `apply_chat_template()` then rebuilds ordinary Qwen assistant dictionaries from role/content and drops it. Adding a tool-call field changes whether the same reasoning reaches the template.

This copies the supplied field after existing content normalization for assistant dictionaries on `qwen3_5` and `qwen3_5_moe`. Text formats and tool-argument normalization stay intact; the template still decides which reasoning to render.

### Reproducer

On base `23f513829724365b0cd8884ecaa10e0a1577dba0`, this assertion fails for both a dictionary and a list containing it:

```python
import mlx.core as mx
mx.set_default_device(mx.cpu)

from mlx_vlm.prompt_utils import apply_chat_template

message = {"role": "assistant", "content": "Done", "reasoning_content": "Synthetic note"}
normalized = apply_chat_template(None, {"model_type": "qwen3_5"}, [message], return_messages=True)
assert normalized[0].get("reasoning_content") == "Synthetic note"
```

### Scope and related work

This follows #1370 and #1411 (which closed #1408). Their server tests mock `apply_chat_template`; the new endpoint test exercises the real normalizer and renders a synthetic Jinja template. Open and closed issue/PR searches found no active contribution covering this downstream loss.

The routing is based on public checkpoint metadata and executable template checks:

- [Qwen3.5-4B at 851bf6e](https://huggingface.co/Qwen/Qwen3.5-4B/tree/851bf6e806efd8d0a36b00ddf55e13ccb7b8cd0a) uses `qwen3_5`.
- [Qwen3.5-35B-A3B at 59d61f3](https://huggingface.co/Qwen/Qwen3.5-35B-A3B/tree/59d61f3ce65a6d9863b86d2e96597125219dc754) uses `qwen3_5_moe` and has the same template bytes. The same failure reproduces on that route.
- [Qwen3.8-27B at 1d4bf0f](https://huggingface.co/Qwen/Qwen3.8-27B/tree/1d4bf0f2ff6012fd82039f2fa52739d0dd7c60c0) also uses `qwen3_5`.

These are pinned representative revisions, not a claim about every Qwen template. Qwen3.5 history rendering differs by revision. Qwen3.8 MoE checkpoints can use `qwen3_5_moe_text` or `qwen4_exp`; this change does not expand those routes. Raw message objects remain outside this dictionary fix. Other model families are covered by unchanged-output controls.

### Validation

New focused tests: **76 failures / 42 passes on the base**, then all pass with the fix. Final relevant regression run: **162 passed**. Tests cover dictionary/list inputs, absent/null/empty reasoning, text and content-part formats, caller immutability, tool continuations and unaffected models. Generation and model loading are mocked.

From the repository root, with the package, pytest and test dependencies installed:

```sh
python -c 'import mlx.core as mx; mx.set_default_device(mx.cpu); import pytest; raise SystemExit(pytest.main(["mlx_vlm/tests/test_prompt_utils.py", "mlx_vlm/tests/test_server.py", "-q", "-k", "test_prompt_utils or test_chat_completions_renders_assistant_reasoning_content or test_chat_completions_endpoint_preserves_assistant_reasoning_content or TestChatMessageSchema"]))'
pre-commit run --all-files
```

All configured hooks (Black, isort, autoflake) pass. Additional checks of the three pinned official templates cover 90 synthetic rendering cases: all lost ordinary active reasoning on the base; all match native template rendering after this fix using equivalent template kwargs, including the wrapper's existing `enable_thinking=False` default. An additional 90-case check with the two official tokenizers confirmed exact token-ID equality with native rendering. This covers string/text-part content, active tool continuations, user-wrapped tool results and explicit template controls.

No model weights or GPU inference were used. The full hardware-dependent suite was not run locally; upstream CI and maintainer review remain pending. Preserving previously dropped reasoning can increase prompt length and context usage and change cache prefixes; no speed or model-recall improvement is claimed. This PR does not set a global reasoning-history policy. The separate optional API control is proposed in #2200; this normalization fix does not depend on it.

AI assistance: Codex assisted with implementation, regression tests and this description. The public diff and validation evidence were reviewed before submission.
