### PR TITLE
Clean up redundant and trivial tests

### DIFF
--- a/mlx_vlm/tests/test_apc_adapters.py
+++ b/mlx_vlm/tests/test_apc_adapters.py
@@ -302,11 +302,6 @@ class TestBatchQuantizedExtract:
 
 class TestSnapshotPromptCacheRow:
 
-    def test_api_exists(self):
-        from mlx_vlm.apc import snapshot_prompt_cache_row
-
-        assert callable(snapshot_prompt_cache_row)
-
     def test_b1_batch_kv_collapses_to_single_row(self):
         from mlx_vlm.apc import snapshot_prompt_cache_row
 

--- a/mlx_vlm/tests/test_apc_all_models.py
+++ b/mlx_vlm/tests/test_apc_all_models.py
@@ -140,9 +140,10 @@ def _model_cache_contract(model_cls: type) -> tuple[str, ...]:
     return tuple(sorted(visit(model_cls) or {"KVCache"}))
 
 
-def _all_generative_model_contracts() -> list[tuple[str, tuple[str, ...]]]:
+def _all_generative_model_contracts(
+    local_factories: dict[str, set[str]],
+) -> list[tuple[str, tuple[str, ...]]]:
     contracts = []
-    local_factories = _cache_factories_by_package()
     for info in pkgutil.iter_modules(model_packages.__path__):
         if not info.ispkg or info.name.startswith("_"):
             continue
@@ -248,7 +249,11 @@ def _populated_cache(name: str, token_count: int):
     raise AssertionError(f"No populated APC sample for {name}")
 
 
-MODEL_CACHE_CONTRACTS = _all_generative_model_contracts()
+MODEL_CACHE_FACTORIES = _cache_factories_by_package()
+MODEL_CACHE_CONTRACTS = _all_generative_model_contracts(MODEL_CACHE_FACTORIES)
+# Synthetic cache hits depend only on the cache types, not the model name.
+# Keep discovery for every model, but exercise each distinct layout once.
+CACHE_CONTRACTS = sorted({names for _, names in MODEL_CACHE_CONTRACTS})
 
 
 def test_all_generative_model_packages_discovered_without_weights():
@@ -262,7 +267,7 @@ def test_all_generative_model_packages_discovered_without_weights():
 
 def test_every_model_cache_factory_has_a_restorable_apc_adapter():
     """All cache types referenced by all model factories are APC-compatible."""
-    by_package = _cache_factories_by_package()
+    by_package = MODEL_CACHE_FACTORIES
     discovered = set().union(*by_package.values())
     samples = _cache_samples()
     unknown = discovered - samples.keys()
@@ -300,19 +305,19 @@ def test_every_model_cache_factory_has_a_restorable_apc_adapter():
 
 
 @pytest.mark.parametrize(
-    ("model_name", "cache_names"),
-    MODEL_CACHE_CONTRACTS,
-    ids=[name for name, _ in MODEL_CACHE_CONTRACTS],
+    "cache_names",
+    CACHE_CONTRACTS,
+    ids=["+".join(names) for names in CACHE_CONTRACTS],
 )
-def test_cache_hit_for_every_model(model_name, cache_names, monkeypatch):
-    """A synthetic second request hits APC for every model cache contract."""
+def test_cache_hit_for_each_model_cache_contract(cache_names, monkeypatch):
+    """A synthetic second request hits APC for every distinct cache layout."""
     monkeypatch.setenv("APC_CHECKPOINT_ENTRIES", "2")
     block_size = 8
     token_count = 2 * block_size
     token_ids = list(range(token_count))
     caches = [_populated_cache(name, token_count) for name in cache_names]
     plan = build_prefix_cache_plan_from_caches(caches)
-    assert plan.restorable, f"{model_name}: {plan.describe()}"
+    assert plan.restorable, f"{cache_names}: {plan.describe()}"
 
     manager = APCManager(num_blocks=8, block_size=block_size)
 
@@ -321,7 +326,7 @@ def test_cache_hit_for_every_model(model_name, cache_names, monkeypatch):
             return caches
 
     coordinator = manager.coordinator(SyntheticModel())
