### PR TITLE
Forward explicit reasoning-history policy to chat templates

### DIFF
--- a/mlx_vlm/prompt_utils.py
+++ b/mlx_vlm/prompt_utils.py
@@ -804,6 +804,8 @@ def get_chat_template(
             return _messages_to_plain_prompt()
 
         template_kwargs = dict(kwargs)
+        if not _supports_template_kw(template_processor, "preserve_thinking"):
+            template_kwargs.pop("preserve_thinking", None)
         if "enable_thinking" not in template_kwargs and _supports_template_kw(
             template_processor, "enable_thinking"
         ):

--- a/mlx_vlm/server/generation.py
+++ b/mlx_vlm/server/generation.py
@@ -641,6 +641,7 @@ class GenerationArguments:
     enable_thinking: bool = DEFAULT_ENABLE_THINKING
     reasoning: Optional[bool] = None
     reasoning_effort: Optional[str] = None
+    preserve_thinking: Optional[bool] = None
     thinking_budget: Optional[int] = None
     thinking_start_token: Optional[str] = None
     thinking_end_token: Optional[str] = None
@@ -725,6 +726,8 @@ class GenerationArguments:
             kw["reasoning_effort"] = self.reasoning_effort
             # Muse Glimmer's chat template reads the reasoning_strength alias.
             kw["reasoning_strength"] = self.reasoning_effort
+        if self.preserve_thinking is not None:
+            kw["preserve_thinking"] = self.preserve_thinking
         if self.thinking_budget is not None:
             kw["thinking_budget"] = self.thinking_budget
         if self.thinking_start_token is not None:

--- a/mlx_vlm/server/request_normalization.py
+++ b/mlx_vlm/server/request_normalization.py
@@ -17,6 +17,7 @@ from .generation import (
     get_server_thinking_start_token,
 )
 from .runtime import runtime
+from .schemas import ChatRequest
 
 _DISABLED_REASONING_EFFORTS = {"none", "off", "disabled", "false", "0"}
 
@@ -230,6 +231,9 @@ def _build_gen_args(
         enable_thinking=enable_thinking,
         reasoning=template_reasoning,
         reasoning_effort=reasoning_effort,
+        preserve_thinking=(
+            request.preserve_thinking if isinstance(request, ChatRequest) else None
+        ),
         thinking_budget=_request_field_or_default(
             request, "thinking_budget", get_server_thinking_budget()
         ),

--- a/mlx_vlm/server/schemas.py
+++ b/mlx_vlm/server/schemas.py
@@ -1,7 +1,14 @@
 import os
 from typing import TYPE_CHECKING, Any, List, Literal, Optional, Tuple, Union
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    StrictBool,
+    field_validator,
+    model_validator,
+)
 from typing_extensions import Required, TypeAlias, TypedDict
 
 if TYPE_CHECKING:
@@ -842,6 +849,13 @@ class StreamOptions(BaseModel):
 
 class ChatRequest(GenerationRequest):
     messages: List[ChatMessage]
+    preserve_thinking: Optional[StrictBool] = Field(
+        None,
+        description=(
+            "Preserve historical assistant reasoning when supported by the chat "
+            "template. Omitted or null uses the template default."
+        ),
+    )
     stream_options: Optional[StreamOptions] = None
     tools: Optional[List[Any]] = Field(None, description="Tools the model may call.")
     tool_choice: Optional[Any] = Field(

--- a/mlx_vlm/tests/test_prompt_utils.py
+++ b/mlx_vlm/tests/test_prompt_utils.py
@@ -849,3 +849,23 @@ class TestModelSpecificPromptContracts:
             "text",
         ]
         assert result[0]["content"][-1]["text"] == "OCR:"
+
+
+def test_preserve_thinking_ignored_by_processor_without_option():
+    class Processor:
+        chat_template = "synthetic"
+
+        def apply_chat_template(self, messages, tokenize, add_generation_prompt):
+            return messages
+
+    expected = apply_chat_template(Processor(), {"model_type": "qwen3_5"}, "Hello")
+    for policy in (True, False):
+        assert (
+            apply_chat_template(
+                Processor(),
+                {"model_type": "qwen3_5"},
+                "Hello",
+                preserve_thinking=policy,
+            )
+            == expected
+        )

--- a/mlx_vlm/tests/test_server.py
+++ b/mlx_vlm/tests/test_server.py
@@ -7,6 +7,7 @@ import os
 import sys
 import time
 from concurrent.futures import ThreadPoolExecutor
+from copy import deepcopy
 from dataclasses import dataclass
 from pathlib import Path
 from queue import Queue
@@ -8180,3 +8181,180 @@ class TestSTTSegmentSerialization:
         assert data["segments"] == [
             {"id": 0, "start": 0.0, "end": 0.5, "text": "hello"}
         ]
+
+
+@pytest.mark.parametrize(
+    "options",
+    [
+        {},
+        {"preserve_thinking": None},
+        {"preserve_thinking": True},
+        {"preserve_thinking": False},
+    ],
+)
+def test_chat_preserve_thinking_request_normalization(options):
+    request = server.ChatRequest(
+        model="demo", messages=[{"role": "user", "content": "Hello"}], **options
+    )
+    original = deepcopy(request.model_dump())
+    args = server._build_gen_args(request)
+    template_kwargs = args.to_template_kwargs()
+    expected = options.get("preserve_thinking")
+    if expected is None:
+        assert "preserve_thinking" not in template_kwargs
+    else:
+        assert template_kwargs["preserve_thinking"] is expected
+    assert "preserve_thinking" not in args.to_generate_kwargs()
+    assert request.model_dump() == original
+
+
+def test_preserve_thinking_is_a_chat_request_option():
+    request = server.OpenAIRequest(model="demo", input="Hello", preserve_thinking=False)
+    assert (
+        "preserve_thinking" not in server._build_gen_args(request).to_template_kwargs()
+    )
+
+
+@pytest.mark.parametrize("value", [0, 1, 0.0, "true", "false", "yes", [], {}])
+def test_chat_preserve_thinking_rejects_invalid_values(client, value):
+    with patch.object(server, "get_cached_model") as load_model:
+        response = client.post(
+            "/chat/completions",
+            json={
+                "model": "demo",
+                "messages": [{"role": "user", "content": "Hello"}],
+                "preserve_thinking": value,
+            },
+        )
+    assert response.status_code == 422
+    assert any(
+        error["loc"] == ["body", "preserve_thinking"]
+        for error in response.json()["detail"]
+    )
+    load_model.assert_not_called()
+
+
+@pytest.mark.parametrize("model_type", ["qwen3_5", "qwen3_5_moe", "qwen3_vl"])
+@pytest.mark.parametrize("supports_policy", [False, True])
+def test_chat_preserve_thinking_reaches_rendering(
+    client, monkeypatch, model_type, supports_policy
+):
+    from tokenizers import Tokenizer
+    from tokenizers.models import WordLevel
+    from tokenizers.pre_tokenizers import Whitespace
+    from transformers import PreTrainedTokenizerFast
+
+    # Synthetic policy template: completed user turns can omit reasoning, while
+    # the active tool continuation retains it. No model or remote tokenizer needed.
+    template = """
+        {% set ns = namespace(last_user=-1) %}
+        {% for message in messages %}
+            {% if message.role == 'user' %}{% set ns.last_user = loop.index0 %}{% endif %}
+        {% endfor %}
+        {% for message in messages %}
+            {{ message.role }}
+            {% if message.role == 'assistant' and
+                  (preserve_thinking is undefined or preserve_thinking is true
+                   or loop.index0 > ns.last_user) %}
+                {{ message.reasoning_content | default('', true) }}
+            {% endif %}
+            {% if message.content is string %}{{ message.content }}
+            {% else %}{% for item in message.content or [] %}{{ item.text }} {% endfor %}{% endif %}
+            {% for call in message.tool_calls or [] %}{{ call.function.name }}{% endfor %}
+        {% endfor %}
+    """
+    if not supports_policy:
+        template = template.replace(
+            "preserve_thinking is undefined or preserve_thinking is true", "true"
+        )
+    backend = Tokenizer(
+        WordLevel(
+            {
+                "[UNK]": 0,
+                "OLD_NOTE": 1,
+                "ACTIVE_NOTE": 2,
+                "VISIBLE": 3,
+                "RESULT": 4,
+                "check": 5,
+            },
+            unk_token="[UNK]",
+        )
+    )
+    backend.pre_tokenizer = Whitespace()
+    tokenizer = PreTrainedTokenizerFast(
+        tokenizer_object=backend, chat_template=template
+    )
+    calls = [
+        {
+            "id": "call_1",
+            "type": "function",
+            "function": {"name": "check", "arguments": "{}"},
+        }
+    ]
+    messages = [
+        {"role": "user", "content": "Earlier query"},
+        {
+            "role": "assistant",
+            "content": "VISIBLE",
+            "reasoning_content": "OLD_NOTE",
+            "tool_calls": calls,
+        },
+        {"role": "tool", "tool_call_id": "call_1", "content": "RESULT"},
+        {"role": "user", "content": "Current query"},
+        {
+            "role": "assistant",
+            "content": [{"type": "text", "text": "VISIBLE"}],
+            "reasoning_content": "ACTIVE_NOTE",
+            "tool_calls": calls,
+        },
+        {"role": "tool", "tool_call_id": "call_1", "content": "RESULT"},
+    ]
+    original = deepcopy(messages)
+    monkeypatch.setattr(server.runtime, "response_generator", None)
+    renders, tokens = [], []
+    for options in (
+        {},
+        {"preserve_thinking": None},
+        {"preserve_thinking": True},
+        {"preserve_thinking": False},
+    ):
+        with (
+            patch.object(
+                server,
+                "get_cached_model",
+                return_value=(
+                    SimpleNamespace(),
+                    tokenizer,
+                    SimpleNamespace(model_type=model_type),
+                ),
+            ),
+            patch.object(
+                server,
+                "generate",
+                return_value=GenerationResult(
+                    text="done", prompt_tokens=8, generation_tokens=1
+                ),
+            ) as generate,
+        ):
+            response = client.post(
+                "/chat/completions",
+                json={"model": "demo", "messages": messages, **options},
+            )
+        assert response.status_code == 200, response.text
+        prompt = generate.call_args.kwargs["prompt"]
+        renders.append(prompt)
+        tokens.append(tokenizer.encode(prompt, add_special_tokens=False))
+        assert "preserve_thinking" not in generate.call_args.kwargs
+        assert all(
+            marker in prompt for marker in ("ACTIVE_NOTE", "VISIBLE", "RESULT", "check")
+        )
+    assert renders[0] == renders[1] == renders[2]
+    assert tokens[0] == tokens[1] == tokens[2]
+    assert 1 in tokens[0] and 2 in tokens[3]
+    if supports_policy:
+        assert "OLD_NOTE" not in renders[3]
+        assert tokens[3] == [token for token in tokens[0] if token != 1]
+    else:
+        assert renders[0] == renders[3]
+        assert tokens[0] == tokens[3]
+    assert messages == original


### PR DESCRIPTION
`ChatRequest` currently accepts `preserve_thinking` as an extra field but drops it when building template kwargs. A client can send `false` and still get the template's default history policy.

This adds an optional strict boolean to Chat Completions and forwards explicit values through the existing `GenerationArguments.to_template_kwargs()` path. Omitted/null values leave the template default unchanged. The field is excluded from generation kwargs; processors whose method cannot accept it ignore it.

### Reproducer

On base `23f513829724365b0cd8884ecaa10e0a1577dba0`, the assertion fails:

```python
import mlx.core as mx
mx.set_default_device(mx.cpu)

import mlx_vlm.server as server

request = server.ChatRequest(
    model="demo",
    messages=[{"role": "user", "content": "Hello"}],
    preserve_thinking=False,
)
assert server._build_gen_args(request).to_template_kwargs().get("preserve_thinking") is False
```

At the HTTP boundary, use a top-level `"preserve_thinking": false` in `/v1/chat/completions` (for an OpenAI SDK, `extra_body={"preserve_thinking": False}`). Boolean strings and numbers now return 422 instead of being accepted and silently ignored.

### API choice and compatibility

This reuses the explicit thinking-control mechanism established by #789/#1644/#1884. In [#784](https://github.com/Blaizzy/mlx-vlm/pull/784#issuecomment-4006172954), the maintainer preferred an allowlist over arbitrary extra-field forwarding. #814 deferred generic `chat_template_kwargs` because of reserved keys and precedence. A generic kwargs API would be a broader design change; this PR stays with one validated option. Open and closed issue/PR searches found no active `preserve_thinking` implementation.

Forwarding is architecture-independent and limited to Chat Completions. Responses and other request types retain their existing behavior. Actual history selection belongs to each template:

- [Qwen3.8-27B at 1d4bf0f](https://huggingface.co/Qwen/Qwen3.8-27B/blob/1d4bf0f2ff6012fd82039f2fa52739d0dd7c60c0/chat_template.jinja), routed as `qwen3_5`, defaults to retaining historical reasoning. Explicit false removes completed-user-turn reasoning while retaining reasoning in the active tool cycle, visible answers, calls and results.
- The pinned [Qwen3.5-4B template](https://huggingface.co/Qwen/Qwen3.5-4B/blob/851bf6e806efd8d0a36b00ddf55e13ccb7b8cd0a/chat_template.jinja) and identical [35B-A3B template](https://huggingface.co/Qwen/Qwen3.5-35B-A3B/blob/59d61f3ce65a6d9863b86d2e96597125219dc754/chat_template.jinja) do not read this option. Their output stays unchanged. Behavior is template/revision-dependent, not a blanket Qwen3.5 capability claim.

This is independent of the companion normalization fix in #2199, which follows #1411/#1408. The endpoint regression here uses tool-bearing assistant history, which already preserves reasoning on the base, so it demonstrates the API bug without depending on that fix. Ordinary assistant dictionary history needs the companion fix as well. No model architecture routing or global false policy is introduced here.

### Validation

Focused regressions: **14 failures / 6 passes on the base**, **20 passed with this change**. Broader relevant regression run: **92 passed**. Tests exercise actual HTTP/request normalization and the real prompt renderer with a synthetic fast tokenizer, asserting rendered text and token IDs. They cover omitted/null/true/false, invalid values, caller immutability, active tool reasoning, architecture-independent forwarding, templates that ignore the option and processor methods without it.

```sh
python -c 'import mlx.core as mx; mx.set_default_device(mx.cpu); import pytest; raise SystemExit(pytest.main(["mlx_vlm/tests/test_prompt_utils.py", "mlx_vlm/tests/test_server.py", "mlx_vlm/tests/test_generation_defaults.py", "mlx_vlm/tests/test_glimmer_reasoning_alias.py", "-q", "-k", "test_prompt_utils or preserve_thinking or build_gen_args or generate_arguments or chat_request_schema or ChatMessageSchema or test_generation_defaults or test_glimmer_reasoning_alias"]))'
pre-commit run --all-files
```

All configured hooks (Black, isort, autoflake) pass. A separate 12-case in-process HTTP check used the two pinned official tokenizers across three template/routing combinations: the Qwen3.8 false-policy request mismatched native rendering on the base; all 12 match native text and token IDs with the fix, using equivalent thinking kwargs. Model loading/generation are mocked; no weights or GPU inference were used. The full hardware-dependent suite was not run locally; upstream CI and maintainer review remain pending. A history-policy change can change prompt length, context usage and cached prefixes; no speed benefit is claimed.

AI assistance: Codex assisted with implementation, regression tests and this description. The public diff and validation evidence were reviewed before submission.
