### PR TITLE
Preserve original Chat history when replaying through Responses

### DIFF
--- a/mlx_vlm/apc.py
+++ b/mlx_vlm/apc.py
@@ -4672,6 +4672,11 @@ def apc_lookup_plan(
         return None
 
     matched, prefix_len = manager.lookup_prefix(ids_list, extra_hash=extra_hash)
+    if prefix_len == n:
+        # Recompute the final block to obtain logits for the first output token.
+        manager.release(matched[-1:])
+        matched = matched[:-1]
+        prefix_len -= manager.block_size
     if prefix_len > 0 and prefix_has_media(prefix_len):
         manager.release(matched)
         matched = []

--- a/mlx_vlm/apc_adapters.py
+++ b/mlx_vlm/apc_adapters.py
@@ -222,7 +222,12 @@ def register_default_capabilities() -> None:
         c.SimpleKVCache,
     ):
         register_capability(cls, Capability.PAGEABLE)
-    for cls in (c.RotatingKVCache, c.BatchRotatingKVCache, c.ChunkedKVCache):
+    for cls in (
+        c.RotatingKVCache,
+        c.BatchRotatingKVCache,
+        c.ChunkedKVCache,
+        c.BatchChunkedKVCache,
+    ):
         register_capability(cls, Capability.WINDOWED)
     for cls in (
         c.ArraysCache,
@@ -427,7 +432,7 @@ class ChunkedKVCacheCloneAdapter:
     def merge_rows(self, caches, prefix_lens):
         from .models import cache as lm
 
-        return lm.BatchKVCache.merge(caches)
+        return lm.BatchChunkedKVCache.merge(caches)
 
 
 class ArraysCacheCloneAdapter:
@@ -575,6 +580,8 @@ def clone_cache_entry(c, *, min_capacity_tokens, eval_targets):
         if not c.is_single_row():
             return None
         if c.empty():
+            if isinstance(c, lm.BatchChunkedKVCache):
+                return c.extract(0)
             if isinstance(c, lm.BatchRotatingKVCache):
                 return lm.RotatingKVCache(max_size=int(c.max_size))
             return lm.KVCache()

--- a/mlx_vlm/apc_coordinator.py
+++ b/mlx_vlm/apc_coordinator.py
@@ -32,7 +32,12 @@ class APCCoordinator:
 
     @property
     def enabled(self) -> bool:
-        return self.manager is not None and self.plan.restorable
+        language_model = getattr(self.model, "language_model", self.model)
+        return (
+            self.manager is not None
+            and self.plan.restorable
+            and getattr(language_model, "supports_prefix_cache", True)
+        )
 
     @property
     def strategy(self) -> Optional[str]:
@@ -148,6 +153,9 @@ class APCCoordinator:
                 pick["warm_cache"] if pick is not None else self.fresh_cache()
                 for pick in picks
             ]
+            if len(row_caches) == 1 and kv_quant_config is None:
+                # Keep native window/state semantics for an unpadded single row.
+                return row_caches[0], prefix_lens[0]
             return make_warm_batch_exact_cache_multi(
                 row_caches,
                 prefix_lens,

--- a/mlx_vlm/generate/ar.py
+++ b/mlx_vlm/generate/ar.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import contextlib
 import functools
 import logging
+import math
 import os
 import sys
 import time
@@ -953,7 +954,7 @@ def _make_cache(
         elif isinstance(c, cache.ChunkedKVCache):
             if kv_bits is not None and quantize:
                 return _make_quant_cache(left_padding)
-            return cache.BatchKVCache(left_padding)
+            return cache.BatchChunkedKVCache(c.chunk_size, left_padding)
         elif isinstance(c, cache.SimpleKVCache):
             if kv_bits is not None and quantize:
                 return _make_quant_cache(left_padding)
@@ -2597,13 +2598,28 @@ class BatchGenerator:
             ),
         }
         if coordinator is not None:
-            return coordinator.lookup(ids_list, **lookup_kwargs)
-        return _apc.apc_lookup_plan(
-            self.apc_manager,
-            ids_list,
-            apc_mode=getattr(self, "apc_mode", "block"),
-            **lookup_kwargs,
-        )
+            pick = coordinator.lookup(ids_list, **lookup_kwargs)
+        else:
+            pick = _apc.apc_lookup_plan(
+                self.apc_manager,
+                ids_list,
+                apc_mode=getattr(self, "apc_mode", "block"),
+                **lookup_kwargs,
+            )
+        prefill_step = getattr(self, "prefill_step_size", None)
+        if pick and pick.get("matched_blocks") and prefill_step and prefill_step > 0:
+            block_size = self.apc_manager.block_size
+            alignment = math.lcm(block_size, prefill_step)
+            prefix_len = pick["prefix_len"] // alignment * alignment
+            keep = prefix_len // block_size
+            # Preserve cold prefill chunk boundaries: changing the suffix shape
+            # can change rounded logits and greedy output even with identical KV.
+            self.apc_manager.release(pick["matched_blocks"][keep:])
+            if not prefix_len:
+                return None
+            pick["matched_blocks"] = pick["matched_blocks"][:keep]
+            pick["prefix_len"] = prefix_len
+        return pick
 
     def _build_mixed_prompt_batch(
         self, sequences: List[tuple]

--- a/mlx_vlm/models/cache.py
+++ b/mlx_vlm/models/cache.py
@@ -1244,18 +1244,16 @@ class ChunkedKVCache(_BaseCache):
 
     @property
     def state(self):
-        if self.offset == self.keys.shape[2]:
-            return self.keys, self.values
-        else:
-            return (
-                self.keys[..., : self.offset, :],
-                self.values[..., : self.offset, :],
-            )
+        if self.keys is None:
+            return None, None
+        length = self.offset - self.start_position
+        return self.keys[..., :length, :], self.values[..., :length, :]
 
     @state.setter
     def state(self, v):
         self.keys, self.values = v
-        self.offset = self.keys.shape[2]
+        self.start_position = 0
+        self.offset = 0 if self.keys is None else self.keys.shape[2]
 
     def is_trimmable(self):
         return True
@@ -1271,7 +1269,9 @@ class ChunkedKVCache(_BaseCache):
 
     @meta_state.setter
     def meta_state(self, v):
+        length = self.offset - self.start_position
         self.chunk_size, self.start_position = map(int, v)
+        self.offset = self.start_position + length
 
     def empty(self):
         return self.keys is None
@@ -1467,7 +1467,7 @@ class BatchKVCache(_BaseCache):
     @property
     def state(self):
         k, v = self.keys, self.values
-        if self._idx < k.shape[2]:
+        if k is not None and self._idx < k.shape[2]:
             k = k[..., : self._idx, :]
             v = v[..., : self._idx, :]
         return k, v, self.offset, self.left_padding
@@ -1475,7 +1475,7 @@ class BatchKVCache(_BaseCache):
     @state.setter
     def state(self, v):
         self.keys, self.values, self.offset, self.left_padding = v
-        self._idx = self.keys.shape[2]
+        self._idx = self.keys.shape[2] if self.keys is not None else 0
 
     def is_trimmable(self):
         return True
@@ -1617,6 +1617,87 @@ class BatchKVCache(_BaseCache):
         if self.keys is None:
             return 0
         return self.keys.nbytes + self.values.nbytes
+
+
+class BatchChunkedKVCache(BatchKVCache):
+    def __init__(self, chunk_size, left_padding):
+        super().__init__(left_padding)
+        self.chunk_size = chunk_size
+
+    def maybe_trim_front(self):
+        trim = max(0, self._idx - self.chunk_size)
+        if trim and self.keys is not None:
+            self.keys = self.keys[..., trim : self._idx, :]
+            self.values = self.values[..., trim : self._idx, :]
+            self.left_padding = mx.maximum(self.left_padding - trim, 0)
+            self._idx -= trim
+
+    def make_chunk_mask(self, length):
+        query_positions = self.offset[:, None, None] + mx.arange(length)[None, :, None]
+        key_columns = mx.arange(self._idx + length)[None, None, :]
+        key_positions = self.offset[:, None, None] - self._idx + key_columns
+        mask = (key_positions <= query_positions) & (
+            key_positions // self.chunk_size == query_positions // self.chunk_size
+        )
+        mask &= key_columns >= self.left_padding[:, None, None]
+        return mask[:, None]
+
+    @property
+    def meta_state(self):
+        return str(self.chunk_size)
+
+    @meta_state.setter
+    def meta_state(self, value):
+        self.chunk_size = int(value)
+
+    def extract(self, idx):
+        cache = ChunkedKVCache(self.chunk_size)
+        padding = int(self.left_padding[idx].item())
+        cache.offset = int(self.offset[idx].item())
+        length = max(0, self._idx - padding)
+        cache.start_position = cache.offset - length
+        if self.keys is not None:
+            cache.keys = mx.contiguous(self.keys[idx : idx + 1, :, padding : self._idx])
+            cache.values = mx.contiguous(
+                self.values[idx : idx + 1, :, padding : self._idx]
+            )
+        return cache
+
+    def extend(self, other):
+        if (
+            not isinstance(other, BatchChunkedKVCache)
+            or other.chunk_size != self.chunk_size
+        ):
+            raise ValueError("Chunked caches must have the same window size")
+        super().extend(other)
+
+    @classmethod
+    def merge(cls, caches):
+        if any(c.chunk_size != caches[0].chunk_size for c in caches):
+            raise ValueError("Chunked caches must have the same window size")
+        lengths = [
+            c.offset - c.start_position if c.keys is not None else 0 for c in caches
+        ]
+        width = max(lengths)
+        padding = [width - length for length in lengths]
+        result = cls(caches[0].chunk_size, padding)
+        result.offset = mx.array([c.offset for c in caches])
+        result._idx = width
+        if width:
+            source = next(c for c in caches if c.keys is not None)
+            result.keys = mx.zeros(
+                (len(caches), source.keys.shape[1], width, source.keys.shape[3]),
+                source.keys.dtype,
+            )
+            result.values = mx.zeros(
+                (len(caches), source.values.shape[1], width, source.values.shape[3]),
+                source.values.dtype,
+            )
+            for i, (cache, length, pad) in enumerate(zip(caches, lengths, padding)):
+                if length:
+                    result.keys[i : i + 1, :, pad:] = cache.keys[..., :length, :]
+                    result.values[i : i + 1, :, pad:] = cache.values[..., :length, :]
+        return result
 
 
 class BatchRotatingKVCache(_BaseCache):

--- a/mlx_vlm/models/ernie4_5/__init__.py
+++ b/mlx_vlm/models/ernie4_5/__init__.py
@@ -2,3 +2,8 @@ from .config import ModelConfig
 from .ernie4_5 import Model
 
 __all__ = ["Model", "ModelConfig"]
+
+from ..base import install_auto_processor_patch
+from .tokenization_ernie4_5 import Ernie45Tokenizer
+
+install_auto_processor_patch("ernie4_5", Ernie45Tokenizer)

--- a/mlx_vlm/models/ernie4_5/tokenization_ernie4_5.py
+++ b/mlx_vlm/models/ernie4_5/tokenization_ernie4_5.py
@@ -18,10 +18,9 @@ from typing import Dict, Optional, Tuple, Union
 
 import numpy as np
 import sentencepiece as spm
-import torch
 from transformers.tokenization_utils import PreTrainedTokenizer
 from transformers.tokenization_utils_base import PaddingStrategy
-from transformers.utils import logging
+from transformers.utils import is_torch_tensor, logging
 
 logger = logging.get_logger(__name__)
 
@@ -190,7 +189,7 @@ class Ernie45Tokenizer(PreTrainedTokenizer):
                 and encoded_inputs["attention_mask"] is not None
             ):
                 attention_mask = encoded_inputs.pop("attention_mask")
-                if isinstance(attention_mask, torch.Tensor):
+                if is_torch_tensor(attention_mask):
                     attention_mask = attention_mask.numpy()
                 elif isinstance(attention_mask, list):
                     attention_mask = np.array(attention_mask)

--- a/mlx_vlm/models/ernie4_5/tokenization_ernie4_5.py
+++ b/mlx_vlm/models/ernie4_5/tokenization_ernie4_5.py
@@ -1,0 +1,237 @@
+# Copyright (c) 2025 Baidu, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+from shutil import copyfile
+from typing import Dict, Optional, Tuple, Union
+
+import numpy as np
+import sentencepiece as spm
+import torch
+from transformers.tokenization_utils import PreTrainedTokenizer
+from transformers.tokenization_utils_base import PaddingStrategy
+from transformers.utils import logging
+
+logger = logging.get_logger(__name__)
+
+
+class Ernie45Tokenizer(PreTrainedTokenizer):
+    vocab_files_names = {"vocab_file": "tokenizer.model"}
+    model_input_names = ["input_ids", "position_ids", "attention_mask", "labels"]
+    padding_side = "right"
+
+    def __init__(
+        self,
+        vocab_file,
+        bos_token="<s>",
+        cls_token="<cls>",
+        eos_token="</s>",
+        mask_token="<mask:0>",
+        pad_token="<pad>",
+        sep_token="<sep>",
+        unk_token="<unk>",
+        additional_special_tokens=None,
+        split_special_tokens=False,
+        tokenizer_alpha=None,
+        **kwargs,
+    ):
+        self.vocab_file = vocab_file
+        self.sp_model = spm.SentencePieceProcessor()
+        self.sp_model.Load(vocab_file)
+        self.tokenizer_alpha = tokenizer_alpha
+        if additional_special_tokens is None:
+            additional_special_tokens = ["<mask:1>", "<mask:7>"]
+        super().__init__(
+            bos_token=bos_token,
+            cls_token=cls_token,
+            eos_token=eos_token,
+            mask_token=mask_token,
+            pad_token=pad_token,
+            sep_token=sep_token,
+            unk_token=unk_token,
+            additional_special_tokens=additional_special_tokens,
+            split_special_tokens=split_special_tokens,
+            **kwargs,
+        )
+
+    @property
+    def vocab_size(self):
+        return self.sp_model.vocab_size()
+
+    def get_vocab(self):
+        vocab = {self.convert_ids_to_tokens(i): i for i in range(self.vocab_size)}
+        vocab.update(self.added_tokens_encoder)
+        return vocab
+
+    def _tokenize(self, text):
+        if self.tokenizer_alpha is not None:
+            return self.sp_model.encode_as_pieces(
+                text, enable_sampling=True, nbest_size=-1, alpha=self.tokenizer_alpha
+            )
+        else:
+            return self.sp_model.encode_as_pieces(text)
+
+    def _convert_token_to_id(self, token):
+        return self.sp_model.piece_to_id(token)
+
+    def _convert_id_to_token(self, id):
+        if id >= self.vocab_size:
+            return self.unk_token
+        else:
+            return self.sp_model.id_to_piece(id)
+
+    def convert_tokens_to_string(self, tokens):
+        current_sub_tokens = []
+        out_string = ""
+        prev_is_special = False
+        for token in tokens:
+            if token in self.all_special_tokens:
+                if not prev_is_special:
+                    out_string += " "
+                out_string += self.sp_model.decode(current_sub_tokens) + token
+                prev_is_special = True
+                current_sub_tokens = []
+            else:
+                current_sub_tokens.append(token)
+                prev_is_special = False
+        out_string += self.sp_model.decode(current_sub_tokens)
+        return out_string
+
+    def build_inputs_with_special_tokens(self, token_ids_0, token_ids_1=None):
+        output = token_ids_0
+        last_cls_index = -1
+        last_sep_index = -1
+        if self.cls_token_id in output:
+            last_cls_index = len(output) - output[::-1].index(self.cls_token_id) - 1
+        if self.sep_token_id in output:
+            last_sep_index = len(output) - output[::-1].index(self.sep_token_id) - 1
+        if last_cls_index > last_sep_index:
+            next_token_id = self.sep_token_id
+        elif last_sep_index > last_cls_index:
+            next_token_id = self.cls_token_id
+        else:
+            output = [self.cls_token_id] + token_ids_0 + [self.sep_token_id]
+            next_token_id = self.cls_token_id
+        output = [self.bos_token_id] + output
+        if token_ids_1 is not None:
+            output = output + token_ids_1 + [next_token_id]
+        return output
+
+    def get_special_tokens_mask(
+        self, token_ids_0, token_ids_1=None, already_has_special_tokens=False
+    ):
+        if already_has_special_tokens:
+            return super().get_special_tokens_mask(
+                token_ids_0, token_ids_1, already_has_special_tokens=True
+            )
+        if token_ids_1 is None:
+            return [1, 1] + [0] * len(token_ids_0) + [1]
+        return [1, 1] + [0] * len(token_ids_0) + [1] + [0] * len(token_ids_1) + [1]
+
+    def save_vocabulary(
+        self, save_directory, filename_prefix: Optional[str] = None
+    ) -> Tuple[str]:
+        if not os.path.isdir(save_directory):
+            logger.error(f"Vocabulary path ({save_directory}) should be a directory")
+            return
+        out_vocab_file = os.path.join(
+            save_directory,
+            (filename_prefix + "-" if filename_prefix else "")
+            + self.vocab_files_names["vocab_file"],
+        )
+        if os.path.abspath(self.vocab_file) != os.path.abspath(
+            out_vocab_file
+        ) and os.path.isfile(self.vocab_file):
+            copyfile(self.vocab_file, out_vocab_file)
+        elif not os.path.isfile(self.vocab_file):
+            with open(out_vocab_file, "wb") as fi:
+                content_spiece_model = self.sp_model.serialized_model_proto()
+                fi.write(content_spiece_model)
+        return (out_vocab_file,)
+
+    def _pad(
+        self,
+        encoded_inputs: Union[Dict],
+        max_length: Optional[int] = None,
+        padding_strategy: PaddingStrategy = PaddingStrategy.DO_NOT_PAD,
+        pad_to_multiple_of: Optional[int] = None,
+        padding_side: Optional[str] = None,
+        return_attention_mask: Optional[bool] = None,
+    ) -> dict:
+        if return_attention_mask is None:
+            return_attention_mask = "attention_mask" in self.model_input_names
+        if return_attention_mask:
+            required_input = encoded_inputs[self.model_input_names[0]]
+            if padding_strategy == PaddingStrategy.LONGEST:
+                max_length = len(required_input)
+            if (
+                max_length is not None
+                and pad_to_multiple_of is not None
+                and (max_length % pad_to_multiple_of != 0)
+            ):
+                max_length = (max_length // pad_to_multiple_of + 1) * pad_to_multiple_of
+            needs_to_be_padded = (
+                padding_strategy != PaddingStrategy.DO_NOT_PAD
+                and len(required_input) != max_length
+            )
+            if (
+                "attention_mask" in encoded_inputs
+                and encoded_inputs["attention_mask"] is not None
+            ):
+                attention_mask = encoded_inputs.pop("attention_mask")
+                if isinstance(attention_mask, torch.Tensor):
+                    attention_mask = attention_mask.numpy()
+                elif isinstance(attention_mask, list):
+                    attention_mask = np.array(attention_mask)
+                elif not isinstance(attention_mask, np.ndarray):
+                    raise ValueError(
+                        f"Unexpected type {type(attention_mask)} of attention_mask, "
+                    )
+            else:
+                attention_mask = np.tril(
+                    np.ones((len(required_input), len(required_input)), dtype=np.int64)
+                )
+                attention_mask = np.expand_dims(attention_mask, axis=0)
+            if needs_to_be_padded:
+                difference = max_length - len(required_input)
+                if self.padding_side == "right":
+                    if attention_mask.ndim == 1:
+                        pad_width = [(0, difference)]
+                    else:
+                        pad_width = [(0, 0), (0, difference), (0, difference)]
+                elif self.padding_side == "left":
+                    if attention_mask.ndim == 1:
+                        pad_width = [(difference, 0)]
+                    else:
+                        pad_width = [(0, 0), (difference, 0), (difference, 0)]
+                else:
+                    raise ValueError(
+                        "Invalid padding strategy:" + str(self.padding_side)
+                    )
+                attention_mask = np.pad(
+                    attention_mask,
+                    pad_width=pad_width,
+                    mode="constant",
+                    constant_values=0,
+                )
+        encoded_inputs = super()._pad(
+            encoded_inputs,
+            max_length,
+            padding_strategy=padding_strategy,
+            pad_to_multiple_of=pad_to_multiple_of,
+            return_attention_mask=False,
+        )
+        if return_attention_mask:
+            encoded_inputs["attention_mask"] = attention_mask.tolist()
+        return encoded_inputs

--- a/mlx_vlm/models/exaone4/__init__.py
+++ b/mlx_vlm/models/exaone4/__init__.py
@@ -1,4 +1,9 @@
+from transformers import PreTrainedTokenizerFast
+
+from ..base import install_auto_processor_patch
 from .config import ModelConfig
 from .exaone4 import Model
+
+install_auto_processor_patch("exaone4", PreTrainedTokenizerFast)
 
 __all__ = ["Model", "ModelConfig"]

--- a/mlx_vlm/models/florence2/language.py
+++ b/mlx_vlm/models/florence2/language.py
@@ -390,7 +390,7 @@ class Florence2LanguageModel(nn.Module):
             inputs_embeds = inputs_embeds * self.embed_scale
 
         if cache is None:
-            cache = [(SimpleKVCache(), SimpleKVCache())] * len(self.decoder.layers)
+            cache = [(SimpleKVCache(), SimpleKVCache()) for _ in self.decoder.layers]
 
         if encoder_outputs is None:
             encoder_outputs = self.encoder(

--- a/mlx_vlm/models/granite4_vision/granite4_vision.py
+++ b/mlx_vlm/models/granite4_vision/granite4_vision.py
@@ -265,7 +265,7 @@ class Model(nn.Module):
                 )
                 deepstack_list.append(full_feat)
 
-            deepstack_visual_embeds = mx.concatenate(deepstack_list, axis=0)
+            deepstack_visual_embeds = mx.stack(deepstack_list, axis=2)
         else:
             deepstack_visual_embeds = None
             target_layers = None

--- a/mlx_vlm/models/granite4_vision/language.py
+++ b/mlx_vlm/models/granite4_vision/language.py
@@ -159,7 +159,23 @@ class Granite(nn.Module):
                 h, cache[0] if cache and cache[0] is not None else cache
             )
 
-        prefill_offset = cache[0].offset if cache and cache[0] is not None else 0
+        if deepstack_visual_embeds is not None and visual_pos_masks is not None:
+            if not isinstance(deepstack_visual_embeds, mx.array):
+                deepstack_visual_embeds = mx.stack(deepstack_visual_embeds)
+            if deepstack_visual_embeds.ndim == 3:
+                deepstack_visual_embeds = deepstack_visual_embeds.transpose(1, 0, 2)[
+                    None
+                ]
+            if visual_pos_masks.shape[1] != h.shape[1]:
+                offset = cache[0].offset if cache and cache[0] is not None else 0
+                offsets = mx.array(offset).reshape(-1, 1)
+                positions = offsets + mx.arange(h.shape[1])[None]
+                visual_pos_masks = mx.take_along_axis(
+                    visual_pos_masks, positions, axis=1
+                )
+                deepstack_visual_embeds = mx.take_along_axis(
+                    deepstack_visual_embeds, positions[..., None, None], axis=1
+                )
 
         for layer_idx, (layer, c) in enumerate(zip(self.layers, cache)):
             if (
@@ -169,14 +185,8 @@ class Granite(nn.Module):
             ):
                 for feat_idx, target_layer in enumerate(deepstack_target_layers):
                     if layer_idx == target_layer:
-                        seq_len = h.shape[1]
-                        pos_mask = visual_pos_masks[
-                            ..., prefill_offset : prefill_offset + seq_len
-                        ]
-                        features = deepstack_visual_embeds[feat_idx][
-                            prefill_offset : prefill_offset + seq_len
-                        ]
-                        h = mx.where(pos_mask[..., None], h + features, h)
+                        features = deepstack_visual_embeds[:, :, feat_idx, :]
+                        h = mx.where(visual_pos_masks[..., None], h + features, h)
 
             h = layer(h, mask, c)
 

--- a/mlx_vlm/models/jina_vlm/jina_vlm.py
+++ b/mlx_vlm/models/jina_vlm/jina_vlm.py
@@ -232,16 +232,19 @@ class Model(nn.Module):
             else:
                 image_features = self.get_image_features(pixel_values, image_masks)
 
-            num_image, num_patch = image_features.shape[1:3]
-
+            image_batch_indices = kwargs.get("image_batch_indices")
+            if image_batch_indices is None:
+                image_batch_indices = mx.arange(batch_size)
+            num_groups = image_batch_indices.size
             image_features = image_features.reshape(
-                batch_size, num_image * num_patch, -1
+                num_groups, -1, inputs_embeds.shape[-1]
             )
-            image_input_idx = image_input_idx.reshape(batch_size, num_image * num_patch)
+            image_input_idx = image_input_idx.reshape(num_groups, -1)
 
-            for b in range(batch_size):
-                idx = image_input_idx[b]
-                features = image_features[b]
+            for group in range(num_groups):
+                b = int(image_batch_indices[group].item())
+                idx = image_input_idx[group]
+                features = image_features[group]
 
                 for i in range(idx.shape[0]):
                     pos = int(idx[i].item())

--- a/mlx_vlm/models/jina_vlm/processing_jinavlm.py
+++ b/mlx_vlm/models/jina_vlm/processing_jinavlm.py
@@ -132,8 +132,9 @@ class JinaVLMProcessor(ProcessorMixin):
                 if image_input_idx_list is not None and current_image_idx < len(
                     image_input_idx_list
                 ):