-    assert coordinator.strategy == plan.strategy, model_name
+    assert coordinator.strategy == plan.strategy, cache_names
     try:
         if plan.strategy == "block":
             stored = manager.store_kv_blocks(
@@ -331,7 +336,7 @@ def test_cache_hit_for_every_model(model_name, cache_names, monkeypatch):
             )
             manager.release(stored)
         else:
-            assert manager.store_exact_cache(token_ids, caches), model_name
+            assert manager.store_exact_cache(token_ids, caches), cache_names
 
         hit = coordinator.lookup(
             token_ids + [999],
@@ -340,14 +345,14 @@ def test_cache_hit_for_every_model(model_name, cache_names, monkeypatch):
             suffix_is_text_only=lambda _prefix_len: True,
             prefix_has_media=lambda _prefix_len: False,
         )
-        assert hit is not None, model_name
-        assert hit["prefix_len"] == token_count, model_name
+        assert hit is not None, cache_names
+        assert hit["prefix_len"] == token_count, cache_names
         stats = manager.stats_snapshot()
         if plan.strategy == "block":
-            assert stats["lookups_hit"] == 1, model_name
+            assert stats["lookups_hit"] == 1, cache_names
         else:
-            assert hit["warm_cache"] is not None, model_name
-            assert stats["exact_hits"] == 1, model_name
+            assert hit["warm_cache"] is not None, cache_names
+            assert stats["exact_hits"] == 1, cache_names
         coordinator.release_hit(hit)
     finally:
         manager.close()

--- a/mlx_vlm/tests/test_batch_quantized_cache.py
+++ b/mlx_vlm/tests/test_batch_quantized_cache.py
@@ -214,11 +214,6 @@ class TestMakeMask:
 class TestPrepareFinalize:
     """Multi-row right-pad lifecycle parity with BatchKVCache (#1567 / #1562)."""
 
-    def test_prepare_finalize_methods_exist(self):
-        cache = BatchQuantizedKVCache([0, 0], group_size=GROUP_SIZE, bits=BITS)
-        assert callable(getattr(cache, "prepare", None))
-        assert callable(getattr(cache, "finalize", None))
-
     def test_prepare_stores_right_padding(self):
         cache = BatchQuantizedKVCache([0, 0], group_size=GROUP_SIZE, bits=BITS)
         cache.prepare(right_padding=[3, 0])

--- a/mlx_vlm/tests/test_batch_turboquant_attention.py
+++ b/mlx_vlm/tests/test_batch_turboquant_attention.py
@@ -13,11 +13,7 @@ from mlx_vlm.models.base import (
     _turboquant_attention_applies,
     scaled_dot_product_attention,
 )
-from mlx_vlm.turboquant import (
-    BatchTurboQuantKVCache,
-    TurboQuantKVCache,
-    _TurboQuantAttentionMixin,
-)
+from mlx_vlm.turboquant import BatchTurboQuantKVCache, TurboQuantKVCache
 
 H, D = 4, 64  # kv heads, head_dim
 BITS = 4
@@ -39,27 +35,6 @@ def _filled(left_padding, seq_len, batch=None, bits=BITS):
 
 class TestSharedAttentionSurface:
     """Both caches expose the same attention API through the mixin."""
-
-    @pytest.mark.parametrize("cls", [TurboQuantKVCache, BatchTurboQuantKVCache])
-    def test_inherits_mixin(self, cls):
-        assert issubclass(cls, _TurboQuantAttentionMixin)
-
-    @pytest.mark.parametrize(
-        "name",
-        [
-            "decode_attention",
-            "prefill_attention",
-            "quantized_attention",
-            "decode_key_chunk_size",
-            "prefill_key_chunk_size",
-            "prefill_query_block_size",
-        ],
-    )
-    @pytest.mark.parametrize("cls", [TurboQuantKVCache, BatchTurboQuantKVCache])
-    def test_attribute_present(self, cls, name):
-        # The chunk-size constants live on the mixin: reading them off the
-        # batch cache used to raise AttributeError mid-decode.
-        assert hasattr(cls, name)
 
     def test_attention_states_ignores_batch_bookkeeping(self):
         # The batch cache's `state` is a 4-tuple; the mixin must not unpack it.

