### PR TITLE
Restore optimized MXFP4 and Q3 verification

### DIFF
--- a/mlx_vlm/models/mxfp4_verifier.py
+++ b/mlx_vlm/models/mxfp4_verifier.py
@@ -1,0 +1,440 @@
+"""Optimized exact MXFP4 operations for speculative verification."""
+
+from functools import lru_cache
+from typing import Optional
+
+import mlx.core as mx
+import mlx.nn as nn
+
+# MLX's wide MXFP4 matmul uses a different reduction order from singleton
+# ``QuantizedLinear`` calls.  Keep that singleton QMV order for each output row
+# while reusing the loaded inputs across the short speculative time dimension.
+_TARGET_VERIFY_MXFP4_HEADER = r"""
+    using namespace metal;
+
+    constant constexpr int SIMD_SIZE = 32;
+    constant constexpr int VERIFY_RESULTS_PER_SIMDGROUP = 4;
+    constant constexpr int VERIFY_NUM_SIMDGROUPS = 2;
+    constant constexpr int VERIFY_ROWS_PER_THREADGROUP =
+        VERIFY_RESULTS_PER_SIMDGROUP * VERIFY_NUM_SIMDGROUPS;
+    constant constexpr int MXFP4_GROUP_SIZE = 32;
+    constant constexpr int MXFP4_PACK_FACTOR = 8;
+    constant constexpr int MXFP4_BYTES_PER_PACK = 4;
+    constant constexpr int MXFP4_PACKS_PER_THREAD = 2;
+    constant constexpr int MXFP4_VALUES_PER_THREAD =
+        MXFP4_PACK_FACTOR * MXFP4_PACKS_PER_THREAD;
+    constant constexpr int MXFP4_BLOCK_SIZE =
+        MXFP4_VALUES_PER_THREAD * SIMD_SIZE;
+    constant constexpr int MXFP4_SCALE_STEP_PER_THREAD =
+        MXFP4_GROUP_SIZE / MXFP4_VALUES_PER_THREAD;
+
+    inline float decode_mxfp4_value(uint code) {
+      half converted = as_type<half>(ushort((code & 7) << 9));
+      converted *= 16384.0;
+      float value = float(converted);
+      return code & 8 ? -value : value;
+    }
+
+    inline float decode_mxfp4_scale(uint8_t encoded) {
+      uint bits = encoded == 0 ? 0x00400000u : uint(encoded) << 23;
+      return as_type<float>(bits);
+    }
+
+    template <typename T>
+    inline void load_mxfp4_vector_exact(
+        const device T* x,
+        thread float* x_thread) {
+      for (int i = 0; i < MXFP4_VALUES_PER_THREAD; ++i) {
+        x_thread[i] = float(x[i]);
+      }
+    }
+
+    inline float mxfp4_qdot_exact(
+        const device uint8_t* w,
+        const thread float* x_thread,
+        float scale) {
+      float accum = 0.0f;
+      const device uint16_t* ws = (const device uint16_t*)w;
+      for (int i = 0; i < (MXFP4_VALUES_PER_THREAD / 4); ++i) {
+        uint packed = ws[i];
+        accum +=
+            (x_thread[4 * i] * decode_mxfp4_value(packed) +
+             x_thread[4 * i + 1] * decode_mxfp4_value(packed >> 4) +
+             x_thread[4 * i + 2] * decode_mxfp4_value(packed >> 8) +
+             x_thread[4 * i + 3] * decode_mxfp4_value(packed >> 12));
+      }
+      return scale * accum;
+    }
+"""
+
+
+_TARGET_VERIFY_MXFP4_QMV_SOURCE = r"""
+    uint n_tile = threadgroup_position_in_grid.y;
+    uint b_idx = threadgroup_position_in_grid.z;
+    uint simd_gid = simdgroup_index_in_threadgroup;
+    uint simd_lid = thread_index_in_simdgroup;
+
+    int out_row =
+        int(n_tile) * VERIFY_ROWS_PER_THREADGROUP +
+        int(simd_gid) * VERIFY_RESULTS_PER_SIMDGROUP;
+    int in_vec_size_w =
+        K_SIZE * MXFP4_BYTES_PER_PACK / MXFP4_PACK_FACTOR;
+    int in_vec_size_g = K_SIZE / MXFP4_GROUP_SIZE;
+
+    const device uint8_t* ws =
+        (const device uint8_t*)w + out_row * in_vec_size_w +
+        int(simd_lid) * MXFP4_PACKS_PER_THREAD * MXFP4_BYTES_PER_PACK;
+    const device uint8_t* sc =
+        scales + out_row * in_vec_size_g +
+        int(simd_lid) / MXFP4_SCALE_STEP_PER_THREAD;
+    const device T* xk =
+        x + int(b_idx) * VERIFY_T * K_SIZE +
+        int(simd_lid) * MXFP4_VALUES_PER_THREAD;
+
+    float result[VERIFY_T][VERIFY_RESULTS_PER_SIMDGROUP];
+    float x_thread[VERIFY_T][MXFP4_VALUES_PER_THREAD];
+    for (int t = 0; t < VERIFY_T; ++t) {
+      for (int row = 0; row < VERIFY_RESULTS_PER_SIMDGROUP; ++row) {
+        result[t][row] = 0.0f;
+      }
+    }
+
+    for (int k = 0; k < K_SIZE; k += MXFP4_BLOCK_SIZE) {
+      for (int t = 0; t < VERIFY_T; ++t) {
+        load_mxfp4_vector_exact<T>(xk + t * K_SIZE, x_thread[t]);
+      }
+
+      for (int row = 0; row < VERIFY_RESULTS_PER_SIMDGROUP; ++row) {
+        const device uint8_t* wl = ws + row * in_vec_size_w;
+        const device uint8_t* sl = sc + row * in_vec_size_g;
+        float scale = decode_mxfp4_scale(sl[0]);
+        for (int t = 0; t < VERIFY_T; ++t) {
+          result[t][row] += mxfp4_qdot_exact(wl, x_thread[t], scale);
+        }
+      }
+
+      ws +=
+          MXFP4_BLOCK_SIZE * MXFP4_BYTES_PER_PACK / MXFP4_PACK_FACTOR;
+      sc += MXFP4_BLOCK_SIZE / MXFP4_GROUP_SIZE;
+      xk += MXFP4_BLOCK_SIZE;
+    }
+
+    for (int row = 0; row < VERIFY_RESULTS_PER_SIMDGROUP; ++row) {
+      int n = out_row + row;
+      for (int t = 0; t < VERIFY_T; ++t) {
+        float reduced = simd_sum(result[t][row]);
+        if (simd_lid == 0) {
+          y[(int(b_idx) * VERIFY_T + t) * N_SIZE + n] = T(reduced);
+        }
+      }
+    }
+"""
+
+
+_TARGET_VERIFY_MXFP4_QARGMAX_SOURCE = _TARGET_VERIFY_MXFP4_QMV_SOURCE.replace(
+    """    for (int row = 0; row < VERIFY_RESULTS_PER_SIMDGROUP; ++row) {
+      int n = out_row + row;
+      for (int t = 0; t < VERIFY_T; ++t) {
+        float reduced = simd_sum(result[t][row]);
+        if (simd_lid == 0) {
+          y[(int(b_idx) * VERIFY_T + t) * N_SIZE + n] = T(reduced);
+        }
+      }
+    }""",
+    """    threadgroup float tile_best_values[VERIFY_T][VERIFY_NUM_SIMDGROUPS];
+    threadgroup int tile_best_indices[VERIFY_T][VERIFY_NUM_SIMDGROUPS];
+
+    for (int t = 0; t < VERIFY_T; ++t) {
+      float best_value = -3.4028234663852886e38f;
+      int best_index = 0;
+      for (int row = 0; row < VERIFY_RESULTS_PER_SIMDGROUP; ++row) {
+        int n = out_row + row;
+        float rounded = float(T(simd_sum(result[t][row])));
+        if (n < N_SIZE && rounded > best_value) {
+          best_value = rounded;
+          best_index = n;
+        }
+      }
+      if (simd_lid == 0) {
+        tile_best_values[t][simd_gid] = best_value;
+        tile_best_indices[t][simd_gid] = best_index;
+      }
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    if (simd_gid == 0 && simd_lid == 0) {
+      for (int t = 0; t < VERIFY_T; ++t) {
+        float best = tile_best_values[t][0];
+        int best_idx = tile_best_indices[t][0];
+        for (int i = 1; i < VERIFY_NUM_SIMDGROUPS; ++i) {
+          float candidate = tile_best_values[t][i];
+          int candidate_idx = tile_best_indices[t][i];
+          if (candidate > best) {
+            best = candidate;
+            best_idx = candidate_idx;
+          }
+        }
+        int offset =
+            (int(b_idx) * VERIFY_T + t) * NUM_TILES + int(n_tile);
+        tile_values[offset] = T(best);
+        tile_indices[offset] = best_idx;
+      }
+    }""",
+)
+
+_TARGET_VERIFY_MASKED_MXFP4_QARGMAX_SOURCE = _TARGET_VERIFY_MXFP4_QARGMAX_SOURCE.replace(
+    "if (n < N_SIZE && rounded > best_value) {",
+    """if (
+          n < N_SIZE &&
+          ((as_type<uint>(mask[
+                (int(b_idx) * VERIFY_T + t) * mask_shape[1] + (n >> 5)]) >>
+            (n & 31)) & 1u) != 0u &&
+          rounded > best_value) {""",
+)
+
+
+def _optimized_fused_mxfp4_qmv_source(n_sizes) -> str:
+    selections = []
+    offset = int(n_sizes[0])
+    for index, n_size in enumerate(n_sizes[1:], start=1):
+        selections.append(f"""    if (global_out >= {offset}) {{
+      local_out = global_out - {offset};
+      selected_w = (const device uint8_t*)w{index};
+      selected_scales = scales{index};
+    }}""")
+        offset += int(n_size)
+    selection = "\n".join(selections)
+    source = _TARGET_VERIFY_MXFP4_QMV_SOURCE.replace(
+        "    int in_vec_size_w =\n        K_SIZE * MXFP4_BYTES_PER_PACK / MXFP4_PACK_FACTOR;",
+        f"""    int global_out = out_row;
+    int local_out = global_out;
+    const device uint8_t* selected_w = (const device uint8_t*)w0;
+    const device uint8_t* selected_scales = scales0;
+{selection}
+    int in_vec_size_w =
+        K_SIZE * MXFP4_BYTES_PER_PACK / MXFP4_PACK_FACTOR;""",
+    )
+    return (
+        source.replace(
+            "(const device uint8_t*)w + out_row * in_vec_size_w",
+            "selected_w + local_out * in_vec_size_w",
+        )
+        .replace(
+            "scales + out_row * in_vec_size_g",
+            "selected_scales + local_out * in_vec_size_g",
+        )
+        .replace("int n = out_row + row;", "int n = global_out + row;")
+    )
+
+
+@lru_cache(maxsize=None)
+def _optimized_mxfp4_qmv_kernel(dtype, verify_t, k_size, n_size):
+    dtype_name = {mx.bfloat16: "bf16", mx.float16: "fp16"}.get(dtype, "unk")
+    return mx.fast.metal_kernel(
+        name=(
+            "quantized_verify_mxfp4_qmv_"
+            f"t{verify_t}_k{k_size}_n{n_size}_{dtype_name}"
+        ),
+        input_names=["x", "w", "scales"],
+        output_names=["y"],
+        header=_TARGET_VERIFY_MXFP4_HEADER,
+        source=_TARGET_VERIFY_MXFP4_QMV_SOURCE,
+    )
+
+
+@lru_cache(maxsize=None)
+def _optimized_mxfp4_qargmax_kernel(dtype, verify_t, k_size, n_size):
+    dtype_name = {mx.bfloat16: "bf16", mx.float16: "fp16"}.get(dtype, "unk")
+    return mx.fast.metal_kernel(
+        name=(
+            "quantized_verify_mxfp4_qargmax_"
+            f"t{verify_t}_k{k_size}_n{n_size}_{dtype_name}"
+        ),
+        input_names=["x", "w", "scales"],
+        output_names=["tile_values", "tile_indices"],
+        header=_TARGET_VERIFY_MXFP4_HEADER,
+        source=_TARGET_VERIFY_MXFP4_QARGMAX_SOURCE,
+    )
+
+
+@lru_cache(maxsize=None)
+def _optimized_masked_mxfp4_qargmax_kernel(dtype, verify_t, k_size, n_size):
+    dtype_name = {mx.bfloat16: "bf16", mx.float16: "fp16"}.get(dtype, "unk")
+    return mx.fast.metal_kernel(
+        name=(
+            "quantized_verify_masked_mxfp4_qargmax_"
+            f"t{verify_t}_k{k_size}_n{n_size}_{dtype_name}"
+        ),
+        input_names=["x", "w", "scales", "mask"],
+        output_names=["tile_values", "tile_indices"],
+        header=_TARGET_VERIFY_MXFP4_HEADER,
+        source=_TARGET_VERIFY_MASKED_MXFP4_QARGMAX_SOURCE,
+    )
+
+
+@lru_cache(maxsize=None)
+def _optimized_fused_mxfp4_qmv_kernel(dtype, verify_t, k_size, n_sizes):
+    dtype_name = {mx.bfloat16: "bf16", mx.float16: "fp16"}.get(dtype, "unk")
+    shape_name = "_".join(str(n) for n in n_sizes)
+    input_names = ["x"]
+    for index in range(len(n_sizes)):
+        input_names.extend([f"w{index}", f"scales{index}"])
+    return mx.fast.metal_kernel(
+        name=(
+            "quantized_verify_fused_mxfp4_qmv_"
+            f"t{verify_t}_k{k_size}_n{shape_name}_{dtype_name}"
+        ),
+        input_names=input_names,
+        output_names=["y"],
+        header=_TARGET_VERIFY_MXFP4_HEADER,
+        source=_optimized_fused_mxfp4_qmv_source(n_sizes),
+    )
+
+
+def supports_optimized_mxfp4_head(linear) -> bool:
+    if (
+        not isinstance(linear, nn.QuantizedLinear)
+        or linear.mode != "mxfp4"
+        or linear.bits != 4
+        or linear.group_size != 32
+        or linear.biases is not None
+    ):
+        return False
+
+    K = linear.weight.shape[1] * 32 // linear.bits
+    N = linear.weight.shape[0]
+    return K % 512 == 0 and N % 8 == 0
+
+
+def _can_optimized_mxfp4(linear, x: mx.array) -> bool:
+    return (
+        supports_optimized_mxfp4_head(linear)
+        and x.ndim == 3
+        and 1 <= x.shape[1] <= 4
+        and x.dtype in (mx.bfloat16, mx.float16)
+        and mx.metal.is_available()
+        and mx.default_device() == mx.gpu
+        and x.shape[-1] == linear.weight.shape[1] * 32 // linear.bits
+    )
+
+
+def optimized_mxfp4_linear(linear, x: mx.array) -> Optional[mx.array]:
+    if not _can_optimized_mxfp4(linear, x):
+        return None
+
+    B, T, K = x.shape
+    N = linear.weight.shape[0]
+    x = mx.contiguous(x)
+    kernel = _optimized_mxfp4_qmv_kernel(x.dtype, T, K, N)
+    out = kernel(
+        inputs=[x, linear.weight, linear.scales],
+        template=[
+            ("T", x.dtype),
+            ("VERIFY_T", int(T)),
+            ("K_SIZE", int(K)),
+            ("N_SIZE", int(N)),
+        ],
+        grid=(32, 2 * (N // 8), B),
+        threadgroup=(32, 2, 1),
+        output_shapes=[(B, T, N)],
+        output_dtypes=[x.dtype],
+    )[0]
+    if "bias" in linear:
+        out = out + linear["bias"]
+    return out
+
+
+def optimized_mxfp4_argmax(
+    linear, x: mx.array, token_mask: Optional[mx.array] = None
+) -> Optional[mx.array]:
+    if not _can_optimized_mxfp4(linear, x):
+        return None
+
+    B, T, K = x.shape
+    N = linear.weight.shape[0]
+    num_tiles = N // 8
+    x = mx.contiguous(x)
+    kernel_factory = (
+        _optimized_masked_mxfp4_qargmax_kernel
+        if token_mask is not None
+        else _optimized_mxfp4_qargmax_kernel
+    )
+    kernel = kernel_factory(x.dtype, T, K, N)
+    inputs = [x, linear.weight, linear.scales]
+    if token_mask is not None:
+        if token_mask.ndim == 1:
+            token_mask = token_mask[None, :]
+        if (
+            token_mask.dtype != mx.int32
+            or token_mask.shape[0] != B * T
+            or token_mask.shape[1] < (N + 31) // 32
+        ):
+            raise ValueError(
+                "packed token mask must be int32 with one complete row per token"
+            )
+        inputs.append(token_mask)
+    tile_values, tile_indices = kernel(
+        inputs=inputs,
+        template=[
+            ("T", x.dtype),
+            ("VERIFY_T", int(T)),
+            ("K_SIZE", int(K)),
+            ("N_SIZE", int(N)),
+            ("NUM_TILES", int(num_tiles)),
+        ],
+        grid=(32, 2 * num_tiles, B),
+        threadgroup=(32, 2, 1),
+        output_shapes=[(B, T, num_tiles), (B, T, num_tiles)],
+        output_dtypes=[x.dtype, mx.int32],
+    )
+    best_tile = mx.argmax(tile_values, axis=-1)
+    return mx.take_along_axis(tile_indices, best_tile[..., None], axis=-1).squeeze(-1)
+
+
+def optimized_mxfp4_linears(linears, x: mx.array):
+    if (
+        not 2 <= len(linears) <= 4
+        or x.ndim != 3
+        or not 1 < x.shape[1] <= 4
+        or not all(
+            "bias" not in linear and _can_optimized_mxfp4(linear, x)
+            for linear in linears
+        )
+    ):
+        return None
+
+    B, T, K = x.shape
+    n_sizes = tuple(int(linear.weight.shape[0]) for linear in linears)
+    total_n = sum(n_sizes)
+    x = mx.contiguous(x)
+    kernel = _optimized_fused_mxfp4_qmv_kernel(x.dtype, T, K, n_sizes)
+    inputs = [x]
+    for linear in linears:
+        inputs.extend([linear.weight, linear.scales])
+    out = kernel(
+        inputs=inputs,
+        template=[
+            ("T", x.dtype),
+            ("VERIFY_T", int(T)),
+            ("K_SIZE", int(K)),
+            ("N_SIZE", int(total_n)),
+        ],
+        grid=(32, 2 * (total_n // 8), B),
+        threadgroup=(32, 2, 1),
+        output_shapes=[(B, T, total_n)],
+        output_dtypes=[x.dtype],
+    )[0]
+    split_indices = []
+    offset = 0
+    for n_size in n_sizes[:-1]:
+        offset += n_size
+        split_indices.append(offset)
+    return tuple(mx.split(out, split_indices, axis=-1))
+
+
+__all__ = [
+    "optimized_mxfp4_argmax",
+    "optimized_mxfp4_linear",
+    "optimized_mxfp4_linears",
+    "supports_optimized_mxfp4_head",
+]

--- a/mlx_vlm/models/mxfp4_verifier.py
+++ b/mlx_vlm/models/mxfp4_verifier.py
@@ -347,7 +347,7 @@ def optimized_mxfp4_linear(linear, x: mx.array) -> Optional[mx.array]:
 def optimized_mxfp4_argmax(
     linear, x: mx.array, token_mask: Optional[mx.array] = None
 ) -> Optional[mx.array]:
-    if not _can_optimized_mxfp4(linear, x):
+    if not _can_optimized_mxfp4(linear, x) or "bias" in linear:
         return None
 
     B, T, K = x.shape

--- a/mlx_vlm/models/quantized_verifier.py
+++ b/mlx_vlm/models/quantized_verifier.py
@@ -758,8 +758,16 @@ def _stable_nvfp4_argmax(
 
 
 def _target_verify_qlinear_header(
-    bits: int, group_size: int, results_per_simdgroup: int = 4
+    bits: int,
+    group_size: int,
+    results_per_simdgroup: int = 4,
+    *,
+    q3_shifted_fields: bool = False,
 ) -> str:
+    # Shifted Q3 extraction is faster but changes floating-point operation
+    # order. Use it only for argmax kernels, where exact token IDs are
+    # verified; projection kernels retain the unshifted form for byte-identical
+    # singleton outputs.
     return (
         r"""
     using namespace metal;
@@ -767,8 +775,11 @@ def _target_verify_qlinear_header(
     constant constexpr int SIMD_SIZE = 32;
     constant constexpr int BITS = __BITS__;
     constant constexpr int GS = __GS__;
-    constant constexpr int PACK_FACTOR = (BITS == 5 ? 8 : 32 / BITS);
-    constant constexpr int BYTES_PER_PACK = (BITS == 5 ? 5 : 32 / 8);
+    constant constexpr bool Q3_SHIFTED = __Q3_SHIFTED__;
+    constant constexpr int PACK_FACTOR =
+        ((BITS == 3 || BITS == 5) ? 8 : 32 / BITS);
+    constant constexpr int BYTES_PER_PACK =
+        ((BITS == 3 || BITS == 5) ? (BITS == 3 ? 3 : 5) : 32 / 8);
     constant constexpr int PACKS_PER_THREAD = 2;
     constant constexpr int VALUES_PER_THREAD = PACK_FACTOR * PACKS_PER_THREAD;
     constant constexpr int BLOCK_SIZE = VALUES_PER_THREAD * SIMD_SIZE;
@@ -780,7 +791,20 @@ def _target_verify_qlinear_header(
     template <typename T>
     inline float load_vector_exact(const device T* x, thread float* x_thread) {
       float sum = 0.0f;
-      if (BITS == 4) {
+      if (BITS == 3) {
+        for (int i = 0; i < VALUES_PER_THREAD; i += 8) {
+          sum += x[i] + x[i + 1] + x[i + 2] + x[i + 3] + x[i + 4] +
+              x[i + 5] + x[i + 6] + x[i + 7];
+          x_thread[i] = x[i];
+          x_thread[i + 1] = Q3_SHIFTED ? x[i + 1] : x[i + 1] / 8.0f;
+          x_thread[i + 2] = Q3_SHIFTED ? x[i + 2] : x[i + 2] / 64.0f;
+          x_thread[i + 3] = Q3_SHIFTED ? x[i + 3] : x[i + 3] / 2.0f;
+          x_thread[i + 4] = Q3_SHIFTED ? x[i + 4] : x[i + 4] / 16.0f;
+          x_thread[i + 5] = Q3_SHIFTED ? x[i + 5] : x[i + 5] / 128.0f;
+          x_thread[i + 6] = Q3_SHIFTED ? x[i + 6] : x[i + 6] / 4.0f;
+          x_thread[i + 7] = Q3_SHIFTED ? x[i + 7] : x[i + 7] / 32.0f;
+        }
+      } else if (BITS == 4) {
         for (int i = 0; i < VALUES_PER_THREAD; i += 4) {
           sum += x[i] + x[i + 1] + x[i + 2] + x[i + 3];
           x_thread[i] = x[i];
@@ -817,7 +841,31 @@ def _target_verify_qlinear_header(
         float bias,
         float sum) {
       float accum = 0.0f;
-      if (BITS == 4) {
+      if (BITS == 3) {
+        for (int i = 0; i < (VALUES_PER_THREAD / 8); i++) {
+          const thread float* xt = x_thread + 8 * i;
+          const device uint8_t* wb = w + 3 * i;
+          accum += (wb[0] & 0x07) * xt[0];
+          accum +=
+              (Q3_SHIFTED ? ((wb[0] >> 3) & 0x07) : (wb[0] & 0x38)) * xt[1];
+          accum +=
+              (Q3_SHIFTED ? (wb[0] >> 6) : (wb[0] & 0xc0)) * xt[2];
+          accum +=
+              (wb[1] & 0x01) * (xt[2] * (Q3_SHIFTED ? 4.0f : 256.0f));
+          accum +=
+              (Q3_SHIFTED ? ((wb[1] >> 1) & 0x07) : (wb[1] & 0x0e)) * xt[3];
+          accum +=
+              (Q3_SHIFTED ? ((wb[1] >> 4) & 0x07) : (wb[1] & 0x70)) * xt[4];
+          accum +=
+              (Q3_SHIFTED ? (wb[1] >> 7) : (wb[1] & 0x80)) * xt[5];
+          accum +=
+              (wb[2] & 0x03) * (xt[5] * (Q3_SHIFTED ? 2.0f : 256.0f));
+          accum +=
+              (Q3_SHIFTED ? ((wb[2] >> 2) & 0x07) : (wb[2] & 0x1c)) * xt[6];
+          accum +=
+              (Q3_SHIFTED ? (wb[2] >> 5) : (wb[2] & 0xe0)) * xt[7];
+        }
+      } else if (BITS == 4) {
         const device uint16_t* ws = (const device uint16_t*)w;
         for (int i = 0; i < (VALUES_PER_THREAD / 4); i++) {
           uint packed = ws[i];
@@ -860,7 +908,36 @@ def _target_verify_qlinear_header(
         float bias,
         float sum) {
       float accum = 0.0f;
-      if (BITS == 4) {
+      if (BITS == 3) {
+        const thread uint8_t* wb = (const thread uint8_t*)ws;
+        for (int i = 0; i < (VALUES_PER_THREAD / 8); i++) {
+          const thread float* xt = x_thread + 8 * i;
+          const thread uint8_t* packed = wb + 3 * i;
+          accum += (packed[0] & 0x07) * xt[0];
+          accum +=
+              (Q3_SHIFTED ? ((packed[0] >> 3) & 0x07) : (packed[0] & 0x38)) *
+              xt[1];
+          accum +=
+              (Q3_SHIFTED ? (packed[0] >> 6) : (packed[0] & 0xc0)) * xt[2];
+          accum +=
+              (packed[1] & 0x01) * (xt[2] * (Q3_SHIFTED ? 4.0f : 256.0f));
+          accum +=
+              (Q3_SHIFTED ? ((packed[1] >> 1) & 0x07) : (packed[1] & 0x0e)) *
+              xt[3];
+          accum +=
+              (Q3_SHIFTED ? ((packed[1] >> 4) & 0x07) : (packed[1] & 0x70)) *
+              xt[4];
+          accum +=
+              (Q3_SHIFTED ? (packed[1] >> 7) : (packed[1] & 0x80)) * xt[5];
+          accum +=
+              (packed[2] & 0x03) * (xt[5] * (Q3_SHIFTED ? 2.0f : 256.0f));
+          accum +=
+              (Q3_SHIFTED ? ((packed[2] >> 2) & 0x07) : (packed[2] & 0x1c)) *
+              xt[6];
+          accum +=
+              (Q3_SHIFTED ? (packed[2] >> 5) : (packed[2] & 0xe0)) * xt[7];
+        }
+      } else if (BITS == 4) {
         for (int i = 0; i < (VALUES_PER_THREAD / 4); i++) {
           uint packed = ws[i];
           accum +=
@@ -876,6 +953,7 @@ def _target_verify_qlinear_header(
 """.replace("__BITS__", str(bits))
         .replace("__GS__", str(group_size))
         .replace("__RESULTS_PER_SIMDGROUP__", str(results_per_simdgroup))
+        .replace("__Q3_SHIFTED__", "true" if q3_shifted_fields else "false")
     )
 
 
@@ -1476,7 +1554,9 @@ def _target_verify_qargmax_kernel(bits, group_size, dtype, verify_t, k_size, n_s
         ),
         input_names=["x", "w", "scales", "biases"],
         output_names=["tile_values", "tile_indices"],
-        header=_target_verify_qlinear_header(bits, group_size),
+        header=_target_verify_qlinear_header(
+            bits, group_size, q3_shifted_fields=bits == 3
+        ),
         source=_TARGET_VERIFY_QARGMAX_SOURCE,
     )
 
@@ -1493,7 +1573,9 @@ def _target_verify_masked_qargmax_kernel(
         ),
         input_names=["x", "w", "scales", "biases", "mask"],
         output_names=["tile_values", "tile_indices"],
-        header=_target_verify_qlinear_header(bits, group_size),
+        header=_target_verify_qlinear_header(
+            bits, group_size, q3_shifted_fields=bits == 3
+        ),
         source=_TARGET_VERIFY_MASKED_QARGMAX_SOURCE,
     )
 
@@ -1646,7 +1728,7 @@ def supports_optimized_affine_head(linear) -> bool:
     """Return whether the exact affine verifier kernel supports ``linear``."""
     if (
         not isinstance(linear, nn.QuantizedLinear)
-        or linear.bits not in (4, 5, 8)
+        or linear.bits not in (3, 4, 5, 8)
         or linear.mode != "affine"
         or linear.biases is None
         or linear.scales.dtype not in (mx.bfloat16, mx.float16)
@@ -1793,7 +1875,7 @@ def optimized_affine_linears(linears, x: mx.array):
         not 2 <= len(linears) <= 4
         or x.ndim != 3
         or not 1 < x.shape[1] <= 8
-        or bits not in (4, 5, 8)
+        or bits not in (3, 4, 5, 8)
         or not all(
             isinstance(linear, nn.QuantizedLinear)
             and linear.bits == bits

--- a/mlx_vlm/models/quantized_verifier.py
+++ b/mlx_vlm/models/quantized_verifier.py
@@ -1529,6 +1529,12 @@ def _target_verify_fused_qmv_source(source: str, n_sizes) -> str:
     )
 
 
+def _projection_results_per_simdgroup(bits, verify_t):
+    # Q3's unshifted projection arithmetic benefits from a smaller output
+    # tile at T=3/4. Keep the singleton reduction order within each output.
+    return 2 if bits == 3 and verify_t in (3, 4) else 4
+
+
 @lru_cache(maxsize=None)
 def _target_verify_qmv_kernel(bits, group_size, dtype, verify_t, k_size, n_size):
     dtype_name = {mx.bfloat16: "bf16", mx.float16: "fp16"}.get(dtype, "unk")
@@ -1539,7 +1545,9 @@ def _target_verify_qmv_kernel(bits, group_size, dtype, verify_t, k_size, n_size)
         ),
         input_names=["x", "w", "scales", "biases"],
         output_names=["y"],
-        header=_target_verify_qlinear_header(bits, group_size),
+        header=_target_verify_qlinear_header(
+            bits, group_size, _projection_results_per_simdgroup(bits, verify_t)
+        ),
         source=_TARGET_VERIFY_QMV_SOURCE,
     )
 
@@ -1696,7 +1704,9 @@ def _target_verify_fused_qmv_kernel(bits, group_size, dtype, verify_t, k_size, n
         ),
         input_names=input_names,
         output_names=["y"],
-        header=_target_verify_qlinear_header(bits, group_size),
+        header=_target_verify_qlinear_header(
+            bits, group_size, _projection_results_per_simdgroup(bits, verify_t)
+        ),
         source=_target_verify_fused_qmv_source(_TARGET_VERIFY_QMV_SOURCE, n_sizes),
     )
 
@@ -1767,7 +1777,9 @@ def optimized_affine_linear(linear, x: mx.array) -> Optional[mx.array]:
     x = mx.contiguous(x)
     streamed = linear.bits == 4 and 6 <= T <= 8
     token_tiled = linear.bits == 4 and T >= 6 and not streamed
-    results_per_simdgroup = 1 if streamed else 4
+    results_per_simdgroup = (
+        1 if streamed else _projection_results_per_simdgroup(linear.bits, T)
+    )
     if streamed:
         kernel_factory = _target_verify_qmv_streamed_kernel
     elif token_tiled:
@@ -1902,6 +1914,9 @@ def optimized_affine_linears(linears, x: mx.array):
     inputs = [x]
     for linear in linears:
         inputs.extend([linear.weight, linear.scales, linear.biases])
+    rows_per_threadgroup = (
+        2 if streamed else 2 * _projection_results_per_simdgroup(bits, T)
+    )
     out = kernel(
         inputs=inputs,
         template=[
@@ -1910,7 +1925,7 @@ def optimized_affine_linears(linears, x: mx.array):
             ("K_SIZE", int(K)),
             ("N_SIZE", int(total_n)),
         ],
-        grid=(32, 2 * (total_n // (2 if streamed else 8)), B),
+        grid=(32, 2 * (total_n // rows_per_threadgroup), B),
         threadgroup=(32, 2, 1),
         output_shapes=[(B, T, total_n)],
         output_dtypes=[x.dtype],

--- a/mlx_vlm/speculative/ops/linear.py
+++ b/mlx_vlm/speculative/ops/linear.py
@@ -7,6 +7,15 @@ from ...models.exact_speculative_verify import exact_speculative_verify_dense_av
 from ...models.exact_speculative_verify import (
     exact_speculative_verify_weight as _target_verify_weight,
 )
+from ...models.mxfp4_verifier import (
+    optimized_mxfp4_argmax as _target_verify_optimized_mxfp4_argmax,
+)
+from ...models.mxfp4_verifier import (
+    optimized_mxfp4_linear as _target_verify_optimized_mxfp4_linear,
+)
+from ...models.mxfp4_verifier import (
+    optimized_mxfp4_linears as _target_verify_optimized_mxfp4_linears,
+)
 from ...models.quantized_verifier import (
     optimized_affine_argmax as _target_verify_optimized_affine_argmax,
 )
@@ -14,7 +23,7 @@ from ...models.quantized_verifier import (
     optimized_affine_linear as _target_verify_optimized_affine_linear,
 )
 from ...models.quantized_verifier import (
-    optimized_affine_linears as _target_verify_quantized_linears,
+    optimized_affine_linears as _target_verify_optimized_affine_linears,
 )
 from ...models.quantized_verifier import (
     optimized_nvfp4_argmax as _target_verify_optimized_nvfp4_argmax,
@@ -38,6 +47,9 @@ def _use_target_verify_dense(linear, x: mx.array) -> bool:
 
 
 def _target_verify_quantized_linear(linear, x: mx.array) -> Optional[mx.array]:
+    output = _target_verify_optimized_mxfp4_linear(linear, x)
+    if output is not None:
+        return output
     output = _target_verify_optimized_affine_linear(linear, x)
     if output is not None:
         return output
@@ -47,6 +59,9 @@ def _target_verify_quantized_linear(linear, x: mx.array) -> Optional[mx.array]:
 def _target_verify_quantized_argmax(
     linear, x: mx.array, token_mask: Optional[mx.array] = None
 ) -> Optional[mx.array]:
+    output = _target_verify_optimized_mxfp4_argmax(linear, x, token_mask=token_mask)
+    if output is not None:
+        return output
     output = _target_verify_optimized_affine_argmax(linear, x, token_mask=token_mask)
     if output is not None:
         return output
@@ -111,7 +126,10 @@ def _target_verify_linears(linears, x: mx.array):
             return out
         return tuple(linear(x) for linear in linears)
 
-    out = _target_verify_quantized_linears(linears, x)
+    out = _target_verify_optimized_mxfp4_linears(linears, x)
+    if out is not None:
+        return out
+    out = _target_verify_optimized_affine_linears(linears, x)
     if out is not None:
         return out
     return tuple(_target_verify_linear(linear, x) for linear in linears)

--- a/mlx_vlm/tests/test_speculative.py
+++ b/mlx_vlm/tests/test_speculative.py
@@ -4430,6 +4430,25 @@ def test_optimized_mxfp4_verifier_matches_singleton_decode(dtype, verify_length)
 
 @pytest.mark.skipif(not mx.metal.is_available(), reason="requires Metal kernels")
 @pytest.mark.parametrize("dtype", [mx.bfloat16, mx.float16])
+@pytest.mark.parametrize("masked", [False, True])
+def test_mxfp4_argmax_preserves_linear_bias(dtype, masked):
+    linear = nn.QuantizedLinear.from_linear(
+        nn.Linear(512, 16, bias=False), group_size=32, bits=4, mode="mxfp4"
+    )
+    linear.bias = mx.array([0.0] * 14 + [5.0, 10.0], dtype=dtype)
+    inputs = mx.zeros((2, 3, 512), dtype=dtype)
+    token_mask = mx.full((6, 1), 0x7FFF, dtype=mx.int32) if masked else None
+    expected = mx.full((2, 3), 14 if masked else 15, dtype=mx.int32)
+
+    actual = verifier_linear._target_verify_quantized_argmax(
+        linear, inputs, token_mask=token_mask
+    )
+    mx.eval(actual, expected)
+    assert mx.array_equal(actual, expected).item()
+
+
+@pytest.mark.skipif(not mx.metal.is_available(), reason="requires Metal kernels")
+@pytest.mark.parametrize("dtype", [mx.bfloat16, mx.float16])
 @pytest.mark.parametrize("group_size", [32, 64])
 def test_optimized_affine_q3_verifier_matches_singleton_decode(dtype, group_size):
     from mlx_vlm.models.quantized_verifier import (

--- a/mlx_vlm/tests/test_speculative.py
+++ b/mlx_vlm/tests/test_speculative.py
@@ -4450,7 +4450,10 @@ def test_mxfp4_argmax_preserves_linear_bias(dtype, masked):
 @pytest.mark.skipif(not mx.metal.is_available(), reason="requires Metal kernels")
 @pytest.mark.parametrize("dtype", [mx.bfloat16, mx.float16])
 @pytest.mark.parametrize("group_size", [32, 64])
-def test_optimized_affine_q3_verifier_matches_singleton_decode(dtype, group_size):
+@pytest.mark.parametrize("batch,verify_length", [(1, 3), (2, 4), (4, 3), (4, 4)])
+def test_optimized_affine_q3_verifier_matches_singleton_decode(
+    dtype, group_size, batch, verify_length
+):
     from mlx_vlm.models.quantized_verifier import (
         optimized_affine_argmax,
         optimized_affine_linear,
@@ -4470,7 +4473,7 @@ def test_optimized_affine_q3_verifier_matches_singleton_decode(dtype, group_size
     for linear in linears:
         linear.scales = linear.scales.astype(dtype)
         linear.biases = linear.biases.astype(dtype)
-    inputs = mx.random.normal((2, 4, 512)).astype(dtype)
+    inputs = mx.random.normal((batch, verify_length, 512)).astype(dtype)
     mx.eval(*(linear.parameters() for linear in linears), inputs)
     expected = tuple(
         verifier_linear._target_verify_singletons(linear, inputs) for linear in linears

--- a/mlx_vlm/tests/test_speculative.py
+++ b/mlx_vlm/tests/test_speculative.py
@@ -4376,6 +4376,105 @@ def test_general_quantized_verifier_matches_decode(
     assert mx.array_equal(tokens, mx.argmax(expected, axis=-1)).item()
 
 
+@pytest.mark.skipif(not mx.metal.is_available(), reason="requires Metal kernels")
+@pytest.mark.parametrize("dtype", [mx.bfloat16, mx.float16])
+@pytest.mark.parametrize("verify_length", [2, 4])
+def test_optimized_mxfp4_verifier_matches_singleton_decode(dtype, verify_length):
+    mx.random.seed(810 + verify_length)
+    linears = tuple(
+        nn.QuantizedLinear.from_linear(
+            nn.Linear(512, output_dims, bias=False),
+            group_size=32,
+            bits=4,
+            mode="mxfp4",
+        )
+        for output_dims in (16, 24, 32)
+    )
+    inputs = mx.random.normal((2, verify_length, 512)).astype(dtype)
+    mx.eval(*(linear.parameters() for linear in linears), inputs)
+    expected = tuple(
+        verifier_linear._target_verify_singletons(linear, inputs) for linear in linears
+    )
+
+    token_mask = mx.full((2 * verify_length, 1), 0x5555, dtype=mx.int32)
+    with (
+        patch.object(
+            verifier_linear,
+            "_target_verify_singleton_quantized_linear",
+            side_effect=AssertionError("MXFP4 must use its optimized projection"),
+        ),
+        patch.object(
+            verifier_linear,
+            "_target_verify_singleton_quantized_argmax",
+            side_effect=AssertionError("MXFP4 must use its optimized argmax"),
+        ),
+    ):
+        actual = verifier_linear._target_verify_quantized_linear(linears[0], inputs)
+        fused = verifier_linear._target_verify_linears(linears, inputs)
+        tokens = verifier_linear._target_verify_quantized_argmax(linears[0], inputs)
+        masked_tokens = verifier_linear._target_verify_quantized_argmax(
+            linears[0], inputs, token_mask=token_mask
+        )
+    masked_expected = mx.argmax(
+        mx.where(mx.arange(16) % 2 == 0, expected[0], -mx.inf), axis=-1
+    )
+    mx.eval(*expected, actual, *fused, tokens, masked_tokens, masked_expected)
+
+    assert actual is not None
+    assert fused is not None
+    assert mx.array_equal(actual, expected[0]).item()
+    assert all(mx.array_equal(a, e).item() for a, e in zip(fused, expected))
+    assert mx.array_equal(tokens, mx.argmax(expected[0], axis=-1)).item()
+    assert mx.array_equal(masked_tokens, masked_expected).item()
+
+
+@pytest.mark.skipif(not mx.metal.is_available(), reason="requires Metal kernels")
+@pytest.mark.parametrize("dtype", [mx.bfloat16, mx.float16])
+@pytest.mark.parametrize("group_size", [32, 64])
+def test_optimized_affine_q3_verifier_matches_singleton_decode(dtype, group_size):
+    from mlx_vlm.models.quantized_verifier import (
+        optimized_affine_argmax,
+        optimized_affine_linear,
+        optimized_affine_linears,
+    )
+
+    mx.random.seed(820 + group_size)
+    linears = tuple(
+        nn.QuantizedLinear.from_linear(
+            nn.Linear(512, output_dims, bias=False),
+            group_size=group_size,
+            bits=3,
+            mode="affine",
+        )
+        for output_dims in (16, 24, 32)
+    )
+    for linear in linears:
+        linear.scales = linear.scales.astype(dtype)
+        linear.biases = linear.biases.astype(dtype)
+    inputs = mx.random.normal((2, 4, 512)).astype(dtype)
+    mx.eval(*(linear.parameters() for linear in linears), inputs)
+    expected = tuple(
+        verifier_linear._target_verify_singletons(linear, inputs) for linear in linears
+    )
+
+    actual = optimized_affine_linear(linears[0], inputs)
+    fused = optimized_affine_linears(linears, inputs)
+    tokens = optimized_affine_argmax(linears[0], inputs)
+    token_mask = mx.full((inputs.shape[0] * inputs.shape[1], 1), 0x5555, dtype=mx.int32)
+    masked_tokens = optimized_affine_argmax(linears[0], inputs, token_mask=token_mask)
+    masked_expected = mx.argmax(
+        mx.where(mx.arange(16) % 2 == 0, expected[0], -mx.inf), axis=-1
+    )
+    mx.eval(*expected, actual, *fused, tokens, masked_tokens, masked_expected)
+
+    assert actual is not None
+    assert fused is not None
+    assert mx.array_equal(actual, expected[0]).item()
+    assert all(mx.array_equal(a, e).item() for a, e in zip(fused, expected))
+    assert mx.array_equal(tokens, mx.argmax(expected[0], axis=-1)).item()
+    assert mx.array_equal(masked_tokens, masked_expected).item()
+
+
 @pytest.mark.parametrize("input_dims", [64, 128])
 @pytest.mark.parametrize("bits", [2, 4, 8])
 def test_general_quantized_verifier_matches_narrow_qmv_quad(input_dims, bits):


### PR DESCRIPTION
MXFP4 speculative verification currently falls back to singleton `gather_qmm`
after the verifier generalization removed the specialized kernels from #2106.
This restores the optimized MXFP4 path in the shared verifier dispatch and adds
affine Q3 support to the optimized affine kernels.

### Changes

- Restore the exact MXFP4 QMV, fused QMV, and masked/unmasked argmax kernels
  removed when the verifier was generalized.
- Dispatch supported MXFP4 projections through those kernels before the generic
  `gather_qmm` singleton fallback.
- Extend the generalized affine verifier to 3-bit weights, including exact
  fused projections and shifted-field masked/unmasked argmax.
- Preserve all generic fallbacks for unsupported shapes, devices, and formats.

### Correctness

- Specialized outputs are compared against the verifier's true B-by-T singleton
  reference, not a wide batched qmm reduction.
- Tests cover BF16 and FP16, MXFP4 batch size 2, T=2/4; Q3 B=1/2/4, T=3/4, affine Q3 group sizes
  32/64, fused projections, and masked/unmasked argmax.
- Real Qwen3.8-27B Q3 checkpoint: attention Q/K/V, Gated DeltaNet projections,
  and MLP gate/up at T=4 were byte-identical (`max_abs_diff=0`). LM-head
  projections and argmax tokens matched at T=1 and T=4.
- `mlx_vlm/tests/test_speculative.py`: **756 passed** on Apple M4 Pro with
  MLX/MLX-Metal 0.32.2.
- Pre-commit: Black, isort, and autoflake passed.

### Performance

Measured against `8f5dc3dd` on Apple M4 Pro with MLX/MLX-Metal 0.32.2:
Qwen3.8-27B target, MTP with draft block size 3, 1,024 tokens of prompt text
before chat templating, and 1,024 forced output tokens. Each arm uses a fresh
server; results are medians from baseline/patched/patched/baseline order.

| Target format | Current main | Patched | Speedup | Output / MTP stats |
|---|---:|---:|---:|---|
| MXFP4 | 13.022 tok/s | 24.609 tok/s | **1.890x** | identical |
| affine Q3 (updated tile) | 13.705 tok/s | 24.186 tok/s | **1.765x** | identical |

MXFP4 T=4 real-checkpoint microbenchmarks were also restored to the earlier
specialized-kernel range: fused Q/K/V 0.469 ms and LM-head argmax 5.119 ms, with
exact outputs.

### Implementation notes

- The MXFP4 path is limited to Metal GPU, BF16/FP16, 4-bit group-size 32,
  bias-free quantization parameters, aligned dimensions, and verifier length at
  most 4. Everything else retains the current generic fallback.
- Q3 projection kernels keep unshifted packed-field arithmetic for byte-identical
  output. Argmax uses shifted extraction, which changes floating-point operation
  order; token IDs matched in the tests and benchmark runs above.

Performance results are specific to these checkpoints and this workload.


### Expanded quantization and batch sweep (September 12)

The broader sweep exposed a Q3 projection regression at T=3/4, which this update fixes by reducing the output tile from four to two results per SIMD group. The projection retains its unshifted arithmetic and singleton reduction order.

I tested affine 3/4/5/8 (group size 32), MXFP4/MXFP8 (group size 32), and NVFP4 (group size 16), with B=1/2/4 and T=1/2/3/4 on an Apple M4 Pro, MLX/MLX-Metal 0.32.2. Each format uses fresh-process ABBA order against base `8f5dc3dd`, five warmups and 30 synchronized wall-clock samples per case. Ratios below are base latency / patched latency; higher is faster.

These are **synthetic-weight component microbenchmarks**, using Qwen3.8-27B dimensions: hidden size 5120, gated Q output 12288, K/V output 1024 each, and full vocabulary head output 248320. They are not seven full-model throughput measurements.

All 252 paired cases passed the checks in all four arms: projection/QKV outputs against native singleton calls, and argmax IDs against the singleton verifier. The speculative test suite also passed (756 tests), including FP16/BF16 and Q3 group sizes 32/64.

| Format | Geomean speedup across 36 cases | Min–max |
|---|---:|---:|
| affine3 | 1.401× | 0.811–1.819× |
| affine4 | 0.998× | 0.977–1.063× |
| affine5 | 0.997× | 0.967–1.010× |
| affine8 | 1.001× | 0.957–1.027× |
| mxfp4 | 1.568× | 0.970–2.190× |
| mxfp8 | 0.998× | 0.967–1.012× |
| nvfp4 | 0.999× | 0.967–1.027× |

T=4 detail:

| Format | Operation | B1 | B2 | B4 |
|---|---|---:|---:|---:|
| affine3 | q_projection | 1.577× | 1.819× | 1.731× |
| affine3 | qkv | 1.643× | 1.796× | 1.776× |
| affine3 | head_argmax | 1.558× | 1.571× | 1.581× |
| mxfp4 | q_projection | 1.741× | 1.967× | 1.956× |
| mxfp4 | qkv | 1.751× | 1.863× | 1.886× |
| mxfp4 | head_argmax | 2.143× | 2.172× | 2.190× |

The unchanged formats stay close to parity overall; individual cases vary by up to about 4% slower. Q3 is not faster at every shape: its T=1 head path remains slower in this sweep. The gains above should not be read as universal speedups across devices or workloads.

For the Q3 regression investigation, I varied only output tile size and loop unrolling while preserving the arithmetic. At B2/T4, K=5120/N=6144, the four-result kernel took 0.743 ms; the two-result variant took 0.424 ms, versus 0.594 ms for singleton gather. All matched exactly. This isolates a kernel tiling/code-generation sensitivity; without GPU register counters, I cannot attribute it specifically to spills. The larger, actual gated-Q shape in the table above independently confirms the fix.

Real Qwen3.8-27B affine-Q3 MTP confirmation (draft block 3, 1024 prompt-text tokens before chat templating, 1024 forced output tokens, fresh-server ABBA): base **13.705 tok/s**, patched **24.186 tok/s**, **1.765×**. Output hashes identical: **True**.
MTP rounds, draft-token count and accepted-token count identical across all four arms: **True**.