-                    offset_idx = image_input_idx_list[current_image_idx] + len(
-                        input_ids
+                    indices = image_input_idx_list[current_image_idx]
+                    offset_idx = np.where(
+                        indices >= 0, indices + len(input_ids), indices
                     )
                     updated_image_input_idx.append(offset_idx)
                 input_ids.extend(img_tokens.tolist())
@@ -251,16 +252,25 @@ class JinaVLMProcessor(ProcessorMixin):
         all_pixel_values = []
         all_image_input_idx = []
         all_image_masks = []
+        all_image_batch_indices = []
 
-        for r in batch_results:
+        for batch_index, r in enumerate(batch_results):
             if "pixel_values" in r:
                 all_pixel_values.append(r["pixel_values"])
-                all_image_input_idx.append(r["image_input_idx"])
+                indices = r["image_input_idx"]
+                pad_len = max_len - r["input_ids"].shape[1]
+                all_image_input_idx.append(
+                    mx.where(indices >= 0, indices + pad_len, indices)
+                )
                 all_image_masks.append(r["image_masks"])
+                all_image_batch_indices.append(
+                    mx.full((indices.shape[0],), batch_index, dtype=mx.int32)
+                )
 
         if all_pixel_values:
             result["pixel_values"] = mx.concatenate(all_pixel_values, axis=0)
             result["image_input_idx"] = mx.concatenate(all_image_input_idx, axis=0)
             result["image_masks"] = mx.concatenate(all_image_masks, axis=0)
+            result["image_batch_indices"] = mx.concatenate(all_image_batch_indices)
 
         return result

--- a/mlx_vlm/models/llama4/language.py
+++ b/mlx_vlm/models/llama4/language.py
@@ -80,22 +80,18 @@ class Attention(nn.Module):
             keys = mx.fast.rms_norm(keys, weight=None, eps=1e-6)
 
         if self.attn_temperature_tuning and not self.use_rope:
-            # arange needs scalar offset
-            offset_scalar = offset
-            if isinstance(offset_scalar, mx.array):
-                offset_scalar = offset_scalar.max().item()
+            positions = mx.arange(1, L + 1)
+            if isinstance(offset, mx.array):
+                positions = positions[None, :] + offset[:, None]
+                positions = positions[:, None, :, None]
+            else:
+                positions = positions + offset
+                positions = positions[:, None]
             attn_scales = (
-                mx.log(
-                    mx.floor(
-                        mx.arange(offset_scalar + 1, offset_scalar + L + 1)
-                        / self.floor_scale
-                    )
-                    + 1.0
-                )
+                mx.log(mx.floor(mx.maximum(positions, 0) / self.floor_scale) + 1.0)
                 * self.attn_scale
                 + 1.0
             )
-            attn_scales = attn_scales[:, None]
             queries = (queries * attn_scales).astype(queries.dtype)
 
         if cache is not None:
@@ -242,7 +238,9 @@ class LlamaModel(nn.Module):
             h = input_embeds
 
         if mask is None:
-            mask = create_attention_mask(h, cache)
+            mask = create_attention_mask(
+                h, cache[3] if cache is not None and len(cache) > 3 else None
+            )
 
         if cache is not None:
             for idx, c in enumerate(cache):
@@ -258,9 +256,12 @@ class LlamaModel(nn.Module):
             offset = 0
 
         # Create a mask for the chunked attention
-        chunk_mask = self.create_chunked_attention_mask(
-            h.shape[1], self.config.attention_chunk_size, start, offset
-        )
+        if cache is not None and hasattr(cache[0], "make_chunk_mask"):
+            chunk_mask = cache[0].make_chunk_mask(h.shape[1])
+        else:
+            chunk_mask = self.create_chunked_attention_mask(
+                h.shape[1], self.config.attention_chunk_size, start, offset
+            )
 
         if cache is None:
             cache = [None] * len(self.layers)

--- a/mlx_vlm/models/llama4/processing_llama4.py
+++ b/mlx_vlm/models/llama4/processing_llama4.py
@@ -169,10 +169,10 @@ class Llama4Processor(ProcessorMixin):
         import json
         from pathlib import Path
 
-        from transformers import AutoTokenizer
+        from transformers import PreTrainedTokenizerFast
 
         kwargs.pop("use_fast", None)
-        tokenizer = AutoTokenizer.from_pretrained(
+        tokenizer = PreTrainedTokenizerFast.from_pretrained(
             pretrained_model_name_or_path, **kwargs
         )
         load_chat_template(tokenizer, pretrained_model_name_or_path)

--- a/mlx_vlm/models/llava/processing_llava.py
+++ b/mlx_vlm/models/llava/processing_llava.py
@@ -4,7 +4,7 @@ Processor class for Llava.
 
 from transformers.feature_extraction_utils import BatchFeature
 from transformers.image_utils import ImageInput, get_image_size, to_numpy_array
-from transformers.processing_utils import ProcessorMixin
+from transformers.processing_utils import ProcessingKwargs, ProcessorMixin
 from transformers.tokenization_utils_base import PreTokenizedInput, TextInput
 
 from ..base import load_chat_template, to_mlx
@@ -85,9 +85,16 @@ class LlavaProcessor(ProcessorMixin):
 
         # Pop common kwargs
         return_tensors = kwargs.pop("return_tensors", None)
+        output_kwargs = self._merge_kwargs(
+            ProcessingKwargs,
+            tokenizer_init_kwargs=self.tokenizer.init_kwargs,
+            **kwargs,
+        )
 
         if images is not None:
-            image_inputs = self.image_processor(images, **kwargs)
+            image_inputs = self.image_processor(
+                images, **output_kwargs["images_kwargs"]
+            )
         else:
             image_inputs = {}
 
@@ -117,7 +124,9 @@ class LlavaProcessor(ProcessorMixin):
                 )
                 prompt_strings.append(sample)
 
-        text_inputs = self.tokenizer(prompt_strings, **kwargs, return_tensors=None)
+        text_inputs = self.tokenizer(
+            prompt_strings, **output_kwargs["text_kwargs"], return_tensors=None
+        )
 
         return BatchFeature(data=to_mlx({**text_inputs, **image_inputs}))
 
@@ -167,6 +176,20 @@ class LlavaProcessor(ProcessorMixin):
                 ip_overrides["patch_size"] = ip_cfg["patch_size"]
             if "size" in ip_cfg:
                 ip_overrides["size"] = ip_cfg["size"]
+
+        model_cfg_path = Path(pretrained_model_name_or_path) / "config.json"
+        if model_cfg_path.exists():
+            with open(model_cfg_path) as f:
+                model_cfg = json.load(f)
+            vision_cfg = model_cfg.get("vision_config", {})
+            if proc_kwargs.get("patch_size") is None:
+                proc_kwargs["patch_size"] = vision_cfg.get("patch_size")
+            if proc_kwargs.get("vision_feature_select_strategy") is None:
+                proc_kwargs["vision_feature_select_strategy"] = model_cfg.get(
+                    "vision_feature_select_strategy", "default"
+                )
+            if vision_cfg.get("model_type") == "clip_vision_model":
+                proc_kwargs.setdefault("num_additional_image_tokens", 1)
 
         try:
             image_processor = AutoImageProcessor.from_pretrained(

--- a/mlx_vlm/models/llava_bunny/llava_bunny.py
+++ b/mlx_vlm/models/llava_bunny/llava_bunny.py
@@ -4,6 +4,7 @@ from typing import Optional, Tuple
 
 import mlx.core as mx
 import mlx.nn as nn
+import numpy as np
 from PIL import Image
 from transformers.image_transforms import (
     convert_to_rgb,
@@ -22,6 +23,8 @@ from .vision import VisionModel
 
 
 class ImageProcessor(BaseImageProcessor):
+    image_seq_length = 729
+
     def preprocess(self, images):
         if isinstance(images, Image.Image):
             images = [images]
@@ -106,7 +109,9 @@ class Model(nn.Module):
                 inputs_embeds=self.language_model.model.embed_tokens(input_ids)
             )
 
-        inputs_embeds = self.language_model.model.embed_tokens(input_ids)
+        inputs_embeds = self.language_model.model.embed_tokens(
+            mx.where(input_ids == self.config.image_token_index, 0, input_ids)
+        )
 
         cached = kwargs.get("cached_image_features", None)
         if cached is not None:
@@ -129,28 +134,30 @@ class Model(nn.Module):
     def _prepare_inputs_for_multimodal(self, image_features, inputs_embeds, input_ids):
         image_token_index = self.config.image_token_index
         num_images, num_image_patches, embed_dim = image_features.shape
+        rows, columns = np.where(np.asarray(input_ids) == image_token_index)
+        image_features = image_features.astype(inputs_embeds.dtype)
+        if len(rows) == num_images * num_image_patches:
+            result = mx.array(inputs_embeds)
+            result[mx.array(rows), mx.array(columns)] = image_features.reshape(
+                -1, embed_dim
+            )
+            return result
+        if len(rows) != num_images:
+            raise ValueError("Image features do not match image placeholders")
 
-        batch_size, seq_length, embed_dim = inputs_embeds.shape
-        num_images, num_image_patches, _ = image_features.shape
-
-        # Positions of <image> tokens in input_ids for each batch
-        image_positions = mx.argmax(input_ids == image_token_index, axis=1)
-
+        # Preserve direct callers that provide one unexpanded placeholder per image.
         final_embeddings = []
-        for b in range(batch_size):
+        image_index = 0
+        for b in range(inputs_embeds.shape[0]):
             text_segments = []
             start_idx = 0
-            position = int(image_positions[b].item())
-
-            text_segments.append(inputs_embeds[b : b + 1, start_idx:position])
-            text_segments.append(image_features[b : b + 1])
-            text_segments.append(inputs_embeds[b : b + 1, position + 1 :])
-
-            batch_embeddings = mx.concatenate(text_segments, axis=1)
-            final_embeddings.append(batch_embeddings)
-
-        # Create a final embedding of shape
-        # (batch_size, num_image_patches + sequence_len, embed_dim)
+            for position in columns[rows == b]:
+                text_segments.append(inputs_embeds[b : b + 1, start_idx:position])
+                text_segments.append(image_features[image_index : image_index + 1])
+                image_index += 1
+                start_idx = position + 1
+            text_segments.append(inputs_embeds[b : b + 1, start_idx:])
+            final_embeddings.append(mx.concatenate(text_segments, axis=1))
         return mx.concatenate(final_embeddings, axis=0)
 
     @property

--- a/mlx_vlm/models/llava_next/config.py
+++ b/mlx_vlm/models/llava_next/config.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Dict, List, Optional, Union
 
 from ..base import BaseModelConfig
@@ -52,6 +52,15 @@ class ModelConfig(BaseModelConfig):
     text_config: TextConfig
     vision_config: VisionConfig
     model_type: str
+    image_grid_pinpoints: List[List[int]] = field(
+        default_factory=lambda: [
+            [336, 672],
+            [672, 336],
+            [672, 672],
+            [1008, 336],
+            [336, 1008],
+        ]
+    )
     ignore_index: int = -100
     image_token_index: int = 32000
     vision_feature_select_strategy: str = "default"

--- a/mlx_vlm/models/llava_next/image_features.py
+++ b/mlx_vlm/models/llava_next/image_features.py
@@ -1,0 +1,42 @@
+import mlx.core as mx
+from transformers.image_processing_utils import select_best_resolution
+
+
+def pack_image_features(
+    features, image_sizes, image_size, patch_size, pinpoints, newline
+):
+    packed = []
+    side = image_size // patch_size
+    for feature, (original_height, original_width) in zip(features, image_sizes):
+        base = feature[0]
+        if feature.shape[0] == 1:
+            packed.append(mx.concatenate([base, newline[None]], axis=0))
+            continue
+        best_height, best_width = select_best_resolution(
+            (original_height, original_width), pinpoints
+        )
+        grid_height, grid_width = best_height // image_size, best_width // image_size
+        spatial = feature[1:].reshape(grid_height, grid_width, side, side, -1)
+        spatial = spatial.transpose(0, 2, 1, 3, 4).reshape(
+            grid_height * side, grid_width * side, -1
+        )
+        height, width = spatial.shape[:2]
+        if original_width / original_height > width / height:
+            retained = int(round(original_height * width / original_width, 7))
+            padding = (height - retained) // 2
+            spatial = spatial[padding : height - padding]
+        else:
+            retained = int(round(original_width * height / original_height, 7))
+            padding = (width - retained) // 2
+            spatial = spatial[:, padding : width - padding]
+        spatial = mx.concatenate(
+            [
+                spatial,
+                mx.broadcast_to(newline, (spatial.shape[0], 1, newline.shape[0])),
+            ],
+            axis=1,
+        )
+        packed.append(
+            mx.concatenate([base, spatial.reshape(-1, newline.shape[0])], axis=0)
+        )
+    return packed

--- a/mlx_vlm/models/llava_next/llava_next.py
+++ b/mlx_vlm/models/llava_next/llava_next.py
@@ -3,10 +3,12 @@ from typing import Optional
 import mlx.core as mx
 import mlx.nn as nn
 import numpy as np
+from transformers.image_processing_utils import select_best_resolution
 
 from ..base import InputEmbeddingsFeatures
 from . import processing_llava_next  # noqa: F401
 from .config import ModelConfig
+from .image_features import pack_image_features
 from .language import LanguageModel
 from .vision import VisionModel
 
@@ -62,9 +64,32 @@ class Model(nn.Module):
         if cached is not None:
             image_features = cached.astype(inputs_embeds.dtype)
         else:
-            # Get the ouptut hidden states from the vision model
+            image_sizes = kwargs.get("image_sizes")
+            if image_sizes is None:
+                raise ValueError(
+                    "LLaVA-NeXT requires original image_sizes for spatial packing"
+                )
+            image_sizes = np.asarray(image_sizes).tolist()
+            patch_counts = []
+            for size in image_sizes:
+                height, width = select_best_resolution(
+                    size, self.config.image_grid_pinpoints
+                )
+                tile_size = self.config.vision_config.image_size
+                patch_counts.append(1 + (height // tile_size) * (width // tile_size))
+            if pixel_values.ndim == 5:
+                if pixel_values.shape[0] != len(patch_counts):
+                    raise ValueError("Image sizes and pixel batch do not match")
+                pixel_values = mx.concatenate(
+                    [
+                        pixels[:count]
+                        for pixels, count in zip(pixel_values, patch_counts)
+                    ]
+                )
+            if pixel_values.ndim != 4 or pixel_values.shape[0] != sum(patch_counts):
+                raise ValueError("Image crop count does not match original image sizes")
             *_, hidden_states = self.vision_tower(
-                pixel_values[0].transpose(0, 2, 3, 1), output_hidden_states=True
+                pixel_values.transpose(0, 2, 3, 1), output_hidden_states=True
             )
 
             # Select the hidden states from the desired layer
@@ -83,15 +108,19 @@ class Model(nn.Module):
             # Pass image features through the multi-modal projector
             image_features = self.multi_modal_projector(selected_image_feature)
 
-            # Add a newline token to the image features
-            if self.image_newline is not None:
-                newline = np.array(self.image_newline)[None, None, :]
-                newline = np.broadcast_to(newline, image_features.shape)
-                image_features = mx.concatenate(
-                    [image_features, mx.array(newline)], axis=0
-                )
-
-            image_features = image_features.astype(inputs_embeds.dtype)
+            boundaries = np.cumsum(patch_counts)[:-1].tolist()
+            features = mx.split(image_features, boundaries, axis=0)
+            image_features = mx.concatenate(
+                pack_image_features(
+                    features,
+                    image_sizes,
+                    self.config.vision_config.image_size,
+                    self.config.vision_config.patch_size,
+                    self.config.image_grid_pinpoints,
+                    self.image_newline,
+                ),
+                axis=0,
+            ).astype(inputs_embeds.dtype)
 
         # Insert special image tokens in the input_ids
         final_inputs_embeds = self._merge_input_ids_with_image_features(
@@ -102,25 +131,16 @@ class Model(nn.Module):
     def _merge_input_ids_with_image_features(
         self, image_features, inputs_embeds, input_ids
     ):
-        image_token_index = self.config.image_token_index
-        num_images, num_image_patches, embed_dim = image_features.shape
-
-        image_positions = np.where(input_ids == image_token_index)[1].tolist()
-
-        text_segments = []
-        start_idx = 0
-
-        for position in image_positions:
-            text_segments.append(inputs_embeds[:, start_idx:position])
-            start_idx = position + 1
-
-        image_embeddings = mx.split(image_features, image_features.shape[0])
-        final_embeddings = [v for p in zip(text_segments, image_embeddings) for v in p]
-        final_embeddings += [inputs_embeds[:, start_idx:]]
-
-        # Create a final embedding of shape
-        # (1, num_image_patches*num_images + sequence_len, embed_dim)
-        return mx.concatenate(final_embeddings, axis=1)
+        positions = np.where(np.asarray(input_ids) == self.config.image_token_index)
+        image_features = image_features.reshape(-1, inputs_embeds.shape[-1])
+        if len(positions[0]) != image_features.shape[0]:
+            raise ValueError(
+                f"Image features and image tokens do not match: "
+                f"{image_features.shape[0]} features, {len(positions[0])} tokens"
+            )
+        result = mx.array(inputs_embeds)
+        result[mx.array(positions[0]), mx.array(positions[1])] = image_features
+        return result
 
     @property
     def layers(self):
@@ -135,7 +155,9 @@ class Model(nn.Module):
         **kwargs,
     ):
 
-        input_embeddings_features = self.get_input_embeddings(input_ids, pixel_values)
+        input_embeddings_features = self.get_input_embeddings(
+            input_ids, pixel_values, **kwargs
+        )
         logits = self.language_model(
             input_ids,
             cache=cache,

--- a/mlx_vlm/models/llava_next/processing_llava_next.py
+++ b/mlx_vlm/models/llava_next/processing_llava_next.py
@@ -108,6 +108,8 @@ class LlavaNextProcessor(ProcessorMixin):
         text: (
             TextInput | PreTokenizedInput | list[TextInput] | list[PreTokenizedInput]
         ) = None,
+        add_special_tokens=False,
+        padding_side="left",
         **kwargs,
     ) -> BatchFeature:
         """
@@ -131,7 +133,7 @@ class LlavaNextProcessor(ProcessorMixin):
 
         # Pop common kwargs that shouldn't be forwarded to sub-processors
         return_tensors = kwargs.pop("return_tensors", None)
-        kwargs.pop("padding", None)
+        padding = kwargs.pop("padding", False)
         do_pad = kwargs.pop("do_pad", True)
 
         if images is not None:
@@ -176,7 +178,13 @@ class LlavaNextProcessor(ProcessorMixin):
                 for sample in prompt_strings
             ]
 
-        text_inputs = self.tokenizer(prompt_strings, **kwargs)
+        text_inputs = self.tokenizer(
+            prompt_strings,
+            padding=padding,
+            padding_side=padding_side,
+            add_special_tokens=add_special_tokens,
+            **kwargs,
+        )
 
         return BatchFeature(data=to_mlx({**text_inputs, **image_inputs}))
 

--- a/mlx_vlm/models/llmjpvl/language.py
+++ b/mlx_vlm/models/llmjpvl/language.py
@@ -181,6 +181,9 @@ class LanguageModel(nn.Module):
             out = self.lm_head(out)
         return LanguageModelOutput(logits=out)
 
+    def make_cache(self):
+        return [KVCache() for _ in self.model.layers]
+
     @staticmethod
     def sanitize(weights):
         # Remove unused precomputed rotary freqs

--- a/mlx_vlm/models/llmjpvl/llmjpvl.py
+++ b/mlx_vlm/models/llmjpvl/llmjpvl.py
@@ -5,6 +5,7 @@ import mlx.nn as nn
 import numpy as np
 
 from ..base import InputEmbeddingsFeatures, pixel_shuffle
+from . import processing_llmjpvl  # noqa: F401
 from .config import ModelConfig
 from .language import LanguageModel
 from .vision import VisionModel, check_array_shape
@@ -85,7 +86,6 @@ class Model(nn.Module):
     def _merge_input_ids_with_image_features(
         self, image_features, inputs_embeds, input_ids, image_token_index=None
     ):
-        B, N, C = inputs_embeds.shape
         if image_token_index is None:
             image_token_index = self.config.image_token_index
 
@@ -98,9 +98,10 @@ class Model(nn.Module):
                 f"({image_features.shape[0]})"
             )
 
-        image_indices = np.where(image_positions)[1].tolist()
-        inputs_embeds[:, image_indices, :] = image_features
-        return inputs_embeds.reshape(B, N, C)
+        rows, columns = np.where(np.asarray(image_positions))
+        result = mx.array(inputs_embeds)
+        result[mx.array(rows), mx.array(columns)] = image_features
+        return result
 
     @property
     def layers(self):

--- a/mlx_vlm/models/llmjpvl/processing_llmjpvl.py
+++ b/mlx_vlm/models/llmjpvl/processing_llmjpvl.py
@@ -1,0 +1,182 @@
+import json
+from pathlib import Path
+
+import numpy as np
+from PIL import Image
+from transformers import (
+    AutoTokenizer,
+    BatchFeature,
+    ProcessorMixin,
+    SiglipImageProcessor,
+)
+
+from ..base import install_auto_processor_patch, load_chat_template, to_mlx
+from ..internvl_chat.processor import dynamic_preprocess
+
+HISTORY_CHAT_TEMPLATE = """
+{%- if not messages or messages[0]['role'] != 'system' -%}
+{{- '<|start|>system<|message|>You are LLM-jp-VL, a Multimodal LLM trained by LLM-jp.<|end|>' -}}
+{%- endif -%}
+{%- if tools -%}
+{{- '<|start|>system<|message|>Available tools: ' + (tools | tojson) + '<|end|>' -}}
+{%- endif -%}
+{%- for message in messages -%}
+{{- '<|start|>' + message['role'] -}}
+{%- if message['role'] == 'assistant' -%}{{- '<|channel|>final' -}}{%- endif -%}
+{{- '<|message|>' -}}
+{{- message['content'] if message['content'] is string else message['content'] | tojson -}}
+{%- for key, value in message.items() if key not in ['role', 'content'] -%}
+{{- '\\nMessage metadata: ' + ({key: value} | tojson) -}}
+{%- endfor -%}
+{{- '<|return|>' if loop.last and message['role'] == 'assistant' and not add_generation_prompt else '<|end|>' -}}
+{%- endfor -%}
+{%- if add_generation_prompt -%}{{- '<|start|>assistant<|channel|>final<|message|>' -}}{%- endif -%}
+"""
+
+
+class LLMjpVLProcessor(ProcessorMixin):
+    attributes = ["image_processor", "tokenizer"]
+    image_processor_class = "AutoImageProcessor"
+    tokenizer_class = "AutoTokenizer"
+
+    def __init__(
+        self,
+        image_processor,
+        tokenizer,
+        image_seq_length=256,
+        max_dynamic_patch=12,
+        min_dynamic_patch=1,
+        use_thumbnail=True,
+    ):
+        self.image_seq_length = image_seq_length
+        self.max_dynamic_patch = max_dynamic_patch
+        self.min_dynamic_patch = min_dynamic_patch
+        self.use_thumbnail = use_thumbnail
+        self.image_token = "<image>"
+        template = tokenizer.chat_template
+        if template:
+            template += (
+                "{% if add_generation_prompt %}<|channel|>final<|message|>{% endif %}"
+            )
+        super().__init__(image_processor, tokenizer, chat_template=template)
+
+    def apply_chat_template(self, conversation, chat_template=None, **kwargs):
+        histories = (
+            conversation
+            if conversation and isinstance(conversation[0], (list, tuple))
+            else [conversation]
+        )
+        rich_history = bool(kwargs.get("tools"))
+        for messages in histories:
+            system_positions = [
+                i for i, message in enumerate(messages) if message["role"] == "system"
+            ]
+            rich_history |= system_positions not in ([], [0]) or any(
+                set(message) != {"role", "content"}
+                or message["role"] not in ("system", "user", "assistant")
+                for message in messages
+            )
+        if chat_template is None and rich_history:
+            chat_template = HISTORY_CHAT_TEMPLATE
+        return super().apply_chat_template(
+            conversation, chat_template=chat_template, **kwargs
+        )
+
+    @classmethod
+    def from_pretrained(cls, pretrained_model_name_or_path, **kwargs):
+        path = Path(pretrained_model_name_or_path)
+        tokenizer = AutoTokenizer.from_pretrained(path, **kwargs)
+        load_chat_template(tokenizer, path)
+        image_config = json.loads((path / "preprocessor_config.json").read_text())
+        image_processor = SiglipImageProcessor.from_dict(image_config)
+        config = json.loads((path / "processor_config.json").read_text())
+        options = {
+            key: config[key]
+            for key in (
+                "image_seq_length",
+                "max_dynamic_patch",
+                "min_dynamic_patch",
+                "use_thumbnail",
+            )
+            if key in config
+        }
+        return cls(image_processor, tokenizer, **options)
+
+    def __call__(
+        self,
+        images=None,
+        text=None,
+        padding=False,
+        padding_side="left",
+        add_special_tokens=False,
+        return_tensors=None,
+        **kwargs,
+    ):
+        texts = [text] if isinstance(text, str) else list(text or [])
+        images = [images] if isinstance(images, Image.Image) else list(images or [])
+        if not texts:
+            raise ValueError("LLM-jp-VL requires text containing image placeholders")
+        if sum(t.count(self.image_token) for t in texts) != len(images):
+            raise ValueError("Image count does not match image placeholders")
+        pixels = []
+        image_index = 0
+        expanded = []
+        size = self.image_processor.size
+        image_size = size["height"] if isinstance(size, dict) else size.height
+        for prompt in texts:
+            count = prompt.count(self.image_token)
+            text_tokens = len(
+                self.tokenizer.encode(
+                    prompt.replace(self.image_token, ""), add_special_tokens=False
+                )
+            )
+            budget = self.tokenizer.model_max_length - text_tokens
+            max_num = max(
+                1,
+                min(
+                    self.max_dynamic_patch,
+                    (budget // max(count, 1) - 2) // self.image_seq_length - 1,
+                ),
+            )
+            for _ in range(count):
+                patches = dynamic_preprocess(
+                    images[image_index].convert("RGB"),
+                    min_num=self.min_dynamic_patch,
+                    max_num=max_num,
+                    image_size=image_size,
+                    use_thumbnail=self.use_thumbnail,
+                )
+                image_index += 1
+                pixels.append(
+                    self.image_processor(images=patches, return_tensors="np")[
+                        "pixel_values"
+                    ]
+                )
+                replacement = (
+                    "<|image_start|>"
+                    + "<|image_pad|>" * (self.image_seq_length * len(patches))
+                    + "<|image_end|>"
+                )
+                prompt = prompt.replace(self.image_token, replacement, 1)
+            expanded.append(prompt)
+        data = dict(
+            self.tokenizer(
+                expanded,
+                padding=padding,
+                padding_side=padding_side,
+                add_special_tokens=add_special_tokens,
+                **kwargs,
+            )
+        )
+        if pixels:
+            data["pixel_values"] = np.concatenate(pixels)
+        return BatchFeature(data=to_mlx(data))
+
+    def decode(self, *args, **kwargs):
+        return self.tokenizer.decode(*args, **kwargs)
+
+    def batch_decode(self, *args, **kwargs):
+        return self.tokenizer.batch_decode(*args, **kwargs)
+
+
+install_auto_processor_patch("llmjpvl", LLMjpVLProcessor)

--- a/mlx_vlm/models/molmo/processing_molmo.py
+++ b/mlx_vlm/models/molmo/processing_molmo.py
@@ -511,6 +511,8 @@ class MolmoProcessor(ProcessorMixin):
             all_image_idx = []
             all_masks = []
             all_input_ids = []
+            shared_prompt = len(tokens_list) == 1
+            image_token_offset = 0
 
             for i, (img, tokens) in enumerate(
                 zip(
@@ -533,13 +535,25 @@ class MolmoProcessor(ProcessorMixin):
                 )
 
                 # Combine image tokens with text tokens
-                combined_tokens = np.concatenate([image_tokens, np.array(tokens)])
+                if shared_prompt:
+                    combined_tokens = image_tokens
+                    patch_idx = np.where(
+                        patch_idx >= 0, patch_idx + image_token_offset, patch_idx
+                    )
+                    image_token_offset += len(image_tokens)
+                else:
+                    combined_tokens = np.concatenate([image_tokens, np.array(tokens)])
 
                 # Adjust patch_idx for the position in combined tokens
                 all_crops.append(crops)
                 all_image_idx.append(patch_idx)
                 all_masks.append(img_mask)
                 all_input_ids.append(combined_tokens)
+
+            if shared_prompt:
+                all_input_ids = [
+                    np.concatenate([*all_input_ids, np.array(tokens_list[0])])
+                ]
 
             # Stack results
             pixel_values = mx.array(
@@ -604,6 +618,39 @@ class MolmoProcessor(ProcessorMixin):
         **kwargs,
     ):
         """Apply chat template."""
+        tools = kwargs.get("tools")
+        rich_history = bool(tools) or any(
+            set(message) != {"role", "content"}
+            or message["role"] != ("user" if i % 2 == 0 else "assistant")
+            for i, message in enumerate(conversation)
+        )
+        if chat_template is None and rich_history:
+            # Molmo's ordinary template accepts only alternating text turns.
+            # Keep richer history explicit in its role-labelled text format.
+            lines = []
+            if tools:
+                lines.append(
+                    f"Available tools: {json.dumps(tools, ensure_ascii=False)}"
+                )
+            for message in conversation:
+                role = message["role"].capitalize()
+                content = message.get("content")
+                if not isinstance(content, str):
+                    content = json.dumps(content, ensure_ascii=False)
+                lines.append(f"{role}: {content}")
+                metadata = {
+                    key: value
+                    for key, value in message.items()
+                    if key not in ("role", "content")
+                }
+                if metadata:
+                    lines.append(
+                        f"{role} metadata: {json.dumps(metadata, ensure_ascii=False)}"
+                    )
+            if add_generation_prompt:
+                lines.append("Assistant:")
+            rendered = "\n".join(lines)
+            return self.tokenizer.encode(rendered) if tokenize else rendered
         if chat_template is None:
             chat_template = self.chat_template
         if chat_template is None:
@@ -621,20 +668,14 @@ class MolmoProcessor(ProcessorMixin):
                 "{% if add_generation_prompt %}Assistant: {% endif %}"
             )
 
-        from jinja2 import Environment
-
-        # Use Environment with loopcontrols extension to support {% continue %} and {% break %}
-        env = Environment(extensions=["jinja2.ext.loopcontrols"])
-        template = env.from_string(chat_template)
-        rendered = template.render(
-            messages=conversation,
+        rendered = self.tokenizer.apply_chat_template(
+            conversation,
+            chat_template=chat_template,
             add_generation_prompt=add_generation_prompt,
+            tokenize=False,
             **kwargs,
         )
-
-        if tokenize:
-            return self.tokenizer.encode(rendered)
-        return rendered
+        return self.tokenizer.encode(rendered) if tokenize else rendered
 
     @property
     def model_input_names(self):

--- a/mlx_vlm/models/moondream2/__init__.py
+++ b/mlx_vlm/models/moondream2/__init__.py
@@ -1,4 +1,5 @@
 from .config import ModelConfig, TextConfig, VisionConfig
 from .language import LanguageModel
 from .moondream2 import Model
+from .processing_moondream2 import Moondream2Processor
 from .vision import VisionModel

--- a/mlx_vlm/models/moondream2/config.py
+++ b/mlx_vlm/models/moondream2/config.py
@@ -46,6 +46,14 @@ class ModelConfig(BaseModelConfig):
     eos_token_id: int = 0
     bos_token_id: int = 0
 
+    @classmethod
+    def from_dict(cls, params):
+        params = dict(params)
+        if params.get("model_type") == "moondream1":
+            params.setdefault("bos_token_id", 50256)
+            params.setdefault("eos_token_id", 50256)
+        return super().from_dict(params)
+
     def __post_init__(self):
         if isinstance(self.text_config, dict):
             self.text_config = TextConfig(

--- a/mlx_vlm/models/moondream2/image_crops.py
+++ b/mlx_vlm/models/moondream2/image_crops.py
@@ -1,174 +1,60 @@
-"""Multi-crop image processing for Moondream3.
-
-Splits images into overlapping crops for high-resolution encoding.
-"""
+"""Overlapping image crops for the Moondream2 vision encoder."""
 
 import math
 
+import mlx.core as mx
 import numpy as np
 from PIL import Image
 
 
 def select_crop_grid(image_width, image_height, crop_size, max_crops, overlap_margin):
-    """Select the optimal crop grid layout for an image.
-
-    Returns:
-        (rows, cols) grid layout, or None if single global crop suffices.
-    """
-    patch_size = 14
-    effective_crop = crop_size - 2 * overlap_margin * patch_size
-
-    if effective_crop <= 0:
-        return None
-
-    best_layout = None
-    best_score = float("inf")
-
-    for rows in range(1, max_crops + 1):
-        for cols in range(1, max_crops + 1):
-            total_crops = rows * cols + 1  # +1 for global
-            if total_crops > max_crops:
-                continue
-
-            # Effective resolution covered
-            eff_h = rows * effective_crop + 2 * overlap_margin * patch_size
-            eff_w = cols * effective_crop + 2 * overlap_margin * patch_size
-
-            # Scale factor to cover the image
-            scale_h = eff_h / image_height
-            scale_w = eff_w / image_width
-
-            # We want the scale to be close to 1 (covering image well)
-            # while minimizing number of crops
-            aspect_ratio = image_width / image_height
-            grid_ratio = cols / rows
-
-            # Penalize aspect ratio mismatch and over/under-coverage
-            ratio_diff = abs(math.log(aspect_ratio / grid_ratio))
-            scale_diff = abs(math.log(min(scale_h, scale_w)))
-            score = ratio_diff + 0.5 * scale_diff + 0.1 * total_crops
-
-            if score < best_score:
-                best_score = score
-                best_layout = (rows, cols)
-
-    return best_layout
+    margin = 2 * overlap_margin * 14
+    height, width = image_height - margin, image_width - margin
+    window = crop_size - margin
+    if window <= 0 or max_crops < 1:
+        raise ValueError("Crop size and crop budget must allow a positive crop window")
+    if height <= window or width <= window:
+        return (1, 1)
+    min_h, min_w = math.ceil(height / window), math.ceil(width / window)
+    if min_h * min_w > max_crops:
+        ratio = math.sqrt(max_crops / (min_h * min_w))
+        return max(1, math.floor(min_h * ratio)), max(1, math.floor(min_w * ratio))
+    rows = max(math.floor(math.sqrt(max_crops * height / width)), min_h)
+    columns = max(math.floor(math.sqrt(max_crops * width / height)), min_w)
+    if rows * columns > max_crops:
+        if columns > rows:
+            columns = math.floor(max_crops / rows)
+        else:
+            rows = math.floor(max_crops / columns)
+    return max(1, rows), max(1, columns)
 
 
 def create_crops(image, crop_size, max_crops, overlap_margin):
-    """Create multi-resolution crops from an image.
-
-    Args:
-        image: PIL Image
-        crop_size: size of each crop (378)
-        max_crops: maximum number of crops including global
-        overlap_margin: overlap in patches between adjacent crops
-
-    Returns:
-        crops: list of numpy arrays (H, W, C) normalized to [-1, 1]
-        layout: (rows, cols) or None for single crop
-    """
-    width, height = image.size
-    patch_size = 14
-
-    # Always create global crop
-    global_img = image.resize((crop_size, crop_size), Image.BICUBIC)
-    global_crop = np.array(global_img).astype(np.float32)
-    global_crop = (global_crop / 255.0 - 0.5) / 0.5  # normalize to [-1, 1]
-
-    crops = [global_crop]
-
-    # Check if we need local crops
-    if max_crops <= 1:
-        return crops, None
-
-    layout = select_crop_grid(width, height, crop_size, max_crops, overlap_margin)
-    if layout is None:
-        return crops, None
-
-    rows, cols = layout
-    if rows * cols + 1 > max_crops:
-        return crops, None
-
-    # Calculate overlap in pixels
-    overlap_pixels = overlap_margin * patch_size
-
-    # Calculate the region each crop covers (with overlap)
-    effective_size = crop_size - 2 * overlap_pixels
-
-    for r in range(rows):
-        for c in range(cols):
-            # Source region in original image coordinates
-            src_y = (
-                r
-                * (
-                    height
-                    - crop_size * height / (rows * effective_size + 2 * overlap_pixels)
-                )
-                if rows > 1
-                else 0
-            )
-            src_x = (
-                c
-                * (
-                    width
-                    - crop_size * width / (cols * effective_size + 2 * overlap_pixels)
-                )
-                if cols > 1
-                else 0
-            )
-
-            # Simpler approach: evenly distribute crops
-            if rows > 1:
-                src_y = (
-                    r
-                    * (height - crop_size * height / (rows * crop_size / crop_size))
-                    / max(rows - 1, 1)
-                )
-            else:
-                src_y = 0
-            if cols > 1:
-                src_x = (
-                    c
-                    * (width - crop_size * width / (cols * crop_size / crop_size))
-                    / max(cols - 1, 1)
-                )
-            else:
-                src_x = 0
-
-            # Scale: map crop_size pixels to image region
-            scale_x = (
-                width / (cols * (crop_size - 2 * overlap_pixels) + 2 * overlap_pixels)
-                if cols > 0
-                else 1
-            )
-            scale_y = (
-                height / (rows * (crop_size - 2 * overlap_pixels) + 2 * overlap_pixels)
-                if rows > 0
-                else 1
-            )
-            scale = max(scale_x, scale_y)
-
-            crop_w = int(crop_size * scale)
-            crop_h = int(crop_size * scale)
-
-            # Center the crop grid
-            total_w = cols * (crop_size - 2 * overlap_pixels) + 2 * overlap_pixels
-            total_h = rows * (crop_size - 2 * overlap_pixels) + 2 * overlap_pixels
-
-            x0 = int(c * (crop_size - 2 * overlap_pixels) * scale)
-            y0 = int(r * (crop_size - 2 * overlap_pixels) * scale)
-
-            x0 = min(x0, max(width - crop_w, 0))
-            y0 = min(y0, max(height - crop_h, 0))
-            x1 = min(x0 + crop_w, width)
-            y1 = min(y0 + crop_h, height)
-
-            crop_img = image.crop((x0, y0, x1, y1))
-            crop_img = crop_img.resize((crop_size, crop_size), Image.BICUBIC)
-
-            crop_arr = np.array(crop_img).astype(np.float32)
-            crop_arr = (crop_arr / 255.0 - 0.5) / 0.5
-            crops.append(crop_arr)
-
-    return crops, layout
+    """Return normalized global and local crops; max_crops counts local crops."""
+    image = image.convert("RGB")
+    layout = select_crop_grid(*image.size, crop_size, max_crops, overlap_margin)
+    rows, columns = layout
+    margin = 2 * overlap_margin * 14
+    window = crop_size - margin
+    resized = np.asarray(
+        image.resize(
+            (columns * window + margin, rows * window + margin),
+            Image.Resampling.LANCZOS,
+        )
+    )
+    crops = [np.asarray(image.resize((crop_size, crop_size), Image.Resampling.LANCZOS))]
+    crops.extend(
+        resized[
+            row * window : row * window + crop_size,
+            column * window : column * window + crop_size,
+        ]
+        for row in range(rows)
+        for column in range(columns)
+    )
+    pixels = mx.array(np.stack(crops)).astype(mx.bfloat16)
+    # Match the reference's bfloat16 rounding at every normalization step.
+    pixels = (pixels / 255.0).astype(mx.bfloat16)
+    pixels = (pixels - 0.5).astype(mx.bfloat16)
+    pixels = (pixels / 0.5).astype(mx.bfloat16)
+    normalized = np.array(pixels.astype(mx.float32))
+    return list(normalized), layout

--- a/mlx_vlm/models/moondream2/language.py
+++ b/mlx_vlm/models/moondream2/language.py
@@ -58,6 +58,8 @@ class Attention(nn.Module):
             queries = self.rope(queries)
             keys = self.rope(keys)
 
+        if isinstance(mask, mx.array) and mask.dtype != mx.bool_:
+            mask = mask.astype(queries.dtype)
         output = mx.fast.scaled_dot_product_attention(
             queries, keys, values, scale=self.scale, mask=mask
         )
@@ -121,6 +123,14 @@ class LanguageModel(nn.Module):
         self.model = TextModel(config)
         self.lm_head = nn.Linear(config.hidden_size, config.vocab_size, bias=True)
 
+    def chunked_prefill_policy(
+        self, *, prefill_kwargs=None, draft_model=None, **kwargs
+    ):
+        # Image-prefix tokens attend to future tokens within the same prefix.
+        return (prefill_kwargs or {}).get(
+            "attention_mask_4d"
+        ) is None and draft_model is None
+
     def __call__(
         self,
         inputs: mx.array,
@@ -129,8 +139,20 @@ class LanguageModel(nn.Module):
         cache=None,
         **kwargs,
     ):
+        full_mask = kwargs.get("attention_mask_4d")
+        if mask is None and full_mask is not None:
+            c = cache[0] if cache else None
+            offset = getattr(c, "_idx", getattr(c, "offset", 0))
+            length = (
+                inputs_embeds.shape[1] if inputs_embeds is not None else inputs.shape[1]
+            )
+            if offset < full_mask.shape[-2]:
+                mask = full_mask[..., offset : offset + length, : offset + length]
         out = self.model(inputs, inputs_embeds=inputs_embeds, mask=mask, cache=cache)
         return LanguageModelOutput(logits=self.lm_head(out))
+
+    def make_cache(self):
+        return [KVCache() for _ in self.model.layers]
 
     @property
     def layers(self):

--- a/mlx_vlm/models/moondream2/moondream2.py
+++ b/mlx_vlm/models/moondream2/moondream2.py
@@ -6,6 +6,7 @@ import mlx.nn as nn
 from ..base import InputEmbeddingsFeatures
 from .config import ModelConfig
 from .language import LanguageModel
+from .packed_weights import unpack_checkpoint_weights
 from .vision import VisionModel
 
 
@@ -38,11 +39,11 @@ class Model(nn.Module):
 
     def get_input_embeddings(
         self,
-        inputs: mx.array,
+        input_ids: mx.array,
         pixel_values: Optional[mx.array] = None,
         **kwargs,
     ):
-        inputs_embeds = self.text.model.embed_tokens(inputs)
+        inputs_embeds = self.text.model.embed_tokens(input_ids)
 
         if pixel_values is None:
             return InputEmbeddingsFeatures(inputs_embeds=inputs_embeds)
@@ -59,21 +60,35 @@ class Model(nn.Module):
             crop_layouts=crop_layouts,
         )
 
-        bos_embed = inputs_embeds[:, :1, :]
+        if input_ids.shape[0] == 1:
+            image_features = image_features.reshape(1, -1, image_features.shape[-1])
+        elif image_features.shape[0] != input_ids.shape[0]:
+            raise ValueError("Image features do not match the prompt batch")
         num_vision_tokens = image_features.shape[1]
-        text_start = 1 + num_vision_tokens
-
-        if inputs_embeds.shape[1] > text_start:
-            text_embeds = inputs_embeds[:, text_start:, :]
-            final_embeds = mx.concatenate(
-                [bos_embed, image_features, text_embeds], axis=1
-            )
+        batch_size, seq_len = input_ids.shape
+        valid = kwargs.get("mask")
+        if valid is None:
+            valid = mx.ones(input_ids.shape, dtype=mx.bool_)
         else:
-            final_embeds = mx.concatenate([bos_embed, image_features], axis=1)
-
+            valid = valid.astype(mx.bool_)
+        starts = mx.argmax(valid, axis=1)
+        columns = starts[:, None] + 1 + mx.arange(num_vision_tokens)[None, :]
+        final_embeds = mx.array(inputs_embeds)
+        final_embeds[mx.arange(batch_size)[:, None], columns] = image_features
         prefix_len = 1 + num_vision_tokens
-        seq_len = final_embeds.shape[1]
-        attention_mask_4d = self._create_prefix_attention_mask(seq_len, prefix_len)
+        positions = mx.arange(seq_len)
+        prefix = (positions[None, :] >= starts[:, None]) & (
+            positions[None, :] < starts[:, None] + prefix_len
+        )
+        allowed = (positions[:, None] >= positions[None, :])[None] | (
+            prefix[:, :, None] & prefix[:, None, :]
+        )
+        allowed &= valid[:, None, :]
+        # Padding queries attend only to themselves to avoid fully masked rows.
+        allowed = mx.where(
+            valid[:, :, None], allowed, mx.eye(seq_len, dtype=mx.bool_)[None]
+        )
+        attention_mask_4d = mx.where(allowed[:, None], 0.0, -mx.inf)
 
         return InputEmbeddingsFeatures(
             inputs_embeds=final_embeds,
@@ -88,6 +103,8 @@ class Model(nn.Module):
         return causal.reshape(1, 1, seq_len, seq_len)
 
     def sanitize(self, weights):
+        if any(key.startswith("model.text.") for key in weights):
+            weights = unpack_checkpoint_weights(weights)
         sanitized = {}
 
         for k, v in weights.items():
@@ -137,6 +154,10 @@ class Model(nn.Module):
             sanitized[new_key] = v
 
         return sanitized
+
+    @property
+    def language_model(self):
+        return self.text
 
     @property
     def layers(self):

--- a/mlx_vlm/models/moondream2/packed_weights.py
+++ b/mlx_vlm/models/moondream2/packed_weights.py
@@ -1,0 +1,36 @@
+import mlx.core as mx
+
+
+def unpack_checkpoint_weights(weights):
+    unpacked = {}
+    for key, value in weights.items():
+        if key.startswith("model.region."):
+            continue
+        if key.endswith((".weight.scale", ".weight.zero_point")):
+            continue
+        if key.endswith(".weight.packed"):
+            base = key.removesuffix(".packed")
+            bias = weights[base.removesuffix(".weight") + ".bias"]
+            scale = weights[base + ".scale"]
+            zero = weights[base + ".zero_point"]
+            codes = mx.concatenate([value >> 4, value & 15], axis=0)
+            # The source decoder rounds after subtraction and multiplication.
+            centered = (codes.astype(mx.bfloat16) - zero).astype(mx.bfloat16)
+            value = (centered * scale).astype(mx.bfloat16).reshape(bias.size, -1)
+            key = base
+        elif (
+            key.endswith(".bias")
+            and key.removesuffix(".bias") + ".weight.packed" in weights
+        ):
+            value = value.astype(mx.bfloat16)
+        key = key.removeprefix("model.")
+        if key == "text.wte":
+            key = "text.model.embed_tokens.weight"
+        elif key.startswith("text.blocks."):
+            key = key.replace("text.blocks.", "text.model.layers.", 1)
+        elif key.startswith("text.post_ln."):
+            key = key.replace("text.post_ln.", "text.model.post_ln.", 1)
+        elif key.startswith("vision.") and not key.startswith("vision.proj_mlp."):
+            key = key.replace("vision.", "vision.encoder.", 1)
+        unpacked[key] = value
+    return unpacked

--- a/mlx_vlm/models/moondream2/processing_moondream2.py
+++ b/mlx_vlm/models/moondream2/processing_moondream2.py
@@ -1,0 +1,82 @@
+import numpy as np
+from transformers import PreTrainedTokenizerFast
+
+from ..base import install_auto_processor_patch
+from .image_crops import create_crops
+
+
+class Moondream2Processor:
+    def __init__(self, tokenizer):
+        self.tokenizer = tokenizer
+
+    @classmethod
+    def from_pretrained(cls, path, **kwargs):
+        return cls(PreTrainedTokenizerFast.from_pretrained(path, **kwargs))
+
+    def __call__(
+        self,
+        text=None,
+        images=None,
+        padding=True,
+        padding_side="left",
+        add_special_tokens=False,
+        return_tensors=None,
+        **kwargs,
+    ):
+        texts = [text] if isinstance(text, str) else list(text or [])
+        images = (
+            list(images)
+            if isinstance(images, (list, tuple))
+            else ([] if images is None else [images])
+        )
+        if not texts:
+            raise ValueError("Moondream2 requires a text prompt")
+        if images and len(texts) != 1 and len(images) != len(texts):
+            raise ValueError("Multiple prompts require one image per prompt")
+        result = {}
+        if images:
+            crops, counts, layouts = [], [], []
+            for image in images:
+                image_crops, layout = create_crops(image, 378, 12, 4)
+                crops.extend(image_crops)
+                counts.append(len(image_crops))
+                layouts.append(layout)
+            result.update(
+                pixel_values=np.stack(crops), num_crops=counts, crop_layouts=layouts
+            )
+        sequences = []
+        per_prompt = len(images) if len(texts) == 1 else 1
+        for prompt in texts:
+            if images:
+                query = (
+                    [198, 198, 24361, 25]
+                    + self.tokenizer.encode(" " + prompt, add_special_tokens=False)
+                    + [198, 198, 33706, 25]
+                )
+                ids = [self.tokenizer.bos_token_id] + [0] * (729 * per_prompt) + query
+            else:
+                ids = self.tokenizer.encode(
+                    prompt, add_special_tokens=add_special_tokens
+                )
+            sequences.append(ids)
+        width = max(map(len, sequences)) if padding else None
+        masks = []
+        for i, ids in enumerate(sequences):
+            count = width - len(ids) if width is not None else 0
+            pad = [self.tokenizer.pad_token_id or self.tokenizer.eos_token_id] * count
+            if padding_side == "left":
+                sequences[i] = pad + ids
+                masks.append([0] * count + [1] * len(ids))
+            elif padding_side == "right":
+                sequences[i] = ids + pad
+                masks.append([1] * len(ids) + [0] * count)
+            else:
+                raise ValueError("padding_side must be left or right")
+        result.update(
+            input_ids=np.array(sequences, dtype=np.int32),
+            attention_mask=np.array(masks, dtype=np.int32),
+        )
+        return result
+
+
+install_auto_processor_patch("moondream1", Moondream2Processor)

--- a/mlx_vlm/models/moondream2/vision.py
+++ b/mlx_vlm/models/moondream2/vision.py
@@ -1,3 +1,4 @@
+import math
 from typing import Optional
 
 import mlx.core as mx
@@ -132,12 +133,12 @@ class VisionModel(nn.Module):
 
         pooled = mx.zeros((grid_size, grid_size, D), dtype=full_grid.dtype)
         for i in range(grid_size):
-            h_start = int(round(i * pool_h))
-            h_end = int(round((i + 1) * pool_h))
+            h_start = math.floor(i * pool_h)
+            h_end = math.ceil((i + 1) * pool_h)
             h_end = max(h_end, h_start + 1)
             for j in range(grid_size):
-                w_start = int(round(j * pool_w))
-                w_end = int(round((j + 1) * pool_w))
+                w_start = math.floor(j * pool_w)
+                w_end = math.ceil((j + 1) * pool_w)
                 w_end = max(w_end, w_start + 1)
                 pooled[i, j] = full_grid[h_start:h_end, w_start:w_end].mean(axis=(0, 1))
 

--- a/mlx_vlm/models/moondream3/language.py
+++ b/mlx_vlm/models/moondream3/language.py
@@ -82,11 +82,11 @@ class Attention(nn.Module):
             offset = int(cache._idx)
             offsets_per_seq = (
                 raw_offset
-                if isinstance(raw_offset, mx.array) and raw_offset.size > 1
+                if isinstance(raw_offset, mx.array) and raw_offset.ndim > 0
                 else None
             )
         elif isinstance(raw_offset, mx.array):
-            if raw_offset.size > 1:
+            if raw_offset.ndim > 0:
                 # Per-sequence offsets from BatchKVCache -- shape (B,).
                 offsets_per_seq = raw_offset
                 offset = int(raw_offset.max().item())
@@ -99,7 +99,7 @@ class Attention(nn.Module):
 
         if offsets_per_seq is not None:
             # Build per-sequence positions: (B, L) = offsets[:, None] + arange(L)
-            positions = offsets_per_seq[:, None] + mx.arange(L)
+            positions = mx.maximum(offsets_per_seq[:, None] + mx.arange(L), 0)
         else:
             positions = mx.arange(offset, offset + L)
         tau_q, tau_v = self.tau(qkv_out, positions)
@@ -120,7 +120,7 @@ class Attention(nn.Module):
         values = values * tau_v
 
         if cache is not None:
-            if offsets_per_seq is not None and B > 1:
+            if offsets_per_seq is not None:
                 # Per-row RoPE offsets for a batched cache. mx.fast.rope only
                 # accepts scalar offsets, so apply it one row at a time and
                 # stitch back.

--- a/mlx_vlm/models/moondream3/moondream3.py
+++ b/mlx_vlm/models/moondream3/moondream3.py
@@ -65,6 +65,10 @@ class Model(nn.Module):
             )
 
         B = inputs.shape[0]
+        if B == 1:
+            image_features = image_features.reshape(1, -1, image_features.shape[-1])
+        elif image_features.shape[0] != B:
+            raise ValueError("Image features do not match the prompt batch")
         bos_embed = inputs_embeds[:, :1, :]
 
         num_vision_tokens = image_features.shape[1]
@@ -136,13 +140,13 @@ class Model(nn.Module):
 
             if new_key == "text.wte":
                 new_key = "text.model.wte.weight"
-            elif new_key.startswith("text.lm_head"):
+            elif new_key.startswith(("text.lm_head", "text.model.")):
                 pass
             elif new_key.startswith("text."):
                 new_key = "text.model." + new_key[len("text.") :]
 
             if new_key.startswith("vision.") and not new_key.startswith(
-                "vision.proj_mlp"
+                ("vision.proj_mlp", "vision.encoder.")
             ):
                 new_key = "vision.encoder." + new_key[len("vision.") :]
 

--- a/mlx_vlm/models/moondream3/processing_moondream3.py
+++ b/mlx_vlm/models/moondream3/processing_moondream3.py
@@ -44,7 +44,7 @@ class Moondream3Processor:
 
     @classmethod
     def from_pretrained(cls, pretrained_model_name_or_path, **kwargs):
-        from transformers import AutoTokenizer
+        from transformers import AutoTokenizer, PreTrainedTokenizerFast
 
         # Filter out kwargs that aren't relevant to tokenizer loading
         tokenizer_kwargs = {}
@@ -60,7 +60,7 @@ class Moondream3Processor:
                 **tokenizer_kwargs,
             )
         except Exception:
-            tokenizer = AutoTokenizer.from_pretrained(
+            tokenizer = PreTrainedTokenizerFast.from_pretrained(
                 TOKENIZER_REPO,
                 **tokenizer_kwargs,
             )
@@ -147,6 +147,9 @@ class Moondream3Processor:
             if isinstance(text, str):
                 text = [text]
 
+            if has_images and len(text) != 1 and len(images) != len(text):
+                raise ValueError("Multiple prompts require one image per prompt")
+            images_per_prompt = len(images) if has_images and len(text) == 1 else 1
             # Build input sequences: [BOS] [image_placeholders] [text_tokens]
             all_input_ids = []
             bos_id = self.tokenizer.bos_token_id or 0
@@ -159,7 +162,10 @@ class Moondream3Processor:
                         formatted, add_special_tokens=False
                     )
                     input_ids = (
-                        [bos_id] + [0] * NUM_VISION_TOKENS + text_tokens + [ANSWER_ID]
+                        [bos_id]
+                        + [0] * (NUM_VISION_TOKENS * images_per_prompt)
+                        + text_tokens
+                        + [ANSWER_ID]
                     )
                 else:
                     text_tokens = self.tokenizer.encode(t, add_special_tokens=False)

--- a/mlx_vlm/models/paligemma/language.py
+++ b/mlx_vlm/models/paligemma/language.py
@@ -260,6 +260,14 @@ class LanguageModel(nn.Module):
                 f"Model type {self.model_type} not supported. Currently only 'gemma' is supported"
             )
 
+    @property
+    def supports_prefix_cache(self):
+        # Bidirectional prefix states depend on tokens beyond the matched prefix.
+        return not bool(self.config.use_bidirectional_attention)
+
+    def chunked_prefill_policy(self, *, draft_model=None, **kwargs):
+        return self.supports_prefix_cache and draft_model is None
+
     def __call__(
         self,
         inputs: mx.array,
@@ -268,6 +276,15 @@ class LanguageModel(nn.Module):
         cache=None,
         **kwargs,
     ):
+        full_mask = kwargs.get("attention_mask_4d")
+        if mask is None and full_mask is not None:
+            c = cache[0] if cache else None
+            offset = getattr(c, "_idx", getattr(c, "offset", 0))
+            length = (
+                inputs_embeds.shape[1] if inputs_embeds is not None else inputs.shape[1]
+            )
+            if offset < full_mask.shape[-2]:
+                mask = full_mask[..., offset : offset + length, : offset + length]
         out = self.model(inputs, mask=mask, cache=cache, inputs_embeds=inputs_embeds)
         out = self.model.embed_tokens.as_linear(out)
 

--- a/mlx_vlm/models/paligemma/paligemma.py
+++ b/mlx_vlm/models/paligemma/paligemma.py
@@ -2,6 +2,7 @@ from typing import Optional
 
 import mlx.core as mx
 import mlx.nn as nn
+import numpy as np
 
 from ..base import InputEmbeddingsFeatures
 from . import processing_paligemma  # noqa: F401
@@ -76,7 +77,7 @@ class Model(nn.Module):
                 output_hidden_states=True,
             )
 
-            image_features = hidden_state[None, :].astype(pixel_values.dtype)
+            image_features = hidden_state.astype(pixel_values.dtype)
             image_features = self.multi_modal_projector(image_features)
 
         final_inputs_embeds, final_attention_mask_4d = (
@@ -91,50 +92,26 @@ class Model(nn.Module):
     def _prepare_inputs_for_multimodal(
         self, image_features, inputs_embeds, input_ids, attention_mask
     ):
-        _, _, embed_dim = image_features.shape
-
+        embed_dim = image_features.shape[-1]
         batch_size, sequence_length = input_ids.shape
         scaled_image_features = image_features / (self.config.hidden_size**0.5)
         final_embedding = mx.zeros((batch_size, sequence_length, embed_dim))
-
-        text_mask = (input_ids != self.config.image_token_index) & (
+        valid = (
             input_ids != self.config.pad_token_id
+            if attention_mask is None
+            else attention_mask.astype(mx.bool_)
         )
-        image_mask = input_ids == self.config.image_token_index
-        pad_mask = input_ids == self.config.pad_token_id
-
-        # expand masks to match embedding dimension
-        text_mask_expanded = mx.expand_dims(text_mask, -1)
-        text_mask_expanded = mx.repeat(text_mask_expanded, embed_dim, axis=-1)
-        pad_mask_expanded = mx.expand_dims(pad_mask, -1)
-        pad_mask_expanded = mx.repeat(pad_mask_expanded, embed_dim, axis=-1)
-
-        # insert padding and text token embeddings
-        final_embedding = mx.where(text_mask_expanded, inputs_embeds, final_embedding)
-        final_embedding = mx.where(
-            pad_mask_expanded, mx.zeros_like(final_embedding), final_embedding
+        final_embedding = mx.where(valid[..., None], inputs_embeds, final_embedding)
+        rows, columns = np.where(np.asarray(input_ids) == self.config.image_token_index)
+        features = scaled_image_features.reshape(-1, embed_dim)
+        if len(rows) != features.shape[0]:
+            raise ValueError("Image features do not match image placeholders")
+        final_embedding[mx.array(rows), mx.array(columns)] = features
+        allowed = valid[:, :, None] & valid[:, None, :]
+        allowed = mx.where(
+            valid[:, :, None], allowed, mx.eye(sequence_length, dtype=mx.bool_)[None]
         )
-        pad_size = final_embedding.shape[1] - scaled_image_features.shape[1]
-        scaled_image_features = mx.pad(
-            scaled_image_features, ((0, 0), (0, pad_size), (0, 0))
-        )
-        # insert image embeddings - the image mask is always less or equal to the sentence in length
-        image_mask_expanded = mx.expand_dims(image_mask, -1)
-        image_mask_expanded = mx.repeat(image_mask_expanded, embed_dim, axis=-1)
-        final_embedding = mx.where(
-            image_mask_expanded, scaled_image_features, final_embedding
-        )
-
-        final_embedding = mx.where(
-            pad_mask_expanded, mx.zeros_like(final_embedding), final_embedding
-        )
-
-        attention_mask_expanded_1 = mx.expand_dims(attention_mask, 1)
-        attention_mask_expanded_2 = mx.expand_dims(attention_mask, 2)
-        final_attention_mask_4d = attention_mask_expanded_1 * attention_mask_expanded_2
-        final_attention_mask_4d = final_attention_mask_4d
-        final_attention_mask_4d = mx.expand_dims(final_attention_mask_4d, 1)
-        final_embedding = mx.array(final_embedding)
+        final_attention_mask_4d = allowed[:, None]
         return final_embedding, final_attention_mask_4d
 
     @property

--- a/mlx_vlm/models/paligemma/vision.py
+++ b/mlx_vlm/models/paligemma/vision.py
@@ -61,7 +61,7 @@ class Encoder(nn.Module):
             if output_hidden_states:
                 encoder_states = encoder_states + (x,)
 
-            h = x[0]
+            h = x
 
         return (h, encoder_states)
 

--- a/mlx_vlm/models/qwen3_5/qwen3_5.py
+++ b/mlx_vlm/models/qwen3_5/qwen3_5.py
@@ -61,51 +61,48 @@ class Model(Qwen3VLModel):
         pixel_values: Optional[mx.array] = None,
         **kwargs,
     ):
-        if pixel_values is None:
-            pixel_values = kwargs.get("pixel_values_videos", None)
+        pixel_values_videos = kwargs.get("pixel_values_videos")
+        image_grid_thw = kwargs.get("image_grid_thw")
+        video_grid_thw = kwargs.get("video_grid_thw")
+        mask = kwargs.get("mask")
+        inputs_embeds = self.language_model.model.embed_tokens(input_ids)
 
-        image_grid_thw = kwargs.get("image_grid_thw", None)
-        video_grid_thw = kwargs.get("video_grid_thw", None)
-        mask = kwargs.get("mask", None)
-        grid_thw = image_grid_thw if image_grid_thw is not None else video_grid_thw
-
-        if pixel_values is None:
+        if pixel_values is None and pixel_values_videos is None:
             position_ids, rope_deltas = self.language_model.get_rope_index(
                 input_ids, attention_mask=mask
             )
             return InputEmbeddingsFeatures(
-                inputs_embeds=self.language_model.model.embed_tokens(input_ids),
+                inputs_embeds=inputs_embeds,
                 position_ids=position_ids,
                 rope_deltas=rope_deltas,
             )
 
         dtype = self.vision_tower.patch_embed.proj.weight.dtype
-        pixel_values = pixel_values.astype(dtype)
+        for pixels, grid, token_index, is_image in (
+            (pixel_values, image_grid_thw, self.config.image_token_index, True),
+            (pixel_values_videos, video_grid_thw, self.config.video_token_index, False),
+        ):
+            if pixels is None:
+                continue
+            vision_cache = kwargs.get("vision_cache") if is_image else None
+            cached = (
+                kwargs.get("cached_image_features")
+                if is_image or pixel_values is None
+                else None
+            )
+            if cached is None and vision_cache is not None:
+                cached = vision_cache.get(kwargs.get("_image_key"))
+            if cached is not None:
+                hidden_states = cached
+            else:
+                hidden_states, _ = self.vision_tower(pixels.astype(dtype), grid)
+                if vision_cache is not None and kwargs.get("_image_key") is not None:
+                    mx.eval(hidden_states)
+                    vision_cache.put(kwargs["_image_key"], hidden_states)
 
-        # Get the input embeddings from the language model
-        inputs_embeds = self.language_model.model.embed_tokens(input_ids)
-
-        vision_cache = kwargs.get("vision_cache", None)
-        cached = kwargs.get("cached_image_features", None)
-        if cached is None and vision_cache is not None:
-            cached = vision_cache.get(kwargs.get("_image_key"))
-        if cached is not None:
-            hidden_states = cached
-        else:
-            # Get the ouptut hidden states from the vision model
-            hidden_states, _ = self.vision_tower(pixel_values, grid_thw)
-            if vision_cache is not None and kwargs.get("_image_key") is not None:
-                mx.eval(hidden_states)
-                vision_cache.put(kwargs["_image_key"], hidden_states)
-
-        # Insert special image tokens in the input_ids
-        inputs_embeds, _ = self.merge_input_ids_with_image_features(
-            hidden_states,
-            inputs_embeds,
-            input_ids,
-            self.config.image_token_index,
-            self.config.video_token_index,
-        )
+            inputs_embeds, _ = self.merge_input_ids_with_image_features(
+                hidden_states, inputs_embeds, input_ids, token_index, token_index
+            )
 
         position_ids, rope_deltas = self.language_model.get_rope_index(
             input_ids, image_grid_thw, video_grid_thw, mask

--- a/mlx_vlm/models/qwen3_omni_moe/thinker.py
+++ b/mlx_vlm/models/qwen3_omni_moe/thinker.py
@@ -230,47 +230,20 @@ class Thinker(nn.Module):
                     if video_mask.ndim == 3
                     else (video_mask | image_mask)
                 )
-                visual_mask_flat = mx.reshape(visual_pos_masks, (-1,))
-                image_mask_flat = mx.reshape(
-                    image_mask[..., 0] if image_mask.ndim == 3 else image_mask, (-1,)
+                image_positions = np.flatnonzero(np.array(image_mask[..., 0]))
+                video_positions = np.flatnonzero(np.array(video_mask[..., 0]))
+                visual_order = mx.array(
+                    np.argsort(np.concatenate((image_positions, video_positions))),
+                    mx.int32,
                 )
-                video_mask_flat = mx.reshape(
-                    video_mask[..., 0] if video_mask.ndim == 3 else video_mask, (-1,)
-                )
-                visual_indices_flat = mx.where(visual_mask_flat)[0]
-                image_mask_on_visual = mx.take(
-                    image_mask_flat, visual_indices_flat, axis=0
-                )
-                video_mask_on_visual = mx.take(
-                    video_mask_flat, visual_indices_flat, axis=0
-                )
-                image_indices = mx.where(image_mask_on_visual)[0]
-                video_indices = mx.where(video_mask_on_visual)[0]
-
-                visual_embeds_multiscale_joint = []
-                for img_embed, vid_embed in zip(
-                    visual_embeds_multiscale, video_embeds_multiscale
-                ):
-                    embed_joint = mx.zeros(
-                        (len(visual_indices_flat), img_embed.shape[-1]),
-                        dtype=img_embed.dtype,
+                visual_embeds_multiscale = tuple(
+                    mx.concatenate((image_features, video_features), axis=0)[
+                        visual_order
+                    ]
+                    for image_features, video_features in zip(
+                        visual_embeds_multiscale, video_embeds_multiscale
                     )
-                    if len(image_indices) > 0:
-                        embed_joint = mx.scatter(
-                            embed_joint,
-                            image_indices,
-                            mx.take(img_embed, image_indices, axis=0),
-                            axis=0,
-                        )
-                    if len(video_indices) > 0:
-                        embed_joint = mx.scatter(
-                            embed_joint,
-                            video_indices,
-                            mx.take(vid_embed, video_indices, axis=0),
-                            axis=0,
-                        )
-                    visual_embeds_multiscale_joint.append(embed_joint)
-                visual_embeds_multiscale = tuple(visual_embeds_multiscale_joint)
+                )
 
         mask = kwargs.get("mask", None)
         position_ids, rope_deltas = self.language_model.get_rope_index(

--- a/mlx_vlm/prompt_utils.py
+++ b/mlx_vlm/prompt_utils.py
@@ -1,5 +1,7 @@
+import hashlib
 import inspect
 import json
+import re
 from copy import deepcopy
 from enum import Enum
 from functools import partial
@@ -671,15 +673,154 @@ def _string_content_messages(messages, image_token):
     return result if changed else messages
 
 
-def _legacy_gemma_history(messages, template, tools=None):
-    if not isinstance(template, str) or not all(
-        marker in template
-        for marker in (
-            "<start_of_turn>",
-            "<end_of_turn>",
-            "Conversation roles must alternate",
+_CALL_ID_LENGTH = re.compile(r"\.(?:id|tool_call_id)\s*\|\s*length\s*!=\s*(\d+)")
+
+
+def _fixed_length_call_id(value, length):
+    return hashlib.sha256(str(value).encode()).hexdigest()[:length]
+
+
+def _template_tool_history(messages, template):
+    """Fit a tool history to templates with a stricter tool protocol.
+
+    Mistral-style templates reject call IDs that are not a fixed number of
+    alphanumeric characters, and render an assistant turn's tool calls instead
+    of its content. Remap the IDs to the required width, keeping each call
+    paired with its result, and carry the content in its own turn.
+    """
+    if not isinstance(template, str):
+        return messages
+    match = _CALL_ID_LENGTH.search(template)
+    length = int(match.group(1)) if match else None
+    split = "message.tool_calls" in template
+    if length is None and not split:
+        return messages
+
+    result = []
+    changed = False
+    for message in messages:
+        message = dict(message)
+        calls = message.get("tool_calls")
+        if length is not None and message.get("tool_call_id") is not None:
+            message["tool_call_id"] = _fixed_length_call_id(
+                message["tool_call_id"], length
+            )
+            changed = True
+        if calls and length is not None:
+            message["tool_calls"] = [
+                (
+                    {**call, "id": _fixed_length_call_id(call["id"], length)}
+                    if call.get("id") is not None
+                    else call
+                )
+                for call in calls
+            ]
+            changed = True
+        if calls and split and message.get("content"):
+            spoken = {
+                key: value for key, value in message.items() if key != "tool_calls"
+            }
+            message = {key: value for key, value in message.items() if key != "content"}
+            result.append(spoken)
+            changed = True
+        result.append(message)
+    return result if changed else messages
+
+
+_SUPPORTED_ROLES = re.compile(
+    r"only (?P<roles>[\w,\s]+?) roles? (?:are|is) supported", re.IGNORECASE
+)
+
+
+def _explicit_content(message):
+    """Content parts for a message whose role the template cannot express."""
+    metadata = {key: value for key, value in message.items() if key != "content"}
+    content = deepcopy(message.get("content") or [])
+    if isinstance(content, str):
+        content = [{"type": "text", "text": content}]
+    return [
+        {"type": "text", "text": json.dumps(metadata, ensure_ascii=False) + "\n"}
+    ] + content
+
+
+def _collapse_text_content(messages):
+    for message in messages:
+        content = message.get("content")
+        if isinstance(content, list) and all(
+            part.get("type") == "text" for part in content
+        ):
+            message["content"] = "".join(part["text"] for part in content)
+    return messages
+
+
+def _supported_role_messages(messages, error_message, template=None, tools=None):
+    """Fold turns a template rejects into the roles it names as supported.
+
+    Templates that raise "Only <roles> roles are supported" state their own
+    contract. Turns outside it, and turns carrying fields the template never
+    reads, keep their original role and metadata as explicit text inside a role
+    the template does render, rather than being dropped on the way through.
+    """
+    rendered = template if isinstance(template, str) else ""
+    match = _SUPPORTED_ROLES.search(f"{error_message}\n{rendered}")
+    if not match:
+        return messages
+    roles = {
+        word
+        for word in re.split(r"[,\s]+", match.group("roles").replace(" and ", " "))
+        if word
+    }
+    if not roles:
+        return messages
+
+    fallback = "user" if "user" in roles else sorted(roles)[0]
+    result = []
+    changed = False
+    for message in messages:
+        role = message.get("role")
+        if role in roles and all(
+            field in rendered for field in set(message) - {"role", "content"}
+        ):
+            result.append(message)
+            continue
+        result.append(
+            {
+                "role": role if role in roles else fallback,
+                "content": _explicit_content(message),
+            }
         )
-    ):
+        changed = True
+    if tools and "tools" not in rendered:
+        index = next(
+            (i for i, message in enumerate(result) if message["role"] == fallback), None
+        )
+        if index is not None:
+            preamble = {
+                "type": "text",
+                "text": "Available tools: "
+                + json.dumps(tools, ensure_ascii=False)
+                + "\n",
+            }
+            content = result[index].get("content")
+            if isinstance(content, str):
+                content = [{"type": "text", "text": content}]
+            elif not isinstance(content, list):
+                content = []
+            else:
+                content = list(content)
+            result[index] = {**result[index], "content": [preamble] + content}
+            changed = True
+    return _collapse_text_content(result) if changed else messages
+
+
+def _alternating_role_history(messages, template_processor, tools=None):
+    if "apply_chat_template" in type(template_processor).__dict__:
+        return messages
+    template = getattr(template_processor, "chat_template", None)
+    if not isinstance(template, str):
+        return messages
+    lowered = template.lower()
+    if "roles must alternate" not in lowered:
         return messages
     if any(field in template for field in ("tools", "tool_calls", "reasoning")):
         return messages
@@ -688,7 +829,8 @@ def _legacy_gemma_history(messages, template, tools=None):
     if (
         ordinary
         and ordinary[0].get("role") == "system"
-        and "System role not supported" not in template
+        and "system" in lowered
+        and "system role not supported" not in lowered
     ):
         ordinary = ordinary[1:]
     rich = tools or any(set(message) - {"role", "content"} for message in messages)
@@ -699,18 +841,10 @@ def _legacy_gemma_history(messages, template, tools=None):
     if not rich:
         return messages
 
-    # Legacy Gemma only accepts alternating user/model turns. Keep the original
-    # roles and metadata explicit inside those turns, including tool results.
     result = []
     for message in messages:
         role = "assistant" if message.get("role") == "assistant" else "user"
-        metadata = {key: value for key, value in message.items() if key != "content"}
-        content = deepcopy(message.get("content") or [])
-        if isinstance(content, str):
-            content = [{"type": "text", "text": content}]
-        content = [
-            {"type": "text", "text": json.dumps(metadata, ensure_ascii=False) + "\n"}
-        ] + content
+        content = _explicit_content(message)
         if result and result[-1]["role"] == role:
             result[-1]["content"] += [{"type": "text", "text": "\n"}] + content
         else:
@@ -727,10 +861,7 @@ def _legacy_gemma_history(messages, template, tools=None):
                 + "\n",
             },
         )
-    for message in result:
-        if all(part.get("type") == "text" for part in message["content"]):
-            message["content"] = "".join(part["text"] for part in message["content"])
-    return result
+    return _collapse_text_content(result)
 
 
 def get_chat_template(
@@ -961,9 +1092,9 @@ def get_chat_template(
             return _messages_to_plain_prompt()
 
         if chat_template_override is None:
-            messages = _legacy_gemma_history(
+            messages = _alternating_role_history(
                 messages,
-                getattr(template_processor, "chat_template", None),
+                template_processor,
                 kwargs.get("tools"),
             )
         template_kwargs = dict(kwargs)
@@ -985,32 +1116,34 @@ def get_chat_template(
                 add_generation_prompt=add_generation_prompt,
                 **template_kwargs,
             )
-        except TypeError as error:
-            normalized = _string_content_messages(messages, _get_image_token())
-            if normalized is messages:
-                raise
-            try:
-                return template_processor.apply_chat_template(
-                    normalized,
-                    tokenize=tokenize,
-                    add_generation_prompt=add_generation_prompt,
-                    **template_kwargs,
-                )
-            except (TemplateError, TypeError, ValueError):
-                raise error
-        except TemplateError as error:
-            normalized = _coalesce_leading_system_text(messages)
-            if normalized is messages:
-                raise
-            try:
-                return template_processor.apply_chat_template(
-                    normalized,
-                    tokenize=tokenize,
-                    add_generation_prompt=add_generation_prompt,
-                    **template_kwargs,
-                )
-            except (TemplateError, TypeError, ValueError):
-                raise error
+        except (TypeError, TemplateError) as error:
+            template = getattr(template_processor, "chat_template", None)
+            normalized = messages
+            for normalize in (
+                _coalesce_leading_system_text,
+                partial(_template_tool_history, template=template),
+                partial(
+                    _supported_role_messages,
+                    error_message=error,
+                    template=template,
+                    tools=kwargs.get("tools"),
+                ),
+                partial(_string_content_messages, image_token=_get_image_token()),
+            ):
+                candidate = normalize(normalized)
+                if candidate is normalized:
+                    continue
+                normalized = candidate
+                try:
+                    return template_processor.apply_chat_template(
+                        normalized,
+                        tokenize=tokenize,
+                        add_generation_prompt=add_generation_prompt,
+                        **template_kwargs,
+                    )
+                except (TemplateError, TypeError, ValueError):
+                    continue
+            raise error
         except ValueError as e:
             if chat_template_override is None and _missing_template_error(e):
                 return _messages_to_plain_prompt()

--- a/mlx_vlm/prompt_utils.py
+++ b/mlx_vlm/prompt_utils.py
@@ -701,27 +701,25 @@ def _template_tool_history(messages, template):
     for message in messages:
         message = dict(message)
         calls = message.get("tool_calls")
-        if length is not None and message.get("tool_call_id") is not None:
-            message["tool_call_id"] = _fixed_length_call_id(
-                message["tool_call_id"], length
-            )
-            changed = True
-        if calls and length is not None:
-            message["tool_calls"] = [
-                (
-                    {**call, "id": _fixed_length_call_id(call["id"], length)}
-                    if call.get("id") is not None
-                    else call
+        if length is not None:
+            if message.get("tool_call_id") is not None:
+                message["tool_call_id"] = _fixed_length_call_id(
+                    message["tool_call_id"], length
                 )
-                for call in calls
-            ]
-            changed = True
+                changed = True
+            if calls:
+                message["tool_calls"] = [
+                    (
+                        {**call, "id": _fixed_length_call_id(call["id"], length)}
+                        if call.get("id") is not None
+                        else call
+                    )
+                    for call in calls
+                ]
+                changed = True
         if calls and split and message.get("content"):
-            spoken = {
-                key: value for key, value in message.items() if key != "tool_calls"
-            }
-            message = {key: value for key, value in message.items() if key != "content"}
-            result.append(spoken)
+            result.append({k: v for k, v in message.items() if k != "tool_calls"})
+            message.pop("content")
             changed = True
         result.append(message)
     return result if changed else messages
@@ -790,26 +788,19 @@ def _supported_role_messages(messages, error_message, template=None, tools=None)
             }
         )
         changed = True
-    if tools and "tools" not in rendered:
-        index = next(
-            (i for i, message in enumerate(result) if message["role"] == fallback), None
-        )
-        if index is not None:
-            preamble = {
-                "type": "text",
-                "text": "Available tools: "
-                + json.dumps(tools, ensure_ascii=False)
-                + "\n",
-            }
-            content = result[index].get("content")
-            if isinstance(content, str):
-                content = [{"type": "text", "text": content}]
-            elif not isinstance(content, list):
-                content = []
-            else:
-                content = list(content)
-            result[index] = {**result[index], "content": [preamble] + content}
-            changed = True
+    for index, message in enumerate(result):
+        if not tools or "tools" in rendered or message["role"] != fallback:
+            continue
+        content = message.get("content") or []
+        if isinstance(content, str):
+            content = [{"type": "text", "text": content}]
+        preamble = {
+            "type": "text",
+            "text": "Available tools: " + json.dumps(tools, ensure_ascii=False) + "\n",
+        }
+        result[index] = {**message, "content": [preamble] + list(content)}
+        changed = True
+        break
     return _collapse_text_content(result) if changed else messages
 
 

--- a/mlx_vlm/prompt_utils.py
+++ b/mlx_vlm/prompt_utils.py
@@ -4,6 +4,8 @@ from enum import Enum
 from functools import partial
 from typing import Any, Dict, List, Union
 
+from jinja2.exceptions import TemplateError
+
 
 class MessageFormat(Enum):
     """Enum for different message format types."""
@@ -108,10 +110,11 @@ MODEL_CONFIG = {
     "florence2": MessageFormat.PROMPT_ONLY,
     "plamo2vl": MessageFormat.PROMPT_ONLY,
     "molmo": MessageFormat.TEXT_ONLY,
+    "moondream1": MessageFormat.TEXT_ONLY,
     "moondream2": MessageFormat.PROMPT_ONLY,
-    "moondream3": MessageFormat.PROMPT_ONLY,
+    "moondream3": MessageFormat.TEXT_ONLY,
     "falcon_ocr": MessageFormat.PROMPT_ONLY,
-    "paligemma": MessageFormat.PROMPT_WITH_IMAGE_TOKEN,
+    "paligemma": MessageFormat.IMAGE_TOKEN,
     "laguna": MessageFormat.TEXT_ONLY,
     "nemotron_labs_diffusion": MessageFormat.TEXT_ONLY,
     "deepseek_v4": MessageFormat.LIST_WITH_IMAGE_FIRST,
@@ -121,10 +124,7 @@ MODEL_CONFIG = {
 
 # Models that don't support multi-image
 SINGLE_IMAGE_ONLY_MODELS = {
-    "llava_next",
-    "llava-qwen2",
     "bunny-llama",
-    "paligemma",
     "multi_modality",
     "mllama",
     "falcon_ocr",
@@ -600,6 +600,76 @@ def get_message_json(
     )
 
 
+def _coalesce_leading_system_text(messages):
+    end = 0
+    texts = []
+    for message in messages:
+        if (
+            not isinstance(message, dict)
+            or set(message) != {"role", "content"}
+            or message["role"] != "system"
+        ):
+            break
+        content = message["content"]
+        if isinstance(content, list):
+            if not all(
+                isinstance(part, dict)
+                and (
+                    set(part) == {"type", "text"}
+                    or (
+                        set(part) == {"type", "text", "content"}
+                        and part["content"] == part["text"]
+                    )
+                )
+                and part["type"] == "text"
+                and isinstance(part["text"], str)
+                for part in content
+            ):
+                break
+            content = " ".join(part["text"] for part in content)
+        if not isinstance(content, str):
+            break
+        texts.append(content)
+        end += 1
+    if end < 2:
+        return messages
+    return [{"role": "system", "content": "\n\n".join(texts)}, *messages[end:]]
+
+
+def _string_content_messages(messages, image_token):
+    result = []
+    changed = False
+    for message in messages:
+        if not isinstance(message, dict):
+            return messages
+        content = message.get("content")
+        if not isinstance(content, list):
+            result.append(message)
+            continue
+        parts = []
+        for part in content:
+            if isinstance(part, dict) and part == {"type": "image"}:
+                parts.append(image_token)
+            elif (
+                isinstance(part, dict)
+                and part.get("type") == "text"
+                and isinstance(part.get("text"), str)
+                and (
+                    set(part) == {"type", "text"}
+                    or (
+                        set(part) == {"type", "text", "content"}
+                        and part["content"] == part["text"]
+                    )
+                )
+            ):
+                parts.append(part["text"])
+            else:
+                return messages
+        result.append({**message, "content": "\n".join(parts)})
+        changed = True
+    return result if changed else messages
+
+
 def get_chat_template(
     processor,
     messages: List[Dict[str, Any]],
@@ -705,6 +775,7 @@ def get_chat_template(
             if isinstance(message, dict):
                 normalized.append(
                     {
+                        **message,
                         "role": message.get("role", "user"),
                         "content": _flatten_content(
                             message.get("content", ""), image_token, video_token
@@ -718,10 +789,19 @@ def get_chat_template(
         if not normalized:
             return ""
 
-        if len(normalized) == 1 and normalized[0]["role"] == "user":
+        if (
+            len(normalized) == 1
+            and normalized[0]["role"] == "user"
+            and len(normalized[0]) == 2
+            and not kwargs.get("tools")
+        ):
             return normalized[0]["content"]
 
         lines = []
+        if kwargs.get("tools"):
+            lines.append(
+                f"Available tools: {json.dumps(kwargs['tools'], ensure_ascii=False)}"
+            )
         for message in normalized:
             role = message.get("role", "user")
             content = message.get("content", "")
@@ -730,6 +810,15 @@ def get_chat_template(
                 lines.append(f"{prefix}: {content}" if content else f"{prefix}:")
             else:
                 lines.append(content if content else "")
+            metadata = {
+                key: value
+                for key, value in message.items()
+                if key not in ("role", "content")
+            }
+            if metadata:
+                lines.append(
+                    f"{role.capitalize()} metadata: {json.dumps(metadata, ensure_ascii=False)}"
+                )
 
         if add_generation_prompt:
             lines.append("Assistant:")
@@ -827,6 +916,32 @@ def get_chat_template(
                 add_generation_prompt=add_generation_prompt,
                 **template_kwargs,
             )
+        except TypeError as error:
+            normalized = _string_content_messages(messages, _get_image_token())
+            if normalized is messages:
+                raise
+            try:
+                return template_processor.apply_chat_template(
+                    normalized,
+                    tokenize=tokenize,
+                    add_generation_prompt=add_generation_prompt,
+                    **template_kwargs,
+                )
+            except (TemplateError, TypeError, ValueError):
+                raise error
+        except TemplateError as error:
+            normalized = _coalesce_leading_system_text(messages)
+            if normalized is messages:
+                raise
+            try:
+                return template_processor.apply_chat_template(
+                    normalized,
+                    tokenize=tokenize,
+                    add_generation_prompt=add_generation_prompt,
+                    **template_kwargs,
+                )
+            except (TemplateError, TypeError, ValueError):
+                raise error
         except ValueError as e:
             if chat_template_override is None and _missing_template_error(e):
                 return _messages_to_plain_prompt()
@@ -1015,12 +1130,20 @@ def apply_chat_template(
                             **kwargs,
                         )
                     )
+                    if isinstance(p, dict) and isinstance(messages[-1], dict):
+                        messages[-1].update(
+                            {
+                                key: value
+                                for key, value in p.items()
+                                if key not in ("role", "content")
+                            }
+                        )
 
     if return_messages:
         return messages
 
     # Some models only need the last message
-    if model_type in ["paligemma", "florence2", "falcon_ocr"]:
+    if model_type in ["florence2", "falcon_ocr"]:
         return messages[-1]
 
     return get_chat_template(processor, messages, add_generation_prompt, **kwargs)

--- a/mlx_vlm/prompt_utils.py
+++ b/mlx_vlm/prompt_utils.py
@@ -1,5 +1,6 @@
 import inspect
 import json
+from copy import deepcopy
 from enum import Enum
 from functools import partial
 from typing import Any, Dict, List, Union
@@ -670,6 +671,68 @@ def _string_content_messages(messages, image_token):
     return result if changed else messages
 
 
+def _legacy_gemma_history(messages, template, tools=None):
+    if not isinstance(template, str) or not all(
+        marker in template
+        for marker in (
+            "<start_of_turn>",
+            "<end_of_turn>",
+            "Conversation roles must alternate",
+        )
+    ):
+        return messages
+    if any(field in template for field in ("tools", "tool_calls", "reasoning")):
+        return messages
+
+    ordinary = _coalesce_leading_system_text(messages)
+    if (
+        ordinary
+        and ordinary[0].get("role") == "system"
+        and "System role not supported" not in template
+    ):
+        ordinary = ordinary[1:]
+    rich = tools or any(set(message) - {"role", "content"} for message in messages)
+    rich = rich or any(
+        message.get("role") != ("user" if index % 2 == 0 else "assistant")
+        for index, message in enumerate(ordinary)
+    )
+    if not rich:
+        return messages
+
+    # Legacy Gemma only accepts alternating user/model turns. Keep the original
+    # roles and metadata explicit inside those turns, including tool results.
+    result = []
+    for message in messages:
+        role = "assistant" if message.get("role") == "assistant" else "user"
+        metadata = {key: value for key, value in message.items() if key != "content"}
+        content = deepcopy(message.get("content") or [])
+        if isinstance(content, str):
+            content = [{"type": "text", "text": content}]
+        content = [
+            {"type": "text", "text": json.dumps(metadata, ensure_ascii=False) + "\n"}
+        ] + content
+        if result and result[-1]["role"] == role:
+            result[-1]["content"] += [{"type": "text", "text": "\n"}] + content
+        else:
+            result.append({"role": role, "content": content})
+    if not result or result[0]["role"] != "user":
+        result.insert(0, {"role": "user", "content": []})
+    if tools:
+        result[0]["content"].insert(
+            0,
+            {
+                "type": "text",
+                "text": "Available tools: "
+                + json.dumps(tools, ensure_ascii=False)
+                + "\n",
+            },
+        )
+    for message in result:
+        if all(part.get("type") == "text" for part in message["content"]):
+            message["content"] = "".join(part["text"] for part in message["content"])
+    return result
+
+
 def get_chat_template(
     processor,
     messages: List[Dict[str, Any]],
@@ -897,6 +960,12 @@ def get_chat_template(
         if template_processor is None:
             return _messages_to_plain_prompt()
 
+        if chat_template_override is None:
+            messages = _legacy_gemma_history(
+                messages,
+                getattr(template_processor, "chat_template", None),
+                kwargs.get("tools"),
+            )
         template_kwargs = dict(kwargs)
         if "enable_thinking" not in template_kwargs and _supports_template_kw(
             template_processor, "enable_thinking"

--- a/mlx_vlm/server/anthropic.py
+++ b/mlx_vlm/server/anthropic.py
@@ -30,6 +30,7 @@ from .responses_state import (
     ToolCallStreamState,
     make_response_stream_state,
     prompt_has_open_thinking,
+    prompt_open_channel,
 )
 from .runtime import runtime
 from .schemas import AnthropicMessageResponse, AnthropicRequest, AnthropicUsage
@@ -565,6 +566,7 @@ async def anthropic_messages_endpoint(http_request: Request):
                     ),
                     gen_args.thinking_start_token,
                     gen_args.thinking_end_token,
+                    open_channel=prompt_open_channel(formatted_prompt),
                 )
                 tc_start = tool_module.tool_call_start if tool_module else None
                 tc_end = tool_module.tool_call_end if tool_module else None
@@ -967,6 +969,7 @@ async def anthropic_messages_endpoint(http_request: Request):
                 gen_args.thinking_start_token,
                 gen_args.thinking_end_token,
                 processor=processor,
+                open_channel=prompt_open_channel(formatted_prompt),
             )
             parsed_tool_calls = None
             if tool_module is not None and tools:

--- a/mlx_vlm/server/app.py
+++ b/mlx_vlm/server/app.py
@@ -310,6 +310,7 @@ def _split_thinking(
     thinking_end_token: Optional[str] = None,
     starts_in_thinking: bool = False,
     processor=None,
+    open_channel: Optional[str] = None,
 ) -> Tuple[Optional[str], str]:
     """Split thinking tags from content. Returns (reasoning, content)."""
     return _split_thinking_text(
@@ -318,6 +319,7 @@ def _split_thinking(
         thinking_end_token,
         starts_in_thinking,
         processor=processor,
+        open_channel=open_channel,
     )
 
 

--- a/mlx_vlm/server/openai.py
+++ b/mlx_vlm/server/openai.py
@@ -579,19 +579,24 @@ async def responses_input_tokens_endpoint(request: Request):
             source, processor, config, gen_args, render=apply_chat_template
         )
         formatted_prompt, images = prepared.prompt, prepared.images
+        audio, videos = prepared.audio, prepared.videos
         if runtime.response_generator is not None:
             raw_inputs = await asyncio.to_thread(
                 runtime.response_generator._cpu_preprocess,
                 formatted_prompt,
                 images if images else None,
-                None,
+                audio if audio else None,
+                **({"videos": videos} if videos else {}),
             )
         else:
             image_token_index = getattr(config, "image_token_index", None)
             raw_inputs = prepare_inputs(
                 processor,
                 images=images if images else None,
+                audio=audio if audio else None,
+                videos=videos if videos else None,
                 prompts=formatted_prompt,
+                **prepared.generation_kwargs,
                 image_token_index=image_token_index,
             )
         return {"input_tokens": _count_prompt_tokens(raw_inputs)}
@@ -737,6 +742,7 @@ async def responses_endpoint(request: Request):
             source, processor, config, gen_args, render=apply_chat_template
         )
         formatted_prompt, images = prepared.prompt, prepared.images
+        audio, videos = prepared.audio, prepared.videos
         kwargs = prepared.generation_kwargs
 
         logger.debug(
@@ -764,7 +770,8 @@ async def responses_endpoint(request: Request):
                 model=openai_request.model,
                 prompt=formatted_prompt,
                 images=images if images else None,
-                audio=None,
+                audio=audio if audio else None,
+                videos=videos if videos else None,
                 args=gen_args,
             )
 
@@ -854,8 +861,9 @@ async def responses_endpoint(request: Request):
                             runtime.response_generator.generate,
                             formatted_prompt,
                             images if images else None,
-                            None,  # audio
+                            audio if audio else None,
                             gen_args,
+                            **({"videos": videos} if videos else {}),
                         )
                         usage_stats["input_tokens"] = ctx.prompt_tokens
 
@@ -915,6 +923,8 @@ async def responses_endpoint(request: Request):
                             processor=processor,
                             prompt=formatted_prompt,
                             image=images,
+                            audio=audio,
+                            video=videos,
                             vision_cache=runtime.model_cache.get("vision_cache"),
                             apc_manager=runtime.apc_manager,
                             **gen_args.to_generate_kwargs(),
@@ -1173,7 +1183,9 @@ async def responses_endpoint(request: Request):
                         ctx_, ti = runtime.response_generator.generate(
                             prompt=formatted_prompt,
                             images=images if images else None,
+                            audio=audio if audio else None,
                             args=gen_args,
+                            **({"videos": videos} if videos else {}),
                         )
                         text = ""
                         ot = 0
@@ -1204,6 +1216,8 @@ async def responses_endpoint(request: Request):
                         processor=processor,
                         prompt=formatted_prompt,
                         image=images,
+                        audio=audio,
+                        video=videos,
                         verbose=logger.isEnabledFor(logging.DEBUG),
                         vision_cache=runtime.model_cache.get("vision_cache"),
                         apc_manager=runtime.apc_manager,

--- a/mlx_vlm/server/openai.py
+++ b/mlx_vlm/server/openai.py
@@ -1,6 +1,4 @@
 import asyncio
-import base64
-import binascii
 import gc
 import json
 import logging
@@ -9,9 +7,8 @@ import re
 import time
 import uuid
 from datetime import datetime
-from io import BytesIO
 from pathlib import Path
-from typing import Any, List, Optional, Tuple
+from typing import List, Optional, Tuple
 
 import mlx.core as mx
 from fastapi import HTTPException, Request
@@ -22,11 +19,9 @@ from ..generate.edit_image import ImageEditRequest as CoreImageEditRequest
 from ..generate.edit_image import edit_image
 from ..generate.image import ImageGenerationRequest as CoreImageGenerationRequest
 from ..generate.image import generate_image, parse_size
-from ..generate.video import resolve_video_inputs
-from ..prompt_utils import apply_chat_template, extract_text_from_content
+from ..prompt_utils import apply_chat_template
 from ..tools import (
     _infer_tool_parser_from_processor,
-    _prepare_chat_tool_choice,
     load_tool_module,
     process_tool_calls,
 )
@@ -37,13 +32,16 @@ from .generation import (
     _build_metrics_envelope,
     _count_prompt_tokens,
 )
+from .request_preparation import (
+    normalize_chat_input,
+    normalize_responses_input,
+    prepare_prompt,
+)
 from .responses_state import (
     ToolCallStreamState,
     _normalize_response_input,
     _response_chain_items,
-    _response_items_to_chat,
     _response_output_items_from_text,
-    _response_tool_registry,
 )
 from .responses_state import _sse_event as _response_sse_event
 from .responses_state import (
@@ -70,7 +68,6 @@ from .schemas import (
     ImageGenerationRequest,
     ImageGenerationResponse,
     ImageGenerationResponseData,
-    InputAudio,
     MessageItem,
     OpenAIRequest,
     OpenAIResponse,
@@ -98,69 +95,6 @@ _preflight_stream_context_budget = None
 _split_thinking = None
 _count_thinking_tag_tokens = None
 _make_logprob_content = None
-_AUDIO_REFERENCE_PREFIXES = ("http://", "https://", "file://", "/", "./", "../")
-_AUDIO_REFERENCE_SUFFIXES = (".wav", ".mp3", ".flac", ".ogg", ".m4a", ".aac", ".webm")
-_MISSING_INPUT_DETAIL = (
-    "Request must include at least one non-empty message content or media input."
-)
-
-
-def _has_non_empty_text(value: Any) -> bool:
-    return isinstance(value, str) and bool(value.strip())
-
-
-def _content_has_effective_input(content: Any) -> bool:
-    if _has_non_empty_text(content):
-        return True
-    if content is None:
-        return False
-    if isinstance(content, list):
-        for item in content:
-            if not isinstance(item, dict):
-                continue
-            item_type = item.get("type")
-            if item_type in ("text", "input_text", "output_text"):
-                if _has_non_empty_text(item.get("text")) or _has_non_empty_text(
-                    item.get("content")
-                ):
-                    return True
-            elif item_type in ("image_url", "input_image"):
-                image = item.get("image_url") or item.get("file_id")
-                if isinstance(image, dict):
-                    image = image.get("url")
-                if image:
-                    return True
-            elif item_type == "input_audio":
-                input_audio = item.get("input_audio")
-                if isinstance(input_audio, dict) and input_audio.get("data"):
-                    return True
-            elif _content_has_effective_input(item.get("content")):
-                return True
-        return False
-    if isinstance(content, dict):
-        return _content_has_effective_input([content])
-    return bool(str(content).strip())
-
-
-def _message_has_effective_input(message: Any) -> bool:
-    if hasattr(message, "model_dump"):
-        message = message.model_dump(exclude_none=True)
-    if not isinstance(message, dict):
-        return False
-    return (
-        _content_has_effective_input(message.get("content"))
-        or bool(message.get("tool_calls"))
-        or _has_non_empty_text(message.get("reasoning_content"))
-        or _has_non_empty_text(message.get("reasoning"))
-    )
-
-
-def _ensure_effective_input(messages, *, images=None, audio=None):
-    if any(image for image in (images or [])) or any(item for item in (audio or [])):
-        return
-    if any(_message_has_effective_input(message) for message in messages or []):
-        return
-    raise HTTPException(status_code=400, detail=_MISSING_INPUT_DETAIL)
 
 
 def _runtime_cache_get(key, default=None, *, kind=None):
@@ -171,87 +105,12 @@ def _runtime_cache_get(key, default=None, *, kind=None):
         return cache.get(key, default)
 
 
-def _looks_like_audio_reference(value: str) -> bool:
-    return value.startswith(_AUDIO_REFERENCE_PREFIXES) or value.lower().endswith(
-        _AUDIO_REFERENCE_SUFFIXES
-    )
-
-
 def _adapter_path_or_inherit(request):
     return (
         request.adapter_path
         if "adapter_path" in request.model_fields_set
         else _INHERIT_ADAPTER
     )
-
-
-def _normalize_response_instruction_messages(
-    chat_messages: List[dict],
-    instructions: Optional[str],
-) -> Optional[str]:
-    instruction_parts = [instructions] if instructions else []
-    conversation = []
-
-    for message in chat_messages:
-        if message.get("role") in ("system", "developer"):
-            content = message.get("content")
-            if content:
-                instruction_parts.append(str(content))
-        else:
-            conversation.append(message)
-
-    normalized_instructions = "\n\n".join(instruction_parts) or None
-    if normalized_instructions:
-        conversation.insert(
-            0,
-            {"role": "system", "content": normalized_instructions},
-        )
-    chat_messages[:] = conversation
-    return normalized_instructions
-
-
-def _decode_input_audio_data(input_audio: InputAudio):
-    data = input_audio["data"]
-    if not isinstance(data, str):
-        return data
-
-    stripped = data.strip()
-    if stripped.startswith("data:"):
-        prefix, separator, encoded = stripped.partition(",")
-        if (
-            separator == ","
-            and ";base64" in prefix
-            and prefix.startswith("data:audio/")
-        ):
-            try:
-                return BytesIO(base64.b64decode(encoded, validate=True))
-            except (binascii.Error, ValueError) as exc:
-                raise HTTPException(
-                    status_code=400,
-                    detail="input_audio data URI is not valid base64 audio",
-                ) from exc
-        return data
-
-    if _looks_like_audio_reference(stripped):
-        return data
-
-    try:
-        return BytesIO(base64.b64decode(stripped, validate=True))
-    except (binascii.Error, ValueError):
-        return data
-
-
-def _extract_video_reference(item):
-    item_type = item.get("type")
-    if item_type == "video":
-        return item.get("video")
-    if item_type == "input_video":
-        video = item.get("video") or item.get("video_url")
-    elif item_type == "video_url":
-        video = item.get("video_url")
-    else:
-        return None
-    return video.get("url") if isinstance(video, dict) else video
 
 
 def _final_chat_chunk(
@@ -708,32 +567,18 @@ async def responses_input_tokens_endpoint(request: Request):
             _response_chain_items(openai_request.previous_response_id)
             + current_input_items
         )
-        chat_messages, images = _response_items_to_chat(prompt_items)
-        _normalize_response_instruction_messages(
-            chat_messages,
-            openai_request.instructions,
-        )
-        _ensure_effective_input(chat_messages, images=images)
-
+        source, _, _ = normalize_responses_input(openai_request, prompt_items)
         model, processor, config = get_cached_model(
             openai_request.model, _adapter_path_or_inherit(openai_request)
         )
         del model
-        chat_tools, _ = _response_tool_registry(openai_request.tools)
         gen_args = _build_gen_args(
             openai_request, processor, tenant_id=_read_tenant_id(request)
         )
-        template_kwargs = gen_args.to_template_kwargs()
-        if openai_request.tool_choice is not None:
-            template_kwargs["tool_choice"] = openai_request.tool_choice
-        formatted_prompt = apply_chat_template(
-            processor,
-            config,
-            chat_messages,
-            num_images=len(images),
-            tools=chat_tools or None,
-            **template_kwargs,
+        prepared = prepare_prompt(
+            source, processor, config, gen_args, render=apply_chat_template
         )
+        formatted_prompt, images = prepared.prompt, prepared.images
         if runtime.response_generator is not None:
             raw_inputs = await asyncio.to_thread(
                 runtime.response_generator._cpu_preprocess,
@@ -858,8 +703,6 @@ async def responses_endpoint(request: Request):
     openai_request = OpenAIRequest(**body)
 
     try:
-        kwargs = {}
-
         if openai_request.input is None:
             logger.warning("Responses request is missing input.")
             raise HTTPException(status_code=400, detail="Missing input.")
@@ -869,19 +712,13 @@ async def responses_endpoint(request: Request):
             _response_chain_items(openai_request.previous_response_id)
             + current_input_items
         )
-        chat_messages, images = _response_items_to_chat(prompt_items)
-        instructions = _normalize_response_instruction_messages(
-            chat_messages,
-            openai_request.instructions,
+        source, instructions, tool_registry = normalize_responses_input(
+            openai_request, prompt_items
         )
-        _ensure_effective_input(chat_messages, images=images)
-
-        # Get model, processor, config - loading if necessary
         model, processor, config = get_cached_model(
             openai_request.model, _adapter_path_or_inherit(openai_request)
         )
-
-        chat_tools, tool_registry = _response_tool_registry(openai_request.tools)
+        chat_tools = source.tools
         tool_parser_type = _infer_tool_parser_from_processor(
             processor, override=openai_request.tool_parser
         )
@@ -896,18 +733,11 @@ async def responses_endpoint(request: Request):
         if chat_tools and tool_module is not None:
             gen_args.skip_special_tokens = False
 
-        template_kwargs = gen_args.to_template_kwargs()
-        if openai_request.tool_choice is not None:
-            template_kwargs["tool_choice"] = openai_request.tool_choice
-
-        formatted_prompt = apply_chat_template(
-            processor,
-            config,
-            chat_messages,
-            num_images=len(images),
-            tools=chat_tools or None,
-            **template_kwargs,
+        prepared = prepare_prompt(
+            source, processor, config, gen_args, render=apply_chat_template
         )
+        formatted_prompt, images = prepared.prompt, prepared.images
+        kwargs = prepared.generation_kwargs
 
         logger.debug(
             "responses request: model=%s images=%d max_tokens=%s temp=%s stream=%s",
@@ -1514,109 +1344,11 @@ async def chat_completions_endpoint(request: ChatRequest, http_request: Request)
 
     request_start = time.perf_counter()
     try:
-        adapter_path = (
-            request.adapter_path
-            if "adapter_path" in request.model_fields_set
-            else _INHERIT_ADAPTER
+        source = normalize_chat_input(request)
+        model, processor, config = get_cached_model(
+            request.model, _adapter_path_or_inherit(request)
         )
-
-        kwargs = {}
-
-        if request.resize_shape is not None:
-            if len(request.resize_shape) not in [1, 2]:
-                raise HTTPException(
-                    status_code=400,
-                    detail="resize_shape must contain exactly two integers (height, width)",
-                )
-            kwargs["resize_shape"] = (
-                (request.resize_shape[0],) * 2
-                if len(request.resize_shape) == 1
-                else tuple(request.resize_shape)
-            )
-
-        images = []
-        audio = []
-        videos = []
-        processed_messages = []
-        for message in request.messages:
-            msg = {"role": message.role}
-
-            if isinstance(message.content, str):
-                msg["content"] = message.content
-            elif isinstance(message.content, list):
-                if message.role == "user":
-                    for item in message.content:
-                        if not isinstance(item, dict):
-                            continue
-                        item_type = item.get("type")
-                        if item_type == "input_image":
-                            images.append(item["image_url"])
-                        elif item_type == "image_url":
-                            images.append(item["image_url"]["url"])
-                        elif item_type == "input_audio":
-                            audio.append(_decode_input_audio_data(item["input_audio"]))
-                        elif item_type in ("input_video", "video_url", "video"):
-                            video = _extract_video_reference(item)
-                            if video:
-                                videos.append(video)
-                msg["content"] = extract_text_from_content(message.content)
-            else:
-                msg["content"] = message.content
-
-            # Preserve tool-calling metadata.
-            # Ensure arguments are dicts (not JSON strings) for Jinja templates
-            # that iterate them with |items (e.g. Qwen3.5).
-            if message.tool_calls is not None:
-                normalized_calls = []
-                for tc in message.tool_calls:
-                    tc = dict(tc) if isinstance(tc, dict) else tc
-                    if isinstance(tc, dict) and "function" in tc:
-                        fn = dict(tc["function"])
-                        args = fn.get("arguments", {})
-                        if isinstance(args, str):
-                            try:
-                                fn["arguments"] = json.loads(args)
-                            except (json.JSONDecodeError, TypeError):
-                                fn["arguments"] = {}
-                        tc["function"] = fn
-                    normalized_calls.append(tc)
-                msg["tool_calls"] = normalized_calls
-            if message.tool_call_id is not None:
-                msg["tool_call_id"] = message.tool_call_id
-            if message.name is not None:
-                msg["name"] = message.name
-            if message.reasoning_content is not None:
-                msg["reasoning_content"] = message.reasoning_content
-                msg["reasoning"] = message.reasoning_content
-
-            processed_messages.append(msg)
-
-        _ensure_effective_input(processed_messages, images=images, audio=audio)
-
-        processed_messages, tools, tool_choice = _prepare_chat_tool_choice(
-            processed_messages,
-            request.tools,
-            request.tool_choice,
-        )
-
-        model, processor, config = get_cached_model(request.model, adapter_path)
-
-        video_resolution = resolve_video_inputs(
-            processor,
-            videos,
-            images=images,
-            fps=2.0,
-            max_frames=16,
-        )
-        images, videos = video_resolution.images, video_resolution.videos
-        if video_resolution.used_fallback:
-            logger.info(
-                "Processor %s has no native video support; sending %d of %d "
-                "sampled frames as ordered images.",
-                processor.__class__.__name__,
-                video_resolution.selected_count,
-                video_resolution.sampled_count,
-            )
+        tools = source.tools
 
         # Detect tool parser from chat template
         tool_parser_type = _infer_tool_parser_from_processor(
@@ -1635,20 +1367,12 @@ async def chat_completions_endpoint(request: ChatRequest, http_request: Request)
         if tools and tool_module is not None:
             gen_args.skip_special_tokens = False
 
-        template_kwargs = gen_args.to_template_kwargs()
-        if tool_choice is not None:
-            template_kwargs["tool_choice"] = tool_choice
-
-        formatted_prompt = apply_chat_template(
-            processor,
-            config,
-            processed_messages,
-            num_images=len(images),
-            num_audios=len(audio),
-            video=videos or None,
-            tools=tools,
-            **template_kwargs,
+        prepared = prepare_prompt(
+            source, processor, config, gen_args, render=apply_chat_template
         )
+        formatted_prompt = prepared.prompt
+        images, audio, videos = prepared.images, prepared.audio, prepared.videos
+        kwargs = prepared.generation_kwargs
 
         logger.debug(
             "chat/completions request: model=%s images=%d audio=%d videos=%d "

--- a/mlx_vlm/server/openai.py
+++ b/mlx_vlm/server/openai.py
@@ -48,6 +48,7 @@ from .responses_state import (
     _store_response,
     make_response_stream_state,
     prompt_has_open_thinking,
+    prompt_open_channel,
     response_store,
     response_store_lock,
 )
@@ -850,6 +851,7 @@ async def responses_endpoint(request: Request):
                         ),
                         gen_args.thinking_start_token,
                         gen_args.thinking_end_token,
+                        open_channel=prompt_open_channel(formatted_prompt),
                     )
                     reasoning_item_id = f"rs_{uuid.uuid4().hex}"
                     streamed_reasoning = ""
@@ -980,6 +982,7 @@ async def responses_endpoint(request: Request):
                             gen_args.thinking_end_token,
                             reasoning_item_id,
                             processor=processor,
+                            open_channel=prompt_open_channel(formatted_prompt),
                         )
                     )
                     tool_output_items = [
@@ -1243,6 +1246,7 @@ async def responses_endpoint(request: Request):
                         gen_args.thinking_start_token,
                         gen_args.thinking_end_token,
                         processor=processor,
+                        open_channel=prompt_open_channel(formatted_prompt),
                     )
                 )
                 if output_finish_reason == "tool_calls":
@@ -1459,6 +1463,7 @@ async def chat_completions_endpoint(request: ChatRequest, http_request: Request)
                             ),
                             gen_args.thinking_start_token,
                             gen_args.thinking_end_token,
+                            open_channel=prompt_open_channel(formatted_prompt),
                         )
                         full_output = ""  # raw output for tool call parsing
                         # Track tool-call state to suppress markup from content
@@ -1612,6 +1617,7 @@ async def chat_completions_endpoint(request: ChatRequest, http_request: Request)
                             ),
                             gen_args.thinking_start_token,
                             gen_args.thinking_end_token,
+                            open_channel=prompt_open_channel(formatted_prompt),
                         )
                         for chunk in token_iterator:
                             if chunk is None or not hasattr(chunk, "text"):
@@ -1856,6 +1862,7 @@ async def chat_completions_endpoint(request: ChatRequest, http_request: Request)
                         gen_args.thinking_end_token,
                     ),
                     processor=processor,
+                    open_channel=prompt_open_channel(formatted_prompt),
                 )
 
                 # Count raw generated tokens minus thinking tag tokens

--- a/mlx_vlm/server/request_preparation.py
+++ b/mlx_vlm/server/request_preparation.py
@@ -15,7 +15,7 @@ from ..prompt_utils import apply_chat_template, extract_text_from_content
 from ..tools import _prepare_chat_tool_choice
 from .generation import GenerationArguments
 from .responses_state import _response_items_to_chat, _response_tool_registry
-from .schemas import InputAudio
+from .schemas import ChatRequest, InputAudio
 
 logger = logging.getLogger("mlx_vlm.server")
 
@@ -274,7 +274,55 @@ def normalize_chat_input(request) -> PromptInput:
 
 
 def normalize_responses_input(request, prompt_items):
-    """Retain Responses instruction merging and response-item conversion semantics."""
+    """Replay Chat-shaped history through Chat normalization; adapt native items."""
+    if any(item.get("type") is None and "role" in item for item in prompt_items):
+        messages = []
+        if request.instructions:
+            messages.append({"role": "system", "content": request.instructions})
+        for item in prompt_items:
+            if item.get("type") is None and "role" in item:
+                messages.append(item)
+                continue
+            converted, images = _response_items_to_chat([item])
+            image_sources = iter(images)
+            for message in converted:
+                content = message.get("content")
+                if isinstance(content, list):
+                    message["content"] = [
+                        (
+                            {
+                                "type": "image_url",
+                                "image_url": {"url": next(image_sources)},
+                            }
+                            if part.get("type") == "image"
+                            else part
+                        )
+                        for part in content
+                    ]
+            messages.extend(converted)
+        tools, registry = _response_tool_registry(request.tools)
+        tool_choice = request.tool_choice
+        if (
+            isinstance(tool_choice, dict)
+            and tool_choice.get("type") == "function"
+            and "function" not in tool_choice
+            and "name" in tool_choice
+        ):
+            tool_choice = {
+                "type": "function",
+                "function": {"name": tool_choice["name"]},
+            }
+        source = normalize_chat_input(
+            ChatRequest(
+                model=request.model,
+                messages=messages,
+                tools=tools if request.tools is not None else None,
+                tool_choice=tool_choice,
+                resize_shape=getattr(request, "resize_shape", None),
+            )
+        )
+        return source, request.instructions, registry
+
     messages, images = _response_items_to_chat(prompt_items)
     instructions = _normalize_response_instruction_messages(
         messages, request.instructions

--- a/mlx_vlm/server/request_preparation.py
+++ b/mlx_vlm/server/request_preparation.py
@@ -1,0 +1,346 @@
+"""Shared prompt preparation after protocol-specific input normalization."""
+
+import base64
+import binascii
+import json
+import logging
+from dataclasses import dataclass, field
+from io import BytesIO
+from typing import Any, Callable, List, Optional
+
+from fastapi import HTTPException
+
+from ..generate.video import resolve_video_inputs
+from ..prompt_utils import apply_chat_template, extract_text_from_content
+from ..tools import _prepare_chat_tool_choice
+from .generation import GenerationArguments
+from .responses_state import _response_items_to_chat, _response_tool_registry
+from .schemas import InputAudio
+
+logger = logging.getLogger("mlx_vlm.server")
+
+
+@dataclass
+class PromptInput:
+    """Normalized messages; absent modalities retain each API's template defaults."""
+
+    messages: List[dict]
+    images: List[Any] = field(default_factory=list)
+    audio: Optional[List[Any]] = None
+    videos: Optional[List[Any]] = None
+    tools: Optional[List[Any]] = None
+    tool_choice: Any = None
+    generation_kwargs: dict = field(default_factory=dict)
+
+
+@dataclass
+class PreparedPrompt:
+    prompt: Any
+    images: List[Any]
+    audio: List[Any]
+    videos: List[Any]
+    generation_kwargs: dict
+
+
+_AUDIO_REFERENCE_PREFIXES = ("http://", "https://", "file://", "/", "./", "../")
+_AUDIO_REFERENCE_SUFFIXES = (".wav", ".mp3", ".flac", ".ogg", ".m4a", ".aac", ".webm")
+_MISSING_INPUT_DETAIL = (
+    "Request must include at least one non-empty message content or media input."
+)
+
+
+def _has_non_empty_text(value: Any) -> bool:
+    return isinstance(value, str) and bool(value.strip())
+
+
+def _content_has_effective_input(content: Any) -> bool:
+    if _has_non_empty_text(content):
+        return True
+    if content is None:
+        return False
+    if isinstance(content, list):
+        for item in content:
+            if not isinstance(item, dict):
+                continue
+            item_type = item.get("type")
+            if item_type in ("text", "input_text", "output_text"):
+                if _has_non_empty_text(item.get("text")) or _has_non_empty_text(
+                    item.get("content")
+                ):
+                    return True
+            elif item_type in ("image_url", "input_image"):
+                image = item.get("image_url") or item.get("file_id")
+                if isinstance(image, dict):
+                    image = image.get("url")
+                if image:
+                    return True
+            elif item_type == "input_audio":
+                input_audio = item.get("input_audio")
+                if isinstance(input_audio, dict) and input_audio.get("data"):
+                    return True
+            elif _content_has_effective_input(item.get("content")):
+                return True
+        return False
+    if isinstance(content, dict):
+        return _content_has_effective_input([content])
+    return bool(str(content).strip())
+
+
+def _message_has_effective_input(message: Any) -> bool:
+    if hasattr(message, "model_dump"):
+        message = message.model_dump(exclude_none=True)
+    if not isinstance(message, dict):
+        return False
+    return (
+        _content_has_effective_input(message.get("content"))
+        or bool(message.get("tool_calls"))
+        or _has_non_empty_text(message.get("reasoning_content"))
+        or _has_non_empty_text(message.get("reasoning"))
+    )
+
+
+def _ensure_effective_input(messages, *, images=None, audio=None):
+    if any(image for image in (images or [])) or any(item for item in (audio or [])):
+        return
+    if any(_message_has_effective_input(message) for message in messages or []):
+        return
+    raise HTTPException(status_code=400, detail=_MISSING_INPUT_DETAIL)
+
+
+def _looks_like_audio_reference(value: str) -> bool:
+    return value.startswith(_AUDIO_REFERENCE_PREFIXES) or value.lower().endswith(
+        _AUDIO_REFERENCE_SUFFIXES
+    )
+
+
+def _normalize_response_instruction_messages(
+    chat_messages: List[dict],
+    instructions: Optional[str],
+) -> Optional[str]:
+    instruction_parts = [instructions] if instructions else []
+    conversation = []
+
+    for message in chat_messages:
+        if message.get("role") in ("system", "developer"):
+            content = message.get("content")
+            if content:
+                instruction_parts.append(str(content))
+        else:
+            conversation.append(message)
+
+    normalized_instructions = "\n\n".join(instruction_parts) or None
+    if normalized_instructions:
+        conversation.insert(
+            0,
+            {"role": "system", "content": normalized_instructions},
+        )
+    chat_messages[:] = conversation
+    return normalized_instructions
+
+
+def _decode_input_audio_data(input_audio: InputAudio):
+    data = input_audio["data"]
+    if not isinstance(data, str):
+        return data
+
+    stripped = data.strip()
+    if stripped.startswith("data:"):
+        prefix, separator, encoded = stripped.partition(",")
+        if (
+            separator == ","
+            and ";base64" in prefix
+            and prefix.startswith("data:audio/")
+        ):
+            try:
+                return BytesIO(base64.b64decode(encoded, validate=True))
+            except (binascii.Error, ValueError) as exc:
+                raise HTTPException(
+                    status_code=400,
+                    detail="input_audio data URI is not valid base64 audio",
+                ) from exc
+        return data
+
+    if _looks_like_audio_reference(stripped):
+        return data
+
+    try:
+        return BytesIO(base64.b64decode(stripped, validate=True))
+    except (binascii.Error, ValueError):
+        return data
+
+
+def _extract_video_reference(item):
+    item_type = item.get("type")
+    if item_type == "video":
+        return item.get("video")
+    if item_type == "input_video":
+        video = item.get("video") or item.get("video_url")
+    elif item_type == "video_url":
+        video = item.get("video_url")
+    else:
+        return None
+    return video.get("url") if isinstance(video, dict) else video
+
+
+def normalize_chat_input(request) -> PromptInput:
+    generation_kwargs = {}
+
+    if request.resize_shape is not None:
+        if len(request.resize_shape) not in [1, 2]:
+            raise HTTPException(
+                status_code=400,
+                detail="resize_shape must contain exactly two integers (height, width)",
+            )
+        generation_kwargs["resize_shape"] = (
+            (request.resize_shape[0],) * 2
+            if len(request.resize_shape) == 1
+            else tuple(request.resize_shape)
+        )
+
+    images = []
+    audio = []
+    videos = []
+    processed_messages = []
+    for message in request.messages:
+        msg = {"role": message.role}
+
+        if isinstance(message.content, str):
+            msg["content"] = message.content
+        elif isinstance(message.content, list):
+            if message.role == "user":
+                for item in message.content:
+                    if not isinstance(item, dict):
+                        continue
+                    item_type = item.get("type")
+                    if item_type == "input_image":
+                        images.append(item["image_url"])
+                    elif item_type == "image_url":
+                        images.append(item["image_url"]["url"])
+                    elif item_type == "input_audio":
+                        audio.append(_decode_input_audio_data(item["input_audio"]))
+                    elif item_type in ("input_video", "video_url", "video"):
+                        video = _extract_video_reference(item)
+                        if video:
+                            videos.append(video)
+            msg["content"] = extract_text_from_content(message.content)
+        else:
+            msg["content"] = message.content
+
+        # Preserve tool-calling metadata.
+        # Ensure arguments are dicts (not JSON strings) for Jinja templates
+        # that iterate them with |items (e.g. Qwen3.5).
+        if message.tool_calls is not None:
+            normalized_calls = []
+            for tc in message.tool_calls:
+                tc = dict(tc) if isinstance(tc, dict) else tc
+                if isinstance(tc, dict) and "function" in tc:
+                    fn = dict(tc["function"])
+                    args = fn.get("arguments", {})
+                    if isinstance(args, str):
+                        try:
+                            fn["arguments"] = json.loads(args)
+                        except (json.JSONDecodeError, TypeError):
+                            fn["arguments"] = {}
+                    tc["function"] = fn
+                normalized_calls.append(tc)
+            msg["tool_calls"] = normalized_calls
+        if message.tool_call_id is not None:
+            msg["tool_call_id"] = message.tool_call_id
+        if message.name is not None:
+            msg["name"] = message.name
+        if message.reasoning_content is not None:
+            msg["reasoning_content"] = message.reasoning_content
+            msg["reasoning"] = message.reasoning_content
+
+        processed_messages.append(msg)
+
+    _ensure_effective_input(processed_messages, images=images, audio=audio)
+
+    processed_messages, tools, tool_choice = _prepare_chat_tool_choice(
+        processed_messages,
+        request.tools,
+        request.tool_choice,
+    )
+
+    return PromptInput(
+        messages=processed_messages,
+        images=images,
+        audio=audio,
+        videos=videos,
+        tools=tools,
+        tool_choice=tool_choice,
+        generation_kwargs=generation_kwargs,
+    )
+
+
+def normalize_responses_input(request, prompt_items):
+    """Retain Responses instruction merging and response-item conversion semantics."""
+    messages, images = _response_items_to_chat(prompt_items)
+    instructions = _normalize_response_instruction_messages(
+        messages, request.instructions
+    )
+    _ensure_effective_input(messages, images=images)
+    tools, registry = _response_tool_registry(request.tools)
+    return (
+        PromptInput(
+            messages=messages,
+            images=images,
+            tools=tools or None,
+            tool_choice=request.tool_choice,
+        ),
+        instructions,
+        registry,
+    )
+
+
+def prepare_prompt(
+    source: PromptInput,
+    processor,
+    config,
+    args: GenerationArguments,
+    *,
+    render: Callable = apply_chat_template,
+) -> PreparedPrompt:
+    """Render normalized history without running a protocol adapter a second time."""
+    images, videos = list(source.images), list(source.videos or [])
+    media_kwargs = {}
+    if source.audio is not None:
+        media_kwargs["num_audios"] = len(source.audio)
+    if source.videos is not None:
+        video_resolution = resolve_video_inputs(
+            processor,
+            videos,
+            images=images,
+            fps=2.0,
+            max_frames=16,
+        )
+        images, videos = video_resolution.images, video_resolution.videos
+        if video_resolution.used_fallback:
+            logger.info(
+                "Processor %s has no native video support; sending %d of %d "
+                "sampled frames as ordered images.",
+                processor.__class__.__name__,
+                video_resolution.selected_count,
+                video_resolution.sampled_count,
+            )
+
+        media_kwargs["video"] = videos or None
+    template_kwargs = args.to_template_kwargs()
+    if source.tool_choice is not None:
+        template_kwargs["tool_choice"] = source.tool_choice
+    prompt = render(
+        processor,
+        config,
+        source.messages,
+        num_images=len(images),
+        tools=source.tools,
+        **media_kwargs,
+        **template_kwargs,
+    )
+    return PreparedPrompt(
+        prompt=prompt,
+        images=images,
+        audio=list(source.audio or []),
+        videos=videos,
+        generation_kwargs=dict(source.generation_kwargs),
+    )

--- a/mlx_vlm/server/request_preparation.py
+++ b/mlx_vlm/server/request_preparation.py
@@ -207,22 +207,39 @@ def normalize_chat_input(request) -> PromptInput:
         if isinstance(message.content, str):
             msg["content"] = message.content
         elif isinstance(message.content, list):
+            content_parts = []
+            saw_media = False
             if message.role == "user":
                 for item in message.content:
                     if not isinstance(item, dict):
                         continue
                     item_type = item.get("type")
+                    if item_type in ("text", "input_text"):
+                        text = item.get("text", "") or item.get("content", "")
+                        if text:
+                            content_parts.append({"type": "text", "text": text})
+                        continue
                     if item_type == "input_image":
                         images.append(item["image_url"])
                     elif item_type == "image_url":
                         images.append(item["image_url"]["url"])
                     elif item_type == "input_audio":
                         audio.append(_decode_input_audio_data(item["input_audio"]))
+                        continue
                     elif item_type in ("input_video", "video_url", "video"):
                         video = _extract_video_reference(item)
                         if video:
                             videos.append(video)
-            msg["content"] = extract_text_from_content(message.content)
+                        continue
+                    else:
+                        continue
+                    # Mark where the image sat so later turns cannot claim it.
+                    content_parts.append({"type": "image"})
+                    saw_media = True
+            if saw_media:
+                msg["content"] = content_parts
+            else:
+                msg["content"] = extract_text_from_content(message.content)
         else:
             msg["content"] = message.content
 
@@ -240,7 +257,10 @@ def normalize_chat_input(request) -> PromptInput:
                         try:
                             fn["arguments"] = json.loads(args)
                         except (json.JSONDecodeError, TypeError):
-                            fn["arguments"] = {}
+                            # Native shell and apply_patch calls carry raw text
+                            # rather than JSON. Keep it: replacing it loses the
+                            # edit the tool result refers to.
+                            pass
                     tc["function"] = fn
                 normalized_calls.append(tc)
             msg["tool_calls"] = normalized_calls

--- a/mlx_vlm/server/responses_state.py
+++ b/mlx_vlm/server/responses_state.py
@@ -493,9 +493,7 @@ def _normalize_response_input(input_value: Any) -> List[Dict[str, Any]]:
         item = _as_plain_dict(item)
         if not isinstance(item, dict):
             raise HTTPException(status_code=400, detail="Invalid input format.")
-        item_type = item.get("type")
-        if item_type is None and item.get("role") is not None:
-            item = {**item, "type": "message"}
+        # An absent type identifies original Chat messages during prompt replay.
         items.append(item)
     return items
 
@@ -587,7 +585,7 @@ def _append_response_item_to_prompt(
     chat_messages: List[Dict[str, Any]],
     images: List[Any],
 ):
-    item_type = item.get("type")
+    item_type = item.get("type") or ("message" if "role" in item else None)
     if item_type == "message":
         role = item.get("role") or "user"
         content = item.get("content")

--- a/mlx_vlm/server/responses_state.py
+++ b/mlx_vlm/server/responses_state.py
@@ -173,6 +173,83 @@ class ThinkingStreamState:
         return text
 
 
+class HarmonyStreamState:
+    """Separate Harmony message headers and channels from generated text."""
+
+    _MARKERS = (
+        "<|start|>",
+        "<|channel|>",
+        "<|message|>",
+        "<|end|>",
+        "<|return|>",
+        "<|call|>",
+        "<|im_end|>",
+        "<|fim_suffix|>",
+        "<|ghissue|>",
+    )
+
+    def __init__(self, starts_in_thinking=False):
+        self.buffer = ""
+        self.header = ""
+        self.in_header = not starts_in_thinking
+        self.reading_channel = False
+        self.channel = "analysis" if starts_in_thinking else None
+
+    def feed(self, text, last=False):
+        self.buffer += text or ""
+        reasoning, content = [], []
+        thinking_closed = False
+
+        def emit(value):
+            if self.in_header:
+                self.header += value
+            elif value:
+                (reasoning if self.channel == "analysis" else content).append(value)
+
+        while self.buffer:
+            index, marker = ThinkingStreamState._find_first(self.buffer, self._MARKERS)
+            if index < 0:
+                value, self.buffer = ThinkingStreamState._split_partial(
+                    self.buffer, self._MARKERS
+                )
+                emit(value)
+                break
+            emit(self.buffer[:index])
+            self.buffer = self.buffer[index + len(marker) :]
+            if marker == "<|message|>":
+                self.channel = (
+                    self.header.split()[0]
+                    if self.reading_channel and self.header.split()
+                    else "final"
+                )
+                self.in_header = False
+                self.reading_channel = False
+            else:
+                if not self.in_header and self.channel == "analysis":
+                    thinking_closed = True
+                self.in_header = True
+                self.header = ""
+                self.reading_channel = marker == "<|channel|>"
+        if last:
+            emit(self.buffer)
+            self.buffer = ""
+        return ThinkingStreamDelta(
+            reasoning="".join(reasoning) or None,
+            content="".join(content) or None,
+            thinking_closed=thinking_closed,
+        )
+
+
+def _uses_harmony_template(processor):
+    tokenizer = getattr(processor, "tokenizer", processor)
+    template = getattr(tokenizer, "chat_template", None)
+    templates = template.values() if isinstance(template, dict) else [template]
+    return any(
+        isinstance(value, str) and "<|channel|>" in value and "<|message|>" in value
+        for value in templates
+    )
+
+
 class ResponseTemplateStreamState:
     """Adapt a Transformers response-template parser to server stream deltas."""
 
@@ -227,6 +304,8 @@ def make_response_stream_state(
     thinking_start_token: Optional[str] = None,
     thinking_end_token: Optional[str] = None,
 ):
+    if _uses_harmony_template(processor):
+        return HarmonyStreamState(enable_thinking)
     tokenizer = _response_template_tokenizer(processor)
     if tokenizer is not None and hasattr(tokenizer, "get_response_parser"):
         try:
@@ -253,6 +332,8 @@ def prompt_has_open_thinking(
         return False
 
     stripped_prompt = prompt.rstrip()
+    if stripped_prompt.endswith("<|channel|>analysis<|message|>"):
+        return True
     for start_marker, _ in ThinkingStreamState._build_open_close_markers(
         thinking_start_token, thinking_end_token
     ):
@@ -367,6 +448,10 @@ def _split_thinking(
 ) -> Tuple[Optional[str], str]:
     if not text:
         return None, text
+
+    if _uses_harmony_template(processor):
+        parsed = HarmonyStreamState(starts_in_thinking).feed(text, last=True)
+        return parsed.reasoning, parsed.content or ""
 
     tokenizer = _response_template_tokenizer(processor)
     if tokenizer is not None and hasattr(tokenizer, "parse_response"):
@@ -676,8 +761,47 @@ def _response_chain_items(previous_response_id: Optional[str]) -> List[Dict[str,
     items: List[Dict[str, Any]] = []
     for stored in reversed(chain):
         items.extend(stored.input_items)
-        items.extend(stored.output_items)
+        items.extend(_stored_output_to_chat(stored.output_items))
     return items
+
+
+def _stored_output_to_chat(output_items: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Reassemble the assistant turn whose boundary is known by the response store."""
+    if not output_items:
+        return []
+    supported = {
+        "message",
+        "reasoning",
+        "function_call",
+        "shell_call",
+        "apply_patch_call",
+    }
+    if any(item.get("type") not in supported for item in output_items):
+        return output_items
+    text, reasoning, calls = [], [], []
+    message_reasoning = []
+    for item in output_items:
+        item_type = item["type"]
+        if item_type == "reasoning":
+            reasoning.extend(part.get("text", "") for part in item.get("summary", []))
+        elif item_type == "message":
+            content = item.get("content") or []
+            if not isinstance(content, list) or any(
+                part.get("type") not in ("output_text", "text") for part in content
+            ):
+                return output_items
+            text.extend(part.get("text", "") for part in content)
+            message_reasoning.append(
+                item.get("reasoning_content") or item.get("reasoning") or ""
+            )
+        else:
+            calls.append(_response_call_to_chat_tool_call(item))
+    message = {"role": "assistant", "content": "".join(text)}
+    if reasoning or any(message_reasoning):
+        message["reasoning_content"] = "".join(reasoning or message_reasoning)
+    if calls:
+        message["tool_calls"] = calls
+    return [message]
 
 
 def _response_items_to_chat(

--- a/mlx_vlm/server/responses_state.py
+++ b/mlx_vlm/server/responses_state.py
@@ -188,12 +188,18 @@ class HarmonyStreamState:
         "<|ghissue|>",
     )
 
-    def __init__(self, starts_in_thinking=False):
+    def __init__(self, starts_in_thinking=False, open_channel=None):
         self.buffer = ""
         self.header = ""
-        self.in_header = not starts_in_thinking
+        if open_channel:
+            # The prompt already named a channel and opened its message, so
+            # generation starts inside the body rather than in a header.
+            self.in_header = False
+            self.channel = open_channel
+        else:
+            self.in_header = not starts_in_thinking
+            self.channel = "analysis" if starts_in_thinking else None
         self.reading_channel = False
-        self.channel = "analysis" if starts_in_thinking else None
 
     def feed(self, text, last=False):
         self.buffer += text or ""
@@ -303,9 +309,10 @@ def make_response_stream_state(
     enable_thinking: bool = False,
     thinking_start_token: Optional[str] = None,
     thinking_end_token: Optional[str] = None,
+    open_channel: Optional[str] = None,
 ):
     if _uses_harmony_template(processor):
-        return HarmonyStreamState(enable_thinking)
+        return HarmonyStreamState(enable_thinking, open_channel)
     tokenizer = _response_template_tokenizer(processor)
     if tokenizer is not None and hasattr(tokenizer, "get_response_parser"):
         try:
@@ -319,6 +326,27 @@ def make_response_stream_state(
         thinking_start_token,
         thinking_end_token,
     )
+
+
+_OPEN_CHANNEL = re.compile(r"<\|channel\|>(\w+)<\|message\|>\s*$")
+
+
+def prompt_open_channel(prompt: Any) -> Optional[str]:
+    """The Harmony channel a prompt leaves open for generation to continue.
+
+    A template that completes its own header ends the prompt inside a message
+    body, so a parser that assumes header mode would read the answer as header
+    text and discard it.
+    """
+    if not isinstance(prompt, str):
+        return None
+    stripped = prompt.rstrip()
+    match = _OPEN_CHANNEL.search(stripped)
+    if match:
+        return match.group(1)
+    if stripped.endswith("<|message|>"):
+        return "final"
+    return None
 
 
 def prompt_has_open_thinking(
@@ -445,12 +473,15 @@ def _split_thinking(
     thinking_end_token: Optional[str] = None,
     starts_in_thinking: bool = False,
     processor=None,
+    open_channel: Optional[str] = None,
 ) -> Tuple[Optional[str], str]:
     if not text:
         return None, text
 
     if _uses_harmony_template(processor):
-        parsed = HarmonyStreamState(starts_in_thinking).feed(text, last=True)
+        parsed = HarmonyStreamState(starts_in_thinking, open_channel).feed(
+            text, last=True
+        )
         return parsed.reasoning, parsed.content or ""
 
     tokenizer = _response_template_tokenizer(processor)
@@ -513,12 +544,14 @@ def _response_output_items_from_text(
     thinking_end_token: Optional[str] = None,
     reasoning_item_id: Optional[str] = None,
     processor=None,
+    open_channel: Optional[str] = None,
 ) -> Tuple[List[Dict[str, Any]], str, Optional[str], str]:
     reasoning, content = _split_thinking(
         full_text,
         thinking_start_token,
         thinking_end_token,
         processor=processor,
+        open_channel=open_channel,
     )
     reasoning_items = _reasoning_output_items(reasoning, reasoning_item_id)
     if tool_module is not None and chat_tools:

--- a/mlx_vlm/server/schemas.py
+++ b/mlx_vlm/server/schemas.py
@@ -331,7 +331,11 @@ class OpenAIRequest(FlexibleBaseModel):
     """
 
     input: Union[str, List[Any]] = Field(
-        ..., description="Input text or list of chat messages."
+        ...,
+        description=(
+            "Input text, native Responses items, or original Chat messages without "
+            "a type field. Chat messages retain their order, metadata, and media."
+        ),
     )
     model: str = Field(..., description="The model to use for generation.")
     adapter_path: Optional[str] = Field(

--- a/mlx_vlm/tests/test_models.py
+++ b/mlx_vlm/tests/test_models.py
@@ -22656,7 +22656,7 @@ class TestPaliGemmaAttentionPolicy(unittest.TestCase):
                 self.assertLess(error, 1e-5)
 
 
-class TestLegacyGemmaHistory(unittest.TestCase):
+class TestAlternatingRoleHistory(unittest.TestCase):
     TEMPLATE = """{{ bos_token }}{% for message in messages %}{% if (message.role == 'user') != (loop.index0 % 2 == 0) %}{{ raise_exception('Conversation roles must alternate') }}{% endif %}{{ '<start_of_turn>' + ('model' if message.role == 'assistant' else message.role) + '\n' }}{% if message.content is string %}{{ message.content | trim }}{% else %}{% for part in message.content %}{% if part.type == 'text' %}{{ part.text }}{% elif part.type == 'image' %}{{ '<start_of_image>' }}{% elif part.type == 'audio' %}{{ '<audio_soft_token>' }}{% endif %}{% endfor %}{% endif %}{{ '<end_of_turn>\n' }}{% endfor %}{% if add_generation_prompt %}{{ '<start_of_turn>model\n' }}{% endif %}"""
 
     def _tokenizer(self, template=None):
@@ -22799,3 +22799,209 @@ class TestLegacyGemmaHistory(unittest.TestCase):
         ]:
             position = rendered.index(marker, position) + len(marker)
         self.assertEqual(messages, original)
+
+    def test_alternating_template_without_system_support_keeps_system_text(self):
+        from mlx_vlm.prompt_utils import get_chat_template
+
+        template = (
+            "{{ bos_token }}{% for message in messages %}"
+            "{% if (message['role'] == 'user') != (loop.index0 % 2 == 0) %}"
+            "{{ raise_exception('Conversation roles must alternate') }}{% endif %}"
+            "{% if message['role'] == 'user' %}{{ '[INST] ' + message['content'] + ' [/INST]' }}"
+            "{% elif message['role'] == 'assistant' %}{{ message['content'] }}"
+            "{% else %}{{ raise_exception('Only user and assistant roles are supported!') }}"
+            "{% endif %}{% endfor %}"
+        )
+        messages = [
+            {"role": "system", "content": "BE_CONCISE"},
+            {"role": "system", "content": "KEEP_PATHS"},
+            {"role": "user", "content": "QUESTION"},
+        ]
+        rendered = get_chat_template(self._tokenizer(template), messages, True)
+        for marker in ["BE_CONCISE", "KEEP_PATHS", "QUESTION", '"role": "system"']:
+            self.assertIn(marker, rendered)
+
+    def test_processor_owning_its_rendering_is_skipped(self):
+        from mlx_vlm.prompt_utils import _alternating_role_history
+
+        class OwnRenderer:
+            chat_template = "{{ raise_exception('Conversation roles must alternate') }}"
+
+            def apply_chat_template(self, messages, **kwargs):
+                return ""
+
+        messages = [{"role": "tool", "content": "RESULT", "tool_call_id": "CALL"}]
+        self.assertIs(
+            _alternating_role_history(messages, OwnRenderer(), tools=[{"a": 1}]),
+            messages,
+        )
+
+
+class TestTemplateToolHistory(unittest.TestCase):
+    TEMPLATE = """{% for message in messages %}{% if message.tool_calls is defined and message.tool_calls is not none %}{% for call in message.tool_calls %}{% if not call.id is defined or call.id|length != 9 %}{{ raise_exception('Tool call IDs should be alphanumeric strings with length 9!') }}{% endif %}{{ '[TOOL_CALLS] ' + call.function|tojson + ' id=' + call.id }}{% endfor %}{% elif message.role == 'tool' %}{% if not message.tool_call_id is defined or message.tool_call_id|length != 9 %}{{ raise_exception('Tool call IDs should be alphanumeric strings with length 9!') }}{% endif %}{{ '[TOOL_RESULTS] ' + message.content + ' call_id=' + message.tool_call_id }}{% elif message.role == 'user' %}{{ '[INST]' + message.content + '[/INST]' }}{% else %}{{ ' ' + message.content }}{% endif %}{% endfor %}"""
+
+    HISTORY = [
+        {"role": "user", "content": "QUESTION"},
+        {
+            "role": "assistant",
+            "content": "SPOKEN",
+            "tool_calls": [
+                {
+                    "id": "call_saved",
+                    "type": "function",
+                    "function": {"name": "FUNCTION", "arguments": '{"path":"ARG"}'},
+                }
+            ],
+        },
+        {"role": "tool", "tool_call_id": "call_saved", "content": "RESULT"},
+    ]
+
+    def _tokenizer(self):
+        from tokenizers import Tokenizer
+        from tokenizers.models import WordLevel
+        from transformers import PreTrainedTokenizerFast
+
+        return PreTrainedTokenizerFast(
+            tokenizer_object=Tokenizer(WordLevel({"[UNK]": 0}, unk_token="[UNK]")),
+            unk_token="[UNK]",
+            chat_template=self.TEMPLATE,
+        )
+
+    def test_call_ids_are_remapped_and_stay_paired(self):
+        from mlx_vlm.prompt_utils import _template_tool_history
+
+        normalized = _template_tool_history(self.HISTORY, self.TEMPLATE)
+        call = next(m for m in normalized if m.get("tool_calls"))["tool_calls"][0]
+        result = next(m for m in normalized if m.get("role") == "tool")
+        self.assertEqual(len(call["id"]), 9)
+        self.assertTrue(call["id"].isalnum())
+        self.assertEqual(call["id"], result["tool_call_id"])
+        repeated = _template_tool_history(self.HISTORY, self.TEMPLATE)
+        repeated_call = next(m for m in repeated if m.get("tool_calls"))["tool_calls"][
+            0
+        ]
+        self.assertEqual(call["id"], repeated_call["id"])
+
+    def test_spoken_content_survives_the_tool_call_turn(self):
+        from mlx_vlm.prompt_utils import _template_tool_history
+
+        normalized = _template_tool_history(self.HISTORY, self.TEMPLATE)
+        spoken = [m for m in normalized if m.get("content") == "SPOKEN"]
+        self.assertEqual(len(spoken), 1)
+        self.assertNotIn("tool_calls", spoken[0])
+        self.assertNotIn("content", next(m for m in normalized if m.get("tool_calls")))
+
+    def test_history_renders_and_caller_is_unchanged(self):
+        import copy
+
+        from jinja2.exceptions import TemplateError
+
+        from mlx_vlm.prompt_utils import get_chat_template
+
+        tokenizer = self._tokenizer()
+        messages = copy.deepcopy(self.HISTORY)
+        original = copy.deepcopy(messages)
+        with self.assertRaises(TemplateError):
+            tokenizer.apply_chat_template(
+                messages, tokenize=False, add_generation_prompt=True
+            )
+        rendered = get_chat_template(tokenizer, messages, True)
+        for marker in ["QUESTION", "SPOKEN", "FUNCTION", "ARG", "RESULT"]:
+            self.assertIn(marker, rendered)
+        self.assertEqual(messages, original)
+
+    def test_template_without_the_contract_is_untouched(self):
+        from mlx_vlm.prompt_utils import _template_tool_history
+
+        self.assertIs(
+            _template_tool_history(self.HISTORY, "{{ messages | tojson }}"),
+            self.HISTORY,
+        )
+        self.assertIs(_template_tool_history(self.HISTORY, None), self.HISTORY)
+
+
+class TestSupportedRoleMessages(unittest.TestCase):
+    TEMPLATE = """{% for message in messages %}{% if message['role'] == 'user' %}{{ '[INST]' + message['content'] + '[/INST]' }}{% elif message['role'] == 'system' %}{{ '[SYSTEM_PROMPT]' + message['content'] + '[/SYSTEM_PROMPT]' }}{% elif message['role'] == 'assistant' %}{{ message['content'] }}{% else %}{{ raise_exception('Only user, system and assistant roles are supported!') }}{% endif %}{% endfor %}"""
+
+    def _tokenizer(self):
+        from tokenizers import Tokenizer
+        from tokenizers.models import WordLevel
+        from transformers import PreTrainedTokenizerFast
+
+        return PreTrainedTokenizerFast(
+            tokenizer_object=Tokenizer(WordLevel({"[UNK]": 0}, unk_token="[UNK]")),
+            unk_token="[UNK]",
+            chat_template=self.TEMPLATE,
+        )
+
+    def test_rejected_roles_and_unread_fields_are_kept(self):
+        import copy
+
+        from mlx_vlm.prompt_utils import get_chat_template
+
+        messages = [
+            {"role": "system", "content": "SYSTEM"},
+            {"role": "user", "content": "QUESTION"},
+            {
+                "role": "assistant",
+                "content": "SPOKEN",
+                "reasoning_content": "REASON",
+                "tool_calls": [
+                    {
+                        "id": "CALL_ID",
+                        "function": {"name": "FUNCTION", "arguments": '{"p":"ARG"}'},
+                    }
+                ],
+            },
+            {"role": "tool", "tool_call_id": "CALL_ID", "content": "RESULT"},
+            {"role": "user", "content": "FOLLOW_UP"},
+        ]
+        original = copy.deepcopy(messages)
+        tools = [
+            {
+                "type": "function",
+                "function": {"name": "FUNCTION", "description": "SCHEMA"},
+            }
+        ]
+        rendered = get_chat_template(self._tokenizer(), messages, True, tools=tools)
+        for marker in [
+            "SYSTEM",
+            "QUESTION",
+            "SPOKEN",
+            "REASON",
+            "CALL_ID",
+            "FUNCTION",
+            "ARG",
+            "RESULT",
+            "FOLLOW_UP",
+            "SCHEMA",
+            '"role": "tool"',
+        ]:
+            self.assertIn(marker, rendered)
+        self.assertIn("[SYSTEM_PROMPT]SYSTEM[/SYSTEM_PROMPT]", rendered)
+        self.assertEqual(messages, original)
+
+    def test_ordinary_history_takes_the_native_path(self):
+        from mlx_vlm.prompt_utils import get_chat_template
+
+        tokenizer = self._tokenizer()
+        messages = [
+            {"role": "system", "content": "SYSTEM"},
+            {"role": "user", "content": "QUESTION"},
+            {"role": "assistant", "content": "ANSWER"},
+        ]
+        self.assertEqual(
+            get_chat_template(tokenizer, messages, True),
+            tokenizer.apply_chat_template(
+                messages, tokenize=False, add_generation_prompt=True
+            ),
+        )
+
+    def test_unrelated_errors_do_not_fold_roles(self):
+        from mlx_vlm.prompt_utils import _supported_role_messages
+
+        messages = [{"role": "tool", "content": "RESULT"}]
+        self.assertIs(
+            _supported_role_messages(messages, "Conversation roles must alternate"),
+            messages,
+        )

--- a/mlx_vlm/tests/test_models.py
+++ b/mlx_vlm/tests/test_models.py
@@ -20990,8 +20990,10 @@ class TestLlavaProcessorCompatibility(unittest.TestCase):
                         return_value=tokenizer,
                     ),
                     patch(
-                        "transformers.AutoImageProcessor.from_pretrained",
-                        return_value=image_processor,
+                        "transformers.AutoImageProcessor",
+                        SimpleNamespace(
+                            from_pretrained=lambda *args, **kwargs: image_processor
+                        ),
                     ),
                 ):
                     processor = LlavaProcessor.from_pretrained(path)
@@ -22652,3 +22654,148 @@ class TestPaliGemmaAttentionPolicy(unittest.TestCase):
                 self.assertGreater(error, 1e-3)
             else:
                 self.assertLess(error, 1e-5)
+
+
+class TestLegacyGemmaHistory(unittest.TestCase):
+    TEMPLATE = """{{ bos_token }}{% for message in messages %}{% if (message.role == 'user') != (loop.index0 % 2 == 0) %}{{ raise_exception('Conversation roles must alternate') }}{% endif %}{{ '<start_of_turn>' + ('model' if message.role == 'assistant' else message.role) + '\n' }}{% if message.content is string %}{{ message.content | trim }}{% else %}{% for part in message.content %}{% if part.type == 'text' %}{{ part.text }}{% elif part.type == 'image' %}{{ '<start_of_image>' }}{% elif part.type == 'audio' %}{{ '<audio_soft_token>' }}{% endif %}{% endfor %}{% endif %}{{ '<end_of_turn>\n' }}{% endfor %}{% if add_generation_prompt %}{{ '<start_of_turn>model\n' }}{% endif %}"""
+
+    def _tokenizer(self, template=None):
+        from tokenizers import Tokenizer
+        from tokenizers.models import WordLevel
+        from transformers import PreTrainedTokenizerFast
+
+        return PreTrainedTokenizerFast(
+            tokenizer_object=Tokenizer(WordLevel({"[UNK]": 0}, unk_token="[UNK]")),
+            unk_token="[UNK]",
+            chat_template=template or self.TEMPLATE,
+        )
+
+    def test_tool_history_retains_metadata_and_does_not_mutate(self):
+        import copy
+
+        from mlx_vlm.prompt_utils import get_chat_template
+
+        messages = [
+            {"role": "user", "content": "USER"},
+            {
+                "role": "assistant",
+                "content": "ANSWER",
+                "reasoning_content": "REASON",
+                "tool_calls": [
+                    {
+                        "id": "CALL_ID",
+                        "function": {
+                            "name": "FUNCTION",
+                            "arguments": '{"path":"ARGUMENT"}',
+                        },
+                    }
+                ],
+            },
+            {"role": "tool", "tool_call_id": "CALL_ID", "content": "RESULT"},
+            {"role": "user", "content": "NEXT"},
+        ]
+        original = copy.deepcopy(messages)
+        tools = [
+            {
+                "type": "function",
+                "function": {"name": "FUNCTION", "description": "SCHEMA"},
+            }
+        ]
+        rendered = get_chat_template(self._tokenizer(), messages, True, tools=tools)
+        for marker in [
+            "USER",
+            "ANSWER",
+            "REASON",
+            "CALL_ID",
+            "FUNCTION",
+            "ARGUMENT",
+            "RESULT",
+            "NEXT",
+            "SCHEMA",
+            '"role": "tool"',
+        ]:
+            self.assertIn(marker, rendered)
+        self.assertEqual(messages, original)
+        self.assertEqual(rendered.count("<start_of_turn>"), 4)
+
+    def test_ordinary_and_explicit_templates_are_unchanged(self):
+        from jinja2.exceptions import TemplateError
+
+        from mlx_vlm.prompt_utils import get_chat_template
+
+        tokenizer = self._tokenizer()
+        messages = [
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "content": "answer"},
+            {"role": "user", "content": "next"},
+        ]
+        for tokenize in [False, True]:
+            self.assertEqual(
+                get_chat_template(tokenizer, messages, True, tokenize),
+                tokenizer.apply_chat_template(
+                    messages, tokenize=tokenize, add_generation_prompt=True
+                ),
+            )
+        rich = messages[:2] + [{"role": "tool", "content": "result"}]
+        with self.assertRaises(TemplateError):
+            get_chat_template(tokenizer, rich, True, chat_template=self.TEMPLATE)
+
+    def test_tool_aware_template_keeps_native_messages(self):
+        from mlx_vlm.prompt_utils import get_chat_template
+
+        template = (
+            "<start_of_turn>{{ messages | tojson }}{{ tools | tojson }}<end_of_turn>"
+        )
+        tokenizer = self._tokenizer(template)
+        messages = [{"role": "tool", "content": "RESULT", "tool_call_id": "CALL"}]
+        tools = [{"type": "function", "function": {"name": "FUNCTION"}}]
+        self.assertEqual(
+            get_chat_template(tokenizer, messages, True, tools=tools),
+            tokenizer.apply_chat_template(
+                messages, tokenize=False, add_generation_prompt=True, tools=tools
+            ),
+        )
+
+    def test_media_order_and_system_role_survive(self):
+        import copy
+
+        from mlx_vlm.prompt_utils import get_chat_template
+
+        template = (
+            "{% if messages[0].role == 'system' %}{{ raise_exception('System role not supported') }}{% endif %}"
+            + self.TEMPLATE
+        )
+        messages = [
+            {"role": "system", "content": "SYSTEM"},
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "BEFORE"},
+                    {"type": "image"},
+                    {"type": "text", "text": "AFTER"},
+                    {"type": "audio"},
+                ],
+            },
+            {"role": "assistant", "content": "ANSWER"},
+            {"role": "tool", "content": "RESULT"},
+            {
+                "role": "user",
+                "content": [{"type": "image"}, {"type": "text", "text": "LAST"}],
+            },
+        ]
+        original = copy.deepcopy(messages)
+        rendered = get_chat_template(self._tokenizer(template), messages, True)
+        position = 0
+        for marker in [
+            "SYSTEM",
+            "BEFORE",
+            "<start_of_image>",
+            "AFTER",
+            "<audio_soft_token>",
+            "ANSWER",
+            "RESULT",
+            "<start_of_image>",
+            "LAST",
+        ]:
+            position = rendered.index(marker, position) + len(marker)
+        self.assertEqual(messages, original)

--- a/mlx_vlm/tests/test_models.py
+++ b/mlx_vlm/tests/test_models.py
@@ -20020,3 +20020,265 @@ class TestSpark2_5Model(unittest.TestCase):
         weights = {"model.embedding.weight": mx.zeros((128, 64))}
         sanitized = model.sanitize(weights)
         self.assertIn("language_model.model.embedding.weight", sanitized)
+
+
+class TestServerRequestPreparation(unittest.TestCase):
+    def test_chat_preserves_source_and_tool_reasoning_metadata(self):
+        import copy
+
+        from mlx_vlm.server.request_preparation import normalize_chat_input
+        from mlx_vlm.server.schemas import ChatRequest
+
+        request = ChatRequest(
+            model="test",
+            messages=[
+                {"role": "system", "content": "Keep exact paths."},
+                {"role": "user", "content": "Excerpt: café /src/app.py:42"},
+                {
+                    "role": "assistant",
+                    "content": None,
+                    "reasoning_content": "Inspect the file first.",
+                    "tool_calls": [
+                        {
+                            "id": "call_1",
+                            "type": "function",
+                            "function": {
+                                "name": "read",
+                                "arguments": '{"path":"/src/app.py"}',
+                            },
+                        }
+                    ],
+                },
+                {
+                    "role": "tool",
+                    "tool_call_id": "call_1",
+                    "name": "read",
+                    "content": "exact result",
+                },
+            ],
+        )
+        before = copy.deepcopy(request.model_dump())
+        source = normalize_chat_input(request)
+        self.assertEqual(request.model_dump(), before)
+        self.assertEqual(
+            [m["role"] for m in source.messages],
+            ["system", "user", "assistant", "tool"],
+        )
+        self.assertEqual(source.messages[1]["content"], "Excerpt: café /src/app.py:42")
+        self.assertEqual(
+            source.messages[2]["reasoning_content"], "Inspect the file first."
+        )
+        self.assertEqual(source.messages[2]["reasoning"], "Inspect the file first.")
+        self.assertEqual(
+            source.messages[2]["tool_calls"][0]["function"]["arguments"],
+            {"path": "/src/app.py"},
+        )
+        self.assertEqual(
+            source.messages[3],
+            {
+                "role": "tool",
+                "content": "exact result",
+                "tool_call_id": "call_1",
+                "name": "read",
+            },
+        )
+
+    def test_media_order_and_resize_survive_preparation(self):
+        import base64
+        from unittest.mock import MagicMock
+
+        from mlx_vlm.server.generation import GenerationArguments
+        from mlx_vlm.server.request_preparation import (
+            normalize_chat_input,
+            prepare_prompt,
+        )
+        from mlx_vlm.server.schemas import ChatRequest
+
+        request = ChatRequest(
+            model="test",
+            resize_shape=[224],
+            messages=[
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": "Compare."},
+                        {"type": "image_url", "image_url": {"url": "first.png"}},
+                        {"type": "input_image", "image_url": "second.png"},
+                        {
+                            "type": "input_audio",
+                            "input_audio": {
+                                "data": base64.b64encode(b"audio bytes").decode(),
+                                "format": "wav",
+                            },
+                        },
+                    ],
+                }
+            ],
+        )
+        source = normalize_chat_input(request)
+        render = MagicMock(return_value="rendered")
+        prepared = prepare_prompt(
+            source,
+            SimpleNamespace(),
+            SimpleNamespace(),
+            GenerationArguments(),
+            render=render,
+        )
+        self.assertEqual(prepared.images, ["first.png", "second.png"])
+        self.assertEqual(prepared.audio[0].getvalue(), b"audio bytes")
+        self.assertEqual(prepared.generation_kwargs, {"resize_shape": (224, 224)})
+        self.assertEqual(render.call_args.kwargs["num_images"], 2)
+        self.assertEqual(render.call_args.kwargs["num_audios"], 1)
+        self.assertEqual(prepared.prompt, "rendered")
+
+    def test_video_fallback_does_not_mutate_source(self):
+        from unittest.mock import MagicMock, patch
+
+        from mlx_vlm.server.generation import GenerationArguments
+        from mlx_vlm.server.request_preparation import (
+            normalize_chat_input,
+            prepare_prompt,
+        )
+        from mlx_vlm.server.schemas import ChatRequest
+
+        source = normalize_chat_input(
+            ChatRequest(
+                model="test",
+                messages=[
+                    {
+                        "role": "user",
+                        "content": [
+                            {"type": "text", "text": "Describe."},
+                            {"type": "input_video", "video_url": "clip.mp4"},
+                        ],
+                    }
+                ],
+            )
+        )
+        render = MagicMock(return_value="rendered")
+        resolution = SimpleNamespace(
+            images=["frame1", "frame2"],
+            videos=[],
+            used_fallback=True,
+            selected_count=2,
+            sampled_count=2,
+        )
+        with patch(
+            "mlx_vlm.server.request_preparation.resolve_video_inputs",
+            return_value=resolution,
+        ) as resolve:
+            prepared = prepare_prompt(
+                source,
+                SimpleNamespace(),
+                SimpleNamespace(),
+                GenerationArguments(),
+                render=render,
+            )
+        self.assertEqual(source.videos, ["clip.mp4"])
+        self.assertEqual(source.images, [])
+        self.assertEqual(prepared.images, ["frame1", "frame2"])
+        self.assertEqual(prepared.videos, [])
+        self.assertEqual(render.call_args.kwargs["num_images"], 2)
+        self.assertIsNone(render.call_args.kwargs["video"])
+        self.assertEqual(resolve.call_args.kwargs["fps"], 2.0)
+        self.assertEqual(resolve.call_args.kwargs["max_frames"], 16)
+
+    def test_responses_preserves_existing_instruction_and_tool_item_semantics(self):
+        import copy
+
+        from mlx_vlm.server.request_preparation import normalize_responses_input
+        from mlx_vlm.server.responses_state import _normalize_response_input
+        from mlx_vlm.server.schemas import OpenAIRequest
+
+        request = OpenAIRequest(
+            model="test",
+            instructions="Primary.",
+            input=[
+                {"role": "system", "content": "Secondary."},
+                {"role": "user", "content": "Read."},
+                {
+                    "type": "function_call",
+                    "call_id": "call_1",
+                    "name": "read",
+                    "arguments": '{"path":"a"}',
+                },
+                {
+                    "type": "function_call_output",
+                    "call_id": "call_1",
+                    "output": "file contents",
+                },
+            ],
+            tools=[
+                {"type": "function", "name": "read", "parameters": {"type": "object"}}
+            ],
+        )
+        items = _normalize_response_input(request.input)
+        before = copy.deepcopy(items)
+        source, instructions, registry = normalize_responses_input(request, items)
+        self.assertEqual(items, before)
+        self.assertEqual(instructions, "Primary.\n\nSecondary.")
+        self.assertEqual(
+            source.messages[0], {"role": "system", "content": instructions}
+        )
+        self.assertEqual(source.messages[2]["tool_calls"][0]["id"], "call_1")
+        self.assertEqual(
+            source.messages[3],
+            {"role": "tool", "tool_call_id": "call_1", "content": "file contents"},
+        )
+        self.assertEqual(source.tools[0]["function"]["name"], "read")
+        self.assertEqual(registry, {"read": "function"})
+
+    def test_equivalent_text_inputs_share_rendered_prompt_and_append_prefix(self):
+        from mlx_vlm.server.request_normalization import _build_gen_args
+        from mlx_vlm.server.request_preparation import (
+            normalize_chat_input,
+            normalize_responses_input,
+            prepare_prompt,
+        )
+        from mlx_vlm.server.responses_state import _normalize_response_input
+        from mlx_vlm.server.schemas import ChatRequest, OpenAIRequest
+
+        class Processor:
+            chat_template = "test"
+
+            def apply_chat_template(self, messages, **kwargs):
+                return (
+                    "".join(
+                        f"<{m['role']}>{m['content']}</{m['role']}>" for m in messages
+                    )
+                    + "<assistant>"
+                )
+
+        processor = Processor()
+        config = SimpleNamespace(model_type="test")
+        messages = [
+            {"role": "system", "content": "Instructions."},
+            {"role": "user", "content": "Exact document excerpt."},
+            {"role": "assistant", "content": "Done."},
+        ]
+        chat = ChatRequest(model="test", messages=messages, enable_thinking=False)
+        response = OpenAIRequest(
+            model="test",
+            instructions="Instructions.",
+            input=messages[1:],
+            enable_thinking=False,
+        )
+        chat_source = normalize_chat_input(chat)
+        response_source, _, _ = normalize_responses_input(
+            response, _normalize_response_input(response.input)
+        )
+        chat_args = _build_gen_args(chat, processor)
+        response_args = _build_gen_args(response, processor)
+        expected = "<system>Instructions.</system><user>Exact document excerpt.</user><assistant>Done.</assistant><assistant>"
+        before = prepare_prompt(chat_source, processor, config, chat_args)
+        self.assertEqual(before.prompt, expected)
+        self.assertEqual(
+            prepare_prompt(response_source, processor, config, response_args).prompt,
+            expected,
+        )
+        chat_source.messages.append(
+            {"role": "user", "content": "Summarize the preceding conversation."}
+        )
+        after = prepare_prompt(chat_source, processor, config, chat_args)
+        self.assertTrue(after.prompt.startswith(expected.removesuffix("<assistant>")))
+        self.assertEqual(chat.messages[-1].content, "Done.")

