### PR TITLE
fix(glm47): strip the tool name before the argument-schema lookup

### DIFF
--- a/mlx_vlm/tests/test_glm47_tool_parser.py
+++ b/mlx_vlm/tests/test_glm47_tool_parser.py
@@ -1,0 +1,52 @@
+"""Tests for the GLM 4.7 tool-call parser."""
+
+import json
+
+import mlx_vlm.tool_parsers.glm47 as glm47
+from mlx_vlm.server.responses_state import process_tool_calls
+from mlx_vlm.tool_parsers.glm47 import parse_tool_call
+
+TOOLS = [
+    {
+        "type": "function",
+        "function": {
+            "name": "get_weather",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "zip": {"type": "string"},
+                    "days": {"type": "integer"},
+                },
+            },
+        },
+    }
+]
+
+# The name sits on its own line right after <tool_call>, so the regex that ends
+# at the first <arg_key> captures the trailing newline with it.
+MODEL_OUTPUT = (
+    "<tool_call>get_weather\n"
+    "<arg_key>zip</arg_key>\n"
+    "<arg_value>10001</arg_value>\n"
+    "<arg_key>days</arg_key>\n"
+    "<arg_value>3</arg_value>\n"
+    "</tool_call>"
+)
+
+
+def _tool_call_body(text: str) -> str:
+    return text.removeprefix(glm47.tool_call_start).removesuffix(glm47.tool_call_end)
+
+
+def test_tool_name_drops_the_trailing_newline():
+    result = parse_tool_call(_tool_call_body(MODEL_OUTPUT), TOOLS)
+
+    assert result["name"] == "get_weather"
+
+
+def test_string_arguments_keep_their_declared_type():
+    parsed = process_tool_calls(MODEL_OUTPUT, glm47, TOOLS)
+
+    assert len(parsed["calls"]) == 1
+    arguments = json.loads(parsed["calls"][0]["function"]["arguments"])
+    assert arguments == {"zip": "10001", "days": 3}

--- a/mlx_vlm/tool_parsers/glm47.py
+++ b/mlx_vlm/tool_parsers/glm47.py
@@ -219,7 +219,7 @@ def parse_tool_call(text: str, tools: list[Any] | None = None):
             return fallback
         return dict(name="unknown", arguments={"raw": text.strip()})
 
-    func_name = match.group(1)
+    func_name = match.group(1).strip()
     string_args = _get_string_arg_names(func_name, tools)
     arg_dct = {}
     for match in _func_arg_regex.finditer(text):


### PR DESCRIPTION
The GLM tool parser reads the function name with `^(.*?)<arg_key>`, and GLM puts
the name on its own line right after `<tool_call>`, so `match.group(1)` keeps the
trailing newline. That name is then handed to `_get_string_arg_names`, which
matches it against the names in `tools` — and `"get_weather\n"` never matches
`"get_weather"`. The lookup silently returns an empty set, so every argument goes
through `_deserialize`, including the ones the schema declares as strings.

I hit this while going through the vendored parsers. The argument key on the very
next line is stripped (`arg_key = match.group(1).strip()`), and `longcat.py`,
which uses the identical `^(.*?)<longcat_arg_key>` shape, strips its name too —
`glm47.py` is the only one that does not.

Here is what I got before the change, feeding the parser what the model emits and
slicing it the way `process_tool_calls` does:

```
name      = 'get_weather\n'
arguments = {"zip": 10001, "days": 3}
```

`zip` is declared `{"type": "string"}` in the tool schema, so the tool receives
the integer `10001` instead of the string `"10001"`. After adding `.strip()`:

```
name      = 'get_weather'
arguments = {"zip": "10001", "days": 3}
```

I also ran both versions side by side over the parser's other paths (the JSON
payload shape, `name {json}`, `name k=v`, the no-tools case, a name with no
trailing newline, and the unparseable fallback). The only output that changes is
the one above:

```
SAME  json shape           old={"name": "get_weather", "arguments": {"zip": "10001"}} new={"name": "get_weather", "arguments": {"zip": "10001"}}
SAME  plain name only      old={"name": "get_weather", "arguments": {}} new={"name": "get_weather", "arguments": {}}
SAME  plain kv             old={"name": "get_weather", "arguments": {"zip": "10001", "days": 3}} new={"name": "get_weather", "arguments": {"zip": "10001", "days": 3}}
SAME  plain json body      old={"name": "get_weather", "arguments": {"zip": "10001", "days": 3}} new={"name": "get_weather", "arguments": {"zip": "10001", "days": 3}}
DIFF  xml no tools         old={"name": "get_weather\n", "arguments": {"zip": 10001}} new={"name": "get_weather", "arguments": {"zip": 10001}}
SAME  xml no trailing nl   old={"name": "get_weather", "arguments": {"zip": "10001"}} new={"name": "get_weather", "arguments": {"zip": "10001"}}
SAME  no match             old={"name": "just", "arguments": {"raw": "some text"}} new={"name": "just", "arguments": {"raw": "some text"}}
```

`process_tool_calls` already calls `.strip()` on the emitted name, so the name
itself never reached users mangled — the argument types did.

`glm47.py` had no tests, so I added `mlx_vlm/tests/test_glm47_tool_parser.py`
with the two assertions: the name is clean, and a string-typed argument stays a
string. Both fail on `main` and pass with the change.

Note that upstream `mlx-lm` has the same line, so the fix likely belongs there
too; I am sending it here because `c0a59acf` vendored these parsers and dropped
the dependency, so this copy is the one mlx-vlm users run.

AI tools used
