### PR TITLE
Preserve message metadata through dictionary formatting

### DIFF
--- a/mlx_vlm/prompt_utils.py
+++ b/mlx_vlm/prompt_utils.py
@@ -179,6 +179,15 @@ def _get_role_content(item: Any) -> Union[tuple[str, Any], None]:
     return None
 
 
+def _preserve_message_metadata(
+    original: Any, formatted: Union[str, Dict[str, Any]]
+) -> Union[str, Dict[str, Any]]:
+    """Preserve dictionary fields while letting formatter-owned fields win."""
+    if isinstance(original, dict) and isinstance(formatted, dict):
+        return {**original, **formatted}
+    return formatted
+
+
 def _content_media_count(content: Any, media_types: tuple[str, ...]) -> int:
     if not isinstance(content, list):
         return 0
@@ -928,13 +937,16 @@ def apply_chat_template(
         else:
             content = extract_text_from_content(prompt["content"])
             messages.append(
-                get_message_json(
-                    model_type,
-                    content,
-                    role,
-                    num_images=num_images,
-                    num_audios=num_audios,
-                    **kwargs,
+                _preserve_message_metadata(
+                    prompt,
+                    get_message_json(
+                        model_type,
+                        content,
+                        role,
+                        num_images=num_images,
+                        num_audios=num_audios,
+                        **kwargs,
+                    ),
                 )
             )
     elif isinstance(prompt, list):
@@ -1002,17 +1014,20 @@ def apply_chat_template(
                     # Handle multimodal content: extract only text, skip image/audio URLs
                     content = extract_text_from_content(content)
                     messages.append(
-                        get_message_json(
-                            model_type,
-                            content,
-                            role,
-                            skip_image_token=image_counts[i] == 0
-                            or role in ["system", "assistant"],
-                            skip_audio_token=audio_counts[i] == 0
-                            or role in ["system", "assistant"],
-                            num_images=image_counts[i],
-                            num_audios=audio_counts[i],
-                            **kwargs,
+                        _preserve_message_metadata(
+                            p,
+                            get_message_json(
+                                model_type,
+                                content,
+                                role,
+                                skip_image_token=image_counts[i] == 0
+                                or role in ["system", "assistant"],
+                                skip_audio_token=audio_counts[i] == 0
+                                or role in ["system", "assistant"],
+                                num_images=image_counts[i],
+                                num_audios=audio_counts[i],
+                                **kwargs,
+                            ),
                         )
                     )
 

--- a/mlx_vlm/prompt_utils.py
+++ b/mlx_vlm/prompt_utils.py
@@ -182,7 +182,10 @@ def _get_role_content(item: Any) -> Union[tuple[str, Any], None]:
 def _preserve_message_metadata(
     original: Any, formatted: Union[str, Dict[str, Any]]
 ) -> Union[str, Dict[str, Any]]:
-    """Preserve dictionary fields while letting formatter-owned fields win."""
+    """Shallow-copy dictionary fields, with formatter-owned fields taking priority.
+
+    Other input/output shapes retain their existing formatter behavior.
+    """
     if isinstance(original, dict) and isinstance(formatted, dict):
         return {**original, **formatted}
     return formatted
@@ -856,6 +859,10 @@ def apply_chat_template(
 ) -> Union[List[Dict[str, Any]], str, Any]:
     """
     Apply chat template to prompts.
+
+    Ordinary dictionary messages retain fields not replaced by their dictionary
+    formatter. Values are not coerced; rendering and reasoning-history policy
+    belong to the template. Retained metadata can affect prompts and validation.
 
     Args:
         processor: The processor with chat template functionality

--- a/mlx_vlm/tests/conftest.py
+++ b/mlx_vlm/tests/conftest.py
@@ -1,9 +1,34 @@
 import os
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
 
 # float32 matmul runs at TF32 precision on hardware with matrix units, which is
 # looser than the float32 references these tests compare against. Set rather than
 # setdefault, so an inherited MLX_ENABLE_TF32=1 doesn't leak into the test run.
 os.environ["MLX_ENABLE_TF32"] = "0"
+
+
+@pytest.fixture
+def template_processor():
+    """Actual pinned templates and the Transformers renderer; no model or vocab."""
+    from transformers.utils.chat_template_utils import render_jinja_template
+
+    def load(name):
+        template = (
+            Path(__file__).parent / "fixtures" / "chat_templates" / f"{name}.jinja"
+        ).read_text()
+
+        def render(messages, *, tokenize=False, **kwargs):
+            assert tokenize is False
+            return render_jinja_template(
+                [messages], chat_template=template, bos_token="<bos>", **kwargs
+            )[0][0]
+
+        return SimpleNamespace(chat_template=template, apply_chat_template=render)
+
+    return load
 
 
 def pytest_sessionfinish(session, exitstatus):

--- a/mlx_vlm/tests/fixtures/chat_templates/LICENSE-APACHE-2.0.txt
+++ b/mlx_vlm/tests/fixtures/chat_templates/LICENSE-APACHE-2.0.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/mlx_vlm/tests/fixtures/chat_templates/README.md
+++ b/mlx_vlm/tests/fixtures/chat_templates/README.md
@@ -1,0 +1,28 @@
+# Chat template fixtures
+
+These full templates are public Apache-2.0 artifacts from the Qwen and Google
+model repositories below. They remain under [Apache-2.0](LICENSE-APACHE-2.0.txt),
+separately from this repository’s MIT-licensed code. All test messages are synthetic.
+Standalone Jinja files are unchanged; Qwen2.5-VL is the unmodified decoded
+`chat_template` string from its tokenizer configuration. No source NOTICE files
+were available at these revisions.
+
+| Fixture | Pinned source | Template SHA-256 |
+| --- | --- | --- |
+| qwen3_5.jinja | [Qwen/Qwen3.5-27B @ feea018b31f8](https://huggingface.co/Qwen/Qwen3.5-27B/blob/feea018b31f89dc0950e61da42577a7a4ab09169/chat_template.jinja) | `a4aee8afcf2e0711942cf848899be66016f8d14a889ff9ede07bca099c28f715` |
+| qwen3_8.jinja | [Qwen/Qwen3.8-27B @ 412f8b6bd7f5](https://huggingface.co/Qwen/Qwen3.8-27B/blob/412f8b6bd7f5e922bea27645dcc3c80246b7f6a8/chat_template.jinja) | `c3cf9e34abf4f9e36c2d72165aa9c132d3e2a725b6c2586aaa3a8af9d7a81041` |
+| gemma4.jinja | [google/gemma-4-E2B-it @ 899537982545](https://huggingface.co/google/gemma-4-E2B-it/blob/899537982545a3e55ce64d34462b2efa5af85232/chat_template.jinja) | `0a2c8073c878ab1da004bee933a998606537bbb62016310352c7285c3f01c5b5` |
+| qwen2_5_vl.jinja | [Qwen/Qwen2.5-VL-7B-Instruct @ cc594898137f](https://huggingface.co/Qwen/Qwen2.5-VL-7B-Instruct/blob/cc594898137f460bfe9f0759e9844b3ce807cfb5/tokenizer_config.json) | `a0bc6f6fc7a29a80017a433e8f03a1cc1236e838a944a2d034295a60c4f2fddb` |
+
+License labels are recorded in each repository’s README at the same revision.
+Gemma4 also links [Google’s Apache-2.0 license](https://ai.google.dev/gemma/apache_2).
+Qwen3.5’s embedded tokenizer-config template differs from its standalone Jinja;
+these tests deliberately use the standalone file. Qwen3.5 and Qwen3.8 templates
+are distinct, even though both checkpoints route through `qwen3_5`.
+
+Tests use the Transformers Jinja renderer with these actual templates, without
+weights, network access, or model-specific processors. They establish normalization
+and representative rendering behavior, not universal checkpoint compatibility.
+Qwen3.5 extracts inline thinking only when structured reasoning is not a string;
+Qwen3.8 keeps inline markup as content and retains historical reasoning by default.
+Gemma4 uses its own thought-channel and history rules. These policies are unchanged.

--- a/mlx_vlm/tests/fixtures/chat_templates/gemma4.jinja
+++ b/mlx_vlm/tests/fixtures/chat_templates/gemma4.jinja
@@ -1,0 +1,386 @@
+{#
+  Template: Google Gemma 4 Canonical Chat Template
+  Author: Google Gemma Engineering Team
+  Published: 2026-07-09
+  Context: Fixed tool-calling loops, turn closures, and thinking content-ordering.
+#}
+{%- macro format_parameters(properties, required, filter_keys=false) -%}
+    {%- set standard_keys = ['description', 'type', 'properties', 'required', 'nullable'] -%}
+    {%- set ns = namespace(found_first=false) -%}
+    {%- for key, value in properties | dictsort -%}
+        {%- set add_comma = false -%}
+        {%- if not filter_keys or key not in standard_keys -%}
+            {%- if ns.found_first %},{% endif -%}
+            {%- set ns.found_first = true -%}
+            {{ key }}:{
+            {%- if value['description'] -%}
+                description:<|"|>{{ value['description'] }}<|"|>
+                {%- set add_comma = true -%}
+            {%- endif -%}
+            {%- if value['type'] | upper == 'STRING' -%}
+                {%- if value['enum'] -%}
+                    {%- if add_comma %},{%- else -%} {%- set add_comma = true -%} {% endif -%}
+                    enum:{{ format_argument(value['enum']) }}
+                {%- endif -%}
+            {%- elif value['type'] | upper == 'ARRAY' -%}
+                {%- if value['items'] is mapping and value['items'] -%}
+                    {%- if add_comma %},{%- else -%} {%- set add_comma = true -%} {% endif -%}
+                    items:{
+                    {%- set ns_items = namespace(found_first=false) -%}
+                    {%- for item_key, item_value in value['items'] | dictsort -%}
+                        {%- if item_value is not none -%}
+                            {%- if ns_items.found_first %},{% endif -%}
+                            {%- set ns_items.found_first = true -%}
+                            {%- if item_key == 'properties' -%}
+                                properties:{
+                                {%- if item_value is mapping -%}
+                                    {{- format_parameters(item_value, value['items']['required'] | default([])) -}}
+                                {%- endif -%}
+                                }
+                            {%- elif item_key == 'required' -%}
+                                required:[
+                                {%- for req_item in item_value -%}
+                                    <|"|>{{- req_item -}}<|"|>
+                                    {%- if not loop.last %},{% endif -%}
+                                {%- endfor -%}
+                                ]
+                            {%- elif item_key == 'type' -%}
+                                {%- if item_value is string -%}
+                                    type:{{ format_argument(item_value | upper) }}
+                                {%- else -%}
+                                    type:{{ format_argument(item_value | map('upper') | list) }}
+                                {%- endif -%}
+                            {%- else -%}
+                                {{ item_key }}:{{ format_argument(item_value) }}
+                            {%- endif -%}
+                        {%- endif -%}
+                    {%- endfor -%}
+                    }
+                {%- endif -%}
+            {%- endif -%}
+            {%- if value['nullable'] %}
+                {%- if add_comma %},{%- else -%} {%- set add_comma = true -%} {% endif -%}
+                nullable:true
+            {%- endif -%}
+            {%- if value['type'] | upper == 'OBJECT' -%}
+                {%- if value['properties'] is defined and value['properties'] is mapping -%}
+                    {%- if add_comma %},{%- else -%} {%- set add_comma = true -%} {% endif -%}
+                    properties:{
+                    {{- format_parameters(value['properties'], value['required'] | default([])) -}}
+                    }
+                {%- elif value is mapping -%}
+                    {%- if add_comma %},{%- else -%} {%- set add_comma = true -%} {% endif -%}
+                    properties:{
+                    {{- format_parameters(value, value['required'] | default([]), filter_keys=true) -}}
+                    }
+                {%- endif -%}
+                {%- if value['required'] -%}
+                    {%- if add_comma %},{%- else -%} {%- set add_comma = true -%} {% endif -%}
+                    required:[
+                    {%- for item in value['required'] | default([]) -%}
+                        <|"|>{{- item -}}<|"|>
+                        {%- if not loop.last %},{% endif -%}
+                    {%- endfor -%}
+                    ]
+                {%- endif -%}
+            {%- endif -%}
+            {%- if add_comma %},{%- else -%} {%- set add_comma = true -%} {% endif -%}
+            type:<|"|>{{ value['type'] | upper }}<|"|>}
+        {%- endif -%}
+    {%- endfor -%}
+{%- endmacro -%}
+{%- macro format_function_declaration(tool_data) -%}
+    declaration:{{- tool_data['function']['name'] -}}{description:<|"|>{{- tool_data['function']['description'] -}}<|"|>
+    {%- set params = tool_data['function']['parameters'] -%}
+    {%- if params -%}
+        ,parameters:{
+        {%- if params['properties'] -%}
+            properties:{ {{- format_parameters(params['properties'], params['required']) -}} },
+        {%- endif -%}
+        {%- if params['required'] -%}
+            required:[
+            {%- for item in params['required'] -%}
+                <|"|>{{- item -}}<|"|>
+                {{- ',' if not loop.last -}}
+            {%- endfor -%}
+            ],
+        {%- endif -%}
+        {%- if params['type'] -%}
+            type:<|"|>{{- params['type'] | upper -}}<|"|>}
+        {%- endif -%}
+    {%- endif -%}
+    {%- if 'response' in tool_data['function'] -%}
+        {%- set response_declaration = tool_data['function']['response'] -%}
+        ,response:{
+        {%- if response_declaration['description'] -%}
+            description:<|"|>{{- response_declaration['description'] -}}<|"|>,
+        {%- endif -%}
+        {%- if response_declaration['type'] | upper == 'OBJECT' -%}
+            type:<|"|>{{- response_declaration['type'] | upper -}}<|"|>}
+        {%- endif -%}
+    {%- endif -%}
+    }
+{%- endmacro -%}
+{%- macro format_argument(argument, escape_keys=True) -%}
+    {%- if argument is none -%}
+        {{- 'null' -}}
+    {%- elif argument is string -%}
+        {{- '<|"|>' + argument + '<|"|>' -}}
+    {%- elif argument is boolean -%}
+        {{- 'true' if argument else 'false' -}}
+    {%- elif argument is mapping -%}
+        {{- '{' -}}
+        {%- set ns = namespace(found_first=false) -%}
+        {%- for key, value in argument | dictsort -%}
+            {%- if ns.found_first %},{% endif -%}
+            {%- set ns.found_first = true -%}
+            {%- if escape_keys -%}
+                {{- '<|"|>' + key + '<|"|>' -}}
+            {%- else -%}
+                {{- key -}}
+            {%- endif -%}
+            :{{- format_argument(value, escape_keys=escape_keys) -}}
+        {%- endfor -%}
+        {{- '}' -}}
+    {%- elif argument is sequence -%}
+        {{- '[' -}}
+        {%- for item in argument -%}
+            {{- format_argument(item, escape_keys=escape_keys) -}}
+            {%- if not loop.last %},{% endif -%}
+        {%- endfor -%}
+        {{- ']' -}}
+    {%- else -%}
+        {{- argument -}}
+    {%- endif -%}
+{%- endmacro -%}
+{%- macro strip_thinking(text) -%}
+    {%- set ns = namespace(result='') -%}
+    {%- for part in text.split('<channel|>') -%}
+        {%- if '<|channel>' in part -%}
+            {%- set ns.result = ns.result + part.split('<|channel>')[0] -%}
+        {%- else -%}
+            {%- set ns.result = ns.result + part -%}
+        {%- endif -%}
+    {%- endfor -%}
+    {{- ns.result | trim -}}
+{%- endmacro -%}
+
+{%- macro format_tool_response_block(tool_name, response) -%}
+    {{- '<|tool_response>' -}}
+    {%- if response is mapping -%}
+        {{- 'response:' + tool_name + '{' -}}
+        {%- for key, value in response | dictsort -%}
+            {{- key -}}:{{- format_argument(value, escape_keys=False) -}}
+            {%- if not loop.last %},{% endif -%}
+        {%- endfor -%}
+        {{- '}' -}}
+    {%- else -%}
+        {{- 'response:' + tool_name + '{value:' + format_argument(response, escape_keys=False) + '}' -}}
+    {%- endif -%}
+    {{- '<tool_response|>' -}}
+{%- endmacro -%}
+
+{#- ===== SETUP ===== -#}
+{%- set ns = namespace(prev_message_type=None, prev_non_tool_role=None) -%}
+{%- set loop_messages = messages -%}
+{%- set enable_thinking = enable_thinking | default(false) -%}
+{%- set preserve_thinking = preserve_thinking | default(false) -%}
+{{- bos_token -}}
+{#- Handle System/Tool Definitions Block -#}
+{%- if enable_thinking or tools or (messages and messages[0]['role'] in ['system', 'developer']) -%}
+    {{- '<|turn>system\n' -}}
+    {#- Inject Thinking token at the very top of the FIRST system turn -#}
+    {%- if enable_thinking -%}
+        {{- '<|think|>\n' -}}
+        {%- set ns.prev_message_type = 'think' -%}
+    {%- endif -%}
+    {%- if messages and messages[0]['role'] in ['system', 'developer'] -%}
+        {%- if messages[0]['content'] is string -%}
+            {{- messages[0]['content'] | trim -}}
+        {%- elif messages[0]['content'] is sequence -%}
+            {%- for item in messages[0]['content'] -%}
+                {{- item['text'] | trim + ' '-}}
+            {%- endfor -%}
+        {%- endif -%}
+        {%- set loop_messages = messages[1:] -%}
+    {%- endif -%}
+    {%- if tools -%}
+        {%- for tool in tools %}
+            {{- '<|tool>' -}}
+            {{- format_function_declaration(tool) | trim -}}
+            {{- '<tool|>' -}}
+        {%- endfor %}
+        {%- set ns.prev_message_type = 'tool' -%}
+    {%- endif -%}
+    {{- '<turn|>\n' -}}
+{%- endif %}
+
+{#- Pre-scan: find last user message index for reasoning guard -#}
+{%- set ns_turn = namespace(last_user_idx=-1) -%}
+{%- for i in range(loop_messages | length) -%}
+    {%- if loop_messages[i]['role'] == 'user' -%}
+        {%- set ns_turn.last_user_idx = i -%}
+    {%- endif -%}
+{%- endfor -%}
+
+{#- Loop through messages -#}
+{%- for message in loop_messages -%}
+    {%- if message['role'] != 'tool' -%}
+    {%- set ns.prev_message_type = None -%}
+    {%- set role = 'model' if message['role'] == 'assistant' else message['role'] -%}
+    {#- Detect continuation using tracked state — O(1) instead of O(n) backward scan -#}
+    {%- set continue_same_model_turn = (role == 'model' and ns.prev_non_tool_role == 'assistant') -%}
+    {%- if not continue_same_model_turn -%}
+        {{- '<|turn>' + role + '\n' }}
+    {%- endif -%}
+
+    {#- Render reasoning/reasoning_content as thinking channel -#}
+    {%- set thinking_text = message.get('reasoning') or message.get('reasoning_content') -%}
+    {%- set thinking_gate = (loop.index0 > ns_turn.last_user_idx) or (preserve_thinking and message.get('tool_calls')) -%}
+    {%- if thinking_text and thinking_gate -%}
+        {{- '<|channel>thought\n' + thinking_text + '\n<channel|>' -}}
+    {%- endif -%}
+
+            {%- if message.get('tool_calls') -%}
+                {%- for tool_call in message.get('tool_calls') -%}
+                    {%- set function = tool_call['function'] -%}
+                    {{- '<|tool_call>call:' + function['name'] + '{' -}}
+                    {%- if function['arguments'] is mapping -%}
+                        {%- set ns_args = namespace(found_first=false) -%}
+                        {%- for key, value in function['arguments'] | dictsort -%}
+                            {%- if ns_args.found_first %},{% endif -%}
+                            {%- set ns_args.found_first = true -%}
+                            {{- key -}}:{{- format_argument(value, escape_keys=False) -}}
+                        {%- endfor -%}
+                    {%- elif function['arguments'] is none -%}
+                    {%- else -%}
+                        {{- raise_exception(
+                            "chat_template: tool_calls[].function.arguments must be a "
+                            "JSON object (mapping), not a string. Deserialize arguments "
+                            "before passing to the template."
+                        ) -}}
+                    {%- endif -%}
+                    {{- '}<tool_call|>' -}}
+                {%- endfor -%}
+                {%- set ns.prev_message_type = 'tool_call' -%}
+            {%- endif -%}
+
+            {%- set ns_tr_out = namespace(flag=false) -%}
+            {%- if message.get('tool_responses') -%}
+                {#- Legacy: tool_responses embedded on the assistant message (Google/Gemma native) -#}
+                {%- for tool_response in message.get('tool_responses') -%}
+                    {{- format_tool_response_block(tool_response['name'] | default('unknown', true), tool_response['response']) -}}
+                    {%- set ns_tr_out.flag = true -%}
+                    {%- set ns.prev_message_type = 'tool_response' -%}
+                {%- endfor -%}
+            {%- elif message.get('tool_calls') -%}
+                {#- OpenAI Chat Completions: forward-scan consecutive role:tool messages -#}
+                {%- set ns_tool_scan = namespace(stopped=false) -%}
+                {%- for k in range(loop.index0 + 1, loop_messages | length) -%}
+                    {%- if ns_tool_scan.stopped -%}
+                    {%- elif loop_messages[k]['role'] != 'tool' -%}
+                        {%- set ns_tool_scan.stopped = true -%}
+                    {%- else -%}
+                        {%- set follow = loop_messages[k] -%}
+                        {#- Resolve tool_call_id to function name -#}
+                        {%- set ns_tname = namespace(name=follow.get('name') or 'unknown') -%}
+                        {%- for tc in message.get('tool_calls') -%}
+                            {%- if tc.get('id') == follow.get('tool_call_id') -%}
+                                {%- set ns_tname.name = tc['function']['name'] -%}
+                            {%- endif -%}
+                        {%- endfor -%}
+                        {#- Handle content as string or content-parts array -#}
+                        {%- set tool_body = follow.get('content') -%}
+                        {%- if tool_body is string -%}
+                            {{- format_tool_response_block(ns_tname.name, tool_body) -}}
+                        {%- elif tool_body is sequence and tool_body is not string -%}
+                            {%- set ns_txt = namespace(s='') -%}
+                            {%- for part in tool_body -%}
+                                {%- if part.get('type') == 'text' -%}
+                                    {%- set ns_txt.s = ns_txt.s + (part.get('text') | default('')) -%}
+                                {%- endif -%}
+                            {%- endfor -%}
+                            {{- format_tool_response_block(ns_tname.name, ns_txt.s) -}}
+                            {%- for part in tool_body -%}
+                                {%- if part.get('type') in ['image', 'image_url'] -%}
+                                    {{- '<|image|>' -}}
+                                {%- elif part.get('type') in ['audio', 'input_audio'] -%}
+                                    {{- '<|audio|>' -}}
+                                {%- elif part.get('type') == 'video' -%}
+                                    {{- '<|video|>' -}}
+                                {%- endif -%}
+                            {%- endfor -%}
+                        {%- else -%}
+                            {{- format_tool_response_block(ns_tname.name, tool_body) -}}
+                        {%- endif -%}
+                        {%- set ns_tr_out.flag = true -%}
+                        {%- set ns.prev_message_type = 'tool_response' -%}
+                    {%- endif -%}
+                {%- endfor -%}
+            {%- endif -%}
+
+            {%- set captured_content -%}
+            {%- if message.get('content') is string -%}
+                {%- if role == 'model' -%}
+                    {{- strip_thinking(message['content']) -}}
+                {%- else -%}
+                    {{- message['content'] | trim -}}
+                {%- endif -%}
+            {%- elif message.get('content') is sequence -%}
+                {%- for item in message['content'] -%}
+                    {%- if item.get('type') == 'text' -%}
+                        {%- if role == 'model' -%}
+                            {{- strip_thinking(item['text']) -}}
+                        {%- else -%}
+                            {{- item['text'] | trim -}}
+                        {%- endif -%}
+                    {%- elif item.get('type') in ['image', 'image_url'] -%}
+                        {{- '<|image|>' -}}
+                    {%- elif item.get('type') in ['audio', 'input_audio'] -%}
+                        {{- '<|audio|>' -}}
+                    {%- elif item.get('type') == 'video' -%}
+                        {{- '<|video|>' -}}
+                    {%- endif -%}
+                {%- endfor -%}
+            {%- endif -%}
+            {%- endset -%}
+
+            {{- captured_content -}}
+            {%- set has_content = captured_content | trim | length > 0 -%}
+
+        {#- Forward-scan: find next non-tool message role for continuation detection -#}
+        {%- set next_nt = namespace(role=None, found=false) -%}
+        {%- for j in range(loop.index0 + 1, loop_messages | length) -%}
+            {%- if not next_nt.found -%}
+                {%- if loop_messages[j]['role'] != 'tool' -%}
+                    {%- set next_nt.role = loop_messages[j]['role'] -%}
+                    {%- set next_nt.found = true -%}
+                {%- endif -%}
+            {%- endif -%}
+        {%- endfor -%}
+
+        {%- set continues_into_next = (
+            role == 'model'
+            and next_nt.role == 'assistant'
+            and (not message.get('tool_calls') or ns_tr_out.flag)
+        ) -%}
+
+        {%- if ns.prev_message_type == 'tool_call' and not ns_tr_out.flag -%}
+            {{- '<|tool_response>' -}}
+        {%- elif continues_into_next -%}
+        {%- elif not (ns_tr_out.flag and not has_content and not next_nt.found) -%}
+            {{- '<turn|>\n' -}}
+        {%- endif -%}
+
+    {#- Track previous non-tool role for next iteration (avoids O(n) backward scan) -#}
+    {%- set ns.prev_non_tool_role = message['role'] -%}
+    {%- endif -%}
+{%- endfor -%}
+
+{%- if add_generation_prompt -%}
+    {%- if ns.prev_message_type != 'tool_response' and ns.prev_message_type != 'tool_call' -%}
+        {{- '<|turn>model\n' -}}
+    {%- elif ns.prev_message_type == 'tool_response' and enable_thinking -%}
+        {{- '<|channel>thought\n' -}}
+    {%- endif -%}
+{%- endif -%}

--- a/mlx_vlm/tests/fixtures/chat_templates/qwen2_5_vl.jinja
+++ b/mlx_vlm/tests/fixtures/chat_templates/qwen2_5_vl.jinja
@@ -1,0 +1,7 @@
+{% set image_count = namespace(value=0) %}{% set video_count = namespace(value=0) %}{% for message in messages %}{% if loop.first and message['role'] != 'system' %}<|im_start|>system
+You are a helpful assistant.<|im_end|>
+{% endif %}<|im_start|>{{ message['role'] }}
+{% if message['content'] is string %}{{ message['content'] }}<|im_end|>
+{% else %}{% for content in message['content'] %}{% if content['type'] == 'image' or 'image' in content or 'image_url' in content %}{% set image_count.value = image_count.value + 1 %}{% if add_vision_id %}Picture {{ image_count.value }}: {% endif %}<|vision_start|><|image_pad|><|vision_end|>{% elif content['type'] == 'video' or 'video' in content %}{% set video_count.value = video_count.value + 1 %}{% if add_vision_id %}Video {{ video_count.value }}: {% endif %}<|vision_start|><|video_pad|><|vision_end|>{% elif 'text' in content %}{{ content['text'] }}{% endif %}{% endfor %}<|im_end|>
+{% endif %}{% endfor %}{% if add_generation_prompt %}<|im_start|>assistant
+{% endif %}

--- a/mlx_vlm/tests/fixtures/chat_templates/qwen3_5.jinja
+++ b/mlx_vlm/tests/fixtures/chat_templates/qwen3_5.jinja
@@ -1,0 +1,154 @@
+{%- set image_count = namespace(value=0) %}
+{%- set video_count = namespace(value=0) %}
+{%- macro render_content(content, do_vision_count, is_system_content=false) %}
+    {%- if content is string %}
+        {{- content }}
+    {%- elif content is iterable and content is not mapping %}
+        {%- for item in content %}
+            {%- if 'image' in item or 'image_url' in item or item.type == 'image' %}
+                {%- if is_system_content %}
+                    {{- raise_exception('System message cannot contain images.') }}
+                {%- endif %}
+                {%- if do_vision_count %}
+                    {%- set image_count.value = image_count.value + 1 %}
+                {%- endif %}
+                {%- if add_vision_id %}
+                    {{- 'Picture ' ~ image_count.value ~ ': ' }}
+                {%- endif %}
+                {{- '<|vision_start|><|image_pad|><|vision_end|>' }}
+            {%- elif 'video' in item or item.type == 'video' %}
+                {%- if is_system_content %}
+                    {{- raise_exception('System message cannot contain videos.') }}
+                {%- endif %}
+                {%- if do_vision_count %}
+                    {%- set video_count.value = video_count.value + 1 %}
+                {%- endif %}
+                {%- if add_vision_id %}
+                    {{- 'Video ' ~ video_count.value ~ ': ' }}
+                {%- endif %}
+                {{- '<|vision_start|><|video_pad|><|vision_end|>' }}
+            {%- elif 'text' in item %}
+                {{- item.text }}
+            {%- else %}
+                {{- raise_exception('Unexpected item type in content.') }}
+            {%- endif %}
+        {%- endfor %}
+    {%- elif content is none or content is undefined %}
+        {{- '' }}
+    {%- else %}
+        {{- raise_exception('Unexpected content type.') }}
+    {%- endif %}
+{%- endmacro %}
+{%- if not messages %}
+    {{- raise_exception('No messages provided.') }}
+{%- endif %}
+{%- if tools and tools is iterable and tools is not mapping %}
+    {{- '<|im_start|>system\n' }}
+    {{- "# Tools\n\nYou have access to the following functions:\n\n<tools>" }}
+    {%- for tool in tools %}
+        {{- "\n" }}
+        {{- tool | tojson }}
+    {%- endfor %}
+    {{- "\n</tools>" }}
+    {{- '\n\nIf you choose to call a function ONLY reply in the following format with NO suffix:\n\n<tool_call>\n<function=example_function_name>\n<parameter=example_parameter_1>\nvalue_1\n</parameter>\n<parameter=example_parameter_2>\nThis is the value for the second parameter\nthat can span\nmultiple lines\n</parameter>\n</function>\n</tool_call>\n\n<IMPORTANT>\nReminder:\n- Function calls MUST follow the specified format: an inner <function=...></function> block must be nested within <tool_call></tool_call> XML tags\n- Required parameters MUST be specified\n- You may provide optional reasoning for your function call in natural language BEFORE the function call, but NOT after\n- If there is no function call available, answer the question like normal with your current knowledge and do not tell the user about function calls\n</IMPORTANT>' }}
+    {%- if messages[0].role == 'system' %}
+        {%- set content = render_content(messages[0].content, false, true)|trim %}
+        {%- if content %}
+            {{- '\n\n' + content }}
+        {%- endif %}
+    {%- endif %}
+    {{- '<|im_end|>\n' }}
+{%- else %}
+    {%- if messages[0].role == 'system' %}
+        {%- set content = render_content(messages[0].content, false, true)|trim %}
+        {{- '<|im_start|>system\n' + content + '<|im_end|>\n' }}
+    {%- endif %}
+{%- endif %}
+{%- set ns = namespace(multi_step_tool=true, last_query_index=messages|length - 1) %}
+{%- for message in messages[::-1] %}
+    {%- set index = (messages|length - 1) - loop.index0 %}
+    {%- if ns.multi_step_tool and message.role == "user" %}
+        {%- set content = render_content(message.content, false)|trim %}
+        {%- if not(content.startswith('<tool_response>') and content.endswith('</tool_response>')) %}
+            {%- set ns.multi_step_tool = false %}
+            {%- set ns.last_query_index = index %}
+        {%- endif %}
+    {%- endif %}
+{%- endfor %}
+{%- if ns.multi_step_tool %}
+    {{- raise_exception('No user query found in messages.') }}
+{%- endif %}
+{%- for message in messages %}
+    {%- set content = render_content(message.content, true)|trim %}
+    {%- if message.role == "system" %}
+        {%- if not loop.first %}
+            {{- raise_exception('System message must be at the beginning.') }}
+        {%- endif %}
+    {%- elif message.role == "user" %}
+        {{- '<|im_start|>' + message.role + '\n' + content + '<|im_end|>' + '\n' }}
+    {%- elif message.role == "assistant" %}
+        {%- set reasoning_content = '' %}
+        {%- if message.reasoning_content is string %}
+            {%- set reasoning_content = message.reasoning_content %}
+        {%- else %}
+            {%- if '</think>' in content %}
+                {%- set reasoning_content = content.split('</think>')[0].rstrip('\n').split('<think>')[-1].lstrip('\n') %}
+                {%- set content = content.split('</think>')[-1].lstrip('\n') %}
+            {%- endif %}
+        {%- endif %}
+        {%- set reasoning_content = reasoning_content|trim %}
+        {%- if loop.index0 > ns.last_query_index %}
+            {{- '<|im_start|>' + message.role + '\n<think>\n' + reasoning_content + '\n</think>\n\n' + content }}
+        {%- else %}
+            {{- '<|im_start|>' + message.role + '\n' + content }}
+        {%- endif %}
+        {%- if message.tool_calls and message.tool_calls is iterable and message.tool_calls is not mapping %}
+            {%- for tool_call in message.tool_calls %}
+                {%- if tool_call.function is defined %}
+                    {%- set tool_call = tool_call.function %}
+                {%- endif %}
+                {%- if loop.first %}
+                    {%- if content|trim %}
+                        {{- '\n\n<tool_call>\n<function=' + tool_call.name + '>\n' }}
+                    {%- else %}
+                        {{- '<tool_call>\n<function=' + tool_call.name + '>\n' }}
+                    {%- endif %}
+                {%- else %}
+                    {{- '\n<tool_call>\n<function=' + tool_call.name + '>\n' }}
+                {%- endif %}
+                {%- if tool_call.arguments is defined %}
+                    {%- for args_name, args_value in tool_call.arguments|items %}
+                        {{- '<parameter=' + args_name + '>\n' }}
+                        {%- set args_value = args_value | tojson | safe if args_value is mapping or (args_value is sequence and args_value is not string) else args_value | string %}
+                        {{- args_value }}
+                        {{- '\n</parameter>\n' }}
+                    {%- endfor %}
+                {%- endif %}
+                {{- '</function>\n</tool_call>' }}
+            {%- endfor %}
+        {%- endif %}
+        {{- '<|im_end|>\n' }}
+    {%- elif message.role == "tool" %}
+        {%- if loop.previtem and loop.previtem.role != "tool" %}
+            {{- '<|im_start|>user' }}
+        {%- endif %}
+        {{- '\n<tool_response>\n' }}
+        {{- content }}
+        {{- '\n</tool_response>' }}
+        {%- if not loop.last and loop.nextitem.role != "tool" %}
+            {{- '<|im_end|>\n' }}
+        {%- elif loop.last %}
+            {{- '<|im_end|>\n' }}
+        {%- endif %}
+    {%- else %}
+        {{- raise_exception('Unexpected message role.') }}
+    {%- endif %}
+{%- endfor %}
+{%- if add_generation_prompt %}
+    {{- '<|im_start|>assistant\n' }}
+    {%- if enable_thinking is defined and enable_thinking is false %}
+        {{- '<think>\n\n</think>\n\n' }}
+    {%- else %}
+        {{- '<think>\n' }}
+    {%- endif %}
+{%- endif %}

--- a/mlx_vlm/tests/fixtures/chat_templates/qwen3_8.jinja
+++ b/mlx_vlm/tests/fixtures/chat_templates/qwen3_8.jinja
@@ -1,0 +1,170 @@
+{%- set image_count = namespace(value=0) %}
+{%- set video_count = namespace(value=0) %}
+{%- macro render_content(content, do_vision_count, is_system_content=false) %}
+    {%- if content is string %}
+        {{- content }}
+    {%- elif content is iterable and content is not mapping %}
+        {%- for item in content %}
+            {%- if 'image' in item or 'image_url' in item or item.type == 'image' %}
+                {%- if is_system_content %}
+                    {{- raise_exception('System message cannot contain images.') }}
+                {%- endif %}
+                {%- if do_vision_count %}
+                    {%- set image_count.value = image_count.value + 1 %}
+                {%- endif %}
+                {%- if add_vision_id %}
+                    {{- 'Picture ' ~ image_count.value ~ ': ' }}
+                {%- endif %}
+                {{- '<|vision_start|><|image_pad|><|vision_end|>' }}
+            {%- elif 'video' in item or item.type == 'video' %}
+                {%- if is_system_content %}
+                    {{- raise_exception('System message cannot contain videos.') }}
+                {%- endif %}
+                {%- if do_vision_count %}
+                    {%- set video_count.value = video_count.value + 1 %}
+                {%- endif %}
+                {%- if add_vision_id %}
+                    {{- 'Video ' ~ video_count.value ~ ': ' }}
+                {%- endif %}
+                {{- '<|vision_start|><|video_pad|><|vision_end|>' }}
+            {%- elif 'text' in item %}
+                {{- item.text }}
+            {%- else %}
+                {{- raise_exception('Unexpected item type in content.') }}
+            {%- endif %}
+        {%- endfor %}
+    {%- elif content is none or content is undefined %}
+        {{- '' }}
+    {%- else %}
+        {{- raise_exception('Unexpected content type.') }}
+    {%- endif %}
+{%- endmacro %}
+{%- if not messages %}
+    {{- raise_exception('No messages provided.') }}
+{%- endif %}
+{%- set reasoning_instructions = '' %}
+{%- if enable_thinking is undefined or enable_thinking is true %}
+    {%- set resolved_reasoning_effort = reasoning_effort|default('xhigh') %}
+    {%- if resolved_reasoning_effort not in ('xhigh', 'medium', 'low') %}
+        {{- raise_exception('Unexpected reasoning effort ' ~ reasoning_effort ~ '. Supported types are xhigh (default), medium, and low.') }}
+    {%- endif %}
+    {%- if resolved_reasoning_effort == 'xhigh' %}
+        {%- set reasoning_instructions = 'Reasoning effort is set to xhigh. Please think carefully through the task, validate key assumptions, consider plausible alternatives, and prioritize correctness, consistency, and clarity in the final answer.' %}
+    {%- elif resolved_reasoning_effort == 'low' %}
+        {%- set reasoning_instructions = 'Reasoning effort is set to low. Keep your thinking brief and focused, moving directly to the conclusion without unnecessary elaboration.' %}
+    {%- endif %}
+{%- endif %}
+{%- if tools and tools is iterable and tools is not mapping %}
+    {{- '<|im_start|>system\n' }}
+    {%- if reasoning_instructions %}
+        {{- reasoning_instructions + '\n\n' }}
+    {%- endif %}
+    {{- "# Tools\n\nYou have access to the following functions:\n\n<tools>" }}
+    {%- for tool in tools %}
+        {{- "\n" }}
+        {{- tool | tojson }}
+    {%- endfor %}
+    {{- "\n</tools>" }}
+    {{- '\n\nIf you choose to call a function ONLY reply in the following format with NO suffix:\n\n<tool_call>\n<function=example_function_name>\n<parameter=example_parameter_1>\nvalue_1\n</parameter>\n<parameter=example_parameter_2>\nThis is the value for the second parameter\nthat can span\nmultiple lines\n</parameter>\n</function>\n</tool_call>\n\n<IMPORTANT>\nReminder:\n- Function calls MUST follow the specified format: an inner <function=...></function> block must be nested within <tool_call></tool_call> XML tags\n- Required parameters MUST be specified\n- You may provide optional reasoning for your function call in natural language BEFORE the function call, but NOT after\n- If there is no function call available, answer the question like normal with your current knowledge and do not tell the user about function calls\n</IMPORTANT>' }}
+    {%- if messages[0].role == 'system' %}
+        {%- set content = render_content(messages[0].content, false, true)|trim %}
+        {%- if content %}
+            {{- '\n\n' + content }}
+        {%- endif %}
+    {%- endif %}
+    {{- '<|im_end|>\n' }}
+{%- else %}
+    {%- if messages[0].role == 'system' %}
+        {%- set content = render_content(messages[0].content, false, true)|trim %}
+        {%- if content %}
+            {{- '<|im_start|>system\n' + (reasoning_instructions + '\n\n' if reasoning_instructions else '')  + content + '<|im_end|>\n' }}
+        {%- elif reasoning_instructions %}
+            {{- '<|im_start|>system\n' + reasoning_instructions + '<|im_end|>\n' }}
+        {%- endif %}
+    {%- elif reasoning_instructions %}
+        {{- '<|im_start|>system\n' + reasoning_instructions + '<|im_end|>\n' }}
+    {%- endif %}
+{%- endif %}
+{%- set ns = namespace(multi_step_tool=true, last_query_index=messages|length - 1) %}
+{%- for message in messages[::-1] %}
+    {%- set index = (messages|length - 1) - loop.index0 %}
+    {%- if ns.multi_step_tool and message.role == "user" %}
+        {%- set content = render_content(message.content, false)|trim %}
+        {%- if not(content.startswith('<tool_response>') and content.endswith('</tool_response>')) %}
+            {%- set ns.multi_step_tool = false %}
+            {%- set ns.last_query_index = index %}
+        {%- endif %}
+    {%- endif %}
+{%- endfor %}
+{%- if ns.multi_step_tool %}
+    {{- raise_exception('No user query found in messages.') }}
+{%- endif %}
+{%- for message in messages %}
+    {%- set content = render_content(message.content, true)|trim %}
+    {%- if message.role == "system" %}
+        {%- if not loop.first %}
+            {{- raise_exception('System message must be at the beginning.') }}
+        {%- endif %}
+    {%- elif message.role == "user" %}
+        {{- '<|im_start|>' + message.role + '\n' + content + '<|im_end|>' + '\n' }}
+    {%- elif message.role == "assistant" %}
+        {%- set reasoning_content = '' %}
+        {%- if message.reasoning_content is string %}
+            {%- set reasoning_content = message.reasoning_content %}
+        {%- endif %}
+        {%- set reasoning_content = reasoning_content|trim %}
+        {%- if preserve_thinking is undefined or preserve_thinking is true or loop.index0 > ns.last_query_index %}
+            {{- '<|im_start|>' + message.role + '\n<think>\n' + reasoning_content + '\n</think>\n\n' + content }}
+        {%- else %}
+            {{- '<|im_start|>' + message.role + '\n' + content }}
+        {%- endif %}
+        {%- if message.tool_calls and message.tool_calls is iterable and message.tool_calls is not mapping %}
+            {%- for tool_call in message.tool_calls %}
+                {%- if tool_call.function is defined %}
+                    {%- set tool_call = tool_call.function %}
+                {%- endif %}
+                {%- if loop.first %}
+                    {%- if content|trim %}
+                        {{- '\n\n<tool_call>\n<function=' + tool_call.name + '>\n' }}
+                    {%- else %}
+                        {{- '<tool_call>\n<function=' + tool_call.name + '>\n' }}
+                    {%- endif %}
+                {%- else %}
+                    {{- '\n<tool_call>\n<function=' + tool_call.name + '>\n' }}
+                {%- endif %}
+                {%- if tool_call.arguments is defined and tool_call.arguments != '' %}
+                    {%- for args_name, args_value in tool_call.arguments|items %}
+                        {{- '<parameter=' + args_name + '>\n' }}
+                        {%- set args_value = args_value | string if args_value is string else args_value | tojson | safe %}
+                        {{- args_value }}
+                        {{- '\n</parameter>\n' }}
+                    {%- endfor %}
+                {%- endif %}
+                {{- '</function>\n</tool_call>' }}
+            {%- endfor %}
+        {%- endif %}
+        {{- '<|im_end|>\n' }}
+    {%- elif message.role == "tool" %}
+        {%- if loop.previtem and loop.previtem.role != "tool" %}
+            {{- '<|im_start|>user' }}
+        {%- endif %}
+        {{- '\n<tool_response>\n' }}
+        {{- content }}
+        {{- '\n</tool_response>' }}
+        {%- if not loop.last and loop.nextitem.role != "tool" %}
+            {{- '<|im_end|>\n' }}
+        {%- elif loop.last %}
+            {{- '<|im_end|>\n' }}
+        {%- endif %}
+    {%- else %}
+        {{- raise_exception('Unexpected message role.') }}
+    {%- endif %}
+{%- endfor %}
+{%- if add_generation_prompt %}
+    {{- '<|im_start|>assistant\n' }}
+    {%- if enable_thinking is defined and enable_thinking is false %}
+        {{- '<think>\n\n</think>\n\n' }}
+    {%- else %}
+        {{- '<think>\n' }}
+    {%- endif %}
+{%- endif %}

--- a/mlx_vlm/tests/test_prompt_utils.py
+++ b/mlx_vlm/tests/test_prompt_utils.py
@@ -151,6 +151,132 @@ class TestMessageMetadata:
         )
 
 
+class TestMessageTemplateMetadata:
+    def test_metadata_does_not_move_history_images(self):
+        messages = [
+            {"role": "system", "content": "rules", "name": "system_name"},
+            {
+                "role": "user",
+                "content": [
+                    {"type": "image_url", "image_url": {"url": "synthetic.png"}},
+                    {"type": "text", "text": "question"},
+                ],
+            },
+            {"role": "assistant", "content": "answer", "reasoning_content": "reason"},
+            {"role": "user", "content": "follow up"},
+        ]
+        before = deepcopy(messages)
+        normalized = apply_chat_template(
+            None,
+            {"model_type": "qwen3_5"},
+            messages,
+            num_images=1,
+            return_messages=True,
+        )
+        assert messages == before
+        assert normalized[0]["name"] == "system_name"
+        assert normalized[2]["reasoning_content"] == "reason"
+        assert [
+            sum(part["type"] == "image" for part in message["content"])
+            for message in normalized
+        ] == [0, 1, 0, 0]
+
+    @pytest.mark.parametrize("name", ["qwen3_5", "qwen3_8"])
+    @pytest.mark.parametrize("reasoning", [None, "", "structured"])
+    def test_qwen_reasoning_precedence_history_and_continuation(
+        self, template_processor, name, reasoning
+    ):
+        processor = template_processor(name)
+        messages = [
+            {"role": "user", "content": "question"},
+            {
+                "role": "assistant",
+                "content": "<think>inline</think>answer",
+                "reasoning_content": reasoning,
+            },
+        ]
+        kwargs = {"add_generation_prompt": False, "enable_thinking": True}
+        rendered = apply_chat_template(
+            processor, {"model_type": "qwen3_5"}, messages, **kwargs
+        )
+        assert rendered == processor.apply_chat_template(messages, **kwargs)
+        inline_fallback = name == "qwen3_5" and reasoning is None
+        thought = "inline" if inline_fallback else reasoning or ""
+        answer = "answer" if inline_fallback else messages[-1]["content"]
+        assert rendered.endswith(
+            f"<|im_start|>assistant\n<think>\n{thought}\n</think>\n\n{answer}<|im_end|>\n"
+        )
+
+        history = messages + [{"role": "user", "content": "next"}]
+        historical = apply_chat_template(
+            processor, {"model_type": "qwen3_5"}, history, **kwargs
+        )
+        assert historical == processor.apply_chat_template(history, **kwargs)
+        assert ("structured" in historical) == (name == "qwen3_8" and bool(reasoning))
+
+        continuation = [messages[0], {**messages[1], "content": "answer"}]
+        continued = apply_chat_template(
+            processor,
+            {"model_type": "qwen3_5"},
+            continuation,
+            continue_final_message=True,
+            **kwargs,
+        )
+        assert continued == processor.apply_chat_template(
+            continuation, continue_final_message=True, **kwargs
+        )
+        assert continued.endswith(f"<think>\n{reasoning or ''}\n</think>\n\nanswer")
+
+    @pytest.mark.parametrize(
+        "metadata,thought",
+        [
+            ({"reasoning_content": None}, ""),
+            ({"reasoning_content": ""}, ""),
+            ({"reasoning_content": "structured"}, "structured"),
+            ({"reasoning": "preferred", "reasoning_content": "secondary"}, "preferred"),
+        ],
+    )
+    def test_gemma_reasoning_remains_template_owned(
+        self, template_processor, metadata, thought
+    ):
+        processor = template_processor("gemma4")
+        messages = [
+            {"role": "user", "content": "question"},
+            {"role": "assistant", "content": "answer", **metadata},
+        ]
+        kwargs = {"add_generation_prompt": False, "enable_thinking": True}
+        rendered = apply_chat_template(
+            processor, {"model_type": "gemma4"}, messages, **kwargs
+        )
+        channel = f"<|channel>thought\n{thought}\n<channel|>" if thought else ""
+        assert rendered == (
+            "<bos><|turn>system\n<|think|>\n<turn|>\n"
+            "<|turn>user\nquestion<turn|>\n"
+            f"<|turn>model\n{channel}answer<turn|>\n"
+        )
+        history = messages + [{"role": "user", "content": "next"}]
+        assert apply_chat_template(
+            processor, {"model_type": "gemma4"}, history, **kwargs
+        ) == processor.apply_chat_template(history, **kwargs)
+        assert "<|channel>thought" not in processor.apply_chat_template(
+            history, **kwargs
+        )
+
+    def test_unaffected_qwen2_5_rendering(self, template_processor):
+        processor = template_processor("qwen2_5_vl")
+        messages = [
+            {"role": "user", "content": "question"},
+            {"role": "assistant", "content": "answer", "reasoning_content": "unused"},
+        ]
+        assert apply_chat_template(
+            processor, {"model_type": "qwen2_5_vl"}, messages
+        ) == (
+            "<|im_start|>system\nYou are a helpful assistant.<|im_end|>\n"
+            "<|im_start|>user\nquestion<|im_end|>\n"
+            "<|im_start|>assistant\nanswer<|im_end|>\n<|im_start|>assistant\n"
+        )
+
+
 class TestExtractTextFromContent:
     """Tests for the extract_text_from_content function."""
 

--- a/mlx_vlm/tests/test_prompt_utils.py
+++ b/mlx_vlm/tests/test_prompt_utils.py
@@ -1,5 +1,8 @@
 """Tests for prompt_utils module, specifically multimodal content handling."""
 
+from copy import deepcopy
+from types import SimpleNamespace
+
 import pytest
 
 from mlx_vlm.prompt_utils import apply_chat_template, extract_text_from_content
@@ -17,6 +20,135 @@ def _assistant_tool_call(content):
             }
         ],
     }
+
+
+class TestMessageMetadata:
+    @pytest.mark.parametrize("as_list", [False, True])
+    def test_formatter_fields_take_precedence(self, monkeypatch, as_list):
+        original = {
+            "role": "user",
+            "content": [{"type": "text", "text": "hello"}],
+            "name": "speaker",
+            "custom": {"nested": [1, None]},
+            "owned": "original",
+        }
+        before = deepcopy(original)
+        formatted = {"role": "assistant", "content": "formatted", "owned": "new"}
+        monkeypatch.setattr(
+            "mlx_vlm.prompt_utils.get_message_json", lambda *a, **kw: formatted
+        )
+        result = apply_chat_template(
+            None,
+            {"model_type": "qwen3_5"},
+            [original] if as_list else original,
+            return_messages=True,
+        )
+        assert result == [{**original, **formatted}]
+        assert original == before
+        assert formatted == {
+            "role": "assistant",
+            "content": "formatted",
+            "owned": "new",
+        }
+
+    @pytest.mark.parametrize(
+        "metadata,content,text",
+        [
+            ({}, "answer", "answer"),
+            ({"reasoning_content": None}, None, ""),
+            ({"reasoning_content": ""}, [], ""),
+            (
+                {"reasoning_content": "reason"},
+                [
+                    {"type": "input_text", "text": "answer"},
+                    {"type": "image_url", "image_url": {"url": "synthetic.png"}},
+                ],
+                "answer",
+            ),
+        ],
+    )
+    def test_reasoning_values_and_content_normalization(self, metadata, content, text):
+        original = {"role": "assistant", "content": content, **metadata}
+        before = deepcopy(original)
+        result = apply_chat_template(
+            None, {"model_type": "qwen3_5"}, [original], return_messages=True
+        )
+        assert result == [
+            {
+                "role": "assistant",
+                "content": [{"type": "text", "text": text, "content": text}],
+                **metadata,
+            }
+        ]
+        assert original == before
+
+    @pytest.mark.parametrize(
+        "model,original,expected",
+        [
+            (
+                "paligemma",
+                {"role": "user", "content": "hello", "name": "speaker"},
+                "hello",
+            ),
+            (
+                "qwen3_5",
+                SimpleNamespace(role="assistant", content="hello", name="speaker"),
+                {
+                    "role": "assistant",
+                    "content": [{"type": "text", "text": "hello", "content": "hello"}],
+                },
+            ),
+        ],
+    )
+    def test_non_dictionary_shapes_keep_formatter_behavior(
+        self, model, original, expected
+    ):
+        assert apply_chat_template(
+            None, {"model_type": model}, [original], return_messages=True
+        ) == [expected]
+
+    @pytest.mark.parametrize(
+        "tool_calls", [None, [], _assistant_tool_call(None)["tool_calls"]]
+    )
+    def test_tool_path_preserves_key_states_and_inputs(self, tool_calls):
+        original = {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": deepcopy(tool_calls),
+            "reasoning_content": "reason",
+            "custom": {"nested": []},
+        }
+        if tool_calls:
+            original["tool_calls"][0]["function"]["arguments"] = '{"city":"Paris"}'
+        before = deepcopy(original)
+        result = apply_chat_template(
+            None, {"model_type": "qwen3_5"}, [original], return_messages=True
+        )[0]
+        assert original == before
+        assert result["reasoning_content"] == "reason"
+        assert result["custom"] == original["custom"]
+        assert result["content"] == ("" if tool_calls else None)
+        if tool_calls:
+            assert result["tool_calls"][0]["function"]["arguments"] == {"city": "Paris"}
+        else:
+            assert result["tool_calls"] == tool_calls
+
+    @pytest.mark.parametrize("model", ["qwen3_5", "qwen3_5_moe"])
+    def test_dense_and_moe_routes_preserve_metadata(self, model):
+        from mlx_vlm.prompt_utils import MODEL_CONFIG, MessageFormat
+
+        assert MODEL_CONFIG[model] == MessageFormat.LIST_WITH_IMAGE_FIRST
+        message = {
+            "role": "assistant",
+            "content": "answer",
+            "reasoning_content": "reason",
+        }
+        assert (
+            apply_chat_template(
+                None, {"model_type": model}, message, return_messages=True
+            )[0]["reasoning_content"]
+            == "reason"
+        )
 
 
 class TestExtractTextFromContent:

--- a/mlx_vlm/tests/test_server.py
+++ b/mlx_vlm/tests/test_server.py
@@ -7,6 +7,7 @@ import os
 import sys
 import time
 from concurrent.futures import ThreadPoolExecutor
+from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from pathlib import Path
 from queue import Queue
@@ -3699,6 +3700,63 @@ def test_chat_completions_endpoint_preserves_assistant_reasoning_content(client)
         "reasoning_content": "Prior thought",
         "reasoning": "Prior thought",
     }
+
+
+def test_chat_completions_renders_assistant_metadata(template_processor, monkeypatch):
+    @asynccontextmanager
+    async def no_lifespan(app):
+        yield
+
+    processor = template_processor("qwen3_5")
+    monkeypatch.setattr(server.app.router, "lifespan_context", no_lifespan)
+    monkeypatch.setattr(server.runtime, "response_generator", None)
+    monkeypatch.setattr(server.runtime, "apc_manager", None)
+    monkeypatch.setenv("MLX_VLM_SERVER_API_KEY", "synthetic-key")
+    result = GenerationResult(text="done", prompt_tokens=1, generation_tokens=1)
+    with (
+        patch.object(
+            server,
+            "get_cached_model",
+            return_value=(
+                SimpleNamespace(),
+                processor,
+                SimpleNamespace(model_type="qwen3_5"),
+            ),
+        ),
+        patch.object(server, "generate", return_value=result) as generate,
+        patch.object(
+            processor, "apply_chat_template", wraps=processor.apply_chat_template
+        ) as render,
+        patch.object(mx, "clear_cache"),
+        TestClient(server.app) as test_client,
+    ):
+        response = test_client.post(
+            "/v1/chat/completions",
+            headers={"Authorization": "Bearer synthetic-key"},
+            json={
+                "model": "synthetic",
+                "stream": False,
+                "max_tokens": 1,
+                "enable_thinking": False,
+                "messages": [
+                    {"role": "user", "content": "question"},
+                    {
+                        "role": "assistant",
+                        "content": "answer",
+                        "name": "speaker",
+                        "reasoning_content": "structured",
+                    },
+                ],
+            },
+        )
+    assert response.status_code == 200
+    assert response.json()["choices"][0]["message"]["content"] == "done"
+    normalized = render.call_args.args[0][1]
+    assert normalized["name"] == "speaker"
+    assert normalized["reasoning_content"] == "structured"
+    assert (
+        "<think>\nstructured\n</think>\n\nanswer" in generate.call_args.kwargs["prompt"]
+    )
 
 
 def test_anthropic_messages_endpoint_maps_text_and_images(client, monkeypatch):


### PR DESCRIPTION
Ordinary dictionary messages lose fields such as `reasoning_content` and `name` when a model formatter rebuilds role/content. This keeps incoming metadata at both dictionary normalization sites, with formatter-produced fields taking precedence.

```python
from mlx_vlm.prompt_utils import apply_chat_template

message = {"role": "assistant", "content": "answer", "reasoning_content": "thought"}
normalized = apply_chat_template(
    None, {"model_type": "qwen3_5"}, [message], return_messages=True
)
assert normalized[0]["reasoning_content"] == "thought"  # KeyError before this fix
```

The shared helper guards both input and output shapes and performs a shallow merge. Retained nested values remain shared with the caller. Absent, null, empty and populated metadata retain their meaning; formatted role/content win. Normalization does not mutate caller inputs. Messages carrying `tool_calls` or `tool_call_id` still enter the existing tool normalizer before the ordinary formatting sites, including null and empty values. String-returning formatters, message-like objects, special model paths and media allocation retain their existing behavior. One rule makes an architecture-specific retention patch unnecessary for each new field.

Templates still own rendering, validation and reasoning-history policy. Retained metadata can intentionally change prompt text and length, available context, cache reuse, or expose template validation errors. For the pinned Qwen3.8 template, echoed historical `reasoning_content` is now visible and retained by default, so those prompts grow. This changes neither reasoning defaults nor the separate `preserve_thinking` API. HTTP coverage demonstrates fields the endpoint already forwards; it does not add arbitrary-extra-field forwarding at the API boundary.

Validation:

- 10 new test functions / 26 cases; on recorded base `d2a1434a03e4c9975b0d505e7178e0cfc4082a83`, 14 targeted failures and 12 passing controls.
- 95 CPU checks pass on both Transformers 5.14.0 (the supported minimum) and 5.17.0: all prompt regressions plus selected HTTP/schema/tool-choice controls and a mocked HTTP request using real normalization/rendering.
- Pinned, licensed Qwen3.5, Qwen3.8, Gemma 4 and Qwen2.5-VL templates run through the Transformers Jinja renderer offline. They cover structured/inline precedence, historical turns, active continuations, null/empty reasoning, and an unaffected rendering control. Qwen3.5 and Qwen3.8 use distinct fixtures; this is representative evidence, not universal checkpoint support.
- Separate offline checks with the pinned official Qwen vocabularies matched native rendered token IDs in 12/12 cases; the base differed in 6/12. Vocabulary downloads are not part of CI.
- Reused #2200’s 20 option-validation tests in a temporary combined checkout: all pass. Its API and tests are not included here.
- `pre-commit run --all-files` and `git diff --check` pass. Python 3.10.20, Transformers 5.14.0/5.17.0, MLX 0.32.2; CPU selected before package import. Two dependency deprecation warnings remain. The full upstream test suite and hardware inference were not run; no weights or GPU workloads were used.

Related work: this is a separate replacement for the narrow fix in #2199 and addresses the normalization issue in #2201. The existing #2199 and #2219 are left unchanged so maintainers can choose which implementation to land. Thanks to @wmlanglois for independently proposing the original-dictionary/formatter-override rule in [this comment](https://github.com/Blaizzy/mlx-vlm/issues/2201#issuecomment-5641455514). #2219 includes an overlapping list-message retention hunk inside a broader request-preparation change; this contribution also covers standalone dictionary input. #2200 remains the separate history-control API work.

AI assistance: implemented and tested with OpenAI Codex, with advisory plan and commit reviews by Anthropic Claude Fable 5.1 at Medium. Fixture sources, revisions, hashes and Apache-2.0 licensing are recorded beside the fixtures; contribution code uses the project’s MIT license. No inference quality or performance improvement is claimed.