--- a/mlx_vlm/tests/test_models.py
+++ b/mlx_vlm/tests/test_models.py
@@ -20194,8 +20194,8 @@ class TestServerRequestPreparation(unittest.TestCase):
             model="test",
             instructions="Primary.",
             input=[
-                {"role": "system", "content": "Secondary."},
-                {"role": "user", "content": "Read."},
+                {"type": "message", "role": "system", "content": "Secondary."},
+                {"type": "message", "role": "user", "content": "Read."},
                 {
                     "type": "function_call",
                     "call_id": "call_1",
@@ -20282,3 +20282,281 @@ class TestServerRequestPreparation(unittest.TestCase):
         after = prepare_prompt(chat_source, processor, config, chat_args)
         self.assertTrue(after.prompt.startswith(expected.removesuffix("<assistant>")))
         self.assertEqual(chat.messages[-1].content, "Done.")
+
+
+class TestChatHistoryReplay(unittest.TestCase):
+    def test_responses_replays_chat_history_without_changing_prepared_input(self):
+        import copy
+
+        from mlx_vlm.server.request_preparation import (
+            normalize_chat_input,
+            normalize_responses_input,
+        )
+        from mlx_vlm.server.responses_state import _normalize_response_input
+        from mlx_vlm.server.schemas import ChatRequest, OpenAIRequest
+
+        messages = [
+            {"role": "system", "content": "First instruction."},
+            {"role": "system", "content": "Second instruction."},
+            {"role": "user", "content": "Read /src/app.py:42 — café."},
+            {
+                "role": "assistant",
+                "content": "Checking both files.",
+                "reasoning_content": "Keep the exact source history.",
+                "tool_calls": [
+                    {
+                        "id": f"call_{i}",
+                        "type": "function",
+                        "function": {"name": "read", "arguments": arguments},
+                    }
+                    for i, arguments in enumerate(
+                        ['{"path":"/src/app.py"}', {"path": "/src/db.py"}]
+                    )
+                ],
+            },
+            {
+                "role": "tool",
+                "name": "read",
+                "tool_call_id": "call_0",
+                "content": "Uses SQLite.",
+            },
+            {
+                "role": "tool",
+                "name": "read",
+                "tool_call_id": "call_1",
+                "content": "No migrations yet.",
+            },
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "Inspect these as well."},
+                    {"type": "image_url", "image_url": {"url": "first.png"}},
+                    {"type": "input_image", "image_url": "second.png"},
+                    {
+                        "type": "input_audio",
+                        "input_audio": {"data": "recording.wav", "format": "wav"},
+                    },
+                    {"type": "input_video", "video_url": "clip.mp4"},
+                ],
+            },
+        ]
+        tools = [
+            {
+                "type": "function",
+                "function": {"name": "read", "parameters": {"type": "object"}},
+            }
+        ]
+        for choice in (
+            None,
+            "auto",
+            "none",
+            "required",
+            {"type": "function", "function": {"name": "read"}},
+        ):
+            with self.subTest(tool_choice=choice):
+                chat = ChatRequest(
+                    model="test",
+                    messages=messages,
+                    tools=tools,
+                    tool_choice=choice,
+                    resize_shape=[224],
+                )
+                response = OpenAIRequest(
+                    model="test",
+                    input=messages,
+                    tools=tools,
+                    tool_choice=choice,
+                    resize_shape=[224],
+                )
+                before = copy.deepcopy(response.model_dump())
+                expected = normalize_chat_input(chat)
+                actual, _, _ = normalize_responses_input(
+                    response, _normalize_response_input(response.input)
+                )
+                self.assertEqual(actual, expected)
+                self.assertEqual(response.model_dump(), before)
+
+    def test_stored_chain_retains_original_chat_prefix(self):
+        import copy
+        import uuid
+
+        from mlx_vlm.server.request_preparation import (
+            normalize_chat_input,
+            normalize_responses_input,
+        )
+        from mlx_vlm.server.responses_state import (
+            StoredResponse,
+            _normalize_response_input,
+            _response_chain_items,
+            response_store,
+            response_store_lock,
+        )
+        from mlx_vlm.server.schemas import ChatRequest, OpenAIRequest
+
+        history = [
+            {"role": "system", "content": "Keep exact paths."},
+            {"role": "system", "content": "Preserve separate instructions."},
+            {"role": "user", "content": "Inspect /src/app.py."},
+            {
+                "role": "assistant",
+                "content": "The file uses SQLite.",
+                "reasoning_content": "Verified by reading the source.",
+            },
+        ]
+        original = copy.deepcopy(history)
+        response_id = f"test_{uuid.uuid4().hex}"
+        with response_store_lock:
+            response_store[response_id] = StoredResponse(
+                response={},
+                input_items=_normalize_response_input(history),
+                output_items=[
+                    {
+                        "type": "message",
+                        "role": "assistant",
+                        "content": [{"type": "output_text", "text": "Done."}],
+                    }
+                ],
+            )
+        try:
+            request = OpenAIRequest(
+                model="test",
+                previous_response_id=response_id,
+                input=[{"role": "user", "content": "Continue."}],
+            )
+            source, _, _ = normalize_responses_input(
+                request,
+                _response_chain_items(response_id)
+                + _normalize_response_input(request.input),
+            )
+            expected = normalize_chat_input(ChatRequest(model="test", messages=history))
+            self.assertEqual(source.messages[: len(history)], expected.messages)
+            self.assertEqual(
+                source.messages[-2:],
+                [
+                    {"role": "assistant", "content": "Done."},
+                    {"role": "user", "content": "Continue."},
+                ],
+            )
+            self.assertEqual(history, original)
+        finally:
+            with response_store_lock:
+                response_store.pop(response_id, None)
+
+    def test_responses_forwards_media_to_counting_and_both_generation_modes(self):
+        from unittest.mock import MagicMock, patch
+
+        from fastapi.testclient import TestClient
+
+        import mlx_vlm.server as server
+
+        def generate(*args, **kwargs):
+            def tokens():
+                yield server.StreamingToken(
+                    text="Done.", token=1, logprobs=0.0, finish_reason="stop"
+                )
+
+            return SimpleNamespace(prompt_tokens=3), tokens()
+
+        worker = SimpleNamespace(
+            generate=MagicMock(side_effect=generate),
+            validate_context_budget=MagicMock(),
+            _cpu_preprocess=MagicMock(
+                return_value={"input_ids": mx.array([[1, 2, 3]])}
+            ),
+        )
+        payload = {
+            "model": "test",
+            "store": False,
+            "input": [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": "Describe the recording."},
+                        {"type": "image_url", "image_url": {"url": "image.png"}},
+                        {
+                            "type": "input_audio",
+                            "input_audio": {"data": "audio.wav", "format": "wav"},
+                        },
+                        {"type": "input_video", "video_url": "video.mp4"},
+                    ],
+                }
+            ],
+        }
+        resolution = SimpleNamespace(
+            images=["image.png"], videos=["video.mp4"], used_fallback=False
+        )
+        with (
+            TestClient(server.app) as client,
+            patch.object(server.runtime, "response_generator", worker),
+            patch.object(
+                server,
+                "get_cached_model",
+                return_value=(
+                    SimpleNamespace(),
+                    SimpleNamespace(),
+                    SimpleNamespace(model_type="test"),
+                ),
+            ),
+            patch.object(server, "apply_chat_template", return_value="prompt"),
+            patch(
+                "mlx_vlm.server.request_preparation.resolve_video_inputs",
+                return_value=resolution,
+            ),
+        ):
+            counted = client.post("/v1/responses/input_tokens", json=payload)
+            self.assertEqual(counted.status_code, 200, counted.text)
+            self.assertEqual(counted.json(), {"input_tokens": 3})
+            self.assertEqual(
+                worker._cpu_preprocess.call_args.args,
+                ("prompt", ["image.png"], ["audio.wav"]),
+            )
+            self.assertEqual(
+                worker._cpu_preprocess.call_args.kwargs["videos"], ["video.mp4"]
+            )
+            for stream in (False, True):
+                with self.subTest(stream=stream):
+                    response = client.post(
+                        "/v1/responses", json={**payload, "stream": stream}
+                    )
+                    self.assertEqual(response.status_code, 200, response.text)
+                    call = worker.generate.call_args
+                    if stream:
+                        self.assertIn("response.completed", response.text)
+                        self.assertEqual(
+                            call.args[:3], ("prompt", ["image.png"], ["audio.wav"])
+                        )
+                        self.assertEqual(
+                            worker.validate_context_budget.call_args.kwargs["videos"],
+                            ["video.mp4"],
+                        )
+                    else:
+                        self.assertEqual(call.kwargs["audio"], ["audio.wav"])
+                        self.assertEqual(call.kwargs["images"], ["image.png"])
+                    self.assertEqual(call.kwargs["videos"], ["video.mp4"])
+
+    def test_native_named_tool_choice_with_original_chat_history(self):
+        from mlx_vlm.server.request_preparation import (
+            normalize_chat_input,
+            normalize_responses_input,
+        )
+        from mlx_vlm.server.responses_state import _normalize_response_input
+        from mlx_vlm.server.schemas import ChatRequest, OpenAIRequest
+
+        messages = [{"role": "user", "content": "Read the source."}]
+        function = {"name": "read", "parameters": {"type": "object"}}
+        chat = ChatRequest(
+            model="test",
+            messages=messages,
+            tools=[{"type": "function", "function": function}],
+            tool_choice={"type": "function", "function": {"name": "read"}},
+        )
+        response = OpenAIRequest(
+            model="test",
+            input=messages,
+            tools=[{"type": "function", "function": function}],
+            tool_choice={"type": "function", "name": "read"},
+        )
+        actual, _, _ = normalize_responses_input(
+            response, _normalize_response_input(response.input)
+        )
+        self.assertEqual(actual, normalize_chat_input(chat))

