### PR TITLE
fix(turboquant): drop shadowed duplicate BatchTurboQuantKVCache.zero_row_tail

### DIFF
--- a/mlx_vlm/turboquant.py
+++ b/mlx_vlm/turboquant.py
@@ -6644,22 +6644,6 @@ class BatchTurboQuantKVCache(_TurboQuantAttentionMixin, _BaseCache):
             _QuantizedStateProxy(vs, self._idx, n_heads),
         )
 
-    def zero_row_tail(self, bi: int, start: int, end: int):
-        if start >= end:
-            return
-
-        def _z(arr, ndim):
-            if ndim == 3:
-                arr[bi, :, start:end] = 0
-            else:
-                arr[bi, :, start:end, :] = 0
-            return arr
-
-        if self.keys is not None:
-            self.keys = _map_state(self.keys, _z)
-        if self.values is not None:
-            self.values = _map_state(self.values, _z)
-
     # ------------------------------------------------------------------
     # Batch operations for Batch.filter / Batch.extend
     # ------------------------------------------------------------------


### PR DESCRIPTION
### Problem

`BatchTurboQuantKVCache` in `mlx_vlm/turboquant.py` defines `zero_row_tail` **twice** inside the same class body:

```python
class BatchTurboQuantKVCache(_TurboQuantAttentionMixin, _BaseCache):
    ...
    def zero_row_tail(self, bi: int, start: int, end: int):        # <-- shadowed, dead
        if start >= end:
            return
        def _z(arr, ndim):
            ...
        if self.keys is not None:
            self.keys = _map_state(self.keys, _z)
        if self.values is not None:
            self.values = _map_state(self.values, _z)
    ...
    def zero_row_tail(self, batch_index: int, start: int, end: int):  # <-- the one Python keeps
        self.keys = _zero_state_row_tail(self.keys, batch_index, start, end)
        self.values = _zero_state_row_tail(self.values, batch_index, start, end)
```

In Python the second definition wins, so the first 15-line hand-rolled version is unreachable dead code — a leftover from before the `_zero_state_row_tail` helper was extracted.

### Fix

Delete the shadowed inline copy. The surviving definition delegates to `_zero_state_row_tail`, exactly like the sibling `TurboQuantKVCache.zero_row_tail`:

```python
    def zero_row_tail(self, batch_index: int, start: int, end: int):
        self.keys = _zero_state_row_tail(self.keys, batch_index, start, end)
        self.values = _zero_state_row_tail(self.values, batch_index, start, end)
```

Pure dead-code removal — no behavior change (the deleted method never ran). 16 lines removed, nothing added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
