### PR TITLE
Preserve image ownership across Chat Completions turns

### DIFF
--- a/mlx_vlm/prompt_utils.py
+++ b/mlx_vlm/prompt_utils.py
@@ -130,6 +130,8 @@ SINGLE_IMAGE_ONLY_MODELS = {
     "falcon_ocr",
 }
 
+LAST_MESSAGE_ONLY_MODELS = {"paligemma", "florence2", "falcon_ocr"}
+
 
 def extract_text_from_content(content: Any) -> str:
     """
@@ -509,7 +511,10 @@ class MessageFormatter:
             prefix_parts = []
             if not skip_image_token and num_images > 0:
                 prefix_parts.append(
-                    "".join([f"<|image_{i+1}|>" for i in range(num_images)])
+                    "".join(
+                        f"<|image_{kwargs.get('image_offset', 0) + i + 1}|>"
+                        for i in range(num_images)
+                    )
                 )
             if not skip_audio_token and num_audios > 0:
                 prefix_parts.append(
@@ -864,6 +869,13 @@ def apply_chat_template(
     config = config if isinstance(config, dict) else config.__dict__
     model_type = config["model_type"]
 
+    # Per-turn allocation must not bypass a model's request-wide image limit.
+    if num_images > 1 and model_type.lower() in SINGLE_IMAGE_ONLY_MODELS:
+        raise ValueError(
+            f"Model {model_type} does not support multi-image chat. "
+            f"Please only use 1 image."
+        )
+
     # Use standard formatting for text-only models.
     if model_type.lower() not in MODEL_CONFIG:
         if isinstance(prompt, str):
@@ -965,11 +977,15 @@ def apply_chat_template(
                 allocated[last_user_idx] += remaining
             return allocated
 
+        # Models that discard history still need the image on the retained turn.
+        if model_type in LAST_MESSAGE_ONLY_MODELS:
+            explicit_image_counts = [0] * len(prompt)
         image_counts = _allocate_media_counts(explicit_image_counts, num_images)
         audio_counts = [0] * len(prompt)
         if last_user_idx >= 0:
             audio_counts[last_user_idx] = num_audios
 
+        image_offset = 0
         for i, p in enumerate(prompt):
             if isinstance(p, str):
                 messages.append(
@@ -979,6 +995,7 @@ def apply_chat_template(
                         skip_image_token=image_counts[i] == 0,
                         skip_audio_token=audio_counts[i] == 0,
                         num_images=image_counts[i],
+                        image_offset=image_offset,
                         num_audios=audio_counts[i],
                         **kwargs,
                     )
@@ -1011,16 +1028,18 @@ def apply_chat_template(
                             skip_audio_token=audio_counts[i] == 0
                             or role in ["system", "assistant"],
                             num_images=image_counts[i],
+                            image_offset=image_offset,
                             num_audios=audio_counts[i],
                             **kwargs,
                         )
                     )
+            image_offset += image_counts[i]
 
     if return_messages:
         return messages
 
     # Some models only need the last message
-    if model_type in ["paligemma", "florence2", "falcon_ocr"]:
+    if model_type in LAST_MESSAGE_ONLY_MODELS:
         return messages[-1]
 
     return get_chat_template(processor, messages, add_generation_prompt, **kwargs)

--- a/mlx_vlm/server/openai.py
+++ b/mlx_vlm/server/openai.py
@@ -180,10 +180,20 @@ def _with_tool_choice_instruction(messages, instruction: str):
         messages[0]["content"] = f"{content}\n\n{instruction}".strip()
     user_instruction_added = False
     for message in reversed(messages):
-        if message.get("role") == "user" and isinstance(message.get("content"), str):
-            message["content"] = f"{message['content']}\n\n{instruction}".strip()
-            user_instruction_added = True
-            break
+        if message.get("role") != "user":
+            continue
+        content = message.get("content")
+        if isinstance(content, str):
+            message["content"] = f"{content}\n\n{instruction}".strip()
+        elif isinstance(content, list):
+            message["content"] = [
+                *content,
+                {"type": "text", "text": f"\n\n{instruction}"},
+            ]
+        else:
+            continue
+        user_instruction_added = True
+        break
     if not user_instruction_added and not (
         messages and messages[0].get("role") == "system"
     ):
@@ -1642,22 +1652,39 @@ async def chat_completions_endpoint(request: ChatRequest, http_request: Request)
             if isinstance(message.content, str):
                 msg["content"] = message.content
             elif isinstance(message.content, list):
+                content_parts = []
+                has_images = False
                 if message.role == "user":
                     for item in message.content:
                         if not isinstance(item, dict):
                             continue
                         item_type = item.get("type")
-                        if item_type == "input_image":
+                        if item_type in ("text", "input_text"):
+                            text = item.get("text", "") or item.get("content", "")
+                            if text:
+                                content_parts.append({"type": "text", "text": text})
+                        elif item_type == "input_image":
                             images.append(item["image_url"])
+                            content_parts.append({"type": "image"})
+                            has_images = True
                         elif item_type == "image_url":
                             images.append(item["image_url"]["url"])
+                            content_parts.append({"type": "image"})
+                            has_images = True
                         elif item_type == "input_audio":
                             audio.append(_decode_input_audio_data(item["input_audio"]))
                         elif item_type in ("input_video", "video_url", "video"):
                             video = _extract_video_reference(item)
                             if video:
                                 videos.append(video)
-                msg["content"] = extract_text_from_content(message.content)
+                # Keep payload-free markers with the text that supplied them,
+                # as in Responses normalization. The shared prompt formatter
+                # assigns them to turns; image payloads stay in processor order.
+                msg["content"] = (
+                    content_parts
+                    if has_images
+                    else extract_text_from_content(message.content)
+                )
             else:
                 msg["content"] = message.content
 

--- a/mlx_vlm/tests/test_prompt_utils.py
+++ b/mlx_vlm/tests/test_prompt_utils.py
@@ -877,6 +877,85 @@ def test_apply_chat_template_keeps_enable_thinking_only_for_other_templates():
 class TestModelSpecificPromptContracts:
     """Guard model-specific multimodal message formats from regressions."""
 
+    @pytest.mark.parametrize("model_type", ["phi3_v", "phi4mm"])
+    @pytest.mark.parametrize(
+        ("first_count", "first_markers", "second_marker"),
+        [
+            (1, "<|image_1|>", "<|image_2|>"),
+            (2, "<|image_1|><|image_2|>", "<|image_3|>"),
+        ],
+    )
+    def test_numbered_images_keep_conversation_wide_indices(
+        self, model_type, first_count, first_markers, second_marker
+    ):
+        messages = [
+            {
+                "role": "user",
+                "content": [{"type": "image"} for _ in range(first_count)]
+                + [{"type": "text", "text": "First."}],
+            },
+            {"role": "assistant", "content": "Ready."},
+            {
+                "role": "user",
+                "content": [
+                    {"type": "image"},
+                    {"type": "text", "text": "Second."},
+                ],
+            },
+            "Compare.",
+        ]
+
+        result = apply_chat_template(
+            None,
+            {"model_type": model_type},
+            messages,
+            return_messages=True,
+            num_images=first_count + 1,
+        )
+
+        assert result == [
+            {"role": "user", "content": first_markers + "First."},
+            {"role": "assistant", "content": "Ready."},
+            {"role": "user", "content": second_marker + "Second."},
+            {"role": "user", "content": "Compare."},
+        ]
+
+    @pytest.mark.parametrize("model_type", ["llava_next", "paligemma"])
+    def test_single_image_models_reject_images_across_separate_turns(self, model_type):
+        messages = [
+            {"role": "user", "content": [{"type": "image"}]},
+            {"role": "assistant", "content": "Ready."},
+            {"role": "user", "content": [{"type": "image"}]},
+        ]
+
+        with pytest.raises(ValueError, match="does not support multi-image chat"):
+            apply_chat_template(
+                None,
+                {"model_type": model_type},
+                messages,
+                return_messages=True,
+                num_images=2,
+            )
+
+    def test_unmarked_images_still_belong_to_last_user_turn(self):
+        result = apply_chat_template(
+            None,
+            {"model_type": "phi3_v"},
+            [
+                {"role": "user", "content": "First."},
+                {"role": "assistant", "content": "Ready."},
+                "Compare.",
+            ],
+            return_messages=True,
+            num_images=2,
+        )
+
+        assert result == [
+            {"role": "user", "content": "First."},
+            {"role": "assistant", "content": "Ready."},
+            {"role": "user", "content": "<|image_1|><|image_2|>Compare."},
+        ]
+
     def test_ernie4_5_vl_uses_image_url_before_text(self):
         from mlx_vlm.prompt_utils import apply_chat_template
 

--- a/mlx_vlm/tests/test_server.py
+++ b/mlx_vlm/tests/test_server.py
@@ -7,7 +7,9 @@ import os
 import sys
 import time
 from concurrent.futures import ThreadPoolExecutor
+from copy import deepcopy
 from dataclasses import dataclass
+from io import BytesIO
 from pathlib import Path
 from queue import Queue
 from threading import Event, Lock, Thread
@@ -20,6 +22,7 @@ import pytest
 from fastapi.testclient import TestClient
 from PIL import Image
 from transformers.utils.chat_parsing import ResponseParser, parse_response
+from transformers.utils.chat_template_utils import render_jinja_template
 
 import mlx_vlm.reranker_loader as reranker_loader
 import mlx_vlm.server as server
@@ -37,6 +40,373 @@ from mlx_vlm.prompt_utils import apply_chat_template
 from mlx_vlm.server.runtime_config import RuntimeConfig
 from mlx_vlm.tokenizer_utils import SPMStreamingDetokenizer, _ServerTokenStreamer
 from mlx_vlm.tool_parsers import _infer_tool_parser, minicpm5
+from mlx_vlm.utils import prepare_inputs
+
+
+class _ImageAssociationProcessor:
+    # Synthetic template: observe the real request/normalizer output without
+    # downloading a tokenizer or a model. Text and media remain distinguishable.
+    chat_template = """{%- for message in messages -%}
+{{ '<' + message.role + '>' }}
+{%- if message.content is string -%}{{ message.content }}
+{%- else -%}{%- for part in message.content -%}
+{%- if part.type == 'text' -%}{{ part.text }}
+{%- else -%}{{ '<' + part.type + '>' }}{%- endif -%}
+{%- endfor -%}{%- endif -%}
+{{ '</' + message.role + '>' }}
+{%- endfor -%}"""
+
+    def apply_chat_template(self, messages, **kwargs):
+        self.messages = deepcopy(messages)
+        self.template_kwargs = kwargs
+        rendered, _ = render_jinja_template(
+            [messages], chat_template=self.chat_template, **kwargs
+        )
+        return rendered[0]
+
+    def __call__(self, text, images, **kwargs):
+        self.image_colors = [image.getpixel((0, 0)) for image in images]
+        return {"input_ids": [[1]], "attention_mask": [[1]]}
+
+
+def _association_image(color, kind="image_url"):
+    buffer = BytesIO()
+    Image.new("RGB", (2, 2), color).save(buffer, format="PNG")
+    url = "data:image/png;base64," + base64.b64encode(buffer.getvalue()).decode()
+    return {"type": kind, "image_url": {"url": url} if kind == "image_url" else url}
+
+
+@pytest.fixture
+def image_chat(monkeypatch):
+    processor = _ImageAssociationProcessor()
+    config = {"model_type": "qwen3_5"}
+    calls = []
+
+    def generate(**kwargs):
+        calls.append(kwargs)
+        # Exercise real image decoding and processor input ordering, stopping
+        # before any model computation. Mixed-media tests inspect side channels.
+        if kwargs["image"] and not kwargs["audio"] and not kwargs["video"]:
+            prepare_inputs(processor, images=kwargs["image"], prompts=kwargs["prompt"])
+        return GenerationResult(text="ACK", prompt_tokens=1, generation_tokens=1)
+
+    monkeypatch.setattr(server.runtime, "response_generator", None)
+    monkeypatch.setattr(
+        server, "get_cached_model", lambda *args: (object(), processor, config)
+    )
+    monkeypatch.setattr(server, "generate", generate)
+    # No lifespan/model preload and no listening socket.
+    client = TestClient(server.app)
+    return SimpleNamespace(
+        client=client, processor=processor, config=config, calls=calls
+    )
+
+
+@pytest.mark.parametrize(
+    "model_type", ["qwen2_vl", "qwen2_5_vl", "qwen3_vl", "qwen3_5", "qwen3_5_moe"]
+)
+@pytest.mark.parametrize("kind", ["image_url", "input_image"])
+def test_chat_image_association_resubmitted_history(image_chat, model_type, kind):
+    image_chat.config["model_type"] = model_type
+    a, b = _association_image("red", kind), _association_image("blue", kind)
+    messages = [{"role": "user", "content": [{"type": "text", "text": "FIRST"}, a]}]
+    # A client resubmits the entire history on each follow-up, then adds B.
+    for followup, expected_turns, colors, images in [
+        (None, [1], [(255, 0, 0)], [a]),
+        ("FOLLOWUP", [1, 0], [(255, 0, 0)], [a]),
+        (
+            [{"type": "input_text", "text": "SECOND"}, b],
+            [1, 0, 1],
+            [(255, 0, 0), (0, 0, 255)],
+            [a, b],
+        ),
+    ]:
+        if followup is not None:
+            messages.extend(
+                [
+                    {"role": "assistant", "content": "ACK"},
+                    {"role": "user", "content": followup},
+                ]
+            )
+        payload = {"model": "synthetic", "messages": messages}
+        original = deepcopy(payload)
+        response = image_chat.client.post("/v1/chat/completions", json=payload)
+        assert response.status_code == 200, response.text
+        prompt = image_chat.calls[-1]["prompt"]
+        turns = [part.split("</user>")[0] for part in prompt.split("<user>")[1:]]
+        assert [turn.count("<image>") for turn in turns] == expected_turns
+        assert "FIRST" in turns[0]
+        if followup is not None:
+            assert "FOLLOWUP" in turns[1]
+        if len(turns) == 3:
+            assert "SECOND" in turns[2]
+        assert prompt.count("<image>") == len(images)
+        assert image_chat.calls[-1]["image"] == [
+            part["image_url"]["url"] if kind == "image_url" else part["image_url"]
+            for part in images
+        ]
+        assert image_chat.processor.image_colors == colors
+        assert "data:image" not in prompt
+        assert payload == original
+
+
+def test_chat_image_association_multiple_images_and_caller_unchanged(image_chat):
+    a, b = _association_image("red"), _association_image("blue", "input_image")
+    request = server.ChatRequest(
+        model="synthetic",
+        messages=[
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "BEFORE"},
+                    a,
+                    {"type": "input_text", "text": "BETWEEN"},
+                    b,
+                    {"type": "text", "text": "AFTER"},
+                ],
+            },
+            {"role": "assistant", "content": "ACK"},
+            {"role": "user", "content": "FOLLOWUP"},
+        ],
+    )
+    original = request.model_dump()
+    asyncio.run(server.chat_completions_endpoint(request, SimpleNamespace(headers={})))
+    assert image_chat.calls[-1]["prompt"] == (
+        "<user><image><image>BEFORE BETWEEN AFTER</user>"
+        "<assistant>ACK</assistant><user>FOLLOWUP</user>"
+    )
+    assert image_chat.calls[-1]["image"] == [a["image_url"]["url"], b["image_url"]]
+    assert image_chat.processor.image_colors == [(255, 0, 0), (0, 0, 255)]
+    assert request.model_dump() == original
+
+
+@pytest.mark.parametrize(
+    "choice", ["required", {"type": "function", "function": {"name": "inspect"}}]
+)
+@pytest.mark.parametrize("system", [False, True])
+def test_chat_image_association_tool_choice_and_reasoning(image_chat, choice, system):
+    messages = [{"role": "system", "content": "SYSTEM"}] if system else []
+    messages += [
+        {"role": "user", "content": "FIRST"},
+        {
+            "role": "assistant",
+            "content": None,
+            "reasoning_content": "NOTE",
+            "tool_calls": [
+                {
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {"name": "inspect", "arguments": '{"value": 1}'},
+                }
+            ],
+        },
+        {"role": "tool", "tool_call_id": "call_1", "content": "RESULT"},
+        {
+            "role": "user",
+            "content": [{"type": "text", "text": "SECOND"}, _association_image("red")],
+        },
+    ]
+    request = server.ChatRequest(
+        model="synthetic",
+        messages=messages,
+        tools=[
+            {
+                "type": "function",
+                "function": {"name": "inspect", "parameters": {"type": "object"}},
+            }
+        ],
+        tool_choice=choice,
+    )
+    original = request.model_dump()
+    asyncio.run(server.chat_completions_endpoint(request, SimpleNamespace(headers={})))
+    prompt = image_chat.calls[-1]["prompt"]
+    assert "<user>FIRST</user>" in prompt
+    assert "<user><image>SECOND" in prompt
+    assert "You must call" in prompt.split("<user>")[-1]
+    formatted = image_chat.processor.messages
+    assistant = formatted[2 if system else 1]
+    assert assistant["reasoning_content"] == "NOTE"
+    assert assistant["tool_calls"][0]["function"]["arguments"] == {"value": 1}
+    assert formatted[3 if system else 2]["tool_call_id"] == "call_1"
+    assert image_chat.processor.template_kwargs["tool_choice"] == choice
+    assert prompt.count("<image>") == 1
+    assert request.model_dump() == original
+
+
+@pytest.mark.parametrize(
+    "content",
+    [
+        "TEXT",
+        [{"type": "text", "text": "TEXT"}],
+        [{"type": "input_text", "text": "TEXT"}],
+    ],
+)
+@pytest.mark.parametrize("model_type", ["qwen3_5", "laguna", "unknown_text_model"])
+def test_chat_image_association_text_controls(image_chat, content, model_type):
+    image_chat.config["model_type"] = model_type
+    response = image_chat.client.post(
+        "/v1/chat/completions",
+        json={"model": "synthetic", "messages": [{"role": "user", "content": content}]},
+    )
+    assert response.status_code == 200
+    assert image_chat.calls[-1]["prompt"] == "<user>TEXT</user>"
+    assert image_chat.calls[-1]["image"] == []
+
+
+@pytest.mark.parametrize(
+    "part", [{"type": "image", "image": "x"}, {"type": "image_url", "image_url": "x"}]
+)
+def test_chat_image_association_rejects_unsupported_schema_forms(image_chat, part):
+    response = image_chat.client.post(
+        "/v1/chat/completions",
+        json={"model": "synthetic", "messages": [{"role": "user", "content": [part]}]},
+    )
+    assert response.status_code == 422
+    assert image_chat.calls == []
+
+
+@pytest.mark.parametrize(
+    "model_type, expected",
+    [
+        ("deepseek_v4", "BEFORE<image>AFTER"),
+        ("gemma3", "BEFORE AFTER<start_of_image>"),
+        ("laguna", "BEFORE AFTER"),
+    ],
+)
+def test_chat_image_association_other_formats(image_chat, model_type, expected):
+    image_chat.config["model_type"] = model_type
+    response = image_chat.client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "synthetic",
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": "BEFORE"},
+                        _association_image("red"),
+                        {"type": "text", "text": "AFTER"},
+                    ],
+                },
+                {"role": "user", "content": "FOLLOWUP"},
+            ],
+        },
+    )
+    assert response.status_code == 200, response.text
+    assert (
+        image_chat.calls[-1]["prompt"]
+        == f"<user>{expected}</user><user>FOLLOWUP</user>"
+    )
+    assert image_chat.processor.image_colors == [(255, 0, 0)]
+
+
+@pytest.mark.parametrize(
+    "model_type, expected",
+    [
+        ("paligemma", "<image>FOLLOWUP"),
+        ("florence2", "FOLLOWUP"),
+        ("falcon_ocr", "FOLLOWUP"),
+    ],
+)
+def test_chat_image_association_last_message_controls(image_chat, model_type, expected):
+    image_chat.config["model_type"] = model_type
+    response = image_chat.client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "synthetic",
+            "messages": [
+                {"role": "user", "content": [_association_image("red")]},
+                {"role": "user", "content": "FOLLOWUP"},
+            ],
+        },
+    )
+    assert response.status_code == 200, response.text
+    assert image_chat.calls[-1]["prompt"] == expected
+    assert image_chat.processor.image_colors == [(255, 0, 0)]
+
+
+@pytest.mark.parametrize("with_image", [False, True])
+def test_chat_image_association_audio_side_channel(image_chat, with_image):
+    content = [
+        {"type": "text", "text": "FIRST"},
+        {
+            "type": "input_audio",
+            "input_audio": {
+                "data": base64.b64encode(b"synthetic-audio").decode(),
+                "format": "wav",
+            },
+        },
+    ]
+    if with_image:
+        content.append(_association_image("red"))
+    response = image_chat.client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "synthetic",
+            "messages": [
+                {"role": "user", "content": content},
+                {"role": "user", "content": "FOLLOWUP"},
+            ],
+        },
+    )
+    assert response.status_code == 200, response.text
+    call = image_chat.calls[-1]
+    assert call["prompt"] == (
+        f"<user>{'<image>' if with_image else ''}FIRST</user>"
+        "<user>FOLLOWUP<audio></user>"
+    )
+    assert len(call["image"]) == int(with_image)
+    assert len(call["audio"]) == 1
+    assert call["audio"][0].getvalue() == b"synthetic-audio"
+
+
+@pytest.mark.parametrize("native", [False, True])
+def test_chat_image_association_video_side_channel(image_chat, monkeypatch, native):
+    from mlx_vlm.generate import video as video_utils
+
+    frame = Image.new("RGB", (2, 2), "blue")
+    if native:
+        image_chat.processor.video_processor = object()
+        image_chat.processor.process = lambda text, images, videos: None
+    else:
+        monkeypatch.setattr(
+            video_utils, "sample_video_frames", lambda *a, **k: ([frame], 2.0)
+        )
+    a = _association_image("red")
+    response = image_chat.client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "synthetic",
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": "FIRST"},
+                        a,
+                        {"type": "video", "video": "synthetic.mp4"},
+                    ],
+                },
+                {"role": "user", "content": "FOLLOWUP"},
+            ],
+        },
+    )
+    assert response.status_code == 200, response.text
+    call = image_chat.calls[-1]
+    assert call["image"][0] == a["image_url"]["url"]
+    if native:
+        # Existing native video formatting repeats videos on each message.
+        # This image fix does not establish video turn association.
+        assert (
+            call["prompt"]
+            == "<user><image><video>FIRST</user><user><video>FOLLOWUP</user>"
+        )
+        assert call["video"] == ["synthetic.mp4"]
+        assert len(call["image"]) == 1
+    else:
+        assert call["prompt"] == "<user><image>FIRST</user><user><image>FOLLOWUP</user>"
+        assert call["image"][1] is frame
+        assert call["video"] == []
+        assert image_chat.processor.image_colors == [(255, 0, 0), (0, 0, 255)]
 
 
 def test_response_generator_prefill_step_override_wins_over_environment(monkeypatch):


### PR DESCRIPTION
Chat Completions currently flattens user content before the shared prompt formatter can associate images with turns. Resubmitting image A, an assistant reply and a text-only follow-up moves A's marker to the follow-up. Two separate image turns become zero markers on the first and two on the second.

Fixes https://github.com/Blaizzy/mlx-vlm/issues/2211.

This preserves canonical text and payload-free image markers in the original content traversal while collecting image inputs in the same order. It builds on Lucas Newman's #1806 and the earlier #1761 approach for Responses. Tool-choice instructions also work when the latest user message contains images, without modifying the caller's list.

### Compatibility

The fix belongs to shared Chat normalization, not a Qwen3.5 endpoint workaround. Existing model formatters still decide marker/text order; DeepSeek-V4 retains supported interleaving. Three small prompt-formatting safeguards keep the shared change compatible:

- Phi3-V/Phi4MM image indices continue across turns instead of restarting at 1.
- Single-image models still reject more than one image across the request.
- Models that discard history retain their last-message behavior, including PaliGemma's image prefix.

Text-only strings/lists, tool metadata and tool-bearing assistant reasoning remain covered by unchanged controls. Audio/video inputs retain their existing side channels: audio and unmarked video fallback frames keep last-user allocation, and native video formatting is unchanged. This does not add audio/video turn association or multi-turn support to models that discard history.

### Validation

Base: `8f5dc3ddddbb8d7dd2b88ac51015def6f81fed21`.

The final focused tests produce **22 failures / 21 passes on the base**, then **43 passes with the fix**. They exercise real schemas, in-process HTTP normalization and Jinja rendering, plus real decoding of tiny synthetic red/blue PNGs into a recording processor. Assertions check per-turn markers, exact image identity/order, normalized text, unchanged callers, resubmitted history, tools, rejected schema forms and mixed-media controls.

Broader CPU regression: **488 passed**, with two dependency deprecation warnings. Existing video-resolution controls: **3 passed**. All configured pre-commit hooks (Black, isort, autoflake) pass.

From the repository root with an editable install, pytest, httpx and pre-commit:

```sh
python -c 'import mlx.core as mx; mx.set_default_device(mx.cpu); import pytest; raise SystemExit(pytest.main(["mlx_vlm/tests/test_server.py", "mlx_vlm/tests/test_prompt_utils.py", "mlx_vlm/tests/test_responses_state.py", "-q"]))'
python -c 'import mlx.core as mx; mx.set_default_device(mx.cpu); import pytest; raise SystemExit(pytest.main(["mlx_vlm/tests/test_generate.py", "-q", "-k", "resolve_video_inputs"]))'
pre-commit run --all-files
```

Additional in-process HTTP checks rendered six pinned official templates: **36 image failures / 12 text passes on the base**, then **48 passes with the fix**. The checkpoints were [Qwen2-VL-2B](https://huggingface.co/Qwen/Qwen2-VL-2B-Instruct/tree/895c3a49bc3fa70a340399125c650a463535e71c), [Qwen2.5-VL-7B](https://huggingface.co/Qwen/Qwen2.5-VL-7B-Instruct/tree/cc594898137f460bfe9f0759e9844b3ce807cfb5), [Qwen3-VL-2B](https://huggingface.co/Qwen/Qwen3-VL-2B-Instruct/tree/89644892e4d85e24eaac8bacfd4f463576704203), [Qwen3.5-4B](https://huggingface.co/Qwen/Qwen3.5-4B/tree/851bf6e806efd8d0a36b00ddf55e13ccb7b8cd0a), [Qwen3.5-35B-A3B](https://huggingface.co/Qwen/Qwen3.5-35B-A3B/tree/59d61f3ce65a6d9863b86d2e96597125219dc754), and [Qwen3.8-27B](https://huggingface.co/Qwen/Qwen3.8-27B/tree/1d4bf0f2ff6012fd82039f2fa52739d0dd7c60c0). These use `qwen2_vl`, `qwen2_5_vl`, `qwen3_vl`, `qwen3_5` and `qwen3_5_moe`. Only public config/template/license files were fetched; they are not vendored here.

No model weights or inference were used. The full hardware-dependent suite was not run locally; upstream CI and maintainer review remain required. These are request/rendering checks, not evidence of model vision accuracy or performance improvement. Correcting prompt ownership changes prompt/cache prefixes.

### Related work

#1806 supplies the existing allocation mechanism. #833/#913 cover older multi-turn handling; #1941 repairs surplus processor placeholders, which does not fix this equal-count failure. #1925 and #1933 concern other image/cache symptoms. The open reasoning contributions #2199/#2200 and issue #2201 do not supply or require this fix; this branch is based directly on upstream main.

AI assistance: Codex assisted with implementation, regression tests and this description. A separate agent reviewed the public diff and synthetic evidence before submission. Maintainer review is still pending.