--- a/mlx_vlm/tests/test_models.py
+++ b/mlx_vlm/tests/test_models.py
@@ -20560,3 +20560,2095 @@ class TestChatHistoryReplay(unittest.TestCase):
             response, _normalize_response_input(response.input)
         )
         self.assertEqual(actual, normalize_chat_input(chat))
+
+
+class TestReplayProcessorLoading(unittest.TestCase):
+    def _tokenizer(self, path):
+        from tokenizers import Tokenizer
+        from tokenizers.models import WordLevel
+        from tokenizers.pre_tokenizers import Whitespace
+        from transformers import PreTrainedTokenizerFast
+
+        backend = Tokenizer(
+            WordLevel({"[UNK]": 0, "Hello": 1, "world": 2}, unk_token="[UNK]")
+        )
+        backend.pre_tokenizer = Whitespace()
+        tokenizer = PreTrainedTokenizerFast(tokenizer_object=backend, unk_token="[UNK]")
+        tokenizer.save_pretrained(path)
+        return tokenizer
+
+    def test_tokenizer_loading_does_not_validate_mlx_model_config(self):
+        import json
+        import tempfile
+        from pathlib import Path
+        from unittest.mock import patch
+
+        from mlx_vlm.utils import load_processor
+
+        for model_type, config in (
+            ("exaone4", {"sliding_window": None, "sliding_window_pattern": None}),
+            ("llama4", {"text_config": {"attn_temperature_tuning": 4}}),
+        ):
+            with (
+                self.subTest(model_type=model_type),
+                tempfile.TemporaryDirectory() as folder,
+            ):
+                path = Path(folder)
+                expected = self._tokenizer(path)
+                model_config = {"model_type": model_type, **config}
+                (path / "config.json").write_text(json.dumps(model_config))
+                importlib.import_module(f"mlx_vlm.models.{model_type}")
+                with patch(
+                    "transformers.AutoConfig.from_pretrained",
+                    side_effect=AssertionError("model config should not be loaded"),
+                ):
+                    processor = load_processor(
+                        path, add_detokenizer=False, local_files_only=True
+                    )
+                tokenizer = getattr(processor, "tokenizer", processor)
+                self.assertEqual(
+                    tokenizer.encode("Hello world"), expected.encode("Hello world")
+                )
+                self.assertEqual(
+                    json.loads((path / "config.json").read_text()), model_config
+                )
+
+    def test_moondream_fallback_loads_standalone_tokenizer(self):
+        import tempfile
+        from pathlib import Path
+        from unittest.mock import patch
+
+        from mlx_vlm.models.moondream3 import processing_moondream3
+
+        with tempfile.TemporaryDirectory() as folder:
+            path = Path(folder)
+            tokenizer_path = path / "tokenizer"
+            expected = self._tokenizer(tokenizer_path)
+            model_path = path / "model"
+            model_path.mkdir()
+            with (
+                patch.object(
+                    processing_moondream3, "TOKENIZER_REPO", str(tokenizer_path)
+                ),
+                patch(
+                    "transformers.AutoTokenizer.from_pretrained",
+                    side_effect=ValueError("no bundled tokenizer"),
+                ),
+            ):
+                processor = processing_moondream3.Moondream3Processor.from_pretrained(
+                    str(model_path)
+                )
+            self.assertEqual(
+                processor.tokenizer.encode("Hello world"),
+                expected.encode("Hello world"),
+            )
+
+
+class TestMixedMediaFeatureOrdering(unittest.TestCase):
+    def _model(self, omni=False):
+        from types import MethodType
+
+        from mlx_vlm.models.qwen3_5.qwen3_5 import Model
+        from mlx_vlm.models.qwen3_omni_moe.thinker import Thinker
+
+        class Vision:
+            patch_embed = SimpleNamespace(proj=SimpleNamespace(weight=mx.zeros((1,))))
+
+            def __call__(self, pixels, grid):
+                return pixels, [pixels * 10, pixels * 100]
+
+        model = SimpleNamespace(
+            config=SimpleNamespace(
+                image_token_index=2,
+                video_token_index=3,
+                image_token_id=2,
+                video_token_id=3,
+                audio_token_id=4,
+            ),
+            vision_tower=Vision(),
+            language_model=SimpleNamespace(
+                model=SimpleNamespace(
+                    embed_tokens=lambda ids: mx.zeros((*ids.shape, 2))
+                ),
+                get_rope_index=lambda ids, *args, **kwargs: (mx.zeros_like(ids), None),
+            ),
+            merge_input_ids_with_image_features=Model.merge_input_ids_with_image_features,
+        )
+        if omni:
+            model.get_placeholder_mask = MethodType(Thinker.get_placeholder_mask, model)
+        model.get_input_embeddings = MethodType(
+            Thinker.get_input_embeddings if omni else Model.get_input_embeddings, model
+        )
+        return model
+
+    def test_interleaved_image_video_features_keep_token_order(self):
+        for omni in (False, True):
+            for tokens in ([3, 0, 2, 3, 2], [2, 3, 2, 0, 3]):
+                with self.subTest(omni=omni, tokens=tokens):
+                    model = self._model(omni)
+                    images = mx.array([[1.0, 2.0], [3.0, 4.0]])
+                    videos = mx.array([[5.0, 6.0], [7.0, 8.0]])
+                    result = model.get_input_embeddings(
+                        mx.array([tokens]), images, pixel_values_videos=videos
+                    )
+                    image_rows, video_rows = iter(images.tolist()), iter(
+                        videos.tolist()
+                    )
+                    expected = [
+                        (
+                            next(image_rows)
+                            if token == 2
+                            else next(video_rows) if token == 3 else [0.0, 0.0]
+                        )
+                        for token in tokens
+                    ]
+                    self.assertEqual(result.inputs_embeds.tolist(), [expected])
+                    if omni:
+                        visual_rows = [
+                            row
+                            for token, row in zip(tokens, expected)
+                            if token in (2, 3)
+                        ]
+                        for layer, scale in zip(
+                            result.deepstack_visual_embeds, (10, 100)
+                        ):
+                            self.assertEqual(
+                                layer.tolist(),
+                                [
+                                    [value * scale for value in row]
+                                    for row in visual_rows
+                                ],
+                            )
+
+    def test_single_modality_features_remain_unchanged(self):
+        for omni in (False, True):
+            for token in (2, 3):
+                with self.subTest(omni=omni, token=token):
+                    model = self._model(omni)
+                    pixels = mx.array([[1.0, 2.0], [3.0, 4.0]])
+                    kwargs = (
+                        {"pixel_values": pixels}
+                        if token == 2
+                        else {"pixel_values_videos": pixels}
+                    )
+                    result = model.get_input_embeddings(
+                        mx.array([[token, 0, token]]), **kwargs
+                    )
+                    self.assertEqual(
+                        result.inputs_embeds.tolist(),
+                        [[[1.0, 2.0], [0.0, 0.0], [3.0, 4.0]]],
+                    )
+
+
+class TestGraniteVisualPrefillWindows(unittest.TestCase):
+    def test_batched_offsets_and_chunk_local_features_inject_same_values(self):
+        from mlx_vlm.models.granite4_vision.language import Granite
+
+        model = SimpleNamespace(
+            embedding_multiplier=1,
+            layers=[lambda h, mask, cache: h, lambda h, mask, cache: h],
+            norm=lambda h: h,
+            _deepstack_target_layers=[0, 1],
+        )
+        full_features = mx.arange(2 * 6 * 2 * 3, dtype=mx.float32).reshape(2, 6, 2, 3)
+        full_mask = mx.array(
+            [
+                [False, True, True, False, True, False],
+                [True, True, False, True, True, False],
+            ]
+        )
+        offsets = [2, 1]
+        expected_features = mx.stack(
+            [full_features[b, offset : offset + 3] for b, offset in enumerate(offsets)]
+        )
+        expected_mask = mx.stack(
+            [full_mask[b, offset : offset + 3] for b, offset in enumerate(offsets)]
+        )
+        expected = mx.where(expected_mask[..., None], expected_features.sum(axis=2), 0)
+        for chunk_local in (False, True):
+            with self.subTest(chunk_local=chunk_local):
+                actual = Granite.__call__(
+                    model,
+                    mx.zeros((2, 3), dtype=mx.int32),
+                    inputs_embeds=mx.zeros((2, 3, 3)),
+                    mask=mx.zeros((2, 1, 3, 3)),
+                    cache=[SimpleNamespace(offset=mx.array(offsets))] * 2,
+                    visual_pos_masks=expected_mask if chunk_local else full_mask,
+                    deepstack_visual_embeds=(
+                        expected_features if chunk_local else full_features
+                    ),
+                )
+                self.assertEqual(actual.tolist(), expected.tolist())
+
+
+class TestEmptyBatchCacheReplay(unittest.TestCase):
+    def test_empty_state_round_trip_preserves_offsets_and_can_append(self):
+        from mlx_vlm.models.cache import BatchKVCache
+
+        original = BatchKVCache([1, 0])
+        restored = BatchKVCache([0, 0])
+        restored.state = original.state
+        self.assertIsNone(restored.keys)
+        self.assertEqual(restored.offset.tolist(), [-1, 0])
+        self.assertEqual(restored.left_padding.tolist(), [1, 0])
+        keys = mx.arange(8, dtype=mx.float32).reshape(2, 1, 2, 2)
+        actual_keys, actual_values = restored.update_and_fetch(keys, keys + 10)
+        self.assertEqual(actual_keys.tolist(), keys.tolist())
+        self.assertEqual(actual_values.tolist(), (keys + 10).tolist())
+        self.assertEqual(restored.offset.tolist(), [1, 2])
+
+    def test_exact_replay_keeps_unused_layer_cache_empty(self):
+        from mlx_vlm.apc import make_warm_batch_exact_cache_multi
+        from mlx_vlm.models.cache import KVCache
+
+        used = KVCache()
+        keys = mx.ones((1, 1, 3, 2))
+        used.update_and_fetch(keys, keys)
+        merged, prefix = make_warm_batch_exact_cache_multi([[used, KVCache()]], [3])
+        self.assertEqual(prefix, 3)
+        self.assertEqual(merged[0].keys.tolist(), keys.tolist())
+        self.assertTrue(merged[1].empty())
+        self.assertEqual(merged[1].state[2].tolist(), [0])
+
+
+class TestSavedAssistantTurnReplay(unittest.TestCase):
+    def test_reasoning_text_and_parallel_calls_keep_one_turn(self):
+        from copy import deepcopy
+
+        from mlx_vlm.server.responses_state import _stored_output_to_chat
+
+        output = [
+            {
+                "type": "reasoning",
+                "summary": [{"type": "summary_text", "text": "Think α\n"}],
+            },
+            {
+                "type": "message",
+                "role": "assistant",
+                "reasoning": "Think α\n",
+                "content": [{"type": "output_text", "text": "Check both.\n"}],
+            },
+            {
+                "type": "function_call",
+                "call_id": "a",
+                "name": "lookup",
+                "arguments": '{"city":"東京"}',
+            },
+            {
+                "type": "function_call",
+                "call_id": "b",
+                "name": "lookup",
+                "arguments": '{"city":"Paris"}',
+            },
+        ]
+        original = deepcopy(output)
+        self.assertEqual(
+            _stored_output_to_chat(output),
+            [
+                {
+                    "role": "assistant",
+                    "content": "Check both.\n",
+                    "reasoning_content": "Think α\n",
+                    "tool_calls": [
+                        {
+                            "type": "function",
+                            "id": "a",
+                            "function": {
+                                "name": "lookup",
+                                "arguments": '{"city":"東京"}',
+                            },
+                        },
+                        {
+                            "type": "function",
+                            "id": "b",
+                            "function": {
+                                "name": "lookup",
+                                "arguments": '{"city":"Paris"}',
+                            },
+                        },
+                    ],
+                }
+            ],
+        )
+        self.assertEqual(output, original)
+
+    def test_unknown_output_and_nontext_content_are_retained(self):
+        from mlx_vlm.server.responses_state import _stored_output_to_chat
+
+        for output in (
+            [{"type": "future_item", "payload": "keep"}],
+            [
+                {
+                    "type": "message",
+                    "content": [{"type": "output_audio", "data": "keep"}],
+                }
+            ],
+        ):
+            with self.subTest(output=output):
+                self.assertEqual(_stored_output_to_chat(output), output)
+
+
+class TestHarmonyResponseChannels(unittest.TestCase):
+    def test_every_stream_boundary_matches_expected_channels(self):
+        from mlx_vlm.server.responses_state import HarmonyStreamState
+
+        cases = [
+            (
+                False,
+                "<|channel|>analysis<|message|> Think α\n<|end|><|start|>assistant<|channel|>final<|message|> Answer β\n<|return|>",
+                " Think α\n",
+                " Answer β\n",
+            ),
+            (False, "<|channel|>final<|message|>42<|return|>", "", "42"),
+            (False, "<|channel|>analysis<|message|>unfinished", "unfinished", ""),
+            (False, "<|channel|>anal", "", ""),
+            (
+                True,
+                "continued<|end|><|start|>assistant<|channel|>final<|message|>done",
+                "continued",
+                "done",
+            ),
+        ]
+        for opened, text, reasoning, content in cases:
+            for split in range(len(text) + 1):
+                with self.subTest(opened=opened, text=text, split=split):
+                    state = HarmonyStreamState(opened)
+                    deltas = [
+                        state.feed(text[:split]),
+                        state.feed(text[split:], last=True),
+                    ]
+                    self.assertEqual(
+                        "".join(d.reasoning or "" for d in deltas), reasoning
+                    )
+                    self.assertEqual("".join(d.content or "" for d in deltas), content)
+            state = HarmonyStreamState(opened)
+            deltas = [state.feed(char) for char in text] + [state.feed("", last=True)]
+            self.assertEqual("".join(d.reasoning or "" for d in deltas), reasoning)
+            self.assertEqual("".join(d.content or "" for d in deltas), content)
+
+    def test_stream_and_nonstream_use_same_template_detection(self):
+        from mlx_vlm.server.responses_state import (
+            _split_thinking,
+            make_response_stream_state,
+        )
+
+        for template in (
+            "<|channel|>analysis<|message|>",
+            {"default": "<|channel|>analysis<|message|>"},
+        ):
+            processor = SimpleNamespace(
+                tokenizer=SimpleNamespace(chat_template=template)
+            )
+            text = "<|channel|>analysis<|message|>reason<|end|><|start|>assistant<|message|>answer"
+            delta = make_response_stream_state(processor).feed(text, last=True)
+            self.assertEqual((delta.reasoning, delta.content), ("reason", "answer"))
+            self.assertEqual(
+                _split_thinking(text, processor=processor), ("reason", "answer")
+            )
+
+
+class TestLlavaProcessorCompatibility(unittest.TestCase):
+    def test_model_metadata_fallback_and_separate_modality_kwargs(self):
+        import json
+        import tempfile
+        from pathlib import Path
+        from unittest.mock import patch
+
+        from PIL import Image
+        from transformers import CLIPImageProcessor
+
+        from mlx_vlm.models.llava.processing_llava import LlavaProcessor
+
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory)
+            tokenizer = TestReplayProcessorLoading()._tokenizer(path)
+            tokenizer.add_special_tokens(
+                {"additional_special_tokens": ["<image>"], "pad_token": "[UNK]"}
+            )
+            (path / "config.json").write_text(
+                json.dumps(
+                    {
+                        "vision_config": {
+                            "model_type": "clip_vision_model",
+                            "patch_size": 14,
+                        }
+                    }
+                )
+            )
+            image_processor = CLIPImageProcessor(do_resize=False, do_center_crop=False)
+            for explicit in (False, True):
+                config = {
+                    "patch_size": 7 if explicit else None,
+                    "vision_feature_select_strategy": "full" if explicit else None,
+                }
+                if explicit:
+                    config["num_additional_image_tokens"] = 0
+                (path / "processor_config.json").write_text(json.dumps(config))
+                with (
+                    patch(
+                        "transformers.AutoTokenizer.from_pretrained",
+                        return_value=tokenizer,
+                    ),
+                    patch(
+                        "transformers.AutoImageProcessor.from_pretrained",
+                        return_value=image_processor,
+                    ),
+                ):
+                    processor = LlavaProcessor.from_pretrained(path)
+                self.assertEqual(processor.patch_size, 7 if explicit else 14)
+                self.assertEqual(
+                    processor.num_additional_image_tokens, 0 if explicit else 1
+                )
+                result = processor(
+                    images=[Image.new("RGB", (28, 28))] * 2,
+                    text=["<image> Hello", "<image> Hello world"],
+                    padding=True,
+                    do_rescale=False,
+                )
+                rows = result["input_ids"].tolist()
+                self.assertEqual(len(rows[0]), len(rows[1]))
+                self.assertEqual(
+                    [row.count(processor.image_token_id) for row in rows],
+                    [16, 16] if explicit else [4, 4],
+                )
+
+
+class TestMoondreamWeightLayout(unittest.TestCase):
+    def test_original_and_converted_weights_sanitize_identically(self):
+        from mlx_vlm.models.moondream3.moondream3 import Model
+
+        original = {
+            "model.text.wte": mx.zeros((2, 3)),
+            "model.text.blocks.0.attn.qkv.weight": mx.ones((3, 3)),
+            "model.text.lm_head.weight": mx.ones((2, 3)),
+            "model.vision.blocks.0.attn.qkv.weight": mx.ones((3, 3)),
+            "model.vision.proj_mlp.fc1.weight": mx.ones((3, 3)),
+        }
+        expected_keys = {
+            "text.model.wte.weight",
+            "text.model.blocks.0.attn.qkv.weight",
+            "text.lm_head.weight",
+            "vision.encoder.blocks.0.attn.qkv.weight",
+            "vision.proj_mlp.fc1.weight",
+        }
+        converted = Model.sanitize(None, original)
+        self.assertEqual(set(converted), expected_keys)
+        again = Model.sanitize(None, converted)
+        self.assertEqual(set(again), expected_keys)
+        for key in expected_keys:
+            self.assertIs(again[key], converted[key])
+
+
+class TestJinaMultiImagePlacement(unittest.TestCase):
+    def test_all_images_keep_hidden_width_and_token_positions(self):
+        from mlx_vlm.models.jina_vlm.jina_vlm import Model
+
+        for batch, images in ((1, 1), (1, 2), (1, 5), (2, 1), (2, 2)):
+            with self.subTest(batch=batch, images=images):
+                features = mx.arange(
+                    batch * images * 2 * 3 * 4, dtype=mx.float32
+                ).reshape(batch * images, 2, 3, 4)
+                positions = mx.arange(images * 6).reshape(1, images, 2, 3) + 1
+                positions = mx.broadcast_to(positions, (batch, images, 2, 3)).reshape(
+                    batch * images, 2, 3
+                )
+                model = SimpleNamespace(
+                    language_model=SimpleNamespace(
+                        embedding=lambda ids: mx.ones((*ids.shape, 4))
+                    ),
+                    get_image_features=lambda pixels, masks: features,
+                )
+                result = Model.get_input_embeddings(
+                    model,
+                    mx.zeros((batch, images * 6 + 2), dtype=mx.int32),
+                    mx.zeros((batch * images, 2, 3, 4)),
+                    image_input_idx=positions,
+                )
+                expected = mx.ones((batch, images * 6 + 2, 4))
+                expected[:, 1:-1, :] = features.reshape(batch, images * 6, 4) + 1
+                self.assertEqual(result.inputs_embeds.tolist(), expected.tolist())
+
+
+class TestJinaBatchedImageOwnership(unittest.TestCase):
+    def test_uneven_images_text_only_rows_and_left_padding(self):
+        from mlx_vlm.models.jina_vlm.jina_vlm import Model
+        from mlx_vlm.models.jina_vlm.processing_jinavlm import JinaVLMProcessor
+
+        rows = []
+        for length, values, positions in (
+            (5, [10.0, 20.0], [[1, -1], [3, 4]]),
+            (8, [], []),
+            (6, [30.0], [[2, 5]]),
+        ):
+            row = {
+                "input_ids": mx.zeros((1, length), dtype=mx.int32),
+                "attention_mask": mx.ones((1, length)),
+            }
+            if values:
+                row.update(
+                    pixel_values=mx.array(values).reshape(-1, 1, 1, 1),
+                    image_masks=mx.ones((len(values), 1, 1)),
+                    image_input_idx=mx.array(positions).reshape(-1, 1, 2),
+                )
+            rows.append(row)
+        batch = JinaVLMProcessor._collate_batch(SimpleNamespace(pad_token_id=0), rows)
+        features = mx.array(
+            [
+                [[[10.0, 11.0], [12.0, 13.0]]],
+                [[[20.0, 21.0], [22.0, 23.0]]],
+                [[[30.0, 31.0], [32.0, 33.0]]],
+            ]
+        )
+        model = SimpleNamespace(
+            language_model=SimpleNamespace(
+                embedding=lambda ids: mx.ones((*ids.shape, 2))
+            ),
+            get_image_features=lambda pixels, masks: features,
+        )
+        actual = Model.get_input_embeddings(model, **batch).inputs_embeds
+        expected = mx.ones((3, 8, 2))
+        expected[0, 4] += features[0, 0, 0]
+        expected[0, 6] += features[1, 0, 0]
+        expected[0, 7] += features[1, 0, 1]
+        expected[2, 4] += features[2, 0, 0]
+        expected[2, 7] += features[2, 0, 1]
+        self.assertEqual(actual.tolist(), expected.tolist())
+        self.assertEqual(rows[0]["image_input_idx"].tolist(), [[[1, -1]], [[3, 4]]])
+
+
+class TestJinaUnusedImageSlots(unittest.TestCase):
+    def test_long_text_offset_does_not_turn_unused_slots_into_valid_positions(self):
+        import numpy as np
+
+        from mlx_vlm.models.jina_vlm.processing_jinavlm import JinaVLMProcessor
+
+        outputs = {
+            "pixel_values": [np.zeros((1, 2, 3))],
+            "image_masks": [np.ones((1, 2))],
+            "image_tokens": [np.array([4, 5])],
+            "image_input_idx": [np.array([[0, -10000]])],
+        }
+        processor = SimpleNamespace(
+            image_token="<|image|>",
+            _image_proc=SimpleNamespace(preprocess=lambda images: outputs),
+            encode=lambda text, **kwargs: [1] * 10001,
+        )
+        result = JinaVLMProcessor.process_one(
+            processor, "long prefix<|image|>", [object()]
+        )
+        self.assertEqual(result["image_input_idx"].tolist(), [[[10001, -10000]]])
+
+
+class TestMolmoSharedPromptImages(unittest.TestCase):
+    def test_images_share_one_prompt_and_indices_follow_all_prefixes(self):
+        import numpy as np
+        from PIL import Image
+
+        from mlx_vlm.models.molmo.processing_molmo import MolmoProcessor
+
+        tokenizer = SimpleNamespace(
+            convert_tokens_to_ids=lambda token: 1,
+            encode=lambda text: [90, 91],
+            pad_token_id=0,
+        )
+
+        def preprocess(image, *args):
+            return (
+                np.zeros((1, 2, 3)),
+                np.array([10, 11, 12]),
+                np.array([[1, -100]]),
+                np.ones((1, 2)),
+            )
+
+        processor = SimpleNamespace(
+            tokenizer=tokenizer,
+            image_processor=SimpleNamespace(preprocess=preprocess),
+            image_patch_token="patch",
+            image_col_token="col",
+            image_start_token="start",
+            image_end_token="end",
+        )
+        for count in (1, 2, 5):
+            with self.subTest(count=count):
+                result = MolmoProcessor.__call__(
+                    processor,
+                    images=[Image.new("RGB", (2, 2))] * count,
+                    text="One question",
+                )
+                self.assertEqual(
+                    result["input_ids"].tolist(), [[10, 11, 12] * count + [90, 91]]
+                )
+                self.assertEqual(
+                    result["image_input_idx"].tolist(),
+                    [[1 + 3 * i, -100] for i in range(count)],
+                )
+
+
+class TestPlainPromptHistoryFields(unittest.TestCase):
+    def test_fallback_keeps_reasoning_calls_and_result_identity(self):
+        import json
+
+        from mlx_vlm.prompt_utils import get_chat_template
+
+        extra = {
+            "reasoning_content": "Keep α\nexact",
+            "tool_calls": [
+                {
+                    "id": "call_a",
+                    "type": "function",
+                    "function": {"name": "lookup", "arguments": '{"city": "東京"}'},
+                }
+            ],
+        }
+        messages = [
+            {"role": "user", "content": "Check."},
+            {"role": "assistant", "content": "Looking.", **extra},
+            {
+                "role": "tool",
+                "name": "lookup",
+                "tool_call_id": "call_a",
+                "content": "Result.",
+            },
+        ]
+        prompt = get_chat_template(None, messages, True)
+        metadata = [
+            json.loads(line.split(": ", 1)[1])
+            for line in prompt.splitlines()
+            if " metadata: " in line
+        ]
+        self.assertEqual(
+            metadata, [extra, {"name": "lookup", "tool_call_id": "call_a"}]
+        )
+        self.assertTrue(prompt.endswith("Assistant:"))
+
+    def test_plain_text_fallback_stays_identical(self):
+        from mlx_vlm.prompt_utils import get_chat_template
+
+        self.assertEqual(
+            get_chat_template(None, [{"role": "user", "content": "Hello"}], True),
+            "Hello",
+        )
+        self.assertEqual(
+            get_chat_template(
+                None,
+                [
+                    {"role": "user", "content": "Hello"},
+                    {"role": "assistant", "content": "Hi"},
+                ],
+                True,
+            ),
+            "User: Hello\nAssistant: Hi\nAssistant:",
+        )
+
+
+class TestMoondreamHistoryRoles(unittest.TestCase):
+    def test_assistant_role_and_reasoning_survive_message_formatting(self):
+        from mlx_vlm.prompt_utils import apply_chat_template
+
+        messages = [
+            {"role": "user", "content": "Hi"},
+            {"role": "assistant", "content": "Answer", "reasoning_content": "Reason"},
+            {"role": "user", "content": "Continue"},
+        ]
+        prompt = apply_chat_template(None, {"model_type": "moondream3"}, messages)
+        self.assertEqual(
+            prompt,
+            'User: Hi\nAssistant: Answer\nAssistant metadata: {"reasoning_content": "Reason"}\nUser: Continue\nAssistant:',
+        )
+
+
+class TestMoondreamPaddedPositions(unittest.TestCase):
+    def test_single_padded_sequence_matches_unpadded_prefill_and_decode(self):
+        from mlx_vlm.models.base import create_attention_mask
+        from mlx_vlm.models.cache import BatchKVCache, KVCache
+        from mlx_vlm.models.moondream3.config import TextConfig
+        from mlx_vlm.models.moondream3.language import Attention
+
+        mx.random.seed(72)
+        attention = Attention(
+            TextConfig(
+                hidden_size=8,
+                num_attention_heads=2,
+                num_key_value_heads=2,
+                head_dim=4,
+                rope_dim=4,
+            )
+        )
+        attention.tau.alpha = mx.array([0.7, -0.4])
+        x = mx.random.normal((1, 4, 8))
+        plain, padded = KVCache(), BatchKVCache([2])
+        expected = attention(x, mask=create_attention_mask(x, plain), cache=plain)
+        padded_x = mx.concatenate([mx.zeros((1, 2, 8)), x], axis=1)
+        actual = attention(
+            padded_x, mask=create_attention_mask(padded_x, padded), cache=padded
+        )
+        self.assertTrue(mx.allclose(actual[:, 2:], expected, atol=1e-5).item())
+        token = mx.random.normal((1, 1, 8))
+        expected = attention(
+            token, mask=create_attention_mask(token, plain), cache=plain
+        )
+        actual = attention(
+            token, mask=create_attention_mask(token, padded), cache=padded
+        )
+        self.assertTrue(mx.allclose(actual, expected, atol=1e-5).item())
+
+
+class TestDenseAPCPrefillBoundaries(unittest.TestCase):
+    def test_reuse_retains_chunk_boundaries_and_releases_unused_blocks(self):
+        from unittest.mock import Mock
+
+        from mlx_vlm.generate.ar import BatchGenerator
+
+        for block_size, step, prefix, expected in (
+            (16, 128, 1008, 896),
+            (48, 128, 1008, 768),
+            (16, 128, 64, 0),
+            (16, 128, 1024, 1024),
+        ):
+            with self.subTest(block_size=block_size, step=step, prefix=prefix):
+                blocks = [object() for _ in range(prefix // block_size)]
+                ids = list(range(1100))
+                plan = {
+                    "matched_blocks": list(blocks),
+                    "prefix_len": prefix,
+                    "full_input_ids": ids,
+                    "extra_hash": 0,
+                }
+                manager = SimpleNamespace(block_size=block_size, release=Mock())
+                model = SimpleNamespace(
+                    apc_manager=manager,
+                    apc=SimpleNamespace(lookup=lambda *args, **kwargs: plan),
+                    prefill_step_size=step,
+                    _apc_extra_hash=lambda kwargs: 0,
+                    _apc_safe_prefix_lookup_min=lambda ids: 0,
+                    _apc_suffix_is_text_only=lambda ids, prefix: True,
+                    _apc_prefix_has_media_tokens=lambda ids, prefix: False,
+                )
+                result = BatchGenerator._apc_pick_for(
+                    model, (0, ids, 10, {}, None, None)
+                )
+                manager.release.assert_called_once_with(
+                    blocks[expected // block_size :]
+                )
+                if expected:
+                    self.assertEqual(result["prefix_len"], expected)
+                    self.assertEqual(
+                        result["matched_blocks"], blocks[: expected // block_size]
+                    )
+                    self.assertIs(result["full_input_ids"], ids)
+                else:
+                    self.assertIsNone(result)
+
+
+class TestDenseAPCReferenceLifecycle(unittest.TestCase):
+    def test_repeated_aligned_hits_and_rejected_hits_release_every_reference(self):
+        from mlx_vlm.apc import APCManager
+        from mlx_vlm.generate.ar import BatchGenerator
+
+        manager = APCManager(num_blocks=32, block_size=16)
+        ids = list(range(257))
+        keys = mx.zeros((1, 1, len(ids), 2))
+        stored = manager.store_kv_blocks(ids, [keys], [keys])
+        manager.release(stored)
+
+        def lookup(tokens, **kwargs):
+            blocks, length = manager.lookup_prefix(tokens)
+            return {
+                "matched_blocks": blocks,
+                "prefix_len": length,
+                "full_input_ids": tokens,
+            }
+
+        model = SimpleNamespace(
+            apc_manager=manager,
+            apc=SimpleNamespace(lookup=lookup),
+            prefill_step_size=128,
+            _apc_extra_hash=lambda kwargs: 0,
+            _apc_safe_prefix_lookup_min=lambda ids: 0,
+            _apc_suffix_is_text_only=lambda ids, prefix: True,
+            _apc_prefix_has_media_tokens=lambda ids, prefix: False,
+        )
+        try:
+            for _ in range(100):
+                for length, expected in ((65, 0), (209, 128), (257, 256)):
+                    pick = BatchGenerator._apc_pick_for(
+                        model, (0, ids[:length], 1, {}, None, None)
+                    )
+                    self.assertEqual(
+                        sum(b.ref_cnt for b in manager.pool), expected // 16
+                    )
+                    if pick:
+                        manager.release(pick["matched_blocks"])
+                    self.assertTrue(all(b.ref_cnt == 0 for b in manager.pool))
+            manager.clear()
+            self.assertEqual(manager.stats_snapshot()["pool_used"], 0)
+            self.assertFalse(manager.hash_table)
+        finally:
+            manager.close()
+
+
+class TestFlorenceIndependentLayerCaches(unittest.TestCase):
+    def test_default_forward_matches_explicit_per_layer_caches(self):
+        from mlx_vlm.models.florence2.config import TextConfig
+        from mlx_vlm.models.florence2.language import LanguageModel
+
+        mx.random.seed(81)
+        model = LanguageModel(
+            TextConfig(
+                d_model=8,
+                encoder_layers=2,
+                decoder_layers=2,
+                encoder_attention_heads=2,
+                decoder_attention_heads=2,
+                encoder_ffn_dim=16,
+                decoder_ffn_dim=16,
+                vocab_size=32,
+                max_position_embeddings=32,
+            )
+        )
+        inputs = mx.array([[3, 4, 5]])
+        decoder = mx.array([[2, 6]])
+        expected = model(
+            inputs, decoder_input_ids=decoder, cache=model.make_cache()
+        ).logits
+        actual = model(inputs, decoder_input_ids=decoder).logits
+        self.assertTrue(mx.allclose(actual, expected, atol=1e-6).item())
+
+
+class TestExactAPCSingleRowRestore(unittest.TestCase):
+    def test_single_row_preserves_chunked_window_on_continuation(self):
+        from mlx_vlm.apc_coordinator import APCCoordinator
+        from mlx_vlm.models.cache import ChunkedKVCache
+
+        cache = ChunkedKVCache(chunk_size=4)
+        values = mx.arange(8, dtype=mx.float32).reshape(1, 1, 8, 1)
+        cache.update_and_fetch(values, values)
+        cache.maybe_trim_front()
+        coordinator = SimpleNamespace(is_checkpoint=True)
+        restored, prefix = APCCoordinator.merge_rows(
+            coordinator, [{"warm_cache": [cache]}], [8]
+        )
+        next_value = mx.array([[[[8.0]]]])
+        keys, values = restored[0].update_and_fetch(next_value, next_value)
+        self.assertEqual(prefix, 8)
+        self.assertEqual(keys.flatten().tolist(), [4.0, 5.0, 6.0, 7.0, 8.0])
+        self.assertEqual(values.flatten().tolist(), keys.flatten().tolist())
+        self.assertEqual(restored[0].offset, 9)
+        self.assertEqual(restored[0].start_position, 4)
+
+
+class TestChunkedCacheStateRoundTrip(unittest.TestCase):
+    def test_empty_state_round_trip(self):
+        from mlx_vlm.models.cache import ChunkedKVCache
+
+        cache = ChunkedKVCache(4)
+        restored = ChunkedKVCache.from_state(cache.state, cache.meta_state)
+        self.assertTrue(restored.empty())
+        self.assertEqual(restored.offset, 0)
+
+    def test_trimmed_state_excludes_padding_and_preserves_position(self):
+        from mlx_vlm.models.cache import ChunkedKVCache
+
+        cache = ChunkedKVCache(4)
+        values = mx.arange(8, dtype=mx.float32).reshape(1, 1, 8, 1)
+        cache.update_and_fetch(values, values)
+        cache.maybe_trim_front()
+        cache.update_and_fetch(mx.array([[[[8.0]]]]), mx.array([[[[8.0]]]]))
+        state = cache.state
+        self.assertEqual(state[0].flatten().tolist(), [4.0, 5.0, 6.0, 7.0, 8.0])
+        restored = ChunkedKVCache.from_state(state, cache.meta_state)
+        self.assertEqual(restored.offset, cache.offset)
+        self.assertEqual(restored.start_position, cache.start_position)
+        for c in (cache, restored):
+            c.maybe_trim_front()
+        next_value = mx.array([[[[9.0]]]])
+        expected = cache.update_and_fetch(next_value, next_value)
+        actual = restored.update_and_fetch(next_value, next_value)
+        self.assertEqual(actual[0].flatten().tolist(), expected[0].flatten().tolist())
+
+    def test_llama4_logits_survive_state_round_trip_after_window_advances(self):
+        from mlx_vlm.models.llama4.config import TextConfig
+        from mlx_vlm.models.llama4.language import LanguageModel
+
+        mx.random.seed(82)
+        model = LanguageModel(
+            TextConfig(
+                model_type="llama4_text",
+                hidden_size=16,
+                intermediate_size=32,
+                intermediate_size_mlp=32,
+                num_hidden_layers=4,
+                num_attention_heads=2,
+                num_key_value_heads=1,
+                head_dim=8,
+                rms_norm_eps=1e-5,
+                vocab_size=32,
+                num_local_experts=2,
+                attention_chunk_size=4,
+            )
+        )
+        model.eval()
+        cache = model.make_cache()
+        for token in range(9):
+            mx.eval(model(mx.array([[token]]), cache=cache).logits)
+        restored = [type(c).from_state(c.state, c.meta_state) for c in cache]
+        self.assertGreater(cache[0].start_position, 0)
+        for token in range(9, 13):
+            expected = model(mx.array([[token]]), cache=cache).logits
+            actual = model(mx.array([[token]]), cache=restored).logits
+            self.assertTrue(mx.allclose(actual, expected, atol=1e-6).item())
+
+
+class TestBatchChunkedCache(unittest.TestCase):
+    @staticmethod
+    def row(length):
+        from mlx_vlm.models.cache import ChunkedKVCache
+
+        cache = ChunkedKVCache(4)
+        for token in range(length):
+            cache.maybe_trim_front()
+            value = mx.array([[[[float(token)]]]])
+            cache.update_and_fetch(value, value)
+        return cache
+
+    def test_merge_trim_extract_filter_and_extend_preserve_rows(self):
+        from mlx_vlm.models.cache import BatchChunkedKVCache
+
+        rows = [self.row(n) for n in (3, 7, 9)]
+        batch = BatchChunkedKVCache.merge(rows[:2])
+        batch.extend(BatchChunkedKVCache.merge(rows[2:]))
+        batch.maybe_trim_front()
+        for row in rows:
+            row.maybe_trim_front()
+        batch.filter(mx.array([2, 0]))
+        for index, original in enumerate((rows[2], rows[0])):
+            restored = batch.extract(index)
+            self.assertEqual(restored.offset, original.offset)
+            self.assertEqual(restored.start_position, original.start_position)
+            self.assertEqual(restored.state[0].tolist(), original.state[0].tolist())
+        restored_batch = BatchChunkedKVCache.from_state(batch.state, batch.meta_state)
+        value = mx.array([[[[12.0]]], [[[13.0]]]])
+        actual = restored_batch.update_and_fetch(value, value)[0]
+        expected = batch.update_and_fetch(value, value)[0]
+        self.assertTrue(mx.array_equal(actual, expected).item())
+        self.assertEqual(restored_batch.chunk_size, 4)
+
+    def test_mask_uses_each_rows_absolute_position(self):
+        from mlx_vlm.models.cache import BatchChunkedKVCache
+
+        batch = BatchChunkedKVCache.merge([self.row(3), self.row(7)])
+        batch.maybe_trim_front()
+        mask = batch.make_chunk_mask(2).tolist()
+        width = batch._idx
+        for row, offset in enumerate((3, 7)):
+            padding = int(batch.left_padding[row].item())
+            for query in range(2):
+                expected = []
+                for column in range(width + 2):
+                    key = offset - width + column
+                    expected.append(
+                        column >= padding
+                        and key <= offset + query
+                        and key // 4 == (offset + query) // 4
+                    )
+                self.assertEqual(mask[row][0][query], expected)
+
+    def test_right_padded_prefill_restores_each_rows_real_offset(self):
+        from mlx_vlm.models.cache import BatchChunkedKVCache
+
+        rows = [self.row(3), self.row(7)]
+        batch = BatchChunkedKVCache.merge(rows)
+        batch.prepare(lengths=[2, 3], right_padding=[1, 0])
+        values = mx.array([[[[12.0], [13.0], [0.0]]], [[[14.0], [15.0], [16.0]]]])
+        batch.update_and_fetch(values, values)
+        batch.finalize()
+        for index, suffix in enumerate(([12.0, 13.0], [14.0, 15.0, 16.0])):
+            values = mx.array(suffix).reshape(1, 1, -1, 1)
+            rows[index].update_and_fetch(values, values)
+            actual = batch.extract(index)
+            self.assertEqual(actual.offset, rows[index].offset)
+            self.assertEqual(actual.start_position, rows[index].start_position)
+            self.assertEqual(actual.state[0].tolist(), rows[index].state[0].tolist())
+
+
+class TestSystemTemplateRetry(unittest.TestCase):
+    def test_rejected_leading_system_text_is_preserved(self):
+        from copy import deepcopy
+
+        from transformers.utils.chat_template_utils import render_jinja_template
+
+        from mlx_vlm.prompt_utils import get_chat_template
+
+        class Processor:
+            chat_template = "{% for m in messages %}{% if m.role == 'system' and not loop.first %}{{ raise_exception('Only first system supported') }}{% endif %}{{ m.content }}{% endfor %}"
+
+            def apply_chat_template(self, messages, **kwargs):
+                result, _ = render_jinja_template(
+                    [messages], chat_template=self.chat_template, **kwargs
+                )
+                return result[0]
+
+        for content in (
+            "Second.",
+            [{"type": "text", "text": "Second.", "content": "Second."}],
+        ):
+            with self.subTest(content=content):
+                messages = [
+                    {"role": "system", "content": "First."},
+                    {"role": "system", "content": content},
+                    {"role": "user", "content": "Question."},
+                ]
+                original = deepcopy(messages)
+                self.assertEqual(
+                    get_chat_template(Processor(), messages, True),
+                    "First.\n\nSecond.Question.",
+                )
+                self.assertEqual(messages, original)
+
+    def test_successful_template_receives_original_messages_once(self):
+        from unittest.mock import Mock
+
+        from mlx_vlm.prompt_utils import get_chat_template
+
+        messages = [
+            {"role": "system", "content": "First."},
+            {"role": "system", "content": "Second."},
+        ]
+        processor = SimpleNamespace(
+            chat_template="template",
+            apply_chat_template=Mock(return_value="original render"),
+        )
+        self.assertEqual(
+            get_chat_template(processor, messages, True), "original render"
+        )
+        processor.apply_chat_template.assert_called_once()
+        self.assertIs(processor.apply_chat_template.call_args.args[0], messages)
+
+    def test_metadata_and_later_system_messages_are_not_rewritten(self):
+        from unittest.mock import Mock
+
+        from jinja2.exceptions import TemplateError
+
+        from mlx_vlm.prompt_utils import get_chat_template
+
+        for messages in (
+            [
+                {"role": "system", "content": "First.", "name": "policy"},
+                {"role": "system", "content": "Second."},
+            ],
+            [
+                {"role": "system", "content": "First."},
+                {"role": "user", "content": "Question."},
+                {"role": "system", "content": "Second."},
+            ],
+            [
+                {
+                    "role": "system",
+                    "content": [
+                        {"type": "text", "text": "First.", "content": "Different."}
+                    ],
+                },
+                {"role": "system", "content": "Second."},
+            ],
+        ):
+            with self.subTest(messages=messages):
+                error = TemplateError("original rejection")
+                processor = SimpleNamespace(
+                    chat_template="template",
+                    apply_chat_template=Mock(side_effect=error),
+                )
+                with self.assertRaises(TemplateError) as caught:
+                    get_chat_template(processor, messages, True)
+                self.assertIs(caught.exception, error)
+                processor.apply_chat_template.assert_called_once()
+
+
+class TestLegacyStringTemplateRetry(unittest.TestCase):
+    def test_string_template_preserves_text_image_order_and_metadata(self):
+        from copy import deepcopy
+
+        from transformers.utils.chat_template_utils import render_jinja_template
+
+        from mlx_vlm.prompt_utils import get_chat_template
+
+        class Processor:
+            chat_template = "{% for m in messages %}{{ '[INST]' + m.content + '[/INST]' }}{{ m.name }}{% endfor %}"
+
+            def __init__(self, marker):
+                self.image_token = marker
+
+            def apply_chat_template(self, messages, **kwargs):
+                result, _ = render_jinja_template(
+                    [messages], chat_template=self.chat_template, **kwargs
+                )
+                return result[0]
+
+        for marker in ("<image>", "[IMG]"):
+            with self.subTest(marker=marker):
+                messages = [
+                    {
+                        "role": "user",
+                        "name": "caller",
+                        "content": [
+                            {"type": "text", "text": "Before.", "content": "Before."},
+                            {"type": "image"},
+                            {"type": "text", "text": "After."},
+                        ],
+                    }
+                ]
+                original = deepcopy(messages)
+                text = get_chat_template(Processor(marker), messages, True)
+                self.assertEqual(
+                    text, "[INST]Before.\n" + marker + "\nAfter.[/INST]caller"
+                )
+                self.assertEqual(messages, original)
+
+    def test_unknown_parts_do_not_trigger_lossy_retry(self):
+        from unittest.mock import Mock
+
+        from mlx_vlm.prompt_utils import get_chat_template
+
+        for part in (
+            {"type": "input_audio", "data": "abc"},
+            {"type": "image", "url": "payload"},
+            {"type": "text", "text": "A", "content": "B"},
+        ):
+            with self.subTest(part=part):
+                processor = SimpleNamespace(
+                    chat_template="template",
+                    apply_chat_template=Mock(
+                        side_effect=TypeError("original rejection")
+                    ),
+                )
+                with self.assertRaisesRegex(TypeError, "original rejection"):
+                    get_chat_template(
+                        processor, [{"role": "user", "content": [part]}], True
+                    )
+                processor.apply_chat_template.assert_called_once()
+
+
+class TestLlavaNextImagePacking(unittest.TestCase):
+    def test_merge_preserves_text_between_images_and_batch_rows(self):
+        from mlx_vlm.models.llava_next.llava_next import Model
+
+        ids = mx.array([[11, 99, 99, 12, 99, 99, 13], [21, 22, 23, 24, 25, 26, 27]])
+        text = mx.arange(28).reshape(2, 7, 2).astype(mx.float32)
+        features = mx.arange(8).reshape(2, 2, 2).astype(mx.float32) + 100
+        fake = SimpleNamespace(config=SimpleNamespace(image_token_index=99))
+        actual = Model._merge_input_ids_with_image_features(fake, features, text, ids)
+        expected = np.array(text)
+        expected[0, [1, 2, 4, 5]] = np.array(features).reshape(4, 2)
+        np.testing.assert_array_equal(np.array(actual), expected)
+        np.testing.assert_array_equal(np.array(text), np.arange(28).reshape(2, 7, 2))
+
+    def test_merge_rejects_missing_features(self):
+        from mlx_vlm.models.llava_next.llava_next import Model
+
+        fake = SimpleNamespace(config=SimpleNamespace(image_token_index=99))
+        with self.assertRaisesRegex(ValueError, "features.*tokens"):
+            Model._merge_input_ids_with_image_features(
+                fake, mx.zeros((1, 2)), mx.zeros((1, 3, 2)), mx.array([[99, 99, 1]])
+            )
+
+    def test_spatial_packing_orders_rows_and_newlines(self):
+        from mlx_vlm.models.llava_next.image_features import pack_image_features
+
+        features = mx.arange(12).reshape(3, 4, 1)
+        actual = pack_image_features(
+            [features], [(2, 4)], 2, 1, [[2, 4]], mx.array([-1])
+        )[0]
+        expected = [0, 1, 2, 3, 4, 5, 8, 9, -1, 6, 7, 10, 11, -1]
+        np.testing.assert_array_equal(np.array(actual).ravel(), expected)
+
+
+class TestLlavaNextProcessorPadding(unittest.TestCase):
+    def test_padding_and_special_tokens(self):
+        from tokenizers import Tokenizer, models, pre_tokenizers, processors
+        from transformers import PreTrainedTokenizerFast
+
+        from mlx_vlm.models.llava_next.processing_llava_next import LlavaNextProcessor
+
+        backend = Tokenizer(
+            models.WordLevel(
+                {"<pad>": 0, "<s>": 1, "a": 2, "b": 3, "<unk>": 4}, unk_token="<unk>"
+            )
+        )
+        backend.pre_tokenizer = pre_tokenizers.Whitespace()
+        backend.post_processor = processors.TemplateProcessing(
+            single="<s> $A", special_tokens=[("<s>", 1)]
+        )
+        tokenizer = PreTrainedTokenizerFast(
+            tokenizer_object=backend,
+            pad_token="<pad>",
+            bos_token="<s>",
+            unk_token="<unk>",
+        )
+        processor = object.__new__(LlavaNextProcessor)
+        processor.tokenizer = tokenizer
+        inputs = processor(
+            text=["a b", "a"],
+            padding=True,
+            add_special_tokens=False,
+            padding_side="left",
+        )
+        np.testing.assert_array_equal(np.array(inputs["input_ids"]), [[2, 3], [0, 2]])
+        np.testing.assert_array_equal(
+            np.array(inputs["attention_mask"]), [[1, 1], [0, 1]]
+        )
+        inputs = processor(
+            text=["a b", "a"],
+            padding=True,
+            add_special_tokens=True,
+            padding_side="right",
+        )
+        np.testing.assert_array_equal(
+            np.array(inputs["input_ids"]), [[1, 2, 3], [1, 2, 0]]
+        )
+
+
+class TestLLMjpVLCacheAndImages(unittest.TestCase):
+    def test_cache_layout_and_continuation(self):
+        from mlx_vlm.apc import self_check_model_apc
+        from mlx_vlm.models.llmjpvl import TextConfig
+        from mlx_vlm.models.llmjpvl.language import LanguageModel
+
+        model = LanguageModel(
+            TextConfig(
+                hidden_size=16,
+                intermediate_size=32,
+                num_hidden_layers=2,
+                num_attention_heads=4,
+                num_key_value_heads=2,
+                vocab_size=32,
+            )
+        )
+        self.assertTrue(self_check_model_apc(model, log=False).ok)
+        cache = model.make_cache()
+        self.assertIsNot(cache[0], cache[1])
+        tokens = mx.array([[1, 2, 3, 4]])
+        expected = model(tokens).logits[:, -1:]
+        model(tokens[:, :3], cache=cache)
+        actual = model(tokens[:, 3:], cache=cache).logits
+        np.testing.assert_allclose(
+            np.array(actual), np.array(expected), atol=1e-5, rtol=1e-5
+        )
+        self.assertEqual([c.offset for c in cache], [4, 4])
+
+    def test_image_scatter_preserves_other_rows(self):
+        from mlx_vlm.models.llmjpvl.llmjpvl import Model
+
+        ids = mx.array([[14, 1, 2, 3], [4, 5, 6, 7], [8, 14, 9, 14]])
+        embeddings = mx.arange(24).reshape(3, 4, 2).astype(mx.float32)
+        features = mx.array([[100, 101], [200, 201], [300, 301]], dtype=mx.float32)
+        fake = SimpleNamespace(config=SimpleNamespace(image_token_index=14))
+        actual = Model._merge_input_ids_with_image_features(
+            fake, features, embeddings, ids
+        )
+        expected = np.arange(24).reshape(3, 4, 2).astype(np.float32)
+        expected[0, 0] = [100, 101]
+        expected[2, 1] = [200, 201]
+        expected[2, 3] = [300, 301]
+        np.testing.assert_array_equal(np.array(actual), expected)
+        np.testing.assert_array_equal(
+            np.array(embeddings), np.arange(24).reshape(3, 4, 2)
+        )
+
+
+class TestErnie45LocalTokenizer(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        import tempfile
+        from pathlib import Path
+
+        import sentencepiece as spm
+
+        from mlx_vlm.models.ernie4_5.tokenization_ernie4_5 import Ernie45Tokenizer
+
+        cls.directory = tempfile.TemporaryDirectory()
+        prefix = str(Path(cls.directory.name) / "tokenizer")
+        spm.SentencePieceTrainer.train(
+            sentence_iterator=iter(["hello world", "hello again", "test tokens"] * 10),
+            model_prefix=prefix,
+            vocab_size=32,
+            hard_vocab_limit=False,
+            user_defined_symbols=["<cls>", "<sep>", "<mask:0>", "<mask:1>", "<mask:7>"],
+            minloglevel=2,
+        )
+        cls.tokenizer = Ernie45Tokenizer(prefix + ".model", pad_token="<unk>")
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.directory.cleanup()
+
+    def test_special_token_boundaries_and_pair(self):
+        tokenizer = self.tokenizer
+        ids = tokenizer.encode("hello", add_special_tokens=False)
+        self.assertEqual(
+            tokenizer.build_inputs_with_special_tokens(ids),
+            [
+                tokenizer.bos_token_id,
+                tokenizer.cls_token_id,
+                *ids,
+                tokenizer.sep_token_id,
+            ],
+        )
+        marked = [tokenizer.cls_token_id, *ids]
+        self.assertEqual(
+            tokenizer.build_inputs_with_special_tokens(marked, ids),
+            [tokenizer.bos_token_id, *marked, *ids, tokenizer.sep_token_id],
+        )
+
+    def test_padding_preserves_causal_mask(self):
+        tokenizer = self.tokenizer
+        for side in ("left", "right"):
+            tokenizer.padding_side = side
+            data = tokenizer(
+                ["hello", "hello world again"], padding=True, add_special_tokens=False
+            )
+            for row, text in enumerate(["hello", "hello world again"]):
+                ids = tokenizer.encode(text, add_special_tokens=False)
+                start = len(data["input_ids"][row]) - len(ids) if side == "left" else 0
+                self.assertEqual(data["input_ids"][row][start : start + len(ids)], ids)
+                mask = np.array(data["attention_mask"][row])[0]
+                expected = np.zeros_like(mask)
+                expected[start : start + len(ids), start : start + len(ids)] = np.tril(
+                    np.ones((len(ids), len(ids)))
+                )
+                np.testing.assert_array_equal(mask, expected)
+
+
+class TestMoondreamPackedCheckpoint(unittest.TestCase):
+    def test_unpack_nibble_order_groups_and_idempotence(self):
+        from mlx_vlm.models.moondream2.moondream2 import Model
+
+        weights = {
+            "model.text.blocks.0.attn.proj.weight.packed": mx.array(
+                [[0x12, 0x34]], dtype=mx.uint8
+            ),
+            "model.text.blocks.0.attn.proj.weight.scale": mx.array([[2.0], [3.0]]),
+            "model.text.blocks.0.attn.proj.weight.zero_point": mx.array([[1.0], [2.0]]),
+            "model.text.blocks.0.attn.proj.bias": mx.array([0.0, 1.0]),
+            "model.region.unused": mx.array([1]),
+        }
+        result = Model.sanitize(None, weights)
+        self.assertEqual(
+            set(result),
+            {
+                "text.model.layers.0.attn.proj.weight",
+                "text.model.layers.0.attn.proj.bias",
+            },
+        )
+        np.testing.assert_array_equal(
+            np.array(result["text.model.layers.0.attn.proj.weight"].astype(mx.float32)),
+            [[0, 4], [0, 6]],
+        )
+        again = Model.sanitize(None, result)
+        self.assertEqual(set(result), set(again))
+        for key in result:
+            self.assertTrue(mx.array_equal(result[key], again[key]).item())
+        self.assertIn("model.text.blocks.0.attn.proj.weight.packed", weights)
+
+    def test_legacy_checkpoint_stop_tokens(self):
+        from mlx_vlm.models.moondream2 import ModelConfig
+
+        self.assertEqual(
+            ModelConfig.from_dict({"model_type": "moondream1"}).eos_token_id, 50256
+        )
+        self.assertEqual(
+            ModelConfig.from_dict(
+                {"model_type": "moondream1", "eos_token_id": 7}
+            ).eos_token_id,
+            7,
+        )
+        self.assertEqual(
+            ModelConfig.from_dict({"model_type": "moondream2"}).eos_token_id, 0
+        )
+
+
+class TestMoondreamCropFidelity(unittest.TestCase):
+    def test_reference_crop_grid_and_pixel_rounding(self):
+        from PIL import Image
+
+        from mlx_vlm.models.moondream2.image_crops import create_crops
+
+        crops, layout = create_crops(
+            Image.new("RGB", (600, 400), (128, 128, 128)), 378, 12, 4
+        )
+        self.assertEqual(layout, (2, 4))
+        self.assertEqual(len(crops), 9)
+        np.testing.assert_array_equal(
+            np.stack(crops), np.full((9, 378, 378, 3), 0.0078125)
+        )
+
+    def test_reconstruction_uses_overlapping_adaptive_pool_bins(self):
+        from mlx_vlm.models.moondream2.vision import VisionModel
+
+        fake = SimpleNamespace(
+            config=SimpleNamespace(crop_size=4, patch_size=1, overlap_margin=1)
+        )
+        features = [
+            mx.arange(16).reshape(16, 1).astype(mx.float32) + 100 * i for i in range(6)
+        ]
+        actual = VisionModel._reconstruct_local_features(fake, features, (2, 3))
+        rows = []
+        for r in range(2):
+            parts = []
+            for c in range(3):
+                tile = np.array(features[r * 3 + c]).reshape(4, 4)
+                parts.append(
+                    tile[
+                        0 if r == 0 else 1 : 4 if r == 1 else 3,
+                        0 if c == 0 else 1 : 4 if c == 2 else 3,
+                    ]
+                )
+            rows.append(np.concatenate(parts, axis=1))
+        grid = np.concatenate(rows, axis=0)
+        expected = np.array(
+            [
+                [
+                    grid[
+                        math.floor(i * grid.shape[0] / 4) : math.ceil(
+                            (i + 1) * grid.shape[0] / 4
+                        ),
+                        math.floor(j * grid.shape[1] / 4) : math.ceil(
+                            (j + 1) * grid.shape[1] / 4
+                        ),
+                    ].mean()
+                    for j in range(4)
+                ]
+                for i in range(4)
+            ]
+        )
+        np.testing.assert_array_equal(np.array(actual).reshape(4, 4), expected)
+
+
+class TestMoondream3VideoPrefix(unittest.TestCase):
+    def test_all_frame_features_and_question_survive(self):
+        from mlx_vlm.models.moondream3.moondream3 import Model
+
+        ids = mx.array([[7, 0, 0, 0, 0, 41, 42]])
+        features = mx.array(
+            [[[100.0, 101.0], [102.0, 103.0]], [[200.0, 201.0], [202.0, 203.0]]]
+        )
+        fake = SimpleNamespace(
+            text=SimpleNamespace(
+                model=SimpleNamespace(
+                    wte=lambda x: mx.stack([x, x], axis=-1).astype(mx.float32)
+                )
+            ),
+            _create_prefix_attention_mask=lambda *args, **kwargs: None,
+        )
+        result = Model.get_input_embeddings(
+            fake,
+            ids,
+            pixel_values=mx.zeros((2, 1, 1, 3)),
+            cached_image_features=features,
+        )
+        expected = mx.concatenate(
+            [
+                mx.array([[[7.0, 7.0]]]),
+                features.reshape(1, 4, 2),
+                mx.array([[[41.0, 41.0], [42.0, 42.0]]]),
+            ],
+            axis=1,
+        )
+        np.testing.assert_array_equal(
+            np.array(result.inputs_embeds), np.array(expected)
+        )
+
+    def test_processor_reserves_space_for_every_frame(self):
+        from unittest.mock import patch
+
+        from mlx_vlm.models.moondream3.processing_moondream3 import (
+            ANSWER_ID,
+            NUM_VISION_TOKENS,
+            Moondream3Processor,
+        )
+
+        tokenizer = SimpleNamespace(
+            bos_token_id=7,
+            pad_token_id=0,
+            bos_token="<s>",
+            eos_token="</s>",
+            pad_token="<pad>",
+            encode=lambda text, **kwargs: [41, 42],
+            chat_template=None,
+        )
+        processor = Moondream3Processor(tokenizer)
+        with patch(
+            "mlx_vlm.models.moondream3.processing_moondream3.create_crops",
+            return_value=([np.zeros((1, 1, 3))], (1, 1)),
+        ):
+            inputs = processor(text="Keep this question.", images=[object(), object()])
+        ids = inputs["input_ids"][0].tolist()
+        self.assertEqual(ids, [7] + [0] * (2 * NUM_VISION_TOKENS) + [41, 42, ANSWER_ID])
+
+
+class TestMoondream2PrefixAttention(unittest.TestCase):
+    def test_generation_mask_matches_explicit_mask_and_cached_continuation(self):
+        from mlx_vlm.generate.common import _chunked_prefill_enabled
+        from mlx_vlm.models.cache import KVCache
+        from mlx_vlm.models.moondream2.config import TextConfig
+        from mlx_vlm.models.moondream2.language import LanguageModel
+
+        mx.random.seed(7)
+        model = LanguageModel(
+            TextConfig(
+                hidden_size=32,
+                intermediate_size=64,
+                num_hidden_layers=2,
+                vocab_size=64,
+                num_attention_heads=4,
+                num_key_value_heads=4,
+            )
+        )
+        ids = mx.array([[1, 2, 3, 4, 5]])
+        mask = mx.triu(mx.full((5, 5), -mx.inf), k=1)
+        mask[:4, :4] = 0
+        mask = mask[None, None]
+        expected = model(ids, mask=mask).logits
+        caches = [KVCache() for _ in model.layers]
+        actual = model(ids, attention_mask_4d=mask, cache=caches).logits
+        np.testing.assert_allclose(np.array(actual), np.array(expected), atol=1e-6)
+        self.assertFalse(
+            _chunked_prefill_enabled(model, prefill_kwargs={"attention_mask_4d": mask})
+        )
+        self.assertTrue(_chunked_prefill_enabled(model))
+        continuation = model(
+            mx.array([[6]]), attention_mask_4d=mask, cache=caches
+        ).logits
+        full_mask = mx.triu(mx.full((6, 6), -mx.inf), k=1)
+        full_mask[:4, :4] = 0
+        full = model(mx.array([[1, 2, 3, 4, 5, 6]]), mask=full_mask[None, None]).logits
+        np.testing.assert_allclose(
+            np.array(continuation[:, -1]),
+            np.array(full[:, -1]),
+            atol=2e-6,
+        )
+
+    def test_float_mask_is_valid_for_bfloat16_attention(self):
+        from mlx_vlm.models.moondream2.config import TextConfig
+        from mlx_vlm.models.moondream2.language import Attention
+
+        model = Attention(
+            TextConfig(hidden_size=32, num_attention_heads=4, num_key_value_heads=4)
+        )
+        model.set_dtype(mx.bfloat16)
+        inputs = mx.ones((1, 4, 32), dtype=mx.bfloat16)
+        mask = mx.triu(mx.full((4, 4), -mx.inf), k=1)
+        actual = model(inputs, mask=mask)
+        expected = model(inputs, mask=mask.astype(mx.bfloat16))
+        np.testing.assert_array_equal(
+            np.array(actual.astype(mx.float32)), np.array(expected.astype(mx.float32))
+        )
+
+
+class TestMoondream2PaddedImages(unittest.TestCase):
+    def test_padded_rows_match_independent_embeddings_and_masks(self):
+        from mlx_vlm.models.moondream2.moondream2 import Model
+
+        features = mx.array(
+            [[[100.0, 101.0], [102.0, 103.0]], [[200.0, 201.0], [202.0, 203.0]]]
+        )
+        fake = SimpleNamespace(
+            text=SimpleNamespace(
+                model=SimpleNamespace(
+                    embed_tokens=lambda x: mx.stack([x, x], axis=-1).astype(mx.float32)
+                )
+            ),
+            vision=lambda *args, **kwargs: features,
+            _create_prefix_attention_mask=lambda n, p: Model._create_prefix_attention_mask(
+                None, n, p
+            ),
+        )
+        ids = mx.array([[0, 0, 7, 0, 0, 41, 42], [7, 0, 0, 51, 52, 53, 54]])
+        valid = mx.array([[0, 0, 1, 1, 1, 1, 1], [1, 1, 1, 1, 1, 1, 1]])
+        result = Model.get_input_embeddings(
+            fake, ids, mx.zeros((2, 1, 1, 3)), mask=valid
+        )
+        for row, start in enumerate((2, 0)):
+            single = SimpleNamespace(**vars(fake))
+            single.vision = lambda *args, row=row, **kwargs: features[row : row + 1]
+            expected = Model.get_input_embeddings(
+                single, ids[row : row + 1, start:], mx.zeros((1, 1, 1, 3))
+            )
+            np.testing.assert_array_equal(
+                np.array(result.inputs_embeds[row : row + 1, start:]),
+                np.array(expected.inputs_embeds),
+            )
+            np.testing.assert_array_equal(
+                np.array(result.attention_mask_4d[row : row + 1, :, start:, start:]),
+                np.array(expected.attention_mask_4d),
+            )
+        self.assertTrue(
+            bool(mx.all(mx.isneginf(result.attention_mask_4d[0, :, 2:, :2])))
+        )
+
+
+class TestMoondream2NativeCache(unittest.TestCase):
+    def test_factory_preserves_cached_continuation(self):
+        from mlx_vlm.models.cache import KVCache
+        from mlx_vlm.models.moondream2.config import TextConfig
+        from mlx_vlm.models.moondream2.language import LanguageModel
+
+        mx.random.seed(11)
+        model = LanguageModel(
+            TextConfig(
+                hidden_size=32,
+                intermediate_size=64,
+                num_hidden_layers=2,
+                vocab_size=64,
+                num_attention_heads=4,
+                num_key_value_heads=4,
+            )
+        )
+        cache = model.make_cache()
+        self.assertEqual(len(cache), 2)
+        self.assertTrue(all(isinstance(c, KVCache) for c in cache))
+        self.assertIsNot(cache[0], cache[1])
+        self.assertIsNot(cache[0], model.make_cache()[0])
+        model(mx.array([[1, 2, 3, 4]]), cache=cache)
+        actual = model(mx.array([[5]]), cache=cache).logits
+        expected = model(mx.array([[1, 2, 3, 4, 5]])).logits[:, -1:]
+        np.testing.assert_allclose(np.array(actual), np.array(expected), atol=2e-6)
+
+
+class TestMolmoHistoryRendering(unittest.TestCase):
+    def test_rich_history_preserves_roles_and_call_metadata(self):
+        import copy
+
+        from mlx_vlm.models.molmo.processing_molmo import MolmoProcessor
+
+        processor = SimpleNamespace(
+            chat_template="{% for message in messages %}{{ message['content'] }}{% endfor %}",
+            tokenizer=SimpleNamespace(encode=lambda x: list(x.encode())),
+        )
+        messages = [
+            {"role": "system", "content": "SYSTEM_MARKER"},
+            {"role": "user", "content": "USER_MARKER"},
+            {
+                "role": "assistant",
+                "content": "ASSISTANT_MARKER",
+                "reasoning_content": "REASONING_MARKER",
+                "tool_calls": [
+                    {
+                        "id": "CALL_MARKER",
+                        "type": "function",
+                        "function": {
+                            "name": "FUNCTION_MARKER",
+                            "arguments": '{"path":"ARGUMENT_MARKER"}',
+                        },
+                    }
+                ],
+            },
+            {"role": "tool", "tool_call_id": "CALL_MARKER", "content": "RESULT_MARKER"},
+            {"role": "user", "content": "FOLLOWUP_MARKER"},
+        ]
+        original = copy.deepcopy(messages)
+        rendered = MolmoProcessor.apply_chat_template(
+            processor, messages, add_generation_prompt=True
+        )
+        for marker in (
+            "SYSTEM_MARKER",
+            "USER_MARKER",
+            "ASSISTANT_MARKER",
+            "REASONING_MARKER",
+            "CALL_MARKER",
+            "FUNCTION_MARKER",
+            "ARGUMENT_MARKER",
+            "RESULT_MARKER",
+            "FOLLOWUP_MARKER",
+        ):
+            self.assertIn(marker, rendered)
+        self.assertIn("System:", rendered)
+        self.assertIn("Tool:", rendered)
+        self.assertTrue(rendered.endswith("Assistant:"))
+        self.assertEqual(messages, original)
+        self.assertEqual(
+            MolmoProcessor.apply_chat_template(
+                processor, messages, add_generation_prompt=True, tokenize=True
+            ),
+            list(rendered.encode()),
+        )
+
+    def test_explicit_template_and_tokenization_keep_existing_contract(self):
+        from mlx_vlm.models.molmo.processing_molmo import MolmoProcessor
+
+        calls = []
+
+        def render(messages, **kwargs):
+            calls.append((messages, kwargs))
+            return "CUSTOM_TEXT"
+
+        processor = SimpleNamespace(
+            chat_template="DEFAULT_TEMPLATE",
+            tokenizer=SimpleNamespace(
+                apply_chat_template=render, encode=lambda text: [99, len(text)]
+            ),
+        )
+        messages = [{"role": "system", "content": "Keep this instruction"}]
+        actual = MolmoProcessor.apply_chat_template(
+            processor, messages, chat_template="EXPLICIT_TEMPLATE", tokenize=True
+        )
+        self.assertEqual(actual, [99, len("CUSTOM_TEXT")])
+        self.assertEqual(calls[0][0], messages)
+        self.assertEqual(calls[0][1]["chat_template"], "EXPLICIT_TEMPLATE")
+        self.assertFalse(calls[0][1]["tokenize"])
+
+    def test_available_tools_survive_without_prior_tool_calls(self):
+        import json
+
+        from mlx_vlm.models.molmo.processing_molmo import MolmoProcessor
+
+        tools = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "read_file",
+                    "description": "Read café_λ",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"path": {"type": "string"}},
+                        "required": ["path"],
+                    },
+                },
+            }
+        ]
+        processor = SimpleNamespace(
+            chat_template="unused",
+            tokenizer=SimpleNamespace(
+                apply_chat_template=lambda *args, **kwargs: "User: Read the file."
+            ),
+        )
+        rendered = MolmoProcessor.apply_chat_template(
+            processor,
+            [{"role": "user", "content": "Read the file."}],
+            tools=tools,
+            add_generation_prompt=True,
+        )
+        first, rest = rendered.split("\n", 1)
+        self.assertEqual(json.loads(first.removeprefix("Available tools: ")), tools)
+        self.assertEqual(rest, "User: Read the file.\nAssistant:")
+
+
+class TestLLMjpVLHistoryRendering(unittest.TestCase):
+    def _processor(self):
+        from tokenizers import Tokenizer
+        from tokenizers.models import WordLevel
+        from transformers import PreTrainedTokenizerFast, SiglipImageProcessor
+
+        from mlx_vlm.models.llmjpvl.processing_llmjpvl import LLMjpVLProcessor
+
+        tokenizer = PreTrainedTokenizerFast(
+            tokenizer_object=Tokenizer(WordLevel({"[UNK]": 0}, unk_token="[UNK]")),
+            unk_token="[UNK]",
+        )
+        tokenizer.chat_template = (
+            "{% for m in messages %}{{ m['role'] }}:{{ m['content'] }};{% endfor %}"
+        )
+        return LLMjpVLProcessor(SiglipImageProcessor(), tokenizer)
+
+    def test_all_roles_metadata_and_tool_definitions_are_preserved(self):
+        processor = self._processor()
+        messages = [
+            {"role": "system", "content": "FIRST_SYSTEM"},
+            {"role": "system", "content": "SECOND_SYSTEM"},
+            {
+                "role": "assistant",
+                "content": "ANSWER",
+                "reasoning_content": "REASONING",
+                "tool_calls": [
+                    {
+                        "id": "CALL_ID",
+                        "type": "function",
+                        "function": {
+                            "name": "FUNCTION_NAME",
+                            "arguments": '{"key":"ARGUMENT_VALUE"}',
+                        },
+                    }
+                ],
+            },
+            {"role": "tool", "content": "TOOL_RESULT", "tool_call_id": "CALL_ID"},
+            {"role": "user", "content": "FOLLOWUP"},
+        ]
+        tools = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "AVAILABLE_TOOL",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"PARAMETER_NAME": {"type": "string"}},
+                    },
+                },
+            }
+        ]
+        result = processor.apply_chat_template(
+            messages, tools=tools, tokenize=False, add_generation_prompt=True
+        )
+        for marker in (
+            "FIRST_SYSTEM",
+            "SECOND_SYSTEM",
+            "ANSWER",
+            "REASONING",
+            "CALL_ID",
+            "FUNCTION_NAME",
+            "ARGUMENT_VALUE",
+            "TOOL_RESULT",
+            "FOLLOWUP",
+            "AVAILABLE_TOOL",
+            "PARAMETER_NAME",
+        ):
+            self.assertIn(marker, result)
+        self.assertLess(result.index("FIRST_SYSTEM"), result.index("SECOND_SYSTEM"))
+        self.assertIn("<|start|>tool<|message|>TOOL_RESULT", result)
+        self.assertTrue(
+            result.endswith("<|start|>assistant<|channel|>final<|message|>")
+        )
+
+    def test_ordinary_history_and_explicit_override_remain_native(self):
+        processor = self._processor()
+        messages = [{"role": "user", "content": "hello"}]
+        self.assertEqual(
+            processor.apply_chat_template(messages, tokenize=False), "user:hello;"
+        )
+        rich = [{"role": "tool", "content": "result"}]
+        self.assertEqual(
+            processor.apply_chat_template(
+                rich, chat_template="EXPLICIT", tokenize=False
+            ),
+            "EXPLICIT",
+        )
+
+    def test_batched_history_keeps_each_conversation(self):
+        processor = self._processor()
+        ordinary = [{"role": "user", "content": "hello"}]
+        self.assertEqual(
+            processor.apply_chat_template([ordinary, ordinary], tokenize=False),
+            ["user:hello;", "user:hello;"],
+        )
+        rich = [{"role": "tool", "content": "TOOL_RESULT", "tool_call_id": "CALL_ID"}]
+        rendered = processor.apply_chat_template([rich, rich], tokenize=False)
+        self.assertEqual(len(rendered), 2)
+        self.assertEqual(rendered[0], rendered[1])
+        self.assertIn("TOOL_RESULT", rendered[0])
+        self.assertIn("CALL_ID", rendered[0])
+
+
+class TestAPCFullPromptBoundary(unittest.TestCase):
+    def test_full_match_keeps_usable_blocks_and_releases_tail(self):
+        from mlx_vlm.apc import apc_lookup_plan
+
+        for length in (16, 48):
+            with self.subTest(length=length):
+                blocks = list(range(length // 16))
+                released = []
+                manager = SimpleNamespace(
+                    block_size=16,
+                    lookup_prefix=lambda *args, **kwargs: (blocks.copy(), length),
+                    lookup_exact_cache=lambda *args, **kwargs: (None, 0),
+                    lookup_prefix_disk_cache=lambda *args, **kwargs: (None, 0),
+                    release=lambda values: released.extend(values),
+                )
+                result = apc_lookup_plan(
+                    manager,
+                    list(range(length)),
+                    extra_hash=0,
+                    apc_mode="block",
+                    safe_lookup_min=0,
+                    suffix_is_text_only=lambda n: True,
+                    prefix_has_media=lambda n: False,
+                )
+                if length == 16:
+                    self.assertIsNone(result)
+                    self.assertEqual(released, blocks)
+                else:
+                    self.assertIsNotNone(result)
+                    self.assertEqual(result["prefix_len"], length - 16)
+                    self.assertEqual(result["matched_blocks"], blocks[:-1])
+                    self.assertEqual(released, blocks[-1:])
+
+
+class TestBunnyMultipleImages(unittest.TestCase):
+    def test_preparation_keeps_all_chunks_and_expands_image_slots(self):
+        from PIL import Image
+
+        from mlx_vlm.models.base import BaseImageProcessor
+        from mlx_vlm.utils import prepare_inputs
+
+        class ImageProcessor(BaseImageProcessor):
+            image_seq_length = 2
+
+            def preprocess(self, images):
+                return [np.zeros((3, 2, 2)) for _ in images]
+
+        class Tokenizer:
+            pad_token = "pad"
+            pad_token_id = 0
+            eos_token = "eos"
+            image_processor = ImageProcessor()
+
+            def __call__(self, text, **kwargs):
+                return SimpleNamespace(input_ids=[ord(c) for c in text])
+
+        result = prepare_inputs(
+            Tokenizer(),
+            images=[Image.new("RGB", (2, 2))] * 2,
+            prompts="A<image>B<image>C",
+            image_token_index=-200,
+        )
+        self.assertEqual(
+            result["input_ids"].tolist(), [[65, -200, -200, 66, -200, -200, 67]]
+        )
+        self.assertEqual(result["attention_mask"].tolist(), [[1] * 7])
+
+    def test_expanded_image_slots_keep_intervening_text_and_rows(self):
+        from mlx_vlm.models.llava_bunny.llava_bunny import Model
+
+        fake = SimpleNamespace(config=SimpleNamespace(image_token_index=-200))
+        ids = mx.array(
+            [[7, -200, -200, 8, -200, -200, 9], [10, 11, 12, 13, 14, 15, 16]]
+        )
+        embeddings = mx.stack([ids, ids], axis=-1).astype(mx.float32)
+        features = mx.array(
+            [[[100.0, 101.0], [102.0, 103.0]], [[200.0, 201.0], [202.0, 203.0]]]
+        )
+        actual = Model._prepare_inputs_for_multimodal(fake, features, embeddings, ids)
+        expected = np.array(embeddings)
+        expected[0, 1:3] = np.array(features[0])
+        expected[0, 4:6] = np.array(features[1])
+        np.testing.assert_array_equal(np.array(actual), expected)
+        np.testing.assert_array_equal(
+            np.array(embeddings), np.array(mx.stack([ids, ids], axis=-1))
+        )
+
+
+class TestPaliGemmaMultipleImages(unittest.TestCase):
+    def test_vision_encoder_preserves_every_image(self):
+        from mlx_vlm.models.paligemma.vision import Encoder
+
+        fake = SimpleNamespace(layers=[lambda x, mask: x + 1])
+        images = mx.arange(24).reshape(2, 3, 4).astype(mx.float32)
+        encoded, states = Encoder.__call__(fake, images, output_hidden_states=True)
+        np.testing.assert_array_equal(np.array(encoded), np.array(images + 1))
+        self.assertEqual(states[-1].shape, (2, 3, 4))
+
+    def test_image_features_follow_slots_across_rows(self):
+        from mlx_vlm.models.paligemma.paligemma import Model
+
+        fake = SimpleNamespace(
+            config=SimpleNamespace(hidden_size=4, image_token_index=19, pad_token_id=0)
+        )
+        ids = mx.array([[19, 19, 1, 19, 19, 2], [0, 0, 0, 3, 4, 5]])
+        embeddings = mx.stack([ids] * 4, axis=-1).astype(mx.float32)
+        features = mx.arange(16).reshape(2, 2, 4).astype(mx.float32) + 100
+        valid = ids != 0
+        actual, mask = Model._prepare_inputs_for_multimodal(
+            fake, features, embeddings, ids, valid
+        )
+        expected = np.array(embeddings)
+        expected[0, :2] = np.array(features[0] / 2)
+        expected[0, 3:5] = np.array(features[1] / 2)
+        np.testing.assert_array_equal(np.array(actual), expected)
+        self.assertEqual(mask.shape, (2, 1, 6, 6))
+        self.assertFalse(bool(mx.any(mask[1, :, 3:, :3])))
+
+
+class TestPaliGemmaHistoryRendering(unittest.TestCase):
+    def test_history_and_tools_are_not_reduced_to_last_message(self):
+        from mlx_vlm.prompt_utils import apply_chat_template
+
+        processor = SimpleNamespace(chat_template=None)
+        config = SimpleNamespace(model_type="paligemma")
+        messages = [
+            {"role": "system", "content": "SYSTEM_MARKER"},
+            {"role": "user", "content": "FIRST_MARKER"},
+            {
+                "role": "assistant",
+                "content": "ANSWER_MARKER",
+                "tool_calls": [
+                    {
+                        "id": "CALL_MARKER",
+                        "type": "function",
+                        "function": {"name": "read_file", "arguments": "{}"},
+                    }
+                ],
+            },
+            {"role": "tool", "tool_call_id": "CALL_MARKER", "content": "RESULT_MARKER"},
+            {"role": "user", "content": "LAST_MARKER"},
+        ]
+        tools = [
+            {
+                "type": "function",
+                "function": {"name": "SCHEMA_MARKER", "parameters": {"type": "object"}},
+            }
+        ]
+        rendered = apply_chat_template(processor, config, messages, tools=tools)
+        for marker in (
+            "SYSTEM_MARKER",
+            "FIRST_MARKER",
+            "ANSWER_MARKER",
+            "CALL_MARKER",
+            "RESULT_MARKER",
+            "LAST_MARKER",
+            "SCHEMA_MARKER",
+        ):
+            self.assertIn(marker, rendered)
+
+
+class TestPaliGemmaAttentionPolicy(unittest.TestCase):
+    def _model(self, bidirectional=True):
+        from mlx_vlm.models.paligemma.config import TextConfig
+        from mlx_vlm.models.paligemma.language import LanguageModel
+
+        mx.random.seed(3)
+        return LanguageModel(
+            TextConfig(
+                hidden_size=32,
+                num_hidden_layers=2,
+                intermediate_size=64,
+                num_attention_heads=4,
+                num_key_value_heads=1,
+                vocab_size=64,
+                use_bidirectional_attention=bidirectional,
+            )
+        )
+
+    def test_bidirectional_attention_rejects_chunking_and_prefix_reuse(self):
+        from mlx_vlm.apc import APCManager
+        from mlx_vlm.apc_coordinator import APCCoordinator
+        from mlx_vlm.generate.common import _chunked_prefill_enabled
+
+        for bidirectional in (True, False):
+            model = self._model(bidirectional)
+            self.assertEqual(_chunked_prefill_enabled(model), not bidirectional)
+            coordinator = APCCoordinator(APCManager(num_blocks=8, block_size=16), model)
+            self.assertEqual(coordinator.enabled, not bidirectional)
+
+    def test_generation_mask_matches_explicit_padding_mask(self):
+        model = self._model()
+        ids = mx.array([[0, 0, 1, 2, 3]])
+        valid = ids != 0
+        mask = mx.where(
+            valid[:, :, None], valid[:, None, :], mx.eye(5, dtype=mx.bool_)[None]
+        )[:, None]
+        expected = model(ids, mask=mask).logits
+        actual = model(ids, attention_mask_4d=mask).logits
+        np.testing.assert_allclose(np.array(actual), np.array(expected), atol=1e-6)
+
+    def test_only_causal_prefix_is_independent_of_later_tokens(self):
+        from mlx_vlm.models.cache import KVCache
+
+        for bidirectional in (True, False):
+            model = self._model(bidirectional)
+            caches = [KVCache() for _ in model.layers]
+            model(mx.array([[1, 2, 3, 4, 5, 6]]), cache=caches)
+            for cache in caches:
+                cache.trim(3)
+            reused = model(mx.array([[4, 5, 9]]), cache=caches).logits[:, -1]
+            expected = model(mx.array([[1, 2, 3, 4, 5, 9]])).logits[:, -1]
+            error = float(mx.max(mx.abs(reused - expected)).item())
+            if bidirectional:
+                self.assertGreater(error, 1e-3)
+            else:
+                self.assertLess(error, 1e-5)

--- a/mlx_vlm/tests/test_server.py
+++ b/mlx_vlm/tests/test_server.py
@@ -8238,3 +8238,133 @@ class TestSTTSegmentSerialization:
         assert data["segments"] == [
             {"id": 0, "start": 0.0, "end": 0.5, "text": "hello"}
         ]
+
+
+class _HarmonyProcessor:
+    """Minimal stand-in for a processor whose template speaks Harmony."""
+
+    class tokenizer:
+        chat_template = "<|start|>{role}<|channel|>final<|message|>{content}<|end|>"
+
+
+def test_prompt_open_channel_detects_a_completed_header():
+    from mlx_vlm.server.responses_state import prompt_open_channel
+
+    assert (
+        prompt_open_channel("<|start|>assistant<|channel|>final<|message|>") == "final"
+    )
+    assert (
+        prompt_open_channel("<|start|>assistant<|channel|>analysis<|message|>")
+        == "analysis"
+    )
+    # header still open: generation starts by naming its channel
+    assert prompt_open_channel("<|start|>assistant") is None
+    assert prompt_open_channel("plain text prompt") is None
+    assert prompt_open_channel(None) is None
+
+
+def test_answer_survives_when_the_prompt_already_closed_the_header():
+    """llm-jp-VL's rich-history template ends the prompt mid-message."""
+    from mlx_vlm.server.responses_state import HarmonyStreamState
+
+    state = HarmonyStreamState(open_channel="final")
+    parsed = state.feed("Hello world<|return|>", last=True)
+
+    assert parsed.content == "Hello world"
+    assert parsed.reasoning is None
+
+
+def test_nonstreaming_split_honors_a_prompt_opened_channel():
+    from mlx_vlm.server.responses_state import _split_thinking
+
+    reasoning, content = _split_thinking(
+        "Hello world<|return|>",
+        processor=_HarmonyProcessor(),
+        open_channel="final",
+    )
+    assert content == "Hello world"
+    assert reasoning is None
+
+
+def test_streamed_answer_survives_a_prompt_opened_channel():
+    from mlx_vlm.server.responses_state import make_response_stream_state
+
+    state = make_response_stream_state(_HarmonyProcessor(), open_channel="final")
+    seen = "".join(
+        (state.feed(chunk).content or "") for chunk in ["Hel", "lo ", "world"]
+    )
+    seen += state.feed("<|return|>", last=True).content or ""
+    assert seen == "Hello world"
+
+
+def test_header_mode_is_unchanged_when_the_prompt_leaves_it_open():
+    from mlx_vlm.server.responses_state import HarmonyStreamState
+
+    state = HarmonyStreamState()
+    parsed = state.feed("<|channel|>final<|message|>Hello world<|return|>", last=True)
+    assert parsed.content == "Hello world"
+
+
+def test_replayed_apply_patch_call_keeps_its_patch_body():
+    """The stored call carries a raw diff, which is not JSON."""
+    from mlx_vlm.server.request_preparation import normalize_chat_input
+    from mlx_vlm.server.responses_state import _response_call_to_chat_tool_call
+
+    patch_body = "*** Begin Patch\n*** Update File: a.py\n-old\n+new\n*** End Patch"
+    stored = {"type": "apply_patch_call", "call_id": "call_1", "patch": patch_body}
+    chat_call = _response_call_to_chat_tool_call(stored)
+    assert chat_call["function"]["arguments"] == patch_body
+
+    request = server.ChatRequest(
+        model="demo",
+        messages=[
+            {"role": "user", "content": "edit it"},
+            {"role": "assistant", "content": None, "tool_calls": [chat_call]},
+        ],
+    )
+    source = normalize_chat_input(request)
+    rendered = json.dumps(source.messages)
+    assert "Begin Patch" in rendered
+    assert "Update File: a.py" in rendered
+
+
+def test_stored_assistant_turn_does_not_move_earlier_images_forward():
+    """A stored turn must not relocate the image that belongs to an earlier turn."""
+    from mlx_vlm.server.request_preparation import normalize_responses_input
+
+    image = "data:image/png;base64,iVBORw0KGgo="
+    items = [
+        {
+            "type": "message",
+            "role": "user",
+            "content": [
+                {"type": "input_text", "text": "DESCRIBE_THIS"},
+                {"type": "input_image", "image_url": image},
+            ],
+        },
+        # what a replayed stored turn looks like: untyped, chat-shaped
+        {"role": "assistant", "content": "A_RED_SHAPE"},
+        {
+            "type": "message",
+            "role": "user",
+            "content": [{"type": "input_text", "text": "WHAT_COLOR"}],
+        },
+    ]
+    request = server.OpenAIRequest(model="demo", input=items)
+    source, _, _ = normalize_responses_input(request, items)
+
+    described = next(
+        m for m in source.messages if "DESCRIBE_THIS" in json.dumps(m.get("content"))
+    )
+    asked = next(
+        m for m in source.messages if "WHAT_COLOR" in json.dumps(m.get("content"))
+    )
+
+    def image_parts(message):
+        content = message.get("content")
+        if not isinstance(content, list):
+            return []
+        return [p for p in content if str(p.get("type", "")).startswith("image")]
+
+    assert image_parts(described), "image left the turn it was sent with"
+    assert not image_parts(asked), "image moved onto the later question"

--- a/mlx_vlm/utils.py
+++ b/mlx_vlm/utils.py
@@ -35,6 +35,7 @@ ACTIVATION_QUANTIZATION_MODES = {"nvfp4", "mxfp8"}
 
 # Constants
 MODEL_REMAPPING = {
+    "moondream1": "moondream2",
     "llava_qwen2": "fastvlm",  # Apple's FastVLM, note it's different to the one below
     "llava-qwen2": "llava_bunny",
     "bunny-llama": "llava_bunny",
@@ -2473,28 +2474,47 @@ def prepare_inputs(
         if processor.pad_token is None:
             processor.pad_token = processor.eos_token
         text_chunks = [
-            [processor(chunk).input_ids for chunk in prompt.split("<image>")]
+            [
+                processor(
+                    chunk, add_special_tokens=add_special_tokens if i == 0 else False
+                ).input_ids
+                for i, chunk in enumerate(prompt.split("<image>"))
+            ]
             for prompt in prompts
         ]
+        if sum(len(chunks) - 1 for chunks in text_chunks) != len(images):
+            raise ValueError("Image count does not match image placeholders")
+        image_seq_length = getattr(processor.image_processor, "image_seq_length", 1)
 
         # Find the maximum length for padding
         max_length = max(
-            sum(len(chunk) for chunk in chunks) + 1 for chunks in text_chunks
+            sum(len(chunk) for chunk in chunks) + image_seq_length * (len(chunks) - 1)
+            for chunks in text_chunks
         )
 
         # Pad and create input_ids
         input_ids = []
+        attention_masks = []
         for chunks in text_chunks:
-            ids = chunks[0] + [image_token_index] + chunks[1]
-            padding = [processor.pad_token_id] * (max_length - len(ids))
-            input_ids.append(mx.array(ids + padding))
+            ids = list(chunks[0])
+            for chunk in chunks[1:]:
+                ids.extend([image_token_index] * image_seq_length)
+                ids.extend(chunk)
+            pad = [processor.pad_token_id] * (max_length - len(ids) if padding else 0)
+            mask = [1] * len(ids)
+            if padding_side == "left":
+                ids, mask = pad + ids, [0] * len(pad) + mask
+            elif padding_side == "right":
+                ids, mask = ids + pad, mask + [0] * len(pad)
+            else:
+                raise ValueError("padding_side must be left or right")
+            input_ids.append(ids)
+            attention_masks.append(mask)
 
         model_inputs["input_ids"] = mx.array(input_ids)
         pixel_values = processor.image_processor.preprocess(images=images)
         model_inputs["pixel_values"] = mx.array(np.stack(pixel_values))
-        model_inputs["attention_mask"] = mx.array(
-            [(ids != processor.pad_token_id) for ids in input_ids]
-        ).astype(mx.int32)
+        model_inputs["attention_mask"] = mx.array(attention_masks, dtype=mx.int32)
 
     else:
         if hasattr(processor, "tokenizer") and processor.tokenizer.pad_token is None:


### PR DESCRIPTION
Share prompt preparation across Chat Completions, Responses, and Responses token counting while preserving each API’s existing message, media, and tool semantics, establishing the input boundary needed for compaction. 

(1st of of several prs for compression)

I made sure to test this extensively, 4068 tests + 448 subtests, and a 122-snapshot sweep.

