### PR TITLE
Use an exact prefix for thought marker removal

### DIFF
--- a/mlx_vlm/server/responses_state.py
+++ b/mlx_vlm/server/responses_state.py
@@ -402,7 +402,7 @@ def _sse_event(event_type: str, payload: Dict[str, Any]) -> str:
 def _clean_reasoning(reasoning: str, start_marker: str) -> str:
     reasoning = reasoning.replace(start_marker, "")
     if start_marker == "<|channel>thought":
-        reasoning = reasoning.lstrip("thought")
+        reasoning = reasoning.removeprefix("thought")
     return reasoning.strip()
 
 

--- a/mlx_vlm/tests/test_server.py
+++ b/mlx_vlm/tests/test_server.py
@@ -6829,6 +6829,10 @@ class TestSplitThinking:
         assert reasoning == "Thinking text"
         assert content == "Answer."
 
+    @pytest.mark.parametrize("prefix", ["", "thought\n"])
+    def test_channel_close_only(self, prefix):
+        assert server._split_thinking(f"{prefix}got it<channel|>42") == ("got it", "42")
+
     def test_no_thinking(self):
         text = "Just plain text."
         reasoning, content = server._split_thinking(text)


### PR DESCRIPTION
`lstrip` uses a character set and can errantly remove non-marker characters. Supersedes https://github.com/Blaizzy/mlx-vlm/pull/1934