### PR TITLE
chore: refresh GLM-5.3 MTP rebuild onto main

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Some models have detailed documentation with prompt formats, examples, and best 
 | Gemma 4 | [Docs](https://github.com/Blaizzy/mlx-vlm/blob/main/mlx_vlm/models/gemma4/README.md) |
 | MiniMax M3 | [Docs](https://github.com/Blaizzy/mlx-vlm/blob/main/mlx_vlm/models/minimax_m3_vl/README.md) |
 | Falcon-OCR | [Docs](https://github.com/Blaizzy/mlx-vlm/blob/main/mlx_vlm/models/falcon_ocr/README.md) |
+| IndicOCR | [Docs](https://github.com/Blaizzy/mlx-vlm/blob/main/mlx_vlm/models/indic_ocr/README.md) |
 | PP-DocLayoutV3 | [Docs](https://github.com/Blaizzy/mlx-vlm/blob/main/mlx_vlm/models/pp_doclayout_v3/README.md) |
 | Granite Vision 3.2 | [Docs](https://github.com/Blaizzy/mlx-vlm/blob/main/mlx_vlm/models/granite_vision/README.md) |
 | Granite 4.0 Vision | [Docs](https://github.com/Blaizzy/mlx-vlm/blob/main/mlx_vlm/models/granite4_vision/README.md) |

--- a/mlx_vlm/models/glm4v_moe/processing.py
+++ b/mlx_vlm/models/glm4v_moe/processing.py
@@ -10,6 +10,8 @@ import numpy as np
 from transformers.feature_extraction_utils import BatchFeature
 from transformers.processing_utils import ProcessorMixin
 
+from ..glm4v.processing import _BOX_TOKENS, _strip_box_markers
+
 
 class Glm46VMoEProcessor(ProcessorMixin):
     """
@@ -40,6 +42,7 @@ class Glm46VMoEProcessor(ProcessorMixin):
         self.video_token = "<|video|>"
 
         if tokenizer is not None:
+            tokenizer.add_special_tokens({"additional_special_tokens": _BOX_TOKENS})
             self.image_token = getattr(tokenizer, "image_token", "<|image|>")
             self.video_token = getattr(tokenizer, "video_token", "<|video|>")
 
@@ -56,6 +59,9 @@ class Glm46VMoEProcessor(ProcessorMixin):
             self.video_token_id = None
 
         super().__init__(image_processor, tokenizer, chat_template=chat_template)
+
+    def clean_output(self, text: str) -> str:
+        return _strip_box_markers(text)
 
     def __call__(
         self,

--- a/mlx_vlm/models/indic_ocr/README.md
+++ b/mlx_vlm/models/indic_ocr/README.md
@@ -1,0 +1,38 @@
+# IndicOCR
+
+OCR for English and 22 Indian languages. IndicDocLayout, a PP-DocLayoutV3
+fine-tune, detects page regions and reading order; IndicBlockOCR, a
+Qwen3.5-0.8B fine-tune, transcribes text, equations, and tables.
+
+- **Original model:** [bodhan-ai/indic-ocr](https://huggingface.co/bodhan-ai/indic-ocr)
+- **MLX port:** [HashNuke/indic-ocr-mlx](https://huggingface.co/HashNuke/indic-ocr-mlx)
+
+## Parse a page
+
+From an mlx-vlm checkout, install with `pip install -e .`. Replace `page.png`
+with an image path:
+
+```python
+from mlx_vlm.utils import get_model_path, load_model
+
+with load_model(get_model_path("HashNuke/indic-ocr-mlx")) as parser:
+    page = parser.parse("page.png")
+
+print(page.markdown)
+page.save("page.json")
+```
+
+The parser is an `nn.Module`. Its `sanitize()` routes indexed tensors to the
+layout and OCR submodels. The standard loader handles weight assignment,
+quantization, and evaluation. The OCR processor is loaded from the OCR stage
+when `parse()` is first called.
+
+Set parsing options on the returned parser (for example,
+`parser.ocr.options = RecognizerOptions(max_tokens=128)`). To use a different
+layout model, assign `parser.layout.model = load_model(layout_path)`.
+`mlx_vlm.load` and `generate` operate on the OCR stage alone, loaded from the
+downloaded repository's `weights/ocr` directory.
+
+`page.markdown` contains reading-ordered text, HTML tables, and LaTeX
+equations. `page.save` writes image metadata and blocks to JSON, with
+pixel-coordinate `[x0, y0, x1, y1]` boxes and zero-based reading order.

--- a/mlx_vlm/models/indic_ocr/__init__.py
+++ b/mlx_vlm/models/indic_ocr/__init__.py
@@ -1,0 +1,16 @@
+from . import processing_indic_ocr  # noqa: F401
+from .blocks import Block, LayoutSchemaError, clean_layout, resolve_nested_equations
+from .config import ModelConfig, TextConfig, VisionConfig
+from .indic_ocr import LanguageModel, Model, VisionModel
+from .pipeline import (
+    BlockOCRRunner,
+    CropOptions,
+    DedupOptions,
+    IndicOCRParser,
+    JsonLayoutBackend,
+    LayoutOptions,
+    MLXLayoutBackend,
+    PageResult,
+    RecognizerOptions,
+)
+from .reconstruct import dehyphenate, reconstruct, repair_math

--- a/mlx_vlm/models/indic_ocr/blocks.py
+++ b/mlx_vlm/models/indic_ocr/blocks.py
@@ -1,0 +1,254 @@
+"""Layout cleanup: geometry, duplicate suppression, nested-equation resolution.
+
+Ported from upstream ``idp_blocks.py`` (bodhan-ai/indic-ocr). Pure geometry
+on blocks -- no PIL, no model -- so the rules that decide what gets
+transcribed stay testable in isolation.
+"""
+
+import dataclasses
+from dataclasses import dataclass
+from typing import Optional
+
+from .processing_indic_ocr import (
+    CLASSES,
+    DROP_TYPES,
+    KEPT_BLOCK_TYPES,
+    PP_DOCLAYOUT_LABEL_TO_TYPE,
+    is_transcribed,
+    map_label,
+)
+
+TEXTLIKE = frozenset({"Text", "Title", "SectionHeader", "Caption", "Footnote"})
+
+
+class LayoutSchemaError(ValueError):
+    """An incoming layout record cannot be interpreted unambiguously."""
+
+
+def _unknown(value, candidates, kind: str) -> str:
+    import difflib
+
+    match = difflib.get_close_matches(str(value), list(candidates), n=1, cutoff=0.6)
+    hint = f"; did you mean {match[0]!r}?" if match else ""
+    return f"unknown {kind} {value!r}{hint}"
+
+
+@dataclass
+class Block:
+    """One detected region. ``text`` is None before OCR, and "" for blocks
+    deliberately not transcribed (kept in place rather than deleted)."""
+
+    order: int
+    label: str
+    type: str
+    bbox_xyxy: list
+    conf: float
+    text: Optional[str] = None
+
+    def as_record(self) -> dict:
+        # Key order is load-bearing: json.dump writes insertion order.
+        record: dict = {
+            "order": self.order,
+            "label": self.label,
+            "type": self.type,
+            "bbox_xyxy": [round(float(v), 1) for v in self.bbox_xyxy],
+            "conf": round(float(self.conf), 3),
+        }
+        if self.text is not None:
+            record["text"] = self.text
+        return record
+
+    @classmethod
+    def problems(cls, record: dict) -> list:
+        found: list = []
+        for key in ("order", "bbox_xyxy"):
+            if key not in record:
+                found.append(f"missing required key {key!r}")
+
+        if "order" in record and (
+            not isinstance(record["order"], int)
+            or isinstance(record["order"], bool)
+            or record["order"] < 0
+        ):
+            found.append(
+                f"order must be a nonnegative integer, got {record['order']!r}"
+            )
+
+        bbox = record.get("bbox_xyxy")
+        if bbox is not None:
+            try:
+                if len([float(v) for v in bbox]) != 4:
+                    found.append(
+                        f"bbox_xyxy must be 4 numbers [x0, y0, x1, y1], got {bbox!r}"
+                    )
+            except (TypeError, ValueError):
+                found.append(
+                    f"bbox_xyxy must be 4 numbers [x0, y0, x1, y1], got {bbox!r}"
+                )
+
+        declared = record.get("type")
+        if declared:
+            valid = tuple(KEPT_BLOCK_TYPES) + tuple(sorted(DROP_TYPES))
+            if str(declared) not in valid:
+                found.append(_unknown(declared, valid, "type"))
+        else:
+            label = str(record.get("label", "")).strip()
+            known = {
+                c.strip().lower() for c in CLASSES
+            } | PP_DOCLAYOUT_LABEL_TO_TYPE.keys()
+            if label.lower() not in known:
+                found.append(
+                    _unknown(
+                        label, list(CLASSES) + list(PP_DOCLAYOUT_LABEL_TO_TYPE), "label"
+                    )
+                    + ' -- use an IndicDocLayout or PP-DocLayoutV3 label, or declare "type"'
+                    " explicitly if your detector has its own taxonomy"
+                )
+        return found
+
+    @classmethod
+    def from_record(cls, record: dict, strict: bool = True) -> "Block":
+        if strict:
+            found = cls.problems(record)
+            if found:
+                raise LayoutSchemaError("; ".join(found))
+
+        label = record.get("label", "")
+        return cls(
+            order=int(record["order"]),
+            label=str(label),
+            type=str(record.get("type") or map_label(label)),
+            bbox_xyxy=[float(v) for v in record["bbox_xyxy"]],
+            conf=float(record.get("conf", 1.0)),
+            text=record.get("text"),
+        )
+
+    def copy(self) -> "Block":
+        return dataclasses.replace(self, bbox_xyxy=list(self.bbox_xyxy))
+
+
+def area(bbox) -> float:
+    return max(0.0, bbox[2] - bbox[0]) * max(0.0, bbox[3] - bbox[1])
+
+
+def contained_frac(small, big) -> float:
+    ix0, iy0 = max(small[0], big[0]), max(small[1], big[1])
+    ix1, iy1 = min(small[2], big[2]), min(small[3], big[3])
+    inter = max(0.0, ix1 - ix0) * max(0.0, iy1 - iy0)
+    a = area(small)
+    return inter / a if a > 0 else 0.0
+
+
+def clamp_to_page(bbox, width: int, height: int) -> list:
+    return [
+        max(0.0, bbox[0]),
+        max(0.0, bbox[1]),
+        min(float(width), bbox[2]),
+        min(float(height), bbox[3]),
+    ]
+
+
+def clean_layout(blocks: list, contain: float = 0.90, wrap: float = 0.5) -> list:
+    """Drop duplicate and spurious boxes. Survivors keep input order.
+
+    1. Nested duplicates -- a box ``contain``-inside a larger box goes.
+    2. One header, one footer -- only the largest of each survives.
+    3. Empty frames -- a header/footer wrapping nothing is dropped.
+    """
+    from .processing_indic_ocr import HEAD_FOOT, MARGINALIA
+
+    n = len(blocks)
+    box = lambda i: blocks[i].bbox_xyxy  # noqa: E731
+    drop: set = set()
+    marginalia = {map_label(label) for label in MARGINALIA}
+    head_foot = tuple(map_label(label) for label in HEAD_FOOT)
+
+    def transcribed(block):
+        return block.type not in DROP_TYPES and is_transcribed(block.label)
+
+    groups = (
+        lambda block: block.type not in marginalia,
+        lambda block: block.type in marginalia and block.type not in head_foot,
+    )
+    for in_group in groups:
+        idxs = sorted(
+            (i for i in range(n) if in_group(blocks[i])),
+            key=lambda i: area(box(i)),
+            reverse=True,
+        )
+        kept: list = []
+        for i in idxs:
+            has_text = transcribed(blocks[i])
+            if any(
+                contained_frac(box(i), box(j)) >= contain
+                and (transcribed(blocks[j]) or not has_text)
+                for j in kept
+            ):
+                drop.add(i)
+            else:
+                kept.append(i)
+
+    for block_type in head_foot:
+        group = [i for i in range(n) if blocks[i].type == block_type and i not in drop]
+        if not group:
+            continue
+        biggest = max(group, key=lambda i: area(box(i)))
+        drop.update(i for i in group if i != biggest)
+        wraps = any(
+            blocks[k].type != block_type
+            and contained_frac(box(k), box(biggest)) >= wrap
+            for k in range(n)
+        )
+        if not wraps:
+            drop.add(biggest)
+
+    return [blocks[i] for i in range(n) if i not in drop]
+
+
+def _nested_in(inner, outer, thresh: float) -> bool:
+    inner_area = area(inner)
+    if inner_area <= 0:
+        return False
+    return contained_frac(inner, outer) >= thresh and inner_area < 0.95 * area(outer)
+
+
+def _absorbs_equation(container: Block, mode: str) -> bool:
+    if container.type == "Equation":
+        return mode != "text_only"
+    if container.type in TEXTLIKE:
+        return mode != "eq_only"
+    return False
+
+
+def resolve_nested_equations(
+    blocks: list, nest: bool = True, mode: str = "both", nested: float = 0.70
+) -> list:
+    """Drop equation boxes nested in a container that already covers them."""
+    if not nest:
+        return list(blocks)
+
+    drop: set = set()
+    for i, inner in enumerate(blocks):
+        if inner.type != "Equation":
+            continue
+        for j, container in enumerate(blocks):
+            if (
+                i != j
+                and _nested_in(inner.bbox_xyxy, container.bbox_xyxy, nested)
+                and _absorbs_equation(container, mode)
+            ):
+                drop.add(i)
+                break
+    return [b for k, b in enumerate(blocks) if k not in drop]
+
+
+__all__ = [
+    "Block",
+    "LayoutSchemaError",
+    "TEXTLIKE",
+    "area",
+    "contained_frac",
+    "clamp_to_page",
+    "clean_layout",
+    "resolve_nested_equations",
+]

--- a/mlx_vlm/models/indic_ocr/config.py
+++ b/mlx_vlm/models/indic_ocr/config.py
@@ -1,0 +1,85 @@
+"""IndicOCR (bodhan-ai/indic-ocr) configuration.
+
+OCR-only configs reuse Qwen3.5. Combined checkpoints embed both stage configs
+as ``layout_config`` and ``ocr_config`` and load as an IndicOCRParser.
+The repository provides a standard shard index pointing to both stages.
+"""
+
+from dataclasses import dataclass
+from typing import List, Optional, Union
+
+from ..base import BaseModelConfig
+from ..pp_doclayout_v3.config import ModelConfig as LayoutConfig
+from ..qwen3_5.config import TextConfig, VisionConfig
+
+
+@dataclass
+class ModelConfig(BaseModelConfig):
+    text_config: TextConfig
+    vision_config: VisionConfig
+    model_type: str = "indic_ocr"
+    ignore_index: int = -100
+    image_token_id: int = 262155
+    video_token_id: int = 262156
+    image_token_index: Optional[int] = None
+    video_token_index: Optional[int] = None
+    vision_start_token_id: int = 262153
+    vision_end_token_id: int = 262154
+    vocab_size: int = 262157
+    eos_token_id: Optional[Union[int, List[int]]] = None
+    quantization: Optional[dict] = None
+    quantization_config: Optional[dict] = None
+
+    def __post_init__(self):
+        if self.image_token_index is None:
+            self.image_token_index = self.image_token_id
+        if self.video_token_index is None:
+            self.video_token_index = self.video_token_id
+
+    @classmethod
+    def from_dict(cls, params):
+        params = dict(params)
+        if "layout_config" in params or "ocr_config" in params:
+            return ParserConfig.from_dict(params)
+        if not params.get("text_config") and "stages" in params:
+            raise ValueError(
+                "indic_ocr wrapper repo detected (stages.layout/stages.ocr). "
+                "Use a repository revision with embedded layout_config and ocr_config "
+                "and a standard safetensors index, or load the weights/ocr or "
+                "weights/layout stage directly."
+            )
+        from ..qwen3_vl.config import _config_kwargs, _maybe_deserialize_config
+
+        params["vision_config"] = _maybe_deserialize_config(
+            VisionConfig, params.get("vision_config")
+        )
+        params["text_config"] = _maybe_deserialize_config(
+            TextConfig, params.get("text_config"), require_all_fields=True
+        )
+        return cls(**_config_kwargs(cls, params))
+
+
+@dataclass
+class ParserConfig(BaseModelConfig):
+    layout_config: LayoutConfig
+    ocr_config: ModelConfig
+    model_type: str = "indic_ocr"
+    quantization: Optional[dict] = None
+    quantization_config: Optional[dict] = None
+    ocr_model_path: Optional[str] = None
+    weight_mapping: Optional[dict] = None
+
+    @classmethod
+    def from_dict(cls, params):
+        if not params.get("layout_config") or not params.get("ocr_config"):
+            raise ValueError(
+                "Combined IndicOCR configs require layout_config and ocr_config"
+            )
+        return cls(
+            layout_config=LayoutConfig.from_dict(params["layout_config"]),
+            ocr_config=ModelConfig.from_dict(params["ocr_config"]),
+            quantization=params.get("quantization"),
+            quantization_config=params.get("quantization_config"),
+            ocr_model_path=params.get("ocr_model_path"),
+            weight_mapping=params.get("weight_mapping"),
+        )

--- a/mlx_vlm/models/indic_ocr/indic_ocr.py
+++ b/mlx_vlm/models/indic_ocr/indic_ocr.py
@@ -1,0 +1,41 @@
+"""IndicOCR OCR-stage model (IndicBlockOCR).
+
+Thin wrapper over the Qwen3.5 implementation: same architecture, same
+weight names (``model.language_model.*`` / ``model.visual.*``), Indic
+vocab (262157) and token ids carried by ``ModelConfig``.
+"""
+
+from dataclasses import replace
+
+from ..qwen3_5.qwen3_5 import LanguageModel
+from ..qwen3_5.qwen3_5 import Model as _Qwen35Model
+from ..qwen3_5.qwen3_5 import (
+    VisionModel,
+    sanitize_key,
+    should_offset_norm_weight,
+    should_shift_norm_weights,
+)
+from .config import ModelConfig, ParserConfig
+
+__all__ = [
+    "LanguageModel",
+    "Model",
+    "VisionModel",
+    "sanitize_key",
+    "should_shift_norm_weights",
+    "should_offset_norm_weight",
+]
+
+
+class Model(_Qwen35Model):
+    def __new__(cls, config):
+        if isinstance(config, ParserConfig):
+            from .pipeline import IndicOCRParser
+
+            return IndicOCRParser.from_config(config)
+        return super().__new__(cls)
+
+    def __init__(self, config: ModelConfig):
+        # This stage uses Qwen3.5's image-first chat format. Keep the checkpoint
+        # model_type for dispatch, but expose the architecture to shared prompting.
+        super().__init__(replace(config, model_type="qwen3_5"))

--- a/mlx_vlm/models/indic_ocr/pipeline.py
+++ b/mlx_vlm/models/indic_ocr/pipeline.py
@@ -1,0 +1,557 @@
+"""End-to-end IndicOCR page pipeline in MLX.
+
+``IndicOCRParser`` mirrors upstream ``IndicOCR`` (``idp_offline.py``):
+
+    page image -> layout detect -> dedup -> per-block OCR -> Markdown + JSON
+
+Stage 1 runs the MLX layout detector; stage 2 the MLX OCR model. A
+layout produced elsewhere (torch upstream, hand-edited JSON, another
+detector) can be replayed via ``JsonLayoutBackend``.
+"""
+
+import json
+import os
+from dataclasses import dataclass, field
+from typing import Optional
+
+import mlx.nn as nn
+from PIL import Image
+
+from .blocks import (
+    Block,
+    LayoutSchemaError,
+    clamp_to_page,
+    clean_layout,
+    resolve_nested_equations,
+)
+from .processing_indic_ocr import is_transcribed
+from .reconstruct import reconstruct
+
+
+@dataclass(frozen=True)
+class LayoutOptions:
+    conf: float = 0.5
+    img_size: int = 1024
+
+
+@dataclass(frozen=True)
+class CropOptions:
+    min_px_side: int = 256
+    max_px_side: int = 1536
+    pad_px: int = 0
+
+    @property
+    def min_px(self) -> int:
+        return self.min_px_side**2
+
+    @property
+    def max_px(self) -> int:
+        return self.max_px_side**2
+
+
+@dataclass(frozen=True)
+class DedupOptions:
+    nest: bool = True
+    mode: str = "both"
+    contain: float = 0.90
+    wrap: float = 0.5
+    nested: float = 0.70
+
+    def __post_init__(self):
+        if self.mode not in ("both", "text_only", "eq_only"):
+            raise ValueError(
+                f"DedupOptions.mode must be both/text_only/eq_only, got {self.mode!r}"
+            )
+
+
+@dataclass(frozen=True)
+class RecognizerOptions:
+    max_tokens: int = 2048
+    temperature: float = 0.0  # greedy: the only reproducible setting
+    table_format: str = "html"
+
+    def __post_init__(self):
+        if self.table_format not in ("html", "markdown"):
+            raise ValueError(
+                "RecognizerOptions.table_format must be 'html' or 'markdown', "
+                f"got {self.table_format!r}"
+            )
+
+
+@dataclass
+class PageResult:
+    image: str
+    width: int
+    height: int
+    blocks: list = field(default_factory=list)
+    markdown: Optional[str] = None
+
+    def as_record(self) -> dict:
+        return {
+            "image": self.image,
+            "width": self.width,
+            "height": self.height,
+            "blocks": [b.as_record() for b in self.blocks],
+        }
+
+    def save(self, path: str) -> None:
+        with open(path, "w", encoding="utf-8") as fh:
+            json.dump(self.as_record(), fh, ensure_ascii=False, indent=2)
+
+    @classmethod
+    def from_record(cls, record: dict, strict: bool = True) -> "PageResult":
+        blocks = list(record.get("blocks", []))
+        if strict:
+            errors = []
+            seen_orders = set()
+            for i, block in enumerate(blocks):
+                if not isinstance(block, dict):
+                    errors.append(f"  block[{i}]: expected a block record")
+                    continue
+                errors.extend(
+                    f"  block[{i}] (order={block.get('order', '?')!r}): {problem}"
+                    for problem in Block.problems(block)
+                )
+                order = block.get("order")
+                if isinstance(order, int):
+                    if order in seen_orders:
+                        errors.append(f"  block[{i}]: duplicate order {order}")
+                    seen_orders.add(order)
+            if errors:
+                raise LayoutSchemaError(
+                    f"{len(errors)} problem(s) in layout for "
+                    f"{record.get('image', '<unknown>')!r}:\n" + "\n".join(errors)
+                )
+        return cls(
+            image=str(record["image"]),
+            width=int(record["width"]),
+            height=int(record["height"]),
+            blocks=[Block.from_record(b, strict=False) for b in blocks],
+        )
+
+
+def _open(image_path: str) -> Image.Image:
+    Image.MAX_IMAGE_PIXELS = None
+    return Image.open(image_path).convert("RGB")
+
+
+def _densify(blocks: list) -> list:
+    """Sort by detector reading order, renumber to a gap-free 0-based rank."""
+    ordered = sorted(blocks, key=lambda b: b.order)
+    for rank, block in enumerate(ordered):
+        block.order = rank
+    return ordered
+
+
+def viewer_records_to_blocks(records: list, width: int, height: int) -> list:
+    """Convert detector viewer records to pixel-coordinate OCR blocks."""
+    blocks = []
+    for rec in records:
+        order = rec["reading_order"]
+        if not isinstance(order, int) or isinstance(order, bool) or order < 1:
+            raise LayoutSchemaError(
+                f"reading_order must be a positive integer, got {order!r}"
+            )
+    for rec in sorted(records, key=lambda item: item["reading_order"]):
+        y0, x0, y1, x1 = rec["bbox"]
+        label = str(rec["label"])
+        block = {
+            "order": rec["reading_order"] - 1,
+            "label": label,
+            "bbox_xyxy": [
+                x0 / 1000 * width,
+                y0 / 1000 * height,
+                x1 / 1000 * width,
+                y1 / 1000 * height,
+            ],
+            "conf": float(rec.get("score", 1.0)),
+        }
+        if "type" in rec:
+            block["type"] = rec["type"]
+        blocks.append(Block.from_record(block))
+    return blocks
+
+
+def _resolve_repo_root(
+    repo_or_path: str,
+    revision: Optional[str] = None,
+    force_download: bool = False,
+):
+    from mlx_vlm.utils import get_model_path
+
+    root = get_model_path(
+        repo_or_path, revision=revision, force_download=force_download
+    )
+    with open(root / "config.json", encoding="utf-8") as fh:
+        config = json.load(fh)
+    stages = dict(config.get("stages", {}))
+    if "text_config" in config and "vision_config" in config:
+        stages.setdefault("ocr", {"config": "config.json"})
+    return root, stages
+
+
+def _stage_dir(root, stages: dict, name: str, default: str):
+    from pathlib import Path
+
+    return root / Path(stages.get(name, {}).get("config", default)).parent
+
+
+def _resolve_layout_source(root, stages: dict, layout_repo: Optional[str] = None):
+    """Where to load the layout stage from: an explicit repo/path, else
+    the single-repo ``weights/layout`` subdir, else an error."""
+    from pathlib import Path
+
+    if layout_repo is not None:
+        return layout_repo
+    candidate = _stage_dir(root, stages, "layout", "weights/layout/config.json")
+    if (Path(candidate) / "config.json").is_file():
+        return str(candidate)
+    raise ValueError(
+        "No layout stage found: pass layout_repo=<hf-id-or-path> (e.g. "
+        "'HashNuke/pp-doclayout-v3-mlx'), or use a single repo containing "
+        "weights/layout (e.g. 'HashNuke/indic-ocr-mlx')."
+    )
+
+
+class MLXLayoutBackend(nn.Module):
+    """Stage 1 with the MLX layout detector."""
+
+    def __init__(
+        self,
+        model,
+        options: Optional[LayoutOptions] = None,
+        dedup: Optional[DedupOptions] = None,
+    ) -> None:
+        super().__init__()
+        self.model = model
+        self.options = options or LayoutOptions()
+        self.dedup = dedup or DedupOptions()
+
+    def detect(self, image: Image.Image) -> list:
+        if self.model is None:
+            raise RuntimeError("Layout backend is closed.")
+        width, height = image.size
+        records = self.model.detect(
+            image, conf=self.options.conf, img_size=self.options.img_size
+        )
+        blocks = viewer_records_to_blocks(records, width, height)
+        for block in blocks:
+            block.bbox_xyxy = [
+                round(v, 1) for v in clamp_to_page(block.bbox_xyxy, width, height)
+            ]
+            block.conf = round(block.conf, 3)
+        return _densify(
+            clean_layout(blocks, contain=self.dedup.contain, wrap=self.dedup.wrap)
+        )
+
+    def close(self) -> None:
+        self.model = None
+
+
+class JsonLayoutBackend:
+    """Replay a layout produced elsewhere. Assumed clean; only renumbered."""
+
+    def __init__(self, layout, strict: bool = True) -> None:
+        if isinstance(layout, PageResult):
+            self.page = layout
+        else:
+            if isinstance(layout, str):
+                with open(layout, encoding="utf-8") as fh:
+                    layout = json.load(fh)
+            self.page = PageResult.from_record(layout, strict=strict)
+
+    def detect(self, image: Image.Image) -> list:
+        return _densify([b.copy() for b in self.page.blocks])
+
+    def close(self) -> None:
+        return None
+
+
+class BlockOCRRunner(nn.Module):
+    """Stage 2: per-block transcription against a layout (any backend)."""
+
+    def __init__(
+        self,
+        model,
+        processor,
+        options: Optional[RecognizerOptions] = None,
+        dedup: Optional[DedupOptions] = None,
+        crop: Optional[CropOptions] = None,
+    ) -> None:
+        super().__init__()
+        self.model = model
+        self.processor = processor
+        self.options = options or RecognizerOptions()
+        self.dedup = dedup or DedupOptions()
+        self.crop = crop or CropOptions()
+
+    def run(self, image_path: str, layout) -> PageResult:
+        """Every block of the layout comes back, in its original order.
+        Blocks that were not transcribed carry ``text: ""``."""
+        from .processing_indic_ocr import transcribe_blocks
+
+        if self.model is None or self.processor is None:
+            raise RuntimeError("OCR backend is closed.")
+        image = _open(image_path)
+        page = PageResult.from_record(
+            layout.as_record()
+            if isinstance(layout, PageResult)
+            else (
+                json.load(open(layout, encoding="utf-8"))
+                if isinstance(layout, str)
+                else layout
+            )
+        )
+        blocks = [b.copy() for b in page.blocks]
+
+        eligible = resolve_nested_equations(
+            [b for b in blocks if is_transcribed(b.label)],
+            nest=self.dedup.nest,
+            mode=self.dedup.mode,
+            nested=self.dedup.nested,
+        )
+        transcribe_blocks(
+            self.model,
+            self.processor,
+            image,
+            eligible,
+            table_format=self.options.table_format,
+            max_tokens=self.options.max_tokens,
+            temperature=self.options.temperature,
+            pad_px=self.crop.pad_px,
+            min_px=self.crop.min_px,
+            max_px=self.crop.max_px,
+        )
+        by_order = {b.order: (b.text or "") for b in eligible}
+        for block in blocks:
+            block.text = (by_order.get(block.order) or "").strip()
+
+        return PageResult(
+            image=page.image,
+            width=page.width,
+            height=page.height,
+            blocks=blocks,
+            markdown=reconstruct(blocks),
+        )
+
+    def close(self) -> None:
+        self.model = None
+        self.processor = None
+
+
+class IndicOCRParser(nn.Module):
+    """Both stages in one object: ``parse("page.png")`` -> PageResult."""
+
+    def __init__(
+        self,
+        layout_model,
+        ocr_model,
+        ocr_processor,
+        layout_options: Optional[LayoutOptions] = None,
+        recognizer_options: Optional[RecognizerOptions] = None,
+        dedup: Optional[DedupOptions] = None,
+        crop: Optional[CropOptions] = None,
+    ) -> None:
+        super().__init__()
+        dedup = dedup or DedupOptions()
+        self.layout = MLXLayoutBackend(layout_model, layout_options, dedup)
+        self.ocr = BlockOCRRunner(
+            ocr_model, ocr_processor, recognizer_options, dedup, crop
+        )
+
+    @classmethod
+    def from_config(cls, config):
+        from ..pp_doclayout_v3 import Model as LayoutModel
+        from .indic_ocr import Model as OCRModel
+
+        parser = cls(
+            LayoutModel(config.layout_config),
+            OCRModel(config.ocr_config),
+            None,
+        )
+        parser.config = config
+        return parser
+
+    def sanitize(self, weights):
+        """Route stage-prefixed tensors through each submodel's sanitizer.
+
+        Input prefixes are ``layout_model.`` and ``ocr_model.``; converted
+        checkpoints use the module paths ``layout.model.`` and ``ocr.model.``.
+        Unknown keys are preserved so strict loading can report them.
+        """
+        remaining = dict(weights)
+        mapping = getattr(getattr(self, "config", None), "weight_mapping", None) or {}
+        for key in list(remaining):
+            if key in mapping:
+                destination = f"{mapping[key]}_model.{key}"
+                if destination in remaining:
+                    raise ValueError(f"Duplicate stage weight: {key}")
+                remaining[destination] = remaining.pop(key)
+        result = {}
+        for name, backend in (("layout", self.layout), ("ocr", self.ocr)):
+            stage_weights = {}
+            for key in list(remaining):
+                for prefix in (f"{name}_model.", f"{name}.model."):
+                    if key.startswith(prefix):
+                        stage_key = key[len(prefix) :]
+                        if stage_key in stage_weights:
+                            raise ValueError(f"Duplicate {name} weight: {stage_key}")
+                        stage_weights[stage_key] = remaining.pop(key)
+                        break
+            stage_weights = backend.model.sanitize(stage_weights)
+            if name == "ocr" and backend.model.vision_tower is not None:
+                stage_weights = backend.model.vision_tower.sanitize(stage_weights)
+            result.update(
+                (f"{name}.model.{key}", value) for key, value in stage_weights.items()
+            )
+        result.update(remaining)
+        return result
+
+    @classmethod
+    def _from_models(cls, *args, **kwargs) -> "IndicOCRParser":
+        return cls(*args, **kwargs)
+
+    @classmethod
+    def from_pretrained(
+        cls,
+        repo_or_path: str,
+        layout_options: Optional[LayoutOptions] = None,
+        recognizer_options: Optional[RecognizerOptions] = None,
+        dedup: Optional[DedupOptions] = None,
+        crop: Optional[CropOptions] = None,
+        revision: Optional[str] = None,
+        layout_repo: Optional[str] = None,
+        lazy: bool = False,
+        strict: bool = True,
+        **kwargs,
+    ) -> "IndicOCRParser":
+        """Load a two-stage repository or a flat OCR stage (HF id or local path).
+
+        ``layout_repo`` overrides the bundled layout stage and is required
+        for a flat OCR model. Both IndicDocLayout and stock PP-DocLayoutV3
+        label taxonomies are supported. ``lazy``, ``strict``, and additional
+        loader arguments are forwarded to both stages.
+        """
+        from mlx_vlm import load as mlx_load
+        from mlx_vlm.utils import get_model_path, load_config
+        from mlx_vlm.utils import load_model as mlx_load_model
+
+        root, stages = _resolve_repo_root(
+            repo_or_path, revision, force_download=kwargs.get("force_download", False)
+        )
+        config = load_config(root)
+        if "layout_config" in config or "ocr_config" in config:
+            from mlx_vlm.utils import load_processor
+
+            parser = mlx_load_model(root, lazy=lazy, strict=strict, **kwargs)
+            if layout_repo is not None:
+                parser.layout.model = mlx_load_model(
+                    get_model_path(layout_repo), lazy=lazy, strict=strict, **kwargs
+                )
+            parser.ocr.processor = load_processor(
+                root / (parser.config.ocr_model_path or "."),
+                eos_token_ids=parser.config.ocr_config.eos_token_id,
+                **kwargs,
+            )
+            parser.layout.options = layout_options or LayoutOptions()
+            parser.ocr.options = recognizer_options or RecognizerOptions()
+            parser.layout.dedup = parser.ocr.dedup = dedup or DedupOptions()
+            parser.ocr.crop = crop or CropOptions()
+            return parser
+
+        ocr_dir = _stage_dir(root, stages, "ocr", "weights/ocr/config.json")
+        if not (ocr_dir / "config.json").is_file():
+            raise FileNotFoundError(f"No OCR config found at {ocr_dir / 'config.json'}")
+        layout_source = _resolve_layout_source(root, stages, layout_repo)
+        layout_path = get_model_path(
+            layout_source, force_download=kwargs.get("force_download", False)
+        )
+        for name, stage_path in (("layout", layout_path), ("ocr", ocr_dir)):
+            stage_config = load_config(stage_path)
+            if (
+                (stage_config.get("model_type") or "").lower() == "indic_ocr"
+                and "stages" in stage_config
+                and "text_config" not in stage_config
+            ):
+                raise ValueError(
+                    f"The {name} stage at {stage_path} points to a two-stage "
+                    "wrapper; each stage must point to an individual model."
+                )
+
+        layout_model = mlx_load_model(
+            layout_path,
+            lazy=lazy,
+            strict=strict,
+            **kwargs,
+        )
+        if hasattr(layout_model, "eval"):
+            layout_model.eval()
+        ocr_model, ocr_processor = mlx_load(
+            str(ocr_dir), lazy=lazy, strict=strict, **kwargs
+        )
+        return cls._from_models(
+            layout_model,
+            ocr_model,
+            ocr_processor,
+            layout_options,
+            recognizer_options,
+            dedup,
+            crop,
+        )
+
+    def detect(self, image_path: str) -> PageResult:
+        image = _open(image_path)
+        return PageResult(
+            image=os.path.basename(image_path),
+            width=image.width,
+            height=image.height,
+            blocks=self.layout.detect(image),
+        )
+
+    def parse(self, image_path: str) -> PageResult:
+        if self.ocr.processor is None and self.ocr.model is not None:
+            from pathlib import Path
+
+            from mlx_vlm.utils import load_processor
+
+            config = getattr(self, "config", None)
+            processor_path = getattr(config, "ocr_model_path", None)
+            model_path = getattr(self, "model_path", None)
+            if processor_path is not None and not Path(processor_path).is_absolute():
+                processor_path = (
+                    Path(model_path) / processor_path
+                    if model_path is not None
+                    else None
+                )
+            elif processor_path is None:
+                processor_path = model_path
+            if processor_path is not None:
+                self.ocr.processor = load_processor(
+                    Path(processor_path),
+                    eos_token_ids=self.ocr.model.config.eos_token_id,
+                )
+        return self.ocr.run(image_path, self.detect(image_path))
+
+    def close(self) -> None:
+        self.layout.close()
+        self.ocr.close()
+
+    def __enter__(self) -> "IndicOCRParser":
+        return self
+
+    def __exit__(self, *exc_info) -> None:
+        self.close()
+
+
+__all__ = [
+    "LayoutOptions",
+    "CropOptions",
+    "DedupOptions",
+    "RecognizerOptions",
+    "PageResult",
+    "viewer_records_to_blocks",
+    "MLXLayoutBackend",
+    "JsonLayoutBackend",
+    "BlockOCRRunner",
+    "IndicOCRParser",
+]

--- a/mlx_vlm/models/indic_ocr/processing_indic_ocr.py
+++ b/mlx_vlm/models/indic_ocr/processing_indic_ocr.py
@@ -1,0 +1,315 @@
+"""Block-level prompts and crop helpers for IndicOCR.
+
+Prompts and the label taxonomy are ported from the upstream repo
+(``idp_contract.py`` / ``idp_crops.py``, bodhan-ai/indic-ocr).
+Image encoding itself uses the standard Qwen3VLProcessor.
+"""
+
+import math
+from typing import Optional
+
+from PIL import Image
+
+from ..base import install_auto_processor_patch
+from ..qwen3_vl.processing_qwen3_vl import Qwen3VLProcessor
+
+# Prompts (verbatim from idp_contract.py)
+TEXT_PROMPT = (
+    "Transcribe the text in this image. Write any mathematical expressions in LaTeX, "
+    "using $...$ for inline math and $$...$$ for display equations."
+)
+EQUATION_PROMPT = "Output only the LaTeX for this equation image."
+TABLE_PROMPT_HTML = (
+    "Convert this table image to HTML. Preserve the structure exactly, using colspan and "
+    "rowspan for merged cells and <br/> for line breaks within a cell. "
+    "Output only the HTML table."
+)
+TABLE_PROMPT_MARKDOWN = "Convert this table image to a GitHub-flavored markdown table. Output only the table."
+
+# Label -> pipeline type (from idp_contract.LABEL_TO_TYPE)
+LABEL_TO_TYPE = {
+    "table": "Table",
+    "table-caption": "Caption",
+    "equation": "Equation",
+    "expression": "Equation",
+    "diagram": "Figure",
+    "chart": "Figure",
+    "image": "Picture",
+    "image-caption": "Caption",
+    "title": "Title",
+    "chapter-title": "Title",
+    "section-title": "SectionHeader",
+    "sub-section-title": "SectionHeader",
+    "sub-sub-section-title": "SectionHeader",
+    "header": "PageHeader",
+    "footer": "PageFooter",
+    "page-number": "PageNumber",
+    "folio": "PageNumber",
+    "footnote": "Footnote",
+}
+
+# Stock PP-DocLayoutV3 labels differ from the IndicDocLayout fine-tune.
+# Keep their original spelling in records while selecting the OCR role here.
+PP_DOCLAYOUT_LABEL_TO_TYPE = {
+    "abstract": "Text",
+    "algorithm": "Text",
+    "aside_text": "Text",
+    "chart": "Figure",
+    "content": "Text",
+    "formula": "Equation",
+    "doc_title": "Title",
+    "figure_title": "Caption",
+    "footer": "PageFooter",
+    "footnote": "Footnote",
+    "formula_number": "Text",
+    "header": "PageHeader",
+    "image": "Picture",
+    "number": "PageNumber",
+    "paragraph_title": "SectionHeader",
+    "reference": "Text",
+    "reference_content": "Text",
+    "seal": "Text",
+    "table": "Table",
+    "text": "Text",
+    "vision_footnote": "Footnote",
+}
+
+# Blocks never sent to the recognizer (from idp_contract.DROP_TYPES)
+DROP_TYPES = frozenset({"Figure", "Picture"})
+
+# Pipeline types map_label can produce, less DROP_TYPES
+KEPT_BLOCK_TYPES = (
+    "Text",
+    "Title",
+    "SectionHeader",
+    "Table",
+    "Equation",
+    "Caption",
+    "Footnote",
+    "PageHeader",
+    "PageFooter",
+    "PageNumber",
+)
+
+# 37-class IndicDocLayout taxonomy (from idp_model_labels.CLASSES)
+CLASSES = [
+    "Question",
+    "Paragraph",
+    "Answer",
+    "List",
+    "Title",
+    "Section-title",
+    "Equation",
+    "Table",
+    "Diagram",
+    "Image",
+    "MCQ",
+    "Infobox",
+    "Sub-section-title",
+    "Expression",
+    "Image-caption",
+    "Placeholder-text",
+    "Chart",
+    "Solved-example",
+    "Footnote",
+    "Table-caption",
+    "Sub-sub-section-title",
+    "Footer",
+    "Header",
+    "Code",
+    "Page-number",
+    "Chapter-title",
+    "Chapter-end-section",
+    "Folio",
+    "Reference",
+    "Table-of-contents",
+    "Index",
+    "Advertisement",
+    "Author",
+    "Dateline",
+    "Contact-info",
+    "Website-link",
+    "Flag",
+]
+
+# Cleaned as their own group so a page-spanning paragraph cannot swallow
+# a page number (from idp_contract.MARGINALIA / HEAD_FOOT)
+MARGINALIA = frozenset({"Header", "Footer", "Page-number", "Folio"})
+HEAD_FOOT = ("Header", "Footer")
+
+# Never sent to the recognizer but kept in place with text "".
+OCR_SKIP_LABELS = frozenset(
+    {"header", "footer", "diagram", "image", "chart", "advertisement"}
+)
+
+
+def is_transcribed(label) -> bool:
+    return str(label).strip().lower() not in OCR_SKIP_LABELS
+
+
+def map_label(label) -> str:
+    label = str(label).strip().lower()
+    return LABEL_TO_TYPE.get(label, PP_DOCLAYOUT_LABEL_TO_TYPE.get(label, "Text"))
+
+
+def prompt_for(block_type: str, table_format: str = "html") -> str:
+    if block_type == "Table":
+        if table_format == "markdown":
+            return TABLE_PROMPT_MARKDOWN
+        if table_format != "html":
+            raise ValueError(
+                f"table_format must be 'html' or 'markdown', got {table_format!r}"
+            )
+        return TABLE_PROMPT_HTML
+    if block_type == "Equation":
+        return EQUATION_PROMPT
+    return TEXT_PROMPT
+
+
+def area_clamp(
+    image: Image.Image, min_px: int = 65536, max_px: int = 2359296
+) -> Image.Image:
+    """Scale a crop so its area lands in [min_px, max_px], preserving aspect."""
+    width, height = image.size
+    pixels = width * height
+    if pixels <= 0:
+        return image
+    if pixels < min_px:
+        scale = math.sqrt(min_px / pixels)
+    elif pixels > max_px:
+        scale = math.sqrt(max_px / pixels)
+    else:
+        return image
+    return image.resize(
+        (max(1, round(width * scale)), max(1, round(height * scale))), Image.LANCZOS
+    )
+
+
+def crop_for_block(
+    bbox_xyxy: list,
+    page: Image.Image,
+    pad_px: int = 0,
+) -> Optional[Image.Image]:
+    """Crop one layout box from the page, or None if it collapses."""
+    width, height = page.size
+    x0, y0, x1, y1 = (round(v) for v in bbox_xyxy)
+    if pad_px:
+        x0, y0 = x0 - pad_px, y0 - pad_px
+        x1, y1 = x1 + pad_px, y1 + pad_px
+    x0, y0 = max(0, x0), max(0, y0)
+    x1, y1 = min(width, x1), min(height, y1)
+    if x1 <= x0 or y1 <= y0:
+        return None
+    return page.crop((x0, y0, x1, y1)).convert("RGB")
+
+
+install_auto_processor_patch("indic_ocr", Qwen3VLProcessor)
+
+
+def build_ocr_requests(
+    blocks,
+    page,
+    table_format: str = "html",
+    pad_px: int = 0,
+    min_px: int = 65536,
+    max_px: int = 2359296,
+) -> list:
+    """Pair each transcribable block with its (crop, prompt).
+
+    Returns ``[(block, crop, prompt)]`` in input order. Blocks that yield
+    no crop are absent -- the caller sets their text to "".
+    """
+    from .blocks import Block  # noqa: F401  (type reference only)
+
+    requests = []
+    for block in blocks:
+        if block.type in DROP_TYPES or not is_transcribed(block.label):
+            continue
+        crop = crop_for_block(block.bbox_xyxy, page, pad_px=pad_px)
+        if crop is None:
+            continue
+        requests.append(
+            (
+                block,
+                area_clamp(crop, min_px, max_px),
+                prompt_for(block.type, table_format),
+            )
+        )
+    return requests
+
+
+def transcribe_blocks(
+    model,
+    processor,
+    page,
+    blocks,
+    table_format: str = "html",
+    max_tokens: int = 2048,
+    temperature: float = 0.0,
+    use_tqdm: bool = True,
+    pad_px: int = 0,
+    min_px: int = 65536,
+    max_px: int = 2359296,
+) -> list:
+    """Transcribe layout blocks in place via the standard generate flow.
+
+    ``blocks`` carry ``label``/``type``/``bbox_xyxy`` (see ``blocks.Block``);
+    each transcribable block gets ``text``, skipped ones get ``""``.
+    Greedy decoding matches upstream's reproducible setting.
+    """
+    from mlx_vlm import generate as mlx_generate
+    from mlx_vlm.prompt_utils import apply_chat_template
+
+    requests = build_ocr_requests(
+        blocks, page, table_format, pad_px=pad_px, min_px=min_px, max_px=max_px
+    )
+    transcribed = {id(block) for block, _, _ in requests}
+
+    iterator = requests
+    if use_tqdm:
+        try:
+            from tqdm import tqdm
+
+            iterator = tqdm(requests, desc="OCR", unit="block")
+        except ImportError:
+            pass
+
+    for block, crop, prompt in iterator:
+        formatted = apply_chat_template(processor, model.config, prompt, num_images=1)
+        block.text = mlx_generate(
+            model,
+            processor,
+            formatted,
+            [crop],
+            max_tokens=max_tokens,
+            temperature=temperature,
+            verbose=False,
+        ).text.strip()
+
+    for block in blocks:
+        if id(block) not in transcribed:
+            block.text = ""
+    return blocks
+
+
+__all__ = [
+    "TEXT_PROMPT",
+    "EQUATION_PROMPT",
+    "TABLE_PROMPT_HTML",
+    "TABLE_PROMPT_MARKDOWN",
+    "LABEL_TO_TYPE",
+    "PP_DOCLAYOUT_LABEL_TO_TYPE",
+    "DROP_TYPES",
+    "KEPT_BLOCK_TYPES",
+    "CLASSES",
+    "MARGINALIA",
+    "HEAD_FOOT",
+    "OCR_SKIP_LABELS",
+    "is_transcribed",
+    "map_label",
+    "prompt_for",
+    "area_clamp",
+    "crop_for_block",
+    "build_ocr_requests",
+    "transcribe_blocks",
+]

--- a/mlx_vlm/models/indic_ocr/reconstruct.py
+++ b/mlx_vlm/models/indic_ocr/reconstruct.py
@@ -1,0 +1,87 @@
+"""Assemble transcribed blocks into the page's markdown.
+
+Ported from upstream ``idp_reconstruct.py`` (bodhan-ai/indic-ocr).
+stdlib-only -- no model, no PIL.
+"""
+
+import re
+
+from .processing_indic_ocr import DROP_TYPES
+
+_HYPHEN_BREAK = re.compile("(\\w)[-\\u2010-\\u2014\\u2212]\\n[ \\t]*(\\w)")
+_MATH_DELIMITERS = ("$", "\\[", "\\(")
+_MATH_SPAN = re.compile(r"\$\$(.+?)\$\$|(?<!\$)\$(?!\$)([^$\n]+?)\$(?!\$)", re.S)
+_NON_LATIN_RUN = re.compile(
+    "[\\u0600-\\u06ff\\u0900-\\u0d7f\\u1c50-\\u1c7f]"
+    "(?:[\\u0600-\\u06ff\\u0900-\\u0d7f\\u1c50-\\u1c7f \\u200c\\u200d]*"
+    "[\\u0600-\\u06ff\\u0900-\\u0d7f\\u1c50-\\u1c7f])?"
+)
+_TEXT_CMD = re.compile(r"\\text\{[^{}]*\}")
+
+
+def dehyphenate(text: str) -> str:
+    """Rejoin words split by a hyphen at a line break (to a fixpoint)."""
+    previous = None
+    while previous != text:
+        previous = text
+        text = _HYPHEN_BREAK.sub(r"\1\2", text)
+    return text
+
+
+def _repair_expression(tex: str, display: bool) -> str:
+    """Make one transcribed expression valid LaTeX.
+
+    Wraps Indic-script runs in ``\\text{}`` (math mode has no glyphs for
+    them) and turns bare newlines in display math into ``\\\\``.
+    """
+    protected: list = []
+
+    def stash(match: re.Match) -> str:
+        protected.append(match.group(0))
+        return f"\x00{len(protected) - 1}\x00"
+
+    tex = _TEXT_CMD.sub(stash, tex)
+    tex = _NON_LATIN_RUN.sub(lambda m: f"\\text{{{m.group(0)}}}", tex)
+    tex = re.sub(r"\x00(\d+)\x00", lambda m: protected[int(m.group(1))], tex)
+
+    if display:
+        tex = re.sub(r"\s*\n\s*", r" \\\\ ", tex.strip())
+    return tex
+
+
+def repair_math(text: str) -> str:
+    """Repair every math span in a markdown string."""
+
+    def fix(match: re.Match) -> str:
+        display = match.group(1) is not None
+        inner = _repair_expression(match.group(1) or match.group(2), display)
+        return f"$${inner}$$" if display else f"${inner}$"
+
+    return _MATH_SPAN.sub(fix, text)
+
+
+def reconstruct(blocks: list, repair: bool = True) -> str:
+    """Reading-ordered markdown. Blocks with no text contribute nothing but
+    are not removed -- they still appear in the JSON with text ""."""
+    kept = sorted(
+        (b for b in blocks if b.type not in DROP_TYPES), key=lambda b: b.order
+    )
+
+    parts = []
+    for block in kept:
+        text = (block.text or "").strip()
+        if not text:
+            continue
+        if (
+            block.type == "Equation"
+            and "$" not in text
+            and not text.startswith(_MATH_DELIMITERS)
+        ):
+            text = f"$${text}$$"
+        parts.append(text)
+
+    markdown = dehyphenate("\n\n".join(parts))
+    return repair_math(markdown) if repair else markdown
+
+
+__all__ = ["dehyphenate", "repair_math", "reconstruct"]

--- a/mlx_vlm/models/mxfp4_verifier.py
+++ b/mlx_vlm/models/mxfp4_verifier.py
@@ -1,0 +1,440 @@
+"""Optimized exact MXFP4 operations for speculative verification."""
+
+from functools import lru_cache
+from typing import Optional
+
+import mlx.core as mx
+import mlx.nn as nn
+
+# MLX's wide MXFP4 matmul uses a different reduction order from singleton
+# ``QuantizedLinear`` calls.  Keep that singleton QMV order for each output row
+# while reusing the loaded inputs across the short speculative time dimension.
+_TARGET_VERIFY_MXFP4_HEADER = r"""
+    using namespace metal;
+
+    constant constexpr int SIMD_SIZE = 32;
+    constant constexpr int VERIFY_RESULTS_PER_SIMDGROUP = 4;
+    constant constexpr int VERIFY_NUM_SIMDGROUPS = 2;
+    constant constexpr int VERIFY_ROWS_PER_THREADGROUP =
+        VERIFY_RESULTS_PER_SIMDGROUP * VERIFY_NUM_SIMDGROUPS;
+    constant constexpr int MXFP4_GROUP_SIZE = 32;
+    constant constexpr int MXFP4_PACK_FACTOR = 8;
+    constant constexpr int MXFP4_BYTES_PER_PACK = 4;
+    constant constexpr int MXFP4_PACKS_PER_THREAD = 2;
+    constant constexpr int MXFP4_VALUES_PER_THREAD =
+        MXFP4_PACK_FACTOR * MXFP4_PACKS_PER_THREAD;
+    constant constexpr int MXFP4_BLOCK_SIZE =
+        MXFP4_VALUES_PER_THREAD * SIMD_SIZE;
+    constant constexpr int MXFP4_SCALE_STEP_PER_THREAD =
+        MXFP4_GROUP_SIZE / MXFP4_VALUES_PER_THREAD;
+
+    inline float decode_mxfp4_value(uint code) {
+      half converted = as_type<half>(ushort((code & 7) << 9));
+      converted *= 16384.0;
+      float value = float(converted);
+      return code & 8 ? -value : value;
+    }
+
+    inline float decode_mxfp4_scale(uint8_t encoded) {
+      uint bits = encoded == 0 ? 0x00400000u : uint(encoded) << 23;
+      return as_type<float>(bits);
+    }
+
+    template <typename T>
+    inline void load_mxfp4_vector_exact(
+        const device T* x,
+        thread float* x_thread) {
+      for (int i = 0; i < MXFP4_VALUES_PER_THREAD; ++i) {
+        x_thread[i] = float(x[i]);
+      }
+    }
+
+    inline float mxfp4_qdot_exact(
+        const device uint8_t* w,
+        const thread float* x_thread,
+        float scale) {
+      float accum = 0.0f;
+      const device uint16_t* ws = (const device uint16_t*)w;
+      for (int i = 0; i < (MXFP4_VALUES_PER_THREAD / 4); ++i) {
+        uint packed = ws[i];
+        accum +=
+            (x_thread[4 * i] * decode_mxfp4_value(packed) +
+             x_thread[4 * i + 1] * decode_mxfp4_value(packed >> 4) +
+             x_thread[4 * i + 2] * decode_mxfp4_value(packed >> 8) +
+             x_thread[4 * i + 3] * decode_mxfp4_value(packed >> 12));
+      }
+      return scale * accum;
+    }
+"""
+
+
+_TARGET_VERIFY_MXFP4_QMV_SOURCE = r"""
+    uint n_tile = threadgroup_position_in_grid.y;
+    uint b_idx = threadgroup_position_in_grid.z;
+    uint simd_gid = simdgroup_index_in_threadgroup;
+    uint simd_lid = thread_index_in_simdgroup;
+
+    int out_row =
+        int(n_tile) * VERIFY_ROWS_PER_THREADGROUP +
+        int(simd_gid) * VERIFY_RESULTS_PER_SIMDGROUP;
+    int in_vec_size_w =
+        K_SIZE * MXFP4_BYTES_PER_PACK / MXFP4_PACK_FACTOR;
+    int in_vec_size_g = K_SIZE / MXFP4_GROUP_SIZE;
+
+    const device uint8_t* ws =
+        (const device uint8_t*)w + out_row * in_vec_size_w +
+        int(simd_lid) * MXFP4_PACKS_PER_THREAD * MXFP4_BYTES_PER_PACK;
+    const device uint8_t* sc =
+        scales + out_row * in_vec_size_g +
+        int(simd_lid) / MXFP4_SCALE_STEP_PER_THREAD;
+    const device T* xk =
+        x + int(b_idx) * VERIFY_T * K_SIZE +
+        int(simd_lid) * MXFP4_VALUES_PER_THREAD;
+
+    float result[VERIFY_T][VERIFY_RESULTS_PER_SIMDGROUP];
+    float x_thread[VERIFY_T][MXFP4_VALUES_PER_THREAD];
+    for (int t = 0; t < VERIFY_T; ++t) {
+      for (int row = 0; row < VERIFY_RESULTS_PER_SIMDGROUP; ++row) {
+        result[t][row] = 0.0f;
+      }
+    }
+
+    for (int k = 0; k < K_SIZE; k += MXFP4_BLOCK_SIZE) {
+      for (int t = 0; t < VERIFY_T; ++t) {
+        load_mxfp4_vector_exact<T>(xk + t * K_SIZE, x_thread[t]);
+      }
+
+      for (int row = 0; row < VERIFY_RESULTS_PER_SIMDGROUP; ++row) {
+        const device uint8_t* wl = ws + row * in_vec_size_w;
+        const device uint8_t* sl = sc + row * in_vec_size_g;
+        float scale = decode_mxfp4_scale(sl[0]);
+        for (int t = 0; t < VERIFY_T; ++t) {
+          result[t][row] += mxfp4_qdot_exact(wl, x_thread[t], scale);
+        }
+      }
+
+      ws +=
+          MXFP4_BLOCK_SIZE * MXFP4_BYTES_PER_PACK / MXFP4_PACK_FACTOR;
+      sc += MXFP4_BLOCK_SIZE / MXFP4_GROUP_SIZE;
+      xk += MXFP4_BLOCK_SIZE;
+    }
+
+    for (int row = 0; row < VERIFY_RESULTS_PER_SIMDGROUP; ++row) {
+      int n = out_row + row;
+      for (int t = 0; t < VERIFY_T; ++t) {
+        float reduced = simd_sum(result[t][row]);
+        if (simd_lid == 0) {
+          y[(int(b_idx) * VERIFY_T + t) * N_SIZE + n] = T(reduced);
+        }
+      }
+    }
+"""
+
+
+_TARGET_VERIFY_MXFP4_QARGMAX_SOURCE = _TARGET_VERIFY_MXFP4_QMV_SOURCE.replace(
+    """    for (int row = 0; row < VERIFY_RESULTS_PER_SIMDGROUP; ++row) {
+      int n = out_row + row;
+      for (int t = 0; t < VERIFY_T; ++t) {
+        float reduced = simd_sum(result[t][row]);
+        if (simd_lid == 0) {
+          y[(int(b_idx) * VERIFY_T + t) * N_SIZE + n] = T(reduced);
+        }
+      }
+    }""",
+    """    threadgroup float tile_best_values[VERIFY_T][VERIFY_NUM_SIMDGROUPS];
+    threadgroup int tile_best_indices[VERIFY_T][VERIFY_NUM_SIMDGROUPS];
+
+    for (int t = 0; t < VERIFY_T; ++t) {
+      float best_value = -3.4028234663852886e38f;
+      int best_index = 0;
+      for (int row = 0; row < VERIFY_RESULTS_PER_SIMDGROUP; ++row) {
+        int n = out_row + row;
+        float rounded = float(T(simd_sum(result[t][row])));
+        if (n < N_SIZE && rounded > best_value) {
+          best_value = rounded;
+          best_index = n;
+        }
+      }
+      if (simd_lid == 0) {
+        tile_best_values[t][simd_gid] = best_value;
+        tile_best_indices[t][simd_gid] = best_index;
+      }
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    if (simd_gid == 0 && simd_lid == 0) {
+      for (int t = 0; t < VERIFY_T; ++t) {
+        float best = tile_best_values[t][0];
+        int best_idx = tile_best_indices[t][0];
+        for (int i = 1; i < VERIFY_NUM_SIMDGROUPS; ++i) {
+          float candidate = tile_best_values[t][i];
+          int candidate_idx = tile_best_indices[t][i];
+          if (candidate > best) {
+            best = candidate;
+            best_idx = candidate_idx;
+          }
+        }
+        int offset =
+            (int(b_idx) * VERIFY_T + t) * NUM_TILES + int(n_tile);
+        tile_values[offset] = T(best);
+        tile_indices[offset] = best_idx;
+      }
+    }""",
+)
+
+_TARGET_VERIFY_MASKED_MXFP4_QARGMAX_SOURCE = _TARGET_VERIFY_MXFP4_QARGMAX_SOURCE.replace(
+    "if (n < N_SIZE && rounded > best_value) {",
+    """if (
+          n < N_SIZE &&
+          ((as_type<uint>(mask[
+                (int(b_idx) * VERIFY_T + t) * mask_shape[1] + (n >> 5)]) >>
+            (n & 31)) & 1u) != 0u &&
+          rounded > best_value) {""",
+)
+
+
+def _optimized_fused_mxfp4_qmv_source(n_sizes) -> str:
+    selections = []
+    offset = int(n_sizes[0])
+    for index, n_size in enumerate(n_sizes[1:], start=1):
+        selections.append(f"""    if (global_out >= {offset}) {{
+      local_out = global_out - {offset};
+      selected_w = (const device uint8_t*)w{index};
+      selected_scales = scales{index};
+    }}""")
+        offset += int(n_size)
+    selection = "\n".join(selections)
+    source = _TARGET_VERIFY_MXFP4_QMV_SOURCE.replace(
+        "    int in_vec_size_w =\n        K_SIZE * MXFP4_BYTES_PER_PACK / MXFP4_PACK_FACTOR;",
+        f"""    int global_out = out_row;
+    int local_out = global_out;
+    const device uint8_t* selected_w = (const device uint8_t*)w0;
+    const device uint8_t* selected_scales = scales0;
+{selection}
+    int in_vec_size_w =
+        K_SIZE * MXFP4_BYTES_PER_PACK / MXFP4_PACK_FACTOR;""",
+    )
+    return (
+        source.replace(
+            "(const device uint8_t*)w + out_row * in_vec_size_w",
+            "selected_w + local_out * in_vec_size_w",
+        )
+        .replace(
+            "scales + out_row * in_vec_size_g",
+            "selected_scales + local_out * in_vec_size_g",
+        )
+        .replace("int n = out_row + row;", "int n = global_out + row;")
+    )
+
+
+@lru_cache(maxsize=None)
+def _optimized_mxfp4_qmv_kernel(dtype, verify_t, k_size, n_size):
+    dtype_name = {mx.bfloat16: "bf16", mx.float16: "fp16"}.get(dtype, "unk")
+    return mx.fast.metal_kernel(
+        name=(
+            "quantized_verify_mxfp4_qmv_"
+            f"t{verify_t}_k{k_size}_n{n_size}_{dtype_name}"
+        ),
+        input_names=["x", "w", "scales"],
+        output_names=["y"],
+        header=_TARGET_VERIFY_MXFP4_HEADER,
+        source=_TARGET_VERIFY_MXFP4_QMV_SOURCE,
+    )
+
+
+@lru_cache(maxsize=None)
+def _optimized_mxfp4_qargmax_kernel(dtype, verify_t, k_size, n_size):
+    dtype_name = {mx.bfloat16: "bf16", mx.float16: "fp16"}.get(dtype, "unk")
+    return mx.fast.metal_kernel(
+        name=(
+            "quantized_verify_mxfp4_qargmax_"
+            f"t{verify_t}_k{k_size}_n{n_size}_{dtype_name}"
+        ),
+        input_names=["x", "w", "scales"],
+        output_names=["tile_values", "tile_indices"],
+        header=_TARGET_VERIFY_MXFP4_HEADER,
+        source=_TARGET_VERIFY_MXFP4_QARGMAX_SOURCE,
+    )
+
+
+@lru_cache(maxsize=None)
+def _optimized_masked_mxfp4_qargmax_kernel(dtype, verify_t, k_size, n_size):
+    dtype_name = {mx.bfloat16: "bf16", mx.float16: "fp16"}.get(dtype, "unk")
+    return mx.fast.metal_kernel(
+        name=(
+            "quantized_verify_masked_mxfp4_qargmax_"
+            f"t{verify_t}_k{k_size}_n{n_size}_{dtype_name}"
+        ),
+        input_names=["x", "w", "scales", "mask"],
+        output_names=["tile_values", "tile_indices"],
+        header=_TARGET_VERIFY_MXFP4_HEADER,
+        source=_TARGET_VERIFY_MASKED_MXFP4_QARGMAX_SOURCE,
+    )
+
+
+@lru_cache(maxsize=None)
+def _optimized_fused_mxfp4_qmv_kernel(dtype, verify_t, k_size, n_sizes):
+    dtype_name = {mx.bfloat16: "bf16", mx.float16: "fp16"}.get(dtype, "unk")
+    shape_name = "_".join(str(n) for n in n_sizes)
+    input_names = ["x"]
+    for index in range(len(n_sizes)):
+        input_names.extend([f"w{index}", f"scales{index}"])
+    return mx.fast.metal_kernel(
+        name=(
+            "quantized_verify_fused_mxfp4_qmv_"
+            f"t{verify_t}_k{k_size}_n{shape_name}_{dtype_name}"
+        ),
+        input_names=input_names,
+        output_names=["y"],
+        header=_TARGET_VERIFY_MXFP4_HEADER,
+        source=_optimized_fused_mxfp4_qmv_source(n_sizes),
+    )
+
+
+def supports_optimized_mxfp4_head(linear) -> bool:
+    if (
+        not isinstance(linear, nn.QuantizedLinear)
+        or linear.mode != "mxfp4"
+        or linear.bits != 4
+        or linear.group_size != 32
+        or linear.biases is not None
+    ):
+        return False
+
+    K = linear.weight.shape[1] * 32 // linear.bits
+    N = linear.weight.shape[0]
+    return K % 512 == 0 and N % 8 == 0
+
+
+def _can_optimized_mxfp4(linear, x: mx.array) -> bool:
+    return (
+        supports_optimized_mxfp4_head(linear)
+        and x.ndim == 3
+        and 1 <= x.shape[1] <= 4
+        and x.dtype in (mx.bfloat16, mx.float16)
+        and mx.metal.is_available()
+        and mx.default_device() == mx.gpu
+        and x.shape[-1] == linear.weight.shape[1] * 32 // linear.bits
+    )
+
+
+def optimized_mxfp4_linear(linear, x: mx.array) -> Optional[mx.array]:
+    if not _can_optimized_mxfp4(linear, x):
+        return None
+
+    B, T, K = x.shape
+    N = linear.weight.shape[0]
+    x = mx.contiguous(x)
+    kernel = _optimized_mxfp4_qmv_kernel(x.dtype, T, K, N)
+    out = kernel(
+        inputs=[x, linear.weight, linear.scales],
+        template=[
+            ("T", x.dtype),
+            ("VERIFY_T", int(T)),
+            ("K_SIZE", int(K)),
+            ("N_SIZE", int(N)),
+        ],
+        grid=(32, 2 * (N // 8), B),
+        threadgroup=(32, 2, 1),
+        output_shapes=[(B, T, N)],
+        output_dtypes=[x.dtype],
+    )[0]
+    if "bias" in linear:
+        out = out + linear["bias"]
+    return out
+
+
+def optimized_mxfp4_argmax(
+    linear, x: mx.array, token_mask: Optional[mx.array] = None
+) -> Optional[mx.array]:
+    if not _can_optimized_mxfp4(linear, x) or "bias" in linear:
+        return None
+
+    B, T, K = x.shape
+    N = linear.weight.shape[0]
+    num_tiles = N // 8
+    x = mx.contiguous(x)
+    kernel_factory = (
+        _optimized_masked_mxfp4_qargmax_kernel
+        if token_mask is not None
+        else _optimized_mxfp4_qargmax_kernel
+    )
+    kernel = kernel_factory(x.dtype, T, K, N)
+    inputs = [x, linear.weight, linear.scales]
+    if token_mask is not None:
+        if token_mask.ndim == 1:
+            token_mask = token_mask[None, :]
+        if (
+            token_mask.dtype != mx.int32
+            or token_mask.shape[0] != B * T
+            or token_mask.shape[1] < (N + 31) // 32
+        ):
+            raise ValueError(
+                "packed token mask must be int32 with one complete row per token"
+            )
+        inputs.append(token_mask)
+    tile_values, tile_indices = kernel(
+        inputs=inputs,
+        template=[
+            ("T", x.dtype),
+            ("VERIFY_T", int(T)),
+            ("K_SIZE", int(K)),
+            ("N_SIZE", int(N)),
+            ("NUM_TILES", int(num_tiles)),
+        ],
+        grid=(32, 2 * num_tiles, B),
+        threadgroup=(32, 2, 1),
+        output_shapes=[(B, T, num_tiles), (B, T, num_tiles)],
+        output_dtypes=[x.dtype, mx.int32],
+    )
+    best_tile = mx.argmax(tile_values, axis=-1)
+    return mx.take_along_axis(tile_indices, best_tile[..., None], axis=-1).squeeze(-1)
+
+
+def optimized_mxfp4_linears(linears, x: mx.array):
+    if (
+        not 2 <= len(linears) <= 4
+        or x.ndim != 3
+        or not 1 < x.shape[1] <= 4
+        or not all(
+            "bias" not in linear and _can_optimized_mxfp4(linear, x)
+            for linear in linears
+        )
+    ):
+        return None
+
+    B, T, K = x.shape
+    n_sizes = tuple(int(linear.weight.shape[0]) for linear in linears)
+    total_n = sum(n_sizes)
+    x = mx.contiguous(x)
+    kernel = _optimized_fused_mxfp4_qmv_kernel(x.dtype, T, K, n_sizes)
+    inputs = [x]
+    for linear in linears:
+        inputs.extend([linear.weight, linear.scales])
+    out = kernel(
+        inputs=inputs,
+        template=[
+            ("T", x.dtype),
+            ("VERIFY_T", int(T)),
+            ("K_SIZE", int(K)),
+            ("N_SIZE", int(total_n)),
+        ],
+        grid=(32, 2 * (total_n // 8), B),
+        threadgroup=(32, 2, 1),
+        output_shapes=[(B, T, total_n)],
+        output_dtypes=[x.dtype],
+    )[0]
+    split_indices = []
+    offset = 0
+    for n_size in n_sizes[:-1]:
+        offset += n_size
+        split_indices.append(offset)
+    return tuple(mx.split(out, split_indices, axis=-1))
+
+
+__all__ = [
+    "optimized_mxfp4_argmax",
+    "optimized_mxfp4_linear",
+    "optimized_mxfp4_linears",
+    "supports_optimized_mxfp4_head",
+]

--- a/mlx_vlm/models/quantized_verifier.py
+++ b/mlx_vlm/models/quantized_verifier.py
@@ -758,8 +758,16 @@ def _stable_nvfp4_argmax(
 
 
 def _target_verify_qlinear_header(
-    bits: int, group_size: int, results_per_simdgroup: int = 4
+    bits: int,
+    group_size: int,
+    results_per_simdgroup: int = 4,
+    *,
+    q3_shifted_fields: bool = False,
 ) -> str:
+    # Shifted Q3 extraction is faster but changes floating-point operation
+    # order. Use it only for argmax kernels, where exact token IDs are
+    # verified; projection kernels retain the unshifted form for byte-identical
+    # singleton outputs.
     return (
         r"""
     using namespace metal;
@@ -767,8 +775,11 @@ def _target_verify_qlinear_header(
     constant constexpr int SIMD_SIZE = 32;
     constant constexpr int BITS = __BITS__;
     constant constexpr int GS = __GS__;
-    constant constexpr int PACK_FACTOR = (BITS == 5 ? 8 : 32 / BITS);
-    constant constexpr int BYTES_PER_PACK = (BITS == 5 ? 5 : 32 / 8);
+    constant constexpr bool Q3_SHIFTED = __Q3_SHIFTED__;
+    constant constexpr int PACK_FACTOR =
+        ((BITS == 3 || BITS == 5) ? 8 : 32 / BITS);
+    constant constexpr int BYTES_PER_PACK =
+        ((BITS == 3 || BITS == 5) ? (BITS == 3 ? 3 : 5) : 32 / 8);
     constant constexpr int PACKS_PER_THREAD = 2;
     constant constexpr int VALUES_PER_THREAD = PACK_FACTOR * PACKS_PER_THREAD;
     constant constexpr int BLOCK_SIZE = VALUES_PER_THREAD * SIMD_SIZE;
@@ -780,7 +791,20 @@ def _target_verify_qlinear_header(
     template <typename T>
     inline float load_vector_exact(const device T* x, thread float* x_thread) {
       float sum = 0.0f;
-      if (BITS == 4) {
+      if (BITS == 3) {
+        for (int i = 0; i < VALUES_PER_THREAD; i += 8) {
+          sum += x[i] + x[i + 1] + x[i + 2] + x[i + 3] + x[i + 4] +
+              x[i + 5] + x[i + 6] + x[i + 7];
+          x_thread[i] = x[i];
+          x_thread[i + 1] = Q3_SHIFTED ? x[i + 1] : x[i + 1] / 8.0f;
+          x_thread[i + 2] = Q3_SHIFTED ? x[i + 2] : x[i + 2] / 64.0f;
+          x_thread[i + 3] = Q3_SHIFTED ? x[i + 3] : x[i + 3] / 2.0f;
+          x_thread[i + 4] = Q3_SHIFTED ? x[i + 4] : x[i + 4] / 16.0f;
+          x_thread[i + 5] = Q3_SHIFTED ? x[i + 5] : x[i + 5] / 128.0f;
+          x_thread[i + 6] = Q3_SHIFTED ? x[i + 6] : x[i + 6] / 4.0f;
+          x_thread[i + 7] = Q3_SHIFTED ? x[i + 7] : x[i + 7] / 32.0f;
+        }
+      } else if (BITS == 4) {
         for (int i = 0; i < VALUES_PER_THREAD; i += 4) {
           sum += x[i] + x[i + 1] + x[i + 2] + x[i + 3];
           x_thread[i] = x[i];
@@ -817,7 +841,31 @@ def _target_verify_qlinear_header(
         float bias,
         float sum) {
       float accum = 0.0f;
-      if (BITS == 4) {
+      if (BITS == 3) {
+        for (int i = 0; i < (VALUES_PER_THREAD / 8); i++) {
+          const thread float* xt = x_thread + 8 * i;
+          const device uint8_t* wb = w + 3 * i;
+          accum += (wb[0] & 0x07) * xt[0];
+          accum +=
+              (Q3_SHIFTED ? ((wb[0] >> 3) & 0x07) : (wb[0] & 0x38)) * xt[1];
+          accum +=
+              (Q3_SHIFTED ? (wb[0] >> 6) : (wb[0] & 0xc0)) * xt[2];
+          accum +=
+              (wb[1] & 0x01) * (xt[2] * (Q3_SHIFTED ? 4.0f : 256.0f));
+          accum +=
+              (Q3_SHIFTED ? ((wb[1] >> 1) & 0x07) : (wb[1] & 0x0e)) * xt[3];
+          accum +=
+              (Q3_SHIFTED ? ((wb[1] >> 4) & 0x07) : (wb[1] & 0x70)) * xt[4];
+          accum +=
+              (Q3_SHIFTED ? (wb[1] >> 7) : (wb[1] & 0x80)) * xt[5];
+          accum +=
+              (wb[2] & 0x03) * (xt[5] * (Q3_SHIFTED ? 2.0f : 256.0f));
+          accum +=
+              (Q3_SHIFTED ? ((wb[2] >> 2) & 0x07) : (wb[2] & 0x1c)) * xt[6];
+          accum +=
+              (Q3_SHIFTED ? (wb[2] >> 5) : (wb[2] & 0xe0)) * xt[7];
+        }
+      } else if (BITS == 4) {
         const device uint16_t* ws = (const device uint16_t*)w;
         for (int i = 0; i < (VALUES_PER_THREAD / 4); i++) {
           uint packed = ws[i];
@@ -860,7 +908,36 @@ def _target_verify_qlinear_header(
         float bias,
         float sum) {
       float accum = 0.0f;
-      if (BITS == 4) {
+      if (BITS == 3) {
+        const thread uint8_t* wb = (const thread uint8_t*)ws;
+        for (int i = 0; i < (VALUES_PER_THREAD / 8); i++) {
+          const thread float* xt = x_thread + 8 * i;
+          const thread uint8_t* packed = wb + 3 * i;
+          accum += (packed[0] & 0x07) * xt[0];
+          accum +=
+              (Q3_SHIFTED ? ((packed[0] >> 3) & 0x07) : (packed[0] & 0x38)) *
+              xt[1];
+          accum +=
+              (Q3_SHIFTED ? (packed[0] >> 6) : (packed[0] & 0xc0)) * xt[2];
+          accum +=
+              (packed[1] & 0x01) * (xt[2] * (Q3_SHIFTED ? 4.0f : 256.0f));
+          accum +=
+              (Q3_SHIFTED ? ((packed[1] >> 1) & 0x07) : (packed[1] & 0x0e)) *
+              xt[3];
+          accum +=
+              (Q3_SHIFTED ? ((packed[1] >> 4) & 0x07) : (packed[1] & 0x70)) *
+              xt[4];
+          accum +=
+              (Q3_SHIFTED ? (packed[1] >> 7) : (packed[1] & 0x80)) * xt[5];
+          accum +=
+              (packed[2] & 0x03) * (xt[5] * (Q3_SHIFTED ? 2.0f : 256.0f));
+          accum +=
+              (Q3_SHIFTED ? ((packed[2] >> 2) & 0x07) : (packed[2] & 0x1c)) *
+              xt[6];
+          accum +=
+              (Q3_SHIFTED ? (packed[2] >> 5) : (packed[2] & 0xe0)) * xt[7];
+        }
+      } else if (BITS == 4) {
         for (int i = 0; i < (VALUES_PER_THREAD / 4); i++) {
           uint packed = ws[i];
           accum +=
@@ -876,6 +953,7 @@ def _target_verify_qlinear_header(
 """.replace("__BITS__", str(bits))
         .replace("__GS__", str(group_size))
         .replace("__RESULTS_PER_SIMDGROUP__", str(results_per_simdgroup))
+        .replace("__Q3_SHIFTED__", "true" if q3_shifted_fields else "false")
     )
 
 
@@ -1451,6 +1529,12 @@ def _target_verify_fused_qmv_source(source: str, n_sizes) -> str:
     )
 
 
+def _projection_results_per_simdgroup(bits, verify_t):
+    # Q3's unshifted projection arithmetic benefits from a smaller output
+    # tile at T=3/4. Keep the singleton reduction order within each output.
+    return 2 if bits == 3 and verify_t in (3, 4) else 4
+
+
 @lru_cache(maxsize=None)
 def _target_verify_qmv_kernel(bits, group_size, dtype, verify_t, k_size, n_size):
     dtype_name = {mx.bfloat16: "bf16", mx.float16: "fp16"}.get(dtype, "unk")
@@ -1461,7 +1545,9 @@ def _target_verify_qmv_kernel(bits, group_size, dtype, verify_t, k_size, n_size)
         ),
         input_names=["x", "w", "scales", "biases"],
         output_names=["y"],
-        header=_target_verify_qlinear_header(bits, group_size),
+        header=_target_verify_qlinear_header(
+            bits, group_size, _projection_results_per_simdgroup(bits, verify_t)
+        ),
         source=_TARGET_VERIFY_QMV_SOURCE,
     )
 
@@ -1476,7 +1562,9 @@ def _target_verify_qargmax_kernel(bits, group_size, dtype, verify_t, k_size, n_s
         ),
         input_names=["x", "w", "scales", "biases"],
         output_names=["tile_values", "tile_indices"],
-        header=_target_verify_qlinear_header(bits, group_size),
+        header=_target_verify_qlinear_header(
+            bits, group_size, q3_shifted_fields=bits == 3
+        ),
         source=_TARGET_VERIFY_QARGMAX_SOURCE,
     )
 
@@ -1493,7 +1581,9 @@ def _target_verify_masked_qargmax_kernel(
         ),
         input_names=["x", "w", "scales", "biases", "mask"],
         output_names=["tile_values", "tile_indices"],
-        header=_target_verify_qlinear_header(bits, group_size),
+        header=_target_verify_qlinear_header(
+            bits, group_size, q3_shifted_fields=bits == 3
+        ),
         source=_TARGET_VERIFY_MASKED_QARGMAX_SOURCE,
     )
 
@@ -1614,7 +1704,9 @@ def _target_verify_fused_qmv_kernel(bits, group_size, dtype, verify_t, k_size, n
         ),
         input_names=input_names,
         output_names=["y"],
-        header=_target_verify_qlinear_header(bits, group_size),
+        header=_target_verify_qlinear_header(
+            bits, group_size, _projection_results_per_simdgroup(bits, verify_t)
+        ),
         source=_target_verify_fused_qmv_source(_TARGET_VERIFY_QMV_SOURCE, n_sizes),
     )
 
@@ -1646,7 +1738,7 @@ def supports_optimized_affine_head(linear) -> bool:
     """Return whether the exact affine verifier kernel supports ``linear``."""
     if (
         not isinstance(linear, nn.QuantizedLinear)
-        or linear.bits not in (4, 5, 8)
+        or linear.bits not in (3, 4, 5, 8)
         or linear.mode != "affine"
         or linear.biases is None
         or linear.scales.dtype not in (mx.bfloat16, mx.float16)
@@ -1685,7 +1777,9 @@ def optimized_affine_linear(linear, x: mx.array) -> Optional[mx.array]:
     x = mx.contiguous(x)
     streamed = linear.bits == 4 and 6 <= T <= 8
     token_tiled = linear.bits == 4 and T >= 6 and not streamed
-    results_per_simdgroup = 1 if streamed else 4
+    results_per_simdgroup = (
+        1 if streamed else _projection_results_per_simdgroup(linear.bits, T)
+    )
     if streamed:
         kernel_factory = _target_verify_qmv_streamed_kernel
     elif token_tiled:
@@ -1793,7 +1887,7 @@ def optimized_affine_linears(linears, x: mx.array):
         not 2 <= len(linears) <= 4
         or x.ndim != 3
         or not 1 < x.shape[1] <= 8
-        or bits not in (4, 5, 8)
+        or bits not in (3, 4, 5, 8)
         or not all(
             isinstance(linear, nn.QuantizedLinear)
             and linear.bits == bits
@@ -1820,6 +1914,9 @@ def optimized_affine_linears(linears, x: mx.array):
     inputs = [x]
     for linear in linears:
         inputs.extend([linear.weight, linear.scales, linear.biases])
+    rows_per_threadgroup = (
+        2 if streamed else 2 * _projection_results_per_simdgroup(bits, T)
+    )
     out = kernel(
         inputs=inputs,
         template=[
@@ -1828,7 +1925,7 @@ def optimized_affine_linears(linears, x: mx.array):
             ("K_SIZE", int(K)),
             ("N_SIZE", int(total_n)),
         ],
-        grid=(32, 2 * (total_n // (2 if streamed else 8)), B),
+        grid=(32, 2 * (total_n // rows_per_threadgroup), B),
         threadgroup=(32, 2, 1),
         output_shapes=[(B, T, total_n)],
         output_dtypes=[x.dtype],

--- a/mlx_vlm/moe_offload.py
+++ b/mlx_vlm/moe_offload.py
@@ -32,10 +32,11 @@ PEREXPERT_RE = re.compile(
     r"^.*\.layers\.(?P<layer>\d+)\..*?experts\.(?P<j>\d+)\." + _PROJ
 )
 STACKED_RE = re.compile(
-    r"^.*\.layers\.(?P<layer>\d+)\..*?(?:experts|switch_mlp)\." + _PROJ
+    r"^.*\.layers\.(?P<layer>\d+)\..*?(?:experts|switch_mlp)(?:\.switch_glu)?\." + _PROJ
 )
 STACKED_FUSED_RE = re.compile(
-    r"^.*\.layers\.(?P<layer>\d+)\..*?(?:experts|switch_mlp)\." + _FUSED_PROJ
+    r"^.*\.layers\.(?P<layer>\d+)\..*?(?:experts|switch_mlp)(?:\.switch_glu)?\."
+    + _FUSED_PROJ
 )
 
 
@@ -393,6 +394,13 @@ def repack(build: str, out: str, resident_shard_gb: float = 5.0) -> None:
         )
 
     import shutil
+
+    if not written_layers:
+        raise ValueError(
+            f"moe_offload.repack: {build!r} produced no MoE expert tensors "
+            "(written_layers is empty). Check STACKED_RE/STACKED_FUSED_RE "
+            "against this model's actual expert tensor naming."
+        )
 
     for fn in os.listdir(build):  # passthrough config/tokenizer/processor/code
         src = os.path.join(build, fn)

--- a/mlx_vlm/speculative/ops/linear.py
+++ b/mlx_vlm/speculative/ops/linear.py
@@ -7,6 +7,15 @@ from ...models.exact_speculative_verify import exact_speculative_verify_dense_av
 from ...models.exact_speculative_verify import (
     exact_speculative_verify_weight as _target_verify_weight,
 )
+from ...models.mxfp4_verifier import (
+    optimized_mxfp4_argmax as _target_verify_optimized_mxfp4_argmax,
+)
+from ...models.mxfp4_verifier import (
+    optimized_mxfp4_linear as _target_verify_optimized_mxfp4_linear,
+)
+from ...models.mxfp4_verifier import (
+    optimized_mxfp4_linears as _target_verify_optimized_mxfp4_linears,
+)
 from ...models.quantized_verifier import (
     optimized_affine_argmax as _target_verify_optimized_affine_argmax,
 )
@@ -14,7 +23,7 @@ from ...models.quantized_verifier import (
     optimized_affine_linear as _target_verify_optimized_affine_linear,
 )
 from ...models.quantized_verifier import (
-    optimized_affine_linears as _target_verify_quantized_linears,
+    optimized_affine_linears as _target_verify_optimized_affine_linears,
 )
 from ...models.quantized_verifier import (
     optimized_nvfp4_argmax as _target_verify_optimized_nvfp4_argmax,
@@ -38,6 +47,9 @@ def _use_target_verify_dense(linear, x: mx.array) -> bool:
 
 
 def _target_verify_quantized_linear(linear, x: mx.array) -> Optional[mx.array]:
+    output = _target_verify_optimized_mxfp4_linear(linear, x)
+    if output is not None:
+        return output
     output = _target_verify_optimized_affine_linear(linear, x)
     if output is not None:
         return output
@@ -47,6 +59,9 @@ def _target_verify_quantized_linear(linear, x: mx.array) -> Optional[mx.array]:
 def _target_verify_quantized_argmax(
     linear, x: mx.array, token_mask: Optional[mx.array] = None
 ) -> Optional[mx.array]:
+    output = _target_verify_optimized_mxfp4_argmax(linear, x, token_mask=token_mask)
+    if output is not None:
+        return output
     output = _target_verify_optimized_affine_argmax(linear, x, token_mask=token_mask)
     if output is not None:
         return output
@@ -111,7 +126,10 @@ def _target_verify_linears(linears, x: mx.array):
             return out
         return tuple(linear(x) for linear in linears)
 
-    out = _target_verify_quantized_linears(linears, x)
+    out = _target_verify_optimized_mxfp4_linears(linears, x)
+    if out is not None:
+        return out
+    out = _target_verify_optimized_affine_linears(linears, x)
     if out is not None:
         return out
     return tuple(_target_verify_linear(linear, x) for linear in linears)

--- a/mlx_vlm/tests/test_indic_ocr.py
+++ b/mlx_vlm/tests/test_indic_ocr.py
@@ -1,0 +1,1042 @@
+import unittest
+
+
+class TestIndicOCR(unittest.TestCase):
+    @staticmethod
+    def ocr_config():
+        return {
+            "model_type": "indic_ocr",
+            "architectures": ["Qwen3_5ForConditionalGeneration"],
+            "image_token_id": 262155,
+            "video_token_id": 262156,
+            "vision_start_token_id": 262153,
+            "vision_end_token_id": 262154,
+            "tie_word_embeddings": True,
+            "text_config": {
+                "model_type": "qwen3_5_text",
+                "hidden_size": 16,
+                "intermediate_size": 32,
+                "linear_num_value_heads": 2,
+                "linear_num_key_heads": 2,
+                "linear_key_head_dim": 8,
+                "linear_value_head_dim": 8,
+                "linear_conv_kernel_dim": 3,
+                "num_hidden_layers": 1,
+                "num_attention_heads": 2,
+                "rms_norm_eps": 1e-5,
+                "vocab_size": 64,
+                "num_key_value_heads": 2,
+                "max_position_embeddings": 128,
+            },
+            "vision_config": {
+                "model_type": "qwen3_5_vision",
+                "patch_size": 2,
+                "depth": 1,
+                "hidden_size": 16,
+                "intermediate_size": 32,
+                "out_hidden_size": 16,
+                "num_heads": 2,
+                "num_position_embeddings": 16,
+            },
+        }
+
+    def test_indic_ocr_config_routes_and_carries_indic_tokens(self):
+        from mlx_vlm.models import indic_ocr
+        from mlx_vlm.utils import get_model_and_args
+
+        raw = self.ocr_config()
+
+        model_class, _ = get_model_and_args(config=dict(raw))
+        self.assertIs(model_class, indic_ocr)
+
+        config = indic_ocr.ModelConfig.from_dict(dict(raw))
+        self.assertEqual(config.model_type, "indic_ocr")
+        self.assertEqual(config.image_token_id, 262155)
+        self.assertEqual(config.video_token_id, 262156)
+        self.assertEqual(config.vision_start_token_id, 262153)
+        self.assertEqual(config.vision_end_token_id, 262154)
+        self.assertEqual(config.image_token_index, 262155)
+
+    def test_ocr_stage_uses_existing_image_prompt_format(self):
+        from mlx_vlm.models.indic_ocr import Model, ModelConfig
+        from mlx_vlm.prompt_utils import apply_chat_template
+
+        config = ModelConfig.from_dict(self.ocr_config())
+        model = Model(config)
+        self.assertEqual(config.model_type, "indic_ocr")
+        self.assertEqual(model.config.model_type, "qwen3_5")
+        messages = apply_chat_template(
+            object(), model.config, "Read this page", num_images=1, return_messages=True
+        )
+        content = messages[0]["content"]
+        self.assertEqual(content[0], {"type": "image"})
+        self.assertEqual(content[1]["type"], "text")
+        self.assertEqual(content[1]["text"], "Read this page")
+
+    def test_indic_ocr_wrapper_repo_raises_helpful_error(self):
+        from mlx_vlm.models import indic_ocr
+
+        with self.assertRaises(ValueError) as ctx:
+            indic_ocr.ModelConfig.from_dict(
+                {
+                    "model_type": "indic_ocr",
+                    "pipeline": "two-stage",
+                    "stages": {"layout": {}, "ocr": {}},
+                }
+            )
+        self.assertIn("weights/ocr", str(ctx.exception))
+
+    def test_combined_checkpoint_loads_and_quantizes_submodules(self):
+        import json
+        import tempfile
+        from pathlib import Path
+        from unittest.mock import patch
+
+        import mlx.core as mx
+        import mlx.nn as nn
+        from mlx.utils import tree_flatten
+
+        from mlx_vlm.models.indic_ocr import (
+            IndicOCRParser,
+            LayoutOptions,
+            Model,
+            ModelConfig,
+        )
+        from mlx_vlm.models.pp_doclayout_v3 import Model as LayoutModel
+        from mlx_vlm.utils import load_model
+
+        class SmallLayout(nn.Module):
+            sanitize = staticmethod(LayoutModel.sanitize)
+
+            def __init__(self, config):
+                super().__init__()
+                self.enc_score_head = nn.Linear(32, config.num_labels)
+
+        config = {
+            "model_type": "indic_ocr",
+            "layout_config": {"model_type": "pp_doclayout_v3", "num_labels": 2},
+            "ocr_config": self.ocr_config(),
+        }
+        with patch("mlx_vlm.models.pp_doclayout_v3.Model", SmallLayout):
+            for quantized in (False, True):
+                with (
+                    self.subTest(quantized=quantized),
+                    tempfile.TemporaryDirectory() as tmp,
+                ):
+                    root = Path(tmp) / "source"
+                    root.mkdir()
+                    model = Model(ModelConfig.from_dict(config))
+                    self.assertIsInstance(model, IndicOCRParser)
+                    self.assertIsInstance(model, nn.Module)
+                    saved_config = dict(config)
+                    if quantized:
+                        nn.quantize(
+                            model,
+                            group_size=32,
+                            bits=4,
+                            class_predicate=lambda p, m: (
+                                {
+                                    "group_size": 32,
+                                    "bits": 8 if p.startswith("layout.") else 4,
+                                }
+                                if hasattr(m, "to_quantized")
+                                and m.weight.shape[-1] % 32 == 0
+                                else False
+                            ),
+                        )
+                        saved_config["quantization"] = {
+                            "group_size": 32,
+                            "bits": 4,
+                            "layout.model.enc_score_head": {
+                                "group_size": 32,
+                                "bits": 8,
+                            },
+                        }
+                    weights = dict(tree_flatten(model.parameters()))
+                    self.assertTrue(any(k.startswith("layout.model.") for k in weights))
+                    self.assertTrue(any(k.startswith("ocr.model.") for k in weights))
+                    # Exercise checkpoint prefixes through the real generic loader.
+                    checkpoint = {
+                        k.replace("layout.model.", "layout_model.", 1).replace(
+                            "ocr.model.", "ocr_model.", 1
+                        ): v
+                        for k, v in weights.items()
+                    }
+                    (root / "config.json").write_text(json.dumps(saved_config))
+                    mx.save_safetensors(str(root / "model.safetensors"), checkpoint)
+                    loaded = load_model(root)
+                    actual = dict(tree_flatten(loaded.parameters()))
+                    self.assertEqual(set(weights), set(actual))
+                    for key in weights:
+                        self.assertTrue(
+                            mx.array_equal(weights[key], actual[key]).item(), key
+                        )
+                    self.assertFalse(loaded.layout.model.training)
+                    self.assertFalse(loaded.ocr.model.training)
+                    # Converted paths must be a fixpoint, including quantized tensors.
+                    sanitized = loaded.sanitize(actual)
+                    self.assertEqual(set(actual), set(sanitized))
+                    for key in actual:
+                        self.assertTrue(
+                            mx.array_equal(actual[key], sanitized[key]).item(), key
+                        )
+                    mx.save_safetensors(str(root / "model.safetensors"), actual)
+                    processor = object()
+                    with patch(
+                        "mlx_vlm.utils.load_processor", return_value=processor
+                    ) as load_processor:
+                        with IndicOCRParser.from_pretrained(
+                            str(root), lazy=True
+                        ) as ready:
+                            self.assertIs(ready.ocr.processor, processor)
+                            self.assertIsInstance(ready.ocr.model, Model)
+                        self.assertIsNone(ready.ocr.processor)
+                        load_processor.assert_called_once_with(root, eos_token_ids=None)
+                    # Exercise the published shard index and embedded stage configs
+                    # through the unmodified standard loader.
+                    stages, weight_map, weight_mapping = {}, {}, {}
+                    for name in ("layout", "ocr"):
+                        stage_path = root / name
+                        stage_path.mkdir()
+                        stage_config = dict(config[f"{name}_config"])
+                        if quantized:
+                            stage_config["quantization"] = {
+                                "group_size": 32,
+                                "bits": 8 if name == "layout" else 4,
+                            }
+                        (stage_path / "config.json").write_text(
+                            json.dumps(stage_config)
+                        )
+                        prefix = f"{name}.model."
+                        stage_weights = {
+                            k[len(prefix) :]: v
+                            for k, v in actual.items()
+                            if k.startswith(prefix)
+                        }
+                        mx.save_safetensors(
+                            str(stage_path / "stage.safetensors"), stage_weights
+                        )
+                        weight_map.update(
+                            (key, f"{name}/stage.safetensors") for key in stage_weights
+                        )
+                        weight_mapping.update((key, name) for key in stage_weights)
+                        stages[name] = {"config": f"{name}/config.json"}
+                        if name == "layout":
+                            stages[name]["weights"] = f"{name}/stage.safetensors"
+                    (root / "model.safetensors").unlink()
+                    published_config = dict(
+                        saved_config,
+                        stages=stages,
+                        weight_mapping=weight_mapping,
+                        ocr_model_path="ocr",
+                    )
+                    (root / "config.json").write_text(json.dumps(published_config))
+                    index_path = root / "model.safetensors.index.json"
+                    index_path.write_text(json.dumps({"weight_map": weight_map}))
+                    options = LayoutOptions(conf=0.7)
+                    bundled = load_model(root, lazy=True)
+                    bundled.layout.options = options
+                    self.assertIs(bundled.layout.options, options)
+                    bundled_weights = dict(tree_flatten(bundled.parameters()))
+                    self.assertEqual(set(actual), set(bundled_weights))
+                    for key in actual:
+                        self.assertTrue(
+                            mx.array_equal(actual[key], bundled_weights[key]).item(),
+                            key,
+                        )
+                    page = object()
+                    with (
+                        patch(
+                            "mlx_vlm.utils.load_processor", return_value=processor
+                        ) as load_processor,
+                        patch.object(IndicOCRParser, "detect", return_value=page),
+                        patch.object(
+                            type(bundled.ocr), "run", return_value=page
+                        ) as run,
+                    ):
+                        self.assertIs(bundled.parse("page.png"), page)
+                        self.assertIs(bundled.parse("page.png"), page)
+                        load_processor.assert_called_once_with(
+                            root / "ocr", eos_token_ids=None
+                        )
+                        run.assert_called_with("page.png", page)
+                    override = root / "override"
+                    override.mkdir()
+                    (override / "config.json").write_text(
+                        json.dumps(
+                            {
+                                "model_type": "pp_doclayout_v3",
+                                "num_labels": 3,
+                            }
+                        )
+                    )
+                    override_weights = {
+                        "enc_score_head.weight": mx.ones((3, 32)),
+                        "enc_score_head.bias": mx.zeros((3,)),
+                    }
+                    mx.save_safetensors(
+                        str(override / "model.safetensors"), override_weights
+                    )
+                    with load_model(root, lazy=True) as overridden:
+                        overridden.layout.model = load_model(override, lazy=True)
+                        self.assertTrue(
+                            mx.array_equal(
+                                overridden.layout.model.enc_score_head.weight,
+                                override_weights["enc_score_head.weight"],
+                            ).item()
+                        )
+                        self.assertEqual(
+                            set(dict(tree_flatten(overridden.ocr.model.parameters()))),
+                            set(dict(tree_flatten(bundled.ocr.model.parameters()))),
+                        )
+                    index_path.unlink()
+                    (root / "config.json").write_text(json.dumps(saved_config))
+                    checkpoint.pop(next(iter(checkpoint)))
+                    mx.save_safetensors(str(root / "model.safetensors"), checkpoint)
+                    with self.assertRaises(ValueError):
+                        load_model(root)
+
+    def test_parser_sanitize_converts_raw_stage_weights(self):
+        import mlx.core as mx
+        import mlx.nn as nn
+
+        from mlx_vlm.models.indic_ocr import IndicOCRParser, Model, ModelConfig
+        from mlx_vlm.models.pp_doclayout_v3 import Model as LayoutModel
+
+        class Layout(nn.Module):
+            sanitize = staticmethod(LayoutModel.sanitize)
+
+        parser = IndicOCRParser(
+            Layout(), Model(ModelConfig.from_dict(self.ocr_config())), None
+        )
+        conv = mx.arange(32 * 3 * 3 * 3).reshape(32, 3, 3, 3)
+        embedding = mx.ones((64, 16))
+        raw = {
+            "layout_model.model.backbone.model.embedder.stem1.convolution.weight": conv,
+            "layout_model.model.denoising_class_embed.weight": mx.ones((2, 16)),
+            "ocr_model.model.language_model.embed_tokens.weight": embedding,
+            "unexpected.weight": mx.ones((1,)),
+        }
+        sanitized = parser.sanitize(raw)
+        self.assertEqual(
+            set(sanitized),
+            {
+                "layout.model.backbone.embedder.stem1.conv.weight",
+                "ocr.model.language_model.model.embed_tokens.weight",
+                "unexpected.weight",
+            },
+        )
+        self.assertTrue(
+            mx.array_equal(
+                sanitized["layout.model.backbone.embedder.stem1.conv.weight"],
+                conv.transpose(0, 2, 3, 1),
+            ).item()
+        )
+        self.assertEqual(len(raw), 4)
+        duplicate = dict(raw)
+        duplicate["ocr.model.model.language_model.embed_tokens.weight"] = embedding
+        with self.assertRaisesRegex(ValueError, "Duplicate ocr weight"):
+            parser.sanitize(duplicate)
+
+    def test_indic_ocr_prompts_and_crops(self):
+        from PIL import Image
+
+        from mlx_vlm.models.indic_ocr.processing_indic_ocr import (
+            DROP_TYPES,
+            crop_for_block,
+            map_label,
+            prompt_for,
+        )
+
+        self.assertEqual(map_label("Paragraph"), "Text")
+        self.assertEqual(map_label("equation"), "Equation")
+        self.assertEqual(map_label("Table"), "Table")
+        self.assertEqual(map_label("page-number"), "PageNumber")
+        self.assertIn("Figure", DROP_TYPES)
+        self.assertIn("LaTeX", prompt_for("Equation"))
+        self.assertIn("HTML", prompt_for("Table"))
+        self.assertIn("markdown", prompt_for("Table", "markdown").lower())
+        self.assertIn("LaTeX", prompt_for("Text"))
+
+        page = Image.new("RGB", (400, 400), "white")
+        crop = crop_for_block([50.0, 50.0, 350.0, 200.0], page)
+        self.assertIsNotNone(crop)
+        self.assertLessEqual(crop.size[0] * crop.size[1], 2359296)
+        tiny = crop_for_block([10.0, 10.0, 12.0, 12.0], page)
+        self.assertEqual(tiny.size, (2, 2))
+        self.assertIsNone(crop_for_block([10.0, 10.0, 10.0, 12.0], page))
+        with self.assertRaises(ValueError):
+            prompt_for("Table", "csv")
+
+    def test_indic_ocr_reconstruct(self):
+        from mlx_vlm.models.indic_ocr.blocks import Block
+        from mlx_vlm.models.indic_ocr.reconstruct import (
+            dehyphenate,
+            reconstruct,
+            repair_math,
+        )
+
+        self.assertEqual(dehyphenate("hyphen-\nated"), "hyphenated")
+
+        # Equation without delimiters gets wrapped; delimited text is untouched
+        blocks = [
+            Block(
+                order=1,
+                label="Equation",
+                type="Equation",
+                bbox_xyxy=[0, 0, 10, 10],
+                conf=1.0,
+                text="\\frac{a}{b}",
+            ),
+            Block(
+                order=0,
+                label="Paragraph",
+                type="Text",
+                bbox_xyxy=[0, 0, 10, 10],
+                conf=1.0,
+                text="Hello",
+            ),
+            Block(
+                order=2,
+                label="Image",
+                type="Picture",
+                bbox_xyxy=[0, 0, 10, 10],
+                conf=1.0,
+                text="should not appear",
+            ),
+        ]
+        md = reconstruct(blocks)
+        self.assertTrue(md.startswith("Hello"))
+        self.assertIn("$$\\frac{a}{b}$$", md)
+        self.assertNotIn("should not appear", md)
+
+        # Indic script inside math gets \text{}; prose outside $ is untouched
+        self.assertIn("\\text{", repair_math("$$x = 9$$".replace("x", "প্রোটন")))
+        self.assertEqual(repair_math("plain prose"), "plain prose")
+
+    def test_indic_ocr_block_records(self):
+        from mlx_vlm.models.indic_ocr.blocks import Block, LayoutSchemaError
+
+        rec = {"order": 0, "label": "Paragraph", "bbox_xyxy": [1, 2, 3, 4]}
+        block = Block.from_record(rec)
+        self.assertEqual(block.type, "Text")
+        self.assertEqual(block.conf, 1.0)
+        as_rec = block.as_record()
+        self.assertEqual(
+            list(as_rec.keys()),
+            ["order", "label", "type", "bbox_xyxy", "conf"],
+        )
+
+        # Foreign taxonomy with explicit type passes; bad type raises
+        foreign = {
+            "order": 1,
+            "label": "para",
+            "type": "Text",
+            "bbox_xyxy": [1, 2, 3, 4],
+        }
+        self.assertEqual(Block.from_record(foreign).type, "Text")
+        with self.assertRaises(LayoutSchemaError):
+            Block.from_record(
+                {
+                    "order": 2,
+                    "label": "para",
+                    "type": "Tabel",
+                    "bbox_xyxy": [1, 2, 3, 4],
+                }
+            )
+        self.assertTrue(Block.problems({"label": "Paragraph"}))
+
+    def test_indic_ocr_clean_layout(self):
+        from mlx_vlm.models.indic_ocr.blocks import (
+            Block,
+            clean_layout,
+            resolve_nested_equations,
+        )
+
+        def b(order, label, box, type=None):
+            from mlx_vlm.models.indic_ocr.processing_indic_ocr import map_label
+
+            return Block(
+                order=order,
+                label=label,
+                type=type or map_label(label),
+                bbox_xyxy=list(box),
+                conf=0.9,
+            )
+
+        # Nested duplicate of the same group goes
+        blocks = [
+            b(0, "Paragraph", [0, 0, 100, 100]),
+            b(1, "Paragraph", [10, 10, 90, 90]),
+        ]
+        self.assertEqual(len(clean_layout(blocks)), 1)
+
+        # Only the largest header survives; it wraps the paragraph so kept
+        blocks = [
+            b(0, "Header", [0, 0, 100, 60]),
+            b(1, "Header", [0, 0, 50, 10]),
+            b(2, "Paragraph", [10, 25, 90, 55]),
+        ]
+        kept = clean_layout(blocks)
+        self.assertEqual(
+            [b_.bbox_xyxy for b_ in kept if b_.label == "Header"],
+            [[0, 0, 100, 60]],
+        )
+
+        # Equation nested in text is absorbed by default
+        blocks = [
+            b(0, "Paragraph", [0, 0, 100, 100]),
+            b(1, "Equation", [10, 10, 90, 30], type="Equation"),
+        ]
+        self.assertEqual(len(resolve_nested_equations(blocks)), 1)
+        self.assertEqual(len(resolve_nested_equations(blocks, nest=False)), 2)
+
+    def test_indic_ocr_build_ocr_requests(self):
+        from PIL import Image
+
+        from mlx_vlm.models.indic_ocr.blocks import Block
+        from mlx_vlm.models.indic_ocr.processing_indic_ocr import build_ocr_requests
+
+        page = Image.new("RGB", (400, 400), "white")
+        blocks = [
+            Block(
+                order=0,
+                label="Paragraph",
+                type="Text",
+                bbox_xyxy=[50, 50, 350, 200],
+                conf=0.9,
+            ),
+            Block(
+                order=1,
+                label="Header",
+                type="PageHeader",
+                bbox_xyxy=[50, 5, 350, 30],
+                conf=0.9,
+            ),
+            Block(
+                order=2,
+                label="Image",
+                type="Picture",
+                bbox_xyxy=[50, 210, 350, 390],
+                conf=0.9,
+            ),
+        ]
+        reqs = build_ocr_requests(blocks, page)
+        self.assertEqual(len(reqs), 1)
+        self.assertIs(reqs[0][0], blocks[0])
+        self.assertIn("LaTeX", reqs[0][2])
+
+    def test_indic_ocr_viewer_records_to_blocks(self):
+        from mlx_vlm.models.indic_ocr.pipeline import viewer_records_to_blocks
+
+        recs = [
+            {
+                "bbox": [0.0, 0.0, 500.0, 500.0],
+                "label": "Paragraph",
+                "reading_order": 2,
+                "score": 0.9,
+            },
+            {
+                "bbox": [500.0, 0.0, 1000.0, 1000.0],
+                "label": "Page-number",
+                "reading_order": 1,
+                "score": 0.8,
+            },
+        ]
+        blocks = viewer_records_to_blocks(recs, 200, 400)
+        self.assertEqual([b.order for b in blocks], [0, 1])
+        self.assertEqual(blocks[0].type, "PageNumber")
+        self.assertEqual(blocks[1].bbox_xyxy, [0.0, 0.0, 100.0, 200.0])
+
+    def test_indic_ocr_page_result_round_trip(self):
+        import json
+
+        from mlx_vlm.models.indic_ocr.pipeline import PageResult
+
+        record = {
+            "image": "page.png",
+            "width": 200,
+            "height": 400,
+            "blocks": [
+                {
+                    "order": 0,
+                    "label": "Paragraph",
+                    "type": "Text",
+                    "bbox_xyxy": [10, 10, 190, 100],
+                    "conf": 0.9,
+                    "text": "hi",
+                },
+                {
+                    "order": 1,
+                    "label": "Image",
+                    "type": "Picture",
+                    "bbox_xyxy": [10, 110, 190, 390],
+                    "conf": 0.8,
+                    "text": "",
+                },
+            ],
+        }
+        page = PageResult.from_record(record)
+        self.assertEqual(page.blocks[0].type, "Text")
+        self.assertIsNone(page.markdown)
+        out = page.as_record()
+        self.assertEqual(out["image"], "page.png")
+        self.assertEqual(len(out["blocks"]), 2)
+        self.assertEqual(out["blocks"][0]["text"], "hi")
+        # Round-trips through JSON.
+        self.assertEqual(
+            PageResult.from_record(json.loads(json.dumps(out))).as_record(), out
+        )
+
+    def test_indic_ocr_backends(self):
+        from PIL import Image
+
+        from mlx_vlm.models.indic_ocr.pipeline import (
+            JsonLayoutBackend,
+            MLXLayoutBackend,
+            PageResult,
+        )
+
+        records = [
+            {
+                "bbox": [0.0, 0.0, 500.0, 1000.0],
+                "label": "Paragraph",
+                "reading_order": 2,
+                "score": 0.9,
+            },
+            {
+                "bbox": [500.0, 0.0, 1000.0, 1000.0],
+                "label": "Page-number",
+                "reading_order": 1,
+                "score": 0.8,
+            },
+        ]
+
+        class StubDetector:
+            def detect(self, image, conf=0.5, img_size=1024):
+                return records
+
+        img = Image.new("RGB", (200, 400), "white")
+        blocks = MLXLayoutBackend(StubDetector()).detect(img)
+        self.assertEqual([b.order for b in blocks], [0, 1])
+        self.assertEqual(blocks[0].label, "Page-number")
+        self.assertEqual(blocks[0].bbox_xyxy, [0.0, 200.0, 200.0, 400.0])
+
+        page = PageResult(image="p.png", width=200, height=400, blocks=blocks)
+        replayed = JsonLayoutBackend(page).detect(img)
+        self.assertEqual([b.order for b in replayed], [0, 1])
+        self.assertEqual(replayed[0].label, "Page-number")
+        # Copies: mutating the replay must not touch the stored page.
+        replayed[0].label = "Changed"
+        self.assertEqual(page.blocks[0].label, "Page-number")
+
+    def test_indic_ocr_stage_dir_resolution(self):
+        import json
+        import tempfile
+        from pathlib import Path
+
+        from mlx_vlm.models.indic_ocr.pipeline import _resolve_repo_root, _stage_dir
+
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "config.json").write_text(
+                json.dumps(
+                    {
+                        "model_type": "indic_ocr",
+                        "stages": {
+                            "layout": {"config": "weights/layout/config.json"},
+                            "ocr": {"config": "weights/ocr/config.json"},
+                        },
+                    }
+                )
+            )
+            resolved, stages = _resolve_repo_root(str(root))
+            self.assertEqual(resolved, root)
+            self.assertEqual(
+                _stage_dir(resolved, stages, "layout", "weights/layout/config.json"),
+                root / "weights/layout",
+            )
+            self.assertEqual(
+                _stage_dir(resolved, stages, "ocr", "weights/ocr/config.json"),
+                root / "weights/ocr",
+            )
+            # Defaults when the pointer is absent.
+            self.assertEqual(
+                _stage_dir(resolved, {}, "ocr", "weights/ocr/config.json"),
+                root / "weights/ocr",
+            )
+
+    def test_indic_ocr_layout_source_resolution(self):
+        import tempfile
+        from pathlib import Path
+
+        from mlx_vlm.models.indic_ocr.pipeline import _resolve_layout_source
+
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "weights" / "layout").mkdir(parents=True)
+            (root / "weights" / "layout" / "config.json").write_text("{}")
+            stages = {"layout": {"config": "weights/layout/config.json"}}
+
+            # Explicit repo/path wins.
+            self.assertEqual(
+                _resolve_layout_source(root, stages, layout_repo="some-id"), "some-id"
+            )
+            # Else the single-repo subdir.
+            self.assertEqual(
+                _resolve_layout_source(root, stages),
+                str(root / "weights" / "layout"),
+            )
+            # Else a helpful error (separate dir without the subdir).
+            with tempfile.TemporaryDirectory() as empty:
+                with self.assertRaises(ValueError) as ctx:
+                    _resolve_layout_source(Path(empty), {})
+                self.assertIn("layout_repo", str(ctx.exception))
+
+    def test_indic_ocr_public_loader_supports_flat_and_bundled_stages(self):
+        import json
+        import tempfile
+        from pathlib import Path
+        from unittest.mock import Mock, patch
+
+        from mlx_vlm.models.indic_ocr.pipeline import IndicOCRParser
+
+        cases = [
+            ({"text_config": {}, "vision_config": {}}, "."),
+            ({"stages": {"ocr": {"config": "config.json"}}}, "."),
+            ({}, "weights/ocr"),
+            ({"stages": {"ocr": {"config": "recognizer/config.json"}}}, "recognizer"),
+        ]
+        for config, subdir in cases:
+            with (
+                self.subTest(subdir=subdir, config=config),
+                tempfile.TemporaryDirectory() as tmp,
+            ):
+                root = Path(tmp)
+                (root / "config.json").write_text(json.dumps(config))
+                ocr = root / subdir
+                if ocr != root:
+                    ocr.mkdir(parents=True)
+                    (ocr / "config.json").write_text("{}")
+                layout = root / "layout"
+                layout.mkdir()
+                (layout / "config.json").write_text("{}")
+                detector, recognizer, processor = Mock(), Mock(), Mock()
+                with (
+                    patch(
+                        "mlx_vlm.load", return_value=(recognizer, processor)
+                    ) as load_ocr,
+                    patch(
+                        "mlx_vlm.utils.load_model", return_value=detector
+                    ) as load_layout,
+                ):
+                    with IndicOCRParser.from_pretrained(
+                        str(root), layout_repo=str(layout)
+                    ) as parser:
+                        self.assertIs(parser.ocr.model, recognizer)
+                        self.assertIs(parser.layout.model, detector)
+                load_ocr.assert_called_once_with(str(ocr), lazy=False, strict=True)
+                load_layout.assert_called_once_with(layout, lazy=False, strict=True)
+                detector.eval.assert_called_once_with()
+
+    def test_indic_ocr_public_loader_returns_configured_parser(self):
+        import json
+        import tempfile
+        from pathlib import Path
+        from unittest.mock import Mock, patch
+
+        from PIL import Image
+
+        from mlx_vlm.models.indic_ocr import (
+            CropOptions,
+            DedupOptions,
+            IndicOCRParser,
+            LayoutOptions,
+            RecognizerOptions,
+        )
+
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            stages = {}
+            for name, dirname in (("layout", "detector"), ("ocr", "recognizer")):
+                stage_path = root / dirname
+                stage_path.mkdir()
+                (stage_path / "config.json").write_text("{}")
+                stages[name] = {"config": f"{dirname}/config.json"}
+            (root / "config.json").write_text(
+                json.dumps({"model_type": "indic_ocr", "stages": stages})
+            )
+            image_path = root / "page.png"
+            Image.new("RGB", (200, 100)).save(image_path)
+            detector, recognizer, processor = Mock(), Mock(), Mock()
+            detector.detect.return_value = [
+                {
+                    "label": "Paragraph",
+                    "reading_order": 1,
+                    "bbox": [100, 200, 900, 800],
+                    "score": 0.9,
+                }
+            ]
+            layout_options = LayoutOptions(conf=0.7)
+            recognizer_options = RecognizerOptions(max_tokens=32)
+            dedup = DedupOptions(nest=False)
+            crop = CropOptions(pad_px=5)
+            with (
+                patch("mlx_vlm.utils.load_model", return_value=detector) as load_layout,
+                patch("mlx_vlm.load", return_value=(recognizer, processor)) as load_ocr,
+            ):
+                with IndicOCRParser.from_pretrained(
+                    root,
+                    lazy=True,
+                    strict=False,
+                    trust_remote_code=False,
+                    layout_options=layout_options,
+                    recognizer_options=recognizer_options,
+                    dedup=dedup,
+                    crop=crop,
+                ) as parser:
+                    self.assertIsInstance(parser, IndicOCRParser)
+                    self.assertIs(parser.ocr.model, recognizer)
+                    self.assertIs(parser.ocr.processor, processor)
+                    self.assertIs(parser.ocr.options, recognizer_options)
+                    self.assertIs(parser.ocr.dedup, dedup)
+                    self.assertIs(parser.ocr.crop, crop)
+                    page = parser.detect(str(image_path))
+                    self.assertEqual(page.blocks[0].bbox_xyxy, [40, 10, 160, 90])
+                    self.assertEqual(page.blocks[0].type, "Text")
+                    self.assertEqual(detector.detect.call_args.kwargs["conf"], 0.7)
+                self.assertIsNone(parser.layout.model)
+                self.assertIsNone(parser.ocr.model)
+                self.assertIsNone(parser.ocr.processor)
+            load_layout.assert_called_once_with(
+                root / "detector", lazy=True, strict=False, trust_remote_code=False
+            )
+            load_ocr.assert_called_once_with(
+                str(root / "recognizer"),
+                lazy=True,
+                strict=False,
+                trust_remote_code=False,
+            )
+
+    def test_indic_ocr_standard_loader_only_dispatches_wrapper_configs(self):
+        import json
+        import tempfile
+        from pathlib import Path
+        from unittest.mock import patch
+
+        from mlx_vlm.models.indic_ocr import IndicOCRParser
+        from mlx_vlm.utils import load_model
+
+        configs = [
+            {"model_type": "indic_ocr", "text_config": {}, "stages": {}},
+            {"model_type": "pp_doclayout_v3", "stages": {}},
+            {"model_type": None, "speculators_model_type": "dflash2", "stages": {}},
+        ]
+        for config in configs:
+            with self.subTest(config=config), tempfile.TemporaryDirectory() as tmp:
+                root = Path(tmp)
+                (root / "config.json").write_text(json.dumps(config))
+                with patch.object(IndicOCRParser, "from_pretrained") as load_parser:
+                    with self.assertRaisesRegex(FileNotFoundError, "No safetensors"):
+                        load_model(root)
+                    load_parser.assert_not_called()
+
+    def test_indic_ocr_public_loader_rejects_wrapper_stages(self):
+        import json
+        import tempfile
+        from pathlib import Path
+        from unittest.mock import patch
+
+        from mlx_vlm.models.indic_ocr import IndicOCRParser
+
+        for name in ("layout", "ocr"):
+            for target in (".", "nested"):
+                with (
+                    self.subTest(stage=name, target=target),
+                    tempfile.TemporaryDirectory() as tmp,
+                ):
+                    root = Path(tmp)
+                    stages = {}
+                    for stage in ("layout", "ocr"):
+                        (root / stage).mkdir()
+                        (root / stage / "config.json").write_text("{}")
+                        stages[stage] = {"config": f"{stage}/config.json"}
+                    stages[name] = {"config": f"{target}/config.json"}
+                    wrapper = json.dumps({"model_type": "indic_ocr", "stages": stages})
+                    (root / "config.json").write_text(wrapper)
+                    if target == "nested":
+                        (root / target).mkdir()
+                        (root / target / "config.json").write_text(wrapper)
+                    with (
+                        patch("mlx_vlm.utils.load_model") as load_layout,
+                        patch("mlx_vlm.load") as load_ocr,
+                        self.assertRaisesRegex(ValueError, f"{name} stage.*two-stage"),
+                    ):
+                        IndicOCRParser.from_pretrained(str(root))
+                    load_layout.assert_not_called()
+                    load_ocr.assert_not_called()
+
+    def test_indic_ocr_missing_ocr_config_fails_before_loading_models(self):
+        import tempfile
+        from pathlib import Path
+        from unittest.mock import patch
+
+        from mlx_vlm.models.indic_ocr.pipeline import IndicOCRParser
+
+        with tempfile.TemporaryDirectory() as tmp:
+            (Path(tmp) / "config.json").write_text("{}")
+            with patch("mlx_vlm.utils.load_model") as load_layout:
+                with self.assertRaisesRegex(FileNotFoundError, "No OCR config"):
+                    IndicOCRParser.from_pretrained(tmp, layout_repo="example/layout")
+                load_layout.assert_not_called()
+
+    def test_indic_ocr_stock_labels_and_foreign_types(self):
+        from PIL import Image
+
+        from mlx_vlm.models.indic_ocr.blocks import Block, LayoutSchemaError
+        from mlx_vlm.models.indic_ocr.pipeline import viewer_records_to_blocks
+        from mlx_vlm.models.indic_ocr.processing_indic_ocr import (
+            EQUATION_PROMPT,
+            PP_DOCLAYOUT_LABEL_TO_TYPE,
+            TABLE_PROMPT_HTML,
+            build_ocr_requests,
+        )
+
+        for label, expected in PP_DOCLAYOUT_LABEL_TO_TYPE.items():
+            block = Block.from_record(
+                {"label": label, "order": 0, "bbox_xyxy": [0, 0, 10, 10]}
+            )
+            self.assertEqual(block.type, expected)
+        records = [
+            {"label": "formula", "reading_order": 1, "bbox": [0, 0, 400, 1000]},
+            {
+                "label": "foreign_table",
+                "type": "Table",
+                "reading_order": 2,
+                "bbox": [500, 0, 1000, 1000],
+            },
+        ]
+        blocks = viewer_records_to_blocks(records, 100, 100)
+        requests = build_ocr_requests(blocks, Image.new("RGB", (100, 100)))
+        self.assertEqual([r[2] for r in requests], [EQUATION_PROMPT, TABLE_PROMPT_HTML])
+        with self.assertRaises(LayoutSchemaError):
+            viewer_records_to_blocks(
+                [{**records[0], "label": "unknown_label"}], 100, 100
+            )
+        for order in (0, 1.5, "1", True):
+            with self.subTest(order=order), self.assertRaises(LayoutSchemaError):
+                viewer_records_to_blocks(
+                    [{**records[0], "reading_order": order}], 100, 100
+                )
+
+    def test_indic_ocr_cleanup_respects_stock_and_foreign_types(self):
+        from mlx_vlm.models.indic_ocr.blocks import Block, clean_layout
+
+        def block(order, label, bbox, **extra):
+            return Block.from_record(
+                {"order": order, "label": label, "bbox_xyxy": bbox, **extra}
+            )
+
+        # A page-number block must not be swallowed by a larger text block.
+        blocks = [
+            block(0, "text", [0, 0, 100, 100]),
+            block(1, "number", [10, 80, 20, 90]),
+        ]
+        self.assertEqual(len(clean_layout(blocks)), 2)
+        # Lowercase stock headers follow the same cleanup rules as Indic headers.
+        blocks = [
+            block(0, "header", [0, 0, 100, 60]),
+            block(1, "header", [0, 0, 50, 10]),
+            block(2, "text", [10, 25, 90, 55]),
+        ]
+        self.assertEqual([b.order for b in clean_layout(blocks)], [0, 2])
+        # A foreign figure with an explicit type cannot absorb a text caption.
+        blocks = [
+            block(0, "foreign_figure", [0, 0, 100, 100], type="Figure"),
+            block(1, "figure_title", [10, 80, 90, 90]),
+        ]
+        self.assertEqual(len(clean_layout(blocks)), 2)
+
+    def test_indic_ocr_close_releases_owned_models(self):
+        import gc
+        import weakref
+
+        from PIL import Image
+
+        from mlx_vlm.models.indic_ocr.pipeline import IndicOCRParser
+
+        class Sentinel:
+            pass
+
+        layout, ocr, processor = Sentinel(), Sentinel(), Sentinel()
+        references = [weakref.ref(value) for value in (layout, ocr, processor)]
+        with IndicOCRParser(layout, ocr, processor) as parser:
+            del layout, ocr, processor
+        gc.collect()
+        self.assertTrue(all(reference() is None for reference in references))
+        parser.close()  # Closing twice is safe.
+        with self.assertRaisesRegex(RuntimeError, "closed"):
+            parser.layout.detect(Image.new("RGB", (10, 10)))
+        with self.assertRaisesRegex(RuntimeError, "closed"):
+            parser.ocr.run("unused.png", {})
+
+    def test_indic_ocr_rejects_ambiguous_block_orders(self):
+        from unittest.mock import patch
+
+        from PIL import Image
+
+        from mlx_vlm.models.indic_ocr.blocks import Block, LayoutSchemaError
+        from mlx_vlm.models.indic_ocr.pipeline import BlockOCRRunner, PageResult
+
+        record = {"order": 0, "label": "Paragraph", "bbox_xyxy": [0, 0, 10, 10]}
+        for order in (-1, 1.5, "1", True):
+            with self.subTest(order=order), self.assertRaises(LayoutSchemaError):
+                Block.from_record({**record, "order": order})
+        page_record = {
+            "image": "unused.png",
+            "width": 10,
+            "height": 10,
+            "blocks": [record, record],
+        }
+        with self.assertRaisesRegex(LayoutSchemaError, "duplicate order"):
+            PageResult.from_record(page_record)
+        # A PageResult supplied directly must not bypass strict validation.
+        page = PageResult.from_record(page_record, strict=False)
+        with patch(
+            "mlx_vlm.models.indic_ocr.pipeline._open",
+            return_value=Image.new("RGB", (10, 10)),
+        ):
+            with self.assertRaisesRegex(LayoutSchemaError, "duplicate order"):
+                BlockOCRRunner(object(), object()).run("unused.png", page)
+
+    def test_indic_ocr_replay_clears_stale_skipped_text(self):
+        from unittest.mock import patch
+
+        from PIL import Image
+
+        from mlx_vlm.models.indic_ocr.blocks import Block
+        from mlx_vlm.models.indic_ocr.pipeline import BlockOCRRunner, PageResult
+        from mlx_vlm.models.indic_ocr.processing_indic_ocr import transcribe_blocks
+
+        blocks = [
+            Block(0, "Image", "Picture", [0, 0, 10, 10], 1.0, "stale image text"),
+            Block(1, "Paragraph", "Text", [0, 0, 0, 0], 1.0, "stale empty crop text"),
+        ]
+        image = Image.new("RGB", (10, 10))
+        with patch("mlx_vlm.generate") as generate:
+            copied = [b.copy() for b in blocks]
+            transcribe_blocks(object(), object(), image, copied, use_tqdm=False)
+            self.assertEqual([b.text for b in copied], ["", ""])
+            page = PageResult("unused.png", 10, 10, blocks)
+            with patch("mlx_vlm.models.indic_ocr.pipeline._open", return_value=image):
+                result = BlockOCRRunner(object(), object()).run("unused.png", page)
+            self.assertEqual([b.text for b in result.blocks], ["", ""])
+            self.assertEqual(
+                [b.text for b in page.blocks],
+                ["stale image text", "stale empty crop text"],
+            )
+            generate.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/mlx_vlm/tests/test_models.py
+++ b/mlx_vlm/tests/test_models.py
@@ -17449,6 +17449,25 @@ class TestMoEOffload(unittest.TestCase):
         modes = {mode for _, _, mode in result["experts"][3]}
         self.assertEqual(modes, {"STACK_FUSED", "STACK"})
 
+    def test_plan_partitions_nested_switch_glu_experts(self):
+        """Gemma 4's MoE wraps SwitchGLU inside an Experts module
+        (experts.switch_glu.{gate,up,down}_proj), so the anchor regex needs
+        to tolerate an optional .switch_glu segment before matching."""
+        from mlx_vlm.moe_offload import plan
+
+        names = [
+            "language_model.model.layers.0.experts.switch_glu.gate_proj.weight",
+            "language_model.model.layers.0.experts.switch_glu.up_proj.weight",
+            "language_model.model.layers.0.experts.switch_glu.down_proj.weight",
+        ]
+        result = plan(names)
+
+        self.assertEqual(result["layers"], [0])
+        stacked_entries = result["experts"][0]
+        self.assertEqual(len(stacked_entries), 3)
+        modes = {mode for _, _, mode in stacked_entries}
+        self.assertEqual(modes, {"STACK"})
+
     def test_expert_store_get_is_thread_safe(self):
         """get() reads only immutable post-init state (no LRU cache -- removed
         after measuring a 0% hit rate for single-request serving), so

--- a/mlx_vlm/tests/test_processors.py
+++ b/mlx_vlm/tests/test_processors.py
@@ -117,6 +117,14 @@ class TestOutputControlTokens(unittest.TestCase):
             _strip_box_markers("<|begin_of_box|>answer<|end_of_box|>"), "answer"
         )
 
+    def test_glm46v_moe_strips_box_markers(self):
+        from mlx_vlm.models.glm4v_moe.processing import Glm46VMoEProcessor
+
+        processor = object.__new__(Glm46VMoEProcessor)
+        self.assertEqual(
+            processor.clean_output("<|begin_of_box|>answer<|end_of_box|>"), "answer"
+        )
+
     def test_kimi_vl_stops_on_assistant_marker(self):
         from mlx_vlm.models.kimi_vl.processing_kimi_vl import KimiVLProcessor
 

--- a/mlx_vlm/tests/test_speculative.py
+++ b/mlx_vlm/tests/test_speculative.py
@@ -4376,6 +4376,127 @@ def test_general_quantized_verifier_matches_decode(
     assert mx.array_equal(tokens, mx.argmax(expected, axis=-1)).item()
 
 
+@pytest.mark.skipif(not mx.metal.is_available(), reason="requires Metal kernels")
+@pytest.mark.parametrize("dtype", [mx.bfloat16, mx.float16])
+@pytest.mark.parametrize("verify_length", [2, 4])
+def test_optimized_mxfp4_verifier_matches_singleton_decode(dtype, verify_length):
+    mx.random.seed(810 + verify_length)
+    linears = tuple(
+        nn.QuantizedLinear.from_linear(
+            nn.Linear(512, output_dims, bias=False),
+            group_size=32,
+            bits=4,
+            mode="mxfp4",
+        )
+        for output_dims in (16, 24, 32)
+    )
+    inputs = mx.random.normal((2, verify_length, 512)).astype(dtype)
+    mx.eval(*(linear.parameters() for linear in linears), inputs)
+    expected = tuple(
+        verifier_linear._target_verify_singletons(linear, inputs) for linear in linears
+    )
+
+    token_mask = mx.full((2 * verify_length, 1), 0x5555, dtype=mx.int32)
+    with (
+        patch.object(
+            verifier_linear,
+            "_target_verify_singleton_quantized_linear",
+            side_effect=AssertionError("MXFP4 must use its optimized projection"),
+        ),
+        patch.object(
+            verifier_linear,
+            "_target_verify_singleton_quantized_argmax",
+            side_effect=AssertionError("MXFP4 must use its optimized argmax"),
+        ),
+    ):
+        actual = verifier_linear._target_verify_quantized_linear(linears[0], inputs)
+        fused = verifier_linear._target_verify_linears(linears, inputs)
+        tokens = verifier_linear._target_verify_quantized_argmax(linears[0], inputs)
+        masked_tokens = verifier_linear._target_verify_quantized_argmax(
+            linears[0], inputs, token_mask=token_mask
+        )
+    masked_expected = mx.argmax(
+        mx.where(mx.arange(16) % 2 == 0, expected[0], -mx.inf), axis=-1
+    )
+    mx.eval(*expected, actual, *fused, tokens, masked_tokens, masked_expected)
+
+    assert actual is not None
+    assert fused is not None
+    assert mx.array_equal(actual, expected[0]).item()
+    assert all(mx.array_equal(a, e).item() for a, e in zip(fused, expected))
+    assert mx.array_equal(tokens, mx.argmax(expected[0], axis=-1)).item()
+    assert mx.array_equal(masked_tokens, masked_expected).item()
+
+
+@pytest.mark.skipif(not mx.metal.is_available(), reason="requires Metal kernels")
+@pytest.mark.parametrize("dtype", [mx.bfloat16, mx.float16])
+@pytest.mark.parametrize("masked", [False, True])
+def test_mxfp4_argmax_preserves_linear_bias(dtype, masked):
+    linear = nn.QuantizedLinear.from_linear(
+        nn.Linear(512, 16, bias=False), group_size=32, bits=4, mode="mxfp4"
+    )
+    linear.bias = mx.array([0.0] * 14 + [5.0, 10.0], dtype=dtype)
+    inputs = mx.zeros((2, 3, 512), dtype=dtype)
+    token_mask = mx.full((6, 1), 0x7FFF, dtype=mx.int32) if masked else None
+    expected = mx.full((2, 3), 14 if masked else 15, dtype=mx.int32)
+
+    actual = verifier_linear._target_verify_quantized_argmax(
+        linear, inputs, token_mask=token_mask
+    )
+    mx.eval(actual, expected)
+    assert mx.array_equal(actual, expected).item()
+
+
+@pytest.mark.skipif(not mx.metal.is_available(), reason="requires Metal kernels")
+@pytest.mark.parametrize("dtype", [mx.bfloat16, mx.float16])
+@pytest.mark.parametrize("group_size", [32, 64])
+@pytest.mark.parametrize("batch,verify_length", [(1, 3), (2, 4), (4, 3), (4, 4)])
+def test_optimized_affine_q3_verifier_matches_singleton_decode(
+    dtype, group_size, batch, verify_length
+):
+    from mlx_vlm.models.quantized_verifier import (
+        optimized_affine_argmax,
+        optimized_affine_linear,
+        optimized_affine_linears,
+    )
+
+    mx.random.seed(820 + group_size)
+    linears = tuple(
+        nn.QuantizedLinear.from_linear(
+            nn.Linear(512, output_dims, bias=False),
+            group_size=group_size,
+            bits=3,
+            mode="affine",
+        )
+        for output_dims in (16, 24, 32)
+    )
+    for linear in linears:
+        linear.scales = linear.scales.astype(dtype)
+        linear.biases = linear.biases.astype(dtype)
+    inputs = mx.random.normal((batch, verify_length, 512)).astype(dtype)
+    mx.eval(*(linear.parameters() for linear in linears), inputs)
+    expected = tuple(
+        verifier_linear._target_verify_singletons(linear, inputs) for linear in linears
+    )
+
+    actual = optimized_affine_linear(linears[0], inputs)
+    fused = optimized_affine_linears(linears, inputs)
+    tokens = optimized_affine_argmax(linears[0], inputs)
+    token_mask = mx.full((inputs.shape[0] * inputs.shape[1], 1), 0x5555, dtype=mx.int32)
+    masked_tokens = optimized_affine_argmax(linears[0], inputs, token_mask=token_mask)
+    masked_expected = mx.argmax(
+        mx.where(mx.arange(16) % 2 == 0, expected[0], -mx.inf), axis=-1
+    )
+    mx.eval(*expected, actual, *fused, tokens, masked_tokens, masked_expected)
+
+    assert actual is not None
+    assert fused is not None
+    assert mx.array_equal(actual, expected[0]).item()
+    assert all(mx.array_equal(a, e).item() for a, e in zip(fused, expected))
+    assert mx.array_equal(tokens, mx.argmax(expected[0], axis=-1)).item()
+    assert mx.array_equal(masked_tokens, masked_expected).item()
+
+
 @pytest.mark.parametrize("input_dims", [64, 128])
 @pytest.mark.parametrize("bits", [2, 4, 8])
 def test_general_quantized_verifier_matches_narrow_qmv_quad(input_dims, bits):


### PR DESCRIPTION
Resolves the current base-branch conflicts for #2206 without changing its intended cache-owned MTP design.

Resolution:
- retains the model-owned quantized ops relocation while incorporating current main MXFP4 and Q3 dispatch
- keeps the retired monolithic speculative test surface deleted and places the new exactness coverage in test_quantized_ops.py
- fixes the Ruff ambiguity found during reconciliation

Validated on M3 Ultra with MLX 0.32.2:
- Ruff format and check pass
- focused quantized/speculative/serving/reporting suites: 551 passed
- full suite was previously qualified on this exact tree; the signed amend changes commit metadata only

This PR deliberately targets the #2206 feature branch so merging it only refreshes that branch and makes the original PR mergeable.