### PR TITLE
Strip box markers in Glm46VMoEProcessor output

### DIFF
--- a/mlx_vlm/models/glm4v_moe/processing.py
+++ b/mlx_vlm/models/glm4v_moe/processing.py
@@ -10,6 +10,8 @@ import numpy as np
 from transformers.feature_extraction_utils import BatchFeature
 from transformers.processing_utils import ProcessorMixin
 
+from ..glm4v.processing import _BOX_TOKENS, _strip_box_markers
+
 
 class Glm46VMoEProcessor(ProcessorMixin):
     """
@@ -40,6 +42,7 @@ class Glm46VMoEProcessor(ProcessorMixin):
         self.video_token = "<|video|>"
 
         if tokenizer is not None:
+            tokenizer.add_special_tokens({"additional_special_tokens": _BOX_TOKENS})
             self.image_token = getattr(tokenizer, "image_token", "<|image|>")
             self.video_token = getattr(tokenizer, "video_token", "<|video|>")
 
@@ -56,6 +59,9 @@ class Glm46VMoEProcessor(ProcessorMixin):
             self.video_token_id = None
 
         super().__init__(image_processor, tokenizer, chat_template=chat_template)
+
+    def clean_output(self, text: str) -> str:
+        return _strip_box_markers(text)
 
     def __call__(
         self,

--- a/mlx_vlm/tests/test_processors.py
+++ b/mlx_vlm/tests/test_processors.py
@@ -117,6 +117,14 @@ class TestOutputControlTokens(unittest.TestCase):
             _strip_box_markers("<|begin_of_box|>answer<|end_of_box|>"), "answer"
         )
 
+    def test_glm46v_moe_strips_box_markers(self):
+        from mlx_vlm.models.glm4v_moe.processing import Glm46VMoEProcessor
+
+        processor = object.__new__(Glm46VMoEProcessor)
+        self.assertEqual(
+            processor.clean_output("<|begin_of_box|>answer<|end_of_box|>"), "answer"
+        )
+
     def test_kimi_vl_stops_on_assistant_marker(self):
         from mlx_vlm.models.kimi_vl.processing_kimi_vl import KimiVLProcessor
 


### PR DESCRIPTION
Follow-up to #2170 — `Glm46VMoEProcessor` (glm4v_moe) never got the box-marker strip, so `mlx-community/GLM-4.6V-nvfp4` still leaked `<|begin_of_box|>`/`<|end_of_box|>` (https://github.com/Blaizzy/mlx-vlm/pull/2170#issuecomment-5554042060).

includes test