--- a/mlx_vlm/tests/test_generate.py
+++ b/mlx_vlm/tests/test_generate.py
@@ -210,49 +210,9 @@ class TestGenerationResult:
         assert result.generation_tps == 0.0
         assert result.peak_memory == 0.0
 
-    def test_with_values(self):
-        result = GenerationResult(
-            text="Hello world",
-            token=42,
-            logprobs=[0.1, 0.2, 0.3],
-            prompt_tokens=10,
-            generation_tokens=5,
-            total_tokens=15,
-            prompt_tps=100.0,
-            generation_tps=50.0,
-            peak_memory=2.5,
-        )
-        assert result.text == "Hello world"
-        assert result.token == 42
-        assert result.logprobs == [0.1, 0.2, 0.3]
-        assert result.prompt_tokens == 10
-        assert result.generation_tokens == 5
-        assert result.total_tokens == 15
-        assert result.prompt_tps == 100.0
-        assert result.generation_tps == 50.0
-        assert result.peak_memory == 2.5
-
 
 class TestBatchGenerationResult:
     """Tests for BatchGenerationResult dataclass."""
-
-    def test_creation(self):
-        result = BatchGenerationResult(
-            texts=["Hello", "World"],
-            tokens=[1, 2],
-            logprobs=[[0.1], [0.2]],
-            prompt_tokens=[10, 12],
-            generation_tokens=[5, 6],
-            total_tokens=[15, 18],
-            prompt_tps=[100.0, 110.0],
-            generation_tps=[50.0, 55.0],
-            peak_memory=3.0,
-            image_sizes=[(224, 224), (336, 336)],
-        )
-        assert result.texts == ["Hello", "World"]
-        assert result.tokens == [1, 2]
-        assert result.peak_memory == 3.0
-        assert result.image_sizes == [(224, 224), (336, 336)]
 
     def test_optional_image_sizes(self):
         result = BatchGenerationResult(
@@ -281,34 +241,9 @@ class TestBatchStats:
         assert stats.generation_time == 0
         assert stats.peak_memory == 0
 
-    def test_with_values(self):
-        stats = BatchStats(
-            prompt_tokens=100,
-            prompt_tps=500.0,
-            prompt_time=0.2,
-            generation_tokens=50,
-            generation_tps=250.0,
-            generation_time=0.2,
-            peak_memory=4.0,
-        )
-        assert stats.prompt_tokens == 100
-        assert stats.prompt_tps == 500.0
-        assert stats.generation_tokens == 50
-
 
 class TestBatchResponse:
     """Tests for BatchResponse dataclass."""
-
-    def test_creation(self):
-        stats = BatchStats(prompt_tokens=100)
-        response = BatchResponse(
-            texts=["Hello", "World"],
-            stats=stats,
-            image_sizes=[(224, 224), (336, 336)],
-        )
-        assert response.texts == ["Hello", "World"]
-        assert response.stats.prompt_tokens == 100
-        assert response.image_sizes == [(224, 224), (336, 336)]
 
     def test_optional_image_sizes(self):
         stats = BatchStats()
@@ -764,15 +699,6 @@ class TestBatchGenerator:
         async_eval_mock.assert_called_once_with([cache_state])
         eval_mock.assert_not_called()
         batch._store_apc_exact_checkpoints.assert_called_once_with()
-
-    def test_response_dataclass(self):
-        response = GenerationBatch.Response(
-            uid=0, token=42, token_logprob=-0.5, finish_reason="stop"
-        )
-
-        assert response.uid == 0
-        assert response.token == 42
-        assert response.finish_reason == "stop"
 
     def test_generation_batch_applies_per_sequence_logits_processors(self):
         class FixedLogitModel:
@@ -1390,9 +1316,22 @@ class TestBatchGenerate:
         mock_generate_batch.side_effect = [
             (
                 ["Response 1", "Response 3"],
-                BatchStats(prompt_tokens=20, generation_tokens=10),
+                BatchStats(
+                    prompt_tokens=20,
+                    prompt_time=0.1,
+                    generation_tokens=10,
+                    generation_time=0.2,
+                ),
             ),
-            (["Response 2"], BatchStats(prompt_tokens=10, generation_tokens=5)),
+            (
+                ["Response 2"],
+                BatchStats(
+                    prompt_tokens=10,
+                    prompt_time=0.15,
+                    generation_tokens=5,
+                    generation_time=0.3,
+                ),
+            ),
         ]
 
         prompts = ["Prompt 1", "Prompt 2", "Prompt 3"]
@@ -1410,6 +1349,13 @@ class TestBatchGenerate:
         assert mock_generate_batch.call_count == 2
         # All 3 responses should be present
         assert len(response.texts) == 3
+        # Check aggregation through batch_generate itself, across both groups.
+        assert response.stats.prompt_tokens == 30
+        assert response.stats.prompt_time == pytest.approx(0.25)
+        assert response.stats.generation_tokens == 15
+        assert response.stats.generation_time == pytest.approx(0.5)
+        assert response.stats.prompt_tps == pytest.approx(120.0)
+        assert response.stats.generation_tps == pytest.approx(30.0)
 
     @patch.object(ar_module, "_generate_batch")
     @patch("mlx_vlm.utils.process_image")
@@ -1602,57 +1548,6 @@ class TestBatchGenerate:
 
 
 # ============================================================================
-# Tests for stats aggregation
-# ============================================================================
-
-
-class TestBatchStatsAggregation:
-    """Tests for stats aggregation in batch generation."""
-
-    def test_stats_accumulation(self):
-        """Test that stats are properly accumulated across batches."""
-        total_stats = BatchStats()
-
-        # Simulate processing multiple batches
-        batch_stats = [
-            BatchStats(
-                prompt_tokens=100,
-                prompt_time=0.1,
-                generation_tokens=50,
-                generation_time=0.2,
-            ),
-            BatchStats(
-                prompt_tokens=150,
-                prompt_time=0.15,
-                generation_tokens=75,
-                generation_time=0.3,
-            ),
-        ]
-
-        for stats in batch_stats:
-            total_stats.prompt_tokens += stats.prompt_tokens
-            total_stats.prompt_time += stats.prompt_time
-            total_stats.generation_tokens += stats.generation_tokens
-            total_stats.generation_time += stats.generation_time
-
-        assert total_stats.prompt_tokens == 250
-        assert total_stats.prompt_time == pytest.approx(0.25)
-        assert total_stats.generation_tokens == 125
-        assert total_stats.generation_time == pytest.approx(0.5)
-
-        # Calculate TPS
-        if total_stats.prompt_time > 0:
-            total_stats.prompt_tps = total_stats.prompt_tokens / total_stats.prompt_time
-        if total_stats.generation_time > 0:
-            total_stats.generation_tps = (
-                total_stats.generation_tokens / total_stats.generation_time
-            )
-
-        assert total_stats.prompt_tps == pytest.approx(1000.0)
-        assert total_stats.generation_tps == pytest.approx(250.0)
-
-
-# ============================================================================
 # Edge Cases
 # ============================================================================
 
@@ -1690,14 +1585,6 @@ class TestEdgeCases:
         # First prompt should have 998 padding tokens
         assert padded[0, 0].item() == 0
         assert padded[0, -1].item() == 2
-
-    def test_batch_response_with_empty_texts(self):
-        """Test BatchResponse with empty texts."""
-        stats = BatchStats()
-        response = BatchResponse(texts=[], stats=stats)
-
-        assert response.texts == []
-        assert response.image_sizes is None
 
 
 # ============================================================================

--- a/mlx_vlm/tests/test_processors.py
+++ b/mlx_vlm/tests/test_processors.py
@@ -2993,7 +2993,7 @@ class TestNemotronHNanoOmniProcessor(unittest.TestCase):
         self.assertGreater(int(result["num_tokens"][0].item()), 0)
 
 
-class TestLagunaProcessor(unittest.TestCase):
+class TestLagunaSpecialTokens(unittest.TestCase):
     def test_chat_template_owns_laguna_special_tokens(self):
         from mlx_vlm.utils import should_add_special_tokens
 

--- a/mlx_vlm/tests/test_quant_sdpa_mask.py
+++ b/mlx_vlm/tests/test_quant_sdpa_mask.py
@@ -46,13 +46,6 @@ class TestAlignAttentionMaskToScores:
         mx.eval(out)
         assert out.shape == scores.shape
 
-    def test_live_server_shapes(self):
-        """Exact shapes from #1567 concurrent curl repro."""
-        scores = mx.zeros((2, 8, 2, 18, 18))
-        mask = mx.ones((2, 1, 18, 18), dtype=mx.bool_)
-        aligned = align_attention_mask_to_scores(mask, scores)
-        mx.eval(mx.where(aligned, scores, mx.array(0.0)))
-
     def test_2d_causal_still_broadcasts(self):
         scores = mx.zeros((2, 8, 2, 4, 4))
         mask = create_causal_mask(4, offset=0)  # (4, 4), no batch pad
@@ -86,24 +79,6 @@ class TestQuantizedSdpaMultiRowGqa:
         queries = mx.random.normal((B, n_q, L, D)).astype(mx.float16)
         q_keys, q_values = _quant_kv(B, n_kv, L, D)
         mask = create_causal_mask(L, offset=0, left_padding=mx.array([0, 0]))
-
-        out = quantized_scaled_dot_product_attention(
-            queries,
-            q_keys,
-            q_values,
-            scale=D**-0.5,
-            mask=mask,
-            group_size=GROUP,
-            bits=BITS,
-        )
-        mx.eval(out)
-        assert out.shape == (B, n_q, L, D)
-
-    def test_batch1_gqa_still_works(self):
-        B, n_q, n_kv, L, D = 1, 16, 8, 4, GROUP
-        queries = mx.random.normal((B, n_q, L, D)).astype(mx.float16)
-        q_keys, q_values = _quant_kv(B, n_kv, L, D)
-        mask = create_causal_mask(L, offset=0, left_padding=mx.array([0]))
 
         out = quantized_scaled_dot_product_attention(
             queries,

--- a/mlx_vlm/tests/test_sample_utils.py
+++ b/mlx_vlm/tests/test_sample_utils.py
@@ -120,6 +120,20 @@ class TestTopPSampling(unittest.TestCase):
         self.assertEqual(tokens.shape, (3,))
 
 
+class TestMakeSampler(unittest.TestCase):
+    def test_default_filters_leave_categorical_sampling_unchanged(self):
+        """Default filtering must preserve the sampled tokens, not just shape."""
+        logits = mx.array([[0.0, 1.0, 2.0, 3.0, 4.0]] * 64)
+        mx.random.seed(0)
+        expected = mx.random.categorical(logits)
+        mx.eval(expected)
+        mx.random.seed(0)
+        actual = make_sampler(temp=1.0)(logits)
+        mx.eval(actual)
+        self.assertEqual(actual.shape, (64,))
+        self.assertEqual(actual.tolist(), expected.tolist())
+
+
 class TestTopNSigma(unittest.TestCase):
     LOGITS = mx.array([0.0, 1.0, 2.0, 3.0, 4.0])
 
@@ -164,13 +178,6 @@ class TestTopNSigma(unittest.TestCase):
         toks = sampler(logits)
         mx.eval(toks)
         self.assertTrue(all(t in (3, 4) for t in toks.tolist()))
-
-    def test_disabled_by_default(self):
-        """top_n_sigma=0 (default) leaves the sampler unfiltered."""
-        sampler = make_sampler(temp=1.0)
-        toks = sampler(mx.array([[0.0, 1.0, 2.0, 3.0, 4.0]] * 16))
-        mx.eval(toks)
-        self.assertEqual(toks.shape, (16,))
 
     def test_float16_large_vocab(self):
         """std must be computed in float32: summing a large float16 vocab
@@ -241,13 +248,6 @@ class TestPLess(unittest.TestCase):
         mx.eval(toks)
         self.assertTrue(all(t == 0 for t in toks.tolist()))
 
-    def test_disabled_by_default(self):
-        """p_less=False (default) leaves the sampler unfiltered."""
-        sampler = make_sampler(temp=1.0)
-        toks = sampler(mx.array([[1.0, 2.0, 3.0, 4.0, 5.0]] * 16))
-        mx.eval(toks)
-        self.assertEqual(toks.shape, (16,))
-
 
 def _np_typical_keep(logits, typical_p):
     logp = np.asarray(logits, dtype=np.float64)
@@ -309,13 +309,6 @@ class TestTypicalP(unittest.TestCase):
         toks = sampler(mx.array([[10.0, 0.0, 0.0, 0.0, 0.0]] * 64))
         mx.eval(toks)
         self.assertTrue(all(t == 0 for t in toks.tolist()))
-
-    def test_disabled_by_default(self):
-        """typical_p=1.0 (default) leaves the sampler unfiltered."""
-        sampler = make_sampler(temp=1.0)
-        toks = sampler(mx.array([[1.0, 2.0, 3.0, 4.0, 5.0]] * 16))
-        mx.eval(toks)
-        self.assertEqual(toks.shape, (16,))
 
     def test_invalid_raises(self):
         x = mx.array([0.0, 1.0, 2.0])

--- a/mlx_vlm/tests/test_speculative.py
+++ b/mlx_vlm/tests/test_speculative.py
@@ -5393,10 +5393,6 @@ def _laguna_language_model(num_hidden_layers=4):
     return model
 
 
-def test_laguna_exposes_speculative_cache_rollback():
-    assert hasattr(laguna_language.LanguageModel, "rollback_speculative_cache")
-
-
 def test_laguna_rollback_trims_rejected_speculative_tail():
     class DummyCache:
         def __init__(self):

--- a/mlx_vlm/tests/test_trainer.py
+++ b/mlx_vlm/tests/test_trainer.py
@@ -448,30 +448,6 @@ class TestTrainer(unittest.TestCase):
 
     @patch("mlx_vlm.trainer.sft_trainer.iterate_batches")
     @patch("mlx_vlm.trainer.sft_trainer.mx.save_safetensors")
-    def test_train_smoke(self, mock_save_safetensors, mock_iterate_batches):
-        mock_batch = {
-            "input_ids": mx.array([[1, 2, 3], [1, 2, 3], [1, 2, 3], [1, 2, 3]]),
-            "attention_mask": mx.array([[1, 1, 1], [1, 1, 1], [1, 1, 1], [1, 1, 1]]),
-            "pixel_values": mx.array(
-                [[[0.1, 0.2]], [[0.1, 0.2]], [[0.1, 0.2]], [[0.1, 0.2]]]
-            ),
-            "labels": mx.array([[0, 1, 2], [0, 1, 2], [0, 1, 2], [0, 1, 2]]),
-        }
-        mock_iterate_batches.return_value = iter([mock_batch])
-
-        train(
-            model=self.mock_model,
-            optimizer=self.mock_optimizer,
-            train_dataset=MagicMock(__len__=lambda self: 4),
-            val_dataset=None,
-            args=TrainingArgs(iters=1, batch_size=4),
-        )
-
-        self.mock_optimizer.update.assert_called()
-        mock_save_safetensors.assert_called()
-
-    @patch("mlx_vlm.trainer.sft_trainer.iterate_batches")
-    @patch("mlx_vlm.trainer.sft_trainer.mx.save_safetensors")
     def test_train_uses_default_adapter_file_when_missing(
         self, mock_save_safetensors, mock_iterate_batches
     ):

--- a/mlx_vlm/tests/test_vision_cache.py
+++ b/mlx_vlm/tests/test_vision_cache.py
@@ -62,15 +62,6 @@ class TestVisionFeatureCache:
         cache.put(url, features)
         assert cache.get(url) is not None
 
-    def test_clear(self):
-        cache = VisionFeatureCache()
-        cache.put("a.jpg", mx.ones((1, 10, 64)))
-        cache.put("b.jpg", mx.ones((1, 10, 64)))
-        assert len(cache) == 2
-        cache.clear()
-        assert len(cache) == 0
-        assert cache.get("a.jpg") is None
-
     def test_contains(self):
         cache = VisionFeatureCache()
         cache.put("a.jpg", mx.ones((1, 10, 64)))


### PR DESCRIPTION
This removes some redundant tests and consolidates overlapping coverage to speed up tests in CI.

This reduces the test count by around 200 (parameterized) tests and reduces about 20-30% of time spent running tests on my local machine.